### PR TITLE
Robustness and input-handling pass across install, shell, TLS/QUIC, HTTP/3, SQL and crypto

### DIFF
--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -323,17 +323,38 @@ declare module "bun" {
       max_lifetime?: number | undefined;
 
       /**
-       * Whether to use TLS/SSL for the connection
+       * Whether to use TLS/SSL for the connection. A string selects the
+       * SSL mode (`"disable"`, `"allow"`, `"prefer"`, `"require"`, `"verify-ca"`, `"verify-full"`).
        * @default false
        */
-      tls?: Bun.BunFile | TLSOptions | boolean | undefined;
+      tls?:
+        | Bun.BunFile
+        | TLSOptions
+        | boolean
+        | "disable"
+        | "allow"
+        | "prefer"
+        | "require"
+        | "verify-ca"
+        | "verify-full"
+        | undefined;
 
       /**
        * Whether to use TLS/SSL for the connection (alias for tls)
        * @deprecated Prefer {@link tls}
        * @default false
        */
-      ssl?: Bun.BunFile | TLSOptions | boolean | undefined;
+      ssl?:
+        | Bun.BunFile
+        | TLSOptions
+        | boolean
+        | "disable"
+        | "allow"
+        | "prefer"
+        | "require"
+        | "verify-ca"
+        | "verify-full"
+        | undefined;
 
       /**
        * Unix domain socket path for connection

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -1676,10 +1676,7 @@ static long us_internal_verify_peer_certificate(const SSL *ssl, long def) {
     err = SSL_get_verify_result(ssl);
   } else {
     const SSL_CIPHER *curr_cipher = SSL_get_current_cipher(ssl);
-    const SSL_SESSION *sess = SSL_get_session(ssl);
-    if ((curr_cipher && SSL_CIPHER_get_auth_nid(curr_cipher) == NID_auth_psk) ||
-        (sess && SSL_SESSION_get_protocol_version(sess) == TLS1_3_VERSION &&
-         SSL_session_reused(ssl))) {
+    if (curr_cipher && SSL_CIPHER_get_auth_nid(curr_cipher) == NID_auth_psk) {
       return X509_V_OK;
     }
   }
@@ -2742,13 +2739,16 @@ static void us_ssl_apply_selected_ctx(SSL *ssl, SSL_CTX *ctx) {
 /* Whether the SNI-selected context of this connection demands closing on a
  * client-certificate verification error (requestCert && rejectUnauthorized
  * of the per-serverName entry). */
-int us_socket_server_name_reject_unauthorized(struct us_socket_t *s) {
-  if (!s->ssl || us_ctx_sni_policy_ex_idx < 0) return 0;
-  SSL_CTX *ctx = SSL_get_SSL_CTX(s_ssl(s));
-  if (!ctx) return 0;
+int us_ssl_ctx_reject_unauthorized(SSL_CTX *ctx) {
+  if (!ctx || us_ctx_sni_policy_ex_idx < 0) return 0;
   uintptr_t packed = (uintptr_t)SSL_CTX_get_ex_data(ctx, us_ctx_sni_policy_ex_idx);
   return (packed & US_SNI_POLICY_REQUEST_CERT) &&
          (packed & US_SNI_POLICY_REJECT_UNAUTHORIZED);
+}
+
+int us_socket_server_name_reject_unauthorized(struct us_socket_t *s) {
+  if (!s->ssl) return 0;
+  return us_ssl_ctx_reject_unauthorized(SSL_get_SSL_CTX(s_ssl(s)));
 }
 
 /* Extracts the host_name from the ClientHello's server_name extension.

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -431,6 +431,7 @@ void us_ssl_ctx_set_sni_policy(struct ssl_ctx_st *ctx, int request_cert,
 /* 1 iff the SNI-selected context for this connection demands closing on a
  * client-certificate verification error. */
 int us_socket_server_name_reject_unauthorized(us_socket_r s);
+int us_ssl_ctx_reject_unauthorized(struct ssl_ctx_st *ctx);
 /* Socket-level SNI resolver, for a server-side socket adopted into TLS with no
  * listen socket behind it. Same contract as the listener resolver: an owned
  * SSL_CTX ref or NULL; *abort_handshake 1 = drop silently, 2 = suspend. */

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -28,6 +28,7 @@ extern SSL_CTX *us_ssl_ctx_build_raw(
     struct us_bun_socket_context_options_t options,
     enum create_bun_socket_error_t *err);
 extern X509_STORE *us_get_default_ca_store(void);
+extern struct us_bun_verify_error_t us_ssl_socket_verify_error_from_ssl(SSL *ssl);
 
 #define US_QUIC_READ_BUF (16 * 1024)
 
@@ -40,6 +41,7 @@ struct us_quic_hset {
     struct lsxpack_header scratch;
     struct us_quic_header_t *headers;
     unsigned int count, hcap;
+    int is_server;
 };
 
 struct us_quic_sni {
@@ -423,8 +425,32 @@ static int us_quic_alpn_select(SSL *ssl, const unsigned char **out, unsigned cha
 /* ───── header-set interface ───── */
 
 static void *us_quic_hsi_create(void *hsi_ctx, lsquic_stream_t *s, int is_push) {
-    (void) hsi_ctx; (void) s; (void) is_push;
-    return us_calloc(1, sizeof(struct us_quic_hset));
+    (void) s; (void) is_push;
+    struct us_quic_hset *h = (struct us_quic_hset *) us_calloc(1, sizeof(struct us_quic_hset));
+    if (h) h->is_server = !((us_quic_socket_context_t *) hsi_ctx)->is_client;
+    return h;
+}
+
+static int us_quic_field_is_malformed(const struct lsxpack_header *hdr) {
+    const unsigned char *name = (const unsigned char *) lsxpack_header_get_name(hdr);
+    const unsigned char *val = (const unsigned char *) lsxpack_header_get_value(hdr);
+    if (hdr->name_len == 0) return 1;
+    if (name[0] == ':' && hdr->name_len == 1) return 1;
+    for (unsigned int i = name[0] == ':'; i < hdr->name_len; i++) {
+        unsigned char c = name[i];
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) continue;
+        switch (c) {
+        case '!': case '#': case '$': case '%': case '&': case '\'': case '*':
+        case '+': case '-': case '.': case '^': case '_': case '`': case '|': case '~':
+            continue;
+        }
+        return 1;
+    }
+    for (unsigned int i = 0; i < hdr->val_len; i++) {
+        unsigned char c = val[i];
+        if (c == 0 || c == '\r' || c == '\n') return 1;
+    }
+    return 0;
 }
 
 static struct lsxpack_header *us_quic_hsi_prepare(void *hset_p, struct lsxpack_header *hdr, size_t space) {
@@ -455,6 +481,7 @@ static struct lsxpack_header *us_quic_hsi_prepare(void *hset_p, struct lsxpack_h
 static int us_quic_hsi_process(void *hset_p, struct lsxpack_header *hdr) {
     struct us_quic_hset *h = (struct us_quic_hset *) hset_p;
     if (hdr == NULL) return 0; /* end of headers */
+    if (h->is_server && us_quic_field_is_malformed(hdr)) return 1;
     if (h->count == h->hcap) {
         unsigned int ncap = h->hcap ? h->hcap * 2 : 16;
         struct us_quic_header_t *nh = (struct us_quic_header_t *)
@@ -496,9 +523,18 @@ static void us_quic_hsi_discard(void *hset_p) {
 
 /* ───── stream interface ───── */
 
+static int us_quic_server_peer_verified(us_quic_socket_context_t *ctx, lsquic_conn_t *conn) {
+    SSL *ssl = lsquic_conn_get_ssl(conn);
+    int enforce = us_ssl_ctx_reject_unauthorized(ctx->ssl_ctx) ||
+        (ssl && us_ssl_ctx_reject_unauthorized(SSL_get_SSL_CTX(ssl)));
+    if (!enforce) return 1;
+    if (!ssl) return 0;
+    return us_ssl_socket_verify_error_from_ssl(ssl).error == 0;
+}
+
 static lsquic_conn_ctx_t *us_quic_on_new_conn(void *if_ctx, lsquic_conn_t *conn) {
     us_quic_socket_context_t *ctx = (us_quic_socket_context_t *) if_ctx;
-    if (ctx->closing) {
+    if (ctx->closing || (!ctx->is_client && !us_quic_server_peer_verified(ctx, conn))) {
         lsquic_conn_close(conn);
         return NULL;
     }
@@ -683,11 +719,12 @@ void us_quic_global_init(void) {
 #endif
 }
 
-static void us_quic_prepare_ssl_ctx(SSL_CTX *ssl) {
+static void us_quic_prepare_ssl_ctx(SSL_CTX *ssl, const struct us_bun_socket_context_options_t *options) {
     SSL_CTX_set_min_proto_version(ssl, TLS1_3_VERSION);
     SSL_CTX_set_max_proto_version(ssl, TLS1_3_VERSION);
     SSL_CTX_set_alpn_select_cb(ssl, us_quic_alpn_select, NULL);
     SSL_CTX_set_early_data_enabled(ssl, 0);
+    us_ssl_ctx_set_sni_policy(ssl, options->request_cert, options->reject_unauthorized);
 }
 
 us_quic_socket_context_t *us_create_quic_socket_context(
@@ -697,7 +734,7 @@ us_quic_socket_context_t *us_create_quic_socket_context(
     enum create_bun_socket_error_t ssl_err = 0;
     SSL_CTX *ssl = us_ssl_ctx_build_raw(options, &ssl_err);
     if (!ssl) return NULL;
-    us_quic_prepare_ssl_ctx(ssl);
+    us_quic_prepare_ssl_ctx(ssl, &options);
 
     us_quic_socket_context_t *ctx = (us_quic_socket_context_t *)
         us_calloc(1, sizeof(us_quic_socket_context_t) + ext_size);
@@ -757,7 +794,9 @@ int us_quic_socket_context_add_server_name(us_quic_socket_context_t *ctx,
     enum create_bun_socket_error_t ssl_err = 0;
     SSL_CTX *ssl = us_ssl_ctx_build_raw(options, &ssl_err);
     if (!ssl) return -1;
-    us_quic_prepare_ssl_ctx(ssl);
+    us_quic_prepare_ssl_ctx(ssl, &options);
+    SSL_CTX_set_verify(ssl, SSL_CTX_get_verify_mode(ssl) | SSL_CTX_get_verify_mode(ctx->ssl_ctx),
+        SSL_CTX_get_verify_callback(ssl));
     if (ctx->sni_count == ctx->sni_cap) {
         unsigned ncap = ctx->sni_cap ? ctx->sni_cap * 2 : 4;
         struct us_quic_sni *n = (struct us_quic_sni *) us_realloc(ctx->sni, ncap * sizeof(*n));

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -3209,21 +3209,29 @@ pub fn initialize_store_or_reset() {
 
 /// RAII guard that pins the thread-local `disable_reset` flag on both AST
 /// `Store`s for its scope.
-#[must_use = "disable_reset is cleared on drop; bind to a named local"]
-pub struct DisableStoreReset(());
+#[must_use = "disable_reset is restored on drop; bind to a named local"]
+pub struct DisableStoreReset {
+    prev_expr: bool,
+    prev_stmt: bool,
+}
 impl DisableStoreReset {
     #[inline]
     pub fn new() -> Self {
+        let prev_expr = expr::data::Store::disable_reset();
+        let prev_stmt = stmt::data::Store::disable_reset();
         expr::data::Store::set_disable_reset(true);
         stmt::data::Store::set_disable_reset(true);
-        Self(())
+        Self {
+            prev_expr,
+            prev_stmt,
+        }
     }
 }
 impl Drop for DisableStoreReset {
     #[inline]
     fn drop(&mut self) {
-        expr::data::Store::set_disable_reset(false);
-        stmt::data::Store::set_disable_reset(false);
+        expr::data::Store::set_disable_reset(self.prev_expr);
+        stmt::data::Store::set_disable_reset(self.prev_stmt);
     }
 }
 

--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1707,12 +1707,12 @@ impl Keywords {
 
 pub(crate) struct RedactedKeywords;
 impl RedactedKeywords {
-    // 5 entries — a `matches!` chain is plenty at this size (the big keyword
+    // 6 entries — a `matches!` chain is plenty at this size (the big keyword
     // table in `Keywords::get` is where the length-dispatched map pays off).
     pub(crate) fn has(s: &[u8]) -> bool {
         matches!(
             s,
-            b"_auth" | b"_authToken" | b"token" | b"_password" | b"email"
+            b"_auth" | b"_authToken" | b"token" | b"_password" | b"password" | b"email"
         )
     }
 }

--- a/src/bun_core/lib.rs
+++ b/src/bun_core/lib.rs
@@ -2047,6 +2047,9 @@ pub(crate) mod strings_impl {
         if let Some(r) = starts_with_redacted_item(str, b"_password") {
             return Some(r);
         }
+        if let Some(r) = starts_with_redacted_item(str, b"password") {
+            return Some(r);
+        }
         if let Some(r) = starts_with_redacted_item(str, b"token") {
             return Some(r);
         }

--- a/src/bun_core/string/immutable/unicode.rs
+++ b/src/bun_core/string/immutable/unicode.rs
@@ -984,14 +984,8 @@ pub fn copy_utf16_into_utf8_impl<const ALLOW_TRUNCATED_UTF8_SEQUENCE: bool>(
                 written: 0,
             };
         }
-        // `trim::utf16` strips a single trailing lone high surrogate so simdutf's
-        // length estimate never sees invalid input. If that empties the input, it
-        // was exactly one unpaired surrogate: 3 bytes of U+FFFD, not nothing.
-        let trimmed = simdutf::trim::utf16(utf16);
-        let out_len = if trimmed.is_empty() {
-            3
-        } else if buf.len() <= (trimmed.len() * 3 + 2) {
-            simdutf::length::utf8::from::utf16::le(trimmed)
+        let out_len = if buf.len() <= utf16.len().saturating_mul(3) {
+            simdutf::length::utf8::from::utf16::le(utf16)
         } else {
             buf.len()
         };

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -179,7 +179,7 @@ fn make_client<'a>(
         custom_ssl_ctx: None,
         result_callback: noop_callback(),
         if_modified_since: b"",
-        request_content_len_buf: [0u8; b"-4294967295".len()],
+        request_content_len_buf: [0u8; b"18446744073709551615".len()],
         http_proxy,
         proxy_settings: None,
         proxy_headers,

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -63,9 +63,8 @@ pub struct InternalStateFlags {
     pub(crate) is_redirect_pending: bool,
     pub(crate) is_libdeflate_fast_path_disabled: bool,
     pub(crate) resend_request_body_on_redirect: bool,
-    /// Cross-origin redirect: the per-request Host override and unix socket
-    /// path must be dropped so the follow-up connection re-derives
-    /// SNI/Host/transport from the redirect target.
+    /// Cross-origin redirect: the per-request Host override must be dropped so
+    /// the follow-up connection re-derives SNI/Host from the redirect target.
     /// The actual clear is deferred to `do_redirect`, after the old socket's
     /// pool/close decision — that decision needs `hostname` still set to know
     /// the handshake was verified against an override.

--- a/src/http/InternalState.rs
+++ b/src/http/InternalState.rs
@@ -63,8 +63,9 @@ pub struct InternalStateFlags {
     pub(crate) is_redirect_pending: bool,
     pub(crate) is_libdeflate_fast_path_disabled: bool,
     pub(crate) resend_request_body_on_redirect: bool,
-    /// Cross-origin redirect: the per-request Host override must be dropped so
-    /// the follow-up connection re-derives SNI/Host from the redirect target.
+    /// Cross-origin redirect: the per-request Host override and unix socket
+    /// path must be dropped so the follow-up connection re-derives
+    /// SNI/Host/transport from the redirect target.
     /// The actual clear is deferred to `do_redirect`, after the old socket's
     /// pool/close decision — that decision needs `hostname` still set to know
     /// the handshake was verified against an override.

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1435,7 +1435,12 @@ pub(crate) fn print_request(
         Protocol::Http2 => "HTTP/2",
         Protocol::Http3 => "HTTP/3",
     };
-    bun_core::pretty_errorln!("> {} {} {}", ver, BStr::new(request.method), BStr::new(url));
+    bun_core::pretty_errorln!(
+        "> {} {} {}",
+        ver,
+        BStr::new(request.method),
+        bun_core::fmt::redacted_npm_url(url),
+    );
     for header in request.headers {
         let name = header.name();
         if strings::eql_case_insensitive_ascii(name, b"authorization", true)

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -840,7 +840,7 @@ pub struct HTTPClient<'a> {
     /// Some HTTP servers (such as npm) report Last-Modified times but ignore If-Modified-Since.
     /// This is a workaround for that.
     pub if_modified_since: &'a [u8],
-    pub(crate) request_content_len_buf: [u8; b"-4294967295".len()],
+    pub(crate) request_content_len_buf: [u8; b"18446744073709551615".len()],
 
     pub(crate) http_proxy: Option<URL<'a>>,
     /// Captured proxy env (http_proxy / https_proxy / no_proxy) so redirects
@@ -1437,7 +1437,20 @@ pub(crate) fn print_request(
     };
     bun_core::pretty_errorln!("> {} {} {}", ver, BStr::new(request.method), BStr::new(url));
     for header in request.headers {
-        bun_core::pretty_errorln!("> {}", header);
+        let name = header.name();
+        if strings::eql_case_insensitive_ascii(name, b"authorization", true)
+            || strings::eql_case_insensitive_ascii(name, b"proxy-authorization", true)
+        {
+            let value = header.value();
+            let scheme_len = value.iter().position(|&b| b == b' ').map_or(0, |i| i + 1);
+            bun_core::pretty_errorln!(
+                "> <r><cyan>{}<r><d>: <r>{}<d>[redacted]<r>",
+                BStr::new(name),
+                BStr::new(&value[..scheme_len]),
+            );
+        } else {
+            bun_core::pretty_errorln!("> {}", header);
+        }
     }
     Output::flush();
 }
@@ -2527,16 +2540,10 @@ impl<'a> HTTPClient<'a> {
                     header_count += 1;
                 }
             } else {
-                // 11-byte buf vs 64-bit usize: must fall back to "0" on
-                // overflow, NOT panic.
-                let value: &[u8] = match bun_core::fmt::buf_print(
-                    &mut self.request_content_len_buf,
-                    format_args!("{body_len}"),
-                ) {
-                    // SAFETY: borrows `self.request_content_len_buf` which lives for `self`.
-                    Ok(s) => unsafe { bun_ptr::detach_lifetime(s) },
-                    Err(_) => b"0",
-                };
+                let value: &[u8] =
+                    bun_core::fmt::int_as_bytes(&mut self.request_content_len_buf, body_len);
+                // SAFETY: borrows `self.request_content_len_buf` which lives for `self`.
+                let value: &[u8] = unsafe { bun_ptr::detach_lifetime(value) };
                 request_headers_buf[header_count] =
                     picohttp::Header::new(CONTENT_LENGTH_HEADER_NAME, value);
                 header_count += 1;
@@ -2585,15 +2592,7 @@ impl<'a> HTTPClient<'a> {
             self.flags.is_streaming_request_body = false;
         }
 
-        // Decided before unix_socket_path is forgotten below: a unix-socket connection must not be pooled.
         let keep_alive_possible = self.is_keep_alive_possible();
-        // There is no struct copy-back
-        // (`sync_progress_from` skips owned fields) and the original retains
-        // its own `Owned(Vec)` aliasing the same allocation (the HTTP-thread
-        // clone was created via `ptr::read`). Dropping it here would
-        // double-free when the original later runs `clear_data()`. Forget the
-        // clone's view; the original is the sole owner.
-        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         // TODO: what we do with stream body?
         let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
@@ -2659,6 +2658,11 @@ impl<'a> HTTPClient<'a> {
         if self.state.flags.clear_hostname_on_redirect {
             self.state.flags.clear_hostname_on_redirect = false;
             self.hostname = None;
+            // The HTTP-thread clone shares this allocation with the JS-thread
+            // original (created via `ptr::read`); dropping it here would
+            // double-free when the original later runs `clear_data()`. Forget
+            // the clone's view; the original is the sole owner.
+            let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         }
 
         // TODO: should this check be before decrementing the redirect count?
@@ -4305,14 +4309,11 @@ impl<'a> HTTPClient<'a> {
         if self.state.flags.clear_hostname_on_redirect {
             self.state.flags.clear_hostname_on_redirect = false;
             self.hostname = None;
+            let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         }
         if matches!(self.state.original_request_body, HTTPRequestBody::Stream(_)) {
             self.flags.is_streaming_request_body = false;
         }
-        // See `do_redirect`: the HTTP-thread clone shares this allocation
-        // with the JS-thread original (created via `ptr::read`); dropping it
-        // here double-frees once the original runs `clear_data()`.
-        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
         {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -2597,7 +2597,15 @@ impl<'a> HTTPClient<'a> {
             self.flags.is_streaming_request_body = false;
         }
 
+        // Decided before unix_socket_path is forgotten below: a unix-socket connection must not be pooled.
         let keep_alive_possible = self.is_keep_alive_possible();
+        // There is no struct copy-back
+        // (`sync_progress_from` skips owned fields) and the original retains
+        // its own `Owned(Vec)` aliasing the same allocation (the HTTP-thread
+        // clone was created via `ptr::read`). Dropping it here would
+        // double-free when the original later runs `clear_data()`. Forget the
+        // clone's view; the original is the sole owner.
+        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         // TODO: what we do with stream body?
         let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
@@ -2663,11 +2671,6 @@ impl<'a> HTTPClient<'a> {
         if self.state.flags.clear_hostname_on_redirect {
             self.state.flags.clear_hostname_on_redirect = false;
             self.hostname = None;
-            // The HTTP-thread clone shares this allocation with the JS-thread
-            // original (created via `ptr::read`); dropping it here would
-            // double-free when the original later runs `clear_data()`. Forget
-            // the clone's view; the original is the sole owner.
-            let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         }
 
         // TODO: should this check be before decrementing the redirect count?
@@ -4314,11 +4317,14 @@ impl<'a> HTTPClient<'a> {
         if self.state.flags.clear_hostname_on_redirect {
             self.state.flags.clear_hostname_on_redirect = false;
             self.hostname = None;
-            let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         }
         if matches!(self.state.original_request_body, HTTPRequestBody::Stream(_)) {
             self.flags.is_streaming_request_body = false;
         }
+        // See `do_redirect`: the HTTP-thread clone shares this allocation
+        // with the JS-thread original (created via `ptr::read`); dropping it
+        // here double-frees once the original runs `clear_data()`.
+        let _ = core::mem::ManuallyDrop::new(core::mem::take(&mut self.unix_socket_path));
         let request_body: &[u8] = if self.state.flags.resend_request_body_on_redirect
             && matches!(self.state.original_request_body, HTTPRequestBody::Bytes(_))
         {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -1447,7 +1447,7 @@ pub(crate) fn print_request(
             || strings::eql_case_insensitive_ascii(name, b"proxy-authorization", true)
         {
             let value = header.value();
-            let scheme_len = value.iter().position(|&b| b == b' ').map_or(0, |i| i + 1);
+            let scheme_len = strings::index_of_char_usize(value, b' ').map_or(0, |i| i + 1);
             bun_core::pretty_errorln!(
                 "> <r><cyan>{}<r><d>: <r>{}<d>[redacted]<r>",
                 BStr::new(name),

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -103,10 +103,7 @@ pub struct PackageInstaller<'a> {
     pub(crate) tree_ids_to_trees_the_id_depends_on: bun_collections::DynamicBitSetList,
     pub(crate) pending_lifecycle_scripts: Vec<PendingLifecycleScript>,
 
-    /// Value is the alias bytes the key hash was computed from; lookups must
-    /// compare it since truncated hashes can collide.
-    pub(crate) trusted_dependencies_from_update_requests:
-        ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>>,
+    pub(crate) trusted_dependencies_from_update_requests: ArrayHashMap<PackageID, ()>,
 
     /// uses same ids as lockfile.trees
     pub(crate) trees: Box<[TreeContext]>,
@@ -1923,8 +1920,7 @@ impl<'a> PackageInstaller<'a> {
                     let (is_trusted, is_trusted_through_update_request) = 'brk: {
                         if self
                             .trusted_dependencies_from_update_requests
-                            .get(&truncated_dep_name_hash)
-                            .is_some_and(|n| **n == *alias.slice(string_buf!()))
+                            .contains(&package_id)
                         {
                             break 'brk (true, true);
                         }
@@ -1988,9 +1984,15 @@ impl<'a> PackageInstaller<'a> {
                                 resolution,
                             ) {
                                 if is_trusted_through_update_request {
+                                    let (trusted_name, trusted_name_hash) =
+                                        if resolution.tag == resolution::Tag::Npm {
+                                            (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
+                                        } else {
+                                            (alias, truncated_dep_name_hash)
+                                        };
                                     self.manager_mut()
                                         .trusted_deps_to_add_to_package_json
-                                        .push(Box::<[u8]>::from(alias.slice(string_buf!())));
+                                        .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
 
                                     if self.lockfile().trusted_dependencies.is_none() {
                                         self.lockfile_mut().trusted_dependencies =
@@ -2001,8 +2003,8 @@ impl<'a> PackageInstaller<'a> {
                                         .as_mut()
                                         .unwrap()
                                         .put(
-                                            truncated_dep_name_hash,
-                                            Box::<[u8]>::from(alias.slice(string_buf!())),
+                                            trusted_name_hash,
+                                            Box::<[u8]>::from(trusted_name.slice(string_buf!())),
                                         )
                                         .unwrap_or_oom();
                                 }
@@ -2229,8 +2231,7 @@ impl<'a> PackageInstaller<'a> {
                 // trusted through a --trust dependency. need to enqueue scripts, write to package.json, and add to lockfile
                 if self
                     .trusted_dependencies_from_update_requests
-                    .get(&truncated_dep_name_hash)
-                    .is_some_and(|n| **n == *alias.slice(string_buf!()))
+                    .contains(&package_id)
                 {
                     break 'brk (true, true, true);
                 }
@@ -2300,10 +2301,17 @@ impl<'a> PackageInstaller<'a> {
                         dep_behavior.contains(crate::dependency::Behavior::OPTIONAL),
                         resolution,
                     ) {
+                        let (trusted_name, trusted_name_hash) =
+                            if resolution.tag == resolution::Tag::Npm {
+                                (pkg_name, pkg_name_hash as TruncatedPackageNameHash)
+                            } else {
+                                (alias, truncated_dep_name_hash)
+                            };
+
                         if is_trusted_through_update_request {
                             self.manager_mut()
                                 .trusted_deps_to_add_to_package_json
-                                .push(Box::<[u8]>::from(alias.slice(string_buf!())));
+                                .push(Box::<[u8]>::from(trusted_name.slice(string_buf!())));
                         }
 
                         if add_to_lockfile {
@@ -2315,8 +2323,8 @@ impl<'a> PackageInstaller<'a> {
                                 .as_mut()
                                 .unwrap()
                                 .put(
-                                    truncated_dep_name_hash,
-                                    Box::<[u8]>::from(alias.slice(string_buf!())),
+                                    trusted_name_hash,
+                                    Box::<[u8]>::from(trusted_name.slice(string_buf!())),
                                 )
                                 .unwrap_or_oom();
                         }

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1011,6 +1011,7 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                         (*this_ptr).manifests.by_name_hash_allow_expired(
                                             cache_ctx,
                                             &*scope,
+                                            &name_str,
                                             name_hash,
                                             Some(&mut expired),
                                             ManifestLoad::LoadFromMemoryFallbackToDisk,
@@ -2347,6 +2348,7 @@ fn get_or_put_resolved_package(
             let Some(manifest) = (unsafe { &mut (*this_ptr).manifests }).by_name_hash(
                 cache_ctx,
                 scope.get(),
+                name_str,
                 name_hash,
                 ManifestLoad::LoadFromMemoryFallbackToDisk,
                 needs_ext,
@@ -2613,6 +2615,39 @@ fn get_or_put_resolved_package(
             }
         }
         dependency::version::Tag::Workspace => {
+            if !behavior.is_workspace() && !this.lockfile.is_workspace_dependency(dependency_id) {
+                let buf = this.lockfile.buffers.string_bytes.as_slice();
+                if !this.lockfile.overrides.contains_name(
+                    dependency.name_hash,
+                    dependency.name.slice(buf),
+                    buf,
+                ) {
+                    let Some(root_package) = this.lockfile.root_package() else {
+                        return Err(crate::Error::MissingPackageJSON);
+                    };
+                    let root_dependencies = root_package
+                        .dependencies
+                        .get(this.lockfile.buffers.dependencies.as_slice());
+                    let root_resolutions = root_package
+                        .resolutions
+                        .get(this.lockfile.buffers.resolutions.as_slice());
+                    for (root_dep, &workspace_package_id) in
+                        root_dependencies.iter().zip(root_resolutions)
+                    {
+                        if workspace_package_id != invalid_package_id
+                            && root_dep.version.tag == dependency::version::Tag::Workspace
+                            && root_dep.name_hash == name_hash
+                        {
+                            success_fn(this, dependency_id, workspace_package_id);
+                            return Ok(Some(ResolvedPackageResult {
+                                package: *this.lockfile.packages.get(workspace_package_id as usize),
+                                ..Default::default()
+                            }));
+                        }
+                    }
+                    return Err(crate::Error::MissingPackageJSON);
+                }
+            }
             // package name hash should be used to find workspace path from map
             // SAFETY: `version.tag == Workspace` discriminates the union arm.
             let workspace_path_raw: SemverString = this

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1921,6 +1921,29 @@ fn update_name_and_name_hash_from_version_replacement(
     }
 }
 
+fn root_workspace_package_id(
+    lockfile: &Lockfile::Lockfile,
+    name_hash: PackageNameHash,
+) -> Option<PackageID> {
+    let root_package = lockfile.root_package()?;
+    let root_dependencies = root_package
+        .dependencies
+        .get(lockfile.buffers.dependencies.as_slice());
+    let root_resolutions = root_package
+        .resolutions
+        .get(lockfile.buffers.resolutions.as_slice());
+    debug_assert_eq!(root_dependencies.len(), root_resolutions.len());
+    for (root_dep, &workspace_package_id) in root_dependencies.iter().zip(root_resolutions) {
+        if workspace_package_id != invalid_package_id
+            && root_dep.version.tag == dependency::version::Tag::Workspace
+            && root_dep.name_hash == name_hash
+        {
+            return Some(workspace_package_id);
+        }
+    }
+    None
+}
+
 pub(crate) enum ResolvedPackageTask {
     /// Pending network task to schedule
     NetworkTask(*mut NetworkTask),
@@ -2285,36 +2308,18 @@ fn get_or_put_resolved_package(
                             // dependency version is wildcard
                             || (workspace_path.is_some() && npm_group.is_star()))
                     {
-                        let Some(root_package) = this.lockfile.root_package() else {
+                        let Some(workspace_package_id) =
+                            root_workspace_package_id(&this.lockfile, name_hash)
+                        else {
                             break 'resolve_from_workspace;
                         };
-                        let root_dependencies = root_package
-                            .dependencies
-                            .get(this.lockfile.buffers.dependencies.as_slice());
-                        let root_resolutions = root_package
-                            .resolutions
-                            .get(this.lockfile.buffers.resolutions.as_slice());
-
-                        debug_assert_eq!(root_dependencies.len(), root_resolutions.len());
-                        for (root_dep, &workspace_package_id) in
-                            root_dependencies.iter().zip(root_resolutions)
-                        {
-                            if workspace_package_id != invalid_package_id
-                                && root_dep.version.tag == dependency::version::Tag::Workspace
-                                && root_dep.name_hash == name_hash
-                            {
-                                // make sure verifyResolutions sees this resolution as a valid package id
-                                success_fn(this, dependency_id, workspace_package_id);
-                                return Ok(Some(ResolvedPackageResult {
-                                    package: *this
-                                        .lockfile
-                                        .packages
-                                        .get(workspace_package_id as usize),
-                                    is_first_time: false,
-                                    task: None,
-                                }));
-                            }
-                        }
+                        // make sure verifyResolutions sees this resolution as a valid package id
+                        success_fn(this, dependency_id, workspace_package_id);
+                        return Ok(Some(ResolvedPackageResult {
+                            package: *this.lockfile.packages.get(workspace_package_id as usize),
+                            is_first_time: false,
+                            task: None,
+                        }));
                     }
                 }
             }
@@ -2438,37 +2443,21 @@ fn get_or_put_resolved_package(
                                 None
                             };
                             if workspace_path.is_some() {
-                                let Some(root_package) = this.lockfile.root_package() else {
+                                let Some(workspace_package_id) =
+                                    root_workspace_package_id(&this.lockfile, name_hash)
+                                else {
                                     break 'resolve_workspace_from_dist_tag;
                                 };
-                                let root_dependencies = root_package
-                                    .dependencies
-                                    .get(this.lockfile.buffers.dependencies.as_slice());
-                                let root_resolutions = root_package
-                                    .resolutions
-                                    .get(this.lockfile.buffers.resolutions.as_slice());
-
-                                debug_assert_eq!(root_dependencies.len(), root_resolutions.len());
-                                for (root_dep, &workspace_package_id) in
-                                    root_dependencies.iter().zip(root_resolutions)
-                                {
-                                    if workspace_package_id != invalid_package_id
-                                        && root_dep.version.tag
-                                            == dependency::version::Tag::Workspace
-                                        && root_dep.name_hash == name_hash
-                                    {
-                                        // make sure verifyResolutions sees this resolution as a valid package id
-                                        success_fn(this, dependency_id, workspace_package_id);
-                                        return Ok(Some(ResolvedPackageResult {
-                                            package: *this
-                                                .lockfile
-                                                .packages
-                                                .get(workspace_package_id as usize),
-                                            is_first_time: false,
-                                            task: None,
-                                        }));
-                                    }
-                                }
+                                // make sure verifyResolutions sees this resolution as a valid package id
+                                success_fn(this, dependency_id, workspace_package_id);
+                                return Ok(Some(ResolvedPackageResult {
+                                    package: *this
+                                        .lockfile
+                                        .packages
+                                        .get(workspace_package_id as usize),
+                                    is_first_time: false,
+                                    task: None,
+                                }));
                             }
                         }
                     }
@@ -2622,30 +2611,16 @@ fn get_or_put_resolved_package(
                     dependency.name.slice(buf),
                     buf,
                 ) {
-                    let Some(root_package) = this.lockfile.root_package() else {
+                    let Some(workspace_package_id) =
+                        root_workspace_package_id(&this.lockfile, name_hash)
+                    else {
                         return Err(crate::Error::MissingPackageJSON);
                     };
-                    let root_dependencies = root_package
-                        .dependencies
-                        .get(this.lockfile.buffers.dependencies.as_slice());
-                    let root_resolutions = root_package
-                        .resolutions
-                        .get(this.lockfile.buffers.resolutions.as_slice());
-                    for (root_dep, &workspace_package_id) in
-                        root_dependencies.iter().zip(root_resolutions)
-                    {
-                        if workspace_package_id != invalid_package_id
-                            && root_dep.version.tag == dependency::version::Tag::Workspace
-                            && root_dep.name_hash == name_hash
-                        {
-                            success_fn(this, dependency_id, workspace_package_id);
-                            return Ok(Some(ResolvedPackageResult {
-                                package: *this.lockfile.packages.get(workspace_package_id as usize),
-                                ..Default::default()
-                            }));
-                        }
-                    }
-                    return Err(crate::Error::MissingPackageJSON);
+                    success_fn(this, dependency_id, workspace_package_id);
+                    return Ok(Some(ResolvedPackageResult {
+                        package: *this.lockfile.packages.get(workspace_package_id as usize),
+                        ..Default::default()
+                    }));
                 }
             }
             // package name hash should be used to find workspace path from map

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -22,10 +22,8 @@ use crate::lifecycle_script_runner::{
 use crate::lockfile_real::package::scripts::List as ScriptsList;
 use crate::package_manager_real::Command;
 use crate::resolution_real::Tag as ResolutionTag;
-use bun_install::lockfile::{self, Lockfile, Package};
-use bun_install::{
-    PackageID, PackageManager, PreinstallState, TruncatedPackageNameHash, invalid_package_id,
-};
+use bun_install::lockfile::{Lockfile, Package};
+use bun_install::{PackageID, PackageManager, PreinstallState, invalid_package_id};
 
 impl PackageManager {
     pub(crate) fn ensure_preinstall_state_list_capacity(&mut self, count: usize) {
@@ -433,9 +431,9 @@ impl PackageManager {
 
     pub(crate) fn find_trusted_dependencies_from_update_requests(
         &mut self,
-    ) -> ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>> {
-        // find all deps originating from --trust packages from cli
-        let mut set: ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>> = ArrayHashMap::default();
+    ) -> ArrayHashMap<PackageID, ()> {
+        // find all packages originating from --trust packages from cli
+        let mut set: ArrayHashMap<PackageID, ()> = ArrayHashMap::default();
         if self.options.do_.trust_dependencies_from_args() && self.lockfile.packages.len() > 0 {
             let root_id = self
                 .root_package_id
@@ -452,19 +450,7 @@ impl PackageManager {
                             continue;
                         }
 
-                        let entry = handle_oom(
-                            set.get_or_put(root_dep.name_hash as TruncatedPackageNameHash),
-                        );
-                        if !entry.found_existing {
-                            *entry.value_ptr = Box::from(
-                                root_dep
-                                    .name
-                                    .slice(self.lockfile.buffers.string_bytes.as_slice()),
-                            );
-                            let dependency_slice =
-                                self.lockfile.packages.items_dependencies()[package_id as usize];
-                            add_dependencies_to_set(&mut set, &self.lockfile, dependency_slice);
-                        }
+                        add_package_to_set(&mut set, &self.lockfile, package_id);
                         break;
                     }
                 }
@@ -476,27 +462,22 @@ impl PackageManager {
     }
 }
 
-fn add_dependencies_to_set(
-    names: &mut ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>>,
+fn add_package_to_set(
+    set: &mut ArrayHashMap<PackageID, ()>,
     lockfile: &Lockfile,
-    dependencies_slice: lockfile::DependencySlice,
+    package_id: PackageID,
 ) {
+    if handle_oom(set.get_or_put(package_id)).found_existing {
+        return;
+    }
+    let dependencies_slice = lockfile.packages.items_dependencies()[package_id as usize];
     let begin = dependencies_slice.off;
     let end = begin.saturating_add(dependencies_slice.len);
     let mut dep_id = begin;
     while dep_id < end {
-        let package_id = lockfile.buffers.resolutions[dep_id as usize];
-        if package_id == invalid_package_id {
-            dep_id += 1;
-            continue;
-        }
-
-        let dep = &lockfile.buffers.dependencies[dep_id as usize];
-        let entry = handle_oom(names.get_or_put(dep.name_hash as TruncatedPackageNameHash));
-        if !entry.found_existing {
-            *entry.value_ptr = Box::from(dep.name.slice(lockfile.buffers.string_bytes.as_slice()));
-            let dependency_slice = lockfile.packages.items_dependencies()[package_id as usize];
-            add_dependencies_to_set(names, lockfile, dependency_slice);
+        let dep_package_id = lockfile.buffers.resolutions[dep_id as usize];
+        if dep_package_id != invalid_package_id {
+            add_package_to_set(set, lockfile, dep_package_id);
         }
         dep_id += 1;
     }

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -470,16 +470,21 @@ fn add_package_to_set(
     if handle_oom(set.get_or_put(package_id)).found_existing {
         return;
     }
-    let dependencies_slice = lockfile.packages.items_dependencies()[package_id as usize];
-    let begin = dependencies_slice.off;
-    let end = begin.saturating_add(dependencies_slice.len);
-    let mut dep_id = begin;
-    while dep_id < end {
-        let dep_package_id = lockfile.buffers.resolutions[dep_id as usize];
-        if dep_package_id != invalid_package_id {
-            add_package_to_set(set, lockfile, dep_package_id);
+    let mut stack: Vec<PackageID> = vec![package_id];
+    while let Some(current) = stack.pop() {
+        let dependencies_slice = lockfile.packages.items_dependencies()[current as usize];
+        let begin = dependencies_slice.off;
+        let end = begin.saturating_add(dependencies_slice.len);
+        let mut dep_id = begin;
+        while dep_id < end {
+            let dep_package_id = lockfile.buffers.resolutions[dep_id as usize];
+            if dep_package_id != invalid_package_id
+                && !handle_oom(set.get_or_put(dep_package_id)).found_existing
+            {
+                stack.push(dep_package_id);
+            }
+            dep_id += 1;
         }
-        dep_id += 1;
     }
 }
 

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -48,9 +48,6 @@ impl PackageManager {
         name_hash: PackageNameHash,
         resolution: &Resolution,
     ) -> Option<semver::version::Formatter<'_, u64>> {
-        // The `.load_from_memory` arm never reads scope; keep the param for
-        // signature parity.
-        let _ = package_name;
         match resolution.tag {
             ResolutionTag::Npm => {
                 let npm_version = resolution.npm().version;
@@ -66,7 +63,9 @@ impl PackageManager {
                 // nothing on `PackageManager` besides the map, so use the
                 // disjoint-borrow helper and read `self.options` / `self.lockfile`
                 // alongside the held `&mut self.manifests` field borrow.
-                let manifest = self.manifests.by_name_hash_in_memory(name_hash)?;
+                let manifest = self
+                    .manifests
+                    .by_name_hash_in_memory(package_name, name_hash)?;
 
                 if let Some(latest_version) = manifest
                     .find_by_dist_tag_with_filter(

--- a/src/install/PackageManifestMap.rs
+++ b/src/install/PackageManifestMap.rs
@@ -67,6 +67,7 @@ impl PackageManifestMap {
         self.by_name_hash(
             ctx,
             scope,
+            name,
             StringBuilder::string_hash(name),
             cache_behavior,
             needs_extended_manifest,
@@ -86,6 +87,7 @@ impl PackageManifestMap {
         &mut self,
         ctx: DiskCacheCtx,
         scope: &npm::registry::Scope,
+        name: &[u8],
         name_hash: PackageNameHash,
         cache_behavior: CacheBehavior,
         needs_extended_manifest: bool,
@@ -93,6 +95,7 @@ impl PackageManifestMap {
         self.by_name_hash_allow_expired(
             ctx,
             scope,
+            name,
             name_hash,
             None,
             cache_behavior,
@@ -107,11 +110,12 @@ impl PackageManifestMap {
     /// `pm.manifests` field.
     pub(crate) fn by_name_hash_in_memory(
         &mut self,
+        name: &[u8],
         name_hash: PackageNameHash,
     ) -> Option<&mut npm::PackageManifest> {
         match self.hash_map.get_mut(&name_hash)? {
-            Value::Manifest(m) => Some(m),
-            Value::Expired(_) | Value::NotFound => None,
+            Value::Manifest(m) if m.name() == name => Some(m),
+            _ => None,
         }
     }
 
@@ -127,6 +131,7 @@ impl PackageManifestMap {
         self.by_name_hash_allow_expired(
             ctx,
             scope,
+            name,
             StringBuilder::string_hash(name),
             is_expired,
             cache_behavior,
@@ -143,6 +148,7 @@ impl PackageManifestMap {
         &mut self,
         ctx: DiskCacheCtx,
         scope: &npm::registry::Scope,
+        name: &[u8],
         name_hash: PackageNameHash,
         is_expired: Option<&mut bool>,
         cache_behavior: CacheBehavior,
@@ -151,8 +157,8 @@ impl PackageManifestMap {
         if cache_behavior == CacheBehavior::LoadFromMemory {
             let entry = self.hash_map.get_mut(&name_hash)?;
             return match entry {
-                Value::Manifest(m) => Some(m),
-                Value::Expired(m) => {
+                Value::Manifest(m) if m.name() == name => Some(m),
+                Value::Expired(m) if m.name() == name => {
                     if let Some(expiry) = is_expired {
                         *expiry = true;
                         Some(m)
@@ -160,13 +166,18 @@ impl PackageManifestMap {
                         None
                     }
                 }
-                Value::NotFound => None,
+                _ => None,
             };
         }
 
         match self.hash_map.entry(name_hash) {
             Entry::Occupied(occ) => {
                 let value_ptr = occ.into_mut();
+                if let Value::Manifest(m) | Value::Expired(m) = &*value_ptr {
+                    if m.name() != name {
+                        return None;
+                    }
+                }
                 // Compute the demote decision first without holding a borrow
                 // that escapes the fn.
                 let demote = matches!(
@@ -198,7 +209,7 @@ impl PackageManifestMap {
                     // (see `manifest_disk_cache_ctx`).
                     let cache_fd = ctx.cache_directory.expect("cache_directory");
                     if let Some(manifest) = npm::package_manifest::Serializer::load_by_file_id(
-                        scope, cache_fd, name_hash,
+                        scope, cache_fd, name, name_hash,
                     )
                     .ok()
                     .flatten()

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -23,6 +23,7 @@ use core::mem::ManuallyDrop;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use bun_collections::VecExt;
+#[cfg(windows)]
 use bun_core::strings;
 use bun_core::{self, Output, ZBox, env_var, fmt as bun_fmt};
 use bun_libarchive::lib;
@@ -859,7 +860,7 @@ impl TarballStream {
             }
             FileKind::SymLink => {
                 #[cfg(unix)]
-                if symlink_target_stays_inside(entry.symlink(), path_slice) {
+                if bun_libarchive::is_symlink_target_safe(path_slice, entry.symlink(), &mut None) {
                     self.deferred_symlinks
                         .push(bun_libarchive::DeferredSymlink::new(
                             path_slice,
@@ -1406,65 +1407,6 @@ fn make_directory(entry: &mut lib::Entry, dest_fd: Fd, path: OSPathZ, path_slice
             },
         }
     }
-}
-
-#[cfg(unix)]
-fn symlink_target_stays_inside(target: &bun_core::ZStr, path_slice: &[OSPathChar]) -> bool {
-    // Same safety rule as `isSymlinkTargetSafe` in the buffered path:
-    // reject absolute targets and anything that escapes via `..`.
-    if target.is_empty() || target[0] == b'/' {
-        return false;
-    }
-    {
-        // Normalize `symlink_dir/target` as a *relative* path with leading
-        // `..` preserved, and reject targets that climb above the extraction
-        // root. A fake absolute root cannot be used here: POSIX normalization
-        // clamps excess `..` at `/`, so a target like `../../packages/x`
-        // would normalize back under the fake root while the kernel still
-        // resolves the raw `..` components and escapes the extraction
-        // directory.
-        let symlink_dir = bun_paths::dirname(path_slice).unwrap_or(b"");
-        let target_bytes = target.as_bytes();
-        let mut seen_named_component = false;
-        for component in strings::split(target_bytes, b"/") {
-            match component {
-                b"" | b"." => {}
-                b".." => {
-                    if seen_named_component {
-                        return false;
-                    }
-                }
-                _ => seen_named_component = true,
-            }
-        }
-        let mut join_buf = PathBuffer::uninit();
-        if symlink_dir.len() + 1 + target_bytes.len() >= join_buf.len() {
-            return false;
-        }
-        let mut written = 0usize;
-        if !symlink_dir.is_empty() {
-            join_buf[..symlink_dir.len()].copy_from_slice(symlink_dir);
-            written = symlink_dir.len();
-            join_buf[written] = b'/';
-            written += 1;
-        }
-        join_buf[written..written + target_bytes.len()].copy_from_slice(target_bytes);
-        written += target_bytes.len();
-
-        let mut norm_buf = PathBuffer::uninit();
-        let resolved = resolve_path::normalize_string_generic_t::<u8, true, false>(
-            &join_buf[..written],
-            &mut norm_buf[..],
-            b'/',
-            |c| c == b'/',
-        );
-        if bun_core::strings::eql(resolved, b"..")
-            || bun_core::strings::has_prefix_comptime(resolved, b"../")
-        {
-            return false;
-        }
-    }
-    true
 }
 
 #[cfg(windows)]

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -143,11 +143,8 @@ pub struct TarballStream {
     want_first_dirname: bool,
     npm_mode: bool,
 
-    /// Symlink entries accepted so far. They are only written to disk after
-    /// every other entry (`deferred_symlinks`), and later entries whose path
-    /// traverses one of them are skipped.
-    #[cfg(unix)]
-    created_symlinks: Vec<Vec<u8>>,
+    /// Symlink entries accepted so far; written to disk only after every
+    /// other entry.
     #[cfg(unix)]
     deferred_symlinks: Vec<bun_libarchive::DeferredSymlink>,
 
@@ -260,8 +257,6 @@ impl TarballStream {
             resolved_github_dirname: b"",
             want_first_dirname,
             npm_mode,
-            #[cfg(unix)]
-            created_symlinks: Vec::new(),
             #[cfg(unix)]
             deferred_symlinks: Vec::new(),
             bytes_received: 0,
@@ -856,17 +851,6 @@ impl TarballStream {
         let path_slice: &[OSPathChar] = &path[..];
         let dest = self.dest.unwrap();
 
-        // Reject any entry whose path traverses a symlink created earlier in
-        // this extraction; the kernel would follow it and the entry could land
-        // outside the extraction root. Same defense as the buffered extractor
-        // in `Archiver::extract_to_dir`.
-        #[cfg(unix)]
-        if bun_libarchive::path_traverses_created_symlink(path_slice, &self.created_symlinks) {
-            self.phase = Phase::WantData;
-            self.out_fd = None;
-            return Ok(());
-        }
-
         match kind {
             FileKind::Directory => {
                 make_directory(entry, dest, path, path_slice);
@@ -881,7 +865,6 @@ impl TarballStream {
                             path_slice,
                             entry.symlink().as_bytes(),
                         ));
-                    self.created_symlinks.push(path_slice.to_vec());
                 }
                 self.phase = Phase::WantData;
                 self.out_fd = None;
@@ -893,11 +876,7 @@ impl TarballStream {
                 // archive never reach `openat`'s mode argument.
                 #[cfg(not(windows))]
                 let mode: Mode = Mode::try_from((entry.perm() & 0o777) | 0o666).expect("int cast");
-                #[cfg(unix)]
-                let nofollow = !self.created_symlinks.is_empty();
-                #[cfg(not(unix))]
-                let nofollow = false;
-                let fd = open_output_file(dest, path, path_slice, mode, nofollow)?;
+                let fd = open_output_file(dest, path, path_slice, mode)?;
                 self.entry_count += 1;
 
                 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -1354,20 +1333,8 @@ fn open_output_file(
     path: OSPathZ,
     path_slice: &[OSPathChar],
     mode: Mode,
-    nofollow: bool,
 ) -> crate::Result<Fd> {
-    // `path_traverses_created_symlink` is a lexical check: on filesystems that
-    // alias differently-encoded names (Unicode NFC/NFD normalization on
-    // APFS/HFS+), a path component can reach a created symlink without
-    // byte-matching its recorded path. Once this extraction has created any
-    // symlink, ask the kernel to refuse to follow symlinks while opening file
-    // entries. `NOFOLLOW_ANY` is 0 on non-Darwin targets. Same defense as the
-    // buffered extractor in `Archiver::extract_to_dir`.
-    let flags = if nofollow {
-        O::WRONLY | O::CREAT | O::TRUNC | O::NOFOLLOW_ANY
-    } else {
-        O::WRONLY | O::CREAT | O::TRUNC
-    };
+    let flags = O::WRONLY | O::CREAT | O::TRUNC;
     #[cfg(windows)]
     {
         let _ = mode;

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -87,7 +87,9 @@ pub struct TarballStream {
 
     /// True while a drain task is either queued on the thread pool or
     /// running. `on_chunk` sets it before scheduling; `drain` clears it when
-    /// it runs out of input and decides to yield.
+    /// it runs out of input and decides to yield. Both transitions happen
+    /// with `mutex` held, and whoever does not own it stops touching `*this`
+    /// at the following `unlock()`.
     draining: AtomicBool,
 
     // ---------------------------------------------------------------------
@@ -101,6 +103,7 @@ pub struct TarballStream {
     /// we only recycle this buffer on the *following* swap.
     reading: Vec<u8>,
     read_pos: usize,
+    archive_holds_reading: bool,
 
     archive: Option<lib::ReadArchive>,
 
@@ -140,12 +143,13 @@ pub struct TarballStream {
     want_first_dirname: bool,
     npm_mode: bool,
 
-    /// Symlinks created so far during this extraction. Later entries whose
-    /// path traverses one of these are skipped: the per-target check in
-    /// `make_symlink` is purely lexical, so once a link is on disk the kernel
-    /// would follow it and a chained link could escape the extraction root.
+    /// Symlink entries accepted so far. They are only written to disk after
+    /// every other entry (`deferred_symlinks`), and later entries whose path
+    /// traverses one of them are skipped.
     #[cfg(unix)]
     created_symlinks: Vec<Vec<u8>>,
+    #[cfg(unix)]
+    deferred_symlinks: Vec<bun_libarchive::DeferredSymlink>,
 
     bytes_received: usize,
     entry_count: u32,
@@ -241,6 +245,7 @@ impl TarballStream {
             draining: AtomicBool::new(false),
             reading: Vec::new(),
             read_pos: 0,
+            archive_holds_reading: false,
             archive: None,
             phase: Phase::WantHeader,
             out_fd: None,
@@ -257,6 +262,8 @@ impl TarballStream {
             npm_mode,
             #[cfg(unix)]
             created_symlinks: Vec::new(),
+            #[cfg(unix)]
+            deferred_symlinks: Vec::new(),
             bytes_received: 0,
             entry_count: 0,
             fail: None,
@@ -287,6 +294,7 @@ impl TarballStream {
         is_last: bool,
         err: Option<crate::Error>,
     ) {
+        let drain_threshold = Self::drain_threshold();
         // SAFETY: see fn-level # Safety — `this` is live, raw-ptr field
         // projection only (no `&mut TarballStream` formed).
         unsafe {
@@ -302,29 +310,29 @@ impl TarballStream {
                 (*this).http_err = Some(e);
             }
             let pending_len = (*this).pending.len();
-            (*this).mutex.unlock();
 
             // Batch sub-threshold chunks so each one doesn't re-wake a worker
             // once the drain has yielded; `is_last`/`err` always schedule so
             // `finish()` never waits on the threshold.
-            if is_last || err.is_some() || pending_len >= Self::drain_threshold() {
+            let schedule = (is_last || err.is_some() || pending_len >= drain_threshold)
+                && !(*this).draining.swap(true, Ordering::AcqRel);
+            (*this).mutex.unlock();
+
+            if schedule {
                 Self::schedule_drain(this);
             }
         }
     }
 
     /// # Safety
-    /// `this` must be live. Runs on the HTTP thread; a worker may be inside
-    /// `drain()` concurrently when `draining.swap` returns `true`, so this
-    /// never forms `&mut TarballStream`.
+    /// `this` must be live and the caller must have just taken `draining`
+    /// (false -> true) with `mutex` held, so no worker is inside `drain()`.
+    /// Never forms `&mut TarballStream`.
     unsafe fn schedule_drain(this: *mut Self) {
         // SAFETY: see fn-level # Safety — `this` is live; `package_manager`
         // outlives this stream (it owns the thread pool that runs us). Field
         // projections via raw ptr — no `&mut TarballStream` is formed.
         unsafe {
-            if (*this).draining.swap(true, Ordering::AcqRel) {
-                return;
-            }
             // `addr_of_mut!` (not `&mut (*this).drain_task`) so the raw
             // pointer inherits `this`'s full-struct provenance: the
             // thread-pool callback recovers the parent `*mut TarballStream`
@@ -378,15 +386,13 @@ impl TarballStream {
                         // libarchive consumed everything we had. Yield the
                         // worker until the HTTP thread delivers the next
                         // chunk.
-                        (*this).draining.store(false, Ordering::Release);
-                        // Close the race between clearing `draining` and a
-                        // chunk arriving: if `pending` is non-empty now, try
-                        // to reclaim the flag ourselves instead of waiting
-                        // for the next schedule.
                         (*this).mutex.lock();
                         let again = !(*this).pending.is_empty() || (*this).closed;
+                        if !again {
+                            (*this).draining.store(false, Ordering::Release);
+                        }
                         (*this).mutex.unlock();
-                        if again && !(*this).draining.swap(true, Ordering::AcqRel) {
+                        if again {
                             continue;
                         }
                         return;
@@ -436,11 +442,13 @@ impl TarballStream {
                 // Archive is done (or failed) but the HTTP response has not
                 // finished yet. Yield; the next `on_chunk` will reschedule us
                 // to discard the new bytes and eventually observe `closed`.
-                (*this).draining.store(false, Ordering::Release);
                 (*this).mutex.lock();
                 let again = !(*this).pending.is_empty() || (*this).closed;
+                if !again {
+                    (*this).draining.store(false, Ordering::Release);
+                }
                 (*this).mutex.unlock();
-                if again && !(*this).draining.swap(true, Ordering::AcqRel) {
+                if again {
                     continue;
                 }
                 return;
@@ -538,8 +546,17 @@ impl TarballStream {
                     Phase::WantHeader => {
                         let mut entry: *mut lib::Entry = core::ptr::null_mut();
                         match archive.read_next_header(&mut entry) {
+                            lib::Result::Retry if (*this).archive_holds_reading => continue,
                             lib::Result::Retry => return Ok(()),
                             lib::Result::Eof => {
+                                #[cfg(unix)]
+                                {
+                                    let dest = (*this).dest.unwrap();
+                                    let symlinks = core::mem::take(&mut (*this).deferred_symlinks);
+                                    bun_libarchive::create_deferred_symlinks(
+                                        dest, &symlinks, false,
+                                    );
+                                }
                                 (*this).phase = Phase::Done;
                                 return Ok(());
                             }
@@ -570,7 +587,7 @@ impl TarballStream {
                             continue;
                         };
                         match block.result {
-                            lib::Result::Retry => return Ok(()),
+                            lib::Result::Retry if !(*this).archive_holds_reading => return Ok(()),
                             lib::Result::Ok | lib::Result::Warn => {
                                 if let Some(fd) = (*this).out_fd {
                                     (*this).write_data_block(fd, &block)?;
@@ -858,7 +875,12 @@ impl TarballStream {
             }
             FileKind::SymLink => {
                 #[cfg(unix)]
-                if make_symlink(entry, dest, path, path_slice) {
+                if symlink_target_stays_inside(entry.symlink(), path_slice) {
+                    self.deferred_symlinks
+                        .push(bun_libarchive::DeferredSymlink::new(
+                            path_slice,
+                            entry.symlink().as_bytes(),
+                        ));
                     self.created_symlinks.push(path_slice.to_vec());
                 }
                 self.phase = Phase::WantData;
@@ -1273,8 +1295,10 @@ extern "C" fn archive_read_callback(
         if !remaining.is_empty() {
             *out_buffer = remaining.as_ptr().cast();
             (*this).read_pos = (*this).reading.len();
+            (*this).archive_holds_reading = true;
             return lib::la_ssize_t::try_from(remaining.len()).expect("int cast");
         }
+        (*this).archive_holds_reading = false;
     }
 
     // No data left in `reading`. Check for more under the lock —
@@ -1306,6 +1330,7 @@ extern "C" fn archive_read_callback(
             if !again.is_empty() {
                 *out_buffer = again.as_ptr().cast();
                 (*this).read_pos = (*this).reading.len();
+                (*this).archive_holds_reading = true;
                 return lib::la_ssize_t::try_from(again.len()).expect("int cast");
             }
         }
@@ -1416,16 +1441,8 @@ fn make_directory(entry: &mut lib::Entry, dest_fd: Fd, path: OSPathZ, path_slice
     }
 }
 
-/// Returns `true` only when a symlink was actually created on disk, so the
-/// caller can record it in `created_symlinks`.
 #[cfg(unix)]
-fn make_symlink(
-    entry: &mut lib::Entry,
-    dest_fd: Fd,
-    path: OSPathZ,
-    path_slice: &[OSPathChar],
-) -> bool {
-    let target = entry.symlink();
+fn symlink_target_stays_inside(target: &bun_core::ZStr, path_slice: &[OSPathChar]) -> bool {
     // Same safety rule as `isSymlinkTargetSafe` in the buffered path:
     // reject absolute targets and anything that escapes via `..`.
     if target.is_empty() || target[0] == b'/' {
@@ -1480,17 +1497,7 @@ fn make_symlink(
             return false;
         }
     }
-    match bun_sys::symlinkat(target, dest_fd, path) {
-        Ok(()) => true,
-        Err(e) if matches!(e.get_errno(), bun_sys::E::EPERM | bun_sys::E::ENOENT) => {
-            let Some(dir) = bun_paths::dirname(path_slice) else {
-                return false;
-            };
-            let _ = dest_fd.make_path(dir);
-            bun_sys::symlinkat(target, dest_fd, path).is_ok()
-        }
-        Err(_) => false,
-    }
+    true
 }
 
 #[cfg(windows)]

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1170,7 +1170,6 @@ pub(crate) fn install_isolated_packages(
 
             let pkgs = lockfile.packages.slice();
             let pkg_names = pkgs.items_name();
-            let pkg_name_hashes = pkgs.items_name_hash();
             let pkg_resolutions = pkgs.items_resolution();
             let pkg_metas = pkgs.items_meta();
 
@@ -1269,24 +1268,16 @@ pub(crate) fn install_isolated_packages(
                                 // Over-excludes the rare "trusted but actually no
                                 // scripts" case in exchange for not needing a
                                 // lockfile-format change.
-                                let (dep_name, dep_name_hash) = if dep_id != invalid_dependency_id {
-                                    (
-                                        dependencies[dep_id as usize].name.slice(string_buf),
-                                        dependencies[dep_id as usize].name_hash,
-                                    )
+                                let dep_name = if dep_id != invalid_dependency_id {
+                                    dependencies[dep_id as usize].name.slice(string_buf)
                                 } else {
-                                    (
-                                        pkg_names[pkg_id as usize].slice(string_buf),
-                                        pkg_name_hashes[pkg_id as usize],
-                                    )
+                                    pkg_names[pkg_id as usize].slice(string_buf)
                                 };
                                 if lockfile.has_trusted_dependency(
                                     dep_name,
                                     pkg_names[pkg_id as usize].slice(string_buf),
                                     pkg_res,
-                                ) || trusted_from_update
-                                    .get(&(dep_name_hash as crate::TruncatedPackageNameHash))
-                                    .is_some_and(|n| **n == *dep_name)
+                                ) || trusted_from_update.contains(&pkg_id)
                                 {
                                     break 'eligible false;
                                 }

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -96,11 +96,8 @@ pub struct Installer<'a> {
     /// round-trip via `Method::from_u8` at the load sites below.
     pub(crate) supported_backend: AtomicU8,
 
-    /// Value is the alias bytes the key hash was computed from; lookups must
-    /// compare it since truncated hashes can collide. Built before tasks
-    /// spawn and only read concurrently afterwards.
-    pub(crate) trusted_dependencies_from_update_requests:
-        ArrayHashMap<TruncatedPackageNameHash, Box<[u8]>>,
+    /// Built before tasks spawn and only read concurrently afterwards.
+    pub(crate) trusted_dependencies_from_update_requests: ArrayHashMap<PackageID, ()>,
 
     /// Absolute path to the global virtual store (`<cache_dir>/links`). When
     /// non-null, npm/git/tarball entries are materialized once into this
@@ -1642,8 +1639,7 @@ impl Task {
                     let (is_trusted, is_trusted_through_update_request) = 'brk: {
                         if installer
                             .trusted_dependencies_from_update_requests
-                            .get(&truncated_dep_name_hash)
-                            .is_some_and(|n| **n == *dep.name.slice(string_buf))
+                            .contains(&pkg_id)
                         {
                             break 'brk (true, true);
                         }
@@ -1722,8 +1718,16 @@ impl Task {
                             entry_scripts[self.entry_id.get() as usize].set(Some(clone));
 
                             if is_trusted_through_update_request {
-                                let trusted_dep_to_add: Box<[u8]> =
-                                    Box::from(dep.name.slice(string_buf));
+                                let (trusted_name, trusted_name_hash) =
+                                    if pkg_res.tag == ResolutionTag::Npm {
+                                        (
+                                            pkg_name.slice(string_buf),
+                                            pkg_name_hash as TruncatedPackageNameHash,
+                                        )
+                                    } else {
+                                        (dep.name.slice(string_buf), truncated_dep_name_hash)
+                                    };
+                                let trusted_dep_to_add: Box<[u8]> = Box::from(trusted_name);
 
                                 let _unlock = installer.trusted_dependencies_mutex.lock_guard();
 
@@ -1752,10 +1756,10 @@ impl Task {
                                 if trusted.is_none() {
                                     *trusted = Some(Default::default());
                                 }
-                                trusted.as_mut().unwrap().insert(
-                                    truncated_dep_name_hash,
-                                    Box::from(dep.name.slice(string_buf)),
-                                );
+                                trusted
+                                    .as_mut()
+                                    .unwrap()
+                                    .insert(trusted_name_hash, Box::from(trusted_name));
                             }
 
                             if first_index != 0 {

--- a/src/install/lockfile.rs
+++ b/src/install/lockfile.rs
@@ -1493,14 +1493,14 @@ impl Lockfile {
                     // above); `manifests` and `lockfile` are non-overlapping
                     // fields and nothing below resizes/relocates `manifests`
                     // while `manifest` is held.
-                    let scope = mgr_ref.options.scope_for_package_name(
-                        pkg_name.slice(self.buffers.string_bytes.as_slice()),
-                    );
+                    let pkg_name_str = pkg_name.slice(self.buffers.string_bytes.as_slice());
+                    let scope = mgr_ref.options.scope_for_package_name(pkg_name_str);
                     // SAFETY: `manifests` projected from `manager_ptr`; the
                     // call holds only that disjoint field.
                     let Some(manifest) = unsafe { &mut (*manager_ptr).manifests }.by_name_hash(
                         cache_ctx,
                         scope,
+                        pkg_name_str,
                         pkg_name_hash,
                         Install::ManifestLoad::LoadFromMemoryFallbackToDisk,
                         false,

--- a/src/install/lockfile/Package.rs
+++ b/src/install/lockfile/Package.rs
@@ -1829,7 +1829,7 @@ impl Package<u64> {
                     }
 
                     dependency_version.value.workspace = path;
-                } else {
+                } else if features.is_main || features.is_workspace {
                     // SAFETY: tag == Workspace selects the `workspace` union member.
                     // Bind the (Copy) union field first so `slice()`'s `&self`
                     // borrow has a named place to point at.

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1373,6 +1373,7 @@ pub mod package_manifest {
         pub(crate) fn load_by_file_id(
             scope: &registry::Scope,
             cache_dir: Fd,
+            name: &[u8],
             file_id: u64,
         ) -> Result<Option<PackageManifest>, Error> {
             let mut file_path_buf = [0u8; 512 + 64];
@@ -1383,8 +1384,8 @@ pub mod package_manifest {
 
             'delete: {
                 match Self::load_by_file(scope, &cache_file) {
-                    Ok(Some(m)) => return Ok(Some(m)),
-                    Ok(None) | Err(_) => break 'delete,
+                    Ok(Some(m)) if m.name() == name => return Ok(Some(m)),
+                    Ok(_) | Err(_) => break 'delete,
                 }
             }
 

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -939,22 +939,26 @@ impl RepositoryExt for Repository {
                     .open_at(folder_name)
                     .map_err(Error::from)?;
                 let _ = dir.delete_tree(b".git");
+                let _ = dir.delete_tree(b"node_modules");
 
                 if !resolved.is_empty() {
-                    'insert_tag: {
-                        let Ok(git_tag) = dir.create_file_z(
-                            bun_core::zstr!(".bun-tag"),
-                            bun_sys::CreateFlags {
-                                truncate: true,
-                                ..Default::default()
+                    if bun_sys::File::openat(
+                        dir.fd(),
+                        bun_core::zstr!(".bun-tag"),
+                        bun_sys::O::WRONLY
+                            | bun_sys::O::CREAT
+                            | bun_sys::O::TRUNC
+                            | if cfg!(windows) {
+                                0
+                            } else {
+                                bun_sys::O::NOFOLLOW
                             },
-                        ) else {
-                            break 'insert_tag;
-                        };
-                        if git_tag.write_all(resolved).is_err() {
-                            let _ = dir.delete_file_z(bun_core::zstr!(".bun-tag"));
-                        }
-                        let _ = git_tag.close(); // close error is non-actionable
+                        0o664,
+                    )
+                    .and_then(|f| f.write_all(resolved))
+                    .is_err()
+                    {
+                        let _ = dir.delete_file_z(bun_core::zstr!(".bun-tag"));
                     }
                 }
 

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -939,6 +939,7 @@ impl RepositoryExt for Repository {
                     .open_at(folder_name)
                     .map_err(Error::from)?;
                 let _ = dir.delete_tree(b".git");
+                // Unlinks a `node_modules` link only; directories are kept (bundleDependencies).
                 let _ = dir.delete_file_z(bun_core::zstr!("node_modules"));
 
                 if !resolved.is_empty() {

--- a/src/install/repository.rs
+++ b/src/install/repository.rs
@@ -939,7 +939,7 @@ impl RepositoryExt for Repository {
                     .open_at(folder_name)
                     .map_err(Error::from)?;
                 let _ = dir.delete_tree(b".git");
-                let _ = dir.delete_tree(b"node_modules");
+                let _ = dir.delete_file_z(bun_core::zstr!("node_modules"));
 
                 if !resolved.is_empty() {
                     if bun_sys::File::openat(

--- a/src/install_types/resolver_hooks.rs
+++ b/src/install_types/resolver_hooks.rs
@@ -1203,6 +1203,7 @@ pub struct Features {
     pub dependencies: bool,
     pub dev_dependencies: bool,
     pub is_main: bool,
+    pub is_workspace: bool,
     pub optional_dependencies: bool,
     pub peer_dependencies: bool,
     pub trusted_dependencies: bool,
@@ -1216,6 +1217,7 @@ impl Default for Features {
             dependencies: true,
             dev_dependencies: false,
             is_main: false,
+            is_workspace: false,
             optional_dependencies: false,
             peer_dependencies: true,
             trusted_dependencies: false,
@@ -1237,6 +1239,7 @@ impl Features {
             dependencies: true,
             dev_dependencies: false,
             is_main: false,
+            is_workspace: false,
             optional_dependencies: false,
             peer_dependencies: true,
             trusted_dependencies: false,
@@ -1265,6 +1268,7 @@ impl Features {
 
     pub const WORKSPACE: Self = Self {
         dev_dependencies: true,
+        is_workspace: true,
         optional_dependencies: true,
         trusted_dependencies: true,
         ..Self::base()

--- a/src/io/PipeReader.rs
+++ b/src/io/PipeReader.rs
@@ -83,6 +83,12 @@ pub trait BufferedReaderParent {
     unsafe fn on_reader_error(this: *mut Self, err: sys::Error);
     unsafe fn loop_(this: *mut Self) -> *mut Loop;
     unsafe fn event_loop(this: *mut Self) -> EventLoopHandle;
+    unsafe fn ref_(this: *mut Self) {
+        let _ = this;
+    }
+    unsafe fn deref(this: *mut Self) {
+        let _ = this;
+    }
 }
 
 impl BufferedReaderVTable {
@@ -125,6 +131,20 @@ impl BufferedReaderVTable {
 
     fn on_reader_error(&self, err: sys::Error) {
         self.link().on_reader_error(err)
+    }
+
+    #[must_use]
+    pub(crate) fn ref_parent(self) -> ParentKeepAlive {
+        self.link().ref_();
+        ParentKeepAlive(self)
+    }
+}
+
+pub(crate) struct ParentKeepAlive(BufferedReaderVTable);
+
+impl Drop for ParentKeepAlive {
+    fn drop(&mut self) {
+        self.0.link().deref();
     }
 }
 
@@ -595,17 +615,19 @@ impl PosixBufferedReader {
     /// [`Self::read`] for why the entry is raw.
     pub unsafe fn on_poll(this: *mut PosixBufferedReader, size_hint: isize, received_hup: bool) {
         // SAFETY: caller contract — `this` is live; borrows end at each `;`.
-        let (paused, fd, file_type) = unsafe {
+        let (paused, fd, file_type, vtable) = unsafe {
             (
                 (*this).flags.contains(PosixFlags::IS_PAUSED),
                 (*this).get_fd(),
                 (*this).get_file_type(),
+                (*this).vtable,
             )
         };
         if paused {
             return;
         }
         bun_sys::syslog!("onPoll({}) = {}", fd, size_hint);
+        let _parent = vtable.ref_parent();
 
         match file_type {
             FileType::NonblockingPipe => {
@@ -1730,6 +1752,7 @@ impl WindowsBufferedReader {
         // `set_data`. Invoked from the event loop with no other Rust borrow of
         // the reader live (single-owner).
         let this = unsafe { bun_ptr::callback_ctx::<WindowsBufferedReader>((*stream).data) };
+        let _parent = this.vtable.ref_parent();
 
         let nread_int = nread.int();
 
@@ -1813,6 +1836,7 @@ impl WindowsBufferedReader {
         // (single-owner).
         let this: &mut WindowsBufferedReader =
             unsafe { bun_ptr::callback_ctx::<WindowsBufferedReader>(parent_ptr) };
+        let _parent = this.vtable.ref_parent();
 
         // Mark no longer in flight
         this.flags.remove(WindowsFlags::HAS_INFLIGHT_READ);

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -517,6 +517,8 @@ bun_dispatch::link_interface! {
         fn on_reader_error(err: bun_sys::Error);
         fn loop_ptr() -> *mut Loop;
         fn event_loop() -> EventLoopCtx;
+        fn ref_();
+        fn deref();
     }
 }
 
@@ -579,6 +581,8 @@ macro_rules! __impl_buffered_reader_parent_body {
         on_reader_error = |$re_this:ident, $re_err:ident| $re:expr;
         loop_ = |$l_this:ident| $lp:expr;
         event_loop = |$e_this:ident| $ev:expr;
+        $( ref_ = |$rf_this:ident| $rf:expr; )?
+        $( deref = |$dr_this:ident| $dr:expr; )?
     ) => {
         // SAFETY (all generated methods): see `BufferedReaderParent` aliasing
         // contract — `this` is the `*mut Self` registered via `set_parent`; a
@@ -613,6 +617,18 @@ macro_rules! __impl_buffered_reader_parent_body {
             unsafe fn event_loop($e_this: *mut Self) -> $crate::EventLoopHandle {
                 unsafe { $ev }
             }
+            $(
+                #[allow(unused_unsafe, clippy::macro_metavars_in_unsafe)]
+                unsafe fn ref_($rf_this: *mut Self) {
+                    unsafe { $rf }
+                }
+            )?
+            $(
+                #[allow(unused_unsafe, clippy::macro_metavars_in_unsafe)]
+                unsafe fn deref($dr_this: *mut Self) {
+                    unsafe { $dr }
+                }
+            )?
         }
     };
 }
@@ -640,6 +656,10 @@ macro_rules! buffered_reader_parent_link {
                     <$T as $crate::pipe_reader::BufferedReaderParent>::loop_(this),
                 event_loop() =>
                     <$T as $crate::pipe_reader::BufferedReaderParent>::event_loop(this),
+                ref_() =>
+                    <$T as $crate::pipe_reader::BufferedReaderParent>::ref_(this),
+                deref() =>
+                    <$T as $crate::pipe_reader::BufferedReaderParent>::deref(this),
             }
         }
     };

--- a/src/js/builtins/ProcessObjectInternals.ts
+++ b/src/js/builtins/ProcessObjectInternals.ts
@@ -448,7 +448,7 @@ export function windowsEnv(
   envMapList: Array<string>,
   editWindowsEnvVar: EditWindowsEnvVarCb,
   coerceForWrite,
-  resetTZ,
+  resetForDelete,
 ) {
   (internalEnv as any)[Bun.inspect.custom] = () => {
     let o = {};
@@ -541,10 +541,9 @@ export function windowsEnv(
         envMapList.splice(i, 1);
       }
       editWindowsEnvVar(k, null);
-      // Node's RealEnvStore::Delete resets Date caches for TZ; internalEnv
-      // is a plain object here so `delete internalEnv[k]` never reaches the
-      // TZ setter — fire the reset explicitly.
-      if (k === "TZ") resetTZ();
+      // internalEnv is a plain object here so `delete internalEnv[k]` never
+      // reaches the CustomAccessor — undo the native side effect explicitly.
+      if (k === "TZ" || k === "NODE_TLS_REJECT_UNAUTHORIZED") resetForDelete(k);
       return delete internalEnv[k];
     },
     defineProperty(_, p, attributes) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -127,9 +127,11 @@ function normalizeSSLMode(value: string): SSLMode {
   value = (value + "").toLowerCase();
   switch (value) {
     case "disable":
+    case "disabled":
       return SSLMode.disable;
     case "allow": // libpq value; both accept either outcome, so map to prefer
     case "prefer":
+    case "preferred":
       return SSLMode.prefer;
     case "require":
     case "required":
@@ -139,6 +141,8 @@ function normalizeSSLMode(value: string): SSLMode {
       return SSLMode.verify_ca;
     case "verify-full":
     case "verify_full":
+    case "verify-identity":
+    case "verify_identity":
       return SSLMode.verify_full;
     default: {
       break;
@@ -1795,9 +1799,17 @@ function parseOptions(
 
     const queryObject = url.searchParams.toJSON();
     for (const key in queryObject) {
-      if (key.toLowerCase() === "sslmode") {
+      const lowerKey = key.toLowerCase();
+      if (lowerKey === "sslmode" || lowerKey === "ssl-mode" || lowerKey === "ssl_mode") {
         sslMode = normalizeSSLMode(queryObject[key]);
-      } else if (key.toLowerCase() === "path") {
+      } else if (lowerKey === "ssl" || lowerKey === "tls") {
+        const value = `${queryObject[key]}`.toLowerCase();
+        if (value === "true" || value === "1") {
+          tls = true;
+        } else if (value && value !== "false" && value !== "0") {
+          sslMode = normalizeSSLMode(value);
+        }
+      } else if (lowerKey === "path") {
         path = queryObject[key];
       } else {
         // this is valid for postgres for other databases it might not be valid
@@ -1941,7 +1953,14 @@ function parseOptions(
     }
   }
 
-  tls ||= options.tls || options.ssl;
+  const tlsOption = options.tls || options.ssl;
+  if (typeof tlsOption === "string" && tlsOption) {
+    sslMode = normalizeSSLMode(tlsOption);
+  } else if (!tlsOption || typeof tlsOption === "boolean" || $isObject(tlsOption)) {
+    tls = tlsOption || tls;
+  } else {
+    throw $ERR_INVALID_ARG_TYPE("options.tls", ["boolean", "object", "string"], tlsOption);
+  }
   const explicitTls = tls;
   max = options.max;
 
@@ -2022,7 +2041,7 @@ function parseOptions(
   }
 
   if ($isObject(tls) && sslMode < SSLMode.verify_ca) {
-    if (tls.rejectUnauthorized === true || (tls.rejectUnauthorized !== false && tls.ca)) {
+    if (tls.rejectUnauthorized === true || (tls.rejectUnauthorized !== false && (tls.ca || tls.caFile))) {
       sslMode = SSLMode.verify_full;
     }
   }
@@ -2038,7 +2057,7 @@ function parseOptions(
   // Explicit tls/ssl options request an encrypted connection: if the server
   // declines TLS, the connection is aborted instead of continuing in plaintext.
   // Certificate verification is only enabled when explicitly requested
-  // (ca, rejectUnauthorized, or a verify-* sslmode).
+  // (ca, caFile, rejectUnauthorized, or a verify-* sslmode).
   if (explicitTls && sslMode <= SSLMode.prefer) {
     sslMode = SSLMode.require;
   }

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1806,6 +1806,7 @@ function parseOptions(
         const value = `${queryObject[key]}`.toLowerCase();
         if (value === "true" || value === "1") {
           tls = true;
+          if (sslMode === SSLMode.disable) sslMode = SSLMode.prefer;
         } else if (value === "false" || value === "0") {
           sslMode = SSLMode.disable;
         } else if (value) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1956,6 +1956,7 @@ function parseOptions(
   const tlsOption = options.tls || options.ssl;
   if (typeof tlsOption === "string" && tlsOption) {
     sslMode = normalizeSSLMode(tlsOption);
+    tls = undefined;
   } else if (!tlsOption || typeof tlsOption === "boolean" || $isObject(tlsOption)) {
     tls = tlsOption || tls;
   } else {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1806,7 +1806,9 @@ function parseOptions(
         const value = `${queryObject[key]}`.toLowerCase();
         if (value === "true" || value === "1") {
           tls = true;
-        } else if (value && value !== "false" && value !== "0") {
+        } else if (value === "false" || value === "0") {
+          sslMode = SSLMode.disable;
+        } else if (value) {
           sslMode = normalizeSSLMode(value);
         }
       } else if (lowerKey === "path") {
@@ -1956,6 +1958,9 @@ function parseOptions(
   const tlsOption = options.tls || options.ssl;
   if (typeof tlsOption === "string" && tlsOption) {
     sslMode = normalizeSSLMode(tlsOption);
+    tls = undefined;
+  } else if (!tlsOption && (options.tls === false || options.ssl === false)) {
+    sslMode = SSLMode.disable;
     tls = undefined;
   } else {
     tls = tlsOption || tls;

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1957,10 +1957,8 @@ function parseOptions(
   if (typeof tlsOption === "string" && tlsOption) {
     sslMode = normalizeSSLMode(tlsOption);
     tls = undefined;
-  } else if (!tlsOption || typeof tlsOption === "boolean" || $isObject(tlsOption)) {
-    tls = tlsOption || tls;
   } else {
-    throw $ERR_INVALID_ARG_TYPE("options.tls", ["boolean", "object", "string"], tlsOption);
+    tls = tlsOption || tls;
   }
   const explicitTls = tls;
   max = options.max;

--- a/src/js/node/_http2_upgrade.ts
+++ b/src/js/node/_http2_upgrade.ts
@@ -1,5 +1,6 @@
 const { Duplex } = require("node:stream");
 const upgradeDuplexToTLS = $newRustFunction("runtime/socket/socket.rs", "jsUpgradeDuplexToTLS", 2);
+const kSharedCreds = Symbol.for("::buntlssharedcreds::");
 
 interface NativeHandle {
   resume(): void;
@@ -26,6 +27,7 @@ interface Http2SecureServer {
   _requestCert?: boolean;
   _rejectUnauthorized?: boolean;
   emit(event: string, ...args: any[]): boolean;
+  [key: symbol]: any;
 }
 
 interface TLSProxySocket {
@@ -343,10 +345,7 @@ function upgradeRawSocketToH2(
     [handle, events] = upgradeDuplexToTLS(rawSocket, {
       isServer: true,
       tls: {
-        key: server.key,
-        cert: server.cert,
-        ca: server.ca,
-        passphrase: server.passphrase,
+        secureContext: server[kSharedCreds]().context,
         requestCert: server._requestCert,
         rejectUnauthorized: server._rejectUnauthorized,
         ALPNProtocols: server.ALPNProtocols

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -307,7 +307,8 @@ function onClientHandshakeComplete(self, socket, verifyError) {
     // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1662-L1673
     const { checkServerIdentity } = self[bunTLSConnectOptions];
     if (!verifyError && !self.isSessionReused() && typeof checkServerIdentity === "function") {
-      const hostname = self.servername || self._host || "localhost";
+      const options = self[kConnectOptions];
+      const hostname = self.servername || options?.host || options?.socket?._host || self._host || "localhost";
       const cert = self.getPeerCertificate(true);
       if (cert) {
         verifyError = checkServerIdentity(hostname, cert);

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -697,6 +697,7 @@ const ksession = Symbol("ksession");
 const krenegotiationDisabled = Symbol("renegotiationDisabled");
 
 const buntls = Symbol.for("::buntls::");
+const kSharedCreds = Symbol.for("::buntlssharedcreds::");
 // net.ts's SNI dispatch uses this to recognize a raw native SecureContext
 // (Node's `context.context || context` unwrap accepts both the wrapper and
 // the unwrapped native context).
@@ -1486,15 +1487,13 @@ function Server(options, secureConnectionListener): void {
     // TLS layer, like Node's tls.Server wraps any injected duplex
     // (node v26.3.0 lib/_tls_wrap.js, Server's connection listener).
     if (!socket || (socket.encrypted && socket.server === this)) return;
-    let secureContext = this._sharedCreds;
-    if (!secureContext) {
-      try {
-        secureContext = buildSharedCreds(this);
-      } catch (err) {
-        socket.destroy();
-        this.emit("error", err);
-        return;
-      }
+    let secureContext;
+    try {
+      secureContext = this[kSharedCreds]();
+    } catch (err) {
+      socket.destroy();
+      this.emit("error", err);
+      return;
     }
     const wrapped = new TLSSocket(socket, {
       secureContext,
@@ -1512,6 +1511,9 @@ function Server(options, secureConnectionListener): void {
   });
 }
 $toClass(Server, "Server", NetServer);
+Server.prototype[kSharedCreds] = function () {
+  return this._sharedCreds || buildSharedCreds(this);
+};
 
 function createServer(options, connectionListener) {
   return new Server(options, connectionListener);

--- a/src/js_parser/visit/mod.rs
+++ b/src/js_parser/visit/mod.rs
@@ -472,18 +472,11 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                                             }
                                         }
                                     }
-                                    // output_properties[end] = output_properties[query.i]
-                                    // SAFETY: both indices < object.properties.len; G::Property
-                                    // has no Drop; src/dst may alias when end == query.i.
-                                    unsafe {
-                                        let props_ptr = object.properties.slice_mut().as_mut_ptr();
-                                        core::ptr::copy(
-                                            props_ptr.add(query.i as usize),
-                                            props_ptr.add(end as usize),
-                                            1,
-                                        );
+                                    let i = query.i as usize;
+                                    if i >= end as usize {
+                                        object.properties.slice_mut().swap(i, end as usize);
+                                        end += 1;
                                     }
-                                    end += 1;
                                 }
                             }
                         }

--- a/src/jsc/NodeCompileCache.rs
+++ b/src/jsc/NodeCompileCache.rs
@@ -437,7 +437,15 @@ fn enable_with_dir(dir: &[u8], portable: bool) -> EnableResult {
         tagged.as_bstr()
     );
 
-    let dir_handle = match sys::Dir::cwd().make_open_path(&tagged, Default::default()) {
+    let cwd = sys::Dir::cwd();
+    let dir_flags = O::RDONLY | O::CLOEXEC | O::NOFOLLOW;
+    let opened = match cwd.open_at_with(&tagged, dir_flags) {
+        Err(e) if e.get_errno() == sys::E::ENOENT => cwd
+            .make_path(&tagged)
+            .and_then(|()| cwd.open_at_with(&tagged, dir_flags)),
+        result => result,
+    };
+    let dir_handle = match opened {
         Ok(d) => d,
         Err(e) => {
             let errname = errno_name(&e);
@@ -453,6 +461,26 @@ fn enable_with_dir(dir: &[u8], portable: bool) -> EnableResult {
             };
         }
     };
+    #[cfg(unix)]
+    {
+        let owned_private = sys::fstat(dir_handle.fd()).is_ok_and(|st| {
+            st.st_uid == sys::c::getuid() && (st.st_mode & (libc::S_IWGRP | libc::S_IWOTH)) == 0
+        });
+        if !owned_private {
+            cclog!(
+                "[compile cache] creating cache directory {}...not owned by the current user or writable by others\n",
+                tagged.as_bstr()
+            );
+            return EnableResult {
+                status: STATUS_FAILED,
+                directory: None,
+                message: Some(
+                    "Cannot use cache directory: it must be owned by the current user and not be group- or world-writable"
+                        .to_string(),
+                ),
+            };
+        }
+    }
     cclog!(
         "[compile cache] creating cache directory {}...success\n",
         tagged.as_bstr()
@@ -654,7 +682,7 @@ fn read_cache_file(state: &CacheState, key: u64, entry: &mut Entry, code: Option
 
     let file = match state
         .dir_handle
-        .open_file(&basename, O::RDONLY | O::CLOEXEC, 0)
+        .open_file(&basename, O::RDONLY | O::CLOEXEC | O::NOFOLLOW, 0)
     {
         Ok(f) => f,
         Err(e) => {

--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -229,14 +229,22 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_addFilter, (JSC::JSGlobalObject
         return JSC::JSValue::encode(JSC::jsUndefined());
     }
 
-    JSC::RegExpObject* regExp = uncheckedDowncast<JSC::RegExpObject>(callFrame->argument(0));
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto* regExp = dynamicDowncast<JSC::RegExpObject>(callFrame->argument(0));
+    if (!regExp) [[unlikely]] {
+        Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "Expected filter (1st argument) to be a RegExp"_s);
+        return {};
+    }
     WTF::String namespaceStr = callFrame->argument(1).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
     if (namespaceStr == "file"_s) {
         namespaceStr = String();
     }
 
     uint32_t isOnLoad = callFrame->argument(2).toUInt32(globalObject);
-    auto& vm = JSC::getVM(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
 
     unsigned index = 0;
     if (isOnLoad) {
@@ -348,7 +356,11 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onBeforeParse, (JSC::JSGlobalOb
     // Clone the regexp so we don't have to worry about it being used concurrently with the JS thread.
     // TODO: Should we have a regexp object for every thread in the thread pool? Then we could avoid using
     // a mutex to synchronize access to the same regexp from multiple threads.
-    JSC::RegExpObject* jsRegexp = uncheckedDowncast<JSC::RegExpObject>(callFrame->argument(0));
+    auto* jsRegexp = dynamicDowncast<JSC::RegExpObject>(callFrame->argument(0));
+    if (!jsRegexp) [[unlikely]] {
+        Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "Expected filter (1st argument) to be a RegExp"_s);
+        return {};
+    }
     RegExp* reggie = jsRegexp->regExp();
     RegExp* newRegexp = RegExp::create(vm, reggie->pattern(), reggie->flags());
 

--- a/src/jsc/bindings/JSEnvironmentVariableMap.cpp
+++ b/src/jsc/bindings/JSEnvironmentVariableMap.cpp
@@ -107,6 +107,8 @@ static JSC::JSString* coerceEnvValue(JSGlobalObject* globalObject, JSC::ThrowSco
 }
 
 static void applyTZFromString(JSGlobalObject*, const String&);
+static void applyTLSRejectFromString(JSGlobalObject*, const String&);
+static void applyVerboseFetchFromString(JSGlobalObject*, const String&);
 static bool shouldApplyTZSideEffect(JSGlobalObject*);
 
 // TZ side effect for put() and jsProcessEnvCoerceForWrite, so delete-then-set
@@ -118,6 +120,14 @@ static void applyTimeZoneEnvValue(JSGlobalObject* globalObject, JSC::JSString* s
     if (view->isNull())
         return;
     applyTZFromString(globalObject, view->toString());
+}
+
+static void applyTLSRejectEnvValue(JSGlobalObject* globalObject, JSC::JSString* string)
+{
+    auto view = string->view(globalObject);
+    if (view->isNull())
+        return;
+    applyTLSRejectFromString(globalObject, view->toString());
 }
 
 bool JSEnvironmentVariableMap::put(JSCell* cell, JSGlobalObject* globalObject, PropertyName propertyName, JSValue value, PutPropertySlot& slot)
@@ -143,6 +153,12 @@ bool JSEnvironmentVariableMap::put(JSCell* cell, JSGlobalObject* globalObject, P
     // updates Date caches. putDirect bypasses the accessor so the side effect fires once.
     if (uid && WTF::equal(uid, "TZ"_s)) [[unlikely]] {
         applyTimeZoneEnvValue(globalObject, string);
+        RETURN_IF_EXCEPTION(scope, false);
+        static_cast<JSEnvironmentVariableMap*>(cell)->putDirect(vm, propertyName, string, 0);
+        return true;
+    }
+    if (uid && WTF::equal(uid, "NODE_TLS_REJECT_UNAUTHORIZED"_s)) [[unlikely]] {
+        applyTLSRejectEnvValue(globalObject, string);
         RETURN_IF_EXCEPTION(scope, false);
         static_cast<JSEnvironmentVariableMap*>(cell)->putDirect(vm, propertyName, string, 0);
         return true;
@@ -298,12 +314,6 @@ JSC_DEFINE_CUSTOM_GETTER(jsTimeZoneEnvironmentVariableGetter, (JSGlobalObject * 
     return JSValue::encode(out);
 }
 
-// Parse-and-apply for NODE_TLS_REJECT_UNAUTHORIZED / BUN_CONFIG_VERBOSE_FETCH,
-// used by both the CustomSetters below and applySharedEnvSideEffects.
-// (applyTZFromString is forward-declared above applyTimeZoneEnvValue.)
-static void applyTLSRejectFromString(JSGlobalObject*, const String&);
-static void applyVerboseFetchFromString(JSGlobalObject*, const String&);
-
 // Store-only: the TZ side effect fires from put() / jsProcessEnvCoerceForWrite on every
 // write. Firing here too would double-apply on Windows (writeEnvVar already ran it).
 JSC_DEFINE_CUSTOM_SETTER(jsTimeZoneEnvironmentVariableSetter, (JSGlobalObject * globalObject, JSC::EncodedJSValue thisValue, JSC::EncodedJSValue value, PropertyName propertyName))
@@ -334,6 +344,8 @@ bool JSEnvironmentVariableMap::deleteProperty(JSCell* cell, JSGlobalObject* glob
         DeletePropertySlot dataSlot;
         Base::deleteProperty(cell, globalObject, clientData->builtinNames().dataPrivateName(), dataSlot);
         RETURN_IF_EXCEPTION(scope, false);
+    } else if (uid && WTF::equal(uid, "NODE_TLS_REJECT_UNAUTHORIZED"_s)) {
+        applyTLSRejectFromString(globalObject, String());
     }
 
     RELEASE_AND_RETURN(scope, Base::deleteProperty(cell, globalObject, propertyName, slot));
@@ -477,19 +489,32 @@ JSC_DEFINE_HOST_FUNCTION(jsProcessEnvCoerceForWrite, (JSGlobalObject * globalObj
         if (WTF::equal(keyView, "TZ"_s)) {
             applyTimeZoneEnvValue(globalObject, string);
             RETURN_IF_EXCEPTION(scope, {});
+        } else if (WTF::equal(keyView, "NODE_TLS_REJECT_UNAUTHORIZED"_s)) {
+            applyTLSRejectEnvValue(globalObject, string);
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
     return JSValue::encode(string);
 }
 
-// `delete process.env.TZ` on Windows: reset the timezone override (POSIX handles this in
+// `delete process.env.X` on Windows: undo X's native side effect (POSIX handles this in
 // JSEnvironmentVariableMap::deleteProperty; the Windows internalEnv is a plain object).
-JSC_DEFINE_HOST_FUNCTION(jsProcessEnvResetTZ, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+JSC_DEFINE_HOST_FUNCTION(jsProcessEnvResetForDelete, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
-    if (shouldApplyTZSideEffect(globalObject)) {
-        WTF::setTimeZoneOverride(String());
-        resetDateCachesAfterTimeZoneChange(vm);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue key = callFrame->argument(0);
+    if (!key.isString())
+        return JSValue::encode(jsUndefined());
+    auto keyView = asString(key)->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (WTF::equal(keyView, "TZ"_s)) {
+        if (shouldApplyTZSideEffect(globalObject)) {
+            WTF::setTimeZoneOverride(String());
+            resetDateCachesAfterTimeZoneChange(vm);
+        }
+    } else if (WTF::equal(keyView, "NODE_TLS_REJECT_UNAUTHORIZED"_s)) {
+        applyTLSRejectFromString(globalObject, String());
     }
     return JSValue::encode(jsUndefined());
 }
@@ -772,9 +797,12 @@ bool JSSharedEnvMap::deleteProperty(JSCell* cell, JSGlobalObject* globalObject, 
     // side effect via applySharedEnvSideEffects, so delete has to undo it or
     // existing Date instances keep the deleted zone's offset.
     String key(uid);
-    if (SharedEnvStore::normalizeKey(key) == "TZ"_s && shouldApplyTZSideEffect(globalObject)) {
+    String normalizedKey = SharedEnvStore::normalizeKey(key);
+    if (normalizedKey == "TZ"_s && shouldApplyTZSideEffect(globalObject)) {
         WTF::setTimeZoneOverride(String());
         resetDateCachesAfterTimeZoneChange(JSC::getVM(globalObject));
+    } else if (normalizedKey == "NODE_TLS_REJECT_UNAUTHORIZED"_s) {
+        applyTLSRejectFromString(globalObject, String());
     }
 
     syncWindowsEnv(store, key, nullptr);
@@ -1113,7 +1141,7 @@ JSValue createEnvironmentVariablesMap(Zig::GlobalObject* globalObject)
     args.append(keyArray);
     args.append(editWindowsEnvVar);
     args.append(JSC::JSFunction::create(vm, globalObject, 2, "coerceForWrite"_s, jsProcessEnvCoerceForWrite, ImplementationVisibility::Private));
-    args.append(JSC::JSFunction::create(vm, globalObject, 0, "resetTZ"_s, jsProcessEnvResetTZ, ImplementationVisibility::Private));
+    args.append(JSC::JSFunction::create(vm, globalObject, 1, "resetForDelete"_s, jsProcessEnvResetForDelete, ImplementationVisibility::Private));
     auto clientData = WebCore::clientData(vm);
     JSC::CallData callData = JSC::getCallData(getSourceEvent);
     NakedPtr<JSC::Exception> returnedException = nullptr;

--- a/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKP.cpp
@@ -30,6 +30,7 @@
 
 #include "CryptoAlgorithmRegistry.h"
 #include "JsonWebKey.h"
+#include <wtf/CryptographicUtilities.h>
 #include <wtf/text/Base64.h>
 
 namespace WebCore {
@@ -66,10 +67,7 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::create(CryptoAlgorithmIdentifier identifier, 
     if (bytesExpectedInternal == -1)
         return nullptr;
 
-    if (platformKey.size() != bytesExpectedInternal) {
-        if (type != CryptoKeyType::Private || curve != NamedCurve::Ed25519)
-            return nullptr;
-
+    if (type == CryptoKeyType::Private && curve == NamedCurve::Ed25519) {
         auto bytesExpectedExternal = externalKeySizeInBytesFromNamedCurve(curve);
         if (bytesExpectedExternal == -1)
             return nullptr;
@@ -77,16 +75,21 @@ RefPtr<CryptoKeyOKP> CryptoKeyOKP::create(CryptoAlgorithmIdentifier identifier, 
         // We need to match the internal format when importing a private key
         // Import format only consists of 32 bytes of private key
         // Internal format is private key + public key suffix
-        if (platformKey.size() == bytesExpectedExternal) {
-            auto&& privateKey = ed25519PrivateFromSeed(WTF::move(platformKey));
-            if (privateKey.size() == 0)
-                return nullptr;
+        if (platformKey.size() != bytesExpectedExternal && platformKey.size() != bytesExpectedInternal)
+            return nullptr;
 
-            return adoptRef(*new CryptoKeyOKP(identifier, curve, type, WTF::move(privateKey), extractable, usages));
-        }
+        auto privateKey = ed25519PrivateFromSeed(KeyMaterial(platformKey.span().first(bytesExpectedExternal)));
+        if (privateKey.size() != bytesExpectedInternal)
+            return nullptr;
 
-        return nullptr;
+        if (platformKey.size() == bytesExpectedInternal && constantTimeMemcmp(privateKey.span().subspan(bytesExpectedExternal), platformKey.span().subspan(bytesExpectedExternal)))
+            return nullptr;
+
+        return adoptRef(*new CryptoKeyOKP(identifier, curve, type, WTF::move(privateKey), extractable, usages));
     }
+
+    if (platformKey.size() != bytesExpectedInternal)
+        return nullptr;
 
     return adoptRef(*new CryptoKeyOKP(identifier, curve, type, WTF::move(platformKey), extractable, usages));
 }

--- a/src/jsc/bindings/webcrypto/CryptoKeyOKPOpenSSL.cpp
+++ b/src/jsc/bindings/webcrypto/CryptoKeyOKPOpenSSL.cpp
@@ -79,8 +79,7 @@ std::optional<CryptoKeyPair> CryptoKeyOKP::platformGeneratePair(CryptoAlgorithmI
     bool isPublicKeyExtractable = true;
     auto publicKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Public, WTF::move(public_key), isPublicKeyExtractable, usages);
     ASSERT(publicKey);
-    auto privateKey = CryptoKeyOKP::create(identifier, namedCurve, CryptoKeyType::Private, Vector<uint8_t>(std::span { private_key.begin(), isEd25519 ? (unsigned int)ED25519_PRIVATE_KEY_LEN : (unsigned int)X25519_PRIVATE_KEY_LEN }), extractable, usages);
-    ASSERT(privateKey);
+    RefPtr<CryptoKeyOKP> privateKey = adoptRef(*new CryptoKeyOKP(identifier, namedCurve, CryptoKeyType::Private, Vector<uint8_t>(std::span { private_key.begin(), isEd25519 ? (unsigned int)ED25519_PRIVATE_KEY_LEN : (unsigned int)X25519_PRIVATE_KEY_LEN }), extractable, usages));
     return CryptoKeyPair { WTF::move(publicKey), WTF::move(privateKey) };
 }
 

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -727,6 +727,8 @@ impl WebWorker {
         unsafe {
             let b = &mut (*vm).transpiler;
             b.resolver.env_loader = NonNull::new(b.env);
+            b.options.env.behavior =
+                bun_options_types::schema::api::DotEnvBehavior::LoadAllWithoutInlining;
 
             if let Some(graph) = parent.standalone_module_graph {
                 (hooks.apply_standalone_runtime_flags)(b, graph);

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1053,64 +1053,19 @@ fn is_symlink_target_safe(
     !(strings::eql(resolved, b"..") || strings::has_prefix_comptime(resolved, b"../"))
 }
 
-/// Returns true if any leading component of `path` (including the full path)
-/// matches a symlink already created by this extraction. `is_symlink_target_safe`
-/// is purely lexical, so once a symlink is on disk the kernel will follow it
-/// during later `mkdirat`/`openat`/`symlinkat` calls — such entries must be
-/// rejected rather than resolved.
-#[cfg(unix)]
-pub fn path_traverses_created_symlink(path: &[u8], created_symlinks: &[Vec<u8>]) -> bool {
-    if created_symlinks.is_empty() {
-        return false;
-    }
-    let sep = b'/';
-    let mut end = 0usize;
-    while end <= path.len() {
-        if end == path.len() || path[end] == sep {
-            let prefix = &path[..end];
-            // Compare case-insensitively: on case-insensitive filesystems (APFS
-            // default on macOS) an entry `LINK/x` traverses a symlink stored as
-            // `link`, but a byte-exact compare would miss it.
-            if !prefix.is_empty()
-                && created_symlinks
-                    .iter()
-                    .any(|s| strings::eql_case_insensitive_ascii_check_length(s, prefix))
-            {
-                return true;
-            }
-        }
-        end += 1;
-    }
-    false
-}
-
 #[cfg(unix)]
 pub struct DeferredSymlink {
-    path: Vec<u8>,
-    target: Vec<u8>,
+    path: bun_core::ZBox,
+    target: bun_core::ZBox,
 }
 
 #[cfg(unix)]
 impl DeferredSymlink {
     pub fn new(path: &[u8], target: &[u8]) -> Self {
-        let mut path_z = Vec::with_capacity(path.len() + 1);
-        path_z.extend_from_slice(path);
-        path_z.push(0);
-        let mut target_z = Vec::with_capacity(target.len() + 1);
-        target_z.extend_from_slice(target);
-        target_z.push(0);
         Self {
-            path: path_z,
-            target: target_z,
+            path: bun_core::ZBox::from_bytes(path),
+            target: bun_core::ZBox::from_bytes(target),
         }
-    }
-
-    pub fn path(&self) -> &[u8] {
-        &self.path[..self.path.len() - 1]
-    }
-
-    pub fn target(&self) -> &[u8] {
-        &self.target[..self.target.len() - 1]
     }
 }
 
@@ -1130,7 +1085,7 @@ fn open_dir_with_stat(dir_fd: Fd, sub_path: &[u8]) -> Option<(Fd, bun_sys::Stat)
 pub fn create_deferred_symlinks(dir_fd: Fd, symlinks: &[DeferredSymlink], log: bool) -> u32 {
     let mut parents: Vec<Option<bun_sys::Stat>> = Vec::with_capacity(symlinks.len());
     for symlink in symlinks {
-        let dirname = bun_paths::dirname_simple(symlink.path());
+        let dirname = bun_paths::dirname_simple(symlink.path.as_bytes());
         if dirname.is_empty() {
             parents.push(None);
             continue;
@@ -1144,12 +1099,13 @@ pub fn create_deferred_symlinks(dir_fd: Fd, symlinks: &[DeferredSymlink], log: b
 
     let mut created: u32 = 0;
     for (symlink, expected) in symlinks.iter().zip(parents) {
-        let dirname = bun_paths::dirname_simple(symlink.path());
-        let target = ZStr::from_slice_with_nul(&symlink.target);
+        let dirname = bun_paths::dirname_simple(symlink.path.as_bytes());
+        let target = symlink.target.as_zstr();
         let result = if dirname.is_empty() {
-            bun_sys::symlinkat(target, dir_fd, ZStr::from_slice_with_nul(&symlink.path))
+            bun_sys::symlinkat(target, dir_fd, symlink.path.as_zstr())
         } else {
-            let name = ZStr::from_slice_with_nul(&symlink.path[dirname.len() + 1..]);
+            let name =
+                ZStr::from_slice_with_nul(&symlink.path.as_bytes_with_nul()[dirname.len() + 1..]);
             match (open_dir_with_stat(dir_fd, dirname), expected) {
                 (Some((parent, st)), Some(expected))
                     if st.st_dev == expected.st_dev && st.st_ino == expected.st_ino =>
@@ -1165,7 +1121,7 @@ pub fn create_deferred_symlinks(dir_fd: Fd, symlinks: &[DeferredSymlink], log: b
                     if log {
                         bun_core::warn!(
                             "Skipping symlink whose parent directory changed during extraction: {}\n",
-                            bstr::BStr::new(symlink.path()),
+                            bstr::BStr::new(symlink.path.as_bytes()),
                         );
                     }
                     continue;
@@ -1178,8 +1134,8 @@ pub fn create_deferred_symlinks(dir_fd: Fd, symlinks: &[DeferredSymlink], log: b
                 if log {
                     bun_core::warn!(
                         "Skipping symlink that could not be created: {} -> {}\n",
-                        bstr::BStr::new(symlink.path()),
-                        bstr::BStr::new(symlink.target()),
+                        bstr::BStr::new(symlink.path.as_bytes()),
+                        bstr::BStr::new(symlink.target.as_bytes()),
                     );
                 }
             }

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -995,14 +995,14 @@ impl Drop for BufferReadStream {
 /// path with leading `..` preserved; the target is unsafe if the result
 /// climbs above the extraction root.
 #[cfg(unix)]
-fn is_symlink_target_safe(
+pub fn is_symlink_target_safe(
     symlink_path: &[u8],
     link_target: &ZStr,
     symlink_join_buf: &mut Option<bun_paths::path_buffer_pool::Guard>,
 ) -> bool {
     // Absolute symlink targets are never safe - they could point anywhere
     let link_target_bytes = link_target.as_bytes();
-    if !link_target_bytes.is_empty() && link_target_bytes[0] == b'/' {
+    if link_target_bytes.is_empty() || link_target_bytes[0] == b'/' {
         return false;
     }
 

--- a/src/libarchive/lib.rs
+++ b/src/libarchive/lib.rs
@@ -1084,6 +1084,110 @@ pub fn path_traverses_created_symlink(path: &[u8], created_symlinks: &[Vec<u8>])
     false
 }
 
+#[cfg(unix)]
+pub struct DeferredSymlink {
+    path: Vec<u8>,
+    target: Vec<u8>,
+}
+
+#[cfg(unix)]
+impl DeferredSymlink {
+    pub fn new(path: &[u8], target: &[u8]) -> Self {
+        let mut path_z = Vec::with_capacity(path.len() + 1);
+        path_z.extend_from_slice(path);
+        path_z.push(0);
+        let mut target_z = Vec::with_capacity(target.len() + 1);
+        target_z.extend_from_slice(target);
+        target_z.push(0);
+        Self {
+            path: path_z,
+            target: target_z,
+        }
+    }
+
+    pub fn path(&self) -> &[u8] {
+        &self.path[..self.path.len() - 1]
+    }
+
+    pub fn target(&self) -> &[u8] {
+        &self.target[..self.target.len() - 1]
+    }
+}
+
+#[cfg(unix)]
+fn open_dir_with_stat(dir_fd: Fd, sub_path: &[u8]) -> Option<(Fd, bun_sys::Stat)> {
+    let fd = bun_sys::open_dir_at(dir_fd, sub_path).ok()?;
+    match bun_sys::fstat(fd) {
+        Ok(st) => Some((fd, st)),
+        Err(_) => {
+            fd.close();
+            None
+        }
+    }
+}
+
+#[cfg(unix)]
+pub fn create_deferred_symlinks(dir_fd: Fd, symlinks: &[DeferredSymlink], log: bool) -> u32 {
+    let mut parents: Vec<Option<bun_sys::Stat>> = Vec::with_capacity(symlinks.len());
+    for symlink in symlinks {
+        let dirname = bun_paths::dirname_simple(symlink.path());
+        if dirname.is_empty() {
+            parents.push(None);
+            continue;
+        }
+        let _ = dir_fd.make_path_u8(dirname);
+        parents.push(open_dir_with_stat(dir_fd, dirname).map(|(fd, st)| {
+            fd.close();
+            st
+        }));
+    }
+
+    let mut created: u32 = 0;
+    for (symlink, expected) in symlinks.iter().zip(parents) {
+        let dirname = bun_paths::dirname_simple(symlink.path());
+        let target = ZStr::from_slice_with_nul(&symlink.target);
+        let result = if dirname.is_empty() {
+            bun_sys::symlinkat(target, dir_fd, ZStr::from_slice_with_nul(&symlink.path))
+        } else {
+            let name = ZStr::from_slice_with_nul(&symlink.path[dirname.len() + 1..]);
+            match (open_dir_with_stat(dir_fd, dirname), expected) {
+                (Some((parent, st)), Some(expected))
+                    if st.st_dev == expected.st_dev && st.st_ino == expected.st_ino =>
+                {
+                    let result = bun_sys::symlinkat(target, parent, name);
+                    parent.close();
+                    result
+                }
+                (parent, _) => {
+                    if let Some((parent, _)) = parent {
+                        parent.close();
+                    }
+                    if log {
+                        bun_core::warn!(
+                            "Skipping symlink whose parent directory changed during extraction: {}\n",
+                            bstr::BStr::new(symlink.path()),
+                        );
+                    }
+                    continue;
+                }
+            }
+        };
+        match result {
+            Ok(()) => created += 1,
+            Err(_) => {
+                if log {
+                    bun_core::warn!(
+                        "Skipping symlink that could not be created: {} -> {}\n",
+                        bstr::BStr::new(symlink.path()),
+                        bstr::BStr::new(symlink.target()),
+                    );
+                }
+            }
+        }
+    }
+    created
+}
+
 /// Recursive mkdir over a WTF-16 path: component-iterates the
 /// wide path and `NtCreateFile`s each prefix with `FILE_OPEN_IF`, walking back
 /// on `FileNotFound` and forward again on success. This stays in WTF-16
@@ -1393,7 +1497,7 @@ impl Archiver {
         let mut symlink_join_buf: Option<bun_paths::path_buffer_pool::Guard> = None;
 
         #[cfg(unix)]
-        let mut created_symlinks: Vec<Vec<u8>> = Vec::new();
+        let mut deferred_symlinks: Vec<DeferredSymlink> = Vec::new();
 
         let mut normalized_buf = OSPathBuffer::uninit();
         let mut use_pwrite = cfg!(unix);
@@ -1564,17 +1668,6 @@ impl Archiver {
 
                     let path_slice: &[OSPathChar] = &path[..];
 
-                    #[cfg(unix)]
-                    if path_traverses_created_symlink(path_slice, &created_symlinks) {
-                        if options.log {
-                            bun_core::warn!(
-                                "Skipping entry that traverses a previously extracted symlink: {}\n",
-                                bun_core::fmt::fmt_os_path(path_slice, Default::default()),
-                            );
-                        }
-                        continue;
-                    }
-
                     if options.log {
                         bun_core::prettyln!(
                             " {}",
@@ -1664,26 +1757,8 @@ impl Archiver {
                                     }
                                     continue;
                                 }
-                                // SAFETY: normalized_buf[path_slice.len()] == 0 (written above),
-                                // so path_slice is a NUL-terminated [:0]u8.
-                                let path_z: &ZStr = unsafe {
-                                    ZStr::from_raw(path_slice.as_ptr(), path_slice.len())
-                                };
-                                match bun_sys::symlinkat(link_target, dir_fd, path_z) {
-                                    Ok(()) => {}
-                                    Err(err) => match err.get_errno() {
-                                        bun_sys::E::EPERM | bun_sys::E::ENOENT => {
-                                            let dirname = bun_paths::dirname_simple(path_slice);
-                                            if dirname.is_empty() {
-                                                return Err(err.into());
-                                            }
-                                            let _ = dir.make_path_u8(dirname);
-                                            bun_sys::symlinkat(link_target, dir_fd, path_z)?;
-                                        }
-                                        _ => return Err(err.into()),
-                                    },
-                                }
-                                created_symlinks.push(path_slice.to_vec());
+                                deferred_symlinks
+                                    .push(DeferredSymlink::new(path_slice, link_target.as_bytes()));
                             }
                             #[cfg(not(unix))]
                             {
@@ -1704,23 +1779,6 @@ impl Archiver {
                             )
                             .unwrap();
 
-                            // `path_traverses_created_symlink` is a lexical check: on
-                            // filesystems that alias differently-encoded names (Unicode
-                            // NFC/NFD normalization on APFS/HFS+), a path component can
-                            // reach a created symlink without byte-matching its recorded
-                            // path. Once this extraction has created any symlink, ask the
-                            // kernel to refuse to follow symlinks while opening file
-                            // entries. `NOFOLLOW_ANY` is 0 on non-Darwin targets.
-                            #[cfg(unix)]
-                            let flags = {
-                                let mut flags =
-                                    bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC;
-                                if !created_symlinks.is_empty() {
-                                    flags |= bun_sys::O::NOFOLLOW_ANY;
-                                }
-                                flags
-                            };
-                            #[cfg(not(unix))]
                             let flags = bun_sys::O::WRONLY | bun_sys::O::CREAT | bun_sys::O::TRUNC;
 
                             #[cfg(windows)]
@@ -1944,6 +2002,9 @@ impl Archiver {
                 }
             }
         }
+
+        #[cfg(unix)]
+        create_deferred_symlinks(dir_fd, &deferred_symlinks, options.log);
 
         Ok(count)
     }

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -966,7 +966,14 @@ pub mod fs {
         /// Checks for `<sep>node_modules<sep>` in the
         /// parsed dir component (`name.dir`, NOT `text`).
         pub fn is_node_module(&self) -> bool {
-            crate::strings::contains(self.name().dir, crate::NODE_MODULES_NEEDLE)
+            if cfg!(any(target_os = "macos", windows)) {
+                crate::strings::contains_case_insensitive_ascii(
+                    self.name().dir,
+                    crate::NODE_MODULES_NEEDLE,
+                )
+            } else {
+                crate::strings::contains(self.name().dir, crate::NODE_MODULES_NEEDLE)
+            }
         }
 
         /// Key used to identify this path in the incremental graph: the real

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -963,13 +963,10 @@ pub mod fs {
             self.name().dir_with_trailing_slash()
         }
 
-        /// Checks for `<sep>node_modules<sep>` (ASCII case-insensitively) in the
+        /// Checks for `<sep>node_modules<sep>` in the
         /// parsed dir component (`name.dir`, NOT `text`).
         pub fn is_node_module(&self) -> bool {
-            crate::strings::contains_case_insensitive_ascii(
-                self.name().dir,
-                crate::NODE_MODULES_NEEDLE,
-            )
+            crate::strings::contains(self.name().dir, crate::NODE_MODULES_NEEDLE)
         }
 
         /// Key used to identify this path in the incremental graph: the real

--- a/src/paths/lib.rs
+++ b/src/paths/lib.rs
@@ -963,17 +963,13 @@ pub mod fs {
             self.name().dir_with_trailing_slash()
         }
 
-        /// Checks for `<sep>node_modules<sep>` in the
+        /// Checks for `<sep>node_modules<sep>` (ASCII case-insensitively) in the
         /// parsed dir component (`name.dir`, NOT `text`).
         pub fn is_node_module(&self) -> bool {
-            if cfg!(any(target_os = "macos", windows)) {
-                crate::strings::contains_case_insensitive_ascii(
-                    self.name().dir,
-                    crate::NODE_MODULES_NEEDLE,
-                )
-            } else {
-                crate::strings::contains(self.name().dir, crate::NODE_MODULES_NEEDLE)
-            }
+            crate::strings::contains_case_insensitive_ascii(
+                self.name().dir,
+                crate::NODE_MODULES_NEEDLE,
+            )
         }
 
         /// Key used to identify this path in the incremental graph: the real

--- a/src/runtime/cli/publish_command.rs
+++ b/src/runtime/cli/publish_command.rs
@@ -31,8 +31,6 @@ use bun_install::dependency;
 use bun_install::{AuthType, LogLevel};
 use bun_sys::FdExt as _;
 
-use crate::api::bun_process::sync as spawn_sync;
-
 // `json_mod::parse_utf8` returns `bun_ast::Expr` (the value-shaped
 // JSON-only `Expr`), not `bun_ast::Expr`, so `Expr::get_string_cloned`
 // can't be applied. Mirror the lookup as a free fn over the JSON `Expr` using
@@ -1116,14 +1114,7 @@ impl PublishCommand {
             }
         }
 
-        let _ = spawn_sync::spawn(&spawn_sync::Options {
-            argv: vec![Box::from(open::OPENER), Box::from(auth_url.as_bytes())],
-            envp: None,
-            stdin: spawn_sync::SyncStdio::Inherit,
-            stdout: spawn_sync::SyncStdio::Inherit,
-            stderr: spawn_sync::SyncStdio::Inherit,
-            ..Default::default()
-        });
+        let _ = bun_core::spawn_sync_inherit(&[open::OPENER, auth_url.as_bytes()]);
     }
 
     fn get_otp<const DIRECTORY_PUBLISH: bool>(

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -291,6 +291,17 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
 
         for part in passthrough {
             copy_script.push(b' ');
+            if cfg!(windows) && use_system_shell && bun_which::batch_arg_has_cmd_metachars(part) {
+                if !silent {
+                    pretty_errorln!(
+                        "<r><red>error<r>: Failed to run script <b>{}<r>: argument {} contains a cmd.exe special character and cannot be passed to the system shell",
+                        bstr::BStr::new(name),
+                        bun_core::fmt::quote(&part[..]),
+                    );
+                    Output::flush();
+                }
+                Global::exit(1);
+            }
             if needs_escape_utf8_ascii_latin1(part) {
                 escape_8bit::<true, false>(part, &mut copy_script).unwrap_or_oom();
                 continue;

--- a/src/runtime/crypto/CryptoHasher.rs
+++ b/src/runtime/crypto/CryptoHasher.rs
@@ -257,7 +257,7 @@ impl CryptoHasher {
             let Some(string_value) = next_eat() else {
                 return Err(global.throw_invalid_arguments(format_args!("Missing argument")));
             };
-            if string_value.is_undefined_or_null() {
+            if !string_value.is_string_literal() {
                 return Err(global.throw_invalid_arguments(format_args!("Expected string")));
             }
             string_value.get_zig_string(global)?
@@ -1416,17 +1416,6 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
         global: &JSGlobalObject,
         callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        if this.digested.get() {
-            return Err(global
-                .err(
-                    ErrorCode::INVALID_STATE,
-                    format_args!(
-                        "{} hasher already digested, create a new instance to update",
-                        H::NAME
-                    ),
-                )
-                .throw());
-        }
         let this_value = callframe.this();
         let input = callframe.argument(0);
         let buffer = match BlobOrStringOrBuffer::from_js(global, input)? {
@@ -1442,6 +1431,17 @@ impl<H: StaticHasher> StaticCryptoHasher<H> {
             return Err(global.throw(format_args!(
                 "Bun.file() is not supported here yet (it needs an async version)"
             )));
+        }
+        if this.digested.get() {
+            return Err(global
+                .err(
+                    ErrorCode::INVALID_STATE,
+                    format_args!(
+                        "{} hasher already digested, create a new instance to update",
+                        H::NAME
+                    ),
+                )
+                .throw());
         }
         this.hashing.with_mut(|h| h.update(buffer.slice()));
         Ok(this_value)

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2370,13 +2370,10 @@ impl CompilerRT {
             return;
         }
         for _ in 0..8 {
-            let mut name_buf = PathBuffer::uninit();
-            let Ok(name) =
-                Fs::FileSystem::tmpname(b"bun-cc", &mut name_buf.0, bun_core::fast_random())
-            else {
+            let Some(name) = Self::fresh_compiler_rt_dir_name() else {
                 return;
             };
-            match bun_sys::mkdirat(tmpdir.fd(), name, 0o700) {
+            match bun_sys::mkdirat(tmpdir.fd(), name.as_zstr(), 0o700) {
                 Ok(()) => {}
                 Err(err) if err.get_errno() == bun_sys::E::EEXIST => continue,
                 Err(_) => return,
@@ -2387,6 +2384,31 @@ impl CompilerRT {
             };
             let _ = Self::populate_compiler_rt_dir(&dir);
             return;
+        }
+    }
+
+    /// Random name for a freshly created header directory. The Windows shape
+    /// keeps the leading characters and the extension random, so a generated
+    /// short (8.3) alias of the directory is random as well.
+    fn fresh_compiler_rt_dir_name() -> Option<ZBox> {
+        #[cfg(unix)]
+        {
+            let mut name_buf = PathBuffer::uninit();
+            let name = Fs::FileSystem::tmpname(b"bun-cc", &mut name_buf.0, bun_core::fast_random())
+                .ok()?;
+            Some(ZBox::from_bytes(name.as_bytes()))
+        }
+        #[cfg(windows)]
+        {
+            let mut name = Vec::new();
+            write!(
+                &mut name,
+                "{}-bun-cc.{}",
+                bun_fmt::truncated_hash32(bun_core::fast_random()),
+                bun_fmt::truncated_hash32(bun_core::fast_random()),
+            )
+            .ok()?;
+            Some(ZBox::from_vec(name))
         }
     }
 

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2421,24 +2421,28 @@ impl CompilerRT {
                 return false;
             }
         }
+        let Ok(node_dir) = bun_cc.make_open_path(b"node", bun_sys::OpenDirOptions::default())
+        else {
+            return false;
+        };
+        for (name, source) in CompilerRtSources::NODE_HEADERS {
+            if !Self::write_compiler_rt_file(&node_dir, name.as_bytes(), source) {
+                return false;
+            }
+        }
 
         let mut path_buf = PathBuffer::uninit();
         let Ok(path) = bun_sys::get_fd_path(bun_cc.fd(), &mut path_buf) else {
             return false;
         };
         // `ZBox::from_bytes` panics on OOM.
-        let _ = COMPILER_RT_DIR.set(ZBox::from_bytes(&*path));
-
-        let Ok(node_dir) = bun_cc.make_open_path(b"node", bun_sys::OpenDirOptions::default())
-        else {
-            return true;
+        let path = ZBox::from_bytes(&*path);
+        let Ok(node_path) = bun_sys::get_fd_path(node_dir.fd(), &mut path_buf) else {
+            return false;
         };
-        for (name, source) in CompilerRtSources::NODE_HEADERS {
-            Self::write_compiler_rt_file(&node_dir, name.as_bytes(), source);
-        }
-        if let Ok(node_path) = bun_sys::get_fd_path(node_dir.fd(), &mut path_buf) {
-            let _ = COMPILER_RT_NODE_DIR.set(ZBox::from_bytes(&*node_path));
-        }
+        let node_path = ZBox::from_bytes(&*node_path);
+        let _ = COMPILER_RT_DIR.set(path);
+        let _ = COMPILER_RT_NODE_DIR.set(node_path);
         true
     }
 

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2361,44 +2361,32 @@ impl CompilerRT {
             return;
         };
 
-        #[cfg(windows)]
+        // Prefer the reusable per-user directory; if it cannot be safely
+        // populated, fall back to a freshly created, randomly named one.
+        #[cfg(unix)]
+        if let Some(bun_cc) = Self::open_owned_compiler_rt_dir(&tmpdir)
+            && Self::populate_compiler_rt_dir(&bun_cc)
         {
-            let Ok(bun_cc) = tmpdir.make_open_path(b"bun-cc", bun_sys::OpenDirOptions::default())
+            return;
+        }
+        for _ in 0..8 {
+            let mut name_buf = PathBuffer::uninit();
+            let Ok(name) =
+                Fs::FileSystem::tmpname(b"bun-cc", &mut name_buf.0, bun_core::fast_random())
             else {
                 return;
             };
-            Self::populate_compiler_rt_dir(&bun_cc);
-        }
-
-        // Prefer the per-user directory; if it (or any candidate) cannot be
-        // safely populated -- wrong owner/mode, or an entry inside it is a
-        // pre-planted symlink -- abandon it and mint a fresh private one.
-        #[cfg(unix)]
-        {
-            if let Some(bun_cc) = Self::open_owned_compiler_rt_dir(&tmpdir)
-                && Self::populate_compiler_rt_dir(&bun_cc)
-            {
-                return;
+            match bun_sys::mkdirat(tmpdir.fd(), name, 0o700) {
+                Ok(()) => {}
+                Err(err) if err.get_errno() == bun_sys::E::EEXIST => continue,
+                Err(_) => return,
             }
-            for _ in 0..8 {
-                let mut name_buf = PathBuffer::uninit();
-                let Ok(name) =
-                    Fs::FileSystem::tmpname(b"bun-cc", &mut name_buf.0, bun_core::fast_random())
-                else {
-                    return;
-                };
-                match bun_sys::mkdirat(tmpdir.fd(), name, 0o700) {
-                    Ok(()) => {}
-                    Err(err) if err.get_errno() == bun_sys::E::EEXIST => continue,
-                    Err(_) => return,
-                }
-                let dir_flags = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOFOLLOW;
-                let Ok(dir) = tmpdir.open_at_with(name.as_bytes(), dir_flags) else {
-                    return;
-                };
-                let _ = Self::populate_compiler_rt_dir(&dir);
+            let dir_flags = bun_sys::O::RDONLY | bun_sys::O::CLOEXEC | bun_sys::O::NOFOLLOW;
+            let Ok(dir) = tmpdir.open_at_with(name.as_bytes(), dir_flags) else {
                 return;
-            }
+            };
+            let _ = Self::populate_compiler_rt_dir(&dir);
+            return;
         }
     }
 
@@ -2407,11 +2395,7 @@ impl CompilerRT {
     /// a pre-planted symlinked entry refused by the no-follow write.
     fn populate_compiler_rt_dir(bun_cc: &bun_sys::Dir) -> bool {
         for (name, source) in CompilerRtSources::SOURCES {
-            let wrote = Self::write_compiler_rt_file(bun_cc, name.as_bytes(), source);
-            // On Unix a refused write means the entry is a planted symlink, so
-            // this directory is abandoned for a fresh one. On Windows the
-            // directory is already per-user; keep staging the rest best-effort.
-            if cfg!(unix) && !wrote {
+            if !Self::write_compiler_rt_file(bun_cc, name.as_bytes(), source) {
                 return false;
             }
         }

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -28,6 +28,7 @@ const DATAGRAM_PAYLOAD_BUDGET: u64 = 1150;
 const CRYPTO_ERROR_CERTIFICATE_REQUIRED: u64 = 0x0100 + 116;
 /// QUIC CRYPTO_ERROR base (RFC 9001 §4.8) + TLS handshake_failure(40).
 const CRYPTO_ERROR_HANDSHAKE_FAILURE: u64 = 0x0100 + 40;
+const CRYPTO_ERROR_BAD_CERTIFICATE: u64 = 0x0100 + 42;
 
 const LISTENER_FLAG_PATH_VALIDATION: u32 = 0x1;
 const LISTENER_FLAG_DATAGRAM: u32 = 0x2;
@@ -390,6 +391,8 @@ pub struct QuicSession {
     close_when_bound: Cell<bool>,
     deferred_close: JsCell<Option<(bool, u64, Vec<u8>)>>,
     handshake_pending_ok: Cell<bool>,
+    reject_unverified_peer: Cell<bool>,
+    peer_cert_rejected: Cell<bool>,
     hsk_snapshot: JsCell<Option<HskSnapshot>>,
     close_reported: Cell<bool>,
     destroyed: Cell<bool>,
@@ -436,6 +439,8 @@ impl QuicSession {
             close_when_bound: Cell::new(false),
             deferred_close: JsCell::new(None),
             handshake_pending_ok: Cell::new(false),
+            reject_unverified_peer: Cell::new(true),
+            peer_cert_rejected: Cell::new(false),
             hsk_snapshot: JsCell::new(None),
             close_reported: Cell::new(false),
             destroyed: Cell::new(false),
@@ -593,6 +598,10 @@ impl QuicSession {
         }
         if let Some(v) = options.get(global, "qlog")? {
             self.qlog_enabled.set(v.to_boolean());
+        }
+        if let Some(v) = options.get(global, "verifyPeer")?.filter(|v| v.is_string()) {
+            self.reject_unverified_peer
+                .set(bun_core::String::from_js(v, global)?.to_utf8_bytes() != b"manual");
         }
         if let Some(app) = options
             .get(global, "application")?
@@ -909,7 +918,7 @@ impl QuicSession {
                 SessionEvent::HandshakeDone { ok } => {
                     if ok {
                         self.capture_hsk_snapshot();
-                        if self.is_server.get() {
+                        if self.is_server.get() || self.peer_verification_refused() {
                             // Node's server reports at handshake COMPLETION
                             // (session.cc: server completion == confirmation
                             // per RFC 9001 §4.1.2).
@@ -970,6 +979,10 @@ impl QuicSession {
                     // session's close is in the same batch must never be
                     // surfaced (Node's onstream count excludes it).
                     if remote && self.conn.get().is_null() && stream.pre_reset_code().is_some() {
+                        stream.suppress_announce();
+                        continue;
+                    }
+                    if remote && self.peer_cert_rejected.get() {
                         stream.suppress_announce();
                         continue;
                     }
@@ -1173,7 +1186,7 @@ impl QuicSession {
                 }
                 SessionEvent::Datagram { payload, early } => {
                     self.add_stat(IDX_STATS_SESSION_DATAGRAMS_RECEIVED, 1);
-                    if !self.has_listener(LISTENER_FLAG_DATAGRAM) {
+                    if !self.has_listener(LISTENER_FLAG_DATAGRAM) || self.peer_cert_rejected.get() {
                         continue;
                     }
                     let buf = ArrayBuffer::create_buffer(global, &payload).or_report(global);
@@ -1469,6 +1482,7 @@ impl QuicSession {
                 true
             }
         };
+        self.peer_cert_rejected.set(!cert_ok);
         let peer_frame_size = if !ok || self.conn.get().is_null() {
             0
         } else {
@@ -1621,6 +1635,16 @@ impl QuicSession {
             }
             self.schedule_process();
         }
+    }
+
+    fn peer_verification_refused(&self) -> bool {
+        !self.is_server.get()
+            && self.reject_unverified_peer.get()
+            && self
+                .hsk_snapshot
+                .get()
+                .as_ref()
+                .is_some_and(|s| s.validation.is_some())
     }
 
     fn capture_hsk_snapshot(&self) {
@@ -2386,6 +2410,25 @@ lsquic_callback! {
 
     pub(super) fn on_hsk_done(session: &QuicSession, status: c_int) {
         let ok = status == lsquic::LSQ_HSK_OK || status == lsquic::LSQ_HSK_RESUMED_OK;
+        if ok && !session.is_server.get() && session.reject_unverified_peer.get() {
+            session.capture_hsk_snapshot();
+            if session.peer_verification_refused() {
+                session.self_close.with_mut(|s| {
+                    *s = Some((
+                        false,
+                        CRYPTO_ERROR_BAD_CERTIFICATE,
+                        b"peer certificate verification failed".to_vec(),
+                    ));
+                });
+                if let Some(c) = session.conn() {
+                    c.abort_error(
+                        false,
+                        CRYPTO_ERROR_BAD_CERTIFICATE as c_uint,
+                        c"peer certificate verification failed",
+                    );
+                }
+            }
+        }
         session.push_event(SessionEvent::HandshakeDone { ok });
     }
 }

--- a/src/runtime/node/quic/session.rs
+++ b/src/runtime/node/quic/session.rs
@@ -1482,7 +1482,10 @@ impl QuicSession {
                 true
             }
         };
-        self.peer_cert_rejected.set(!cert_ok);
+        if !cert_ok {
+            self.peer_cert_rejected.set(true);
+        }
+        let open_allowed = ok && !self.peer_cert_rejected.get();
         let peer_frame_size = if !ok || self.conn.get().is_null() {
             0
         } else {
@@ -1495,7 +1498,7 @@ impl QuicSession {
         self.with_state(|s| {
             s.handshake_completed = ok as u8;
             s.handshake_confirmed = ok as u8;
-            s.stream_open_allowed = (ok && cert_ok) as u8;
+            s.stream_open_allowed = open_allowed as u8;
             s.max_datagram_size = peer_frame_size
                 .saturating_sub(DATAGRAM_FRAME_OVERHEAD)
                 .min(DATAGRAM_PAYLOAD_BUDGET) as u16;
@@ -2413,6 +2416,7 @@ lsquic_callback! {
         if ok && !session.is_server.get() && session.reject_unverified_peer.get() {
             session.capture_hsk_snapshot();
             if session.peer_verification_refused() {
+                session.peer_cert_rejected.set(true);
                 session.self_close.with_mut(|s| {
                     *s = Some((
                         false,

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -406,10 +406,15 @@ impl Context {
         use c::NodeMode::*;
         self.err = c::ReturnCode::Ok;
         match self.mode {
-            // SAFETY: FFI — state is an initialized deflate stream.
-            DEFLATE | DEFLATERAW => unsafe {
-                self.err = c::deflateParams(&raw mut self.state, level, strategy);
-            },
+            DEFLATE | DEFLATERAW => {
+                self.set_buffers(None, Some(&mut []));
+                // SAFETY: FFI — state is an initialized deflate stream; avail_in/avail_out
+                // are 0 (next_out non-null) so the internal deflate(Z_BLOCK) returns
+                // Z_BUF_ERROR without touching any previously installed caller buffer.
+                unsafe {
+                    self.err = c::deflateParams(&raw mut self.state, level, strategy);
+                }
+            }
             _ => {}
         }
         if self.err != c::ReturnCode::Ok && self.err != c::ReturnCode::BufError {

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -3270,16 +3270,18 @@ where
             // returned slices alias the same uWS-owned header buffer. Format
             // the `https://{host}` prefix while `host` is borrowed so the
             // second `&mut req` borrow for `url` is unconflicted.
-            let prefix: Option<Vec<u8>> = ReqLike::header(req, b"host").map(|host| {
-                let fmt = bun_fmt::HostFormatter {
-                    is_https: true,
-                    host,
-                    port: None,
-                };
-                let mut s = Vec::new();
-                let _ = write!(&mut s, "https://{}", fmt);
-                s
-            });
+            let prefix: Option<Vec<u8>> = ReqLike::header(req, b"host")
+                .filter(|host| Request::is_valid_host_header(host))
+                .map(|host| {
+                    let fmt = bun_fmt::HostFormatter {
+                        is_https: true,
+                        host,
+                        port: None,
+                    };
+                    let mut s = Vec::new();
+                    let _ = write!(&mut s, "https://{}", fmt);
+                    s
+                });
             let path = ReqLike::url(req);
             if !path.is_empty() && path[0] == b'/' {
                 if let Some(mut s) = prefix {

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -54,6 +54,7 @@ struct State {
     /// without unsafe Arc-pointer reconstruction. Set via `Arc::new_cyclic` in
     /// `init()` (the sole constructor).
     self_weak: std::sync::Weak<IOReader>,
+    read_guards: Vec<std::sync::Arc<IOReader>>,
     /// Backref so async read callbacks can drive `Yield::run`. See
     /// `IOWriter::interp`.
     interp: Option<bun_ptr::ParentRef<Interpreter>>,
@@ -109,6 +110,15 @@ impl IOReader {
             .expect("IOReader::keepalive after last Arc dropped")
     }
 
+    fn push_read_guard(&self) {
+        let guard = self.keepalive();
+        self.state().read_guards.push(guard);
+    }
+
+    fn pop_read_guard(&self) -> Option<std::sync::Arc<IOReader>> {
+        self.state().read_guards.pop()
+    }
+
     pub(crate) fn init(fd: Fd, evtloop: EventLoopHandle) -> std::sync::Arc<IOReader> {
         let mut reader = ReaderImpl::init::<IOReader>();
         #[cfg(not(windows))]
@@ -132,6 +142,7 @@ impl IOReader {
                 #[cfg(windows)]
                 is_reading: false,
                 self_weak: std::sync::Weak::clone(w),
+                read_guards: Vec::new(),
                 interp: None,
             }),
         });
@@ -359,6 +370,8 @@ bun_io::impl_buffered_reader_parent! {
     on_reader_error = |this, err| (*this).on_reader_error(&err);
     loop_           = |this| (*this).io_evtloop().native_loop();
     event_loop      = |this| (*this).io_evtloop();
+    ref_            = |this| (*this).push_read_guard();
+    deref           = |this| drop((*this).pop_read_guard());
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -367,12 +380,9 @@ bun_io::impl_buffered_reader_parent! {
 
 impl Drop for IOReader {
     fn drop(&mut self) {
-        // With `Arc` the last ref drops after the callback returns, so this
-        // does not run from inside a read callback while BufferedReader is
-        // still iterating.
-        // TODO: revisit if a child callback can drop the last Arc while
-        // BufferedReader is still on the stack — would need the
-        // EventLoopTask hop once the shell EventLoopHandle shim is real.
+        // The bun_io read loop brackets every event-loop entry with the
+        // parent `ref_`/`deref` hooks (`read_guards`), so the last ref never
+        // drops while BufferedReader is still iterating.
         let s = self.state.get_mut();
         let r = self.reader.get_mut();
         if s.fd != Fd::INVALID {

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -530,11 +530,14 @@ impl ShellMvBatchedTask {
             return bun_sys::unlinkat(src_dir, src);
         }
 
+        // Windows `lstatat` never reports S_IFLNK; follow there so a reparse-point source fails the dev/ino compare.
+        let src_nofollow = if cfg!(windows) { 0 } else { O::NOFOLLOW };
+
         if S::ISDIR(mode) {
             let sd = Dir::from_fd(shell_openat(
                 src_dir,
                 src,
-                O::RDONLY | O::DIRECTORY | O::NOFOLLOW,
+                O::RDONLY | O::DIRECTORY | src_nofollow,
                 0,
             )?);
             let sst = bun_sys::fstat(sd.fd())?;
@@ -584,7 +587,7 @@ impl ShellMvBatchedTask {
         let in_ = File::openat(
             src_dir,
             src.as_bytes(),
-            O::RDONLY | O::CLOEXEC | O::NOFOLLOW,
+            O::RDONLY | O::CLOEXEC | src_nofollow,
             0,
         )?;
         let fst = bun_sys::fstat(in_.fd())?;

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -531,6 +531,16 @@ impl ShellMvBatchedTask {
         }
 
         if S::ISDIR(mode) {
+            let sd = Dir::from_fd(shell_openat(
+                src_dir,
+                src,
+                O::RDONLY | O::DIRECTORY | O::NOFOLLOW,
+                0,
+            )?);
+            let sst = bun_sys::fstat(sd.fd())?;
+            if sst.st_dev != st.st_dev || sst.st_ino != st.st_ino {
+                return Err(bun_sys::Error::from_code(E::ENOENT, Tag::rename));
+            }
             // `| 0o700` so children can be written even when the source mode is read-only; restored via `fchmod` below.
             if let Err(e) = bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700) {
                 if e.get_errno() != E::EEXIST {
@@ -540,8 +550,12 @@ impl ShellMvBatchedTask {
                 bun_sys::rmdirat(dst_dir, dst)?;
                 bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700)?;
             }
-            let sd = Dir::from_fd(shell_openat(src_dir, src, O::RDONLY | O::DIRECTORY, 0)?);
-            let dd = Dir::from_fd(shell_openat(dst_dir, dst, O::RDONLY | O::DIRECTORY, 0)?);
+            let dd = Dir::from_fd(shell_openat(
+                dst_dir,
+                dst,
+                O::RDONLY | O::DIRECTORY | O::NOFOLLOW,
+                0,
+            )?);
             // Boxed: `WrappedIterator` embeds an 8 KB inline readdir buffer.
             let mut iter = Box::new(bun_sys::dir_iterator::iterate(sd.fd()));
             let mut nbuf = bun_paths::path_buffer_pool::get();
@@ -567,7 +581,18 @@ impl ShellMvBatchedTask {
             return Err(bun_sys::Error::from_code(E::ENOTSUP, Tag::rename));
         }
 
-        let in_ = File::openat(src_dir, src.as_bytes(), O::RDONLY | O::CLOEXEC, 0)?;
+        let in_ = File::openat(
+            src_dir,
+            src.as_bytes(),
+            O::RDONLY | O::CLOEXEC | O::NOFOLLOW,
+            0,
+        )?;
+        let fst = bun_sys::fstat(in_.fd())?;
+        if fst.st_dev != st.st_dev || fst.st_ino != st.st_ino {
+            return Err(bun_sys::Error::from_code(E::ENOENT, Tag::rename));
+        }
+        let st = fst;
+        let mode = st.st_mode as bun_core::Mode;
         // Unlink first so a symlink-at-dest isn't followed by `O_TRUNC`; also avoids ETXTBUSY.
         let _ = bun_sys::unlinkat(dst_dir, dst);
         let out = File::openat(

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -544,6 +544,8 @@ impl ShellMvBatchedTask {
             if sst.st_dev != st.st_dev || sst.st_ino != st.st_ino {
                 return Err(bun_sys::Error::from_code(E::ENOENT, Tag::rename));
             }
+            let st = sst;
+            let mode = st.st_mode as bun_core::Mode;
             // `| 0o700` so children can be written even when the source mode is read-only; restored via `fchmod` below.
             if let Err(e) = bun_sys::mkdirat(dst_dir, dst, (mode & 0o7777) | 0o700) {
                 if e.get_errno() != E::EEXIST {

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -638,7 +638,10 @@ impl<'a> ShellSrcBuilder<'a> {
             // `needs_escape_bunstr` is true for empty strings: `${''}` must still
             // produce an argument. Routing through appendJSStrRef makes the \x08
             // marker recognized regardless of quote context (e.g. inside single quotes).
-            if needs_escape_bunstr(bunstr) || is_if_clause_keyword_bunstr(bunstr) {
+            if needs_escape_bunstr(bunstr)
+                || is_if_clause_keyword_bunstr(bunstr)
+                || self.outbuf_ends_with_var_ref()
+            {
                 self.append_js_str_ref(bunstr)?;
                 return Ok(true);
             }
@@ -665,7 +668,10 @@ impl<'a> ShellSrcBuilder<'a> {
             return Ok(false);
         }
         if ALLOW_ESCAPE {
-            if needs_escape_utf8_ascii_latin1(utf8) || IfClauseTok::from_text(utf8).is_some() {
+            if needs_escape_utf8_ascii_latin1(utf8)
+                || IfClauseTok::from_text(utf8).is_some()
+                || self.outbuf_ends_with_var_ref()
+            {
                 let bunstr = OwnedString::new(BunString::clone_utf8(utf8));
                 self.append_js_str_ref(bunstr.get())?;
                 return Ok(true);
@@ -674,6 +680,17 @@ impl<'a> ShellSrcBuilder<'a> {
 
         self.append_utf8_impl(utf8)?;
         Ok(true)
+    }
+
+    fn outbuf_ends_with_var_ref(&self) -> bool {
+        match self
+            .outbuf
+            .iter()
+            .rposition(|b| !(b.is_ascii_alphanumeric() || *b == b'_'))
+        {
+            Some(i) => self.outbuf[i] == b'$',
+            None => false,
+        }
     }
 
     pub(crate) fn append_utf16_impl(&mut self, utf16: &[u16]) -> Result<(), bun_alloc::AllocError> {

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1948,10 +1948,8 @@ impl PipeReader {
     /// the latter. No `&`/`&mut PipeReader` is held across the re-entrant
     /// `try_signal_done_to_cmd` / `run_yield_with` calls — both reach back
     /// into this same allocation via the `Readable::Pipe` `Arc` clone.
-    ///
-    /// NOTE: this does **not** gate on `is_done()` — the error path runs
-    /// unconditionally. The `is_done()` early-return is `on_reader_done`-only
-    /// and lives in [`on_reader_done`].
+    /// Callers gate on `is_done()` first so the captured-writer tee has
+    /// drained before `on_close_io` drops the `Readable::Pipe` Arc.
     fn finish_after_state_set(guard: &Arc<Self>) {
         let me = arc_as_mut_ptr(guard);
         // Snapshot `interp` *before* the Cmd call: `try_signal_done_to_cmd`
@@ -1996,8 +1994,6 @@ impl PipeReader {
             unsafe {
                 let owned = (*me).to_owned_slice();
                 (*me).state = PipeReaderState::Done(owned);
-                // `on_reader_done` (only) waits for the
-                // captured-writer tee to drain before signalling.
                 if !(*me).is_done() {
                     return;
                 }
@@ -2140,6 +2136,9 @@ impl PipeReader {
                     drop(buf);
                 }
                 (*me).state = PipeReaderState::Err(Some(Box::new(err.to_system_error())));
+                if !(*me).is_done() {
+                    return;
+                }
             }
         }
         Self::finish_after_state_set(&guard);

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1694,21 +1694,21 @@ impl<const SSL: bool> NewSocket<SSL> {
 
         if SSL && authorized && !this.acts_as_tls_server() {
             if let Some(ssl_ptr) = this.socket.get().ssl() {
-                let hostname: &[u8] = if let Some(server_name) = this.server_name.get() {
-                    &server_name[..]
-                } else if let Some(super::listener::UnixOrHost::Host { host, .. }) =
-                    this.connection.get()
-                {
-                    &host[..]
-                } else {
-                    b""
+                let hostname: &[u8] = match this.server_name.get() {
+                    Some(server_name) if !server_name.is_empty() => &server_name[..],
+                    _ => match this.connection.get() {
+                        Some(super::listener::UnixOrHost::Host { host, .. })
+                            if !host.is_empty() =>
+                        {
+                            &host[..]
+                        }
+                        _ => b"localhost",
+                    },
                 };
-                if !hostname.is_empty()
-                    && !bun_boringssl::check_server_identity(
-                        boringssl_sys::SSL::opaque_mut(ssl_ptr),
-                        hostname,
-                    )
-                {
+                if !bun_boringssl::check_server_identity(
+                    boringssl_sys::SSL::opaque_mut(ssl_ptr),
+                    hostname,
+                ) {
                     authorized = false;
                     hostname_mismatch = true;
                     let mut message =

--- a/src/runtime/webcore/Request.rs
+++ b/src/runtime/webcore/Request.rs
@@ -878,7 +878,7 @@ impl Request {
     /// RFC 3986 3.2.2 `uri-host [ ":" port ]` byte set. A Host value outside it, or an empty
     /// one, cannot form a URL authority, so `request.url` synthesis falls back to the
     /// configured host instead of pasting the client bytes into the URL.
-    fn is_valid_host_header(host: &[u8]) -> bool {
+    pub(crate) fn is_valid_host_header(host: &[u8]) -> bool {
         !host.is_empty()
             && host.iter().all(|&c| {
                 c.is_ascii_alphanumeric()

--- a/src/simdutf_sys/simdutf.rs
+++ b/src/simdutf_sys/simdutf.rs
@@ -516,24 +516,6 @@ pub mod length {
     }
 }
 
-pub mod trim {
-    fn utf16_len(buf: &[u16]) -> usize {
-        let len = buf.len();
-
-        if len == 0 {
-            return 0;
-        }
-        if (buf[len - 1] >= 0xD800) && (buf[len - 1] <= 0xDBFF) {
-            return len - 1;
-        }
-        len
-    }
-
-    pub fn utf16(buf: &[u16]) -> &[u16] {
-        &buf[0..utf16_len(buf)]
-    }
-}
-
 pub mod base64 {
     use super::SIMDUTFResult;
     use core::ffi::c_int;

--- a/src/sql/mysql/protocol/PacketHeader.rs
+++ b/src/sql/mysql/protocol/PacketHeader.rs
@@ -10,7 +10,7 @@ impl PacketHeader {
     /// The header's length field is 24 bits. A single packet's payload must be
     /// strictly smaller than this; a length of exactly 0xFFFFFF signals a
     /// multi-packet continuation.
-    pub(crate) const MAX_PAYLOAD_LENGTH: usize = 0xFF_FF_FF;
+    pub const MAX_PAYLOAD_LENGTH: usize = 0xFF_FF_FF;
 
     pub fn decode(bytes: &[u8]) -> Option<PacketHeader> {
         if bytes.len() < 4 {

--- a/src/sql/shared/ColumnIdentifier.rs
+++ b/src/sql/shared/ColumnIdentifier.rs
@@ -35,7 +35,12 @@ impl ColumnIdentifier {
             }
         }
 
-        Ok(Self::Name(Data::Owned(name.to_owned()?)))
+        let owned = name.to_owned()?;
+        let owned = match bstr::ByteSlice::to_str_lossy(owned.as_slice()) {
+            std::borrow::Cow::Owned(replaced) => replaced.into_bytes(),
+            std::borrow::Cow::Borrowed(_) => owned,
+        };
+        Ok(Self::Name(Data::Owned(owned)))
     }
 }
 

--- a/src/sql_jsc/mysql/MySQLConnection.rs
+++ b/src/sql_jsc/mysql/MySQLConnection.rs
@@ -587,6 +587,10 @@ impl MySQLConnection {
             reader
                 .ensure_capacity(packet_length)
                 .map_err(|_| AnyMySQLError::ShortRead)?;
+            if header_length as usize == PacketHeader::MAX_PAYLOAD_LENGTH {
+                self.process_split_packet(reader)?;
+                continue;
+            }
             // `NewReader<C>: Copy` so the scopeguard captures by copy; the inner
             // `C` writes through a raw pointer so the offset update still lands.
             // Always skip the full packet, we dont care about padding or unread bytes.
@@ -1128,6 +1132,65 @@ impl MySQLConnection {
                 connection: std::ptr::from_mut::<Self>(self),
             },
         }
+    }
+
+    fn process_split_packet<C: ReaderContext>(
+        &mut self,
+        reader: NewReader<C>,
+    ) -> Result<(), AnyMySQLError> {
+        if self.status != ConnectionState::Connected {
+            return Err(AnyMySQLError::UnexpectedPacket);
+        }
+        let buffered = reader.peek();
+        let mut sequence_id = PacketHeader::decode(buffered)
+            .ok_or(AnyMySQLError::ShortRead)?
+            .sequence_id;
+        let mut wire_length: usize = 0;
+        let mut payload_length: usize = 0;
+        loop {
+            let header =
+                PacketHeader::decode(&buffered[wire_length..]).ok_or(AnyMySQLError::ShortRead)?;
+            if header.sequence_id != sequence_id {
+                return Err(AnyMySQLError::UnexpectedPacket);
+            }
+            sequence_id = sequence_id.wrapping_add(1);
+            wire_length += PacketHeader::SIZE + header.length as usize;
+            payload_length += header.length as usize;
+            u32::try_from(wire_length).map_err(|_| AnyMySQLError::Overflow)?;
+            if buffered.len() < wire_length {
+                return Err(AnyMySQLError::ShortRead);
+            }
+            if (header.length as usize) < PacketHeader::MAX_PAYLOAD_LENGTH {
+                break;
+            }
+        }
+
+        let mut payload: Vec<u8> = Vec::new();
+        payload
+            .try_reserve_exact(payload_length)
+            .map_err(|_| AnyMySQLError::OutOfMemory)?;
+        let mut offset = PacketHeader::SIZE;
+        while offset < wire_length {
+            let end = (offset + PacketHeader::MAX_PAYLOAD_LENGTH).min(wire_length);
+            payload.extend_from_slice(&buffered[offset..end]);
+            offset = end + PacketHeader::SIZE;
+        }
+
+        reader.set_offset_from_start(wire_length);
+        self.sequence_id = sequence_id;
+        let payload_length = u32::try_from(payload_length).map_err(|_| AnyMySQLError::Overflow)?;
+        let mut cursor: usize = 0;
+        let mut message_start: usize = 0;
+        let assembled: NewReader<StackReader<'_>> =
+            StackReader::init(&payload, &mut cursor, &mut message_start);
+        self.handle_command(assembled, payload_length)
+            .map_err(|err| {
+                if err == AnyMySQLError::ShortRead {
+                    AnyMySQLError::UnexpectedPacket
+                } else {
+                    err
+                }
+            })
     }
 
     fn check_if_prepared_statement_is_done(&mut self, statement: &mut MySQLStatement) {

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -2975,13 +2975,19 @@ impl PostgresSQLConnection {
                         stmt.error_response = Some(
                             crate::postgres::postgres_sql_statement::Error::Protocol(err),
                         );
-                        if self
-                            .statements
-                            .with_mut(|m| m.remove(&stmt.signature.name[..]))
-                            .is_some()
-                        {
-                            // SAFETY: `stmt` is a live `Box`-allocated statement; the
-                            // request still holds its own ref so this cannot drop to 0.
+                        let owned_by_map = self.statements.with_mut(|m| {
+                            let name = &stmt.signature.name[..];
+                            if m.get(name)
+                                .is_some_and(|&p| core::ptr::eq(p, core::ptr::from_ref(&*stmt)))
+                            {
+                                m.remove(name).is_some()
+                            } else {
+                                false
+                            }
+                        });
+                        if owned_by_map {
+                            // SAFETY: the map entry just removed was `stmt` itself, so the map
+                            // held one ref and the request still holds another; cannot drop to 0.
                             unsafe { PostgresSQLStatement::deref(core::ptr::from_mut(stmt)) };
                         }
                     }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1973,8 +1973,26 @@ mod posix_impl {
         if !UNAVAILABLE.load(Ordering::Relaxed) {
             match super::linux_syscall::openat2_in_root(dir, path, flags, mode) {
                 Ok(fd) => return Ok(fd),
-                Err(libc::ENOSYS | libc::EPERM | libc::EINVAL | libc::E2BIG) => {
-                    UNAVAILABLE.store(true, Ordering::Relaxed);
+                Err(e @ (libc::ENOSYS | libc::EPERM | libc::EINVAL | libc::E2BIG)) => {
+                    let probe = super::linux_syscall::openat2_in_root(
+                        dir,
+                        bun_core::zstr!("."),
+                        O::PATH | O::DIRECTORY | O::CLOEXEC,
+                        0,
+                    );
+                    match probe {
+                        Err(libc::ENOSYS | libc::EPERM | libc::EINVAL | libc::E2BIG) => {
+                            UNAVAILABLE.store(true, Ordering::Relaxed);
+                        }
+                        other => {
+                            if let Ok(fd) = other {
+                                let _ = close(fd);
+                            }
+                            return Err(
+                                Error::from_code_int(e, Tag::open).with_path(path.as_bytes())
+                            );
+                        }
+                    }
                 }
                 Err(e) => {
                     return Err(Error::from_code_int(e, Tag::open).with_path(path.as_bytes()));

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1681,9 +1681,10 @@ describe("bundler", () => {
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-      expect(stdout).toBe(
-        `TypeError|ERR_INVALID_ARG_TYPE|Expected filter (1st argument) to be a RegExp\ncalls=${call}\n`,
-      );
+      expect({ stdout, stderr }).toEqual({
+        stdout: `TypeError|ERR_INVALID_ARG_TYPE|Expected filter (1st argument) to be a RegExp\ncalls=${call}\n`,
+        stderr: "",
+      });
       expect(exitCode).toBe(0);
     });
   }

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import path, { dirname, join, resolve } from "node:path";
 import { itBundled } from "./expectBundled";
 
@@ -1634,4 +1635,56 @@ describe("bundler", () => {
       },
     };
   });
+
+  for (const [name, call, tuple] of [
+    ["addFilter", 1, `[123, () => {}]`],
+    ["onBeforeParse", 3, `[123, {}, "symbol", undefined]`],
+  ] as const) {
+    test.concurrent(`plugin/${name} throws a TypeError when the filter is not a RegExp`, async () => {
+      using dir = tempDir("plugin-filter-not-regexp", {
+        "index.ts": `console.log("hi");`,
+        "build.mjs": `
+          const originalEntries = Map.prototype.entries;
+          let calls = 0;
+          try {
+            await Bun.build({
+              entrypoints: ["./index.ts"],
+              plugins: [
+                {
+                  name: "entries",
+                  setup(build) {
+                    Map.prototype.entries = function () {
+                      if (++calls !== ${call}) return originalEntries.call(this);
+                      Map.prototype.entries = originalEntries;
+                      return [["file", [${tuple}]]][Symbol.iterator]();
+                    };
+                  },
+                },
+              ],
+            });
+            console.log("resolved");
+          } catch (e) {
+            console.log([e.name, e.code, e.message].join("|"));
+          } finally {
+            Map.prototype.entries = originalEntries;
+          }
+          console.log("calls=" + calls);
+        `,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "build.mjs"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(stdout).toBe(
+        `TypeError|ERR_INVALID_ARG_TYPE|Expected filter (1st argument) to be a RegExp\ncalls=${call}\n`,
+      );
+      expect(exitCode).toBe(0);
+    });
+  }
 });

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -182,42 +182,6 @@ test("object destructuring of a macro result keeps every bound property regardle
   expect(exitCode).toBe(0);
 });
 
-test("macros are not run from a node_modules file reached through a differently-cased path", async () => {
-  using dir = tempDir("macro-node-modules-casing", {
-    "Node_Modules/pkg/package.json": JSON.stringify({ name: "pkg", version: "1.0.0", main: "index.js" }),
-    "Node_Modules/pkg/m.js": `
-      import { writeFileSync } from "node:fs";
-      export function f() {
-        writeFileSync("MACRO_RAN", "macro executed");
-        return "INLINED_RESULT";
-      }
-    `,
-    "Node_Modules/pkg/index.js": `
-      import { f } from "./m.js" with { type: "macro" };
-      export const value = f();
-    `,
-    "entry.ts": `
-      import { value } from "./Node_Modules/pkg/index.js";
-      console.log(value);
-    `,
-  });
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "build", "./entry.ts", "--outdir", "dist"],
-    env: bunEnv,
-    cwd: String(dir),
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ stdout, stderr }).toMatchObject({
-    stderr: expect.stringContaining("macros cannot be run from node_modules"),
-  });
-  expect(existsSync(path.join(String(dir), "MACRO_RAN"))).toBe(false);
-  expect(existsSync(path.join(String(dir), "Node_Modules", "pkg", "MACRO_RAN"))).toBe(false);
-  expect(existsSync(path.join(String(dir), "dist", "entry.js"))).toBe(false);
-  expect(exitCode).toBe(1);
-});
-
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -159,6 +159,65 @@ test("object argument with a sparse numeric key", async () => {
   });
 });
 
+test("object destructuring of a macro result keeps every bound property regardless of key order or repeated keys", async () => {
+  using dir = tempDir("macro-destructure-object", {
+    "m.ts": `export function m() {\n  return { a: 1, c: 2 };\n}\n`,
+    "index.ts": [
+      `import { m } from "./m.ts" with { type: "macro" };`,
+      `const { c, a } = m();`,
+      `const { a: x, a: y, c: z } = m();`,
+      `console.log(JSON.stringify([c, a, x, y, z]));`,
+      ``,
+    ].join("\n"),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "run", "index.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toMatchObject({ lastLine: "[2,1,1,1,2]" });
+  expect(exitCode).toBe(0);
+});
+
+test("macros are not run from a node_modules file reached through a differently-cased path", async () => {
+  using dir = tempDir("macro-node-modules-casing", {
+    "Node_Modules/pkg/package.json": JSON.stringify({ name: "pkg", version: "1.0.0", main: "index.js" }),
+    "Node_Modules/pkg/m.js": `
+      import { writeFileSync } from "node:fs";
+      export function f() {
+        writeFileSync("MACRO_RAN", "macro executed");
+        return "INLINED_RESULT";
+      }
+    `,
+    "Node_Modules/pkg/index.js": `
+      import { f } from "./m.js" with { type: "macro" };
+      export const value = f();
+    `,
+    "entry.ts": `
+      import { value } from "./Node_Modules/pkg/index.js";
+      console.log(value);
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", "./entry.ts", "--outdir", "dist"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr }).toMatchObject({
+    stderr: expect.stringContaining("macros cannot be run from node_modules"),
+  });
+  expect(existsSync(path.join(String(dir), "MACRO_RAN"))).toBe(false);
+  expect(existsSync(path.join(String(dir), "Node_Modules", "pkg", "MACRO_RAN"))).toBe(false);
+  expect(existsSync(path.join(String(dir), "dist", "entry.js"))).toBe(false);
+  expect(exitCode).toBe(1);
+});
+
 describe("--no-macros", () => {
   const files = {
     "macro.ts": `

--- a/test/bundler/transpiler/macro-test.test.ts
+++ b/test/bundler/transpiler/macro-test.test.ts
@@ -178,7 +178,7 @@ test("object destructuring of a macro result keeps every bound property regardle
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toMatchObject({ lastLine: "[2,1,1,1,2]" });
+  expect({ lastLine: stdout.trim().split("\n").pop(), stderr }).toEqual({ lastLine: "[2,1,1,1,2]", stderr: "" });
   expect(exitCode).toBe(0);
 });
 

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4424,6 +4424,58 @@ console.log(foo, array);
       expect(out.includes("otherNamesStillWork")).toBe(true);
     });
 
+    it("a macro that runs a nested transformSync macro and then requires a module leaves the importing file intact", async () => {
+      const otherLines = [];
+      for (let i = 0; i < 300; i++) {
+        otherLines.push(`const v${i} = { a: [${i}, "s${i}"], b: (${i} + 1) * 2, c: String(${i}).length };`);
+      }
+      otherLines.push(`module.exports = { value: v299.b + v0.c };`);
+
+      using dir = tempDir("macro-nested-transform-sync", {
+        "inner-macro.ts": `export function inner() { return "inner-value"; }`,
+        "outer-macro.ts": `
+          import { join } from "node:path";
+          export function outer() {
+            const source =
+              "import { inner } from " +
+              JSON.stringify(join(import.meta.dir, "inner-macro.ts")) +
+              ' with { type: "macro" };\\nexport const v = inner();\\n';
+            const code = new Bun.Transpiler({ loader: "ts" }).transformSync(source);
+            const expanded = code.includes('"inner-value"') && !code.includes("inner(");
+            const other = import.meta.require("./other.cjs");
+            return "expanded=" + expanded + " other=" + other.value;
+          }
+        `,
+        "other.cjs": otherLines.join("\n"),
+        "index.ts": `
+          import { writeFileSync } from "node:fs";
+          import { join } from "node:path";
+          import { inner } from "./inner-macro.ts" with { type: "macro" };
+          import { outer } from "./outer-macro.ts" with { type: "macro" };
+          const pre = inner();
+          const res = outer();
+          const tail = { list: [1, 2, 3].map(n => n * 2), label: ["a", "b"].join("-") };
+          writeFileSync(join(import.meta.dir, "out.json"), JSON.stringify({ pre, res, tail }));
+        `,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "index.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(await Bun.file(join(String(dir), "out.json")).text()).toBe(
+        JSON.stringify({
+          pre: "inner-value",
+          res: "expanded=true other=601",
+          tail: { list: [2, 4, 6], label: "a-b" },
+        }),
+      );
+      expect(exitCode).toBe(0);
+    });
+
     it("special identifier in import statement", () => {
       const out = transpiler.transformSync(`
         import {ɵtest} from 'foo'

--- a/test/bundler/transpiler/transpiler.test.js
+++ b/test/bundler/transpiler/transpiler.test.js
@@ -4466,6 +4466,7 @@ console.log(foo, array);
         stderr: "pipe",
       });
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stderr, exitCode }).toEqual({ stderr: "", exitCode: 0 });
       expect(await Bun.file(join(String(dir), "out.json")).text()).toBe(
         JSON.stringify({
           pre: "inner-value",
@@ -4473,7 +4474,6 @@ console.log(foo, array);
           tail: { list: [2, 4, 6], label: "a-b" },
         }),
       );
-      expect(exitCode).toBe(0);
     });
 
     it("special identifier in import statement", () => {

--- a/test/cli/install/bun-install-lifecycle-scripts.test.ts
+++ b/test/cli/install/bun-install-lifecycle-scripts.test.ts
@@ -3103,6 +3103,68 @@ for (const forceWaiterThread of isLinux ? [false, true] : [false]) {
         expect(trusted![1]).not.toContain(colliderName);
       });
 
+      for (const linker of ["hoisted", "isolated"]) {
+        test(`only trusts packages resolved inside the trusted subtree, not same-named dependencies elsewhere (${linker})`, async () => {
+          using ctx = await setupTest();
+          const { packageDir, packageJson, env } = ctx;
+          const testEnv = forceWaiterThread ? { ...env, BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" } : env;
+
+          const localPath = join(packageDir, "local-what-bin");
+          await mkdir(localPath, { recursive: true });
+          await Promise.all([
+            writeFile(
+              join(localPath, "package.json"),
+              JSON.stringify({
+                name: "what-bin",
+                version: "9.9.9",
+                scripts: {
+                  postinstall: `${bunExe()} -e "require('fs').writeFileSync('postinstall-ran.txt', 'ran')"`,
+                },
+              }),
+            ),
+            writeFile(
+              packageJson,
+              JSON.stringify({
+                name: "foo",
+                dependencies: {
+                  "what-bin": "file:./local-what-bin",
+                },
+              }),
+            ),
+          ]);
+
+          const { stderr, exited } = spawn({
+            cmd: [bunExe(), "i", `--linker=${linker}`, "--trust", "uses-what-bin@1.0.0"],
+            cwd: packageDir,
+            stdout: "pipe",
+            stderr: "pipe",
+            stdin: "ignore",
+            env: testEnv,
+          });
+
+          const err = await stderr.text();
+          expect(err).toContain("Saved lockfile");
+          expect(err).not.toContain("error:");
+          expect(await exited).toBe(0);
+
+          expect(await exists(join(packageDir, "node_modules", "uses-what-bin", "what-bin.txt"))).toBeTrue();
+          expect(await exists(join(packageDir, "node_modules", "what-bin", "postinstall-ran.txt"))).toBeFalse();
+          expect(await file(join(packageDir, "node_modules", "what-bin", "package.json")).json()).toMatchObject({
+            name: "what-bin",
+            version: "9.9.9",
+          });
+
+          const pkgJson = await file(packageJson).json();
+          expect(pkgJson.trustedDependencies).toEqual(["uses-what-bin"]);
+
+          const lockfile = await file(join(packageDir, "bun.lock")).text();
+          const trusted = lockfile.match(/"trustedDependencies":\s*\[([^\]]*)\]/);
+          expect(trusted).not.toBeNull();
+          expect(trusted![1]).toContain('"uses-what-bin"');
+          expect(trusted![1]).not.toContain('"what-bin"');
+        });
+      }
+
       const trustTests = [
         {
           label: "only name",

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -9295,3 +9295,87 @@ test("npm manifest cache entries with invalid package version records are treate
 
   expect(() => parseManifest(corrupted, registryUrl())).toThrow("manifest is invalid");
 });
+
+test("npm manifest cache entries are only reused for the package name they were saved for", async () => {
+  const { parseManifest } = npm_manifest_test_helpers;
+  const cacheDir = join(packageDir, ".bun-cache");
+
+  await write(
+    packageJson,
+    JSON.stringify({
+      name: "foo",
+      version: "1.0.0",
+      dependencies: {
+        "basic-1": "1.0.0",
+        "no-deps": "1.0.0",
+      },
+    }),
+  );
+
+  {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).toContain("Saved lockfile");
+    expect(out).toContain("+ basic-1@1.0.0");
+    expect(out).toContain("+ no-deps@1.0.0");
+    expect(exitCode).toBe(0);
+  }
+
+  const manifestFiles = (await readdirSorted(cacheDir)).filter(name => name.endsWith(".npm"));
+  const byName: Record<string, string> = {};
+  for (const manifestFile of manifestFiles) {
+    const fullPath = join(cacheDir, manifestFile);
+    byName[parseManifest(fullPath, registryUrl()).name] = fullPath;
+  }
+  expect(Object.keys(byName).sort()).toEqual(["basic-1", "no-deps"]);
+
+  copyFileSync(byName["basic-1"], byName["no-deps"]);
+  expect(parseManifest(byName["no-deps"], registryUrl()).name).toBe("basic-1");
+
+  await Promise.all([
+    rm(join(packageDir, "node_modules"), { recursive: true, force: true }),
+    rm(join(packageDir, "bun.lockb"), { force: true }),
+    rm(join(packageDir, "bun.lock"), { force: true }),
+    write(
+      packageJson,
+      JSON.stringify({
+        name: "foo",
+        version: "1.0.0",
+        dependencies: {
+          "no-deps": "1.0.0",
+        },
+      }),
+    ),
+  ]);
+
+  await using proc = spawn({
+    cmd: [bunExe(), "install"],
+    cwd: packageDir,
+    stdout: "pipe",
+    stdin: "ignore",
+    stderr: "pipe",
+    env,
+  });
+  const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(err).toContain("Saved lockfile");
+  expect(out).toContain("+ no-deps@1.0.0");
+  expect(await file(join(packageDir, "node_modules", "no-deps", "package.json")).json()).toEqual({
+    name: "no-deps",
+    version: "1.0.0",
+  });
+
+  const lockfile = parseLockfile(packageDir);
+  const npmPackages = (Object.values(lockfile.packages) as any[]).filter(pkg => pkg.resolution.tag === "npm");
+  expect(npmPackages.map(pkg => pkg.name)).toEqual(["no-deps"]);
+  expect(npmPackages[0].resolution.resolved).toBe(`http://localhost:${port}/no-deps/-/no-deps-1.0.0.tgz`);
+
+  expect(parseManifest(byName["no-deps"], registryUrl()).name).toBe("no-deps");
+  expect(exitCode).toBe(0);
+});

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
-import { createHash, randomFillSync } from "node:crypto";
+import { createHash } from "node:crypto";
 import { createWriteStream, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { join } from "node:path";
@@ -383,7 +383,11 @@ describe("streaming tarball extraction", () => {
     const before = Buffer.alloc(4 * 1024 * 1024, 0);
     const after = Buffer.alloc(16 * 1024 * 1024, 0);
     const tail = Buffer.alloc(8 * 1024 * 1024);
-    randomFillSync(tail);
+    let seed = createHash("sha512").update("tail.bin").digest();
+    for (let off = 0; off < tail.length; off += seed.length) {
+      seed.copy(tail, off);
+      seed = createHash("sha512").update(seed).digest();
+    }
 
     const damaged = Buffer.alloc(512, 0);
     damaged.write("junk", 0, "utf8");

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, readdirSorted, tempDir } from "harness";
-import { createHash } from "node:crypto";
+import { createHash, randomFillSync } from "node:crypto";
 import { createWriteStream, existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { createServer, type Server } from "node:http";
 import { join } from "node:path";
@@ -375,6 +375,62 @@ describe("streaming tarball extraction", () => {
       expect([path, got.equals(body)]).toEqual([path, true]);
     }
     expect(existsSync(join(pkgRoot, longName))).toBe(false);
+    expect(exitCode).toBe(0);
+  });
+
+  test("streaming extract skips a damaged header block and extracts the entries after it byte-for-byte while more data is still arriving", async () => {
+    const pkgJson = Buffer.from(JSON.stringify({ name: "stream-pkg", version: "1.0.0" }) + "\n");
+    const before = Buffer.alloc(4 * 1024 * 1024, 0);
+    const after = Buffer.alloc(16 * 1024 * 1024, 0);
+    const tail = Buffer.alloc(8 * 1024 * 1024);
+    randomFillSync(tail);
+
+    const damaged = Buffer.alloc(512, 0);
+    damaged.write("junk", 0, "utf8");
+    damaged.fill(" ", 148, 156);
+
+    const damagedEntries: Entry[] = [
+      { path: "package.json", body: pkgJson },
+      { path: "before.bin", body: before },
+      { path: "after.bin", body: after },
+      { path: "tail.bin", body: tail },
+    ];
+    const tar = Buffer.concat([
+      ...tarFile("package/package.json", pkgJson),
+      ...tarFile("package/before.bin", before),
+      damaged,
+      ...tarFile("package/after.bin", after),
+      ...tarFile("package/tail.bin", tail),
+      Buffer.alloc(1024, 0),
+    ]);
+    const damagedTgz = gzipSync(tar);
+    const damagedShasum = createHash("sha1").update(damagedTgz).digest("hex");
+    const damagedIntegrity = "sha512-" + createHash("sha512").update(damagedTgz).digest("base64");
+    expect(damagedTgz.length).toBeGreaterThan(2 * 1024 * 1024);
+
+    await using reg = await makeRegistry(damagedTgz, damagedShasum, damagedIntegrity, chunkBytes);
+    const registry = reg.url;
+
+    using dir = tempDir("streaming-extract-damaged-block", {
+      "package.json": JSON.stringify({
+        name: "app",
+        version: "1.0.0",
+        dependencies: { "stream-pkg": "1.0.0" },
+      }),
+      "bunfig.toml": Bun.TOML.stringify({ install: { registry } }),
+    });
+
+    const { stderr, exitCode } = await runInstall(String(dir));
+    expect(stderr).not.toContain("extracting tarball for");
+    expect(stderr).not.toContain("error:");
+    expect(stderr).toContain("Streamed ");
+    expect(reg.tarballHits).toBe(1);
+
+    const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
+    for (const { path, body } of damagedEntries) {
+      const got = readFileSync(join(pkgRoot, path));
+      expect([path, got.length, got.equals(body)]).toEqual([path, body.length, true]);
+    }
     expect(exitCode).toBe(0);
   });
 

--- a/test/cli/install/bun-install-streaming-extract.test.ts
+++ b/test/cli/install/bun-install-streaming-extract.test.ts
@@ -378,66 +378,6 @@ describe("streaming tarball extraction", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("streaming extract skips a damaged header block and extracts the entries after it byte-for-byte while more data is still arriving", async () => {
-    const pkgJson = Buffer.from(JSON.stringify({ name: "stream-pkg", version: "1.0.0" }) + "\n");
-    const before = Buffer.alloc(4 * 1024 * 1024, 0);
-    const after = Buffer.alloc(16 * 1024 * 1024, 0);
-    const tail = Buffer.alloc(8 * 1024 * 1024);
-    let seed = createHash("sha512").update("tail.bin").digest();
-    for (let off = 0; off < tail.length; off += seed.length) {
-      seed.copy(tail, off);
-      seed = createHash("sha512").update(seed).digest();
-    }
-
-    const damaged = Buffer.alloc(512, 0);
-    damaged.write("junk", 0, "utf8");
-    damaged.fill(" ", 148, 156);
-
-    const damagedEntries: Entry[] = [
-      { path: "package.json", body: pkgJson },
-      { path: "before.bin", body: before },
-      { path: "after.bin", body: after },
-      { path: "tail.bin", body: tail },
-    ];
-    const tar = Buffer.concat([
-      ...tarFile("package/package.json", pkgJson),
-      ...tarFile("package/before.bin", before),
-      damaged,
-      ...tarFile("package/after.bin", after),
-      ...tarFile("package/tail.bin", tail),
-      Buffer.alloc(1024, 0),
-    ]);
-    const damagedTgz = gzipSync(tar);
-    const damagedShasum = createHash("sha1").update(damagedTgz).digest("hex");
-    const damagedIntegrity = "sha512-" + createHash("sha512").update(damagedTgz).digest("base64");
-    expect(damagedTgz.length).toBeGreaterThan(2 * 1024 * 1024);
-
-    await using reg = await makeRegistry(damagedTgz, damagedShasum, damagedIntegrity, chunkBytes);
-    const registry = reg.url;
-
-    using dir = tempDir("streaming-extract-damaged-block", {
-      "package.json": JSON.stringify({
-        name: "app",
-        version: "1.0.0",
-        dependencies: { "stream-pkg": "1.0.0" },
-      }),
-      "bunfig.toml": Bun.TOML.stringify({ install: { registry } }),
-    });
-
-    const { stderr, exitCode } = await runInstall(String(dir));
-    expect(stderr).not.toContain("extracting tarball for");
-    expect(stderr).not.toContain("error:");
-    expect(stderr).toContain("Streamed ");
-    expect(reg.tarballHits).toBe(1);
-
-    const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
-    for (const { path, body } of damagedEntries) {
-      const got = readFileSync(join(pkgRoot, path));
-      expect([path, got.length, got.equals(body)]).toEqual([path, body.length, true]);
-    }
-    expect(exitCode).toBe(0);
-  });
-
   test("tarballs below BUN_INSTALL_STREAMING_MIN_SIZE take the buffered path", async () => {
     // Reuse the same large tarball but raise the threshold above it.
     // The server sends Content-Length, so `notify()` sees a body_size
@@ -772,4 +712,64 @@ test("buffered extract does not hold the decompressed local tarball in memory", 
   const maxRssBytes = resourceUsage?.maxRSS ?? 0;
   expect(maxRssBytes).toBeGreaterThan(1024 * 1024);
   expect(maxRssBytes).toBeLessThan(2 * PAYLOAD_SIZE);
+});
+
+test("streaming extract skips a damaged header block and extracts the entries after it byte-for-byte while more data is still arriving", async () => {
+  const pkgJson = Buffer.from(JSON.stringify({ name: "stream-pkg", version: "1.0.0" }) + "\n");
+  const before = Buffer.alloc(4 * 1024 * 1024, 0);
+  const after = Buffer.alloc(16 * 1024 * 1024, 0);
+  const tail = Buffer.alloc(8 * 1024 * 1024);
+  let seed = createHash("sha512").update("tail.bin").digest();
+  for (let off = 0; off < tail.length; off += seed.length) {
+    seed.copy(tail, off);
+    seed = createHash("sha512").update(seed).digest();
+  }
+
+  const damaged = Buffer.alloc(512, 0);
+  damaged.write("junk", 0, "utf8");
+  damaged.fill(" ", 148, 156);
+
+  const damagedEntries: Entry[] = [
+    { path: "package.json", body: pkgJson },
+    { path: "before.bin", body: before },
+    { path: "after.bin", body: after },
+    { path: "tail.bin", body: tail },
+  ];
+  const tar = Buffer.concat([
+    ...tarFile("package/package.json", pkgJson),
+    ...tarFile("package/before.bin", before),
+    damaged,
+    ...tarFile("package/after.bin", after),
+    ...tarFile("package/tail.bin", tail),
+    Buffer.alloc(1024, 0),
+  ]);
+  const damagedTgz = gzipSync(tar);
+  const damagedShasum = createHash("sha1").update(damagedTgz).digest("hex");
+  const damagedIntegrity = "sha512-" + createHash("sha512").update(damagedTgz).digest("base64");
+  expect(damagedTgz.length).toBeGreaterThan(2 * 1024 * 1024);
+
+  await using reg = await makeRegistry(damagedTgz, damagedShasum, damagedIntegrity, 4096);
+  const registry = reg.url;
+
+  using dir = tempDir("streaming-extract-damaged-block", {
+    "package.json": JSON.stringify({
+      name: "app",
+      version: "1.0.0",
+      dependencies: { "stream-pkg": "1.0.0" },
+    }),
+    "bunfig.toml": Bun.TOML.stringify({ install: { registry } }),
+  });
+
+  const { stderr, exitCode } = await runInstall(String(dir));
+  expect(stderr).not.toContain("extracting tarball for");
+  expect(stderr).not.toContain("error:");
+  expect(stderr).toContain("Streamed ");
+  expect(reg.tarballHits).toBe(1);
+
+  const pkgRoot = join(String(dir), "node_modules", "stream-pkg");
+  for (const { path, body } of damagedEntries) {
+    const got = readFileSync(join(pkgRoot, path));
+    expect([path, got.length, got.equals(body)]).toEqual([path, body.length, true]);
+  }
+  expect(exitCode).toBe(0);
 });

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,6 +1,6 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
-import { readlinkSync, realpathSync } from "fs";
+import { lstatSync, readFileSync, readlinkSync, realpathSync, statSync } from "fs";
 import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
 import {
   bunEnv,
@@ -65,6 +65,59 @@ async function withContext(
 
 // Default context options for most tests
 const defaultOpts = { linker: "hoisted" as const };
+
+const gitEnv = {
+  ...bunEnv,
+  GIT_AUTHOR_NAME: "bun-test",
+  GIT_AUTHOR_EMAIL: "bun-test@example.com",
+  GIT_COMMITTER_NAME: "bun-test",
+  GIT_COMMITTER_EMAIL: "bun-test@example.com",
+  GIT_CONFIG_NOSYSTEM: "1",
+};
+
+async function git(cwd: string, args: string[], stdin?: string): Promise<string> {
+  await using proc = spawn({
+    cmd: ["git", ...args],
+    cwd,
+    env: gitEnv,
+    stdin: stdin === undefined ? "ignore" : Buffer.from(stdin),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) {
+    throw new Error(`git ${args.join(" ")} exited with ${exitCode}: ${stderr}`);
+  }
+  return stdout.trim();
+}
+
+async function createDumbHttpGitRepo(dir: string, symlinks: Record<string, string>): Promise<string> {
+  const work = join(dir, "work");
+  await git(work, ["-c", "init.defaultBranch=main", "init", "--quiet"]);
+  await git(work, ["add", "-A"]);
+  for (const [path, target] of Object.entries(symlinks)) {
+    const oid = await git(work, ["hash-object", "-w", "--no-filters", "--stdin"], target);
+    await git(work, ["update-index", "--add", "--cacheinfo", `120000,${oid},${path}`]);
+  }
+  await git(work, ["-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "init"]);
+  const sha = await git(work, ["rev-parse", "HEAD"]);
+  await git(dir, ["clone", "--quiet", "--bare", "work", "repo.git"]);
+  await git(join(dir, "repo.git"), ["update-server-info"]);
+  return sha;
+}
+
+function serveDirectory(root: string) {
+  return Bun.serve({
+    port: 0,
+    fetch(req) {
+      const path = join(root, decodeURIComponent(new URL(req.url).pathname));
+      if (!statSync(path, { throwIfNoEntry: false })?.isFile()) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(file(path));
+    },
+  });
+}
 
 describe.concurrent("bun-install", () => {
   for (let input of ["abcdef", "65537", "-1"]) {
@@ -5245,6 +5298,97 @@ describe.concurrent("bun-install", () => {
       expect(package_json.name).toBe("uglify-js");
       expect(package_json.version).toBe("3.14.1");
       await access(join(ctx.package_dir, "bun.lockb"));
+    });
+  });
+
+  it("does not keep a checked-in node_modules entry from a git dependency", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(ctx, dummyRegistryForContext(ctx, urls));
+      using dir = tempDir("git-dep-node-modules", {
+        "work/package.json": JSON.stringify({ name: "has-node-modules", version: "1.0.0" }),
+        "outside/keep.txt": "keep",
+      });
+      const sha = await createDumbHttpGitRepo(String(dir), { node_modules: join(String(dir), "outside") });
+      using server = serveDirectory(String(dir));
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            "has-node-modules": `git+http://localhost:${server.port}/repo.git`,
+          },
+        }),
+      );
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(err).toContain("Saved lockfile");
+      expect(out).toContain("1 package installed");
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache", `@G@${sha}`))).toEqual([
+        ".bun-tag",
+        "package.json",
+      ]);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "has-node-modules"))).toEqual([
+        ".bun-tag",
+        "package.json",
+      ]);
+      expect(await readdirSorted(join(String(dir), "outside"))).toEqual(["keep.txt"]);
+      expect(urls).toBeEmpty();
+      expect(exitCode).toBe(0);
+    });
+  });
+
+  it("does not follow a symlinked .bun-tag when tagging a git dependency checkout", async () => {
+    await withContext(defaultOpts, async ctx => {
+      const urls: string[] = [];
+      setContextHandler(ctx, dummyRegistryForContext(ctx, urls));
+      using dir = tempDir("git-dep-bun-tag", {
+        "work/package.json": JSON.stringify({ name: "has-bun-tag", version: "1.0.0" }),
+        "outside/target.txt": "original\n",
+      });
+      const target = join(String(dir), "outside", "target.txt");
+      const sha = await createDumbHttpGitRepo(String(dir), { ".bun-tag": target });
+      using server = serveDirectory(String(dir));
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            "has-bun-tag": `git+http://localhost:${server.port}/repo.git`,
+          },
+        }),
+      );
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "ignore",
+        stderr: "pipe",
+        env,
+      });
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(err).toContain("Saved lockfile");
+      expect(out).toContain("1 package installed");
+      expect(readFileSync(target, "utf8")).toBe("original\n");
+      const tag = lstatSync(join(ctx.package_dir, "node_modules", ".cache", `@G@${sha}`, ".bun-tag"), {
+        throwIfNoEntry: false,
+      });
+      expect(tag?.isSymbolicLink() ?? false).toBe(false);
+      expect(await file(join(ctx.package_dir, "node_modules", "has-bun-tag", "package.json")).json()).toEqual({
+        name: "has-bun-tag",
+        version: "1.0.0",
+      });
+      expect(urls).toBeEmpty();
+      expect(exitCode).toBe(0);
     });
   });
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -1,6 +1,6 @@
 import { file, listen, Socket, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, jest, setDefaultTimeout, test } from "bun:test";
-import { lstatSync, readFileSync, readlinkSync, realpathSync, statSync } from "fs";
+import { readFileSync, readlinkSync, realpathSync, statSync } from "fs";
 import { access, cp, exists, mkdir, readlink, rm, stat, writeFile } from "fs/promises";
 import {
   bunEnv,
@@ -5379,10 +5379,9 @@ describe.concurrent("bun-install", () => {
       expect(err).toContain("Saved lockfile");
       expect(out).toContain("1 package installed");
       expect(readFileSync(target, "utf8")).toBe("original\n");
-      const tag = lstatSync(join(ctx.package_dir, "node_modules", ".cache", `@G@${sha}`, ".bun-tag"), {
-        throwIfNoEntry: false,
-      });
-      expect(tag?.isSymbolicLink() ?? false).toBe(false);
+      expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache", `@G@${sha}`))).toEqual(
+        isWindows ? [".bun-tag", "package.json"] : ["package.json"],
+      );
       expect(await file(join(ctx.package_dir, "node_modules", "has-bun-tag", "package.json")).json()).toEqual({
         name: "has-bun-tag",
         version: "1.0.0",

--- a/test/cli/install/bun-publish.test.ts
+++ b/test/cli/install/bun-publish.test.ts
@@ -1,8 +1,19 @@
 import { file, spawn, write } from "bun";
 import { afterAll, beforeAll, describe, expect, it, test } from "bun:test";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { exists, rm } from "fs/promises";
-import { VerdaccioRegistry, bunExe, bunEnv as env, isWindows, pack, runBunInstall, tmpdirSync } from "harness";
-import { join } from "path";
+import {
+  VerdaccioRegistry,
+  bunExe,
+  bunEnv as env,
+  isLinux,
+  isWindows,
+  pack,
+  runBunInstall,
+  tempDir,
+  tmpdirSync,
+} from "harness";
+import { delimiter, join } from "path";
 
 const registry = new VerdaccioRegistry();
 
@@ -302,6 +313,85 @@ describe("otp", async () => {
     expect(out).toContain(" + otp-pkg-6@6.6.6");
     expect(exitCode).toBe(0);
   });
+
+  test.skipIf(!isLinux)(
+    "web login opens the auth url with the opener found on PATH, not one in the package directory",
+    async () => {
+      const otpCode = "515151";
+
+      using dir = tempDir("publish-web-login-opener", {
+        "package.json": JSON.stringify({ name: "otp-pkg-7", version: "7.7.7" }),
+      });
+      const packageDir = String(dir);
+      const openedMarker = join(packageDir, "opened.txt");
+      const openerScript = (label: string) =>
+        `#!/bin/sh\nprintf '%s %s' '${label}' "$1" > '${join(packageDir, label + ".tmp")}' && mv '${join(packageDir, label + ".tmp")}' '${openedMarker}'\n`;
+      mkdirSync(join(packageDir, "opener-bin"));
+      writeFileSync(join(packageDir, "xdg-open"), openerScript("package-dir"), { mode: 0o755 });
+      writeFileSync(join(packageDir, "opener-bin", "xdg-open"), openerScript("path"), { mode: 0o755 });
+      chmodSync(join(packageDir, "xdg-open"), 0o755);
+      chmodSync(join(packageDir, "opener-bin", "xdg-open"), 0o755);
+
+      let donePolls = 0;
+      using mockRegistry = Bun.serve({
+        port: 0,
+        fetch(req: Request) {
+          if (req.method === "PUT") {
+            if (req.headers.get("npm-otp") === otpCode) {
+              return new Response("OK", { status: 200 });
+            }
+            return new Response(
+              JSON.stringify({
+                authUrl: `http://localhost:${mockRegistry.port}/auth`,
+                doneUrl: `http://localhost:${mockRegistry.port}/done`,
+              }),
+              { status: 401, headers: { "www-authenticate": "OTP" } },
+            );
+          }
+          if (req.url.endsWith("done")) {
+            donePolls++;
+            if (!existsSync(openedMarker) && donePolls < 40) {
+              return new Response("{}", { status: 202 });
+            }
+            return new Response(JSON.stringify({ token: otpCode }), { status: 200 });
+          }
+          return new Response("unexpected url", { status: 500 });
+        },
+      });
+
+      await write(
+        join(packageDir, "bunfig.toml"),
+        Bun.TOML.stringify({
+          install: {
+            cache: false,
+            registry: { url: `http://localhost:${mockRegistry.port}`, token: "unused" },
+          },
+        }),
+      );
+
+      await using proc = spawn({
+        cmd: [bunExe(), "publish"],
+        cwd: packageDir,
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: Buffer.from("\n"),
+        env: {
+          ...env,
+          PATH: [join(packageDir, "opener-bin"), env.PATH ?? ""].join(delimiter),
+        },
+      });
+
+      const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect(out).toContain("open in browser");
+      expect(out).toContain(`http://localhost:${mockRegistry.port}/auth`);
+      expect(existsSync(openedMarker)).toBe(true);
+      expect(readFileSync(openedMarker, "utf8")).toBe(`path http://localhost:${mockRegistry.port}/auth`);
+      expect(out).toContain(" + otp-pkg-7@7.7.7");
+      expect(exitCode).toBe(0);
+    },
+    30_000,
+  );
 
   for (const shouldIgnoreNotice of [false, true]) {
     test(`npm-notice with login url${shouldIgnoreNotice ? " (ignored)" : ""}`, async () => {

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -1119,4 +1119,55 @@ describe.concurrent("bun run", () => {
       exitCode: 0,
     });
   });
+
+  it.if(isWindows)("--shell=system refuses a passthrough argument containing a cmd.exe special character", async () => {
+    using dir = tempDir("bun-run-system-shell-metachar", {
+      "package.json": JSON.stringify({ name: "system-shell-metachar", scripts: { say: "echo" } }),
+    });
+
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "--shell=system", "say", "hello"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout.trim()).toBe("hello");
+      expect(exitCode).toBe(0);
+    }
+
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "--shell=system", "say", 'x" & echo marker & "'],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(
+        'error: Failed to run script say: argument "x\\" & echo marker & \\"" contains a cmd.exe special character and cannot be passed to the system shell',
+      );
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    }
+
+    {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "run", "--shell=system", "say", "%PATH%"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toContain(
+        'error: Failed to run script say: argument "%PATH%" contains a cmd.exe special character and cannot be passed to the system shell',
+      );
+      expect(stdout).toBe("");
+      expect(exitCode).toBe(1);
+    }
+  });
 });

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1912,6 +1912,85 @@ test.concurrent("can override npm package with workspace package under a differe
   });
 });
 
+test.concurrent(
+  "workspace: dependencies declared inside a tarball package do not create workspace packages",
+  async () => {
+    using ctx = await setupTest();
+    const { packageDir, packageJson, env } = ctx;
+    const marker = join(packageDir, "extra-postinstall.txt");
+    await Promise.all([
+      write(
+        packageJson,
+        JSON.stringify({
+          name: "foo",
+          dependencies: {
+            lib: "file:./lib.tgz",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "lib-src", "lib", "package.json"),
+        JSON.stringify({
+          name: "lib",
+          version: "1.0.0",
+          optionalDependencies: {
+            extra: "workspace:extra",
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "lib-src", "lib", "extra", "package.json"),
+        JSON.stringify({
+          name: "extra",
+          version: "1.0.0",
+          scripts: {
+            postinstall: `${bunExe()} postinstall.js`,
+          },
+        }),
+      ),
+      write(
+        join(packageDir, "lib-src", "lib", "extra", "postinstall.js"),
+        `require("fs").writeFileSync(${JSON.stringify(marker)}, "")`,
+      ),
+    ]);
+
+    {
+      await using tar = spawn({
+        cmd: ["tar", "-czf", join(packageDir, "lib.tgz"), "-C", join(packageDir, "lib-src"), "lib"],
+        stdout: "ignore",
+        stderr: "ignore",
+        env,
+      });
+      expect(await tar.exited).toBe(0);
+    }
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env,
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(err).not.toContain("error:");
+    expect(out).toContain("1 package installed");
+    expect(await readdirSorted(join(packageDir, "node_modules"))).toEqual(["lib"]);
+    expect(await file(join(packageDir, "node_modules", "lib", "package.json")).json()).toEqual({
+      name: "lib",
+      version: "1.0.0",
+      optionalDependencies: {
+        extra: "workspace:extra",
+      },
+    });
+    expect(await exists(marker)).toBeFalse();
+    const lockfile = parseLockfile(packageDir);
+    expect(lockfile.workspace_paths).toEqual({});
+    expect(lockfile.packages.map((pkg: any) => pkg.name).sort()).toEqual(["foo", "lib"]);
+    expect(exitCode).toBe(0);
+  },
+);
+
 describe("LinkWorkspacePackages", () => {
   // Shared setup previously done in a `beforeEach`: each test gets its own dir,
   // a root workspace package.json, and a `no-deps` workspace package.

--- a/test/cli/install/bun-workspaces.test.ts
+++ b/test/cli/install/bun-workspaces.test.ts
@@ -1928,41 +1928,28 @@ test.concurrent(
           },
         }),
       ),
-      write(
-        join(packageDir, "lib-src", "lib", "package.json"),
-        JSON.stringify({
-          name: "lib",
-          version: "1.0.0",
-          optionalDependencies: {
-            extra: "workspace:extra",
-          },
-        }),
-      ),
-      write(
-        join(packageDir, "lib-src", "lib", "extra", "package.json"),
-        JSON.stringify({
-          name: "extra",
-          version: "1.0.0",
-          scripts: {
-            postinstall: `${bunExe()} postinstall.js`,
-          },
-        }),
-      ),
-      write(
-        join(packageDir, "lib-src", "lib", "extra", "postinstall.js"),
-        `require("fs").writeFileSync(${JSON.stringify(marker)}, "")`,
+      Bun.Archive.write(
+        join(packageDir, "lib.tgz"),
+        {
+          "lib/package.json": JSON.stringify({
+            name: "lib",
+            version: "1.0.0",
+            optionalDependencies: {
+              extra: "workspace:extra",
+            },
+          }),
+          "lib/extra/package.json": JSON.stringify({
+            name: "extra",
+            version: "1.0.0",
+            scripts: {
+              postinstall: `${bunExe()} postinstall.js`,
+            },
+          }),
+          "lib/extra/postinstall.js": `require("fs").writeFileSync(${JSON.stringify(marker)}, "")`,
+        },
+        { compress: "gzip" },
       ),
     ]);
-
-    {
-      await using tar = spawn({
-        cmd: ["tar", "-czf", join(packageDir, "lib.tgz"), "-C", join(packageDir, "lib-src"), "lib"],
-        stdout: "ignore",
-        stderr: "ignore",
-        env,
-      });
-      expect(await tar.exited).toBe(0);
-    }
 
     await using proc = spawn({
       cmd: [bunExe(), "install"],

--- a/test/cli/install/redacted-config-logs.test.ts
+++ b/test/cli/install/redacted-config-logs.test.ts
@@ -73,6 +73,48 @@ test("registry port is not mistaken for a credential when the package is scoped"
   expect(exitCode).toBe(1);
 });
 
+test("bunfig password value is masked in config error output", async () => {
+  using dir = tempDir("redacted-bunfig-password", {
+    "bunfig.toml": `l;password = "supersecretvalue"`,
+    "package.json": "{}",
+  });
+
+  await using plain = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...bunEnv, NO_COLOR: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [plainOut, plainErr, plainExit] = await Promise.all([plain.stdout.text(), plain.stderr.text(), plain.exited]);
+
+  expect(plainOut).not.toContain("supersecretvalue");
+  expect(plainErr).not.toContain("supersecretvalue");
+  expect(plainErr).toContain(`l;password = "****************"`);
+
+  await using colored = Bun.spawn({
+    cmd: [bunExe(), "install"],
+    cwd: String(dir),
+    env: { ...bunEnv, NO_COLOR: undefined, FORCE_COLOR: "1" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [coloredOut, coloredErr, coloredExit] = await Promise.all([
+    colored.stdout.text(),
+    colored.stderr.text(),
+    colored.exited,
+  ]);
+
+  expect(coloredOut).not.toContain("supersecretvalue");
+  expect(coloredErr).not.toContain("supersecretvalue");
+  expect(coloredErr).toContain("****************");
+
+  expect(plainExit).toBe(1);
+  expect(coloredExit).toBe(1);
+});
+
 describe.concurrent("redact", async () => {
   const tests = [
     {

--- a/test/cli/install/redacted-config-logs.test.ts
+++ b/test/cli/install/redacted-config-logs.test.ts
@@ -91,6 +91,11 @@ describe.concurrent("redact", async () => {
       expected: `"*"`,
     },
     {
+      title: "registry password",
+      bunfig: `l;password = "hunter2"`,
+      expected: `"*******"`,
+    },
+    {
       title: "random UUID",
       bunfig: 'unre;lated = "f1b0b6b4-4b1b-4b1b-8b1b-4b1b4b1b4b1b"',
       expected: '"************************************"',

--- a/test/cli/install/symlink-path-traversal.test.ts
+++ b/test/cli/install/symlink-path-traversal.test.ts
@@ -616,6 +616,13 @@ describe.concurrent.skipIf(isWindows)("symlink path traversal protection", () =>
           expect(stderr).not.toContain("Streamed ");
         }
 
+        if (exitCode !== 0) {
+          console.error("Install failed with exit code:", exitCode);
+          console.error("stdout:", stdout);
+          console.error("stderr:", stderr);
+        }
+        expect(exitCode).toBe(0);
+
         const misplaced: string[] = [];
         let markerDirs = 0;
         for (const entry of await readdir(installDir, { recursive: true, withFileTypes: true })) {
@@ -637,13 +644,6 @@ describe.concurrent.skipIf(isWindows)("symlink path traversal protection", () =>
         expect(literalX.isSymbolicLink()).toBe(false);
         expect(literalX.isDirectory()).toBe(true);
         expect(await Bun.file(join(pkgDir, decomposed, "x", "nested.txt")).text()).toBe("written at its literal path");
-
-        if (exitCode !== 0) {
-          console.error("Install failed with exit code:", exitCode);
-          console.error("stdout:", stdout);
-          console.error("stderr:", stderr);
-        }
-        expect(exitCode).toBe(0);
       } finally {
         httpServer.closeAllConnections?.();
         await new Promise<void>(resolve => httpServer.close(() => resolve()));

--- a/test/cli/install/symlink-path-traversal.test.ts
+++ b/test/cli/install/symlink-path-traversal.test.ts
@@ -5,7 +5,7 @@ import { bunExe, bunEnv as env, tempDir } from "harness";
 import { createHash } from "node:crypto";
 import { createServer } from "node:http";
 import { tmpdir } from "os";
-import { join } from "path";
+import { basename, join } from "path";
 
 // This test validates the fix for a symlink path traversal vulnerability in tarball extraction.
 // CVE: Path traversal via symlink when installing packages
@@ -520,6 +520,136 @@ describe.concurrent.skipIf(isWindows)("symlink path traversal protection", () =>
       server.stop();
     }
   });
+
+  for (const mode of ["streaming", "buffered"] as const) {
+    it(`writes every directory and file entry inside the package root before creating symlink entries whose names differ only by Unicode normalization (${mode} extraction)`, async () => {
+      let pad = "";
+      let seed = `deferred-symlink-pad-${mode}`;
+      while (pad.length < 256 * 1024) {
+        seed = createHash("sha256").update(seed).digest("hex");
+        pad += seed;
+      }
+
+      const composed = "d/" + String.fromCharCode(0xe9);
+      const decomposed = "d/e" + String.fromCharCode(0x301);
+      const tarball = createTarball([
+        { name: "test-package/", type: "dir" },
+        {
+          name: "test-package/package.json",
+          type: "file",
+          content: JSON.stringify({ name: "test-package", version: "1.0.0" }),
+        },
+        { name: "test-package/z/", type: "dir" },
+        { name: "test-package/q/", type: "dir" },
+        { name: `test-package/${composed}`, type: "symlink", linkname: "../q" },
+        { name: `test-package/${decomposed}/x`, type: "symlink", linkname: "../../z" },
+        { name: "test-package/q/x/marker/", type: "dir" },
+        { name: "test-package/q/x/marker/proof.txt", type: "file", content: "stays inside the package" },
+        { name: `test-package/${decomposed}/x/nested.txt`, type: "file", content: "written at its literal path" },
+        { name: "test-package/pad.bin", type: "file", content: pad },
+      ]);
+
+      const httpServer = createServer((req, res) => {
+        const url = new URL(req.url!, "http://localhost");
+        if (url.pathname.includes("/tarball/")) {
+          res.setHeader("Content-Type", "application/gzip");
+          res.setHeader("Content-Length", String(tarball.length));
+          req.socket.setNoDelay(true);
+          let offset = 0;
+          const step = () => {
+            if (offset >= tarball.length) {
+              res.end();
+              return;
+            }
+            res.write(Buffer.from(tarball.subarray(offset, Math.min(offset + 1024, tarball.length))));
+            offset += 1024;
+            setImmediate(step);
+          };
+          step();
+          return;
+        }
+        if (url.pathname.includes("/repos/")) {
+          res.setHeader("Content-Type", "application/json");
+          res.end(JSON.stringify({ default_branch: "main" }));
+          return;
+        }
+        res.statusCode = 404;
+        res.end("Not Found");
+      });
+      await new Promise<void>(resolve => httpServer.listen(0, "127.0.0.1", () => resolve()));
+      const port = (httpServer.address() as { port: number }).port;
+
+      try {
+        using dir = tempDir(`deferred-symlink-${mode}-test`, {
+          "package.json": JSON.stringify({
+            name: "test-app",
+            version: "1.0.0",
+            dependencies: { "test-package": "github:user/repo#main" },
+          }),
+        });
+        const installDir = String(dir);
+        const scratch = join(installDir, ".bun-tmp");
+        const cache = join(installDir, ".bun-cache");
+        await mkdir(join(scratch, "z"), { recursive: true });
+        await mkdir(join(cache, "z"), { recursive: true });
+
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install", "--verbose"],
+          cwd: installDir,
+          stdout: "pipe",
+          stderr: "pipe",
+          env: {
+            ...env,
+            GITHUB_API_URL: `http://127.0.0.1:${port}`,
+            BUN_INSTALL_CACHE_DIR: cache,
+            BUN_TMPDIR: scratch,
+            TMPDIR: scratch,
+            BUN_INSTALL_STREAMING_MIN_SIZE: "1024",
+            ...(mode === "buffered" ? { BUN_FEATURE_FLAG_DISABLE_STREAMING_INSTALL: "1" } : {}),
+          },
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        if (mode === "streaming") {
+          expect(stderr).toContain("Streamed ");
+        } else {
+          expect(stderr).not.toContain("Streamed ");
+        }
+
+        const misplaced: string[] = [];
+        let markerDirs = 0;
+        for (const entry of await readdir(installDir, { recursive: true, withFileTypes: true })) {
+          if (entry.name !== "marker") continue;
+          const parentStats = await lstat(entry.parentPath);
+          if (basename(entry.parentPath) === "x" && parentStats.isDirectory() && !parentStats.isSymbolicLink()) {
+            markerDirs++;
+          } else {
+            misplaced.push(join(entry.parentPath, entry.name));
+          }
+        }
+        expect(misplaced).toEqual([]);
+        expect(markerDirs).toBeGreaterThan(0);
+
+        const pkgDir = join(installDir, "node_modules", "test-package");
+        expect((await lstat(join(pkgDir, "q", "x"))).isSymbolicLink()).toBe(false);
+        expect(await Bun.file(join(pkgDir, "q", "x", "marker", "proof.txt")).text()).toBe("stays inside the package");
+        const literalX = await lstat(join(pkgDir, decomposed, "x"));
+        expect(literalX.isSymbolicLink()).toBe(false);
+        expect(literalX.isDirectory()).toBe(true);
+        expect(await Bun.file(join(pkgDir, decomposed, "x", "nested.txt")).text()).toBe("written at its literal path");
+
+        if (exitCode !== 0) {
+          console.error("Install failed with exit code:", exitCode);
+          console.error("stdout:", stdout);
+          console.error("stderr:", stderr);
+        }
+        expect(exitCode).toBe(0);
+      } finally {
+        httpServer.closeAllConnections?.();
+        await new Promise<void>(resolve => httpServer.close(() => resolve()));
+      }
+    });
+  }
 });
 
 it.skipIf(isWindows)(

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1,6 +1,15 @@
 import { cc, CString, JSCallback, ptr, type FFIFunction, type Library } from "bun:ffi";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { chmodSync, promises as fs, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "fs";
+import {
+  chmodSync,
+  existsSync,
+  promises as fs,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from "fs";
 import { bunEnv, bunExe, isASAN, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 
@@ -1078,7 +1087,7 @@ describe("double <-> JSValue conversions", () => {
   });
 });
 
-describe.skipIf(isWindows || isASAN)("compiler runtime header directory under BUN_TMPDIR", () => {
+describe("compiler runtime header directory under BUN_TMPDIR", () => {
   const plantedHeader = "#define bool int\n#define true 100\n#define false 0\n";
   const files = {
     "sentinel.txt": "sentinel-unchanged\n",
@@ -1111,7 +1120,7 @@ describe.skipIf(isWindows || isASAN)("compiler runtime header directory under BU
     return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   }
 
-  it("compiles a source that includes a compiler runtime header", async () => {
+  it.skipIf(isWindows)("compiles a source that includes a compiler runtime header", async () => {
     using dir = tempDir("bun-ffi-cc-rt-dir", files);
 
     const [stdout, stderr, exitCode] = await runFixture(String(dir));
@@ -1123,7 +1132,7 @@ describe.skipIf(isWindows || isASAN)("compiler runtime header directory under BU
     expect(exitCode).toBe(0);
   });
 
-  it("does not write compiler runtime headers through a symlinked entry", async () => {
+  it.skipIf(isWindows)("does not write compiler runtime headers through a symlinked entry", async () => {
     using dir = tempDir("bun-ffi-cc-rt-dir-symlink", files);
     for (const name of ["bun-cc", `bun-cc-${process.getuid!()}`]) {
       const headerDir = path.join(String(dir), name);
@@ -1139,21 +1148,43 @@ describe.skipIf(isWindows || isASAN)("compiler runtime header directory under BU
     expect(exitCode).toBe(0);
   });
 
-  it("does not place compiler runtime headers in a pre-existing group- and world-writable directory", async () => {
-    using dir = tempDir("bun-ffi-cc-rt-dir-mode", files);
-    const sharedName = `bun-cc-${process.getuid!()}`;
-    for (const name of ["bun-cc", sharedName]) {
-      const headerDir = path.join(String(dir), name);
-      mkdirSync(headerDir, { recursive: true });
-      writeFileSync(path.join(headerDir, "stdbool.h"), plantedHeader);
-    }
-    chmodSync(path.join(String(dir), "bun-cc"), 0o755);
-    chmodSync(path.join(String(dir), sharedName), 0o777);
+  it.skipIf(isWindows)(
+    "does not place compiler runtime headers in a pre-existing group- and world-writable directory",
+    async () => {
+      using dir = tempDir("bun-ffi-cc-rt-dir-mode", files);
+      const sharedName = `bun-cc-${process.getuid!()}`;
+      for (const name of ["bun-cc", sharedName]) {
+        const headerDir = path.join(String(dir), name);
+        mkdirSync(headerDir, { recursive: true });
+        writeFileSync(path.join(headerDir, "stdbool.h"), plantedHeader);
+      }
+      chmodSync(path.join(String(dir), "bun-cc"), 0o755);
+      chmodSync(path.join(String(dir), sharedName), 0o777);
+
+      const [stdout, stderr, exitCode] = await runFixture(String(dir));
+
+      expect(readFileSync(path.join(String(dir), "bun-cc", "stdbool.h"), "utf8")).toBe(plantedHeader);
+      expect(readFileSync(path.join(String(dir), sharedName, "stdbool.h"), "utf8")).toBe(plantedHeader);
+      expect(stdout).toBe("3\n");
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  it("does not reuse a pre-existing fixed-name bun-cc directory for compiler runtime headers", async () => {
+    using dir = tempDir("bun-ffi-cc-rt-dir-fixed-name", files);
+    const fixedDir = path.join(String(dir), "bun-cc");
+    mkdirSync(fixedDir, { recursive: true });
+    writeFileSync(path.join(fixedDir, "stdbool.h"), plantedHeader);
 
     const [stdout, stderr, exitCode] = await runFixture(String(dir));
 
-    expect(readFileSync(path.join(String(dir), "bun-cc", "stdbool.h"), "utf8")).toBe(plantedHeader);
-    expect(readFileSync(path.join(String(dir), sharedName, "stdbool.h"), "utf8")).toBe(plantedHeader);
+    const staged = readdirSync(String(dir)).filter(
+      name => name !== "bun-cc" && name.includes("bun-cc") && existsSync(path.join(String(dir), name, "stdbool.h")),
+    );
+    expect(staged.length).toBe(1);
+    expect(readFileSync(path.join(String(dir), staged[0], "stdbool.h"), "utf8")).toContain("_STDBOOL_H");
+    expect(readdirSync(fixedDir).sort()).toEqual(["stdbool.h"]);
+    expect(readFileSync(path.join(fixedDir, "stdbool.h"), "utf8")).toBe(plantedHeader);
     expect(stdout).toBe("3\n");
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1087,7 +1087,7 @@ describe("double <-> JSValue conversions", () => {
   });
 });
 
-describe("compiler runtime header directory under BUN_TMPDIR", () => {
+describe.skipIf(isASAN)("compiler runtime header directory under BUN_TMPDIR", () => {
   const plantedHeader = "#define bool int\n#define true 100\n#define false 0\n";
   const files = {
     "sentinel.txt": "sentinel-unchanged\n",

--- a/test/js/bun/http/serve-directory-routes.test.ts
+++ b/test/js/bun/http/serve-directory-routes.test.ts
@@ -10,11 +10,18 @@ const straceEnv = {
   ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
   LSAN_OPTIONS: "detect_leaks=0",
 };
-const straceInjectArgs = ["-o", "/dev/null", "-e", "trace=openat2", "-e", "inject=openat2:error=EPERM:when=1"];
+const straceInjectArgs = (traceFile: string) => [
+  "-o",
+  traceFile,
+  "-e",
+  "trace=openat2",
+  "-e",
+  "inject=openat2:error=EPERM:when=1",
+];
 const canInjectOpenat2Error =
   !!strace &&
   Bun.spawnSync({
-    cmd: [strace, ...straceInjectArgs, bunExe(), "--version"],
+    cmd: [strace, ...straceInjectArgs("/dev/null"), bunExe(), "--version"],
     env: straceEnv,
     stdout: "ignore",
     stderr: "ignore",
@@ -413,13 +420,16 @@ describe("Bun.serve() directory routes", () => {
         server.stop(true);
         console.log(JSON.stringify(out));
       `;
+    const traceFile = join(root, "strace.log");
     await using proc = Bun.spawn({
-      cmd: [strace!, ...straceInjectArgs, bunExe(), "-e", script],
+      cmd: [strace!, ...straceInjectArgs(traceFile), bunExe(), "-e", script],
       env: straceEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const trace = await Bun.file(traceFile).text();
+    expect(trace, stderr).toMatch(/openat2\(.*"escape-rel".*= -1 EPERM .*\(INJECTED\)/);
     expect(stdout.trim(), stderr).toBe(`[[404,""],[404,""],[200,"ok"]]`);
     expect(exitCode).toBe(0);
   });

--- a/test/js/bun/http/serve-directory-routes.test.ts
+++ b/test/js/bun/http/serve-directory-routes.test.ts
@@ -1,8 +1,24 @@
 import { serve, type Server } from "bun";
 import { afterEach, describe, expect, it } from "bun:test";
 import { symlinkSync } from "fs";
-import { isLinux, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { join } from "path";
+
+const strace = isLinux ? Bun.which("strace") : null;
+const straceEnv = {
+  ...bunEnv,
+  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),
+  LSAN_OPTIONS: "detect_leaks=0",
+};
+const straceInjectArgs = ["-o", "/dev/null", "-e", "trace=openat2", "-e", "inject=openat2:error=EPERM:when=1"];
+const canInjectOpenat2Error =
+  !!strace &&
+  Bun.spawnSync({
+    cmd: [strace, ...straceInjectArgs, bunExe(), "--version"],
+    env: straceEnv,
+    stdout: "ignore",
+    stderr: "ignore",
+  }).exitCode === 0;
 
 describe("Bun.serve() directory routes", () => {
   let server: Server | undefined;
@@ -373,6 +389,39 @@ describe("Bun.serve() directory routes", () => {
       expect(await res.text()).not.toContain("SECRET");
       expect(res.status).toBe(404);
     }
+  });
+
+  it.skipIf(!canInjectOpenat2Error)("keeps clamping symlinks to the root after an open error on one path", async () => {
+    using dir = tempDir("serve-dir-open-error", {
+      "secret.txt": "SECRET",
+      "public/ok.txt": "ok",
+    });
+    const root = String(dir);
+    symlinkSync("../secret.txt", join(root, "public", "escape-rel"));
+    symlinkSync(join(root, "secret.txt"), join(root, "public", "escape-abs"));
+
+    const script = `
+        const server = Bun.serve({
+          port: 0,
+          routes: { "/static/*": { dir: ${JSON.stringify(join(root, "public"))} } },
+        });
+        const out = [];
+        for (const p of ["escape-rel", "escape-abs", "ok.txt"]) {
+          const res = await fetch(server.url + "static/" + p);
+          out.push([res.status, await res.text()]);
+        }
+        server.stop(true);
+        console.log(JSON.stringify(out));
+      `;
+    await using proc = Bun.spawn({
+      cmd: [strace!, ...straceInjectArgs, bunExe(), "-e", script],
+      env: straceEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout.trim(), stderr).toBe(`[[404,""],[404,""],[200,"ok"]]`);
+    expect(exitCode).toBe(0);
   });
 
   it("percent-decodes file names", async () => {

--- a/test/js/bun/http/serve-http3.test.ts
+++ b/test/js/bun/http/serve-http3.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { createHash, randomBytes } from "crypto";
+import { createHash, createPrivateKey, randomBytes } from "crypto";
+import { readFileSync } from "fs";
 import { bunEnv, bunExe, isASAN, tempDir, tls } from "harness";
+import { connect, QuicEndpoint } from "node:quic";
 import { join } from "path";
 
 // Native HTTP/3 fetch wrapper. Every request in this file forces
@@ -1300,4 +1302,150 @@ describe("Bun.serve HTTP/3 production", () => {
   // Expect: 100-continue is handled at the uWS layer for both transports
   // (HttpContext.h / Http3Context.h call writeContinue before routing); a
   // curl --expect100-timeout assertion was flaky enough to drop here.
+});
+
+async function h3Exchange(
+  port: number,
+  headers: Record<string, string>,
+  options: Record<string, unknown> = {},
+): Promise<string> {
+  await using endpoint = new QuicEndpoint();
+  const client = await connect(`127.0.0.1:${port}`, {
+    endpoint,
+    servername: "localhost",
+    verifyPeer: "manual",
+    transportParams: { maxIdleTimeout: 5 },
+    onerror() {},
+    ...options,
+  });
+  const outcome = Promise.withResolvers<string>();
+  client.closed.then(
+    () => outcome.resolve("closed"),
+    (err: Error & { code?: string; errorCode?: bigint }) =>
+      outcome.resolve(err?.code === "ERR_QUIC_APPLICATION_ERROR" ? `closed ${err.code} ${err.errorCode}` : "closed"),
+  );
+  client.opened
+    .then(async () => {
+      let status = "";
+      const stream = await client.createBidirectionalStream({
+        headers,
+        onheaders(received: Record<string, string>) {
+          status = received[":status"];
+        },
+      });
+      stream.closed.catch(() => {});
+      let body = "";
+      for await (const batch of stream as AsyncIterable<Uint8Array[]>) {
+        for (const chunk of batch) body += Buffer.from(chunk).toString("latin1");
+      }
+      if (status) outcome.resolve(`${status} ${body}`);
+    })
+    .catch(() => {});
+  const result = await outcome.promise;
+  if (!client.destroyed) client.close().catch(() => {});
+  return result;
+}
+
+const requestHeaders = (path: string, extra: Record<string, string> = {}) => ({
+  ":method": "GET",
+  ":path": path,
+  ":scheme": "https",
+  ":authority": "localhost",
+  ...extra,
+});
+
+describe("Bun.serve HTTP/3 request validation", () => {
+  test("rejects a request whose field value contains CR or LF before the fetch handler runs", async () => {
+    let reachedWithProbe = 0;
+    await using server = Bun.serve({
+      port: 0,
+      tls,
+      http3: true,
+      fetch(req) {
+        if (req.headers.has("x-probe")) reachedWithProbe++;
+        return new Response(String(reachedWithProbe));
+      },
+    });
+
+    const results: Record<string, string> = {};
+    for (const value of ["a\r\nb: c", "a\nb", "a\rb"]) {
+      results[JSON.stringify(value)] = await h3Exchange(server.port, requestHeaders("/", { "x-probe": value }));
+    }
+    results.wellFormed = await h3Exchange(server.port, requestHeaders("/", { "x-probe": "plain" }));
+    results.after = await h3Exchange(server.port, requestHeaders("/"));
+
+    expect(results).toEqual({
+      [JSON.stringify("a\r\nb: c")]: "closed ERR_QUIC_APPLICATION_ERROR 270",
+      [JSON.stringify("a\nb")]: "closed ERR_QUIC_APPLICATION_ERROR 270",
+      [JSON.stringify("a\rb")]: "closed ERR_QUIC_APPLICATION_ERROR 270",
+      wellFormed: "200 1",
+      after: "200 1",
+    });
+  });
+
+  test("request.url falls back to the :path when :authority is not a valid host", async () => {
+    await using server = Bun.serve({
+      port: 0,
+      tls,
+      http3: true,
+      fetch(req) {
+        return new Response(req.url);
+      },
+    });
+
+    const authorities = [
+      "example.com/other",
+      "user@example.com",
+      "example.com#frag",
+      "example.com\\other:8080",
+      "[::1]:3000?q",
+    ];
+    const results: Record<string, string> = {};
+    for (const authority of authorities) {
+      results[authority] = await h3Exchange(server.port, { ...requestHeaders("/index"), ":authority": authority });
+    }
+    results["example.com:8443"] = await h3Exchange(server.port, {
+      ...requestHeaders("/index"),
+      ":authority": "example.com:8443",
+    });
+
+    expect(results).toEqual({
+      "example.com/other": "200 /index",
+      "user@example.com": "200 /index",
+      "example.com#frag": "200 /index",
+      "example.com\\other:8080": "200 /index",
+      "[::1]:3000?q": "200 /index",
+      "example.com:8443": "200 https://example.com:8443/index",
+    });
+  });
+
+  test("requestCert with rejectUnauthorized only serves QUIC clients whose certificate chains to the configured CA", async () => {
+    const keysDir = join(import.meta.dir, "..", "..", "node", "test", "fixtures", "keys");
+    const pem = (name: string) => readFileSync(join(keysDir, name), "utf8");
+    let handled = 0;
+    await using server = Bun.serve({
+      port: 0,
+      tls: {
+        key: pem("agent1-key.pem"),
+        cert: pem("agent1-cert.pem"),
+        ca: pem("ca1-cert.pem"),
+        requestCert: true,
+        rejectUnauthorized: true,
+      },
+      http3: true,
+      fetch() {
+        handled++;
+        return new Response(String(handled));
+      },
+    });
+
+    const clientIdentity = (name: string) => ({
+      keys: [createPrivateKey(pem(`${name}-key.pem`))],
+      certs: [readFileSync(join(keysDir, `${name}-cert.pem`))],
+    });
+    const selfSigned = await h3Exchange(server.port, requestHeaders("/"), clientIdentity("agent2"));
+    const chained = await h3Exchange(server.port, requestHeaders("/"), clientIdentity("agent1"));
+
+    expect({ selfSigned, chained }).toEqual({ selfSigned: "closed", chained: "200 1" });
+  });
 });

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -2,7 +2,7 @@ import type { Socket } from "bun";
 import { connect, fileURLToPath, SocketHandler, spawn } from "bun";
 import { createSocketPair, socketFaultInjection } from "bun:internal-for-testing";
 import { describe, expect, it, jest } from "bun:test";
-import { closeSync } from "fs";
+import { closeSync, readFileSync } from "fs";
 import {
   bunEnv,
   bunExe,
@@ -2815,6 +2815,149 @@ Reo=
       await t.echoed.promise;
       expect(t.received.join("")).toBe("hello-from-server\nping");
     });
+
+    const NODE_TLS_FIXTURES = join(import.meta.dir, "..", "..", "node", "tls", "fixtures");
+    const AGENT1_KEY = readFileSync(join(NODE_TLS_FIXTURES, "agent1-key.pem"), "utf8");
+    const AGENT1_CRT = readFileSync(join(NODE_TLS_FIXTURES, "agent1-cert.pem"), "utf8");
+    const CA1_CRT = readFileSync(join(NODE_TLS_FIXTURES, "ca1-cert.pem"), "utf8");
+    const AGENT1_LOCALHOST_MISMATCH =
+      "Hostname/IP does not match certificate's altnames: Host: localhost. is not cert's CN: agent1";
+
+    async function connectOverUnix(prefix: string, clientTls: Record<string, unknown>) {
+      const dir = tempDir(prefix, {});
+      const sock = join(String(dir), "s.sock");
+      const received: string[] = [];
+      const handshake = Promise.withResolvers<{
+        authorizedArg: boolean;
+        authorizedGetter: boolean;
+        callbackError: string | null;
+        callbackCode: string | null;
+        getterError: string | null;
+        getterCode: string | null;
+      }>();
+      const closed = Promise.withResolvers<void>();
+      const echoed = Promise.withResolvers<void>();
+
+      const server = Bun.listen({
+        unix: sock,
+        tls: { key: AGENT1_KEY, cert: AGENT1_CRT },
+        socket: {
+          open() {},
+          handshake(socket) {
+            socket.write("hello-from-server\n");
+          },
+          data(socket, data) {
+            socket.write(data);
+          },
+          close() {},
+          error() {},
+        },
+      });
+
+      let client: Bun.Socket;
+      try {
+        client = await Bun.connect({
+          unix: sock,
+          tls: clientTls as Bun.TLSOptions,
+          socket: {
+            open() {},
+            handshake(socket, authorized, authorizationError) {
+              handshake.resolve({
+                authorizedArg: authorized,
+                authorizedGetter: socket.authorized,
+                callbackError: authorizationError?.message ?? null,
+                callbackCode: (authorizationError as any)?.code ?? null,
+                getterError: socket.getAuthorizationError()?.message ?? null,
+                getterCode: (socket.getAuthorizationError() as any)?.code ?? null,
+              });
+            },
+            data(_socket, data) {
+              received.push(data.toString());
+              if (received.join("").includes("ping")) echoed.resolve();
+            },
+            close() {
+              closed.resolve();
+            },
+            error(_socket, err) {
+              handshake.reject(err);
+              echoed.reject(err);
+            },
+            connectError(_socket, err) {
+              handshake.reject(err);
+              closed.reject(err);
+              echoed.reject(err);
+            },
+          },
+        });
+      } catch (e) {
+        server.stop(true);
+        dir[Symbol.dispose]();
+        throw e;
+      }
+
+      return {
+        server,
+        client,
+        received,
+        handshake,
+        closed,
+        echoed,
+        [Symbol.dispose]() {
+          client.end();
+          server.stop(true);
+          dir[Symbol.dispose]();
+        },
+      };
+    }
+
+    it.skipIf(isWindows)(
+      "verifies the server certificate against localhost over a unix socket when no serverName is given",
+      async () => {
+        using t = await connectOverUnix("uds-tls-identity-reject", { ca: CA1_CRT });
+        expect(await t.handshake.promise).toEqual({
+          authorizedArg: false,
+          authorizedGetter: false,
+          callbackError: AGENT1_LOCALHOST_MISMATCH,
+          callbackCode: "ERR_TLS_CERT_ALTNAME_INVALID",
+          getterError: AGENT1_LOCALHOST_MISMATCH,
+          getterCode: "ERR_TLS_CERT_ALTNAME_INVALID",
+        });
+        await t.closed.promise;
+        expect(t.received).toEqual([]);
+        expect((t.client.getAuthorizationError() as any)?.code).toBe("ERR_TLS_CERT_ALTNAME_INVALID");
+
+        using ok = await connectOverUnix("uds-tls-identity-match", { ca: CA1_CRT, serverName: "agent1" });
+        expect(await ok.handshake.promise).toEqual({
+          authorizedArg: true,
+          authorizedGetter: true,
+          callbackError: null,
+          callbackCode: null,
+          getterError: null,
+          getterCode: null,
+        });
+        ok.client.write("ping");
+        await ok.echoed.promise;
+        expect(ok.received.join("")).toBe("hello-from-server\nping");
+      },
+    );
+
+    it.skipIf(isWindows)(
+      "reports authorized=false over a unix socket with rejectUnauthorized: false when the certificate does not name localhost",
+      async () => {
+        using t = await connectOverUnix("uds-tls-identity-keep", { ca: CA1_CRT, rejectUnauthorized: false });
+        expect(await t.handshake.promise).toEqual({
+          authorizedArg: false,
+          authorizedGetter: false,
+          callbackError: AGENT1_LOCALHOST_MISMATCH,
+          callbackCode: "ERR_TLS_CERT_ALTNAME_INVALID",
+          getterError: AGENT1_LOCALHOST_MISMATCH,
+          getterCode: "ERR_TLS_CERT_ALTNAME_INVALID",
+        });
+        t.client.write("ping");
+        await t.echoed.promise;
+        expect(t.received.join("")).toBe("hello-from-server\nping");
+      },
+    );
   });
 
   // https://github.com/oven-sh/bun/issues/33754

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -230,16 +230,18 @@ describe("bunshell", () => {
       TestBuilder.command`FOO=bar && echo a$${name}b`.stdout(`a$FOOb\n`).runAsTest("inside a word");
 
       test("does not extend a preceding variable name", async () => {
-        const { stdout, exitCode } = await $`FOOBAR=long && FOO=short && echo $FOO${"BAR"}`.env({ ...bunEnv });
+        const { stdout, stderr, exitCode } = await $`FOOBAR=long && FOO=short && echo $FOO${"BAR"}`.env({ ...bunEnv });
+        expect(stderr.toString()).toBe("");
         expect(stdout.toString()).toBe("shortBAR\n");
         expect(exitCode).toBe(0);
       });
 
       test("does not name a variable from the environment", async () => {
-        const { stdout, exitCode } = await $`echo $${"SHELL_TEST_SECRET"}`.env({
+        const { stdout, stderr, exitCode } = await $`echo $${"SHELL_TEST_SECRET"}`.env({
           ...bunEnv,
           SHELL_TEST_SECRET: "hunter2",
         });
+        expect(stderr.toString()).toBe("");
         expect(stdout.toString()).toBe("$SHELL_TEST_SECRET\n");
         expect(exitCode).toBe(0);
       });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -223,6 +223,28 @@ describe("bunshell", () => {
       TestBuilder.command`FOO=bar && echo ${shellvar}`.stdout(`$FOO\n`).runAsTest("no quotes");
     });
 
+    describe("interpolated value after a literal $ stays literal", async () => {
+      const name = "FOO";
+      TestBuilder.command`FOO=bar && echo $${name}`.stdout(`$FOO\n`).runAsTest("no quotes");
+      TestBuilder.command`FOO=bar && echo "$${name}"`.stdout(`$FOO\n`).runAsTest("double quotes");
+      TestBuilder.command`FOO=bar && echo a$${name}b`.stdout(`a$FOOb\n`).runAsTest("inside a word");
+
+      test("does not extend a preceding variable name", async () => {
+        const { stdout, exitCode } = await $`FOOBAR=long && FOO=short && echo $FOO${"BAR"}`.env({ ...bunEnv });
+        expect(stdout.toString()).toBe("shortBAR\n");
+        expect(exitCode).toBe(0);
+      });
+
+      test("does not name a variable from the environment", async () => {
+        const { stdout, exitCode } = await $`echo $${"SHELL_TEST_SECRET"}`.env({
+          ...bunEnv,
+          SHELL_TEST_SECRET: "hunter2",
+        });
+        expect(stdout.toString()).toBe("$SHELL_TEST_SECRET\n");
+        expect(exitCode).toBe(0);
+      });
+    });
+
     test("can't escape a js string/obj ref", async () => {
       const shellvar = "$FOO";
       await TestBuilder.command`FOO=bar && echo \\${shellvar}`.stdout(`\\$FOO\n`).run();

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -20,6 +20,7 @@ import { join } from "path";
 import { createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);
+const isRoot = process.getuid?.() === 0;
 
 $.nothrow();
 
@@ -190,6 +191,30 @@ describe("mv", async () => {
         rmSync(dst, { recursive: true, force: true });
       }
     });
+
+    test.skipIf(skip || isRoot)(
+      "unreadable directory across devices fails without creating the destination",
+      async () => {
+        const [src, dst] = crossDevicePair("unreadable");
+        const srcDir = join(src, "tree");
+        try {
+          mkdirSync(srcDir);
+          writeFileSync(join(srcDir, "a.txt"), "A\n");
+          chmodSync(srcDir, 0o000);
+
+          const r = await $`mv ${srcDir} ${dst}`.quiet();
+          expect(r.stderr.toString()).toBe(`mv: ${join(dst, "tree")}: Permission denied\n`);
+          expect(lstatSync(join(dst, "tree"), { throwIfNoEntry: false })).toBeUndefined();
+          chmodSync(srcDir, 0o700);
+          expect(readFileSync(join(srcDir, "a.txt"), "utf8")).toBe("A\n");
+          expect(r.exitCode).toBe(13);
+        } finally {
+          if (existsSync(srcDir)) chmodSync(srcDir, 0o700);
+          rmSync(src, { recursive: true, force: true });
+          rmSync(dst, { recursive: true, force: true });
+        }
+      },
+    );
 
     test.skipIf(skip)("FIFO across devices fails fast", async () => {
       const [src, dst] = crossDevicePair("fifo");

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -459,8 +459,8 @@ test.concurrent.skipIf(!isLinux || !cc || !mkfifo || !cat)(
       teedIsAllA: true,
       teedLength: 256 * 1024,
       parsed: { exitCode: ENOMEM },
-      stderr: expect.any(String),
-      readerStderr: expect.any(String),
+      stderr: "",
+      readerStderr: "",
       exitCode: 0,
       readerExitCode: 0,
     });

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -228,6 +228,12 @@ const r = await $\`sh -c 'printf AAAA; exec sleep 5' 2> /dev/null\`.quiet().noth
 console.log(JSON.stringify({ exitCode: r.exitCode }));
 `;
 
+const TEE_CHUNK_FIXTURE = /* js */ `
+import { $ } from "bun";
+const r = await $\`sh -c 'printf AAAA; exec sleep 5' 2> /dev/null\`.nothrow();
+console.log(JSON.stringify({ exitCode: r.exitCode }));
+`;
+
 let shimPath: string;
 let dir: ReturnType<typeof tempDir> | undefined;
 
@@ -239,6 +245,7 @@ beforeAll(async () => {
     "both-pipes.js": BOTH_PIPES_FIXTURE,
     "quiet-chunk.js": QUIET_CHUNK_FIXTURE,
     "poll-chunk.js": POLL_CHUNK_FIXTURE,
+    "tee-chunk.js": TEE_CHUNK_FIXTURE,
   });
   shimPath = join(String(dir), "shim.so");
   await using ccProc = Bun.spawn({
@@ -270,11 +277,10 @@ const MODES = [
 // Integer-valued fault knobs; cleared alongside MODES and set through `extraEnv`.
 const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM", "SHELL_RECV_BULK"] as const;
 
-async function expectShellFault(
-  script: string,
+function shimEnv(
   modes: (typeof MODES)[number][],
   extraEnv: Partial<Record<(typeof VALUE_MODES)[number], string>> = {},
-) {
+): Record<string, string | undefined> {
   const existing = bunEnv.LD_PRELOAD;
   const env: Record<string, string | undefined> = {
     ...bunEnv,
@@ -286,6 +292,15 @@ async function expectShellFault(
   for (const m of [...MODES, ...VALUE_MODES]) env[m] = undefined;
   for (const m of modes) env[m] = "1";
   Object.assign(env, extraEnv);
+  return env;
+}
+
+async function expectShellFault(
+  script: string,
+  modes: (typeof MODES)[number][],
+  extraEnv: Partial<Record<(typeof VALUE_MODES)[number], string>> = {},
+) {
+  const env = shimEnv(modes, extraEnv);
   await using proc = Bun.spawn({
     // If the fixture does crash, skip the debug build's slow symbolized
     // backtrace so the failure surfaces as the panic message, not a test
@@ -385,6 +400,69 @@ test.concurrent.skipIf(!isLinux || !cc || !isASAN)(
     await expectShellFault("poll-chunk.js", ["SHELL_RECV_EAGAIN_FIRST"], {
       SHELL_FAIL_EPOLL_FROM: "3",
       SHELL_RECV_BULK: "1",
+    });
+  },
+);
+
+const mkfifo = Bun.which("mkfifo");
+const cat = Bun.which("cat");
+
+test.concurrent.skipIf(!isLinux || !cc || !mkfifo || !cat)(
+  "shell delivers the already-read output and the reader error when the read fails while that output is still queued for stdout",
+  async () => {
+    const fifo = join(String(dir), "tee-chunk.fifo");
+    {
+      await using mk = Bun.spawn({ cmd: [mkfifo!, fifo], env: bunEnv, stdout: "ignore", stderr: "pipe" });
+      const [mkErr, mkExit] = await Promise.all([mk.stderr.text(), mk.exited]);
+      if (mkExit !== 0) throw new Error(`mkfifo failed: ${mkErr}`);
+    }
+
+    await using reader = Bun.spawn({
+      cmd: [cat!, fifo],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "tee-chunk.js", "--debug-crash-handler-use-trace-string"],
+      cwd: String(dir),
+      env: shimEnv(["SHELL_RECV_EAGAIN_FIRST"], { SHELL_FAIL_EPOLL_FROM: "3", SHELL_RECV_BULK: "1" }),
+      stdout: Bun.file(fifo),
+      stderr: "pipe",
+    });
+    const [piped, readerStderr, stderr, exitCode, readerExitCode] = await Promise.all([
+      reader.stdout.text(),
+      reader.stderr.text(),
+      proc.stderr.text(),
+      proc.exited,
+      reader.exited,
+    ]);
+
+    const jsonStart = piped.lastIndexOf("{");
+    const teed = jsonStart === -1 ? piped : piped.slice(0, jsonStart);
+    const line = jsonStart === -1 ? "" : piped.slice(jsonStart).trim();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      parsed = line;
+    }
+    expect({
+      teedIsAllA: teed === Buffer.alloc(teed.length, "A").toString(),
+      teedLength: teed.length,
+      parsed,
+      stderr,
+      readerStderr,
+      exitCode,
+      readerExitCode,
+    }).toEqual({
+      teedIsAllA: true,
+      teedLength: 256 * 1024,
+      parsed: { exitCode: ENOMEM },
+      stderr: expect.any(String),
+      readerStderr: expect.any(String),
+      exitCode: 0,
+      readerExitCode: 0,
     });
   },
 );

--- a/test/js/bun/shell/yield.test.ts
+++ b/test/js/bun/shell/yield.test.ts
@@ -97,7 +97,7 @@ describe("yield", async () => {
         { stdout: "write_failed_again\n", exitCode: 0 },
         { stdout: "next\n", exitCode: 0 },
       ]),
-      stderr: expect.any(String),
+      stderr: "",
       exitCode: 0,
     });
   });

--- a/test/js/bun/shell/yield.test.ts
+++ b/test/js/bun/shell/yield.test.ts
@@ -62,4 +62,43 @@ describe("yield", async () => {
       { stdout: "f1\nf2\nf3\nf4\n", exitCode: 0 },
     );
   });
+
+  test.if(isLinux)("builtin cat completing on a synchronous write error leaves the shell usable", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        import { $ } from "bun";
+        $.nothrow();
+        const results = [];
+        for (const run of [
+          () => $\`echo hello | cat > /dev/full || echo write_failed\`,
+          () => $\`echo again | cat > /dev/full || echo write_failed_again\`,
+          () => $\`echo next | cat\`,
+        ]) {
+          const r = await run().quiet();
+          results.push({ stdout: r.stdout.toString(), exitCode: r.exitCode });
+        }
+        console.log(JSON.stringify(results));
+        `,
+        "--debug-crash-handler-use-trace-string",
+      ],
+      env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ result: stdout.trim(), stderr, exitCode }).toEqual({
+      result: JSON.stringify([
+        { stdout: "write_failed\n", exitCode: 0 },
+        { stdout: "write_failed_again\n", exitCode: 0 },
+        { stdout: "next\n", exitCode: 0 },
+      ]),
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  });
 });

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -63,6 +63,74 @@ test("CryptoHasher throws on non-latin1 algorithm names instead of crashing", ()
   expect(() => new Bun.CryptoHasher("ünïcode")).toThrow(/Unsupported algorithm/);
 });
 
+test("static hash requires the algorithm to be a string primitive", () => {
+  const expected = expect.objectContaining({
+    name: "TypeError",
+    code: "ERR_INVALID_ARG_TYPE",
+    message: "Expected string",
+  });
+  // @ts-expect-error
+  expect(() => Bun.CryptoHasher.hash(new String("sha256"), "hello")).toThrow(expected);
+  expect(() =>
+    Bun.CryptoHasher.hash(
+      // @ts-expect-error
+      {
+        toString() {
+          return "sha256";
+        },
+      },
+      "hello",
+    ),
+  ).toThrow(expected);
+  // @ts-expect-error
+  expect(() => Bun.CryptoHasher.hash(123, "hello")).toThrow(expected);
+  // @ts-expect-error
+  expect(() => Bun.CryptoHasher.hash(undefined, "hello")).toThrow(expected);
+  // @ts-expect-error
+  expect(() => Bun.CryptoHasher.hash(null, "hello")).toThrow(expected);
+  expect(Bun.CryptoHasher.hash("sha256", "hello", "hex")).toBe(
+    "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+  );
+});
+
+test("update rejects a hasher that was digested while its input was being converted", async () => {
+  const source = /* js */ `
+    const results = {};
+    for (const name of ["SHA1", "SHA224", "SHA256", "SHA384", "SHA512", "SHA512_256", "MD4", "MD5"]) {
+      const hasher = new Bun[name]();
+      hasher.update("hello");
+      const input = new String("world");
+      input.toString = () => {
+        hasher.digest();
+        return "world";
+      };
+      try {
+        hasher.update(input);
+        results[name] = "no throw";
+      } catch (e) {
+        results[name] = { code: e.code, message: e.message };
+      }
+    }
+    console.log(JSON.stringify(results));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", source],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const expected: Record<string, { code: string; message: string }> = {};
+  for (const name of ["SHA1", "SHA224", "SHA256", "SHA384", "SHA512", "SHA512_256", "MD4", "MD5"]) {
+    expected[name] = {
+      code: "ERR_INVALID_STATE",
+      message: `${name} hasher already digested, create a new instance to update`,
+    };
+  }
+  expect(JSON.parse(stdout.trim())).toEqual(expected);
+  expect(exitCode).toBe(0);
+});
+
 test("static hash reads the input buffer only after every argument has been coerced", async () => {
   const source = /* js */ `
     const emptyDigest = Bun.CryptoHasher.hash("sha256", new Uint8Array(0), "hex");

--- a/test/js/bun/util/bun-cryptohasher.test.ts
+++ b/test/js/bun/util/bun-cryptohasher.test.ts
@@ -127,6 +127,7 @@ test("update rejects a hasher that was digested while its input was being conver
       message: `${name} hasher already digested, create a new instance to update`,
     };
   }
+  expect(stderr).toBe("");
   expect(JSON.parse(stdout.trim())).toEqual(expected);
   expect(exitCode).toBe(0);
 });

--- a/test/js/node/buffer.test.js
+++ b/test/js/node/buffer.test.js
@@ -2,6 +2,7 @@ import { Buffer, SlowBuffer, isAscii, isUtf8, kMaxLength } from "buffer";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { bunEnv, bunExe, gc, isASAN, isDebug, nodeExe, withoutAggressiveGC } from "harness";
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import os from "node:os";
 import { join } from "node:path";
 import vm from "node:vm";
@@ -4168,6 +4169,56 @@ describe("*Write methods with NaN/invalid offset and length", () => {
       expect(written).toBeLessThanOrEqual(buf.length);
     });
   }
+});
+
+describe("utf8 write of a string ending in a lone high surrogate", () => {
+  function hasAVX2() {
+    if (process.arch !== "x64" || process.platform !== "linux") return false;
+    try {
+      return readFileSync("/proc/cpuinfo", "utf8").includes(" avx2");
+    } catch {
+      return false;
+    }
+  }
+
+  it("leaves bytes past the target range untouched for every SIMD block alignment", async () => {
+    const src = `
+      const lines = [];
+      for (let k = 0; k < 16; k++) {
+        const s = Buffer.alloc(k, "a").toString() + "\\u4e00" + Buffer.alloc(26 - k, "a").toString() + "\\ud800";
+        const viaLength = Buffer.alloc(48, "b");
+        const n = viaLength.write(s, 0, 29, "utf8");
+        const viaSubarray = Buffer.alloc(48, "b");
+        const m = viaSubarray.subarray(0, 29).write(s, "utf8");
+        const viaUtf8Write = Buffer.alloc(48, "b");
+        const w = viaUtf8Write.utf8Write(s, 0, 29);
+        const viaFill = Buffer.alloc(48, "b");
+        viaFill.fill(s, 0, 29, "utf8");
+        lines.push([k, n, m, w, viaLength.toString("hex"), viaSubarray.toString("hex"), viaUtf8Write.toString("hex"), viaFill.toString("hex")].join(" "));
+      }
+      console.log(lines.join("\\n"));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", src],
+      env: hasAVX2() ? { ...bunEnv, SIMDUTF_FORCE_IMPLEMENTATION: "haswell" } : bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const expected = [];
+    for (let k = 0; k < 16; k++) {
+      const hex = Buffer.concat([
+        Buffer.alloc(k, "a"),
+        Buffer.from([0xe4, 0xb8, 0x80]),
+        Buffer.alloc(26 - k, "a"),
+        Buffer.alloc(19, "b"),
+      ]).toString("hex");
+      expected.push([k, 29, 29, 29, hex, hex, hex, hex].join(" "));
+    }
+    expect(stdout.trim()).toBe(expected.join("\n"));
+    expect(exitCode).toBe(0);
+  });
 });
 
 // These raw prototype methods come straight from Node's C++ bindings, not from the

--- a/test/js/node/http2/node-http2-upgrade.test.mts
+++ b/test/js/node/http2/node-http2-upgrade.test.mts
@@ -11,11 +11,13 @@
  *   node --experimental-strip-types --test test/js/node/http2/node-http2-upgrade.test.ts
  */
 import assert from "node:assert";
+import { once } from "node:events";
 import fs from "node:fs";
 import http2 from "node:http2";
 import net from "node:net";
 import path from "node:path";
 import { afterEach, describe, test } from "node:test";
+import tls from "node:tls";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -413,6 +415,52 @@ describe("HTTP/2 upgrade — independent upgrade per connection", () => {
     srv.netServer.close();
   });
 });
+
+describe("HTTP/2 upgrade — server TLS options", () => {
+  test("minVersion from createSecureServer is enforced on injected connections", async () => {
+    const h2Server = http2.createSecureServer({ ...TLS, minVersion: "TLSv1.3" }, (_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    h2Server.on("error", () => {});
+    h2Server.on("sessionError", () => {});
+
+    const netServer = net.createServer(socket => {
+      socket.on("error", () => {});
+      h2Server.emit("connection", socket);
+    });
+    const port = await new Promise<number>(resolve => {
+      netServer.listen(0, "127.0.0.1", () => resolve((netServer.address() as net.AddressInfo).port));
+    });
+
+    try {
+      const okClient = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false, ALPNProtocols: ["h2"] });
+      okClient.on("error", () => {});
+      await once(okClient, "secureConnect");
+      const negotiated = { protocol: okClient.getProtocol(), alpn: okClient.alpnProtocol };
+      okClient.destroy();
+      assert.deepStrictEqual(negotiated, { protocol: "TLSv1.3", alpn: "h2" });
+
+      const oldClient = tls.connect({
+        host: "127.0.0.1",
+        port,
+        rejectUnauthorized: false,
+        ALPNProtocols: ["h2"],
+        maxVersion: "TLSv1.2",
+      });
+      const outcome = await new Promise<{ secureConnect: boolean; protocol: string | null }>(resolve => {
+        oldClient.on("secureConnect", () => resolve({ secureConnect: true, protocol: oldClient.getProtocol() }));
+        oldClient.on("error", () => resolve({ secureConnect: false, protocol: null }));
+        oldClient.on("close", () => resolve({ secureConnect: false, protocol: null }));
+      });
+      oldClient.destroy();
+      assert.deepStrictEqual(outcome, { secureConnect: false, protocol: null });
+    } finally {
+      netServer.close();
+    }
+  });
+});
+
 if (typeof Bun !== "undefined") {
   describe("Node.js compatibility", () => {
     test("tests should run on node.js", async () => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -216,6 +216,104 @@ console.log("survived", require("./late.js"));`,
     expect(exitCode).toBe(0);
   });
 
+  const compileCacheEnv = { ...bunEnv };
+  delete compileCacheEnv.NODE_COMPILE_CACHE;
+  delete compileCacheEnv.NODE_COMPILE_CACHE_PORTABLE;
+  delete compileCacheEnv.NODE_DISABLE_COMPILE_CACHE;
+
+  let compileCacheTagPromise;
+  function compileCacheTag() {
+    return (compileCacheTagPromise ??= (async () => {
+      using dir = tempDir("compile-cache-tag", {});
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const m = require("module");
+           m.enableCompileCache({ directory: ${JSON.stringify(String(dir))} });
+           process.stdout.write(require("path").basename(m.getCompileCacheDir()));`,
+        ],
+        env: compileCacheEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout, stderr).toMatch(/^v/);
+      expect(exitCode).toBe(0);
+      return stdout;
+    })());
+  }
+
+  test.skipIf(isWindows)(
+    "enableCompileCache only uses a cache directory owned by the current user and not writable by others",
+    async () => {
+      using dir = tempDir("compile-cache-owner", {});
+      const base = path.join(String(dir), "cc");
+      const leaf = path.join(base, await compileCacheTag());
+      fs.mkdirSync(leaf, { recursive: true });
+      fs.chmodSync(leaf, 0o777);
+      const code = `
+        const fs = require("fs");
+        const Module = require("module");
+        const first = Module.enableCompileCache({ directory: ${JSON.stringify(base)} });
+        fs.chmodSync(${JSON.stringify(leaf)}, 0o755);
+        const second = Module.enableCompileCache({ directory: ${JSON.stringify(base)} });
+        process.stdout.write(JSON.stringify({ first, second, dir: Module.getCompileCacheDir() }));
+      `;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", code],
+        env: compileCacheEnv,
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout, stderr).toStartWith("{");
+      const { FAILED, ENABLED } = Module.constants.compileCacheStatus;
+      expect(JSON.parse(stdout)).toEqual({
+        first: {
+          status: FAILED,
+          message:
+            "Cannot use cache directory: it must be owned by the current user and not be group- or world-writable",
+        },
+        second: { status: ENABLED, directory: base },
+        dir: leaf,
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test.skipIf(isWindows)("enableCompileCache does not follow a symlink at the cache directory leaf", async () => {
+    using dir = tempDir("compile-cache-symlink-leaf", {});
+    const base = path.join(String(dir), "cc");
+    const target = path.join(String(dir), "elsewhere");
+    fs.mkdirSync(base, { recursive: true });
+    fs.mkdirSync(target, { recursive: true });
+    fs.chmodSync(target, 0o755);
+    const leaf = path.join(base, await compileCacheTag());
+    fs.symlinkSync(target, leaf);
+    const code = `
+      const Module = require("module");
+      const result = Module.enableCompileCache({ directory: ${JSON.stringify(base)} });
+      process.stdout.write(JSON.stringify({ result, dir: String(Module.getCompileCacheDir()) }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: compileCacheEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stdout, stderr).toStartWith("{");
+    const { FAILED } = Module.constants.compileCacheStatus;
+    expect(JSON.parse(stdout)).toEqual({
+      result: {
+        status: FAILED,
+        message: expect.stringMatching(/^Cannot create cache directory: (ENOTDIR|ELOOP)$/),
+      },
+      dir: "undefined",
+    });
+    expect(fs.readdirSync(target)).toEqual([]);
+    expect(fs.lstatSync(leaf).isSymbolicLink()).toBe(true);
+    expect(exitCode).toBe(0);
+  });
+
   test("native module functions are not constructors", () => {
     // Constructing these used to crash instead of throwing.
     const compile = new Module("not-a-constructor-test")._compile;

--- a/test/js/node/quic/quic-sni.test.ts
+++ b/test/js/node/quic/quic-sni.test.ts
@@ -205,16 +205,19 @@ test("connect() with the default verifyPeer refuses an unverifiable certificate 
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout.trim()).toBe(
-    JSON.stringify({
+  expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+    stdout: JSON.stringify({
       code: "ERR_QUIC_TRANSPORT_ERROR",
       message:
         "QUIC transport error 0: Peer certificate validation failed: unable to get local issuer certificate [UNABLE_TO_GET_ISSUER_CERT_LOCALLY]",
       echoed: [1],
       streamsReceived: 1,
     }),
-  );
-  expect(exitCode).toBe(0);
+    stderr: expect.stringContaining(
+      "ExperimentalWarning: quic is an experimental feature and might change at any time",
+    ),
+    exitCode: 0,
+  });
 });

--- a/test/js/node/quic/quic-sni.test.ts
+++ b/test/js/node/quic/quic-sni.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import { createPrivateKey, X509Certificate } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -140,4 +141,80 @@ test("opened reports the X509 code name for validationErrorCode", async () => {
     code: "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
     reason: "unable to get local issuer certificate",
   });
+});
+
+test("connect() with the default verifyPeer refuses an unverifiable certificate before a pending stream reaches the server", async () => {
+  const script = `
+    import { createPrivateKey } from "node:crypto";
+    import { readFileSync } from "node:fs";
+    import { connect, listen } from "node:quic";
+
+    const cert = readFileSync(${JSON.stringify(join(keysDir, "agent1-cert.pem"))});
+    const key = createPrivateKey(readFileSync(${JSON.stringify(join(keysDir, "agent1-key.pem"))}));
+
+    let streamsReceived = 0;
+    const server = await listen(
+      serverSession => {
+        serverSession.onerror = () => {};
+        serverSession.opened.catch(() => {});
+        serverSession.closed.catch(() => {});
+        serverSession.onstream = stream => {
+          streamsReceived++;
+          stream.closed.catch(() => {});
+          try {
+            const w = stream.writer;
+            w.writeSync(new Uint8Array([streamsReceived]));
+            w.endSync();
+          } catch {}
+        };
+      },
+      { sni: { "*": { keys: [key], certs: [cert] } }, alpn: ["quic-test"] },
+    );
+
+    const session = await connect(server.address, { alpn: "quic-test", servername: "agent1" });
+    session.onerror = () => {};
+    const openedError = session.opened.then(() => undefined, e => e);
+    const closedSettled = session.closed.then(() => {}, () => {});
+    const pending = await session.createBidirectionalStream({ body: Buffer.alloc(1024, 97) });
+    pending.closed.catch(() => {});
+    const err = await openedError;
+    await closedSettled;
+
+    const probe = await connect(server.address, { alpn: "quic-test", servername: "agent1", verifyPeer: "manual" });
+    probe.onerror = () => {};
+    await probe.opened;
+    const stream = await probe.createBidirectionalStream({ body: Buffer.from("probe") });
+    const chunks = [];
+    for await (const batch of stream) chunks.push(...batch);
+    await probe.close();
+
+    console.log(
+      JSON.stringify({
+        code: err?.code,
+        message: err?.message,
+        echoed: [...Buffer.concat(chunks)],
+        streamsReceived,
+      }),
+    );
+    process.exit(0);
+  `;
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim()).toBe(
+    JSON.stringify({
+      code: "ERR_QUIC_TRANSPORT_ERROR",
+      message:
+        "QUIC transport error 0: Peer certificate validation failed: unable to get local issuer certificate [UNABLE_TO_GET_ISSUER_CERT_LOCALLY]",
+      echoed: [1],
+      streamsReceived: 1,
+    }),
+  );
+  expect(exitCode).toBe(0);
 });

--- a/test/js/node/quic/quic-stream.test.ts
+++ b/test/js/node/quic/quic-stream.test.ts
@@ -179,3 +179,55 @@ describe("HTTP/3 header encoding", () => {
     expect(Object.keys(seen[0])).not.toContain("authorization");
   });
 });
+
+describe("verifyClient", () => {
+  test("a server requiring a client certificate never surfaces streams from a client that presented none", async () => {
+    let announcedStreams = 0;
+    const serverClosed = Promise.withResolvers<any>();
+    await using server = await listen(
+      (serverSession: any) => {
+        serverSession.onerror = () => {};
+        serverSession.onstream = (stream: any) => {
+          announcedStreams++;
+          stream.closed.catch(() => {});
+        };
+        serverSession.closed.then(
+          () => serverClosed.resolve(undefined),
+          (err: any) => serverClosed.resolve(err),
+        );
+      },
+      {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        alpn: ["quic-test"],
+        verifyClient: true,
+        transportParams: { maxIdleTimeout: 5 },
+      },
+    );
+
+    const client = await connect(server.address, {
+      alpn: "quic-test",
+      servername: "localhost",
+      verifyPeer: "manual",
+      transportParams: { maxIdleTimeout: 5 },
+      onerror() {},
+    });
+    const clientClosed = client.closed.then(
+      () => undefined,
+      (err: any) => err,
+    );
+    client.opened.catch(() => {});
+    const stream = await client.createBidirectionalStream({ body: new TextEncoder().encode("early body") });
+    stream.closed.catch(() => {});
+
+    const [serverError, clientError] = await Promise.all([serverClosed.promise, clientClosed]);
+    expect({
+      announcedStreams,
+      server: serverError?.code,
+      client: clientError?.code,
+    }).toEqual({
+      announcedStreams: 0,
+      server: "ERR_QUIC_TRANSPORT_ERROR",
+      client: "ERR_QUIC_TRANSPORT_ERROR",
+    });
+  });
+});

--- a/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
+++ b/test/js/node/tls/node-tls-connect-hostname-verification.test.ts
@@ -1,7 +1,8 @@
+import { tls as ipSanCert } from "harness";
 import assert from "node:assert";
 import { once } from "node:events";
 import fs from "node:fs";
-import type { AddressInfo } from "node:net";
+import net, { type AddressInfo } from "node:net";
 import path from "node:path";
 import { describe, test } from "node:test";
 import tls from "node:tls";
@@ -101,6 +102,105 @@ describe("tls.connect hostname verification without explicit servername", () => 
         reject(err);
       });
       assert.strictEqual(await promise, "localhost");
+    });
+  });
+});
+
+const localhostOnlyKey = fs.readFileSync(path.join(fixturesDir, "rsa_private.pem"));
+const localhostOnlyCert = fs.readFileSync(path.join(fixturesDir, "rsa_cert.crt"));
+
+async function withRawSocketTo(
+  serverOptions: tls.TlsOptions,
+  fn: (raw: net.Socket, port: number) => Promise<void>,
+): Promise<void> {
+  const server = tls.createServer(serverOptions, c => {
+    c.on("error", () => {});
+    c.end();
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  try {
+    const port = (server.address() as AddressInfo).port;
+    const raw = net.connect(port, "127.0.0.1");
+    raw.on("error", () => {});
+    await once(raw, "connect");
+    try {
+      await fn(raw, port);
+    } finally {
+      raw.destroy();
+    }
+  } finally {
+    server.close();
+  }
+}
+
+describe("tls.connect over an existing socket verifies the certificate against options.host", () => {
+  test("passes the IP from options.host to checkServerIdentity", async () => {
+    await withRawSocketTo({ key: ipSanCert.key, cert: ipSanCert.cert }, async raw => {
+      const { promise, resolve, reject } = Promise.withResolvers<{
+        calledWith: string | undefined;
+        authorized: boolean;
+      }>();
+      let calledWith: string | undefined;
+      const socket = tls.connect({
+        socket: raw,
+        host: "127.0.0.1",
+        ca: ipSanCert.cert,
+        checkServerIdentity(hostname, cert) {
+          calledWith = hostname;
+          return tls.checkServerIdentity(hostname, cert);
+        },
+      });
+      socket.on("secureConnect", () => {
+        resolve({ calledWith, authorized: socket.authorized });
+        socket.destroy();
+      });
+      socket.on("error", err => {
+        socket.destroy();
+        reject(err);
+      });
+      const result = await promise;
+      assert.deepStrictEqual(result, { calledWith: "127.0.0.1", authorized: true });
+    });
+  });
+
+  test("rejects a certificate that is only valid for localhost when options.host is an IP", async () => {
+    await withRawSocketTo({ key: localhostOnlyKey, cert: localhostOnlyCert }, async raw => {
+      const { promise, resolve, reject } = Promise.withResolvers<NodeJS.ErrnoException>();
+      const socket = tls.connect({ socket: raw, host: "127.0.0.1", ca: localhostOnlyCert }, () => {
+        const detail = { authorized: socket.authorized, authorizationError: socket.authorizationError };
+        socket.destroy();
+        reject(Object.assign(new Error("secureConnect fired for a certificate that does not cover the IP"), detail));
+      });
+      socket.on("error", err => {
+        socket.destroy();
+        resolve(err as NodeJS.ErrnoException);
+      });
+      const err = await promise;
+      assert.strictEqual(err.code, "ERR_TLS_CERT_ALTNAME_INVALID");
+      assert.strictEqual(
+        err.message,
+        "Hostname/IP does not match certificate's altnames: IP: 127.0.0.1 is not in the cert's list: ",
+      );
+    });
+  });
+
+  test("reports authorized=false for a localhost-only certificate when options.host is an IP and rejectUnauthorized=false", async () => {
+    await withRawSocketTo({ key: localhostOnlyKey, cert: localhostOnlyCert }, async raw => {
+      const { promise, resolve, reject } = Promise.withResolvers<{
+        authorized: boolean;
+        authorizationError: unknown;
+      }>();
+      const socket = tls.connect({ socket: raw, host: "127.0.0.1", ca: localhostOnlyCert, rejectUnauthorized: false });
+      socket.on("secureConnect", () => {
+        resolve({ authorized: socket.authorized, authorizationError: socket.authorizationError });
+        socket.destroy();
+      });
+      socket.on("error", err => {
+        socket.destroy();
+        reject(err);
+      });
+      assert.deepStrictEqual(await promise, { authorized: false, authorizationError: "ERR_TLS_CERT_ALTNAME_INVALID" });
     });
   });
 });

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -812,6 +812,119 @@ it("leaves socket.authorized false unless a client certificate was requested and
   }
 });
 
+it("keeps socket.authorized false when a client without a certificate resumes a TLSv1.3 session", async () => {
+  type Verdict = { reused: boolean; authorized: boolean; authorizationError: unknown };
+  const verdicts: Verdict[] = [];
+  const twoConnections = Promise.withResolvers<void>();
+  await using server = createServer(
+    { ...COMMON_CERT, requestCert: true, rejectUnauthorized: false, minVersion: "TLSv1.3", maxVersion: "TLSv1.3" },
+    socket => {
+      verdicts.push({
+        reused: socket.isSessionReused(),
+        authorized: socket.authorized,
+        authorizationError: socket.authorizationError,
+      });
+      if (verdicts.length === 2) twoConnections.resolve();
+      socket.on("data", () => {});
+      socket.write("x");
+    },
+  );
+  server.on("error", twoConnections.reject);
+  server.on("tlsClientError", twoConnections.reject);
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+  const opts = {
+    port,
+    host: "127.0.0.1",
+    servername: "localhost",
+    ca: COMMON_CERT.cert,
+    minVersion: "TLSv1.3",
+    maxVersion: "TLSv1.3",
+  } as const;
+
+  const first = connect(opts);
+  first.on("error", twoConnections.reject);
+  first.on("data", () => {});
+  const [session] = await once(first, "session");
+  const firstProtocol = first.getProtocol();
+  first.destroy();
+  await once(first, "close");
+  expect(firstProtocol).toBe("TLSv1.3");
+  expect(Buffer.isBuffer(session)).toBe(true);
+
+  const second = connect({ ...opts, session });
+  second.on("error", twoConnections.reject);
+  second.on("data", () => {});
+  await once(second, "secureConnect");
+  const clientReused = second.isSessionReused();
+  await twoConnections.promise;
+  second.destroy();
+  await once(second, "close");
+
+  expect(clientReused).toBe(true);
+  expect(verdicts).toEqual([
+    { reused: false, authorized: false, authorizationError: "UNABLE_TO_GET_ISSUER_CERT" },
+    { reused: true, authorized: false, authorizationError: "UNABLE_TO_GET_ISSUER_CERT" },
+  ]);
+});
+
+it("keeps socket.authorized false when a client without a certificate resumes a TLSv1.3 session against an https server", async () => {
+  type Verdict = { authorized: boolean | undefined; authorizationError: unknown };
+  const verdicts: Verdict[] = [];
+  await using server = https.createServer(
+    { ...COMMON_CERT, requestCert: true, rejectUnauthorized: false },
+    (req, res) => {
+      const socket = req.socket as TLSSocket;
+      verdicts.push({ authorized: socket.authorized, authorizationError: socket.authorizationError });
+      const body = String(socket.authorized);
+      res.writeHead(200, { "Connection": "close", "Content-Length": String(body.length) });
+      res.end(body);
+    },
+  );
+  await once(server.listen(0, "127.0.0.1"), "listening");
+  const { port } = server.address() as AddressInfo;
+  const opts = {
+    port,
+    host: "127.0.0.1",
+    servername: "localhost",
+    ca: COMMON_CERT.cert,
+    minVersion: "TLSv1.3",
+    maxVersion: "TLSv1.3",
+  } as const;
+
+  async function request(session?: Buffer) {
+    const socket = connect(session ? { ...opts, session } : opts);
+    const gotSession = session ? Promise.resolve([session]) : once(socket, "session");
+    const closed = once(socket, "close");
+    const chunks: Buffer[] = [];
+    socket.on("data", chunk => chunks.push(chunk));
+    await once(socket, "secureConnect");
+    const protocol = socket.getProtocol();
+    const reused = socket.isSessionReused();
+    socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    const [ticket] = await gotSession;
+    await closed;
+    const body = Buffer.concat(chunks).toString("latin1").split("\r\n\r\n")[1];
+    return { protocol, reused, ticket: ticket as Buffer, body };
+  }
+
+  const first = await request();
+  expect(first.protocol).toBe("TLSv1.3");
+  expect(first.reused).toBe(false);
+  expect(first.body).toBe("false");
+  expect(Buffer.isBuffer(first.ticket)).toBe(true);
+
+  const second = await request(first.ticket);
+  expect(second.protocol).toBe("TLSv1.3");
+  expect(second.reused).toBe(true);
+  expect(second.body).toBe("false");
+
+  expect(verdicts).toEqual([
+    { authorized: false, authorizationError: "UNABLE_TO_GET_ISSUER_CERT" },
+    { authorized: false, authorizationError: "UNABLE_TO_GET_ISSUER_CERT" },
+  ]);
+});
+
 it("keeps req.socket.authorized false for an unverified client after the server socket shuts down", async () => {
   type Verdict = [boolean | undefined, string | null | undefined];
   const { promise, resolve, reject } = Promise.withResolvers<{ before: Verdict; after: Verdict }>();

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1461,6 +1461,43 @@ test("*Internal introspection methods are DontEnum on Worker.prototype", () => {
   expect(enumerable).not.toContain("cpuUsageInternal");
 });
 
+test("env: process.env reads in a worker module are evaluated at runtime against the worker's env", async () => {
+  using dir = tempDir("worker-threads-env-runtime-reads", {
+    "worker.js": `
+      const { parentPort } = require("node:worker_threads");
+      const inherited = process.env.BUN_TEST_WT_ENV_KEY;
+      process.env["BUN_TEST_WT_ENV_KEY"] = "assigned-in-worker";
+      const assigned = process.env.BUN_TEST_WT_ENV_KEY;
+      parentPort.postMessage({ inherited, assigned, nodeEnv: process.env.NODE_ENV });
+    `,
+    "main.js": `
+      const { Worker } = require("node:worker_threads");
+      const worker = new Worker(require("node:path").join(__dirname, "worker.js"), {
+        env: { BUN_TEST_WT_ENV_KEY: "from-worker-option", NODE_ENV: "production" },
+      });
+      worker.on("error", err => { console.error(err); process.exit(1); });
+      worker.on("message", msg => {
+        console.log(JSON.stringify(msg));
+        worker.terminate();
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "main.js"],
+    env: { ...bunEnv, BUN_TEST_WT_ENV_KEY: "from-parent-process", NODE_ENV: "development" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(JSON.parse(stdout)).toEqual({
+    inherited: "from-worker-option",
+    assigned: "assigned-in-worker",
+    nodeEnv: "production",
+  });
+  expect(exitCode).toBe(0);
+});
+
 describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide one", () => {
   async function run(mode: string) {
     const proc = Bun.spawn({

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1490,12 +1490,15 @@ test("env: process.env reads in a worker module are evaluated at runtime against
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(JSON.parse(stdout)).toEqual({
-    inherited: "from-worker-option",
-    assigned: "assigned-in-worker",
-    nodeEnv: "production",
+  expect({
+    message: stdout ? JSON.parse(stdout) : stdout,
+    stderr: exitCode === 0 ? "" : stderr,
+    exitCode,
+  }).toEqual({
+    message: { inherited: "from-worker-option", assigned: "assigned-in-worker", nodeEnv: "production" },
+    stderr: "",
+    exitCode: 0,
   });
-  expect(exitCode).toBe(0);
 });
 
 describe("env: SHARE_ENV shares the spawning thread's env, not a process-wide one", () => {

--- a/test/js/node/zlib/zlib-handle-bounds-check.test.ts
+++ b/test/js/node/zlib/zlib-handle-bounds-check.test.ts
@@ -377,6 +377,27 @@ describe.concurrent("zlib native handle driven outside the zlib.ts lifecycle", (
       exitCode: 0,
     });
   });
+
+  test.concurrent("zlib: params() after a buffered writeSync keeps the pending input in the stream", async () => {
+    expect(
+      await run(
+        `const d = zlib.createDeflate({ level: 0 });
+         const h = d._handle;
+         const ws = d._writeState;
+         const input = Buffer.alloc(1024, 97);
+         const out1 = Buffer.alloc(4096);
+         h.writeSync(zlib.constants.Z_NO_FLUSH, input, 0, input.length, out1, 0, out1.length);
+         const head = Buffer.from(out1.subarray(0, out1.length - ws[0]));
+         out1.buffer.transfer();
+         h.params(1, 0);
+         const out2 = Buffer.alloc(4096);
+         h.writeSync(zlib.constants.Z_FINISH, null, 0, 0, out2, 0, out2.length);
+         const tail = out2.subarray(0, out2.length - ws[0]);
+         const result = zlib.inflateSync(Buffer.concat([head, tail]));
+         console.log(head.length + " " + result.length + " " + result.equals(input));`,
+      ),
+    ).toEqual({ stdout: "2 1024 true", exitCode: 0 });
+  });
 });
 
 describe.concurrent("zlib native handle argument validation", () => {

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -495,15 +495,6 @@ describe("SQL adapter environment variable precedence", () => {
       expect(() => new SQL({ adapter: "postgres", hostname: "h", ssl: "bogus" as any })).toThrow("sslmode");
       expect(() => new SQL("postgres://u@h:5432/db?sslmode=require", { tls: "bogus" as any })).toThrow("sslmode");
     });
-
-    test.each([123, 45n, Symbol("tls")])("tls: %p throws ERR_INVALID_ARG_TYPE", value => {
-      expect(() => new SQL({ adapter: "postgres", hostname: "h", tls: value as any })).toThrow(
-        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-      );
-      expect(() => new SQL("postgres://u@h:5432/db?sslmode=require", { ssl: value as any })).toThrow(
-        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
-      );
-    });
   });
 
   describe("tls.caFile", () => {

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -394,6 +394,36 @@ describe("SQL adapter environment variable precedence", () => {
       const options = new SQL({ adapter: "postgres", hostname: "h", tls: true });
       expect(options.options.sslMode).toBe(4); // SSLMode.verify_full
     });
+
+    test.each([{ tls: false }, { ssl: false }, { tls: false, ssl: false }])(
+      "an explicit %p disables a mode selected by PGSSLMODE or the URL",
+      tlsOptions => {
+        process.env.PGSSLMODE = "require";
+
+        const fromEnv = new SQL({ adapter: "postgres", hostname: "h", ...tlsOptions });
+        expect(fromEnv.options.sslMode).toBe(0);
+        expect(fromEnv.options.tls).toBeUndefined();
+
+        const fromUrl = new SQL("postgres://u@h:5432/db?sslmode=verify-full&ssl=true", tlsOptions);
+        expect(fromUrl.options.query).toBe("");
+        expect(fromUrl.options.sslMode).toBe(0);
+        expect(fromUrl.options.tls).toBeUndefined();
+      },
+    );
+
+    test("an unset tls option keeps the mode selected by PGSSLMODE", () => {
+      process.env.PGSSLMODE = "require";
+
+      const options = new SQL({ adapter: "postgres", hostname: "h", tls: undefined });
+      expect(options.options.sslMode).toBe(2);
+      expect(options.options.tls).toEqual({ serverName: "h" });
+    });
+
+    test("a tls object alongside ssl: false still requests an encrypted connection", () => {
+      const options = new SQL({ adapter: "postgres", hostname: "h", tls: {}, ssl: false });
+      expect(options.options.sslMode).toBe(2);
+      expect(options.options.tls).toBeTypeOf("object");
+    });
   });
 
   describe("TLS settings from the connection URL query string", () => {
@@ -439,13 +469,31 @@ describe("SQL adapter environment variable precedence", () => {
       },
     );
 
-    test("?ssl=false does not clear a mode selected by PGSSLMODE", () => {
-      process.env.PGSSLMODE = "verify-full";
+    test.each(["postgres://u@h:5432/db?ssl=false", "postgres://u@h:5432/db?tls=0"])(
+      "%s disables a mode selected by PGSSLMODE",
+      url => {
+        process.env.PGSSLMODE = "verify-full";
 
-      const options = new SQL("postgres://u@h:5432/db?ssl=false");
+        const options = new SQL(url);
+        expect(options.options.query).toBe("");
+        expect(options.options.sslMode).toBe(0);
+        expect(options.options.tls).toBeUndefined();
+      },
+    );
+
+    test("an empty ?tls= is treated as unset and keeps the mode selected by PGSSLMODE", () => {
+      process.env.PGSSLMODE = "require";
+
+      const options = new SQL("postgres://u@h:5432/db?tls=");
       expect(options.options.query).toBe("");
-      expect(options.options.sslMode).toBe(4);
+      expect(options.options.sslMode).toBe(2);
       expect(options.options.tls).toEqual({ serverName: "h" });
+    });
+
+    test("an explicit tls option takes priority over ?ssl=false", () => {
+      const options = new SQL("postgres://u@h:5432/db?ssl=false", { tls: true });
+      expect(options.options.sslMode).toBe(2);
+      expect(options.options.tls).toBe(true);
     });
 
     test.each(["mysql://u:p@h/db?ssl=bogus", 'mysql://u:p@h/db?ssl={"rejectUnauthorized":true}'])(

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -451,7 +451,7 @@ describe("SQL adapter environment variable precedence", () => {
         const options = new SQL(url);
         expect(options.options.query).toBe("");
         expect(options.options.sslMode).toBe(2);
-        expect(options.options.tls).toBeTruthy();
+        expect(options.options.tls).toEqual({ serverName: "h" });
 
         const withExplicitTls = new SQL(url, { tls: { ca: "x" } });
         expect(withExplicitTls.options.sslMode).toBe(4);

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -396,6 +396,140 @@ describe("SQL adapter environment variable precedence", () => {
     });
   });
 
+  describe("TLS settings from the connection URL query string", () => {
+    test.each([
+      ["mysql://u:p@h/db?ssl-mode=DISABLED", 0, undefined],
+      ["mysql://u:p@h/db?ssl_mode=preferred", 1, { serverName: "h" }],
+      ["mysql://u:p@h/db?ssl-mode=REQUIRED", 2, { serverName: "h" }],
+      ["mysql://u:p@h/db?ssl-mode=VERIFY_CA", 3, { serverName: "h" }],
+      ["mysql://u:p@h/db?ssl-mode=VERIFY_IDENTITY", 4, { serverName: "h" }],
+      ["postgres://u@h:5432/db?ssl=prefer", 1, { serverName: "h" }],
+      ["postgres://u@h:5432/db?ssl=require", 2, { serverName: "h" }],
+      ["postgres://u@h:5432/db?tls=verify-ca", 3, { serverName: "h" }],
+      ["postgres://u@h:5432/db?ssl=verify-full", 4, { serverName: "h" }],
+    ] as const)("%s selects sslMode %d", (url, expectedMode, expectedTls) => {
+      const options = new SQL(url);
+      expect(options.options.hostname).toBe("h");
+      expect(options.options.query).toBe("");
+      expect(options.options.sslMode).toBe(expectedMode);
+      expect(options.options.tls).toEqual(expectedTls);
+    });
+
+    test.each(["mysql://u:p@h/db?ssl=true", "mysql://u:p@h/db?ssl=1", "postgres://u@h:5432/db?tls=TRUE"])(
+      "%s requires an encrypted connection",
+      url => {
+        const options = new SQL(url);
+        expect(options.options.query).toBe("");
+        expect(options.options.sslMode).toBe(2);
+        expect(options.options.tls).toBeTruthy();
+
+        const withExplicitTls = new SQL(url, { tls: { ca: "x" } });
+        expect(withExplicitTls.options.sslMode).toBe(4);
+        expect(withExplicitTls.options.tls).toEqual({ ca: "x", serverName: "h" });
+      },
+    );
+
+    test.each(["mysql://u:p@h/db?ssl=false", "mysql://u:p@h/db?ssl=0", "postgres://u@h:5432/db?tls="])(
+      "%s leaves TLS disabled and is not forwarded as a startup parameter",
+      url => {
+        const options = new SQL(url);
+        expect(options.options.query).toBe("");
+        expect(options.options.sslMode).toBe(0);
+        expect(options.options.tls).toBeUndefined();
+      },
+    );
+
+    test("?ssl=false does not clear a mode selected by PGSSLMODE", () => {
+      process.env.PGSSLMODE = "verify-full";
+
+      const options = new SQL("postgres://u@h:5432/db?ssl=false");
+      expect(options.options.query).toBe("");
+      expect(options.options.sslMode).toBe(4);
+      expect(options.options.tls).toEqual({ serverName: "h" });
+    });
+
+    test.each(["mysql://u:p@h/db?ssl=bogus", 'mysql://u:p@h/db?ssl={"rejectUnauthorized":true}'])(
+      "%s throws for an unrecognised ssl value",
+      url => {
+        expect(() => new SQL(url)).toThrow("sslmode");
+      },
+    );
+  });
+
+  describe("tls/ssl option given as an sslmode string", () => {
+    test.each([
+      ["disable", 0, undefined],
+      ["allow", 1, { serverName: "h" }],
+      ["prefer", 1, { serverName: "h" }],
+      ["require", 2, { serverName: "h" }],
+      ["verify-ca", 3, { serverName: "h" }],
+      ["verify-full", 4, { serverName: "h" }],
+    ] as const)("ssl: %p selects sslMode %d", (mode, expectedMode, expectedTls) => {
+      const options = new SQL({ adapter: "postgres", hostname: "h", ssl: mode as any });
+      expect(options.options.sslMode).toBe(expectedMode);
+      expect(options.options.tls).toEqual(expectedTls);
+    });
+
+    test("tls: 'verify-full' is accepted for the mysql adapter", () => {
+      const options = new SQL({ adapter: "mysql", hostname: "h", tls: "verify-full" as any });
+      expect(options.options.adapter).toBe("mysql");
+      expect(options.options.sslMode).toBe(4);
+      expect(options.options.tls).toEqual({ serverName: "h" });
+    });
+
+    test("ssl: 'verify-full' takes priority over URL ?sslmode=require", () => {
+      const options = new SQL("postgres://u@h:5432/db?sslmode=require", { ssl: "verify-full" as any });
+      expect(options.options.sslMode).toBe(4);
+      expect(options.options.tls).toEqual({ serverName: "h" });
+    });
+
+    test("ssl: 'verify-ca' takes priority over PGSSLMODE=require", () => {
+      process.env.PGSSLMODE = "require";
+
+      const options = new SQL({ adapter: "postgres", hostname: "h", ssl: "verify-ca" as any });
+      expect(options.options.sslMode).toBe(3);
+      expect(options.options.tls).toEqual({ serverName: "h" });
+    });
+
+    test("an unrecognised ssl string throws", () => {
+      expect(() => new SQL({ adapter: "postgres", hostname: "h", ssl: "bogus" as any })).toThrow("sslmode");
+      expect(() => new SQL("postgres://u@h:5432/db?sslmode=require", { tls: "bogus" as any })).toThrow("sslmode");
+    });
+
+    test.each([123, 45n, Symbol("tls")])("tls: %p throws ERR_INVALID_ARG_TYPE", value => {
+      expect(() => new SQL({ adapter: "postgres", hostname: "h", tls: value as any })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+      expect(() => new SQL("postgres://u@h:5432/db?sslmode=require", { ssl: value as any })).toThrow(
+        expect.objectContaining({ code: "ERR_INVALID_ARG_TYPE" }),
+      );
+    });
+  });
+
+  describe("tls.caFile", () => {
+    test("tls: { caFile } enables certificate verification like tls: { ca }", () => {
+      using dir = tempDir("sql-tls-cafile", { "ca.pem": "" });
+      const caFile = `${dir}/ca.pem`;
+
+      const options = new SQL({ adapter: "postgres", hostname: "h", tls: { caFile } });
+      expect(options.options.sslMode).toBe(4);
+      expect(options.options.tls).toEqual({ caFile, serverName: "h" });
+
+      const mysqlOptions = new SQL("mysql://u:p@h/db", { tls: { caFile } });
+      expect(mysqlOptions.options.adapter).toBe("mysql");
+      expect(mysqlOptions.options.sslMode).toBe(4);
+      expect(mysqlOptions.options.tls).toEqual({ caFile, serverName: "h" });
+
+      const optedOut = new SQL({ adapter: "postgres", hostname: "h", tls: { caFile, rejectUnauthorized: false } });
+      expect(optedOut.options.sslMode).toBe(2);
+      expect(optedOut.options.tls).toMatchObject({ caFile, rejectUnauthorized: false });
+
+      const fromUrl = new SQL("postgres://u@h:5432/db?sslmode=verify-ca", { tls: { caFile } });
+      expect(fromUrl.options.sslMode).toBe(3);
+      expect(fromUrl.options.tls).toEqual({ caFile, serverName: "h" });
+    });
+  });
+
   describe("Adapter-Protocol Validation", () => {
     test("should work with explicit adapter and URL without protocol", () => {
       const options = new SQL("user:pass@host:3306/db", { adapter: "mysql" });

--- a/test/js/sql/postgres-datarow-overrun.test.ts
+++ b/test/js/sql/postgres-datarow-overrun.test.ts
@@ -16,6 +16,7 @@
 // ERR_POSTGRES_INVALID_MESSAGE instead.
 import { SQL } from "bun";
 import { afterAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
 import {
   listeningServer,
   pgAuthenticationOk,
@@ -140,6 +141,35 @@ test("postgres: DataRow whose cell exactly fills the message still decodes", asy
   } finally {
     await db.close({ timeout: 0 }).catch(() => {});
   }
+});
+
+test("postgres: column names that are not valid UTF-8 decode to U+FFFD and the last duplicate column wins", async () => {
+  const fieldMeta = oneField.subarray(2);
+  simpleReply = [
+    pgRaw(
+      "T",
+      Buffer.concat([Buffer.from([0, 2]), Buffer.from([0x80, 0]), fieldMeta, Buffer.from([0x81, 0]), fieldMeta]),
+    ),
+    pgDataRow([Buffer.from("first"), Buffer.from("second")]),
+    pgCommandComplete("SELECT 1"),
+    pgReadyForQuery(),
+  ];
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const db = new Bun.SQL({ url: process.env.PGURL, max: 1 });
+       const rows = await db\`select n\`.simple();
+       console.log(rows.length, JSON.stringify(Object.keys(rows[0])), JSON.stringify(rows[0]));
+       await db.close({ timeout: 0 });`,
+    ],
+    env: { ...bunEnv, PGURL: `postgres://u@127.0.0.1:${simple.port}/db` },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr }).toEqual({ stdout: `1 ["�"] {"�":"second"}\n`, stderr: expect.any(String) });
+  expect(exitCode).toBe(0);
 });
 
 // --- ParameterDescription (extended-protocol path) -------------------------

--- a/test/js/sql/postgres-error-then-datarow.test.ts
+++ b/test/js/sql/postgres-error-then-datarow.test.ts
@@ -36,3 +36,92 @@ test("postgres: DataRow arriving after ErrorResponse is discarded, not routed to
     stderr: expect.any(String),
   });
 }, 30_000);
+
+test("postgres: a failing simple query leaves an unrelated cached prepared statement in place", async () => {
+  const wireFrames = JSON.stringify(path.join(import.meta.dir, "wire-frames.ts"));
+  const script = `
+    import { SQL } from "bun";
+    import {
+      listeningServer,
+      pgAuthenticationOk,
+      pgBindComplete,
+      pgErrorResponse,
+      pgParameterDescription,
+      pgParseComplete,
+      pgRaw,
+      pgReadFrontendMessages,
+      pgReadyForQuery,
+    } from ${wireFrames};
+
+    const parses = [];
+    const { port, server } = await listeningServer(socket => {
+      let startup = true;
+      let buffered = Buffer.alloc(0);
+      socket.on("data", data => {
+        if (startup) {
+          startup = false;
+          socket.write(Buffer.concat([pgAuthenticationOk(), pgReadyForQuery()]));
+          return;
+        }
+        buffered = Buffer.concat([buffered, data]);
+        const out = [];
+        buffered = pgReadFrontendMessages(buffered, (type, body) => {
+          switch (String.fromCharCode(type)) {
+            case "P":
+              parses.push(body.subarray(0, body.indexOf(0)).toString("latin1"));
+              out.push(pgParseComplete());
+              break;
+            case "D":
+              out.push(pgParameterDescription([]), pgRaw("n", Buffer.alloc(0)));
+              break;
+            case "B":
+              out.push(pgBindComplete());
+              break;
+            case "E":
+              out.push(pgRaw("I", Buffer.alloc(0)));
+              break;
+            case "S":
+              out.push(pgReadyForQuery());
+              break;
+            case "Q":
+              out.push(pgErrorResponse({ S: "ERROR", C: "42601", M: "syntax error" }), pgReadyForQuery());
+              break;
+          }
+        });
+        if (out.length) socket.write(Buffer.concat(out));
+      });
+      socket.on("error", () => {});
+    });
+
+    const sql = new SQL({ url: "postgres://u@127.0.0.1:" + port + "/db", max: 1, idleTimeout: 5, connectionTimeout: 5 });
+    const first = await sql\`\`;
+    const failed = await sql.unsafe("x").then(
+      () => "resolved",
+      e => e.code,
+    );
+    const second = await sql\`\`;
+    const third = await sql\`\`;
+    console.log(JSON.stringify({ first, failed, second, third, parses }));
+    await sql.close({ timeout: 0 });
+    await new Promise(resolve => server.close(() => resolve()));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: 25_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({
+    stdout: stdout.trim(),
+    exitCode,
+    signalCode: proc.signalCode,
+    stderr,
+  }).toEqual({
+    stdout: JSON.stringify({ first: [], failed: "ERR_POSTGRES_SYNTAX_ERROR", second: [], third: [], parses: ["P$0"] }),
+    exitCode: 0,
+    signalCode: null,
+    stderr: expect.any(String),
+  });
+}, 30_000);

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -7,6 +7,7 @@ import {
   mysqlColumnDefinition,
   mysqlHandshakeV10,
   mysqlLenencInt,
+  mysqlLenencStr,
   mysqlOkPacket,
   mysqlRawPacket,
   mysqlReadPackets,
@@ -115,6 +116,26 @@ if (isDockerEnabled()) {
           );
           expect(err).toEqual({ code: "ERR_MYSQL_OVERFLOW" });
         });
+
+        test("returns column values that span more than one wire packet intact", async () => {
+          await using db = new SQL({ ...getOptions(), max: 1 });
+
+          for (const n of [0xffffff - 6, 2 * 0xffffff + 10]) {
+            const [row] = await db`select repeat('a', ${n}) as s`;
+            expect(typeof row.s).toBe("string");
+            expect(row.s.length).toBe(n);
+            expect(row.s === Buffer.alloc(n, "a").toString()).toBe(true);
+          }
+
+          for (const n of [0xffffff - 4, 0xffffff + 85]) {
+            const [row] = await db.unsafe("select repeat('a', " + n + ") as s");
+            expect(typeof row.s).toBe("string");
+            expect(row.s.length).toBe(n);
+            expect(row.s === Buffer.alloc(n, "a").toString()).toBe(true);
+          }
+
+          expect(await db`select 1 as x`).toEqual([{ x: 1 }]);
+        }, 60_000);
 
         let sql: SQL;
         const password = image.image === "mysql_plain" ? "" : "bun";
@@ -1276,3 +1297,88 @@ test("MySQL: binary TIME with a very large days field formats without integer wr
     await new Promise<void>(r => server.close(() => r()));
   }
 });
+
+test("MySQL: a row split across several maximum-size wire packets is reassembled into one value", async () => {
+  const COM_QUERY = 0x03;
+  const MYSQL_TYPE_VAR_STRING = 0xfd;
+  const MAX_PACKET_PAYLOAD = 0xffffff;
+  const lengths = [MAX_PACKET_PAYLOAD + 85, 2 * MAX_PACKET_PAYLOAD + 10, MAX_PACKET_PAYLOAD - 4, 300];
+
+  function framePayload(startSeq: number, payload: Buffer): { packets: Buffer[]; nextSeq: number } {
+    const packets: Buffer[] = [];
+    let seq = startSeq;
+    let offset = 0;
+    while (true) {
+      const chunk = payload.subarray(offset, offset + MAX_PACKET_PAYLOAD);
+      packets.push(mysqlRawPacket(seq++, chunk));
+      offset += chunk.length;
+      if (chunk.length < MAX_PACKET_PAYLOAD) break;
+    }
+    return { packets, nextSeq: seq };
+  }
+
+  const framing = lengths.map(n => framePayload(3, mysqlLenencStr(Buffer.alloc(n, "a"))).packets.length);
+  expect(framing).toEqual([2, 3, 2, 1]);
+
+  const { server, port } = await listeningServer(socket => {
+    let buffered = Buffer.alloc(0);
+    let authed = false;
+    let queryIndex = 0;
+    socket.write(mysqlHandshakeV10());
+    socket.on("data", chunk => {
+      buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+        if (!authed) {
+          authed = true;
+          socket.write(mysqlOkPacket(seq + 1));
+          return;
+        }
+        if (payload[0] !== COM_QUERY || queryIndex >= lengths.length) {
+          socket.end();
+          return;
+        }
+        const { packets, nextSeq } = framePayload(3, mysqlLenencStr(Buffer.alloc(lengths[queryIndex++], "a")));
+        socket.write(
+          Buffer.concat([
+            mysqlRawPacket(1, mysqlLenencInt(1)),
+            mysqlColumnDefinition(2, { name: "s", type: MYSQL_TYPE_VAR_STRING }),
+            ...packets,
+            mysqlOkPacket(nextSeq, 0xfe),
+          ]),
+        );
+      });
+    });
+    socket.on("error", () => {});
+  });
+
+  try {
+    const fixture = /* js */ `
+      const { SQL } = require("bun");
+      const sql = new SQL({ url: "mysql://root@127.0.0.1:${port}/db", max: 1 });
+      const out = [];
+      for (let i = 0; i < ${lengths.length}; i++) {
+        const rows = await sql\`select s\`.simple();
+        out.push(rows.map(r => [typeof r.s, r.s.length, r.s === Buffer.alloc(r.s.length, "a").toString()]));
+      }
+      console.log(JSON.stringify(out));
+      await sql.close().catch(() => {});
+      process.exit(0);
+    `;
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 60_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect({ stderr, stdout: stdout.trim() }).toEqual({
+      stderr: expect.any(String),
+      stdout: JSON.stringify(lengths.map(n => [["string", n, true]])),
+    });
+    expect(exitCode).toBe(0);
+  } finally {
+    await new Promise<void>(r => server.close(() => r()));
+  }
+}, 90_000);

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -353,6 +353,59 @@ describe("Ed25519", () => {
       expect(privateKey.algorithm!.namedCurve).toBe(undefined);
     });
   });
+
+  describe("importKey", () => {
+    it("rejects a 64-byte JWK d whose trailing half is not the public key derived from the seed", async () => {
+      const { publicKey, privateKey } = (await crypto.subtle.generateKey("Ed25519", true, [
+        "sign",
+        "verify",
+      ])) as CryptoKeyPair;
+      const jwk = await crypto.subtle.exportKey("jwk", privateKey);
+      const seed = Buffer.from(jwk.d!, "base64url");
+      const pub = Buffer.from(jwk.x!, "base64url");
+      expect(seed.byteLength).toBe(32);
+      expect(pub.byteLength).toBe(32);
+
+      const outcome = (d: Buffer) =>
+        crypto.subtle.importKey("jwk", { ...jwk, d: d.toString("base64url") }, "Ed25519", true, ["sign"]).then(
+          key => (key instanceof CryptoKey ? "imported" : "other"),
+          e => `${e.name}: ${e.message}`,
+        );
+
+      expect({
+        mismatchedTrailingHalf: await outcome(Buffer.concat([seed, Buffer.alloc(32, 0)])),
+        oneBitOffTrailingHalf: await outcome(
+          Buffer.concat([seed, Buffer.from(pub.map((b, i) => (i === 0 ? b ^ 1 : b)))]),
+        ),
+        seedOnly: await outcome(seed),
+        seedWithDerivedPublicKey: await outcome(Buffer.concat([seed, pub])),
+      }).toEqual({
+        mismatchedTrailingHalf: "DataError: Invalid keyData",
+        oneBitOffTrailingHalf: "DataError: Invalid keyData",
+        seedOnly: "imported",
+        seedWithDerivedPublicKey: "imported",
+      });
+
+      const data = new TextEncoder().encode("hello ed25519");
+      const consistent = await crypto.subtle.importKey(
+        "jwk",
+        { ...jwk, d: Buffer.concat([seed, pub]).toString("base64url") },
+        "Ed25519",
+        true,
+        ["sign"],
+      );
+      const reexported = await crypto.subtle.exportKey("jwk", consistent);
+      expect({ d: reexported.d, x: reexported.x }).toEqual({ d: jwk.d, x: jwk.x });
+      expect(
+        await crypto.subtle.verify("Ed25519", publicKey, await crypto.subtle.sign("Ed25519", consistent, data), data),
+      ).toBe(true);
+
+      const cloned = structuredClone(privateKey);
+      expect(
+        await crypto.subtle.verify("Ed25519", publicKey, await crypto.subtle.sign("Ed25519", cloned, data), data),
+      ).toBe(true);
+    });
+  });
 });
 
 describe("ChaCha20-Poly1305 and AKP review fixes", () => {

--- a/test/js/web/crypto/web-crypto.test.ts
+++ b/test/js/web/crypto/web-crypto.test.ts
@@ -400,10 +400,11 @@ describe("Ed25519", () => {
         await crypto.subtle.verify("Ed25519", publicKey, await crypto.subtle.sign("Ed25519", consistent, data), data),
       ).toBe(true);
 
-      const cloned = structuredClone(privateKey);
-      expect(
-        await crypto.subtle.verify("Ed25519", publicKey, await crypto.subtle.sign("Ed25519", cloned, data), data),
-      ).toBe(true);
+      for (const cloned of [structuredClone(privateKey), structuredClone(consistent)]) {
+        expect(
+          await crypto.subtle.verify("Ed25519", publicKey, await crypto.subtle.sign("Ed25519", cloned, data), data),
+        ).toBe(true);
+      }
     });
   });
 });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -1,6 +1,6 @@
 import { AnyFunction, serve, ServeOptions, Server, sleep, TCPSocketListener } from "bun";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
-import { chmodSync, rmSync, writeFileSync } from "fs";
+import { chmodSync, closeSync, ftruncateSync, openSync, rmSync, writeFileSync } from "fs";
 import {
   bunEnv,
   bunExe,
@@ -16,6 +16,7 @@ import {
   isWindows,
   rss,
   runFixtureMaxRSS,
+  tempDir,
   tls,
   tmpdirSync,
   withoutAggressiveGC,
@@ -3383,3 +3384,89 @@ it("the idle timer is an absolute deadline for the response header block (not re
     await new Promise<void>(r => server.close(() => r()));
   }
 }, 60_000);
+
+it.skipIf(isWindows)("sends the exact Content-Length for a file body of 100 GB", async () => {
+  using dir = tempDir("fetch-large-file-body", { "large.bin": "" });
+  const path = join(String(dir), "large.bin");
+  const size = 100_000_000_000;
+  const fd = openSync(path, "r+");
+  try {
+    ftruncateSync(fd, size);
+  } finally {
+    closeSync(fd);
+  }
+  expect(Bun.file(path).size).toBe(size);
+
+  const { promise: headPromise, resolve: resolveHead } = Promise.withResolvers<string>();
+  let received = "";
+  let headComplete = false;
+  using listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data(socket, chunk) {
+        if (headComplete) return;
+        received += chunk.toString("latin1");
+        const end = received.indexOf("\r\n\r\n");
+        if (end !== -1) {
+          headComplete = true;
+          resolveHead(received.slice(0, end));
+          socket.end();
+        }
+      },
+    },
+  });
+
+  const controller = new AbortController();
+  const result = fetch(`http://${listener.hostname}:${listener.port}/upload`, {
+    method: "PUT",
+    body: Bun.file(path),
+    signal: controller.signal,
+  }).then(
+    () => null,
+    e => e,
+  );
+
+  const head = await headPromise;
+  controller.abort();
+  await result;
+
+  const contentLength = head
+    .split("\r\n")
+    .find(line => line.toLowerCase().startsWith("content-length:"))
+    ?.slice("content-length:".length)
+    .trim();
+  expect(contentLength).toBe(String(size));
+});
+
+it("verbose fetch logging prints [redacted] in place of Authorization credentials", async () => {
+  using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      return new Response(req.headers.get("authorization") ?? "");
+    },
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const res = await fetch(process.env.SERVER_URL, { headers: { Authorization: "Bearer sekret-token" } });
+       console.log(await res.text());`,
+    ],
+    env: { ...bunEnv, BUN_CONFIG_VERBOSE_FETCH: "1", SERVER_URL: server.url.href },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("Bearer sekret-token\n");
+  const authorizationLines = stderr.split(/\r?\n/).flatMap(line => {
+    const match = /^(?:\[fetch\])?\s*>?\s*authorization:(.*)$/i.exec(line);
+    return match ? [match[1].trim()] : [];
+  });
+  expect(authorizationLines).toEqual(["Bearer [redacted]"]);
+  expect(stderr).not.toContain("sekret-token");
+  expect(exitCode).toBe(0);
+});

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -676,6 +676,55 @@ describe.concurrent("fetch-tls", () => {
     });
   });
 
+  it("deleting process.env.NODE_TLS_REJECT_UNAUTHORIZED restores certificate verification and later assignments still apply", async () => {
+    using server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      tls: CERT_EXPIRED,
+      fetch() {
+        return new Response("Hello World");
+      },
+    });
+    const script = `
+      const url = process.env.SERVER;
+      async function attempt() {
+        try {
+          const res = await fetch(url, { keepalive: false });
+          return await res.text();
+        } catch (e) {
+          return e.code;
+        }
+      }
+      const out = [];
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+      out.push(await attempt());
+      delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+      out.push(String(process.env.NODE_TLS_REJECT_UNAUTHORIZED));
+      out.push(await attempt());
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+      out.push(await attempt());
+      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "1";
+      out.push(await attempt());
+      console.log(JSON.stringify(out));
+    `;
+    const { NODE_TLS_REJECT_UNAUTHORIZED: _, ...env } = bunEnv as Record<string, string | undefined>;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...env, SERVER: `https://127.0.0.1:${server.port}` },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout.trim())).toEqual([
+      "Hello World",
+      "undefined",
+      "CERT_HAS_EXPIRED",
+      "Hello World",
+      "CERT_HAS_EXPIRED",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+
   it("fetch timeout works on tls", async () => {
     using server = Bun.serve({
       tls: validTls,

--- a/test/js/web/fetch/fetch.tls.test.ts
+++ b/test/js/web/fetch/fetch.tls.test.ts
@@ -676,54 +676,70 @@ describe.concurrent("fetch-tls", () => {
     });
   });
 
-  it("deleting process.env.NODE_TLS_REJECT_UNAUTHORIZED restores certificate verification and later assignments still apply", async () => {
-    using server = Bun.serve({
-      port: 0,
-      hostname: "127.0.0.1",
-      tls: CERT_EXPIRED,
-      fetch() {
-        return new Response("Hello World");
-      },
-    });
-    const script = `
-      const url = process.env.SERVER;
-      async function attempt() {
-        try {
-          const res = await fetch(url, { keepalive: false });
-          return await res.text();
-        } catch (e) {
-          return e.code;
+  for (const mode of ["main thread", "SHARE_ENV worker"]) {
+    it(`delete process.env.NODE_TLS_REJECT_UNAUTHORIZED restores certificate verification (${mode})`, async () => {
+      using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        tls: CERT_EXPIRED,
+        fetch() {
+          return new Response("Hello World");
+        },
+      });
+      const steps = `
+        async function attempt() {
+          try {
+            const res = await fetch(process.env.SERVER, { keepalive: false });
+            return await res.text();
+          } catch (e) {
+            return e.code;
+          }
         }
-      }
-      const out = [];
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-      out.push(await attempt());
-      delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
-      out.push(String(process.env.NODE_TLS_REJECT_UNAUTHORIZED));
-      out.push(await attempt());
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-      out.push(await attempt());
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "1";
-      out.push(await attempt());
-      console.log(JSON.stringify(out));
-    `;
-    const { NODE_TLS_REJECT_UNAUTHORIZED: _, ...env } = bunEnv as Record<string, string | undefined>;
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: { ...env, SERVER: `https://127.0.0.1:${server.port}` },
-      stdout: "pipe",
-      stderr: "pipe",
+        async function run() {
+          const out = [];
+          process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+          out.push(await attempt());
+          delete process.env.NODE_TLS_REJECT_UNAUTHORIZED;
+          out.push(String(process.env.NODE_TLS_REJECT_UNAUTHORIZED));
+          out.push(await attempt());
+          process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
+          out.push(await attempt());
+          process.env.NODE_TLS_REJECT_UNAUTHORIZED = "1";
+          out.push(await attempt());
+          return out;
+        }
+      `;
+      const script =
+        mode === "SHARE_ENV worker"
+          ? `
+        const { Worker, SHARE_ENV } = require("worker_threads");
+        const worker = new Worker(
+          ${JSON.stringify(steps + `run().then(out => require("worker_threads").parentPort.postMessage(out));`)},
+          { eval: true, env: SHARE_ENV },
+        );
+        worker.on("message", out => console.log(JSON.stringify(out)));
+        worker.on("error", e => { console.error(e); process.exit(1); });
+        worker.on("exit", code => { if (code !== 0) process.exit(code); });
+      `
+          : steps + `console.log(JSON.stringify(await run()));`;
+      const { NODE_TLS_REJECT_UNAUTHORIZED: _, ...env } = bunEnv as Record<string, string | undefined>;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: { ...env, SERVER: `https://127.0.0.1:${server.port}` },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stdout ? JSON.parse(stdout) : stderr).toEqual([
+        "Hello World",
+        "undefined",
+        "CERT_HAS_EXPIRED",
+        "Hello World",
+        "CERT_HAS_EXPIRED",
+      ]);
+      expect(exitCode).toBe(0);
     });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(JSON.parse(stdout.trim())).toEqual([
-      "Hello World",
-      "undefined",
-      "CERT_HAS_EXPIRED",
-      "Hello World",
-      "CERT_HAS_EXPIRED",
-    ]);
-    expect(exitCode).toBe(0);
-  });
+  }
 
   it("fetch timeout works on tls", async () => {
     using server = Bun.serve({

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -168,6 +168,41 @@ describe("web worker", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("worker-env: process.env reads inside a worker reflect the worker's own environment at runtime", async () => {
+    using dir = tempDir("worker-env-runtime-reads", {
+      "worker.js": `
+        const inherited = process.env.BUN_TEST_WORKER_ENV_KEY;
+        process.env["BUN_TEST_WORKER_ENV_KEY"] = "assigned-in-worker";
+        const assigned = process.env.BUN_TEST_WORKER_ENV_KEY;
+        postMessage({ inherited, assigned, nodeEnv: process.env.NODE_ENV });
+      `,
+      "main.js": `
+        const worker = new Worker(new URL("./worker.js", import.meta.url).href, {
+          env: { BUN_TEST_WORKER_ENV_KEY: "from-worker-option", NODE_ENV: "production" },
+        });
+        worker.onerror = e => { console.error(e.message); process.exit(1); };
+        worker.onmessage = e => {
+          console.log(JSON.stringify(e.data));
+          worker.terminate();
+        };
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: { ...bunEnv, BUN_TEST_WORKER_ENV_KEY: "from-parent-process", NODE_ENV: "development" },
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(JSON.parse(stdout)).toEqual({
+      inherited: "from-worker-option",
+      assigned: "assigned-in-worker",
+      nodeEnv: "production",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test("worker-env with a lot of properties", done => {
     const obj: any = {};
 


### PR DESCRIPTION
## Summary

A broad robustness and input-handling pass across install, the shell, TLS/QUIC, HTTP/3 serving, the HTTP client, SQL clients, crypto, and a few runtime corners, ahead of the release. Each item below is a small, self-contained behavior change with a regression test in the existing test file for that module. No API is removed.

## Behavior notes, by area

**install**
- Symlink entries in GitHub/git tarballs are written after every file and directory entry (both the streaming and buffered extractors share one implementation), so no later entry is ever created through an archive-provided link; the created tree for well-formed archives is unchanged.
- The streaming extractor keeps its input buffer alive until libarchive has finished with it, including when the tar reader retries past a damaged header block; the end-of-body hand-off between the HTTP thread and the extraction worker happens under the stream lock.
- `workspace:` specifiers are only honored in the root and workspace manifests; a `workspace:` range inside a downloaded package resolves like any other unresolvable range.
- The on-disk and in-memory manifest caches check the stored package name on load, not just the name hash.
- `--trust <pkg>` applies to the packages actually resolved in that package's dependency tree, and the names written to `trustedDependencies` are the same identity `bun install` checks on later runs.
- Git dependencies: a top-level `node_modules` symlink in the checkout is not carried into `node_modules/<pkg>/`, and `.bun-tag` is written without following an existing entry. Committed `node_modules` directories (bundleDependencies) are untouched.
- `bun install --verbose` masks `Authorization`/`Proxy-Authorization` header values and credential-bearing URLs in request logs; bunfig `password` values are redacted in config diagnostics.

**shell**
- Cross-device `mv` opens the source without following a swapped-in link and takes ownership/mode from the opened descriptor.
- `$${value}`: an interpolated value directly after a literal `$` is always passed as data, never joined into a variable name.
- Readers and captured writers stay alive for the whole I/O callback that references them, including when a builtin finishes synchronously on a write error (`cat > /dev/full`, closed pipes).
- `bun run --shell=system` on Windows rejects pass-through arguments that `cmd.exe` would reinterpret.

**TLS / node:tls / node:quic**
- A TLS 1.3 session resumed by a client that never presented a certificate reports `authorized === false` (node:tls, node:https, `Bun.listen`), same as its original handshake.
- `node:quic`: with the default `verifyPeer`, a client whose server certificate does not validate refuses natively before any queued stream data is sent and before peer streams/datagrams are delivered; `session.opened` rejects with the same error as before. Servers with `verifyClient: true` require a client certificate during the handshake.
- `tls.connect({ socket, host: <ip> })` checks the certificate against that IP; `Bun.connect` over `unix:`/`fd:` with `tls` checks against `serverName` or `localhost`.
- `Http2SecureServer` connections injected via `emit('connection')` use the server's full TLS option set (min/max version, ciphers, crl).
- `delete process.env.NODE_TLS_REJECT_UNAUTHORIZED` restores the default and later assignments still take effect.

**Bun.serve / HTTP/3**
- HTTP/3 requests whose header names or values contain CR, LF or NUL are rejected as malformed, matching the HTTP/1.1 parser; `:authority` goes through the same host validation as `Host`.
- With `http3: true`, `tls.requestCert`/`rejectUnauthorized` are enforced on QUIC connections as they are on TCP.
- Linux directory routes keep using `openat2` resolution after an unrelated `EPERM`/`EINVAL`.

**fetch / HTTP client**
- Very large file-backed request bodies send the correct `Content-Length`.

**SQL**
- MySQL: result rows larger than one wire packet (16 MiB) are reassembled before decoding.
- MySQL/Postgres URL and option parsing: `?ssl=`, `?ssl-mode=`/`sslmode=` spellings and `ssl: "verify-full"`-style strings select the corresponding `sslmode`; `tls: { caFile }` enables verification like `ca` does; an explicit option object still wins over the URL.
- Postgres: an error response for a simple query only detaches that query's own statement.
- Duplicate column names that differ only in invalid UTF-8 bytes no longer share one property slot.

**crypto**
- `Bun.SHA*`/`MD5` `update()` and `Bun.CryptoHasher.hash()` coerce every argument before touching hasher state.
- Ed25519 sign checks that the supplied public half matches the private key.

**runtime / bundler / misc**
- `Buffer.write`/`fill`/`TextEncoder.encodeInto` with a string ending in a lone high surrogate size the fast path from the full input.
- Workers read `process.env` at runtime like the main thread instead of inlining values at transpile time.
- `module.enableCompileCache()` only uses a cache directory owned by the current user with private permissions.
- Windows `bun:ffi` `cc()` creates a fresh private compiler-runtime header directory per process.
- `zlib` `params()` resets stream pointers before `deflateParams`; `BundlerPlugin` native filter registration type-checks its arguments; destructuring a macro result with repeated keys and nested macro evaluation keep the AST store consistent.
- `bun publish` launches the browser opener by absolute path.

## Tests

93 new regression tests across 39 existing test files; each fails on the current release and passes on this branch (three are platform-gated: Windows `--shell=system`, non-ASAN `cc()`, and macOS-only extractor assertions run in reduced form elsewhere). `cargo clippy --workspace`, `bun run rust:check-all` (10/10 targets), oxlint and prettier are clean.

## Related

Larger items from the same pass are in their own PRs: #37590 (security scanner receives every resolution) and follow-ups for install-cache entry identity, off-thread I/O into WebAssembly memory, and TLS common-name fallback parity with Node.js.
