### PR TITLE
Update SAFETY comments that still named pre-port identifiers

### DIFF
--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -624,7 +624,7 @@ impl Map {
         // writers of `Symbol::link` are (a) the default `Ref::NONE`
         // (tag=Invalid — rejected by `is_valid()` above), (b) `merge()`,
         // which stores a Ref that came from `declare_symbol` / `new_symbol` /
-        // `LinkerGraph::generate_symbol`, and (c) prior `follow()` path
+        // `LinkerGraph::generate_new_symbol`, and (c) prior `follow()` path
         // compression, which stores a `root` that itself satisfied (b). All
         // such refs satisfy the in-bounds contract (see `get_const`):
         // `(source_index, inner_index)` with tag ∈ {Symbol, AllocatedName},

--- a/src/ast/symbol.rs
+++ b/src/ast/symbol.rs
@@ -529,7 +529,7 @@ impl Map {
         // non-null source index and a non-SourceContentsSlice tag was emitted
         // by the parser as an index into this table (`declare_symbol` /
         // `new_symbol` write `inner_index = symbols.len()` then push) or
-        // minted by the linker (`LinkerGraph::generate_symbol`, which appends
+        // minted by the linker (`LinkerGraph::generate_new_symbol`, which appends
         // to the same per-source Vec). Both indices are therefore in-bounds.
         // The bundler never fabricates Refs from untrusted input.
         //

--- a/src/bun_core/string/immutable.rs
+++ b/src/bun_core/string/immutable.rs
@@ -2599,7 +2599,7 @@ pub fn to_utf16_alloc(
         .map_err(|_| ToUTF16Error::OutOfMemory)?;
     // SAFETY: `out` has ≥ `out_length` u16 of capacity (just reserved). simdutf
     // never reads from the output buffer and writes at most `out_length` code
-    // units (the upper bound returned by `utf16_length_from_utf8`), so passing
+    // units (the upper bound returned by `simdutf__utf16_length_from_utf8`), so passing
     // uninitialised storage is sound. We only commit the length after success.
     let res = unsafe {
         simdutf::simdutf__convert_utf8_to_utf16le_with_errors(

--- a/src/bundler/AstBuilder.rs
+++ b/src/bundler/AstBuilder.rs
@@ -387,7 +387,7 @@ impl<'a, 'bump> AstBuilder<'a, 'bump> {
                         self.record_export(st.default_name.loc, b"default", default_ref)?;
                         // convertStmt: AstBuilder only emits the `.expr` arm
                         // (`registerClientReference(...)`), which is not
-                        // `canBeMoved()` — generate a temp const binding and
+                        // `can_be_moved()` — generate a temp const binding and
                         // reference it from `export_props`.
                         // SAFETY: `StmtOrExpr` lives in the arena and has no
                         // Drop fields, so a bitwise read is a plain value copy.

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1742,7 +1742,7 @@ impl<'a> LinkerContext<'a> {
             .contains(crate::chunk::Flags::IS_BROWSER_CHUNK_FROM_SERVER_BUILD)
         {
             // SAFETY: self is BundleV2.linker; container_of recovers the parent.
-            // `transpiler_for_target` only reads `bundle.browser_transpiler`.
+            // `transpiler_for_target` only reads `bundle.client_transpiler`.
             let bundle = unsafe {
                 &mut *LinkerContext::bundle_v2_ptr(std::ptr::from_mut::<LinkerContext>(self))
             };
@@ -2977,7 +2977,7 @@ impl<'a> LinkerContext<'a> {
         log: &mut Log,
     ) -> ScanCssImportsResult {
         // SAFETY: `css_asts` points at the `graph.ast.items_css()` column for
-        // the duration of `scanImportsAndExports`; we only test `is_none()`.
+        // the duration of `scan_imports_and_exports`; we only test `is_none()`.
         let css_asts = unsafe { &*css_asts };
         for record in file_import_records.iter() {
             if record.source_index.is_valid() {

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2208,7 +2208,7 @@ pub mod parse_worker {
         // SAFETY: `data.transpiler` is initialized (see above) and pinned for the
         // bundle pass.
         let transpiler: *mut Transpiler<'static> = &raw mut data.transpiler;
-        // errdefer transpiler.resetStore() — reshaped: call on the err
+        // errdefer transpiler.reset_store() — reshaped: call on the err
         // path explicitly (scopeguard would alias `transpiler` access below).
         // SAFETY: `transpiler` is live; `resolver` projects a field of it.
         let resolver: *mut Resolver = unsafe { core::ptr::addr_of_mut!((*transpiler).resolver) };

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2272,7 +2272,7 @@ pub mod parse_worker {
         // SAFETY: `worker_raw` just derived from the live `this: &mut Worker`.
         let mut transpiler: *mut Transpiler<'static> =
             std::ptr::from_mut(unsafe { (*worker_raw).transpiler_for_target(task.known_target) });
-        // Error-path cleanup (`transpiler.resetStore()` and
+        // Error-path cleanup (`transpiler.reset_store()` and
         // `if (.fd) entry.deinit(arena)`) is reshaped into the
         // explicit `match ast_result { Err(e) => ... }` cleanup below — scopeguard
         // would alias the `&mut Transpiler` / `&mut CacheEntry` borrows that

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -237,7 +237,7 @@ impl ThreadPool {
     pub(crate) fn worker_pool(&self) -> &ThreadPoolLib::ThreadPool {
         debug_assert!(!self.worker_pool.is_null());
         // SAFETY: `worker_pool` is initialized before any caller can observe
-        // `self` and lives until `deinit_v2`; all driver methods take `&self`.
+        // `self` and lives until `deinit`; all driver methods take `&self`.
         unsafe { &*self.worker_pool }
     }
 

--- a/src/bundler/linker_context/doStep5.rs
+++ b/src/bundler/linker_context/doStep5.rs
@@ -61,7 +61,7 @@ impl LinkerContext<'_> {
         }
 
         // SAFETY: `this` points to `BundleV2.linker` (caller is the worker-pool
-        // dispatch from `scanImportsAndExports`); `container_of` shape.
+        // dispatch from `scan_imports_and_exports`); `container_of` shape.
         // `Worker::get` only needs `&BundleV2`, so derive a shared ref — never
         // form `&mut BundleV2` here (concurrent tasks would alias it).
         let bundle_v2: &BundleV2<'_> = unsafe { &*LinkerContext::bundle_v2_ptr(this) };

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -903,7 +903,7 @@ impl<K, V, C, A: MapAllocator> ArrayHashMap<K, V, C, A> {
         // SAFETY: `keys` and `values` are distinct allocations; producing one
         // `&mut` into each is sound even though both derive from `&mut self`.
         // `index < self.keys.len() == self.values.len()` — every caller
-        // (`get_or_put*`/`put_index`) passes the index just returned by
+        // (`get_or_put*`) passes the index just returned by
         // `push_entry` or `find_hash`.
         let (key_ptr, value_ptr) = unsafe {
             (

--- a/src/collections/linear_fifo.rs
+++ b/src/collections/linear_fifo.rs
@@ -241,7 +241,7 @@ impl<T, B: LinearFifoBuffer<T>> LinearFifo<T, B> {
                 let n = self.head.min(tmp_len);
                 let m = buf_len - n;
                 let buf = self.buf.as_mut_slice().as_mut_ptr();
-                // SAFETY: `tmp` is disjoint from `buf`. The tmp↔buf copies move
+                // SAFETY: `tmp_bytes` is disjoint from `buf`. The tmp↔buf copies move
                 // `n * size_of::<T>()` raw bytes (no `T` typed access through
                 // the 1-aligned scratch). The buf→buf shift overlaps, so use
                 // `ptr::copy` (memmove); it operates on properly-aligned `*T`.

--- a/src/collections/pool.rs
+++ b/src/collections/pool.rs
@@ -402,7 +402,7 @@ where
         // SAFETY: `node` was created via `heap::alloc` in `push`/`get` and
         // is exclusively owned by the caller. `data` is initialized: `destroy_node`
         // is only reached from `release()` (caller had a usable node, so `data`
-        // was written) or `delete_all()` (free-list nodes, always initialized).
+        // was written).
         unsafe {
             (*node).data.assume_init_drop();
             drop(bun_core::heap::take(node));

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -1576,7 +1576,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         let overflow_ptr: *mut u8 = if overflow_len > 0 {
             let mut v: Vec<u8> = Vec::new();
             if v.try_reserve_exact(overflow_len).is_err() {
-                // OOM here terminates with `invalid_response` rather than
+                // OOM here terminates with `InvalidResponse` rather than
                 // aborting the process.
                 // SAFETY: no `&mut Self` is live across this call.
                 unsafe { Self::terminate(this, ErrorCode::InvalidResponse) };
@@ -1658,7 +1658,7 @@ impl<const SSL: bool> HTTPClient<SSL> {
         }
 
         // Normal (non-tunnel) mode — original code path. Transfer the
-        // custom `us_ssl_ctx_t` to the connected WebSocket (it must outlive
+        // custom `SslCtxOwned` to the connected WebSocket (it must outlive
         // the upgrade client because the socket's SSL* still references the
         // SSL_CTX inside it).
         // SAFETY: short-lived `&mut` for the field take.

--- a/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
+++ b/src/http_jsc/websocket_client/WebSocketUpgradeClient.rs
@@ -109,7 +109,7 @@ enum HeadParse {
     NeedMore,
 }
 
-/// Owned +1 reference to a `us_ssl_ctx_t` (`SSL_CTX*`); releases the ref via
+/// Owned +1 reference to an `SslCtx` (`SSL_CTX*`); releases the ref via
 /// `SSL_CTX_free` on drop (BoringSSL decrements its internal refcount).
 /// Either dropped here, or transferred to the connected `WebSocket` via
 /// `into_raw()` after the upgrade completes.
@@ -160,7 +160,7 @@ pub struct HTTPClient<const SSL: bool> {
     /// TLS options (full SSLConfig for complete TLS customization)
     ssl_config: Option<Box<SSLConfig>>,
 
-    /// `us_ssl_ctx_t` built from `ssl_config` when it carries a custom CA.
+    /// `SslCtx` built from `ssl_config` when it carries a custom CA.
     /// Heap-allocated because ownership transfers to the connected
     /// `WebSocket` after the upgrade completes (so the `SSL_CTX` outlives
     /// this struct). RAII: dropping the wrapper releases the retained ref.

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -918,7 +918,7 @@ impl NetworkTask {
 
     /// Release any streaming-extraction resources that were never used because
     /// the request errored before a drain was scheduled. Called on the main
-    /// thread from `runTasks` when falling back to the buffered path.
+    /// thread from `run_tasks` when falling back to the buffered path.
     pub(crate) fn discard_unused_streaming_state(&mut self, manager: &mut PackageManager) {
         debug_assert!(!self.streaming_committed);
         if let Some(stream) = self.tarball_stream.take() {

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -239,14 +239,14 @@ impl NetworkTask {
             if committed || (ok_status && big_enough && result.fail.is_none()) {
                 if result.has_more {
                     if !chunk.is_empty() {
-                        // The drain task is scheduled by `onChunk`
+                        // The drain task is scheduled by `on_chunk`
                         // (guarded by its own `draining` atomic) so it
                         // runs at most once at a time, releases the
                         // worker on ARCHIVE_RETRY, and is re-enqueued by
                         // the next chunk. Pending-task accounting stays
                         // balanced: this NetworkTask is never pushed to
                         // `async_network_task_queue` once committed, so
-                        // its `incrementPendingTasks()` is satisfied by
+                        // its `increment_pending_tasks()` is satisfied by
                         // the extract Task that `TarballStream.finish()`
                         // publishes to `resolve_tasks`.
                         // SAFETY: `this` is live; the HTTP thread is its sole writer here.
@@ -608,7 +608,7 @@ impl NetworkTask {
                 let appended = header_builder.content.append(last_modified);
                 // SAFETY: lifetime extension — the appended slice points into
                 // `header_builder.content`'s heap buffer, which is moved into
-                // `self.unsafe_http_client.request_header_buf` below and
+                // `self.unsafe_http_client.client.header_buf` below and
                 // outlives the request. Detach the borrow so
                 // `header_builder.content` can be read again for `headers_buf`.
                 last_modified = unsafe { bun_ptr::detach_lifetime(appended) };

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1978,7 +1978,7 @@ pub fn init(
         // make sure folder packages can find the root package without creating a new one
         // Posix-normalize the
         // separators before hashing; `FolderResolution.hash` is always fed `/`-separated
-        // bytes by every resolver-side caller. On Windows `getFdPath` yields `\`, so
+        // bytes by every resolver-side caller. On Windows `get_fd_path` yields `\`, so
         // hashing the raw bytes would seed a key the resolver never looks up — copy into
         // a stack buffer and convert separators in place.
         // SAFETY: ROOT_PACKAGE_JSON_PATH set above on the main thread.

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -324,7 +324,7 @@ impl<'a> Task<'a> {
                         loaded_manifest,
                         // SAFETY: see `manager` decl — short-lived `&mut` at call
                         // boundary only (callee touches `cache_directory` /
-                        // `temporary_directory` lazily).
+                        // `get_temporary_directory` lazily).
                         unsafe { &mut *manager },
                         is_extended_manifest,
                     ) {

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -200,7 +200,7 @@ impl TarballStream {
         // Wrapped once as `ParentRef` so
         // the union read goes through the centralised tag-checked
         // `request_extract()` accessor; `extract` is the active `Request`
-        // variant for streaming tarballs (set by `enqueueExtractNPMPackage`,
+        // variant for streaming tarballs (set by `enqueue_extract_npm_package`,
         // `tag == Tag::Extract`).
         let extract_task =
             core::ptr::NonNull::new(extract_task).expect("extract_task non-null (Zig *Task)");
@@ -1045,7 +1045,7 @@ impl TarballStream {
             drop((*network).tarball_stream.take());
 
             // `task.apply_patch_task` is intentionally not touched: the
-            // buffered `.extract` path (`enqueueExtractNPMPackage` →
+            // buffered `.extract` path (`enqueue_extract_npm_package` →
             // `Task.callback`) never populates it for npm tarballs either —
             // patching is handled later by the install phase.
             //

--- a/src/install/TarballStream.rs
+++ b/src/install/TarballStream.rs
@@ -1073,7 +1073,7 @@ impl TarballStream {
     unsafe fn populate_result(&mut self, task: *mut Task) {
         // SAFETY: see fn-level # Safety — `task` is live and exclusively
         // owned by this drain; union field `extract` is the active variant
-        // for streaming tarballs (set by `enqueueExtractNPMPackage`).
+        // for streaming tarballs (set by `enqueue_extract_npm_package`).
         unsafe {
             let tarball = &(&(*task).request.extract).tarball;
             (*task).data = TaskData {

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -542,8 +542,8 @@ pub(crate) fn install_hoisted_packages(
             };
 
             // Whenever the event loop wakes up, we need to call `run_tasks`
-            // If we call sleep() instead of sleepUntil(), it will wait forever until there are no more lifecycle scripts
-            // which means it will not call runTasks until _all_ current lifecycle scripts have finished running
+            // If we call sleep() instead of sleep_until(), it will wait forever until there are no more lifecycle scripts
+            // which means it will not call run_tasks until _all_ current lifecycle scripts have finished running
             // SAFETY: `mgr` is derived from the live exclusive `this` borrow;
             // `sleep_until` + `tick_raw` hold no `&mut PackageManager` across
             // `Closure::is_done`, so the callback's `&mut *closure.manager`

--- a/src/install/hoisted_install.rs
+++ b/src/install/hoisted_install.rs
@@ -541,7 +541,7 @@ pub(crate) fn install_hoisted_packages(
                 manager: mgr,
             };
 
-            // Whenever the event loop wakes up, we need to call `runTasks`
+            // Whenever the event loop wakes up, we need to call `run_tasks`
             // If we call sleep() instead of sleepUntil(), it will wait forever until there are no more lifecycle scripts
             // which means it will not call runTasks until _all_ current lifecycle scripts have finished running
             // SAFETY: `mgr` is derived from the live exclusive `this` borrow;

--- a/src/install/lifecycle_script_runner.rs
+++ b/src/install/lifecycle_script_runner.rs
@@ -760,7 +760,7 @@ impl<'a> LifecycleScriptSubprocess<'a> {
             // in `reset_polls` via `process.deref()`.
             let process: *mut Process = spawned.to_process(event_loop);
 
-            debug_assert!((*this).process.is_null(), "forgot to call `resetPolls`");
+            debug_assert!((*this).process.is_null(), "forgot to call `reset_polls`");
             (*this).process = process;
             // SAFETY: `this` is the allocation-rooted `LifecycleScriptSubprocess`;
             // we hold no live `&mut Self` here, so the synchronous `on_exit`

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -438,7 +438,7 @@ impl FilePoll {
 
         debug_assert!(!self.owner.is_null());
 
-        // Hot-path hoisted-match: the per-tag `switch` lives in
+        // Hot-path hoisted-match: the per-tag `match` lives in
         // `bun_runtime::dispatch::__bun_run_file_poll` (link-time extern) so
         // this T3 crate names no variant types.
         // SAFETY: `self` is a live FilePoll for the duration of the call

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -1108,7 +1108,7 @@ impl JSValue {
         property: impl AsRef<[u8]>,
     ) -> JsResult<Option<JSValue>> {
         let property = property.as_ref();
-        // Never route a runtime key to `fastGet`: a runtime byte-slice match
+        // Never route a runtime key to `fast_get`: a runtime byte-slice match
         // here is wrong because
         // C++ `builtinNameMap` maps e.g. `asyncIterator` → `Symbol.asyncIterator`
         // (and `inspectCustom` → `Symbol.for("nodejs.util.inspect.custom")`), so

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -178,7 +178,7 @@ pub struct VirtualMachine {
     pub runtime_state: *mut c_void,
     pub event_loop_handle: Option<*mut PlatformEventLoop>,
     /// Pending `unref` count drained by the event-loop thread. Atomic because
-    /// `KeepAlive::unref_on_next_tick_concurrently` increments it from OTHER
+    /// `KeepAlive::unref_on_next_tick` increments it from OTHER
     /// threads.
     pub pending_unref_counter: core::sync::atomic::AtomicI32,
     pub preload: Vec<Box<[u8]>>,
@@ -2202,7 +2202,7 @@ bun_io::link_impl_EventLoopCtx! {
             let rare = vm_from_owner(this.cast()).rare_data();
             &raw mut **rare.file_polls.get_or_insert_with(|| Box::new(bun_io::Store::init()))
         },
-        // CROSS-THREAD: reached via `KeepAlive::unref_on_next_tick_concurrently`.
+        // CROSS-THREAD: reached via `KeepAlive::unref_on_next_tick`.
         // Do NOT route through `vm_from_owner()` — that mints `&mut VM`, which
         // would alias the JS thread's `&mut`. Atomic RMW through a shared ref.
         increment_pending_unref_counter() => {

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3067,7 +3067,7 @@ impl<'a> bun_js_printer::OnSourceMapChunk for SourceMapHandlerGetter<'a> {
         // the writer's lifetime. The caller MUST rederive its own
         // `&mut BufferPrinter` from the raw pointer after
         // `print_with_source_map` returns (see jsc_hooks.rs). See
-        // `printer_ptr()` for why this is not a `&mut`-returning accessor.
+        // `SourceMapHandlerGetter` doc for why `printer` is not stored as `&'a mut`.
         let printer = unsafe { &mut *self.printer };
 
         let encode_len = bun_base64::encode_len(temp_json_buffer.list.as_slice());

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1067,7 +1067,9 @@ impl EventLoop {
     #[inline(always)]
     pub fn global_ref(&self) -> &'static JSGlobalObject {
         // `self.global` is always assigned `vm.global` at every write site
-        // (`__bun_spawn_sync_*`, `init_runtime_state`, `swap_global_for_test_isolation`), so
+        // (`VirtualMachine::init`/`init_bake`, `enable_macro_mode`,
+        // `swap_global_for_test_isolation`, `__bun_spawn_sync_*`, bake
+        // `production.rs`), so
         // read it directly instead of the vm→global dependent-load chain.
         // `'static` so callers can hold it across `&mut self` (see
         // `drain_microtasks`), matching `vm_ref()`.

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -329,7 +329,7 @@ impl EventLoop {
         jsc_vm: &jsc::VM,
     ) -> Result<(), JsTerminated> {
         // Hoist the VM backref once. LLVM can't CSE the `Option<NonNull>` field
-        // load across the FFI calls below (`release_weak_refs`, `drainMicrotasks`,
+        // load across the FFI calls below (`release_weak_refs`, `JSC__JSGlobalObject__drainMicrotasks`,
         // `deferred_tasks.run`), so each `self.vm_ref()` re-loaded
         // `self.virtual_machine` from memory (5× per call, ~2×/request).
         // SAFETY: `virtual_machine` is set in `VirtualMachine::init()` to the
@@ -870,7 +870,7 @@ impl EventLoop {
         let mut exception_thrown = false;
         for task in to_run_now.iter() {
             // SAFETY: ImmediateObject pointers are kept alive by the JS heap
-            // until `runImmediateTask` consumes them; `virtual_machine` is the
+            // until `__bun_run_immediate_task` consumes them; `virtual_machine` is the
             // live owning VM per caller contract.
             exception_thrown = unsafe { __bun_run_immediate_task(*task, virtual_machine) };
         }
@@ -1067,7 +1067,7 @@ impl EventLoop {
     #[inline(always)]
     pub fn global_ref(&self) -> &'static JSGlobalObject {
         // `self.global` is always assigned `vm.global` at every write site
-        // (`__bun_spawn_sync_*`, `init_runtime_state`, `reload_global`), so
+        // (`__bun_spawn_sync_*`, `init_runtime_state`, `swap_global_for_test_isolation`), so
         // read it directly instead of the vm→global dependent-load chain.
         // `'static` so callers can hold it across `&mut self` (see
         // `drain_microtasks`), matching `vm_ref()`.

--- a/src/jsc/hot_reloader.rs
+++ b/src/jsc/hot_reloader.rs
@@ -113,7 +113,7 @@ impl HotReloaderCtx for VirtualMachine {
     fn bun_watcher_mut(&mut self) -> &mut Watcher {
         // `VirtualMachine.bun_watcher` is the
         // `*mut ImportWatcher` (see the field comment in
-        // VirtualMachine.rs), and `getContext` only runs after
+        // VirtualMachine.rs), and `get_context` only runs after
         // `enable_hot_module_reloading` has populated it, so the `.None` arm
         // is unreachable.
         // SAFETY: `bun_watcher` is the `*mut ImportWatcher` set by

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -3527,7 +3527,7 @@ impl<'a> Resolver<'a> {
         .expect("unreachable");
 
         // `dir_path` is a slice into the threadlocal `bufs(.path_in_global_disk_cache)` buffer,
-        // which gets overwritten on the next auto-install resolution. `dirInfoUncached` stores
+        // which gets overwritten on the next auto-install resolution. `dir_info_uncached` stores
         // its `path` argument directly as `DirInfo.abs_path` in the permanent `dir_cache`, so
         // pass the interned copy from `DirEntry.dir` (always backed by `DirnameStore`) instead.
         // SAFETY: ARENA — `dir_entries_option` is a slot in `rfs.entries` (BSSMap) and

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -6673,8 +6673,8 @@ impl<'a> Resolver<'a> {
                         // (strings live in dirname_store or default_allocator and outlive the
                         // struct). The heap-allocated TSConfigJSON itself is no longer needed;
                         // without this, every intermediate config in an extends chain leaks on
-                        // each dirInfoUncached() call, which is especially bad under HMR where
-                        // bustDirCache triggers a re-parse of the whole chain on every reload.
+                        // each dir_info_uncached() call, which is especially bad under HMR where
+                        // bust_dir_cache triggers a re-parse of the whole chain on every reload.
                         // SAFETY: parent_config_ptr came from TSConfigJSON::new (heap::alloc)
                         TSConfigJSON::destroy(unsafe { bun_core::heap::take(parent_config_ptr) });
                     }

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1505,13 +1505,13 @@ pub mod js_bundler {
 
             // Notify the *bundler thread* about the deferral. This will
             // decrement the pending item counter and increment the deferred
-            // counter. Must land on `parse_task.ctx.loop()` (the loop running
-            // BundleV2), which is distinct from the `enqueue_on_js_loop_for_plugins`
-            // target (the plugin host's JS loop) when `Bun.build` runs the bundler on its
-            // own Mini event loop.
-            // SAFETY: parse_task.ctx and bv2 are valid backrefs; `r#loop()`
-            // points at a live `AnyEventLoop` owned by the bundle thread /
-            // runtime for the duration of the bundle.
+            // counter. Must land on `parse_task.completion_ctx`'s `r#loop()` (the
+            // loop running BundleV2), which is distinct from the
+            // `enqueue_on_js_loop_for_plugins` target (the plugin host's JS loop)
+            // when `Bun.build` runs the bundler on its own Mini event loop.
+            // SAFETY: `parse_task.completion_ctx` and `bv2` are valid backrefs;
+            // `r#loop()` points at a live `AnyEventLoop` owned by the bundle
+            // thread / runtime for the duration of the bundle.
             unsafe {
                 let ctx = (*self.parse_task).ctx.expect("ParseTask.ctx unset");
                 // SAFETY: write provenance from `ParseTask::init`; bundle outlives plugin.

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1506,8 +1506,8 @@ pub mod js_bundler {
             // Notify the *bundler thread* about the deferral. This will
             // decrement the pending item counter and increment the deferred
             // counter. Must land on `parse_task.ctx.loop()` (the loop running
-            // BundleV2), which is distinct from `js_loop_for_plugins()` (the
-            // plugin host's JS loop) when `Bun.build` runs the bundler on its
+            // BundleV2), which is distinct from the `enqueue_on_js_loop_for_plugins`
+            // target (the plugin host's JS loop) when `Bun.build` runs the bundler on its
             // own Mini event loop.
             // SAFETY: parse_task.ctx and bv2 are valid backrefs; `r#loop()`
             // points at a live `AnyEventLoop` owned by the bundle thread /
@@ -1556,7 +1556,7 @@ pub mod js_bundler {
     fn on_notify_defer_mini_wrap(load: *mut Load, ctx: *mut BundleV2<'static>) {
         // SAFETY: callback contract — `load` was passed as the `Context` arg to
         // `enqueue_task_concurrent_with_extra_ctx`; `ctx` is the bundle-thread
-        // `BundleV2` backref the mini loop's tick supplies as `ParentContext`.
+        // `BundleV2` backref the mini loop's tick supplies as `extra`.
         BundleV2::on_notify_defer_mini(unsafe { &mut *load }, unsafe { &mut *ctx });
     }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1194,7 +1194,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             spawn_options.deinit();
             let display_path: &ZStr = if !argv.is_empty() && !argv[0].is_null() {
                 // SAFETY: argv[0] is non-null and points at a NUL-terminated
-                // string we built above (lives in `arg0_backing`/`arg_backing`).
+                // string we built above (lives in `cstr_storage`).
                 ZStr::from_cstr(unsafe { bun_core::ffi::cstr(argv[0]) })
             } else {
                 ZStr::EMPTY
@@ -1241,7 +1241,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                     | sys::Errno::ENOTDIR) => {
                         let display_path: &ZStr = if !argv.is_empty() && !argv[0].is_null() {
                             // SAFETY: argv[0] is non-null and points at a NUL-terminated
-                            // string we built above (lives in `arg0_backing`/`arg_backing`).
+                            // string we built above (lives in `cstr_storage`).
                             ZStr::from_cstr(unsafe { bun_core::ffi::cstr(argv[0]) })
                         } else {
                             ZStr::EMPTY

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1352,7 +1352,7 @@ impl Subprocess<'_> {
 
         if let Some(ipc_data) = this.ipc_data.take() {
             // In normal operation the socket is already `.closed` by the time we
-            // get here (that is what allowed `computeHasPendingActivity` to drop
+            // get here (that is what allowed `compute_has_pending_activity` to drop
             // to false and let GC collect us). Detach and release our ref; any
             // still-queued close task holds its own ref and frees the SendQueue
             // when it runs.

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -422,7 +422,7 @@ impl<'a> Writable<'a> {
                         .contains(Flags::HAS_STDIN_DESTRUCTOR_CALLED)
                 {
                     // `Writable::init()` already called `subprocess.ref()` and
-                    // set `deref_on_stdin_destroyed`. `on_attached_process_exit()`
+                    // set `DEREF_ON_STDIN_DESTROYED`. `on_attached_process_exit()`
                     // → `writer.close()` → `pipe.source` → `Writable::on_close`
                     // → `on_stdin_destroyed()` balances that ref, so a ref-count
                     // drop across this call is expected (previously these

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -862,7 +862,7 @@ static COMPLETION_VTABLE: dispatch::CompletionDispatch = dispatch::CompletionDis
             .load(core::sync::atomic::Ordering::Acquire)
     },
     enqueue_task_concurrent: |c, task| {
-        // SAFETY: `task` is a fresh non-null `ConcurrentTaskItem` passed through
+        // SAFETY: `task` is a fresh non-null `ConcurrentTask` passed through
         // from the bundler vtable; the queue takes ownership. The VM waits for
         // this build (embedded work) before closing its handle: always queued.
         unsafe {

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1785,7 +1785,7 @@ fn on_js_request(dev: &mut DevServer, req: &mut Request, resp: AnyResponse) {
         );
         // SAFETY: `init_from_any_blob` returns a fresh ref_count=1 box.
         scopeguard::defer! { unsafe { StaticRoute::deref_(response) } };
-        // SAFETY: `response` is live until `_deref` runs after this returns.
+        // SAFETY: `response` is live until the deferred `deref_` runs after this returns.
         unsafe { StaticRoute::on_request(response, bun_uws::AnyRequest::H1(req), resp) };
         return;
     }
@@ -3861,7 +3861,7 @@ pub(super) fn finalize_bundle(
     macro_rules! current_bundle {
         () => {
             // SAFETY: `dev.current_bundle` is `Some` for the entire fn body —
-            // it is only set to `None` inside `_outer_defer`, which runs after
+            // it is only set to `None` inside the outer `finalize_bundle_cleanup` defer, which runs after
             // every use of this macro. `dev.current_bundle` is never reassigned
             // (so the inner `CurrentBundle` is not moved) between here and the
             // outer-defer.
@@ -4620,12 +4620,12 @@ pub(super) fn finalize_bundle(
         let mut inspector_agent_ptr: Option<*const BunFrontendDevServerAgent> =
             dev.inspector().map(std::ptr::from_ref);
         if current_bundle!().promise.strong.has_value() {
-            // SAFETY: see `current_bundle!` SAFETY; guard runs before `_outer_defer`.
+            // SAFETY: see `current_bundle!` SAFETY; guard runs before the outer `finalize_bundle_cleanup` defer.
             // Note: copy the raw ptr so `defer!`'s by-ref capture does not
             // hold `*current_bundle_ptr` borrowed across `current_bundle!()` uses.
             let cb_ptr_defer: *mut CurrentBundle = current_bundle_ptr;
             scopeguard::defer! {
-                // SAFETY: `cb_ptr_defer` points into `dev.current_bundle`, live until `_outer_defer` runs.
+                // SAFETY: `cb_ptr_defer` points into `dev.current_bundle`, live until the outer `finalize_bundle_cleanup` defer runs.
                 unsafe { (*cb_ptr_defer).promise.reset() }
             };
             current_bundle!()
@@ -4829,12 +4829,12 @@ pub(super) fn finalize_bundle(
     }
 
     if current_bundle!().promise.strong.has_value() {
-        // SAFETY: see `current_bundle!` SAFETY; guard runs before `_outer_defer`.
+        // SAFETY: see `current_bundle!` SAFETY; guard runs before the outer `finalize_bundle_cleanup` defer.
         // Note: copy the raw ptr so `defer!`'s by-ref capture does not
         // hold `*current_bundle_ptr` borrowed across `current_bundle!()` uses.
         let cb_ptr_defer: *mut CurrentBundle = current_bundle_ptr;
         scopeguard::defer! {
-            // SAFETY: `cb_ptr_defer` points into `dev.current_bundle`, live until `_outer_defer` runs.
+            // SAFETY: `cb_ptr_defer` points into `dev.current_bundle`, live until the outer `finalize_bundle_cleanup` defer runs.
             unsafe { (*cb_ptr_defer).promise.deinit_idempotently() }
         };
         current_bundle!()

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -924,12 +924,14 @@ impl WatcherAtomics {
             #[cfg(debug_assertions)]
             {
                 let Some(dbg_event) = (*this).dbg_watcher_event else {
-                    panic!("must call `watcherAcquireEvent` before `watcherReleaseAndSubmitEvent`");
+                    panic!(
+                        "must call `watcher_acquire_event` before `watcher_release_and_submit_event`"
+                    );
                 };
                 debug_assert!(
                     dbg_event == ev,
-                    "watcherReleaseAndSubmitEvent: event is not from last \
-                     `watcherAcquireEvent` call (expected {:p}, got {:p})",
+                    "watcher_release_and_submit_event: event is not from last \
+                     `watcher_acquire_event` call (expected {:p}, got {:p})",
                     dbg_event,
                     ev,
                 );
@@ -996,7 +998,7 @@ impl WatcherAtomics {
                     let old_index: u8 = old_next.0;
                     debug_assert!(
                         (*this).pending_event == Some(old_index),
-                        "watcherReleaseAndSubmitEvent: expected `pending_event` to be {}; got {:?}",
+                        "watcher_release_and_submit_event: expected `pending_event` to be {}; got {:?}",
                         old_index,
                         (*this).pending_event,
                     );

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -875,7 +875,7 @@ impl WatcherAtomics {
             {
                 debug_assert!(
                     (*this).dbg_watcher_event.is_none(),
-                    "must call `watcherReleaseEvent` before calling `watcherAcquireEvent` again",
+                    "must call `watcher_release_and_submit_event` before calling `watcher_acquire_event` again",
                 );
                 (*this).dbg_watcher_event = Some(ev);
             }

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -197,7 +197,7 @@ pub fn build_command(ctx: Context) -> crate::Result<()> {
     vm.is_main_thread = true;
     jsc::virtual_machine::IS_MAIN_THREAD_VM.set(true);
 
-    // SAFETY: vm.jsc_vm is the live JSC::VM* set in `VirtualMachine::initBake`;
+    // SAFETY: vm.jsc_vm is the live JSC::VM* set in `VirtualMachine::init_bake`;
     // raw-ptr deref yields an unbounded `&VM` so the `ApiLock<'_>` does not
     // borrow `vm` (the VirtualMachine) and the body below can keep using it.
     //

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1274,7 +1274,7 @@ pub struct Run {
 // Process-global, written once in `boot`.
 // PORTING.md §Global mutable state: `Run` is `!Sync` (raw ptrs); RacyCell so
 // `boot`/`boot_standalone` can `ptr::write` it on the single CLI thread and
-// the `holdAPILock` trampoline can re-derive `&mut Run` from the static.
+// the `hold_api_lock` trampoline can re-derive `&mut Run` from the static.
 static RUN: bun_core::RacyCell<Run> = bun_core::RacyCell::new(Run {
     ctx: ::core::ptr::null_mut(),
     vm: ::core::ptr::null_mut(),
@@ -1283,7 +1283,7 @@ static RUN: bun_core::RacyCell<Run> = bun_core::RacyCell::new(Run {
 
 // The unhandled-rejection callback fires
 // while `Run::start` holds `&mut self` (via the
-// `holdAPILock` trampoline). Storing the flag on `Run` and writing through a
+// `hold_api_lock` trampoline). Storing the flag on `Run` and writing through a
 // fresh `&raw mut RUN` would alias that exclusive borrow (PORTING.md
 // §Forbidden — Stacked Borrows UB). Keep it as a sibling static instead so the
 // callback's write and `start()`'s reads never overlap a `&mut`.
@@ -1537,9 +1537,8 @@ impl Run {
         // don't run the GC if we don't actually need to
         if vm.is_event_loop_alive() || vm.event_loop_ref().tick_concurrent_with_count() > 0 {
             vm.global().vm().release_weak_refs();
-            // `bun_alloc::Arena = bumpalo::Bump` has no
-            // per-heap collect, so this is a no-op unless the arena type
-            // changes. Semantically a memory-usage hint, not correctness.
+            // `bun_alloc::Arena` has no per-heap collect to run alongside this
+            // GC; it would only be a memory-usage hint, not correctness.
             let _ = vm.global().vm().run_gc(false);
             vm.tick();
         }

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -1096,7 +1096,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         vm.hot_reload = ctx.debug.hot_reload as u8;
 
         extern "C" fn trampoline(ctx: *mut c_void) {
-            // SAFETY: `ctx` is `&mut RUN` passed through `holdAPILock`'s
+            // SAFETY: `ctx` is `&mut RUN` passed through `hold_api_lock`'s
             // opaque slot; the API lock is held for the full call so no
             // other thread touches the VM.
             let this = unsafe { &mut *ctx.cast::<Run>() };
@@ -1233,7 +1233,7 @@ Full documentation is available at <magenta>https://bun.com/docs/cli/run<r>
         }
 
         extern "C" fn trampoline(ctx: *mut c_void) {
-            // SAFETY: `ctx` is `&mut RUN` passed through `holdAPILock`'s
+            // SAFETY: `ctx` is `&mut RUN` passed through `hold_api_lock`'s
             // opaque slot; the API lock is held for the full call.
             let this = unsafe { &mut *ctx.cast::<Run>() };
             this.start();
@@ -3893,7 +3893,7 @@ impl RunCommand {
             .map(|k| -> &'static [u8] {
                 // SAFETY: every key is a freshly-boxed `Box<[u8]>` owned by
                 // `results`. The owning `ArrayHashMap` is parked in the
-                // process-lifetime `runner_arena()` below and `bumpalo::Bump`
+                // process-lifetime `runner_arena()` below and `bun_alloc::Arena`
                 // never runs `Drop`, so the boxed bytes live until process
                 // exit and erasing to `'static` is sound.
                 unsafe { ::core::slice::from_raw_parts(k.as_ptr(), k.len()) }

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3304,7 +3304,7 @@ impl TestCommand {
                         // `global_exit()` diverges, so the `exit_file()` defer
                         // above never fires. Release the active file's
                         // `Strong`s and the preload-hook scope here so
-                        // `destructOnExit()`'s `collectNow()` can reclaim them,
+                        // `Zig__GlobalObject__destructOnExit()`'s `collectNow()` can reclaim them,
                         // then clear `RUNNER` so finalizers can't observe a
                         // partially-torn-down `TestRunner`.
                         // SAFETY: single-threaded; raw-ptr reborrow mirrors the

--- a/src/runtime/cli/test_command.rs
+++ b/src/runtime/cli/test_command.rs
@@ -3043,7 +3043,7 @@ impl TestCommand {
         }
         // on_exit() already set is_shutting_down; global_exit() asserts it.
         // Release `bun:test` GC roots before `global_exit()` so
-        // `destructOnExit()`'s `collectNow()` can reach the closures they pin
+        // `Zig__GlobalObject__destructOnExit()`'s `collectNow()` can reach the closures they pin
         // (preload hooks, per-file describe/test callbacks). Clear `RUNNER`
         // before dropping `reporter` so finalizers running inside the GC can't
         // observe a dangling `TestRunner`.

--- a/src/runtime/hw_exports.rs
+++ b/src/runtime/hw_exports.rs
@@ -414,7 +414,7 @@ pub fn bindgen_bunobject_dispatch_gc(
     // SAFETY: `arg_force`/`out` are valid C++ stack locals.
     let force = unsafe { *arg_force };
     // `garbage_collect(force)`: mimalloc cleanup, then sync `runGC(true)`
-    // when `force`, else `collectAsync()` + `heap.size()`.
+    // when `force`, else `collect_async()` + `heap_size()`.
     // SAFETY: bun_vm() never null for a Bun-owned global.
     unsafe { *out = global.bun_vm().as_mut().garbage_collect(force) };
     true

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -2370,7 +2370,7 @@ fn transpile_source_code_inner(
                     let slot = unsafe { &mut (*jsc_vm).module_loader.transpile_source_code_arena };
                     if !give_back {
                         // When `give_back_arena == false`, ownership is held past
-                        // `processFetchLog` so log spans pointing into the
+                        // `process_fetch_log` so log spans pointing into the
                         // arena stay valid. (The AsyncModule path never reaches
                         // here: its enqueue site defuses this guard via
                         // `ScopeGuard::into_inner` and hands the `Box<Arena>`
@@ -5118,7 +5118,7 @@ fn normalize_source(source: &[u8]) -> &[u8] {
 /// # Safety
 /// `vm` is the live per-thread VM. `specifier` / `source` borrow the caller's
 /// `to_utf8()` buffers and must outlive the returned slices (which the caller
-/// immediately `cloneUTF8`s).
+/// immediately `clone_utf8`s).
 unsafe fn resolve<'a>(
     vm: *mut VirtualMachine,
     specifier: &'a [u8],

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -923,7 +923,7 @@ unsafe fn ensure_debugger(vm: *mut VirtualMachine, block_until_connected: bool) 
     // Note: `Debugger::create` / `wait_for_debugger_if_necessary` live in
     // `bun_jsc::debugger::Debugger` (Debugger.rs); the heavy bodies (futex
     // spin, debugger-thread spawn, deadline poll-loop) are there. This hook
-    // is the literal `ensureDebugger` body — it owns the "is a debugger
+    // is the literal `VirtualMachine::ensure_debugger` body — it owns the "is a debugger
     // configured?" guard and the `block_until_connected` branch, then
     // delegates to those two fns.
     // SAFETY: `vm` is the live per-thread VM.
@@ -983,7 +983,7 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     {
         // SAFETY: per fn contract. `swap(0)` so a concurrent
         // `increment_pending_unref_counter()` (cross-thread, see
-        // `KeepAlive::unref_on_next_tick_concurrently`) can't be lost between
+        // `KeepAlive::unref_on_next_tick`) can't be lost between
         // the read and the reset.
         let pending_unref = unsafe { &*vm }
             .pending_unref_counter
@@ -1015,7 +1015,7 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     if state.is_null() {
         // No high-tier state (unit test) — fall back to a non-blocking I/O
         // poll. The uws loop must always be polled
-        // (`tickWithTimeout`/`tickWithoutIdle`); `EventLoop::tick()` would only
+        // (`tick_with_timeout`/`tick_without_idle`); `EventLoop::tick()` would only
         // drain JS tasks and never touch kqueue/epoll.
         // SAFETY: `loop_` is the live per-thread uws loop.
         unsafe { (*loop_).tick_without_idle() };
@@ -1143,7 +1143,7 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
     {
         // SAFETY: per fn contract. `swap(0)` so a concurrent
         // `increment_pending_unref_counter()` (cross-thread, see
-        // `KeepAlive::unref_on_next_tick_concurrently`) can't be lost between
+        // `KeepAlive::unref_on_next_tick`) can't be lost between
         // the read and the reset.
         let pending_unref = unsafe { &*vm }
             .pending_unref_counter
@@ -1571,7 +1571,7 @@ unsafe fn apply_standalone_runtime_flags(
     // the concrete `Graph` (originally upcast from `&Graph`, so the data
     // pointer is `Graph`-aligned). Read-only downcast (`&*`, not `&mut *` —
     // the shared-ref provenance carries no write permission); the body only
-    // reads `graph.runtime_flags`.
+    // reads `graph.flags`.
     let graph = unsafe {
         &*std::ptr::from_ref::<dyn bun_resolver::StandaloneModuleGraph>(graph)
             .cast::<c_void>()
@@ -2255,7 +2255,7 @@ unsafe fn transpile_source_code(
         Err(_) => {
             // Note: on `error.ParseError` /
             // `error.AsyncModule` the caller (`Bun__transpileFile`) catches and
-            // routes through `processFetchLog`. Mirror that: write `.err` so the
+            // routes through `process_fetch_log`. Mirror that: write `.err` so the
             // low tier surfaces it; `process_fetch_log` is invoked by the
             // `transpile_file` hook, not here.
             // SAFETY: per fn contract.
@@ -3950,7 +3950,7 @@ unsafe fn fetch_builtin_module(
         if let Some(&entry) = unsafe { &*jsc_vm }.macro_entry_points.get(&id) {
             let entry = entry.cast::<MacroEntryPoint>();
             // SAFETY: `entry` is the `heap::alloc`d `MacroEntryPoint`
-            // inserted by `js_run_macro_entry_point`; map ownership keeps it
+            // inserted by `load_macro_entry_point`; map ownership keeps it
             // alive for the VM lifetime.
             unsafe {
                 *out = ErrorableResolvedSource::ok(ResolvedSource {
@@ -4368,7 +4368,7 @@ fn intern_transpile_path(value: &[u8]) -> &'static [u8] {
     // backing arena (resolver-interned, or a prior `intern_transpile_path`
     // result) — no hash, no probe, no append.
     if Fs::FilenameStore::instance().exists(value) {
-        // SAFETY: `exists` is the pointer-range check `isSliceInBuffer` — the
+        // SAFETY: `exists` is a pointer-range check (like `is_slice_in_buffer`): the
         // bytes lie wholly within `FilenameStore`'s backing storage, which is
         // process-lifetime and never freed, so widening to `'static` is sound.
         // Same widening as `FilenameStore::append_slice` itself performs.
@@ -5214,7 +5214,7 @@ unsafe fn resolve<'a>(
         top_level_dir
     };
 
-    // `resolveAndAutoInstall` retry-on-not-found loop.
+    // `resolve_and_auto_install` retry-on-not-found loop.
     // SAFETY: `resolver.opts.global_cache` is a plain enum field.
     let global_cache = unsafe { &*vm }.transpiler.resolver.opts.global_cache;
     let kind = if is_esm {
@@ -5306,7 +5306,7 @@ unsafe fn resolve<'a>(
     // Note: `result_path.text` is a `&'_ [u8]` borrowed from the
     // resolver's interned `'static` BSSStringList stores (see resolver/lib.rs
     // §allocators) — the same store `load_preloads` reads from. Transmute the
-    // lifetime to `'a` so the caller can `cloneUTF8` it; the underlying bytes
+    // lifetime to `'a` so the caller can `clone_utf8` it; the underlying bytes
     // outlive the program.
     // SAFETY: `result_path.text` borrows the resolver's `'static` interned
     // string store; detaching the borrow lifetime is sound (see Note).
@@ -5373,7 +5373,7 @@ unsafe fn resolve_hook(
     let specifier_utf8 = specifier.to_utf8();
     let source_utf8 = source.to_utf8();
 
-    // `PluginRunner.onResolveJSC`.
+    // `plugin_runner::on_resolve_jsc`.
     // SAFETY: `vm` is the live per-thread VM.
     if unsafe { &*vm }.plugin_runner.is_some() {
         use bun_bundler_jsc::PluginRunner as plugin_runner;

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -266,7 +266,7 @@ impl StatWatcherScheduler {
         // after `bun_runtime::init()`. Raw-ptr-per-field re-entry pattern.
         let timer_all = unsafe { &mut (*crate::jsc_hooks::runtime_state()).timer };
         // SAFETY: `this` is live — the caller holds a ref (`set_interval`'s
-        // BACKREF, or `update_timer`'s `ParentRef`).
+        // BACKREF, or `StatWatcherTimerUpdate`'s `ParentRef`).
         let elt = unsafe { core::ptr::addr_of_mut!((*this).event_loop_timer) };
 
         // if the interval is 0 means that we stop the timer
@@ -630,7 +630,7 @@ impl StatWatcher {
             }
         };
         // SAFETY: `raw` was produced by `into_raw` above (or on a prior call) and
-        // the VM ref keeps it alive; bump the count for the caller's `dupeRef()`.
+        // the VM ref keeps it alive; bump the count for the caller's `RefPtr`.
         unsafe { RefPtr::init_ref(raw) }
     }
 
@@ -764,7 +764,7 @@ impl StatWatcher {
         // `path` freed by ZBox Drop below.
 
         // SAFETY: the caller is the sole owner (refcount hit zero, or the
-        // error-path scopeguard in `do_watch` holds the only reference);
+        // error-path scopeguard in `init` holds the only reference);
         // heap::take reclaims and drops the allocation.
         drop(unsafe { bun_core::heap::take(this) });
     }

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -265,8 +265,11 @@ impl StatWatcherScheduler {
         // SAFETY: main-thread-only per fn contract; `runtime_state()` is non-null
         // after `bun_runtime::init()`. Raw-ptr-per-field re-entry pattern.
         let timer_all = unsafe { &mut (*crate::jsc_hooks::runtime_state()).timer };
-        // SAFETY: `this` is live — the caller holds a ref (`set_interval`'s
-        // BACKREF, or `StatWatcherTimerUpdate`'s `ParentRef`).
+        // SAFETY: `this` is live: a scheduler ref is held for the whole call by
+        // every caller (`set_interval`'s caller, `timer_callback`'s `&mut self`,
+        // `shutdown_for_exit`'s `RareData` ref) or, for `StatWatcherTimerUpdate`
+        // (whose `scheduler` is a non-owning `ParentRef`), by the watcher's
+        // `RefPtr<StatWatcherScheduler>` held across the hop.
         let elt = unsafe { core::ptr::addr_of_mut!((*this).event_loop_timer) };
 
         // if the interval is 0 means that we stop the timer
@@ -415,7 +418,7 @@ impl StatWatcherScheduler {
         }
 
         if this_ref.is_shutdown.load(Ordering::Relaxed) {
-            // Do not enqueue an `update_timer` Holder onto a JS-thread queue
+            // Do not enqueue a `StatWatcherTimerUpdate` onto a JS-thread queue
             // that will never tick again.
             this_ref.current_interval.store(0, Ordering::Relaxed);
         } else if contain_watchers {
@@ -729,7 +732,7 @@ impl StatWatcher {
 
     // Safe fn: reachable via the `#[ref_count(destroy = …)]` derive (whose
     // generated trait `destructor` upholds the sole-owner contract) and
-    // the `errdefer` scopeguard in `do_watch` (which owns the only reference
+    // the `errdefer` scopeguard in `init` (which owns the only reference
     // on the error path). Not `impl Drop` — this is a `.classes.ts` m_ctx
     // payload with intrusive refcount; teardown is driven by ref_count, and
     // `finalize()` is the GC entry point.

--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -2637,7 +2637,7 @@ impl NodeHTTPResponse {
         self.body_read_ref.with_mut(|r| r.unref(vm_get()));
 
         self.promise.with_mut(|p| p.deinit());
-        // SAFETY: self was allocated via `heap::into_raw` in `createForJS`;
+        // SAFETY: self was allocated via `heap::into_raw` in `NodeHTTPResponse__createForJS`;
         // refcount is zero so no other references remain — `self` is the unique
         // owner at count==0, so the `*const → *mut` cast is sound.
         unsafe { drop(bun_core::heap::take(self.as_ctx_ptr())) };

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -1525,7 +1525,7 @@ impl Interpreter {
                 }
 
                 if let Some(worker_ptr) = vm.worker {
-                    // SAFETY: `vm.worker` is set in `VirtualMachine::initWorker`
+                    // SAFETY: `vm.worker` is set in `VirtualMachine::init_worker`
                     // to a live `*WebWorker` for the worker's lifetime.
                     let worker = unsafe { &*worker_ptr.cast::<bun_jsc::web_worker::WebWorker>() };
                     let argv = worker.argv();

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -889,7 +889,7 @@ impl Cmd {
             Exec::None => {}
             Exec::Builtin(b) => drop(b),
             Exec::Subproc(sub) if !sub.child.is_null() => {
-                // SAFETY: `child` was set by `initSubproc` from a
+                // SAFETY: `child` was set by `spawn_async` from a
                 // `heap::alloc(ShellSubprocess)` and stays valid until this
                 // drop. Single-threaded. Reclaiming the box runs
                 // `ShellSubprocess::drop` → `finalize_sync` (closes stdio).

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -1223,7 +1223,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         }
 
         // `_scope_guard` (declared after `cleanup`) drops first → scope.exit();
-        // then `cleanup` → needs_deref/markInactive/deref.
+        // then `cleanup` → needs_deref/mark_inactive/deref.
     }
 
     /// Takes `ThisPtr<Self>` for the same re-entrancy reason as
@@ -1307,7 +1307,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             // uSockets will defer freeing the TCP socket until the next tick
             if !self.socket.get().is_closed() {
                 self.close_and_detach(uws::CloseCode::Normal);
-                // onClose will call markInactive again
+                // on_close will call mark_inactive again
                 return;
             }
 
@@ -3034,14 +3034,14 @@ impl<const SSL: bool> NewSocket<SSL> {
     #[bun_jsc::host_fn(method)]
     pub fn flush(this: &Self, _global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSValue> {
         jsc::mark_binding!();
-        // `end()` → `internalFlush` → `markInactive` → `closeAndDetach(.normal)`
+        // `end()` → `internal_flush` → `mark_inactive` → `close_and_detach(Normal)`
         // detaches `this.socket` and, for TLS, defers the raw close until the
         // peer's close_notify arrives — leaving `is_active` set so the eventual
-        // `onClose` can run `handlers.markInactive()`. Without this guard a
-        // follow-up `flush()` re-enters `markInactive`, sees the detached
+        // `on_close` can run `handlers.mark_inactive()`. Without this guard a
+        // follow-up `flush()` re-enters `mark_inactive`, sees the detached
         // socket as closed, and decrements `active_connections` a second time;
-        // the deferred `onClose` then underflows it. Every other
-        // `internalFlush` caller already has this check.
+        // the deferred `on_close` then underflows it. Every other
+        // `internal_flush` caller already has this check.
         if this.socket.get().is_detached() {
             return Ok(JSValue::UNDEFINED);
         }
@@ -3626,7 +3626,7 @@ impl<const SSL: bool> NewSocket<SSL> {
         if this.flags.get().contains(Flags::IS_ACTIVE) {
             this.poll_ref.with_mut(|p| p.disable());
             this.update_flags(|f| f.remove(Flags::IS_ACTIVE));
-            // Do NOT markInactive raw_handlers — ownership of the
+            // Do NOT mark_inactive raw_handlers — ownership of the
             // active_connections=1 it holds is transferring to `raw`.
             this.this_value.with_mut(|r| r.downgrade());
         }
@@ -3656,7 +3656,7 @@ impl<const SSL: bool> NewSocket<SSL> {
             local_binding: JsCell::new(None),
             protos: JsCell::new(None),
             server_name: JsCell::new(None),
-            // is_active so the chained `raw.onClose` → `markInactive` path
+            // is_active so the chained `raw.on_close` → `mark_inactive` path
             // releases `raw_handlers`. No poll_ref — `tls` keeps the loop
             // alive. active_connections=1 was already on raw_handlers from
             // `this`.
@@ -4176,7 +4176,7 @@ pub enum SocketMode {
     /// Listener-owned server. TLS (if any) configured at the listener level.
     Server,
     /// Duplex upgraded to TLS server role. Not listener-owned —
-    /// markInactive uses client lifecycle path.
+    /// mark_inactive uses client lifecycle path.
     DuplexServer,
 }
 
@@ -4232,7 +4232,7 @@ pub(crate) struct DuplexUpgradeContext {
     /// Mutually exclusive with `owned_ctx` — `runEvent` prefers `owned_ctx`.
     pub ssl_config: Option<SSLConfig>,
     /// One ref on a prebuilt `SSL_CTX` (from `opts.tls.secureContext` — the
-    /// memoised `tls.createSecureContext` path). Adopted by `startTLSWithCTX`
+    /// memoised `tls.createSecureContext` path). Adopted by `start_tls_with_ctx`
     /// on success, freed in `deinit` if Close races ahead of StartTLS.
     pub owned_ctx: Option<*mut SSL_CTX>,
     pub is_open: bool,
@@ -4402,15 +4402,15 @@ impl DuplexUpgradeContext {
         let socket = unsafe { Self::duplex_socket(this) };
         // SAFETY: fn contract; take the tls out (disjoint field).
         if let Some(tls) = unsafe { (*this).tls.take() } {
-            // `tls.onClose` consumes the +1 we hold (its scope-exit deref
+            // `TLSSocket::on_close` consumes the +1 we hold (its scope-exit deref
             // is the ext-slot/owner pin). Null our pointer first so the
-            // `deinitInNextTick` → `deinit` path doesn't deref it a second
+            // `deinit_in_next_tick` → `deinit` path doesn't deref it a second
             // time — that's the over-deref behind the cross-file
-            // `TLSSocket.finalize` use-after-poison. It also means a throw
+            // `TLSSocket::finalize` use-after-poison. It also means a throw
             // from `duplex.end()` (called right after this returns via
-            // `UpgradedDuplex.onClose` → `callWriteOrEnd`) hits the null-check
-            // in `onError` instead of reading the Handlers that `tls.onClose`
-            // → `markInactive` just released.
+            // `UpgradedDuplex::on_close` → `call_write_or_end`) hits the null-check
+            // in `on_error` instead of reading the Handlers that `TLSSocket::on_close`
+            // → `mark_inactive` just released.
             let p = tls.into_this_ptr();
             TLSSocket::on_close(p, socket, 0, None);
         }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -4358,8 +4358,8 @@ impl DuplexUpgradeContext {
             // SAFETY: fn contract; take the tls out (disjoint field).
             if let Some(tls) = unsafe { (*this).tls.take() } {
                 // Pre-open error (e.g. the duplex emitted non-Buffer data
-                // before the queued `.StartTLS` task ran). `handleConnectError`
-                // → `markInactive` releases `tls.handlers`; null `tls` so the
+                // before the queued `.StartTLS` task ran). `handle_connect_error`
+                // → `mark_inactive` releases `tls.handlers`; null `tls` so the
                 // still-queued `.StartTLS` → `onOpen` — and any further
                 // duplex events — skip the TLSSocket instead of hitting
                 // `has_handlers() == false` in `onOpen`.
@@ -4476,7 +4476,7 @@ impl DuplexUpgradeContext {
                     let errno = sys::SystemErrno::ECONNREFUSED as c_int;
                     // SAFETY: `this` is live; short-lived `&mut` for `take`.
                     if let Some(tls) = unsafe { (*this).tls.take() } {
-                        // `handleConnectError` consumes our +1 — `tls.socket`
+                        // `handle_connect_error` consumes our +1 — `tls.socket`
                         // is `InternalSocket::UpgradedDuplex` (set before
                         // `start_tls()` was queued), so `needs_deref =
                         // !is_detached()` is true — and detaches. Null
@@ -4490,7 +4490,7 @@ impl DuplexUpgradeContext {
                         let p = tls.into_this_ptr();
                         TLSSocket::handle_connect_error(p, errno, 0);
                     }
-                    // `startTLS`/`startTLSWithCTX` failed before the
+                    // `start_tls`/`start_tls_with_ctx` failed before the
                     // SSLWrapper was assigned, so its close callback
                     // was never registered and nothing will schedule
                     // `.Close`. Same as the `tls == null` early-return

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -487,7 +487,7 @@ impl BunTestRoot {
         // `bun_test_then_or_catch` when the promise settles — which it now
         // never will (the VM is going away). Release each orphan ourselves;
         // any reaction that is still queued is dropped wholesale by
-        // `destructOnExit`.
+        // `Zig__GlobalObject__destructOnExit`.
         for ptr in self.pending_then_refs.borrow_mut().drain(..) {
             // SAFETY: `ptr` was produced by `IntrusiveRc::into_raw` in
             // `BunTest::run_test_callback`; it is live because the promise
@@ -1513,7 +1513,7 @@ pub struct RefData {
     pub(crate) phase: RefDataValue,
     pub(crate) ref_count: bun_ptr::RefCount<RefData>,
 }
-// `*RefData` crosses FFI (asPromisePtr), so this MUST be `bun_ptr::IntrusiveRc` (= `RefPtr`), never `Rc`.
+// `*RefData` crosses FFI (`as_promise_ptr`), so this MUST be `bun_ptr::IntrusiveRc` (= `RefPtr`), never `Rc`.
 pub type RefDataPtr = bun_ptr::IntrusiveRc<RefData>;
 impl RefData {
     /// `RefCounted` destructor — last ref dropped.

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -754,7 +754,7 @@ impl BunTest {
 
         let raw_ref: *mut RefData = this_ptr.as_promise_ptr::<RefData>();
         // SAFETY: `raw_ref` was produced by `IntrusiveRc::into_raw` in `run_test_callback`
-        // and round-tripped via `asPromisePtr`; we adopt the +1 it carried.
+        // and round-tripped via `as_promise_ptr`; we adopt the +1 it carried.
         let refdata: RefDataPtr = unsafe { bun_ptr::IntrusiveRc::from_raw(raw_ref) };
         // Remove the pending_then_refs entry before `deref()` so a freed `RefData` never lingers.
         if let Some(runner) = Jest::runner() {

--- a/src/runtime/timer/WTFTimer.rs
+++ b/src/runtime/timer/WTFTimer.rs
@@ -226,7 +226,7 @@ impl WTFTimer {
     }
 
     /// # Safety
-    /// `this` must be the unique owner of a `heap::alloc`-produced `WTFTimer`.
+    /// `this` must be the unique owner of a `WTFTimer` produced by `WTFTimer__create`.
     pub(crate) unsafe fn deinit(this: *mut Self) {
         // SAFETY: per fn contract.
         unsafe { Self::cancel(this) };

--- a/src/runtime/timer/WTFTimer.rs
+++ b/src/runtime/timer/WTFTimer.rs
@@ -230,8 +230,8 @@ impl WTFTimer {
     pub(crate) unsafe fn deinit(this: *mut Self) {
         // SAFETY: per fn contract.
         unsafe { Self::cancel(this) };
-        // SAFETY: `bun.TrivialNew` ↔ `heap::alloc`, so `heap::take` is
-        // the paired free.
+        // SAFETY: allocated via `heap::into_raw` in `WTFTimer__create`, so
+        // `heap::take` is the paired free.
         drop(unsafe { bun_core::heap::take(this) });
     }
 }

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -838,7 +838,7 @@ impl TimerObjectInternals {
 
         // (c) `vm.timer.maps.get(kind).swapRemove(id)` if
         //     `has_accessed_primitive` — drops the i32→*mut EventLoopTimer
-        //     entry minted by `toPrimitive`. Swap-remove: the id map is only
+        //     entry minted by `to_primitive`. Swap-remove: the id map is only
         //     ever keyed into, never iterated in order, and `deinit` runs for
         //     every id-accessed timer a GC sweep collects, so the ordered
         //     remove's O(n) shift + index rebuild here was O(n²) across a

--- a/src/runtime/timer/timer_object_internals.rs
+++ b/src/runtime/timer/timer_object_internals.rs
@@ -309,7 +309,7 @@ impl TimerObjectInternals {
                 unreachable!()
             };
             // SAFETY: `vm` is the live per-thread VM. Low tier stores `*mut ()`
-            // (PORTING.md §Dispatch); `run_immediate_task_hook` casts it back
+            // (PORTING.md §Dispatch); `__bun_run_immediate_task` casts it back
             // to `*mut ImmediateObject`.
             unsafe { (*vm).enqueue_immediate_task(parent.cast()) };
             self.set_enable_keeping_event_loop_alive(vm, true);
@@ -861,7 +861,7 @@ impl TimerObjectInternals {
             } else if kind == Kind::SetInterval {
                 // A `setTimeout` promoted to a `setInterval` by
                 // `convert_to_interval()` keeps the entry minted by
-                // `toPrimitive` in `maps.set_timeout`. Remove it from there
+                // `to_primitive` in `maps.set_timeout`. Remove it from there
                 // too, or `remove_timer_by_id` would hand out a dangling
                 // `*mut EventLoopTimer` after the parent is freed.
                 // SAFETY: as above.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1938,10 +1938,10 @@ impl BlobExt for Blob {
             .set(self.content_type_was_set.get() || content_type_was_allocated);
 
         let ptr = Blob::new(blob);
-        // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`. Explicit
-        // `&mut *` forces the inherent `Blob::to_js(&mut self)` (which calls
+        // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`. Spelled
+        // `BlobExt::to_js(&*ptr, ..)` so the `&self` impl below (which calls
         // `calculate_estimated_byte_size` and routes S3 blobs to
-        // `s3_file::to_js_unchecked`) over the by-value `JsClass::to_js`.
+        // `s3_file::to_js_unchecked`) is chosen over the by-value `JsClass::to_js`.
         unsafe { BlobExt::to_js(&*ptr, global_this) }
     }
 
@@ -1953,8 +1953,9 @@ impl BlobExt for Blob {
 
         if self.size.get() == 0 {
             let ptr = Blob::new(Blob::init_empty(global_this));
-            // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`; force
-            // the inherent `Blob::to_js(&mut self)` over `JsClass::to_js`.
+            // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`; spelled
+            // `BlobExt::to_js(&*ptr, ..)` to pick the `&self` impl over the
+            // by-value `JsClass::to_js`.
             return Ok(unsafe { BlobExt::to_js(&*ptr, global_this) });
         }
 
@@ -4206,8 +4207,9 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
     }
 
     let blob_ptr = scopeguard::ScopeGuard::into_inner(blob_guard);
-    // SAFETY: blob_ptr is valid; toJS is infallible. Explicit `&mut *` forces
-    // the inherent `Blob::to_js(&mut self)` over `JsClass::to_js(self)`.
+    // SAFETY: blob_ptr is valid; to_js is infallible. Spelled
+    // `BlobExt::to_js(&*blob_ptr, ..)` to pick the `&self` impl over the
+    // by-value `JsClass::to_js`.
     Ok(unsafe { BlobExt::to_js(&*blob_ptr, global_this) })
 }
 
@@ -4714,8 +4716,8 @@ pub(crate) fn write_file_with_source_destination(
         // this is an edgecase
         // it will happen if someone did Bun.write(new Blob([123]), new Blob([456]))
         let cloned = Blob::new(source_blob.dupe());
-        // SAFETY: ptr was just produced by heap::alloc in Blob::new; the
-        // inherent `to_js(&mut self)` (not the by-value `JsClass` one) hands
+        // SAFETY: `cloned` was just produced by heap::alloc in Blob::new;
+        // `BlobExt::to_js(&self)` (not the by-value `JsClass` one) hands
         // ownership to the C++ wrapper.
         return Ok(JSPromise::resolved_promise_value(ctx, unsafe {
             BlobExt::to_js(&*cloned, ctx)
@@ -5689,8 +5691,9 @@ pub(crate) fn construct_bun_file(
     }
 
     let ptr = Blob::new(blob);
-    // SAFETY: ptr was just produced by heap::alloc in Blob::new. Explicit
-    // `&mut *` forces inherent `Blob::to_js(&mut self)` over `JsClass::to_js(self)`.
+    // SAFETY: ptr was just produced by heap::alloc in Blob::new. Spelled
+    // `BlobExt::to_js(&*ptr, ..)` to pick the `&self` impl over the by-value
+    // `JsClass::to_js`.
     Ok(unsafe { BlobExt::to_js(&*ptr, global_object) })
 }
 
@@ -6423,8 +6426,8 @@ impl Any {
             streams::BufferActionTag::Blob => {
                 let result = Blob::new(self.to_blob(global_this));
                 // SAFETY: `Blob::new` returns a fresh heap allocation we own;
-                // `BlobExt::to_js` (the `&mut self` overload) consumes the
-                // pointer into a JS wrapper which takes ownership.
+                // `BlobExt::to_js(&self)` (not the by-value `JsClass` one) consumes
+                // the pointer into a JS wrapper which takes ownership.
                 unsafe { (*result).global_this.set(global_this) };
                 // SAFETY: same fresh `result` allocation; ownership transfers to the JS wrapper.
                 Ok(BlobExt::to_js(unsafe { &*result }, global_this))

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1941,7 +1941,7 @@ impl BlobExt for Blob {
         // SAFETY: `ptr` just came from `heap::alloc` in `Blob::new`. Explicit
         // `&mut *` forces the inherent `Blob::to_js(&mut self)` (which calls
         // `calculate_estimated_byte_size` and routes S3 blobs to
-        // `S3File.toJSUnchecked`) over the by-value `JsClass::to_js`.
+        // `s3_file::to_js_unchecked`) over the by-value `JsClass::to_js`.
         unsafe { BlobExt::to_js(&*ptr, global_this) }
     }
 
@@ -3667,7 +3667,7 @@ impl BlobExt for Blob {
                         bun_sys::Stdio::StdErr => vm.rare_data().stderr(),
                         bun_sys::Stdio::StdOut => vm.rare_data().stdout(),
                     };
-                    // SAFETY: the ctor hook (`webcore::blob::store::stdio_store_ctor`)
+                    // SAFETY: the ctor hook (`__bun_stdio_blob_store_new`)
                     // returns `Box::<Store>::into_raw` — non-null, live for the
                     // process lifetime, and laid out as `Store`.
                     let store = unsafe {

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -75,7 +75,7 @@ enum Backend {
 pub struct CompressionStreamCoder {
     backend: Backend,
     /// Shared-ownership count: 1 for the JS cell (released by its finalizer /
-    /// `nativeTransformReleaseState` via `__destroy`), plus 1 per in-flight
+    /// `nativeTransformReleaseState` via `CompressionStreamCoder__destroy`), plus 1 per in-flight
     /// `CompressionAsyncCtx`. VM teardown (`lastChanceToFinalize`) runs the
     /// cell's finalizer even while a pool thread is inside `transform` — the
     /// ctx's reference is what keeps the coder alive through that.
@@ -798,8 +798,8 @@ unsafe extern "C" {
 /// One large `CompressionStream`/`DecompressionStream` chunk transformed off
 /// the JS thread.
 pub struct CompressionAsyncCtx {
-    /// Holds one coder reference (taken in `__transformAsync`, released by
-    /// `Drop`); see [`CompressionStreamCoder::ref_count`]. TransformStream
+    /// Holds one coder reference (taken in `CompressionStreamCoder__transformAsync`,
+    /// released by `Drop`); see [`CompressionStreamCoder::ref_count`]. TransformStream
     /// serializes writes, so nothing else touches it while the pool has it.
     coder: *mut CompressionStreamCoder,
     input: AsyncInput,

--- a/src/runtime/webcore/CompressionStreamCoder.rs
+++ b/src/runtime/webcore/CompressionStreamCoder.rs
@@ -746,10 +746,10 @@ pub extern "C" fn CompressionStreamCoder__transformInto(
     let slice = if input.is_null() {
         &[][..]
     } else {
-        // SAFETY: as in `__transform`.
+        // SAFETY: as in `CompressionStreamCoder__transform`.
         unsafe { core::slice::from_raw_parts(input, input_len) }
     };
-    // SAFETY: as in `__transform`.
+    // SAFETY: as in `CompressionStreamCoder__transform`.
     match unsafe { (*this).transform(slice, finish) } {
         Ok(()) => {
             // SAFETY: as above; the sink copies before returning.
@@ -809,7 +809,7 @@ pub struct CompressionAsyncCtx {
 
 impl Drop for CompressionAsyncCtx {
     fn drop(&mut self) {
-        // SAFETY: `coder` was ref'd in `__transformAsync`; this ctx owns that
+        // SAFETY: `coder` was ref'd in `CompressionStreamCoder__transformAsync`; this ctx owns that
         // reference and drops it exactly once (in `then`, or when the job is
         // released unrun / its off-thread part finishes after the VM is gone).
         unsafe { bun_ptr::ThreadSafeRefCount::<CompressionStreamCoder>::deref(self.coder) };
@@ -855,7 +855,7 @@ impl bun_jsc::JobContext for CompressionAsyncCtx {
             None => {
                 // SAFETY: `this` holds a coder reference until it drops at the
                 // end of this fn, so `coder` (and its `out` buffer) stay live
-                // while `deliverAsync` copies.
+                // while `Bun__CompressionStream__deliverAsync` copies.
                 let coder = unsafe { &*this.coder };
                 (coder.out.as_ptr(), coder.out.len(), JSValue::ZERO)
             }

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -423,7 +423,7 @@ impl S3Client {
         // `Blob::new` heap-promotes and marks `ref_count = 1` so
         // the JSS3File wrapper's `finalize` knows to free the blob.
         let blob = crate::webcore::blob::Blob::new(ptr.construct_blob(global, path, options)?);
-        // `to_js` runs `calculateEstimatedByteSize()`
+        // `to_js` runs `calculate_estimated_byte_size()`
         // before wrapping the heap Blob in a JSS3File so JSC sees the correct
         // GC pressure. Route through `BlobExt::to_js` (the `&mut self` method
         // that owns the heap pointer), same as `S3File::construct_internal_js`.

--- a/src/runtime/webcore/S3Client.rs
+++ b/src/runtime/webcore/S3Client.rs
@@ -425,8 +425,8 @@ impl S3Client {
         let blob = crate::webcore::blob::Blob::new(ptr.construct_blob(global, path, options)?);
         // `to_js` runs `calculate_estimated_byte_size()`
         // before wrapping the heap Blob in a JSS3File so JSC sees the correct
-        // GC pressure. Route through `BlobExt::to_js` (the `&mut self` method
-        // that owns the heap pointer), same as `S3File::construct_internal_js`.
+        // GC pressure. Route through `BlobExt::to_js` (the `&self` impl, which
+        // hands the heap pointer to the wrapper), same as `S3File::construct_internal_js`.
         // SAFETY: `blob` is a freshly leaked `*mut Blob` from `Blob::new`;
         // `to_js` hands ownership of that pointer to the C++ wrapper.
         Ok(unsafe { &mut *blob }.to_js(global))

--- a/src/runtime/webcore/TextDecoder.rs
+++ b/src/runtime/webcore/TextDecoder.rs
@@ -719,7 +719,7 @@ pub extern "C" fn TextDecoder__createForStream(
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn TextDecoder__destroyForStream(this: *mut TextDecoder) {
     if !this.is_null() {
-        // SAFETY: `this` was returned by `__createForStream` and has not been
+        // SAFETY: `this` was returned by `TextDecoder__createForStream` and has not been
         // freed (the C++ cell clears its pointer before calling).
         unsafe { bun_core::heap::destroy(this) };
     }

--- a/src/runtime/webcore/TextEncoderStreamEncoder.rs
+++ b/src/runtime/webcore/TextEncoderStreamEncoder.rs
@@ -219,7 +219,7 @@ pub extern "C" fn TextEncoderStreamEncoder__createForStream() -> *mut TextEncode
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn TextEncoderStreamEncoder__destroyForStream(this: *mut TextEncoderStreamEncoder) {
     if !this.is_null() {
-        // SAFETY: `this` was returned by `__createForStream` and has not been
+        // SAFETY: `this` was returned by `TextEncoderStreamEncoder__createForStream` and has not been
         // freed (the C++ cell clears its pointer before calling).
         drop(unsafe { Box::from_raw(this) });
     }
@@ -255,7 +255,7 @@ pub extern "C" fn TextEncoderStreamEncoder__flushForStream(
     this: *mut TextEncoderStreamEncoder,
     global: &JSGlobalObject,
 ) -> JSValue {
-    // SAFETY: as in `__encodeForStream`.
+    // SAFETY: as in `TextEncoderStreamEncoder__encodeForStream`.
     unsafe { &*this }.flush_body(global)
 }
 
@@ -332,7 +332,7 @@ pub extern "C" fn TextEncoderStreamEncoder__flushIntoSink(
     sink_id: u8,
     sink_ptr: *mut core::ffi::c_void,
 ) -> JSValue {
-    // SAFETY: as in `__encodeForStream`.
+    // SAFETY: as in `TextEncoderStreamEncoder__encodeForStream`.
     let this = unsafe { &*this };
     if this.pending_lead_surrogate.get().is_none() {
         return JSValue::UNDEFINED;
@@ -341,7 +341,7 @@ pub extern "C" fn TextEncoderStreamEncoder__flushIntoSink(
     let Some(ptr) = NonNull::new(sink_ptr) else {
         return JSValue::UNDEFINED;
     };
-    // SAFETY: as in `__encodeIntoSink`.
+    // SAFETY: as in `TextEncoderStreamEncoder__encodeIntoSink`.
     let handle = unsafe { sink_handle_from_id(sink_id, ptr) };
     if handle.is_none() {
         return JSValue::UNDEFINED;

--- a/src/runtime/webcore/TextEncoderStreamEncoder.rs
+++ b/src/runtime/webcore/TextEncoderStreamEncoder.rs
@@ -323,7 +323,7 @@ pub extern "C" fn TextEncoderStreamEncoder__encodeIntoSink(
     wrote
 }
 
-/// Native-sink flush step; see `__encodeIntoSink` for the return contract.
+/// Native-sink flush step; see `TextEncoderStreamEncoder__encodeIntoSink` for the return contract.
 #[unsafe(no_mangle)]
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub extern "C" fn TextEncoderStreamEncoder__flushIntoSink(

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -124,9 +124,10 @@ impl<'a, F: ReadFileToJs> ReadFileCompletion for NewReadFileHandler<'a, F> {
                 })?;
             }
             ReadFileResultType::Err(err) => {
-                // SAFETY: `promise` was just swapped out of a live `Strong`
-                // handle; the JS heap cell is kept alive by the caller's
-                // `JSRef` over the ReadFile task.
+                // SAFETY: `promise` was just swapped out of `handler.promise`,
+                // the `JSPromiseStrong` that rooted it across the async read;
+                // from here to `reject` it is a JS-thread stack local, kept
+                // alive by JSC's conservative stack scan.
                 let promise = unsafe { &mut *promise };
                 let val = err.to_error_instance_with_async_stack(global_this, promise);
                 promise.reject(global_this, Ok(val))?;

--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -206,7 +206,7 @@ impl S3HttpDownloadStreamingTask {
             // bitwise read+write copies its current state into `self.http` without running
             // destructors (the HTTP thread retains ownership of the source until the request
             // completes). `self.http` was previously initialised in
-            // `execute_s3_streaming_download`.
+            // `client::download_stream`.
             unsafe { core::ptr::write(self.http.as_mut_ptr(), core::ptr::read(async_http)) };
         }
         wait_until_done

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -288,7 +288,7 @@ impl S3HttpSimpleTask {
         crate::jsc_hooks::ActiveHandle::S3Request(core::ptr::NonNull::new(this).expect("task"))
             .unregister();
         // SAFETY: `this` was produced by `S3HttpSimpleTask::new` (heap::alloc) and ownership is
-        // reclaimed here exactly once via the ConcurrentTask `.manual_deinit` contract;
+        // reclaimed here exactly once via the ConcurrentTask `AutoDeinit::ManualDeinit` contract;
         // `this` is dropped at scope exit.
         let mut this = unsafe { bun_core::heap::take(this) };
 

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1093,7 +1093,7 @@ pub(crate) fn to_bytes(
         flags,
     };
 
-    // SAFETY: `Offsets` is `#[repr(C)]` POD; same `sliceAsBytes` rationale as above.
+    // SAFETY: `Offsets` is `#[repr(C)]` POD; same `modules_as_bytes` rationale as above.
     let offsets_as_bytes: &[u8] = unsafe {
         core::slice::from_raw_parts((&raw const offsets).cast::<u8>(), size_of::<Offsets>())
     };

--- a/test/internal/source-lints/pre-port-identifiers.test.ts
+++ b/test/internal/source-lints/pre-port-identifiers.test.ts
@@ -1,0 +1,85 @@
+// Guards against comments (SAFETY comments in particular) naming functions and
+// fields by their pre-port Zig spelling. A SAFETY comment that points at
+// `markInactive` cannot be checked against a tree whose function is
+// `mark_inactive`, and the stale name tends to get copied into neighbouring
+// comments.
+//
+// Each name below was driven to zero occurrences in comment lines of
+// src/**/*.rs, and none of them is also a C++ or JS identifier in this tree, so
+// a reappearance is a stale reference rather than a cross-language one. Names
+// with a live C++/JS namesake (`collectAsync`, `drainMicrotasks`, ...) and the
+// `/// \`Zig.name\`` provenance line that heads many ported functions are
+// deliberately not listed.
+
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import path from "node:path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+const renamed: { zig: string; rust: string }[] = [
+  { zig: "calculateEstimatedByteSize", rust: "calculate_estimated_byte_size" },
+  { zig: "callWriteOrEnd", rust: "call_write_or_end" },
+  { zig: "closeAndDetach", rust: "close_and_detach" },
+  { zig: "computeHasPendingActivity", rust: "compute_has_pending_activity" },
+  { zig: "deinitInNextTick", rust: "deinit_in_next_tick" },
+  { zig: "dirInfoUncached", rust: "dir_info_uncached" },
+  { zig: "handleConnectError", rust: "handle_connect_error" },
+  { zig: "incrementPendingTasks", rust: "increment_pending_tasks" },
+  { zig: "initBake", rust: "VirtualMachine::init_bake" },
+  { zig: "initSubproc", rust: "ShellSubprocess::spawn_async" },
+  { zig: "internalFlush", rust: "internal_flush" },
+  { zig: "isSliceInBuffer", rust: "bun_alloc::is_slice_in_buffer" },
+  { zig: "markInactive", rust: "mark_inactive" },
+  { zig: "onResolveJSC", rust: "plugin_runner::on_resolve_jsc" },
+  { zig: "resetStore", rust: "reset_store" },
+  { zig: "startTLSWithCTX", rust: "start_tls_with_ctx" },
+  { zig: "toJSUnchecked", rust: "to_js_unchecked" },
+];
+
+const banned = renamed.map(({ zig, rust }) => ({
+  zig,
+  rust,
+  // `\b` keeps `Prefix__name` C symbols (`_` is a word character) from matching.
+  pattern: new RegExp(`\\b${zig}\\b`),
+}));
+
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+const hits: Record<string, string[]> = {};
+for (const { zig } of banned) {
+  hits[zig] = [];
+}
+
+for (const abs of rustSources) {
+  const rel = path.relative(root, abs);
+  const lines = (await file(abs).text()).split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // Only comments are linted; a string literal such as a log message that
+    // still carries the old spelling is not a stale cross-reference.
+    if (!line.includes("//")) continue;
+    for (const { zig, pattern } of banned) {
+      if (pattern.test(line)) {
+        hits[zig].push(`${rel}:${i + 1}`);
+      }
+    }
+  }
+}
+
+for (const { zig, rust } of banned) {
+  test(`comments do not name pre-port \`${zig}\``, () => {
+    const found = hits[zig];
+    if (found.length > 0) {
+      const sample = found.slice(0, 20);
+      throw new Error(
+        `Found ${found.length} comment(s) in src/**/*.rs naming \`${zig}\`, which no longer exists; ` +
+          `the Rust identifier is \`${rust}\`.\n` +
+          `Locations${found.length > 20 ? ` (first 20 of ${found.length})` : ""}:\n` +
+          sample.map(l => `  ${l}`).join("\n"),
+      );
+    }
+    expect(found).toEqual([]);
+  });
+}


### PR DESCRIPTION
Supersedes #37625 (same two commits, rebased onto main, plus a follow-up commit addressing the review there and a source lint that pins the result).

### What does this PR do?

Comment-only, plus a few debug assert messages. About a hundred `// SAFETY:` comments still justified their `unsafe` block by naming a Zig-era function or field that the Rust port renamed or folded away (`incrementPendingTasks`, `resetPolls`, `watcherReleaseEvent`, `has_pending_wake`, `arg0_backing`, and so on). Each one now names the identifier that actually exists, so the justification can be checked against the code again. Where the named guard was genuinely gone (`read_file.rs` claimed a `JSRef` root that does not exist), the comment now states the real mechanism.

The follow-up commit addresses the review on #37625:

- Every name the sweep renamed is now renamed at the remaining comment sites in the same files too, so a file no longer carries both spellings (`run_tasks`/`sleep_until` in `hoisted_install.rs`, `enqueue_extract_npm_package` in `TarballStream.rs`, `unref_on_next_tick` in `VirtualMachine.rs`, `mark_inactive`/`start_tls_with_ctx` in `socket_body.rs`, `hold_api_lock`, `as_promise_ptr`, `dir_info_uncached`, `process_fetch_log`, `clone_utf8`, `Zig__GlobalObject__destructOnExit`, the `*__transformAsync`/`*__destroy`/`*__encodeIntoSink` exports, `SslCtx`, and the release-side assert messages in `dev_server/mod.rs` that still named `watcherAcquireEvent`/`watcherReleaseAndSubmitEvent`).
- `Blob.rs`: the `to_js` call sites said they force an inherent `Blob::to_js(&mut self)` via `&mut *`; the code calls `BlobExt::to_js(&*ptr, ..)`, whose receiver is `&self`. All six sites in the file, and the same claim in `S3Client.rs`, now describe that.
- `JSBundler.rs`: the defer comment named `parse_task.ctx`; the code reads `completion_ctx`.
- `node_fs_stat_watcher.rs`: `set_timer`'s SAFETY comment credited `StatWatcherTimerUpdate`'s `ParentRef` (non-owning) with keeping the scheduler alive. It now names what actually does: the refs held by `set_interval`'s callers, `timer_callback`, `shutdown_for_exit`, and the watcher's `RefPtr<StatWatcherScheduler>` across the hop.
- `event_loop.rs`: the `global_ref` comment listed `init_runtime_state` as a writer of `EventLoop.global`; it is not one, so the list now names the actual write sites.

Leftovers of the same names in files this PR does not otherwise touch (for example `sleepUntil` in `install_with_manager.rs`) are left for a separate pass.

Names that are real but live on the C++/JS side (`m_ctx`, `drainMicrotasks`, `collectNow`) and the `/// \`Zig.name\` ...` provenance line at the top of ported functions were deliberately left alone.

The last commit adds `test/internal/source-lints/pre-port-identifiers.test.ts` next to `port-era-markers.test.ts`. It lists the 17 Zig-era names this PR drove to zero in `src/**/*.rs` comment lines that have no C++ or JS namesake in the tree (`markInactive`, `dirInfoUncached`, `incrementPendingTasks`, `startTLSWithCTX`, ...), and each failure names the Rust identifier to use instead. Names with a live namesake on the other side of the FFI (`collectAsync`, `deliverAsync`) are not listed so the lint cannot fire on a legitimate cross-language reference.

### How did you verify your code works?

The only non-comment lines in the `src/` diff are debug assert / panic message strings (checked with `git diff | grep` for non-comment lines). Every replacement name was grepped for before use. `cargo fmt --all -- --check`, `cargo check -p bun_runtime -p bun_install`, and `bun test test/internal/source-lints/` are clean.

The new lint passes on this branch and fails all 17 entries with `src/` at the merge base (one of them, `calculateEstimatedByteSize`, also surfaced a fresh copy of the old comment that the `S3Client.rs` refactor on main carried over; fixed while resolving the rebase conflict).

The one red lane on #37625's build (`worker_threads.test.ts` under the x64-asan exception-check validator, `handleTraps` reported at `JSC__JSModuleLoader__loadAndEvaluateModule`) is the termination race #37267 fixes and is unrelated to this diff.
