### PR TITLE
blob: delete Blob::deinit, which freed the allocation through &mut self

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -212,8 +212,11 @@ const _: () = {
 };
 
 impl Blob {
-    /// Heap-promote and mark as
-    /// heap-allocated so `deinit` knows to free the heap box.
+    /// Heap-promote with one count. The allocation is freed by [`Blob__deref`]
+    /// releasing the last count (JS wrapper finalizer, C++ `BlobRefPtr`,
+    /// [`bun_ptr::ExternalShared`]) and by nothing else. A `Blob` that is not
+    /// promoted needs no teardown call: its store ref, name and content type
+    /// are released by their own drops.
     #[inline]
     pub fn new(mut blob: Blob) -> *mut Blob {
         blob.ref_count = bun_ptr::RawRefCount::init(1);
@@ -234,8 +237,8 @@ impl Blob {
         );
         // SAFETY: `self` is the allocation `Blob::new` produced and the JS
         // wrapper's `+1` is the count released here. `into_raw` hands the box
-        // over without dropping it; `Blob__deref` runs `deinit()` (which
-        // `drop(heap::take)`s) when the count reaches zero.
+        // over without dropping it; `Blob__deref` frees the allocation when
+        // the count reaches zero.
         unsafe { Blob__deref(bun_core::heap::into_raw(self)) }
     }
 
@@ -450,21 +453,6 @@ impl Blob {
             store::Data::S3(s3) => Some(s3.path()),
         }
     }
-
-    /// Tear down owned resources; if
-    /// heap-allocated, also frees the heap box.
-    pub fn deinit(&mut self) {
-        self.detach();
-        self.name.set(bun_core::String::dead());
-
-        self.content_type.set(BlobContentType::default());
-
-        if self.is_heap_allocated() {
-            // SAFETY: `self` is the `*mut Blob` originally produced by
-            // `Blob::new` (`heap::alloc`).
-            unsafe { drop(bun_core::heap::take(std::ptr::from_mut::<Blob>(self))) };
-        }
-    }
 }
 
 // SAFETY: `Blob__ref`/`Blob__deref` operate on the intrusive `ref_count` and
@@ -487,8 +475,9 @@ unsafe impl bun_ptr::ExternalSharedDescriptor for Blob {
 /// # Safety
 /// `this` must point to a live `Blob` produced by [`Blob::new`], and the call
 /// must happen on the thread that owns it (the count is not atomic). A
-/// by-value `Blob` has a count of zero; bumping it would make a later
-/// [`Blob::deinit`] free an address that was never heap-allocated.
+/// by-value `Blob` has a count of zero; giving it one would make the
+/// [`Blob__deref`] that later releases it free an address that was never
+/// heap-allocated.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Blob__ref(this: *mut Blob) {
     // SAFETY: caller contract above.
@@ -512,18 +501,17 @@ unsafe extern "C" fn Blob__ref(this: *mut Blob) {
 /// last count frees the `Blob`, so `this` is dangling once this returns.
 #[unsafe(no_mangle)]
 unsafe extern "C" fn Blob__deref(this: *mut Blob) {
-    // SAFETY: caller contract above. `deinit` frees the allocation, so `this`
-    // is not touched after it.
+    // SAFETY: caller contract above: `this` is the `Blob::new` allocation and
+    // the count released here was owned by the caller. When it was the last
+    // one nothing else refers to the allocation, so the box is freed here;
+    // dropping it releases the store ref, name and content type.
     unsafe {
         debug_assert!(
             (*this).is_heap_allocated(),
             "cannot deref: this Blob is not heap-allocated"
         );
         if (*this).ref_count.decrement() == bun_ptr::raw_ref_count::DecrementResult::ShouldDestroy {
-            // `deinit` has its own `is_heap_allocated()` guard around the
-            // `drop(heap::take)`, so re-arm so it returns true.
-            (*this).ref_count.increment();
-            (*this).deinit();
+            bun_core::heap::destroy(this);
         }
     }
 }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -4473,16 +4473,10 @@ unsafe fn transpile_file(
             return ptr::null_mut();
         }
     };
-    // Deinit the blob (if any) on scope exit.
-    // Note: reshaped for borrowck — capture the `is_some()` flag *before*
-    // moving the option into the scopeguard so the `transpile_async` predicate
-    // can still read it without aliasing the guard's `&mut`.
+    // `blob_to_deinit` stays alive (and so does the store `lr` /
+    // `virtual_source_to_use` point into) until this function returns, where
+    // its drop releases the store.
     let had_blob = blob_to_deinit.is_some();
-    let _blob_guard = scopeguard::guard(blob_to_deinit, |mut slot| {
-        if let Some(mut blob) = slot.take() {
-            blob.deinit();
-        }
-    });
 
     // ── force_loader / require.extensions override ──────────────────────────
     if let Some(loader_type) = force_loader_type {

--- a/src/runtime/server/FileRoute.rs
+++ b/src/runtime/server/FileRoute.rs
@@ -23,7 +23,6 @@ use crate::webcore::body::Value as BodyValue;
 use crate::webcore::{Blob, FetchHeaders, Response};
 
 #[derive(bun_ptr::CellRefCounted)]
-#[ref_count(destroy = FileRoute::deinit)]
 pub struct FileRoute {
     // Owned via intrusive refcount; the
     // raw `*mut FileRoute` is round-tripped through `FileResponseStream`'s
@@ -129,16 +128,6 @@ impl FileRoute {
             status_code: opts.status_code,
             stat_hash: Cell::new(StatHash::default()),
         }))
-    }
-
-    fn deinit(this: *mut FileRoute) {
-        // SAFETY: `this` was allocated via heap::alloc in init_from_blob/from_js and the
-        // intrusive ref_count has reached 0.
-        // `headers` is freed by its own Drop when the Box is dropped.
-        unsafe {
-            (*this).blob.deinit();
-            drop(bun_core::heap::take(this));
-        }
     }
 
     pub fn from_js(global: &JSGlobalObject, argument: JSValue) -> JsResult<Option<*mut FileRoute>> {

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -290,7 +290,7 @@ impl Drop for PinnedArrayBuf {
 }
 
 /// Refcounted wrapper around a `webcore.Blob`. `Arc` provides the refcount;
-/// `Drop` runs `Blob::deinit`.
+/// dropping the last one releases the blob's store.
 pub struct BuiltinBlob {
     pub(crate) blob: crate::webcore::Blob,
 }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -141,7 +141,7 @@ pub use bun_jsc::generated::JSBlob as js;
 
 // ──────────────────────────────────────────────────────────────────────────
 // BlobExt — `bun_runtime`-tier behaviour layered on the `bun_jsc` data type.
-// Inherent methods (`new`/`init`/`shared_view`/`dupe`/`detach`/`deinit`/…)
+// Inherent methods (`new`/`init`/`shared_view`/`dupe`/`detach`/…)
 // live on `bun_jsc::webcore_types::Blob`; everything that touches the event
 // loop / S3 / fs / `VirtualMachine` is here.
 // ──────────────────────────────────────────────────────────────────────────
@@ -584,7 +584,6 @@ impl BlobExt for Blob {
             impl<H: ReadBytesHandler> Task<H> {
                 fn done(mut self: Box<Self>, r: ReadBytesResult) {
                     self.poll.unref(bun_io::js_vm_ctx());
-                    self.blob.deinit();
                     let ctx = self.ctx;
                     drop(self);
                     // SAFETY: `ctx` is the pointer handed to `read_bytes_to_handler`;
@@ -650,7 +649,7 @@ impl BlobExt for Blob {
                 payer = s3.request_payer;
             }
             // SAFETY: `path` borrows the store held by `t.blob` (a fresh +1 ref);
-            // it stays valid until `Task::done` deinits the blob in the callback.
+            // it stays valid until `Task::done` drops the task in the callback.
             let path = unsafe { &*path };
             let t_ptr = bun_core::heap::into_raw(t).cast::<c_void>();
             if self.offset.get() > 0 || self.size.get() != MAX_SIZE {
@@ -4075,16 +4074,15 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
     // Bun.file() keeps its window's end. MAX_SIZE means unknown.
     let mut file_size: Option<u64> = None;
 
-    let blob: *mut Blob = match store_tag {
-        store::SerializeTag::Bytes => 'bytes: {
+    // `blob` stays by value until every field has been read: an early return
+    // below drops it, which releases its store (and with it the payload
+    // bytes). It is heap-promoted only once the record has fully parsed.
+    let blob: Blob = match store_tag {
+        store::SerializeTag::Bytes => {
             let bytes_len = reader.read_int_le::<u32>()?;
             let bytes = read_slice(reader, bytes_len as usize)?;
 
             let blob = Blob::init(bytes, global_this);
-            // `blob` now owns `bytes` (via its Store when non-empty). If any
-            // of the remaining reads fail before we heap-promote it, Drop on
-            // `blob` releases the store so the payload bytes don't leak.
-            let guard = scopeguard::guard(blob, |mut b| b.deinit());
 
             'versions: {
                 if version == 1 {
@@ -4094,8 +4092,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                 let name_len = reader.read_int_le::<u32>()?;
                 let name = read_slice(reader, name_len as usize)?;
 
-                // ScopeGuard derefs to its inner Blob.
-                if let Some(store) = (*guard).store() {
+                if let Some(store) = blob.store() {
                     if let store::Data::Bytes(bytes_store) = &mut store.data_mut() {
                         // Transfer ownership of the local `name: Vec<u8>` into
                         // `stored_name` (a `Box<[u8]>`); freed by `Bytes::Drop`.
@@ -4109,10 +4106,9 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                 }
             }
 
-            let blob = scopeguard::ScopeGuard::into_inner(guard);
-            break 'bytes Blob::new(blob);
+            blob
         }
-        store::SerializeTag::File => 'file: {
+        store::SerializeTag::File => {
             use crate::node::types::PathOrFileDescriptorSerializeTag;
             if version >= 4 {
                 file_size = Some(reader.read_int_le::<u64>()?);
@@ -4132,11 +4128,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                         return Err(crate::Error::InvalidValue);
                     }
                     let mut path_or_fd = PathOrFileDescriptor::Fd(fd);
-                    break 'file Blob::new(Blob::find_or_create_file_from_path(
-                        &mut path_or_fd,
-                        global_this,
-                        true,
-                    ));
+                    Blob::find_or_create_file_from_path(&mut path_or_fd, global_this, true)
                 }
                 PathOrFileDescriptorSerializeTag::Path => {
                     let path_len = reader.read_int_le::<u32>()?;
@@ -4154,25 +4146,12 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                     let mut dest = PathOrFileDescriptor::Path(node::PathLike::String(
                         bun_ptr::cow_slice::CowSlice::init_owned(path.into_boxed_slice()),
                     ));
-                    break 'file Blob::new(Blob::find_or_create_file_from_path(
-                        &mut dest,
-                        global_this,
-                        true,
-                    ));
+                    Blob::find_or_create_file_from_path(&mut dest, global_this, true)
                 }
             }
         }
-        store::SerializeTag::Empty => Blob::new(Blob::init_empty(global_this)),
+        store::SerializeTag::Empty => Blob::init_empty(global_this),
     };
-    // `blob` is heap-allocated past this point; on any remaining error
-    // (truncated trailer fields) tear down both the heap object and its
-    // store. `content_type` is handled by its own Drop above since it
-    // hasn't been attached to `blob` yet.
-    // SAFETY: blob is a freshly-allocated heap pointer from Blob::new.
-    let blob_guard = scopeguard::guard(blob, |b| unsafe { (*b).deinit() });
-    // SAFETY: `blob_guard` holds the sole pointer to the fresh heap allocation.
-    // Shared access only — Blob state is Cell/JsCell-based.
-    let blob = unsafe { &**blob_guard };
 
     'versions: {
         if version == 1 {
@@ -4197,11 +4176,6 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
             break 'versions;
         }
     }
-
-    debug_assert!(
-        blob.is_heap_allocated(),
-        "expected blob to be heap-allocated"
-    );
 
     // `offset` comes from untrusted bytes. Clamp it so a crafted payload cannot
     // make shared_view() slice past the end of the backing store (OOB heap read).
@@ -4229,9 +4203,9 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         blob.content_type_was_set.set(content_type_was_set);
     }
 
-    let blob_ptr = scopeguard::ScopeGuard::into_inner(blob_guard);
-    // SAFETY: blob_ptr is valid; toJS is infallible. Explicit `&mut *` forces
-    // the inherent `Blob::to_js(&mut self)` over `JsClass::to_js(self)`.
+    let blob_ptr = Blob::new(blob);
+    // SAFETY: `blob_ptr` is the fresh `Blob::new` allocation; `to_js` hands it
+    // to the JS wrapper, whose finalizer releases the count `new` gave it.
     Ok(unsafe { BlobExt::to_js(&*blob_ptr, global_this) })
 }
 
@@ -5881,9 +5855,8 @@ impl S3BlobDownloadTask {
 
 impl Drop for S3BlobDownloadTask {
     fn drop(&mut self) {
-        Blob::deinit(&mut self.blob);
         self.poll_ref.unref(bun_io::js_vm_ctx());
-        // promise: Drop handles deinit.
+        // `blob` and `promise` are released by their own drops.
     }
 }
 

--- a/src/runtime/webcore/Body.rs
+++ b/src/runtime/webcore/Body.rs
@@ -768,8 +768,7 @@ impl Value {
             Value::Empty => ReadableStream::empty(global_this),
             Value::Null => Ok(JSValue::NULL),
             Value::InternalBlob(_) | Value::Blob(_) | Value::WTFStringImpl(_) => {
-                // `deinit` must run on every exit incl. `?` paths.
-                let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
+                let blob = self.use_();
                 blob.resolve_size();
                 let blob_size = blob.size.get();
                 let value = ReadableStream::from_blob_copy_ref(global_this, &blob, blob_size)?;
@@ -821,7 +820,7 @@ impl Value {
             }
             Value::Blob(_) => {
                 let stream = {
-                    let blob = scopeguard::guard(self.use_(), |mut b| b.deinit());
+                    let blob = self.use_();
                     blob.resolve_size();
                     if blob.needs_to_read_file() || blob.is_s3() {
                         let blob_size = blob.size.get();
@@ -1216,8 +1215,8 @@ impl Value {
         match self {
             Value::Blob(b) => {
                 // `Value` has `Drop`, so we cannot move the `Blob` out by
-                // value (E0509). `mem::take` leaves a default `Blob` whose `deinit()`
-                // (run by `Value::drop` on the assignment below) is a no-op.
+                // value (E0509). `mem::take` leaves a default `Blob`, which
+                // owns nothing, for the assignment below to drop.
                 let new_blob = core::mem::take(b);
                 *self = Value::Used;
                 debug_assert!(!new_blob.is_heap_allocated()); // owned by Body
@@ -1429,8 +1428,9 @@ impl Value {
             }
             return;
         }
-        // Assignment runs `Drop` on the old variant: deref WTFStringImpl, deinit
-        // Blob, free InternalBlob's Vec, reset Error. Null/Used/Empty are no-ops.
+        // Assignment drops the old variant: deref WTFStringImpl, release the
+        // Blob's store, free InternalBlob's Vec, reset Error. Null/Used/Empty
+        // are no-ops.
         *self = Value::Null;
     }
 }
@@ -1454,10 +1454,10 @@ impl Drop for Value {
                 }
             }
             Value::WTFStringImpl(s) => wtf_impl(s).deref(),
-            Value::Blob(b) => b.deinit(),
             Value::Error(e) => e.reset(),
-            // `InternalBlob`'s `Vec<u8>` is freed by the compiler's drop glue.
-            Value::InternalBlob(_) | Value::Used | Value::Empty | Value::Null => {}
+            // `Blob`'s store ref / name / content type and `InternalBlob`'s
+            // `Vec<u8>` are freed by the compiler's drop glue.
+            Value::Blob(_) | Value::InternalBlob(_) | Value::Used | Value::Empty | Value::Null => {}
         }
     }
 }

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -45,13 +45,6 @@ impl Entry {
     }
 }
 
-impl Drop for Entry {
-    fn drop(&mut self) {
-        self.blob.deinit();
-        // The allocation itself is freed by the `Box<Entry>` drop.
-    }
-}
-
 impl ObjectURLRegistry {
     pub(crate) fn register(&self, vm: &mut VirtualMachine, blob: &Blob) -> UUID {
         let uuid = vm.rare_data().next_uuid();

--- a/test/internal/source-lints/self-receiver-reclaim.test.ts
+++ b/test/internal/source-lints/self-receiver-reclaim.test.ts
@@ -74,13 +74,9 @@ const SELF_AS_POINTER = [
 const BANNED = new RegExp(`${RECLAIM}(?:${SELF_AS_POINTER})`, "g");
 
 // Documented, ratcheted exceptions: files allowed to keep exactly N of the
-// shape. Prefer converting over adding an entry here.
-const ALLOW: Record<string, number> = {
-  // `Blob::deinit(&mut self)` frees heap-allocated blobs through its receiver.
-  // It is being converted separately (#37672); delete this entry when that
-  // lands.
-  "src/jsc/webcore_types.rs": 1,
-};
+// shape. Empty by design: the whole tree is at zero. Prefer converting over
+// adding an entry here.
+const ALLOW: Record<string, number> = {};
 
 const counts: Record<string, number> = {};
 const offenders: string[] = [];
@@ -122,7 +118,8 @@ test("the pattern recognizes the spellings it claims to", () => {
     // `<BlobReadChain as ReadBytesHandler>::on_read_bytes(&mut self)`, as it
     // was before the trait handed the pointer over.
     "let boxed = unsafe { bun_core::heap::take(std::ptr::from_mut::<Self>(self)) };",
-    // `Blob::deinit(&mut self)`.
+    // `Blob::deinit(&mut self)`, as it was before it was deleted in favour of
+    // the field drops.
     "unsafe { drop(bun_core::heap::take(std::ptr::from_mut::<Blob>(self))) };",
     "unsafe { bun_core::heap::destroy(self) };",
     "drop(unsafe { Box::from_raw(self) });",

--- a/test/internal/source-lints/unsafe-refcount-exports.test.ts
+++ b/test/internal/source-lints/unsafe-refcount-exports.test.ts
@@ -10,8 +10,8 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // Adjusting an intrusive count is only sound when the caller holds a count on
 // an object that is actually refcounted, and no signature can prove that:
 // releasing a count nobody owns frees the object out from under its owner, and
-// bumping the count of a by-value instance turns its ordinary teardown into a
-// free of a non-heap address. That obligation has to be an `unsafe` contract on
+// bumping the count of a by-value instance makes the release that later
+// balances it free a non-heap address. That obligation has to be an `unsafe` contract on
 // the export itself, because the same symbol is callable from Rust (the
 // `ExternalSharedDescriptor` impl, finalizers) as well as from the C++
 // `RefDerefTraits` it exists for.

--- a/test/js/web/fetch/blob-file-name-ownership.test.ts
+++ b/test/js/web/fetch/blob-file-name-ownership.test.ts
@@ -69,3 +69,66 @@ test("structuredClone round-trips File (Bytes) and Bun.file (File) names without
   });
   expect(exitCode).toBe(0);
 });
+
+// The deserializer builds the Blob (and its store) before it has read the
+// record's trailer (is-a-File flag, lastModified, File name), so a record cut
+// short inside the trailer bails out holding a half-built Blob, which has to be
+// released exactly once. `bun:jsc`'s serialize() produces the same record
+// structuredClone() does; deserializing every proper prefix of it walks every
+// early return in the deserializer, for each of the three store kinds the
+// record can carry. Under the debug (ASAN) build a double free aborts the
+// subprocess and, on the lanes that enable leak detection, a leak is reported
+// on stderr at exit.
+test("a truncated structured-clone record releases the half-built Blob exactly once", async () => {
+  using dir = tempDir("blob-truncated-clone", {
+    "payload.bin": "the file contents",
+  });
+  const filePath = `${String(dir)}/payload.bin`;
+  const name = "owned-name.bin";
+  const script = `
+    import { deserialize, serialize } from "bun:jsc";
+    const NAME = ${JSON.stringify(name)};
+    const FILE_PATH = ${JSON.stringify(filePath)};
+    const inputs = {
+      // Data::Bytes store (SerializeTag::Bytes), with a stored name and a File name.
+      bytes: new File(["payload"], NAME, { type: "text/plain", lastModified: 1234 }),
+      // Data::File store (SerializeTag::File).
+      file: Bun.file(FILE_PATH),
+      // No store at all (SerializeTag::Empty), but still a File with a name.
+      empty: new File([], NAME),
+    };
+    const out = {};
+    for (const [kind, value] of Object.entries(inputs)) {
+      const full = serialize(value);
+      // From 1: an empty buffer deserializes to null instead of throwing.
+      for (let len = 1; len < full.byteLength; len++) {
+        let threw = false;
+        try {
+          deserialize(full.slice(0, len));
+        } catch {
+          threw = true;
+        }
+        if (!threw) throw new Error(kind + ": a record truncated to " + len + " bytes deserialized");
+      }
+      const clone = deserialize(full);
+      out[kind] = { name: clone.name, size: clone.size, type: clone.type };
+    }
+    Bun.gc(true);
+    process.stdout.write(JSON.stringify(out));
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const stderrLines = stderr.split("\n").filter(line => !line.startsWith("WARNING: ASAN interferes"));
+  expect(stderrLines.join("\n")).toBe("");
+  expect(JSON.parse(stdout)).toEqual({
+    bytes: { name, size: 7, type: "text/plain;charset=utf-8" },
+    file: { name: filePath, size: 17, type: "application/octet-stream" },
+    empty: { name, size: 0, type: "" },
+  });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `Blob::deinit(&mut self)` released the blob's resources and then, whenever the intrusive count was non-zero, freed the allocation it had been called through. A safe method call could therefore free memory.
- `Blob` is built by value in many places and `ref_count` is public, so a by-value `Blob` with a count set made a safe `deinit()` free a stack address, and a `&mut` into a JS-owned `Blob` freed it out from under the wrapper, `BlobRefPtr` or `ExternalShared<Blob>` holding its counts.
- Even on the intended path (last count released) freeing through the `&mut self` argument is invalid: a reduction of this shape fails under Miri with `deallocation through <tag> ... is forbidden ... the strongly protected tag disallows deallocations`. This is why bun's other freeing teardowns take `this: *mut Self`.
- No in-tree caller misused it. This is a contract fix in the same family as #37597, #37681 and #37577, split out because it needed a caller audit.

### Fix
- `deinit()` is deleted. Without the free it did exactly what dropping a `Blob` already does (`Blob` has no `Drop` impl; store ref, name and content type release themselves), so the nine by-value callers now let their `Blob` drop, and two custom destructors that existed only to make this call go away.
- The one free of a `Blob::new` allocation is now `Blob__deref` releasing the last count, which destroys the `*mut Blob` it receives. Property to check: after this PR no safe function frees a `Blob`, and each converted call site releases the same things at the same point as before.
- The structured-clone deserializer, the other caller that relied on the free, now keeps the blob by value until the record has fully parsed and heap-promotes it right before wrapping it, so every early return drops a local instead of running a raw-pointer guard.
- Verification: the source lint's allowlist entry for this line is removed (on `main` it reports exactly this line, with the fix zero); a new test deserializes every truncated prefix of three record kinds under the ASAN build, also run 20 times under leak detection; the existing suites for each converted drop site pass on the ASAN build.

### Background
- `Blob` carries an intrusive `ref_count`. Count zero means a by-value `Blob` owned by whatever struct holds it (a `Body`, a route, a download task). `Blob::new` moves it to the heap with one count; JS wrappers, C++ `BlobRefPtr` and `ExternalShared<Blob>` hold further counts through `Blob__ref` / `Blob__deref`.
- A blob's resources (store ref, name, content type) are fields with their own destructors, so ordinary Rust drop fully tears down a by-value `Blob`. Only a heap-promoted one needs an explicit free.
- Freeing memory through a `&mut self` receiver is undefined behaviour even when the caller holds the last count, because the reference protects the memory for the duration of the call. The tree's convention for teardowns that free is a raw `this: *mut Self`.
- The structured-clone deserializer reads a blob record in two halves: the store (bytes, file path, or empty), then a trailer (File flag, lastModified, name). A record cut short inside the trailer leaves a half-built blob that has to be released exactly once.
- `test/internal/source-lints/self-receiver-reclaim.test.ts` is a ratchet: it scans `src/` for reclaiming a method's own receiver and its allowlist holds an exact count per file, so removing the last offender also requires removing its entry.

<details>
<summary>Original description</summary>

### Problem

`Blob::deinit(&mut self)` (src/jsc/webcore_types.rs) released the store ref, the name and the content type, and then ended with

```rust
if self.is_heap_allocated() {            // == ref_count != 0
    unsafe { drop(bun_core::heap::take(std::ptr::from_mut::<Blob>(self))) };
}
```

so it freed whatever allocation it happened to be called through whenever the intrusive count was non-zero. Nothing about a `&mut Blob` supports that:

* `Blob` is constructed by value all over the tree (`Blob::dupe()`, `AnyBlob` / `Body::Value::Blob` payloads, stack locals), `Default` is public and so is `ref_count`, so this was an invalid free with no `unsafe` anywhere in the caller:

  ```rust
  let mut b = bun_jsc::webcore_types::Blob::default();
  b.ref_count = bun_ptr::RawRefCount::init(1);
  b.deinit();            // heap::take on a stack address
  ```

  and a `&mut Blob` into a JS-owned heap `Blob` (src/runtime/image/Image.rs and src/runtime/api/Archive.rs form those today) turned a safe `deinit()` into freeing the object out from under the wrapper, `BlobRefPtr` or `ExternalShared<Blob>` that owns its counts.
* Even on the intended path (`Blob__deref` releasing the last count) freeing through the `&mut self` argument deallocates memory that a reference argument protects for the duration of the call. A standalone reduction of exactly this shape fails under Miri with both models: Tree Borrows (what `bun run rust:miri` uses) reports `deallocation through <tag> ... is forbidden ... the strongly protected tag disallows deallocations`, pointing at the `&mut self` receiver; Stacked Borrows reports `deallocating while item [Unique] is strongly protected`. This is why the tree's other teardown functions that end in a free take `this: *mut Self` (see the comments on `deinit` in src/sql_jsc/postgres/PostgresSQLConnection.rs and src/sql_jsc/mysql/JSMySQLConnection.rs, and #37681 for the same conversion on `ReadBytesHandler`).

No in-tree caller misused it; this is a contract fix in the same family as #37597 (`Blob__ref`/`Blob__deref`), #37681 and #37577, split out of #37597 because it needed a caller audit.

### Fix

The audit of every `Blob`-typed `deinit()` call found two callers that relied on the free and nine that did not, and the nine all drop the `Blob` immediately after the call. Once the free is gone, `deinit()` is exactly what dropping a `Blob` already does (`Blob` has no `Drop` impl; `StoreRef`, `OwnedStringCell` and the content type `Arc` release themselves), so rather than keeping a method that duplicates the drop glue (Body.rs already carries three "never expose `pub fn deinit(&mut self)`" notes from the port), it is deleted:

* A `Blob::new` allocation is freed in exactly one place: `Blob__deref` releasing the last count now runs `heap::destroy` on the `*mut Blob` it receives (#37597 gave it that signature) instead of re-arming the count and calling `deinit()`. `Blob::new` and `Blob__ref` document that nothing else frees it.
* `on_structured_clone_deserialize` (src/runtime/webcore/Blob.rs), the other caller that relied on the free, heap-promoted the blob before reading the record's trailer and used a raw-pointer scope guard calling `deinit()` to free it on a truncated record. It now keeps the blob by value until the record has fully parsed and calls `Blob::new` immediately before wrapping it, so every early return drops a local. Both scope guards, the `unsafe` reborrow and the `is_heap_allocated` assertion go away; the rest of the function is unchanged.
* The by-value callers now just let their `Blob` drop: `Body::Value`'s `Drop` arm and the two `to_readable_stream` scope guards (Body.rs), the S3 `read_bytes_to_handler` task and `S3BlobDownloadTask::drop` (Blob.rs), the `blob:` import keep-alive in jsc_hooks.rs, and `ObjectURLRegistry::Entry` and `FileRoute`, whose custom destructors existed only to make this call (`FileRoute` goes back to `CellRefCounted`'s default `destroy`, which its docs prescribe for exactly this case). Each of these released the same things at the same point before; the only ordering change is `S3BlobDownloadTask`, whose blob now drops after `poll_ref.unref()` instead of before, and nothing in between looks at it.

`ref_count` staying `pub` is now only a hygiene question (one struct literal in Blob.rs needs it): no safe function's free depends on it any more, so it is left alone here. #37656 (open) makes the same by-value change to the deserializer as part of replacing `BlobExt::to_js`; the arms here are written to match it, and whichever lands second drops its copy of that hunk.

### Tests

* test/internal/source-lints/self-receiver-reclaim.test.ts (landed by #37681) bans reclaiming a method's own receiver through `heap::take` / `heap::destroy` / `Box::from_raw`, and on `main` carries a ratcheted allowlist entry of exactly 1 for src/jsc/webcore_types.rs naming this PR. This PR deletes the entry, leaving the allowlist empty. With this test change and `main`'s `src/` the lint reports exactly

  ```
  src/jsc/webcore_types.rs:465: heap::take(std::ptr::from_mut::<Blob>(self)
  ```

  and with the fix the tree is at zero (the ratchet test would also fail if the entry were left in place once the line is gone). The rationale sentence in unsafe-refcount-exports.test.ts that described the old `deinit()` behaviour is updated to match.
* test/js/web/fetch/blob-file-name-ownership.test.ts gets a second test for the restructured deserializer: it serializes a `File` with bytes, a `Bun.file()` and an empty `File` through `bun:jsc` (same record `structuredClone` produces), deserializes every truncated prefix of each (which reaches every early return in the deserializer, including the trailer ones that previously went through the heap guard), and checks the full record still round-trips with an empty stderr, so a double free shows up under the ASAN build. The existing test in that file (4000 structuredClone round-trips, each finalized through `Blob__deref`) covers the new free path.

### Verification

On the debug (ASAN) build: the two test files above; for the converted drop sites, test/js/web/fetch/{body,body-stream,response}.test.ts and test/js/web/fetch/wpt/textstream-wpt.test.ts (Body), test/js/node/buffer-resolveObjectURL.test.ts, test/js/web/workers/worker_blob.test.ts and test/js/web/url/url.test.ts (object URL entries and `blob:` imports), test/js/bun/http/{bun-serve-file,bun-serve-static,serve-file-slice-read-error,tls-bunfile-leak}.test.ts (`FileRoute`, `StaticRoute`, the SSLConfig `ExternalShared<Blob>` fields), test/js/bun/s3/{s3-requester-pays,s3-connection-close,s3-insecure,s3-stream-error-gc}.test.ts against their local servers (`S3BlobDownloadTask`), test/js/bun/image/image.test.ts (the S3/file read task), and test/js/web/fetch/blob.test.ts, test/js/web/structured-clone-blob-file.test.ts, test/js/web/html/FormData.test.ts, test/js/web/websocket/websocket-blob.test.ts (C++ `BlobRefPtr` releasing through `Blob__deref`); plus test/js/bun/http/serve-body-leak.test.ts and the `Sending Blob` / `Body.Value` cases of test/js/web/fetch/fetch-leak.test.ts. Running the truncated-record sweep 20 times over under `detect_leaks=1` reports no allocation from the blob or deserializer code. `bun test test/internal/source-lints/` passes, and the lint fails with `main`'s `src/` as shown above. `cargo clippy` and `cargo fmt --check` on `bun_jsc` and `bun_runtime` are clean.


</details>
