### PR TITLE
tls: deliver application data written before the handshake over a Duplex or named pipe

### DIFF
--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -189,14 +189,8 @@ impl UpgradedDuplex {
                 .map(Into::into),
         });
         (this.handlers.on_handshake)(this.handlers.ctx, handshake_success, ssl_error);
-        // Application data written before this point is parked in the owner
-        // (`buffered_data_for_node_net`): `encode_and_write` took none of it
-        // while the engine was missing or `SSL_write` wanted the handshake
-        // first. A real socket gets a synthetic writable event for this from
-        // openssl.c (`ssl_write_wants_read`); a duplex has no fd and only
-        // reports its own backpressure, so the retry has to be driven here.
-        // The handshake callback may have torn the engine down (rejected
-        // certificate, `destroy()`); the close path fails the parked write.
+        // Flush writes parked during the handshake (openssl.c's
+        // `ssl_write_wants_read`); a duplex emits no writable event of its own.
         if handshake_success && !this.is_shutdown() {
             (this.handlers.on_writable)(this.handlers.ctx);
         }
@@ -566,12 +560,8 @@ impl UpgradedDuplex {
         }
     }
 
-    /// `wrapper` is `None` only until the queued `start_tls` task runs
-    /// (`teardown` neuters the engine in place, it never clears the slot), so
-    /// a missing engine is a connection that has not started, not one that is
-    /// over: the owner's write path must park data written in that window
-    /// (like it does for a pre-handshake `SSL_write`) instead of dropping it
-    /// as a write to a shut-down socket. `on_handshake` retries it.
+    /// No engine yet (`start_tls` still queued; teardown never clears the slot)
+    /// is not shut down: writes made then are parked and flushed by `on_handshake`.
     #[uws_callback(export = "UpgradedDuplex__is_shutdown", no_catch)]
     pub(crate) fn is_shutdown(&self) -> bool {
         self.wrapper_ref().is_some_and(|w| w.is_shutdown())

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -189,8 +189,7 @@ impl UpgradedDuplex {
                 .map(Into::into),
         });
         (this.handlers.on_handshake)(this.handlers.ctx, handshake_success, ssl_error);
-        // Flush writes parked during the handshake (openssl.c's
-        // `ssl_write_wants_read`); a duplex emits no writable event of its own.
+        // Retry writes parked during the handshake, like openssl.c's `ssl_write_wants_read`.
         if handshake_success && !this.is_shutdown() {
             (this.handlers.on_writable)(this.handlers.ctx);
         }
@@ -560,8 +559,7 @@ impl UpgradedDuplex {
         }
     }
 
-    /// No engine yet (`start_tls` still queued; teardown never clears the slot)
-    /// is not shut down: writes made then are parked and flushed by `on_handshake`.
+    /// `None` means `start_tls` has not run yet (teardown never clears the slot), not shut down.
     #[uws_callback(export = "UpgradedDuplex__is_shutdown", no_catch)]
     pub(crate) fn is_shutdown(&self) -> bool {
         self.wrapper_ref().is_some_and(|w| w.is_shutdown())

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -189,6 +189,17 @@ impl UpgradedDuplex {
                 .map(Into::into),
         });
         (this.handlers.on_handshake)(this.handlers.ctx, handshake_success, ssl_error);
+        // Application data written before this point is parked in the owner
+        // (`buffered_data_for_node_net`): `encode_and_write` took none of it
+        // while the engine was missing or `SSL_write` wanted the handshake
+        // first. A real socket gets a synthetic writable event for this from
+        // openssl.c (`ssl_write_wants_read`); a duplex has no fd and only
+        // reports its own backpressure, so the retry has to be driven here.
+        // The handshake callback may have torn the engine down (rejected
+        // certificate, `destroy()`); the close path fails the parked write.
+        if handshake_success && !this.is_shutdown() {
+            (this.handlers.on_writable)(this.handlers.ctx);
+        }
     }
 
     fn on_close(this: *mut Self) {
@@ -555,14 +566,21 @@ impl UpgradedDuplex {
         }
     }
 
+    /// `wrapper` is `None` only until the queued `start_tls` task runs
+    /// (`teardown` neuters the engine in place, it never clears the slot), so
+    /// a missing engine is a connection that has not started, not one that is
+    /// over: the owner's write path must park data written in that window
+    /// (like it does for a pre-handshake `SSL_write`) instead of dropping it
+    /// as a write to a shut-down socket. `on_handshake` retries it.
     #[uws_callback(export = "UpgradedDuplex__is_shutdown", no_catch)]
     pub(crate) fn is_shutdown(&self) -> bool {
-        self.wrapper_ref().is_none_or(|w| w.is_shutdown())
+        self.wrapper_ref().is_some_and(|w| w.is_shutdown())
     }
 
+    /// See [`Self::is_shutdown`] for the not-yet-started case.
     #[uws_callback(export = "UpgradedDuplex__is_closed", no_catch)]
     pub(crate) fn is_closed(&self) -> bool {
-        self.wrapper_ref().is_none_or(|w| w.is_closed())
+        self.wrapper_ref().is_some_and(|w| w.is_closed())
     }
 
     #[uws_callback(export = "UpgradedDuplex__is_established", no_catch)]

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -398,8 +398,7 @@ impl WindowsNamedPipe {
                 .map(Into::into),
         });
         (self.handlers.on_handshake)(self.handlers.ctx, handshake_success, ssl_error);
-        // Flush writes parked during the handshake; a TLS 1.2 client sends
-        // nothing on completion, so no pipe write completion would do it.
+        // Retry writes parked during the handshake; a TLS 1.2 client's completion sends nothing.
         if handshake_success && !self.is_shutdown() {
             (self.handlers.on_writable)(self.handlers.ctx);
         }

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -398,6 +398,15 @@ impl WindowsNamedPipe {
                 .map(Into::into),
         });
         (self.handlers.on_handshake)(self.handlers.ctx, handshake_success, ssl_error);
+        // Retry data the owner parked while `SSL_write` still wanted the
+        // handshake (same as `UpgradedDuplex::on_handshake`). The writer's own
+        // drain only covers this when completing the handshake happens to
+        // send something (TLS 1.3 client Finished); a TLS 1.2 client completes
+        // on the server's Finished and writes nothing, so nothing else would
+        // ever flush the parked bytes.
+        if handshake_success && !self.is_shutdown() {
+            (self.handlers.on_writable)(self.handlers.ctx);
+        }
     }
 
     fn on_close(&self) {

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -398,12 +398,8 @@ impl WindowsNamedPipe {
                 .map(Into::into),
         });
         (self.handlers.on_handshake)(self.handlers.ctx, handshake_success, ssl_error);
-        // Retry data the owner parked while `SSL_write` still wanted the
-        // handshake (same as `UpgradedDuplex::on_handshake`). The writer's own
-        // drain only covers this when completing the handshake happens to
-        // send something (TLS 1.3 client Finished); a TLS 1.2 client completes
-        // on the server's Finished and writes nothing, so nothing else would
-        // ever flush the parked bytes.
+        // Flush writes parked during the handshake; a TLS 1.2 client sends
+        // nothing on completion, so no pipe write completion would do it.
         if handshake_success && !self.is_shutdown() {
             (self.handlers.on_writable)(self.handlers.ctx);
         }

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -869,6 +869,13 @@ describe("application data written over a Duplex transport before the handshake 
   }
   const synchronously = (push: () => void) => push();
   const serverContext = () => ({ isServer: true, secureContext: tls.createSecureContext(COMMON_CERT_) });
+  // Resolves when `closing` emits 'close'; an 'error' on any of `failing` rejects instead.
+  function closeOf(closing: TLSSocket, failing: TLSSocket[] = [closing]) {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    closing.on("close", () => resolve());
+    for (const socket of failing) socket.on("error", reject);
+    return promise;
+  }
 
   it("client write() issued right after tls.connect() reaches the server, in order", async () => {
     // The engine for a Duplex transport is created on a later event-loop
@@ -888,9 +895,10 @@ describe("application data written over a Duplex transport before the handshake 
       client.end();
     });
     client.on("data", () => {});
+    const closed = closeOf(client, [client, server]);
     client.write("one", err => log.push(`write callback err=${err}`));
     log.push(`write() returned writableLength=${client.writableLength}`);
-    await once(client, "close");
+    await closed;
 
     expect({ log, received: Buffer.concat(received).toString() }).toEqual({
       log: ["write() returned writableLength=3", "secureConnect writableLength=3", "write callback err=null"],
@@ -916,11 +924,13 @@ describe("application data written over a Duplex transport before the handshake 
     const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
     client.on("secureConnect", () => log.push(`secureConnect writableLength=${client.writableLength}`));
     client.on("data", () => {});
+    client.on("error", clientHelloWritten.reject);
+    const closed = closeOf(client, [client, server]);
     await clientHelloWritten.promise;
     log.push(`ClientHello written secureConnecting=${client.secureConnecting}`);
     client.write("one", err => log.push(`write callback err=${err}`));
     client.end();
-    await once(client, "close");
+    await closed;
 
     expect({ log, received: Buffer.concat(received).toString() }).toEqual({
       log: ["ClientHello written secureConnecting=true", "secureConnect writableLength=3", "write callback err=null"],
@@ -942,7 +952,7 @@ describe("application data written over a Duplex transport before the handshake 
     const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
     client.on("data", (chunk: Buffer) => received.push(chunk));
     client.on("end", () => client.end());
-    await once(client, "close");
+    await closeOf(client, [client, server]);
 
     expect({ log, received: Buffer.concat(received).toString() }).toEqual({
       log: ["secure writableLength=6", "write callback err=null"],
@@ -964,7 +974,7 @@ describe("application data written over a Duplex transport before the handshake 
     const client = tls.connect({ socket: clientSide });
     client.on("error", clientError.resolve);
     client.write("secret", err => writeOutcome.resolve(err ? "failed" : "succeeded"));
-    const closed = new Promise<void>(resolve => client.on("close", () => resolve()));
+    const closed = closeOf(client, []);
 
     const [{ code: clientErrorCode }, outcome] = await Promise.all([clientError.promise, writeOutcome.promise, closed]);
     // 'close' is emitted a macrotask after the teardown, so anything the engine
@@ -988,10 +998,9 @@ describe("application data written over a Duplex transport before the handshake 
     server.on("error", () => {});
 
     const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
-    client.on("error", () => {});
     client.write("parked", err => writeOutcome.resolve(err ? "failed" : "succeeded"));
     client.on("secureConnect", () => client.destroy());
-    const closed = new Promise<void>(resolve => client.on("close", () => resolve()));
+    const closed = closeOf(client);
 
     const [outcome] = await Promise.all([writeOutcome.promise, closed]);
     expect({ outcome, serverReceived: Buffer.concat(received).toString() }).toEqual({
@@ -1006,10 +1015,9 @@ describe("application data written over a Duplex transport before the handshake 
     const writeOutcome = Promise.withResolvers<string>();
 
     const server = new TLSSocket(serverSide, serverContext());
-    server.on("error", () => {});
     server.write("banner", err => writeOutcome.resolve(err ? "failed" : "succeeded"));
     server.on("secure", () => server.destroy());
-    const closed = new Promise<void>(resolve => server.on("close", () => resolve()));
+    const closed = closeOf(server);
 
     const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
     client.on("error", () => {});

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -975,6 +975,52 @@ describe("application data written over a Duplex transport before the handshake 
       serverReceived: "",
     });
   });
+
+  // Destroying from the handshake event tears the engine down right under the
+  // retry of the pending write: it must be failed, not delivered.
+  it("a pending client write is failed when a 'secureConnect' listener destroys the socket", async () => {
+    const { clientSide, serverSide } = inMemoryPair(synchronously);
+    const received: Buffer[] = [];
+    const writeOutcome = Promise.withResolvers<string>();
+
+    const server = new TLSSocket(serverSide, serverContext());
+    server.on("data", (chunk: Buffer) => received.push(chunk));
+    server.on("error", () => {});
+
+    const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
+    client.on("error", () => {});
+    client.write("parked", err => writeOutcome.resolve(err ? "failed" : "succeeded"));
+    client.on("secureConnect", () => client.destroy());
+    const closed = new Promise<void>(resolve => client.on("close", () => resolve()));
+
+    const [outcome] = await Promise.all([writeOutcome.promise, closed]);
+    expect({ outcome, serverReceived: Buffer.concat(received).toString() }).toEqual({
+      outcome: "failed",
+      serverReceived: "",
+    });
+  });
+
+  it("a pending server write is failed when a 'secure' listener destroys the socket", async () => {
+    const { clientSide, serverSide } = inMemoryPair(synchronously);
+    const received: Buffer[] = [];
+    const writeOutcome = Promise.withResolvers<string>();
+
+    const server = new TLSSocket(serverSide, serverContext());
+    server.on("error", () => {});
+    server.write("banner", err => writeOutcome.resolve(err ? "failed" : "succeeded"));
+    server.on("secure", () => server.destroy());
+    const closed = new Promise<void>(resolve => server.on("close", () => resolve()));
+
+    const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
+    client.on("error", () => {});
+    client.on("data", (chunk: Buffer) => received.push(chunk));
+
+    const [outcome] = await Promise.all([writeOutcome.promise, closed]);
+    expect({ outcome, clientReceived: Buffer.concat(received).toString() }).toEqual({
+      outcome: "failed",
+      clientReceived: "",
+    });
+  });
 });
 
 it("delivers 'session' even when the data handler destroys the socket immediately", async () => {

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -843,6 +843,114 @@ it("a client and a server TLSSocket connected through a synchronous in-memory du
   });
 });
 
+describe("application data written over a Duplex transport before the handshake completes", () => {
+  // Node parks such a write (TLSWrap's pending cleartext) and sends it right
+  // after the handshake: the write is still pending when 'secureConnect' /
+  // 'secure' fires, its callback runs afterwards, and the peer receives it
+  // ahead of anything written later. Bun's fd-backed path behaves the same;
+  // these pin the stream-level engine to it.
+  function inMemoryPair(deliver: (push: () => void) => void, onClientTransportWrite = () => {}) {
+    const makeSide = (peer: () => Duplex, onWrite = () => {}) =>
+      new Duplex({
+        read() {},
+        write(chunk, _encoding, callback) {
+          onWrite();
+          deliver(() => peer().push(chunk));
+          callback();
+        },
+        final(callback) {
+          deliver(() => peer().push(null));
+          callback();
+        },
+      });
+    const clientSide: Duplex = makeSide(() => serverSide, onClientTransportWrite);
+    const serverSide: Duplex = makeSide(() => clientSide);
+    return { clientSide, serverSide };
+  }
+  const synchronously = (push: () => void) => push();
+  const serverContext = () => ({ isServer: true, secureContext: tls.createSecureContext(COMMON_CERT_) });
+
+  it("client write() issued right after tls.connect() reaches the server, in order", async () => {
+    // The engine for a Duplex transport is created on a later event-loop
+    // turn, so this write lands before it even exists.
+    const { clientSide, serverSide } = inMemoryPair(synchronously);
+    const log: string[] = [];
+    const received: Buffer[] = [];
+
+    const server = new TLSSocket(serverSide, serverContext());
+    server.on("data", (chunk: Buffer) => received.push(chunk));
+    server.on("end", () => server.end());
+
+    const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
+    client.on("secureConnect", () => {
+      log.push(`secureConnect writableLength=${client.writableLength}`);
+      client.write("two");
+      client.end();
+    });
+    client.on("data", () => {});
+    client.write("one", err => log.push(`write callback err=${err}`));
+    log.push(`write() returned writableLength=${client.writableLength}`);
+    await once(client, "close");
+
+    expect({ log, received: Buffer.concat(received).toString() }).toEqual({
+      log: ["write() returned writableLength=3", "secureConnect writableLength=3", "write callback err=null"],
+      received: "onetwo",
+    });
+  });
+
+  it("client write() issued while the engine is waiting for the server's flight reaches the server", async () => {
+    // The transport hands chunks over on a later macrotask, so once the engine
+    // has written its ClientHello nothing can answer it before the write below.
+    const clientHelloWritten = Promise.withResolvers<void>();
+    const { clientSide, serverSide } = inMemoryPair(
+      push => setImmediate(push),
+      () => clientHelloWritten.resolve(),
+    );
+    const log: string[] = [];
+    const received: Buffer[] = [];
+
+    const server = new TLSSocket(serverSide, serverContext());
+    server.on("data", (chunk: Buffer) => received.push(chunk));
+    server.on("end", () => server.end());
+
+    const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
+    client.on("secureConnect", () => log.push(`secureConnect writableLength=${client.writableLength}`));
+    client.on("data", () => {});
+    await clientHelloWritten.promise;
+    log.push(`ClientHello written secureConnecting=${client.secureConnecting}`);
+    client.write("one", err => log.push(`write callback err=${err}`));
+    client.end();
+    await once(client, "close");
+
+    expect({ log, received: Buffer.concat(received).toString() }).toEqual({
+      log: ["ClientHello written secureConnecting=true", "secureConnect writableLength=3", "write callback err=null"],
+      received: "one",
+    });
+  });
+
+  it("server-side TLSSocket write() issued before the handshake reaches the client", async () => {
+    const { clientSide, serverSide } = inMemoryPair(synchronously);
+    const log: string[] = [];
+    const received: Buffer[] = [];
+
+    const server = new TLSSocket(serverSide, serverContext());
+    server.on("secure", () => log.push(`secure writableLength=${server.writableLength}`));
+    server.on("data", () => {});
+    server.write("banner", err => log.push(`write callback err=${err}`));
+    server.end();
+
+    const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
+    client.on("data", (chunk: Buffer) => received.push(chunk));
+    client.on("end", () => client.end());
+    await once(client, "close");
+
+    expect({ log, received: Buffer.concat(received).toString() }).toEqual({
+      log: ["secure writableLength=6", "write callback err=null"],
+      received: "banner",
+    });
+  });
+});
+
 it("delivers 'session' even when the data handler destroys the socket immediately", async () => {
   // The TLS1.3 NewSessionTickets ride in the same read pass as the response
   // bytes. If the parked session were only flushed after the data dispatch,

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -949,6 +949,32 @@ describe("application data written over a Duplex transport before the handshake 
       received: "banner",
     });
   });
+
+  it("a pending write is failed, not delivered, when the server's certificate is rejected", async () => {
+    const { clientSide, serverSide } = inMemoryPair(synchronously);
+    const received: Buffer[] = [];
+    const clientError = Promise.withResolvers<NodeJS.ErrnoException>();
+    const writeOutcome = Promise.withResolvers<string>();
+
+    const server = new TLSSocket(serverSide, serverContext());
+    server.on("data", (chunk: Buffer) => received.push(chunk));
+    server.on("error", () => {});
+
+    // The self-signed fixture fails verification under the default rejectUnauthorized.
+    const client = tls.connect({ socket: clientSide });
+    client.on("error", clientError.resolve);
+    client.write("secret", err => writeOutcome.resolve(err ? "failed" : "succeeded"));
+    const closed = new Promise<void>(resolve => client.on("close", () => resolve()));
+
+    const [{ code: clientErrorCode }, outcome] = await Promise.all([clientError.promise, writeOutcome.promise, closed]);
+    // 'close' is emitted a macrotask after the teardown, so anything the engine
+    // had handed to the synchronous transport has reached the server by now.
+    expect({ clientErrorCode, outcome, serverReceived: Buffer.concat(received).toString() }).toEqual({
+      clientErrorCode: "DEPTH_ZERO_SELF_SIGNED_CERT",
+      outcome: "failed",
+      serverReceived: "",
+    });
+  });
 });
 
 it("delivers 'session' even when the data handler destroys the socket immediately", async () => {

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -71,7 +71,9 @@ describe.each(["TLSv1.2", "TLSv1.3"] as const)(
       let client: ReturnType<typeof connect> | null = null;
       const server = createServer({ ...tls, minVersion: version, maxVersion: version }, socket => {
         socket.on("data", data => received.resolve(`${data} (${socket.getProtocol()})`));
+        socket.on("error", received.reject);
       });
+      server.on("tlsClientError", received.reject);
       try {
         const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
         server.listen(pipeName);
@@ -79,14 +81,14 @@ describe.each(["TLSv1.2", "TLSv1.3"] as const)(
 
         const socket = connect({ path: pipeName, ca: tls.cert, minVersion: version, maxVersion: version });
         client = socket;
+        socket.on("error", received.reject);
         socket.on("secureConnect", () => log.push(`secureConnect writableLength=${socket.writableLength}`));
         socket.write("Hello World!", err => {
           log.push(`write callback err=${err}`);
           written.resolve();
         });
 
-        const data = await received.promise;
-        await written.promise;
+        const [data] = await Promise.all([received.promise, written.promise]);
         expect({ received: data, log }).toEqual({
           received: `Hello World! (${version})`,
           log: ["secureConnect writableLength=12", "write callback err=null"],
@@ -98,15 +100,20 @@ describe.each(["TLSv1.2", "TLSv1.3"] as const)(
     });
 
     it.if(isWindows)("is failed, not delivered, when a 'secureConnect' listener destroys the socket", async () => {
-      const serverSocketClosed = Promise.withResolvers<void>();
+      // Settles once the server is done with the connection, whichever way the
+      // client's teardown lands there (clean close of the accepted socket, or a
+      // handshake it could no longer finish); either way every byte the client
+      // sent has been consumed by then.
+      const serverDone = Promise.withResolvers<void>();
       const writeOutcome = Promise.withResolvers<string>();
       const received: Buffer[] = [];
       let client: ReturnType<typeof connect> | null = null;
       const server = createServer({ ...tls, minVersion: version, maxVersion: version }, socket => {
         socket.on("data", (chunk: Buffer) => received.push(chunk));
         socket.on("error", () => {});
-        socket.on("close", () => serverSocketClosed.resolve());
+        socket.on("close", () => serverDone.resolve());
       });
+      server.on("tlsClientError", () => serverDone.resolve());
       try {
         const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
         server.listen(pipeName);
@@ -114,13 +121,11 @@ describe.each(["TLSv1.2", "TLSv1.3"] as const)(
 
         const socket = connect({ path: pipeName, ca: tls.cert, minVersion: version, maxVersion: version });
         client = socket;
-        socket.on("error", () => {});
+        socket.on("error", serverDone.reject);
         socket.write("parked", err => writeOutcome.resolve(err ? "failed" : "succeeded"));
         socket.on("secureConnect", () => socket.destroy());
 
-        // The server socket closes only after consuming everything the client
-        // sent before destroying itself.
-        const [outcome] = await Promise.all([writeOutcome.promise, serverSocketClosed.promise]);
+        const [outcome] = await Promise.all([writeOutcome.promise, serverDone.promise]);
         expect({ outcome, serverReceived: Buffer.concat(received).toString() }).toEqual({
           outcome: "failed",
           serverReceived: "",

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -96,6 +96,40 @@ describe.each(["TLSv1.2", "TLSv1.3"] as const)(
         server.close();
       }
     });
+
+    it.if(isWindows)("is failed, not delivered, when a 'secureConnect' listener destroys the socket", async () => {
+      const serverSocketClosed = Promise.withResolvers<void>();
+      const writeOutcome = Promise.withResolvers<string>();
+      const received: Buffer[] = [];
+      let client: ReturnType<typeof connect> | null = null;
+      const server = createServer({ ...tls, minVersion: version, maxVersion: version }, socket => {
+        socket.on("data", (chunk: Buffer) => received.push(chunk));
+        socket.on("error", () => {});
+        socket.on("close", () => serverSocketClosed.resolve());
+      });
+      try {
+        const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
+        server.listen(pipeName);
+        await once(server, "listening");
+
+        const socket = connect({ path: pipeName, ca: tls.cert, minVersion: version, maxVersion: version });
+        client = socket;
+        socket.on("error", () => {});
+        socket.write("parked", err => writeOutcome.resolve(err ? "failed" : "succeeded"));
+        socket.on("secureConnect", () => socket.destroy());
+
+        // The server socket closes only after consuming everything the client
+        // sent before destroying itself.
+        const [outcome] = await Promise.all([writeOutcome.promise, serverSocketClosed.promise]);
+        expect({ outcome, serverReceived: Buffer.concat(received).toString() }).toEqual({
+          outcome: "failed",
+          serverReceived: "",
+        });
+      } finally {
+        client?.destroy();
+        server.close();
+      }
+    });
   },
 );
 

--- a/test/js/node/tls/node-tls-namedpipes.test.ts
+++ b/test/js/node/tls/node-tls-namedpipes.test.ts
@@ -1,4 +1,4 @@
-import { expect, it } from "bun:test";
+import { describe, expect, it } from "bun:test";
 import { expectMaxObjectTypeCount, isWindows, tls } from "harness";
 import { randomUUID } from "node:crypto";
 import { once } from "node:events";
@@ -55,6 +55,49 @@ it.if(isWindows)("should work with named pipes and tls", async () => {
   // accepted socket's finalizer runs on Windows ARM64.
   await expectMaxObjectTypeCount(expect, "TLSSocket", 3);
 });
+
+describe.each(["TLSv1.2", "TLSv1.3"] as const)(
+  "%s over a named pipe: write() issued before the handshake completes",
+  version => {
+    // Same contract as the Duplex transport tests in node-tls-connect.test.ts:
+    // the write stays pending through 'secureConnect' and is delivered right
+    // after the handshake. TLS 1.2 is the interesting half: a 1.2 client
+    // finishes the handshake on the server's Finished without sending
+    // anything of its own, so no pipe write completion follows it.
+    it.if(isWindows)("is delivered after the handshake", async () => {
+      const received = Promise.withResolvers<string>();
+      const written = Promise.withResolvers<void>();
+      const log: string[] = [];
+      let client: ReturnType<typeof connect> | null = null;
+      const server = createServer({ ...tls, minVersion: version, maxVersion: version }, socket => {
+        socket.on("data", data => received.resolve(`${data} (${socket.getProtocol()})`));
+      });
+      try {
+        const pipeName = `\\\\.\\pipe\\test\\${randomUUID()}`;
+        server.listen(pipeName);
+        await once(server, "listening");
+
+        const socket = connect({ path: pipeName, ca: tls.cert, minVersion: version, maxVersion: version });
+        client = socket;
+        socket.on("secureConnect", () => log.push(`secureConnect writableLength=${socket.writableLength}`));
+        socket.write("Hello World!", err => {
+          log.push(`write callback err=${err}`);
+          written.resolve();
+        });
+
+        const data = await received.promise;
+        await written.promise;
+        expect({ received: data, log }).toEqual({
+          received: `Hello World! (${version})`,
+          log: ["secureConnect writableLength=12", "write callback err=null"],
+        });
+      } finally {
+        client?.destroy();
+        server.close();
+      }
+    });
+  },
+);
 
 it.if(isWindows)("should be able to upgrade a named pipe connection to TLS", async () => {
   await expectMaxObjectTypeCount(expect, "TLSSocket", 3);


### PR DESCRIPTION
### Problem
- A TLS socket over a stream (`tls.connect({ socket: duplex })`, `new tls.TLSSocket(duplex, { isServer: true })`, or a Windows named pipe) loses data written before the handshake completes. Node parks such a write and sends it after the handshake; Bun's fd-backed TLS path already does too.
- Written right after `tls.connect()`, Bun 1.4.0 runs the write callback with no error and the bytes never reach the peer. Written a moment later, or over a named pipe with TLS 1.2, the write is never acknowledged and the socket hangs.
- First cause: for a Duplex the engine is created on a later event-loop turn, and until then the socket reported itself as shut down. The write was refused without being buffered while node:net still held it as pending, so the later retry wrote nothing and acknowledged it.
- Second cause: once the engine exists a pre-handshake write is parked correctly, but nothing retried it when the handshake finished. The fd-backed path fires a synthetic writable event at that point; the stream and named-pipe engines only relayed the transport's own `'drain'`, which a small write never triggers.

### Fix
- A Duplex whose engine does not exist yet now reports not shut down and not closed, so the write is parked like any pre-handshake write. An empty engine slot can only mean "not started": teardown neuters the engine in place and never clears the slot.
- After a successful handshake, the Duplex and named pipe engines invoke the writable handler, which flushes the parked bytes and completes the JS write, as the fd-backed path already does. Skipped when the handshake failed or a listener tore the socket down, so those writes still fail as before.
- Property to check: parked bytes are encrypted after the handshake's final flight and before anything a `'secureConnect'` / `'secure'` listener writes, so the peer receives them in order. A drain with nothing pending is a no-op in every handler table this engine feeds.
- Verification: new in-memory Duplex tests for the lost write, the hanging write, a server-side write, a rejected certificate and destroy-from-listener, each failing on main. Named-pipe tests for TLS 1.2 and 1.3 were run on a Windows x64 machine, where the 1.2 case times out on main. Ordering was checked against node v26.3.0 with standalone scripts.

### Background
- Bun has two TLS engines. Real sockets are driven by `openssl.c` on the fd. `tls.connect({ socket })`, server-side stream wraps and Windows named pipes use a stream-level engine (`UpgradedDuplex` / `WindowsNamedPipe` owning an `SSLWrapper`) that moves bytes through the transport. Only the second is touched here.
- Before the handshake completes, `SSL_write` of application data fails with `WANT_READ`. The socket layer keeps the bytes in a per-socket buffer, and a later writable callback is what retries them, runs the JS `drain` handler, and completes the pending write.
- node:net keeps a write pending until native reports it written. A native write that says "shut down" is not buffered, and a retry that finds nothing pending succeeds, which is how the first case was acknowledged but lost.
- A TLS 1.2 client finishes the handshake on the server's Finished and sends nothing of its own, so no pipe write completion follows it. A TLS 1.3 client sends its own Finished, which is why 1.3 over a named pipe happened to work.

<details>
<summary>Original description</summary>

A TLS socket running over a generic stream (`tls.connect({ socket: duplex })`, `new tls.TLSSocket(duplex, { isServer: true })`, and on Windows `tls.connect({ path: namedPipe })`) loses application data written before the handshake completes. Node parks such a write (TLSWrap's pending cleartext) and sends it as soon as the handshake is done; Bun's fd-backed TLS path already does the same.

### Reproduction

```js
import tls from "node:tls"; import fs from "node:fs"; import { Duplex } from "node:stream";
const K = "test/js/node/tls/fixtures/";
const CERT = { key: fs.readFileSync(K + "agent1-key.pem"), cert: fs.readFileSync(K + "agent1-cert.pem") };
const makeSide = peer => new Duplex({ read() {}, write(c, _e, cb) { peer().push(c); cb(); }, final(cb) { peer().push(null); cb(); } });
const clientSide = makeSide(() => serverSide); const serverSide = makeSide(() => clientSide);
const server = new tls.TLSSocket(serverSide, { isServer: true, ...CERT });
server.on("data", d => { console.log("server got", String(d)); process.exit(0); });
const client = tls.connect({ socket: clientSide, rejectUnauthorized: false });
client.write("one", err => console.log("write cb", err));
client.on("secureConnect", () => setTimeout(() => { console.log("nothing arrived"); process.exit(1); }, 300));
```

Node v26.3.0 prints `server got one`. Bun 1.4.0 prints `write cb null` and then `nothing arrived`: the write is acknowledged but the bytes never reach the server. A write issued a moment later (after the engine exists but before the server's flight arrives) is never acknowledged at all and the socket never finishes. Over a Windows named pipe the same write hangs forever with TLS 1.2 (with TLS 1.3 it only works because the client's Finished happens to trigger a pipe write completion).

### Cause

Two gaps in the stream-level engine (`UpgradedDuplex` driving an `SSLWrapper`), neither of which the fd-backed path has:

1. `upgradeDuplexToTLS` defers creating the engine to an event-loop task, and `UpgradedDuplex::is_shutdown()` / `is_closed()` answered `true` while the engine did not exist yet (`wrapper == None`, which since the neuter-in-place teardown can only mean "not started"). `write_or_end` therefore refused the write as a write to a shut-down socket and returned `-1` without buffering it, while node:net kept the write pending; the `open` -> `drain` retry then wrote the (empty) pending data, which succeeded, and acknowledged the write.
2. Once the engine exists, a pre-handshake `SSL_write` fails with `WANT_READ`, `$write` returns 0 and the bytes are correctly parked in `buffered_data_for_node_net`. On a real socket `openssl.c` records this (`ssl_write_wants_read`) and dispatches a synthetic `on_writable` when the handshake completes, which flushes the parked bytes and completes the JS write. The stream-level engine only ever reported the transport's own `'drain'`, which a small write never triggers, so the parked bytes (and the write callback) waited forever.

### Fix

* `UpgradedDuplex::is_shutdown()` / `is_closed()` report `false` while the engine has not been created, so the write path parks the data the same way it does for a pre-handshake `SSL_write`. Nothing else distinguishes this state: teardown neuters the engine in place and never clears the slot, and every other consumer (`mark_inactive`, `close`, the connect-error paths) either sees a detached socket or an engine.
* `UpgradedDuplex::on_handshake` dispatches `on_writable` after a successful handshake, which is exactly what the fd-backed path does. `TLSSocket::on_writable` flushes `buffered_data_for_node_net` through the now-established engine and then runs the JS `drain` handler, which completes the pending write. Parked bytes are written after the handshake's final flight (same write BIO, FIFO) and before anything written from the `'secureConnect'` / `'secure'` handler, which node:net's Writable holds behind the pending write. A handshake that failed or whose callback tore the engine down (rejected certificate, `destroy()`) is skipped; the close path fails the pending write as before.
* `WindowsNamedPipe::on_handshake` gets the same dispatch: that owner already parks pre-handshake writes but relied on the pipe writer draining, which a TLS 1.2 client never does at handshake completion.

The observable ordering now matches Node and Bun's own TCP path in all three scenarios (verified with a script against node v26.3.0): the write is still pending when `'secureConnect'` / `'secure'` fires (`writableLength` unchanged), its callback runs afterwards with no error, and the peer receives it ahead of later writes. The extra `drain` dispatch after the handshake is the same thing the TCP path has always done; every handler table fed by `upgradeDuplexToTLS` (node:net client, server-side wraps, `_http2_upgrade`) treats a drain with nothing pending as a no-op.

### Tests

`test/js/node/tls/node-tls-connect.test.ts` (next to the existing in-memory duplex pair test), all over an in-memory Duplex pair:
* client write issued right after `tls.connect()` (before the engine exists): on main the data is lost and the callback runs before `'secureConnect'`
* client write issued after the ClientHello went out but before the server's flight (engine exists, handshake pending): on main the write never completes (test times out)
* server-side `TLSSocket` write before the handshake: on main it never completes (test times out)
* a write pending while the server's certificate is rejected is failed and never delivered: on main it is acknowledged as successful
* a `'secureConnect'` / `'secure'` listener destroying the socket while a write is pending: the write is failed and nothing is delivered (the retry runs right after that listener, so this exercises the teardown-under-the-retry path; the client case is acknowledged as successful on main)

`test/js/node/tls/node-tls-namedpipes.test.ts` (Windows only): the delivered and destroyed-from-`'secureConnect'` cases over a named pipe for TLS 1.2 and 1.3. Verified on a Windows x64 machine: the TLS 1.2 delivery case times out on the canary and on a debug build of main, everything passes with this change; TLS 1.3 delivery passes either way and pins the previously accidental behaviour.

The event ordering asserted by the tests (write still pending at the handshake event, callback afterwards, data ahead of later writes) was checked against node v26.3.0 with a standalone script for each scenario, as was a 200 KB pre-handshake write followed by a second write and `end()` (delivered byte for byte, same callback order as node).

Also run against this build: the rest of `node-tls-connect.test.ts`, `node-tls-server.test.ts`, `node-tls-upgrade.test.ts`, `node-tls-duplex-close-throw-uaf.test.ts`, `renegotiation.test.ts`, `node-net.test.ts`, `socket.test.ts`, and 29 vendored Node tests around stream-wrapped TLS (`test-tls-connect-stream-writes`, `test-tls-js-stream`, `test-tls-streamwrap-buffersize`, `test-tls-destroy-stream*`, `test-double-tls-server`, `test-http2-generic-streams`, ...). The remaining failures in the net suites reproduce without this change and come from this container's `localhost` resolving to `::1` or from external-network tests.

### Review notes

Things checked while reviewing the change, for the record:
* Every consumer of `is_shutdown()` / `is_closed()` / `is_established()` on a socket handler (`write_or_end`, `write_or_end_buffered`, `write_maybe_corked`, `write_vectored_raw`, `mark_inactive`, `finalize`, `reject_unauthorized_connection`, the native `readyState` getter, the `is_semi_connect` sites, h2's dead-transport close). Only the write guards change behaviour for a live duplex upgrade: `mark_inactive`'s other callers all detach the socket first, `finalize` cannot run while the wrapper is held strongly by `mark_active`, `is_semi_connect` is false for the duplex arm, h2 only gets there after a fatal write result a duplex never produces, and the native `readyState` is read by exactly one place (`_write`'s `< 0` check).
* The code after the handshake callback runs on an allocation that is only freed by a later event-loop task on both transports (`DuplexUpgradeContext::deinit` via `deinit_in_next_tick` / `run_event`; `WindowsNamedPipeContext` via `schedule_deinit`), the same invariant `on_close` in both files already relies on; a teardown from the callback leaves the engine's shutdown flags readable, which is what the guard checks.
* Ordering: the parked bytes are encrypted after the handshake's final flight is already queued in the same write BIO, and node:net's Writable holds anything written from the handshake listener behind the pending write, so delivery order is preserved (first test).
* Renegotiation re-dispatches the handshake callback and therefore also retries parked writes, which is what the fd-backed path does too.


</details>
