### PR TITLE
upgrade: pass a stack Progress instead of a leaked Box and raw ptrs

### DIFF
--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -177,12 +177,11 @@ pub(crate) struct UpgradeCommand;
 impl UpgradeCommand {
     const DEFAULT_GITHUB_HEADERS: &'static [u8] = b"Acceptapplication/vnd.github.v3+json";
 
-    pub(crate) fn get_latest_version<const SILENT: bool>(
+    pub(crate) fn get_latest_version(
         env_loader: &mut DotEnv::Loader,
-        refresher: Option<&mut Progress::Progress>,
-        mut progress: Option<&mut Progress::Node>,
+        progress: &mut Progress::Progress,
         use_profile: bool,
-    ) -> crate::Result<Option<Version>> {
+    ) -> crate::Result<Version> {
         let mut headers_buf: Vec<u8> = Self::DEFAULT_GITHUB_HEADERS.to_vec();
 
         let mut header_entries: headers::EntryList = headers::EntryList::default();
@@ -197,7 +196,6 @@ impl UpgradeCommand {
             },
         };
         header_entries.append(accept).expect("oom");
-        // defer if SILENT header_entries.deinit() — Drop handles this
 
         // Incase they're using a GitHub proxy in e.g. China
         let mut github_api_domain: &[u8] = b"api.github.com";
@@ -271,12 +269,8 @@ impl UpgradeCommand {
         ));
         async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
 
-        if !SILENT {
-            // `progress_node` stores an untracked NonNull borrow of the caller's
-            // `progress`; sound because `send_sync` below completes before this
-            // frame returns, so the pointee outlives every use.
-            async_http.client.progress_node = Some(NonNull::from(progress.as_deref_mut().unwrap()));
-        }
+        // Untracked borrow; the HTTP thread only touches the node while `send_sync` runs.
+        async_http.client.progress_node = Some(NonNull::from(&mut progress.root));
         let response = async_http.send_sync(metadata_body)?;
 
         match response.status_code() {
@@ -298,36 +292,28 @@ impl UpgradeCommand {
         let expr = match JSON::parse_utf8(&source, &mut log, bump) {
             Ok(e) => e,
             Err(err) => {
-                if !SILENT {
-                    progress.expect("infallible: progress active").end();
-                    refresher.expect("infallible: progress active").refresh();
+                progress.root.end();
+                progress.refresh();
 
-                    if log.errors > 0 {
-                        let _ = log.print(std::ptr::from_mut(Output::error_writer()));
-                        Global::exit(1);
-                    } else {
-                        bun_core::pretty_errorln!(
-                            "Error parsing releases from GitHub: <r><red>{}<r>",
-                            err.name()
-                        );
-                        Global::exit(1);
-                    }
+                if log.errors > 0 {
+                    let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+                    Global::exit(1);
+                } else {
+                    bun_core::pretty_errorln!(
+                        "Error parsing releases from GitHub: <r><red>{}<r>",
+                        err.name()
+                    );
+                    Global::exit(1);
                 }
-
-                return Ok(None);
             }
         };
 
         if log.errors > 0 {
-            if !SILENT {
-                progress.expect("infallible: progress active").end();
-                refresher.expect("infallible: progress active").refresh();
+            progress.root.end();
+            progress.refresh();
 
-                let _ = log.print(std::ptr::from_mut(Output::error_writer()));
-                Global::exit(1);
-            }
-
-            return Ok(None);
+            let _ = log.print(std::ptr::from_mut(Output::error_writer()));
+            Global::exit(1);
         }
 
         let mut version = Version {
@@ -338,18 +324,14 @@ impl UpgradeCommand {
         };
 
         if !expr.is_object() {
-            if !SILENT {
-                progress.expect("infallible: progress active").end();
-                refresher.expect("infallible: progress active").refresh();
+            progress.root.end();
+            progress.refresh();
 
-                bun_core::pretty_errorln!(
-                    "JSON error - expected an object but received {:?}",
-                    core::mem::discriminant(&expr.data)
-                );
-                Global::exit(1);
-            }
-
-            return Ok(None);
+            bun_core::pretty_errorln!(
+                "JSON error - expected an object but received {:?}",
+                core::mem::discriminant(&expr.data)
+            );
+            Global::exit(1);
         }
 
         if let Some(tag_name_) = expr.as_property(b"tag_name") {
@@ -359,20 +341,16 @@ impl UpgradeCommand {
         }
 
         if version.tag.is_empty() {
-            if !SILENT {
-                progress.expect("infallible: progress active").end();
-                refresher.expect("infallible: progress active").refresh();
+            progress.root.end();
+            progress.refresh();
 
-                bun_core::pretty_errorln!(
-                    "JSON Error parsing releases from GitHub: <r><red>tag_name<r> is missing?\n{}",
-                    // `version.buf` is still empty at this point;
-                    // print the raw payload instead.
-                    bstr::BStr::new(metadata_body.list.as_slice())
-                );
-                Global::exit(1);
-            }
-
-            return Ok(None);
+            bun_core::pretty_errorln!(
+                "JSON Error parsing releases from GitHub: <r><red>tag_name<r> is missing?\n{}",
+                // `version.buf` is still empty at this point;
+                // print the raw payload instead.
+                bstr::BStr::new(metadata_body.list.as_slice())
+            );
+            Global::exit(1);
         }
 
         'get_asset: {
@@ -447,27 +425,23 @@ impl UpgradeCommand {
                                     u32::try_from(((n.value().ceil()) as i32).max(0)).unwrap();
                             }
                         }
-                        return Ok(Some(version));
+                        return Ok(version);
                     }
                 }
             }
         }
 
-        if !SILENT {
-            progress.expect("infallible: progress active").end();
-            refresher.expect("infallible: progress active").refresh();
-            if let Some(name) = version.name() {
-                bun_core::pretty_errorln!(
-                    "Bun v{} is out, but not for this platform ({}) yet.",
-                    bstr::BStr::new(&name),
-                    Version::TRIPLET
-                );
-            }
-
-            Global::exit(0);
+        progress.root.end();
+        progress.refresh();
+        if let Some(name) = version.name() {
+            bun_core::pretty_errorln!(
+                "Bun v{} is out, but not for this platform ({}) yet.",
+                bstr::BStr::new(&name),
+                Version::TRIPLET
+            );
         }
 
-        Ok(None)
+        Global::exit(0);
     }
 
     const EXE_SUFFIX: &'static str = if cfg!(windows) { ".exe" } else { "" };
@@ -558,33 +532,13 @@ impl UpgradeCommand {
         let use_profile = argv_contains(b"--profile");
 
         let mut version: Version = if !use_canary {
-            // `Progress::start` returns `&mut Node` borrowing `refresher`;
-            // leak the Progress and use raw pointers so we can pass both
-            // `&mut refresher` and `&mut progress` to `get_latest_version`.
-            let refresher: *mut Progress::Progress =
-                bun_core::heap::into_raw(Box::new(Progress::Progress::default()));
-            // SAFETY: refresher is a fresh leaked allocation.
-            let progress: *mut Progress::Node =
-                unsafe { (*refresher).start(b"Fetching version tags", 0) };
+            let mut progress = Progress::Progress::default();
+            progress.start(b"Fetching version tags", 0);
 
-            let Some(version) = Self::get_latest_version::<false>(
-                &mut env_loader,
-                // SAFETY: refresher/progress point into the same leaked allocation;
-                // `get_latest_version` only touches them on the !SILENT error
-                // path (no overlapping live borrows).
-                Some(unsafe { &mut *refresher }),
-                // SAFETY: progress points into the same leaked allocation (see above).
-                Some(unsafe { &mut *progress }),
-                use_profile,
-            )?
-            else {
-                return Ok(());
-            };
+            let version = Self::get_latest_version(&mut env_loader, &mut progress, use_profile)?;
 
-            // SAFETY: see above.
-            unsafe { (*progress).end() };
-            // SAFETY: refresher is a leaked Box (process-lifetime); no other &mut is live.
-            unsafe { (*refresher).refresh() };
+            progress.root.end();
+            progress.refresh();
 
             if !Environment::IS_CANARY {
                 if version.name().is_some() && version.is_current() {
@@ -638,15 +592,10 @@ impl UpgradeCommand {
         let http_proxy = env_loader.get_http_proxy_for(&zip_url);
 
         {
-            let refresher: *mut Progress::Progress =
-                bun_core::heap::into_raw(Box::new(Progress::Progress::default()));
-            // SAFETY: refresher is a fresh leaked allocation.
-            let progress: *mut Progress::Node =
-                unsafe { (*refresher).start(b"Downloading", version.size as usize) };
-            // SAFETY: see above.
-            unsafe { (*progress).unit = Progress::Unit::Bytes };
-            // SAFETY: refresher is a leaked Box (process-lifetime); no other &mut is live.
-            unsafe { (*refresher).refresh() };
+            let mut progress = Progress::Progress::default();
+            progress.start(b"Downloading", version.size as usize);
+            progress.root.unit = Progress::Unit::Bytes;
+            progress.refresh();
             // Store in the process-lifetime CLI arena.
             let zip_file_buffer: &'static mut MutableString = crate::cli::cli_arena()
                 .alloc(MutableString::init(version.size.max(1024) as usize)?);
@@ -661,10 +610,8 @@ impl UpgradeCommand {
                 None,
                 HTTP::FetchRedirect::Follow,
             ));
-            // `progress` is intentionally leaked (process-lifetime), so the
-            // untracked NonNull stored in `progress_node` can never dangle.
-            async_http.client.progress_node =
-                Some(NonNull::new(progress).expect("leaked Box is non-null"));
+            // Untracked borrow; the HTTP thread only touches the node while `send_sync` runs.
+            async_http.client.progress_node = Some(NonNull::from(&mut progress.root));
             async_http.client.flags.reject_unauthorized = env_loader.get_tls_reject_unauthorized();
 
             let response = async_http.send_sync(zip_file_buffer)?;
@@ -693,10 +640,8 @@ impl UpgradeCommand {
 
             let bytes = zip_file_buffer.slice();
 
-            // SAFETY: refresher/progress are leaked allocations.
-            unsafe { (*progress).end() };
-            // SAFETY: refresher is a leaked Box (process-lifetime); no other &mut is live.
-            unsafe { (*refresher).refresh() };
+            progress.root.end();
+            progress.refresh();
 
             if bytes.is_empty() {
                 bun_core::pretty_errorln!(

--- a/test/cli/install/bun-upgrade.test.ts
+++ b/test/cli/install/bun-upgrade.test.ts
@@ -154,8 +154,8 @@ function startReleaseServer(opts: {
     NODE_TLS_REJECT_UNAUTHORIZED: "0",
     GITHUB_API_DOMAIN: `${server.hostname}:${server.port}`,
     // The upgrade-failure path exits via Global::exit(1) while the HTTP
-    // thread and the intentionally-leaked progress/download buffers are
-    // still live; LeakSanitizer reports those at exit and abort_on_error
+    // thread and the intentionally-leaked download buffers are still
+    // live; LeakSanitizer reports those at exit and abort_on_error
     // turns the clean exit(1) into SIGABRT on the ASAN lane. Leak
     // detection is not what these tests assert.
     ASAN_OPTIONS: [env.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":"),


### PR DESCRIPTION
### Problem
- No user-visible bug. `bun upgrade` leaks its two progress bars on purpose and drives them through raw pointers, 10 `unsafe` blocks in all.
- Cause: the version lookup took the progress bar and its node as two `&mut` parameters that borrow the same object, so the caller could only satisfy it by leaking the object.
- The lookup also had a `SILENT` mode and an `Option<Version>` return that nothing uses: the one caller is non-silent, and every non-silent path without a version exits the process, so `Ok(None)` was unreachable and the `Option` parameters were unwrapped 11 times.

### Fix
- The lookup takes one `&mut Progress` and reaches the node through it; both call sites keep the progress bar as a stack local, so the leaks, raw pointers and `unsafe` go away.
- Sound because the HTTP client only touches the node during the blocking send, which returns before the frame owning the progress bar does. `Progress` has no `Drop`, so the only runtime change is two allocations that no longer happen.
- The `SILENT` parameter, the `Option` return and the caller's dead `else` branch are deleted; every remaining path returns a version or exits. A test comment that called the progress object leaked is updated.
- Verification: refactor only, no new test. Existing upgrade tests pass on a debug build (8 pass, 0 fail); `cargo check` and `cargo clippy` are clean.

### Background
- `Progress` is bun's terminal progress bar. `start()` fills its public `root` node, `refresh()` redraws, `root.end()` finishes it. Since `root` is public, holding the `Progress` is enough to reach the node.
- The HTTP client stores an untracked `NonNull<Node>` and updates it from the HTTP thread while `send_sync` blocks; its soundness rests on the node outliving that call, before and after this change.
- `Global::exit` ends the process, so any `return` after it is dead code; that is what made the `Option` return unreachable.

<details>
<summary>Original description</summary>

## What

`UpgradeCommand::get_latest_version` was declared as

```rust
pub(crate) fn get_latest_version<const SILENT: bool>(
    env_loader: &mut DotEnv::Loader,
    refresher: Option<&mut Progress::Progress>,
    mut progress: Option<&mut Progress::Node>,
    use_profile: bool,
) -> crate::Result<Option<Version>>
```

but its only instantiation is `get_latest_version::<false>` with both options `Some`. Of its six `!SILENT` blocks, five are error paths that each did `progress.expect(..).end(); refresher.expect(..).refresh();` (10 `expect` calls standing in for a type invariant) and the sixth set `progress_node` from `progress.as_deref_mut().unwrap()`. To produce both references at once the caller leaked a `Box<Progress>` via `heap::into_raw` and kept two raw pointers into it, and the download block in `_exec` repeated the same pattern, plus an `expect` on `NonNull::new` of the leaked pointer (10 `unsafe` blocks between the two sites).

`Progress::start` writes the node into the `pub root` field, so a single `&mut Progress` reaches both objects. The function now takes

```rust
pub(crate) fn get_latest_version(
    env_loader: &mut DotEnv::Loader,
    progress: &mut Progress::Progress,
    use_profile: bool,
) -> crate::Result<Version>
```

and the error paths are `progress.root.end(); progress.refresh();`. Its single caller and the download block in `_exec` each own a plain stack `Progress`:

```rust
let mut progress = Progress::Progress::default();
progress.start(b"Fetching version tags", 0);
let version = Self::get_latest_version(&mut env_loader, &mut progress, use_profile)?;
progress.root.end();
progress.refresh();
```

The return type loses its `Option`: with the `SILENT` branches gone, every path that does not return a version ends in `Global::exit`, so the `Ok(None)` returns and the caller's `else { return Ok(()) }` were unreachable and are deleted. Net: removes 10 `unsafe` blocks, 2 leaked heap allocations, 11 `expect` calls and 1 `unwrap`, one const generic, and one impossible return state; 1 Rust file plus a one-word update to a comment in `bun-upgrade.test.ts` that described the progress object as intentionally leaked. This is the same shape `standalone_graph/StandaloneModuleGraph.rs::download_to_path` already uses (`refresher.root.end()`, `refresher.refresh()`). No dependency changes.

## Why

Ownership of the progress bar is now visible in the types: it is a local of `_exec`, borrowed for the duration of `get_latest_version`, and the "no progress bar" state the `Option` parameters and `Ok(None)` return allowed is no longer representable. It is zero-cost: `Progress` has no `Drop` impl, the HTTP client receives the same `NonNull<Node>` as before, the start/end/refresh sequence is unchanged, and the only runtime difference is that two allocations that were never freed no longer happen.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds on upgrade-stack-progress; bun bd test test/cli/install/bun-upgrade.test.ts: 8 pass, 0 fail.

</details>
