### PR TITLE
usockets(tls): park writes issued while the SSL is in use; guard SSL_write like the read and handshake drivers

### DIFF
--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2478,6 +2478,18 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
     return 0;
   }
 
+  /* Written from a callback that SSL_do_handshake/SSL_read on this very
+   * socket is running (the server ALPN/SNI selection hands the socket to
+   * JS): SSL_write would re-enter BoringSSL on the SSL* that call is still
+   * working on, which fails the handshake with internal_error. Park it like
+   * any other write issued before the handshake is done (the WANT_READ case
+   * below): the caller buffers, and the driver's ssl_retry_parked_write
+   * dispatches writable once the handshake completes. */
+  if (s->ssl_in_use) {
+    s->ssl_write_wants_read = 1;
+    return 0;
+  }
+
     struct loop_ssl_data *loop_ssl_data = (struct loop_ssl_data *)s->group->loop->data.ssl_data;
 
   /* Earlier batched records of ours must reach the wire before anything new:
@@ -2506,7 +2518,24 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
   while (total < length) {
     int chunk = length - total;
     if (chunk > 16384) chunk = 16384;
+    /* SSL_write drives the handshake while it is pending, so it is a driver
+     * like SSL_do_handshake/SSL_read above and follows the same protocol: a
+     * close requested from inside it is deferred to this epilogue. */
+    s->ssl_in_use = 1;
     last_ssl_written = SSL_write(s_ssl(s), data + total, chunk);
+    s->ssl_in_use = 0;
+    if (s->ssl_pending_detach) {
+      /* The socket was destroyed from inside this call. The connection is
+       * being dropped, so the records this write sealed are discarded along
+       * with whatever the BIO swallowed after the close was requested, and
+       * the caller sees 0 like any other write to a socket that is going
+       * away. */
+      loop_ssl_data->ssl_write_batching = 0;
+      loop_ssl_data->ssl_write_batch_len = 0;
+      s->ssl_pending_detach = 0;
+      us_socket_close(s, s->ssl_pending_close_code, NULL);
+      return 0;
+    }
     if (last_ssl_written <= 0) break;
     total += last_ssl_written;
     /* A batching allocation failure marks the socket fatal from inside the BIO;

--- a/packages/bun-usockets/src/crypto/openssl.c
+++ b/packages/bun-usockets/src/crypto/openssl.c
@@ -2478,13 +2478,8 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
     return 0;
   }
 
-  /* Written from a callback that SSL_do_handshake/SSL_read on this very
-   * socket is running (the server ALPN/SNI selection hands the socket to
-   * JS): SSL_write would re-enter BoringSSL on the SSL* that call is still
-   * working on, which fails the handshake with internal_error. Park it like
-   * any other write issued before the handshake is done (the WANT_READ case
-   * below): the caller buffers, and the driver's ssl_retry_parked_write
-   * dispatches writable once the handshake completes. */
+  /* Called from inside SSL_read/SSL_do_handshake on this socket (an ALPN/SNI
+   * callback writing): wait for the handshake, same as WANT_READ below. */
   if (s->ssl_in_use) {
     s->ssl_write_wants_read = 1;
     return 0;
@@ -2518,18 +2513,12 @@ int us_internal_ssl_write(struct us_socket_t *s, const char *data, int length) {
   while (total < length) {
     int chunk = length - total;
     if (chunk > 16384) chunk = 16384;
-    /* SSL_write drives the handshake while it is pending, so it is a driver
-     * like SSL_do_handshake/SSL_read above and follows the same protocol: a
-     * close requested from inside it is deferred to this epilogue. */
+    /* Same deferred-close protocol as the SSL_do_handshake/SSL_read drivers. */
     s->ssl_in_use = 1;
     last_ssl_written = SSL_write(s_ssl(s), data + total, chunk);
     s->ssl_in_use = 0;
     if (s->ssl_pending_detach) {
-      /* The socket was destroyed from inside this call. The connection is
-       * being dropped, so the records this write sealed are discarded along
-       * with whatever the BIO swallowed after the close was requested, and
-       * the caller sees 0 like any other write to a socket that is going
-       * away. */
+      /* Closed from inside the call: drop this write's records and close now. */
       loop_ssl_data->ssl_write_batching = 0;
       loop_ssl_data->ssl_write_batch_len = 0;
       s->ssl_pending_detach = 0;

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -308,10 +308,12 @@ struct us_socket_t {
    * already dispatched to the user layer; both EOF paths can fire for one
    * connection, and the end handler must run once. */
   unsigned char ssl_end_delivered : 1;
-  /* Set while SSL_do_handshake/SSL_read is on the stack: JS run from inside
-   * those calls (ALPN/SNI/keylog callbacks) may destroy the socket, and the
-   * SSL must not be freed under BoringSSL's feet - the detach is deferred to
-   * the driver's epilogue via ssl_pending_detach. */
+  /* Set while SSL_do_handshake/SSL_read/SSL_write is on the stack: JS run from
+   * inside those calls (ALPN/SNI/keylog callbacks) may destroy the socket, and
+   * the SSL must not be freed under BoringSSL's feet - the detach is deferred
+   * to the driver's epilogue via ssl_pending_detach. A write issued while the
+   * bit is set is parked (us_internal_ssl_write) rather than re-entering
+   * BoringSSL on the SSL the outer call is still working on. */
   unsigned char ssl_in_use : 1;
   unsigned char ssl_pending_detach : 1;
   /* Peer FIN was dispatched as on_end on a half-open socket; readable interest is never re-added and on_end never re-fires. */

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -308,12 +308,10 @@ struct us_socket_t {
    * already dispatched to the user layer; both EOF paths can fire for one
    * connection, and the end handler must run once. */
   unsigned char ssl_end_delivered : 1;
-  /* Set while SSL_do_handshake/SSL_read/SSL_write is on the stack: JS run from
-   * inside those calls (ALPN/SNI/keylog callbacks) may destroy the socket, and
-   * the SSL must not be freed under BoringSSL's feet - the detach is deferred
-   * to the driver's epilogue via ssl_pending_detach. A write issued while the
-   * bit is set is parked (us_internal_ssl_write) rather than re-entering
-   * BoringSSL on the SSL the outer call is still working on. */
+  /* Set while SSL_do_handshake/SSL_read is on the stack: JS run from inside
+   * those calls (ALPN/SNI/keylog callbacks) may destroy the socket, and the
+   * SSL must not be freed under BoringSSL's feet - the detach is deferred to
+   * the driver's epilogue via ssl_pending_detach. */
   unsigned char ssl_in_use : 1;
   unsigned char ssl_pending_detach : 1;
   /* Peer FIN was dispatched as on_end on a half-open socket; readable interest is never re-added and on_end never re-fires. */

--- a/test/js/bun/net/socket.test.ts
+++ b/test/js/bun/net/socket.test.ts
@@ -1448,6 +1448,98 @@ it("TLS mid-read boundary dispatch: writing to another TLS socket from data() do
   }
 }, 60_000);
 
+describe.concurrent("TLS server: write() to the accepted socket from inside its own selection callback", () => {
+  // alpnCallback / serverName are the listener hooks node:tls's ALPNCallback /
+  // SNICallback go through. Both run from inside the read that is processing
+  // the ClientHello and hand the accepted socket to JS, so a write() there
+  // lands on a TLS engine that is mid-handshake on this very socket. It gets
+  // the same treatment as any other write issued before the handshake is done:
+  // nothing is consumed (write() reports 0) and drain() fires once the
+  // handshake completes. Encrypting it on the spot instead re-entered the
+  // engine and failed the handshake (client: TLSV1_ALERT_INTERNAL_ERROR).
+  const MESSAGE = "written-from-drain;";
+  const cases: Array<[string, (attempt: (socket: Socket) => void) => object, string | false]> = [
+    [
+      "alpnCallback",
+      attempt => ({
+        alpnCallback(socket: Socket) {
+          attempt(socket);
+          return "x/1";
+        },
+      }),
+      "x/1",
+    ],
+    [
+      "serverName",
+      attempt => ({
+        serverName(_listenerData: unknown, _servername: string, socket: Socket) {
+          attempt(socket);
+        },
+      }),
+      false,
+    ],
+  ];
+  for (const [hook, selection, expectedAlpn] of cases) {
+    it(`${hook}: the write is parked and the handshake still completes`, async () => {
+      const events: string[] = [];
+      const serverSideClosed = Promise.withResolvers<void>();
+      let pending = "";
+      using server = Bun.listen({
+        hostname: "127.0.0.1",
+        port: 0,
+        tls,
+        socket: {
+          ...selection(socket => {
+            const written = socket.write(MESSAGE);
+            events.push(`write:${written}`);
+            pending = MESSAGE.slice(written);
+          }),
+          handshake(socket, success) {
+            events.push(`handshake:${success}`);
+            if (!pending) socket.end();
+          },
+          drain(socket) {
+            events.push("drain");
+            pending = pending.slice(socket.write(pending));
+            if (!pending) socket.end();
+          },
+          data() {},
+          error(_socket, err) {
+            events.push(`error:${err.message}`);
+          },
+          close() {
+            events.push("close");
+            serverSideClosed.resolve();
+          },
+        },
+      });
+
+      const client = tlsConnect({
+        port: server.port,
+        host: "127.0.0.1",
+        ca: tls.cert,
+        servername: "localhost",
+        ALPNProtocols: ["x/1"],
+      });
+      const received = await new Promise<string>(resolve => {
+        let data = "";
+        client.setEncoding("utf8");
+        client.on("data", chunk => (data += chunk));
+        client.on("end", () => resolve(data));
+        client.on("error", err => resolve(`client error: ${err.message}`));
+      });
+      client.end();
+      await serverSideClosed.promise;
+
+      expect({ received, alpn: client.alpnProtocol, events }).toEqual({
+        received: MESSAGE,
+        alpn: expectedAlpn,
+        events: ["write:0", "handshake:true", "drain", "close"],
+      });
+    });
+  }
+});
+
 // Bun.connect() on a Windows named pipe takes a dedicated early branch in
 // Listener.connectInner that heap-allocates a standalone Handlers block. That
 // block's `.mode` must be `.client` so Handlers.markInactive() destroys it on

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -740,6 +740,72 @@ it("destroying the socket from inside SNICallback or ALPNCallback does not crash
   expect(true).toBe(true);
 });
 
+it("writing to the socket from inside SNICallback or ALPNCallback delivers the data after the handshake", async () => {
+  // Same callbacks as above: they run from inside the native read that is
+  // processing the ClientHello. A write issued there has to be held until that
+  // call unwinds and the handshake completes; encrypting it on the spot
+  // re-enters the TLS engine mid-handshake and the client gets
+  // TLSV1_ALERT_INTERNAL_ERROR instead of a connection.
+  const connections: TLSSocket[] = [];
+  const cases: Array<[string, tls.TlsOptions, string | false]> = [
+    [
+      "ALPNCallback",
+      {
+        ALPNCallback({ protocols }) {
+          connections.at(-1)!.write("from-callback;");
+          return protocols[0];
+        },
+      },
+      "x/1",
+    ],
+    [
+      "SNICallback",
+      {
+        SNICallback(_name, cb) {
+          connections.at(-1)!.write("from-callback;");
+          cb(null, undefined);
+        },
+      },
+      false,
+    ],
+  ];
+  for (const [label, extra, expectedAlpn] of cases) {
+    connections.length = 0;
+    const tlsClientErrors: Error[] = [];
+    const server = createServer({ ...COMMON_CERT, ...extra }, socket => socket.end("after-handshake;"));
+    server.on("connection", socket => connections.push(socket as TLSSocket));
+    server.on("tlsClientError", err => tlsClientErrors.push(err));
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const { promise, resolve } = Promise.withResolvers<string>();
+    let received = "";
+    const client = connect({
+      port,
+      host: "127.0.0.1",
+      ca: COMMON_CERT.cert,
+      servername: "localhost",
+      ALPNProtocols: ["x/1"],
+    });
+    client.setEncoding("utf8");
+    client.on("data", chunk => (received += chunk));
+    client.on("end", () => resolve(received));
+    client.on("error", err => resolve(`client error: ${err.message}`));
+    const data = await promise;
+    client.end();
+    server.close();
+    await once(server, "close");
+
+    expect({ label, data, alpn: client.alpnProtocol, tlsClientErrors: tlsClientErrors.map(e => e.message) }).toEqual({
+      label,
+      data: "from-callback;after-handshake;",
+      alpn: expectedAlpn,
+      tlsClientErrors: [],
+    });
+  }
+});
+
 it("leaves socket.authorized false unless a client certificate was requested and verified", async () => {
   // A server that never requested a client certificate must not report the
   // connection as authorized (matches Node.js fail-closed semantics).


### PR DESCRIPTION
### What

`us_internal_ssl_write` was the one handshake-driving call in `openssl.c` (`SSL_write` runs the handshake while it is pending) that did not follow the `ssl_in_use` protocol `ssl_update_handshake` (around `SSL_do_handshake`) and `us_internal_ssl_on_data` (around `SSL_read`) use. This makes the write path consistent with them:

- A write issued while `ssl_in_use` is set, i.e. from a callback that `SSL_read` / `SSL_do_handshake` on this same socket is currently running, is parked instead of calling `SSL_write`: it returns 0 and sets `ssl_write_wants_read`, exactly what a write issued before the handshake already gets on the `WANT_READ` path. The caller buffers, and the existing `ssl_retry_parked_write` dispatches writable once the handshake completes.
- `SSL_write` itself now runs with `ssl_in_use` set and honors `ssl_pending_detach` in its epilogue, the same shape as the other two drivers (`SSL_write` drives the handshake while it is pending, so it is a driver too).

### Observable before / after

The first point is reachable today. The server-side ALPN and SNI selection callbacks run from inside the `SSL_read` that is processing the ClientHello, and both hand the accepted socket to JS (`Bun.listen`'s `alpnCallback` / `serverName` hooks, which `node:tls`'s `ALPNCallback` / `SNICallback` are built on). A `socket.write()` there re-entered BoringSSL on the SSL it was still working on and the handshake failed:

```ts
const server = tls.createServer({ key, cert, ALPNCallback({ protocols }) { conn.write("hi"); return protocols[0]; } });
server.on("connection", s => (conn = s));
// client: error:10000438:SSL routines:OPENSSL_internal:TLSV1_ALERT_INTERNAL_ERROR
// server: tlsClientError error:100000c2:SSL routines:OPENSSL_internal:PROTOCOL_IS_SHUTDOWN
```

With this change the handshake completes and the bytes are delivered right after it, ahead of anything written from `secureConnection`. At the `Bun.listen` level the write reports 0 and `drain` fires once the handshake is done, which is the contract a pre-handshake write already has. (`socket.end("bye")` from inside the callback goes through the same path and now works as well.)

The second point has no reachable trigger at the moment: `us_internal_ssl_write` zeroes the read-input window before calling `SSL_write`, so the ClientHello-driven callbacks cannot fire from inside it, the session and keylog callbacks are parked in ex_data and flushed after the SSL call returns, and `us_socket_raw_write` (what the BIO calls) never closes the socket. It is included so the write driver keeps the same invariants as the other two if that ever changes; if the deferred close did fire, the epilogue resets the batching state (so leftover records cannot leak into the next socket's batch), runs the close, and reports 0 like any write to a socket that is going away.

`us_internal_ssl_shutdown` is intentionally left alone. It is reachable from the same callbacks (`socket.shutdown()` from inside the ALPN/SNI selection), but BoringSSL's `SSL_shutdown` returns 1 without touching any state while the handshake is in progress (`ssl_lib.cc`, "If we are in the middle of a handshake, silently succeed"), so the only effect is the TCP FIN and the connection the caller asked to shut down goes away; verified under the ASAN build from both callbacks. There is nothing to defer there, unlike a write, which has bytes to deliver after the handshake.

### Why this is the right place

The guard has to live in `us_internal_ssl_write`: it is the only function that knows whether a BoringSSL call on this `SSL*` is on the stack, and every caller (`Bun.listen` sockets, `node:tls`, uWS) already treats 0 as "buffer and wait for writable", so parking needs no changes above it. Buffering in usockets or gating on the JS side would add a second buffer for a case the existing parked-write machinery already handles. It keys on `ssl_in_use` rather than on the handshake state because the two are different conditions: before the handshake completes, a write issued from outside any BoringSSL call is still meant to reach `SSL_write` (the https client flushes its headers on connect and that write drives the handshake; the tail of this function reports the handshake failure for it, #33390), so only a write issued while a BoringSSL call is actually on the stack is parked.

### Tests

- `test/js/node/tls/node-tls-server.test.ts`: `write()` from inside `ALPNCallback` and from inside `SNICallback`; asserts the client receives the callback's bytes followed by the `secureConnection` bytes, the ALPN selection still applies, and no `tlsClientError` fires. Fails on main with the errors quoted above.
- `test/js/bun/net/socket.test.ts`: the same through `Bun.listen`'s `alpnCallback` and `serverName` hooks, asserting the exact sequence `write:0` -> `handshake:true` -> `drain` -> `close` and that the data written from `drain` arrives. On main the sequence is `write:0` -> `handshake:false` -> `close`.

Both pass 15/15 reruns with the debug (ASAN) build. Also ran `test/js/node/tls/`, `test/js/bun/net/socket.test.ts`, `tcp-server.test.ts`, `test/js/web/fetch/fetch.tls.test.ts`, `test/js/bun/http/bun-serve-ssl.test.ts` and `test/js/node/http2/node-http2.test.js` locally; the only failures are unrelated to this change (plain-TCP `localhost` listen/connect family mismatch in this container, reported separately, and a few subprocess-spawning tests that sit right at the 5s default timeout under the debug build here and pass with a longer timeout).


