### PR TITLE
node:http2: keep the next local stream id independent of the peer's streams

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1330,7 +1330,12 @@ pub struct H2FrameParser {
     /// node strictSingleValueFields session option (default true): when false, duplicate
     /// single-value headers and array values for them are encoded as-is instead of rejected.
     strict_single_value_fields: Cell<bool>,
+    /// Highest stream id registered in either direction (see highest_started_stream_id).
     last_stream_id: Cell<u32>,
+    /// Id the next locally initiated stream gets (a request on a client, a push on a server):
+    /// nghttp2's next_stream_id. Only local allocations and setNextStreamID move it; the peer's
+    /// streams advance `last_stream_id`, never this.
+    next_stream_id: Cell<u32>,
     /// Highest PEER-initiated stream id processed (odd ids for a server, even for a
     /// client). This — not `last_stream_id` — is what an auto-filled GOAWAY must carry:
     /// RFC 9113 §6.8 last_stream_id refers to streams the RECEIVER initiated, and
@@ -5318,6 +5323,11 @@ impl H2FrameParser {
         {
             self.last_peer_stream_id.set(stream_identifier);
         }
+        if self.has_local_parity(stream_identifier)
+            && stream_identifier >= self.next_stream_id.get()
+        {
+            self.next_stream_id.set(stream_identifier + 2);
+        }
 
         // new stream open
         let local_window_size = if self.outstanding_settings.get() > 0 {
@@ -6814,7 +6824,7 @@ impl H2FrameParser {
         result.put(
             global_object,
             b"nextStreamID",
-            JSValue::js_number(this.get_next_stream_id() as f64),
+            JSValue::js_number(this.next_stream_id.get() as f64),
         );
         result.put(
             global_object,
@@ -8271,21 +8281,13 @@ impl H2FrameParser {
         Ok(JSValue::js_number(result as f64))
     }
 
-    /// `set_next_stream_id` can park `last_stream_id` anywhere in the u32 range, so the step
-    /// saturates; callers that open the stream reject anything above `MAX_STREAM_ID`.
-    fn get_next_stream_id(&self) -> u32 {
-        let stream_id = self.last_stream_id.get();
-        if self.is_server.get() {
-            if stream_id.is_multiple_of(2) {
-                stream_id.saturating_add(2)
-            } else {
-                stream_id.saturating_add(1)
-            }
-        } else if stream_id.is_multiple_of(2) {
-            stream_id.saturating_add(1)
-        } else {
-            stream_id.saturating_add(2)
-        }
+    /// RFC 9113 §5.1.1: a server initiates even streams, a client odd ones.
+    fn first_local_stream_id(&self) -> u32 {
+        if self.is_server.get() { 2 } else { 1 }
+    }
+
+    fn has_local_parity(&self, stream_id: u32) -> bool {
+        stream_id % 2 == self.first_local_stream_id() % 2
     }
 
     #[bun_jsc::host_fn(method)]
@@ -8298,22 +8300,16 @@ impl H2FrameParser {
         debug_assert!(args_list.len() >= 1);
         let stream_id_arg = args_list[0];
         debug_assert!(stream_id_arg.is_number());
-        // Store the id `get_next_stream_id` steps from. A fractional id passes the JS layer's
-        // `id <= 0` check and truncates to 0 here; 0 (and 1 on a client) has no predecessor,
-        // so the subtraction saturates to the initial state instead of wrapping.
-        let next_stream_id = stream_id_arg.to_u32();
-        let last_stream_id = if this.is_server.get() {
-            if next_stream_id.is_multiple_of(2) {
-                next_stream_id.saturating_sub(2)
-            } else {
-                next_stream_id.saturating_sub(1)
-            }
-        } else if next_stream_id.is_multiple_of(2) {
-            next_stream_id.saturating_sub(1)
+        let requested = stream_id_arg.to_u32();
+        // An id of the peer's parity rounds up to the next one of ours; 0 (the JS layer lets a
+        // fraction below 1 through) lands on the first id, as on a fresh session.
+        let next_stream_id = if this.has_local_parity(requested) {
+            requested
         } else {
-            next_stream_id.saturating_sub(2)
+            requested.saturating_add(1)
         };
-        this.last_stream_id.set(last_stream_id);
+        this.next_stream_id
+            .set(next_stream_id.max(this.first_local_stream_id()));
         Ok(JSValue::UNDEFINED)
     }
 
@@ -8335,10 +8331,11 @@ impl H2FrameParser {
         _global_object: &JSGlobalObject,
         _callframe: &CallFrame,
     ) -> JsResult<JSValue> {
-        let id = this.get_next_stream_id();
+        let id = this.next_stream_id.get();
         if id > MAX_STREAM_ID {
             return Ok(JSValue::js_number(-1.0));
         }
+        // Registering the stream is what advances next_stream_id.
         if this.handle_received_stream_id(id).is_none() {
             return Ok(JSValue::js_number(-1.0));
         }
@@ -8828,7 +8825,7 @@ impl H2FrameParser {
             if !stream_id_arg.is_empty_or_undefined_or_null() && stream_id_arg.is_number() {
                 stream_id_arg.to_u32()
             } else {
-                this.get_next_stream_id()
+                this.next_stream_id.get()
             };
         if stream_id > MAX_STREAM_ID {
             return Ok(JSValue::js_number(-1.0));
@@ -9839,6 +9836,7 @@ impl H2FrameParser {
             max_send_header_block_length: Cell::new(0),
             strict_single_value_fields: Cell::new(true),
             last_stream_id: Cell::new(0),
+            next_stream_id: Cell::new(1),
             last_peer_stream_id: Cell::new(0),
             expecting_continuation: Cell::new(0),
             is_server: Cell::new(false),
@@ -10019,6 +10017,9 @@ impl H2FrameParser {
         }
 
         this_ref.is_server.set(is_server);
+        this_ref
+            .next_stream_id
+            .set(this_ref.first_local_stream_id());
         JSH2FrameParser::Gc::context.set(this_value, global_object, context_obj);
 
         this_ref

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1332,16 +1332,11 @@ pub struct H2FrameParser {
     strict_single_value_fields: Cell<bool>,
     /// Highest stream id registered in either direction (see highest_started_stream_id).
     last_stream_id: Cell<u32>,
-    /// Id the next locally initiated stream gets (a request on a client, a push on a server).
-    /// Mirrors nghttp2's `nghttp2_session.next_stream_id`, which it keeps apart from its
-    /// last sent/received/processed marks:
-    /// https://github.com/nghttp2/nghttp2/blob/master/lib/nghttp2_session.h (next_stream_id).
-    /// Starts at 1 or 2 (nghttp2_session_client_new3 / nghttp2_session_server_new3 in
-    /// lib/nghttp2_session.c), advances by 2 only when this side takes an id
-    /// (submit_headers_shared and nghttp2_submit_push_promise in lib/nghttp2_submit.c) or via
-    /// nghttp2_session_set_next_stream_id, and is what node reports as state.nextStreamID
-    /// (nghttp2_session_get_next_stream_id). The peer's streams advance `last_stream_id`, never
-    /// this.
+    /// Id of the next stream this side initiates (a request on a client, a push on a server):
+    /// https://github.com/nghttp2/nghttp2/blob/master/lib/nghttp2_session.h (next_stream_id),
+    /// which only submit_headers_shared / nghttp2_submit_push_promise (lib/nghttp2_submit.c,
+    /// `+= 2`) and nghttp2_session_set_next_stream_id move, and which node reports as
+    /// state.nextStreamID. The peer's streams advance `last_stream_id`, never this.
     next_stream_id: Cell<u32>,
     /// Highest PEER-initiated stream id processed (odd ids for a server, even for a
     /// client). This — not `last_stream_id` — is what an auto-filled GOAWAY must carry:
@@ -8308,15 +8303,16 @@ impl H2FrameParser {
         let stream_id_arg = args_list[0];
         debug_assert!(stream_id_arg.is_number());
         let requested = stream_id_arg.to_u32();
-        // An id of the peer's parity rounds up to the next one of ours; 0 (the JS layer lets a
-        // fraction below 1 through) lands on the first id, as on a fresh session.
+        // 0 is a fractional id below 1 that passed the JS range check; nghttp2 rejects it too.
+        if requested == 0 {
+            return Ok(JSValue::UNDEFINED);
+        }
         let next_stream_id = if this.has_local_parity(requested) {
             requested
         } else {
             requested.saturating_add(1)
         };
-        this.next_stream_id
-            .set(next_stream_id.max(this.first_local_stream_id()));
+        this.next_stream_id.set(next_stream_id);
         Ok(JSValue::UNDEFINED)
     }
 

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1332,11 +1332,9 @@ pub struct H2FrameParser {
     strict_single_value_fields: Cell<bool>,
     /// Highest stream id registered in either direction (see highest_started_stream_id).
     last_stream_id: Cell<u32>,
-    /// Id of the next stream this side initiates (a request on a client, a push on a server):
-    /// https://github.com/nghttp2/nghttp2/blob/master/lib/nghttp2_session.h (next_stream_id),
-    /// which only submit_headers_shared / nghttp2_submit_push_promise (lib/nghttp2_submit.c,
-    /// `+= 2`) and nghttp2_session_set_next_stream_id move, and which node reports as
-    /// state.nextStreamID. The peer's streams advance `last_stream_id`, never this.
+    /// Id of the next stream this side initiates (request on a client, push on a server); the
+    /// peer's streams never move it. Same contract as nghttp2_session.next_stream_id:
+    /// https://github.com/nghttp2/nghttp2/blob/master/lib/nghttp2_session.h
     next_stream_id: Cell<u32>,
     /// Highest PEER-initiated stream id processed (odd ids for a server, even for a
     /// client). This — not `last_stream_id` — is what an auto-filled GOAWAY must carry:

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1332,9 +1332,16 @@ pub struct H2FrameParser {
     strict_single_value_fields: Cell<bool>,
     /// Highest stream id registered in either direction (see highest_started_stream_id).
     last_stream_id: Cell<u32>,
-    /// Id the next locally initiated stream gets (a request on a client, a push on a server):
-    /// nghttp2's next_stream_id. Only local allocations and setNextStreamID move it; the peer's
-    /// streams advance `last_stream_id`, never this.
+    /// Id the next locally initiated stream gets (a request on a client, a push on a server).
+    /// Mirrors nghttp2's `nghttp2_session.next_stream_id`, which it keeps apart from its
+    /// last sent/received/processed marks:
+    /// https://github.com/nghttp2/nghttp2/blob/master/lib/nghttp2_session.h (next_stream_id).
+    /// Starts at 1 or 2 (nghttp2_session_client_new3 / nghttp2_session_server_new3 in
+    /// lib/nghttp2_session.c), advances by 2 only when this side takes an id
+    /// (submit_headers_shared and nghttp2_submit_push_promise in lib/nghttp2_submit.c) or via
+    /// nghttp2_session_set_next_stream_id, and is what node reports as state.nextStreamID
+    /// (nghttp2_session_get_next_stream_id). The peer's streams advance `last_stream_id`, never
+    /// this.
     next_stream_id: Cell<u32>,
     /// Highest PEER-initiated stream id processed (odd ids for a server, even for a
     /// client). This — not `last_stream_id` — is what an auto-filled GOAWAY must carry:

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1334,7 +1334,7 @@ pub struct H2FrameParser {
     last_stream_id: Cell<u32>,
     /// Id of the next stream this side initiates (request on a client, push on a server); the
     /// peer's streams never move it. Same contract as nghttp2_session.next_stream_id:
-    /// https://github.com/nghttp2/nghttp2/blob/master/lib/nghttp2_session.h
+    /// https://github.com/nghttp2/nghttp2/blob/master/lib/nghttp2_session.h#L289
     next_stream_id: Cell<u32>,
     /// Highest PEER-initiated stream id processed (odd ids for a server, even for a
     /// client). This — not `last_stream_id` — is what an auto-filled GOAWAY must carry:

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4086,41 +4086,34 @@ it("http2 server push stream ids are independent of the client's stream ids", as
 
 it("http2 setNextStreamID ignores a fractional id below 1 instead of reusing stream ids", async () => {
   // 0.5 passes setNextStreamID's range check and reaches the native setter as 0, which nghttp2
-  // rejects: node leaves the counter where it was (values below are node v26.3.0's). Spawned
-  // because the unfixed native setter aborts a debug build on this input.
-  const fixture = `
-    const http2 = require("node:http2");
-    const server = http2.createServer((req, res) => res.end());
-    server.listen(0, "127.0.0.1", () => {
-      const client = http2.connect("http://127.0.0.1:" + server.address().port);
-      client.on("error", err => {
-        console.error(err);
-        process.exit(1);
-      });
-      const first = client.request();
-      first.resume();
-      first.on("close", () => {
-        const before = client.state.nextStreamID;
-        client.setNextStreamID(0.5);
-        const after = client.state.nextStreamID;
-        const second = client.request();
-        console.log(JSON.stringify({ firstId: first.id, before, after, secondId: second.id }));
-        second.destroy();
-        client.destroy();
-        server.close();
-      });
+  // rejects. On a fresh session ("at the edges of the id space" above) ignoring it and resetting
+  // to the first id read the same; after a stream has been used, only ignoring it keeps the next
+  // request off an id this side already used. Values are node v26.3.0's.
+  const server = http2.createServer((req, res) => res.end());
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  try {
+    const first = client.request();
+    first.resume();
+    await new Promise((resolve, reject) => {
+      client.on("error", reject);
+      first.on("error", reject);
+      first.on("close", resolve);
     });
-  `;
-  await using proc = Bun.spawn({
-    cmd: [bunExe(), "-e", fixture],
-    env: bunEnv,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  expect(JSON.parse(stdout)).toEqual({ firstId: 1, before: 3, after: 3, secondId: 3 });
-  expect(exitCode).toBe(0);
+    const before = client.state.nextStreamID;
+    client.setNextStreamID(0.5);
+    const after = client.state.nextStreamID;
+    const second = client.request();
+    expect({ firstId: first.id, before, after, secondId: second.id }).toEqual({
+      firstId: 1,
+      before: 3,
+      after: 3,
+      secondId: 3,
+    });
+  } finally {
+    client.destroy();
+    server.close();
+  }
 });
 
 it("http2 option range error messages use the options. prefix", () => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3984,6 +3984,106 @@ it("http2 pushStream reports an unsendable array element through the callback", 
   expect(blocks).toEqual([]);
 });
 
+it("http2 server push stream ids are independent of the client's stream ids", async () => {
+  // node keeps the server's next stream id as its own counter (nghttp2 next_stream_id): however
+  // many client streams have arrived, pushes go out on 2, 4, ..., and setNextStreamID() moves that
+  // counter without touching lastProcStreamID. Every expected value below is what node v26.3.0
+  // reports for this exact sequence.
+  const { promise: failure, reject } = Promise.withResolvers();
+  const serverSide = { arrivals: [] };
+  const server = http2.createServer();
+  server.on("error", reject);
+  server.on("sessionError", reject);
+  server.on("stream", (stream, headers) => {
+    const { session } = stream;
+    const push = path =>
+      new Promise((resolve, rejectPush) => {
+        stream.pushStream({ ":path": path }, (err, pushed) => {
+          if (err) return rejectPush(err);
+          pushed.respond({ ":status": 200 });
+          pushed.end();
+          resolve(pushed.id);
+        });
+      });
+    const respond = () => {
+      stream.respond({ ":status": 200 });
+      stream.end();
+    };
+    switch (headers[":path"]) {
+      case "/push": {
+        const before = session.state.nextStreamID;
+        const pushed = push("/pushed");
+        const after = session.state.nextStreamID;
+        pushed.then(pushedId => {
+          serverSide.push = { parent: stream.id, before, pushedId, after };
+          respond();
+        }, reject);
+        return;
+      }
+      case "/set-then-push": {
+        // ServerHttp2Session does not expose setNextStreamID yet; call the native setter it wraps.
+        session[Symbol.for("::bunhttp2native::")].setNextStreamID(6);
+        const { nextStreamID, lastProcStreamID } = session.state;
+        const pushed = push("/pushed-after-set");
+        const after = session.state.nextStreamID;
+        pushed.then(pushedId => {
+          serverSide.setThenPush = { parent: stream.id, afterSet: { nextStreamID, lastProcStreamID }, pushedId, after };
+          respond();
+        }, reject);
+        return;
+      }
+      default:
+        serverSide.arrivals.push({ clientStream: stream.id, nextStreamID: session.state.nextStreamID });
+        respond();
+    }
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+
+  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+  try {
+    client.on("error", reject);
+    const pushesSeen = [];
+    client.on("stream", (pushed, pushHeaders) => {
+      pushed.on("error", reject);
+      pushed.resume();
+      pushesSeen.push({ id: pushed.id, path: pushHeaders[":path"] });
+    });
+    const request = path =>
+      new Promise(resolve => {
+        const req = client.request({ ":path": path });
+        req.on("error", reject);
+        req.on("close", () => resolve(req.id));
+        req.resume();
+      });
+    const requestIds = [];
+    for (const path of ["/a", "/b", "/c", "/push", "/set-then-push"]) {
+      requestIds.push(await Promise.race([failure, request(path)]));
+    }
+
+    // A PUSH_PROMISE precedes its parent's response on the wire, so both pushes have been seen.
+    expect({ requestIds, clientNextStreamID: client.state.nextStreamID, pushesSeen, serverSide }).toEqual({
+      requestIds: [1, 3, 5, 7, 9],
+      clientNextStreamID: 11,
+      pushesSeen: [
+        { id: 2, path: "/pushed" },
+        { id: 6, path: "/pushed-after-set" },
+      ],
+      serverSide: {
+        arrivals: [
+          { clientStream: 1, nextStreamID: 2 },
+          { clientStream: 3, nextStreamID: 2 },
+          { clientStream: 5, nextStreamID: 2 },
+        ],
+        push: { parent: 7, before: 2, pushedId: 2, after: 4 },
+        setThenPush: { parent: 9, afterSet: { nextStreamID: 6, lastProcStreamID: 9 }, pushedId: 6, after: 8 },
+      },
+    });
+  } finally {
+    client.close();
+    server.close();
+  }
+});
+
 it("http2 option range error messages use the options. prefix", () => {
   for (const opt of ["maxSessionInvalidFrames", "maxSessionRejectedStreams", "unknownProtocolTimeout"]) {
     let error;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4084,6 +4084,45 @@ it("http2 server push stream ids are independent of the client's stream ids", as
   }
 });
 
+it("http2 setNextStreamID ignores a fractional id below 1 instead of reusing stream ids", async () => {
+  // 0.5 passes setNextStreamID's range check and reaches the native setter as 0, which nghttp2
+  // rejects: node leaves the counter where it was (values below are node v26.3.0's). Spawned
+  // because the unfixed native setter aborts a debug build on this input.
+  const fixture = `
+    const http2 = require("node:http2");
+    const server = http2.createServer((req, res) => res.end());
+    server.listen(0, "127.0.0.1", () => {
+      const client = http2.connect("http://127.0.0.1:" + server.address().port);
+      client.on("error", err => {
+        console.error(err);
+        process.exit(1);
+      });
+      const first = client.request();
+      first.resume();
+      first.on("close", () => {
+        const before = client.state.nextStreamID;
+        client.setNextStreamID(0.5);
+        const after = client.state.nextStreamID;
+        const second = client.request();
+        console.log(JSON.stringify({ firstId: first.id, before, after, secondId: second.id }));
+        second.destroy();
+        client.destroy();
+        server.close();
+      });
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ firstId: 1, before: 3, after: 3, secondId: 3 });
+  expect(exitCode).toBe(0);
+});
+
 it("http2 option range error messages use the options. prefix", () => {
   for (const opt of ["maxSessionInvalidFrames", "maxSessionRejectedStreams", "unknownProtocolTimeout"]) {
     let error;


### PR DESCRIPTION
### Problem
- A `node:http2` server's `state.nextStreamID`, and the ids `pushStream()` hands out, differ from node for the same program: after four client requests node pushes on stream 2, bun 1.4.0 and main push on stream 8.
- The ids bun sends are still legal (RFC 9113 only requires each side's own ids to increase), so this is a node compat divergence, not a protocol bug.
- Cause: the parser had one counter that every stream, peer or local, advanced, and derived the next local id from it. Node keeps the next local id as a separate counter that only local streams and `setNextStreamID()` move.
- Because the counter was shared, `setNextStreamID()` on a server also moved `state.lastProcStreamID` and the high-water mark used to tolerate a late RST_STREAM on an evicted stream. Node's setter moves neither.

### Fix
- Adds a dedicated next-local-id counter: 2 on a server, 1 on a client, advanced only when a stream of this side's parity is registered. Because it advances at registration, any local id that enters the stream map pushes the counter past itself, so an id in use is never handed out again.
- `setNextStreamID()` now writes to this counter. The old shared counter is still raised by every stream, so `lastProcStreamID`, the late-RST mark and the GOAWAY paths that read it behave as before.
- One input changes: a setter argument that truncates to 0 (a fractional id below 1) is now ignored, as nghttp2 does, instead of rewinding a used session onto ids it already handed out.
- Verification: two new tests whose expected values come from running the same sequences on node v26.3.0. Both fail on main (7 differing values in the first, stream 1 reused in the second) and pass with this change; the existing http2 suites still pass on a debug build.

### Background
- HTTP/2 stream ids: a client opens odd-numbered streams, a server even-numbered ones. Each side's ids must increase, but nothing ties one side's sequence to the other's.
- Server push: `pushStream()` makes the server open a stream itself, announced with a PUSH_PROMISE frame, so a server consumes ids from its own even sequence.
- `H2FrameParser` (`h2_frame_parser.rs`) is the native engine behind `node:http2`. `session.state` and `setNextStreamID()` read and write its counters directly.
- nghttp2 is the C library node's http2 is built on. Node's `state.nextStreamID` reads nghttp2's `next_stream_id` field, so matching that field's contract is what node compat means here.
- `lastProcStreamID` is node's name for the last peer-initiated stream the session processed. The parser also keeps a highest-id-ever mark, which is the cell the setter used to write into.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (c2e587460)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1068.49ms]
(pass) node none > Client Basics > should be able to send a POST request [787.51ms]
(pass) node none > Client Basics > constants [25.19ms]
(pass) node none > Client Basics > getDefaultSettings [9.09ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [26.06ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [6.23ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.36ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.21ms]
(pass) node none > Client Basics > should be able to send data using end [837.18ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [828.11ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving
... (truncated)

release without fix: 12 failed, 6 skipped
bun test v1.4.0-canary.1 (da3851e57)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.82ms]
(pass) node none > Client Basics > getDefaultSettings [0.17ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.37ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.10ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.06ms]
(pass) node none > Client Basics > is possible to abort request [1.69ms]
(pass) node none > Client Basics > aborted event should work with abortController [0.74ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [0.65ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.11ms]
(pass) node none > Client Basics > should fail to connect over HTTP/1.1 [32.69ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > headers cannot be bigge
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (c2e587460)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [816.38ms]
(pass) node none > Client Basics > should be able to send a POST request [539.51ms]
(pass) node none > Client Basics > constants [17.80ms]
(pass) node none > Client Basics > getDefaultSettings [6.68ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.02ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.01ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.12ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [5.15ms]
(pass) node none > Client Basics > should be able to send data using end [568.21ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [557.95ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c2e5874605
  features     baseline

22 deps, 107 codegen, 1176 objects in 1090ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [12.00ms]
[2/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (da3851e57)

Checked 1 install across 2 packages (no changes) [1.00ms]
[3/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (da3851e57)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[4/1238] gen ErrorCode+*.h
[5/1238] gen bindgenv2
[6/1238] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[7/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1238] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessB
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs |  66 +++++++++--------
 test/js/node/http2/node-http2.test.js  | 132 +++++++++++++++++++++++++++++++++
 2 files changed, 166 insertions(+), 32 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs     20     16      0
test/js/node/http2/node-http2.test.js       9      3      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

```js
const http2 = require("node:http2");
const server = http2.createServer();
server.on("stream", (stream, headers) => {
  console.log(`client stream ${stream.id} arrived; server nextStreamID = ${stream.session.state.nextStreamID}`);
  if (headers[":path"] !== "/push") return stream.respond(), stream.end();
  stream.pushStream({ ":path": "/pushed" }, (err, pushed) => {
    console.log("pushed on stream", pushed.id);
    pushed.respond(); pushed.end(); stream.respond(); stream.end();
  });
});
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  client.on("stream", pushed => pushed.resume());
  const paths = ["/a", "/b", "/c", "/push"];
  (function next() {
    const path = paths.shift();
    if (!path) return client.close(), server.close();
    client.request({ ":path": path }).on("close", next).resume();
  })();
});
```

```
node v26.3.0                                   bun 1.4.0 (and main)
client stream 1 arrived; nextStreamID = 2       client stream 1 arrived; nextStreamID = 2
client stream 3 arrived; nextStreamID = 2       client stream 3 arrived; nextStreamID = 4
client stream 5 arrived; nextStreamID = 2       client stream 5 arrived; nextStreamID = 6
client stream 7 arrived; nextStreamID = 2       client stream 7 arrived; nextStreamID = 8
pushed on stream 2                              pushed on stream 8
```

The promised ids bun puts on the wire are still legal (RFC 9113 section 5.1.1 only requires each side's ids to increase), so this is a node compat divergence: `state.nextStreamID` and the ids `pushStream()` hands out differ from node for the same program, and `setNextStreamID()` on a server session (the native setter today, the public method once #37547 lands) had two side effects node's does not have: `state.lastProcStreamID` changed with it (node: the last peer stream processed, unaffected by the setter), and so did the stream id high-water mark the engine consults to tolerate a late RST_STREAM on an evicted stream.

### Cause

`H2FrameParser` had one counter, `last_stream_id`, advanced by `handle_received_stream_id` for every stream registered on the session, peer-initiated or local, and `get_next_stream_id()` derived the next local id from it (`set_next_stream_id` wrote into it too). That counter is legitimately shared for its other job (the highest id that has ever existed on the session, `highest_started_stream_id`), but the next local id is a different quantity. nghttp2 keeps `next_stream_id` as an independent counter that only local submissions and `nghttp2_session_set_next_stream_id` move, and node's `state.nextStreamID` reads it directly, which is why a node server keeps pushing on 2, 4, ... regardless of how many client streams have arrived.

### Fix

`src/runtime/api/bun/h2_frame_parser.rs` gets a dedicated `next_stream_id`, modeled on nghttp2's field:

* initialized to 2 on a server and 1 on a client (`first_local_stream_id()`, set where the constructor settles `is_server`);
* `handle_received_stream_id` advances it to `id + 2` when a stream of this side's parity is registered, next to the existing `last_stream_id` / `last_peer_stream_id` bookkeeping. Peer streams leave it alone. Keeping the advance at the registration point (rather than in `getNextStream()`) means any local-parity id that enters the stream map, through `getNextStream()` or `request()`, pushes the counter past itself, so an id in use can never be handed out again;
* `getCurrentState()`, `getNextStream()` and the no-id path of `request()` read the field; `get_next_stream_id()` is gone;
* `setNextStreamID()` stores into it. Its observable behavior is unchanged for every id it handled before (an id of the peer's parity still rounds up to this side's next one; moving backwards is still allowed, that part is #37553's subject), and it no longer touches `last_stream_id`, so `lastProcStreamID` and the high-water mark stay put. The one input whose outcome changes is 0 (what a fractional id below 1 truncates to after passing the JS range check): #37542, now on main, saturates it back to the initial state, which on a session that has already used ids rewinds the counter onto them; this branch ignores it, which is what nghttp2 does, so node and this branch both leave the counter where it was.

`last_stream_id` is otherwise untouched: it is still raised by every registration, so `highest_started_stream_id()` and the GOAWAY paths that read it behave as before (`h2-late-rst-staged.test.ts` and the late-RST test in `node-http2.test.js` cover that mark and still pass). That the setter no longer lowers the mark is pinned through the `lastProcStreamID` assertion in the first test, which reads the same cell today; I did not add a setter variant of the late-RST wire test, since it would only stay distinguishable until #37553 turns backwards ids into no-ops, and that scenario is the one with a known platform flake.

Why this is the right shape rather than, say, subtracting peer ids back out: the two quantities have different definitions in both the RFC and nghttp2, and only a separate counter gives node's values in every case, including the edges. After a client uses `2 ** 31 - 1`, both node and this branch report `nextStreamID` 2147483649 and fail the next request with `ERR_HTTP2_OUT_OF_STREAMS` (`test-http2-no-more-streams.js`). Storing the next id directly also supersedes the saturating predecessor arithmetic #37542 added (merged while this was open; this branch is rebased over it and replaces both of the functions it touched), since there is no predecessor arithmetic left. #37542's test stays and passes unchanged: on a fresh session a server setter argument of 0 or `2 ** 32 - 1` still reads back as 2 and 4294967295. The difference is only visible on a used session, where 0 is ignored instead of rewinding the counter, which is what the second test below pins.

Relationship to the other open `setNextStreamID` work: #37553 rewrites the setter body this PR replaces; on top of this branch it reduces to its nghttp2 validity checks followed by `next_stream_id.set(id)` (its "not above the current next id" check also covers the `requested == 0` arm here, which it can then drop). #37588 (GOAWAY / `lastProcStreamID` from the peer mark) touches adjacent lines in `handle_received_stream_id` but a different field; the `lastProcStreamID` value asserted below is the same under both definitions. The client side was compared against node as well: received PUSH_PROMISEs do not register in the embedder's map, so a client's next request id already matched node (3 after pushes 2, 4, 6, 8 arrive); the refactor keeps it that way and the new test pins the client's `nextStreamID` too.

### Verification

New test `http2 server push stream ids are independent of the client's stream ids` in `test/js/node/http2/node-http2.test.js`: three client requests, then a request whose handler pushes, then one whose handler sets the next id to 6 and pushes. It asserts the server's `nextStreamID` as each client stream arrives, the id before/after each push, `nextStreamID`/`lastProcStreamID` after the setter, the promised ids the client actually receives on the wire, and the client's own request ids and `nextStreamID`. Every expected value was produced by running the same sequence on node v26.3.0 (`session.setNextStreamID` there; here the native setter, since `ServerHttp2Session` does not expose the method yet). On `USE_SYSTEM_BUN=1` it fails with 7 differing values (`nextStreamID` 4/6 on arrival, push on 8 instead of 2, `lastProcStreamID` 4 instead of 9 after the setter); with this change it passes.

Second test, `http2 setNextStreamID ignores a fractional id below 1 instead of reusing stream ids`: a client uses stream 1, calls `setNextStreamID(0.5)` and requests again. Node keeps `nextStreamID` at 3 and uses 3; main (with #37542) and the released bun rewind to 1 and hand out stream 1 again, so the test fails there on `after` and `secondId`, and passes with this change. It runs in-process: #37542's own test already covers the input that used to abort, and nothing aborts on it any more.

Also passing on the debug build, rebased onto current main: all of `node-http2.test.js` (359 tests, #37542's included), `h2-conformance`, `h2-late-rst-staged`, `h2-push-refusal-staged`, `node-http2-streams-rehash`, `node-http2-continuation`, `node-http2-invalid-padding`, and the ported node tests that exercise push or stream ids (`test-http2-no-more-streams`, `test-http2-client-setNextStreamID-errors`, `test-http2-session-stream-state`, `test-http2-client-destroy`, `test-http2-server-push-stream*`, `test-http2-respond-file-push`, `test-http2-compat-serverresponse-createpushresponse`, `test-http2-misbehaving-multiplex`, `test-http2-invalid-last-stream-id`, the goaway and rst tests; 23 files in all). `cargo fmt --check` and `cargo clippy -p bun_runtime` are clean.

</details>
