### PR TITLE
bundler: build the ESM bytecode module record from what the printer emits

### DIFF
--- a/src/bundler/Chunk.rs
+++ b/src/bundler/Chunk.rs
@@ -1591,13 +1591,6 @@ pub mod bun_renamer {
     }
 
     impl ChunkRenamer {
-        pub(crate) fn name_for_symbol(&mut self, ref_: bun_ast::Ref) -> &[u8] {
-            match self {
-                ChunkRenamer::None => unreachable!("ChunkRenamer not initialized"),
-                ChunkRenamer::Number(r) => r.name_for_symbol(ref_),
-                ChunkRenamer::Minify(r) => r.name_for_symbol(ref_),
-            }
-        }
         pub(crate) fn as_renamer(&mut self) -> bun_js_printer::renamer::Renamer<'_, '_> {
             match self {
                 ChunkRenamer::None => unreachable!("ChunkRenamer not initialized"),

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -1268,6 +1268,17 @@ pub struct LinkerOptions {
     pub(crate) public_path: &'static [u8],
 }
 
+impl LinkerOptions {
+    /// ESM bytecode in a `--compile` build: JSC does not parse the chunk, so
+    /// its `JSModuleRecord` is built from a `ModuleInfo` the linker records
+    /// while printing (see `post_process_js_chunk`).
+    pub(crate) fn generates_module_info(&self) -> bool {
+        self.generate_bytecode_cache
+            && self.output_format == Format::Esm
+            && self.compile_mode.is_executable()
+    }
+}
+
 impl Default for LinkerOptions {
     fn default() -> Self {
         Self {
@@ -2142,6 +2153,7 @@ impl<'a> LinkerContext<'a> {
         runtime_require_ref: Option<Ref>,
         source_index: Index,
         source: &Source,
+        module_info: Option<&mut crate::analyze_transpiled_module::ModuleInfo>,
     ) -> js_printer::PrintResult {
         let parts_to_print = &[Part {
             stmts: bun_ast::StoreSlice::new_mut(out_stmts),
@@ -2221,6 +2233,7 @@ impl<'a> LinkerContext<'a> {
                 None
             },
             mangled_props: Some(mangled_props),
+            module_info,
             ..Default::default()
         };
 

--- a/src/bundler/analyze_transpiled_module.rs
+++ b/src/bundler/analyze_transpiled_module.rs
@@ -25,11 +25,6 @@ pub use bun_js_printer::analyze_transpiled_module::{
 /// `bundler_jsc::analyze_jsc::to_js_module_record`.
 pub type RequestedModuleValue = FetchParameters;
 
-/// Legacy name used by `linker_context::postProcessJSChunk` — the type was
-/// renamed `ImportAttributes` → `FetchParameters` but the bundler call site
-/// still spells `ImportAttributes::None`.
-pub(crate) type ImportAttributes = FetchParameters;
-
 // ──────────────────────────────────────────────────────────────────────────
 // RecordKind
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7454,6 +7454,11 @@ pub mod bv2_impl {
         Javascript {
             source_index: IndexInt,
             result: bun_js_printer::PrintResult,
+            /// The imports/exports the printer emitted for this part range.
+            /// Only present when `LinkerOptions::generates_module_info()`;
+            /// `post_process_js_chunk` appends these to the chunk's
+            /// `ModuleInfo` in output order.
+            module_info: Option<Box<crate::analyze_transpiled_module::ModuleInfo>>,
         },
         Css {
             result: crate::Result<Box<[u8]>>,
@@ -7513,48 +7518,6 @@ pub mod bv2_impl {
         }
     }
 
-    impl Clone for CompileResult {
-        fn clone(&self) -> Self {
-            match self {
-                CompileResult::Javascript {
-                    source_index,
-                    result,
-                } => CompileResult::Javascript {
-                    source_index: *source_index,
-                    result: match result {
-                        bun_js_printer::PrintResult::Result(r) => {
-                            bun_js_printer::PrintResult::Result(
-                                bun_js_printer::PrintResultSuccess {
-                                    code: r.code.clone(),
-                                    source_map: r.source_map.clone(),
-                                },
-                            )
-                        }
-                        bun_js_printer::PrintResult::Err(e) => bun_js_printer::PrintResult::Err(*e),
-                    },
-                },
-                CompileResult::Css {
-                    result,
-                    source_index,
-                    source_map,
-                } => CompileResult::Css {
-                    result: result.clone(),
-                    source_index: *source_index,
-                    source_map: source_map.clone(),
-                },
-                CompileResult::Html {
-                    source_index,
-                    code,
-                    script_injection_offset,
-                } => CompileResult::Html {
-                    source_index: *source_index,
-                    code: code.clone(),
-                    script_injection_offset: *script_injection_offset,
-                },
-            }
-        }
-    }
-
     impl Default for CompileResult {
         fn default() -> Self {
             CompileResult::Javascript {
@@ -7563,6 +7526,7 @@ pub mod bv2_impl {
                     code: Box::new([]),
                     source_map: None,
                 }),
+                module_info: None,
             }
         }
     }

--- a/src/bundler/linker_context/OutputFileListBuilder.rs
+++ b/src/bundler/linker_context/OutputFileListBuilder.rs
@@ -28,7 +28,7 @@
 //!    file for a chunk.
 
 use crate::mal_prelude::*;
-use crate::options::{self, Format, Loader, OutputFile};
+use crate::options::{self, Loader, OutputFile};
 use crate::{Chunk, LinkerContext};
 pub(crate) struct OutputFileList {
     pub(crate) output_files: Vec<options::OutputFile>,
@@ -126,11 +126,7 @@ impl OutputFileList {
             0
         };
 
-        // module_info is generated for ESM bytecode in --compile builds
-        let module_info_count: usize = if c.options.generate_bytecode_cache
-            && c.options.output_format == Format::Esm
-            && c.options.compile_mode.is_executable()
-        {
+        let module_info_count: usize = if c.options.generates_module_info() {
             bytecode_count
         } else {
             0

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -502,10 +502,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
     // cross-chunk import specifiers. During printing, cross-chunk imports use
     // unique_key placeholders as paths. Now that final paths are known, replace
     // those placeholders with the resolved paths and serialize.
-    if c.options.generate_bytecode_cache
-        && c.options.output_format == options::Format::Esm
-        && c.options.compile_mode.is_executable()
-    {
+    if c.options.generates_module_info() {
         // Build map from unique_key -> final resolved path
         // SAFETY: c points to LinkerContext which is the `linker` field of BundleV2.
         let b: &mut BundleV2 =
@@ -1152,10 +1149,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
             // Create module_info output file for ESM bytecode in --compile builds
             let module_info_output_file: Option<options::OutputFile> = 'brk: {
-                if c.options.generate_bytecode_cache
-                    && c.options.output_format == options::Format::Esm
-                    && c.options.compile_mode.is_executable()
-                {
+                if c.options.generates_module_info() {
                     let loader: Loader = if chunk.entry_point.is_entry_point() {
                         c.parse_graph().input_files.items_loader()
                             [chunk.entry_point.source_index() as usize]

--- a/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
+++ b/src/bundler/linker_context/generateCodeForFileInChunkJS.rs
@@ -7,6 +7,7 @@ use bun_collections::{BoundedArray, VecExt};
 use bun_js_printer::renamer;
 use bun_js_printer::{self as js_printer, PrintResult, PrintResultSuccess};
 
+use crate::analyze_transpiled_module::ModuleInfo;
 use crate::generic_path_with_pretty_initialized;
 use crate::linker_context_mod::{StmtList, StmtListWhich};
 use crate::options::Format as OutputFormat;
@@ -33,6 +34,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
     stmts: &mut StmtList,
     arena: &Bump,
     temp_arena: &Bump,
+    module_info: Option<&mut ModuleInfo>,
 ) -> js_printer::PrintResult {
     let source_index = part_range.source_index.get() as usize;
 
@@ -226,6 +228,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
                 None,
                 part_range.source_index,
                 source,
+                module_info,
             );
         }
     }
@@ -930,6 +933,7 @@ pub fn generate_code_for_file_in_chunk_js<'r, 'src>(
         runtime_require_ref,
         part_range.source_index,
         source,
+        module_info,
     )
 }
 

--- a/src/bundler/linker_context/generateCompileResultForJSChunk.rs
+++ b/src/bundler/linker_context/generateCompileResultForJSChunk.rs
@@ -5,6 +5,7 @@ use bun_ast::Scope;
 use bun_js_printer::{self as js_printer, PrintResult};
 use bun_threading::thread_pool as ThreadPoolLib;
 
+use crate::analyze_transpiled_module::ModuleInfo;
 use crate::linker_context_mod::LinkerContext;
 use crate::options::OutputFormat;
 use crate::thread_pool::Worker;
@@ -125,6 +126,13 @@ fn generate_compile_result_for_js_chunk_impl(
     // `worker.temporary_arena` / `worker.stmt_list` borrowed `&mut` above, so
     // a direct shared borrow is fine. Heap is pinned; see `Worker::arena`.
     let worker_alloc = worker.arena.get();
+    // Collects what the printer emits for this part range; `post_process_js_chunk`
+    // appends it to the chunk's ModuleInfo, which is the one that gets finalized,
+    // so the `is_typescript` flag of this accumulator is never read.
+    let mut module_info: Option<Box<ModuleInfo>> = c
+        .options
+        .generates_module_info()
+        .then(|| ModuleInfo::create(false));
     // SAFETY: split borrow of `chunk` — `generate_code_for_file_in_chunk_js` never
     // touches `chunk.renamer` through its `chunk` parameter; take a raw-ptr view so borrowck doesn't
     // see two overlapping `&mut chunk` borrows.
@@ -144,6 +152,7 @@ fn generate_compile_result_for_js_chunk_impl(
         stmt_list,
         worker_alloc,
         &**arena,
+        module_info.as_deref_mut(),
     );
 
     // Update bytesInOutput for this source in the chunk (for metafile)
@@ -168,5 +177,6 @@ fn generate_compile_result_for_js_chunk_impl(
     CompileResult::Javascript {
         source_index: part_range.source_index.get(),
         result,
+        module_info,
     }
 }

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -1,5 +1,5 @@
 use crate::LinkerContext;
-use crate::analyze_transpiled_module::{self, ModuleInfo};
+use crate::analyze_transpiled_module::ModuleInfo;
 use crate::bundle_v2::bake_types::{HmrRuntimeSide, get_hmr_runtime};
 use crate::linker_context_mod::{GenerateChunkCtx, LinkerOptionsMode};
 use crate::mal_prelude::*;
@@ -10,9 +10,7 @@ use crate::{
     ThreadPool,
 };
 use bun_alloc::Arena;
-use bun_ast::{
-    self as js_ast, B, Binding, E, Expr, G, Part, Ref, S, Scope, Stmt, StmtData, StmtOrExpr,
-};
+use bun_ast::{self as js_ast, B, Binding, E, Expr, G, Part, Ref, S, Scope, Stmt, StmtOrExpr};
 use bun_ast::{ImportRecord, ImportRecordFlags, ImportRecordTag};
 use bun_collections::MultiArrayList;
 use bun_collections::VecExt;
@@ -95,19 +93,16 @@ pub(crate) fn post_process_js_chunk(
         )
     };
 
-    // Create ModuleInfo for ESM bytecode in --compile builds
-    let generate_module_info = c.options.generate_bytecode_cache
-        && c.options.output_format == options::OutputFormat::Esm
-        && c.options.compile_mode.is_executable();
-    let loader =
-        c.parse_graph().input_files.items_loader()[chunk.entry_point.source_index() as usize];
-    let is_typescript = loader.is_type_script();
+    // The chunk's module record, assembled in output order: the printer records
+    // the cross-chunk prefix imports below, then the per-part-range results
+    // (printed in parallel into their own ModuleInfo) are appended, then the
+    // cross-chunk suffix and entry point tail exports are printed into it.
     // Stored on chunk.content.javascript.module_info — owned `Box<ModuleInfo>`.
-    let mut module_info: Option<Box<ModuleInfo>> = if generate_module_info {
-        Some(ModuleInfo::create(is_typescript))
-    } else {
-        None
-    };
+    let mut module_info: Option<Box<ModuleInfo>> = c.options.generates_module_info().then(|| {
+        let loader =
+            c.parse_graph().input_files.items_loader()[chunk.entry_point.source_index() as usize];
+        ModuleInfo::create(loader.is_type_script())
+    });
 
     // SAFETY: worker.arena is set in Worker::init() before any task runs.
     let worker_arena: &Arena = worker.arena();
@@ -201,6 +196,18 @@ pub(crate) fn post_process_js_chunk(
             }],
             chunk.renamer.as_renamer(),
         );
+        if let Some(mi) = module_info.as_deref_mut() {
+            // One result per entry of `parts_in_chunk_in_order`, in that order.
+            for compile_result in chunk.compile_results_for_chunk.iter() {
+                if let CompileResult::Javascript {
+                    module_info: Some(part_module_info),
+                    ..
+                } = compile_result
+                {
+                    mi.append(part_module_info);
+                }
+            }
+        }
         cross_chunk_suffix = js_printer::print::<false>(
             worker_arena,
             target,
@@ -219,161 +226,27 @@ pub(crate) fn post_process_js_chunk(
         );
     }
 
-    // Populate ModuleInfo with the import.meta flag and the external
-    // import records from the original AST.
+    // The printer does not know about top-level await, so derive that flag from
+    // the AST. The JSC module loader decides sync vs async evaluation from
+    // JSModuleRecord::hasTLA(), which is set from this bit when the record is
+    // constructed from module_info (BunAnalyzeTranspiledModule). Without it, a
+    // bytecode-compiled module that contains TLA gets evaluated on the sync path
+    // and the suspended generator is dropped — the entry promise resolves
+    // immediately and the process exits before the awaited value lands.
     if let Some(mi) = module_info.as_deref_mut() {
-        // Check if any source in this chunk uses import.meta. The per-part
-        // parallel printer does not have module_info, so the printer cannot set
-        // this flag during per-part printing. We derive it from the AST instead.
-        // Note: the runtime source (index 0) also uses import.meta (e.g.
-        // `import.meta.require`), so we must not skip it.
-        {
-            let all_ast_flags = c.graph.ast.items_flags();
-            for part_range in chunk.content.javascript().parts_in_chunk_in_order.iter() {
-                if all_ast_flags[part_range.source_index.get() as usize]
-                    .contains(crate::bundled_ast::Flags::HAS_IMPORT_META)
-                {
-                    mi.flags.contains_import_meta = true;
-                    break;
-                }
-            }
-        }
-
-        // 1c. Same idea for top-level await. The new JSC module loader decides
-        // sync vs async evaluation from JSModuleRecord::hasTLA(), which we set
-        // from this bit when constructing the record from cached module_info
-        // (BunAnalyzeTranspiledModule). Without it, a bytecode-compiled module
-        // that contains TLA gets evaluated on the sync path and the suspended
-        // generator is dropped — the entry promise resolves immediately and the
-        // process exits before the awaited value lands.
-        {
-            let tla_keywords = c.parse_graph().ast.items_top_level_await_keyword();
-            let wraps = c.graph.meta.items_flags();
-            for part_range in chunk.content.javascript().parts_in_chunk_in_order.iter() {
-                let idx = part_range.source_index.get() as usize;
-                if idx >= tla_keywords.len() {
-                    continue;
-                }
-                if wraps[idx].wrap != crate::WrapKind::None {
-                    continue;
-                }
-                if !tla_keywords[idx].is_empty() {
-                    mi.flags.has_tla = true;
-                    break;
-                }
-            }
-        }
-
-        // 2. Collect truly-external imports from the original AST. Bundled imports
-        // (where source_index is valid) are removed by convertStmtsForChunk and
-        // re-created as cross-chunk imports — those are already captured by the
-        // printer when it prints cross_chunk_prefix_stmts above. Only truly-external
-        // imports (node built-ins, etc.) survive as s_import in per-file parts and
-        // need recording here.
-        let all_parts = c.graph.ast.items_parts();
-        let all_flags = c.graph.meta.items_flags();
-        let all_import_records = c.graph.ast.items_import_records();
+        let tla_keywords = c.parse_graph().ast.items_top_level_await_keyword();
+        let wraps = c.graph.meta.items_flags();
         for part_range in chunk.content.javascript().parts_in_chunk_in_order.iter() {
-            if all_flags[part_range.source_index.get() as usize].wrap == crate::WrapKind::Cjs {
+            let idx = part_range.source_index.get() as usize;
+            if idx >= tla_keywords.len() {
                 continue;
             }
-            let source_parts = all_parts[part_range.source_index.get() as usize].as_slice();
-            let source_import_records =
-                all_import_records[part_range.source_index.get() as usize].as_slice();
-            // A wrapped file's range spans all of its parts, including the tree-shaken ones.
-            let parts_live = &c.graph.parts_live[part_range.source_index.get() as usize];
-            let mut part_i = part_range.part_index_begin;
-            while part_i < part_range.part_index_end {
-                if !parts_live.is_set(part_i as usize) {
-                    part_i += 1;
-                    continue;
-                }
-                // `Part.stmts: StoreSlice<Stmt>` — arena-backed, safe `Deref`.
-                for stmt in source_parts[part_i as usize].stmts.iter() {
-                    match &stmt.data {
-                        StmtData::SImport(s) => {
-                            let record = &source_import_records[s.import_record_index as usize];
-                            if record.path.is_disabled {
-                                continue;
-                            }
-                            if record.tag == ImportRecordTag::Bun {
-                                continue;
-                            }
-                            // Skip bundled imports — these are converted to cross-chunk
-                            // imports by the linker. The printer already recorded them
-                            // when printing cross_chunk_prefix_stmts.
-                            if record.source_index.is_valid() {
-                                continue;
-                            }
-                            // Skip barrel-optimized-away imports — marked is_unused by
-                            // `barrel_imports`. Never resolved (source_index invalid),
-                            // and removed by convertStmtsForChunk. Not in emitted code.
-                            if record.flags.contains(ImportRecordFlags::IS_UNUSED) {
-                                continue;
-                            }
-
-                            let import_path = record.path.text;
-                            let irp_id = mi.str(import_path);
-                            mi.request_module(
-                                irp_id,
-                                analyze_transpiled_module::ImportAttributes::None,
-                            );
-
-                            if let Some(name) = &s.default_name {
-                                if let Some(name_ref) = name.ref_.to_nullable() {
-                                    let local_name_id = {
-                                        let local_name = chunk.renamer.name_for_symbol(name_ref);
-                                        mi.str(local_name)
-                                    };
-                                    let default_id = mi.str(b"default");
-                                    mi.add_import_info_single(
-                                        irp_id,
-                                        default_id,
-                                        local_name_id,
-                                        analyze_transpiled_module::ImportAttributes::None,
-                                        false,
-                                    );
-                                }
-                            }
-
-                            // `S::Import.items: StoreSlice<ClauseItem>` — safe `Deref`.
-                            for item in s.items.iter() {
-                                if let Some(name_ref) = item.name.ref_.to_nullable() {
-                                    let local_name_id = {
-                                        let local_name = chunk.renamer.name_for_symbol(name_ref);
-                                        mi.str(local_name)
-                                    };
-                                    // SAFETY: ClauseItem.alias is an arena `*const [u8]`; never null.
-                                    let alias_id = mi.str(item.alias.slice());
-                                    mi.add_import_info_single(
-                                        irp_id,
-                                        alias_id,
-                                        local_name_id,
-                                        analyze_transpiled_module::ImportAttributes::None,
-                                        false,
-                                    );
-                                }
-                            }
-
-                            if record
-                                .flags
-                                .contains(ImportRecordFlags::CONTAINS_IMPORT_STAR)
-                            {
-                                let local_name_id = {
-                                    let local_name = chunk.renamer.name_for_symbol(s.namespace_ref);
-                                    mi.str(local_name)
-                                };
-                                mi.add_import_info_namespace(
-                                    irp_id,
-                                    local_name_id,
-                                    analyze_transpiled_module::ImportAttributes::None,
-                                );
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                part_i += 1;
+            if wraps[idx].wrap != crate::WrapKind::None {
+                continue;
+            }
+            if !tla_keywords[idx].is_empty() {
+                mi.flags.has_tla = true;
+                break;
             }
         }
     }
@@ -401,6 +274,7 @@ pub(crate) fn post_process_js_chunk(
                 code: Box::default(),
                 source_map: None,
             }),
+            module_info: None,
         };
     };
 
@@ -1242,6 +1116,7 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                 code: Box::default(),
                 source_map: None,
             }),
+            module_info: None,
         };
     }
 
@@ -1287,5 +1162,7 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
             r,
         ),
         source_index,
+        // The exports were recorded straight into the chunk's ModuleInfo above.
+        module_info: None,
     }
 }

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -364,7 +364,7 @@ pub mod analyze_transpiled_module {
             self.record_kinds.push(kind);
             self.buffer.extend_from_slice(data);
         }
-        pub fn add_import_info_single(
+        pub(crate) fn add_import_info_single(
             &mut self,
             module_name: StringID,
             import_name: StringID,
@@ -386,7 +386,7 @@ pub mod analyze_transpiled_module {
                 ],
             );
         }
-        pub fn add_import_info_namespace(
+        pub(crate) fn add_import_info_namespace(
             &mut self,
             module_name: StringID,
             local_name: StringID,
@@ -506,7 +506,7 @@ pub mod analyze_transpiled_module {
             StringID(idx)
         }
 
-        pub fn request_module(
+        pub(crate) fn request_module(
             &mut self,
             import_record_path: StringID,
             fetch_parameters: FetchParameters,
@@ -528,6 +528,67 @@ pub mod analyze_transpiled_module {
         ) {
             self.requested_modules
                 .insert_if_absent(import_record_path, fetch_parameters, phase);
+        }
+
+        /// Appends `other`'s requested modules and import/export records to
+        /// `self`, re-interning its strings. The bundler prints the part ranges
+        /// of a chunk in parallel, each into its own `ModuleInfo`, then appends
+        /// them to the chunk's `ModuleInfo` in output order, so the chunk's
+        /// record lists its dependencies in the order JSC's parser would derive
+        /// from the printed source. `is_typescript` describes the destination
+        /// module and is left alone.
+        pub fn append(&mut self, other: &ModuleInfo) {
+            debug_assert!(!self.finalized);
+            debug_assert!(!other.finalized);
+
+            let mut ids: Vec<StringID> = Vec::with_capacity(other.strings_lens.len());
+            let mut offset = 0usize;
+            for &len in other.strings_lens.iter() {
+                let len = len as usize;
+                ids.push(self.str(&other.strings_buf[offset..offset + len]));
+                offset += len;
+            }
+            // Record slots also hold `STAR_DEFAULT` / `STAR_NAMESPACE`, the
+            // `ExportInfoLocal` padding word, and bitcast `FetchParameters`
+            // (a string ID for host-defined loaders, otherwise a sentinel);
+            // everything that is not an index into `other`'s string table is
+            // copied through unchanged.
+            let map = |raw: u32| -> u32 { ids.get(raw as usize).map_or(raw, |id| id.0) };
+
+            let (keys, values, phases) = (
+                other.requested_modules.keys(),
+                other.requested_modules.values(),
+                other.requested_modules.phases(),
+            );
+            for ((&key, &value), &phase) in keys.iter().zip(values).zip(phases) {
+                self.requested_modules.insert_if_absent(
+                    StringID(map(key.0)),
+                    FetchParameters(map(value.0)),
+                    phase,
+                );
+            }
+
+            let mut i = 0usize;
+            for &kind in other.record_kinds.iter() {
+                let data = &other.buffer[i..i + kind.len()];
+                i += kind.len();
+                // Same first-declaration-wins rule as `add_export_info_*`.
+                if matches!(
+                    kind,
+                    RecordKind::ExportInfoIndirect
+                        | RecordKind::ExportInfoLocal
+                        | RecordKind::ExportInfoNamespace
+                ) && self.has_or_add_exported_name(StringID(map(data[0].0)))
+                {
+                    continue;
+                }
+                self.record_kinds.push(kind);
+                self.buffer
+                    .extend(data.iter().map(|slot| StringID(map(slot.0))));
+            }
+
+            self.flags.contains_import_meta |= other.flags.contains_import_meta;
+            self.flags.has_tla |= other.flags.has_tla;
         }
 
         /// Replace all occurrences of `old_id` with `new_id` in records and requested_modules.

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -4788,14 +4788,12 @@ pub(crate) mod __gated_printer {
                     self.print_space_before_identifier();
                     self.add_source_mapping(binding.loc);
                     self.print_symbol(b.r#ref);
-                    if Self::MAY_HAVE_MODULE_INFO {
+                    if Self::MAY_HAVE_MODULE_INFO && tlm.is_export {
                         // reshaped for borrowck — fetch name before borrowing module_info.
                         let local_name = self.name_for_symbol(b.r#ref);
                         if let Some(mi) = self.module_info() {
                             let name_id = mi.str(local_name);
-                            if tlm.is_export {
-                                mi.add_export_info_local(name_id, name_id);
-                            }
+                            mi.add_export_info_local(name_id, name_id);
                         }
                     }
                 }
@@ -4905,14 +4903,14 @@ pub(crate) mod __gated_printer {
                                                     if str.slice8()
                                                         == self.name_for_symbol(id.r#ref)
                                                     {
-                                                        if Self::MAY_HAVE_MODULE_INFO {
+                                                        if Self::MAY_HAVE_MODULE_INFO
+                                                            && tlm.is_export
+                                                        {
                                                             if let Some(mi) = self.module_info() {
                                                                 let name_id = mi.str(str.slice8());
-                                                                if tlm.is_export {
-                                                                    mi.add_export_info_local(
-                                                                        name_id, name_id,
-                                                                    );
-                                                                }
+                                                                mi.add_export_info_local(
+                                                                    name_id, name_id,
+                                                                );
                                                             }
                                                         }
                                                         self.maybe_print_default_binding_value(
@@ -4938,16 +4936,14 @@ pub(crate) mod __gated_printer {
                                                     str.slice16(),
                                                     self.name_for_symbol(id.r#ref),
                                                 ) {
-                                                    if Self::MAY_HAVE_MODULE_INFO {
+                                                    if Self::MAY_HAVE_MODULE_INFO && tlm.is_export {
                                                         // reshaped for borrowck — bump access first.
                                                         let str8 = str.slice(self.bump);
                                                         if let Some(mi) = self.module_info() {
                                                             let name_id = mi.str(str8);
-                                                            if tlm.is_export {
-                                                                mi.add_export_info_local(
-                                                                    name_id, name_id,
-                                                                );
-                                                            }
+                                                            mi.add_export_info_local(
+                                                                name_id, name_id,
+                                                            );
                                                         }
                                                     }
                                                     self.maybe_print_default_binding_value(
@@ -5054,12 +5050,10 @@ pub(crate) mod __gated_printer {
                     self.print_identifier(local_name);
                     self.print_func(&s.func);
 
-                    if Self::MAY_HAVE_MODULE_INFO {
+                    if Self::MAY_HAVE_MODULE_INFO && s.func.flags.contains(G::FnFlags::IsExport) {
                         if let Some(mi) = self.module_info() {
                             let name_id = mi.str(local_name);
-                            if s.func.flags.contains(G::FnFlags::IsExport) {
-                                mi.add_export_info_local(name_id, name_id);
-                            }
+                            mi.add_export_info_local(name_id, name_id);
                         }
                     }
 
@@ -5085,12 +5079,10 @@ pub(crate) mod __gated_printer {
                     self.print_identifier(name_str);
                     self.print_class(&s.class);
 
-                    if Self::MAY_HAVE_MODULE_INFO {
+                    if Self::MAY_HAVE_MODULE_INFO && s.is_export {
                         if let Some(mi) = self.module_info() {
                             let name_id = mi.str(name_str);
-                            if s.is_export {
-                                mi.add_export_info_local(name_id, name_id);
-                            }
+                            mi.add_export_info_local(name_id, name_id);
                         }
                     }
 

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -253,6 +253,59 @@ describe("bundler", () => {
       },
       stdout: "a b",
     },
+    {
+      // When the re-exporting file is inlined into the chunk, `export * as ns from`
+      // and `export { x } from` an external module are rewritten into imports. The
+      // chunk's module record is built by the bundler (JSC does not parse bytecode
+      // modules), so it must list these imports too; otherwise `fs` hits a TDZ
+      // ReferenceError and `rfs` is undefined.
+      name: "ReExportExternalFromInlinedModule",
+      files: {
+        "/entry.ts": `
+          import { fs, rfs } from "./reexports.ts";
+          console.log(typeof fs.readFileSync, typeof rfs);
+        `,
+        "/reexports.ts": `
+          export * as fs from "node:fs";
+          export { readFileSync as rfs } from "node:fs";
+        `,
+      },
+      stdout: "function function",
+    },
+    {
+      // Same re-exports on the entry point itself: `export * from` is printed
+      // verbatim and needs a star export entry, the other two become imports that
+      // the entry's `export { ... }` tail must resolve back to. The debug build
+      // cross-checks the record against JSC's parser and refuses to start the
+      // binary when they differ.
+      name: "ReExportExternalFromEntryPoint",
+      files: {
+        "/entry.ts": `
+          export * from "node:path";
+          export * as fs from "node:fs";
+          export { readFileSync as rfs } from "node:fs";
+          console.log("entry ran");
+        `,
+      },
+      stdout: "entry ran",
+    },
+    {
+      // A file mixing `import` with `module.exports` is wrapped in __commonJS();
+      // its external imports are hoisted out of the wrapper and still have to be
+      // in the module record, otherwise `join` is not defined at runtime.
+      name: "ExternalImportInCommonJSWrapper",
+      files: {
+        "/entry.ts": `
+          import mixed from "./mixed.js";
+          console.log(typeof mixed.join);
+        `,
+        "/mixed.js": `
+          import { join } from "node:path";
+          module.exports = { join };
+        `,
+      },
+      stdout: "function",
+    },
   ];
 
   for (const scenario of esmBytecodeScenarios) {

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -120,5 +120,34 @@ describe("bundler", () => {
         }
       }
     }
+
+    // A split chunk gets its own bytecode + module record. Re-exports of
+    // externals in it are printed as `export * from`, or as imports plus the
+    // chunk's `export { ... }` tail; the record has to describe all of them in
+    // addition to the cross-chunk imports, or reading `fs` off the namespace
+    // throws a TDZ ReferenceError.
+    for (const minify of [false, true]) {
+      itBundled(`compile/splitting/ReExportExternalFromSplitChunk${minify ? "+minify" : ""}`, {
+        compile: true,
+        splitting: true,
+        bytecode: true,
+        format: "esm",
+        ...(minify ? { minifySyntax: true, minifyIdentifiers: true, minifyWhitespace: true } : {}),
+        files: {
+          "/entry.ts": /* js */ `
+            const mod = await import("./reexports.ts");
+            console.log(typeof mod.fs.readFileSync, typeof mod.join, typeof mod.rfs);
+          `,
+          "/reexports.ts": /* js */ `
+            export * from "node:path";
+            export * as fs from "node:fs";
+            export { readFileSync as rfs } from "node:fs";
+          `,
+        },
+        run: {
+          stdout: "function function function",
+        },
+      });
+    }
   });
 });


### PR DESCRIPTION
## Repro

```js
// reexports.js
export * as ns from "node:fs";
// entry.js
import { ns } from "./reexports.js";
console.log(typeof ns.readFileSync);
```

```
$ bun build --compile --bytecode --format=esm ./entry.js --outfile=app && ./app
ReferenceError: Cannot access 'ns' before initialization.
      at /$bunfs/root/app:6:28
```

Without `--bytecode` it prints `function`. The same record problem shows up in other shapes:

- `export { readFileSync as rfs } from "node:fs"` in a bundled file: `typeof rfs` is `"undefined"` in the compiled binary.
- `import { join } from "node:path"` in a file that also assigns `module.exports` (so it gets the `__commonJS` wrapper): `ReferenceError: join is not defined`.
- `export * from "node:path"` / `export * as ns from` / `export { x } from` an external on an entry point (or on a split chunk, where it becomes observable through `import()`): the star export is missing and the tail exports are recorded as `[Local]` instead of `[Namespace]` / `[Indirect]`. In a split chunk this is the same TDZ error as above.

Debug builds cross-check the record against JSC's own analyzer and refuse to start the binary in every one of these cases: `error: Imports different between parseFromSourceCode and fallbackParse`.

## Cause

With `--compile --bytecode --format=esm`, JSC does not parse the chunk; its `JSModuleRecord` is built from a `ModuleInfo` the linker assembles. `post_process_js_chunk` filled in the external imports by scanning the pre-link AST for `SImport` statements. That scan does not see what is actually printed:

- `convert_stmts_for_chunk` rewrites `export * as ns from "<external>"` and `export { x } from "<external>"` into `import` statements at print time (and, with `CALLS_RUNTIME_RE_EXPORT_FN`, `export * from` too), so those are `SExportStar` / `SExportFrom` in the AST and were never recorded.
- `export * from "<external>"` kept verbatim on an entry point needs a star export entry; nothing added one.
- Files with `wrap == Cjs` were skipped entirely, but their ESM imports are hoisted out of the wrapper and printed.
- It also had to be taught about tree-shaken parts separately (#37619), and it ignored loader attributes and `import defer`, which the printer handles.

Every missing import entry leaves the binding uninitialized in the module environment (or resolves it as a global), hence the TDZ error / `undefined` / `is not defined`.

## Fix

Stop re-deriving the record from the AST and record what is printed. Each part range printed by `generate_compile_result_for_js_chunk` now gets its own `ModuleInfo` (the printer already records every `import` / `export ... from` statement it prints, plus `import.meta`), carried on `CompileResult::Javascript`. `post_process_js_chunk` appends them to the chunk's `ModuleInfo` in `parts_in_chunk_in_order` order, after the cross-chunk prefix imports and before the suffix / entry point tail exports, so the requested modules end up in the same order JSC's parser would produce from the chunk source. `ModuleInfo::finalize` then turns the tail's `export { ns, readFileSync as rfs }` into the namespace / indirect exports JSC expects, since the matching import entries now exist.

`ModuleInfo::append` (new, in the printer crate next to the other builders) re-interns the appended record's strings, copies sentinel slots and fetch parameters through, and applies the same first-export-wins rule as `add_export_info_*`. The top-level await flag is still derived from the AST because the printer does not track it; the `import.meta` flag now comes from the printer, which sets it at the only places it prints `import.meta`. The three-clause "is this an ESM bytecode compile build" condition that was repeated in four places is now `LinkerOptions::generates_module_info()`. `CompileResult`'s unused `Clone` impl is removed rather than given a lossy clone of the new field. The `parts_live` check from #37619 goes away with the loop it was added to; the per-part printer only prints live parts, and that PR's tests still pass here.

Second commit: `print_binding` and the function/class statement arms interned every declared name into the record's string table before checking whether the declaration was exported. With module info now attached to the per-part printer, that would have put every binding name in the bundle into the embedded record (which JSC atomizes at startup), so those arms now check for the export first and only intern names they record. The records themselves are unchanged; this also applies to the runtime's `--isolate` module records, which go through the same arms.

This is correct because the record's only job is to describe the chunk text that was bytecode-compiled; deriving it from the printer makes it match by construction instead of mirroring `convert_stmts_for_chunk`'s rewrites by hand. It also means changes that would otherwise have to teach the removed loop about skipped statements (such as the external import dedupe in #35635 / #35645) no longer need to. One intentional difference: browser-side chunks of a full-stack `--compile` build are printed with the browser target, so their (never loaded as modules, served as assets) records now only carry the cross-chunk entries; a `Bun.serve` + HTML import binary built with these flags still builds and serves.

## Verification

New tests, all failing before this change (release: the errors above; debug: the cross-check error) and passing after:

- `test/bundler/bundler_compile.test.ts`, ESM bytecode matrix (each runs plain and minified): `ReExportExternalFromInlinedModule`, `ReExportExternalFromEntryPoint`, `ExternalImportInCommonJSWrapper`.
- `test/bundler/bundler_compile_splitting.test.ts`: `ReExportExternalFromSplitChunk` (+minify), which also covers appending after the cross-chunk prefix imports.

With the debug build: the rest of `bundler_compile.test.ts` (including the existing `ImportMeta` / TLA / `import defer` bytecode scenarios, which now exercise the printer-derived `import.meta` flag), all of `bundler_compile_splitting` (including #37619's `DeadExternalImportInWrappedModule` matrix), `bundler_barrel` `ESMBytecodeCompileSkipsDeferredImports`, `test/js/bun/typescript/type-export.test.ts`, `bun-build-compile`, `bundler_bun`, `regression/issue/26298`, `esbuild/importstar` + the splitting suites, and for the runtime record path `test/cli/test/isolation.test.ts` and `test/cli/run/transpiler-cache.test.ts` pass. For the string table, a compiled fixture with a non-exported function, parameter and local was checked with `grep -c` on the output binary: each name occurs exactly as often as in a binary produced by the released 1.4.0 (source text plus bytecode), i.e. the record does not pick them up. `compile/HelloWorldWithProcessVersionsBun` fails locally both with and without this change.