### PR TITLE
Blob: keep File and FormData entry names on the Blob instead of the shared store

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -434,8 +434,7 @@ impl Blob {
         matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::File(_)))
     }
 
-    /// `Blob.getFileName()` — the store's name (`Bytes.stored_name`, the file path,
-    /// or the S3 key), which [`Self::name`] overrides. `None` for fd-backed or unnamed stores.
+    /// The store's own name (`stored_name`, path, or S3 key); `None` when fd-backed or unnamed.
     pub fn get_file_name(&self) -> Option<&[u8]> {
         match &self.store.get().as_deref()?.data {
             store::Data::Bytes(bytes) => {
@@ -611,8 +610,7 @@ pub mod store {
         pub len: SizeType,
         pub cap: SizeType,
         pub allocator: bun_alloc::StdAllocator,
-        /// Set only when the store is created; a name given to one of the Blobs
-        /// sharing the store goes in `Blob::name`. Heap-owned (or empty); freed by `Drop`.
+        /// Set only at store creation (names given later go in `Blob::name`); heap-owned or empty.
         pub stored_name: Box<[u8]>,
     }
 

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -138,7 +138,9 @@ pub struct Blob {
     pub ref_count: bun_ptr::RawRefCount,
     pub global_this: Cell<*const JSGlobalObject>,
     pub last_modified: Cell<f64>,
-    /// Only used by `<input type="file">` / `File` (issue #10178).
+    /// Name given to this Blob in particular (`File` constructor, FormData
+    /// filename, `.name =`); `Dead` when none was, and the store's
+    /// [`Self::get_file_name`] applies.
     pub name: bun_core::OwnedStringCell,
 }
 
@@ -434,8 +436,10 @@ impl Blob {
         matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::File(_)))
     }
 
-    /// `Blob.getFileName()` — the user-visible name: `Bytes.stored_name`,
-    /// the file path, or the S3 key. `None` for fd-backed or unnamed blobs.
+    /// `Blob.getFileName()` — the name the *store* carries: `Bytes.stored_name`,
+    /// the file path, or the S3 key. `None` for fd-backed or unnamed stores.
+    /// A name given to this Blob itself is in `name`; `BlobExt::get_name_string`
+    /// combines the two.
     pub fn get_file_name(&self) -> Option<&[u8]> {
         match &self.store.get().as_deref()?.data {
             store::Data::Bytes(bytes) => {
@@ -611,7 +615,10 @@ pub mod store {
         pub len: SizeType,
         pub cap: SizeType,
         pub allocator: bun_alloc::StdAllocator,
-        /// Used by standalone module graph and the `File` constructor.
+        /// Set when the store is created (standalone module graph, structured
+        /// clone) and never afterwards: the store is shared by every Blob
+        /// viewing it, so a name given to one Blob (`new File([blob], name)`,
+        /// a FormData filename) lives in `Blob::name` instead.
         /// Heap-owned (or empty); freed by `Bytes`'s `Drop`.
         pub stored_name: Box<[u8]>,
     }
@@ -710,14 +717,6 @@ pub mod store {
                 cap,
                 allocator,
                 stored_name: Box::default(),
-            }
-        }
-
-        #[inline]
-        pub fn init_empty_with_name(name: Box<[u8]>) -> Bytes {
-            Bytes {
-                stored_name: name,
-                ..Default::default()
             }
         }
 

--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -138,9 +138,7 @@ pub struct Blob {
     pub ref_count: bun_ptr::RawRefCount,
     pub global_this: Cell<*const JSGlobalObject>,
     pub last_modified: Cell<f64>,
-    /// Name given to this Blob in particular (`File` constructor, FormData
-    /// filename, `.name =`); `Dead` when none was, and the store's
-    /// [`Self::get_file_name`] applies.
+    /// This Blob's own name; `Dead` means the store's [`Self::get_file_name`] applies.
     pub name: bun_core::OwnedStringCell,
 }
 
@@ -436,10 +434,8 @@ impl Blob {
         matches!(self.store.get().as_deref(), Some(s) if matches!(s.data, store::Data::File(_)))
     }
 
-    /// `Blob.getFileName()` — the name the *store* carries: `Bytes.stored_name`,
-    /// the file path, or the S3 key. `None` for fd-backed or unnamed stores.
-    /// A name given to this Blob itself is in `name`; `BlobExt::get_name_string`
-    /// combines the two.
+    /// `Blob.getFileName()` — the store's name (`Bytes.stored_name`, the file path,
+    /// or the S3 key), which [`Self::name`] overrides. `None` for fd-backed or unnamed stores.
     pub fn get_file_name(&self) -> Option<&[u8]> {
         match &self.store.get().as_deref()?.data {
             store::Data::Bytes(bytes) => {
@@ -615,11 +611,8 @@ pub mod store {
         pub len: SizeType,
         pub cap: SizeType,
         pub allocator: bun_alloc::StdAllocator,
-        /// Set when the store is created (standalone module graph, structured
-        /// clone) and never afterwards: the store is shared by every Blob
-        /// viewing it, so a name given to one Blob (`new File([blob], name)`,
-        /// a FormData filename) lives in `Blob::name` instead.
-        /// Heap-owned (or empty); freed by `Bytes`'s `Drop`.
+        /// Set only when the store is created; a name given to one of the Blobs
+        /// sharing the store goes in `Blob::name`. Heap-owned (or empty); freed by `Drop`.
         pub stored_name: Box<[u8]>,
     }
 

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1502,6 +1502,7 @@ mod vm_loader_ctx {
             // Returned slices borrow blob heap storage that lives until
             // `blob_deinit`; erased to `'static` per the interface signature —
             // sound because the bundler caller drops them before `blob_deinit`.
+            // The store's path (what gets read), not the File's own name.
             blob_file_name(b) => blob(b)
                 .get_file_name()
                 .map(|s| core::slice::from_raw_parts(s.as_ptr(), s.len())),
@@ -4241,6 +4242,7 @@ unsafe fn get_loader_and_virtual_source<'a>(
                 loader = blob.get_loader(unsafe { &*jsc_vm });
 
                 // "file:" loader makes no sense for blobs, so default to tsx.
+                // The store's path (what gets read), not the File's own name.
                 if let Some(filename) = blob.get_file_name() {
                     // Only treat it as a file if it is a `Bun.file()`.
                     if blob.needs_to_read_file() {

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3857,8 +3857,8 @@ where
         // 1. Bun.file("foo")
         // 2. The content-disposition header is not present
         if !has_content_disposition && content_type.category.autoset_filename() {
-            if let Some(filename) = blob.get_file_name() {
-                let basename = bun_paths::basename(filename);
+            if let Some(filename) = blob.get_name_utf8() {
+                let basename = bun_paths::basename(filename.slice());
                 if !basename.is_empty() {
                     let mut filename_buf = [0u8; 1024];
                     let truncated = &basename[..basename.len().min(1024 - 32)];

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4249,8 +4249,7 @@ pub(crate) extern "C" fn Blob__dupeFromJS(value: JSValue) -> Option<NonNull<Blob
     )
 }
 
-/// blob.cpp `toJS`: names the FormData entry's own Blob (its store is shared with
-/// the appended blob). An empty `path_str` means no filename was given.
+/// blob.cpp `toJS`: names the FormData entry's Blob; empty means no filename was given.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &mut BunString) {
     this.is_jsdom_file.set(true);
@@ -4264,8 +4263,7 @@ pub(crate) extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
     Blob::new(this.dupe_with_content_type(true))
 }
 
-/// JSDOMFormData.cpp's default entry filename. Borrowed: the caller refs it via
-/// `toWTFString` and never derefs it.
+/// Borrowed: JSDOMFormData.cpp refs it via `toWTFString` and never derefs it.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
     this.get_name_string().unwrap_or_else(BunString::empty)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2055,8 +2055,7 @@ impl BlobExt for Blob {
         None
     }
 
-    /// The name `.name` reports, for consumers that derive something from it
-    /// (loader, `filename=`). `None` when there is none or it is empty.
+    /// [`Self::get_name_string`] as UTF-8; `None` when there is no name or it is empty.
     fn get_name_utf8(&self) -> Option<ZigStringSlice> {
         let name = self.get_name_string()?;
         if name.is_empty() {
@@ -4250,9 +4249,8 @@ pub(crate) extern "C" fn Blob__dupeFromJS(value: JSValue) -> Option<NonNull<Blob
     )
 }
 
-/// blob.cpp `toJS`: `this` is the natively held FormData entry, which shares
-/// its store with the blob the user appended, so the entry's filename is set
-/// on `this` alone. Empty means no filename was given.
+/// blob.cpp `toJS`: names the FormData entry's own Blob (its store is shared with
+/// the appended blob). An empty `path_str` means no filename was given.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &mut BunString) {
     this.is_jsdom_file.set(true);
@@ -4266,8 +4264,7 @@ pub(crate) extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
     Blob::new(this.dupe_with_content_type(true))
 }
 
-/// JSDOMFormData.cpp: the default entry filename when `append`/`set` is given
-/// none. Borrowed (`this` keeps it alive); the caller takes its own ref via
+/// JSDOMFormData.cpp's default entry filename. Borrowed: the caller refs it via
 /// `toWTFString` and never derefs it.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
@@ -5539,19 +5536,14 @@ pub(crate) fn jsdom_file_construct(
         )));
     }
 
-    // +1 WTF ref; `OwnedString` releases it if `get` throws, otherwise
-    // `into_inner` hands it to `blob.name`.
     let mut name = OwnedString::new(BunString::from_js(args[1], global_this)?);
     if name.is_utf16() {
-        // `name` is a USVString: the UTF-8 round trip turns lone surrogates
-        // (only possible in a 16-bit string) into U+FFFD.
+        // USVString: the UTF-8 round trip replaces lone surrogates with U+FFFD.
         let utf8 = name.to_utf8();
         name = OwnedString::new(BunString::clone_utf8(utf8.slice()));
     }
     let blob = Blob::get::<false, true>(global_this, args[0])?;
-    // A single-Blob `bits` shares the source's store (and `dupe()` copied its
-    // name), so the name goes on this Blob only: writing it into the store
-    // would rename every Blob sharing it.
+    // Not into the store: a single-Blob `bits` shares the source's store.
     blob.name.set(name.into_inner());
 
     let mut set_last_modified = false;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -246,6 +246,7 @@ pub trait BlobExt {
     fn get_mime_type_or_content_type(&self) -> Option<MimeType>;
     fn get_type(&self, global_this: &JSGlobalObject) -> JSValue;
     fn get_name_string(&self) -> Option<BunString>;
+    fn get_name_utf8(&self) -> Option<ZigStringSlice>;
     fn get_name(&self, _: JSValue, global_this: &JSGlobalObject) -> JsResult<JSValue>;
     fn set_name(
         &self,
@@ -2054,6 +2055,16 @@ impl BlobExt for Blob {
         None
     }
 
+    /// The name `.name` reports, for consumers that derive something from it
+    /// (loader, `filename=`). `None` when there is none or it is empty.
+    fn get_name_utf8(&self) -> Option<ZigStringSlice> {
+        let name = self.get_name_string()?;
+        if name.is_empty() {
+            return None;
+        }
+        Some(name.to_utf8())
+    }
+
     // TODO: Move this to a separate `File` object or BunFile
     fn get_name(&self, _: JSValue, global_this: &JSGlobalObject) -> JsResult<JSValue> {
         Ok(match self.get_name_string() {
@@ -2087,8 +2098,8 @@ impl BlobExt for Blob {
 
     fn get_loader(&self, jsc_vm: &VirtualMachine) -> Option<bun_ast::Loader> {
         use bun_resolver::fs::PathResolverExt as _;
-        if let Some(filename) = self.get_file_name() {
-            let current_path = bun_resolver::fs::Path::init(filename);
+        if let Some(filename) = self.get_name_utf8() {
+            let current_path = bun_resolver::fs::Path::init(filename.slice());
             return Some(
                 current_path
                     .loader(&jsc_vm.transpiler.options.loaders)
@@ -4239,19 +4250,14 @@ pub(crate) extern "C" fn Blob__dupeFromJS(value: JSValue) -> Option<NonNull<Blob
     )
 }
 
+/// blob.cpp `toJS`: `this` is the natively held FormData entry, which shares
+/// its store with the blob the user appended, so the entry's filename is set
+/// on `this` alone. Empty means no filename was given.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &mut BunString) {
     this.is_jsdom_file.set(true);
-
-    // This is not 100% correct...
-    if let Some(store) = this.store() {
-        if let store::Data::Bytes(bytes) = &mut store.data_mut() {
-            if bytes.stored_name.is_empty() {
-                // Owned heap slice
-                // owned by `stored_name` (`Box<[u8]>`) and freed by `Bytes::Drop`.
-                bytes.stored_name = path_str.to_owned_slice().into_boxed_slice();
-            }
-        }
+    if !path_str.is_empty() {
+        this.name.set(path_str.dupe_ref());
     }
 }
 
@@ -4260,12 +4266,12 @@ pub(crate) extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
     Blob::new(this.dupe_with_content_type(true))
 }
 
+/// JSDOMFormData.cpp: the default entry filename when `append`/`set` is given
+/// none. Borrowed (`this` keeps it alive); the caller takes its own ref via
+/// `toWTFString` and never derefs it.
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__getFileNameString(this: &Blob) -> BunString {
-    if let Some(filename) = this.get_file_name() {
-        return BunString::from_bytes(filename);
-    }
-    BunString::empty()
+    this.get_name_string().unwrap_or_else(BunString::empty)
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -5525,7 +5531,6 @@ pub(crate) fn jsdom_file_construct(
     callframe: &CallFrame,
 ) -> JsResult<*mut Blob> {
     jsc::mark_binding();
-    let blob: Blob;
     let args = callframe.arguments();
 
     if args.len() < 2 {
@@ -5533,39 +5538,21 @@ pub(crate) fn jsdom_file_construct(
             "new File(bits, name) expects at least 2 arguments"
         )));
     }
-    {
-        use bun_jsc::StringJsc as _;
-        // +1 WTF ref; `OwnedString` releases it at scope exit.
-        // Every consumer below either
-        // copies bytes (`to_owned_slice`) or takes its own ref (`dupe_ref`).
-        let name_value_str = OwnedString::new(BunString::from_js(args[1], global_this)?);
 
-        blob = Blob::get::<false, true>(global_this, args[0])?;
-        if let Some(store_) = blob.store.get() {
-            match store_.data_mut() {
-                store::Data::Bytes(bytes) => {
-                    // `get::<_, true>` on a single-Blob sequence returns
-                    // `dupe()` (a shared StoreRef), so this `Bytes` may already
-                    // carry an owned `stored_name` from the source blob; the
-                    // assignment drops (frees) the previous `Box<[u8]>`.
-                    bytes.stored_name = name_value_str.to_owned_slice().into_boxed_slice();
-                }
-                store::Data::S3(_) | store::Data::File(_) => {
-                    blob.name.set(name_value_str.dupe_ref());
-                }
-            }
-        } else if !name_value_str.is_empty() {
-            // not store but we have a name so we need a store
-            blob.store.set(Some(StoreRef::from(Store::new(Store {
-                data: store::Data::Bytes(store::Bytes::init_empty_with_name(
-                    name_value_str.to_owned_slice().into_boxed_slice(),
-                )),
-                ref_count: bun_ptr::ThreadSafeRefCount::init(),
-                mime_type: bun_http_types::MimeType::NONE,
-                is_all_ascii: None,
-            }))));
-        }
+    // +1 WTF ref; `OwnedString` releases it if `get` throws, otherwise
+    // `into_inner` hands it to `blob.name`.
+    let mut name = OwnedString::new(BunString::from_js(args[1], global_this)?);
+    if name.is_utf16() {
+        // `name` is a USVString: the UTF-8 round trip turns lone surrogates
+        // (only possible in a 16-bit string) into U+FFFD.
+        let utf8 = name.to_utf8();
+        name = OwnedString::new(BunString::clone_utf8(utf8.slice()));
     }
+    let blob = Blob::get::<false, true>(global_this, args[0])?;
+    // A single-Blob `bits` shares the source's store (and `dupe()` copied its
+    // name), so the name goes on this Blob only: writing it into the store
+    // would rename every Blob sharing it.
+    blob.name.set(name.into_inner());
 
     let mut set_last_modified = false;
 
@@ -6345,9 +6332,9 @@ impl Any {
         }
     }
 
-    pub(crate) fn get_file_name(&self) -> Option<&[u8]> {
+    pub(crate) fn get_name_utf8(&self) -> Option<ZigStringSlice> {
         match self {
-            Any::Blob(b) => b.get_file_name(),
+            Any::Blob(b) => b.get_name_utf8(),
             Any::WTFStringImpl(_) | Any::InternalBlob(_) => None,
         }
     }

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2055,9 +2055,14 @@ impl BlobExt for Blob {
         None
     }
 
-    /// [`Self::get_name_string`] as UTF-8; `None` when there is no name or it is empty.
+    /// [`Self::get_name_string`]'s lookup as bytes, without caching; `None` when absent or empty.
     fn get_name_utf8(&self) -> Option<ZigStringSlice> {
-        let name = self.get_name_string()?;
+        let name = self.name.get();
+        if name.tag() == bun_core::Tag::Dead {
+            return self
+                .get_file_name()
+                .map(ZigStringSlice::from_utf8_never_free);
+        }
         if name.is_empty() {
             return None;
         }

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -45,11 +45,8 @@ impl Entry {
     }
 }
 
-/// The registry is shared by every thread; a `WTF::StringImpl` must not be.
-/// The first thread to use one as a property key turns it into an atom of its
-/// own string table, and dropping the last reference from any other thread
-/// then aborts in `AtomStringImpl::remove`. So the entry and every resolved
-/// copy each get a `name` impl that no thread's JS can reach.
+/// A name impl that some thread's JS can reach may become that thread's atom, and an
+/// atom must not be released on another thread (`AtomStringImpl::remove`), so none is shared.
 fn dupe_with_private_name(blob: &Blob) -> Blob {
     let copy = blob.dupe_with_content_type(true);
     let mut name = copy.name.replace(bun_core::String::dead()).into_inner();

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -40,9 +40,22 @@ const _: fn() = || {
 impl Entry {
     pub(crate) fn init(blob: &Blob) -> Box<Entry> {
         Box::new(Entry {
-            blob: blob.dupe_with_content_type(true),
+            blob: dupe_with_private_name(blob),
         })
     }
+}
+
+/// The registry is shared by every thread; a `WTF::StringImpl` must not be.
+/// The first thread to use one as a property key turns it into an atom of its
+/// own string table, and dropping the last reference from any other thread
+/// then aborts in `AtomStringImpl::remove`. So the entry and every resolved
+/// copy each get a `name` impl that no thread's JS can reach.
+fn dupe_with_private_name(blob: &Blob) -> Blob {
+    let copy = blob.dupe_with_content_type(true);
+    let mut name = copy.name.replace(bun_core::String::dead()).into_inner();
+    name.to_thread_safe();
+    copy.name.set(name);
+    copy
 }
 
 impl Drop for Entry {
@@ -70,7 +83,7 @@ impl ObjectURLRegistry {
         let uuid = uuid_from_pathname(pathname)?;
         let map = self.map.lock();
         map.get(&uuid.bytes)
-            .map(|e| e.blob.dupe_with_content_type(true))
+            .map(|e| dupe_with_private_name(&e.blob))
     }
 
     pub(crate) fn resolve_and_dupe_to_js(

--- a/src/runtime/webcore/ObjectURLRegistry.rs
+++ b/src/runtime/webcore/ObjectURLRegistry.rs
@@ -45,8 +45,7 @@ impl Entry {
     }
 }
 
-/// A name impl that some thread's JS can reach may become that thread's atom, and an
-/// atom must not be released on another thread (`AtomStringImpl::remove`), so none is shared.
+/// A name impl reachable from JS may become that thread's atom, which no other thread may release.
 fn dupe_with_private_name(blob: &Blob) -> Blob {
     let copy = blob.dupe_with_content_type(true);
     let mut name = copy.name.replace(bun_core::String::dead()).into_inner();

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -382,29 +382,31 @@ describe("new File([blob], name) names only the new File", () => {
     ]).toEqual(["a\uFFFDb", "a\uFFFDb", "a\uFFFDb", "caf\u00e9 \u{1F600}"]);
   });
 
-  test("blob: imports pick the loader from each File's own name", async () => {
+  test("blob: imports pick the loader from each File's own name, or from a Bun.file's path", async () => {
+    using dir = tempDir("blob-url-loader", { "on-disk.json": '{"a":1}' });
     const source = new File(['{"a":1}'], "source.json");
-    const wrapped = new File([source], "wrapped.txt");
-    const sourceURL = URL.createObjectURL(source);
-    const wrappedURL = URL.createObjectURL(wrapped);
+    const urls = [
+      URL.createObjectURL(source),
+      URL.createObjectURL(new File([source], "wrapped.txt")),
+      URL.createObjectURL(Bun.file(path.join(String(dir), "on-disk.json"))),
+    ];
     try {
-      const [sourceModule, wrappedModule] = await Promise.all([import(sourceURL), import(wrappedURL)]);
-      expect([sourceModule.default, wrappedModule.default]).toEqual([{ a: 1 }, '{"a":1}']);
+      const modules = await Promise.all(urls.map(url => import(url)));
+      expect(modules.map(module => module.default)).toEqual([{ a: 1 }, '{"a":1}', { a: 1 }]);
     } finally {
-      URL.revokeObjectURL(sourceURL);
-      URL.revokeObjectURL(wrappedURL);
+      urls.forEach(url => URL.revokeObjectURL(url));
     }
   });
 
-  test("Bun.serve derives Content-Disposition from each File's own name", async () => {
+  test("Bun.serve derives Content-Disposition from each File's own name, or from a Bun.file's path", async () => {
     using dir = tempDir("file-name-content-disposition", { "on-disk.bin": "xyz" });
+    const bunFile = Bun.file(path.join(String(dir), "on-disk.bin"));
     const source = new File(["xyz"], "source.zip", { type: "application/zip" });
     const bodies: Record<string, Blob> = {
       source,
       wrapped: new File([source], "wrapped.zip", { type: "application/zip" }),
-      wrappedBunFile: new File([Bun.file(path.join(String(dir), "on-disk.bin"))], "display.zip", {
-        type: "application/zip",
-      }),
+      wrappedBunFile: new File([bunFile], "display.zip", { type: "application/zip" }),
+      bunFile,
     };
     await using server = Bun.serve({
       port: 0,
@@ -420,6 +422,7 @@ describe("new File([blob], name) names only the new File", () => {
       source: 'filename="source.zip"',
       wrapped: 'filename="wrapped.zip"',
       wrappedBunFile: 'filename="display.zip"',
+      bunFile: 'filename="on-disk.bin"',
     });
   });
 

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -427,8 +427,7 @@ describe("new File([blob], name) names only the new File", () => {
   // as a zero-copy view. Renaming through the shared store freed the bytes that
   // view pointed at, so the multipart body read freed memory. Spawned so that
   // the ASAN report for that read fails this test instead of taking down the
-  // test run; symbolizing that report in a debug build takes the child several
-  // seconds (the passing run is well under a second), hence the timeout.
+  // test run.
   test("wrapping a File does not disturb a FormData entry made from it", async () => {
     const name = "source-" + Buffer.alloc(64, "s").toString() + ".txt";
     const script = `
@@ -461,7 +460,7 @@ describe("new File([blob], name) names only the new File", () => {
       stderr: "",
       exitCode: 0,
     });
-  }, 30_000);
+  });
 });
 
 test("dupeWithContentType does not alias the source's allocated content_type", async () => {

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -307,6 +307,163 @@ test("#12894", () => {
   expect(new File([bunFile], "bar.txt").name).toBe("bar.txt");
 });
 
+describe("new File([blob], name) names only the new File", () => {
+  // A single-Blob `bits` shares the source's byte store instead of copying it.
+  // The name used to be written into that shared store, renaming the source
+  // (and every other Blob sharing the store) along with the new File.
+  //
+  // `.name` is cached on first read, so the source's name is always read after
+  // wrapping unless the test is about reading it before.
+  test.each([
+    ["a File", () => new File(["xyz"], "source.txt"), "source.txt"],
+    ["an empty File", () => new File([], "source.txt"), "source.txt"],
+    ["a Blob", () => new Blob(["xyz"]), undefined],
+    ["an empty Blob", () => new Blob([]), undefined],
+  ])("wrapping %s", async (_, makeSource, sourceName) => {
+    const source = makeSource();
+    const wrapped = new File([source], "wrapped.txt");
+    expect({
+      source: (source as File).name,
+      wrapped: wrapped.name,
+      wrappedBytes: await wrapped.text(),
+    }).toEqual({
+      source: sourceName,
+      wrapped: "wrapped.txt",
+      wrappedBytes: await source.text(),
+    });
+  });
+
+  test("wrapping a slice of a File", async () => {
+    const source = new File(["hello world"], "source.txt");
+    const wrapped = new File([source.slice(0, 5)], "wrapped.txt");
+    expect({ source: source.name, wrapped: wrapped.name, wrappedBytes: await wrapped.text() }).toEqual({
+      source: "source.txt",
+      wrapped: "wrapped.txt",
+      wrappedBytes: "hello",
+    });
+  });
+
+  test("every File in a chain of wrappers keeps its own name", () => {
+    const a = new File(["xyz"], "a.txt");
+    const b = new File([a], "b.txt");
+    const c = new File([b], "c.txt");
+    expect([a.name, b.name, c.name]).toEqual(["a.txt", "b.txt", "c.txt"]);
+  });
+
+  test("reading the source's name first does not hand it to the wrapper", () => {
+    const source = new File(["xyz"], "source.txt");
+    expect(source.name).toBe("source.txt");
+    const wrapped = new File([source], "wrapped.txt");
+    expect({ source: source.name, wrapped: wrapped.name }).toEqual({ source: "source.txt", wrapped: "wrapped.txt" });
+  });
+
+  test("structuredClone copies each File's own name", () => {
+    const source = new File(["xyz"], "source.txt");
+    const wrapped = new File([source], "wrapped.txt");
+    expect([structuredClone(source).name, structuredClone(wrapped).name]).toEqual(["source.txt", "wrapped.txt"]);
+  });
+
+  test("an empty name is reported as an empty string", () => {
+    expect([new File(["xyz"], "").name, new File([], "").name, new File([new Blob(["xyz"])], "").name]).toEqual([
+      "",
+      "",
+      "",
+    ]);
+  });
+
+  test("the name is converted as a USVString", async () => {
+    using dir = tempDir("file-name-usvstring", { "on-disk.txt": "xyz" });
+    const bunFile = Bun.file(path.join(String(dir), "on-disk.txt"));
+    expect([
+      new File(["xyz"], "a\uD800b").name,
+      new File([new Blob(["xyz"])], "a\uD800b").name,
+      new File([bunFile], "a\uD800b").name,
+      new File(["xyz"], "caf\u00e9 \u{1F600}").name,
+    ]).toEqual(["a\uFFFDb", "a\uFFFDb", "a\uFFFDb", "caf\u00e9 \u{1F600}"]);
+  });
+
+  test("blob: imports pick the loader from each File's own name", async () => {
+    const source = new File(['{"a":1}'], "source.json");
+    const wrapped = new File([source], "wrapped.txt");
+    const sourceURL = URL.createObjectURL(source);
+    const wrappedURL = URL.createObjectURL(wrapped);
+    try {
+      const [sourceModule, wrappedModule] = await Promise.all([import(sourceURL), import(wrappedURL)]);
+      expect([sourceModule.default, wrappedModule.default]).toEqual([{ a: 1 }, '{"a":1}']);
+    } finally {
+      URL.revokeObjectURL(sourceURL);
+      URL.revokeObjectURL(wrappedURL);
+    }
+  });
+
+  test("Bun.serve derives Content-Disposition from each File's own name", async () => {
+    using dir = tempDir("file-name-content-disposition", { "on-disk.bin": "xyz" });
+    const source = new File(["xyz"], "source.zip", { type: "application/zip" });
+    const bodies: Record<string, Blob> = {
+      source,
+      wrapped: new File([source], "wrapped.zip", { type: "application/zip" }),
+      wrappedBunFile: new File([Bun.file(path.join(String(dir), "on-disk.bin"))], "display.zip", {
+        type: "application/zip",
+      }),
+    };
+    await using server = Bun.serve({
+      port: 0,
+      fetch: req => new Response(bodies[new URL(req.url).pathname.slice(1)]),
+    });
+    const headers: Record<string, string | null> = {};
+    for (const key of Object.keys(bodies)) {
+      const res = await fetch(new URL(key, server.url));
+      headers[key] = res.headers.get("content-disposition");
+      expect(await res.text()).toBe("xyz");
+    }
+    expect(headers).toEqual({
+      source: 'filename="source.zip"',
+      wrapped: 'filename="wrapped.zip"',
+      wrappedBunFile: 'filename="display.zip"',
+    });
+  });
+
+  // FormData reads the entry's default filename from the blob at append() time
+  // as a zero-copy view. Renaming through the shared store freed the bytes that
+  // view pointed at, so the multipart body read freed memory. Spawned so that
+  // the ASAN report for that read fails this test instead of taking down the
+  // test run; symbolizing that report in a debug build takes the child several
+  // seconds (the passing run is well under a second), hence the timeout.
+  test("wrapping a File does not disturb a FormData entry made from it", async () => {
+    const name = "source-" + Buffer.alloc(64, "s").toString() + ".txt";
+    const script = `
+      const source = new File(["xyz"], ${JSON.stringify(name)});
+      const formData = new FormData();
+      formData.append("file", source);
+      for (let i = 0; i < 8; i++) {
+        new File([source], "wrapped-" + Buffer.alloc(64, String(i)).toString() + ".txt");
+      }
+      const body = await new Response(formData).text();
+      console.log(JSON.stringify({ entry: formData.get("file").name, body: body.match(/filename="([^"]*)"/)[1] }));
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({
+      stdout,
+      // ASAN builds may print a "WARNING: ASAN interferes ..." banner at startup.
+      stderr: stderr
+        .split("\n")
+        .filter(line => line && !line.startsWith("WARNING: ASAN interferes"))
+        .join("\n"),
+      exitCode,
+    }).toEqual({
+      stdout: JSON.stringify({ entry: name, body: name }) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  }, 30_000);
+});
+
 test("dupeWithContentType does not alias the source's allocated content_type", async () => {
   // Regression: #23015 refactored Blob to be ref-counted and moved
   // `setNotHeapAllocated()` before the `isHeapAllocated()` guard in

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -463,6 +463,87 @@ describe("new File([blob], name) names only the new File", () => {
   });
 });
 
+describe("a File's name reaches other threads through an object URL as a private copy", () => {
+  // A name that has been used as a property key is an atom of the thread that
+  // did so, and the process aborts if the last reference to it is dropped on a
+  // different thread. The registry used to hand the File's own name string to
+  // whichever thread resolved the URL; here the worker holds the resolved Blob
+  // until the main thread has dropped everything else that referenced the name.
+  test.concurrent.each(["bytes", "Bun.file"])("File backed by %s", async backing => {
+    using dir = tempDir("blob-url-name-thread", { "on-disk.txt": "xyz" });
+    const bits =
+      backing === "bytes" ? `["xyz"]` : `[Bun.file(${JSON.stringify(path.join(String(dir), "on-disk.txt"))})]`;
+    const script = `
+      const workerURL = URL.createObjectURL(
+        new Blob(
+          [
+            \`
+              import { resolveObjectURL } from "node:buffer";
+              let held;
+              self.onmessage = ({ data }) => {
+                if (data.url) {
+                  held = resolveObjectURL(data.url);
+                  postMessage({ holdsName: held.name === data.name });
+                } else {
+                  held = undefined;
+                  Bun.gc(true);
+                  postMessage({ released: true });
+                }
+              };
+            \`,
+          ],
+          { type: "text/javascript" },
+        ),
+      );
+      const worker = new Worker(workerURL);
+      const { promise, resolve, reject } = Promise.withResolvers();
+      worker.onerror = event => reject(new Error(event.message));
+
+      let name = "name-" + process.pid;
+      ({})[name]; // used as a property key: the string is now an atom of this thread
+      let file = new File(${bits}, name);
+      let url = URL.createObjectURL(file);
+      worker.onmessage = ({ data }) => {
+        if ("holdsName" in data) {
+          console.log("worker holds the name:", data.holdsName);
+          // Drop every reference this thread has to the name (the structured
+          // clone sent to the worker is a separate string), so the worker's is
+          // the last one.
+          URL.revokeObjectURL(url);
+          file = url = name = undefined;
+          Bun.gc(true);
+          worker.postMessage({ release: true });
+        } else {
+          resolve();
+        }
+      };
+      worker.postMessage({ url, name });
+      await promise;
+      worker.terminate();
+      console.log("released on the worker");
+    `;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({
+      stdout,
+      stderr: stderr
+        .split("\n")
+        .filter(line => line && !line.startsWith("WARNING: ASAN interferes"))
+        .join("\n"),
+      exitCode,
+    }).toEqual({
+      stdout: "worker holds the name: true\nreleased on the worker\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 test("dupeWithContentType does not alias the source's allocated content_type", async () => {
   // Regression: #23015 refactored Blob to be ref-counted and moved
   // `setNotHeapAllocated()` before the `isHeapAllocated()` guard in

--- a/test/js/web/fetch/blob.test.ts
+++ b/test/js/web/fetch/blob.test.ts
@@ -383,16 +383,20 @@ describe("new File([blob], name) names only the new File", () => {
   });
 
   test("blob: imports pick the loader from each File's own name, or from a Bun.file's path", async () => {
-    using dir = tempDir("blob-url-loader", { "on-disk.json": '{"a":1}' });
+    using dir = tempDir("blob-url-loader", { "on-disk.json": '{"onDisk":true}' });
+    const onDisk = Bun.file(path.join(String(dir), "on-disk.json"));
     const source = new File(['{"a":1}'], "source.json");
     const urls = [
       URL.createObjectURL(source),
       URL.createObjectURL(new File([source], "wrapped.txt")),
-      URL.createObjectURL(Bun.file(path.join(String(dir), "on-disk.json"))),
+      URL.createObjectURL(onDisk),
+      // A File wrapping a Bun.file() is named like any other File: the loader
+      // follows the name it was given, the bytes still come from the disk.
+      URL.createObjectURL(new File([onDisk], "wrapped-on-disk.txt")),
     ];
     try {
       const modules = await Promise.all(urls.map(url => import(url)));
-      expect(modules.map(module => module.default)).toEqual([{ a: 1 }, '{"a":1}', { a: 1 }]);
+      expect(modules.map(module => module.default)).toEqual([{ a: 1 }, '{"a":1}', { onDisk: true }, '{"onDisk":true}']);
     } finally {
       urls.forEach(url => URL.revokeObjectURL(url));
     }

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -958,6 +958,75 @@ test("FormData.toJSON merges duplicate numeric field names into an array", async
   expect(exitCode).toBe(0);
 });
 
+describe("entry filenames belong to the entry, not to the byte store it shares with the appended blob", () => {
+  // A FormData entry holds a dupe of the appended blob that shares its byte
+  // store. Filenames used to be written into that store, so they showed up on
+  // the blob the caller appended (and on anything else sharing the store).
+  //
+  // `.name` is cached on first read, so the appended blob's name is read only
+  // after the entry has been converted back to JS.
+  it.each(["append", "set"] as const)("%s(name, blob, filename) leaves the appended Blob nameless", method => {
+    const blob = new Blob(["xyz"]);
+    const formData = new FormData();
+    formData[method]("file", blob, "entry.txt");
+    const entry = formData.get("file") as File;
+    expect({ entry: entry.name, blob: (blob as File).name }).toEqual({ entry: "entry.txt", blob: undefined });
+  });
+
+  // A zero-byte Blob has no byte store at all, so a filename written into the
+  // store was simply dropped.
+  it("an empty Blob appended with a filename gets that filename", () => {
+    const formData = new FormData();
+    formData.append("file", new Blob([]), "empty.txt");
+    const entry = formData.get("file") as File;
+    expect({ name: entry.name, size: entry.size }).toEqual({ name: "empty.txt", size: 0 });
+  });
+
+  it("a parsed zero-byte file part keeps its filename", async () => {
+    const response = new Response(
+      '--boundary\r\nContent-Disposition: form-data; name="file"; filename="empty.txt"\r\n\r\n\r\n--boundary--\r\n',
+      { headers: { "content-type": "multipart/form-data; boundary=boundary" } },
+    );
+    const entry = (await response.formData()).get("file") as File;
+    expect({ name: entry.name, size: entry.size }).toEqual({ name: "empty.txt", size: 0 });
+  });
+
+  it("defaults the filename to the appended File's own name", async () => {
+    const source = new File(["xyz"], "source.txt");
+    const wrapped = new File([source], "wrapped.txt");
+    const formData = new FormData();
+    formData.append("source", source);
+    formData.append("wrapped", wrapped);
+    const body = await new Response(formData).text();
+    expect({
+      entries: [(formData.get("source") as File).name, (formData.get("wrapped") as File).name],
+      body: body.match(/filename="[^"]*"/g),
+    }).toEqual({
+      entries: ["source.txt", "wrapped.txt"],
+      body: ['filename="source.txt"', 'filename="wrapped.txt"'],
+    });
+  });
+
+  it("wrapping a parsed entry in new File() does not rename the entry", async () => {
+    const response = new Response(
+      '--boundary\r\nContent-Disposition: form-data; name="file"; filename="parsed.txt"\r\n\r\nxyz\r\n--boundary--\r\n',
+      { headers: { "content-type": "multipart/form-data; boundary=boundary" } },
+    );
+    const formData = await response.formData();
+    const entry = formData.get("file") as File;
+    const wrapped = new File([entry], "wrapped.txt");
+    expect({
+      entry: entry.name,
+      entryAgain: (formData.get("file") as File).name,
+      wrapped: wrapped.name,
+    }).toEqual({
+      entry: "parsed.txt",
+      entryAgain: "parsed.txt",
+      wrapped: "wrapped.txt",
+    });
+  });
+});
+
 describe("USVString conversion of lone surrogates", () => {
   const loneHigh = "a\uD800b";
   const loneLow = "a\uDC00b";

--- a/test/js/web/html/FormData.test.ts
+++ b/test/js/web/html/FormData.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isDebug } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, tempDir } from "harness";
 import { join } from "path";
 
 describe("FormData", () => {
@@ -1004,6 +1004,53 @@ describe("entry filenames belong to the entry, not to the byte store it shares w
     }).toEqual({
       entries: ["source.txt", "wrapped.txt"],
       body: ['filename="source.txt"', 'filename="wrapped.txt"'],
+    });
+  });
+
+  // The default filename used to come from the byte store, which for these two
+  // is the on-disk path and nothing at all, while .name already said otherwise.
+  it("defaults the filename to the name a File wrapping a Bun.file() was given", async () => {
+    using dir = tempDir("formdata-wrapped-bun-file", { "on-disk.bin": "xyz" });
+    const formData = new FormData();
+    formData.append("file", new File([Bun.file(join(String(dir), "on-disk.bin"))], "display.bin"));
+    const body = await new Response(formData).text();
+    expect({
+      entry: (formData.get("file") as File).name,
+      body: body.match(/filename="[^"]*"/g),
+    }).toEqual({
+      entry: "display.bin",
+      body: ['filename="display.bin"'],
+    });
+  });
+
+  it("defaults the filename to a name assigned through the Blob name setter", async () => {
+    const blob = new Blob(["xyz"]) as Blob & { name: string };
+    blob.name = "assigned.txt";
+    const formData = new FormData();
+    formData.append("file", blob);
+    const body = await new Response(formData).text();
+    expect({
+      entry: (formData.get("file") as File).name,
+      body: body.match(/filename="[^"]*"/g),
+    }).toEqual({
+      entry: "assigned.txt",
+      body: ['filename="assigned.txt"'],
+    });
+  });
+
+  it.each(["append", "set"] as const)("%s(name, file, filename) renames only the entry", async method => {
+    const file = new File(["xyz"], "original.txt");
+    const formData = new FormData();
+    formData[method]("file", file, "override.txt");
+    const body = await new Response(formData).text();
+    expect({
+      entry: (formData.get("file") as File).name,
+      body: body.match(/filename="[^"]*"/g),
+      file: file.name,
+    }).toEqual({
+      entry: "override.txt",
+      body: ['filename="override.txt"'],
+      file: "original.txt",
     });
   });
 


### PR DESCRIPTION
### Problem
- `new File([a], "b.txt")` renames `a` as well: `a.name` becomes `"b.txt"` (Node and browsers keep `"a.txt"`). `fd.append("f", blob, "entry.txt")` likewise names the caller's `blob`, and a zero-byte blob appended with a filename reports no name at all.
- Serializing a FormData after one of its files was wrapped in `new File([file], other)` reads freed memory. A debug build reports `AddressSanitizer: heap-use-after-free` in `FormDataContext::on_entry`, freed by `jsdom_file_construct`.
- Cause: `new File([blob], name)` shares the source's byte store, and the byte-backed constructor and FormData entry naming both wrote the name into that shared store. That renamed every Blob on the store and freed the old name buffer FormData still borrowed. File- and S3-backed Files already kept the name on the Blob.
- Second, pre-existing bug, reachable for every File once names live on the Blob: object URLs shared one name string across threads. If one thread had used it as a property key and another released it last, bun aborted with `ASSERTION FAILED: wasRemoved (AtomStringImpl.cpp:462)`. On 1.4.0 this needed a file-backed File.

### Fix
- The File constructor and FormData entry naming set the per-Blob name for every kind of blob; a store's name is written only when the store is created and is just the fallback. Naming one Blob therefore never changes another, and nothing rewrites a live store's name, so the borrowed FormData view stays valid.
- Three readers of the store's name (FormData's default filename, the loader for `blob:` imports, the `Content-Disposition` filename `Bun.serve` adds) now use the `.name` lookup, so a File wrapping a `Bun.file()` goes by its display name everywhere and a plain `Bun.file()` still uses its path. The resulting behavior changes are listed in the original below.
- Registering an object URL and resolving it each take a thread-safe copy of the name, so no thread holds a name string that another thread's JS can atomize.
- Verification: 25 new tests. 23 fail on 1.4.0 and on a debug build of main (the file-backed object URL case by aborting), the byte-backed object URL case aborts with only the first part of the change applied, and all pass with the change. The use-after-free test runs in a spawned process so ASAN fails the test rather than the run.

### Background
- A `Blob` is a window (offset, size) onto a refcounted store holding bytes, a file path, or an S3 key. `new File([blob], name)` and `blob.slice()` share the source's store on purpose; only the Blob-level fields differ.
- A name can live in two places: a per-Blob field, or a byte copy inside a byte store (set for standalone executables' embedded files and structured clone). The `.name` getter prefers the per-Blob field, so the store's name is only a fallback.
- FormData holds its own dupe of each blob entry. Reading an entry back into JS stamps the entry's filename onto that dupe; an entry appended without a filename defaults to the blob's name, which the C++ side takes as an uncopied view of the name bytes.
- WTF strings are atomized in place when a thread uses one as a property key; the atom belongs to that thread's table, and releasing its last reference from another thread is a release assertion. `URL.createObjectURL` hands the registered blob to whichever thread resolves the URL, workers included.

<details>
<summary>Original description</summary>

### Repro

```js
const a = new File(["xyz"], "a.txt");
const b = new File([a], "b.txt");
console.log(a.name, b.name);        // bun 1.4.0: "b.txt b.txt"   node/browsers: "a.txt b.txt"

const blob = new Blob(["xyz"]);
new File([blob], "c.txt");
console.log(blob.name);             // bun 1.4.0: "c.txt"         expected: undefined

const fd = new FormData();
fd.append("f", blob, "entry.txt");
fd.get("f");
console.log(blob.name);             // bun 1.4.0: "entry.txt"     expected: undefined

fd.set("g", new Blob([]), "empty.txt");
console.log(fd.get("g").name);      // bun 1.4.0: undefined       expected: "empty.txt"
```

The rename also reaches memory that is still in use. `FormData.append(name, file)` takes the default filename from `Blob__getFileNameString`, a borrowed view of the store's name bytes that the C++ side wraps without copying. A later `new File([file], other)` freed those bytes, so serializing the FormData read freed memory. Released build:

```js
const file = new File(["xyz"], "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.txt");
const fd = new FormData();
fd.append("f", file);
new File([file], "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.txt");
(await new Response(fd).text()).match(/filename="([^"]*)"/)[1];
// '\^@\^@\^@\^@\^@\^@\^@\^@aaaaaaaaaaaaaaaaaaaaaaaa.txt'
```

Debug build of main on the same script:

```
ERROR: AddressSanitizer: heap-use-after-free
READ of size 64
    #7 <bun_runtime::webcore::blob::FormDataContext>::on_entry src/runtime/webcore/Blob.rs:3897
freed by thread T0 here:
    #9 <alloc::boxed::Box<[u8]> as core::ops::drop::Drop>::drop
    #11 bun_runtime::webcore::blob::jsdom_file_construct src/runtime/webcore/Blob.rs:5551
```

### Cause

A `Blob` is a window (`store`, `offset`, `size`) onto a refcounted `Store`, and `new File([blob], name)` shares the part's store rather than copying it. `jsdom_file_construct` stored the new name in `store::Bytes::stored_name`, i.e. on the object shared with the source, so every Blob viewing that store was renamed and the previous name buffer was freed under any FormData entry still pointing at it. `Blob__setAsFile` (which attaches a FormData entry's filename when the entry is converted to JS) wrote into the shared store the same way, and dropped the name when the blob had no store, which is the case for every zero-byte blob.

The store already has no say in a File's name for file- and S3-backed Files: that arm of the constructor set the per-Blob `name` field, and `get_name_string()` (the `.name` getter) prefers that field over the store's name. The byte-backed arm was the odd one out.

### Fix

* `jsdom_file_construct` sets `blob.name` for every kind of `bits`, and no longer creates an empty store whose only purpose was to carry the name of an empty File. Names are now kept as a WTF string instead of a UTF-8 copy, so the constructor converts them as a USVString explicitly; the UTF-8 copy used to do that implicitly for byte-backed Files, and file-backed Files (`new File([Bun.file(p)], "a\uD800b")`) did not get it at all.
* `Blob__setAsFile` sets the per-Blob name on the entry's own dupe. The store is not touched, and a storeless (zero-byte) blob keeps its name too.
* Readers that want the name for something other than the getter now use the same lookup the getter uses: `Blob__getFileNameString` (FormData's default filename), `get_loader` (`blob:` imports pick the loader from the File's name), and the `Content-Disposition` filename `Bun.serve` adds to `new Response(file)`. Without this, those three would stop seeing File names once the constructor no longer writes them into the store. `BlobExt::get_name_utf8` is the shared helper; `AnyBlob::get_file_name` becomes `get_name_utf8` on top of it. It does not go through the getter's caching: a blob without a name of its own (a `Bun.file()` response body) still borrows the store's path exactly as before, so serving files does not gain an allocation; a File's own ASCII name is a ref-holding view, also allocation free.
* `store::Bytes::init_empty_with_name` loses its last caller and is removed. `stored_name` is now only written when a store is created (standalone executables' embedded files, structured clone) and serves as the fallback for blobs with no name of their own.

The two `blob:` module-loading sites in `jsc_hooks.rs` and `bundler/options.rs` keep using the store-level `get_file_name()` on purpose: they use it as the path to read when the blob is a `Bun.file()`, which must stay the on-disk path even when the File was given a different display name.

Why this is the right place rather than copying the bytes on `new File([blob])`: sharing the store is deliberate (and #36001 shares even more), and every consumer of the name already had a per-Blob field to read; the bug was the one writer that bypassed it. It also removes the only code that reassigns a live store's `stored_name`, which is what made the borrowed `Blob__getFileNameString` view unsound.

### Object URLs and other threads

Keeping the name on the Blob as a `WTF::StringImpl` (instead of a byte copy in the store) exposed a second pre-existing bug, so this PR also fixes it. `ObjectURLRegistry` stored a `dupe()` of the registered blob and handed `dupe()`s of that entry to whichever thread resolved the URL, so all of them shared one name impl. A string that a thread has used as a property key is an atom of that thread's string table (WTF atomizes the impl in place), and releasing the last reference to it from another thread hits `RELEASE_ASSERT` in `AtomStringImpl::remove`. On 1.4.0 this was reachable with a file-backed File, whose name already lived on the Blob:

```js
let name = "report-" + id;  ({})[name];             // now an atom of this thread
const url = URL.createObjectURL(new File([Bun.file(p)], name));
// worker: held = require("node:buffer").resolveObjectURL(url)
// main: URL.revokeObjectURL(url), drop the File and the name, Bun.gc(true)
// worker: held = undefined; Bun.gc(true)
// => ASSERTION FAILED: wasRemoved  (AtomStringImpl.cpp:462), "panic: abort() called" on the release build
```

With this change the same would have applied to every File, so `Entry::init` and `resolve_and_dupe` now both go through `dupe_with_private_name`, which `to_thread_safe()`s (copies) the name: the entry's impl is never reachable from any thread's JS, and each resolving thread gets its own. Copying on both sides is what makes it safe; a plain impl handed to a worker could still be atomized there and then released last by the registering thread. #31487 does the same for `name` as part of a larger change that also snapshots the store contents; this is just the part this PR needs.

Behavior changes besides the bug itself. The first four match Node; the rest are the places where Bun used to consult the store's name and now consult the same name `.name` reports, so a File wrapping a `Bun.file()`, or a blob named through Bun's `.name` setter, is treated according to that name everywhere. Each has a test:

* `new File(bits, "").name` is `""` (was `undefined`).
* `fd.append(name, blob, filename)` / `fd.set(...)` no longer name the blob that was passed in.
* A zero-byte blob appended with a filename, or parsed from a zero-byte multipart part, reports that filename (was `undefined`). This is the bug #36435 fixes by creating a named store in `Blob__setAsFile`; with this change that store is not needed.
* `fd.append(name, file, filename)` / `set` on a File that already has a name: `get()` now returns a File named `filename`, as the multipart body already said (it returned the File's original name; this is #35079's bug).
* FormData's default filename for `new File([Bun.file(p)], "display.bin")` is `display.bin` in the multipart body as well (the body used to carry the full path of `p` while `get().name` said `display.bin`), and a blob given a name through the `.name` setter gets that as its default filename (the body used to carry `filename=""`). A plain `Bun.file(p)` entry still defaults to `p` as before (#35523 wants that to become the basename; it would apply on top of the new lookup).
* `Bun.serve` responding with `new File([Bun.file(p)], "display.zip")` now advertises `filename="display.zip"` instead of the basename of `p`; a plain `Bun.file(p)` body still advertises the basename of `p`.
* A `blob:` import or `Worker` of `new File([Bun.file("x.ts")], "x.txt")` now picks the loader from `x.txt` (text) while still reading the bytes from `x.ts`; it used to pick it from the path. A plain `Bun.file()` object URL is unchanged. The two module-loading sites that need the on-disk path keep reading it from the store and now say so.

Not observable from tests here but following from the same rule: a standalone executable's embedded files keep their names when wrapped in a `new File()` (the wrapper used to rename the embedded blob's store).

Unchanged here and left to their own PRs: a single-Blob part still hands its `name`/`is_jsdom_file` to the wrapper via `dupe()` (#33603), and `file.slice()` still reports the File's name (#33604). This change is what makes the store stop leaking names into those wrappers once they stop copying metadata. #35079 (`Blob__setAsFile` honoring a filename override) and #35523 (`Blob__getFileNameString` returning a basename for `Bun.file`) touch the same two functions; see the list above for how each case comes out here.

### Verification

New tests in `test/js/web/fetch/blob.test.ts` (13 under "new File([blob], name) names only the new File", plus 2 under "a File's name reaches other threads through an object URL as a private copy") and `test/js/web/html/FormData.test.ts` (10, under "entry filenames belong to the entry ..."). They cover: File, empty File, Blob, slice, and chained sources; the source's name being read before wrapping (the `dupe()`d name used to win); structuredClone; the empty name; USVString conversion; the `blob:` loader and `Content-Disposition`, each for byte-backed Files, for a File wrapping a `Bun.file()`, and (to pin the unchanged fallback) for a plain `Bun.file()`; the freed FormData filename (in a spawned process, so ASAN fails the test rather than the run); the object URL scenario above for a byte-backed and a file-backed File (spawned, handshaking with the worker over postMessage so the worker provably holds the last reference); and on the FormData side `append`/`set` with a filename on a Blob and on an already named File, zero-byte blobs (appended and parsed), default filenames of wrapped Files, of a File wrapping a `Bun.file()` and of a setter-named blob in both `get()` and the multipart body, and wrapping a parsed entry.

Of the 25, 23 fail on 1.4.0 and on a debug build of main (the file-backed object URL case by aborting); the byte-backed object URL case passes there and aborts with only the first part of this change applied, and the "wrapping an empty Blob" row passes either way and is there for the matrix. All pass with the change. `blob.test.ts`, `FormData.test.ts`, `FormData-multipart-serialization.test.ts`, `blob-file-name-ownership.test.ts`, `blob-array-fast-path.test.ts`, `structured-clone-blob-file.test.ts`, `structuredClone-classes.test.ts`, `globals.test.js`, `worker_blob.test.ts`, `buffer-resolveObjectURL.test.ts`, `body.test.ts`, `response.test.ts`, `bun-serve-file.test.ts`, `fetch-file-upload.test.ts` and node's `test-blob-createobjecturl.js` pass on the debug build (`response.test.ts`'s "handle stack overflow" times out there on main as well, without this change).

</details>
