### PR TITLE
fs.promises: build read/readv/write/writev and mkdtempDisposable results with a null prototype like node

### DIFF
--- a/src/js/node/fs.promises.ts
+++ b/src/js/node/fs.promises.ts
@@ -292,7 +292,7 @@ const exports = {
       // force makes repeated removal a no-op; real failures (EACCES) still throw
       await fs.rm(fullPath, { recursive: true, force: true });
     }
-    return { path, remove, [Symbol.asyncDispose]: remove };
+    return { __proto__: null, path, remove, [Symbol.asyncDispose]: remove };
   },
   statfs: asyncWrap(fs.statfs, "statfs"),
   open: async (path, flags = "r", mode = 0o666) => {
@@ -368,19 +368,12 @@ const exports = {
     return fs.rmdir(path, options);
   },
   writev: async (fd, buffers, position) => {
-    var bytesWritten = await fs.writev(fd, buffers, position);
-    return {
-      bytesWritten,
-      buffers,
-    };
+    const bytesWritten = await fs.writev(fd, buffers, position);
+    return { __proto__: null, bytesWritten, buffers };
   },
   readv: async (fd, buffers, position) => {
-    var bytesRead = await fs.readv(fd, buffers, position);
-
-    return {
-      bytesRead,
-      buffers,
-    };
+    const bytesRead = await fs.readv(fd, buffers, position);
+    return { __proto__: null, bytesRead, buffers };
   },
   constants,
   watch,
@@ -558,7 +551,7 @@ function asyncWrap(fn: any, name: string) {
       try {
         this[kRef]();
         const bytesRead = await read(fd, buffer, offset, length, position);
-        return { buffer, bytesRead };
+        return { __proto__: null, bytesRead, buffer };
       } finally {
         this[kUnref]();
       }
@@ -659,10 +652,8 @@ function asyncWrap(fn: any, name: string) {
       }
       try {
         this[kRef]();
-        return {
-          buffer,
-          bytesWritten: await write(fd, buffer, offset, length, position),
-        };
+        const bytesWritten = await write(fd, buffer, offset, length, position);
+        return { __proto__: null, bytesWritten, buffer };
       } finally {
         this[kUnref]();
       }

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -310,16 +310,34 @@ it("fs.writev returns object", async done => {
 });
 
 describe("FileHandle", () => {
-  it("FileHandle#read returns object", async () => {
+  // Node builds these results as `{ __proto__: null, bytesRead | bytesWritten, buffer | buffers }`
+  // (https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1350-L1426),
+  // so both the prototype and the key order are observable.
+  function expectNodeResultShape(result: object, expected: Record<string, unknown>) {
+    expect(Object.getPrototypeOf(result)).toBeNull();
+    expect(Object.keys(result)).toEqual(Object.keys(expected));
+    expect(result).toEqual(expected);
+  }
+
+  it("FileHandle#read returns a null-prototype { bytesRead, buffer }", async () => {
     await using fd = await fs.promises.open(__filename);
     const buf = Buffer.alloc(10);
-    expect(await fd.read(buf, 0, 10, 0)).toEqual({ bytesRead: 10, buffer: buf });
+    expectNodeResultShape(await fd.read(buf, 0, 10, 0), { bytesRead: 10, buffer: buf });
+    expectNodeResultShape(await fd.read(buf, { position: 0 }), { bytesRead: 10, buffer: buf });
+    expectNodeResultShape(await fd.read({ buffer: buf, length: 4, position: 0 }), { bytesRead: 4, buffer: buf });
+    expectNodeResultShape(await fd.read(buf, 0, 0, 0), { bytesRead: 0, buffer: buf });
+
+    const result = await fd.read();
+    expectNodeResultShape(result, { bytesRead: result.bytesRead, buffer: result.buffer });
+    expect(result.buffer).toBeInstanceOf(Buffer);
+    expect(result.buffer.byteLength).toBe(16384);
   });
 
-  it("FileHandle#readv returns object", async () => {
+  it("FileHandle#readv returns a null-prototype { bytesRead, buffers }", async () => {
     await using fd = await fs.promises.open(__filename);
     const buffers = [Buffer.alloc(10), Buffer.alloc(10)];
-    expect(await fd.readv(buffers, 0)).toEqual({ bytesRead: 20, buffers });
+    expectNodeResultShape(await fd.readv(buffers, 0), { bytesRead: 20, buffers });
+    expectNodeResultShape(await fd.readv(buffers), { bytesRead: 20, buffers });
   });
 
   it("FileHandle#write throws EBADF when closed", async () => {
@@ -336,16 +354,28 @@ describe("FileHandle", () => {
     expect(async () => await handle.read(Buffer.alloc(10))).toThrow("Bad file descriptor");
   });
 
-  it("FileHandle#write returns object", async () => {
-    await using fd = await fs.promises.open(`${tmpdir()}/${Date.now()}.writeFile.txt`, "w");
+  it("FileHandle#write returns a null-prototype { bytesWritten, buffer }", async () => {
+    using dir = tempDir("fh-write-result", {});
+    await using fd = await fs.promises.open(join(String(dir), "out.txt"), "w");
     const buf = Buffer.from("test");
-    expect(await fd.write(buf, 0, 4, 0)).toEqual({ bytesWritten: 4, buffer: buf });
+    expectNodeResultShape(await fd.write(buf, 0, 4, 0), { bytesWritten: 4, buffer: buf });
+    expectNodeResultShape(await fd.write(buf), { bytesWritten: 4, buffer: buf });
+    expectNodeResultShape(await fd.write(buf, { offset: 1, length: 2 }), { bytesWritten: 2, buffer: buf });
+    // Like node, the `buffer` property holds whatever was passed in, a string included.
+    expectNodeResultShape(await fd.write("héllo"), { bytesWritten: 6, buffer: "héllo" });
+    expectNodeResultShape(await fd.write("héllo", null, "latin1"), { bytesWritten: 5, buffer: "héllo" });
+    const empty = Buffer.alloc(0);
+    expectNodeResultShape(await fd.write(empty), { bytesWritten: 0, buffer: empty });
   });
 
-  it("FileHandle#writev returns object", async () => {
-    await using fd = await fs.promises.open(`${tmpdir()}/${Date.now()}.writeFile.txt`, "w");
+  it("FileHandle#writev returns a null-prototype { bytesWritten, buffers }", async () => {
+    using dir = tempDir("fh-writev-result", {});
+    await using fd = await fs.promises.open(join(String(dir), "out.txt"), "w");
     const buffers = [Buffer.from("test"), Buffer.from("test")];
-    expect(await fd.writev(buffers, 0)).toEqual({ bytesWritten: 8, buffers });
+    expectNodeResultShape(await fd.writev(buffers, 0), { bytesWritten: 8, buffers });
+    expectNodeResultShape(await fd.writev(buffers), { bytesWritten: 8, buffers });
+    const none: Buffer[] = [];
+    expectNodeResultShape(await fd.writev(none), { bytesWritten: 0, buffers: none });
   });
 
   it("FileHandle#readFile returns buffer", async () => {
@@ -1608,6 +1638,33 @@ describe("mkdtemp encoding option", () => {
     const result = await promises.mkdtemp(prefix, { encoding: "buffer" });
     expect(Buffer.isBuffer(result)).toBe(true);
     expect(existsSync(result)).toBe(true);
+  });
+});
+
+describe("mkdtempDisposable result shape", () => {
+  // Node's promises variant builds its result with `__proto__: null`
+  // (https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1872-L1879) while the
+  // sync variant returns an ordinary object (https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L3058).
+  it("promises.mkdtempDisposable resolves to a null-prototype { path, remove }", async () => {
+    using base = tempDir("mkdtemp-disposable", {});
+    const result = await promises.mkdtempDisposable(join(String(base), "p-"));
+    expect(Object.getPrototypeOf(result)).toBeNull();
+    expect(Object.keys(result)).toEqual(["path", "remove"]);
+    expect(result[Symbol.asyncDispose]).toBeFunction();
+    expect(existsSync(result.path)).toBe(true);
+    await result.remove();
+    expect(existsSync(result.path)).toBe(false);
+  });
+
+  it("mkdtempDisposableSync returns an ordinary object", () => {
+    using base = tempDir("mkdtemp-disposable-sync", {});
+    const result = fs.mkdtempDisposableSync(join(String(base), "s-"));
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect(Object.keys(result)).toEqual(["path", "remove"]);
+    expect(result[Symbol.dispose]).toBeFunction();
+    expect(existsSync(result.path)).toBe(true);
+    result.remove();
+    expect(existsSync(result.path)).toBe(false);
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -327,9 +327,10 @@ describe("FileHandle", () => {
     expectNodeResultShape(await fd.read({ buffer: buf, length: 4, position: 0 }), { bytesRead: 4, buffer: buf });
     expectNodeResultShape(await fd.read(buf, 0, 0, 0), { bytesRead: 0, buffer: buf });
 
+    // No arguments: node allocates a 16 KiB buffer and reads from the current position (0 here,
+    // the reads above were all positional). This file is far larger than that, so the read fills it.
     const result = await fd.read();
-    expectNodeResultShape(result, { bytesRead: result.bytesRead, buffer: result.buffer });
-    expect(result.buffer).toBeInstanceOf(Buffer);
+    expectNodeResultShape(result, { bytesRead: 16384, buffer: expect.any(Buffer) });
     expect(result.buffer.byteLength).toBe(16384);
   });
 


### PR DESCRIPTION
### Problem
- `FileHandle.read` / `readv` / `write` / `writev` and `fs.promises.mkdtempDisposable` resolve to ordinary objects in Bun; node resolves the same calls to null-prototype objects with the byte count as the first key.
- Observable: `assert.deepStrictEqual(result, { __proto__: null, bytesRead, buffer })` fails in Bun, `Object.keys()` / `JSON.stringify()` order differs for `read()` and `write()`, and `"toString" in result` is true in Bun and false in node.
- Bun also disagreed with itself: the zero-length early return in `FileHandle.write` already produced a null-prototype object, so an empty write and a real write resolved to differently shaped objects.

### Fix
- The five result literals in `fs.promises` are built with `__proto__: null` and node's key order; `write` awaits the byte count into a local so it can be listed before `buffer`.
- Correct because nothing inside Bun reads these results except by destructuring, which does not care about the prototype, and every other result literal in the file already matched node.
- `mkdtempDisposableSync` deliberately keeps returning an ordinary object, because node's sync variant does; a test pins both sides.
- Verification: the five new promises-side tests fail on the unfixed build (`USE_SYSTEM_BUN=1`: 5 fail, 1 pass) and pass with this change; the same assertions pass as a plain script under node v26.3.0.

### Background
- A null-prototype object (`{ __proto__: null, ... }`) has no `Object.prototype` behind it, so `"toString" in obj` is false, and `assert.deepStrictEqual` treats it as unequal to an ordinary object with the same keys.
- Object literal key order is the order `Object.keys()` and `JSON.stringify()` report, so `{ buffer, bytesRead }` and `{ bytesRead, buffer }` are distinguishable.
- `src/js/node/fs.promises.ts` is Bun's TypeScript implementation of `node:fs/promises`; `FileHandle.readv` / `writev` return whatever the module-level `readv` / `writev` helpers return, so those helpers are changed in place.
- `bun:test`'s `toStrictEqual()` does not distinguish a null-prototype object from an ordinary one, so the tests check `Object.getPrototypeOf` and `Object.keys` directly.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

`FileHandle.prototype.read` / `readv` / `write` / `writev` and `fs.promises.mkdtempDisposable` now resolve to the same objects node builds: null prototype, byte count first.

### Repro

```js
import fs from "node:fs";
const fh = await fs.promises.open("probe.txt", "w+");
const buf = Buffer.from("hello");
const show = (l, r) => console.log(l, Object.getPrototypeOf(r) === null, Object.keys(r));
show("write", await fh.write(buf));
show("writev", await fh.writev([buf]));
show("read", await fh.read(Buffer.alloc(4), 0, 4, 0));
show("readv", await fh.readv([Buffer.alloc(4)], 0));
await fh.close();
const dir = await fs.promises.mkdtempDisposable("probe-");
show("mkdtempDisposable", dir);
await dir.remove();
```

Node v26.3.0:

```
write true [ 'bytesWritten', 'buffer' ]
writev true [ 'bytesWritten', 'buffers' ]
read true [ 'bytesRead', 'buffer' ]
readv true [ 'bytesRead', 'buffers' ]
mkdtempDisposable true [ 'path', 'remove' ]
```

Bun 1.4.0 (and main before this change):

```
write false [ "buffer", "bytesWritten" ]
writev false [ "bytesWritten", "buffers" ]
read false [ "buffer", "bytesRead" ]
readv false [ "bytesRead", "buffers" ]
mkdtempDisposable false [ "path", "remove" ]
```

The difference is observable: `assert.deepStrictEqual(result, { __proto__: null, bytesRead, buffer })` fails in Bun (deepStrictEqual compares prototypes), `Object.keys()` / `JSON.stringify()` order differs for `read()` and `write()`, and `"toString" in result` is true in Bun and false in node.

### Cause

`src/js/node/fs.promises.ts` built ordinary object literals at every one of these sites, and `FileHandle.read` / `FileHandle.write` listed `buffer` before the byte count. Node builds all of them with `__proto__: null` and the byte count first:

- read: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1350
- readv: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1364
- write: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1398 and #L1408
- writev: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1426
- mkdtempDisposable: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/fs/promises.js#L1872-L1879

Bun was also inconsistent with itself: the zero-length early return in `FileHandle.write` already returned `{ __proto__: null, bytesWritten: 0, buffer }`, so `fh.write(Buffer.alloc(0))` and `fh.write(buf)` resolved to differently shaped objects.

### Fix

The five object literals now use `__proto__: null` with node's key order. `FileHandle.write` awaits the byte count into a local first so the literal can list it before `buffer`. The module level `readv` / `writev` helpers are what `FileHandle.readv` / `writev` return, so they are changed in place rather than re-wrapped.

`mkdtempDisposable` is the one other site in this file with the same defect (I swept the rest: `watch()` events, `pull()` / `pullSync()` / `writer()` already match node). Its sync counterpart `fs.mkdtempDisposableSync` keeps returning an ordinary object, because that is what node's sync variant does (https://github.com/nodejs/node/blob/v26.3.0/lib/fs.js#L3058); the test pins both so the asymmetry is deliberate rather than accidental.

Nothing inside Bun reads these results other than by destructuring (`readableWebStream`, `writeFile` with an async iterable), which is unaffected by the prototype.

### Verification

`test/js/node/fs/fs.test.ts`: the four `FileHandle#... returns object` tests now assert the prototype and key order across the argument forms (`read(buf, off, len, pos)`, `read(buf, opts)`, `read(opts)`, `read()`, zero-length read, `write(buf)`, `write(buf, opts)`, string writes with and without an encoding, empty buffer, `readv` / `writev` with and without a position, `writev([])`), plus a new `mkdtempDisposable result shape` block. The five new tests on the promises side fail on the unfixed build (`USE_SYSTEM_BUN=1`: 5 fail, 1 pass) and pass with this change. The same assertions, as a plain script, pass under node v26.3.0.

The tests are hand-written because no upstream test pins these shapes: the in-tree ports of node's fs-promises / FileHandle tests only destructure the results, and the five upstream FileHandle tests not yet in the tree (`test-fs-filehandle.js`, `-aggregate-errors`, `-close-errors`, `-op-errors`, `test-worker-message-port-transfer-filehandle.js`) are about other things, so this change does not flip any of them. (`expect().toStrictEqual()` in bun:test does not distinguish a null-prototype object from an ordinary one, so the tests check `Object.getPrototypeOf` and `Object.keys` directly.)

Also ran the full `fs.test.ts`, `promises.test.js`, `fs-promises-writeFile-async-iterator.test.ts` and the upstream `test-fs-promises-file-handle-*`, `test-fs-readv-promises.js`, `test-fs-writev-promises.js`, `test-fs-promises-write-optional-params.js`, `test-fs-read-promises-optional-params.js`, `test-filehandle-readablestream.js`, `test-http2-respond-file-filehandle.js` and `test-fs-promises-mkdtempDisposable.js` / `test-fs-mkdtempDisposableSync.js` against the debug build; all pass.

</details>
