### PR TITLE
test: update the request.url Host byte matrix for the unparseable-authority fallback

### DIFF
--- a/test/js/bun/http/request-smuggling.test.ts
+++ b/test/js/bun/http/request-smuggling.test.ts
@@ -1581,6 +1581,32 @@ describe("Host header field values in request.url", () => {
   });
 
   test.each([
+    ["1.2.3.4.5"],
+    ["[::1"],
+    // Long enough that the URL is assembled on the heap instead of the 128-byte stack buffer.
+    [`${Buffer.alloc(130, "x").toString()}.example:abc`],
+  ])(
+    "request.url is the request-target when the Host header %j is in the authority byte set but does not parse",
+    async host => {
+      await using server = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          return new Response(req.url);
+        },
+      });
+
+      const response = await sendRawRequest(
+        server,
+        `GET /index HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`,
+      );
+      expect(response).toStartWith("HTTP/1.1 200");
+      // Not `http://<host>/index`, which `new URL()` rejects.
+      expect(response.slice(response.indexOf("\r\n\r\n") + 4)).toBe("/index");
+    },
+  );
+
+  test.each([
     ["example.com", "http://example.com/index"],
     ["example.com:8080", "http://example.com:8080/index"],
     ["[::1]:3000", "http://[::1]:3000/index"],
@@ -1652,13 +1678,15 @@ describe("Host header field values in request.url", () => {
 
       // RFC 3986 `uri-host [ ":" port ]`: unreserved / sub-delims / "%" / ":" / "[" / "]".
       // Every byte in [0x7f, 0xff] is outside that set, so neither URL uses any of them.
-      const isHostByte = (char: string) => /^[A-Za-z0-9._~%!$&'()*+,;=:\[\]-]$/.test(char);
+      // "%", ":", "[" and "]" are inside it, but `a%b`, `a:b`, `a[b` and `a]b` are not
+      // authorities the URL parser accepts, so those fall back to the request-target too.
+      const formsUrlAuthority = (char: string) => /^[A-Za-z0-9._~!$&'()*+,;=-]$/.test(char);
 
       async function checkByte(byte: number) {
         const char = String.fromCharCode(byte);
         const host = `a${char}b`;
-        // Request::is_valid_host_header decides whether the Host header becomes the
-        // request URL's authority; the request itself is served either way.
+        // Request::is_valid_host_header and then the URL parser decide whether the Host
+        // header becomes the request URL's authority; the request itself is served either way.
         // The two probes run sequentially so each batch keeps at most one socket per byte open.
         const http11 = await sendRawRequest(server, `GET /p HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`);
         const http10 = await sendRawRequest(server, `GET /p HTTP/1.0\r\nHost: ${host}\r\n\r\n`);
@@ -1682,7 +1710,7 @@ describe("Host header field values in request.url", () => {
         bytes.map(byte => {
           const char = String.fromCharCode(byte);
           // `req.url` carries the lowercased host (URL host normalization).
-          const url = isHostByte(char) ? `http://a${char.toLowerCase()}b/p` : "/p";
+          const url = formsUrlAuthority(char) ? `http://a${char.toLowerCase()}b/p` : "/p";
           return {
             char,
             http11Accepted: true,


### PR DESCRIPTION
### Problem
- Test-only. e47da94 on the base branch (#37635) makes `req.url` fall back to the bare request-target when a Host header passes the byte check but does not parse as a URL authority.
- With that fallback in place, the per-byte Host matrix in `test/js/bun/http/request-smuggling.test.ts` fails for the 33-64 and 65-96 byte ranges.
- Cause: the matrix still expects `http://a%b/p`, `http://a:b/p`, `http://a[b/p` and `http://a]b/p` for `%`, `:`, `[` and `]`; those hosts now come back as `/p` like the other rejected bytes.
- Related: #17348 tracks this symptom class. The code change is in #37635 (and #33721), not here.

### Fix
- The matrix's expected-URL predicate drops `%`, `:`, `[` and `]`, with a comment on why those four differ from the rest of the RFC 3986 byte set.
- This is the right expectation because `a%b`, `a:b`, `a[b` and `a]b` are inside the RFC 3986 host byte set but are not authorities the URL parser accepts, so the fallback applies to them too.
- Three more unparseable Host values sent over a raw socket: `1.2.3.4.5`, an unclosed `[::1`, and a 130-byte label with a bad port. The last one is long enough to take the heap path in `ensure_url`; the existing cases only reach the 128-byte stack buffer.
- Verification: against a build of e47da94, the unmodified file fails those two ranges and the updated file passes in full (86 tests). The three new cases fail on the 1.4.0 release build.

### Background
- For HTTP/1 requests, `Bun.serve` synthesizes `req.url` by joining the Host header and the request-target: `Host: x` plus `GET /p` becomes `http://x/p`.
- Two checks gate that join. `Request::is_valid_host_header` accepts only the bytes RFC 3986 allows in `uri-host [ ":" port ]`, and the joined string then has to pass the URL parser. If either fails, `req.url` is the bare request-target (`/p`); the request is served either way.
- The per-byte matrix sends `Host: a<byte>b` for each byte over HTTP/1.1 and HTTP/1.0, in batches, and checks which bytes produce a full URL. 33-64 and 65-96 are two of those batches.
- `ensure_url` assembles the URL in a 128-byte stack buffer and moves to the heap when the host is longer. The 130-byte case exists to reach that second path.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 2 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/http/request-smuggling.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/http/request-smuggling.test.ts
bun test v1.4.0 (252c96386)

test/js/bun/http/request-smuggling.test.ts:
(pass) rejects multiple Transfer-Encoding headers with chunked [478.38ms]
(pass) rejects Transfer-Encoding with chunked not last [121.83ms]
(pass) rejects duplicate chunked in Transfer-Encoding [63.24ms]
(pass) rejects Transfer-Encoding + Content-Length [55.39ms]
(pass) rejects conflicting duplicate Content-Length headers [55.69ms]
(pass) accepts duplicate Content-Length headers with identical values [64.57ms]
(pass) rejects empty-valued Content-Length followed by smuggled Content-Length [60.60ms]
(pass) accepts valid Transfer-Encoding: chunked [78.27ms]
(pass) rejects Transfer-Encoding: gzip, chunked [56.96ms]
(pass) accepts Transfer-Encoding with whitespace around chunked [60.64ms]
(pass) rejects malformed Transfer-Encoding with chunked-false [58.19ms]
(pass) prevents request smuggling attack [53.43ms]
(pass) rejects split Transfer-Encoding headers gzip + chunked [49.47ms]
(pass) Transfer-Encoding lists with codings other than a single chunked > Bun.serve rejects Transfer-Encoding: x, chunked [61.30ms]
(pass) Transfer-Encoding lists with codings other than a single chunked > Bun.serve rejects Transfer-Encoding: chunked, chunked [31.93ms]
(pass) Transfer-Encoding lists with codings other than a single chunked > Bun.serve rejects Transfer-Encoding: gzip,\tchunked [33.47ms]
(pass) Transfer-Encoding lists with codings other than a single chunked > Bun.serve rejects Transfer-Encoding: identity, chunked [46.69ms]
(pass) Transfer-Encoding lists with codings other than a single chunked > Bun.serve rejects a real gzip,chunked body instead of delivering it raw [48.69ms]
(pass) Transfer-Encoding lists with codings other than a single chunked > node:http accepts Transfer-Encoding: gzip, chunked (llhttp compat) [318.04ms]
(pass) Transfer-Encoding lists with codings other th
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/http/request-smuggling.test.ts | 36 ++++++++++++++++++++++++++----
 1 file changed, 32 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 2 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
test/js/bun/http/request-smuggling.test.ts      0      0      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

Test-only follow-up to #37635 (base is `ali/h3-request-url-host-validation`). The first version of this PR also carried the `Request.rs` fallback; e47da94 on the base branch now does that, so this is down to the test file that commit did not touch.

### Problem

With the parse-failure fallback from e47da94, the per-byte matrix in `test/js/bun/http/request-smuggling.test.ts` ("HTTP/1.1 and HTTP/1.0 requests synthesize request.url from the same Host bytes") fails for the 33-64 and 65-96 ranges. It expects `req.url` to be `http://a%b/p`, `http://a:b/p`, `http://a[b/p` and `http://a]b/p` for those four bytes, which is the unparseable-URL behavior the fallback removes; they now come back as `/p` like the rest of the rejected bytes.

Verified against a build of e47da94: the unmodified file fails those two cases, the updated file passes in full (86 tests).

### Change

- The matrix's expected-URL predicate drops `%`, `:`, `[`, `]`, with a comment saying why those four differ from the rest of the RFC 3986 byte set.
- Three more parse-failure shapes for HTTP/1 over a raw socket, complementing the `example.com:abc` / `example.com:99999` / `exa%zzmple.com` cases already on the base branch: `1.2.3.4.5`, an unclosed `[::1`, and a 130-byte label with a bad port. The last one is long enough to take the heap path in `ensure_url` (the 128-byte stack buffer is the only path the existing cases reach). All three fail on the 1.4.0 release build.

Related: #17348 is the issue for this symptom class; the code change that addresses it is in #37635 (and, more broadly, #33721), not here.

</details>
