### PR TITLE
bundler: make Worker::deinit_soon take the worker pointer instead of &mut self

### DIFF
--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -570,33 +570,22 @@ impl Worker {
         unsafe { Self::deinit(this) };
     }
 
-    /// Hands the `Worker` at `this` to its pool thread for teardown, or tears
-    /// it down right here when it was created off the pool.
-    ///
-    /// Raw-pointer receiver, like `schedule_with_options`: the `else` branch
-    /// frees `*this` before returning, and once `push_idle_task` has published
-    /// `deinit_task` the pool thread may free `*this` at any moment
-    /// (`Thread::drain_idle_events` runs after every task batch and on every
-    /// idle wake, not only after `wake_for_idle_events`). A `&mut self`
-    /// argument would be protected for the whole call, and freeing protected
-    /// memory is UB under both aliasing models, so no reference to the
-    /// `Worker` is formed here: each access is a raw place expression that
-    /// ends before the free can happen.
+    /// Raw-pointer receiver, as in `schedule_with_options`: `*this` is freed
+    /// during this call (synchronously below, or by the pool thread as soon as
+    /// `deinit_task` is pushed; it drains idle tasks between batches, not only
+    /// on `wake_for_idle_events`), and a `&mut self` argument must stay
+    /// allocated until the call returns.
     ///
     /// # Safety
-    /// `this` must be a live `Worker` from [`ThreadPool::get_worker`] that
-    /// nothing else will touch again (the caller is clearing the
-    /// `workers_assignments` map it came from); at most one call per
-    /// `Worker`. Afterwards `*this` belongs to the pool thread or is freed.
+    /// `this` is a live `Worker` from [`ThreadPool::get_worker`] that nothing
+    /// touches afterwards; called once per `Worker`.
     pub(crate) unsafe fn deinit_soon(this: *mut Self) {
-        // SAFETY: caller contract; `thread` is `Copy`, so the read of `*this`
-        // ends at the `;`.
+        // SAFETY: caller contract; `thread` is `Copy`, the read ends here.
         let thread = unsafe { (*this).thread };
         if let Some(thread) = thread {
-            // SAFETY: caller contract; a field projection through the
-            // allocation's own pointer, so the `Task` pointer carries
-            // whole-`Worker` provenance for `from_field_ptr!` in
-            // `deinit_callback`. Nothing touches `*this` after the push.
+            // SAFETY: caller contract. Projected from the allocation's own
+            // pointer so `from_field_ptr!` in `deinit_callback` gets whole-
+            // `Worker` provenance; `*this` is not touched after the push.
             let task = unsafe { &raw mut (*this).deinit_task };
             thread.push_idle_task(task);
         } else {
@@ -610,9 +599,8 @@ impl Worker {
             // `ast_memory_store` mi_heap (every `AstAlloc` buffer the inline
             // parse produced) and `data.transpiler` per `Bun.build()` call.
             //
-            // SAFETY: caller contract: `this` is the heap-allocated Worker and
-            // we are its sole owner now that the caller is clearing the
-            // `workers_assignments` map.
+            // SAFETY: caller contract; `this` is the heap-allocated Worker and
+            // nothing else holds it once the caller clears `workers_assignments`.
             unsafe { Self::deinit(this) };
         }
     }

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -570,9 +570,35 @@ impl Worker {
         unsafe { Self::deinit(this) };
     }
 
-    pub(crate) fn deinit_soon(&mut self) {
-        if let Some(thread) = self.thread {
-            thread.push_idle_task(&raw mut self.deinit_task);
+    /// Hands the `Worker` at `this` to its pool thread for teardown, or tears
+    /// it down right here when it was created off the pool.
+    ///
+    /// Raw-pointer receiver, like `schedule_with_options`: the `else` branch
+    /// frees `*this` before returning, and once `push_idle_task` has published
+    /// `deinit_task` the pool thread may free `*this` at any moment
+    /// (`Thread::drain_idle_events` runs after every task batch and on every
+    /// idle wake, not only after `wake_for_idle_events`). A `&mut self`
+    /// argument would be protected for the whole call, and freeing protected
+    /// memory is UB under both aliasing models, so no reference to the
+    /// `Worker` is formed here: each access is a raw place expression that
+    /// ends before the free can happen.
+    ///
+    /// # Safety
+    /// `this` must be a live `Worker` from [`ThreadPool::get_worker`] that
+    /// nothing else will touch again (the caller is clearing the
+    /// `workers_assignments` map it came from); at most one call per
+    /// `Worker`. Afterwards `*this` belongs to the pool thread or is freed.
+    pub(crate) unsafe fn deinit_soon(this: *mut Self) {
+        // SAFETY: caller contract; `thread` is `Copy`, so the read of `*this`
+        // ends at the `;`.
+        let thread = unsafe { (*this).thread };
+        if let Some(thread) = thread {
+            // SAFETY: caller contract; a field projection through the
+            // allocation's own pointer, so the `Task` pointer carries
+            // whole-`Worker` provenance for `from_field_ptr!` in
+            // `deinit_callback`. Nothing touches `*this` after the push.
+            let task = unsafe { &raw mut (*this).deinit_task };
+            thread.push_idle_task(task);
         } else {
             // `thread` is `ThreadPoolLib::Thread::current()` captured at
             // creation. When null, the Worker was created on a non-pool thread
@@ -584,10 +610,10 @@ impl Worker {
             // `ast_memory_store` mi_heap (every `AstAlloc` buffer the inline
             // parse produced) and `data.transpiler` per `Bun.build()` call.
             //
-            // SAFETY: `self` is the heap-allocated Worker; sole owner now that
-            // the caller is about to `clear_retaining_capacity()` the
+            // SAFETY: caller contract: `this` is the heap-allocated Worker and
+            // we are its sole owner now that the caller is clearing the
             // `workers_assignments` map.
-            unsafe { Self::deinit(std::ptr::from_mut::<Self>(self)) };
+            unsafe { Self::deinit(this) };
         }
     }
 

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -570,11 +570,9 @@ impl Worker {
         unsafe { Self::deinit(this) };
     }
 
-    /// Raw-pointer receiver, as in `schedule_with_options`: `*this` is freed
-    /// during this call (synchronously below, or by the pool thread as soon as
-    /// `deinit_task` is pushed; it drains idle tasks between batches, not only
-    /// on `wake_for_idle_events`), and a `&mut self` argument must stay
-    /// allocated until the call returns.
+    /// Takes `*mut Self`, not `&mut self`: `*this` is freed during this call
+    /// (below, or by the pool thread as soon as `deinit_task` is pushed), and a
+    /// `&mut self` argument would have to stay allocated until it returned.
     ///
     /// # Safety
     /// `this` is a live `Worker` from [`ThreadPool::get_worker`] that nothing
@@ -585,7 +583,9 @@ impl Worker {
         if let Some(thread) = thread {
             // SAFETY: caller contract. Projected from the allocation's own
             // pointer so `from_field_ptr!` in `deinit_callback` gets whole-
-            // `Worker` provenance; `*this` is not touched after the push.
+            // `Worker` provenance. The pool thread drains idle tasks between
+            // batches, not only on `wake_for_idle_events`, so `*this` may be
+            // freed as soon as it is pushed; nothing touches it after that.
             let task = unsafe { &raw mut (*this).deinit_task };
             thread.push_idle_task(task);
         } else {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5015,9 +5015,11 @@ pub mod bv2_impl {
             {
                 let mut assignments = pool.workers_assignments.lock();
                 if assignments.count() > 0 {
-                    for worker in assignments.values() {
-                        // SAFETY: worker ptrs are live until `deinit_soon`.
-                        unsafe { (**worker).deinit_soon() };
+                    for &worker in assignments.values() {
+                        // SAFETY: the map only holds live Workers from
+                        // `get_worker`, each exactly once, and it is cleared
+                        // below, so this is the one teardown of each.
+                        unsafe { crate::thread_pool::Worker::deinit_soon(worker) };
                     }
                     pool.worker_pool().wake_for_idle_events();
                 }

--- a/test/internal/source-lints/self-receiver-teardown.test.ts
+++ b/test/internal/source-lints/self-receiver-teardown.test.ts
@@ -1,0 +1,188 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A `&self` / `&mut self` method must not hand its own receiver to a teardown
+// function: `Self::deinit(ptr::from_mut(self))`, `Self::destroy(self as *mut _)`
+// and the other spellings of "`self`, as a raw pointer" as the argument of a
+// `deinit(..)` / `destroy(..)` call are banned.
+//
+// The tree's `deinit(this: *mut Self)` / `destroy(this: *mut Self)` functions
+// end in `heap::take(this)`: they free the allocation. A reference argument is
+// protected for the duration of the call it was passed to, and deallocating
+// protected memory is UB under both aliasing models (Stacked Borrows:
+// "deallocating while item is strongly protected"; Tree Borrows, which
+// `bun run rust:miri` uses: "the strongly protected tag disallows
+// deallocations"). Spelling the receiver as a raw pointer at the call does not
+// help: the `&mut self` that the pointer was derived from is still a live,
+// protected argument of the enclosing method while the callee frees it. This
+// holds whether the callee frees synchronously or publishes the allocation to
+// another thread that frees it before the method returns (the bundler's
+// `Worker::deinit_soon` did both, depending on the branch).
+//
+// The fix is to take the pointer the owner actually holds all the way down:
+// make the method `unsafe fn f(this: *mut Self)` (or return a disposition the
+// raw-pointer caller acts on), read fields through statement-scoped
+// `(*this).field` place expressions, and pass `this` itself to the teardown
+// function. Templates: `Worker::deinit_soon` / `schedule_with_options` in
+// src/bundler/ThreadPool.rs, `deinit` in
+// src/sql_jsc/postgres/PostgresSQLConnection.rs,
+// `run_from_js_thread` in src/runtime/node/node_zlib_binding.rs.
+//
+// Scope: the single-expression spellings below with `self` as the receiver and
+// `deinit` / `destroy` as the callee (the tree's names for an unconditional
+// free). Refcount releases (`deref(ptr::from_mut(self))`, which free only on
+// the last count), `finalize` hops whose receiver shape a trait dictates, a
+// self-derived pointer stashed in a local first, and reference *parameters*
+// (`fn f(this: &mut T)` freeing `this`) are outside this lint.
+//
+// Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts,
+// unsound-erased-box.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `deinit(` / `destroy(`, optionally path-qualified (`Self::deinit`,
+// `Worker::deinit`, `RefCount::<Self>::destroy`, `bun_core::heap::destroy`) and
+// turbofished. `\s*` after the paren so a rustfmt-wrapped argument list still
+// matches.
+const TEARDOWN = String.raw`\b(?:[\w:]+::)?(?:deinit|destroy)(?:::<[^>]*>)?\s*\(\s*`;
+
+// The ways of spelling "`self`, as a raw pointer" as the first argument. A
+// trailing `.cast_mut()` / `.cast()` on any of them still matches because the
+// pattern only anchors the front of the argument. `(?!\s*\.)` after the bare
+// `self` in the `&raw` form keeps `&raw mut *self.field` (a field's pointee,
+// which the receiver owns) out of it.
+const SELF_AS_POINTER = [
+  String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
+  String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+  String.raw`self\s+as\s+\*(?:mut|const)\b`,
+  String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
+  String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+].join("|");
+
+const BANNED = new RegExp(`${TEARDOWN}(?:${SELF_AS_POINTER})`, "g");
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape while their conversion is in flight. Delete an entry when its file is
+// converted; never raise one.
+const ALLOW: Record<string, number> = {
+  // `CopyFile::throw` / `resolve_promise` (`&mut self`) destroy the
+  // heap-allocated task before resolving the promise.
+  "src/runtime/webcore/blob/copy_file.rs": 2,
+  // `LifecycleScriptSubprocess::handle_exit` (`&mut self`) destroys the
+  // subprocess on five of its exit paths.
+  "src/install/lifecycle_script_runner.rs": 5,
+  // `AsyncCpTask::run_from_js_thread` (`&mut self`) destroys the task on both
+  // of its completion paths.
+  "src/runtime/node/node_fs.rs": 2,
+};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (doc comments describing this
+  // hazard included) don't count. `[ \t]*`, not `\s*`: `\s` crosses newlines
+  // and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const m of stripped.matchAll(BANNED)) {
+    const line = stripped.slice(0, m.index).split("\n").length;
+    counts[source] = (counts[source] ?? 0) + 1;
+    if ((counts[source] ?? 0) > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${line}: ${m[0].replace(/\s+/g, " ")}`);
+    }
+  }
+}
+
+function matches(snippet: string): boolean {
+  BANNED.lastIndex = 0;
+  return BANNED.test(snippet);
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the pattern recognizes the spellings it claims to", () => {
+  const banned = [
+    // The `Worker::deinit_soon` line this lint was written for.
+    "unsafe { Self::deinit(std::ptr::from_mut::<Self>(self)) };",
+    // The allowlisted shapes.
+    "unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };",
+    "unsafe { Self::destroy(core::ptr::from_mut(self)) };",
+    // Other paths, callee spellings and pointer spellings.
+    "unsafe { Worker::deinit(ptr::from_mut(self)) }",
+    "unsafe { RefCount::<Self>::destroy(std::ptr::from_mut::<Self>(self)) };",
+    "unsafe { Self::destroy::<true>(std::ptr::from_mut(self)) };",
+    "unsafe { deinit(std::ptr::from_ref(self).cast_mut()) };",
+    "unsafe { bun_core::heap::destroy(std::ptr::from_mut::<Self>(self)) };",
+    "unsafe { Self::deinit(self as *mut Self) };",
+    "unsafe { Self::deinit(self as *const Self as *mut Self) };",
+    "unsafe { Self::destroy(&raw mut *self) };",
+    "unsafe { Self::destroy(core::ptr::addr_of_mut!(*self)) };",
+    "Self::deinit(NonNull::from(self));",
+    // rustfmt-wrapped call.
+    "unsafe {\n    Self::destroy(\n        std::ptr::from_mut::<Self>(self),\n    )\n};",
+  ];
+  const allowed = [
+    // Passing the pointer the caller handed us is the intended shape.
+    "unsafe { Self::deinit(this) };",
+    "unsafe { crate::thread_pool::Worker::deinit_soon(worker) };",
+    "unsafe { Self::destroy(std::ptr::from_mut::<Self>(this_)) };",
+    "unsafe { Self::destroy(ptr::from_mut(other)) };",
+    // Tearing down something the receiver owns is fine.
+    "unsafe { Self::destroy(self.task) };",
+    "unsafe { Worker::deinit(self.worker.as_ptr()) };",
+    "unsafe { Self::deinit(&raw mut *self.inner) };",
+    "unsafe { drop(bun_core::heap::take(self.worker_pool)) };",
+    // UFCS forwarding of a reference receiver to a same-shaped inherent
+    // method, and by-value teardown, are not this shape.
+    "Self::deinit(self)",
+    "self.deinit();",
+    "Self::deinit(self, id)",
+    // Producing the pointer without tearing anything down is fine.
+    "let this = std::ptr::from_mut::<Self>(self);",
+    // Other callee names are out of scope (see the header).
+    "unsafe { Self::deref(std::ptr::from_mut::<Self>(self)) };",
+    "Self::finalize(std::ptr::from_mut::<Self>(self));",
+  ];
+  expect(banned.filter(s => !matches(s))).toEqual([]);
+  expect(allowed.filter(matches)).toEqual([]);
+});
+
+test("no method hands its own receiver to deinit/destroy", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: once an allowlisted file is converted, delete its entry so a new
+  // instance cannot take the converted one's place.
+  for (const [f, n] of Object.entries(ALLOW)) {
+    expect(counts[f] ?? 0).toBe(n);
+  }
+});

--- a/test/internal/source-lints/self-receiver-teardown.test.ts
+++ b/test/internal/source-lints/self-receiver-teardown.test.ts
@@ -11,12 +11,13 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // in the epilogue, while the receiver argument is still live) are banned.
 //
 // `destroy(this: *mut Self)` / `deinit(this: *mut Self)` / `finalize(this: *mut
-// Self)` are this tree's names for "reclaim the Box" (`heap::take` /
-// `heap::destroy` inside). Under Stacked and Tree Borrows a reference argument
-// is protected for the whole call, and deallocating protected memory is UB
-// regardless of whether the reference is used again afterwards ("deallocating
-// while item is strongly protected" / "the strongly protected tag disallows
-// deallocations" under Miri, the model `bun run rust:miri` checks; the
+// Self)` are the names this tree's "reclaim the Box" routines (`heap::take` /
+// `heap::destroy` inside) usually go by. Under Stacked and Tree Borrows a
+// reference argument is protected for the whole call, and deallocating
+// protected memory is UB regardless of whether the reference is used again
+// afterwards (Miri reports "deallocating while item is strongly protected"
+// under Stacked Borrows and "the strongly protected tag disallows
+// deallocations" under Tree Borrows, the model `bun run rust:miri` uses; the
 // protector is the model's counterpart of the `dereferenceable` attribute
 // rustc puts on reference arguments, so this is not only a Miri concern). The
 // function that frees has to take the allocation pointer (`this: *mut Self`)
@@ -28,17 +29,23 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // publishes the allocation to another thread that frees it.
 //
 // Scope: the two single-expression shapes above, with the callee literally
-// named `destroy`, `deinit` or `finalize` (the name list is the enforcement
-// boundary; a new teardown routine under another name goes here too;
-// `heap::destroy` counts as a `destroy` spelling). An in-place finalizer
-// (`JsSinkType::finalize(&mut self)`, called as `self.finalize()`) never takes
-// the receiver's address and so is not matched. Deliberately outside it:
+// named `destroy`, `deinit` or `finalize` (`heap::destroy` counts as a
+// `destroy` spelling). The name list is the enforcement boundary: a reclaim
+// routine under another name (src/runtime/dns_jsc/dns.rs's `on_cares_complete`
+// at the time of writing) is not caught until its name is added here, which is
+// the thing to do once its remaining sites are converted. In-place
+// finalizers, and `&mut self` methods that forward `self` itself
+// (`Self::finalize(self)`), take no address and are not matched; the one
+// `finalize` forwarder that does take the address is allowlisted below.
+// Deliberately outside it:
 //   - the other reclaim primitives (`heap::take(from_mut(self))`,
 //     `Box::from_raw(self as *mut _)`), a separate population one layer down;
 //   - refcount releases (`Self::deref(from_mut(self))`), which only free on the
 //     last count, so each site needs its own argument about who else holds one;
-//   - a self-derived pointer stashed in a local and freed later, and reference
-//     parameters (`fn f(this: &mut T)` freeing `this`).
+//   - a bare `self` argument coerced to `*mut Self` by a raw-pointer callee
+//     (textually identical to the UFCS forwarding above), a self-derived
+//     pointer stashed in a local and freed later, and reference parameters
+//     (`fn f(this: &mut T)` freeing `this`).
 //
 // Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts,
 // unsound-erased-box.test.ts.
@@ -59,25 +66,31 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-// The ways of spelling "`self`, as a raw pointer", optionally followed by
-// pointer-to-pointer conversions that keep it the same address (`.cast()`,
-// `.cast_mut()`, `.as_ptr()`). `(?!\s*\.)` after `&raw mut *self` keeps a
-// field's address (`&raw mut *self.inner`) out of it.
+// An optional `::<..>`, allowing one level of nesting (`::<Request<'a>>`).
+const TURBOFISH = String.raw`(?:::<(?:[^<>]|<[^<>]*>)*>)?`;
+
+// `self` (or a reborrow of it) as the sole argument of a pointer constructor.
+const SELF_ARG = String.raw`\(\s*(?:&(?:mut\s+)?\*\s*)?self\s*\)`;
+
+// The ways of spelling "`self`, as a raw pointer", optionally parenthesized and
+// optionally followed by pointer-to-pointer conversions that keep it the same
+// address (`.cast()`, `.cast_mut()`, `.as_ptr()`). `(?!\s*\.)` after
+// `&raw mut *self` keeps a field's address (`&raw mut *self.inner`) out of it.
 const SELF_AS_POINTER =
-  String.raw`(?:` +
+  String.raw`\(?\s*(?:` +
   [
-    String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
-    String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+    String.raw`(?:[\w:]+::)?from_(?:mut|ref)${TURBOFISH}${SELF_ARG}`,
+    String.raw`(?:[\w:]+::)?NonNull::from${SELF_ARG}`,
     String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
     String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
     String.raw`self\s+as\s+\*(?:mut|const)\b[^,()]*`,
   ].join("|") +
-  String.raw`)(?:\s*\.\s*(?:cast(?:_mut|_const)?(?:::<[^>]*>)?|as_ptr)\(\))*`;
+  String.raw`)\s*\)?(?:\s*\.\s*(?:cast(?:_mut|_const)?${TURBOFISH}|as_ptr)\(\))*`;
 
 // `destroy(` / `deinit(` / `finalize(`, optionally path-qualified (`Self::`,
 // `Worker::`, `bun_core::heap::`) and turbofished. `\s*` after the paren so a
 // rustfmt-wrapped argument list still matches.
-const TEARDOWN = String.raw`\b(?:[\w:]+::)?(?:destroy|deinit|finalize)(?:::<[^>]*>)?\s*\(\s*`;
+const TEARDOWN = String.raw`\b(?:[\w:]+::)?(?:destroy|deinit|finalize)${TURBOFISH}\s*\(\s*`;
 
 const DIRECT = new RegExp(`${TEARDOWN}${SELF_AS_POINTER}\\s*[,)]`, "g");
 
@@ -172,6 +185,10 @@ test("the patterns recognize the spellings they claim to", () => {
     "unsafe { Self::destroy::<true>(std::ptr::from_mut(self)) }",
     "unsafe { crate::node::fs::AsyncCpTask::destroy(std::ptr::from_mut(self)) }",
     "unsafe { bun_core::heap::destroy(std::ptr::from_mut::<Self>(self)) };",
+    // Nested turbofish, a reborrow of the receiver, a parenthesized cast.
+    "unsafe { Self::destroy(std::ptr::from_mut::<Request<'a>>(self)) };",
+    "unsafe { Self::deinit(core::ptr::from_mut(&mut *self)) };",
+    "unsafe { Self::destroy((self as *mut Self).cast()) };",
     // Extra arguments after the pointer, and a rustfmt-wrapped call.
     "unsafe { Self::deinit(std::ptr::from_mut(self), allocator) }",
     "unsafe {\n    Self::destroy(\n        std::ptr::from_mut::<Self>(self),\n    )\n}",
@@ -191,8 +208,8 @@ test("the patterns recognize the spellings they claim to", () => {
     "unsafe { Worker::deinit(self.worker.as_ptr()) }",
     "unsafe { Self::destroy(&raw mut *self.inner) }",
     "unsafe { TCC::State::destroy(s.as_ptr()) };",
-    // By-value / in-place teardown and UFCS forwarding of the reference itself
-    // are not this shape.
+    // By-value / in-place teardown and forwarding `self` itself are not this
+    // shape (the raw-pointer-callee coercion case is out of scope, see header).
     "self.deinit();",
     "self.finalize();",
     "self.io_request.deinit();",
@@ -225,8 +242,8 @@ test("no method hands its own receiver to destroy/deinit/finalize", () => {
 
 test("allowlisted files still carry exactly their documented count", () => {
   // Ratchet: once an allowlisted file is converted, delete its entry so a new
-  // instance cannot take the old one's place.
-  for (const [f, n] of Object.entries(ALLOW)) {
-    expect(counts[f] ?? 0).toBe(n);
-  }
+  // instance cannot take the old one's place. Compared as one object so a
+  // failure names the file.
+  const actual = Object.fromEntries(Object.keys(ALLOW).map(f => [f, counts[f] ?? 0]));
+  expect(actual).toEqual(ALLOW);
 });

--- a/test/internal/source-lints/self-receiver-teardown.test.ts
+++ b/test/internal/source-lints/self-receiver-teardown.test.ts
@@ -4,39 +4,41 @@ import { realpathSync } from "fs";
 import path from "path";
 import { globAllSources } from "../../../scripts/glob-sources.ts";
 
-// A `&self` / `&mut self` method must not hand its own receiver to a teardown
-// function: `Self::deinit(ptr::from_mut(self))`, `Self::destroy(self as *mut _)`
-// and the other spellings of "`self`, as a raw pointer" as the argument of a
-// `deinit(..)` / `destroy(..)` call are banned.
+// A `&self` / `&mut self` method must not hand its own receiver to the type's
+// teardown routine: `Self::destroy(ptr::from_mut(self))`, `Self::deinit(self as
+// *mut _)`, `Self::finalize(ptr::from_mut(self))`, or the deferred form
+// `scopeguard::guard(ptr::from_mut(self), |p| Self::destroy(p))` (which frees
+// in the epilogue, while the receiver argument is still live) are banned.
 //
-// The tree's `deinit(this: *mut Self)` / `destroy(this: *mut Self)` functions
-// end in `heap::take(this)`: they free the allocation. A reference argument is
-// protected for the duration of the call it was passed to, and deallocating
-// protected memory is UB under both aliasing models (Stacked Borrows:
-// "deallocating while item is strongly protected"; Tree Borrows, which
-// `bun run rust:miri` uses: "the strongly protected tag disallows
-// deallocations"). Spelling the receiver as a raw pointer at the call does not
-// help: the `&mut self` that the pointer was derived from is still a live,
-// protected argument of the enclosing method while the callee frees it. This
-// holds whether the callee frees synchronously or publishes the allocation to
-// another thread that frees it before the method returns (the bundler's
-// `Worker::deinit_soon` did both, depending on the branch).
+// `destroy(this: *mut Self)` / `deinit(this: *mut Self)` / `finalize(this: *mut
+// Self)` are this tree's names for "reclaim the Box" (`heap::take` /
+// `heap::destroy` inside). Under Stacked and Tree Borrows a reference argument
+// is protected for the whole call, and deallocating protected memory is UB
+// regardless of whether the reference is used again afterwards ("deallocating
+// while item is strongly protected" / "the strongly protected tag disallows
+// deallocations" under Miri, the model `bun run rust:miri` checks; the
+// protector is the model's counterpart of the `dereferenceable` attribute
+// rustc puts on reference arguments, so this is not only a Miri concern). The
+// function that frees has to take the allocation pointer (`this: *mut Self`)
+// and reborrow per statement, with its caller (a dispatch arm, a C callback, a
+// scope guard over the raw pointer) passing the pointer through; see the
+// comment on `deinit(this: *mut Self)` in
+// src/sql_jsc/postgres/PostgresSQLConnection.rs and `Worker::deinit_soon` in
+// src/bundler/ThreadPool.rs, which also covers the case where the callee
+// publishes the allocation to another thread that frees it.
 //
-// The fix is to take the pointer the owner actually holds all the way down:
-// make the method `unsafe fn f(this: *mut Self)` (or return a disposition the
-// raw-pointer caller acts on), read fields through statement-scoped
-// `(*this).field` place expressions, and pass `this` itself to the teardown
-// function. Templates: `Worker::deinit_soon` / `schedule_with_options` in
-// src/bundler/ThreadPool.rs, `deinit` in
-// src/sql_jsc/postgres/PostgresSQLConnection.rs,
-// `run_from_js_thread` in src/runtime/node/node_zlib_binding.rs.
-//
-// Scope: the single-expression spellings below with `self` as the receiver and
-// `deinit` / `destroy` as the callee (the tree's names for an unconditional
-// free). Refcount releases (`deref(ptr::from_mut(self))`, which free only on
-// the last count), `finalize` hops whose receiver shape a trait dictates, a
-// self-derived pointer stashed in a local first, and reference *parameters*
-// (`fn f(this: &mut T)` freeing `this`) are outside this lint.
+// Scope: the two single-expression shapes above, with the callee literally
+// named `destroy`, `deinit` or `finalize` (the name list is the enforcement
+// boundary; a new teardown routine under another name goes here too;
+// `heap::destroy` counts as a `destroy` spelling). An in-place finalizer
+// (`JsSinkType::finalize(&mut self)`, called as `self.finalize()`) never takes
+// the receiver's address and so is not matched. Deliberately outside it:
+//   - the other reclaim primitives (`heap::take(from_mut(self))`,
+//     `Box::from_raw(self as *mut _)`), a separate population one layer down;
+//   - refcount releases (`Self::deref(from_mut(self))`), which only free on the
+//     last count, so each site needs its own argument about who else holds one;
+//   - a self-derived pointer stashed in a local and freed later, and reference
+//     parameters (`fn f(this: &mut T)` freeing `this`).
 //
 // Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts,
 // unsound-erased-box.test.ts.
@@ -57,40 +59,58 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-// `deinit(` / `destroy(`, optionally path-qualified (`Self::deinit`,
-// `Worker::deinit`, `RefCount::<Self>::destroy`, `bun_core::heap::destroy`) and
-// turbofished. `\s*` after the paren so a rustfmt-wrapped argument list still
-// matches.
-const TEARDOWN = String.raw`\b(?:[\w:]+::)?(?:deinit|destroy)(?:::<[^>]*>)?\s*\(\s*`;
+// The ways of spelling "`self`, as a raw pointer", optionally followed by
+// pointer-to-pointer conversions that keep it the same address (`.cast()`,
+// `.cast_mut()`, `.as_ptr()`). `(?!\s*\.)` after `&raw mut *self` keeps a
+// field's address (`&raw mut *self.inner`) out of it.
+const SELF_AS_POINTER =
+  String.raw`(?:` +
+  [
+    String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
+    String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+    String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
+    String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+    String.raw`self\s+as\s+\*(?:mut|const)\b[^,()]*`,
+  ].join("|") +
+  String.raw`)(?:\s*\.\s*(?:cast(?:_mut|_const)?(?:::<[^>]*>)?|as_ptr)\(\))*`;
 
-// The ways of spelling "`self`, as a raw pointer" as the first argument. A
-// trailing `.cast_mut()` / `.cast()` on any of them still matches because the
-// pattern only anchors the front of the argument. `(?!\s*\.)` after the bare
-// `self` in the `&raw` form keeps `&raw mut *self.field` (a field's pointee,
-// which the receiver owns) out of it.
-const SELF_AS_POINTER = [
-  String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
-  String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
-  String.raw`self\s+as\s+\*(?:mut|const)\b`,
-  String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
-  String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
-].join("|");
+// `destroy(` / `deinit(` / `finalize(`, optionally path-qualified (`Self::`,
+// `Worker::`, `bun_core::heap::`) and turbofished. `\s*` after the paren so a
+// rustfmt-wrapped argument list still matches.
+const TEARDOWN = String.raw`\b(?:[\w:]+::)?(?:destroy|deinit|finalize)(?:::<[^>]*>)?\s*\(\s*`;
 
-const BANNED = new RegExp(`${TEARDOWN}(?:${SELF_AS_POINTER})`, "g");
+const DIRECT = new RegExp(`${TEARDOWN}${SELF_AS_POINTER}\\s*[,)]`, "g");
+
+// `scopeguard::guard(<self as pointer>, |p| { unsafe { Self::destroy(p) } })`:
+// the guard's closure must apply the teardown routine to the guarded pointer
+// (the back-reference), so a guard over `self`'s address that does something
+// else with it (src/runtime/ffi/ffi_body.rs frees a field) does not count.
+const DEFERRED = new RegExp(
+  String.raw`scopeguard::guard\(\s*${SELF_AS_POINTER}\s*,\s*(?:move\s+)?\|\s*(\w+)\s*\|\s*(?:\{\s*)?(?:unsafe\s*\{\s*)?${TEARDOWN}\1\s*\)`,
+  "g",
+);
 
 // Documented, ratcheted exceptions: files allowed to keep exactly N of the
 // shape while their conversion is in flight. Delete an entry when its file is
 // converted; never raise one.
 const ALLOW: Record<string, number> = {
-  // `CopyFile::throw` / `resolve_promise` (`&mut self`) destroy the
-  // heap-allocated task before resolving the promise.
-  "src/runtime/webcore/blob/copy_file.rs": 2,
-  // `LifecycleScriptSubprocess::handle_exit` (`&mut self`) destroys the
-  // subprocess on five of its exit paths.
+  // `<ArrayBufferSink as JsSinkType>::finalize(&mut self)` forwards to the
+  // `Self::finalize(*mut Self)` that frees the sink's m_ctx payload; the
+  // receiver shape comes from the trait / generated `__finalize` thunk.
+  "src/runtime/webcore/ArrayBufferSink.rs": 1,
+  // `LifecycleScriptSubprocess::handle_exit` / `deinit_and_delete_package`
+  // (`&mut self`) free the subprocess at five sites; #37551 turns them into a
+  // disposition that the raw-pointer thunks act on.
   "src/install/lifecycle_script_runner.rs": 5,
-  // `AsyncCpTask::run_from_js_thread` (`&mut self`) destroys the task on both
-  // of its completion paths.
-  "src/runtime/node/node_fs.rs": 2,
+  // `UVFSRequest::run_from_js_thread` (the deferred form) and the two
+  // completion paths of `NewAsyncCpTask::run_from_js_thread` (`&mut self`)
+  // free the task they run on; #37693 converts them.
+  "src/runtime/node/node_fs.rs": 3,
+  // `CopyFileWindows::throw` / `resolve_promise` and `ReadFileUV::on_finish`
+  // (`&mut self`) free the task they run on, reached through further
+  // `&mut self` frames; #37705 converts them.
+  "src/runtime/webcore/blob/copy_file.rs": 2,
+  "src/runtime/webcore/blob/read_file.rs": 1,
 };
 
 const counts: Record<string, number> = {};
@@ -104,22 +124,26 @@ for (const abs of rustSources) {
   if (tracked !== null && !tracked.has(source)) continue;
   scanned++;
   const content = await file(abs).text();
-  // Strip full-line comments so prose mentions (doc comments describing this
-  // hazard included) don't count. `[ \t]*`, not `\s*`: `\s` crosses newlines
-  // and would swallow blank lines, shifting the reported line numbers.
+  // Strip full-line comments so prose mentions (and SAFETY comments inside a
+  // guard's closure) don't count or break a match. `[ \t]*`, not `\s*`: `\s`
+  // crosses newlines and would swallow blank lines, shifting the reported line
+  // numbers.
   const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
-  for (const m of stripped.matchAll(BANNED)) {
-    const line = stripped.slice(0, m.index).split("\n").length;
-    counts[source] = (counts[source] ?? 0) + 1;
-    if ((counts[source] ?? 0) > (ALLOW[source] ?? 0)) {
-      offenders.push(`${source}:${line}: ${m[0].replace(/\s+/g, " ")}`);
-    }
+  const hits = [DIRECT, DEFERRED]
+    .flatMap(re => [...stripped.matchAll(re)])
+    .map(m => ({ line: stripped.slice(0, m.index).split("\n").length, text: m[0].replace(/\s+/g, " ") }))
+    .sort((a, b) => a.line - b.line);
+  if (hits.length === 0) continue;
+  counts[source] = hits.length;
+  for (const { line, text } of hits.slice(ALLOW[source] ?? 0)) {
+    offenders.push(`${source}:${line}: ${text}`);
   }
 }
 
 function matches(snippet: string): boolean {
-  BANNED.lastIndex = 0;
-  return BANNED.test(snippet);
+  DIRECT.lastIndex = 0;
+  DEFERRED.lastIndex = 0;
+  return DIRECT.test(snippet) || DEFERRED.test(snippet);
 }
 
 test("scans a non-empty set of tracked Rust sources", () => {
@@ -128,60 +152,80 @@ test("scans a non-empty set of tracked Rust sources", () => {
   expect(scanned).toBeGreaterThan(0);
 });
 
-test("the pattern recognizes the spellings it claims to", () => {
+test("the patterns recognize the spellings they claim to", () => {
   const banned = [
     // The `Worker::deinit_soon` line this lint was written for.
     "unsafe { Self::deinit(std::ptr::from_mut::<Self>(self)) };",
-    // The allowlisted shapes.
+    // The same shape elsewhere in the tree (the allowlisted sites).
     "unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };",
     "unsafe { Self::destroy(core::ptr::from_mut(self)) };",
-    // Other paths, callee spellings and pointer spellings.
-    "unsafe { Worker::deinit(ptr::from_mut(self)) }",
-    "unsafe { RefCount::<Self>::destroy(std::ptr::from_mut::<Self>(self)) };",
-    "unsafe { Self::destroy::<true>(std::ptr::from_mut(self)) };",
-    "unsafe { deinit(std::ptr::from_ref(self).cast_mut()) };",
+    "Self::finalize(core::ptr::from_mut(self));",
+    "Self::finalize(std::ptr::from_mut::<Self>(self));",
+    "let _deinit =\n    scopeguard::guard(core::ptr::from_mut(self), |p| unsafe { Self::destroy(p) });",
+    // Other spellings of the receiver's address.
+    "unsafe { Worker::deinit(self as *mut Self) };",
+    "unsafe { destroy(self as *const Self as *mut Self) }",
+    "unsafe { Self::destroy(&raw mut *self) }",
+    "unsafe { Self::destroy(core::ptr::addr_of_mut!(*self)) }",
+    "unsafe { Self::destroy(ptr::from_ref(self).cast_mut()) }",
+    "unsafe { Self::destroy(NonNull::from(self).as_ptr()) }",
+    "unsafe { Self::destroy::<true>(std::ptr::from_mut(self)) }",
+    "unsafe { crate::node::fs::AsyncCpTask::destroy(std::ptr::from_mut(self)) }",
     "unsafe { bun_core::heap::destroy(std::ptr::from_mut::<Self>(self)) };",
-    "unsafe { Self::deinit(self as *mut Self) };",
-    "unsafe { Self::deinit(self as *const Self as *mut Self) };",
-    "unsafe { Self::destroy(&raw mut *self) };",
-    "unsafe { Self::destroy(core::ptr::addr_of_mut!(*self)) };",
-    "Self::deinit(NonNull::from(self));",
-    // rustfmt-wrapped call.
-    "unsafe {\n    Self::destroy(\n        std::ptr::from_mut::<Self>(self),\n    )\n};",
+    // Extra arguments after the pointer, and a rustfmt-wrapped call.
+    "unsafe { Self::deinit(std::ptr::from_mut(self), allocator) }",
+    "unsafe {\n    Self::destroy(\n        std::ptr::from_mut::<Self>(self),\n    )\n}",
+    // Deferred: block body, `move`, a SAFETY comment already stripped to a blank line.
+    "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |this| {\n\n    unsafe { Self::destroy(this) }\n});",
+    "let _g = scopeguard::guard(self as *mut Self, move |p| unsafe { Self::deinit(p) });",
   ];
   const allowed = [
-    // Passing the pointer the caller handed us is the intended shape.
-    "unsafe { Self::deinit(this) };",
-    "unsafe { crate::thread_pool::Worker::deinit_soon(worker) };",
-    "unsafe { Self::destroy(std::ptr::from_mut::<Self>(this_)) };",
-    "unsafe { Self::destroy(ptr::from_mut(other)) };",
-    // Tearing down something the receiver owns is fine.
-    "unsafe { Self::destroy(self.task) };",
-    "unsafe { Worker::deinit(self.worker.as_ptr()) };",
-    "unsafe { Self::deinit(&raw mut *self.inner) };",
-    "unsafe { drop(bun_core::heap::take(self.worker_pool)) };",
-    // UFCS forwarding of a reference receiver to a same-shaped inherent
-    // method, and by-value teardown, are not this shape.
-    "Self::deinit(self)",
+    // The converted shapes: the pointer comes in as a parameter.
+    "unsafe { Self::destroy(this) }",
+    "unsafe { Self::finalize(this) };",
+    "let _deinit = scopeguard::guard(this, |p| unsafe { Self::destroy(p) });",
+    "unsafe { Self::destroy(cast_ptr!(crate::node::fs::AsyncCpTask)) }",
+    "unsafe { FSWatchTask::deinit(t) };",
+    // Freeing something the receiver owns is fine.
+    "unsafe { Self::destroy(self.child) }",
+    "unsafe { Worker::deinit(self.worker.as_ptr()) }",
+    "unsafe { Self::destroy(&raw mut *self.inner) }",
+    "unsafe { TCC::State::destroy(s.as_ptr()) };",
+    // By-value / in-place teardown and UFCS forwarding of the reference itself
+    // are not this shape.
     "self.deinit();",
+    "self.finalize();",
+    "self.io_request.deinit();",
+    "Self::deinit(self)",
     "Self::deinit(self, id)",
-    // Producing the pointer without tearing anything down is fine.
-    "let this = std::ptr::from_mut::<Self>(self);",
-    // Other callee names are out of scope (see the header).
-    "unsafe { Self::deref(std::ptr::from_mut::<Self>(self)) };",
-    "Self::finalize(std::ptr::from_mut::<Self>(self));",
+    "Self::finalize(self)",
+    // Producing the receiver's address for something other than teardown.
+    "self.req.data = core::ptr::from_mut(self).cast::<c_void>();",
+    "unsafe { Self::deref_(std::ptr::from_mut::<Self>(self)) };",
+    "unsafe { Self::teardown(core::ptr::from_mut(self), Teardown::MainThreadExit) };",
+    // The other primitives are a separate population (see the scope note).
+    "unsafe { drop(bun_core::heap::take(std::ptr::from_mut::<Self>(self))) };",
+    // A guard over the receiver's address whose closure frees a field, or
+    // releases a refcount, is out of scope.
+    "let _guard = scopeguard::guard(std::ptr::from_mut::<Function>(self), |this_ptr| {\n    if let Some(s) = unsafe { (*this_ptr).state.take() } {\n        unsafe { TCC::State::destroy(s.as_ptr()) };\n    }\n});",
+    "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |s| {\n    unsafe { Self::deref_(s) }\n});",
+    // A guard that frees a different pointer than the one it guards.
+    "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |_p| unsafe { Self::destroy(other) });",
+    // Not the receiver.
+    "unsafe { Self::destroy(std::ptr::from_mut::<Self>(self_)) };",
+    "unsafe { Self::destroy(ptr::from_mut(task)) }",
   ];
   expect(banned.filter(s => !matches(s))).toEqual([]);
   expect(allowed.filter(matches)).toEqual([]);
 });
 
-test("no method hands its own receiver to deinit/destroy", () => {
+test("no method hands its own receiver to destroy/deinit/finalize", () => {
   expect(offenders).toEqual([]);
 });
 
 test("allowlisted files still carry exactly their documented count", () => {
   // Ratchet: once an allowlisted file is converted, delete its entry so a new
-  // instance cannot take the converted one's place.
+  // instance cannot take the old one's place.
   for (const [f, n] of Object.entries(ALLOW)) {
     expect(counts[f] ?? 0).toBe(n);
   }

--- a/test/internal/source-lints/self-receiver-teardown.test.ts
+++ b/test/internal/source-lints/self-receiver-teardown.test.ts
@@ -35,11 +35,11 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // at the time of writing) is not caught until its name is added here, which is
 // the thing to do once its remaining sites are converted. In-place
 // finalizers, and `&mut self` methods that forward `self` itself
-// (`Self::finalize(self)`), take no address and are not matched; the one
-// `finalize` forwarder that does take the address is allowlisted below.
+// (`Self::finalize(self)`), take no address and are not matched.
 // Deliberately outside it:
 //   - the other reclaim primitives (`heap::take(from_mut(self))`,
-//     `Box::from_raw(self as *mut _)`), a separate population one layer down;
+//     `Box::from_raw(self as *mut _)`), which self-receiver-reclaim.test.ts
+//     covers one layer down;
 //   - refcount releases (`Self::deref(from_mut(self))`), which only free on the
 //     last count, so each site needs its own argument about who else holds one;
 //   - a bare `self` argument coerced to `*mut Self` by a raw-pointer callee
@@ -47,8 +47,8 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //     pointer stashed in a local and freed later, and reference parameters
 //     (`fn f(this: &mut T)` freeing `this`).
 //
-// Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts,
-// unsound-erased-box.test.ts.
+// Sibling guards: self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
+// frozen-nonnull-reborrow.test.ts, unsound-erased-box.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
@@ -107,10 +107,6 @@ const DEFERRED = new RegExp(
 // shape while their conversion is in flight. Delete an entry when its file is
 // converted; never raise one.
 const ALLOW: Record<string, number> = {
-  // `<ArrayBufferSink as JsSinkType>::finalize(&mut self)` forwards to the
-  // `Self::finalize(*mut Self)` that frees the sink's m_ctx payload; the
-  // receiver shape comes from the trait / generated `__finalize` thunk.
-  "src/runtime/webcore/ArrayBufferSink.rs": 1,
   // `LifecycleScriptSubprocess::handle_exit` / `deinit_and_delete_package`
   // (`&mut self`) free the subprocess at five sites; #37551 turns them into a
   // disposition that the raw-pointer thunks act on.


### PR DESCRIPTION
### Problem
- No crash is known from this. `Worker::deinit_soon(&mut self)` in the bundler thread pool frees the `Worker` it is called on, and every `Bun.build()` / `bun build` teardown goes through it.
- A `&mut self` argument has to stay allocated until the call returns. Freeing it during the call is undefined behaviour under both of Rust's aliasing models, whichever thread does the freeing.
- On the branch teardown normally takes, a pool thread may free the worker before `deinit_soon` returns; on the other branch the function frees it itself. A standalone reduction of this shape fails under Miri on both branches (`the strongly protected tag disallows deallocations`).
- The task pointer handed to the pool thread was derived from `&mut self`, so under Stacked Borrows it covers one field, not the whole allocation that later gets freed.

### Fix
- `deinit_soon` takes `this: *mut Worker`. It reads `thread` and takes the task address through statement-scoped raw place expressions, and the one caller (bundler teardown) passes the pointer it already stores. Same code path and order as before; no behaviour change.
- Correct because no reference to the `Worker` exists at either point where it can be freed, and the pointer that reaches the free is derived from the allocation itself. The reduction in the fixed shape passes under both models. This is the same contract the tree's other freeing teardown functions already use.
- The branch that frees inline looks defensive: no path that creates a `Worker` off a pool thread was found. The pool-thread branch is the one that matters.
- A new source lint bans handing `self` as a raw pointer to `deinit` / `destroy` / `finalize`, directly or through a `scopeguard`. On `main` it reports exactly this line; four other files keep their current counts in an allowlist that ratchets down as sibling PRs convert them (#37551, #37693, #37705).
- Verification: the lint fails without the fix and passes with it. On a debug (ASAN) build the bundler API and plugin suites, which tear workers down through the fixed branch, pass. The UB itself was only demonstrated in the standalone Miri reduction, not in bun.

### Background
- Bundler workers: `Bun.build()` parses on a thread pool. Each pool thread gets a heap-allocated `Worker` (parser state, allocators), recorded in a `workers_assignments` map, and the bundle tears every entry down once at the end.
- Idle tasks: `deinit_task` is a task struct embedded inside the `Worker`. `push_idle_task` hands its address to the pool thread, whose callback recovers the enclosing `Worker` from it (`container_of`) and frees it. Pool threads drain idle tasks between batches, so this can happen as soon as the task is pushed.
- Protectors: under Stacked Borrows and Tree Borrows (the aliasing models Miri checks; `bun run rust:miri` uses the latter) a reference argument is protected for the whole call, so freeing it mid-call is UB even if it is never touched again. rustc's `dereferenceable` attribute on reference arguments encodes the same assumption.
- Provenance: a raw pointer remembers what it was derived from. One taken from a field reference may only be valid for that field, so a callback that reclaims the whole `Box` needs a pointer derived from the allocation's own pointer.
- Source lints: `test/internal/source-lints/` holds tests that regex-scan the tree for banned code shapes. Files still carrying a shape are allowlisted with an exact count, so converting a file forces its entry to be deleted and nothing new can take its place.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-teardown.test.ts
bun test v1.4.0 (5c9febbb0)

test/internal/source-lints/self-receiver-teardown.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.01ms]
(pass) the patterns recognize the spellings they claim to [21.31ms]
231 |   expect(banned.filter(s => !matches(s))).toEqual([]);
232 |   expect(allowed.filter(matches)).toEqual([]);
233 | });
234 | 
235 | test("no method hands its own receiver to destroy/deinit/finalize", () => {
236 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/bundler/ThreadPool.rs:590: Self::deinit(std::ptr::from_mut::<Self>(self))",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/self-receiver-teardown.test.ts:236:21)
(fail) no method hands its own receiver to destroy/deinit/finalize [5.04ms]
(pass) allowlisted files still carry exactly their documented count [6.89ms]

 3 pass
 1 fail
 5 expect() calls
Ran 4 tests across 1 file. [2
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/internal/source-lints/self-receiver-teardown.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.67ms]
(pass) the patterns recognize the spellings they claim to [0.50ms]
231 |   expect(banned.filter(s => !matches(s))).toEqual([]);
232 |   expect(allowed.filter(matches)).toEqual([]);
233 | });
234 | 
235 | test("no method hands its own receiver to destroy/deinit/finalize", () => {
236 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/bundler/ThreadPool.rs:590: Self::deinit(std::ptr::from_mut::<Self>(self))",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/self-receiver-teardown.test.ts:236:21)
(fail) no method hands its own receiver to destroy/deinit/finalize [0.21ms]
(pass) allowlisted files still carry exactly their documented count [0.18ms]

 3 pass
 1 fail
 5 expect() calls
Ran 4 tests across 1 file. [776.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-teardown.test.ts
bun test v1.4.0 (5c9febbb0)

test/internal/source-lints/self-receiver-teardown.test.ts:
(pass) scans a non-empty set of tracked Rust sources [3.92ms]
(pass) the patterns recognize the spellings they claim to [34.64ms]
(pass) no method hands its own receiver to destroy/deinit/finalize [2.35ms]
(pass) allowlisted files still carry exactly their documented count [10.40ms]

 4 pass
 0 fail
 5 expect() calls
Ran 4 tests across 1 file. [36.13s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1652ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
^[[1m^[[92m   Compiling^[[0m bun_crash_handler v0.0.0 (/workspace/bun/src/crash_handler)
^[[1m^[[92m   Compiling^[[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
^[[1m^[[92m   Compiling^[[0m bun_api v0.0.0 (/workspace/bun/src/api)
^[[1m^[[92m   Compiling^[[0m bun_js_parser v0.0.0 (/workspace/bun/src/js_parser)
^[[1m^[[92m   Compiling^[[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
^[[1m^[[92m   Compiling^[[0m bun_spawn v0.0.0 (/workspace/bun/src/spawn)
^[[1m^[[92m   Compiling^[[0m bun_patch v0.0.0 (/workspace/bun/src/patch)
^[[1m^[[92m   Compiling^[[0m bun_resolver v0.0.0 (/workspace/bun/src/resolve
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/ThreadPool.rs                          |  28 ++-
 src/bundler/bundle_v2.rs                           |   8 +-
 .../source-lints/self-receiver-teardown.test.ts    | 245 +++++++++++++++++++++
 3 files changed, 271 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/ThreadPool.rs                                     5     12      0
src/bundler/bundle_v2.rs                                      2      1      0
…st/internal/source-lints/self-receiver-teardown.test.ts      4     13      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

`Worker::deinit_soon(&mut self)` in src/bundler/ThreadPool.rs frees the `Worker` it is called on:

```rust
pub(crate) fn deinit_soon(&mut self) {
    if let Some(thread) = self.thread {
        thread.push_idle_task(&raw mut self.deinit_task);   // pool thread frees *self from deinit_callback
    } else {
        unsafe { Self::deinit(std::ptr::from_mut::<Self>(self)) };   // heap::take(this) right here
    }
}
```

A `&mut self` argument is protected for the duration of the call, and deallocating memory that a protected reference points into is UB under both aliasing models, whoever does the deallocating:

* `else` branch: `deinit` reclaims the Box while the `deinit_soon` frame still holds the protected `&mut self`.
* `if` branch: `push_idle_task` publishes the intrusive `deinit_task`, and the pool thread may run `deinit_callback` immediately. `Thread::drain_idle_events` runs after every task batch and on every idle wake (src/threading/ThreadPool.rs), not only after the `wake_for_idle_events()` the caller issues afterwards, so a pool thread can free the `Worker` before `deinit_soon` returns. This is the branch every `Bun.build()` / `bun build` teardown takes. The task pointer was also derived from the `&mut self` reborrow rather than from the allocation's own pointer; under Tree Borrows that still covers the whole `Worker`, but under Stacked Borrows it only carries the field's range, which is the second Miri error below, and deriving it from the allocation pointer is the shape `bun_core::container_of`'s docs describe.

A standalone reduction of exactly this shape (boxed struct, intrusive task field, `push_idle_task` modelled as the pool thread running the task immediately) fails under Miri on both branches. Tree Borrows, which `bun run rust:miri` uses:

```
error: Undefined Behavior: deallocation through <1834> at alloc841[0x0] is forbidden
     = help: the strongly protected tag <1823> disallows deallocations
help: the strongly protected tag <1823> was created here, in the initial state Reserved
  45 |     fn deinit_soon(&mut self) {
```

Stacked Borrows reports `deallocating while item [Unique for <1870>] is strongly protected` for the `else` branch and, for the `if` branch, rejects the `Box` reclaim in the callback because the field pointer derived from `&mut self` does not carry the whole allocation (`trying to retag from <1902> for Unique permission at alloc845[0x8], but that tag does not exist in the borrow stack`). The fixed shape below passes under both models on both branches.

No crash is known from this; it is the same contract fix as the tree's other teardown functions that end in a free and therefore take `this: *mut Self` (see the comment on `deinit` in src/sql_jsc/postgres/PostgresSQLConnection.rs, and `schedule_with_options` in this same file for the same reasoning applied to a publish).

### Fix

`deinit_soon` becomes `unsafe fn deinit_soon(this: *mut Self)`. It reads `thread` and takes the `deinit_task` address through statement-scoped raw place expressions, so no reference to the `Worker` exists when either free can happen, and the task pointer now carries the allocation's own provenance. The `else` branch passes `this` straight to `deinit`. The only caller, the worker teardown loop in `BundleV2::deinit_without_freeing_arena` (src/bundler/bundle_v2.rs), passes the pointer stored in `workers_assignments`. Same code path and order as before; no behaviour change.

I could not find a path that creates a `Worker` off a pool thread today (all nine `Worker::get` callers are pool-task callbacks, and pool threads always have `Thread::current()` set), so the `else` branch looks defensive; the `if` branch is the one that matters in practice.

### Tests

test/internal/source-lints/self-receiver-teardown.test.ts bans `deinit(..)` / `destroy(..)` / `finalize(..)` calls whose argument is `self` spelled as a raw pointer (`ptr::from_mut(self)`, `self as *mut _`, `&raw mut *self`, `addr_of_mut!(*self)`, `NonNull::from(self)`, with or without a trailing cast), and the deferred `scopeguard::guard(ptr::from_mut(self), |p| Self::destroy(p))` form; it checks the patterns against positive and negative examples and ratchets an allowlist. On `main` it reports exactly

```
src/bundler/ThreadPool.rs:590: Self::deinit(std::ptr::from_mut::<Self>(self))
```

The other files that carry the shape are allowlisted at their current counts, so each conversion deletes its entry: src/install/lifecycle_script_runner.rs (5, #37551), src/runtime/node/node_fs.rs (3, #37693), src/runtime/webcore/blob/copy_file.rs (2) and read_file.rs (1, both #37705). The ratchet has already fired once: #37716 converting `ArrayBufferSink` landed while this was open, the entry went stale, and the Source lints job failed on the merge commit until the entry was deleted, which is the intended behaviour. #37693 and #37705 add this same file; the copies share the same body and differ in which entry each one deletes (this one additionally matches nested turbofish, `from_mut(&mut *self)` and a parenthesized cast, and names the file when the ratchet fails), so whichever lands first, the other two resolve the add/add conflict by taking the landed file and deleting their own entry. The header states the boundary honestly: the callee name list is what is enforced (src/runtime/dns_jsc/dns.rs's `on_cares_complete` sites have the same shape under another name and are being converted separately; the name can be added once they are), and refcount releases (`deref(..)`), a bare `self` coerced to `*mut Self` by the callee, and the `heap::take` / `Box::from_raw` layer (covered by self-receiver-reclaim.test.ts, now on main) are out of scope.

### Verification

Debug (ASAN) build: test/bundler/bun-build-api.test.ts (52 pass) and test/bundler/bundler_plugin.test.ts (53 pass), which tear down workers through the `if` branch on every build including the failing ones; `bun bd test test/internal/source-lints/` (18 files, 82 tests) passes, and the new lint fails with the two src files at their `main` versions, reporting exactly the line shown above. `cargo clippy` and `cargo fmt --check` on `bun_bundler` are clean.

</details>
