### PR TITLE
streams: deliver a direct stream's idle-time flush to the next read

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -9,6 +9,7 @@
 #include "JSReadRequest.h"
 #include "JSReadableStream.h"
 #include "JSReadableStreamDefaultReader.h"
+#include "JSSink.h"
 #include "JSStreamsRuntime.h"
 #include "WebCoreJSClientData.h"
 #include "WebStreamsHeapAnalyzer.h"
@@ -30,6 +31,7 @@
 #include <wtf/text/StringBuilder.h>
 
 extern "C" void Bun__Process__queueNextTick2(Zig::GlobalObject*, JSC::EncodedJSValue func, JSC::EncodedJSValue arg1, JSC::EncodedJSValue arg2);
+extern "C" bool ArrayBufferSink__hasBufferedBytes(void* sinkPtr); // src/runtime/webcore/ArrayBufferSink.rs
 
 namespace WebCore {
 
@@ -366,11 +368,22 @@ static JSValue endDirectSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
     return {};
 }
 
+// Whether flushDirectSink would currently produce bytes.
+static bool directSinkHoldsBytes(JSDirectStreamController* controller)
+{
+    if (controller->m_sinkKind != DirectSinkKind::ArrayBuffer)
+        return false;
+    auto* sink = dynamicDowncast<JSArrayBufferSink>(controller->m_arrayBufferSink.get());
+    if (!sink)
+        return false;
+    void* sinkPtr = sink->wrapped();
+    return sinkPtr && ArrayBufferSink__hasBufferedBytes(sinkPtr);
+}
+
 // `sink.flush()`: only the ArrayBuffer sink produces bytes; the Text/Array sinks return 0.
-// onFlush calls this once it has a consumer for the result, which is what both flags wait for.
+// onFlush calls this once it has a consumer for the result, which is what m_flushDeferred waits for.
 static JSValue flushDirectSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirectStreamController* controller)
 {
-    controller->m_sinkHoldsWrites = false;
     controller->m_flushDeferred = false;
     switch (controller->m_sinkKind) {
     case DirectSinkKind::ArrayBuffer: {
@@ -705,7 +718,7 @@ void JSDirectStreamController::onFlush(JSGlobalObject* globalObject)
     if (m_closed || (m_sinkKind == DirectSinkKind::ArrayBuffer && !m_arrayBufferSink))
         return;
     // Stands unless a consumer below takes the bytes (flushDirectSink clears it again).
-    m_flushDeferred = m_sinkHoldsWrites;
+    m_flushDeferred = directSinkHoldsBytes(this);
     auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(stream->m_reader.get());
     if (!reader)
         return;
@@ -869,9 +882,6 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject *
         return JSValue::encode(jsNumber(0));
     JSValue wrote = writeToDirectSink(globalObject, controller, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
-    // An empty chunk comes back as 0 and buffered nothing.
-    if (!(wrote.isNumber() && wrote.asNumber() == 0))
-        controller->m_sinkHoldsWrites = true;
     controller->armEndOfTickFlush(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(wrote);

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -367,8 +367,11 @@ static JSValue endDirectSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirect
 }
 
 // `sink.flush()`: only the ArrayBuffer sink produces bytes; the Text/Array sinks return 0.
+// onFlush calls this once it has a consumer for the result, which is what both flags wait for.
 static JSValue flushDirectSink(JSC::VM& vm, JSGlobalObject* globalObject, JSDirectStreamController* controller)
 {
+    controller->m_sinkHoldsWrites = false;
+    controller->m_flushDeferred = false;
     switch (controller->m_sinkKind) {
     case DirectSinkKind::ArrayBuffer: {
         JSObject* sink = controller->m_arrayBufferSink.get();
@@ -543,21 +546,18 @@ JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject, bool read
         return jsUndefined();
 
     int8_t deferredClose = 0;
-    int8_t deferredFlush = 0;
+    bool drainSink = false;
 
     // Serialize pull(): while an async pull's promise is pending, subsequent reads install
     // m_pendingRead for it to deliver into via flush()/end(); its fulfillment reaction
     // clears m_pullInFlight and re-pulls if a consumer is still waiting.
     if (!m_pullInFlight) {
         m_deferClose = -1;
-        m_deferFlush = -1;
 
         JSValue abrupt = callDirectPull(vm, globalObject, this);
 
         deferredClose = m_deferClose;
-        deferredFlush = m_deferFlush;
         m_deferClose = 0;
-        m_deferFlush = 0;
         // A VM termination from the pull, or a failure while registering the reaction.
         RETURN_IF_EXCEPTION(scope, {});
 
@@ -570,12 +570,14 @@ JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject, bool read
                 return jsUndefined();
             RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, abrupt));
         }
+        // Flushed before this read existed, by this pull() or by the source between pulls.
+        drainSink = m_flushDeferred;
     } else {
         // A new read arrived while an async pull is pending: the fulfillment reaction will
         // re-pull. Drain anything that pull already wrote; onFlush is a no-op-restore on an
         // empty sink.
         m_pullAgain = true;
-        deferredFlush = 1;
+        drainSink = true;
     }
 
     // controller.error() inside pull is not deferred: re-validate before registering a consumer.
@@ -614,7 +616,7 @@ JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject, bool read
         m_deferCloseReason.clear();
         onClose(globalObject, reason);
         RETURN_IF_EXCEPTION(scope, {});
-    } else if (deferredFlush == 1) {
+    } else if (drainSink) {
         onFlush(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
     }
@@ -702,7 +704,8 @@ void JSDirectStreamController::onFlush(JSGlobalObject* globalObject)
         return;
     if (m_closed || (m_sinkKind == DirectSinkKind::ArrayBuffer && !m_arrayBufferSink))
         return;
-    // No default reader: return WITHOUT deferring.
+    // Stands unless a consumer below takes the bytes (flushDirectSink clears it again).
+    m_flushDeferred = m_sinkHoldsWrites;
     auto* reader = dynamicDowncast<JSReadableStreamDefaultReader>(stream->m_reader.get());
     if (!reader)
         return;
@@ -740,11 +743,7 @@ void JSDirectStreamController::onFlush(JSGlobalObject* globalObject)
                 m_pullAgain = true;
             RELEASE_AND_RETURN(scope, readableStreamFulfillReadRequest(globalObject, stream, flushed, false));
         }
-        return;
     }
-
-    if (m_deferFlush == -1)
-        m_deferFlush = 1;
 }
 
 static bool takeDirectPullAgain(JSDirectStreamController* controller)
@@ -784,12 +783,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullFulfilled, (JSGlobalObj
     while (pullAgain && !controller->m_closed && !controller->m_pullInFlight
         && directControllerHasWaitingConsumer(controller, controller->m_stream.get())) {
         controller->m_deferClose = -1;
-        controller->m_deferFlush = -1;
         JSValue abrupt = callDirectPull(vm, globalObject, controller);
         int8_t deferredClose = controller->m_deferClose;
-        int8_t deferredFlush = controller->m_deferFlush;
         controller->m_deferClose = 0;
-        controller->m_deferFlush = 0;
         RETURN_IF_EXCEPTION(scope, {});
         if (!abrupt.isEmpty()) {
             controller->handleError(globalObject, abrupt);
@@ -805,7 +801,7 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullFulfilled, (JSGlobalObj
             // An async re-pull left m_pullInFlight set: its own fulfillment reaction drains
             // and picks up m_pullAgain.
             if (controller->m_pullInFlight) {
-                if (deferredFlush == 1)
+                if (controller->m_flushDeferred)
                     controller->onFlush(globalObject);
                 RETURN_IF_EXCEPTION(scope, {});
                 break;
@@ -873,6 +869,9 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_boundDirectWrite, (JSGlobalObject *
         return JSValue::encode(jsNumber(0));
     JSValue wrote = writeToDirectSink(globalObject, controller, callFrame->argument(1));
     RETURN_IF_EXCEPTION(scope, {});
+    // An empty chunk comes back as 0 and buffered nothing.
+    if (!(wrote.isNumber() && wrote.asNumber() == 0))
+        controller->m_sinkHoldsWrites = true;
     controller->armEndOfTickFlush(globalObject);
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(wrote);

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -68,9 +68,7 @@ public:
     // Once closed, the five methods are no-ops (there is NO "swap all 5 methods to a
     // throwing stub" trick).
     bool m_closed : 1 { false };
-    // write() buffered bytes that flushDirectSink has not taken out yet.
-    bool m_sinkHoldsWrites : 1 { false };
-    // A flush found nothing waiting for those bytes; onPull drains them into the read it adds.
+    // A flush found bytes but nothing waiting for them; onPull drains them into the read it adds.
     bool m_flushDeferred : 1 { false };
     // An async pull()'s returned promise has not yet settled; cleared by its settlement
     // reactions. m_pullAgain is set only when a NEW read arrives while m_pullInFlight

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -63,13 +63,15 @@ public:
     JSC::WriteBarrier<JSC::Unknown> m_deferCloseReason;
     // -1 = pull in progress (reentrancy guard), 0 = idle, 1 = close deferred
     int8_t m_deferClose { 0 };
-    // -1 = pull in progress, 0 = idle, 1 = flush deferred
-    int8_t m_deferFlush { 0 };
     // which of the 3 sink flavors this controller runs.
     DirectSinkKind m_sinkKind { DirectSinkKind::ArrayBuffer };
     // Once closed, the five methods are no-ops (there is NO "swap all 5 methods to a
     // throwing stub" trick).
     bool m_closed : 1 { false };
+    // write() buffered bytes that flushDirectSink has not taken out yet.
+    bool m_sinkHoldsWrites : 1 { false };
+    // A flush found nothing waiting for those bytes; onPull drains them into the read it adds.
+    bool m_flushDeferred : 1 { false };
     // An async pull()'s returned promise has not yet settled; cleared by its settlement
     // reactions. m_pullAgain is set only when a NEW read arrives while m_pullInFlight
     // (edge-triggered, matching the spec default controller's [[pullAgain]]).

--- a/src/runtime/webcore/ArrayBufferSink.rs
+++ b/src/runtime/webcore/ArrayBufferSink.rs
@@ -189,9 +189,7 @@ impl ArrayBufferSink {
     }
 }
 
-/// Whether a streaming sink holds bytes that `flush()` would hand out.
-/// `JSDirectStreamController` calls this with the null-checked
-/// `JSArrayBufferSink::wrapped()` pointer, like the codegen `__memoryCost` thunk.
+/// `JSDirectStreamController` passes a live (null-checked) `JSArrayBufferSink::wrapped()`.
 #[unsafe(no_mangle)]
 pub extern "C" fn ArrayBufferSink__hasBufferedBytes(this: &ArrayBufferSink) -> bool {
     !this.bytes.is_empty()

--- a/src/runtime/webcore/ArrayBufferSink.rs
+++ b/src/runtime/webcore/ArrayBufferSink.rs
@@ -189,6 +189,14 @@ impl ArrayBufferSink {
     }
 }
 
+/// Whether a streaming sink holds bytes that `flush()` would hand out.
+/// `JSDirectStreamController` calls this with the null-checked
+/// `JSArrayBufferSink::wrapped()` pointer, like the codegen `__memoryCost` thunk.
+#[unsafe(no_mangle)]
+pub extern "C" fn ArrayBufferSink__hasBufferedBytes(this: &ArrayBufferSink) -> bool {
+    !this.bytes.is_empty()
+}
+
 // `JsSinkType` impl: routes the codegen `ArrayBufferSink__*` thunks (via
 // `JSSink::<Self>::js_*`) into the inherent streaming methods above. Mirrors
 // `Sink.JSSink(@This(), "ArrayBufferSink")`.

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1292,6 +1292,38 @@ describe("multi-chunk consumers produce exactly the concatenated bytes", () => {
       },
     );
 
+    // Or from the re-pull that an async pull()'s settlement issues for a read that queued up
+    // behind it: once that read is served, a further flush by the re-pull finds nothing waiting.
+    it.each([
+      ["returns synchronously", () => {}],
+      ["returns a promise", () => Promise.resolve()],
+    ])(
+      "flushed by a settlement re-pull (which %s) after it served its read are served to the next read()",
+      async (_, finishRePull) => {
+        const { promise: firstPull, resolve: settleFirstPull } = Promise.withResolvers();
+        const { rs, state } = makeSource((c, pulls) => {
+          if (pulls === 1) return firstPull;
+          if (pulls !== 2) return;
+          c.write("a");
+          c.flush(); // into the read that queued up while the first pull() was pending
+          c.write("b");
+          c.flush(); // nothing is waiting any more
+          return finishRePull();
+        });
+        const reader = rs.getReader();
+        const first = reader.read();
+        const second = reader.read();
+        state.ctrl.write("x");
+        state.ctrl.flush();
+        expect(decode((await first).value)).toBe("x");
+        settleFirstPull();
+        expect({ second: decode((await second).value), pulls: state.pulls }).toEqual({ second: "a", pulls: 2 });
+        await macrotask();
+        const third = reader.read();
+        expect({ third: await valueOrStalled(third), pulls: state.pulls }).toEqual({ third: "b", pulls: 3 });
+      },
+    );
+
     // The converse: a read only drains the sink when a flush was left holding bytes. A pull()
     // that writes without flushing keeps relying on the end-of-tick flush, so bytes written
     // later in the same tick still share its chunk.
@@ -1305,6 +1337,16 @@ describe("multi-chunk consumers produce exactly the concatenated bytes", () => {
 
       it("on a fresh stream", async () => {
         const { rs, state } = makeSource(c => c.write("a"));
+        expect(await readBatchesWithSameTickWrite(rs.getReader(), state)).toBe("ab");
+      });
+
+      it("when the pull() flush()ed before writing", async () => {
+        // A flush() that found nothing buffered defers nothing, even inside pull() (it used to
+        // make the read drain as soon as pull() returned, splitting "a" off).
+        const { rs, state } = makeSource(c => {
+          c.flush();
+          c.write("a");
+        });
         expect(await readBatchesWithSameTickWrite(rs.getReader(), state)).toBe("ab");
       });
 

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1169,6 +1169,186 @@ describe("multi-chunk consumers produce exactly the concatenated bytes", () => {
     });
   });
 
+  // Bytes the source flushes while no read is waiting stay in the controller's sink. The
+  // read issued next must drain them itself: a source that already flushed has no reason to
+  // flush again, so otherwise that read hangs until the source happens to flush or end.
+  describe("bytes a direct stream's source flushed while nothing was waiting", () => {
+    const decode = chunk => new TextDecoder().decode(chunk);
+    const macrotask = () => new Promise(resolve => setImmediate(resolve));
+    // A read this bug stalls settles only on the source's NEXT flush, so it is still pending
+    // once the microtask queue has drained; a read served from the sink has settled by then.
+    const valueOrStalled = read =>
+      Promise.race([read.then(({ value }) => decode(value)), macrotask().then(() => "stalled")]);
+    // Unless a test passes a pull(), it is only the per-read demand signal: the test writes
+    // every byte itself, so it decides whether a read is waiting at the time.
+    const makeSource = (pull = () => {}) => {
+      const state = { ctrl: undefined, pulls: 0 };
+      const rs = new ReadableStream({
+        type: "direct",
+        pull(c) {
+          state.ctrl = c;
+          state.pulls++;
+          return pull(c, state.pulls);
+        },
+      });
+      return { rs, state };
+    };
+    const readOne = async (reader, state, text) => {
+      const read = reader.read();
+      state.ctrl.write(text);
+      state.ctrl.flush();
+      return decode((await read).value);
+    };
+    // Written (and flushed, unless the test is about a bare write) with nothing waiting. The
+    // macrotask yield is the point: it also puts the write's own end-of-tick flush behind us.
+    // A read issued in the same tick as the write would be served by that flush, and the sink
+    // would never be left holding bytes that nothing is going to flush again.
+    const writeWhileIdle = async (state, text, { flush = true } = {}) => {
+      state.ctrl.write(text);
+      if (flush) state.ctrl.flush();
+      await macrotask();
+    };
+
+    it.each([
+      ["explicitly flushed", { flush: true }],
+      ["flushed only by the write's end-of-tick flush", { flush: false }],
+    ])("are served to the next read() of a sync-pull stream (%s)", async (_, options) => {
+      const { rs, state } = makeSource();
+      const reader = rs.getReader();
+      expect(await readOne(reader, state, "x")).toBe("x");
+
+      await writeWhileIdle(state, "y", options);
+      // pull() still runs as this read's demand signal; the bytes come from the sink.
+      const read = reader.read();
+      expect({ read: await valueOrStalled(read), pulls: state.pulls }).toEqual({ read: "y", pulls: 2 });
+      // Delivered exactly once: the following flush reaches the following read.
+      expect(await readOne(reader, state, "z")).toBe("z");
+    });
+
+    it("are served to the next read() even though that read's pull() parks on a promise", async () => {
+      const { promise: parked, resolve: unpark } = Promise.withResolvers();
+      const { rs, state } = makeSource((_, pulls) => (pulls === 1 ? Promise.resolve() : parked));
+      const reader = rs.getReader();
+      expect(await readOne(reader, state, "x")).toBe("x");
+
+      await writeWhileIdle(state, "y");
+      const read = reader.read();
+      expect({ read: await valueOrStalled(read), pulls: state.pulls }).toEqual({ read: "y", pulls: 2 });
+      unpark();
+    });
+
+    it("are served to the next for-await step", async () => {
+      const { rs, state } = makeSource();
+      const iterator = rs[Symbol.asyncIterator]();
+      const first = iterator.next();
+      state.ctrl.write("x");
+      state.ctrl.flush();
+      expect(decode((await first).value)).toBe("x");
+
+      await writeWhileIdle(state, "y");
+      expect(await valueOrStalled(iterator.next())).toBe("y");
+      await iterator.return();
+    });
+
+    it("are served to the first read() of the next reader when no reader was attached at the time", async () => {
+      const { rs, state } = makeSource();
+      const first = rs.getReader();
+      expect(await readOne(first, state, "x")).toBe("x");
+      first.releaseLock();
+
+      await writeWhileIdle(state, "y");
+      expect(await valueOrStalled(rs.getReader().read())).toBe("y");
+    });
+
+    // The flush can also come from inside a pull(): from the async tail of the previous one,
+    // which then settles with nothing waiting. (A later pull() that is itself async and settles
+    // is no variant: its settlement drains the sink either way.)
+    it.each([
+      ["returns synchronously", () => {}],
+      ["parks on a promise", () => new Promise(() => {})],
+    ])(
+      "flushed by the previous pull()'s async tail are served to the next read(), whose pull() %s",
+      async (_, laterPull) => {
+        let tail;
+        const { rs, state } = makeSource((c, pulls) => {
+          if (pulls > 1) return laterPull();
+          tail = (async () => {
+            await macrotask();
+            c.write("x");
+            c.flush(); // into the first read
+            await macrotask();
+            c.write("y");
+            c.flush(); // nothing is waiting; this pull() is still in flight
+          })();
+          return tail;
+        });
+        const reader = rs.getReader();
+        expect(decode((await reader.read()).value)).toBe("x");
+        await tail;
+        // The first pull()'s settlement has been processed too, and found nothing waiting.
+        await macrotask();
+        const read = reader.read();
+        expect({ read: await valueOrStalled(read), pulls: state.pulls }).toEqual({ read: "y", pulls: 2 });
+      },
+    );
+
+    // The converse: a read only drains the sink when a flush was left holding bytes. A pull()
+    // that writes without flushing keeps relying on the end-of-tick flush, so bytes written
+    // later in the same tick still share its chunk.
+    describe("do not make other reads drain eagerly", () => {
+      const readBatchesWithSameTickWrite = async (reader, state) => {
+        const read = reader.read();
+        // pull() wrote "a" inside read(); this write lands after read() returned.
+        state.ctrl.write("b");
+        return decode((await read).value);
+      };
+
+      it("on a fresh stream", async () => {
+        const { rs, state } = makeSource(c => c.write("a"));
+        expect(await readBatchesWithSameTickWrite(rs.getReader(), state)).toBe("ab");
+      });
+
+      it.each([
+        ["a flush() with nothing buffered", state => state.ctrl.flush()],
+        ['a write("") (nothing gets buffered for it) and its flush', state => writeWhileIdle(state, "")],
+        ["a write() of an empty Uint8Array and its flush", state => writeWhileIdle(state, new Uint8Array(0))],
+      ])("after %s while nothing was waiting", async (_, idle) => {
+        const { rs, state } = makeSource(c => c.write("a"));
+        const reader = rs.getReader();
+        expect(decode((await reader.read()).value)).toBe("a");
+        await idle(state);
+        await macrotask();
+        expect(await readBatchesWithSameTickWrite(reader, state)).toBe("ab");
+      });
+
+      it("for a read issued synchronously after one that did drain", async () => {
+        const { rs, state } = makeSource(c => c.write("a"));
+        const reader = rs.getReader();
+        expect(decode((await reader.read()).value)).toBe("a");
+
+        await writeWhileIdle(state, "y");
+        const drained = reader.read();
+        const batched = readBatchesWithSameTickWrite(reader, state);
+        // The deferred "y" and its own pull()'s "a" drain into the first read (without the
+        // drain, everything piles up into it at the end of the tick and the second read hangs).
+        expect(decode((await drained).value)).toBe("ya");
+        // That drain is spent: the second read batches like the very first one did.
+        expect(await batched).toBe("ab");
+      });
+
+      it("for a read issued after the end-of-tick flush armed by a draining read's pull() found the sink empty", async () => {
+        const { rs, state } = makeSource(c => c.write("a"));
+        const reader = rs.getReader();
+        expect(decode((await reader.read()).value)).toBe("a");
+
+        await writeWhileIdle(state, "y");
+        expect(decode((await reader.read()).value)).toBe("ya");
+        await macrotask();
+        expect(await readBatchesWithSameTickWrite(reader, state)).toBe("ab");
+      });
+    });
+  });
+
   it("a patched Object.prototype.then that releases the reader mid-resolution does not crash", async () => {
     let releaseNow = null;
     Object.defineProperty(Object.prototype, "then", {


### PR DESCRIPTION
### Problem
- A `type: "direct"` ReadableStream read from JS: when the source writes and flushes while no `read()` is pending, the next `read()` hangs until the source flushes or ends again, and then gets the stalled bytes batched with the new ones. The repro below prints `STALLED` then `yz` on 1.4.0 and main; expected `y`.
- Same stall for a bare `write()` between reads, a flush made from a pull's async tail or from a settlement re-pull, `readMany()` and for-await, a reader attached after the flush, and a next `pull()` that returns a pending promise.
- Cause: a flush with nobody waiting left the bytes in the sink and recorded nothing durable. The only record of it lived during the synchronous part of a `pull()` call, so a later read drained the sink only if its own `pull()` had flushed synchronously.
- Not affected: reads that arrive while an async pull is still in flight (that path already drains), and direct streams served by `Bun.serve` (driven by the native HTTP sink, not this controller).

### Fix
- The pull-scoped tri-state is replaced by one persistent bit. Every flush sets it to "the sink holds bytes right now"; flushing the sink into a consumer clears it. So it is set exactly when a flush had bytes but nobody to give them to, whenever that flush happened.
- The next read (and the re-pull loop after an async pull settles) drains the sink into itself when the bit is set. Property to check: flushed bytes reach the first consumer to appear, and only once.
- The bit is computed by asking the sink whether it holds bytes (a small new Rust extern), so a `flush()` or empty `write()` with nothing buffered defers nothing and same-tick writes inside a `pull()` still batch into one chunk. One deliberate change: a `flush()` inside `pull()` before any write no longer splits later same-tick writes; a test pins that.
- Verification: 16 new tests in `streams.test.js`; 11 fail on current bun (nine stall cases, two batching cases) and all pass with the fix. The rest of the streams suite and the related body and serve tests still pass.

### Background
- A `type: "direct"` ReadableStream is a Bun extension: instead of enqueueing chunks, `pull(controller)` gets `write()`, `flush()` and `end()`. Writes accumulate in a native sink (an ArrayBufferSink for bytes) and a flush turns what is buffered into one chunk for a reader.
- Every `write()` also arms an end-of-tick flush, which is why same-tick writes normally arrive as one chunk and why a bare `write()` between reads hits the same bug as an explicit flush.
- `JSDirectStreamController` is the C++ adapter between that sink and the WHATWG reader side. It is only installed when the stream is consumed from JS (reader, tee, pipeTo, for-await, `.text()`); its `onPull` runs the source's `pull()` per read, and `onFlush` hands buffered bytes to a waiting read.
- `pull()` may return a promise. While it is pending later reads queue behind it, and its settlement re-pulls if a consumer is still waiting; several stall variants are flushes made from that async tail or from the re-pull, after the read they were serving was already satisfied.
- `m_deferClose` uses the same tri-state (-1 while inside `pull()`) and stays as the re-entrancy marker; only the flush half is replaced.

<details>
<summary>Original description</summary>

### Repro

A `type: "direct"` ReadableStream read from JS, whose source writes and flushes while no `read()` is pending:

```js
let ctrl;
const rs = new ReadableStream({ type: "direct", pull(c) { ctrl = c; } });
const r = rs.getReader();
const p1 = r.read();
ctrl.write("x"); ctrl.flush();
await p1;                                  // "x"
ctrl.write("y"); ctrl.flush();             // nobody is reading right now
await Bun.sleep(10);
const p2 = r.read();                       // pull() runs again, then... nothing
console.log(await Promise.race([p2.then(v => new TextDecoder().decode(v.value)), Bun.sleep(200).then(() => "STALLED")]));
ctrl.write("z"); ctrl.flush();
console.log(new TextDecoder().decode((await p2).value));
```

Bun 1.4.0 and main print `STALLED` and then `yz`: the second read only settles when the source flushes (or ends) again, and the stalled bytes arrive batched with the new ones. Expected: the second read resolves with `y`. The same happens for a bare `write()` between reads (its end-of-tick flush finds nobody either), for a consumer-less flush made from the async tail of a `pull()` whose promise then settles, or by the re-pull that such a settlement issues, for `readMany()` and for-await, after `releaseLock()` when a new reader attaches, and when the next `pull()` returns a promise that stays pending.

### Cause

`JSDirectStreamController::onFlush` does not flush the sink unless a consumer is registered. The only memory of a consumer-less flush was the tail `if (m_deferFlush == -1) m_deferFlush = 1;`, which is live only while `onPull` is inside the synchronous part of `pull()` (`onPull` sets `-1` before the call and resets to `0` right after it returns). A flush between two pulls, or from a pull's async tail, therefore left the bytes in the sink and recorded nothing, and the next `onPull` only drained when the `pull()` it had just run had flushed synchronously (`deferredFlush == 1`).

This only bites when no pull is in flight when the read arrives (a sync `pull()`, or an async one whose promise already settled): the `m_pullInFlight` branch of `onPull` already drains unconditionally after registering the read, which is why the existing test "a write buffered while no reader is waiting is delivered on the next read" passes.

### Fix

Replace the `m_deferFlush` tri-state with one persistent bit, `m_flushDeferred`:

- `onFlush` sets it on entry to whether the sink currently holds bytes (`directSinkHoldsBytes`: a new `ArrayBufferSink__hasBufferedBytes` extern over the `JSArrayBufferSink::wrapped()` pointer, the same shape as the codegen `__memoryCost` thunk; the Text/Array sinks never produce anything from `flush()`, so they never defer), and `flushDirectSink` clears it. It therefore stands exactly when a flush (explicit or end-of-tick, inside a pull or between pulls, with or without a reader attached) had bytes but nobody to give them to.
- `onPull` drains the sink into the read it registers when the bit is set; the settlement re-pull loop reads the same bit where it used to read `deferredFlush`.

Why this shape: a flush means "deliver what is buffered", and when nobody is there the only sensible time to do that is the next read, which is what the in-flight branch already does. Asking the sink (rather than tracking writes in a second flag, which an earlier revision of this PR did) means a `flush()` or empty `write()` with nothing buffered defers nothing, so a `pull()` that writes without flushing still relies on the end-of-tick flush and writes made later in the same tick still share its chunk, and no read pays for an empty `sink.flush()`. `m_deferClose == -1` remains the re-entrancy marker for "inside pull()"; `m_deferFlush` had no other reader.

One behaviour besides the stall changes on purpose: a `flush()` issued inside `pull()` before anything was written used to make that read drain as soon as `pull()` returned (so bytes written later in the pull were split off from same-tick writes); it now defers nothing, the same as such a flush does between pulls. The test "when the pull() flush()ed before writing" pins this.

`JSDirectStreamController` is only installed when a direct stream is consumed from JS (reader, tee, pipeTo, for-await, the `.text()` / `readableStreamToArray` consume loop). A direct stream served by `Bun.serve` is driven by the native HTTP sink and does not go through this file. Rebased onto #37692, which restructured `onPull` for queued read requests; with it, the drain for a for-await/tee/pipeTo read goes through `onFlush`'s read-request branch.

### Verification

New tests in `test/js/web/streams/streams.test.js` (`bytes a direct stream's source flushed while nothing was waiting`):

- stall cases: explicit flush and bare write on a sync-pull stream (also checking the following flush reaches the following read), a next `pull()` that parks on a promise, a consumer-less flush made from the previous pull's async tail (next pull sync / parked) and by the settlement re-pull after it served its read (re-pull sync / async), for-await, and a reader attached after the flush;
- negative contract ("do not make other reads drain eagerly"): same-tick batching on a fresh stream, when the pull flushed before writing, after an idle `flush()` with nothing buffered, after an idle `write("")` / `write(new Uint8Array(0))`, synchronously after a read that did drain, and after the end-of-tick flush that follows a draining read.

`USE_SYSTEM_BUN=1 bun test test/js/web/streams/streams.test.js -t "flushed while nothing was waiting"`: 11 fail (nine stall cases, the synchronous follow-up read whose bytes all pile into the previous read on main, and the flush-before-write case which gets `"a"`), 5 pass. With the fix, `bun bd test` passes all 16, the rest of `streams.test.js` (191 tests, also under `BUN_JSC_validateExceptionChecks=1`), `body.test.ts`, `body-stream.test.ts`, `body-async-iterator.test.ts`, `html-rewriter.test.js`, `AsyncLocalStorage.test.ts`, `serve-direct-readable-stream.test.ts` and `sync-pull-fast-path.test.ts` still pass; `cargo clippy -p bun_runtime` is clean.

</details>
