### PR TITLE
shell: keep OutputTask boxed through the vtable and output queues

### DIFF
--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -8,17 +8,17 @@ use crate::shell::interpreter::{
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
 use crate::shell::{ExitCode, ShellErr};
+use core::ops::ControlFlow;
 
 #[derive(Default)]
 pub struct Cp {
     pub(crate) opts: Opts,
     pub(crate) state: State,
-    /// FIFO of in-flight OutputTask pointers awaiting an IOWriter chunk
-    /// completion. Stopgap until `WriterTag` can carry the `*mut OutputTask`
-    /// directly (see mkdir.rs `Exec::output_queue`). Lives on `Cp` (not
-    /// `ExecState`) because `print_shell_cp_task` is also driven from
-    /// `State::Ebusy` on Windows; both states must be able to stash/pop.
-    pub(crate) output_queue: std::collections::VecDeque<*mut OutputTask<Cp>>,
+    /// Tasks parked while their IOWriter chunk is in flight; the chunk's
+    /// `ChildPtr` only names the builtin, so completions are matched FIFO.
+    /// Lives on `Cp` (not `ExecState`) because `print_shell_cp_task` is also
+    /// driven from `State::Ebusy` on Windows.
+    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Cp>>>,
 }
 
 #[derive(Default)]
@@ -199,9 +199,7 @@ impl Cp {
             return Builtin::done(interp, cmd, 1);
         }
         if let Some(task) = Self::state_mut(interp, cmd).output_queue.pop_front() {
-            // SAFETY: `task` was heap-allocated in `OutputTask::new` and
-            // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Cp>::on_io_writer_chunk(task, interp, written, e) };
+            return OutputTask::<Cp>::on_io_writer_chunk(task, interp, written, e);
         }
         Self::next(interp, cmd)
     }
@@ -330,25 +328,23 @@ impl OutputTaskVTable for Cp {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        task: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield> {
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
         if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
-            // Stash so on_io_writer_chunk can route to the OutputTask state
-            // machine and reclaim the box (stopgap for missing WriterTag).
-            Self::state_mut(interp, cmd).output_queue.push_back(child);
+            Self::state_mut(interp, cmd).output_queue.push_back(task);
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Some(
+            return ControlFlow::Break(
                 Builtin::of_mut(interp, cmd)
                     .stderr
                     .enqueue(childptr, errbuf, safeguard),
             );
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        None
+        ControlFlow::Continue(task)
     }
     fn on_write_err(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
@@ -358,25 +354,23 @@ impl OutputTaskVTable for Cp {
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield> {
+        task: Box<OutputTask<Self>>,
+        output: &[u8],
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
         if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-            Self::state_mut(interp, cmd).output_queue.push_back(child);
+            Self::state_mut(interp, cmd).output_queue.push_back(task);
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            let buf = output.slice().to_vec();
-            return Some(
+            return ControlFlow::Break(
                 Builtin::of_mut(interp, cmd)
                     .stdout
-                    .enqueue(childptr, &buf, safeguard),
+                    .enqueue(childptr, output, safeguard),
             );
         }
-        let buf = output.slice().to_vec();
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-        None
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, output);
+        ControlFlow::Continue(task)
     }
     fn on_write_out(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {

--- a/src/runtime/shell/builtin/ls.rs
+++ b/src/runtime/shell/builtin/ls.rs
@@ -1,3 +1,4 @@
+use core::ops::ControlFlow;
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicUsize, Ordering};
 use std::io::Write as _;
@@ -35,10 +36,9 @@ pub struct ExecState {
     pub(crate) tasks_done: usize,
     pub(crate) output_waiting: usize,
     pub(crate) output_done: usize,
-    /// FIFO of in-flight OutputTask pointers awaiting an IOWriter chunk
-    /// completion. Stopgap until `WriterTag` can carry the `*mut OutputTask`
-    /// directly — see mkdir.rs `Exec::output_queue` for rationale.
-    pub(crate) output_queue: std::collections::VecDeque<*mut OutputTask<Ls>>,
+    /// Tasks parked while their IOWriter chunk is in flight; the chunk's
+    /// `ChildPtr` only names the builtin, so completions are matched FIFO.
+    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Ls>>>,
 }
 
 enum ParseFlag {
@@ -188,9 +188,7 @@ impl Ls {
             None
         };
         if let Some(task) = pending {
-            // SAFETY: `task` was heap-allocated in `OutputTask::new` and
-            // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Ls>::on_io_writer_chunk(task, interp, written, e) };
+            return OutputTask::<Ls>::on_io_writer_chunk(task, interp, written, e);
         }
         Self::next(interp, cmd)
     }
@@ -278,27 +276,25 @@ impl OutputTaskVTable for Ls {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        task: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield> {
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
         if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
-            // Stash so on_io_writer_chunk can route to the OutputTask state
-            // machine and reclaim the box (stopgap for missing WriterTag).
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
+                exec.output_queue.push_back(task);
             }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Some(
+            return ControlFlow::Break(
                 Builtin::of_mut(interp, cmd)
                     .stderr
                     .enqueue(childptr, errbuf, safeguard),
             );
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        None
+        ControlFlow::Continue(task)
     }
     fn on_write_err(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
@@ -308,27 +304,25 @@ impl OutputTaskVTable for Ls {
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield> {
+        task: Box<OutputTask<Self>>,
+        output: &[u8],
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
         if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
+                exec.output_queue.push_back(task);
             }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            let buf = output.slice().to_vec();
-            return Some(
+            return ControlFlow::Break(
                 Builtin::of_mut(interp, cmd)
                     .stdout
-                    .enqueue(childptr, &buf, safeguard),
+                    .enqueue(childptr, output, safeguard),
             );
         }
-        let buf = output.slice().to_vec();
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-        None
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, output);
+        ControlFlow::Continue(task)
     }
     fn on_write_out(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -8,6 +8,7 @@ use crate::shell::interpreter::{
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
+use core::ops::ControlFlow;
 use core::ptr::NonNull;
 
 #[derive(Default)]
@@ -36,13 +37,9 @@ pub struct Exec {
     /// self-reference).
     pub(crate) args_start: usize,
     pub(crate) err: Option<bun_sys::Error>,
-    /// FIFO of in-flight OutputTask pointers awaiting an IOWriter chunk
-    /// completion. Stopgap until `WriterTag` can carry the `*mut OutputTask`
-    /// directly (IOWriter.rs is out of scope here): `write_err`/`write_out`
-    /// push, `on_io_writer_chunk` pops and forwards to
-    /// `OutputTask::on_io_writer_chunk` so the box is reclaimed and the
-    /// writeErr→writeOut→onDone state machine runs.
-    pub(crate) output_queue: std::collections::VecDeque<*mut OutputTask<Mkdir>>,
+    /// Tasks parked while their IOWriter chunk is in flight; the chunk's
+    /// `ChildPtr` only names the builtin, so completions are matched FIFO.
+    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Mkdir>>>,
 }
 
 impl Mkdir {
@@ -149,9 +146,7 @@ impl Mkdir {
             State::Idle | State::Done => panic!("Invalid state"),
         };
         if let Some(task) = pending {
-            // SAFETY: `task` was heap-allocated in `OutputTask::new` and
-            // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Mkdir>::on_io_writer_chunk(task, interp, written, e) };
+            return OutputTask::<Mkdir>::on_io_writer_chunk(task, interp, written, e);
         }
         Self::next(interp, cmd)
     }
@@ -186,30 +181,25 @@ impl OutputTaskVTable for Mkdir {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        task: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield> {
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
         if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
-            // OutputTask has no `WriterTag` of its own (it is not directly
-            // dispatchable as an IOWriter child), so the enqueue is tagged
-            // `WriterTag::Builtin` and `child` is stashed on `output_queue`;
-            // `on_io_writer_chunk` pops it to route the completion back to
-            // the OutputTask state machine and reclaim the box.
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
+                exec.output_queue.push_back(task);
             }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Some(
+            return ControlFlow::Break(
                 Builtin::of_mut(interp, cmd)
                     .stderr
                     .enqueue(childptr, errbuf, safeguard),
             );
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        None
+        ControlFlow::Continue(task)
     }
 
     fn on_write_err(interp: &Interpreter, cmd: NodeId) {
@@ -221,29 +211,25 @@ impl OutputTaskVTable for Mkdir {
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield> {
+        task: Box<OutputTask<Self>>,
+        output: &[u8],
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
         if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
-            // See write_err — stash `child` so the chunk callback routes to
-            // OutputTask::on_io_writer_chunk.
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
+                exec.output_queue.push_back(task);
             }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            let buf = output.slice().to_vec();
-            return Some(
+            return ControlFlow::Break(
                 Builtin::of_mut(interp, cmd)
                     .stdout
-                    .enqueue(childptr, &buf, safeguard),
+                    .enqueue(childptr, output, safeguard),
             );
         }
-        let buf = output.slice().to_vec();
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-        None
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, output);
+        ControlFlow::Continue(task)
     }
 
     fn on_write_out(interp: &Interpreter, cmd: NodeId) {

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -6,6 +6,7 @@ use crate::shell::interpreter::{
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
+use core::ops::ControlFlow;
 
 #[derive(Default)]
 pub struct Touch {
@@ -30,10 +31,9 @@ pub struct ExecState {
     /// Index into argv where filepath args start.
     pub(crate) args_start: usize,
     pub(crate) err: Option<bun_sys::Error>,
-    /// FIFO of in-flight OutputTask pointers awaiting an IOWriter chunk
-    /// completion. Stopgap until `WriterTag` can carry the `*mut OutputTask`
-    /// directly — see mkdir.rs `Exec::output_queue` for rationale.
-    pub(crate) output_queue: std::collections::VecDeque<*mut OutputTask<Touch>>,
+    /// Tasks parked while their IOWriter chunk is in flight; the chunk's
+    /// `ChildPtr` only names the builtin, so completions are matched FIFO.
+    pub(crate) output_queue: std::collections::VecDeque<Box<OutputTask<Touch>>>,
 }
 
 impl Touch {
@@ -137,9 +137,7 @@ impl Touch {
             None
         };
         if let Some(task) = pending {
-            // SAFETY: `task` was heap-allocated in `OutputTask::new` and
-            // pushed by `write_err`/`write_out`; not yet freed.
-            return unsafe { OutputTask::<Touch>::on_io_writer_chunk(task, interp, written, e) };
+            return OutputTask::<Touch>::on_io_writer_chunk(task, interp, written, e);
         }
         Self::next(interp, cmd)
     }
@@ -170,27 +168,25 @@ impl OutputTaskVTable for Touch {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        task: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield> {
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
         if let Some(safeguard) = Builtin::of(interp, cmd).stderr.needs_io() {
-            // Stash so on_io_writer_chunk can route to the OutputTask state
-            // machine and reclaim the box (stopgap for missing WriterTag).
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
+                exec.output_queue.push_back(task);
             }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Some(
+            return ControlFlow::Break(
                 Builtin::of_mut(interp, cmd)
                     .stderr
                     .enqueue(childptr, errbuf, safeguard),
             );
         }
         let _ = Builtin::write_no_io(interp, cmd, IoKind::Stderr, errbuf);
-        None
+        ControlFlow::Continue(task)
     }
     fn on_write_err(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
@@ -200,27 +196,25 @@ impl OutputTaskVTable for Touch {
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield> {
+        task: Box<OutputTask<Self>>,
+        output: &[u8],
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>> {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
             exec.output_waiting += 1;
         }
         if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
             if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.output_queue.push_back(child);
+                exec.output_queue.push_back(task);
             }
             let childptr = ChildPtr::new(cmd, WriterTag::Builtin);
-            let buf = output.slice().to_vec();
-            return Some(
+            return ControlFlow::Break(
                 Builtin::of_mut(interp, cmd)
                     .stdout
-                    .enqueue(childptr, &buf, safeguard),
+                    .enqueue(childptr, output, safeguard),
             );
         }
-        let buf = output.slice().to_vec();
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
-        None
+        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, output);
+        ControlFlow::Continue(task)
     }
     fn on_write_out(interp: &Interpreter, cmd: NodeId) {
         if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -30,6 +30,7 @@ use bun_core::WTFStringImplExt as _;
 use bun_jsc::JsCell;
 use core::cell::Cell;
 use core::fmt;
+use core::ops::ControlFlow;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 
 use bun_sys::{self, Fd};
@@ -2399,6 +2400,12 @@ impl OutputSrc {
     }
 }
 
+impl Default for OutputSrc {
+    fn default() -> Self {
+        OutputSrc::Arrlist(Vec::new())
+    }
+}
+
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum OutputTaskState {
     WaitingWriteErr,
@@ -2406,34 +2413,31 @@ pub enum OutputTaskState {
     Done,
 }
 
-/// Vtable trait the parent builtin implements. All hooks
-/// take `(&mut Interpreter, NodeId)` (NodeId style — the parent builtin lives
-/// inside the interpreter's node arena).
-///
-/// `child` is the heap-allocated `OutputTask` itself, passed so `write_*` can
-/// register it as the IOWriter callback target.
+/// Vtable trait the parent builtin implements. All hooks take
+/// `(&Interpreter, NodeId)`: the parent builtin lives in the interpreter's
+/// node arena. `write_err`/`write_out` either park the task in the builtin's
+/// output queue and `Break` with the enqueue's `Yield` (park first: the writer
+/// may complete the chunk synchronously), or write without IO and
+/// `Continue(task)`.
 pub trait OutputTaskVTable: Sized {
     fn write_err(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
+        task: Box<OutputTask<Self>>,
         errbuf: &[u8],
-    ) -> Option<Yield>;
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>>;
     fn on_write_err(interp: &Interpreter, cmd: NodeId);
     fn write_out(
         interp: &Interpreter,
         cmd: NodeId,
-        child: *mut OutputTask<Self>,
-        output: &mut OutputSrc,
-    ) -> Option<Yield>;
+        task: Box<OutputTask<Self>>,
+        output: &[u8],
+    ) -> ControlFlow<Yield, Box<OutputTask<Self>>>;
     fn on_write_out(interp: &Interpreter, cmd: NodeId);
     fn on_done(interp: &Interpreter, cmd: NodeId) -> Yield;
 }
 
 /// A task that can write to stdout and/or stderr.
-///
-/// Heap-allocated (`heap::alloc`) so the IOWriter can hold a raw pointer to
-/// it across async chunks; freed by `deinit`.
 pub struct OutputTask<P: OutputTaskVTable> {
     /// Owning Cmd node (the builtin's `cmd` id).
     pub(crate) parent: NodeId,
@@ -2452,84 +2456,65 @@ impl<P: OutputTaskVTable> OutputTask<P> {
         })
     }
 
-    /// Takes the freshly-constructed task by `Box` (callers always pair `new`
-    /// → `start`), leaks it to the raw `*mut Self` the IOWriter callback chain
-    /// needs, and drives the first state transition. The box is reclaimed by
-    /// [`Self::deinit`] (via `heap::take`) when the task reaches `Done`.
-    pub(crate) fn start(me: Box<Self>, interp: &Interpreter, errbuf: Option<&[u8]>) -> Yield {
-        // Leak so `P::write_*` can stash `this` as the IOWriter's `ChildPtr`;
-        // address is stable for the task's lifetime. Re-derive `&mut` per
-        // step (the `P::*` callbacks re-enter via raw `this`, not a reborrow
-        // of `me`).
-        let this = bun_core::heap::into_raw(me);
-        // SAFETY: `this` is a fresh, uniquely-owned heap allocation.
-        unsafe {
-            let me = &mut *this;
-            log!(
-                "OutputTask(0x{:x}) start errbuf={:?}",
-                this as usize,
-                errbuf.map(|b| b.len())
-            );
-            me.state = OutputTaskState::WaitingWriteErr;
-            if let Some(err) = errbuf {
-                if let Some(y) = P::write_err(interp, me.parent, this, err) {
-                    return y;
-                }
-                return Self::next(this, interp);
-            }
-            me.state = OutputTaskState::WaitingWriteOut;
-            if let Some(y) = P::write_out(interp, me.parent, this, &mut me.output) {
-                return y;
-            }
-            P::on_write_out(interp, me.parent);
-            me.state = OutputTaskState::Done;
-            Self::deinit(this, interp)
+    pub(crate) fn start(mut me: Box<Self>, interp: &Interpreter, errbuf: Option<&[u8]>) -> Yield {
+        log!(
+            "OutputTask(0x{:x}) start errbuf={:?}",
+            &raw const *me as usize,
+            errbuf.map(|b| b.len())
+        );
+        me.state = OutputTaskState::WaitingWriteErr;
+        let Some(err) = errbuf else {
+            return Self::write_out(me, interp);
+        };
+        let parent = me.parent;
+        match P::write_err(interp, parent, me, err) {
+            ControlFlow::Break(y) => y,
+            ControlFlow::Continue(me) => Self::next(me, interp),
         }
     }
 
-    pub(crate) unsafe fn next(this: *mut Self, interp: &Interpreter) -> Yield {
-        // SAFETY: caller contract — see `start`.
-        unsafe {
-            let me = &mut *this;
-            match me.state {
-                OutputTaskState::WaitingWriteErr => {
-                    P::on_write_err(interp, me.parent);
-                    me.state = OutputTaskState::WaitingWriteOut;
-                    if let Some(y) = P::write_out(interp, me.parent, this, &mut me.output) {
-                        return y;
-                    }
-                    P::on_write_out(interp, me.parent);
-                    me.state = OutputTaskState::Done;
-                    Self::deinit(this, interp)
-                }
-                OutputTaskState::WaitingWriteOut => {
-                    P::on_write_out(interp, me.parent);
-                    me.state = OutputTaskState::Done;
-                    Self::deinit(this, interp)
-                }
-                OutputTaskState::Done => panic!("Invalid state"),
+    fn next(mut me: Box<Self>, interp: &Interpreter) -> Yield {
+        match me.state {
+            OutputTaskState::WaitingWriteErr => {
+                P::on_write_err(interp, me.parent);
+                Self::write_out(me, interp)
             }
+            OutputTaskState::WaitingWriteOut => {
+                P::on_write_out(interp, me.parent);
+                me.state = OutputTaskState::Done;
+                Self::deinit(me, interp)
+            }
+            OutputTaskState::Done => panic!("Invalid state"),
         }
     }
 
-    pub(crate) unsafe fn on_io_writer_chunk(
-        this: *mut Self,
+    fn write_out(mut me: Box<Self>, interp: &Interpreter) -> Yield {
+        me.state = OutputTaskState::WaitingWriteOut;
+        let parent = me.parent;
+        let output = core::mem::take(&mut me.output);
+        match P::write_out(interp, parent, me, output.slice()) {
+            ControlFlow::Break(y) => y,
+            ControlFlow::Continue(me) => Self::next(me, interp),
+        }
+    }
+
+    pub(crate) fn on_io_writer_chunk(
+        me: Box<Self>,
         interp: &Interpreter,
         _written: usize,
         _err: Option<bun_sys::SystemError>,
     ) -> Yield {
-        log!("OutputTask(0x{:x}) onIOWriterChunk", this as usize);
-        // SAFETY: `this` is the live heap-allocated `OutputTask` guaranteed by
-        // this fn's caller contract; forwarded unchanged to `next`.
-        unsafe { Self::next(this, interp) }
+        log!(
+            "OutputTask(0x{:x}) onIOWriterChunk",
+            &raw const *me as usize
+        );
+        Self::next(me, interp)
     }
 
-    /// Fires `on_done` then frees.
-    unsafe fn deinit(this: *mut Self, interp: &Interpreter) -> Yield {
-        // SAFETY: `this` was heap-allocated in `new`; reclaim and drop.
-        let me = unsafe { bun_core::heap::take(this) };
+    /// Frees the task, then fires `on_done`.
+    fn deinit(me: Box<Self>, interp: &Interpreter) -> Yield {
         debug_assert!(me.state == OutputTaskState::Done);
-        log!("OutputTask(0x{:x}) deinit", this as usize);
+        log!("OutputTask(0x{:x}) deinit", &raw const *me as usize);
         let parent = me.parent;
         drop(me);
         P::on_done(interp, parent)


### PR DESCRIPTION
### Problem
- No user-visible bug. The shell's `ls`, `mkdir`, `touch` and `cp` builtins print each finished task's output through an `OutputTask`, and every in-flight one was held as a raw pointer.
- The task was boxed on creation, leaked to a pointer at once, parked in the builtin's queue as that pointer, and freed by hand. Nothing in the types said who owned it, and a task still parked when the builtin was torn down leaked.
- Each stdout write also copied the task's bytes with `to_vec()` before handing them to the writer.

### Fix
- The write hooks take the task as a `Box` and hand it back: `Continue(task)` after a synchronous write, or `Break(yield)` after parking the box in the queue. The state machine's steps become safe fns that pass the box along; the last one drops it and fires `on_done` as before.
- Ordering is unchanged: the task is still parked before the enqueue, popped FIFO, and freed at the same point. Only the owner is now named by the type, and the queue frees anything still parked at teardown.
- No added cost: the box is the allocation that already existed, and the stdout bytes are moved out of the task and passed as a slice, so the copies go away. Removes 8 unsafe blocks and 3 `unsafe fn`s.
- Verification: `cargo check` and `clippy` clean; the shell tests were run in a debug build. 20 fail, 18 of them identically on main; the other 2 were 5s timeouts in a slow run that pass on main. No new test, this is a refactor.

### Background
- These four builtins fan file work out to a thread pool. As each pool task finishes, its stderr and stdout are printed by an `OutputTask`, a small state machine (write err, write out, `on_done`) whose hooks the builtin implements.
- Builtin output goes through an `IOWriter`. When the destination needs real IO the bytes are enqueued and the builtin is called back later; a hook returns a `Yield` to hand control back to the interpreter until then. Otherwise the write finishes synchronously.
- The callback names only the builtin, not which task, so each builtin keeps a FIFO `output_queue` and matches completions to parked tasks in order. This PR changes what the queue holds, not the matching.
- `ControlFlow<B, C>` is std's "stop with B, or keep going with C" enum; `Break` carries the `Yield`, `Continue` carries the task back for the next step.
- `OutputSrc` is the task's stdout buffer; it gains `Default` so `mem::take` can move the bytes out before the task itself is passed to the hook.

<details>
<summary>Original description</summary>

## What

`OutputTask` (`src/runtime/shell/interpreter.rs`) is the small writeErr/writeOut/onDone state machine the `ls`, `mkdir`, `touch` and `cp` builtins run once per finished pool task. `OutputTask::new` already returned a `Box`, but `start` immediately turned it into a raw pointer so the `OutputTaskVTable` write hooks could receive `child: *mut OutputTask<Self>` and push it onto the builtin's `output_queue: VecDeque<*mut OutputTask<_>>` before enqueueing the chunk; `next`, `on_io_writer_chunk` and `deinit` were `unsafe fn`s over that pointer, each builtin's `on_io_writer_chunk` popped the pointer and called the unsafe entry point, and each `write_out` copied the task's bytes with `to_vec()` before handing them to the writer.

```rust
// before
fn write_err(interp: &Interpreter, cmd: NodeId, child: *mut OutputTask<Self>, errbuf: &[u8]) -> Option<Yield>;
fn write_out(interp: &Interpreter, cmd: NodeId, child: *mut OutputTask<Self>, output: &mut OutputSrc) -> Option<Yield>;
pub(crate) output_queue: VecDeque<*mut OutputTask<Ls>>,

// after
fn write_err(interp: &Interpreter, cmd: NodeId, task: Box<OutputTask<Self>>, errbuf: &[u8]) -> ControlFlow<Yield, Box<OutputTask<Self>>>;
fn write_out(interp: &Interpreter, cmd: NodeId, task: Box<OutputTask<Self>>, output: &[u8]) -> ControlFlow<Yield, Box<OutputTask<Self>>>;
pub(crate) output_queue: VecDeque<Box<OutputTask<Ls>>>,
```

The hooks now take the task by value. When the stream needs async IO the builtin parks the `Box` in its queue (still before the enqueue, so the ordering relative to completions the writer may deliver synchronously is unchanged) and returns `Break` with the enqueue's `Yield`; otherwise it writes synchronously and returns `Continue(task)`, and `OutputTask` moves the box into the next step. `start`, `next`, `on_io_writer_chunk` and `deinit` are safe fns taking `Box<Self>`; `deinit` drops the box and fires `on_done` in the same order as before. The bytes for `write_out` are taken out of the task (`OutputSrc` gains a `Default` impl for `mem::take`) and passed as a slice, so the 8 `to_vec()` copies in the four `write_out` impls are gone. The four builtins' `on_io_writer_chunk` become `OutputTask::on_io_writer_chunk(task, ..)` on the popped `Box`. This removes 8 unsafe blocks and 3 `unsafe fn`s; the 4 `new`/`start` call sites are unchanged. 5 files, 136 insertions, 183 deletions.

## Why

Who owns an in-flight `OutputTask` is now visible in the types: the caller of `start` until a hook takes it, the builtin's `output_queue` while a chunk is pending, and nobody once `deinit` drops it; a task still parked when a builtin is torn down is freed with the queue instead of leaked. It is zero-cost: the `Box` is the allocation `new` already made, `VecDeque<Box<T>>` has the same element size and backing buffer as `VecDeque<*mut T>`, `ControlFlow` replaces `Option<Yield>` on the same return path, and the only added work is the three-word `mem::take`, which replaces a heap allocation, copy and free per `write_out`.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. bun bd test test/js/bun/shell/commands/ls.test.ts test/js/bun/shell/shell-cmdsub-crash.test.ts test/js/bun/shell/bunshell.test.ts test/js/bun/shell/leak.test.ts: debug build succeeds; 470 pass, 2 skip, 20 fail, of which 18 fail identically on main in this environment (/dev/null is a regular file here: condexprs -c, -f character device and the 7 zero-length stdin-redirect cases; running as root: ls permission denied directory / recursive; 7 memleak_* 500-run/128KB-blob cases hit their 100s debug-build timeout on main too); shell-cmdsub-crash.test.ts passes fully.
The other 2 (fd leak > #11816 > external, bunshell ls > recursive > node_modules) were 5s timeouts in a run where unrelated tests also ran ~2x slower than on main (main passes them at 4.6s/3.7s); #11816 external spawns only external processes and never reaches OutputTask, and the recursive-ls tests that do (ls recursive basic, -Ra/-RA, fdleak_ls x1000, memleak_protect ls -R) pass on this branch.

</details>
