### PR TITLE
socket: own DuplexUpgradeContext's SSL_CTX ref with OwnedSslCtx

### DIFF
--- a/src/boringssl_sys/boringssl.rs
+++ b/src/boringssl_sys/boringssl.rs
@@ -300,6 +300,10 @@ impl OwnedSslCtx {
         self.0.as_ptr()
     }
 
+    pub fn as_non_null(&self) -> core::ptr::NonNull<SSL_CTX> {
+        self.0
+    }
+
     /// Transfers the reference back out; the caller must free it.
     pub fn into_raw(self) -> *mut SSL_CTX {
         core::mem::ManuallyDrop::new(self).0.as_ptr()

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -14,7 +14,6 @@
 
 use core::cell::Cell;
 use core::ffi::{CStr, c_uint, c_void};
-use core::ptr::NonNull;
 
 use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{CallFrame, GlobalRef, JSGlobalObject, JSValue, JsCell, JsResult, host_fn};
@@ -485,26 +484,19 @@ impl UpgradedDuplex {
         Ok(())
     }
 
-    /// Adopts `ctx` (one ref) — freed on both success (via `wrapper.deinit`) and
-    /// error. Mirrors `start_tls` but skips the
+    /// Mirrors `start_tls` but skips the
     /// `SSLConfig.asUSockets() → us_ssl_ctx_from_options()` round-trip so a
     /// memoised `SecureContext` can be reused on the duplex/named-pipe path.
     pub(crate) fn start_tls_with_ctx(
         &self,
-        ctx: *mut bun_boringssl_sys::SSL_CTX,
+        ctx: bun_boringssl_sys::OwnedSslCtx,
         is_client: bool,
         verify: ServerVerify,
     ) -> Result<(), crate::Error> {
-        // errdefer SSL_CTX_free(ctx) — free the adopted ref on the error path only.
-        let ctx_guard = scopeguard::guard(ctx, |ctx| {
-            // SAFETY: ctx is a valid SSL_CTX* with one ref adopted by this fn.
-            unsafe { bun_boringssl_sys::SSL_CTX_free(ctx) };
-        });
-        let ctx_nn =
-            NonNull::new(ctx).expect("caller passes a non-null SSL_CTX* with one adopted ref");
-        let wrapper = WrapperType::init_with_ctx(ctx_nn, is_client, self.wrapper_handlers())?;
-        // Success: disarm the errdefer.
-        scopeguard::ScopeGuard::into_inner(ctx_guard);
+        let wrapper =
+            WrapperType::init_with_ctx(ctx.as_non_null(), is_client, self.wrapper_handlers())?;
+        // `init_with_ctx` adopted the ref; `SSLWrapper::deinit` frees it.
+        let _ = ctx.into_raw();
         self.install_and_start(wrapper, verify);
         Ok(())
     }

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -3528,13 +3528,13 @@ impl<const SSL: bool> NewSocket<SSL> {
         let vm = handlers.vm;
 
         let cfg = ssl_opts.as_ref();
-        let ctx_ptr = owned_ctx.as_ref().map(|c| c.as_ptr());
-        let reject_unauthorized = upgrade_reject_policy(vm, cfg, is_server, ctx_ptr);
+        let ctx = owned_ctx.as_ref();
+        let reject_unauthorized = upgrade_reject_policy(vm, cfg, is_server, ctx);
         let (adopt_request_cert, adopt_reject_unauthorized) = match cfg {
             Some(c) => (c.request_cert != 0, c.reject_unauthorized != 0),
             None => (
-                server_ctx_requests_cert(ctx_ptr),
-                server_ctx_rejects_unauthorized(ctx_ptr),
+                server_ctx_requests_cert(ctx),
+                server_ctx_rejects_unauthorized(ctx),
             ),
         };
         let mut initial_flags = Flags::initial(reject_unauthorized);
@@ -4131,7 +4131,7 @@ fn upgrade_reject_policy(
     vm: &VirtualMachine,
     cfg: Option<&SSLConfig>,
     is_server: bool,
-    ctx: Option<*mut SSL_CTX>,
+    ctx: Option<&boringssl_sys::OwnedSslCtx>,
 ) -> bool {
     if cfg.is_none() && is_server {
         server_ctx_rejects_unauthorized(ctx)
@@ -4143,18 +4143,20 @@ fn upgrade_reject_policy(
 /// A bare server-side `secureContext` carries no parsed config, so the policy
 /// comes from the ctx itself: `us_ssl_ctx_from_options` sets
 /// `FAIL_IF_NO_PEER_CERT` iff the context was created with `rejectUnauthorized`.
-fn server_ctx_rejects_unauthorized(ctx: Option<*mut SSL_CTX>) -> bool {
+fn server_ctx_rejects_unauthorized(ctx: Option<&boringssl_sys::OwnedSslCtx>) -> bool {
     let Some(ctx) = ctx else { return false };
     const MODE: c_int =
         boringssl_sys::SSL_VERIFY_PEER | boringssl_sys::SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
-    // SAFETY: `ctx` is the +1 `SSL_CTX` ref held for this socket; read-only.
-    unsafe { boringssl_sys::SSL_CTX_get_verify_mode(ctx) & MODE == MODE }
+    // SAFETY: `ctx` owns a live `SSL_CTX` ref; read-only.
+    unsafe { boringssl_sys::SSL_CTX_get_verify_mode(ctx.as_ptr()) & MODE == MODE }
 }
 
-fn server_ctx_requests_cert(ctx: Option<*mut SSL_CTX>) -> bool {
+fn server_ctx_requests_cert(ctx: Option<&boringssl_sys::OwnedSslCtx>) -> bool {
     let Some(ctx) = ctx else { return false };
-    // SAFETY: `ctx` is the +1 `SSL_CTX` ref held for this socket; read-only.
-    unsafe { boringssl_sys::SSL_CTX_get_verify_mode(ctx) & boringssl_sys::SSL_VERIFY_PEER != 0 }
+    // SAFETY: `ctx` owns a live `SSL_CTX` ref; read-only.
+    unsafe {
+        boringssl_sys::SSL_CTX_get_verify_mode(ctx.as_ptr()) & boringssl_sys::SSL_VERIFY_PEER != 0
+    }
 }
 
 impl Default for Flags {
@@ -4231,10 +4233,10 @@ pub(crate) struct DuplexUpgradeContext {
     /// Config to build a fresh `SSL_CTX` from (legacy `{ca,cert,key}` callers).
     /// Mutually exclusive with `owned_ctx` — `runEvent` prefers `owned_ctx`.
     pub ssl_config: Option<SSLConfig>,
-    /// One ref on a prebuilt `SSL_CTX` (from `opts.tls.secureContext` — the
-    /// memoised `tls.createSecureContext` path). Adopted by `startTLSWithCTX`
-    /// on success, freed in `deinit` if Close races ahead of StartTLS.
-    pub owned_ctx: Option<*mut SSL_CTX>,
+    /// One ref on a prebuilt `SSL_CTX` (from `opts.tls.secureContext`, the
+    /// memoised `tls.createSecureContext` path). `StartTLS` moves it into the
+    /// SSL wrapper; if Close races ahead it drops with the context in `deinit`.
+    pub owned_ctx: Option<boringssl_sys::OwnedSslCtx>,
     pub is_open: bool,
     /// Server-side `requestCert`/`rejectUnauthorized`, applied to the `SSL*`
     /// when `StartTLS` builds it. Unused for client upgrades.
@@ -4460,8 +4462,6 @@ impl DuplexUpgradeContext {
                     let is_client = (*this).mode == SocketMode::Client;
                     let verify = (*this).server_verify;
                     if let Some(ctx) = (*this).owned_ctx.take() {
-                        // Transfer the ref into SSLWrapper; null first so the
-                        // failure path / deinit don't double-free it.
                         (*this).upgrade.start_tls_with_ctx(ctx, is_client, verify)
                     } else if let Some(config) = &(*this).ssl_config {
                         (*this).upgrade.start_tls(config, is_client, verify)
@@ -4589,12 +4589,6 @@ impl DuplexUpgradeContext {
                 if let Some(tls) = (*this).tls.take() {
                     // Release the owner's +1.
                     tls.deref();
-                }
-                // Close raced ahead of StartTLS — drop the unconsumed config.
-                (*this).ssl_config = None;
-                if let Some(ctx) = (*this).owned_ctx.take() {
-                    // SAFETY: BoringSSL FFI; we hold one owned ref.
-                    boringssl_sys::SSL_CTX_free(ctx);
                 }
             }
         }
@@ -4727,12 +4721,8 @@ pub fn js_upgrade_duplex_to_tls(
         default_data.ensure_still_alive();
     }
 
-    let reject_unauthorized = upgrade_reject_policy(
-        handlers.vm,
-        socket_config,
-        is_server,
-        owned_ctx.as_ref().map(|c| c.as_ptr()),
-    );
+    let reject_unauthorized =
+        upgrade_reject_policy(handlers.vm, socket_config, is_server, owned_ctx.as_ref());
     // Server-side peer-cert policy, applied per-SSL once the engine exists.
     // A bare `secureContext` carries no parsed config, so read `requestCert`
     // back off the ctx's verify mode the same way `upgrade_reject_policy` does
@@ -4740,7 +4730,7 @@ pub fn js_upgrade_duplex_to_tls(
     let server_verify = crate::socket::upgraded_duplex::ServerVerify {
         request_cert: match socket_config {
             Some(cfg) => cfg.request_cert != 0,
-            None => server_ctx_requests_cert(owned_ctx.as_ref().map(|c| c.as_ptr())),
+            None => server_ctx_requests_cert(owned_ctx.as_ref()),
         },
         reject_unauthorized,
     };
@@ -4780,9 +4770,6 @@ pub fn js_upgrade_duplex_to_tls(
     let tls_js_value = tls_ref.get_this_value(global);
     TLSSocket::data_set_cached(tls_js_value, global, default_data);
 
-    // The +1 `SSL_CTX` ref transfers into `DuplexUpgradeContext.owned_ctx` below.
-    let owned_ctx_taken = owned_ctx.map(|c| c.into_raw());
-
     // `DuplexUpgradeContext` is self-referential: `task.ctx` and
     // `upgrade.handlers.ctx` both point at the containing allocation, and
     // `UpgradedDuplex` has fn-ptr-niched fields plus a `Drop` impl, so it
@@ -4806,12 +4793,12 @@ pub fn js_upgrade_duplex_to_tls(
         // `ssl_config` for SSL_CTX construction; servername/ALPN already
         // copied onto `tls` above so the config's only remaining use is the
         // legacy build path.
-        ptr::addr_of_mut!((*duplex_context).ssl_config).write(if owned_ctx_taken.is_none() {
+        ptr::addr_of_mut!((*duplex_context).ssl_config).write(if owned_ctx.is_none() {
             ssl_opts.take()
         } else {
             None
         });
-        ptr::addr_of_mut!((*duplex_context).owned_ctx).write(owned_ctx_taken);
+        ptr::addr_of_mut!((*duplex_context).owned_ctx).write(owned_ctx);
         ptr::addr_of_mut!((*duplex_context).is_open).write(false);
         ptr::addr_of_mut!((*duplex_context).server_verify).write(server_verify);
         ptr::addr_of_mut!((*duplex_context).mode).write(if is_server {


### PR DESCRIPTION
### Problem
- No user-visible bug; this is a type-system hardening change. `upgradeDuplexToTLS` with a `secureContext` holds one `SSL_CTX` ref from the JS call until the queued `StartTLS` task builds the TLS engine.
- That ref was a bare `*mut SSL_CTX`, so ownership lived in comments and three hand-maintained sites: `into_raw()` at construction, an `SSL_CTX_free` in `deinit` for a Close that beats `StartTLS`, and a scopeguard plus null re-check on the `StartTLS` error path.
- Nothing checked those sites against each other, so a new teardown exit could leak the ref or free it twice.

### Fix
- The field becomes `Option<OwnedSslCtx>` and `start_tls_with_ctx` takes it by value; the caller already had one and now moves it in. Drop is the same `SSL_CTX_free` the deleted code called; the field shrinks from 16 bytes to 8.
- Both hand-written `SSL_CTX_free` calls are deleted. Property to check: every path that does not hand the ref to the SSL wrapper drops it (the `?` on the error path, or the `Box` that `deinit` already reclaims), and the one path that does calls `into_raw()` only after the wrapper accepted it.
- Verification: no new test. `cargo check` and `clippy` are clean; the existing node tls upgrade suites pass (83 pass, 1 failure that fails identically on the base commit).
- Left alone: `TLSSocket.owned_ssl_ctx` and the Windows named-pipe path still hold raw pointers.

### Background
- `SSL_CTX` is BoringSSL's refcounted TLS configuration object; each holder owns one ref and releases it with `SSL_CTX_free`. A `tls.createSecureContext` result is memoised, so an upgrade given one adopts a ref instead of building a context from `{ca, cert, key}`.
- `OwnedSslCtx` (`boringssl_sys`) is bun's RAII wrapper for one such ref: dropping it frees, `into_raw()` hands the ref out and suppresses the drop. This PR adds `as_non_null()` because the wrapper constructor takes a `NonNull`.
- `DuplexUpgradeContext` is the heap object behind a duplex upgrade. The engine is built by a queued `StartTLS` task, and a Close can run first; that race is what the manual free in `deinit` existed for.
- `SSLWrapper::init_with_ctx` adopts the ref it is given and frees it in its own deinit, so on success the caller must give up its ref rather than let it drop.

<details>
<summary>Original description</summary>

## What

`DuplexUpgradeContext` (`src/runtime/socket/socket_body.rs`) is the heap context behind `upgradeDuplexToTLS`; when the caller passes a `secureContext` it carries one `SSL_CTX` ref from construction until the queued `StartTLS` task builds the TLS engine. That ref was held as `owned_ctx: Option<*mut SSL_CTX>` with the ownership rules in a doc comment: `js_upgrade_duplex_to_tls` already held an `Option<OwnedSslCtx>` and called `into_raw()` on it only to store the bare pointer, `deinit` freed the pointer by hand for the case where Close runs before `StartTLS`, and `UpgradedDuplex::start_tls_with_ctx` (`src/runtime/socket/UpgradedDuplex.rs`) took the raw pointer, armed a `scopeguard` that called `SSL_CTX_free` on the error path, and re-checked the pointer with `NonNull::new(..).expect(..)` before handing it to `SSLWrapper::init_with_ctx`.

```rust
// before
pub owned_ctx: Option<*mut SSL_CTX>,
pub(crate) fn start_tls_with_ctx(&self, ctx: *mut SSL_CTX, ..) -> Result<(), Error>

// after
pub owned_ctx: Option<boringssl_sys::OwnedSslCtx>,
pub(crate) fn start_tls_with_ctx(&self, ctx: OwnedSslCtx, ..) -> Result<(), Error>
```

The builder now moves its `Option<OwnedSslCtx>` straight into the field. `run_event` still does `owned_ctx.take()` and passes the value to `start_tls_with_ctx`, whose body is now the `init_with_ctx(ctx.as_non_null(), ..)?` call (the `?` drops `ctx`, which is what the scopeguard did) followed by `ctx.into_raw()` once the wrapper holds the ref. The manual free in `deinit` is gone: a context torn down before `StartTLS` drops `owned_ctx` (and the sibling `ssl_config`, which `deinit` also reset by hand) with the `Box` that `deinit` already reclaims. The three upgrade policy helpers (`upgrade_reject_policy`, `server_ctx_rejects_unauthorized`, `server_ctx_requests_cert`) take `Option<&OwnedSslCtx>` instead of `Option<*mut SSL_CTX>`, so their two call sites (`upgrade_tls_impl` and `js_upgrade_duplex_to_tls`) pass `owned_ctx.as_ref()` instead of `.as_ref().map(|c| c.as_ptr())`. `OwnedSslCtx` (`src/boringssl_sys/boringssl.rs`) gains a two-line `as_non_null()` because `SSLWrapper::init_with_ctx` takes a `NonNull`. Removes both hand-written `SSL_CTX_free` calls: the scopeguard closure in `start_tls_with_ctx` (the one unsafe block this change removes, together with the scopeguard and the `expect`) and the call in `deinit`, whose enclosing unsafe block stays for the `tls` deref; `start_tls_with_ctx` has exactly one caller. 3 files, 32 insertions, 49 deletions.

Left as they are: `TLSSocket.owned_ssl_ctx` (the real-socket upgrade path) and the Windows named-pipe `init_tls_wrapper`, which hold their refs as raw pointers through their own lifecycles and are separate changes.

## Why

Who frees the duplex context's `SSL_CTX` ref is now stated by the types: the field owns it, `start_tls_with_ctx` consumes it, and every teardown exit (`deinit`, reached from the Close task, both `StartTLS` failure paths and `release_unrun`) frees it through `OwnedSslCtx::drop`, so an unconsumed ref cannot leak or be freed twice by a new exit path. It is zero-cost: `Option<OwnedSslCtx>` is 8 bytes (`NonNull` niche) where `Option<*mut SSL_CTX>` was 16, `OwnedSslCtx::drop` is the same `SSL_CTX_free` call the deleted code made, `as_non_null()` returns the stored `NonNull` so the null re-check disappears, and all of this runs once per upgrade at setup or teardown.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. bun bd test test/js/node/tls/node-tls-duplex-close-throw-uaf.test.ts test/js/node/tls/node-tls-upgrade.test.ts test/js/node/http2/node-http2-upgrade.test.mts test/js/node/tls/node-tls-server.test.ts: 83 pass, 1 fail. The one failure ("SNICallback runs even when the requested servername matches the bind hostname" in node-tls-server.test.ts, connect ECONNREFUSED 127.0.0.1 from localhost IPv4/IPv6 resolution) is pre-existing: it fails identically on main at the branch's base commit 54d6d16cc and is unrelated to the duplex-upgrade changes.

</details>
