### PR TITLE
streams: deliver a direct stream's post-flush bytes to pipeTo/tee/for-await read requests

### DIFF
--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.cpp
@@ -503,7 +503,7 @@ static JSValue callDirectPull(JSC::VM& vm, JSGlobalObject* globalObject, JSDirec
     return {};
 }
 
-JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject)
+JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject, bool readRequestQueued)
 {
     auto& vm = getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
@@ -514,8 +514,8 @@ JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject)
         JSValue chunk = m_finalChunk.get();
         m_finalChunk.clear();
         auto* stream = m_stream.get();
-        // Non-Promise readers (for-await/tee/pipeTo) queue the request BEFORE this call and
-        // drop the returned promise; deliver through chunkSteps instead of a wrapped promise.
+        // A queued read request (for-await/tee/pipeTo) takes the chunk through its own
+        // chunkSteps; a promise-backed read gets it wrapped in the returned promise.
         if (stream && readableStreamHasDefaultReader(stream) && readableStreamGetNumReadRequests(stream) > 0) {
             readableStreamFulfillReadRequest(globalObject, stream, chunk, false);
             RETURN_IF_EXCEPTION(scope, {});
@@ -558,15 +558,18 @@ JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject)
         deferredFlush = m_deferFlush;
         m_deferClose = 0;
         m_deferFlush = 0;
-
-        if (!abrupt.isEmpty()) {
-            // A synchronous throw from pull errors the stream and rejects the returned read.
-            handleError(globalObject, abrupt);
-            RETURN_IF_EXCEPTION(scope, {});
-            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, abrupt));
-        }
         // A VM termination from the pull, or a failure while registering the reaction.
         RETURN_IF_EXCEPTION(scope, {});
+
+        if (!abrupt.isEmpty()) {
+            // A synchronous throw from pull errors the stream, which settles a queued read
+            // request through its errorSteps; a promise-backed read gets the rejection here.
+            handleError(globalObject, abrupt);
+            RETURN_IF_EXCEPTION(scope, {});
+            if (readRequestQueued)
+                return jsUndefined();
+            RELEASE_AND_RETURN(scope, promiseRejectedWith(globalObject, abrupt));
+        }
     } else {
         // A new read arrived while an async pull is pending: the fulfillment reaction will
         // re-pull. Drain anything that pull already wrote; onFlush is a no-op-restore on an
@@ -575,9 +578,12 @@ JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject)
         deferredFlush = 1;
     }
 
-    // controller.error() inside pull is not deferred: re-validate before adding a read request.
+    // controller.error() inside pull is not deferred: re-validate before registering a consumer.
+    // A queued read request was already settled by the stream's error/close steps.
     stream = m_stream.get();
     if (!stream || stream->m_state != ReadableStreamState::Readable) {
+        if (readRequestQueued)
+            return jsUndefined();
         if (auto* pendingRead = m_pendingRead.get())
             return pendingRead;
         if (stream && stream->m_state == ReadableStreamState::Errored)
@@ -589,17 +595,18 @@ JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject)
         return doneP;
     }
 
+    // Register the consumer before replaying what pull() deferred. A queued read request is
+    // already registered; a promise made for it here would swallow that delivery unobserved.
     JSPromise* promiseToReturn = nullptr;
-    if (!m_pendingRead) {
-        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        m_pendingRead.set(vm, this, promise);
-        promiseToReturn = promise;
-    } else {
-        auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
-        auto* runtime = JSStreamsRuntime::from(globalObject);
-        auto* readRequest = JSReadRequest::create(vm, runtime->readRequestStructure(defaultGlobalObject(globalObject)), ReadRequestKind::Promise, promise);
-        readableStreamAddReadRequest(vm, stream, readRequest);
-        promiseToReturn = promise;
+    if (!readRequestQueued) {
+        promiseToReturn = JSPromise::create(vm, globalObject->promiseStructure());
+        if (!m_pendingRead)
+            m_pendingRead.set(vm, this, promiseToReturn);
+        else {
+            auto* runtime = JSStreamsRuntime::from(globalObject);
+            auto* readRequest = JSReadRequest::create(vm, runtime->readRequestStructure(defaultGlobalObject(globalObject)), ReadRequestKind::Promise, promiseToReturn);
+            readableStreamAddReadRequest(vm, stream, readRequest);
+        }
     }
 
     if (deferredClose == 1) {
@@ -607,24 +614,11 @@ JSValue JSDirectStreamController::onPull(JSGlobalObject* globalObject)
         m_deferCloseReason.clear();
         onClose(globalObject, reason);
         RETURN_IF_EXCEPTION(scope, {});
-        return promiseToReturn;
-    }
-    if (deferredFlush == 1) {
+    } else if (deferredFlush == 1) {
         onFlush(globalObject);
         RETURN_IF_EXCEPTION(scope, {});
     }
-    return promiseToReturn;
-}
-
-// The pump's head-of-line promise (m_pendingRead) is the active consumer only while no
-// non-promise read request (pipeTo / tee / for-await) is queued ahead of it: those are
-// registered in [[readRequests]] BEFORE the pull runs and must get chunks via chunkSteps.
-static bool headOfLinePromiseIsActiveConsumer(JSReadableStreamDefaultReader* reader)
-{
-    Locker locker { reader->cellLock() };
-    if (reader->m_readRequests.isEmpty())
-        return true;
-    return reader->m_readRequests.first().get()->kind() == ReadRequestKind::Promise;
+    return promiseToReturn ? JSValue(promiseToReturn) : jsUndefined();
 }
 
 void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue reason)
@@ -667,12 +661,8 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
         }
     }
 
-    size_t flushedByteLength = byteLengthOf(flushed);
-    if (readableStreamHasDefaultReader(stream)) {
-        auto* reader = static_cast<JSReadableStreamDefaultReader*>(stream->m_reader.get());
-        auto* pendingRead = m_pendingRead.get();
-        // Skipped when a non-promise read request is at the head: it is delivered below.
-        if (pendingRead && flushedByteLength && headOfLinePromiseIsActiveConsumer(reader)) {
+    if (byteLengthOf(flushed)) {
+        if (auto* pendingRead = m_pendingRead.get()) {
             m_pendingRead.clear();
             JSObject* result = createIteratorResultObject(globalObject, flushed, false);
             RETURN_IF_EXCEPTION(scope, );
@@ -680,9 +670,6 @@ void JSDirectStreamController::onClose(JSGlobalObject* globalObject, JSValue rea
             RETURN_IF_EXCEPTION(scope, );
             RELEASE_AND_RETURN(scope, readableStreamCloseIfPossible(globalObject, stream));
         }
-    }
-
-    if (flushedByteLength) {
         // The reader can have been released while the (async) pull was still running.
         if (readableStreamHasDefaultReader(stream) && readableStreamGetNumReadRequests(stream) > 0) {
             readableStreamFulfillReadRequest(globalObject, stream, flushed, false);
@@ -725,26 +712,16 @@ void JSDirectStreamController::onFlush(JSGlobalObject* globalObject)
         JSValue flushed = flushDirectSink(vm, globalObject, this);
         RETURN_IF_EXCEPTION(scope, );
         if (byteLengthOf(flushed)) {
-            // A non-promise read request at the head is the active consumer: deliver the
-            // chunk through its own chunkSteps and leave the head-of-line promise pending
-            // (its registrar drops it).
-            if (!headOfLinePromiseIsActiveConsumer(reader)) {
-                m_pendingRead.set(vm, this, pendingRead);
-                // The spec's enqueue → CallPullIfNeeded equivalent: re-arm when this delivery
-                // still leaves a consumer queued behind the in-flight pull.
-                if (m_pullInFlight && readableStreamGetNumReadRequests(stream) > 1)
-                    m_pullAgain = true;
-                RELEASE_AND_RETURN(scope, readableStreamFulfillReadRequest(globalObject, stream, flushed, false));
-            }
+            // onPull queues concurrent promise-backed reads behind the head-of-line one.
             {
                 Locker locker { reader->cellLock() };
-                if (!reader->m_readRequests.isEmpty()) {
-                    auto nextRequest = reader->m_readRequests.takeFirst();
-                    auto* readRequest = nextRequest.get();
-                    if (readRequest && readRequest->kind() == ReadRequestKind::Promise)
-                        m_pendingRead.set(vm, this, uncheckedDowncast<JSPromise>(readRequest->m_context.get()));
+                if (!reader->m_readRequests.isEmpty() && reader->m_readRequests.first().get()->kind() == ReadRequestKind::Promise) {
+                    auto* readRequest = reader->m_readRequests.takeFirst().get();
+                    m_pendingRead.set(vm, this, uncheckedDowncast<JSPromise>(readRequest->m_context.get()));
                 }
             }
+            // The spec's enqueue → CallPullIfNeeded equivalent: re-arm when this delivery
+            // still leaves a consumer waiting behind the in-flight pull.
             if (m_pullInFlight && (m_pendingRead || readableStreamGetNumReadRequests(stream) > 0))
                 m_pullAgain = true;
             JSObject* result = createIteratorResultObject(globalObject, flushed, false);
@@ -813,12 +790,12 @@ JSC_DEFINE_HOST_FUNCTION(jsWebStreamsHandler_onDirectPullFulfilled, (JSGlobalObj
         int8_t deferredFlush = controller->m_deferFlush;
         controller->m_deferClose = 0;
         controller->m_deferFlush = 0;
+        RETURN_IF_EXCEPTION(scope, {});
         if (!abrupt.isEmpty()) {
             controller->handleError(globalObject, abrupt);
             RETURN_IF_EXCEPTION(scope, {});
             return JSValue::encode(jsUndefined());
         }
-        RETURN_IF_EXCEPTION(scope, {});
         if (deferredClose == 1) {
             JSValue reason = controller->m_deferCloseReason.get();
             controller->m_deferCloseReason.clear();

--- a/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
+++ b/src/jsc/bindings/webcore/streams/JSDirectStreamController.h
@@ -55,8 +55,9 @@ public:
     // setUpDirectStreamController, matching the native-sink path's m_onPull).
     JSC::WriteBarrier<JSC::JSObject> m_underlyingSource;
     JSC::WriteBarrier<JSC::JSObject> m_pull;
-    // _pendingRead — the promise the in-flight read() is waiting on. handleError rejects
-    // AND CLEARS it.
+    // _pendingRead — the promise the in-flight read()/readMany() is waiting on. Only
+    // promise-backed reads register here; pipeTo / tee / for-await reads wait in the
+    // reader's [[readRequests]] instead (see onPull). handleError rejects AND CLEARS it.
     JSC::WriteBarrier<JSC::JSPromise> m_pendingRead;
     // _deferCloseReason
     JSC::WriteBarrier<JSC::Unknown> m_deferCloseReason;
@@ -104,8 +105,12 @@ public:
     JSC::WriteBarrier<JSC::Unknown> m_finalChunk;
 
     // The state machine. All userJS: YES.
-    // the READ pump: the default reader's read()/readMany() on a Direct stream lands here.
-    JSC::JSValue onPull(JSC::JSGlobalObject*);
+    // The READ pump: every default-reader read on a Direct stream lands here. A promise-backed
+    // read()/readMany() passes readRequestQueued=false and adopts the returned promise
+    // (undefined when the pump refused). A pipeTo / tee / for-await read adds its
+    // JSReadRequest to [[readRequests]] first and passes readRequestQueued=true: that
+    // request is the consumer, the pump registers no promise for it and returns undefined.
+    JSC::JSValue onPull(JSC::JSGlobalObject*, bool readRequestQueued);
     // `end()` / `close(reason)` — reason may be the empty JSValue (absent).
     void onClose(JSC::JSGlobalObject*, JSC::JSValue reason);
     // `flush()` — BRANCH ORDER IS LOAD-BEARING.

--- a/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
+++ b/src/jsc/bindings/webcore/streams/JSReadableStreamDefaultReader.cpp
@@ -128,7 +128,7 @@ void readableStreamDefaultReaderRead(JSGlobalObject* globalObject, JSReadableStr
         // promise-backed read adopts it instead of waiting in [[readRequests]].
         if (readRequest->kind() == ReadRequestKind::Promise) {
             auto* readPromise = uncheckedDowncast<JSPromise>(readRequest->m_context.get());
-            JSValue pulled = controller->onPull(globalObject);
+            JSValue pulled = controller->onPull(globalObject, /* readRequestQueued */ false);
             RETURN_IF_EXCEPTION(scope, void());
             if (!pulled.isObject()) {
                 // The pump refused (already closed / re-entrant pull): report done.
@@ -138,14 +138,11 @@ void readableStreamDefaultReaderRead(JSGlobalObject* globalObject, JSReadableStr
             }
             RELEASE_AND_RETURN(scope, resolvePromise(globalObject, readPromise, pulled));
         }
-        // Other read-request kinds wait in [[readRequests]]; the pump's unobserved
-        // head-of-line promise for this read is dropped so delivery reaches the request.
+        // Other read-request kinds wait in [[readRequests]] and are delivered through their
+        // own chunk/close/error steps.
         readableStreamAddReadRequest(vm, stream, readRequest);
-        bool hadPendingRead = !!controller->m_pendingRead;
-        JSValue pulled = controller->onPull(globalObject);
-        RETURN_IF_EXCEPTION(scope, void());
-        if (!hadPendingRead && controller->m_pendingRead && pulled == JSValue(controller->m_pendingRead.get()))
-            controller->m_pendingRead.clear();
+        scope.release();
+        controller->onPull(globalObject, /* readRequestQueued */ true);
         return;
     }
     case ControllerKind::NativeSink: {
@@ -393,7 +390,7 @@ JSValue readableStreamDefaultReaderReadMany(JSGlobalObject* globalObject, JSRead
         if (state == ReadableStreamState::Closed)
             break;
         auto* controller = uncheckedDowncast<WebCore::JSDirectStreamController>(stream->m_controller.get());
-        JSValue pulled = controller->onPull(globalObject);
+        JSValue pulled = controller->onPull(globalObject, /* readRequestQueued */ false);
         RETURN_IF_EXCEPTION(scope, {});
         auto* pulledPromise = dynamicDowncast<JSPromise>(pulled);
         if (!pulledPromise)

--- a/test/js/web/streams/streams.test.js
+++ b/test/js/web/streams/streams.test.js
@@ -1022,6 +1022,153 @@ describe("multi-chunk consumers produce exactly the concatenated bytes", () => {
     });
   });
 
+  // pipeTo / tee / for-await / textStream() read a direct stream through read requests, not
+  // reader.read() promises. A flush() inside a synchronous pull() satisfies that request on
+  // the spot; whatever the pull writes afterwards must still reach the consumer's next read.
+  describe("a sync direct pull() that flush()es mid-pull delivers the bytes written after the flush", () => {
+    const decoder = new TextDecoder();
+    const readerText = async rs => {
+      const reader = rs.getReader();
+      const parts = [];
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) return parts.join("");
+        parts.push(decoder.decode(value));
+      }
+    };
+    const pipeToText = async rs => {
+      const parts = [];
+      await rs.pipeTo(
+        new WritableStream({
+          write(chunk) {
+            parts.push(decoder.decode(chunk));
+          },
+        }),
+      );
+      return parts.join("");
+    };
+    const forAwaitText = async rs => {
+      const parts = [];
+      for await (const chunk of rs) parts.push(decoder.decode(chunk));
+      return parts.join("");
+    };
+    const textStreamText = async rs => {
+      const parts = [];
+      for await (const chunk of new Response(rs).textStream()) parts.push(chunk);
+      return parts.join("");
+    };
+
+    describe.each(["end", "close"])("finishing with %s()", finish => {
+      const mk = () =>
+        new ReadableStream({
+          type: "direct",
+          pull(c) {
+            c.write("hello");
+            c.flush();
+            c.write("world");
+            c[finish]();
+          },
+        });
+
+      it("getReader()", async () => {
+        expect(await readerText(mk())).toBe("helloworld");
+      });
+
+      it("pipeTo()", async () => {
+        expect(await pipeToText(mk())).toBe("helloworld");
+      });
+
+      it("pipeThrough()", async () => {
+        expect(await readableStreamToText(mk().pipeThrough(new TransformStream()))).toBe("helloworld");
+      });
+
+      it("tee()", async () => {
+        const [a, b] = mk().tee();
+        expect(await Promise.all([readableStreamToText(a), readableStreamToText(b)])).toEqual([
+          "helloworld",
+          "helloworld",
+        ]);
+      });
+
+      it("for await", async () => {
+        expect(await forAwaitText(mk())).toBe("helloworld");
+      });
+
+      it("Response.textStream()", async () => {
+        expect(await textStreamText(mk())).toBe("helloworld");
+      });
+    });
+
+    it("a second flush() in the same pull() is delivered to the consumer's next read", async () => {
+      const mk = () => {
+        let pulls = 0;
+        return new ReadableStream({
+          type: "direct",
+          pull(c) {
+            if (pulls++ > 0) return c.end();
+            c.write("a");
+            c.flush();
+            c.write("b");
+            c.flush();
+          },
+        });
+      };
+      const [a, b] = mk().tee();
+      expect({
+        reader: await readerText(mk()),
+        pipeTo: await pipeToText(mk()),
+        tee: await Promise.all([readableStreamToText(a), readableStreamToText(b)]),
+        forAwait: await forAwaitText(mk()),
+      }).toEqual({ reader: "ab", pipeTo: "ab", tee: ["ab", "ab"], forAwait: "ab" });
+    });
+
+    it("a pull() that throws rejects only the consumer, with no stray unhandled rejection", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+          let unhandled = 0;
+          process.on("unhandledRejection", () => unhandled++);
+          const settle = promise => promise.then(() => "fulfilled", e => e.message);
+          const mk = () => new ReadableStream({ type: "direct", pull() { throw new Error("boom"); } });
+          const out = {};
+          out.pipeTo = await settle(mk().pipeTo(new WritableStream()));
+          out.tee = await settle(Bun.readableStreamToText(mk().tee()[0]));
+          out.forAwait = await settle((async () => { for await (const _ of mk()); })());
+          // Two reads during an async pull() make its fulfillment re-pull; the re-pull throws.
+          let pulls = 0;
+          const reader = new ReadableStream({
+            type: "direct",
+            pull() {
+              if (pulls++ === 0) return Promise.resolve();
+              throw new Error("boom");
+            },
+          }).getReader();
+          out.rePull = await Promise.all([settle(reader.read()), settle(reader.read())]);
+          // Unhandled rejections are reported once the current turn's microtasks drain.
+          await new Promise(resolve => setTimeout(resolve, 0));
+          out.unhandled = unhandled;
+          console.log(JSON.stringify(out));
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(JSON.parse(stdout)).toEqual({
+        pipeTo: "boom",
+        tee: "boom",
+        forAwait: "boom",
+        rePull: ["boom", "boom"],
+        unhandled: 0,
+      });
+      expect(stderr).toBe("");
+      expect(exitCode).toBe(0);
+    });
+  });
+
   it("a patched Object.prototype.then that releases the reader mid-resolution does not crash", async () => {
     let releaseNow = null;
     Object.defineProperty(Object.prototype, "then", {


### PR DESCRIPTION
### Repro

```js
const mk = () => new ReadableStream({
  type: "direct",
  pull(c) { c.write("hello"); c.flush(); c.write("world"); c.end(); },   // same with c.close()
});
let acc = "";
await mk().pipeTo(new WritableStream({ write(ch) { acc += new TextDecoder().decode(ch); } }));
console.log(acc);                                                           // "hello"   (expected "helloworld")
console.log(await new Response(mk().tee()[0]).text());                      // "hello"
console.log(await new Response(mk().pipeThrough(new TransformStream())).text()); // "hello"
console.log(await new Response(mk()).text());                               // "helloworld"
```

On 1.4.0 and current main, `pipeTo`, `pipeThrough`, `tee()`, `for await` and `Response.textStream()` all deliver only the bytes flushed before the mid-pull `flush()`; a plain reader and `text()` get everything. Two `flush()` calls in one sync `pull()` lose the second chunk the same way, and a `pull()` that throws synchronously additionally reports a stray `unhandledRejection` next to the consumer's own rejection.

### Cause

Those consumers read a direct stream through read requests queued in the reader's `[[readRequests]]`, but `JSDirectStreamController::onPull` created a head-of-line promise (`m_pendingRead`) for every read, and `readableStreamDefaultReaderRead` dropped it again once `onPull` returned. The mid-pull `flush()` fulfils the queued request immediately, so when `onPull` replays the `end()`/`close()` (or second `flush()`) that the pull deferred, `headOfLinePromiseIsActiveConsumer` sees an empty request queue and hands the remaining bytes to the promise nobody holds. The sync-throw path rejected that same unobserved promise.

### Fix

`onPull` takes a `readRequestQueued` flag. For a read request it registers no promise, so deferred close/flush deliveries reach the queued request, or arm the final chunk / stay in the sink for the consumer's next read, and a throwing pull only errors the stream. With no dropped promises left, `headOfLinePromiseIsActiveConsumer` and the post-pull `m_pendingRead` cleanup are removed, and `onFlush` only promotes a promise-kind request to head-of-line. The exception check after `callDirectPull` now runs before `handleError`, which the throwing-pull paths needed to pass `BUN_JSC_validateExceptionChecks` (the new test spawns one and inherits it on the ASAN lane).

Related, not overlapping: #37687 fixes bytes flushed while nothing was waiting staying in the sink; the two PRs touch neighbouring lines of `onPull`.

### Verification

New tests in `test/js/web/streams/streams.test.js` (reader, `pipeTo`, `pipeThrough`, `tee`, `for await`, `textStream()` with `end()` and `close()`, the double-flush case, and the throwing-pull subprocess): 12 of 14 fail on the unfixed build (`"hello"` / `"a"` received, `unhandled: 3`), all pass with the fix. `streams.test.js` passes in full under `BUN_JSC_validateExceptionChecks=1`; the other direct-stream suites (`body-stream`, `body-async-iterator`, `sync-pull-fast-path`, `AsyncLocalStorage`, `html-rewriter`, `node-stream`) are unchanged.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/web/streams/streams.test.js

<!-- robobun:evidence:end -->