### PR TITLE
node:fs: let the fs completions own their task box instead of freeing it through &mut self

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -300,14 +300,22 @@ pub(crate) fn run_task(
             }
             .run();
         }
+        // `run_from_js_thread` frees the task, so it takes the raw pointer (no
+        // `&mut` at this boundary, same as `DuplexUpgradeContext` above).
         task_tag::AsyncCpTask => {
             // SAFETY: posted by `on_subtask_done` with the count at zero (exclusive).
-            unsafe { (*task.ptr.cast::<crate::node::fs::AsyncCpTask>()).run_from_js_thread()? };
+            unsafe {
+                crate::node::fs::AsyncCpTask::run_from_js_thread(cast_ptr!(
+                    crate::node::fs::AsyncCpTask
+                ))?
+            };
         }
         task_tag::ShellAsyncCpTask => {
             // SAFETY: as above.
             unsafe {
-                (*task.ptr.cast::<crate::node::fs::ShellAsyncCpTask>()).run_from_js_thread()?
+                crate::node::fs::ShellAsyncCpTask::run_from_js_thread(cast_ptr!(
+                    crate::node::fs::ShellAsyncCpTask
+                ))?
             };
         }
         task_tag::StatWatcherHop => {
@@ -429,7 +437,12 @@ pub(crate) fn run_task(
         for_each_fs_uv_op!(__fs_pat) => {
             macro_rules! __fs_run {
                 ($($tag:ident $ty:ident;)*) => { match task.tag {
-                    $(task_tag::$tag => cast!(fs_async::$ty).run_from_js_thread()?,)*
+                    // SAFETY: §Dispatch — tag identifies the pointee, a `UVFSRequest`
+                    // enqueued exactly once on completion. Raw pointer because
+                    // `run_from_js_thread` frees it.
+                    $(task_tag::$tag => unsafe {
+                        fs_async::$ty::run_from_js_thread(cast_ptr!(fs_async::$ty))?
+                    },)*
                     // SAFETY: outer arm guard proves one of the table tags matched.
                     _ => unsafe { core::hint::unreachable_unchecked() },
                 }};

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -300,23 +300,16 @@ pub(crate) fn run_task(
             }
             .run();
         }
-        // `run_from_js_thread` frees the task, so it takes the raw pointer (no
-        // `&mut` at this boundary, same as `DuplexUpgradeContext` above).
         task_tag::AsyncCpTask => {
-            // SAFETY: posted by `on_subtask_done` with the count at zero (exclusive).
-            unsafe {
-                crate::node::fs::AsyncCpTask::run_from_js_thread(cast_ptr!(
-                    crate::node::fs::AsyncCpTask
-                ))?
-            };
+            // SAFETY: leaked by `schedule_new`; posted by `on_subtask_done` with the
+            // count at zero, so this is the last pointer to it and the arm consumes it.
+            unsafe { bun_core::heap::take(cast_ptr!(crate::node::fs::AsyncCpTask)) }
+                .run_from_js_thread()?;
         }
         task_tag::ShellAsyncCpTask => {
             // SAFETY: as above.
-            unsafe {
-                crate::node::fs::ShellAsyncCpTask::run_from_js_thread(cast_ptr!(
-                    crate::node::fs::ShellAsyncCpTask
-                ))?
-            };
+            unsafe { bun_core::heap::take(cast_ptr!(crate::node::fs::ShellAsyncCpTask)) }
+                .run_from_js_thread()?;
         }
         task_tag::StatWatcherHop => {
             // SAFETY: posted by `StatWatcher::post_to_js_thread` with a ref held.
@@ -437,12 +430,11 @@ pub(crate) fn run_task(
         for_each_fs_uv_op!(__fs_pat) => {
             macro_rules! __fs_run {
                 ($($tag:ident $ty:ident;)*) => { match task.tag {
-                    // SAFETY: §Dispatch — tag identifies the pointee, a `UVFSRequest`
-                    // enqueued exactly once on completion. Raw pointer because
-                    // `run_from_js_thread` frees it.
-                    $(task_tag::$tag => unsafe {
-                        fs_async::$ty::run_from_js_thread(cast_ptr!(fs_async::$ty))?
-                    },)*
+                    // SAFETY: §Dispatch — tag identifies the pointee, the box
+                    // `UVFSRequest::create` leaked, enqueued exactly once on
+                    // completion; the arm consumes it.
+                    $(task_tag::$tag => unsafe { bun_core::heap::take(cast_ptr!(fs_async::$ty)) }
+                        .run_from_js_thread()?,)*
                     // SAFETY: outer arm guard proves one of the table tags matched.
                     _ => unsafe { core::hint::unreachable_unchecked() },
                 }};

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -301,8 +301,8 @@ pub(crate) fn run_task(
             .run();
         }
         task_tag::AsyncCpTask => {
-            // SAFETY: leaked by `schedule_new`; posted by `on_subtask_done` with the
-            // count at zero, so this is the last pointer to it and the arm consumes it.
+            // SAFETY: boxed by `schedule_new`; posted once by `on_subtask_done` with
+            // the count at zero; the arm consumes it.
             unsafe { bun_core::heap::take(cast_ptr!(crate::node::fs::AsyncCpTask)) }
                 .run_from_js_thread()?;
         }
@@ -430,9 +430,8 @@ pub(crate) fn run_task(
         for_each_fs_uv_op!(__fs_pat) => {
             macro_rules! __fs_run {
                 ($($tag:ident $ty:ident;)*) => { match task.tag {
-                    // SAFETY: §Dispatch — tag identifies the pointee, the box
-                    // `UVFSRequest::create` leaked, enqueued exactly once on
-                    // completion; the arm consumes it.
+                    // SAFETY: §Dispatch — tag identifies the pointee: the box
+                    // `UVFSRequest::create` leaked, enqueued once; the arm consumes it.
                     $(task_tag::$tag => unsafe { bun_core::heap::take(cast_ptr!(fs_async::$ty)) }
                         .run_from_js_thread()?,)*
                     // SAFETY: outer arm guard proves one of the table tags matched.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -648,9 +648,6 @@ mod _async_tasks {
         pub(crate) tracker: AsyncTaskTracker,
     }
 
-    /// Runs when the completion (or `release_unrun`) drops the reclaimed box, on
-    /// the JS thread; the promise handle and the protected arguments are released
-    /// by their own field drops.
     #[cfg(windows)]
     impl<R, A: Unprotect, const F: NodeFSFunctionEnum> Drop for UVFSRequest<R, A, F> {
         fn drop(&mut self) {
@@ -691,10 +688,7 @@ mod _async_tasks {
                 r#ref: KeepAlive::default(),
                 tracker: AsyncTaskTracker::init(vm),
             });
-            // Transfer ownership to libuv: the box outlives the async request and is
-            // reclaimed (`heap::take`) by the task-queue arm that runs
-            // `run_from_js_thread`, or by `release_unrun`. `heap::release` names that
-            // hand-off — it is `Box::leak` under the hood.
+            // Reclaimed by the task-queue arm (`run_from_js_thread`) or `release_unrun`.
             let task: &mut Self = bun_core::heap::release(task);
             // KeepAlive::ref_ now takes the type-erased aio EventLoopCtx; the JS
             // event loop is the only one that owns AsyncFSTask/UVFSRequest.
@@ -952,15 +946,11 @@ mod _async_tasks {
                 .enqueue_task(bun_jsc::Task::init(this_ptr));
         }
 
-        /// Settles the promise. The task-queue arm reclaims the box `create()` leaked
-        /// and passes it in; dropping it on the way out (every return path) releases
-        /// the keep-alive and frees the request. Owning the box, rather than taking
-        /// `&mut self`, is what makes freeing it here sound: a reference argument is
-        /// protected for the whole call and must not be deallocated through.
+        /// Settles the promise; dropping the box on the way out releases the
+        /// keep-alive and frees the request.
         #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
         pub(crate) fn run_from_js_thread(mut self: Box<Self>) -> Result<(), bun_jsc::JsTerminated> {
-            // Move `result` out so the `global_object()` borrow below can coexist with
-            // the `&mut` conversion; the sentinel left behind drops with the box.
+            // Moved out: `fs_to_js` needs `&mut` while `global_object()` borrows `self`.
             let mut result = core::mem::replace(&mut self.result, Err(sys::Error::default()));
             let global_object = self.global_object();
             let success = result.is_ok();
@@ -1398,9 +1388,6 @@ mod _async_tasks {
         pub(crate) shelltask: Option<bun_ptr::ParentRef<ShellCpTask, bun_ptr::Mut>>,
     }
 
-    /// Runs on the owning thread when the completion (or `release_unrun`) drops
-    /// the box `schedule_new` leaked. `Drop for ThreadSafe<args::Cp>` releases the
-    /// `protect()` taken by `to_thread_safe()` when `src`/`dest` are Buffers.
     impl<const IS_SHELL: bool> Drop for NewAsyncCpTask<IS_SHELL> {
         fn drop(&mut self) {
             if !IS_SHELL {
@@ -1469,9 +1456,7 @@ mod _async_tasks {
         }
 
         fn run_owned(self: Box<Self>) {
-            // `ParentRef` preserves the `Box::leak` mutable provenance so the
-            // completion `on_subtask_done` enqueues (via `as_mut_ptr()`) may free
-            // the parent once the refcount reaches zero.
+            // `ParentRef` keeps the `Box::leak` provenance the completion frees with.
             let cp_task = self.cp_task;
             // Shared borrow only — other workpool threads (and the directory-scan
             // thread) may hold `&Self` to the same parent concurrently; `ParentRef`
@@ -1661,10 +1646,8 @@ mod _async_tasks {
         /// drops to zero) enqueues `runFromJSThread`, which resolves the promise
         /// and destroys `this`.
         ///
-        /// Takes a raw `*mut Self` (not `&self`) so the pointer retains the
-        /// mutable provenance from the original `Box::leak`; the JS-thread
-        /// callback later frees the allocation through it, which would be UB if
-        /// the pointer were derived from a shared reference.
+        /// Takes `*mut Self` (not `&self`): the completion frees the box through
+        /// this pointer, so it must keep the `Box::leak` provenance.
         fn on_subtask_done(this: *mut Self) {
             // SAFETY: `this` is a live Box-leaked task; shared access only here —
             // other workpool threads may concurrently hold `&Self` until the
@@ -1683,9 +1666,7 @@ mod _async_tasks {
                 this_ref.result.set(Ok(()));
             }
 
-            // Count reached zero ⇒ exclusive access. `this` carries mutable
-            // provenance from `Box::leak`, so the enqueued `run_from_js_thread`
-            // may free `*this` on the JS thread.
+            // Count reached zero ⇒ exclusive access; the completion frees `*this`.
             let poster = this_ref.poster.clone();
             if poster.is_js() {
                 let ct = ConcurrentTask::ConcurrentTask::create(bun_jsc::Task::init(this));
@@ -1697,10 +1678,8 @@ mod _async_tasks {
                 let at =
                     AnyTaskWithExtraContext::from_callback_auto_deinit(this, |p: *mut Self, _| {
                         debug_assert!(IS_SHELL, "only the shell posts cp tasks to a mini loop");
-                        // SAFETY: subtask count hit zero ⇒ this is the only pointer left to
-                        // the box `schedule_new` leaked; reclaim it. The shell
-                        // specialization settles no promise, so there is no termination to
-                        // report: the result is always `Ok`.
+                        // SAFETY: count hit zero ⇒ sole pointer to the box `schedule_new` leaked.
+                        // The shell path settles no promise, so the result is always `Ok`.
                         let _ = unsafe { bun_core::heap::take(p) }.run_from_js_thread();
                     });
                 // `from_callback_auto_deinit` heap-allocates; never null.
@@ -1710,13 +1689,9 @@ mod _async_tasks {
             poster.embedded_work_finished();
         }
 
-        /// Delivers the result: settles the promise, or hands it to the shell's
-        /// `ShellCpTask`. The completion `on_subtask_done` posted reclaims the box
-        /// `schedule_new` leaked and passes it in; dropping it on the way out (every
-        /// return path) releases the keep-alive and frees the task. Owning the box,
-        /// rather than taking `&mut self`, is what makes freeing it here sound: a
-        /// reference argument is protected for the whole call and must not be
-        /// deallocated through.
+        /// Settles the promise (or, for the shell, continues the `ShellCpTask`);
+        /// dropping the box on the way out releases the keep-alive and
+        /// frees the task.
         #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
         pub(crate) fn run_from_js_thread(self: Box<Self>) -> Result<(), bun_jsc::JsTerminated> {
             // `Maybe<ret::Cp>` (= `Maybe<()>`) has a cheap `Ok(())` placeholder.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -946,8 +946,7 @@ mod _async_tasks {
                 .enqueue_task(bun_jsc::Task::init(this_ptr));
         }
 
-        /// Settles the promise; dropping the box on the way out releases the
-        /// keep-alive and frees the request.
+        /// Settles the promise; the request (and its keep-alive) is released on return.
         #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
         pub(crate) fn run_from_js_thread(mut self: Box<Self>) -> Result<(), bun_jsc::JsTerminated> {
             // Moved out: `fs_to_js` needs `&mut` while `global_object()` borrows `self`.
@@ -1646,8 +1645,7 @@ mod _async_tasks {
         /// drops to zero) enqueues `runFromJSThread`, which resolves the promise
         /// and destroys `this`.
         ///
-        /// Takes `*mut Self` (not `&self`): the completion frees the box through
-        /// this pointer, so it must keep the `Box::leak` provenance.
+        /// `*mut Self`, not `&self`: the completion frees the box through this pointer.
         fn on_subtask_done(this: *mut Self) {
             // SAFETY: `this` is a live Box-leaked task; shared access only here —
             // other workpool threads may concurrently hold `&Self` until the
@@ -1679,8 +1677,8 @@ mod _async_tasks {
                     AnyTaskWithExtraContext::from_callback_auto_deinit(this, |p: *mut Self, _| {
                         debug_assert!(IS_SHELL, "only the shell posts cp tasks to a mini loop");
                         // SAFETY: count hit zero ⇒ sole pointer to the box `schedule_new` leaked.
-                        // The shell path settles no promise, so the result is always `Ok`.
-                        let _ = unsafe { bun_core::heap::take(p) }.run_from_js_thread();
+                        let task = unsafe { bun_core::heap::take(p) };
+                        let _ = task.run_from_js_thread(); // shell tasks settle no promise: always `Ok`
                     });
                 // `from_callback_auto_deinit` heap-allocates; never null.
                 poster.post_mini(core::ptr::NonNull::new(at).expect("heap task"));
@@ -1689,9 +1687,7 @@ mod _async_tasks {
             poster.embedded_work_finished();
         }
 
-        /// Settles the promise (or, for the shell, continues the `ShellCpTask`);
-        /// dropping the box on the way out releases the keep-alive and
-        /// frees the task.
+        /// Settles the promise (shell: continues the `ShellCpTask`); the task is freed on return.
         #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
         pub(crate) fn run_from_js_thread(self: Box<Self>) -> Result<(), bun_jsc::JsTerminated> {
             // `Maybe<ret::Cp>` (= `Maybe<()>`) has a cheap `Ok(())` placeholder.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -3,7 +3,7 @@
 // The top-level functions assume the arguments are already validated
 
 use bun_paths::strings;
-use core::ffi::{c_char, c_int, c_uint, c_void};
+use core::ffi::{c_char, c_int, c_uint};
 use core::ptr::NonNull;
 use core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
@@ -693,7 +693,7 @@ mod _async_tasks {
             task.tracker.did_schedule(global_object);
 
             let loop_ = uv::Loop::get();
-            task.req.data = core::ptr::from_mut::<Self>(task).cast::<c_void>();
+            task.req.data = core::ptr::from_mut::<Self>(task).cast();
 
             // The match resolves at compile time (`F` is a const generic), but
             // each arm's body needs `A` re-asserted to its concrete `args::*`
@@ -942,17 +942,35 @@ mod _async_tasks {
                 .enqueue_task(bun_jsc::Task::init(this_ptr));
         }
 
-        pub(crate) fn run_from_js_thread(&mut self) -> Result<(), bun_jsc::JsTerminated> {
-            // SAFETY: self was Box::leak'd in create(); destroy() runs exactly once on scope exit
-            let _deinit =
-                scopeguard::guard(core::ptr::from_mut(self), |p| unsafe { Self::destroy(p) });
-            // Move `result` out so the `global_object()` `&self` borrow can coexist
-            // with `&mut result` below; the sentinel left behind is dropped in `destroy()`.
-            let mut result = core::mem::replace(&mut self.result, Err(sys::Error::default()));
-            let global_object = self.global_object();
+        /// Settles the promise and frees the request (the task queue's entry point).
+        ///
+        /// Raw-pointer receiver: this function ends in `destroy(this)`. A `&mut self`
+        /// argument would be protected for the whole frame, and freeing the allocation
+        /// while that protector is live is UB ("deallocating while item is protected");
+        /// the borrows below are plain locals whose last use precedes the free.
+        ///
+        /// # Safety
+        /// `this` is the pointer leaked in `create()`, enqueued exactly once (by the
+        /// libuv callback, or by `create()` itself for the no-op `writev`), and is not
+        /// used after this call.
+        pub(crate) unsafe fn run_from_js_thread(
+            this: *mut Self,
+        ) -> Result<(), bun_jsc::JsTerminated> {
+            // SAFETY: fn contract — frees `*this` once, on every return path, after
+            // everything below has run.
+            let _deinit = scopeguard::guard(this, |p| unsafe { Self::destroy(p) });
+            // Move `result` out (the sentinel left behind is dropped in `destroy()`) so
+            // the rest of the function only needs shared access.
+            // SAFETY: fn contract — exclusive access; the `&mut` is statement-scoped.
+            let mut result =
+                core::mem::replace(unsafe { &mut (*this).result }, Err(sys::Error::default()));
+            // SAFETY: fn contract — `*this` is live until the guard runs and nothing
+            // below mutates it.
+            let task = unsafe { &*this };
+            let global_object = task.global_object();
             let success = matches!(result, Ok(_));
-            let promise_value = self.promise.value();
-            let promise = self.promise.get();
+            let promise_value = task.promise.value();
+            let promise = task.promise.get();
             let result = match &mut result {
                 Err(err) => match err.to_js_with_async_stack(global_object, promise) {
                     Ok(v) => v,
@@ -969,7 +987,7 @@ mod _async_tasks {
             };
             promise_value.ensure_still_alive();
 
-            let _dispatch = self.tracker.dispatch(global_object);
+            let _dispatch = task.tracker.dispatch(global_object);
 
             if success {
                 promise.resolve(global_object, result)?;
@@ -1403,7 +1421,7 @@ mod _async_tasks {
         /// subtask via the `subtask_count` refcount (see `on_subtask_done`). Stored
         /// as `ParentRef` (constructed from the `*mut` with `Box::leak` provenance)
         /// so shared reads are safe-projected and `as_mut_ptr()` round-trips the
-        /// original write provenance for `on_subtask_done`'s `&mut` promotion.
+        /// original write provenance that `on_subtask_done`'s completion frees with.
         pub(crate) cp_task: bun_ptr::ParentRef<NewAsyncCpTask<IS_SHELL>, bun_ptr::Mut>,
         /// Single owned allocation laid out as `<src>\0<dest>\0`. Ownership is
         /// encoded directly as `Box<[OSPathChar]>` and
@@ -1454,9 +1472,9 @@ mod _async_tasks {
         }
 
         fn run_owned(self: Box<Self>) {
-            // `ParentRef` preserves the `Box::leak` mutable provenance so
-            // `on_subtask_done` may later promote it to `&mut` via `as_mut_ptr()`
-            // once the refcount reaches zero.
+            // `ParentRef` preserves the `Box::leak` mutable provenance so the
+            // completion `on_subtask_done` enqueues (via `as_mut_ptr()`) may free
+            // the parent once the refcount reaches zero.
             let cp_task = self.cp_task;
             // Shared borrow only — other workpool threads (and the directory-scan
             // thread) may hold `&Self` to the same parent concurrently; `ParentRef`
@@ -1646,8 +1664,8 @@ mod _async_tasks {
         ///
         /// Takes a raw `*mut Self` (not `&self`) so the pointer retains the
         /// mutable provenance from the original `Box::leak`; the JS-thread
-        /// callback later materializes `&mut *this`, which would be UB if the
-        /// pointer were derived from a shared reference.
+        /// callback later frees the allocation through it, which would be UB if
+        /// the pointer were derived from a shared reference.
         fn on_subtask_done(this: *mut Self) {
             // SAFETY: `this` is a live Box-leaked task; shared access only here —
             // other workpool threads may concurrently hold `&Self` until the
@@ -1667,8 +1685,8 @@ mod _async_tasks {
             }
 
             // Count reached zero ⇒ exclusive access. `this` carries mutable
-            // provenance from `Box::leak`, so the enqueued callback may safely
-            // form `&mut *this` on the JS thread.
+            // provenance from `Box::leak`, so the enqueued `run_from_js_thread`
+            // may free `*this` on the JS thread.
             let poster = this_ref.poster.clone();
             if poster.is_js() {
                 let ct = ConcurrentTask::ConcurrentTask::create(bun_jsc::Task::init(this));
@@ -1677,13 +1695,14 @@ mod _async_tasks {
                     unreachable!("VM handle closed with an fs.cp outstanding");
                 };
             } else {
-                let at = AnyTaskWithExtraContext::from_callback_auto_deinit(
-                    this,
-                    |p: *mut Self, ctx| {
-                        // SAFETY: subtask count hit zero ⇒ exclusive access to the leaked task.
-                        unsafe { (*p).run_from_js_thread_mini(ctx) }
-                    },
-                );
+                let at =
+                    AnyTaskWithExtraContext::from_callback_auto_deinit(this, |p: *mut Self, _| {
+                        debug_assert!(IS_SHELL, "only the shell posts cp tasks to a mini loop");
+                        // SAFETY: subtask count hit zero ⇒ exclusive access to the leaked
+                        // task. The shell specialization settles no promise, so there is
+                        // no termination to report: the result is always `Ok`.
+                        let _ = unsafe { Self::run_from_js_thread(p) };
+                    });
                 // `from_callback_auto_deinit` heap-allocates; never null.
                 poster.post_mini(core::ptr::NonNull::new(at).expect("heap task"));
             }
@@ -1691,25 +1710,37 @@ mod _async_tasks {
             poster.embedded_work_finished();
         }
 
-        pub(crate) fn run_from_js_thread_mini(&mut self, _: *mut c_void) {
-            let _ = self.run_from_js_thread(); // TODO: properly propagate exception upwards
-        }
-
-        pub(crate) fn run_from_js_thread(&mut self) -> Result<(), bun_jsc::JsTerminated> {
+        /// Delivers the result (settles the promise, or hands it to the shell's
+        /// `ShellCpTask`) and frees the task. Posted by `on_subtask_done`.
+        ///
+        /// Raw-pointer receiver: this function ends in `destroy(this)`. A `&mut self`
+        /// argument would be protected for the whole frame, and freeing the allocation
+        /// while that protector is live is UB ("deallocating while item is protected");
+        /// the borrows below are plain locals whose last use precedes the free.
+        ///
+        /// # Safety
+        /// `this` is the pointer `schedule_new()` leaked, every subtask has dropped its
+        /// reference (`subtask_count` reached zero, so this thread has exclusive
+        /// access), and it is not used after this call.
+        pub(crate) unsafe fn run_from_js_thread(
+            this: *mut Self,
+        ) -> Result<(), bun_jsc::JsTerminated> {
+            // SAFETY: fn contract — frees `*this` once, on every return path, after
+            // everything below has run.
+            let _deinit = scopeguard::guard(this, |p| unsafe { Self::destroy(p) });
+            // SAFETY: fn contract — `*this` is live until the guard runs; `result` is a
+            // `Cell`, so moving it out below needs only this shared borrow.
+            let task = unsafe { &*this };
+            // `Maybe<ret::Cp>` (= `Maybe<()>`) has a cheap `Ok(())` placeholder.
+            let mut result = task.result.replace(Ok(()));
             if IS_SHELL {
-                // SAFETY: shelltask is set by create_for_shell and outlives this task
-                // Move the result out — `Maybe<ret::Cp>` (= `Maybe<()>`) has a cheap
-                // `Ok(())` placeholder.
-                let result = core::mem::replace(self.result.get_mut(), Ok(()));
-                let shelltask = self.shelltask.expect("IS_SHELL ⇒ shelltask").as_mut_ptr();
+                let shelltask = task.shelltask.expect("IS_SHELL ⇒ shelltask").as_mut_ptr();
                 // SAFETY: shelltask is non-null in the IS_SHELL specialization and
-                // outlives this task; `cp_on_finish` enqueues it concurrently.
+                // outlives this task; `cp_on_finish` continues it in place.
                 unsafe { ShellCpTask::cp_on_finish(shelltask, result) };
-                // SAFETY: self was Box::leak'd in create*(); destroyed exactly once here
-                unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
                 return Ok(());
             }
-            let go_ptr = self.evtloop.global_object();
+            let go_ptr = task.evtloop.global_object();
             if go_ptr.is_null() {
                 panic!(
                     "No global object, this indicates a bug in Bun. Please file a GitHub issue."
@@ -1717,41 +1748,31 @@ mod _async_tasks {
             }
             // SAFETY: non-null erased *mut JSGlobalObject from the JS event loop vtable.
             let global_object: &JSGlobalObject = unsafe { &*go_ptr.cast::<JSGlobalObject>() };
-            let success = (*self.result.get_mut()).is_ok();
-            let promise_value = self.promise.value();
-            // Captured as a raw pointer because `Self::destroy(self)` runs *before* the
-            // resolve/reject. The `JSPromise` itself lives on the JS heap
-            // and is kept alive past `destroy` by `promise_value.ensure_still_alive()`.
-            let promise: *mut bun_jsc::JSPromise = self.promise.get();
-            let result = match self.result.get_mut() {
-                // SAFETY: `promise` is the sole live reference to the heap `JSPromise`.
-                Err(err) => match err.to_js_with_async_stack(global_object, unsafe { &*promise }) {
+            let success = result.is_ok();
+            let promise_value = task.promise.value();
+            let promise = task.promise.get();
+            let result = match &mut result {
+                Err(err) => match err.to_js_with_async_stack(global_object, promise) {
                     Ok(v) => v,
                     Err(e) => {
-                        // SAFETY: `promise` points at a GC-rooted JS heap cell; sole live
-                        // reference on this thread (see comment above `let promise`).
-                        return unsafe { &mut *promise }.reject(global_object, Err(e));
+                        return promise.reject(global_object, Err(e));
                     }
                 },
                 Ok(res) => match FsReturn::fs_to_js(res, global_object) {
                     Ok(v) => v,
                     Err(e) => {
-                        // SAFETY: `promise` points at a GC-rooted JS heap cell; sole live
-                        // reference on this thread (see comment above `let promise`).
-                        return unsafe { &mut *promise }.reject(global_object, Err(e));
+                        return promise.reject(global_object, Err(e));
                     }
                 },
             };
             promise_value.ensure_still_alive();
 
-            let _dispatch = self.tracker.dispatch(global_object);
+            let _dispatch = task.tracker.dispatch(global_object);
 
-            // SAFETY: self was Box::leak'd in create*(); destroyed exactly once here
-            unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };
             if success {
-                bun_jsc::JSPromise::opaque_mut(promise).resolve(global_object, result)?;
+                promise.resolve(global_object, result)?;
             } else {
-                bun_jsc::JSPromise::opaque_mut(promise).reject(global_object, Ok(result))?;
+                promise.reject(global_object, Ok(result))?;
             }
             Ok(())
         }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -648,6 +648,16 @@ mod _async_tasks {
         pub(crate) tracker: AsyncTaskTracker,
     }
 
+    /// Runs when the completion (or `release_unrun`) drops the reclaimed box, on
+    /// the JS thread; the promise handle and the protected arguments are released
+    /// by their own field drops.
+    #[cfg(windows)]
+    impl<R, A: Unprotect, const F: NodeFSFunctionEnum> Drop for UVFSRequest<R, A, F> {
+        fn drop(&mut self) {
+            self.r#ref.unref(bun_io::js_vm_ctx());
+        }
+    }
+
     #[cfg(windows)]
     impl<R: FsReturn, A: FsArgument, const F: NodeFSFunctionEnum> UVFSRequest<R, A, F>
     where
@@ -682,9 +692,9 @@ mod _async_tasks {
                 tracker: AsyncTaskTracker::init(vm),
             });
             // Transfer ownership to libuv: the box outlives the async request and is
-            // reclaimed in `destroy()` (run_from_js_thread → scopeguard). `heap::release`
-            // names that hand-off — it is `Box::leak` under the hood; the reclaim
-            // happens in `destroy()`, not in this scope.
+            // reclaimed (`heap::take`) by the task-queue arm that runs
+            // `run_from_js_thread`, or by `release_unrun`. `heap::release` names that
+            // hand-off — it is `Box::leak` under the hood.
             let task: &mut Self = bun_core::heap::release(task);
             // KeepAlive::ref_ now takes the type-erased aio EventLoopCtx; the JS
             // event loop is the only one that owns AsyncFSTask/UVFSRequest.
@@ -942,35 +952,20 @@ mod _async_tasks {
                 .enqueue_task(bun_jsc::Task::init(this_ptr));
         }
 
-        /// Settles the promise and frees the request (the task queue's entry point).
-        ///
-        /// Raw-pointer receiver: this function ends in `destroy(this)`. A `&mut self`
-        /// argument would be protected for the whole frame, and freeing the allocation
-        /// while that protector is live is UB ("deallocating while item is protected");
-        /// the borrows below are plain locals whose last use precedes the free.
-        ///
-        /// # Safety
-        /// `this` is the pointer leaked in `create()`, enqueued exactly once (by the
-        /// libuv callback, or by `create()` itself for the no-op `writev`), and is not
-        /// used after this call.
-        pub(crate) unsafe fn run_from_js_thread(
-            this: *mut Self,
-        ) -> Result<(), bun_jsc::JsTerminated> {
-            // SAFETY: fn contract — frees `*this` once, on every return path, after
-            // everything below has run.
-            let _deinit = scopeguard::guard(this, |p| unsafe { Self::destroy(p) });
-            // Move `result` out (the sentinel left behind is dropped in `destroy()`) so
-            // the rest of the function only needs shared access.
-            // SAFETY: fn contract — exclusive access; the `&mut` is statement-scoped.
-            let mut result =
-                core::mem::replace(unsafe { &mut (*this).result }, Err(sys::Error::default()));
-            // SAFETY: fn contract — `*this` is live until the guard runs and nothing
-            // below mutates it.
-            let task = unsafe { &*this };
-            let global_object = task.global_object();
-            let success = matches!(result, Ok(_));
-            let promise_value = task.promise.value();
-            let promise = task.promise.get();
+        /// Settles the promise. The task-queue arm reclaims the box `create()` leaked
+        /// and passes it in; dropping it on the way out (every return path) releases
+        /// the keep-alive and frees the request. Owning the box, rather than taking
+        /// `&mut self`, is what makes freeing it here sound: a reference argument is
+        /// protected for the whole call and must not be deallocated through.
+        #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
+        pub(crate) fn run_from_js_thread(mut self: Box<Self>) -> Result<(), bun_jsc::JsTerminated> {
+            // Move `result` out so the `global_object()` borrow below can coexist with
+            // the `&mut` conversion; the sentinel left behind drops with the box.
+            let mut result = core::mem::replace(&mut self.result, Err(sys::Error::default()));
+            let global_object = self.global_object();
+            let success = result.is_ok();
+            let promise_value = self.promise.value();
+            let promise = self.promise.get();
             let result = match &mut result {
                 Err(err) => match err.to_js_with_async_stack(global_object, promise) {
                     Ok(v) => v,
@@ -987,7 +982,7 @@ mod _async_tasks {
             };
             promise_value.ensure_still_alive();
 
-            let _dispatch = task.tracker.dispatch(global_object);
+            let _dispatch = self.tracker.dispatch(global_object);
 
             if success {
                 promise.resolve(global_object, result)?;
@@ -995,15 +990,6 @@ mod _async_tasks {
                 promise.reject(global_object, Ok(result))?;
             }
             Ok(())
-        }
-
-        /// SAFETY: `this` must be the pointer Box::leak'd in `create()`; called exactly once.
-        pub(crate) unsafe fn destroy(this: *mut Self) {
-            // SAFETY: caller guarantees `this` is the live Box-leaked allocation;
-            // reclaim ownership (paired with the Box::leak in create()).
-            let mut task = unsafe { bun_core::heap::take(this) };
-            // `bun_sys::Error` frees its path on Drop.
-            task.r#ref.unref(bun_io::js_vm_ctx());
         }
     }
 
@@ -1238,10 +1224,10 @@ mod _async_tasks {
     {
         const TAG: bun_event_loop::TaskTag = F.task_tag();
         /// A libuv fs request that completed into the queue after the last
-        /// tick: destroy releases its promise handle and keep-alive.
+        /// tick: dropping it releases its promise handle and keep-alive.
         unsafe fn release_unrun(this: *mut Self) {
-            // SAFETY: fn contract — `Box::leak`'d in `UVFSRequest::create`.
-            unsafe { Self::destroy(this) }
+            // SAFETY: fn contract — leaked in `UVFSRequest::create`, reclaimed once.
+            unsafe { bun_core::heap::destroy(this) }
         }
     }
 
@@ -1412,6 +1398,17 @@ mod _async_tasks {
         pub(crate) shelltask: Option<bun_ptr::ParentRef<ShellCpTask, bun_ptr::Mut>>,
     }
 
+    /// Runs on the owning thread when the completion (or `release_unrun`) drops
+    /// the box `schedule_new` leaked. `Drop for ThreadSafe<args::Cp>` releases the
+    /// `protect()` taken by `to_thread_safe()` when `src`/`dest` are Buffers.
+    impl<const IS_SHELL: bool> Drop for NewAsyncCpTask<IS_SHELL> {
+        fn drop(&mut self) {
+            if !IS_SHELL {
+                self.r#ref.unref(event_loop_handle_to_ctx(self.evtloop));
+            }
+        }
+    }
+
     bun_threading::intrusive_work_task!([const IS_SHELL: bool] NewAsyncCpTask<IS_SHELL>, task);
 
     /// This task is used by `AsyncCpTask/fs.promises.cp` to copy a single file.
@@ -1525,11 +1522,11 @@ mod _async_tasks {
         } else {
             bun_event_loop::task_tag::AsyncCpTask
         };
-        /// A finished fs.cp whose completion will not run: destroy releases
+        /// A finished fs.cp whose completion will not run: dropping it releases
         /// its promise handle, protected arguments and keep-alive.
         unsafe fn release_unrun(this: *mut Self) {
             // SAFETY: fn contract — posted by `on_subtask_done` with the count at zero.
-            unsafe { Self::destroy(this) }
+            unsafe { bun_core::heap::destroy(this) }
         }
     }
 
@@ -1568,7 +1565,9 @@ mod _async_tasks {
                 tracker,
                 core::ptr::null_mut(),
             );
-            // SAFETY: `schedule_new` returns a Box::leak'd pointer; valid until destroy()
+            // SAFETY: `schedule_new` returns the leaked box, which only the completion
+            // posted to this thread reclaims, so it is live until we return to the
+            // event loop; the pool side never touches `promise`.
             unsafe { &*task }.promise.value()
         }
 
@@ -1698,10 +1697,11 @@ mod _async_tasks {
                 let at =
                     AnyTaskWithExtraContext::from_callback_auto_deinit(this, |p: *mut Self, _| {
                         debug_assert!(IS_SHELL, "only the shell posts cp tasks to a mini loop");
-                        // SAFETY: subtask count hit zero ⇒ exclusive access to the leaked
-                        // task. The shell specialization settles no promise, so there is
-                        // no termination to report: the result is always `Ok`.
-                        let _ = unsafe { Self::run_from_js_thread(p) };
+                        // SAFETY: subtask count hit zero ⇒ this is the only pointer left to
+                        // the box `schedule_new` leaked; reclaim it. The shell
+                        // specialization settles no promise, so there is no termination to
+                        // report: the result is always `Ok`.
+                        let _ = unsafe { bun_core::heap::take(p) }.run_from_js_thread();
                     });
                 // `from_callback_auto_deinit` heap-allocates; never null.
                 poster.post_mini(core::ptr::NonNull::new(at).expect("heap task"));
@@ -1710,37 +1710,25 @@ mod _async_tasks {
             poster.embedded_work_finished();
         }
 
-        /// Delivers the result (settles the promise, or hands it to the shell's
-        /// `ShellCpTask`) and frees the task. Posted by `on_subtask_done`.
-        ///
-        /// Raw-pointer receiver: this function ends in `destroy(this)`. A `&mut self`
-        /// argument would be protected for the whole frame, and freeing the allocation
-        /// while that protector is live is UB ("deallocating while item is protected");
-        /// the borrows below are plain locals whose last use precedes the free.
-        ///
-        /// # Safety
-        /// `this` is the pointer `schedule_new()` leaked, every subtask has dropped its
-        /// reference (`subtask_count` reached zero, so this thread has exclusive
-        /// access), and it is not used after this call.
-        pub(crate) unsafe fn run_from_js_thread(
-            this: *mut Self,
-        ) -> Result<(), bun_jsc::JsTerminated> {
-            // SAFETY: fn contract — frees `*this` once, on every return path, after
-            // everything below has run.
-            let _deinit = scopeguard::guard(this, |p| unsafe { Self::destroy(p) });
-            // SAFETY: fn contract — `*this` is live until the guard runs; `result` is a
-            // `Cell`, so moving it out below needs only this shared borrow.
-            let task = unsafe { &*this };
+        /// Delivers the result: settles the promise, or hands it to the shell's
+        /// `ShellCpTask`. The completion `on_subtask_done` posted reclaims the box
+        /// `schedule_new` leaked and passes it in; dropping it on the way out (every
+        /// return path) releases the keep-alive and frees the task. Owning the box,
+        /// rather than taking `&mut self`, is what makes freeing it here sound: a
+        /// reference argument is protected for the whole call and must not be
+        /// deallocated through.
+        #[allow(clippy::boxed_local, reason = "reclaim point for the boxed task")]
+        pub(crate) fn run_from_js_thread(self: Box<Self>) -> Result<(), bun_jsc::JsTerminated> {
             // `Maybe<ret::Cp>` (= `Maybe<()>`) has a cheap `Ok(())` placeholder.
-            let mut result = task.result.replace(Ok(()));
+            let mut result = self.result.replace(Ok(()));
             if IS_SHELL {
-                let shelltask = task.shelltask.expect("IS_SHELL ⇒ shelltask").as_mut_ptr();
+                let shelltask = self.shelltask.expect("IS_SHELL ⇒ shelltask").as_mut_ptr();
                 // SAFETY: shelltask is non-null in the IS_SHELL specialization and
                 // outlives this task; `cp_on_finish` continues it in place.
                 unsafe { ShellCpTask::cp_on_finish(shelltask, result) };
                 return Ok(());
             }
-            let go_ptr = task.evtloop.global_object();
+            let go_ptr = self.evtloop.global_object();
             if go_ptr.is_null() {
                 panic!(
                     "No global object, this indicates a bug in Bun. Please file a GitHub issue."
@@ -1749,8 +1737,8 @@ mod _async_tasks {
             // SAFETY: non-null erased *mut JSGlobalObject from the JS event loop vtable.
             let global_object: &JSGlobalObject = unsafe { &*go_ptr.cast::<JSGlobalObject>() };
             let success = result.is_ok();
-            let promise_value = task.promise.value();
-            let promise = task.promise.get();
+            let promise_value = self.promise.value();
+            let promise = self.promise.get();
             let result = match &mut result {
                 Err(err) => match err.to_js_with_async_stack(global_object, promise) {
                     Ok(v) => v,
@@ -1767,7 +1755,7 @@ mod _async_tasks {
             };
             promise_value.ensure_still_alive();
 
-            let _dispatch = task.tracker.dispatch(global_object);
+            let _dispatch = self.tracker.dispatch(global_object);
 
             if success {
                 promise.resolve(global_object, result)?;
@@ -1775,21 +1763,6 @@ mod _async_tasks {
                 promise.reject(global_object, Ok(result))?;
             }
             Ok(())
-        }
-
-        /// SAFETY: `this` must be the pointer returned by Box::leak in
-        /// `schedule_new()`; called exactly once.
-        pub(crate) unsafe fn destroy(this: *mut Self) {
-            // SAFETY: caller guarantees `this` is the live Box-leaked allocation;
-            // reclaim ownership (paired with the Box::leak in
-            // schedule_new()).
-            let mut task = unsafe { bun_core::heap::take(this) };
-            if !IS_SHELL {
-                let ctx = event_loop_handle_to_ctx(task.evtloop);
-                task.r#ref.unref(ctx);
-            }
-            // `Drop for ThreadSafe<args::Cp>` releases the `protect()` taken by
-            // `to_thread_safe()` when `src`/`dest` are Buffers, so nothing leaks here.
         }
 
         /// Directory scanning + clonefile will block this thread, then each individual file copy (what the sync version

--- a/test/internal/source-lints/self-receiver-teardown.test.ts
+++ b/test/internal/source-lints/self-receiver-teardown.test.ts
@@ -1,0 +1,219 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A `&self` / `&mut self` method must not hand its own receiver to the type's
+// teardown routine: `Self::destroy(ptr::from_mut(self))`, `Self::deinit(self as
+// *mut _)`, or the deferred form `scopeguard::guard(ptr::from_mut(self), |p|
+// Self::destroy(p))` (which frees in the epilogue, while the receiver argument
+// is still live) are banned.
+//
+// `destroy(this: *mut Self)` / `deinit(this: *mut Self)` are this tree's names
+// for "reclaim the Box" (`heap::take` / `heap::destroy` inside). Under Stacked
+// and Tree Borrows a reference argument is protected for the whole call, and
+// deallocating protected memory is UB regardless of whether the reference is
+// used again afterwards ("deallocating while item is strongly protected" /
+// "the strongly protected tag disallows deallocations" under Miri, the model
+// `bun run rust:miri` checks; the protector is the model's counterpart of the
+// `dereferenceable` attribute rustc puts on reference arguments, so this is not
+// only a Miri concern). The function that frees has to take the allocation
+// pointer (`this: *mut Self`) and reborrow per statement, with its caller (a
+// dispatch arm, a C callback, a scope guard over the raw pointer) passing the
+// pointer through; see the comment on `deinit(this: *mut Self)` in
+// src/sql_jsc/postgres/PostgresSQLConnection.rs and
+// `UVFSRequest::run_from_js_thread` / `NewAsyncCpTask::run_from_js_thread` in
+// src/runtime/node/node_fs.rs.
+//
+// Scope: the two single-expression shapes above, with the callee literally
+// named `destroy` or `deinit` (the name list is the enforcement boundary; a new
+// teardown routine under another name goes here too; `heap::destroy` counts as
+// a `destroy` spelling). Deliberately outside it:
+//   - the other reclaim primitives (`heap::take(from_mut(self))`,
+//     `Box::from_raw(self as *mut _)`), a separate population one layer down;
+//   - refcount releases (`Self::deref(from_mut(self))`), which only free on the
+//     last count, so each site needs its own argument about who else holds one;
+//   - `finalize` and similar names, which in this tree also denote in-place
+//     finalizers that do not free (`JsSinkType::finalize`);
+//   - a self-derived pointer stashed in a local and freed later, and reference
+//     parameters (`fn f(this: &mut T)` freeing `this`).
+//
+// Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts,
+// unsound-erased-box.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// The ways of spelling "`self`, as a raw pointer", optionally followed by
+// pointer-to-pointer conversions that keep it the same address (`.cast()`,
+// `.cast_mut()`, `.as_ptr()`). `(?!\s*\.)` after `&raw mut *self` keeps a
+// field's address (`&raw mut *self.inner`) out of it.
+const SELF_AS_POINTER =
+  String.raw`(?:` +
+  [
+    String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
+    String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+    String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
+    String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+    String.raw`self\s+as\s+\*(?:mut|const)\b[^,()]*`,
+  ].join("|") +
+  String.raw`)(?:\s*\.\s*(?:cast(?:_mut|_const)?(?:::<[^>]*>)?|as_ptr)\(\))*`;
+
+// `destroy(` / `deinit(`, optionally path-qualified (`Self::`, `Worker::`,
+// `bun_core::heap::`) and turbofished. `\s*` after the paren so a
+// rustfmt-wrapped argument list still matches.
+const TEARDOWN = String.raw`\b(?:[\w:]+::)?(?:destroy|deinit)(?:::<[^>]*>)?\s*\(\s*`;
+
+const DIRECT = new RegExp(`${TEARDOWN}${SELF_AS_POINTER}\\s*[,)]`, "g");
+
+// `scopeguard::guard(<self as pointer>, |p| { unsafe { Self::destroy(p) } })`:
+// the guard's closure must apply the teardown routine to the guarded pointer
+// (the back-reference), so a guard over `self`'s address that does something
+// else with it (src/runtime/ffi/ffi_body.rs frees a field) does not count.
+const DEFERRED = new RegExp(
+  String.raw`scopeguard::guard\(\s*${SELF_AS_POINTER}\s*,\s*(?:move\s+)?\|\s*(\w+)\s*\|\s*(?:\{\s*)?(?:unsafe\s*\{\s*)?${TEARDOWN}\1\s*\)`,
+  "g",
+);
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape while their conversion is in flight. Delete an entry when its file is
+// converted; never raise one.
+const ALLOW: Record<string, number> = {
+  // `CopyFileWindows::throw` and `resolve_promise` (`&mut self`) end in
+  // `Self::destroy`, reached through further `&mut self` frames.
+  "src/runtime/webcore/blob/copy_file.rs": 2,
+  // `LifecycleScriptSubprocess::handle_exit` / `deinit_and_delete_package`
+  // (`&mut self`) free the subprocess at five sites; #37551 turns them into a
+  // disposition that the raw-pointer thunks act on.
+  "src/install/lifecycle_script_runner.rs": 5,
+  // `Worker::deinit_soon` (`&mut self`) frees itself inline when the worker
+  // was created off the pool; #37685 converts it.
+  "src/bundler/ThreadPool.rs": 1,
+};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (and SAFETY comments inside a
+  // guard's closure) don't count or break a match. `[ \t]*`, not `\s*`: `\s`
+  // crosses newlines and would swallow blank lines, shifting the reported line
+  // numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  const hits = [DIRECT, DEFERRED]
+    .flatMap(re => [...stripped.matchAll(re)])
+    .map(m => ({ line: stripped.slice(0, m.index).split("\n").length, text: m[0].replace(/\s+/g, " ") }))
+    .sort((a, b) => a.line - b.line);
+  if (hits.length === 0) continue;
+  counts[source] = hits.length;
+  for (const { line, text } of hits.slice(ALLOW[source] ?? 0)) {
+    offenders.push(`${source}:${line}: ${text}`);
+  }
+}
+
+function matches(snippet: string): boolean {
+  DIRECT.lastIndex = 0;
+  DEFERRED.lastIndex = 0;
+  return DIRECT.test(snippet) || DEFERRED.test(snippet);
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the patterns recognize the spellings they claim to", () => {
+  const banned = [
+    // The node_fs.rs lines this lint was written for.
+    "unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };",
+    "let _deinit =\n    scopeguard::guard(core::ptr::from_mut(self), |p| unsafe { Self::destroy(p) });",
+    // Other spellings of the receiver's address.
+    "unsafe { Self::destroy(core::ptr::from_mut(self)) };",
+    "unsafe { Self::deinit(std::ptr::from_mut::<Self>(self)) };",
+    "unsafe { Worker::deinit(self as *mut Self) };",
+    "unsafe { destroy(self as *const Self as *mut Self) }",
+    "unsafe { Self::destroy(&raw mut *self) }",
+    "unsafe { Self::destroy(core::ptr::addr_of_mut!(*self)) }",
+    "unsafe { Self::destroy(ptr::from_ref(self).cast_mut()) }",
+    "unsafe { Self::destroy(NonNull::from(self).as_ptr()) }",
+    "unsafe { Self::destroy::<true>(std::ptr::from_mut(self)) }",
+    "unsafe { crate::node::fs::AsyncCpTask::destroy(std::ptr::from_mut(self)) }",
+    "unsafe { bun_core::heap::destroy(std::ptr::from_mut::<Self>(self)) };",
+    // Extra arguments after the pointer, and a rustfmt-wrapped call.
+    "unsafe { Self::deinit(std::ptr::from_mut(self), allocator) }",
+    "unsafe {\n    Self::destroy(\n        std::ptr::from_mut::<Self>(self),\n    )\n}",
+    // Deferred: block body, `move`, a SAFETY comment already stripped to a blank line.
+    "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |this| {\n\n    unsafe { Self::destroy(this) }\n});",
+    "let _g = scopeguard::guard(self as *mut Self, move |p| unsafe { Self::deinit(p) });",
+  ];
+  const allowed = [
+    // The converted shapes: the pointer comes in as a parameter.
+    "unsafe { Self::destroy(this) }",
+    "let _deinit = scopeguard::guard(this, |p| unsafe { Self::destroy(p) });",
+    "unsafe { Self::destroy(cast_ptr!(crate::node::fs::AsyncCpTask)) }",
+    "unsafe { FSWatchTask::deinit(t) };",
+    // Freeing something the receiver owns is fine.
+    "unsafe { Self::destroy(self.child) }",
+    "unsafe { Worker::deinit(self.worker.as_ptr()) }",
+    "unsafe { Self::destroy(&raw mut *self.inner) }",
+    "unsafe { TCC::State::destroy(s.as_ptr()) };",
+    // By-value teardown and UFCS forwarding of the reference itself are not
+    // this shape.
+    "self.deinit();",
+    "self.io_request.deinit();",
+    "Self::deinit(self)",
+    "Self::deinit(self, id)",
+    // Producing the receiver's address for something other than teardown.
+    "self.req.data = core::ptr::from_mut(self).cast::<c_void>();",
+    "Self::finalize(core::ptr::from_mut(self));",
+    "unsafe { Self::deref_(std::ptr::from_mut::<Self>(self)) };",
+    "unsafe { Self::teardown(core::ptr::from_mut(self), Teardown::MainThreadExit) };",
+    // The other primitives are a separate population (see the scope note).
+    "unsafe { drop(bun_core::heap::take(std::ptr::from_mut::<Self>(self))) };",
+    // A guard over the receiver's address whose closure frees a field, or
+    // releases a refcount, is out of scope.
+    "let _guard = scopeguard::guard(std::ptr::from_mut::<Function>(self), |this_ptr| {\n    if let Some(s) = unsafe { (*this_ptr).state.take() } {\n        unsafe { TCC::State::destroy(s.as_ptr()) };\n    }\n});",
+    "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |s| {\n    unsafe { Self::deref_(s) }\n});",
+    // A guard that frees a different pointer than the one it guards.
+    "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |_p| unsafe { Self::destroy(other) });",
+    // Not the receiver.
+    "unsafe { Self::destroy(std::ptr::from_mut::<Self>(self_)) };",
+    "unsafe { Self::destroy(ptr::from_mut(task)) }",
+  ];
+  expect(banned.filter(s => !matches(s))).toEqual([]);
+  expect(allowed.filter(matches)).toEqual([]);
+});
+
+test("no method hands its own receiver to destroy/deinit", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: once an allowlisted file is converted, delete its entry so a new
+  // instance cannot take the old one's place.
+  for (const [f, n] of Object.entries(ALLOW)) {
+    expect(counts[f] ?? 0).toBe(n);
+  }
+});

--- a/test/internal/source-lints/self-receiver-teardown.test.ts
+++ b/test/internal/source-lints/self-receiver-teardown.test.ts
@@ -6,16 +6,18 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 
 // A `&self` / `&mut self` method must not hand its own receiver to the type's
 // teardown routine: `Self::destroy(ptr::from_mut(self))`, `Self::deinit(self as
-// *mut _)`, or the deferred form `scopeguard::guard(ptr::from_mut(self), |p|
-// Self::destroy(p))` (which frees in the epilogue, while the receiver argument
-// is still live) are banned.
+// *mut _)`, `Self::finalize(ptr::from_mut(self))`, or the deferred forms
+// `scopeguard::guard(ptr::from_mut(self), |p| Self::destroy(p))` and
+// `scopeguard::guard(ptr::from_mut(self), Self::destroy)` (which free in the
+// epilogue, while the receiver argument is still live) are banned.
 //
-// `destroy(this: *mut Self)` / `deinit(this: *mut Self)` are this tree's names
-// for "reclaim the Box" (`heap::take` / `heap::destroy` inside). Under Stacked
-// and Tree Borrows a reference argument is protected for the whole call, and
-// deallocating protected memory is UB regardless of whether the reference is
-// used again afterwards ("deallocating while item is strongly protected" /
-// "the strongly protected tag disallows deallocations" under Miri, the model
+// `destroy(this: *mut Self)` / `deinit(this: *mut Self)` / `finalize(this: *mut
+// Self)` are the names this tree's "reclaim the Box" routines (`heap::take` /
+// `heap::destroy` inside) go by. Under Stacked and Tree Borrows a reference
+// argument is protected for the whole call, and deallocating protected memory
+// is UB regardless of whether the reference is used again afterwards (Miri:
+// "deallocating while item is strongly protected" under Stacked Borrows, "the
+// strongly protected tag disallows deallocations" under Tree Borrows, the model
 // `bun run rust:miri` checks; the protector is the model's counterpart of the
 // `dereferenceable` attribute rustc puts on reference arguments, so this is not
 // only a Miri concern). The method has to own the allocation instead: the
@@ -29,18 +31,20 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // reborrows per statement and frees through `this` (see the comment on
 // `deinit(this: *mut Self)` in src/sql_jsc/postgres/PostgresSQLConnection.rs).
 //
-// Scope: the two single-expression shapes above, with the callee literally
-// named `destroy` or `deinit` (the name list is the enforcement boundary; a new
-// teardown routine under another name goes here too; `heap::destroy` counts as
-// a `destroy` spelling). Deliberately outside it:
+// Scope: the single-expression shapes above, with the callee literally named
+// `destroy`, `deinit` or `finalize` (`heap::destroy` counts as a `destroy`
+// spelling). The name list is the enforcement boundary: a reclaim routine under
+// another name is not caught until its name is added here. Deliberately
+// outside it:
 //   - the other reclaim primitives (`heap::take(from_mut(self))`,
-//     `Box::from_raw(self as *mut _)`), a separate population one layer down;
+//     `Box::from_raw(self as *mut _)`), a separate population one layer down
+//     (#37672 adds the lint for them);
 //   - refcount releases (`Self::deref(from_mut(self))`), which only free on the
 //     last count, so each site needs its own argument about who else holds one;
-//   - `finalize` and similar names, which in this tree also denote in-place
-//     finalizers that do not free (`JsSinkType::finalize`);
-//   - a self-derived pointer stashed in a local and freed later, and reference
-//     parameters (`fn f(this: &mut T)` freeing `this`).
+//   - in-place finalizers and UFCS forwarding (`Self::finalize(self)`), which
+//     take no address; a self-derived pointer stashed in a local and freed
+//     later; reference parameters (`fn f(this: &mut T)` freeing `this`); and a
+//     guard closure that does more than the one call.
 //
 // Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts,
 // unsound-erased-box.test.ts.
@@ -61,44 +65,65 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-// The ways of spelling "`self`, as a raw pointer", optionally followed by
-// pointer-to-pointer conversions that keep it the same address (`.cast()`,
-// `.cast_mut()`, `.as_ptr()`). `(?!\s*\.)` after `&raw mut *self` keeps a
-// field's address (`&raw mut *self.inner`) out of it.
+// An optional `::<..>`, allowing one level of nesting (`::<Request<'a>>`).
+const TURBOFISH = String.raw`(?:::<(?:[^<>]|<[^<>]*>)*>)?`;
+
+// `self` (or a reborrow of it) as the sole argument of a pointer constructor.
+const SELF_ARG = String.raw`\(\s*(?:&(?:mut\s+)?\*\s*)?self\s*\)`;
+
+// The ways of spelling "`self`, as a raw pointer", optionally parenthesized and
+// optionally followed by pointer-to-pointer conversions that keep it the same
+// address (`.cast()`, `.cast_mut()`, `.as_ptr()`). `(?!\s*\.)` after
+// `&raw mut *self` keeps a field's address (`&raw mut *self.inner`) out of it.
 const SELF_AS_POINTER =
-  String.raw`(?:` +
+  String.raw`\(?\s*(?:` +
   [
-    String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
-    String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+    String.raw`(?:[\w:]+::)?from_(?:mut|ref)${TURBOFISH}${SELF_ARG}`,
+    String.raw`(?:[\w:]+::)?NonNull::from${SELF_ARG}`,
     String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
     String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
     String.raw`self\s+as\s+\*(?:mut|const)\b[^,()]*`,
   ].join("|") +
-  String.raw`)(?:\s*\.\s*(?:cast(?:_mut|_const)?(?:::<[^>]*>)?|as_ptr)\(\))*`;
+  String.raw`)\s*\)?(?:\s*\.\s*(?:cast(?:_mut|_const)?${TURBOFISH}|as_ptr)\(\))*`;
 
-// `destroy(` / `deinit(`, optionally path-qualified (`Self::`, `Worker::`,
-// `bun_core::heap::`) and turbofished. `\s*` after the paren so a
-// rustfmt-wrapped argument list still matches.
-const TEARDOWN = String.raw`\b(?:[\w:]+::)?(?:destroy|deinit)(?:::<[^>]*>)?\s*\(\s*`;
+// A teardown routine by path (`destroy`, `Self::deinit`, `bun_core::heap::destroy`,
+// `Worker::deinit::<T>`), and the same followed by its opening paren (`\s*`
+// after it so a rustfmt-wrapped argument list still matches).
+const TEARDOWN_FN = String.raw`\b(?:[\w:]+::)?(?:destroy|deinit|finalize)${TURBOFISH}`;
+const TEARDOWN = String.raw`${TEARDOWN_FN}\s*\(\s*`;
 
 const DIRECT = new RegExp(`${TEARDOWN}${SELF_AS_POINTER}\\s*[,)]`, "g");
 
-// `scopeguard::guard(<self as pointer>, |p| { unsafe { Self::destroy(p) } })`:
-// the guard's closure must apply the teardown routine to the guarded pointer
-// (the back-reference), so a guard over `self`'s address that does something
-// else with it (src/runtime/ffi/ffi_body.rs frees a field) does not count.
+// `scopeguard::guard(<self as pointer>, |p| { unsafe { Self::destroy(p) } })` or
+// `scopeguard::guard(<self as pointer>, Self::destroy)`: the guard's callback
+// must be the teardown routine, applied (in the closure form, via the
+// back-reference) to the guarded pointer itself. A guard over `self`'s address
+// that does something else with it (src/runtime/ffi/ffi_body.rs frees a field)
+// does not count.
 const DEFERRED = new RegExp(
-  String.raw`scopeguard::guard\(\s*${SELF_AS_POINTER}\s*,\s*(?:move\s+)?\|\s*(\w+)\s*\|\s*(?:\{\s*)?(?:unsafe\s*\{\s*)?${TEARDOWN}\1\s*\)`,
+  String.raw`scopeguard::guard\(\s*${SELF_AS_POINTER}\s*,\s*(?:` +
+    String.raw`(?:move\s+)?\|\s*(\w+)\s*\|\s*(?:\{\s*)?(?:unsafe\s*\{\s*)?${TEARDOWN}\1\s*\)` +
+    String.raw`|${TEARDOWN_FN}\s*\))`,
   "g",
 );
+
+/** Every banned occurrence in one file's text, in line order. */
+function scanText(content: string): { line: number; text: string }[] {
+  // Strip full-line comments so prose mentions don't count and a SAFETY comment
+  // inside a guard's closure doesn't break the match. `[ \t]*`, not `\s*`: `\s`
+  // crosses newlines and would swallow blank lines, shifting the reported line
+  // numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  return [DIRECT, DEFERRED]
+    .flatMap(re => [...stripped.matchAll(re)])
+    .map(m => ({ line: stripped.slice(0, m.index).split("\n").length, text: m[0].replace(/\s+/g, " ") }))
+    .sort((a, b) => a.line - b.line);
+}
 
 // Documented, ratcheted exceptions: files allowed to keep exactly N of the
 // shape while their conversion is in flight. Delete an entry when its file is
 // converted; never raise one.
 const ALLOW: Record<string, number> = {
-  // `CopyFileWindows::throw` and `resolve_promise` (`&mut self`) end in
-  // `Self::destroy`, reached through further `&mut self` frames.
-  "src/runtime/webcore/blob/copy_file.rs": 2,
   // `LifecycleScriptSubprocess::handle_exit` / `deinit_and_delete_package`
   // (`&mut self`) free the subprocess at five sites; #37551 turns them into a
   // disposition that the raw-pointer thunks act on.
@@ -106,6 +131,11 @@ const ALLOW: Record<string, number> = {
   // `Worker::deinit_soon` (`&mut self`) frees itself inline when the worker
   // was created off the pool; #37685 converts it.
   "src/bundler/ThreadPool.rs": 1,
+  // `CopyFileWindows::throw` / `resolve_promise` and `ReadFileUV::on_finish`
+  // (`&mut self`) free the task they run on, reached through further
+  // `&mut self` frames; #37705 converts them.
+  "src/runtime/webcore/blob/copy_file.rs": 2,
+  "src/runtime/webcore/blob/read_file.rs": 1,
 };
 
 const counts: Record<string, number> = {};
@@ -118,16 +148,7 @@ for (const abs of rustSources) {
   if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
   if (tracked !== null && !tracked.has(source)) continue;
   scanned++;
-  const content = await file(abs).text();
-  // Strip full-line comments so prose mentions (and SAFETY comments inside a
-  // guard's closure) don't count or break a match. `[ \t]*`, not `\s*`: `\s`
-  // crosses newlines and would swallow blank lines, shifting the reported line
-  // numbers.
-  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
-  const hits = [DIRECT, DEFERRED]
-    .flatMap(re => [...stripped.matchAll(re)])
-    .map(m => ({ line: stripped.slice(0, m.index).split("\n").length, text: m[0].replace(/\s+/g, " ") }))
-    .sort((a, b) => a.line - b.line);
+  const hits = scanText(await file(abs).text());
   if (hits.length === 0) continue;
   counts[source] = hits.length;
   for (const { line, text } of hits.slice(ALLOW[source] ?? 0)) {
@@ -135,11 +156,7 @@ for (const abs of rustSources) {
   }
 }
 
-function matches(snippet: string): boolean {
-  DIRECT.lastIndex = 0;
-  DEFERRED.lastIndex = 0;
-  return DIRECT.test(snippet) || DEFERRED.test(snippet);
-}
+const matches = (snippet: string): boolean => scanText(snippet).length > 0;
 
 test("scans a non-empty set of tracked Rust sources", () => {
   // Guards against the tracked/realpath filters above over-firing and leaving
@@ -152,24 +169,30 @@ test("the patterns recognize the spellings they claim to", () => {
     // The node_fs.rs lines this lint was written for.
     "unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };",
     "let _deinit =\n    scopeguard::guard(core::ptr::from_mut(self), |p| unsafe { Self::destroy(p) });",
-    // Other spellings of the receiver's address.
+    // Other callees and other spellings of the receiver's address.
     "unsafe { Self::destroy(core::ptr::from_mut(self)) };",
     "unsafe { Self::deinit(std::ptr::from_mut::<Self>(self)) };",
+    "Self::finalize(core::ptr::from_mut(self));",
     "unsafe { Worker::deinit(self as *mut Self) };",
     "unsafe { destroy(self as *const Self as *mut Self) }",
     "unsafe { Self::destroy(&raw mut *self) }",
     "unsafe { Self::destroy(core::ptr::addr_of_mut!(*self)) }",
     "unsafe { Self::destroy(ptr::from_ref(self).cast_mut()) }",
     "unsafe { Self::destroy(NonNull::from(self).as_ptr()) }",
+    "unsafe { Self::destroy(ptr::from_mut(&mut *self)) }",
+    "unsafe { Self::destroy((self as *mut Self).cast::<Base>()) }",
     "unsafe { Self::destroy::<true>(std::ptr::from_mut(self)) }",
+    "unsafe { Self::destroy(std::ptr::from_mut::<Request<'a>>(self)) }",
     "unsafe { crate::node::fs::AsyncCpTask::destroy(std::ptr::from_mut(self)) }",
     "unsafe { bun_core::heap::destroy(std::ptr::from_mut::<Self>(self)) };",
     // Extra arguments after the pointer, and a rustfmt-wrapped call.
     "unsafe { Self::deinit(std::ptr::from_mut(self), allocator) }",
     "unsafe {\n    Self::destroy(\n        std::ptr::from_mut::<Self>(self),\n    )\n}",
-    // Deferred: block body, `move`, a SAFETY comment already stripped to a blank line.
-    "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |this| {\n\n    unsafe { Self::destroy(this) }\n});",
+    // Deferred: block body with a SAFETY comment, `move`, and the fn-value form.
+    "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |this| {\n    // SAFETY: leaked in new(); freed exactly once here.\n    unsafe { Self::destroy(this) }\n});",
     "let _g = scopeguard::guard(self as *mut Self, move |p| unsafe { Self::deinit(p) });",
+    "let _g = scopeguard::guard(core::ptr::from_mut(self), Self::destroy);",
+    "let _g = scopeguard::guard(self as *mut Self, Worker::deinit);",
   ];
   const allowed = [
     // The converted shapes: the caller reclaims the box, or the pointer comes
@@ -177,41 +200,74 @@ test("the patterns recognize the spellings they claim to", () => {
     "unsafe { bun_core::heap::take(cast_ptr!(crate::node::fs::AsyncCpTask)) }.run_from_js_thread()?;",
     "unsafe { Self::destroy(this) }",
     "let _deinit = scopeguard::guard(this, |p| unsafe { Self::destroy(p) });",
-    "unsafe { Self::destroy(cast_ptr!(crate::node::fs::AsyncCpTask)) }",
+    "let _guard = scopeguard::guard(this_ptr, Self::deinit);",
     "unsafe { FSWatchTask::deinit(t) };",
     // Freeing something the receiver owns is fine.
     "unsafe { Self::destroy(self.child) }",
     "unsafe { Worker::deinit(self.worker.as_ptr()) }",
     "unsafe { Self::destroy(&raw mut *self.inner) }",
     "unsafe { TCC::State::destroy(s.as_ptr()) };",
-    // By-value teardown and UFCS forwarding of the reference itself are not
-    // this shape.
+    // By-value teardown and UFCS forwarding of the reference itself take no
+    // address.
     "self.deinit();",
     "self.io_request.deinit();",
     "Self::deinit(self)",
     "Self::deinit(self, id)",
+    "Self::finalize(self)",
     // Producing the receiver's address for something other than teardown.
     "self.req.data = core::ptr::from_mut(self).cast::<c_void>();",
-    "Self::finalize(core::ptr::from_mut(self));",
     "unsafe { Self::deref_(std::ptr::from_mut::<Self>(self)) };",
     "unsafe { Self::teardown(core::ptr::from_mut(self), Teardown::MainThreadExit) };",
     // The other primitives are a separate population (see the scope note).
     "unsafe { drop(bun_core::heap::take(std::ptr::from_mut::<Self>(self))) };",
-    // A guard over the receiver's address whose closure frees a field, or
-    // releases a refcount, is out of scope.
-    "let _guard = scopeguard::guard(std::ptr::from_mut::<Function>(self), |this_ptr| {\n    if let Some(s) = unsafe { (*this_ptr).state.take() } {\n        unsafe { TCC::State::destroy(s.as_ptr()) };\n    }\n});",
+    // A guard over the receiver's address whose callback frees a field,
+    // releases a refcount, or frees some other pointer is out of scope.
+    "let _guard = scopeguard::guard(std::ptr::from_mut::<Function>(self), |this_ptr| {\n    // SAFETY: this_ptr is self for the duration of compile().\n    if let Some(s) = unsafe { (*this_ptr).state.take() } {\n        unsafe { TCC::State::destroy(s.as_ptr()) };\n    }\n});",
     "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |s| {\n    unsafe { Self::deref_(s) }\n});",
-    // A guard that frees a different pointer than the one it guards.
+    "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), Self::deref_);",
     "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |_p| unsafe { Self::destroy(other) });",
     // Not the receiver.
     "unsafe { Self::destroy(std::ptr::from_mut::<Self>(self_)) };",
     "unsafe { Self::destroy(ptr::from_mut(task)) }",
+    // Prose.
+    "// Unlike `Self::destroy(std::ptr::from_mut::<Self>(self))`, this takes the box.",
   ];
   expect(banned.filter(s => !matches(s))).toEqual([]);
   expect(allowed.filter(matches)).toEqual([]);
 });
 
-test("no method hands its own receiver to destroy/deinit", () => {
+test("a file is scanned with comments stripped and hits attributed to their lines", () => {
+  // The three shapes `main` had in node_fs.rs, behind a comment that mentions
+  // one of them and with a SAFETY comment inside the guard's closure. Unlike the
+  // ratchet below, this keeps exercising the whole per-file pipeline once the
+  // allowlist is empty.
+  const fixture = [
+    "// `Self::destroy(std::ptr::from_mut::<Self>(self))` is what this replaces.",
+    "impl Task {",
+    "    fn uv(&mut self) {",
+    "        let _deinit =",
+    "            scopeguard::guard(core::ptr::from_mut(self), |p| unsafe { Self::destroy(p) });",
+    "    }",
+    "    fn cp(&mut self) {",
+    "        unsafe { Self::destroy(std::ptr::from_mut::<Self>(self)) };",
+    "        unsafe { Self::destroy(self.child) };",
+    "    }",
+    "    fn guarded(&mut self) {",
+    "        let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |this| {",
+    "            // SAFETY: leaked in new(); freed exactly once here.",
+    "            unsafe { Self::deinit(this) }",
+    "        });",
+    "    }",
+    "}",
+  ].join("\n");
+  expect(scanText(fixture)).toEqual([
+    { line: 5, text: "scopeguard::guard(core::ptr::from_mut(self), |p| unsafe { Self::destroy(p)" },
+    { line: 8, text: "Self::destroy(std::ptr::from_mut::<Self>(self))" },
+    { line: 12, text: "scopeguard::guard(std::ptr::from_mut::<Self>(self), |this| { unsafe { Self::deinit(this)" },
+  ]);
+});
+
+test("no method hands its own receiver to destroy/deinit/finalize", () => {
   expect(offenders).toEqual([]);
 });
 

--- a/test/internal/source-lints/self-receiver-teardown.test.ts
+++ b/test/internal/source-lints/self-receiver-teardown.test.ts
@@ -18,13 +18,16 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // "the strongly protected tag disallows deallocations" under Miri, the model
 // `bun run rust:miri` checks; the protector is the model's counterpart of the
 // `dereferenceable` attribute rustc puts on reference arguments, so this is not
-// only a Miri concern). The function that frees has to take the allocation
-// pointer (`this: *mut Self`) and reborrow per statement, with its caller (a
-// dispatch arm, a C callback, a scope guard over the raw pointer) passing the
-// pointer through; see the comment on `deinit(this: *mut Self)` in
-// src/sql_jsc/postgres/PostgresSQLConnection.rs and
+// only a Miri concern). The method has to own the allocation instead: the
+// caller that holds the raw pointer (a dispatch arm, a C callback) reclaims
+// the box (`heap::take`) and calls a `self: Box<Self>` method, with the
+// teardown in `Drop`, so every return path frees it; see
 // `UVFSRequest::run_from_js_thread` / `NewAsyncCpTask::run_from_js_thread` in
-// src/runtime/node/node_fs.rs.
+// src/runtime/node/node_fs.rs and the arms that call them in
+// src/runtime/dispatch.rs. Where the pointer cannot be turned back into a box
+// at the entry point, the fallback is a `this: *mut Self` function that
+// reborrows per statement and frees through `this` (see the comment on
+// `deinit(this: *mut Self)` in src/sql_jsc/postgres/PostgresSQLConnection.rs).
 //
 // Scope: the two single-expression shapes above, with the callee literally
 // named `destroy` or `deinit` (the name list is the enforcement boundary; a new
@@ -169,7 +172,9 @@ test("the patterns recognize the spellings they claim to", () => {
     "let _g = scopeguard::guard(self as *mut Self, move |p| unsafe { Self::deinit(p) });",
   ];
   const allowed = [
-    // The converted shapes: the pointer comes in as a parameter.
+    // The converted shapes: the caller reclaims the box, or the pointer comes
+    // in as a parameter.
+    "unsafe { bun_core::heap::take(cast_ptr!(crate::node::fs::AsyncCpTask)) }.run_from_js_thread()?;",
     "unsafe { Self::destroy(this) }",
     "let _deinit = scopeguard::guard(this, |p| unsafe { Self::destroy(p) });",
     "unsafe { Self::destroy(cast_ptr!(crate::node::fs::AsyncCpTask)) }",

--- a/test/internal/source-lints/self-receiver-teardown.test.ts
+++ b/test/internal/source-lints/self-receiver-teardown.test.ts
@@ -44,7 +44,8 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //   - in-place finalizers and UFCS forwarding (`Self::finalize(self)`), which
 //     take no address; a self-derived pointer stashed in a local and freed
 //     later; reference parameters (`fn f(this: &mut T)` freeing `this`); and a
-//     guard closure that does more than the one call.
+//     guard closure whose first expression is not the teardown call (whatever
+//     follows that call is not looked at).
 //
 // Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts,
 // unsound-erased-box.test.ts.
@@ -97,9 +98,10 @@ const DIRECT = new RegExp(`${TEARDOWN}${SELF_AS_POINTER}\\s*[,)]`, "g");
 // `scopeguard::guard(<self as pointer>, |p| { unsafe { Self::destroy(p) } })` or
 // `scopeguard::guard(<self as pointer>, Self::destroy)`: the guard's callback
 // must be the teardown routine, applied (in the closure form, via the
-// back-reference) to the guarded pointer itself. A guard over `self`'s address
-// that does something else with it (src/runtime/ffi/ffi_body.rs frees a field)
-// does not count.
+// back-reference, as the closure's first expression; anything after it still
+// runs after the free and does not rescue the guard) to the guarded pointer
+// itself. A guard over `self`'s address that does something else with it
+// (src/runtime/ffi/ffi_body.rs frees a field) does not count.
 const DEFERRED = new RegExp(
   String.raw`scopeguard::guard\(\s*${SELF_AS_POINTER}\s*,\s*(?:` +
     String.raw`(?:move\s+)?\|\s*(\w+)\s*\|\s*(?:\{\s*)?(?:unsafe\s*\{\s*)?${TEARDOWN}\1\s*\)` +
@@ -120,23 +122,46 @@ function scanText(content: string): { line: number; text: string }[] {
     .sort((a, b) => a.line - b.line);
 }
 
-// Documented, ratcheted exceptions: files allowed to keep exactly N of the
-// shape while their conversion is in flight. Delete an entry when its file is
-// converted; never raise one.
-const ALLOW: Record<string, number> = {
+// Documented, ratcheted exceptions: a file may keep exactly `count` hits whose
+// (whitespace-collapsed) text is exactly `text` while their conversion is in
+// flight; any other spelling in the file, or one more of this one, is an
+// offender. Delete an entry when its file is converted; never raise one.
+const ALLOW: Record<string, { count: number; text: string }> = {
   // `LifecycleScriptSubprocess::handle_exit` / `deinit_and_delete_package`
   // (`&mut self`) free the subprocess at five sites; #37551 turns them into a
   // disposition that the raw-pointer thunks act on.
-  "src/install/lifecycle_script_runner.rs": 5,
+  "src/install/lifecycle_script_runner.rs": {
+    count: 5,
+    text: "Self::destroy(std::ptr::from_mut::<Self>(self))",
+  },
   // `Worker::deinit_soon` (`&mut self`) frees itself inline when the worker
   // was created off the pool; #37685 converts it.
-  "src/bundler/ThreadPool.rs": 1,
+  "src/bundler/ThreadPool.rs": { count: 1, text: "Self::deinit(std::ptr::from_mut::<Self>(self))" },
   // `CopyFileWindows::throw` / `resolve_promise` and `ReadFileUV::on_finish`
   // (`&mut self`) free the task they run on, reached through further
   // `&mut self` frames; #37705 converts them.
-  "src/runtime/webcore/blob/copy_file.rs": 2,
-  "src/runtime/webcore/blob/read_file.rs": 1,
+  "src/runtime/webcore/blob/copy_file.rs": { count: 2, text: "Self::destroy(core::ptr::from_mut(self))" },
+  "src/runtime/webcore/blob/read_file.rs": { count: 1, text: "Self::finalize(core::ptr::from_mut(self))" },
 };
+
+/**
+ * Applies one file's allowlist entry: `documented` counts the hits with the
+ * documented text (the ratchet), and everything that is not one of the first
+ * `count` of those is an offender.
+ */
+function triage(
+  source: string,
+  hits: { line: number; text: string }[],
+  allow: { count: number; text: string } | undefined,
+): { documented: number; offenders: string[] } {
+  let documented = 0;
+  const offenders: string[] = [];
+  for (const { line, text } of hits) {
+    if (allow !== undefined && text === allow.text && documented++ < allow.count) continue;
+    offenders.push(`${source}:${line}: ${text}`);
+  }
+  return { documented, offenders };
+}
 
 const counts: Record<string, number> = {};
 const offenders: string[] = [];
@@ -148,12 +173,9 @@ for (const abs of rustSources) {
   if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
   if (tracked !== null && !tracked.has(source)) continue;
   scanned++;
-  const hits = scanText(await file(abs).text());
-  if (hits.length === 0) continue;
-  counts[source] = hits.length;
-  for (const { line, text } of hits.slice(ALLOW[source] ?? 0)) {
-    offenders.push(`${source}:${line}: ${text}`);
-  }
+  const result = triage(source, scanText(await file(abs).text()), ALLOW[source]);
+  if (result.documented > 0) counts[source] = result.documented;
+  offenders.push(...result.offenders);
 }
 
 const matches = (snippet: string): boolean => scanText(snippet).length > 0;
@@ -191,6 +213,7 @@ test("the patterns recognize the spellings they claim to", () => {
     // Deferred: block body with a SAFETY comment, `move`, and the fn-value form.
     "let _g = scopeguard::guard(std::ptr::from_mut::<Self>(self), |this| {\n    // SAFETY: leaked in new(); freed exactly once here.\n    unsafe { Self::destroy(this) }\n});",
     "let _g = scopeguard::guard(self as *mut Self, move |p| unsafe { Self::deinit(p) });",
+    'let _g = scopeguard::guard(core::ptr::from_mut(self), |p| { unsafe { Self::destroy(p) }; log!("freed"); });',
     "let _g = scopeguard::guard(core::ptr::from_mut(self), Self::destroy);",
     "let _g = scopeguard::guard(self as *mut Self, Worker::deinit);",
   ];
@@ -267,14 +290,32 @@ test("a file is scanned with comments stripped and hits attributed to their line
   ]);
 });
 
+test("an allowlist entry exempts only its documented spelling, and only that many of it", () => {
+  const destroy = "Self::destroy(core::ptr::from_mut(self))";
+  const deinit = "Self::deinit(core::ptr::from_mut(self))";
+  const hits = [
+    { line: 10, text: destroy },
+    { line: 20, text: destroy },
+    { line: 30, text: deinit },
+  ];
+  expect(triage("x.rs", hits, { count: 1, text: destroy })).toEqual({
+    documented: 2,
+    offenders: [`x.rs:20: ${destroy}`, `x.rs:30: ${deinit}`],
+  });
+  expect(triage("x.rs", hits, undefined)).toEqual({
+    documented: 0,
+    offenders: [`x.rs:10: ${destroy}`, `x.rs:20: ${destroy}`, `x.rs:30: ${deinit}`],
+  });
+});
+
 test("no method hands its own receiver to destroy/deinit/finalize", () => {
   expect(offenders).toEqual([]);
 });
 
-test("allowlisted files still carry exactly their documented count", () => {
+test("allowlisted files still carry exactly their documented sites", () => {
   // Ratchet: once an allowlisted file is converted, delete its entry so a new
   // instance cannot take the old one's place.
-  for (const [f, n] of Object.entries(ALLOW)) {
-    expect(counts[f] ?? 0).toBe(n);
-  }
+  const actual = Object.fromEntries(Object.keys(ALLOW).map(f => [f, counts[f] ?? 0]));
+  const documented = Object.fromEntries(Object.entries(ALLOW).map(([f, { count }]) => [f, count]));
+  expect(actual).toEqual(documented);
 });


### PR DESCRIPTION
### Problem
- Two of the JS-thread completions for async `node:fs` work take `&mut self` and free the heap box that holds `self` before returning: the Windows libuv-backed promise ops (`open`/`close`/`read`/`write`/`readv`/`writev`/`statfs`), and `fs.cp` / `fs.promises.cp` on every platform, which the shell's `cp` builtin also goes through.
- Under both of Rust's aliasing models a reference argument is protected for the whole call it was passed to, so deallocating it is undefined behaviour whether or not it is touched again. Miri reports `deallocating while item is strongly protected` (Stacked Borrows) or `the strongly protected tag disallows deallocations` (Tree Borrows, which `bun run rust:miri` uses), pointing at the `&mut self` receiver.
- The cp completion also leaked its task on its two error returns.
- No crash is known from this.

### Fix
- Both completions now take `self: Box<Self>`. The caller holding the raw pointer (the dispatch arm, or the shell's mini-loop thunk) reclaims the box and hands it over, the same shape as the neighbouring task arms; the box drops on every return path, so the error returns no longer leak.
- The keep-alive unref that `destroy()` did moves into `Drop` on the two task types and `destroy()` is deleted. This is correct because a callee may deallocate a box it owns but never a reference it was lent, and with the unref in `Drop` there is no way to free the task without it.
- Only one ordering changes: the cp task now drops after settling its promise instead of before, as the Windows requests already did. Both still happen inside the same task turn, before microtasks drain.
- Verification: the new source lint reports exactly the three sites on `main` and passes here; the same shape in four other files is allowlisted by exact spelling and count, each with its own conversion PR. There is no runtime repro since no crash is known; the fs `cp` and promises tests pass on Linux debug (ASAN) and Windows debug builds, and the shell `cp` builtin was run by hand on both loops.

### Background
- An async fs task is a heap box that is leaked so a raw pointer can be handed to libuv or the thread pool; whichever completion runs last on the JS thread must free it exactly once. `heap::take` turns that pointer back into a `Box`, `heap::destroy` takes and drops it.
- Stacked Borrows and Tree Borrows are the aliasing models Miri checks unsafe Rust against. A reference argument carries a protector for the duration of the call, the model's counterpart of the `dereferenceable` attribute rustc puts on the compiled function, so this is not only a Miri concern.
- Each pending fs task holds a keep-alive ref on the event loop so the process does not exit before the promise settles; releasing it is the one piece of teardown these tasks do beyond dropping their fields.
- The event loop's task queue holds tag plus pointer pairs; `run_task` in `src/runtime/dispatch.rs` matches on the tag and casts the pointer. The shell `cp` builtin can instead complete on a separate mini event loop, which is why the cp task has a second entry point.
- `test/internal/source-lints/` holds bun tests that regex-scan the tree's own sources for banned shapes, with a ratcheting allowlist so existing sites can be converted one PR at a time.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-teardown.test.ts
bun test v1.4.0 (5900596d7)

test/internal/source-lints/self-receiver-teardown.test.ts:
(pass) scans a non-empty set of tracked Rust sources [3.14ms]
(pass) the patterns recognize the spellings they claim to [38.10ms]
(pass) a file is scanned with comments stripped and hits attributed to their lines [9.45ms]
(pass) an allowlist entry exempts only its documented spelling, and only that many of it [6.99ms]
307 |     offenders: [`x.rs:10: ${destroy}`, `x.rs:20: ${destroy}`, `x.rs:30: ${deinit}`],
308 |   });
309 | });
310 | 
311 | test("no method hands its own receiver to destroy/deinit/finalize", () => {
312 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/node/node_fs.rs:948: scopeguard::guard(core::ptr::from_mut(self), |p| unsafe { Self::destroy(p)",
+   "src/runtime/node/node_fs.rs:1709: Self::destroy(std::ptr::from_mut::<Self>(self))",
+   "src/runtime/node/node_fs.rs:1750: Self::destroy(std::pt
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/internal/source-lints/self-receiver-teardown.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.16ms]
(pass) the patterns recognize the spellings they claim to [0.61ms]
(pass) a file is scanned with comments stripped and hits attributed to their lines [0.19ms]
(pass) an allowlist entry exempts only its documented spelling, and only that many of it [0.09ms]
307 |     offenders: [`x.rs:10: ${destroy}`, `x.rs:20: ${destroy}`, `x.rs:30: ${deinit}`],
308 |   });
309 | });
310 | 
311 | test("no method hands its own receiver to destroy/deinit/finalize", () => {
312 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/node/node_fs.rs:948: scopeguard::guard(core::ptr::from_mut(self), |p| unsafe { Self::destroy(p)",
+   "src/runtime/node/node_fs.rs:1709: Self::destroy(std::ptr::from_mut::<Self>(self))",
+   "src/runtime/node/node_fs.rs:1750: Self::destroy(std::ptr::from_mut::<Self>(self))",
+ ]

- Expected  - 1
+ Received  + 5

      at <anonymous> (/workspace/bun/test/internal/source-lints/self-receiver-teardown.test.ts:312:21)
(fail) no met
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-teardown.test.ts
bun test v1.4.0 (5900596d7)

test/internal/source-lints/self-receiver-teardown.test.ts:
(pass) scans a non-empty set of tracked Rust sources [3.10ms]
(pass) the patterns recognize the spellings they claim to [37.98ms]
(pass) a file is scanned with comments stripped and hits attributed to their lines [7.49ms]
(pass) an allowlist entry exempts only its documented spelling, and only that many of it [6.59ms]
(pass) no method hands its own receiver to destroy/deinit/finalize [2.38ms]
(pass) allowlisted files still carry exactly their documented sites [14.30ms]

 6 pass
 0 fail
 8 expect() calls
Ran 6 tests across 1 file. [39.36s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1026ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/6] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/6] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
^[[1m^[[92m   Compiling^[[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
^[[1m^[[92m   Compiling^[[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
^[[1m^[[92m   Compiling^[[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
^[[1m^[[92m   Compiling^[[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
^[[1m^[[92m   Compiling^[[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
^[[1m^[[92m   Compiling^[[0m bun_brotli 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/dispatch.rs                            |  16 +-
 src/runtime/node/node_fs.rs                        | 147 ++++------
 .../source-lints/self-receiver-teardown.test.ts    | 321 +++++++++++++++++++++
 3 files changed, 387 insertions(+), 97 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/dispatch.rs                                       8      8      0
src/runtime/node/node_fs.rs                                  23     40      0
…st/internal/source-lints/self-receiver-teardown.test.ts      6     15      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

Two JS-thread completion methods in src/runtime/node/node_fs.rs take `&mut self` and free the Box that contains `self` before returning:

* `UVFSRequest::run_from_js_thread(&mut self)` (Windows: the libuv-backed `open`/`close`/`read`/`write`/`readv`/`writev`/`statfs` promises) arms `scopeguard::guard(ptr::from_mut(self), |p| Self::destroy(p))`, so the free runs in the epilogue while the receiver is still live.
* `NewAsyncCpTask::run_from_js_thread(&mut self)` (`fs.cp` / `fs.promises.cp` on every platform, and the shell's `cp` builtin through `NewAsyncCpTask<true>`) calls `Self::destroy(ptr::from_mut(self))` inline on both of its completion paths. The shell's mini-loop path added one more `&mut` frame (`run_from_js_thread_mini`), and the two dispatch arms in src/runtime/dispatch.rs formed the `&mut` with `(*task.ptr.cast::<AsyncCpTask>()).run_from_js_thread()`.

`destroy` is an unconditional `heap::take`. A reference argument is protected for the duration of the call it was passed to, and deallocating protected memory is undefined behaviour under both aliasing models regardless of whether the reference is touched again afterwards: Stacked Borrows reports it as `deallocating while item is strongly protected`, Tree Borrows (what `bun run rust:miri` uses) as `the strongly protected tag disallows deallocations`, pointing at the `&mut self` receiver. Spelling the receiver as a raw pointer at the call site does not change that; the protected argument is the method's own receiver. No crash is known from this.

### Fix

The completions own their allocation instead of freeing it from behind a reference (RAII, as suggested in review):

* Both `run_from_js_thread`s take `self: Box<Self>`. The dispatch arms (and the Windows `__fs_run` table) reclaim the box with `heap::take(task.ptr)` and call it, the same shape as the `StatWatcherTimerUpdate` / `AsyncModule` / `ValkeyDeferredClose` arms next to them; the shell's mini-loop thunk does the same, so `run_from_js_thread_mini` goes away (it was only reachable for the shell specialization, whose result is always `Ok`, which the thunk now asserts). The box drops on every return path, including the two `Err` returns from the conversion helpers that previously leaked the task.
* The keep-alive unref that `destroy()` did moves into `Drop` impls on the two task types, so `destroy()` is deleted and `Taskable::release_unrun` becomes `heap::destroy`. Field drops (promise handle, protected arguments) run in the same order as before, after the unref.
* A `Box<Self>` argument is what the aliasing models (and clippy's `boxed_local`, suppressed here the same way as at the other reclaim points in the tree) are designed around: a box may be deallocated by the callee that owns it, a reference may not.

The only order-of-operations change is in the cp task, which used to destroy itself before settling the promise (hence its raw `*mut JSPromise` copy and the comments explaining why the promise outlived `destroy`); it now drops after settling, like `UVFSRequest` already did and like the by-value `AsyncFSTask::then`. Everything still happens inside the same task turn, before microtasks drain. `c_void` drops out of the file's imports because the removed parameter was its last non-Windows use.

### Tests

test/internal/source-lints/self-receiver-teardown.test.ts bans `destroy(..)` / `deinit(..)` / `finalize(..)` applied to a pointer spelled from `self` (`ptr::from_mut(self)`, `from_mut(&mut *self)`, `self as *mut _`, `&raw mut *self`, `addr_of_mut!(*self)`, `NonNull::from(self)`, optionally parenthesized or `.cast()`ed, turbofish allowed), and the deferred forms `scopeguard::guard(<that pointer>, |p| .. destroy(p))` and `scopeguard::guard(<that pointer>, Self::destroy)`; the first of those is the shape `UVFSRequest` had and a direct-call pattern cannot see it, the second is what clippy's `redundant_closure` turns the first into when the callee is a safe fn. The per-file step is one `scanText()` (strip full-line comments, match, attribute lines); the ~50 positive and negative snippets go through it, and a small fixture (the three shapes `main` had, behind a prose mention and with a SAFETY comment inside the guard's closure) pins its exact `{line, text}` output, so the pipeline stays exercised after the allowlist below has emptied. Against `main` it reports exactly

```
src/runtime/node/node_fs.rs:948:  scopeguard::guard(core::ptr::from_mut(self), |p| unsafe { Self::destroy(p)
src/runtime/node/node_fs.rs:1709: Self::destroy(std::ptr::from_mut::<Self>(self))
src/runtime/node/node_fs.rs:1750: Self::destroy(std::ptr::from_mut::<Self>(self))
```

and nothing else beyond the files carrying the same shape, which are allowlisted by exact spelling and count (any other spelling in those files is still reported) so each conversion deletes its entry: src/install/lifecycle_script_runner.rs (5, #37551), src/bundler/ThreadPool.rs (1, #37685), src/runtime/webcore/blob/copy_file.rs (2) and read_file.rs (1, both #37705). Refcount releases and the `heap::take` / `Box::from_raw` primitives are documented as out of scope (#37672 covers the latter).

#37685 and #37705 carry a copy of this lint at the same path with their own file's sites allowlisted and this file's three listed against this PR. The identical path is deliberate: whichever PR lands second gets a conflict on the file instead of landing a stale ratchet entry on `main`, and resolves it by keeping one copy and deleting the entries for the conversions that have landed. The copies have been kept in step (this one currently has the fn-value guard form, the fixture and the spelling-bound allowlist on top of the shared regexes).

### Verification

Debug (ASAN) build on Linux: test/js/node/fs/cp.test.ts and cp-symlink-target.test.ts (49 pass), the 36 upstream `test-fs-cp-async-*` / `test-fs-cp-promises-*` scripts under test/js/node/test/parallel (all pass), `fs.promises.cp` keeping the process alive until it settles and the process exiting afterwards (the `Drop` unref), and, since the shell `cp` builtin is off on POSIX without `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`, an ad hoc run with it on: 20 recursive `$\`cp -R\`` copies plus the error and `-v` paths from JS (the JS event loop arm), and recursive, error, `-v` and `&&`-chained copies through `bun exec` (the mini event loop thunk). `bun test test/internal/source-lints/` (18 files, 82 tests) passes, and the new lint fails against `main`'s node_fs.rs as shown above. On a Windows debug build of the same head: test/js/node/fs/promises.test.js and cp.test.ts (74 pass), the readv/writev/statfs/promises subset of fs.test.ts (98 pass; the one failure, `fs/promises > writeFile`, fails identically on `main` when the file is run with that filter because it relies on a directory an earlier test creates), and test/js/bun/shell/commands/cp.test.ts (30 pass, which on Windows runs the `cp` builtin through `NewAsyncCpTask<true>` on both the JS loop and, in the `(exec)` variants, the mini loop). `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` also passes; `cargo clippy -p bun_runtime` and `cargo fmt --check` are clean.

</details>
