### PR TITLE
http: move the cross-thread state out of HttpThread and claim HTTP_THREAD on the HTTP thread

### DIFF
--- a/src/bun_core/atomic_cell.rs
+++ b/src/bun_core/atomic_cell.rs
@@ -487,7 +487,7 @@ unsafe impl<U> Atom for Option<NonNull<U>> {
 /// **Migration note:** until [`claim`](Self::claim) is called, `get()` does
 /// *not* assert (matching `RacyCell`). This lets a static be initialized on
 /// the spawning thread, then claimed from the worker thread's entry point.
-/// `test/internal/source-lints/thread-cell-claimed.test.ts` requires that `claim()` for every static.
+/// `test/internal/source-lints/thread-cell-claimed.test.ts` requires a `claim()` for every static.
 #[repr(C)]
 pub struct ThreadCell<T: ?Sized> {
     #[cfg(debug_assertions)]

--- a/src/bun_core/atomic_cell.rs
+++ b/src/bun_core/atomic_cell.rs
@@ -484,15 +484,10 @@ unsafe impl<U> Atom for Option<NonNull<U>> {
 /// This is the worker-thread sibling of `JsCell<T>` (which is JS-thread-
 /// affine and additionally documents reentrancy as the hazard).
 ///
-/// Until [`claim`](Self::claim) is called, `get()` does *not* assert
-/// (matching `RacyCell`). This lets a static be initialized on the spawning
-/// thread, then claimed from the worker thread's entry point. A static that
-/// is never claimed is just a `RacyCell` with a misleading type, so
-/// `test/internal/source-lints/thread-cell-claimed.test.ts` requires a
-/// `claim()` for every `ThreadCell` static. Before switching a `RacyCell`
-/// over, cross-thread callers therefore have to either move to a separate
-/// `Sync` static (`bun_http`'s HTTP thread) or be confined to the fields
-/// [`get_unchecked`](Self::get_unchecked) documents (`bun_io`'s request loop).
+/// **Migration note:** until [`claim`](Self::claim) is called, `get()` does
+/// *not* assert (matching `RacyCell`). This lets a static be initialized on
+/// the spawning thread, then claimed from the worker thread's entry point.
+/// `test/internal/source-lints/thread-cell-claimed.test.ts` requires that `claim()` for every static.
 #[repr(C)]
 pub struct ThreadCell<T: ?Sized> {
     #[cfg(debug_assertions)]

--- a/src/bun_core/atomic_cell.rs
+++ b/src/bun_core/atomic_cell.rs
@@ -489,9 +489,10 @@ unsafe impl<U> Atom for Option<NonNull<U>> {
 /// thread, then claimed from the worker thread's entry point. A static that
 /// is never claimed is just a `RacyCell` with a misleading type, so
 /// `test/internal/source-lints/thread-cell-claimed.test.ts` requires a
-/// `claim()` for every `ThreadCell` static: route cross-thread callers away
-/// from the cell (e.g. into a separate `Sync` static, as `bun_http` does for
-/// its HTTP thread) before switching a `RacyCell` over.
+/// `claim()` for every `ThreadCell` static. Before switching a `RacyCell`
+/// over, cross-thread callers therefore have to either move to a separate
+/// `Sync` static (`bun_http`'s HTTP thread) or be confined to the fields
+/// [`get_unchecked`](Self::get_unchecked) documents (`bun_io`'s request loop).
 #[repr(C)]
 pub struct ThreadCell<T: ?Sized> {
     #[cfg(debug_assertions)]

--- a/src/bun_core/atomic_cell.rs
+++ b/src/bun_core/atomic_cell.rs
@@ -484,11 +484,14 @@ unsafe impl<U> Atom for Option<NonNull<U>> {
 /// This is the worker-thread sibling of `JsCell<T>` (which is JS-thread-
 /// affine and additionally documents reentrancy as the hazard).
 ///
-/// **Migration note:** until [`claim`](Self::claim) is called, `get()` does
-/// *not* assert (matching `RacyCell`). This lets a static be initialized on
-/// the spawning thread, then claimed from the worker thread's entry point.
-/// Existing `RacyCell` sites can swap to `ThreadCell` as a drop-in first
-/// step, then add `claim()` once cross-thread callers are routed away.
+/// Until [`claim`](Self::claim) is called, `get()` does *not* assert
+/// (matching `RacyCell`). This lets a static be initialized on the spawning
+/// thread, then claimed from the worker thread's entry point. A static that
+/// is never claimed is just a `RacyCell` with a misleading type, so
+/// `test/internal/source-lints/thread-cell-claimed.test.ts` requires a
+/// `claim()` for every `ThreadCell` static: route cross-thread callers away
+/// from the cell (e.g. into a separate `Sync` static, as `bun_http` does for
+/// its HTTP thread) before switching a `RacyCell` over.
 #[repr(C)]
 pub struct ThreadCell<T: ?Sized> {
     #[cfg(debug_assertions)]

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -795,12 +795,12 @@ impl<'a> AsyncHTTP<'a> {
             }
         }
 
-        let thread = crate::http_thread();
-        if (!thread.queued_tasks.is_empty() || !thread.deferred_tasks.is_empty())
+        if (crate::HTTPThread::has_queued_tasks()
+            || !crate::http_thread().deferred_tasks.is_empty())
             && ACTIVE_REQUESTS_COUNT.load(Ordering::Relaxed)
                 < MAX_SIMULTANEOUS_REQUESTS.load(Ordering::Relaxed)
         {
-            thread.wakeup();
+            crate::HTTPThread::wakeup();
         }
     }
 }

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -357,12 +357,7 @@ pub fn preconnect(url: URL<'static>, is_url_owned: bool) {
         return;
     }
 
-    // `Bun__fetchPreconnect` reaches here without going through any path that
-    // calls `HTTPThread::init`, so if `fetch.preconnect()` is the process's
-    // first HTTP operation nothing would have started the thread that drains
-    // what `schedule()` below enqueues (it asserts as much). `init` is
-    // idempotent (`Once`) and every other JS-side entry point (`send_sync`,
-    // `FetchTasklet::start`, S3) passes default opts too.
+    // `fetch.preconnect()` may be the process's first HTTP operation; `schedule()` asserts this ran.
     crate::http_thread::init(&Default::default());
 
     let this: *mut Preconnect = bun_core::heap::into_raw(Box::new(Preconnect {

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -357,12 +357,12 @@ pub fn preconnect(url: URL<'static>, is_url_owned: bool) {
         return;
     }
 
-    // Write-before-read: `Bun__fetchPreconnect` reaches here without going
-    // through any path that calls `HTTPThread::init`, so `schedule()` below
-    // would deref the uninitialized `HTTP_THREAD` static (UB on niche-bearing
-    // fields) if `fetch.preconnect()` is the process's first HTTP operation.
-    // `init` is idempotent (`Once`) and every other JS-side entry point
-    // (`send_sync`, `FetchTasklet::start`, S3) passes default opts too.
+    // `Bun__fetchPreconnect` reaches here without going through any path that
+    // calls `HTTPThread::init`, so if `fetch.preconnect()` is the process's
+    // first HTTP operation nothing would have started the thread that drains
+    // what `schedule()` below enqueues (it asserts as much). `init` is
+    // idempotent (`Once`) and every other JS-side entry point (`send_sync`,
+    // `FetchTasklet::start`, S3) passes default opts too.
     crate::http_thread::init(&Default::default());
 
     let this: *mut Preconnect = bun_core::heap::into_raw(Box::new(Preconnect {

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -84,16 +84,16 @@ use bun_event_loop::MiniEventLoop as mini_event_loop;
 use bun_event_loop::MiniEventLoop::MiniEventLoop;
 
 /// The HTTP thread's inbox: everything other threads hand to it, plus the loop
-/// pointer they wake it through. Producers (the JS thread via the associated
-/// `HttpThread::schedule*` fns and [`shutdown_for_exit`], DNS workers via
-/// `h3_client::PendingConnect`) and the consuming HTTP thread
-/// ([`HttpThread::drain_events`]) all hold only `&SHARED`, and every field is
-/// interior-mutable, so none of this is covered by the `&'static mut
-/// HttpThread` the HTTP thread holds across `process_events` for the life of
-/// the process. [`HttpThread`] itself is HTTP-thread-only: `on_start` claims
-/// [`HTTP_THREAD`](crate::HTTP_THREAD), so a debug build panics if
-/// `http_thread()` is ever called from anywhere else. (Same split as
-/// `h3_client::PendingConnect`'s `RESOLVED`.)
+/// pointer they wake it through. Producers (whichever thread owns a request,
+/// via the associated `HttpThread::schedule*` fns and `shutdown_for_exit`; DNS
+/// workers via `h3_client::PendingConnect`) and the consuming HTTP thread
+/// (`drain_events`, `dealloc_in_flight_for_exit`) all hold only `&SHARED`, and
+/// every field is interior-mutable, so none of this is covered by the
+/// `&'static mut HttpThread` the HTTP thread holds across `process_events` for
+/// the life of the process. `HttpThread` itself is HTTP-thread-only: `on_start`
+/// claims `HTTP_THREAD`, so a debug build panics if `http_thread()` is ever
+/// called from anywhere else. `h3_client::PendingConnect`'s `RESOLVED` is the
+/// same split for the h3 DNS handoff.
 struct Shared {
     queued_tasks: Queue,
     queued_shutdowns: Guarded<Vec<ShutdownMessage>>,
@@ -116,9 +116,8 @@ static SHARED: Shared = Shared {
     uws_loop: AtomicPtr::new(core::ptr::null_mut()),
 };
 
-/// State owned by the HTTP thread. Only reachable through
-/// [`http_thread()`](crate::http_thread), on the HTTP thread; state that other
-/// threads touch lives in [`Shared`].
+/// State owned by the HTTP thread. Only reachable through `http_thread()`, on
+/// the HTTP thread; state that other threads touch lives in `Shared`.
 pub struct HttpThread {
     /// Per-thread `MiniEventLoop` singleton — published by
     /// `MiniEventLoop::init_global()` in [`on_start`]; outlives the thread.
@@ -1121,9 +1120,11 @@ impl HttpThread {
         if batch.len == 0 {
             return;
         }
-        // Nothing drains `SHARED` until `init()` has spawned the thread, so a
-        // task scheduled before that would leave its owner waiting forever;
-        // fail loudly instead (`async_http::preconnect` once skipped `init`).
+        // Every caller is expected to `init()` first; a task scheduled by one
+        // that forgot would sit in the queue until something else happened to
+        // start the thread (`async_http::preconnect` once skipped `init`), so
+        // fail loudly instead. The message entry points above don't need this:
+        // they only ever refer to requests that already went through here.
         assert!(
             crate::HTTP_THREAD_INIT.load(Ordering::Acquire),
             "HTTPThread::schedule() called before HTTPThread::init()"

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -83,27 +83,14 @@ fn custom_ssl_context_map() -> &'static mut ArrayHashMap<*const SSLConfig, SslCo
 use bun_event_loop::MiniEventLoop as mini_event_loop;
 use bun_event_loop::MiniEventLoop::MiniEventLoop;
 
-/// The HTTP thread's inbox: everything other threads hand to it, plus the loop
-/// pointer they wake it through. Producers (whichever thread owns a request,
-/// via the associated `HttpThread::schedule*` fns and `shutdown_for_exit`; DNS
-/// workers via `h3_client::PendingConnect`) and the consuming HTTP thread
-/// (`drain_events`, `dealloc_in_flight_for_exit`) all hold only `&SHARED`, and
-/// every field is interior-mutable, so none of this is covered by the
-/// `&'static mut HttpThread` the HTTP thread holds across `process_events` for
-/// the life of the process. `HttpThread` itself is HTTP-thread-only: `on_start`
-/// claims `HTTP_THREAD`, so a debug build panics if `http_thread()` is ever
-/// called from anywhere else. `h3_client::PendingConnect`'s `RESOLVED` is the
-/// same split for the h3 DNS handoff.
+/// Touched by other threads, so it lives outside the `&'static mut HttpThread` the HTTP thread holds.
 struct Shared {
     queued_tasks: Queue,
     queued_shutdowns: Guarded<Vec<ShutdownMessage>>,
     queued_writes: Guarded<Vec<WriteMessage>>,
     queued_receive_resumes: Guarded<Vec<u32>>,
     queued_cert_check_resumes: Guarded<Vec<CertCheckResumeMessage>>,
-    /// `HttpThread::uws_loop`, published (Release) by `on_start` right before
-    /// it enters `process_events`. Null until then, which makes
-    /// [`HttpThread::wakeup`] a no-op; anything queued that early is picked
-    /// up by the first `drain_events` regardless.
+    /// Published by `on_start` right before `process_events`; `wakeup` is a no-op while it is null.
     uws_loop: AtomicPtr<uws::Loop>,
 }
 
@@ -116,8 +103,7 @@ static SHARED: Shared = Shared {
     uws_loop: AtomicPtr::new(core::ptr::null_mut()),
 };
 
-/// State owned by the HTTP thread. Only reachable through `http_thread()`, on
-/// the HTTP thread; state that other threads touch lives in `Shared`.
+/// HTTP-thread-only (`HTTP_THREAD` is claimed in `on_start`); other threads only touch `Shared`.
 pub struct HttpThread {
     /// Per-thread `MiniEventLoop` singleton — published by
     /// `MiniEventLoop::init_global()` in [`on_start`]; outlives the thread.
@@ -402,11 +388,10 @@ impl HttpThread {
 
     /// Mutable access to the live uSockets event loop.
     ///
-    /// INVARIANT: `uws_loop` is set once in [`on_start`] and outlives the HTTP
-    /// thread. The loop is a separate C heap allocation disjoint from `self`.
-    /// HTTP-thread-only at every caller — other threads only reach the loop
-    /// through [`HttpThread::wakeup`], which goes through `SHARED.uws_loop` and
-    /// the raw FFI call instead. Centralises the raw `&mut *self.uws_loop`
+    /// INVARIANT: `uws_loop` is set once in [`on_start`] and outlives the HTTP thread. The loop is a
+    /// separate C heap allocation disjoint from `self`. HTTP-thread-only at
+    /// every caller — `wakeup()` is the sole cross-thread entry and uses the
+    /// raw FFI call instead. Centralises the raw `&mut *self.uws_loop`
     /// upgrade repeated in `process_events`.
     #[inline]
     fn uws_loop_mut<'a>(&self) -> &'a mut uws::Loop {
@@ -962,10 +947,7 @@ impl HttpThread {
         }
     }
 
-    // The `schedule*` associated fns below (and `schedule` / `wakeup` further
-    // down) are the cross-thread entry points: they only touch `SHARED`.
-    // Everything taking `self` is HTTP-thread-only.
-
+    // Associated fns (no `self`) are callable from any thread; they only touch `SHARED`.
     pub fn schedule_receive_resume(async_http_id: u32) {
         {
             let mut queued = SHARED.queued_receive_resumes.lock();
@@ -1092,25 +1074,18 @@ impl HttpThread {
         }
     }
 
-    /// Make the HTTP thread's loop return from its poll so it runs
-    /// [`drain_events`](Self::drain_events). Any thread; a no-op until
-    /// `on_start` has published the loop.
+    /// Any thread. A no-op until `on_start` has published the loop.
     pub(crate) fn wakeup() {
-        // Acquire pairs with the Release store in `on_start`, which publishes
-        // the loop's initialization along with the pointer.
         let loop_ = SHARED.uws_loop.load(Ordering::Acquire);
         if !loop_.is_null() {
-            // SAFETY: once published, the loop is the HTTP thread's live loop
-            // and is never destroyed (`process_events` never returns).
-            // `us_wakeup_loop` is uSockets' thread-safe wake and takes the raw
-            // pointer, so no `&mut Loop` is formed here next to the one
-            // `process_events` holds across `tick()`.
+            // SAFETY: the Acquire load pairs with the Release store in `on_start`, so the loop it
+            // published is fully initialized; it is never destroyed (`process_events` never
+            // returns). `us_wakeup_loop` is the thread-safe wake and takes the raw pointer, so no
+            // `&mut Loop` is formed here next to the one `process_events` holds across `tick()`.
             unsafe { uws::us_wakeup_loop(loop_) };
         }
     }
 
-    /// Whether [`schedule`](Self::schedule) has queued tasks that
-    /// [`drain_events`](Self::drain_events) has not popped yet.
     pub(crate) fn has_queued_tasks() -> bool {
         !SHARED.queued_tasks.is_empty()
     }
@@ -1120,11 +1095,7 @@ impl HttpThread {
         if batch.len == 0 {
             return;
         }
-        // Every caller is expected to `init()` first; a task scheduled by one
-        // that forgot would sit in the queue until something else happened to
-        // start the thread (`async_http::preconnect` once skipped `init`), so
-        // fail loudly instead. The message entry points above don't need this:
-        // they only ever refer to requests that already went through here.
+        // A caller that skipped `init()` would otherwise hang (`async_http::preconnect` once did).
         assert!(
             crate::HTTP_THREAD_INIT.load(Ordering::Acquire),
             "HTTPThread::schedule() called before HTTPThread::init()"
@@ -1315,8 +1286,6 @@ mod _event_loop_draft {
             }
         }
 
-        // From here on only this thread may touch `HTTP_THREAD`; debug builds
-        // panic on any `http_thread()` call from another thread.
         crate::HTTP_THREAD.claim();
         let thread = crate::http_thread_mut();
         thread.loop_ = loop_;
@@ -1345,8 +1314,7 @@ mod _event_loop_draft {
             // none).
             thread.lazy_https_init = Some(opts);
         }
-        // Release: publishes the loop (and its initialization above) to
-        // `wakeup()` callers on other threads, which Acquire-load it.
+        // Release pairs with the Acquire load in `wakeup`.
         SHARED.uws_loop.store(uws_loop, Ordering::Release);
         thread.process_events();
     }
@@ -1421,9 +1389,7 @@ static SHUTDOWN_DONE: (bun_threading::Guarded<bool>, bun_threading::Condvar) = (
 #[must_use]
 pub fn shutdown_for_exit() -> bool {
     if SHARED.uws_loop.load(Ordering::Acquire).is_null() {
-        // The thread was never started, or `on_start` hasn't reached
-        // `process_events` yet — either way no `start_queued_task` can have
-        // run, so no boxes exist.
+        // Never started, or not yet in `process_events`: `start_queued_task` has not run, no boxes.
         return true;
     }
     SHUTDOWN_REQUESTED.store(true, Ordering::Release);

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1,12 +1,12 @@
 use core::ffi::c_void;
 use core::ptr::NonNull;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::time::Instant;
 
 use bun_collections::ArrayHashMap;
 use bun_core::{self, Output};
 
-use bun_threading::{Mutex, UnboundedQueue};
+use bun_threading::{Guarded, UnboundedQueue};
 use bun_uws as uws;
 
 use crate::async_http::{ACTIVE_REQUESTS_COUNT, MAX_SIMULTANEOUS_REQUESTS};
@@ -83,6 +83,42 @@ fn custom_ssl_context_map() -> &'static mut ArrayHashMap<*const SSLConfig, SslCo
 use bun_event_loop::MiniEventLoop as mini_event_loop;
 use bun_event_loop::MiniEventLoop::MiniEventLoop;
 
+/// The HTTP thread's inbox: everything other threads hand to it, plus the loop
+/// pointer they wake it through. Producers (the JS thread via the associated
+/// `HttpThread::schedule*` fns and [`shutdown_for_exit`], DNS workers via
+/// `h3_client::PendingConnect`) and the consuming HTTP thread
+/// ([`HttpThread::drain_events`]) all hold only `&SHARED`, and every field is
+/// interior-mutable, so none of this is covered by the `&'static mut
+/// HttpThread` the HTTP thread holds across `process_events` for the life of
+/// the process. [`HttpThread`] itself is HTTP-thread-only: `on_start` claims
+/// [`HTTP_THREAD`](crate::HTTP_THREAD), so a debug build panics if
+/// `http_thread()` is ever called from anywhere else. (Same split as
+/// `h3_client::PendingConnect`'s `RESOLVED`.)
+struct Shared {
+    queued_tasks: Queue,
+    queued_shutdowns: Guarded<Vec<ShutdownMessage>>,
+    queued_writes: Guarded<Vec<WriteMessage>>,
+    queued_receive_resumes: Guarded<Vec<u32>>,
+    queued_cert_check_resumes: Guarded<Vec<CertCheckResumeMessage>>,
+    /// `HttpThread::uws_loop`, published (Release) by `on_start` right before
+    /// it enters `process_events`. Null until then, which makes
+    /// [`HttpThread::wakeup`] a no-op; anything queued that early is picked
+    /// up by the first `drain_events` regardless.
+    uws_loop: AtomicPtr<uws::Loop>,
+}
+
+static SHARED: Shared = Shared {
+    queued_tasks: Queue::new(),
+    queued_shutdowns: Guarded::new(Vec::new()),
+    queued_writes: Guarded::new(Vec::new()),
+    queued_receive_resumes: Guarded::new(Vec::new()),
+    queued_cert_check_resumes: Guarded::new(Vec::new()),
+    uws_loop: AtomicPtr::new(core::ptr::null_mut()),
+};
+
+/// State owned by the HTTP thread. Only reachable through
+/// [`http_thread()`](crate::http_thread), on the HTTP thread; state that other
+/// threads touch lives in [`Shared`].
 pub struct HttpThread {
     /// Per-thread `MiniEventLoop` singleton — published by
     /// `MiniEventLoop::init_global()` in [`on_start`]; outlives the thread.
@@ -106,8 +142,7 @@ pub struct HttpThread {
     /// reentrant).
     lazy_https_init: Option<InitOpts>,
 
-    pub(crate) queued_tasks: Queue,
-    /// Tasks popped from `queued_tasks` that couldn't start because
+    /// Tasks popped from `SHARED.queued_tasks` that couldn't start because
     /// `active_requests_count >= max_simultaneous_requests`. Kept in FIFO order
     /// and processed before `queued_tasks` on the next `drainEvents`. Owned by
     /// the HTTP thread; never accessed concurrently.
@@ -120,19 +155,8 @@ pub struct HttpThread {
     /// path stays O(1). Owned by the HTTP thread.
     pub(crate) has_pending_queued_abort: bool,
 
-    pub(crate) queued_shutdowns: Vec<ShutdownMessage>,
-    pub(crate) queued_writes: Vec<WriteMessage>,
-    pub(crate) queued_receive_resumes: Vec<u32>,
-    pub(crate) queued_cert_check_resumes: Vec<CertCheckResumeMessage>,
-
-    pub(crate) queued_shutdowns_lock: Mutex,
-    pub(crate) queued_writes_lock: Mutex,
-    pub(crate) queued_receive_resumes_lock: Mutex,
-    pub(crate) queued_cert_check_resumes_lock: Mutex,
-
     pub(crate) queued_threadlocal_proxy_derefs: Vec<*mut ProxyTunnel>,
 
-    pub(crate) has_awoken: AtomicBool,
     pub(crate) timer: Instant,
     pub(crate) lazy_libdeflater: Option<Box<LibdeflateState>>,
     pub(crate) lazy_request_body_buffer: Option<Box<HeapRequestBodyBuffer>>,
@@ -174,19 +198,9 @@ impl HttpThread {
                 session_cache: crate::session_cache::SessionCache::new(),
             },
             lazy_https_init: None,
-            queued_tasks: Queue::new(),
             deferred_tasks: Vec::new(),
             has_pending_queued_abort: false,
-            queued_shutdowns: Vec::new(),
-            queued_writes: Vec::new(),
-            queued_receive_resumes: Vec::new(),
-            queued_cert_check_resumes: Vec::new(),
-            queued_shutdowns_lock: Mutex::new(),
-            queued_writes_lock: Mutex::new(),
-            queued_receive_resumes_lock: Mutex::new(),
-            queued_cert_check_resumes_lock: Mutex::new(),
             queued_threadlocal_proxy_derefs: Vec::new(),
-            has_awoken: AtomicBool::new(false),
             timer: Instant::now(),
             lazy_libdeflater: None,
             lazy_request_body_buffer: None,
@@ -389,11 +403,11 @@ impl HttpThread {
 
     /// Mutable access to the live uSockets event loop.
     ///
-    /// INVARIANT: `uws_loop` is set once in [`on_start`] (published via the
-    /// `has_awoken` Release store) and outlives the HTTP thread. The loop is a
-    /// separate C heap allocation disjoint from `self`. HTTP-thread-only at
-    /// every caller — `wakeup()` is the sole cross-thread entry and uses the
-    /// raw FFI call instead. Centralises the raw `&mut *self.uws_loop`
+    /// INVARIANT: `uws_loop` is set once in [`on_start`] and outlives the HTTP
+    /// thread. The loop is a separate C heap allocation disjoint from `self`.
+    /// HTTP-thread-only at every caller — other threads only reach the loop
+    /// through [`HttpThread::wakeup`], which goes through `SHARED.uws_loop` and
+    /// the raw FFI call instead. Centralises the raw `&mut *self.uws_loop`
     /// upgrade repeated in `process_events`.
     #[inline]
     fn uws_loop_mut<'a>(&self) -> &'a mut uws::Loop {
@@ -638,10 +652,7 @@ impl HttpThread {
         loop {
             // socket.close() can potentially be slow
             // Let's not block other threads while this runs.
-            let queued_shutdowns = {
-                let _guard = self.queued_shutdowns_lock.lock_guard();
-                core::mem::take(&mut self.queued_shutdowns)
-            };
+            let queued_shutdowns = core::mem::take(&mut *SHARED.queued_shutdowns.lock());
 
             for http in &queued_shutdowns {
                 let tracker = abort_tracker();
@@ -709,10 +720,7 @@ impl HttpThread {
 
     fn drain_queued_writes(&mut self) {
         loop {
-            let queued_writes = {
-                let _guard = self.queued_writes_lock.lock_guard();
-                core::mem::take(&mut self.queued_writes)
-            };
+            let queued_writes = core::mem::take(&mut *SHARED.queued_writes.lock());
             for write in &queued_writes {
                 let message = write.kind;
                 let ended = message == WriteMessageType::End;
@@ -769,10 +777,8 @@ impl HttpThread {
 
     fn drain_queued_cert_check_resumes(&mut self) {
         loop {
-            let queued_cert_check_resumes = {
-                let _guard = self.queued_cert_check_resumes_lock.lock_guard();
-                core::mem::take(&mut self.queued_cert_check_resumes)
-            };
+            let queued_cert_check_resumes =
+                core::mem::take(&mut *SHARED.queued_cert_check_resumes.lock());
             for resume in &queued_cert_check_resumes {
                 // Both arms are required: an HTTPS target behind a plaintext
                 // proxy parks behind a SocketTcp tracker entry.
@@ -814,10 +820,7 @@ impl HttpThread {
 
     fn drain_queued_receive_resumes(&mut self) {
         loop {
-            let queued = {
-                let _guard = self.queued_receive_resumes_lock.lock_guard();
-                core::mem::take(&mut self.queued_receive_resumes)
-            };
+            let queued = core::mem::take(&mut *SHARED.queued_receive_resumes.lock());
             if queued.is_empty() {
                 return;
             }
@@ -931,7 +934,7 @@ impl HttpThread {
         }
 
         loop {
-            let Some(http) = NonNull::new(self.queued_tasks.pop()) else {
+            let Some(http) = NonNull::new(SHARED.queued_tasks.pop()) else {
                 break;
             };
             // AsyncHttp is heap-owned by the caller and alive until its
@@ -960,57 +963,57 @@ impl HttpThread {
         }
     }
 
-    pub fn schedule_receive_resume(&mut self, async_http_id: u32) {
+    // The `schedule*` associated fns below (and `schedule` / `wakeup` further
+    // down) are the cross-thread entry points: they only touch `SHARED`.
+    // Everything taking `self` is HTTP-thread-only.
+
+    pub fn schedule_receive_resume(async_http_id: u32) {
         {
-            let _guard = self.queued_receive_resumes_lock.lock_guard();
-            if self.queued_receive_resumes.last() == Some(&async_http_id) {
+            let mut queued = SHARED.queued_receive_resumes.lock();
+            if queued.last() == Some(&async_http_id) {
                 return;
             }
-            self.queued_receive_resumes.push(async_http_id);
+            queued.push(async_http_id);
         }
-        self.wakeup();
+        Self::wakeup();
     }
 
-    pub fn schedule_shutdown(&mut self, http: &AsyncHttp) {
-        self.schedule_shutdown_by_id(http.async_http_id);
+    pub fn schedule_shutdown(http: &AsyncHttp) {
+        Self::schedule_shutdown_by_id(http.async_http_id);
     }
 
-    pub fn schedule_shutdown_by_id(&mut self, async_http_id: u32) {
+    pub fn schedule_shutdown_by_id(async_http_id: u32) {
         bun_core::scoped_log!(HTTPThread, "scheduleShutdown {}", async_http_id);
-        {
-            let _guard = self.queued_shutdowns_lock.lock_guard();
-            self.queued_shutdowns
-                .push(ShutdownMessage { async_http_id });
-        }
-        self.wakeup();
+        SHARED
+            .queued_shutdowns
+            .lock()
+            .push(ShutdownMessage { async_http_id });
+        Self::wakeup();
     }
 
-    pub fn schedule_cert_check_resume(&mut self, http: &AsyncHttp) {
+    pub fn schedule_cert_check_resume(http: &AsyncHttp) {
         bun_core::scoped_log!(HTTPThread, "scheduleCertCheckResume {}", http.async_http_id);
-        {
-            let _guard = self.queued_cert_check_resumes_lock.lock_guard();
-            self.queued_cert_check_resumes.push(CertCheckResumeMessage {
+        SHARED
+            .queued_cert_check_resumes
+            .lock()
+            .push(CertCheckResumeMessage {
                 async_http_id: http.async_http_id,
             });
-        }
-        self.wakeup();
+        Self::wakeup();
     }
 
-    pub fn schedule_request_write(&mut self, http: &AsyncHttp, kind: WriteMessageType) {
-        {
-            let _guard = self.queued_writes_lock.lock_guard();
-            self.queued_writes.push(WriteMessage {
-                async_http_id: http.async_http_id,
-                kind,
-            });
-        }
-        self.wakeup();
+    pub fn schedule_request_write(http: &AsyncHttp, kind: WriteMessageType) {
+        SHARED.queued_writes.lock().push(WriteMessage {
+            async_http_id: http.async_http_id,
+            kind,
+        });
+        Self::wakeup();
     }
 
     pub(crate) fn schedule_proxy_deref(&mut self, proxy: *mut ProxyTunnel) {
         // this is always called on the http thread,
         self.queued_threadlocal_proxy_derefs.push(proxy);
-        self.wakeup();
+        Self::wakeup();
     }
 
     /// Called from [`crate::shutdown_for_exit`] on the HTTP thread once
@@ -1048,7 +1051,7 @@ impl HttpThread {
         for http in core::mem::take(&mut self.deferred_tasks) {
             release_unstarted(http);
         }
-        while let Some(http) = NonNull::new(self.queued_tasks.pop()) {
+        while let Some(http) = NonNull::new(SHARED.queued_tasks.pop()) {
             release_unstarted(http);
         }
         for nn in core::mem::take(&mut self.in_flight) {
@@ -1090,64 +1093,50 @@ impl HttpThread {
         }
     }
 
-    pub(crate) fn wakeup(&self) {
-        // Acquire (not Relaxed): pairs with the Release store in `on_start`
-        // so the read of `self.uws_loop` (a non-atomic field set there)
-        // observes the published value. This is the canonical "Relaxed gives
-        // no happens-before for the init it guards" case.
-        if self.has_awoken.load(Ordering::Acquire) {
-            // SAFETY: uws_loop is the live HTTP-thread loop set in on_start.
-            // Call the raw extern (not `Loop::wakeup(&mut self)`) — this runs
-            // cross-thread while the HTTP thread owns the loop, so forming
-            // `&mut Loop` here would alias.
-            unsafe { uws::us_wakeup_loop(self.uws_loop) };
+    /// Make the HTTP thread's loop return from its poll so it runs
+    /// [`drain_events`](Self::drain_events). Any thread; a no-op until
+    /// `on_start` has published the loop.
+    pub(crate) fn wakeup() {
+        // Acquire pairs with the Release store in `on_start`, which publishes
+        // the loop's initialization along with the pointer.
+        let loop_ = SHARED.uws_loop.load(Ordering::Acquire);
+        if !loop_.is_null() {
+            // SAFETY: once published, the loop is the HTTP thread's live loop
+            // and is never destroyed (`process_events` never returns).
+            // `us_wakeup_loop` is uSockets' thread-safe wake and takes the raw
+            // pointer, so no `&mut Loop` is formed here next to the one
+            // `process_events` holds across `tick()`.
+            unsafe { uws::us_wakeup_loop(loop_) };
         }
     }
 
-    /// Enqueue a batch of `AsyncHttp` tasks for the HTTP thread. Safe to
-    /// call from any thread: only touches the lock-free `queued_tasks` MPSC
-    /// queue and `wakeup()` (atomic load + raw FFI call). This is the
-    /// **only** cross-thread entry point — every other `HttpThread` method
-    /// is HTTP-thread-only via [`http_thread()`](crate::http_thread).
-    pub fn schedule(batch: bun_threading::thread_pool::Batch) {
+    /// Whether [`schedule`](Self::schedule) has queued tasks that
+    /// [`drain_events`](Self::drain_events) has not popped yet.
+    pub(crate) fn has_queued_tasks() -> bool {
+        !SHARED.queued_tasks.is_empty()
+    }
+
+    /// Enqueue a batch of `AsyncHttp` tasks for the HTTP thread. Any thread.
+    pub fn schedule(mut batch: bun_threading::thread_pool::Batch) {
         if batch.len == 0 {
             return;
         }
-        // Release-mode guard: `HttpThread` has niche-bearing fields, so
-        // dereffing `as_mut_ptr()` below on an uninitialized static is UB.
-        // The "every caller goes through `init`" invariant was unenforced
-        // (e.g. `async_http::preconnect` did not), so check it here. The
-        // `Acquire` load pairs with `init_once`'s `Release` store to publish
-        // the `HTTP_THREAD.write(..)` to this thread.
+        // Nothing drains `SHARED` until `init()` has spawned the thread, so a
+        // task scheduled before that would leave its owner waiting forever;
+        // fail loudly instead (`async_http::preconnect` once skipped `init`).
         assert!(
             crate::HTTP_THREAD_INIT.load(Ordering::Acquire),
             "HTTPThread::schedule() called before HTTPThread::init()"
         );
-        // SAFETY: `HTTP_THREAD_INIT == true` (checked above) ⇒ `HTTP_THREAD`
-        // is fully written. `get_unchecked` (no owner assert) so the
-        // `ThreadCell` debug-owner check is skipped on this cross-thread
-        // caller. Wrap the result in a `ParentRef` (process-lifetime backref)
-        // so the `&self`-only calls below — `queued_tasks.push` (lock-free
-        // MPSC) and `wakeup` (atomics + raw uws ptr) — go through the safe
-        // `Deref` impl instead of open-coded `(*this_p)` raw derefs. Only a
-        // shared `&HttpThread` is ever materialised; the HTTP thread itself
-        // never holds a long-lived `&mut HttpThread` across the points these
-        // touch (both fields are designed for cross-thread shared access).
-        let this = unsafe {
-            bun_ptr::ParentRef::<Self>::from_raw((*crate::HTTP_THREAD.get_unchecked()).as_mut_ptr())
-        };
-        {
-            let mut batch_ = batch;
-            while let Some(task) = batch_.pop() {
-                // SAFETY: task points to AsyncHttp.task; recover parent via field offset.
-                let http: *mut AsyncHttp =
-                    unsafe { bun_core::from_field_ptr!(AsyncHttp, task, task.as_ptr()) };
-                // SAFETY: `http` recovered from a live batch node (non-null); valid until popped.
-                let http = unsafe { core::ptr::NonNull::new_unchecked(http) };
-                this.queued_tasks.push(http);
-            }
+        while let Some(task) = batch.pop() {
+            // SAFETY: task points to AsyncHttp.task; recover parent via field offset.
+            let http: *mut AsyncHttp =
+                unsafe { bun_core::from_field_ptr!(AsyncHttp, task, task.as_ptr()) };
+            // SAFETY: `http` recovered from a live batch node (non-null); valid until popped.
+            let http = unsafe { core::ptr::NonNull::new_unchecked(http) };
+            SHARED.queued_tasks.push(http);
         }
-        this.wakeup();
+        Self::wakeup();
     }
 }
 
@@ -1253,12 +1242,13 @@ mod _event_loop_draft {
     }
 
     fn init_once(opts: &InitOpts) {
-        // Initialize the global (with timer
-        // started on the calling thread) BEFORE spawning, so `on_start`'s
-        // `crate::http_thread_mut()` finds `Some(..)` and can fill in
-        // `loop_`/`uws_loop`/contexts.
-        // SAFETY: `init_once` runs under `Once`; no other thread reads
-        // `HTTP_THREAD` until `has_awoken` is set in `on_start`.
+        // Initialize the global (with timer started on the calling thread)
+        // BEFORE spawning, so `on_start`'s `crate::http_thread_mut()` finds it
+        // written and can fill in `loop_`/`uws_loop`/contexts.
+        // SAFETY: `init_once` runs under `Once`, and the only other code that
+        // touches `HTTP_THREAD` runs on the thread spawned below (which
+        // `claim`s the cell in `on_start`), so this write is unaliased and the
+        // spawn publishes it.
         unsafe {
             (*crate::HTTP_THREAD.get()).write(HttpThread::new());
         }
@@ -1324,6 +1314,9 @@ mod _event_loop_draft {
             }
         }
 
+        // From here on only this thread may touch `HTTP_THREAD`; debug builds
+        // panic on any `http_thread()` call from another thread.
+        crate::HTTP_THREAD.claim();
         let thread = crate::http_thread_mut();
         thread.loop_ = loop_;
         thread.uws_loop = uws_loop;
@@ -1351,9 +1344,9 @@ mod _event_loop_draft {
             // none).
             thread.lazy_https_init = Some(opts);
         }
-        // Release: publishes `uws_loop`/`loop_` to cross-thread `wakeup()`
-        // readers (which Acquire-load `has_awoken`).
-        thread.has_awoken.store(true, Ordering::Release);
+        // Release: publishes the loop (and its initialization above) to
+        // `wakeup()` callers on other threads, which Acquire-load it.
+        SHARED.uws_loop.store(uws_loop, Ordering::Release);
         thread.process_events();
     }
 
@@ -1426,26 +1419,14 @@ static SHUTDOWN_DONE: (bun_threading::Guarded<bool>, bun_threading::Condvar) = (
 /// touch requests, so the caller must not free anything it shares with it.
 #[must_use]
 pub fn shutdown_for_exit() -> bool {
-    if !crate::HTTP_THREAD_INIT.load(Ordering::Acquire) {
-        return true;
-    }
-    // SAFETY: `HTTP_THREAD_INIT == true` ⇒ `HTTP_THREAD` is fully written.
-    // `get_unchecked` so the `ThreadCell` owner assert is skipped on this
-    // cross-thread caller; `ParentRef` so only a shared `&HttpThread` is
-    // materialised — `process_events(&mut self)` is live on the HTTP thread,
-    // so a `&mut` here would alias. Same shape as `schedule()` above.
-    let thread = unsafe {
-        bun_ptr::ParentRef::<HttpThread>::from_raw(
-            (*crate::HTTP_THREAD.get_unchecked()).as_mut_ptr(),
-        )
-    };
-    if !thread.has_awoken.load(Ordering::Acquire) {
-        // `on_start` hasn't published the loop yet — no `start_queued_task`
-        // can have run, so no boxes exist.
+    if SHARED.uws_loop.load(Ordering::Acquire).is_null() {
+        // The thread was never started, or `on_start` hasn't reached
+        // `process_events` yet — either way no `start_queued_task` can have
+        // run, so no boxes exist.
         return true;
     }
     SHUTDOWN_REQUESTED.store(true, Ordering::Release);
-    thread.wakeup();
+    HttpThread::wakeup();
     let mut done = SHUTDOWN_DONE.0.lock();
     // 1s upper bound: a stuck HTTP thread shouldn't deadlock process exit.
     let deadline = Instant::now() + std::time::Duration::from_secs(1);

--- a/src/http/h3_client/ClientContext.rs
+++ b/src/http/h3_client/ClientContext.rs
@@ -164,8 +164,7 @@ impl ClientContext {
                     bstr::BStr::new(hostname),
                     port,
                 );
-                let l = self.qctx_mut().r#loop();
-                PendingConnect::register(session, pending, l.cast::<UwsLoop>());
+                PendingConnect::register(session, pending);
             }
             ConnectResult::Err => {
                 bun_core::scoped_log!(

--- a/src/http/h3_client/PendingConnect.rs
+++ b/src/http/h3_client/PendingConnect.rs
@@ -99,8 +99,7 @@ impl PendingConnect {
     /// DNS worker may call from off the HTTP thread; mirror
     /// us_internal_dns_callback_threadsafe: push onto a mutex-protected list and
     /// wake the loop. `drain_resolved` runs from `HTTPThread.drainEvents` on the
-    /// next loop iteration after the wakeup. Once pushed, the HTTP thread may
-    /// free `this` at any time, so it is not touched here.
+    /// next loop iteration after the wakeup.
     ///
     /// SAFETY: `this` must be the pointer produced by `heap::alloc` in `register`.
     pub unsafe fn on_dns_resolved_threadsafe(this: *mut PendingConnect) {
@@ -164,6 +163,5 @@ unsafe impl Send for Resolved {}
 /// to the HTTP thread — projecting a shared `&` to an interior field from the
 /// DNS worker would alias that exclusive borrow under Stacked Borrows. A
 /// dedicated `Sync` static sidesteps that without weakening the singleton
-/// accessor's `&mut` contract; `SHARED` in `HTTPThread.rs` is the same
-/// arrangement for everything request owners on other threads hand over.
+/// accessor's `&mut` contract.
 static RESOLVED: Guarded<Vec<Resolved>> = Guarded::new(Vec::new());

--- a/src/http/h3_client/PendingConnect.rs
+++ b/src/http/h3_client/PendingConnect.rs
@@ -164,5 +164,6 @@ unsafe impl Send for Resolved {}
 /// to the HTTP thread — projecting a shared `&` to an interior field from the
 /// DNS worker would alias that exclusive borrow under Stacked Borrows. A
 /// dedicated `Sync` static sidesteps that without weakening the singleton
-/// accessor's `&mut` contract.
+/// accessor's `&mut` contract; `SHARED` in `HTTPThread.rs` is the same
+/// arrangement for everything request owners on other threads hand over.
 static RESOLVED: Guarded<Vec<Resolved>> = Guarded::new(Vec::new());

--- a/src/http/h3_client/PendingConnect.rs
+++ b/src/http/h3_client/PendingConnect.rs
@@ -12,7 +12,6 @@ use core::ptr::NonNull;
 use core::sync::atomic::Ordering;
 
 use bun_threading::Guarded;
-use bun_uws as uws;
 use bun_uws::quic;
 
 use super::ClientSession;
@@ -24,8 +23,6 @@ pub struct PendingConnect {
     session: *mut ClientSession,
     // FFI: C handle owned until exactly one of resolved()/cancel() consumes it.
     pc: *mut quic::PendingConnect,
-    // BACKREF: the uws event loop (lives as long as the HTTP thread).
-    loop_ptr: *mut uws::Loop,
 }
 
 impl Drop for PendingConnect {
@@ -52,20 +49,12 @@ impl PendingConnect {
         unsafe { &mut *self.pc }
     }
 
-    pub(crate) fn register(
-        session: *mut ClientSession,
-        pc: *mut quic::PendingConnect,
-        l: *mut uws::Loop,
-    ) {
+    pub(crate) fn register(session: *mut ClientSession, pc: *mut quic::PendingConnect) {
         // Caller passes a live intrusive-refcounted ClientSession; PendingConnect
         // holds one ref from construction until Drop. `session_mut` centralises
         // the backref upgrade (same invariant as the other call sites below).
         session_mut(session).ref_();
-        let self_ = Box::new(PendingConnect {
-            session,
-            pc,
-            loop_ptr: l,
-        });
+        let self_ = Box::new(PendingConnect { session, pc });
         // Route the addrinfo read through the existing [`pc_mut`] accessor
         // (centralised raw upgrade) instead of an open-coded `(*pc)` deref.
         let addrinfo = self_.pc_mut().addrinfo();
@@ -73,10 +62,6 @@ impl PendingConnect {
         // SAFETY: `self_` is the Box we just leaked above and is consumed by
         // `on_dns_resolved` (via the global cache's notify path).
         unsafe { bun_dns::internal::register_quic(addrinfo, self_.cast()) };
-    }
-
-    pub(crate) fn r#loop(&self) -> *mut uws::Loop {
-        self.loop_ptr
     }
 
     /// SAFETY: `this` must be the pointer produced by `heap::alloc` in `register`
@@ -114,22 +99,13 @@ impl PendingConnect {
     /// DNS worker may call from off the HTTP thread; mirror
     /// us_internal_dns_callback_threadsafe: push onto a mutex-protected list and
     /// wake the loop. `drain_resolved` runs from `HTTPThread.drainEvents` on the
-    /// next loop iteration after the wakeup.
+    /// next loop iteration after the wakeup. Once pushed, the HTTP thread may
+    /// free `this` at any time, so it is not touched here.
     ///
     /// SAFETY: `this` must be the pointer produced by `heap::alloc` in `register`.
     pub unsafe fn on_dns_resolved_threadsafe(this: *mut PendingConnect) {
-        // `this` is a live heap-allocated PendingConnect (caller contract);
-        // wrap it in a `ParentRef` (pointee outlives holder) so the shared
-        // `loop_ptr` read goes through the safe `Deref` impl instead of an
-        // open-coded `(*this)`. Read *before* publishing — once pushed, the
-        // HTTP thread may free `this` at any time via `drain_resolved`.
-        let loop_ptr = bun_ptr::ParentRef::from(
-            NonNull::new(this).expect("on_dns_resolved_threadsafe: non-null"),
-        )
-        .r#loop();
         RESOLVED.lock().push(Resolved(this));
-        // SAFETY: `loop_ptr` is a live uws::Loop for as long as the HTTP thread runs.
-        unsafe { (*loop_ptr).wakeup() };
+        crate::HTTPThread::wakeup();
     }
 
     pub(crate) fn drain_resolved() {

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -950,8 +950,9 @@ impl Drop for HTTPClient<'_> {
 // type: `init_once` writes it before spawning the thread, `on_start` `claim()`s
 // it, and from then on debug builds panic on access from any other thread.
 // Other threads never need it — everything they hand to the HTTP thread goes
-// through the `Sync` static in `HTTPThread.rs` (the associated
-// `HTTPThread::schedule*` fns and `shutdown_for_exit`).
+// through `Sync` statics instead (`SHARED` in `HTTPThread.rs`, behind the
+// associated `HTTPThread::schedule*` fns and `shutdown_for_exit`; `RESOLVED` in
+// `h3_client/PendingConnect.rs`).
 pub(crate) static HTTP_THREAD: bun_core::ThreadCell<core::mem::MaybeUninit<HTTPThread>> =
     bun_core::ThreadCell::new(core::mem::MaybeUninit::uninit());
 static HTTP_THREAD_INIT: core::sync::atomic::AtomicBool =

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -947,27 +947,20 @@ impl Drop for HTTPClient<'_> {
 // every process.
 //
 // `ThreadCell` (not `RacyCell`) to encode "HTTP-thread-only after init" in the
-// type: `init_once` writes it before spawning the thread, `on_start` `claim()`s
-// it, and from then on debug builds panic on access from any other thread.
-// Other threads never need it — everything they hand to the HTTP thread goes
-// through `Sync` statics instead (`SHARED` in `HTTPThread.rs`, behind the
-// associated `HTTPThread::schedule*` fns and `shutdown_for_exit`; `RESOLVED` in
-// `h3_client/PendingConnect.rs`).
+// type. `claim()` is invoked from `HTTPThread::on_start`; other threads use `SHARED` (HTTPThread.rs).
 pub(crate) static HTTP_THREAD: bun_core::ThreadCell<core::mem::MaybeUninit<HTTPThread>> =
     bun_core::ThreadCell::new(core::mem::MaybeUninit::uninit());
 static HTTP_THREAD_INIT: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
-/// The HTTP thread's own state. HTTP-thread-only (see [`HTTP_THREAD`]); code
-/// on other threads uses the associated `HTTPThread::schedule*` fns instead.
+/// HTTP-thread-only; other threads use the associated `HTTPThread::schedule*` fns.
 #[inline]
 pub(crate) fn http_thread() -> &'static mut HTTPThread {
     // Release-mode guard, not `debug_assert!`: `HTTPThread` contains
     // niche-bearing fields (`Box`, `Vec`, `NonNull`, `Option<Arc>` …), so
     // `assume_init_mut()` on the uninitialized static is *immediate* UB — a
     // `debug_assert!` leaves release builds unguarded. The `Acquire` load
-    // pairs with `init_once`'s `Release` store on `HTTP_THREAD_INIT`. Cost is
-    // a single relaxed-on-x86 atomic load.
+    // pairs with `init_once`'s `Release` store on `HTTP_THREAD_INIT`.
     assert!(
         HTTP_THREAD_INIT.load(core::sync::atomic::Ordering::Acquire),
         "http_thread() called before HTTPThread::init()"

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -947,25 +947,26 @@ impl Drop for HTTPClient<'_> {
 // every process.
 //
 // `ThreadCell` (not `RacyCell`) to encode "HTTP-thread-only after init" in the
-// type. `claim()` is invoked from `HTTPThread::on_start`. JS-side callers that
-// only touch the lock-free `queued_tasks` + `wakeup` (e.g. `schedule()`) go
-// through [`http_thread_shared`] / `get_unchecked` until those fields are
-// hoisted out of the thread-confined struct.
+// type: `init_once` writes it before spawning the thread, `on_start` `claim()`s
+// it, and from then on debug builds panic on access from any other thread.
+// Other threads never need it — everything they hand to the HTTP thread goes
+// through the `Sync` static in `HTTPThread.rs` (the associated
+// `HTTPThread::schedule*` fns and `shutdown_for_exit`).
 pub(crate) static HTTP_THREAD: bun_core::ThreadCell<core::mem::MaybeUninit<HTTPThread>> =
     bun_core::ThreadCell::new(core::mem::MaybeUninit::uninit());
 static HTTP_THREAD_INIT: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
+/// The HTTP thread's own state. HTTP-thread-only (see [`HTTP_THREAD`]); code
+/// on other threads uses the associated `HTTPThread::schedule*` fns instead.
 #[inline]
-pub fn http_thread() -> &'static mut HTTPThread {
+pub(crate) fn http_thread() -> &'static mut HTTPThread {
     // Release-mode guard, not `debug_assert!`: `HTTPThread` contains
     // niche-bearing fields (`Box`, `Vec`, `NonNull`, `Option<Arc>` …), so
     // `assume_init_mut()` on the uninitialized static is *immediate* UB — a
     // `debug_assert!` leaves release builds unguarded. The `Acquire` load
-    // pairs with `init_once`'s `Release` store on `HTTP_THREAD_INIT`,
-    // establishing happens-before for cross-thread callers that did not
-    // themselves go through `Once::call_once` (e.g. `schedule_*` paths from
-    // the JS thread). Cost is a single relaxed-on-x86 atomic load.
+    // pairs with `init_once`'s `Release` store on `HTTP_THREAD_INIT`. Cost is
+    // a single relaxed-on-x86 atomic load.
     assert!(
         HTTP_THREAD_INIT.load(core::sync::atomic::Ordering::Acquire),
         "http_thread() called before HTTPThread::init()"

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -928,7 +928,7 @@ impl FetchTasklet {
             // request slot until the idle timeout.
             if self.result.certificate_info.take().is_some() {
                 if let Some(http_) = self.http.as_mut() {
-                    http::http_thread().schedule_shutdown(http_);
+                    http::HTTPThread::schedule_shutdown(http_);
                 }
             }
             self.mutex.unlock();
@@ -1069,7 +1069,7 @@ impl FetchTasklet {
             // the connection already closed/failed the resume is a no-op
             // (keyed through the abort tracker).
             if let Some(http_) = self.http.as_mut() {
-                http::http_thread().schedule_cert_check_resume(http_);
+                http::HTTPThread::schedule_cert_check_resume(http_);
             }
             // Fall through. The common case (certificate-only update) returns
             // at the metadata-less early return below; the #27275 coalesced
@@ -1267,7 +1267,7 @@ impl FetchTasklet {
         // Empty or unparseable certificate bytes: every false return must have
         // scheduled the parked socket's shutdown, like the paths above.
         if let Some(http_) = self.http.as_mut() {
-            http::http_thread().schedule_shutdown(http_);
+            http::HTTPThread::schedule_shutdown(http_);
         }
         self.result.fail = Some(http::Error::ERR_TLS_CERT_ALTNAME_INVALID);
         false
@@ -1641,7 +1641,7 @@ impl FetchTasklet {
             // and if the server doesn't close the connection by itself
             // and doesn't send any follow-up data
             // then we must make sure the HTTP thread flushes.
-            http::http_thread().schedule_receive_resume(http_.async_http_id);
+            http::HTTPThread::schedule_receive_resume(http_.async_http_id);
         }
 
         this.mutex.lock();
@@ -1730,7 +1730,7 @@ impl FetchTasklet {
 
     fn schedule_receive_resume(&self) {
         if let Some(http_) = self.http.as_ref() {
-            http::http_thread().schedule_receive_resume(http_.async_http_id);
+            http::HTTPThread::schedule_receive_resume(http_.async_http_id);
         }
     }
 
@@ -2267,7 +2267,7 @@ impl FetchTasklet {
 
         if needs_schedule {
             // wakeup the http thread to write the data
-            http::http_thread().schedule_request_write(
+            http::HTTPThread::schedule_request_write(
                 self.http.as_mut().unwrap(),
                 http::http_thread::WriteMessageType::Data,
             );
@@ -2310,8 +2310,10 @@ impl FetchTasklet {
                     .write(http::END_OF_CHUNKED_HTTP1_1_ENCODING_RESPONSE_BODY); // OOM/capacity: fire-and-forget
             }
             if let Some(http_) = self.http.as_mut() {
-                http::http_thread()
-                    .schedule_request_write(http_, http::http_thread::WriteMessageType::End);
+                http::HTTPThread::schedule_request_write(
+                    http_,
+                    http::http_thread::WriteMessageType::End,
+                );
             }
         }
         // SAFETY: `this_ptr` derived from live `&mut self`; we hold a ref.
@@ -2328,7 +2330,7 @@ impl FetchTasklet {
         self.tracker.did_cancel(&self.global_this);
 
         if let Some(http_) = self.http.as_mut() {
-            http::http_thread().schedule_shutdown(http_);
+            http::HTTPThread::schedule_shutdown(http_);
         }
     }
 

--- a/src/runtime/webcore/s3/client.rs
+++ b/src/runtime/webcore/s3/client.rs
@@ -1409,7 +1409,7 @@ impl S3DownloadStreamWrapper {
                 // Wake the HTTP thread so it observes the abort even when the
                 // socket is idle; otherwise the final `has_more == false`
                 // callback never fires and both the task and wrapper leak.
-                bun_http::http_thread().schedule_shutdown_by_id((*task).async_http_id);
+                bun_http::HTTPThread::schedule_shutdown_by_id((*task).async_http_id);
             }
         }
     }

--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -352,7 +352,7 @@ impl S3HttpDownloadStreamingTask {
         // SAFETY: fn contract; `http` is initialised before the task is registered.
         unsafe {
             (*this).signal_store.aborted.store(true, Ordering::Relaxed);
-            bun_http::http_thread().schedule_shutdown((*this).http.assume_init_ref());
+            bun_http::HTTPThread::schedule_shutdown((*this).http.assume_init_ref());
         }
     }
 

--- a/src/runtime/webcore/s3/simple_request.rs
+++ b/src/runtime/webcore/s3/simple_request.rs
@@ -480,7 +480,7 @@ impl S3HttpSimpleTask {
         // SAFETY: fn contract; `http` is initialised before the task is registered.
         unsafe {
             (*this).signal_store.aborted.store(true, Ordering::Relaxed);
-            bun_http::http_thread().schedule_shutdown((*this).http.assume_init_ref());
+            bun_http::HTTPThread::schedule_shutdown((*this).http.assume_init_ref());
         }
     }
 

--- a/src/uws_sys/quic/Context.rs
+++ b/src/uws_sys/quic/Context.rs
@@ -17,12 +17,6 @@ unsafe extern "C" {
         stream_ext: c_uint,
     ) -> *mut Context;
 
-    // `Context` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so
-    // `&mut Context` is ABI-identical to a non-null `*mut Context` with no
-    // `noalias`/`readonly` attribute. Shims taking only the handle + value
-    // types (incl. fn-pointer callbacks) are `safe fn`.
-    safe fn us_quic_socket_context_loop(ctx: &mut Context) -> *mut Loop;
-
     fn us_quic_socket_context_connect(
         ctx: *mut Context,
         host: *const c_char,
@@ -34,6 +28,10 @@ unsafe extern "C" {
         user: *mut c_void,
     ) -> c_int;
 
+    // `Context` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so
+    // `&mut Context` is ABI-identical to a non-null `*mut Context` with no
+    // `noalias`/`readonly` attribute. Shims taking only the handle + value
+    // types (incl. fn-pointer callbacks) are `safe fn`.
     safe fn us_quic_socket_context_on_hsk_done(
         ctx: &mut Context,
         cb: unsafe extern "C" fn(*mut Socket, c_int),
@@ -93,15 +91,6 @@ impl Context {
         // SAFETY: thin FFI forward; all args are POD, return is nullable.
         let p = unsafe { us_create_quic_client_context(loop_, ext_size, conn_ext, stream_ext) };
         if p.is_null() { None } else { Some(p) }
-    }
-
-    #[inline]
-    pub fn r#loop(&mut self) -> *mut Loop {
-        // Returns a raw pointer because the Loop is shared across every
-        // context/socket/timer on the thread —
-        // materializing `&mut Loop` here would assert uniqueness we cannot
-        // guarantee.
-        us_quic_socket_context_loop(self)
     }
 
     pub fn connect(

--- a/src/uws_sys/quic/Context.rs
+++ b/src/uws_sys/quic/Context.rs
@@ -17,6 +17,11 @@ unsafe extern "C" {
         stream_ext: c_uint,
     ) -> *mut Context;
 
+    // `Context` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so
+    // `&mut Context` is ABI-identical to a non-null `*mut Context` with no
+    // `noalias`/`readonly` attribute. Shims taking only the handle + value
+    // types (incl. fn-pointer callbacks) are `safe fn`.
+
     fn us_quic_socket_context_connect(
         ctx: *mut Context,
         host: *const c_char,
@@ -28,10 +33,6 @@ unsafe extern "C" {
         user: *mut c_void,
     ) -> c_int;
 
-    // `Context` is an `opaque_ffi!` ZST (`UnsafeCell<[u8; 0]>`), so
-    // `&mut Context` is ABI-identical to a non-null `*mut Context` with no
-    // `noalias`/`readonly` attribute. Shims taking only the handle + value
-    // types (incl. fn-pointer callbacks) are `safe fn`.
     safe fn us_quic_socket_context_on_hsk_done(
         ctx: &mut Context,
         cb: unsafe extern "C" fn(*mut Socket, c_int),

--- a/test/internal/source-lints/thread-cell-claimed.test.ts
+++ b/test/internal/source-lints/thread-cell-claimed.test.ts
@@ -7,14 +7,13 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // `bun_core::ThreadCell<T>` is `RacyCell<T>` plus a debug-only owner latch:
 // once the owning thread calls `CELL.claim()`, every `CELL.get()` from another
 // thread panics in debug builds. A `ThreadCell` static that is never claimed
-// has no latch at all, so the "thread-confined" claim its type makes is
-// unchecked and cross-thread callers accumulate silently. That is how
-// `bun_http`'s `HTTP_THREAD` ended up with the JS thread materialising
-// `&'static mut HttpThread` (via `http_thread()`) for every fetch abort, body
-// write and stream resume while the HTTP thread held its own `&'static mut`
-// across `process_events` for the life of the process. The fix moved the
-// cross-thread state into a separate `Sync` static and claimed the cell; this
-// lint keeps every `ThreadCell` static claimed so the latch stays armed.
+// has no latch at all, so the thread confinement its type advertises goes
+// unchecked and cross-thread callers accumulate silently. `bun_http`'s
+// `HTTP_THREAD` went unclaimed long enough for the JS thread to be handed
+// `&'static mut HttpThread` on every fetch abort, body write and stream resume
+// while the HTTP thread held its own `&'static mut` for the life of the
+// process. This lint requires a `claim()` for every `ThreadCell` static so
+// the latch stays armed.
 //
 // Claims are looked up within the declaring crate (the directory of the
 // nearest `Cargo.toml`): `bun_io` declares `LOOP` and claims it in the same
@@ -52,7 +51,7 @@ function crateOf(source: string): string {
   return crateDirs.find(dir => source.startsWith(dir + "/")) ?? path.posix.dirname(source);
 }
 
-// `static NAME: ThreadCell<` with any path prefix (`bun_core::ThreadCell`,
+// `static [mut] NAME: ThreadCell<` with any path prefix (`bun_core::ThreadCell`,
 // `crate::atomic_cell::ThreadCell`) and any visibility; the type may start on
 // the line after the colon.
 const DECLARATION = /\bstatic\s+(?:mut\s+)?([A-Za-z_]\w*)\s*:\s*(?:[\w:]+::)?ThreadCell\s*</g;
@@ -108,6 +107,6 @@ test("DECLARATION still matches real ThreadCell statics", () => {
   expect(declared.length).toBeGreaterThan(0);
 });
 
-test("every ThreadCell static is claim()ed by its owning thread", () => {
+test("every ThreadCell static is claim()ed somewhere in its crate", () => {
   expect(unclaimed).toEqual([]);
 });

--- a/test/internal/source-lints/thread-cell-claimed.test.ts
+++ b/test/internal/source-lints/thread-cell-claimed.test.ts
@@ -1,0 +1,113 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// `bun_core::ThreadCell<T>` is `RacyCell<T>` plus a debug-only owner latch:
+// once the owning thread calls `CELL.claim()`, every `CELL.get()` from another
+// thread panics in debug builds. A `ThreadCell` static that is never claimed
+// has no latch at all, so the "thread-confined" claim its type makes is
+// unchecked and cross-thread callers accumulate silently. That is how
+// `bun_http`'s `HTTP_THREAD` ended up with the JS thread materialising
+// `&'static mut HttpThread` (via `http_thread()`) for every fetch abort, body
+// write and stream resume while the HTTP thread held its own `&'static mut`
+// across `process_events` for the life of the process. The fix moved the
+// cross-thread state into a separate `Sync` static and claimed the cell; this
+// lint keeps every `ThreadCell` static claimed so the latch stays armed.
+//
+// Claims are looked up within the declaring crate (the directory of the
+// nearest `Cargo.toml`): `bun_io` declares `LOOP` and claims it in the same
+// file, `bun_http` declares `HTTP_THREAD` in lib.rs and claims it in
+// HTTPThread.rs.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rust = globAllSources().rust;
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+function repoRelative(abs: string): string {
+  return path.relative(root, abs).replaceAll(path.sep, "/");
+}
+
+// Crate roots, longest first, so a file inside a nested crate is attributed to
+// the nested crate rather than to a parent crate's directory.
+const crateDirs = rust
+  .filter(p => path.basename(p) === "Cargo.toml")
+  .map(p => repoRelative(path.dirname(p)))
+  .sort((a, b) => b.length - a.length);
+
+function crateOf(source: string): string {
+  return crateDirs.find(dir => source.startsWith(dir + "/")) ?? path.posix.dirname(source);
+}
+
+// `static NAME: ThreadCell<` with any path prefix (`bun_core::ThreadCell`,
+// `crate::atomic_cell::ThreadCell`) and any visibility; the type may start on
+// the line after the colon.
+const DECLARATION = /\bstatic\s+(?:mut\s+)?([A-Za-z_]\w*)\s*:\s*(?:[\w:]+::)?ThreadCell\s*</g;
+
+// Per crate: comment-stripped source of every tracked file.
+const crates = new Map<string, { source: string; stripped: string }[]>();
+let scanned = 0;
+for (const abs of rust) {
+  if (!abs.endsWith(".rs")) continue;
+  const source = repoRelative(abs);
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (repoRelative(realpathSync(abs)) !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so doc prose ("`claim()` is invoked from ...")
+  // neither declares nor claims anything.
+  const stripped = content.replace(/^\s*\/\/.*$/gm, "");
+  const crate = crateOf(source);
+  let files = crates.get(crate);
+  if (files === undefined) crates.set(crate, (files = []));
+  files.push({ source, stripped });
+}
+
+const declared: { name: string; source: string; crate: string }[] = [];
+for (const [crate, files] of crates) {
+  for (const { source, stripped } of files) {
+    for (const match of stripped.matchAll(DECLARATION)) {
+      declared.push({ name: match[1], source, crate });
+    }
+  }
+}
+
+const unclaimed: string[] = [];
+for (const { name, source, crate } of declared) {
+  const claim = new RegExp(String.raw`\b${name}\s*\.\s*claim\s*\(`);
+  const claimed = crates.get(crate)!.some(f => claim.test(f.stripped));
+  if (!claimed) unclaimed.push(`${source}: static ${name} (crate ${crate}) is never claim()ed`);
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing (e.g. a
+  // symlinked checkout root) and leaving nothing to scan, which would make the
+  // assertions below pass vacuously. Same guard as unsound-erased-box.test.ts.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("DECLARATION still matches real ThreadCell statics", () => {
+  // `bun_io`'s LOOP and `bun_http`'s HTTP_THREAD exist today; if the type or
+  // the declaration shape changes, the regex needs updating rather than the
+  // claim check below passing with nothing to check.
+  expect(declared.length).toBeGreaterThan(0);
+});
+
+test("every ThreadCell static is claim()ed by its owning thread", () => {
+  expect(unclaimed).toEqual([]);
+});

--- a/test/internal/source-lints/thread-cell-claimed.test.ts
+++ b/test/internal/source-lints/thread-cell-claimed.test.ts
@@ -100,6 +100,14 @@ test("scans a non-empty set of tracked Rust sources", () => {
   expect(scanned).toBeGreaterThan(0);
 });
 
+test("crate roots were found", () => {
+  // If glob-sources.ts stopped listing Cargo.toml, crateOf() would degrade to
+  // the file's own directory. That can only cause false failures (a claim in
+  // another directory of the same crate would be missed), but fail here with a
+  // clear reason rather than on whichever static moves first.
+  expect(crateDirs.length).toBeGreaterThan(0);
+});
+
 test("DECLARATION still matches real ThreadCell statics", () => {
   // `bun_io`'s LOOP and `bun_http`'s HTTP_THREAD exist today; if the type or
   // the declaration shape changes, the regex needs updating rather than the


### PR DESCRIPTION
### Problem
- Nothing is known to break today: no user-visible failure and no known miscompile. What this fixes is undefined behaviour under Rust's aliasing rules in `bun_http`.
- The HTTP thread holds a `&'static mut HttpThread` for the life of the process, yet every JS-thread path that queues a message for it (fetch abort, body write, stream resume, cert-check resume, S3 cancel) materialised a second `&'static mut` to the same struct, and an HTTP/3 DNS callback formed a `&mut uws::Loop` next to the one the HTTP thread holds.
- Cause: the state other threads need lived inside the thread-confined struct, and the `ThreadCell` around `HTTP_THREAD` was never `claim()`ed, so the debug check meant to catch this was never armed and the callers accumulated unnoticed.
- Follow-up to #37626, which fixed the same shape in `IoRequestLoop::schedule`.

### Fix
- The state other threads touch (the task queue, the four message vectors, and the loop pointer used to wake the thread) moves out of `HttpThread` into a `Sync` static. The schedule, wakeup and exit entry points become associated functions over that static and callers are updated mechanically.
- Property to check: after this change, every `HttpThread` method that takes `self` runs only on the HTTP thread, and no cross-thread path forms a reference to `HttpThread` or `uws::Loop` at all.
- The HTTP thread now claims `HTTP_THREAD` on start, so a debug build panics on any future cross-thread `http_thread()` call, and `http_thread()` becomes crate-private. The HTTP/3 loop accessor loses its only caller and is deleted.
- Verification: there is no runtime behaviour to observe, so the test is a source lint requiring every `ThreadCell` static to be claimed in its crate; it fails on main and passes here. Beyond that, cargo check/clippy across targets, and fetch, TLS, HTTP/3, S3 and process-exit tests on a debug ASAN build with the latch armed, none of which panicked.

### Background
- `bun_http` runs one HTTP thread per process. JS threads hand it work (new requests, aborts, body writes, resumes) by pushing onto queues and waking its uSockets event loop; the thread drains the queues on each tick.
- A Rust `&mut` asserts uniqueness. Two live `&mut` to the same memory is undefined behaviour regardless of thread, even when the fields actually touched are atomics or behind a mutex, and rustc passes `&mut` arguments to LLVM as `noalias`.
- `ThreadCell` (in `bun_core`) wraps a static so that, once one thread calls `claim()`, any other thread's `get()` panics in debug builds. Unclaimed, it checks nothing and is equivalent to `RacyCell`.
- `Guarded<T>` is bun's mutex that owns its data, which is what lets a mutable `Vec` live in an immutable `static` and be locked from any thread.
- `test/internal/source-lints/` holds tests that scan the source tree for a structural property instead of exercising runtime behaviour.

<details>
<summary>Original description</summary>

Follow-up to #37626, which fixed this shape in `IoRequestLoop::schedule` and left the HTTP thread out because the HTTP thread holds `&'static mut HttpThread` for the life of the process.

### What does this PR do?

`bun_http`'s HTTP thread takes `&'static mut HttpThread` from `http_thread()` in `on_start` and holds it across `process_events(&mut self) -> !` forever. Meanwhile other threads were reaching into the same struct:

- `HTTPThread::schedule` and `shutdown_for_exit` did `(*HTTP_THREAD.get_unchecked()).as_mut_ptr()`. `MaybeUninit::as_mut_ptr` takes `&mut self`, so that line autoref'd a `&mut MaybeUninit<HttpThread>` over the whole struct on the calling thread, directly under SAFETY comments saying only a `&HttpThread` is ever formed. The `ParentRef` it then built was a `&HttpThread` aliasing the HTTP thread's live `&mut`.
- Every other JS-thread entry point was worse: `FetchTasklet` (abort, body write, stream resume, `checkServerIdentity` resume) and the S3 client (stream cancel, VM teardown) all called `http::http_thread().schedule_shutdown(..)` etc., materialising a second `&'static mut HttpThread` on the JS thread while the HTTP thread's `&mut` was live and in use. The `ThreadCell` that `HTTP_THREAD` is wrapped in exists to catch exactly this in debug builds, but nothing ever `claim()`ed it (the comment in `lib.rs` said `on_start` did, and pointed at an `http_thread_shared` accessor that does not exist), so the latch was never armed.
- `h3_client::PendingConnect::on_dns_resolved_threadsafe` woke the loop from a DNS worker with `(*loop_ptr).wakeup()`, which is `uws::Loop::wakeup(&mut self)`, forming a `&mut Loop` next to the one `process_events` holds across `tick()`.

Nothing is known to miscompile today (the data these paths touch is a lock-free queue, mutex-guarded vectors and a pointer published by a Release store), but under the aliasing rules every one of these is UB, and the `&mut` arguments involved do carry `noalias` to LLVM.

The fix is the one the existing `lib.rs` comment (and the `RESOLVED` static in `PendingConnect.rs`) already describe: the state other threads touch is moved out of `HttpThread` into a `Sync` static (`SHARED` in `HTTPThread.rs`: the task queue, the four queued message vectors as `Guarded<Vec<_>>`, and an `AtomicPtr<uws::Loop>` that replaces the `has_awoken` flag; the HTTP thread keeps its own plain copy of the loop pointer). Concretely:

- `schedule_shutdown[_by_id]`, `schedule_request_write`, `schedule_receive_resume` and `schedule_cert_check_resume` become associated fns over `SHARED`, the same shape `HTTPThread::schedule` already had; `schedule`, `wakeup` and `shutdown_for_exit` only touch `SHARED`. The 11 call sites in `FetchTasklet.rs` and `s3/` are updated mechanically. `HttpThread` methods taking `self` are now all HTTP-thread-only. (The four message entry points used to inherit `http_thread()`'s init assertion; they no longer check it, since they only ever refer to requests that already went through `schedule`, which still asserts. A message queued before the thread starts would simply be drained by the first `drain_events`.)
- `on_start` calls `HTTP_THREAD.claim()` (the load-bearing line), so a debug build now panics on any `http_thread()` call from another thread, and `http_thread()` is `pub(crate)` since no other crate has a legitimate use for it any more.
- `PendingConnect` wakes the thread through `HTTPThread::wakeup()` and drops its loop pointer; `quic::Context::r#loop` and the `us_quic_socket_context_loop` extern in `bun_uws_sys` lose their only caller and are deleted (the C function itself is still used by uWS's HTTP/3 server code).
- The `ThreadCell` doc no longer recommends landing an unclaimed cell as a first step, since the new lint rejects that.

Footprint: roughly 300 bytes (two cache-line-padded queue words, four `Guarded<Vec>`s, one pointer) move from the zero-initialised `HTTP_THREAD` static into a `.data` static, because `Vec::new()` is not all-zero bytes; `HttpThread` shrinks by the same fields. Same arrangement as the existing `RESOLVED` static.

### Test

There is no runtime behaviour to observe: the generated code for these paths is the same apart from which static the fields live in. The test is a source lint, `test/internal/source-lints/thread-cell-claimed.test.ts`, following the other lints in that directory: every `static X: ThreadCell<..>` in the tree must have an `X.claim()` somewhere in its crate. On main it fails with

```
"src/http/lib.rs: static HTTP_THREAD (crate src/http) is never claim()ed"
```

and passes with this change (`bun_io`'s `LOOP` was already claimed). An unclaimed `ThreadCell` is a `RacyCell` with a misleading type, which is how the cross-thread callers above accumulated unnoticed, so the lint guards the property this PR restores rather than the specific lines it touched.

### How did you verify your code works?

- `cargo check` / `cargo clippy` on `bun_http`, `bun_runtime`, `bun_uws_sys`, `bun_core` (linux); `cargo check` of `bun_http`/`bun_uws_sys`/`bun_core` for `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`, `x86_64-unknown-linux-musl`, `x86_64-unknown-freebsd`, and of `bun_runtime` for darwin and windows-msvc; `cargo fmt --check`; the whole `test/internal/source-lints/` directory passes.
- Debug (ASAN) build, which now has the `claim()` latch armed, so any remaining cross-thread `http_thread()` call would panic with `ThreadCell: accessed from thread ...`. None did across: `fetch.test.ts`, `fetch.stream.test.ts`, `body-stream.test.ts`, `fetch-abort-queued`, `fetch-abort-stream-body`, `fetch-abort-socket-close-race`, `exiting`, `fetch-preconnect` (about 9.5k tests; the failures in this container are the same localhost/permissions/no-network ones the released binary shows here, plus 5 s timeouts on gc-heavy tests that pass when run alone), and a second batch of `fetch.tls.test.ts`, `node/tls/fetch-tls-cert.test.ts`, `bun/http/proxy.test.ts`, `fetch-compress`, `fetch-abort-ssl-context-eviction`, `fetch-http3-client`, `body-stream-excess`, `fetch-stream-cancel-leak` (203 pass, 0 fail), and the local-server S3 tests including `s3-stream-cancel-leak` (the `schedule_shutdown_by_id` path).
- `shutdown_for_exit` / `dealloc_in_flight_for_exit`: a script that opens 8 to 64 fetches against a server that never answers, with `BUN_CONFIG_MAX_HTTP_REQUESTS=4` so requests sit in every state (on a socket, deferred, and still queued when exiting synchronously), then `process.exit(0)`; exits 0 with CI's `ASAN_OPTIONS=detect_leaks=1` + `test/leaksan.supp`, which would report the in-flight boxes if the wake or the reclaim were lost.
- `PendingConnect`: `fetch-http3-client.test.ts` "hostname (DNS path)" takes the `(dns pending)` branch (confirmed with `BUN_DEBUG_h3_client=1`) and completes promptly through the new wakeup.


</details>
