### PR TITLE
webcore: replace FileSink's ref guard with bun_ptr::ScopedRef

### DIFF
--- a/src/runtime/webcore/FileSink.rs
+++ b/src/runtime/webcore/FileSink.rs
@@ -5,6 +5,7 @@ use core::sync::atomic::{AtomicI32, Ordering};
 use bun_io::pipe_writer::BaseWindowsPipeWriter as _;
 use bun_io::{self, WriteResult, WriteStatus};
 use bun_jsc::JsCell;
+use bun_ptr::ScopedRef;
 use bun_sys::{self as sys, Fd, FdExt as _};
 
 use crate::api::bun::process::Status as SpawnStatus;
@@ -71,46 +72,6 @@ pub struct FileSink {
 // refcount derived via #[derive(CellRefCounted)] above. `*FileSink` crosses FFI
 // (JSSink wrapper, `@fieldParentPtr`, `asPromisePtr`), so this stays intrusive
 // rather than `Rc<T>`.
-
-/// RAII owner of one intrusive ref on a `FileSink`. Drops the ref (and frees
-/// the allocation if it was the last) on scope exit, without borrowing `self`.
-struct FileSinkRef(*mut FileSink);
-
-impl FileSinkRef {
-    /// Take a fresh ref on `this` for the guard's lifetime.
-    ///
-    /// # Safety
-    /// `this` must point to a live `FileSink` with write+dealloc provenance
-    /// (see [`FileSink::deref`]).
-    #[inline]
-    unsafe fn new_ref(this: *mut FileSink) -> Self {
-        // SAFETY: caller contract — `this` is live; `ref_` only touches the
-        // `Cell<u32>` field via shared borrow.
-        unsafe { (*this).ref_() };
-        Self(this)
-    }
-
-    /// Adopt an existing ref previously taken elsewhere (e.g. balanced against
-    /// the `ref_()` in `run_pending_later`/`assign_to_stream`). Does not bump
-    /// the count.
-    ///
-    /// # Safety
-    /// `this` must point to a live `FileSink` and the caller must own one
-    /// outstanding ref that is being transferred to this guard.
-    #[inline]
-    unsafe fn adopt(this: *mut FileSink) -> Self {
-        Self(this)
-    }
-}
-
-impl Drop for FileSinkRef {
-    #[inline]
-    fn drop(&mut self) {
-        // SAFETY: constructor contract — `self.0` is live and carries
-        // write+dealloc provenance for `deref`'s potential `deinit`.
-        unsafe { FileSink::deref(self.0) };
-    }
-}
 
 /// Count of live native FileSink instances. Incremented at allocation,
 /// decremented in `deinit`. Exposed to tests via `bun:internal-for-testing`
@@ -313,7 +274,7 @@ impl FileSink {
             // keep-alive ref, and `stream.cancel`/`runPending` drain microtasks
             // which may drop the JS wrapper's ref. Hold a local ref so `this`
             // stays valid for the rest of this function (same pattern as `onWrite`).
-            let _guard = FileSinkRef::new_ref(this);
+            let _guard = ScopedRef::new(this);
 
             (*this).done.set(true);
             let mut readable_stream = (*this)
@@ -365,7 +326,7 @@ impl FileSink {
     unsafe fn run_pending(this: *mut FileSink) {
         // SAFETY: caller contract — `this` is live with write+dealloc provenance.
         unsafe {
-            let _guard = FileSinkRef::new_ref(this);
+            let _guard = ScopedRef::new(this);
 
             (*this).run_pending_later.has.set(false);
 
@@ -393,7 +354,7 @@ impl FileSink {
             // ref, and `writer.end()`/`writer.close()` re-enter `onClose` which
             // releases the keep-alive ref. Hold a local ref so `this` stays valid
             // for the rest of this function (same pattern as `runPending`/`onAutoFlush`).
-            let _guard = FileSinkRef::new_ref(this);
+            let _guard = ScopedRef::new(this);
 
             (*this).written.set((*this).written.get() + amount);
 
@@ -820,7 +781,7 @@ impl FileSink {
                 return false;
             }
 
-            let _guard = FileSinkRef::new_ref(this);
+            let _guard = ScopedRef::new(this);
 
             let amount_buffered = (*this).writer.get().outgoing.size();
 
@@ -1464,7 +1425,7 @@ impl bun_event_loop::Taskable for FlushPendingTask {
         unsafe {
             (*this).has.set(false);
             let sink: *mut FileSink = bun_core::from_field_ptr!(FileSink, run_pending_later, this);
-            drop(FileSinkRef::adopt(sink));
+            drop(ScopedRef::<FileSink>::adopt(sink));
         }
     }
 }
@@ -1485,7 +1446,7 @@ impl FlushPendingTask {
             unsafe { bun_core::from_field_ptr!(FileSink, run_pending_later, flush_pending) };
         // SAFETY: balances the `ref_()` taken in `run_pending_later()` when
         // this task was enqueued; `this` is live for at least that ref.
-        let _guard = unsafe { FileSinkRef::adopt(this) };
+        let _guard = unsafe { ScopedRef::adopt(this) };
         if had {
             // SAFETY: `this` is the canonical `*mut FileSink` recovered via
             // `from_field_ptr!` from the embedded `run_pending_later` task;
@@ -1525,7 +1486,7 @@ fn on_resolve_stream(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsR
     let args = callframe.arguments();
     let this: *mut FileSink = args[args.len() - 1].as_promise_ptr::<FileSink>();
     // SAFETY: `this` is kept alive by the ref taken in `assign_to_stream`; this guard balances it.
-    let _guard = unsafe { FileSinkRef::adopt(this) };
+    let _guard = unsafe { ScopedRef::adopt(this) };
     // SAFETY: `as_promise_ptr` recovers the `*mut FileSink` stashed by `assign_to_stream`.
     unsafe { (*this).handle_resolve_stream(global_this) };
     Ok(JSValue::UNDEFINED)
@@ -1537,7 +1498,7 @@ fn on_reject_stream(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsRe
     let this: *mut FileSink = args[args.len() - 1].as_promise_ptr::<FileSink>();
     let err = args[0];
     // SAFETY: `this` is kept alive by the ref taken in `assign_to_stream`; this guard balances it.
-    let _guard = unsafe { FileSinkRef::adopt(this) };
+    let _guard = unsafe { ScopedRef::adopt(this) };
     // SAFETY: `as_promise_ptr` recovers the `*mut FileSink` stashed by `assign_to_stream`.
     unsafe { (*this).handle_reject_stream(global_this, err) };
     Ok(JSValue::UNDEFINED)
@@ -1550,7 +1511,7 @@ impl FileSink {
         global_this: &JSGlobalObject,
     ) -> JSValue {
         // SAFETY: `&mut self` carries write+dealloc provenance over the allocation.
-        let _guard = unsafe { FileSinkRef::new_ref(std::ptr::from_mut::<FileSink>(self)) };
+        let _guard = unsafe { ScopedRef::new(std::ptr::from_mut::<FileSink>(self)) };
 
         self.readable_stream
             .set(readable_stream::Strong::init(*stream, global_this));
@@ -1606,16 +1567,7 @@ impl FileSink {
 
         if !promise_result.is_empty_or_undefined_or_null() {
             if let Some(promise) = promise_result.as_any_promise() {
-                // `bun_jsc::AnyPromise` (the active raw-ptr variant in
-                // lib.rs) does not yet expose `status()`/`result()`; recover the
-                // underlying `JSPromise` (JSInternalPromise subclasses JSPromise
-                // in C++, so the cast is layout-safe).
-                let js_promise: *mut bun_jsc::JSPromise = match promise {
-                    bun_jsc::AnyPromise::Normal(p) => p,
-                    bun_jsc::AnyPromise::Internal(p) => p.cast::<bun_jsc::JSPromise>(),
-                };
-                // SAFETY: `as_any_promise` returned non-null.
-                match unsafe { (*js_promise).status() } {
+                match promise.status() {
                     bun_jsc::js_promise::Status::Pending => {
                         self.writer
                             .with_mut(|w| w.enable_keeping_process_alive(self.io_evtloop()));
@@ -1637,8 +1589,7 @@ impl FileSink {
                     }
                     bun_jsc::js_promise::Status::Rejected => {
                         // These don't ref().
-                        // SAFETY: `js_promise` is non-null (`as_any_promise`).
-                        let result = unsafe { (*js_promise).result(global_this.vm()) };
+                        let result = promise.result(global_this.vm());
                         self.handle_reject_stream(global_this, result);
                     }
                 }


### PR DESCRIPTION
### Problem
- No user-facing bug; cleanup in one file. `FileSink.rs` has a private ref guard, `FileSinkRef`, that is a one-type copy of `bun_ptr::ScopedRef`, which `FileSink` already qualifies for.
- `assign_to_stream` casts its `AnyPromise` to a raw `*mut JSPromise` and reads it in two `unsafe` blocks, under a comment saying `AnyPromise` lacks `status()`/`result()`. It has both; the cast and comment are stale.

### Fix
- Delete `FileSinkRef`; its 9 sites use `ScopedRef` in the same mode as before (5 `new`, which takes a ref; 4 `adopt`, which takes over one).
- `assign_to_stream` calls `promise.status()` and `promise.result(vm)`, as the other `assign_to_stream` callers already do.
- Property to check: no site changed mode. Both guards are one pointer wide, bump the same `Cell<u32>` and drop through the same `CellRefCounted::deref`; the promise accessors reach the same JSC calls the cast did.
- Verification: refactor only, no new test. `cargo check`/`clippy` clean, debug build passes, existing filesink and spawn stdin tests pass (92). Removes 4 `unsafe` blocks and 2 `unsafe fn`s, adds none.

### Background
- `FileSink` is the native sink behind file and pipe writers. It is intrusively refcounted: the count lives in the struct (`bun_ptr::CellRefCounted` derive) and it is freed at zero. JS holds raw pointers into it, so it is not an `Rc`.
- Its callbacks (`on_write`, `run_pending`, promise reactions) re-enter JS, which can drop the last outside ref mid-function, so each holds a local ref until it returns.
- `bun_ptr::ScopedRef<T>` is the shared guard for that: `new(p)` takes a ref, `unsafe adopt(p)` takes over a ref taken earlier (when a task or promise reaction was queued) without bumping the count, and drop releases one ref.
- `bun_jsc::AnyPromise` wraps a `JSPromise` or `JSInternalPromise` (an alias of `JSPromise` in `bun_jsc`) and exposes `status()`/`result(vm)` for both.

<details>
<summary>Original description</summary>

## What

`src/runtime/webcore/FileSink.rs` defined a private `struct FileSinkRef(*mut FileSink)` with `unsafe fn new_ref` (bumps the count), `unsafe fn adopt` (does not) and a `Drop` that calls `FileSink::deref`. That is a one-type copy of `bun_ptr::ScopedRef`, and `FileSink` already derives `bun_ptr::CellRefCounted`, which emits the `AnyRefCounted` bridge `ScopedRef` requires. The local type is deleted and its 9 call sites use the shared guard: 5 `new_ref` sites become `ScopedRef::new`, 4 `adopt` sites become `ScopedRef::adopt` (the `FlushPendingTask::release_unrun` site becomes `drop(ScopedRef::<FileSink>::adopt(sink))`, the same shape as `FileResponseStream`'s `Taskable::release_unrun`).

```rust
// before
let _guard = FileSinkRef::new_ref(this);
let _guard = unsafe { FileSinkRef::adopt(this) };

// after
let _guard = ScopedRef::new(this);
let _guard = unsafe { ScopedRef::adopt(this) };
```

`FileSink::assign_to_stream` also matched on the `AnyPromise` to recover a raw `*mut JSPromise` and dereferenced it in two `unsafe` blocks, under a comment saying `AnyPromise` had no `status()`/`result()`. It has both, so the function now calls `promise.status()` and `promise.result(vm)` like the sibling `assign_to_stream` callers in `Blob.rs`, `s3/client.rs`, `FetchTasklet.rs` and `html_rewriter.rs`, and the cast block and stale comment are gone.

Net effect in `FileSink.rs`: removes 4 `unsafe` blocks and 2 `unsafe fn`s, no new `unsafe`. One file, +12/-61 lines.

## Why

The ref/deref bracket around FileSink's re-entrant callbacks (`on_write`, `run_pending`, `on_auto_flush`, `on_attached_process_exit`, the promise reactions and the flush task) is now expressed with the same `ScopedRef` type used by the other intrusively refcounted types in the runtime, so a reader sees one guard with one documented `new`/`adopt` contract instead of a file-local variant. It is zero-cost: `ScopedRef<FileSink>` is a `NonNull<FileSink>`, the same size as the `*mut FileSink` it replaces; the derive's `rc_ref` is the same `Cell<u32>` increment `new_ref` performed, and `ScopedRef`'s `Drop` calls the same `CellRefCounted::deref` that `FileSink::deref` forwards to, all `#[inline]`. `AnyPromise::status()`/`result()` reach the same `JSC__JSPromise__status`/`__result` calls the removed cast did (`JSInternalPromise` is an alias of `JSPromise` in `bun_jsc`); the only difference is the opaque handle's non-null assertion, which `as_any_promise` has already established for both variants, and it is the shape the four sibling sites already use.

Part of a series of small type-system hardening changes; each PR stands alone.

## Verification

`cargo check` and `cargo clippy` are clean for the touched crates. Debug build succeeds. `bun bd test test/js/bun/util/filesink.test.ts test/js/bun/spawn/spawn-stdin-readable-stream.test.ts test/js/bun/spawn/spawn-streaming-stdin.test.ts`: 92 pass, 0 fail (92 tests across 3 files).

</details>
