### PR TITLE
Bun.serve: send the buffered tail when a direct stream controller is close()d

### DIFF
--- a/src/runtime/webcore/streams.rs
+++ b/src/runtime/webcore/streams.rs
@@ -1051,8 +1051,8 @@ pub struct HTTPServerWritable<const SSL: bool, const HTTP3: bool> {
     /// `flush_promise()` → `pending.run()`.
     pub(crate) pending: WritablePending,
     pub(crate) wrote_at_start_of_flush: BlobSizeType,
-    // JSC_BORROW: process-lifetime VM global; `None` until `flush_from_js`/
-    // `end_from_js` install it. Safe `Deref` via `BackRef`.
+    // JSC_BORROW: process-lifetime VM global, installed by
+    // `RequestContext::do_render_stream` at construction. Safe `Deref` via `BackRef`.
     pub global_this: Option<BackRef<JSGlobalObject>>,
     pub(crate) high_water_mark: BlobSizeType,
 
@@ -1643,13 +1643,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             }
         }
         self.wrote_at_start_of_flush = self.wrote;
-        self.pending_flush = Some(JSPromise::create(global_this));
-        self.global_this = Some(BackRef::new(global_this));
-        // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-        let promise_value = JSPromise::opaque_ref(self.pending_flush.unwrap()).to_js();
-        promise_value.protect();
-
-        bun_sys::Result::Ok(promise_value)
+        bun_sys::Result::Ok(self.park_pending_flush(global_this))
     }
 
     pub fn flush(&mut self) -> bun_sys::Result<()> {
@@ -1806,7 +1800,9 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
         self.unregister_auto_flusher();
     }
 
-    /// In this case, it's always an error
+    /// Controller `close()`. The buffered tail is sent here rather than left
+    /// to the auto-flusher: a `pull()` that closes synchronously has its sink
+    /// torn down by `do_render_stream` before any deferred task runs.
     pub(crate) fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
         bun_core::scoped_log!(HTTPServerWritableLog, "end({:?})", err);
 
@@ -1833,6 +1829,13 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             self.finalize();
             return bun_sys::Result::Ok(());
         }
+
+        if self.send_readable(0) {
+            self.handle_ended_response(err);
+        } else {
+            let global_this = BackRef::new(self.global_this());
+            self.park_pending_flush(&global_this);
+        }
         bun_sys::Result::Ok(())
     }
 
@@ -1857,12 +1860,7 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
 
         if readable_len > 0 {
             if !self.send_readable(0) {
-                self.pending_flush = Some(JSPromise::create(global_this));
-                self.global_this = Some(BackRef::new(global_this));
-                // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
-                let value = JSPromise::opaque_ref(self.pending_flush.unwrap()).to_js();
-                value.protect();
-                return bun_sys::Result::Ok(value);
+                return bun_sys::Result::Ok(self.park_pending_flush(global_this));
             }
         } else {
             if let Some(res) = self.any_res() {
@@ -1870,19 +1868,38 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             }
         }
 
+        self.handle_ended_response(None);
+
+        bun_sys::Result::Ok(JSValue::from(self.wrote))
+    }
+
+    /// uWS could not drain what was handed to it: `on_writable` settles this
+    /// promise via `flush_promise` once it has (resending the `try_end` tail
+    /// still in `buffer` first). For an ended sink the request waits on it
+    /// instead of tearing the sink down (`do_render_stream`,
+    /// `handle_resolve_stream`).
+    fn park_pending_flush(&mut self, global_this: &JSGlobalObject) -> JSValue {
+        let promise = JSPromise::create(global_this);
+        self.pending_flush = Some(promise);
+        self.global_this = Some(BackRef::new(global_this));
+        // S008: `JSPromise` is an `opaque_ffi!` ZST — safe `*const → &` deref.
+        let value = JSPromise::opaque_ref(promise).to_js();
+        value.protect();
+        value
+    }
+
+    /// `end()`/`end_from_js()` fully ended the response through uWS, which
+    /// `markDone()`s it and drops its `onAborted` (see `ended_response`).
+    fn handle_ended_response(&mut self, err: Option<SysError>) {
         if let Some(res) = self.any_res() {
             // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
             res.resume();
         }
-        // Both branches above fully ended the response through uWS, which
-        // `markDone()`s it and drops its `onAborted`.
         self.ended_response = true;
         self.mark_done();
-        let _ = self.flush_promise(); // TODO: properly propagate exception upwards
-        self.source.close(None);
+        let _ = self.flush_promise();
+        self.source.close(err);
         self.finalize();
-
-        bun_sys::Result::Ok(JSValue::from(self.wrote))
     }
 
     /// Takes `*mut Self`, not `&mut self`: closing the signal runs the controller's
@@ -1942,6 +1959,9 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             self.auto_flusher.registered.set(false);
             return false;
         }
+        // `end()`/`end_from_js()` send their own tail (or park it for
+        // `on_writable`) and unregister this flusher on the way.
+        debug_assert!(!self.requested_end);
 
         let readable_len = self.readable_slice().len();
 
@@ -1955,20 +1975,6 @@ impl<const SSL: bool, const HTTP3: bool> HTTPServerWritable<SSL, HTTP3> {
             return true;
         }
         self.auto_flusher.registered.set(false);
-
-        if self.requested_end {
-            if let Some(res) = self.any_res() {
-                res.clear_on_writable();
-                // Release any request-body pause while `res` is live (see `end_already_responded_stream`).
-                res.resume();
-            }
-            // `send_readable` drained the parked `try_end`/`end`, so uWS has
-            // `markDone()`d the response and dropped its `onAborted`.
-            self.ended_response = true;
-            self.source.close(None);
-            let _ = self.flush_promise();
-            self.finalize();
-        }
         false
     }
 

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -617,6 +617,40 @@ describe("end() under transport backpressure over h3", () => {
     const res = await h3fetch(server);
     expect(await res.text()).toBe("hey");
   });
+
+  // close() must park the same pending flush as end(). It used to leave the
+  // tail to the auto-flusher instead, and when that try_end hit backpressure
+  // nothing was parked for the request to wait on, so the sink was torn down
+  // and the body came back empty even from an async pull().
+  test("async pull() that closes synchronously", async () => {
+    using server = serveH3(
+      () =>
+        new ReadableStream({
+          type: "direct",
+          async pull(c: any) {
+            c.write("hey");
+            c.close();
+          },
+        } as any),
+    );
+    const res = await h3fetch(server);
+    expect(await res.text()).toBe("hey");
+  });
+
+  test("sync pull() that closes synchronously", async () => {
+    using server = serveH3(
+      () =>
+        new ReadableStream({
+          type: "direct",
+          pull(c: any) {
+            c.write("hey");
+            c.close();
+          },
+        } as any),
+    );
+    const res = await h3fetch(server);
+    expect(await res.text()).toBe("hey");
+  });
 });
 
 // The controller's detach() used to skip the close callback when it was
@@ -728,4 +762,57 @@ test("close() with unflushed data writes the chunked terminator exactly once", a
   const afterTerminator = data.slice(data.indexOf("0\r\n\r\n") + 5);
   expect(afterTerminator.slice(0, 12)).toBe("HTTP/1.1 200");
   expect(afterTerminator).toEndWith("ok");
+});
+
+// close() with bytes still buffered below the high-water mark left them for
+// the auto-flusher. A pull() that closes synchronously never gets there: the
+// request finalizes the sink as soon as pull() returns, so the buffered tail
+// was dropped and the client got Content-Length: 0 (or, after a mid-stream
+// flush(), a chunked body missing its tail). end() in the same position sent
+// everything; close() must too.
+describe("buffered bytes are sent when the controller finishes", () => {
+  type Framing = { body: string; contentLength: string | null; transferEncoding: string | null };
+  const unflushed: Framing = { body: "helloworld", contentLength: "10", transferEncoding: null };
+  const flushedMidway: Framing = { body: "helloworld", contentLength: null, transferEncoding: "chunked" };
+
+  // The writes stay below the sink's high-water mark, so whatever follows the
+  // last flush() is still buffered when the controller is finished.
+  const writeThen = (finish: "close" | "end", flushMidway: boolean) => (c: any) => {
+    c.write("hello");
+    if (flushMidway) c.flush();
+    c.write("world");
+    c[finish]();
+  };
+
+  const cases: [name: string, pull: (c: any) => unknown, expected: Framing][] = [
+    ["sync pull, close()", writeThen("close", false), unflushed],
+    ["sync pull, end()", writeThen("end", false), unflushed],
+    ["sync pull, flush() midway, close()", writeThen("close", true), flushedMidway],
+    ["sync pull, flush() midway, end()", writeThen("end", true), flushedMidway],
+    ["async pull, close()", async c => writeThen("close", false)(c), unflushed],
+    ["async pull, flush() midway, close()", async c => writeThen("close", true)(c), flushedMidway],
+    [
+      "sync pull, single write, close()",
+      c => {
+        c.write("helloworld");
+        c.close();
+      },
+      unflushed,
+    ],
+  ];
+
+  test.concurrent.each(cases)("%s", async (_name, pull, expected) => {
+    using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response(new ReadableStream({ type: "direct", pull } as any)),
+    });
+
+    const response = await fetch(server.url);
+    expect({
+      body: await response.text(),
+      contentLength: response.headers.get("content-length"),
+      transferEncoding: response.headers.get("transfer-encoding"),
+    }).toEqual(expected);
+    expect(response.status).toBe(200);
+  });
 });

--- a/test/js/bun/http/serve-direct-readable-stream.test.ts
+++ b/test/js/bun/http/serve-direct-readable-stream.test.ts
@@ -774,6 +774,12 @@ describe("buffered bytes are sent when the controller finishes", () => {
   type Framing = { body: string; contentLength: string | null; transferEncoding: string | null };
   const unflushed: Framing = { body: "helloworld", contentLength: "10", transferEncoding: null };
   const flushedMidway: Framing = { body: "helloworld", contentLength: null, transferEncoding: "chunked" };
+  const nothingWritten: Framing = { body: "", contentLength: "0", transferEncoding: null };
+  // A write of at least the sink's high-water mark (2048 bytes by default)
+  // goes straight to the socket instead of the buffer, so close() finds
+  // nothing left to send and only has to terminate the chunked response.
+  const highWaterMarkBody = Buffer.alloc(2048, "x").toString();
+  const sentByWrite: Framing = { body: highWaterMarkBody, contentLength: null, transferEncoding: "chunked" };
 
   // The writes stay below the sink's high-water mark, so whatever follows the
   // last flush() is still buffered when the controller is finished.
@@ -799,20 +805,39 @@ describe("buffered bytes are sent when the controller finishes", () => {
       },
       unflushed,
     ],
+    // Nothing is buffered in these two, so close() takes its empty-buffer
+    // path; they pin down that it still ends the response.
+    ["sync pull, close() without writing", c => c.close(), nothingWritten],
+    [
+      "sync pull, write at the high-water mark, close()",
+      c => {
+        c.write(highWaterMarkBody);
+        c.close();
+      },
+      sentByWrite,
+    ],
   ];
 
-  test.concurrent.each(cases)("%s", async (_name, pull, expected) => {
-    using server = Bun.serve({
-      port: 0,
-      fetch: () => new Response(new ReadableStream({ type: "direct", pull } as any)),
-    });
+  // The TLS server uses a separate instantiation of the sink, so the matrix
+  // runs over both.
+  describe.each([
+    ["http", {}, {}],
+    ["https", { tls }, { tls: { rejectUnauthorized: false } }],
+  ])("over %s", (_protocol, serveOptions, fetchOptions) => {
+    test.concurrent.each(cases)("%s", async (_name, pull, expected) => {
+      using server = Bun.serve({
+        port: 0,
+        ...serveOptions,
+        fetch: () => new Response(new ReadableStream({ type: "direct", pull } as any)),
+      });
 
-    const response = await fetch(server.url);
-    expect({
-      body: await response.text(),
-      contentLength: response.headers.get("content-length"),
-      transferEncoding: response.headers.get("transfer-encoding"),
-    }).toEqual(expected);
-    expect(response.status).toBe(200);
+      const response = await fetch(server.url, fetchOptions);
+      expect({
+        body: await response.text(),
+        contentLength: response.headers.get("content-length"),
+        transferEncoding: response.headers.get("transfer-encoding"),
+      }).toEqual(expected);
+      expect(response.status).toBe(200);
+    });
   });
 });


### PR DESCRIPTION
### Problem
- A `Bun.serve` response from a direct `ReadableStream` whose `pull()` writes and then calls `controller.close()` synchronously loses whatever is still buffered: the client gets a well formed `200` with `Content-Length: 0`, or after a mid-stream `flush()` a chunked body missing its tail. `controller.end()` in the same spot sends everything. Bun 1.4.0 and main.
- Over HTTP/3 the same happens from an `async pull()` too (`c.write("hey"); c.close()` returns an empty body).
- Cause: `close()` with buffered bytes only marked the sink as ending and left the send to a deferred auto-flush task, but a synchronous close has its sink torn down as soon as `pull()` returns, before that task runs.
- The deferred path also parked nothing for the request to wait on when the transport could not take the tail (common on QUIC right after HEADERS), so the sink was torn down mid-send even from an async `pull()`.

### Fix
- `close()` with buffered bytes now sends the tail at once, the way `end()` already did: hand it to uWS, and if uWS cannot drain it, park the pending-flush promise the request already waits on.
- Correct because `close()` and `end()` now finish through one path, and that path already survives a synchronous `pull()` and backpressure.
- The auto-flusher's finish-the-response branch becomes unreachable, so it is deleted and replaced with a debug assertion. Empty-buffer `close()` is unchanged; `close(error)` for a body that errors mid-stream also takes the new path and is observably the same on HTTP/1 as before.
- Verification: new tests for sync and async `close()` and `end()`, with and without a mid-stream `flush()`, run over both plain HTTP and TLS (the TLS sink is a separate instantiation of the same code), plus two HTTP/3 backpressure cases. Eight fail on the unfixed build (three sync `close()` cases on each of HTTP and HTTPS, both HTTP/3 cases); all pass with the fix, and the existing serve and stream suites still pass.
- The same matrix also pins down the two `close()` shapes that have nothing buffered (no write at all, and a single write at the high-water mark that went straight to the socket), which this change leaves alone; they pass before and after. These and the TLS runs are the cases #34334 covered that were missing here.
- Supersedes #34334, which fixed the same bug in the generated controller code and has conflicted with main.

### Background
- Direct stream (`new ReadableStream({ type: "direct", pull })`): a Bun extension where `pull()` writes bytes straight into a sink via `controller.write()` / `flush()` / `close()` / `end()` instead of enqueueing chunks. As a `Response` body, that sink is the HTTP response itself.
- Sink buffering: writes below the high-water mark sit in memory. A stream that finishes with nothing flushed goes out whole with `Content-Length`; once a `flush()` has gone out, the response is chunked and the rest follows as more chunks.
- Auto-flusher: a deferred task the sink registers to push its buffer to the socket later. It only helps if the sink is still alive when the event loop gets to it.
- Rendering a stream body: if `pull()` returns nothing to wait on and no flush promise is parked, the request treats the body as done and finalizes the sink immediately; a parked promise makes it wait.
- uWS `try_end`: the HTTP layer's finish call reports whether it managed to write the tail. If not (backpressure), the sink must retry from its writable callback, so something has to keep the sink alive until then.

<details>
<summary>Original description</summary>

### Repro

```ts
const mk = (fin, flushMid) =>
  new ReadableStream({
    type: "direct",
    pull(c) { c.write("hello"); if (flushMid) c.flush(); c.write("world"); c[fin](); },
  });
const srv = Bun.serve({
  port: 0,
  fetch(req) {
    const u = new URL(req.url);
    return new Response(mk(u.searchParams.get("fin"), u.searchParams.has("flush")));
  },
});
for (const q of ["fin=close", "fin=end", "fin=close&flush", "fin=end&flush"]) {
  const r = await fetch(`${srv.url}?${q}`);
  console.log(q, r.headers.get("content-length"), r.headers.get("transfer-encoding"), JSON.stringify(await r.text()));
}
```

Bun 1.4.0 and current main:

```
fin=close        0     null     ""            <- whole body lost
fin=end          10    null     "helloworld"
fin=close&flush  null  chunked  "hello"       <- "world" lost
fin=end&flush    null  chunked  "helloworld"
```

Every byte still buffered in the sink when a synchronous `pull()` calls `controller.close()` is dropped, and the response is a well formed `200` with `Content-Length: 0` (or a chunked body missing its tail). `controller.end()` in the same position sends everything. This is what you get by combining the sync `pull()` from the direct stream docs with `controller.close()`.

Over HTTP/3 the same thing happens from an `async pull()` too (`c.write("hey"); c.close()` returns an empty body).

### Cause

`controller.close()` reaches `HTTPServerWritable::end()` in `src/runtime/webcore/streams.rs`. With bytes buffered it only set `requested_end` / `end_len` and returned, leaving the send to the auto-flusher (a deferred task), and `on_auto_flush()` had a `requested_end` branch to finish the response afterwards.

That never runs for a synchronous close: `readDirectStream` returns `undefined` because the stream is already closed, and `do_render_stream` takes its no-promise path, which calls `mark_done()` (unregistering the flusher) before `finalize()`, destroys the sink with the bytes still in its buffer, and ends the response through `render_missing()`.

The deferred design also had no answer for transport backpressure: when the flusher's `try_end` could not drain (common on QUIC right after HEADERS), nothing was parked for `handle_resolve_stream` to wait on, so the sink was torn down and the body truncated even from an async `pull()`.

`end_from_js()` (the `end()` controller method) has neither problem: it sends the tail immediately and parks a `pending_flush` promise on backpressure, which `do_render_stream` and `handle_resolve_stream` already wait for.

### Fix

`HTTPServerWritable::end()` now sends the tail the same way `end_from_js()` does: `send_readable(0)` (uWS `try_end` / `end`), then the same post-end bookkeeping, or `park_pending_flush()` when uWS could not drain it, so `on_writable` resends the tail and settles the promise the request is waiting on. The shared pieces are factored into `park_pending_flush()` (also used by `flush_from_js()`, which had the same block) and `handle_ended_response()`.

With that, the `requested_end` branch in `on_auto_flush()` is unreachable (`end()` / `end_from_js()` unregister the flusher on every path and writes after `requested_end` are rejected), so it is deleted and replaced by a debug assertion. uWS `markDone()` already drops `onWritable` on both HTTP/1 and HTTP/3, which is what `end_from_js()` was relying on, so the `clear_on_writable()` from that branch is not needed.

The empty-buffer `close()` path is unchanged. `close(error)` from `readStreamIntoSink` (a default `ReadableStream` body that errors while bytes are still buffered in the sink) also goes through `end()`; on HTTP/1 those bytes were already being delivered by the auto-flusher before this change, so the observable behaviour there is the same, just no longer dependent on a deferred task running first. The existing mid-stream error tests in `serve-stream-body-error.test.ts` still pass.

Supersedes #34334, which fixed the same bug by routing `close()` to `endWithSink` in the generated controller code based on the argument count; it has conflicted with main since #36006 / #36943.

### Verification

New cases in `test/js/bun/http/serve-direct-readable-stream.test.ts`:

- `buffered bytes are sent when the controller finishes`: sync `close()`, sync `end()`, both with and without a mid-stream `flush()`, async `close()` siblings, and a single-write `close()`. Each asserts the body plus the framing (`Content-Length: 10` for the unflushed cases, `Transfer-Encoding: chunked` for the flushed ones).
- Two `close()` siblings in the existing h3 backpressure block (sync and async `pull()`).

On the unfixed build 5 of them fail (3 HTTP/1 sync `close()` cases, both h3 cases); with the fix all 23 tests in the file pass, including the #36940 single-terminator test, whose `close()` now goes through the new path. `serve.test.ts`, `bun-server.test.ts`, `serve-http3.test.ts`, the other `serve-*stream*` / `*-leak` files and `test/js/web/streams` pass as well (the remaining failures in `serve.test.ts` / `bun-server.test.ts` are the `localhost` / IPv6 / root-port ones that fail identically with the stock binary in this environment).


</details>

