### PR TITLE
blob: report the size of Blobs created by the native bindings to the GC

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -2371,8 +2371,7 @@ impl BlobExt for Blob {
             }
         }
 
-        blob.calculate_estimated_byte_size();
-        Ok(Blob::new(blob))
+        Ok(new_for_bindings(blob))
     }
 
     // `finalize` is inherent on `Blob` (bun_jsc::webcore_types) so codegen's
@@ -4255,9 +4254,10 @@ pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &mut BunStri
     }
 }
 
-/// Heap-promotes a Blob that C++ wraps directly (`WebCore::Blob`, `Blob__create`)
-/// instead of via `BlobExt::to_js`. `Blob__estimatedSize` only reads the cached
-/// size (it also runs on the GC thread), so it has to be computed here.
+/// Heap-promotes a Blob whose wrapper the bindings build from the returned pointer
+/// (the generated constructor, `Blob__create`, `WebCore::Blob`) rather than via
+/// `BlobExt::to_js`. `Blob__estimatedSize` only reads the cached size (it also
+/// runs on the GC thread), so it is computed here, once every field is final.
 fn new_for_bindings(blob: Blob) -> *mut Blob {
     blob.calculate_estimated_byte_size();
     Blob::new(blob)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4255,9 +4255,17 @@ pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &mut BunStri
     }
 }
 
+/// Heap-promotes a Blob that C++ wraps directly (`WebCore::Blob`, `Blob__create`)
+/// instead of via `BlobExt::to_js`. `Blob__estimatedSize` only reads the cached
+/// size (it also runs on the GC thread), so it has to be computed here.
+fn new_for_bindings(blob: Blob) -> *mut Blob {
+    blob.calculate_estimated_byte_size();
+    Blob::new(blob)
+}
+
 #[unsafe(no_mangle)]
 pub(crate) extern "C" fn Blob__dupe(this: &Blob) -> *mut Blob {
-    Blob::new(this.dupe_with_content_type(true))
+    new_for_bindings(this.dupe_with_content_type(true))
 }
 
 #[unsafe(no_mangle)]
@@ -5997,28 +6005,44 @@ pub(crate) extern "C" fn Blob__getSize(value: JSValue) -> usize {
 
 /// # Safety
 /// `[ptr, ptr+len)` must be a valid readable byte range (or `ptr` null / `len` 0).
+unsafe fn blob_from_bytes(global_this: &JSGlobalObject, ptr: *const u8, len: usize) -> Blob {
+    if ptr.is_null() || len == 0 {
+        return Blob::init_empty(global_this);
+    }
+    // SAFETY: caller guarantees [ptr, ptr+len) is valid.
+    let bytes = unsafe { bun_core::ffi::slice(ptr, len) }.to_vec();
+    Blob::init_with_store(Store::init(bytes), global_this)
+}
+
+/// # Safety
+/// `mime` must be a NUL-terminated C string.
+unsafe fn set_content_type_from_cstr(blob: &Blob, mime: *const c_char) {
+    // SAFETY: forwarded from caller's contract.
+    let mime_slice = unsafe { bun_core::ffi::cstr(mime) }.to_bytes();
+    if !mime_slice.is_empty() {
+        blob.content_type
+            .set(BlobContentType::Owned(mime_slice.into()));
+        blob.content_type_was_set.set(true);
+    }
+}
+
+/// # Safety
+/// `[ptr, ptr+len)` must be a valid readable byte range (or `ptr` null / `len` 0).
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn Blob__fromBytes(
     global_this: &JSGlobalObject,
     ptr: *const u8,
     len: usize,
 ) -> *mut Blob {
-    if ptr.is_null() || len == 0 {
-        return Blob::new(Blob::init_empty(global_this));
-    }
-    // SAFETY: caller guarantees [ptr, ptr+len) is valid.
-    let bytes = unsafe { bun_core::ffi::slice(ptr, len) }.to_vec();
-    let store = Store::init(bytes);
-    Blob::new(Blob::init_with_store(store, global_this))
+    // SAFETY: forwarded from caller's contract.
+    new_for_bindings(unsafe { blob_from_bytes(global_this, ptr, len) })
 }
 
-/// Same as Blob__fromBytes but stamps content_type. `mime` must be a
-/// string literal with process lifetime (not freed by deinit — the caller
-/// passes one of the image/* constants).
+/// Same as Blob__fromBytes but stamps content_type (copied out of `mime`).
 ///
 /// # Safety
 /// `[ptr, ptr+len)` must be a valid readable byte range and `mime` a
-/// NUL-terminated `'static` C string.
+/// NUL-terminated C string.
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn Blob__fromBytesWithType(
     global_this: &JSGlobalObject,
@@ -6027,20 +6051,10 @@ pub(crate) unsafe extern "C" fn Blob__fromBytesWithType(
     mime: *const c_char,
 ) -> *mut Blob {
     // SAFETY: forwarded from caller's contract.
-    let blob = unsafe { Blob__fromBytes(global_this, ptr, len) };
-    // SAFETY: caller guarantees `mime` is a NUL-terminated 'static C string.
-    let mime_slice = unsafe { bun_core::ffi::cstr(mime) }.to_bytes();
-    if !mime_slice.is_empty() {
-        // SAFETY: `blob` is a fresh heap allocation returned by `Blob__fromBytes`;
-        // we are the sole owner until this function returns it.
-        unsafe {
-            (*blob)
-                .content_type
-                .set(BlobContentType::Owned(mime_slice.into()));
-            (*blob).content_type_was_set.set(true);
-        }
-    }
-    blob
+    let blob = unsafe { blob_from_bytes(global_this, ptr, len) };
+    // SAFETY: forwarded from caller's contract.
+    unsafe { set_content_type_from_cstr(&blob, mime) };
+    new_for_bindings(blob)
 }
 
 /// Adopts an mmap'd region — no copy. The Blob's store holds the mapping;
@@ -6069,19 +6083,10 @@ pub(crate) unsafe extern "C" fn Blob__fromMmapWithType(
         // SAFETY: caller (C++ WebKit screenshot path) guarantees `[ptr, ptr+len)`
         // is a valid page-aligned mmap'd region we now own.
         let store = Store::init_mmap(unsafe { core::slice::from_raw_parts_mut(ptr, len) });
-        let blob = Blob::new(Blob::init_with_store(store, global_this));
+        let blob = Blob::init_with_store(store, global_this);
         // SAFETY: caller (C++) passes a valid NUL-terminated C string.
-        let mime_slice = unsafe { bun_core::ffi::cstr(mime) }.to_bytes();
-        if !mime_slice.is_empty() {
-            // SAFETY: `blob` was just produced by heap::alloc in Blob::new.
-            unsafe {
-                (*blob)
-                    .content_type
-                    .set(BlobContentType::Owned(mime_slice.into()));
-                (*blob).content_type_was_set.set(true);
-            }
-        }
-        blob
+        unsafe { set_content_type_from_cstr(&blob, mime) };
+        new_for_bindings(blob)
     }
 }
 

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -4254,10 +4254,7 @@ pub(crate) extern "C" fn Blob__setAsFile(this: &mut Blob, path_str: &mut BunStri
     }
 }
 
-/// Heap-promotes a Blob whose wrapper the bindings build from the returned pointer
-/// (the generated constructor, `Blob__create`, `WebCore::Blob`) rather than via
-/// `BlobExt::to_js`. `Blob__estimatedSize` only reads the cached size (it also
-/// runs on the GC thread), so it is computed here, once every field is final.
+/// The bindings wrap the returned pointer themselves; `Blob__estimatedSize` only reads the cache.
 fn new_for_bindings(blob: Blob) -> *mut Blob {
     blob.calculate_estimated_byte_size();
     Blob::new(blob)

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -6060,8 +6060,7 @@ pub(crate) unsafe extern "C" fn Blob__fromBytesWithType(
 ///
 /// # Safety
 /// `[ptr, ptr+len)` must be a valid page-aligned mmap'd region whose ownership
-/// is transferred to the returned Blob, and `mime` a NUL-terminated `'static`
-/// C string.
+/// is transferred to the returned Blob, and `mime` a NUL-terminated C string.
 #[unsafe(no_mangle)]
 pub(crate) unsafe extern "C" fn Blob__fromMmapWithType(
     global_this: &JSGlobalObject,

--- a/test/js/bun/util/heap-snapshot.test.ts
+++ b/test/js/bun/util/heap-snapshot.test.ts
@@ -200,6 +200,82 @@ describe("Native types report their size correctly", () => {
 
     delete globalThis.ws;
   });
+
+  // These Blobs are created by the native bindings rather than by `new Blob()`,
+  // so each of those constructors has to record the size on its own.
+  describe("Blob handed to JS by the native bindings", () => {
+    const payloadSize = 1024 * 1024;
+
+    function multipartUpload() {
+      const upload = new FormData();
+      upload.append("file", new Blob([Buffer.alloc(payloadSize, "abc")]), "upload.bin");
+      return upload;
+    }
+
+    it.each(["Request", "Response"] as const)("File parsed from a multipart %s body", async bodyOwner => {
+      const parsed =
+        bodyOwner === "Request"
+          ? await new Request("http://example.com/", { method: "POST", body: multipartUpload() }).formData()
+          : await new Response(multipartUpload()).formData();
+
+      const file = parsed.get("file") as File;
+      expect(file.size).toBe(payloadSize);
+      expect(estimateShallowMemoryUsageOf(file)).toBeGreaterThan(payloadSize);
+      expect(estimateShallowMemoryUsageOf(file)).toBeLessThan(payloadSize * 2);
+
+      // FormData's own size goes through the entry it holds, not through the JS File.
+      expect(estimateShallowMemoryUsageOf(parsed)).toBeGreaterThan(payloadSize);
+      expect(estimateShallowMemoryUsageOf(parsed)).toBeLessThan(payloadSize * 2);
+    });
+
+    it("parsed multipart File appended to another FormData", async () => {
+      const parsed = await new Response(multipartUpload()).formData();
+
+      const forwarded = new FormData();
+      const empty = estimateShallowMemoryUsageOf(forwarded);
+      forwarded.append("file", parsed.get("file") as File);
+      expect(estimateShallowMemoryUsageOf(forwarded)).toBeGreaterThan(empty + payloadSize);
+      expect(estimateShallowMemoryUsageOf(forwarded)).toBeLessThan(empty + payloadSize * 2);
+    });
+
+    it('WebSocket message received with binaryType = "blob"', async () => {
+      using server = Bun.serve({
+        port: 0,
+        fetch(req, server) {
+          if (server.upgrade(req)) return;
+          return new Response("expected a websocket upgrade", { status: 400 });
+        },
+        websocket: {
+          open(ws) {
+            ws.sendBinary(new Uint8Array(payloadSize));
+          },
+          message() {},
+        },
+      });
+
+      const ws = new WebSocket(server.url);
+      ws.binaryType = "blob";
+      const { promise, resolve, reject } = Promise.withResolvers<MessageEvent>();
+      ws.onmessage = resolve;
+      ws.onerror = reject;
+      ws.onclose = event => reject(new Error(`WebSocket closed before a message arrived (code ${event.code})`));
+      try {
+        const event = await promise;
+        const blob = event.data as Blob;
+        expect(blob).toBeInstanceOf(Blob);
+        expect(blob.size).toBe(payloadSize);
+        expect(estimateShallowMemoryUsageOf(blob)).toBeGreaterThan(payloadSize);
+        expect(estimateShallowMemoryUsageOf(blob)).toBeLessThan(payloadSize * 2);
+
+        // MessageEvent reports the Blob it holds as its own cost.
+        expect(estimateShallowMemoryUsageOf(event)).toBeGreaterThan(payloadSize);
+        expect(estimateShallowMemoryUsageOf(event)).toBeLessThan(payloadSize * 2);
+      } finally {
+        ws.onclose = null;
+        ws.close();
+      }
+    });
+  });
 });
 
 describe("CommonJS Module cached slots are visible in heap snapshots", () => {

--- a/test/js/bun/webview/webview-chrome.test.ts
+++ b/test/js/bun/webview/webview-chrome.test.ts
@@ -1,3 +1,4 @@
+import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast } from "harness";
 
@@ -178,6 +179,8 @@ it("chrome: screenshot returns a PNG Blob", async () => {
   expect(bytes[3]).toBe(0x47);
   // Bun.write accepts the Blob directly — the MIME type carries through.
   expect(blob.size).toBeGreaterThan(100);
+  // The natively created Blob has to report its bytes to the GC like a Blob built from them.
+  expect(estimateShallowMemoryUsageOf(blob)).toBeGreaterThanOrEqual(estimateShallowMemoryUsageOf(new Blob([bytes])));
 });
 
 it("chrome: screenshot format options produce the right magic bytes", async () => {

--- a/test/js/bun/webview/webview.test.ts
+++ b/test/js/bun/webview/webview.test.ts
@@ -1,4 +1,5 @@
 import { dlopen, FFIType, ptr, toArrayBuffer } from "bun:ffi";
+import { estimateShallowMemoryUsageOf } from "bun:jsc";
 import { expect, test } from "bun:test";
 import { bunEnv, bunExe, isCI, isMacOS, isMacOSVersionAtLeast, tempDir } from "harness";
 
@@ -369,6 +370,8 @@ it("screenshot returns a PNG Blob", async () => {
   expect(bytes[1]).toBe(0x50);
   expect(bytes[2]).toBe(0x4e);
   expect(bytes[3]).toBe(0x47);
+  // The mmap-backed Blob has to report its bytes to the GC like a Blob built from them.
+  expect(estimateShallowMemoryUsageOf(blob)).toBeGreaterThanOrEqual(estimateShallowMemoryUsageOf(new Blob([bytes])));
 });
 
 it("screenshot format options", async () => {


### PR DESCRIPTION
### Problem
- Blobs that bun builds natively tell the GC they are about 48 bytes whatever their payload: a File parsed from a multipart `Request` or `Response` body (and the `FormData` holding it, 81), a WebSocket message received with `binaryType = "blob"` (and its `MessageEvent`, 56), and `Bun.WebView#screenshot()`. `new Blob()` of the same 1 MiB reports 1048896. Reproduces on 1.4.0 and main.
- Cause: a Blob's estimated size is a cached field that only the JS `Blob` constructor and the ordinary Rust to JS conversion fill in. The native entry points hand the Blob to JSC with the cache still 0, and duplicating a Blob copies its source's 0.
- The bytes are still freed by the periodic event loop GC. What is wrong is the number JSC uses to schedule collections, and what heap snapshots and `estimateShallowMemoryUsageOf` show.

### Fix
- The four native entry points (dupe, from bytes, from bytes with type, from mmap with type) and the `Blob` constructor go through one helper that computes the estimate and then moves the Blob to the heap. The typed variants set the content type before the size is taken, so it is counted.
- Correct because at these points the Blob is freshly built, exclusively owned, on the JS thread, and has its final fields, and every later reader (the JS wrapper, `FormData`, `MessageEvent`) reads that same allocation. The value only goes to JSC, and it now matches `new Blob(sameBytes)` plus the stored name and content type.
- Producers with the same symptom (`new File(...)`, `Bun.Image#blob()`, server and bundler accounting) are left to #37667, #37656 and a separate issue. Moving the computation into `Blob::new` itself is a follow-up once #37656 lands.
- Verification: new heap-snapshot tests for the multipart, re-appended File and WebSocket cases fail on the released bun and pass with the fix. One assertion was added to each existing screenshot test; the Chrome one was run locally against a real Chrome (48 before, 1123 after, for a 370 byte PNG), the WebKit one is left to CI.

### Background
- JSC only sees memory it allocated itself. A native object holding a buffer outside the JS heap reports that size as extra memory, once at creation and again at every GC, so JSC knows when a collection is worth running. The number is advisory and does not decide when the object is freed.
- Blob's estimate is a cache because the accessor is also called from the GC marking thread, so it never computes anything. Whoever builds the Blob has to compute it once, on the JS thread, before handing it over.
- A Blob is assembled on the stack and then `Blob::new` moves it to a heap allocation whose pointer the C++ bindings wrap in a JS object. The cache has to be filled before that move and after every field it counts (name, content type) is set.
- C++ code (multipart parsing, WebSocket, WebView) creates Blobs through a handful of `extern "C"` exports rather than the JS constructor, so a fix in the constructor never reaches them. Dupe copies an existing Blob, cache included.
- `estimateShallowMemoryUsageOf` from `bun:jsc` returns the size JSC currently holds for one object, which is how the tests observe the number.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/webview/webview-chrome.test.ts test/js/bun/webview/webview.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

```ts
import { estimateShallowMemoryUsageOf } from "bun:jsc";

const payload = Buffer.alloc(1 << 20, "x");
console.log(estimateShallowMemoryUsageOf(new Blob([payload]))); // 1048896

const upload = new FormData();
upload.append("f", new Blob([payload]), "u.bin");
const parsed = await new Response(upload).formData();
console.log(parsed.get("f").size);                         // 1048576
console.log(estimateShallowMemoryUsageOf(parsed.get("f"))); // 48  (the bare cell)
console.log(estimateShallowMemoryUsageOf(parsed));          // 81

// Same for a WebSocket with ws.binaryType = "blob": a 1 MiB binary message
// arrives as a Blob whose estimate is 48, inside a MessageEvent whose estimate is 56.
// Same for Bun.WebView#screenshot(): a 370 byte PNG Blob reports 48.
```

Reproduces on bun 1.4.0 and on main (`Request#formData()` behaves the same as `Response#formData()`).

### Cause

`Blob.reported_estimated_size` is a cache. The generated `Blob__estimatedSize` (what `Blob__create`'s `reportExtraMemoryAllocated`, `JSBlob::visitChildren`, `JSBlob::memoryCost` and therefore `WebCore::Blob::memoryCost()` read) only returns it, because it is also called from the GC marking thread. Whoever creates a Blob that JSC will account for has to fill it first; `BlobExt::to_js` and the `Blob` constructor do.

The Blobs above never pass through either of those. They are created by the exports behind the C++ `WebCore::Blob` wrapper (`src/jsc/bindings/blob.h`) and the webview backends, and none of them computed the size:

- `Blob__dupe`: every `WebCore::Blob` to JS conversion (`src/jsc/bindings/blob.cpp`: `Blob__setAsFile`, then `Blob__dupe`, then `Blob__create`), every multipart file entry (`FormData.rs` builds a stack Blob and `appendBlob` dupes it) and every `formData.append(name, blob)` from JS (`Blob__dupeFromJS`). `dupe_with_content_type` copies the source's cached value, which for a multipart entry is the never-computed 0, so the 0 was copied into the FormData entry and again into the JS wrapper. `Blob__create` then reported 0 bytes at allocation and the marking thread reported 0 at every GC.
- `Blob__fromBytes`: WebSocket binary messages in blob mode (`WebSocket.cpp`). The JS-visible Blob is a `Blob__dupe` of this one, and `MessageEvent::memoryCost()` reads this one directly.
- `Blob__fromBytesWithType` / `Blob__fromMmapWithType`: `Bun.WebView#screenshot()` on the Chrome and WebKit backends, which hand the pointer straight to `Blob__create`.

### Fix

The four exports, and the `Blob` constructor (which already did the same two steps inline), go through one helper, `new_for_bindings`, which calls `calculate_estimated_byte_size()` and then `Blob::new`. `Blob__fromBytes` / `Blob__fromBytesWithType` / `Blob__fromMmapWithType` are restructured so the content type is set on the stack Blob before the size is taken; the two copies of the content type stamping become `set_content_type_from_cstr`. The `'static` requirement on `mime` in the two `*WithType` doc comments is dropped, since the string has been copied into an owned `content_type` since #29910.

Why this is the right place: these exports are exactly the points where a Blob is handed to a consumer that reads the cache without going through `BlobExt::to_js`, and the freshly built Blob is exclusively owned and on the JS thread there, so computing is safe and covers every consumer of that allocation at once (the JS wrapper, `DOMFormData::memoryCost`, `MessageEvent::memoryCost`). Computing in `Blob__dupe` rather than at the `toJS` call site also means the estimate includes the file name that `Blob__setAsFile` stores just before it, and it fixes the JS `append()` path for a source whose own cache was never filled (a parsed entry appended to another FormData). The computation is a handful of field reads, negligible next to the heap allocation and wrapper creation in the same call. Behaviour is otherwise unchanged: the value is only reported to JSC, and it now reports what `new Blob(sameBytes)` reports (plus the stored name / content type). This does not produce unbounded retention on its own, since Bun's periodic event loop GC still collects these Blobs eventually; what was wrong is the accounting JSC uses to schedule collections and what heap snapshots and `estimateShallowMemoryUsageOf` show.

Sibling paths with the same symptom, intentionally not in this PR:

- `new File(...)` (`jsdom_file_construct` + `JSDOMFile.cpp`): #37667.
- `Bun.Image#blob()`, the one Rust producer that used the by-value `JsClass::to_js` (which also skips the computation): #37656, which makes that path compute the size and removes the split. This PR does not touch the functions #37656 or #37667 change, and `new_for_bindings` keeps working if `calculate_estimated_byte_size` becomes an inherent method there.
- The `BuildArtifact` inline Blob and `FileRoute::memory_cost()` read the same cache for a Blob that is never computed; that is server / bundler accounting rather than a JS Blob and has been filed separately.

Where this should end up: `Blob::new` is the one heap-promotion point every reader of the cache goes through, so once #37656 has moved `calculate_estimated_byte_size` into `bun_jsc` (it has to live next to `Blob::new` to be called from there), the computation belongs in `Blob::new` itself, and `new_for_bindings`, the constructor's call and the explicit calls added by #37656 / #37667 all become deletable. Every current `Blob::new` caller either has its fields final at that point or recomputes in `BlobExt::to_js` afterwards, so that move is mechanical. It is not done here because it needs the hoist that #37656 is already making; this PR keeps the fix in `bun_runtime` so the three PRs stay independent, and the consolidation is a follow-up on top of whichever lands last.

### Verification

Four tests added at the end of the "Native types report their size correctly" group in `test/js/bun/util/heap-snapshot.test.ts`, each asserting the estimate is between 1x and 2x a 1 MiB payload:

- File parsed from a multipart `Request` body, and from a multipart `Response` body: the `File` itself and the parsed `FormData` (the latter goes through the entry's `WebCore::Blob`, i.e. the `appendBlob` dupe). Without the fix: 48 and 81.
- A parsed multipart File appended to another FormData (`Blob__dupeFromJS` with an uncomputed source). Without the fix: 84.
- A WebSocket message received with `binaryType = "blob"`: `event.data` (the `Blob__dupe`) and the `MessageEvent` itself (`MessageEvent::memoryCost()` reads the `Blob__fromBytes` Blob, so this assertion is the one that depends on `Blob__fromBytes` computing). Without the fix: 48 and 56.

The two `*WithType` exports are covered by one added assertion in each existing screenshot test: `test/js/bun/webview/webview-chrome.test.ts` ("screenshot returns a PNG Blob", `Blob__fromBytesWithType`, runs on the Linux lanes that have Chrome) and `test/js/bun/webview/webview.test.ts` (same name, `Blob__fromMmapWithType`, macOS lanes). Each asserts the screenshot Blob reports at least what `new Blob([itsBytes])` reports. The Chrome one was run here through a real Chrome: 48 vs 690 for a 370 byte PNG without the fix, 1123 vs 1114 with it (the 9 extra bytes are the owned `image/png`); the WebKit one is the same code path on a `Bytes` store and is left to CI. The existing `Blob` constructor coverage (`blob.test.ts`, the `FormData` test in the same group) still passes with the constructor routed through the helper.

With the fix the debug build reports 1049325 for the parsed File (`new Blob` of the same bytes: 1049320, the difference being the stored `u.bin` name), 1049361 for the FormData, 1049320 for the WebSocket Blob and 1049336 for its MessageEvent.

The heap-snapshot tests fail with `USE_SYSTEM_BUN=1 bun test` and pass with `bun bd test`. Also run on the fixed debug build: `test/js/web/html/FormData.test.ts`, `FormData-multipart-serialization.test.ts`, `FormData-file-error-leak.test.ts`, `test/js/web/fetch/blob.test.ts`, `test/js/web/websocket/websocket-blob.test.ts` (all pass; `blob-file-name-ownership.test.ts` and two pre-existing tests in `heap-snapshot.test.ts` only exceed the 5s default per-test timeout locally under debug+ASAN, which they also do without this change). `cargo fmt --check` is clean.

</details>
