### PR TITLE
node:http2: send NGHTTP2_NO_ERROR from ClientHttp2Session#destroy(undefined, code)

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -5992,7 +5992,12 @@ class ClientHttp2Session extends Http2Session {
       }
       cancelPendingPings(this.#pingCallbacks);
       this.#pingCallbacks = null;
-      if (typeof error === "number") {
+      if (error === undefined) {
+        // node's signature is destroy(error = NGHTTP2_NO_ERROR, code): the defaulted error is a
+        // number and replaces code, so destroy(undefined, code) is destroy(). An explicit code only
+        // reaches the wire next to an Error (or null).
+        code = undefined;
+      } else if (typeof error === "number") {
         code = error;
         error = code !== constants.NGHTTP2_NO_ERROR ? $ERR_HTTP2_SESSION_ERROR(code) : undefined;
       }

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1417,8 +1417,9 @@ describe("inbound stream lifecycle", () => {
         } catch (e) {
           console.log("destroy threw: " + e.message);
         }
-        // A numeric code must still tear every open stream down.
-        client.destroy(undefined, 8);
+        // A numeric code must still tear every open stream down. (null, not undefined: like node,
+        // an undefined error takes the NGHTTP2_NO_ERROR default and the code argument is ignored.)
+        client.destroy(null, 8);
         console.log("destroy:done");
       });
     `;

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2286,6 +2286,77 @@ describe.concurrent("http2 session goawayCode / goawayLastStreamID", () => {
   });
 });
 
+// node declares Http2Session#destroy(error = NGHTTP2_NO_ERROR, code). An undefined error takes
+// the numeric default, which then replaces code, so destroy(undefined, code) puts NGHTTP2_NO_ERROR
+// on the wire exactly like destroy(); the code argument is only sent next to an Error (or null).
+// The table is what the peer's 'goaway' event reports under node v26.3.0 for client and server
+// sessions alike.
+describe.concurrent("http2 session.destroy(error, code) sends the GOAWAY code node sends", () => {
+  const { NGHTTP2_NO_ERROR, NGHTTP2_REFUSED_STREAM } = http2.constants;
+  const shapes = {
+    "destroy()": [],
+    "destroy(undefined, REFUSED_STREAM)": [undefined, NGHTTP2_REFUSED_STREAM],
+    "destroy(undefined, -1)": [undefined, -1],
+    "destroy(null, REFUSED_STREAM)": [null, NGHTTP2_REFUSED_STREAM],
+    "destroy(REFUSED_STREAM)": [NGHTTP2_REFUSED_STREAM],
+    "destroy(new Error('boom'), REFUSED_STREAM)": [new Error("boom"), NGHTTP2_REFUSED_STREAM],
+  };
+  const expected = {
+    "destroy()": { goaway: NGHTTP2_NO_ERROR, error: undefined },
+    "destroy(undefined, REFUSED_STREAM)": { goaway: NGHTTP2_NO_ERROR, error: undefined },
+    "destroy(undefined, -1)": { goaway: NGHTTP2_NO_ERROR, error: undefined },
+    "destroy(null, REFUSED_STREAM)": { goaway: NGHTTP2_REFUSED_STREAM, error: undefined },
+    "destroy(REFUSED_STREAM)": { goaway: NGHTTP2_REFUSED_STREAM, error: "ERR_HTTP2_SESSION_ERROR" },
+    "destroy(new Error('boom'), REFUSED_STREAM)": { goaway: NGHTTP2_REFUSED_STREAM, error: "boom" },
+  };
+
+  // Destroys a fresh session with `args` and reports the GOAWAY code its peer received plus the
+  // 'error' (code, or message for a plain Error) the destroyed session itself emitted, if any.
+  async function destroySession(side, args) {
+    const server = http2.createServer();
+    const { promise: serverSessionPromise, resolve: onServerSession } = Promise.withResolvers();
+    server.once("session", onServerSession);
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const { promise: connected, resolve: onConnect } = Promise.withResolvers();
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`, onConnect);
+    client.on("error", () => {});
+    const serverSession = await serverSessionPromise;
+    serverSession.on("error", () => {});
+    await connected;
+    try {
+      const [session, peer] = side === "client" ? [client, serverSession] : [serverSession, client];
+      let error;
+      session.on("error", e => (error = e.code ?? e.message));
+      const { promise: goawayReceived, resolve: onGoaway } = Promise.withResolvers();
+      peer.once("goaway", onGoaway);
+      const { promise: closed, resolve: onClose } = Promise.withResolvers();
+      session.once("close", onClose);
+      session.destroy(...args);
+      const goaway = await goawayReceived;
+      await closed;
+      return { goaway, error };
+    } finally {
+      client.destroy();
+      serverSession.destroy();
+      server.close();
+    }
+  }
+
+  async function destroyEveryShape(side) {
+    const names = Object.keys(shapes);
+    const results = await Promise.all(names.map(name => destroySession(side, shapes[name])));
+    return Object.fromEntries(names.map((name, i) => [name, results[i]]));
+  }
+
+  it("from a client session", async () => {
+    expect(await destroyEveryShape("client")).toEqual(expected);
+  });
+
+  it("from a server session", async () => {
+    expect(await destroyEveryShape("server")).toEqual(expected);
+  });
+});
+
 it(
   "http2 server with minimal maxSessionMemory handles multiple requests",
   async () => {


### PR DESCRIPTION
### Problem
- `destroy(undefined, 7)` on a client `node:http2` session puts 7 in the GOAWAY frame (`destroy(undefined, -1)` puts `0xffffffff`). Node, and Bun's own server session, send `NGHTTP2_NO_ERROR` for both.
- Not cosmetic: the peer destroys its session with `ERR_HTTP2_SESSION_ERROR` and emits `'error'`, where node's peer sees a clean shutdown.
- Cause: in node an undefined `error` takes a numeric default that replaces `code`, so `destroy(undefined, anything)` is `destroy()`. Bun's server session has that default; the client session did not, so the explicit `code` reached the wire.

### Fix
- The client session's `destroy()` now discards `code` when `error` is undefined, so `destroy(undefined, code)` takes exactly the path `destroy()` takes, on the wire and on the streams. Every other argument shape is unchanged, and no internal caller uses this one.
- Copying the server's default parameter instead would also change the code a plain `destroy()` gives the streams it tears down (that teardown is being reworked in #33802), so this change stays limited to the GOAWAY code.
- One conformance test that meant "send code 8" now passes `null` instead of `undefined`, which means that under node and under Bun before and after; its snapshot is unchanged.
- Verification: a new test destroys a client and a server session with six argument shapes and compares the peer's GOAWAY code and the local `'error'` against a table checked against node v26.3.0. Without the fix the client case fails on exactly the two `undefined` rows; the server case passes before and after.

### Background
- GOAWAY is the HTTP/2 frame a session sends when it shuts down. It carries an error code; `NGHTTP2_NO_ERROR` (0) is a clean close, and a peer that receives any other code reports a session error.
- node's `Http2Session#destroy(error, code)` accepts an `Error`, a number, `null`, or nothing as `error`. A bare number is itself the GOAWAY code; the separate `code` argument is only used when `error` is an `Error` or `null`.
- A JavaScript default parameter applies when the argument is `undefined` but not when it is `null`, which is why `destroy(undefined, 7)` and `destroy(null, 7)` differ in node.
- Bun's `node:http2` has separate client and server session classes, so this default existed on one side and not the other.

<details>
<summary>Original description</summary>

`ClientHttp2Session#destroy(undefined, code)` sent `code` in the GOAWAY frame. Node (and Bun's own `ServerHttp2Session`) send `NGHTTP2_NO_ERROR`.

## Reproduction

```js
const http2 = require("node:http2");
const server = http2.createServer();
server.once("session", s => s.once("goaway", code => { console.log("server saw 0x" + code.toString(16)); server.close(); }));
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  client.on("error", () => {});
  client.once("connect", () => client.destroy(undefined, 7));
});
```

| call (client session) | node v26.3.0 | bun 1.4.0 / main |
|---|---|---|
| `destroy(undefined, 7)` | `server saw 0x0` | `server saw 0x7` |
| `destroy(undefined, -1)` | `0x0` | `0xffffffff` |
| `destroy(null, 7)` | `0x7` | `0x7` |
| `destroy(new Error("x"), 7)` | `0x7` | `0x7` |

The same four calls on a server session already produce node's values.

## Cause

Node declares `Http2Session#destroy(error = NGHTTP2_NO_ERROR, code)`. An undefined `error` takes the numeric default, and the `typeof error === 'number'` branch then does `code = error`, so `destroy(undefined, anything)` is `destroy()`; the `code` argument is only consulted when `error` is an `Error` (or `null`, which does not trigger the default). `ServerHttp2Session#destroy` in `src/js/node/http2.ts` is declared with that default. `ClientHttp2Session#destroy` is declared `destroy(error?, code?)`, so the explicit `code` survived and went out in the GOAWAY. A non-zero GOAWAY code is not cosmetic: the peer destroys its session with `ERR_HTTP2_SESSION_ERROR` and emits `'error'`, where node's peer sees a clean shutdown.

## Fix

In the client's `destroy()`, an undefined `error` now discards `code`, which routes the call through the same path as `destroy()`.

Why not add the server's default parameter to the client: the client's stream teardown still distinguishes "no code" from code 0 (`code !== undefined ? code : NGHTTP2_CANCEL`, in two places), so the default would also change what a plain `destroy()` does to the streams it tears down. Measured on main against node v26.3.0: active streams currently close with `rstCode` 8 and would move to 2 (node: 0, with no error; that teardown is what #33802 reworks), and requests still queued would move from 8 to 2 (node: 2; tracked separately). Neither belongs in this change, which is limited to the GOAWAY code: `destroy(undefined, code)` now takes exactly the path `destroy()` takes, on the wire and on the streams, and `destroy()`, `destroy(0)`, `destroy(code)`, `destroy(null, code)` and `destroy(err, code)` are left exactly as they were. No internal caller passes an undefined error with an explicit code (`#onClose` passes `null` or an error). Note for #33802 when it is rebased: its `this.destroy(undefined, NGHTTP2_CANCEL)` calls would need `null` as the first argument, which is also node's idiom for "this code, no error".

## Verification

New `describe` in `test/js/node/http2/node-http2.test.js` destroys a fresh session with each of six argument shapes, from a client session and from a server session, and compares the GOAWAY code the peer received plus the `'error'` the destroyed session emitted against a table checked against node v26.3.0 (the same table run as a plain script under node produces identical output). Without the fix the client case fails on exactly the two `undefined` rows (`7` and `4294967295` instead of `0`); the server case passes before and after.

`h2-conformance.test.ts` had one `client.destroy(undefined, 8)` whose intent is a numeric code; it now passes `null`, which means that under node and under Bun before and after this change. Its snapshot is unchanged.

Also run against the debug build: the rest of `node-http2.test.js` and `h2-conformance.test.ts`, the upstream `test-http2-*destroy*` / `*goaway*` / `*graceful-close*` tests, and grpc-js `test-server.test.ts`.

</details>
