### PR TITLE
spawn: hold the Subprocess as a RefPtr across spawn_maybe_sync

### DIFF
--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -15,6 +15,7 @@ use bun_jsc::{
     JsResult, SystemError,
 };
 use bun_jsc::{JsCell, SysErrorJsc as _};
+use bun_ptr::RefPtr;
 #[cfg(unix)]
 use bun_sys::Fd;
 use bun_sys::UV_E;
@@ -51,11 +52,6 @@ impl JSValueSpawnExt for JSValue {
 #[inline]
 fn signal_code_from_js(val: JSValue, global: &JSGlobalObject) -> JsResult<SignalCode> {
     bun_sys_jsc::signal_code_jsc::from_js(val, global)
-}
-
-#[inline]
-fn subprocess_ipc_owner(ptr: *mut SubprocessT<'_>) -> Option<IPC::SendQueueOwner> {
-    core::ptr::NonNull::new(ptr.cast::<SubprocessT<'static>>()).map(IPC::SendQueueOwner::Subprocess)
 }
 
 bun_output::declare_scope!(Subprocess, hidden);
@@ -1278,7 +1274,7 @@ fn spawn_maybe_sync(
     // Note: build
     // the struct once with its final field values, then fill in the
     // address-dependent fields (maxbufs, ipc_data on Windows) afterward.
-    let subprocess_ptr = bun_core::heap::into_raw(Box::new(SubprocessT {
+    let spawn_ref = RefPtr::new(SubprocessT {
         global_this: bun_ptr::BackRef::new(global_this),
         // SAFETY: `to_process` returns a non-null `Box::into_raw` pointer; the
         // intrusive ref is released in `Subprocess::finalize`.
@@ -1297,9 +1293,11 @@ fn spawn_maybe_sync(
         stdin: JsCell::new(Writable::Ignore),
         stdout: JsCell::new(Readable::Ignore),
         stderr: JsCell::new(Readable::Ignore),
-        // 1=JS (released in Subprocess::finalize), 2=Process exit handler
-        // (released in Subprocess::on_process_exit; stranded if child outlives VM teardown).
-        ref_count: bun_ptr::RefCount::init_exact_refs(2),
+        // The one ref is `spawn_ref`, which this function holds until it
+        // returns (spawnSync: until it tears the Subprocess down). The exit
+        // handler and the JS wrapper take their own refs where they are
+        // installed below.
+        ref_count: bun_ptr::RefCount::init(),
         stdio_pipes: JsCell::new(core::mem::take(&mut spawned_extra_pipes)),
         ipc_data: Cell::new(None),
         flags: Cell::new(if is_sync {
@@ -1326,15 +1324,13 @@ fn spawn_maybe_sync(
             crate::timer::EventLoopTimerTag::SubprocessTimeout,
         )),
         exited_due_to_maxbuf: Cell::new(None),
-    }));
-    // SAFETY: subprocess_ptr is a freshly-boxed Subprocess; we hold the only reference.
-    let subprocess = unsafe { &mut *subprocess_ptr };
+    });
+    // Shared, because the callbacks wired below re-enter the Subprocess before
+    // this function returns (R-2); `spawn_ref` keeps it alive for every use.
+    let subprocess: &SubprocessT<'static> = &spawn_ref;
     #[cfg(windows)]
-    SubprocessT::record_stdio_pipe_ownership(subprocess_ptr);
-    // Erase the borrow lifetime to 'static for the intrusive back-pointer
-    // (PipeReader stores it as raw NonNull). subprocess_ptr is non-null (just boxed).
-    let subprocess_nn: NonNull<SubprocessT<'static>> =
-        NonNull::new(subprocess_ptr.cast()).expect("Box::into_raw returned null");
+    SubprocessT::record_stdio_pipe_ownership(spawn_ref.as_ptr());
+    let subprocess_nn = spawn_ref.as_non_null();
 
     // Address-dependent fields, filled now that `subprocess` has a stable address.
     {
@@ -1357,7 +1353,7 @@ fn spawn_maybe_sync(
                 .ipc_data
                 .set(core::ptr::NonNull::new(IPC::SendQueue::new(
                     ipc_mode,
-                    subprocess_ipc_owner(subprocess_ptr),
+                    Some(IPC::SendQueueOwner::Subprocess(subprocess_nn)),
                     IPC::SocketUnion::Uninitialized,
                 )));
         }
@@ -1375,13 +1371,13 @@ fn spawn_maybe_sync(
     ) {
         Ok(v) => subprocess.stdin.set(v),
         Err(err) => {
-            // ref_count = 2 from the aggregate above, but neither the JS
-            // wrapper nor the process exit handler are wired up yet, so
-            // release both. stdout/stderr are still `.ignore` — close the raw
-            // spawned pipe handles directly since `Readable.init()` will not
-            // run. `finalizeStreams()` here only closes `stdio_pipes` and the
-            // pidfd; stdin/stdout/stderr are `.ignore` so their `closeIO` is a
-            // no-op.
+            // Neither the JS wrapper nor the process exit handler is wired up
+            // yet, so `spawn_ref` is the only ref and dropping it at the end
+            // of this arm frees the Subprocess. stdout/stderr are still
+            // `.ignore` — close the raw spawned pipe handles directly since
+            // `Readable.init()` will not run. `finalizeStreams()` here only
+            // closes `stdio_pipes` and the pidfd; stdin/stdout/stderr are
+            // `.ignore` so their `closeIO` is a no-op.
             #[cfg(unix)]
             {
                 if let Some(fd) = spawned_stdout {
@@ -1434,8 +1430,7 @@ fn spawn_maybe_sync(
             let mut mb = subprocess.stderr_maxbuf.get();
             MaxBuf::remove_from_subprocess(&mut mb);
             subprocess.stderr_maxbuf.set(mb);
-            subprocess.deref();
-            subprocess.deref();
+            drop(spawn_ref);
             // Note: `Writable::init` returns
             // `crate::Error`. Map non-thrown to OOM.
             if global_this.has_exception() {
@@ -1486,10 +1481,16 @@ fn spawn_maybe_sync(
     }
     // existing_terminal: don't close slave_fd - user manages lifecycle and can reuse
 
-    // SAFETY: `subprocess_ptr` is the live JSC-allocated Subprocess that owns
-    // `process` and outlives it (handler ctx invariant).
+    // The handler holds its own ref, released at the end of
+    // `Subprocess::on_process_exit`, or by `finalize` if it never runs.
+    // SAFETY: `Subprocess` is the type the `Subprocess` variant dispatches to,
+    // and the ref handed over here keeps it live until the handler has run or
+    // been detached.
     subprocess.process_mut().set_exit_handler(unsafe {
-        bun_spawn::ProcessExit::new(bun_spawn::ProcessExitKind::Subprocess, subprocess_ptr)
+        bun_spawn::ProcessExit::new(
+            bun_spawn::ProcessExitKind::Subprocess,
+            spawn_ref.clone().into_raw(),
+        )
     });
 
     promise_for_stream.ensure_still_alive();
@@ -1510,6 +1511,10 @@ fn spawn_maybe_sync(
         let err = global_this.take_exception(JsError::Thrown);
         // Ensure we kill the process so we don't leave things in an unexpected state.
         let _ = subprocess.try_kill(subprocess.kill_signal);
+        // Leaked, as before: no wrapper is created on this exit and nothing
+        // else tears the Subprocess down, while the exit handler and the pipes
+        // still point at it.
+        let _ = spawn_ref.into_raw();
 
         if global_this.has_exception() {
             return Err(JsError::Thrown);
@@ -1543,7 +1548,7 @@ fn spawn_maybe_sync(
                     .ipc_data
                     .set(core::ptr::NonNull::new(IPC::SendQueue::new(
                         mode,
-                        subprocess_ipc_owner(subprocess_ptr),
+                        Some(IPC::SendQueueOwner::Subprocess(subprocess_nn)),
                         IPC::SocketUnion::Uninitialized,
                     )));
                 posix_ipc_info = Some(IPC::Socket::from(socket));
@@ -1600,33 +1605,29 @@ fn spawn_maybe_sync(
                     .as_err()
             {
                 let err_js = err.to_js(global_this);
-                subprocess.deref();
+                // `spawn_ref` drops on the way out; the exit handler's ref
+                // keeps the Subprocess alive until the child has been reaped.
                 return Err(global_this.throw_value(err_js));
             }
         }
         ipc_data.write_version_packet(global_this);
     }
 
-    if matches!(subprocess.stdin.get(), Writable::Pipe(_)) && promise_for_stream == JSValue::ZERO {
-        // Store the whole-allocation `*mut Subprocess` so Writable::on_close can raw-project stdin.
-        // SAFETY: `subprocess_ptr` is the stable boxed Subprocess; stdin was just confirmed `Pipe`.
-        unsafe {
-            if let Writable::Pipe(pipe) = (*subprocess_ptr).stdin.get() {
-                (*pipe.as_ptr())
-                    .source
-                    .set(WebCore::streams::SourceHandle::Subprocess(
-                        bun_ptr::BackRef::from_raw(subprocess_ptr.cast::<SubprocessT<'static>>()),
-                    ));
-            }
-        }
+    if let Writable::Pipe(pipe) = subprocess.stdin.get()
+        && promise_for_stream == JSValue::ZERO
+    {
+        // `Writable::on_close` reads the Subprocess through this handle as
+        // `&Subprocess`, so a shared back-pointer is enough.
+        pipe.source.set(WebCore::streams::SourceHandle::Subprocess(
+            bun_ptr::BackRef::new(subprocess),
+        ));
     }
 
     let out = if !is_sync {
-        // `subprocess_ptr` came from `heap::alloc` above and has not yet been
-        // wrapped; ownership transfers to the C++ JS cell (released via
-        // `SubprocessClass__finalize`). Use the raw-ptr entrypoint instead of
-        // the by-value `JsClass::to_js` (which would re-box).
-        SubprocessT::to_js_from_ptr(subprocess_ptr, global_this)
+        // The wrapper gets a ref of its own (released by
+        // `SubprocessClass__finalize`); `spawn_ref` stays with this function,
+        // which keeps using the Subprocess below.
+        SubprocessT::to_js_from_ref(spawn_ref.clone(), global_this)
     } else {
         JSValue::ZERO
     };
@@ -1636,7 +1637,11 @@ fn spawn_maybe_sync(
         subprocess.update_has_pending_activity();
     }
 
-    let mut send_exit_notification = false;
+    // Set when `watch()` fails below (the child may already be gone); the
+    // guard after it then delivers the exit on the way out of this function,
+    // once the readers have been started. It carries its own ref rather than
+    // borrowing `spawn_ref`, which the spawnSync tail consumes.
+    let mut deliver_exit: Option<RefPtr<SubprocessT<'static>>> = None;
 
     if !is_sync {
         // This must go before other things happen so that the exit handler is
@@ -1696,20 +1701,15 @@ fn spawn_maybe_sync(
         match subprocess.process_mut().watch() {
             sys::Result::Ok(()) => {}
             sys::Result::Err(_) => {
-                send_exit_notification = true;
+                deliver_exit = Some(spawn_ref.clone());
                 lazy = false;
             }
         }
     }
 
-    // Note: reshaped for borrowck — copy `subprocess_ptr` so the
-    // non-`move` `defer!` closure captures a disjoint place from the
-    // `(*subprocess_ptr).abort_signal = …` writes that follow.
-    let subprocess_ptr_exit = subprocess_ptr;
     scopeguard::defer! {
-        if send_exit_notification {
-            // SAFETY: subprocess_ptr is live for the lifetime of this defer.
-            let proc = unsafe { &*subprocess_ptr_exit }.process_mut();
+        if let Some(subprocess) = &deliver_exit {
+            let proc = subprocess.process_mut();
             if proc.has_exited() {
                 // process has already exited, we called wait4(), but we did not call onProcessExit()
                 // SAFETY: all-zero is a valid Rusage (POD).
@@ -1727,9 +1727,6 @@ fn spawn_maybe_sync(
     // the writer's start() throws below, both PipeReaders have taken their
     // start() ref and on_process_exit's later drain is refcount-balanced.
     if let Readable::Pipe(pipe) = subprocess.stdout.get() {
-        // Note: pass `subprocess_nn` (the `NonNull<Subprocess<'static>>`
-        // captured above) instead of the live `&mut subprocess`, which would
-        // alias with the `&mut subprocess.stdout` borrow held by `pipe`.
         Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, !is_sync && lazy);
         if (is_sync || !lazy) && matches!(subprocess.stdout.get(), Readable::Pipe(_)) {
             if let Readable::Pipe(pipe) = subprocess.stdout.get() {
@@ -1739,7 +1736,6 @@ fn spawn_maybe_sync(
     }
 
     if let Readable::Pipe(pipe) = subprocess.stderr.get() {
-        // Note: see stdout arm above — avoid aliased &mut.
         Readable::pipe_reader_mut(pipe).start(subprocess_nn, event_loop_nn, !is_sync && lazy);
 
         if (is_sync || !lazy) && matches!(subprocess.stderr.get(), Readable::Pipe(_)) {
@@ -1752,6 +1748,11 @@ fn spawn_maybe_sync(
     if let Writable::Buffer(buffer) = subprocess.stdin.get() {
         if let Err(err) = Writable::buffer_writer_mut(buffer).start() {
             let _ = subprocess.try_kill(subprocess.kill_signal);
+            if is_sync {
+                // Leaked, as before: spawnSync has no wrapper, and this exit is
+                // before its own teardown below.
+                let _ = spawn_ref.into_raw();
+            }
             return Err(global_this.throw_value(err.to_js(global_this)));
         }
     }
@@ -1787,13 +1788,13 @@ fn spawn_maybe_sync(
         // SAFETY: `signal` is a live *mut AbortSignal carrying the +1 ref taken
         // above; ownership of that ref transfers to `subprocess.abort_signal`.
         // `add_listener` may synchronously fire `on_abort_signal` (already
-        // aborted), which re-enters via `subprocess_ptr` — write through the
-        // raw pointer so no `&mut Subprocess` is held across the call.
+        // aborted), which re-enters the Subprocess through the pointer; that is
+        // shared access, like every other use through `subprocess`.
         unsafe {
             (*signal).pending_activity_ref();
-            let _ = (*signal).add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
-            (*subprocess_ptr).abort_signal.set(NonNull::new(signal));
+            let _ = (*signal).add_listener(spawn_ref.as_ptr().cast(), Subprocess::on_abort_signal);
         }
+        subprocess.abort_signal.set(NonNull::new(signal));
     }
 
     if !is_sync {
@@ -1831,10 +1832,10 @@ fn spawn_maybe_sync(
                 // SAFETY: see the matching block above.
                 unsafe {
                     (*signal).pending_activity_ref();
-                    let _ =
-                        (*signal).add_listener(subprocess_ptr.cast(), Subprocess::on_abort_signal);
-                    (*subprocess_ptr).abort_signal.set(NonNull::new(signal));
+                    let _ = (*signal)
+                        .add_listener(spawn_ref.as_ptr().cast(), Subprocess::on_abort_signal);
                 }
+                subprocess.abort_signal.set(NonNull::new(signal));
             }
         }
         sys::Result::Err(_) => {
@@ -1989,10 +1990,14 @@ fn spawn_maybe_sync(
             }
         }
     }
+
+    // There is no JS wrapper whose finalizer would tear the Subprocess down
+    // later, so from here on every exit does it, the throwing ones included.
+    let spawn_ref = scopeguard::guard(spawn_ref, SubprocessT::finalize_owned);
+    let subprocess: &SubprocessT<'static> = &spawn_ref;
+
     if global_this.has_exception() {
         // e.g. a termination exception.
-        // SAFETY: same as the `finalize` below; `subprocess` is not used after this line.
-        SubprocessT::finalize(unsafe { Box::from_raw(subprocess_ptr) });
         return Ok(JSValue::ZERO);
     }
 
@@ -2014,10 +2019,8 @@ fn spawn_maybe_sync(
     let exited_due_to_timeout = did_timeout;
     let exited_due_to_max_buffer = subprocess.exited_due_to_maxbuf.get();
     let result_pid = JSValue::js_number_from_int32(subprocess.pid());
-    // SAFETY: `subprocess_ptr` was produced by `heap::into_raw(Box::new(...))`
-    // above (spawnSync path: never handed to a JS wrapper); reclaim ownership.
-    // `subprocess` (`&mut *subprocess_ptr`) is not used after this line.
-    SubprocessT::finalize(unsafe { Box::from_raw(subprocess_ptr) });
+    // Tears the Subprocess down; nothing below reads it.
+    drop(spawn_ref);
     let (stdout, stderr, resource_usage) = output?;
 
     let sync_value = JSValue::create_empty_object(global_this, 0);

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -5,7 +5,7 @@ use core::cell::Cell;
 use core::ffi::c_void;
 use core::ptr::NonNull;
 
-use bun_ptr::RefCount;
+use bun_ptr::{RefCount, RefPtr};
 
 use bun_jsc::{
     self as jsc, CallFrame, JSGlobalObject, JSPromise, JSValue, JsCell, JsRef, JsResult,
@@ -113,8 +113,10 @@ pub use bun_spawn::process::StdioKind;
 // codegen shim hands to whichever method JS calls next. `UnsafeCell`-backed
 // fields suppress `noalias` on the outer `&Subprocess`, making the miscompile
 // structurally impossible.
-// Intrusive ref-count: `RefPtr<Subprocess>` provides ref/deref and frees the
-// Box when ref_count → 0; `deinit` runs when the last ref drops.
+// Intrusive ref-count, freed with the Box when it reaches zero. Holders: the
+// JS wrapper (`to_js_from_ref` hands it its ref, `finalize` releases it; for
+// spawnSync, `spawn_maybe_sync` plays that part itself), the process exit
+// handler, and the stdio pipes while they are open.
 #[derive(bun_ptr::RefCounted)]
 pub struct Subprocess<'a> {
     pub(crate) ref_count: RefCount<Subprocess<'a>>,
@@ -179,23 +181,19 @@ const _: () = {
     use crate::generated_classes::js_Subprocess as js;
 
     impl<'a> Subprocess<'a> {
-        /// Wrap an already-heap-allocated `Subprocess` (via `heap::alloc`) in
-        /// its JS cell. `Bun.spawn` boxes early so address-dependent
-        /// back-pointers (`stdin.pipe.signal`, MaxBuf owner, IPC owner) can be
-        /// wired before `subprocess.toJS(globalThis)` runs; this is the raw-ptr
-        /// entrypoint that avoids re-boxing.
-        ///
-        /// `ptr` must come from `heap::alloc(Box::new(Subprocess { .. }))` and
-        /// not yet be owned by any JS wrapper; ownership transfers to the C++
-        /// side (released via `SubprocessClass__finalize`). Thin forwarder to
-        /// the (already safe) generated `js_Subprocess::to_js`, which
-        /// encapsulates the FFI `__create` call internally.
+        /// Wrap an already-allocated `Subprocess` in its JS cell. `this`
+        /// becomes the wrapper's ref (stored as `m_ctx`); [`Self::finalize`]
+        /// releases it. `Bun.spawn` allocates before it has a wrapper so that
+        /// address-dependent back-pointers (`stdin.pipe.signal`, MaxBuf owner,
+        /// IPC owner) can be wired first; this is the entrypoint that avoids
+        /// re-boxing. Thin forwarder to the (already safe) generated
+        /// `js_Subprocess::to_js`, which encapsulates the FFI `__create` call.
         #[inline]
-        pub(crate) fn to_js_from_ptr(ptr: *mut Self, global: &JSGlobalObject) -> JSValue {
+        pub(crate) fn to_js_from_ref(this: RefPtr<Self>, global: &JSGlobalObject) -> JSValue {
             // The codegen wrapper is monomorphized at `'static`; the lifetime
             // parameter is purely a borrow-checker artifact (C++ stores the
             // pointer as opaque `m_ctx`), so erase it via `cast`.
-            js::to_js(ptr.cast(), global)
+            js::to_js(this.into_raw().cast(), global)
         }
     }
 
@@ -1306,12 +1304,22 @@ impl Subprocess<'_> {
         }
     }
 
+    /// JS wrapper finalizer. The `Box` is the codegen's spelling of the ref
+    /// `to_js_from_ref` gave the wrapper; the allocation outlives this call if
+    /// the exit handler or a pipe still holds a ref, so it is turned back into
+    /// that ref rather than dropped as a `Box`.
     pub fn finalize(self: Box<Self>) {
+        // SAFETY: the wrapper holds exactly the one ref `to_js_from_ref`
+        // handed it, and the finalizer runs once.
+        Self::finalize_owned(unsafe { RefPtr::from_raw(bun_core::heap::into_raw(self)) });
+    }
+
+    /// Tear down and release the ref that stands for the JS wrapper: the
+    /// wrapper's own ref from the finalizer above, or, for `spawnSync`, which
+    /// never creates a wrapper, the ref `spawn_maybe_sync` holds.
+    pub(crate) fn finalize_owned(owned: RefPtr<Self>) {
         bun_output::scoped_log!(Subprocess, "finalize");
-        // Refcounted: the trailing `this.deref()` releases the JS wrapper's +1;
-        // allocation may outlive this call if other refs remain, so hand
-        // ownership back to the raw refcount.
-        let this = bun_core::heap::release(self);
+        let this: &Self = &owned;
         // Ensure any code which references the "this" value doesn't attempt to
         // access it after it's been freed We cannot call any methods which
         // access GC'd values during the finalizer
@@ -1383,7 +1391,9 @@ impl Subprocess<'_> {
         }
 
         this.update_flags(|f| f.insert(Flags::FINALIZED));
-        this.deref();
+        // Releases the ref; the allocation goes with it unless a pipe or the
+        // exit handler still holds one.
+        drop(owned);
     }
 
     pub(crate) fn get_exited(&self, this_value: JSValue, global_this: &JSGlobalObject) -> JSValue {

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -120,7 +120,7 @@ impl<'a> Writable<'a> {
     pub(crate) fn init(
         stdio: &mut Stdio,
         event_loop: &EventLoop,
-        subprocess: &mut Subprocess<'a>,
+        subprocess: &Subprocess<'a>,
         result: StdioResult,
         promise_for_stream: &mut JSValue,
     ) -> crate::Result<Writable<'a>> {
@@ -203,7 +203,7 @@ impl<'a> Writable<'a> {
                     };
                     return Ok(Writable::Buffer(StaticPipeWriter::create(
                         evtloop,
-                        subprocess as *mut Subprocess<'a>,
+                        subprocess.as_ctx_ptr(),
                         result,
                         super::source_from_blob(blob),
                     )));
@@ -211,7 +211,7 @@ impl<'a> Writable<'a> {
                 Stdio::ArrayBuffer(array_buffer) => {
                     return Ok(Writable::Buffer(StaticPipeWriter::create(
                         evtloop,
-                        subprocess as *mut Subprocess<'a>,
+                        subprocess.as_ctx_ptr(),
                         result,
                         super::source_from_array_buffer(core::mem::take(array_buffer)),
                     )));
@@ -307,14 +307,14 @@ impl<'a> Writable<'a> {
                 };
                 Ok(Writable::Buffer(StaticPipeWriter::create(
                     evtloop,
-                    std::ptr::from_mut::<Subprocess<'a>>(subprocess),
+                    subprocess.as_ctx_ptr(),
                     result,
                     super::source_from_blob(blob),
                 )))
             }
             Stdio::ArrayBuffer(array_buffer) => Ok(Writable::Buffer(StaticPipeWriter::create(
                 evtloop,
-                std::ptr::from_mut::<Subprocess<'a>>(subprocess),
+                subprocess.as_ctx_ptr(),
                 result,
                 super::source_from_array_buffer(core::mem::take(array_buffer)),
             ))),


### PR DESCRIPTION
### Problem
- Nothing user-visible breaks. This is a lifetime cleanup of `spawn_maybe_sync` (`src/runtime/api/bun/js_bun_spawn_bindings.rs`), which builds a `Subprocess` for `Bun.spawn` and `Bun.spawnSync`.
- It held the new `Subprocess` as `&mut` for its whole length, but stdin setup, an already aborted signal, and the `spawnSync` loop all re-enter the object before it returns. Each collision had its own raw-pointer workaround. The ref count started at 2 for two holders named in a comment, and every exit balanced it by hand.

### Fix
- The allocation is a `RefPtr<Subprocess>`. The function's ref is a local, the exit handler and the JS wrapper each `clone()` one where they are installed, and a release is a drop. `finalize` turns the wrapper's `Box` back into its `RefPtr`. The `spawnSync` tail releases its own through a scope guard.
- The body binds `&Subprocess` (every field is `Cell`-style), so the workarounds become plain field access.
- Correct because the count after every exit is the same as before. Two exits leaked the `Subprocess` before and still do, now with an explicit `into_raw()`: a release there would free the object without its teardown while pipes still point at it.
- Verified: `test/js/bun/spawn/` (35 files) and `test/js/node/child_process/` under the debug build. Windows `cargo check` and clippy are clean.

### Background
- `Subprocess` is intrusively ref-counted: the last holder to release frees it. Holders are the JS wrapper, the exit handler, and the stdin pipe while open.
- `RefPtr<T>` (`bun_ptr`, since #40478) is one counted ref held as a value: `clone` takes a ref, drop releases it, `into_raw`/`from_raw` move it across an FFI boundary.
- The generated finalizer hands the wrapper's `m_ctx` back as a `Box<Subprocess>`. Other holders may still be alive then, so `finalize` must not drop it as a `Box`.
- `spawnSync` never creates a JS wrapper. It runs an isolated event loop until the child exits, then tears the `Subprocess` down itself.

<details><summary>Notes</summary>

This PR was first stacked on #37665, which added an `OwnedRef<T>` type for this purpose. #40478 gave `RefPtr<T>` that role (release on drop, `Clone`, `into_raw`/`from_raw`), so the PR was redone on top of main with `RefPtr` in place of `OwnedRef`.

The leak fix the earlier revision carried (the `spawnSync` tail returned without `finalize` when building the result threw) landed on main in #39564. The scope guard here covers the same exits.

`to_js_from_ptr(*mut)` becomes `to_js_from_ref(RefPtr)`, which moves the wrapper's ref into `m_ctx`. `Writable::init` takes `&Subprocess` and passes `as_ctx_ptr()` to the four `StaticPipeWriter::create` sites. The stdin source handle is a `BackRef::new`, the abort signal is stored through the `Cell`, and the failed-`watch()` exit notification holds its own `RefPtr` clone instead of a raw pointer behind a flag. The `subprocess_ipc_owner` helper (a null check on a pointer that cannot be null) is gone.

Ref count per exit, before and after. `Writable::init` error: two derefs vs one drop, both reach 0. Handler installed, then the stdin `ReadableStream` setup throws: leaked before, leaked now (`into_raw()`). Buffer-stdin `start()` fails in `spawnSync`: same. Windows IPC setup error: one deref vs one drop. Normal `Bun.spawn` return: wrapper + handler both times. `Bun.spawnSync`: the function's ref is consumed by `finalize_owned` where `finalize(Box::from_raw(..))` ran before. The earlier `OwnedRef` revision dropped the function's ref on the two leaking exits as well. That is the one place this revision differs from it. On Windows the uv exit callback fires without `watch()`, so the handler's release could then free the object with `finalize_streams` never run, while the readers and the extra stdio `uv_pipe_t` handles still point at it.

Test results in the container used here: two tests in `spawnsync-isolated-event-loop.test.ts` (the GC keep-alive ones from #40508) hit the 5 s timeout under the debug ASAN build. Their fixtures print `OK` in about 7 s with and without this change. `spawn_waiter_thread.test.ts` fails its CPU-time bound the same way on main's build. `child_process.test.ts` "default shell" needs `$SHELL`. Everything else passes: spawn.test.ts 140 pass, the other 34 spawn files 207 pass, child_process 130 pass.

<details><summary>Original description</summary>

Stacked on #37665 (the base of this PR is that branch). Two commits: the original one, which binds the Subprocess as `&Subprocess` instead of `&mut` across `spawn_maybe_sync`, and, following review ("Can we use a better RAII container type instead?"), a second one that holds it as an `OwnedRef`.

`spawn_maybe_sync` materialised the freshly boxed `Subprocess` as `&mut` and kept that borrow live to the end of the function, although the code in between hands out back-pointers to the same allocation and re-enters it. Each collision had its own workaround. The binding became the shared form every field of `Subprocess` is built for, `Writable::init` takes `&Subprocess`, and the workarounds became plain field access. The allocation became an `OwnedRef`: the function's ref is a local, the exit handler and the JS wrapper each take a clone where they are installed, and a release is a drop.

</details>
</details>
