### PR TITLE
uws: make Loop::wakeup take the raw loop pointer instead of &mut self

### DIFF
--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -85,9 +85,8 @@ impl AnyEventLoop {
     }
 
     /// Make the poll in progress on this loop (or the next one) return. Any
-    /// thread (`PackageManager::wake_raw` calls it from task threads while the
-    /// owning thread is inside `tick_raw`), hence `&self`; neither arm forms a
-    /// reference to the uws loop itself.
+    /// thread: `PackageManager::wake_raw` calls it from task threads while the
+    /// owning thread is inside `tick_raw`.
     pub fn wakeup(&self) {
         match self {
             AnyEventLoop::Js { owner } => owner.wakeup(),

--- a/src/event_loop/AnyEventLoop.rs
+++ b/src/event_loop/AnyEventLoop.rs
@@ -84,6 +84,17 @@ impl AnyEventLoop {
         }
     }
 
+    /// Make the poll in progress on this loop (or the next one) return. Any
+    /// thread (`PackageManager::wake_raw` calls it from task threads while the
+    /// owning thread is inside `tick_raw`), hence `&self`; neither arm forms a
+    /// reference to the uws loop itself.
+    pub fn wakeup(&self) {
+        match self {
+            AnyEventLoop::Js { owner } => owner.wakeup(),
+            AnyEventLoop::Mini(mini) => mini.wakeup(),
+        }
+    }
+
     /// Convert to an owned [`EventLoopHandle`]. Thin alias for
     /// [`EventLoopHandle::from_any`].
     #[inline]
@@ -175,7 +186,7 @@ impl AnyEventLoop {
 
 // ─── AnyEventLoop → EventLoopHandle forwarders ──────────────────────────────
 // `EventLoopHandle` (below, same file) is the canonical Js/Mini dispatcher for
-// these four methods. `AnyEventLoop` forwards through `from_any` instead of
+// these three methods. `AnyEventLoop` forwards through `from_any` instead of
 // duplicating each `match`.
 impl AnyEventLoop {
     #[inline]
@@ -195,12 +206,6 @@ impl AnyEventLoop {
     #[inline]
     pub fn native_loop(&mut self) -> *mut bun_io::Loop {
         bun_io::uws_to_native(self.r#loop())
-    }
-
-    #[inline]
-    pub fn wakeup(&mut self) {
-        // SAFETY: `r#loop()` returns a valid live loop pointer.
-        unsafe { (*self.r#loop()).wakeup() };
     }
 }
 

--- a/src/event_loop/MiniEventLoop.rs
+++ b/src/event_loop/MiniEventLoop.rs
@@ -190,9 +190,8 @@ impl MiniEventLoop {
     /// Make a poll in progress (or the next one) return immediately, so the
     /// `is_done` predicate a `tick` loop spins on is evaluated again. Any thread.
     pub fn wakeup(&self) {
-        // SAFETY: `loop_` is the live uws loop; `us_wakeup_loop` is thread-safe
-        // and takes the raw pointer (no `&mut Loop` formed).
-        unsafe { bun_uws::us_wakeup_loop(self.loop_) };
+        // SAFETY: see `loop_ptr()` invariant.
+        unsafe { UwsLoop::wakeup(self.loop_) };
     }
 
     /// Raw pointer to the `DotEnv::Loader` backref.
@@ -387,8 +386,7 @@ impl MiniEventLoop {
     /// node stays with the caller until the callback runs.
     pub fn enqueue_task_concurrent(&mut self, task: NonNull<AnyTaskWithExtraContext>) {
         self.concurrent_tasks.push(task);
-        // SAFETY: see `loop_ptr()` invariant.
-        unsafe { (*self.loop_ptr()).wakeup() };
+        self.wakeup();
     }
 
     /// The caller supplies `field_offset = core::mem::offset_of!(C, <field>)` of the
@@ -412,9 +410,7 @@ impl MiniEventLoop {
         // SAFETY: `task` was just initialized above and is non-null (derived from `ctx`).
         self.concurrent_tasks
             .push(unsafe { NonNull::new_unchecked(task) });
-
-        // SAFETY: see `loop_ptr()` invariant.
-        unsafe { (*self.loop_ptr()).wakeup() };
+        self.wakeup();
     }
 }
 

--- a/src/event_loop/lib.rs
+++ b/src/event_loop/lib.rs
@@ -50,6 +50,8 @@ bun_dispatch::link_interface! {
         fn file_polls() -> *mut bun_io::file_poll::Store;
         fn put_file_poll(poll: *mut bun_io::FilePoll, was_ever_registered: bool);
         fn uws_loop() -> *mut bun_uws::Loop;
+        // Any thread; everything else here is for the loop's own thread.
+        fn wakeup();
         fn pipe_read_buffer() -> *mut [u8];
         fn tick();
         fn auto_tick();

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -392,9 +392,9 @@ impl HttpThread {
     /// INVARIANT: `uws_loop` is set once in [`on_start`] (published via the
     /// `has_awoken` Release store) and outlives the HTTP thread. The loop is a
     /// separate C heap allocation disjoint from `self`. HTTP-thread-only at
-    /// every caller — `wakeup()` is the sole cross-thread entry and uses the
-    /// raw FFI call instead. Centralises the raw `&mut *self.uws_loop`
-    /// upgrade repeated in `process_events`.
+    /// every caller — `wakeup()` is the sole cross-thread entry and passes the
+    /// raw pointer to `uws::Loop::wakeup` instead. Centralises the raw
+    /// `&mut *self.uws_loop` upgrade repeated in `process_events`.
     #[inline]
     fn uws_loop_mut<'a>(&self) -> &'a mut uws::Loop {
         // SAFETY: see INVARIANT above.
@@ -1097,10 +1097,7 @@ impl HttpThread {
         // no happens-before for the init it guards" case.
         if self.has_awoken.load(Ordering::Acquire) {
             // SAFETY: uws_loop is the live HTTP-thread loop set in on_start.
-            // Call the raw extern (not `Loop::wakeup(&mut self)`) — this runs
-            // cross-thread while the HTTP thread owns the loop, so forming
-            // `&mut Loop` here would alias.
-            unsafe { uws::us_wakeup_loop(self.uws_loop) };
+            unsafe { uws::Loop::wakeup(self.uws_loop) };
         }
     }
 

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -392,9 +392,9 @@ impl HttpThread {
     /// INVARIANT: `uws_loop` is set once in [`on_start`] (published via the
     /// `has_awoken` Release store) and outlives the HTTP thread. The loop is a
     /// separate C heap allocation disjoint from `self`. HTTP-thread-only at
-    /// every caller — `wakeup()` is the sole cross-thread entry and passes the
-    /// raw pointer to `uws::Loop::wakeup` instead. Centralises the raw
-    /// `&mut *self.uws_loop` upgrade repeated in `process_events`.
+    /// every caller — `wakeup()` is the sole cross-thread entry and uses the
+    /// raw FFI call instead. Centralises the raw `&mut *self.uws_loop`
+    /// upgrade repeated in `process_events`.
     #[inline]
     fn uws_loop_mut<'a>(&self) -> &'a mut uws::Loop {
         // SAFETY: see INVARIANT above.

--- a/src/http/h3_client/PendingConnect.rs
+++ b/src/http/h3_client/PendingConnect.rs
@@ -128,8 +128,8 @@ impl PendingConnect {
         )
         .r#loop();
         RESOLVED.lock().push(Resolved(this));
-        // SAFETY: `loop_ptr` is a live uws::Loop for as long as the HTTP thread runs.
-        unsafe { (*loop_ptr).wakeup() };
+        // SAFETY: `loop_ptr` is the HTTP thread's loop, live for as long as that thread runs.
+        unsafe { uws::Loop::wakeup(loop_ptr) };
     }
 
     pub(crate) fn drain_resolved() {

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -859,20 +859,19 @@ impl PackageManager {
     }
 
     /// Raw-pointer wake for concurrent task-thread callers (see
-    /// `isolated_install::Installer::Task::callback`). Never materializes
-    /// `&mut PackageManager`, so two task threads finishing simultaneously do
-    /// not hold aliased exclusive borrows. `on_wake` is read-only; the handler
-    /// receives the raw `*mut`;
-    /// `event_loop.wakeup()` is the cross-thread signal and is
-    /// internally synchronized — we reach it via `addr_of_mut!` so the `&mut`
-    /// covers only the event-loop field, never the whole `PackageManager`.
+    /// `isolated_install::Installer::Task::callback`). Never materializes a
+    /// `&mut` to anything: task threads finish concurrently with each other and
+    /// with the main thread, which sits in `sleep_until` holding `&mut` to
+    /// `event_loop` across the poll being woken here. Only shared reads of
+    /// `on_wake` and of `event_loop` (whose `wakeup` takes `&self`) are formed,
+    /// and the handler receives the raw `*mut`.
     ///
     /// # Safety
     /// `this` must point to a live `PackageManager` (BACKREF).
     pub(crate) unsafe fn wake_raw(this: *mut Self) {
-        // SAFETY: caller guarantees `this` points to a live `PackageManager`; we
-        // only form field pointers via `addr_of!`/`addr_of_mut!` (no whole-struct
-        // borrow) and `wakeup()` is internally synchronized for cross-thread use.
+        // SAFETY: caller guarantees `this` points to a live `PackageManager`; only
+        // shared field borrows via `addr_of!` are formed (no whole-struct borrow),
+        // and `on_wake` / `wakeup()` are the documented cross-thread surfaces.
         unsafe {
             let on_wake = &*core::ptr::addr_of!((*this).on_wake);
             if let Some(ctx) = on_wake.context {
@@ -881,7 +880,7 @@ impl PackageManager {
                 // type); cast back to `*mut c_void` here.
                 (on_wake.get_handler())(ctx.as_ptr(), this.cast::<c_void>());
             }
-            (*core::ptr::addr_of_mut!((*this).event_loop)).wakeup();
+            (*core::ptr::addr_of!((*this).event_loop)).wakeup();
         }
     }
 

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -858,20 +858,15 @@ impl PackageManager {
         }
     }
 
-    /// Raw-pointer wake for concurrent task-thread callers (see
-    /// `isolated_install::Installer::Task::callback`). Never materializes a
-    /// `&mut` to anything: task threads finish concurrently with each other and
-    /// with the main thread, which sits in `sleep_until` holding `&mut` to
-    /// `event_loop` across the poll being woken here. Only shared reads of
-    /// `on_wake` and of `event_loop` (whose `wakeup` takes `&self`) are formed,
-    /// and the handler receives the raw `*mut`.
+    /// Wake from a task thread (see `isolated_install::Installer::Task::callback`).
+    /// Forms no `&mut`: the main thread is inside `sleep_until` holding one to
+    /// `event_loop`, and other task threads may be in here at the same time.
     ///
     /// # Safety
     /// `this` must point to a live `PackageManager` (BACKREF).
     pub(crate) unsafe fn wake_raw(this: *mut Self) {
-        // SAFETY: caller guarantees `this` points to a live `PackageManager`; only
-        // shared field borrows via `addr_of!` are formed (no whole-struct borrow),
-        // and `on_wake` / `wakeup()` are the documented cross-thread surfaces.
+        // SAFETY: `this` is live per fn contract; only shared borrows of single
+        // fields are formed, and `on_wake` / `wakeup()` are the cross-thread surfaces.
         unsafe {
             let on_wake = &*core::ptr::addr_of!((*this).on_wake);
             if let Some(ctx) = on_wake.context {

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -40,9 +40,9 @@ pub struct PatchTask {
     /// is held via raw pointer through the intrusive thread-pool queue while
     /// the manager is concurrently borrowed `&mut` on the main thread; a `&`
     /// reference here would alias that exclusive borrow under Stacked Borrows.
-    /// Constructed via `BackRef::new_mut` so the underlying pointer carries
-    /// write provenance for `PackageManager::wake_raw(*mut Self)`, which
-    /// writes the event-loop wake flag.
+    /// `Mut` because `PackageManager::wake_raw` takes `*mut Self` (it hands
+    /// the pointer on to the registered wake handler); `wake_raw` itself only
+    /// reads through it.
     pub(crate) manager: bun_ptr::BackRef<PackageManager, bun_ptr::Mut>,
     /// Borrowed view of the manager's temp directory fd (see comment at top of file).
     pub(crate) tempdir: Fd,

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -2162,15 +2162,8 @@ pub mod waker {
         }
 
         pub fn wake(&self) {
-            // See `wait()` — this is the cross-thread wake path; forming a
-            // `&mut WindowsLoop` here would alias the event-loop thread's
-            // borrow held across `us_loop_run`. Pass the raw pointer to the
-            // thread-safe C wake (`uv_async_send`) instead.
-            // SAFETY: `loop_` is the live `WindowsLoop::get()` singleton;
-            // `us_wakeup_loop` → `uv_async_send` is documented thread-safe.
-            unsafe {
-                bun_uws_sys::loop_::us_wakeup_loop(self.loop_ref().as_const_ptr().cast_mut())
-            };
+            // SAFETY: `loop_` is the live `WindowsLoop::get()` singleton.
+            unsafe { bun_uws_sys::WindowsLoop::wakeup(self.loop_ref().as_const_ptr().cast_mut()) };
         }
 
         /// Raw libuv `uv_loop_t*` underlying this waker's `WindowsLoop`.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1018,7 +1018,10 @@ impl VirtualMachine {
     ///
     /// Same single-JS-thread soundness contract as [`Self::uws_loop_mut`] —
     /// the `PlatformEventLoop` is a separate heap allocation (uws/uv-owned),
-    /// so the returned `&mut` cannot alias any field of `self`.
+    /// so the returned `&mut` cannot alias any field of `self`. The one thing
+    /// other threads do to this loop, wake it, goes through `EventLoop::wakeup`,
+    /// which reads `event_loop_handle` as a raw pointer instead of calling this:
+    /// the `&mut` returned here is live across the poll they are waking.
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn platform_loop_opt(&self) -> Option<&mut PlatformEventLoop> {
@@ -1187,8 +1190,8 @@ impl VirtualMachine {
             || !el.next_immediate_tasks.is_empty()
     }
 
-    pub fn wakeup(&mut self) {
-        self.event_loop_mut().wakeup();
+    pub fn wakeup(&self) {
+        self.event_loop_shared().wakeup();
     }
 
     pub fn on_quiet_unhandled_rejection_handler_capture_value(

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -1018,10 +1018,7 @@ impl VirtualMachine {
     ///
     /// Same single-JS-thread soundness contract as [`Self::uws_loop_mut`] —
     /// the `PlatformEventLoop` is a separate heap allocation (uws/uv-owned),
-    /// so the returned `&mut` cannot alias any field of `self`. The one thing
-    /// other threads do to this loop, wake it, goes through `EventLoop::wakeup`,
-    /// which reads `event_loop_handle` as a raw pointer instead of calling this:
-    /// the `&mut` returned here is live across the poll they are waking.
+    /// so the returned `&mut` cannot alias any field of `self`.
     #[inline(always)]
     #[allow(clippy::mut_from_ref)]
     pub(crate) fn platform_loop_opt(&self) -> Option<&mut PlatformEventLoop> {

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -991,24 +991,25 @@ impl EventLoop {
         Ok(())
     }
 
+    /// Any thread (`VmHandle` posts, the debugger thread, the signal handler): make the thread
+    /// running this loop return from its poll. A no-op before `ensure_waker` has run; the
+    /// first tick drains whatever was queued until then.
+    ///
+    /// Only the loop *pointer* is read here. The loop itself is passed to `uws::Loop::wakeup`
+    /// as that pointer, never as a reference: the thread running it may be inside
+    /// `tick_with_timeout` right now, holding the `&mut Loop` that `platform_loop_opt` hands out.
     pub fn wakeup(&self) {
         #[cfg(windows)]
-        {
-            if let Some(loop_) = self.uws_loop {
-                // SAFETY: uws_loop is a valid live uws::Loop handle
-                unsafe { (*loop_.as_ptr()).wakeup() };
-            }
-            return;
-        }
+        let loop_ = self.uws_loop.map(NonNull::as_ptr);
         #[cfg(not(windows))]
-        {
-            // Route through the single audited `platform_loop_opt()` accessor
-            // (set-once `Option<*mut>` deref) instead of open-coding the raw
-            // `(*event_loop_handle).wakeup()` here. Same `&mut Loop` is formed
-            // either way (autoref), so no soundness change vs the prior code.
-            if let Some(loop_) = self.vm_ref().platform_loop_opt() {
-                loop_.wakeup();
-            }
+        let loop_ = {
+            // SAFETY: `vm()` is the owning VM (see `vm_ref`); `addr_of!` reads the field
+            // without forming a `&VirtualMachine`.
+            unsafe { core::ptr::addr_of!((*self.vm()).event_loop_handle).read() }
+        };
+        if let Some(loop_) = loop_ {
+            // SAFETY: once set, the handle is this VM's loop and stays live for the VM lifetime.
+            unsafe { uws::Loop::wakeup(loop_) };
         }
     }
 
@@ -1294,7 +1295,7 @@ fn el_ref<'a>(owner: *mut ()) -> &'a mut EventLoop {
 
 // `this: *mut EventLoop` — owner was erased from a live `*mut EventLoop` in
 // `__bun_js_event_loop_current` / `EventLoopHandle::js`. All calls run on the
-// JS thread.
+// JS thread, except `wakeup`, which is the cross-thread signal.
 bun_event_loop::link_impl_JsEventLoop! {
     Jsc for EventLoop => |this| {
         // Reads the EventLoop's own `uws_loop` field; on
@@ -1330,6 +1331,7 @@ bun_event_loop::link_impl_JsEventLoop! {
             (*store).put(core::ptr::NonNull::new_unchecked(poll), ctx, was_ever_registered);
         },
         uws_loop() => (*this).usockets_loop(),
+        wakeup() => (*this).wakeup(),
         pipe_read_buffer() => core::ptr::from_mut::<[u8]>((*this).pipe_read_buffer()),
         tick() => (*this).tick(),
         auto_tick() => (*this).auto_tick(),

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -993,8 +993,8 @@ impl EventLoop {
 
     /// Any thread: make the thread running this loop return from its poll. A no-op before
     /// `ensure_waker` has run (the first tick drains whatever was queued). Only the loop pointer
-    /// is read here: the loop's thread may be inside `tick_with_timeout` holding
-    /// `platform_loop_opt()`'s `&mut`, so the loop is only touched through `uws::Loop::wakeup`.
+    /// is read here: the loop's thread may be parked in one of the `&mut self` tick methods on
+    /// the loop, so it is only touched through `uws::Loop::wakeup`.
     pub fn wakeup(&self) {
         #[cfg(windows)]
         let loop_ = self.uws_loop.map(NonNull::as_ptr);

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -991,13 +991,10 @@ impl EventLoop {
         Ok(())
     }
 
-    /// Any thread (`VmHandle` posts, the debugger thread, the signal handler): make the thread
-    /// running this loop return from its poll. A no-op before `ensure_waker` has run; the
-    /// first tick drains whatever was queued until then.
-    ///
-    /// Only the loop *pointer* is read here. The loop itself is passed to `uws::Loop::wakeup`
-    /// as that pointer, never as a reference: the thread running it may be inside
-    /// `tick_with_timeout` right now, holding the `&mut Loop` that `platform_loop_opt` hands out.
+    /// Any thread: make the thread running this loop return from its poll. A no-op before
+    /// `ensure_waker` has run (the first tick drains whatever was queued). Only the loop pointer
+    /// is read here: the loop's thread may be inside `tick_with_timeout` holding
+    /// `platform_loop_opt()`'s `&mut`, so the loop is only touched through `uws::Loop::wakeup`.
     pub fn wakeup(&self) {
         #[cfg(windows)]
         let loop_ = self.uws_loop.map(NonNull::as_ptr);

--- a/src/libuv_sys/libuv.rs
+++ b/src/libuv_sys/libuv.rs
@@ -597,10 +597,6 @@ impl Loop {
         let _ = unsafe { uv_run(self, RunMode::NoWait) };
     }
     #[inline]
-    pub fn wakeup(&mut self) {
-        self.wq_async.send();
-    }
-    #[inline]
     pub fn dump_active_handles(&mut self, stream: *mut c_void) {
         // SAFETY: self is a live loop.
         unsafe { uv_print_active_handles(self, stream) };

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -619,7 +619,7 @@ impl JSBundleCompletionTask {
             (*this).cancelled.store(true, Ordering::Release);
             let l = (*this).bundle_loop.load(Ordering::Acquire);
             if !l.is_null() {
-                bun_uws::us_wakeup_loop(l);
+                bun_uws::Loop::wakeup(l);
             }
         }
     }

--- a/src/uws/lib.rs
+++ b/src/uws/lib.rs
@@ -1301,7 +1301,7 @@ pub mod ssl_wrapper {
 // loop_data.h) and `struct us_loop_t` (epoll_kqueue.h / libuv.h). Re-exported
 // from bun_uws_sys so `bun_uws::Loop` and `bun_uws_sys::Loop` are the same
 // type (bun_io's EventLoopCtxVTable is typed against the uws_sys version).
-pub use bun_uws_sys::loop_::{LoopHandler, us_wakeup_loop};
+pub use bun_uws_sys::loop_::LoopHandler;
 pub use bun_uws_sys::{InternalLoopData, Loop, NOW_NS_UNKNOWN};
 
 /// Extension methods on the re-exported `bun_uws_sys::InternalLoopData` for the

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -243,14 +243,18 @@ impl PosixLoop {
         p
     }
 
-    pub fn wakeup(&mut self) {
-        // SAFETY: self is a valid loop pointer
-        unsafe { c::us_wakeup_loop(self) };
-    }
-
-    #[inline]
-    pub fn wake(&mut self) {
-        self.wakeup();
+    /// Make the poll in progress on this loop (or the next one) return. Any thread.
+    ///
+    /// Takes `this: *mut Self` (not `&mut self`): callers are typically other threads (or a
+    /// signal handler) waking a loop whose own thread is inside `tick*`/`run`, holding a
+    /// `&mut Loop` across the blocking call, and `us_wakeup_loop` writes to `pending_wakeups`.
+    /// A `&mut self` receiver would be a second `&mut` over those bytes, live at the same time.
+    ///
+    /// # Safety
+    /// `this` must be a live loop returned by `create`/`get` and not yet destroyed.
+    pub unsafe fn wakeup(this: *mut Self) {
+        // SAFETY: `this` is a live loop per fn contract; `us_wakeup_loop` is thread-safe.
+        unsafe { c::us_wakeup_loop(this) };
     }
 
     pub fn tick(&mut self) {
@@ -444,14 +448,15 @@ impl WindowsLoop {
         self.uv().is_active()
     }
 
-    pub fn wakeup(&mut self) {
-        // SAFETY: self is a valid loop pointer
-        unsafe { c::us_wakeup_loop(self) };
-    }
-
-    #[inline]
-    pub fn wake(&mut self) {
-        self.wakeup();
+    /// Make the poll in progress on this loop (or the next one) return. Any thread. See
+    /// `PosixLoop::wakeup` for why this takes the raw pointer rather than `&mut self`.
+    ///
+    /// # Safety
+    /// `this` must be a live loop returned by `create`/`get` and not yet destroyed.
+    pub unsafe fn wakeup(this: *mut Self) {
+        // SAFETY: `this` is a live loop per fn contract; `us_wakeup_loop` (`uv_async_send`)
+        // is thread-safe.
+        unsafe { c::us_wakeup_loop(this) };
     }
 
     /// Signature matches the POSIX impl so callers need no `cfg`. `now_ns` is unused here: on
@@ -623,7 +628,7 @@ mod c {
         pub fn us_loop_run(loop_: *mut Loop);
         #[cfg(windows)]
         pub(super) fn us_loop_pump(loop_: *mut Loop);
-        pub fn us_wakeup_loop(loop_: *mut Loop);
+        pub(super) fn us_wakeup_loop(loop_: *mut Loop);
         pub(super) fn uws_loop_addPostHandler(loop_: *mut Loop, ctx: *mut c_void, cb: LoopCtxCb);
         pub(super) fn uws_loop_addPreHandler(loop_: *mut Loop, ctx: *mut c_void, cb: LoopCtxCb);
         #[cfg(not(windows))]
@@ -643,14 +648,10 @@ mod c {
         pub(super) fn uws_loop_date_header_timer_update(loop_: *mut Loop);
     }
 }
-// Re-exported raw externs for cross-thread callers (e.g. bun_http's
-// `HTTPThread::wakeup`, bun_io's `WindowsWaker`) that hold only a `*mut Loop`
-// and MUST NOT form a `&mut Loop` via `Loop::wakeup`/`Loop::run` — see the
-// noalias warning on `mod c` above. `us_loop_run` is included because the
-// event-loop thread parks inside it while worker threads call
-// `us_wakeup_loop` concurrently; routing either through a `&mut self`
-// receiver would create two live `&mut Loop` to the same singleton (UB).
-pub use c::{us_loop_run, us_wakeup_loop};
+// Re-exported raw for bun_io's `WindowsWaker::wait`, which parks its thread inside it while
+// other threads call `Loop::wakeup` on the same loop; going through the `&mut self` `run` would
+// hold a `&mut Loop` across the park (see the noalias warning on `mod c` above).
+pub use c::us_loop_run;
 
 unsafe extern "C" {
     // safe: no args; frees this thread's lazily-created uws loop if it exists.

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -245,10 +245,8 @@ impl PosixLoop {
 
     /// Make the poll in progress on this loop (or the next one) return. Any thread.
     ///
-    /// Takes `this: *mut Self` (not `&mut self`): callers are typically other threads (or a
-    /// signal handler) waking a loop whose own thread is inside `tick*`/`run`, holding a
-    /// `&mut Loop` across the blocking call, and `us_wakeup_loop` writes to `pending_wakeups`.
-    /// A `&mut self` receiver would be a second `&mut` over those bytes, live at the same time.
+    /// Raw pointer, not `&mut self`: the loop's own thread holds `&mut Loop` across `tick*`/`run`
+    /// while other threads call this, and `us_wakeup_loop` writes `pending_wakeups`.
     ///
     /// # Safety
     /// `this` must be a live loop returned by `create`/`get` and not yet destroyed.
@@ -448,14 +446,13 @@ impl WindowsLoop {
         self.uv().is_active()
     }
 
-    /// Make the poll in progress on this loop (or the next one) return. Any thread. See
-    /// `PosixLoop::wakeup` for why this takes the raw pointer rather than `&mut self`.
+    /// See `PosixLoop::wakeup`. Any thread.
     ///
     /// # Safety
     /// `this` must be a live loop returned by `create`/`get` and not yet destroyed.
     pub unsafe fn wakeup(this: *mut Self) {
-        // SAFETY: `this` is a live loop per fn contract; `us_wakeup_loop` (`uv_async_send`)
-        // is thread-safe.
+        // SAFETY: `this` is a live loop per fn contract; `us_wakeup_loop` (`uv_async_send`) is
+        // thread-safe.
         unsafe { c::us_wakeup_loop(this) };
     }
 
@@ -648,9 +645,8 @@ mod c {
         pub(super) fn uws_loop_date_header_timer_update(loop_: *mut Loop);
     }
 }
-// Re-exported raw for bun_io's `WindowsWaker::wait`, which parks its thread inside it while
-// other threads call `Loop::wakeup` on the same loop; going through the `&mut self` `run` would
-// hold a `&mut Loop` across the park (see the noalias warning on `mod c` above).
+// For bun_io's `WindowsWaker::wait`, which must not hold the `&mut Loop` that `run` would take
+// across the park (see there).
 pub use c::us_loop_run;
 
 unsafe extern "C" {

--- a/test/internal/source-lints/mut-self-wakeup.test.ts
+++ b/test/internal/source-lints/mut-self-wakeup.test.ts
@@ -4,22 +4,30 @@ import { realpathSync } from "fs";
 import path from "path";
 import { globAllSources } from "../../../scripts/glob-sources.ts";
 
-// `fn wakeup(&mut self)` is banned on every loop wrapper.
+// `fn wakeup(&mut self)` / `fn wake(&mut self)` are banned on every loop and
+// waker wrapper.
 //
-// A wakeup is the one thing other threads (and signal handlers) do to an
-// event loop, and they do it while the loop's own thread is parked inside
-// `tick`/`run` holding a `&mut` to that loop across the blocking call. A
-// `&mut self` receiver therefore cannot be called correctly from where wakeups
-// come from: every caller has to autoref a second `&mut` over the same struct
-// while the first one is live, which is aliasing UB under Stacked/Tree Borrows
-// (and on POSIX `us_wakeup_loop` really does write to the struct, bumping
-// `pending_wakeups`). Before this lint, `uws::Loop::wakeup(&mut self)` was
-// reached that way from `VmHandle` posts, the signal handler, the debugger
-// thread, `PackageManager::wake_raw` and the h3 DNS callback.
+// Waking is the one thing other threads (and signal handlers) do to an event
+// loop, and they do it while the loop's own thread is parked inside
+// `tick`/`run`/`wait` holding a `&mut` (or `&`) to that loop across the
+// blocking call. A `&mut self` receiver therefore cannot be called correctly
+// from where wakeups come from: every caller has to autoref a second `&mut`
+// over the same struct while the first borrow is live, which is aliasing UB
+// under Stacked/Tree Borrows (and on POSIX `us_wakeup_loop` really does write
+// to the struct, bumping `pending_wakeups`). Before this lint,
+// `uws::Loop::wakeup(&mut self)` was reached that way from `VmHandle` posts,
+// the signal handler, the debugger thread, `PackageManager::wake_raw` and the
+// h3 DNS callback, and the macOS `bun_io` waker's `wake(&mut self)` from the
+// bundler and IO threads.
 //
 // Shapes that are fine:
-//   - `fn wakeup(&self)` when the body only reads atomics / set-once pointers
-//     (`jsc::EventLoop::wakeup`, `MiniEventLoop::wakeup`, `HttpThread::wakeup`).
+//   - `fn wakeup(&self)` / `fn wake(&self)` whose body only loads the pointer
+//     or fd it needs and hands it to the raw wake (`uws::Loop::wakeup`, a write
+//     to the eventfd, ...), forming no reference to the loop being woken:
+//     `HttpThread::wakeup` (pointer published through an atomic),
+//     `MiniEventLoop::wakeup` (set-once field), the `bun_io::waker` types (fds),
+//     `jsc::EventLoop::wakeup` (reads `event_loop_handle`; making that load
+//     atomic is a separate change, the receiver shape is already right).
 //   - `unsafe fn wakeup(this: *mut Self)` for the `#[repr(C)]` mirror of the C
 //     loop itself (`bun_uws_sys::PosixLoop::wakeup` / `WindowsLoop::wakeup`),
 //     since the C side is what gets woken and no Rust reference is needed.
@@ -42,11 +50,16 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-// `fn wakeup(&mut self` / `fn wakeup(&'a mut self`, with any visibility and
-// qualifiers in front of `fn`. Matched across newlines so a rustfmt-wrapped
-// signature can't evade it. Does not match the `&self` and `this: *mut Self`
-// shapes above, nor the `extern "C" fn wakeup(loop_: *mut Loop)` trampolines.
-const BANNED = /\bfn\s+wakeup\s*\(\s*&\s*(?:'\w+\s+)?mut\s+self\b/g;
+// `fn wake(&mut self` / `fn wakeup(&'a mut self`, with any visibility and
+// qualifiers in front of `fn` and optional generics after the name. Matched
+// across newlines so a rustfmt-wrapped signature can't evade it. Does not match
+// the `&self` and `this: *mut Self` shapes above, nor the
+// `extern "C" fn wakeup(loop_: *mut Loop)` trampolines.
+//
+// The name list is the enforcement boundary: `wake` and `wakeup` are the two
+// spellings the tree uses for this operation. A cross-thread wake entry point
+// under another name has to be added here to be covered.
+const BANNED = /\bfn\s+(?:wake|wakeup)\s*(?:<[^>]*>)?\s*\(\s*&\s*(?:'\w+\s+)?mut\s+self\b/g;
 
 /** `line: matched text` for every banned definition in one file's source. */
 function findBanned(content: string): string[] {
@@ -79,14 +92,18 @@ test("the matcher recognizes the banned receiver shapes and nothing else", () =>
   // The tree is expected to contain zero matches, so the ban below would also
   // pass if the pattern silently stopped matching; pin it on literal snippets.
   expect(findBanned("impl PosixLoop {\n    pub fn wakeup(&mut self) {}\n}\n")).toEqual(["2: fn wakeup(&mut self"]);
+  expect(findBanned("impl KEventWaker {\n    pub fn wake(&mut self) {}\n}\n")).toEqual(["2: fn wake(&mut self"]);
   expect(findBanned("pub(crate) fn wakeup(&'a mut self, n: u32) {}")).toEqual(["1: fn wakeup(&'a mut self"]);
+  expect(findBanned("fn wake<W: Waker>(&mut self) {}")).toEqual(["1: fn wake<W: Waker>(&mut self"]);
   expect(findBanned("pub unsafe fn wakeup(\n    &mut self,\n    reason: Reason,\n) {}")).toEqual([
     "1: fn wakeup( &mut self",
   ]);
   expect(findBanned("// was `fn wakeup(&mut self)` before\npub fn wakeup(&self) {}")).toEqual([]);
+  expect(findBanned("pub fn wake(&self) {}")).toEqual([]);
   expect(findBanned("pub unsafe fn wakeup(this: *mut Self) {}")).toEqual([]);
   expect(findBanned('extern "C" fn wakeup(_loop: *mut uws::Loop) {}')).toEqual([]);
   expect(findBanned("fn wakeup_all(&mut self) {}")).toEqual([]);
+  expect(findBanned("pub(crate) fn wake_own_loop(&mut self) {}")).toEqual([]);
 });
 
 test("scans a non-empty set of tracked Rust sources", () => {
@@ -95,6 +112,6 @@ test("scans a non-empty set of tracked Rust sources", () => {
   expect(scanned).toBeGreaterThan(0);
 });
 
-test("`fn wakeup(&mut self)` is banned: wakeups are called from other threads while the loop's thread holds &mut", () => {
+test("`fn wake(&mut self)` / `fn wakeup(&mut self)` are banned: wakes come from other threads while the loop's thread holds a borrow", () => {
   expect(offenders).toEqual([]);
 });

--- a/test/internal/source-lints/mut-self-wakeup.test.ts
+++ b/test/internal/source-lints/mut-self-wakeup.test.ts
@@ -48,6 +48,19 @@ const tracked: Set<string> | null = (() => {
 // shapes above, nor the `extern "C" fn wakeup(loop_: *mut Loop)` trampolines.
 const BANNED = /\bfn\s+wakeup\s*\(\s*&\s*(?:'\w+\s+)?mut\s+self\b/g;
 
+/** `line: matched text` for every banned definition in one file's source. */
+function findBanned(content: string): string[] {
+  // Strip full-line comments so prose mentions don't count. `[ \t]*`, not
+  // `\s*`: `\s` crosses newlines and would shift the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  const hits: string[] = [];
+  for (const m of stripped.matchAll(BANNED)) {
+    const line = stripped.slice(0, m.index).split("\n").length;
+    hits.push(`${line}: ${m[0].replace(/\s+/g, " ")}`);
+  }
+  return hits;
+}
+
 const offenders: string[] = [];
 let scanned = 0;
 for (const abs of rustSources) {
@@ -57,15 +70,24 @@ for (const abs of rustSources) {
   if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
   if (tracked !== null && !tracked.has(source)) continue;
   scanned++;
-  const content = await file(abs).text();
-  // Strip full-line comments so prose mentions don't count. `[ \t]*`, not
-  // `\s*`: `\s` crosses newlines and would shift the reported line numbers.
-  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
-  for (const m of stripped.matchAll(BANNED)) {
-    const line = stripped.slice(0, m.index).split("\n").length;
-    offenders.push(`${source}:${line}: ${m[0].replace(/\s+/g, " ")}`);
+  for (const hit of findBanned(await file(abs).text())) {
+    offenders.push(`${source}:${hit}`);
   }
 }
+
+test("the matcher recognizes the banned receiver shapes and nothing else", () => {
+  // The tree is expected to contain zero matches, so the ban below would also
+  // pass if the pattern silently stopped matching; pin it on literal snippets.
+  expect(findBanned("impl PosixLoop {\n    pub fn wakeup(&mut self) {}\n}\n")).toEqual(["2: fn wakeup(&mut self"]);
+  expect(findBanned("pub(crate) fn wakeup(&'a mut self, n: u32) {}")).toEqual(["1: fn wakeup(&'a mut self"]);
+  expect(findBanned("pub unsafe fn wakeup(\n    &mut self,\n    reason: Reason,\n) {}")).toEqual([
+    "1: fn wakeup( &mut self",
+  ]);
+  expect(findBanned("// was `fn wakeup(&mut self)` before\npub fn wakeup(&self) {}")).toEqual([]);
+  expect(findBanned("pub unsafe fn wakeup(this: *mut Self) {}")).toEqual([]);
+  expect(findBanned('extern "C" fn wakeup(_loop: *mut uws::Loop) {}')).toEqual([]);
+  expect(findBanned("fn wakeup_all(&mut self) {}")).toEqual([]);
+});
 
 test("scans a non-empty set of tracked Rust sources", () => {
   // Guards against the tracked/realpath filters above over-firing and leaving

--- a/test/internal/source-lints/mut-self-wakeup.test.ts
+++ b/test/internal/source-lints/mut-self-wakeup.test.ts
@@ -1,0 +1,78 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// `fn wakeup(&mut self)` is banned on every loop wrapper.
+//
+// A wakeup is the one thing other threads (and signal handlers) do to an
+// event loop, and they do it while the loop's own thread is parked inside
+// `tick`/`run` holding a `&mut` to that loop across the blocking call. A
+// `&mut self` receiver therefore cannot be called correctly from where wakeups
+// come from: every caller has to autoref a second `&mut` over the same struct
+// while the first one is live, which is aliasing UB under Stacked/Tree Borrows
+// (and on POSIX `us_wakeup_loop` really does write to the struct, bumping
+// `pending_wakeups`). Before this lint, `uws::Loop::wakeup(&mut self)` was
+// reached that way from `VmHandle` posts, the signal handler, the debugger
+// thread, `PackageManager::wake_raw` and the h3 DNS callback.
+//
+// Shapes that are fine:
+//   - `fn wakeup(&self)` when the body only reads atomics / set-once pointers
+//     (`jsc::EventLoop::wakeup`, `MiniEventLoop::wakeup`, `HttpThread::wakeup`).
+//   - `unsafe fn wakeup(this: *mut Self)` for the `#[repr(C)]` mirror of the C
+//     loop itself (`bun_uws_sys::PosixLoop::wakeup` / `WindowsLoop::wakeup`),
+//     since the C side is what gets woken and no Rust reference is needed.
+//
+// Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `fn wakeup(&mut self` / `fn wakeup(&'a mut self`, with any visibility and
+// qualifiers in front of `fn`. Matched across newlines so a rustfmt-wrapped
+// signature can't evade it. Does not match the `&self` and `this: *mut Self`
+// shapes above, nor the `extern "C" fn wakeup(loop_: *mut Loop)` trampolines.
+const BANNED = /\bfn\s+wakeup\s*\(\s*&\s*(?:'\w+\s+)?mut\s+self\b/g;
+
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions don't count. `[ \t]*`, not
+  // `\s*`: `\s` crosses newlines and would shift the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const m of stripped.matchAll(BANNED)) {
+    const line = stripped.slice(0, m.index).split("\n").length;
+    offenders.push(`${source}:${line}: ${m[0].replace(/\s+/g, " ")}`);
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("`fn wakeup(&mut self)` is banned: wakeups are called from other threads while the loop's thread holds &mut", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- No observed misbehaviour and nothing miscompiles today; this is aliasing hygiene on the uSockets loop wrapper, same family as #37663.
- Waking a loop is the one thing other threads do to it, and they do it while the loop's own thread is parked inside `tick`/`run` holding `&mut Loop`. `Loop::wakeup` took `&mut self`, so every cross-thread waker (worker posts, the signal handler, the debugger thread, install task threads, the HTTP/3 DNS callback) formed a second `&mut` to a struct another thread was already borrowing exclusively.
- On POSIX the C wake also writes a counter inside that struct, so the bytes under the owner's `&mut` are modified through the waker's pointer.
- Four other call sites had already worked around the receiver by calling the raw C extern, with comments saying not to use the method, so the tree had two ways to wake a loop and the method was the wrong one.

### Fix
- `Loop::wakeup` on the POSIX and Windows loop types becomes `unsafe fn wakeup(this: *mut Self)`, the shape `destroy` already has; the `wake()` alias, the raw extern re-exports and the unused libuv `wakeup(&mut self)` go away. There is now one way to wake a loop and it forms no Rust reference to the loop on the waking side; what remains is the owner's `&mut` across an FFI call plus C-side writes, the shape every other FFI wrapper on the type already has.
- The `&self` layer above it (JS event loop, mini loop, `AnyEventLoop`) reads its set-once loop pointer and passes it down; the JS one gets a new link-interface slot because the existing loop accessor is JS-thread-only. Not changed: the owner still holds `&mut Loop` across `tick`/`run`, and the JS loop handle is still a plain non-atomic field (#33314).
- A source lint bans `fn wakeup(&mut self)` / `fn wake(&mut self)` tree-wide; on main it reports the seven definitions removed here, on this branch it passes.
- Verification: identical by construction (same pointer to the same C function; the one semantic change is that `AnyEventLoop`'s JS arm no longer panics before the waker exists), so the checks are the compiler on all 10 Rust targets, the lint above, and a debug build run through the tests that exercise each cross-thread path (workers, signals, inspector, fetch, HTTP/3, isolated install, bundler). The failures seen in that container were identical with the change reverted.

### Background
- The uws loop: bun's event loop is a C struct from the vendored uSockets library. The Rust `Loop` types are `repr(C)` mirrors of it, and `tick`/`run` are `&mut self` wrappers that block inside C while the loop's thread waits for I/O.
- `us_wakeup_loop` is the thread-safe C call that makes a blocked poll return (`uv_async_send` on Windows). It is how another thread gets a loop to notice something it queued.
- Aliasing: a live `&mut T` is a promise to the compiler that nothing else reaches those bytes, passed to LLVM as `noalias`. Two live `&mut` to one struct, even from different threads and even if the body only forwards a pointer to C, is undefined behaviour under the Stacked/Tree Borrows models. A raw `*mut T` makes no such promise, which is why cross-thread entry points on FFI mirror types take one.
- Three loop layers sit above one uws loop: `jsc::EventLoop` (the JS thread's, owned by the VM), `MiniEventLoop` (install, bundler and other non-JS mains) and `AnyEventLoop` (an enum over the two, for code such as the package manager that runs under either). Other crates reach the JS one through a link interface, a table of function slots the JS crate fills in; this PR adds a slot to it.
- `test/internal/source-lints/` holds bun tests that scan the Rust tree for banned shapes and run in ordinary CI; that is what keeps the receiver from coming back.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 15 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/mut-self-wakeup.test.ts
bun test v1.4.0 (990f79693)

test/internal/source-lints/mut-self-wakeup.test.ts:
(pass) the matcher recognizes the banned receiver shapes and nothing else [10.57ms]
(pass) scans a non-empty set of tracked Rust sources [1.66ms]
111 |   // nothing to scan, which would make the ban below pass vacuously.
112 |   expect(scanned).toBeGreaterThan(0);
113 | });
114 | 
115 | test("`fn wake(&mut self)` / `fn wakeup(&mut self)` are banned: wakes come from other threads while the loop's thread holds a borrow", () => {
116 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/event_loop/AnyEventLoop.rs:201: fn wakeup(&mut self",
+   "src/jsc/VirtualMachine.rs:1190: fn wakeup(&mut self",
+   "src/libuv_sys/libuv.rs:600: fn wakeup(&mut self",
+   "src/uws_sys/Loop.rs:246: fn wakeup(&mut self",
+   "src/uws_sys/Loop.rs:252: fn wake(&mut self",
+   "src/uws_sys/Loop.rs:447: fn wakeup(&mut self",
+   "src/uws_sys/Loop.rs:453: fn wake(
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/internal/source-lints/mut-self-wakeup.test.ts:
(pass) the matcher recognizes the banned receiver shapes and nothing else [0.34ms]
(pass) scans a non-empty set of tracked Rust sources [0.03ms]
111 |   // nothing to scan, which would make the ban below pass vacuously.
112 |   expect(scanned).toBeGreaterThan(0);
113 | });
114 | 
115 | test("`fn wake(&mut self)` / `fn wakeup(&mut self)` are banned: wakes come from other threads while the loop's thread holds a borrow", () => {
116 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/event_loop/AnyEventLoop.rs:201: fn wakeup(&mut self",
+   "src/jsc/VirtualMachine.rs:1190: fn wakeup(&mut self",
+   "src/libuv_sys/libuv.rs:600: fn wakeup(&mut self",
+   "src/uws_sys/Loop.rs:246: fn wakeup(&mut self",
+   "src/uws_sys/Loop.rs:252: fn wake(&mut self",
+   "src/uws_sys/Loop.rs:447: fn wakeup(&mut self",
+   "src/uws_sys/Loop.rs:453: fn wake(&mut self",
+ ]

- Expected  - 1
+ Received  + 9

      at <anonymous> (/workspace/bun/test/internal/source-lints/mut-self-wakeup.test.ts:116:21)
(fail) `fn wake(&mut self)` / 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/mut-self-wakeup.test.ts
bun test v1.4.0 (990f79693)

test/internal/source-lints/mut-self-wakeup.test.ts:
(pass) the matcher recognizes the banned receiver shapes and nothing else [17.95ms]
(pass) scans a non-empty set of tracked Rust sources [2.21ms]
(pass) `fn wake(&mut self)` / `fn wakeup(&mut self)` are banned: wakes come from other threads while the loop's thread holds a borrow [2.71ms]

 3 pass
 0 fail
 13 expect() calls
Ran 3 tests across 1 file. [23.72s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     990f79693d
  features     baseline

22 deps, 107 codegen, 1176 objects in 768ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen bindgenv2
[2/1238] gen ErrorCode+*.h
[3/1238] fetch zlib
[zlib] up to date
[4/1238] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [52.00ms]
[5/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (da3851e57)

Checked 1 install across 2 packages (no changes) [3.00ms]
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] gen .bind.ts → GeneratedBindings.cpp
[8/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (da3851e57)

Checked 129 installs across 147 packages (no changes) [13.00ms]
[10/1238] fetch tinycc
[tinycc] up to date
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/event_loop/AnyEventLoop.rs                     |  18 ++--
 src/event_loop/MiniEventLoop.rs                    |  12 +--
 src/event_loop/lib.rs                              |   2 +
 src/http/HTTPThread.rs                             |   5 +-
 src/http/h3_client/PendingConnect.rs               |   4 +-
 src/install/PackageManager.rs                      |  18 ++--
 src/install/patch_install.rs                       |   6 +-
 src/io/lib.rs                                      |  11 +-
 src/jsc/VirtualMachine.rs                          |   4 +-
 src/jsc/event_loop.rs                              |  31 +++---
 src/libuv_sys/libuv.rs                             |   4 -
 src/runtime/api/js_bundle_completion_task.rs       |   2 +-
 src/uws/lib.rs                                     |   2 +-
 src/uws_sys/Loop.rs                                |  47 ++++-----
 test/internal/source-lints/mut-self-wakeup.test.ts | 117 +++++++++++++++++++++
 15 files changed, 189 insertions(+), 94 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
src/event_loop/AnyEventLoop.rs                          3      5      0
src/event_loop/MiniEventLoop.rs                         2      3      0
src/event_loop/lib.rs                                   1      2      0
src/http/HTTPThread.rs                                  3      3      0
src/http/h3_client/PendingConnect.rs                    1      1      0
src/install/PackageManager.rs                           3      2      0
src/install/patch_install.rs                            3      3      0
src/io/lib.rs                                           2      1      0
src/jsc/VirtualMachine.rs                               5      3      0
src/jsc/event_loop.rs                                  11     10      0
src/libuv_sys/libuv.rs                                  3      1      0
src/runtime/api/js_bundle_completion_task.rs            1      1      0
src/uws/lib.rs                                          1      2      0
src/uws_sys/Loop.rs                                     3     10      0
test/internal/source-lints/mut-self-wakeup.test.ts      3      8      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What does this PR do?

Aliasing hygiene on the uSockets loop wrapper, same family as #37663 (bun_io waker). No observed misbehaviour; see "Why" for what is wrong and what the change guarantees.

`bun_uws_sys::PosixLoop::wakeup` / `WindowsLoop::wakeup` took `&mut self`. A wakeup is the one thing other threads do to a loop, and they do it while the loop's own thread is parked inside `tick_with_timeout` / `tick` / `run` (all `&mut self`, so it holds a `&mut Loop` across the blocking call). On POSIX `us_wakeup_loop` also writes to the struct (`__atomic_fetch_add(&loop->pending_wakeups, 1)`, `packages/bun-usockets/src/loop.c`), so the bytes covered by the owner's `&mut` are modified through the waker's pointer. Every cross-thread waker autoref'd a second `&mut Loop` purely to satisfy the receiver:

- `jsc::EventLoop::wakeup` (POSIX arm) went through `VirtualMachine::platform_loop_opt()`, whose SAFETY comment says only the JS thread reborrows mutably; its callers are `VmHandle::post` / `ref_keep_alive` / `unref_keep_alive` (pool and HTTP threads), `IsolatedPosterInner::post`, `WebWorker::request_termination` (parent thread), `Debugger::start` (debugger thread) and `PosixSignalHandle::enqueue` (signal handler, i.e. possibly nested inside the ticking thread's own `&mut`). The Windows arm did the same on `uws_loop`. The comment at the call site acknowledged the `&mut` and called it a wash.
- `MiniEventLoop::enqueue_task_concurrent*` did `(*self.loop_ptr()).wakeup()` while the loop's thread is in `tick_once`.
- `AnyEventLoop::wakeup(&mut self)` did the same via `r#loop()`, reached from `PackageManager::wake_raw` on install task threads while the main thread is inside `tick_raw`; the `wake_raw` comment argued the `&mut` was fine because it only covered the `event_loop` field, which is exactly the field being ticked.
- `h3_client::PendingConnect::on_dns_resolved_threadsafe` did `(*loop_ptr).wakeup()` on the HTTP thread's loop from the DNS worker, while `HttpThread::process_events` holds `uws_loop_mut()` across `tick()`.

`HttpThread::wakeup`, `WindowsWaker::wake`, `JSBundleCompletionTask::stop_for_vm_teardown` and `MiniEventLoop::wakeup` had each already worked around the receiver by calling the re-exported raw `us_wakeup_loop` extern, with comments saying not to use `Loop::wakeup`. `Loop::wake()` had no callers.

Changes:

- `PosixLoop::wakeup` and `WindowsLoop::wakeup` are `pub unsafe fn wakeup(this: *mut Self)` (the shape `destroy` already uses on this type); `wake()` is deleted; `us_wakeup_loop` is `pub(super)` and its re-exports from `bun_uws_sys` / `bun_uws` are gone, so `Loop::wakeup(ptr)` is the only way to wake a loop and the four raw-extern call sites use it. The `us_loop_run` re-export stays for `WindowsWaker::wait`.
- `jsc::EventLoop::wakeup` reads `event_loop_handle` through `addr_of!` (the pattern `uv_loop()` in the same file already uses) and passes the pointer on; it stays a no-op while the handle is unset, as before. `platform_loop_opt` keeps returning `&mut` for its JS-thread callers (`apply_concurrent_ref_delta`, `tick_while_paused`, `is_event_loop_alive_excluding_immediates`); with no `&mut self` wakeup left on the loop types, routing a wakeup through it no longer compiles, so its existing JS-thread-only SAFETY comment is now simply true. `VirtualMachine::wakeup` takes `&self` (it only needs `event_loop_shared()`).
- `AnyEventLoop::wakeup` takes `&self` and dispatches to the two existing `&self` wakeups: `MiniEventLoop::wakeup`, and a new `wakeup` slot on the `JsEventLoop` link interface that forwards to `jsc::EventLoop::wakeup`. The existing `uws_loop()` slot is documented JS-thread-only and panics before `ensure_waker`, so the cross-thread arm gets its own slot rather than reusing it. `MiniEventLoop::enqueue_task_concurrent*` call `self.wakeup()`. `PackageManager::wake_raw` and the other rewritten sites get comments that describe what is actually formed (shared reads of set-once pointers, the C loop reached by raw pointer).
- `bun_libuv_sys::Loop::wakeup(&mut self)` had no callers on any target and is removed.
- `test/internal/source-lints/mut-self-wakeup.test.ts` bans `fn wakeup(&mut self)` and `fn wake(&mut self)` tree-wide (`wake` is the spelling the `bun_io` wakers use; #37626 fixed the macOS one the same way, and this PR deletes the uws `wake()` aliases). On main it reports the seven definitions this PR removes (`uws_sys/Loop.rs` x4, `AnyEventLoop.rs`, `VirtualMachine.rs`, `libuv.rs`); here it passes, and its matcher is pinned on literal snippets of the shapes it must and must not match. The usockets rewrites in flight add new loop wrappers, which is the case it is there for.

### Why

Nothing miscompiles today: each `wakeup` body only passes the pointer straight to C, so there is no load for LLVM to hoist or cache around the `noalias` it is given. What the `&mut` receiver does is make the contract wrong at the type level: it tells the compiler the waker has exclusive access to a struct that another thread is simultaneously using through its own `&mut` (N wakers at once in the install and HTTP cases), and it is what forced four call sites into raw externs with "do not use the method" comments while the other six quietly used the method. With a `*mut Self` receiver the Rust side forms no reference to the loop on the waking side at all; what remains is the owner's `&mut` across the FFI call plus concurrent C-side writes, which is the shape every `&mut self` FFI wrapper in `mod c` has and is documented on the extern block. The `&self` layer above it (`EventLoop::wakeup`, `MiniEventLoop::wakeup`, `AnyEventLoop::wakeup`) matches how `VmHandle::post` already posts to the JS loop from other threads.

Not changed here: the owner side still holds `&mut Loop` across `tick*`/`run`, and `event_loop_handle` is still a plain field read from other threads (#33314 makes it atomic; this PR changes the same function but not that aspect). Two sibling PRs opened against the layers next to this one while it was being written: #37691 makes the mini-loop posting receivers `&self` (it touches the same `MiniEventLoop` / `AnyEventLoop` / `wake_raw` lines and calls the `us_wakeup_loop` re-export this PR removes) and #37694 moves `HttpThread`'s cross-thread state out of the struct (it rewrites `HttpThread::wakeup` and routes `PendingConnect` through it, also via the re-export). Whichever of the three lands later has a one-line rebase at each overlap: `us_wakeup_loop(p)` becomes `uws::Loop::wakeup(p)`.

### How did you verify your code works?

Behaviour is identical by construction (every site passes the same pointer to the same C function; the only semantic difference is that `AnyEventLoop::wakeup`'s JS arm no longer panics if called before `ensure_waker`), so the checks are the compiler, the lint, and running the cross-thread paths on a debug build:

- `bun run rust:check-all`: 10/10 targets; `cargo clippy` and `cargo fmt --check` clean on the nine touched crates. Changing the receiver makes every remaining `.wakeup()` on a uws loop a compile error, which is how the call-site list above was confirmed complete, including the Windows-only ones.
- `bun bd test test/internal/source-lints/` (all pass); the new lint fails with `src/` at main (seven hits) and passes with it. The branch is rebased onto current main so it includes #37626.
- Debug build, paths exercised: `test/js/web/workers/{worker,worker-terminate-lifetime,worker-refused-completion}.test.ts` (`VmHandle` posts and refusals, `request_termination`), the `signal` tests in `test/js/node/process/process.test.js` (`PosixSignalHandle`), `test/cli/inspect/inspect.test.ts` (debugger thread), `test/js/web/fetch/fetch.test.ts` (HTTP thread), `test/js/web/fetch/fetch-http3-client.test.ts` (53 pass, includes the DNS-path test that goes through `PendingConnect`), `test/cli/install/isolated-install.test.ts` (`wake_raw` on the mini arm; 62/62 on two runs, one earlier run had a single order-dependent failure that passes on its own and also needs `--timeout` raised under ASAN), `test/bundler/bun-build-api.test.ts` (workers posting into the bundle thread's mini loop), and a local run of the runtime auto-installer against the harness registry (`wake_raw` on the JS arm). `worker.test.ts`, `inspect.test.ts` and `fetch.test.ts` have failures in this container (tests run as root, `localhost` connectivity, debug-build timeouts); I rebuilt with `src/` reverted and the failure sets are identical with and without this change, and the inspector one reproduces with the released bun as the inspectee.

</details>
