### PR TITLE
plugin: run onResolve/onLoad for imports whose query string contains a dot

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -86,19 +86,32 @@ impl PluginRunner {
     /// Cheap pre-filter that rules
     /// out `./` / `../` / absolute paths before hitting the resolve hook.
     pub fn could_be_plugin(specifier: &[u8]) -> bool {
-        if let Some(last_dot) = bun_core::strings::last_index_of_char(specifier, b'.') {
-            let ext = &specifier[last_dot + 1..];
-            // '.' followed by either a letter or a non-ascii character
-            // maybe there are non-ascii file extensions?
-            // we mostly want to cheaply rule out "../" and ".." and "./"
-            if !ext.is_empty()
-                && (ext[0].is_ascii_lowercase() || ext[0].is_ascii_uppercase() || ext[0] > 127)
-            {
+        // The loader is chosen from the path's extension, so judge
+        // "/a/b.ts?v=1.2" by ".ts", not ".2" (`normalizeSpecifier` splits the
+        // query off at the first '?' later). Also check the full specifier so
+        // paths that legitimately contain '?' keep passing this pre-filter.
+        if let Some(query_start) = bun_core::strings::index_of_char_usize(specifier, b'?') {
+            if Self::starts_with_letter_after_last_dot(&specifier[..query_start as usize]) {
                 return true;
             }
         }
+        if Self::starts_with_letter_after_last_dot(specifier) {
+            return true;
+        }
         !bun_paths::is_absolute(specifier)
             && bun_core::strings::index_of_char_usize(specifier, b':').is_some()
+    }
+
+    fn starts_with_letter_after_last_dot(specifier: &[u8]) -> bool {
+        let Some(last_dot) = bun_core::strings::last_index_of_char(specifier, b'.') else {
+            return false;
+        };
+        let ext = &specifier[last_dot + 1..];
+        // '.' followed by either a letter or a non-ascii character
+        // maybe there are non-ascii file extensions?
+        // we mostly want to cheaply rule out "../" and ".." and "./"
+        !ext.is_empty()
+            && (ext[0].is_ascii_lowercase() || ext[0].is_ascii_uppercase() || ext[0] > 127)
     }
 }
 

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -86,29 +86,23 @@ impl PluginRunner {
     /// Cheap pre-filter that rules
     /// out `./` / `../` / absolute paths before hitting the resolve hook.
     pub fn could_be_plugin(specifier: &[u8]) -> bool {
-        // Judge "/a/b.ts?v=1.2" by ".ts", not ".2": the loader path splits
-        // the query off at the first '?'.
-        if let Some(query_start) = bun_core::strings::index_of_char_usize(specifier, b'?') {
-            if Self::starts_with_letter_after_last_dot(&specifier[..query_start as usize]) {
+        // The loader ignores everything from the first '?' (`normalizeSpecifier`),
+        // so judge "/a/b.ts?v=1.2" by ".ts", not ".2".
+        let path = match bun_core::strings::index_of_char_usize(specifier, b'?') {
+            Some(query_start) => &specifier[..query_start as usize],
+            None => specifier,
+        };
+        if let Some(last_dot) = bun_core::strings::last_index_of_char(path, b'.') {
+            let ext = &path[last_dot + 1..];
+            // A letter or non-ascii byte; rules out "../", "..", and "./".
+            if !ext.is_empty()
+                && (ext[0].is_ascii_lowercase() || ext[0].is_ascii_uppercase() || ext[0] > 127)
+            {
                 return true;
             }
         }
-        // Fallback for paths containing a literal '?'.
-        if Self::starts_with_letter_after_last_dot(specifier) {
-            return true;
-        }
         !bun_paths::is_absolute(specifier)
             && bun_core::strings::index_of_char_usize(specifier, b':').is_some()
-    }
-
-    fn starts_with_letter_after_last_dot(specifier: &[u8]) -> bool {
-        let Some(last_dot) = bun_core::strings::last_index_of_char(specifier, b'.') else {
-            return false;
-        };
-        let ext = &specifier[last_dot + 1..];
-        // A letter or non-ascii byte; rules out "../", "..", and "./".
-        !ext.is_empty()
-            && (ext[0].is_ascii_lowercase() || ext[0].is_ascii_uppercase() || ext[0] > 127)
     }
 }
 

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -86,15 +86,14 @@ impl PluginRunner {
     /// Cheap pre-filter that rules
     /// out `./` / `../` / absolute paths before hitting the resolve hook.
     pub fn could_be_plugin(specifier: &[u8]) -> bool {
-        // The loader is chosen from the path's extension, so judge
-        // "/a/b.ts?v=1.2" by ".ts", not ".2" (`normalizeSpecifier` splits the
-        // query off at the first '?' later). Also check the full specifier so
-        // paths that legitimately contain '?' keep passing this pre-filter.
+        // Judge "/a/b.ts?v=1.2" by ".ts", not ".2": the loader path splits
+        // the query off at the first '?'.
         if let Some(query_start) = bun_core::strings::index_of_char_usize(specifier, b'?') {
             if Self::starts_with_letter_after_last_dot(&specifier[..query_start as usize]) {
                 return true;
             }
         }
+        // Fallback for paths containing a literal '?'.
         if Self::starts_with_letter_after_last_dot(specifier) {
             return true;
         }
@@ -107,9 +106,7 @@ impl PluginRunner {
             return false;
         };
         let ext = &specifier[last_dot + 1..];
-        // '.' followed by either a letter or a non-ascii character
-        // maybe there are non-ascii file extensions?
-        // we mostly want to cheaply rule out "../" and ".." and "./"
+        // A letter or non-ascii byte; rules out "../", "..", and "./".
         !ext.is_empty()
             && (ext[0].is_ascii_lowercase() || ext[0].is_ascii_uppercase() || ext[0] > 127)
     }

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -850,14 +850,7 @@ it.concurrent("plugins run for file imports whose query string contains a dot (#
       "?v=1.2.3": "plugin",
       "?mtime=1786494961337.0317": "plugin",
     },
-    onResolveQueries: [
-      "?mtime=1786494961337.0317",
-      "?v=.456",
-      "?v=1.2.3",
-      "?v=123",
-      "?v=123.",
-      "?v=123.456",
-    ],
+    onResolveQueries: ["?mtime=1786494961337.0317", "?v=.456", "?v=1.2.3", "?v=123", "?v=123.", "?v=123.456"],
   });
   expect(exitCode).toBe(0);
 });

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -803,3 +803,46 @@ it.concurrent("a no-op onResolve that returns args.path unchanged is transparent
   expect(stdout.trim() || stderr).toBe("entry ran:dep");
   expect(exitCode).toBe(0);
 });
+
+it.concurrent("plugins run for file imports whose query string contains a dot (#37699)", async () => {
+  using dir = tempDir("plugin-query-string-dot", {
+    "plain.ts": `export const source = "disk";`,
+    "entry.ts": `
+      Bun.plugin({
+        name: "query-string-dot",
+        setup(build) {
+          build.onLoad({ filter: /plain\\.ts/ }, () => ({
+            contents: "export const source = 'plugin'",
+            loader: "ts",
+          }));
+        },
+      });
+
+      const queries = ["?v=123", "?v=123.456", "?v=.456", "?v=123.", "?v=1.2.3", "?mtime=1786494961337.0317"];
+      const results = {};
+      for (const q of queries) {
+        const mod = await import("./plain.ts" + q).catch(err => ({ source: "error: " + err.message }));
+        results[q] = mod.source;
+      }
+      console.log(JSON.stringify(results));
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
+    "?v=123": "plugin",
+    "?v=123.456": "plugin",
+    "?v=.456": "plugin",
+    "?v=123.": "plugin",
+    "?v=1.2.3": "plugin",
+    "?mtime=1786494961337.0317": "plugin",
+  });
+  expect(exitCode).toBe(0);
+});

--- a/test/js/bun/plugin/plugins.test.ts
+++ b/test/js/bun/plugin/plugins.test.ts
@@ -808,9 +808,14 @@ it.concurrent("plugins run for file imports whose query string contains a dot (#
   using dir = tempDir("plugin-query-string-dot", {
     "plain.ts": `export const source = "disk";`,
     "entry.ts": `
+      const resolvedQueries = new Set();
       Bun.plugin({
         name: "query-string-dot",
         setup(build) {
+          build.onResolve({ filter: /plain\\.ts/ }, args => {
+            resolvedQueries.add(args.path.slice(args.path.indexOf("?")));
+            return undefined;
+          });
           build.onLoad({ filter: /plain\\.ts/ }, () => ({
             contents: "export const source = 'plugin'",
             loader: "ts",
@@ -819,12 +824,12 @@ it.concurrent("plugins run for file imports whose query string contains a dot (#
       });
 
       const queries = ["?v=123", "?v=123.456", "?v=.456", "?v=123.", "?v=1.2.3", "?mtime=1786494961337.0317"];
-      const results = {};
+      const sources = {};
       for (const q of queries) {
         const mod = await import("./plain.ts" + q).catch(err => ({ source: "error: " + err.message }));
-        results[q] = mod.source;
+        sources[q] = mod.source;
       }
-      console.log(JSON.stringify(results));
+      console.log(JSON.stringify({ sources, onResolveQueries: [...resolvedQueries].sort() }));
     `,
   });
 
@@ -837,12 +842,22 @@ it.concurrent("plugins run for file imports whose query string contains a dot (#
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout.trim() ? JSON.parse(stdout) : { crashed: stderr }).toEqual({
-    "?v=123": "plugin",
-    "?v=123.456": "plugin",
-    "?v=.456": "plugin",
-    "?v=123.": "plugin",
-    "?v=1.2.3": "plugin",
-    "?mtime=1786494961337.0317": "plugin",
+    sources: {
+      "?v=123": "plugin",
+      "?v=123.456": "plugin",
+      "?v=.456": "plugin",
+      "?v=123.": "plugin",
+      "?v=1.2.3": "plugin",
+      "?mtime=1786494961337.0317": "plugin",
+    },
+    onResolveQueries: [
+      "?mtime=1786494961337.0317",
+      "?v=.456",
+      "?v=1.2.3",
+      "?v=123",
+      "?v=123.",
+      "?v=123.456",
+    ],
   });
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Fixes #37699.

## Repro

```ts
// main.ts
Bun.plugin({
  name: "repro",
  setup(build) {
    build.onLoad({ filter: /plain\.ts/ }, () => ({ contents: "export const source = 'plugin'", loader: "ts" }));
  },
});
const mod = await import(process.argv[2]);
console.log("source =", mod.source);
```

```console
$ bun main.ts "$PWD/plain.ts?v=123"
source = plugin
$ bun main.ts "$PWD/plain.ts?v=123.456"
source = disk
```

With `?v=123.456` neither onResolve nor onLoad fires; the file silently loads through the native loader. Real-world trigger: OpenCode cache-busts plugin imports with `?mtime=${stat.mtimeMs}`, and fractional mtimes disabled the plugin that supplies their JSX transform.

## Cause

`PluginRunner::could_be_plugin` (src/bundler/transpiler.rs) is the cheap pre-filter that decides whether plugin hooks run at all. It looked at the byte after the last `.` of the full specifier, query string included. For `/app/plain.ts?v=123.456` the last dot is inside the query and the next byte is a digit, so the pre-filter returned false and `run_on_load_plugins` / the resolve hook were skipped entirely. This matches the reporter's matrix exactly: hooks are skipped iff the text after the last `.` of the whole specifier starts with a non-letter.

## Fix

Slice the specifier at the first `?` and run the existing extension check on the path portion only. This mirrors `normalizeSpecifier` in the loader path, which unconditionally splits the query off at the first `?` before picking a loader, so the pre-filter now agrees with what the loader will actually do. No extra cases: the function is the same single check as before, applied to the pre-query slice.

Related but distinct from #36592, which accepts digit-leading extensions (no query involved); that change alone would still miss `?v=123.` and `?v=1..`, where the pseudo-extension is empty.

## Verification

New test in test/js/bun/plugin/plugins.test.ts covers `?v=123` (control), `?v=123.456`, `?v=.456`, `?v=123.`, `?v=1.2.3`, and `?mtime=1786494961337.0317`, asserting both onResolve and onLoad fire. It fails on main and passes with this change. Full plugins.test.ts (39 tests) and bundler_plugin.test.ts (53 tests) pass.

<details>
<summary>Earlier revision</summary>

The first version kept a second extension check on the full specifier as a fallback for paths containing a literal `?`. Dropped after review: the loader's `normalizeSpecifier` already treats everything after the first `?` as a query regardless, so the fallback defended a case the loader does not support anyway.

Dropping the fallback intentionally narrows one accidental case: an extensionless specifier whose query contains a dot followed by a letter (e.g. `./LICENSE?v=1.a`) previously slipped through the pre-filter because the query was misread as an extension. It now behaves like its no-query form, which was always skipped.

</details>

