### PR TITLE
fetch: release the FetchTasklet through its raw pointer, not a &mut receiver

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -348,8 +348,10 @@ pub(crate) fn run_task(
         | task_tag::ShellYesTask => run_task_cold(task),
 
         // ── fetch / S3 ───────────────────────────────────────────────────
+        // The final hop releases the tasklet's JS-side ref, which may free it,
+        // so it takes the raw pointer (no `&mut` at this boundary).
         task_tag::FetchTasklet => {
-            cast!(FetchTasklet).on_progress_update()?;
+            FetchTasklet::on_progress_update(cast_ptr!(FetchTasklet))?;
         }
         task_tag::FetchTaskletDeinit => {
             // SAFETY: posted by `deref_from_thread` with the last ref.

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -348,8 +348,6 @@ pub(crate) fn run_task(
         | task_tag::ShellYesTask => run_task_cold(task),
 
         // ── fetch / S3 ───────────────────────────────────────────────────
-        // The final hop releases the tasklet's JS-side ref, which may free it,
-        // so it takes the raw pointer (no `&mut` at this boundary).
         task_tag::FetchTasklet => {
             FetchTasklet::on_progress_update(cast_ptr!(FetchTasklet))?;
         }

--- a/src/runtime/webcore.rs
+++ b/src/runtime/webcore.rs
@@ -413,9 +413,10 @@ impl SinkHandle {
         match *self {
             SinkHandle::None => {}
             SinkHandle::ServerResponse(any) => any.end_chunk(err.as_ref()),
-            // SAFETY: live backref; ByteStream clears sink before free.
-            SinkHandle::FetchRequestBody(mut p) => unsafe { p.get_mut() }.end_from_stream(err),
-            // Raw-ptr dispatch: may re-borrow and free the sink (see its doc).
+            // Raw-ptr dispatch for both: the call may free the sink (see their docs).
+            SinkHandle::FetchRequestBody(p) => {
+                fetch::FetchRequestBodySink::end_from_stream(p.as_ptr(), err)
+            }
             SinkHandle::S3Upload(p) => streams::NetworkSink::end_from_stream(p.as_ptr(), err),
             SinkHandle::FileSink(p) => p.end_from_stream(err),
             SinkHandle::HTMLRewriter(p) => p.end_from_stream(err),

--- a/src/runtime/webcore/fetch/FetchRequestBodySink.rs
+++ b/src/runtime/webcore/fetch/FetchRequestBodySink.rs
@@ -199,17 +199,39 @@ impl FetchRequestBodySink {
         ))
     }
 
+    /// JS entry (`end_from_js` / the JSSink forwarder). Only JS-pump sinks have
+    /// a JS object, so this only ever reaches the non-releasing branch.
     pub fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
-        self.end_from_stream(err.map(StreamError::Error));
+        Self::end_from_stream(self, err.map(StreamError::Error));
         bun_sys::Result::Ok(())
     }
 
     /// Native-path terminator called from `SinkHandle::end`. Carries the full
     /// `StreamError` so a JS-valued upstream error (e.g. fetch reset) reaches
     /// `write_end_request(Some(js))` instead of being silently dropped to EOF.
-    pub fn end_from_stream(&mut self, err: Option<StreamError>) {
-        if self.ended {
+    ///
+    /// Takes the raw pointer, like `NetworkSink::end_from_stream`: the release
+    /// at the end may free the tasklet and, through `clear_sink`, this sink.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
+    pub fn end_from_stream(this: *mut Self, err: Option<StreamError>) {
+        // SAFETY: `this` is the live sink behind the handle; the borrow is
+        // scoped to this call and nothing touches `*this` after it.
+        let Some((task, err_js)) = (unsafe { (*this).end_and_take_task(err) }) else {
             return;
+        };
+        FetchTasklet::write_end_request(task.as_ptr(), err_js);
+    }
+
+    /// Marks the sink ended. For a native source, returns the tasklet ref to
+    /// release (the one `start_request_stream` took) and the error to end it
+    /// with; the JS pump path closes the source instead and its pump promise
+    /// does the releasing.
+    fn end_and_take_task(
+        &mut self,
+        err: Option<StreamError>,
+    ) -> Option<(BackRef<FetchTasklet, bun_ptr::Mut>, Option<JSValue>)> {
+        if self.ended {
+            return None;
         }
         self.ended = true;
         if matches!(
@@ -220,20 +242,16 @@ impl FetchRequestBodySink {
             // field; detach (not cancel) so we don't re-enter the source while
             // it is still on the stack (FileReader.on_reader_error ref-leak).
             self.source.clear();
-            if let Some(task) = self.task.take() {
-                let err_js = err.map(|e| e.to_js(&task.global_this));
-                // Releases the `start_request_stream` ref; that may free the
-                // tasklet and, through `clear_sink`, `*self`.
-                FetchTasklet::write_end_request(task.as_ptr(), err_js);
-            }
-            return;
+            let task = self.task.take()?;
+            let err_js = err.map(|e| e.to_js(&task.global_this));
+            return Some((task, err_js));
         }
-        // JS pump path: the assign_to_stream result handler is the single balancing release.
         let sys_err = match err {
             Some(StreamError::Error(e)) => Some(e),
             _ => None,
         };
         self.source.close(sys_err);
+        None
     }
 
     pub fn end_from_js(&mut self, _global_this: &JSGlobalObject) -> bun_sys::Result<JSValue> {

--- a/src/runtime/webcore/fetch/FetchRequestBodySink.rs
+++ b/src/runtime/webcore/fetch/FetchRequestBodySink.rs
@@ -222,10 +222,8 @@ impl FetchRequestBodySink {
             self.source.clear();
             if let Some(task) = self.task.take() {
                 let err_js = err.map(|e| e.to_js(&task.global_this));
-                // The `+1` taken in `start_request_stream` kept the tasklet
-                // live while `task` was `Some`; `write_end_request` is the
-                // balancing release. It may free the tasklet, and `*self` with
-                // it via `clear_sink`, so do not touch `self` afterwards.
+                // Releases the `start_request_stream` ref; that may free the
+                // tasklet and, through `clear_sink`, `*self`.
                 FetchTasklet::write_end_request(task.as_ptr(), err_js);
             }
             return;

--- a/src/runtime/webcore/fetch/FetchRequestBodySink.rs
+++ b/src/runtime/webcore/fetch/FetchRequestBodySink.rs
@@ -220,13 +220,13 @@ impl FetchRequestBodySink {
             // field; detach (not cancel) so we don't re-enter the source while
             // it is still on the stack (FileReader.on_reader_error ref-leak).
             self.source.clear();
-            if let Some(mut task) = self.task.take() {
+            if let Some(task) = self.task.take() {
                 let err_js = err.map(|e| e.to_js(&task.global_this));
-                // SAFETY: the `+1` taken in `start_request_stream` keeps the
-                // tasklet live while `task` was `Some`; `write_end_request` is
-                // the balancing release and may free `*self` via `clear_sink`,
-                // so do not touch `self` afterwards.
-                unsafe { task.get_mut() }.write_end_request(err_js);
+                // The `+1` taken in `start_request_stream` kept the tasklet
+                // live while `task` was `Some`; `write_end_request` is the
+                // balancing release. It may free the tasklet, and `*self` with
+                // it via `clear_sink`, so do not touch `self` afterwards.
+                FetchTasklet::write_end_request(task.as_ptr(), err_js);
             }
             return;
         }

--- a/src/runtime/webcore/fetch/FetchRequestBodySink.rs
+++ b/src/runtime/webcore/fetch/FetchRequestBodySink.rs
@@ -199,19 +199,19 @@ impl FetchRequestBodySink {
         ))
     }
 
-    /// JS entry (`end_from_js` / the JSSink forwarder). Only JS-pump sinks have
-    /// a JS object, so this only ever reaches the non-releasing branch.
+    /// JS entry: only a JS-pump sink has a JS object, and its release belongs
+    /// to the pump promise, so there is never a ref to release here.
     pub fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
-        Self::end_from_stream(self, err.map(StreamError::Error));
+        let release = self.end_and_take_task(err.map(StreamError::Error));
+        debug_assert!(release.is_none());
         bun_sys::Result::Ok(())
     }
 
     /// Native-path terminator called from `SinkHandle::end`. Carries the full
     /// `StreamError` so a JS-valued upstream error (e.g. fetch reset) reaches
     /// `write_end_request(Some(js))` instead of being silently dropped to EOF.
-    ///
-    /// Takes the raw pointer, like `NetworkSink::end_from_stream`: the release
-    /// at the end may free the tasklet and, through `clear_sink`, this sink.
+    /// Raw pointer like `NetworkSink::end_from_stream`: the release may free
+    /// the tasklet and, through `clear_sink`, this sink.
     #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn end_from_stream(this: *mut Self, err: Option<StreamError>) {
         // SAFETY: `this` is the live sink behind the handle; the borrow is
@@ -222,10 +222,8 @@ impl FetchRequestBodySink {
         FetchTasklet::write_end_request(task.as_ptr(), err_js);
     }
 
-    /// Marks the sink ended. For a native source, returns the tasklet ref to
-    /// release (the one `start_request_stream` took) and the error to end it
-    /// with; the JS pump path closes the source instead and its pump promise
-    /// does the releasing.
+    /// Marks the sink ended; for a native source, hands back the tasklet ref
+    /// `start_request_stream` took and the error to end the request with.
     fn end_and_take_task(
         &mut self,
         err: Option<StreamError>,

--- a/src/runtime/webcore/fetch/FetchRequestBodySink.rs
+++ b/src/runtime/webcore/fetch/FetchRequestBodySink.rs
@@ -1,5 +1,5 @@
 use bun_collections::ByteVecExt;
-use bun_ptr::BackRef;
+use bun_ptr::{BackRef, ScopedRef};
 use bun_sys::Error as SysError;
 
 use crate::webcore::blob::SizeType as BlobSizeType;
@@ -253,7 +253,9 @@ impl FetchRequestBodySink {
         if let Some(task) = task {
             // Balances the `ref_()` taken in `start_request_stream` when the
             // assign_to_stream-result handler never ran to release it.
-            FetchTasklet::deref(task.as_ptr());
+            // SAFETY: that handler clears `task` before releasing, so `task`
+            // being `Some` means the ref is still held and the tasklet live.
+            drop(unsafe { ScopedRef::<FetchTasklet>::adopt(task.as_ptr()) });
         }
     }
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -610,10 +610,9 @@ impl FetchTasklet {
         self.get_current_response().map(|r| unsafe { &mut *r })
     }
 
-    /// `this` is the allocation pointer the hop was dispatched with; it is what
-    /// gets stashed past this frame (the sink's back-pointer and the promise
-    /// ctx), so the releases made through those later carry the allocation's
-    /// provenance rather than that of a borrow that has long ended.
+    /// `this` is the allocation pointer; it is what gets stashed past this frame
+    /// (the sink's back-pointer, the promise ctx), so the later releases through
+    /// those carry the allocation's provenance, not a dead borrow's.
     fn start_request_stream(&mut self, this: *mut FetchTasklet) {
         self.is_waiting_request_stream_start = false;
         debug_assert!(matches!(

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -321,11 +321,9 @@ impl FetchTasklet {
     /// serialised: HTTP-thread writes happen under `mutex.lock()` and
     /// JS-thread access is single-threaded.
     ///
-    /// An entry point that owns one of those refs adopts it into a
-    /// [`ScopedRef`] from the raw pointer before calling this, and lets the
-    /// guard drop after the borrow is dead: the release may be the last one,
-    /// and freeing the tasklet while a `&mut` to it is live is UB. There is no
-    /// JS-thread release a `&mut self` method could call instead.
+    /// An entry point that owns a ref adopts it into a [`ScopedRef`] before
+    /// calling this; the guard (which may free the tasklet) drops after the
+    /// borrow is gone.
     #[inline]
     fn from_raw_mut<'a>(this: *mut FetchTasklet) -> &'a mut Self {
         // SAFETY: see INVARIANT above.
@@ -403,9 +401,8 @@ impl FetchTasklet {
             .map(|p| unsafe { &mut *p.as_ptr() })
     }
 
-    /// Takes a ref. Each one is released on the JS thread by a `ScopedRef`
-    /// adopted at the entry point that owns it (see `from_raw_mut`), or on the
-    /// HTTP thread by `deref_from_thread`.
+    /// Released by a `ScopedRef` adopted at the JS-thread entry point that
+    /// owns the ref, or by `deref_from_thread` on the HTTP thread.
     fn ref_(&self) {
         // SAFETY: `self` is live; `ref_` only touches the interior-mutable
         // atomic counter.
@@ -634,9 +631,8 @@ impl FetchTasklet {
         // assign_to_stream-result side (on_resolve/on_reject or the synchronous
         // Fulfilled/Rejected/undefined branches below), or by the sink's
         // `finalize` as a fallback if that path never runs. The synchronous
-        // branches release it through `self_ptr` while the progress hop that
-        // called us still holds the JS-side ref, so none of them can free the
-        // tasklet.
+        // branches release it while our caller, the progress hop, still holds
+        // the JS-side ref.
         self.ref_();
         let self_ptr = std::ptr::from_mut::<FetchTasklet>(self);
 
@@ -918,15 +914,9 @@ impl FetchTasklet {
         Ok(())
     }
 
-    /// `task_tag::FetchTasklet` arm: one progress hop posted by `callback`.
-    ///
-    /// Takes the raw pointer, like `callback` and `resume_request_data_stream`:
-    /// the final hop owns the JS-side ref from `get()`, which is the last one
-    /// once the HTTP thread has dropped its own (the usual order, as
-    /// `callback` derefs right after posting the final hop), so releasing it
-    /// frees the tasklet. The ref is adopted into a guard here and everything
-    /// that needs `&mut` runs inside `on_progress_update_locked`; the guard
-    /// drops, and the tasklet with it, only after that borrow is gone.
+    /// `task_tag::FetchTasklet` arm: one progress hop posted by `callback`. The
+    /// final hop owns the JS-side ref from `get()`, normally the last one
+    /// (`callback` drops the HTTP thread's right after posting the hop).
     pub(crate) fn on_progress_update(this: *mut FetchTasklet) -> JsTerminatedResult<()> {
         jsc::mark_binding!();
         bun_output::scoped_log!(FetchTasklet, "onProgressUpdate");
@@ -934,17 +924,13 @@ impl FetchTasklet {
         shared.mutex.lock();
         shared.has_schedule_callback.store(false, Ordering::Relaxed);
         let is_done = !shared.result.has_more;
-        // SAFETY: `this` is the live heap tasklet and the final hop owns the
-        // JS-side ref from `get()`.
+        // SAFETY: `this` is live; the final hop owns the JS-side ref.
         let _js_ref = is_done.then(|| unsafe { ScopedRef::adopt(this) });
-        // `_js_ref` drops after this call returns.
         Self::from_raw_mut(this).on_progress_update_locked(is_done)
     }
 
-    /// Body of [`on_progress_update`](Self::on_progress_update). Entered with
-    /// `mutex` held; unlocks it on every path. Does not release the JS-side
-    /// ref, so no release reached from here (`write_end_request` via
-    /// `cancel_request_body_sink`) can be the tasklet's last one.
+    /// Entered with `mutex` held; unlocks it on every path. The caller holds
+    /// the JS-side ref throughout, so no release reached from here is the last.
     fn on_progress_update_locked(&mut self, is_done: bool) -> JsTerminatedResult<()> {
         let vm = self.global_this.bun_vm();
         // teardown forbade script: we cannot touch JS
@@ -2296,21 +2282,12 @@ impl FetchTasklet {
 
     /// Ends the streamed request body (terminating chunk + End, or an abort
     /// carrying `err`) and releases the ref `start_request_stream` took for it.
-    ///
-    /// That ref is the tasklet's last one when the response finished before
-    /// the upload did: the final progress hop cancels the sink and drops the
-    /// JS-side ref, and the pump promise then settles into
-    /// `on_resolve_request_stream` / `on_reject_request_stream`, whose release
-    /// here frees the tasklet (`FetchRequestBodySink::end_from_stream` releases
-    /// it the same way). Hence the raw pointer: the ref is adopted into a guard
-    /// that drops after `end_request_body`, the `&mut` part, has returned. The
-    /// callers that pass a pointer to their own receiver
-    /// (`start_request_stream`, `cancel_request_body_sink`) each say why their
-    /// release cannot be the last one.
+    /// That ref is the last one when the response finished before the upload
+    /// (the pump promise settles after the final hop), so this frees the
+    /// tasklet from the promise handlers and `end_from_stream`.
     pub(crate) fn write_end_request(this: *mut FetchTasklet, err: Option<JSValue>) {
         bun_output::scoped_log!(FetchTasklet, "writeEndRequest hasError? {}", err.is_some());
-        // SAFETY: `this` is the live heap tasklet; the caller owns the
-        // `start_request_stream` ref.
+        // SAFETY: `this` is live; the caller owns the `start_request_stream` ref.
         let _body_ref = unsafe { ScopedRef::adopt(this) };
         Self::from_raw_mut(this).end_request_body(err);
     }
@@ -2398,10 +2375,8 @@ impl FetchTasklet {
         if is_native {
             // No pump promise exists to balance the `+1` from
             // `start_request_stream`; `aborted` is set above so
-            // `write_end_request(Some(_))` is just the balancing deref. Never
-            // the last one: the final progress hop ends the sink (through this
-            // function) before its JS-side ref is released, so an un-ended
-            // sink means that ref is still held.
+            // `write_end_request(Some(_))` is just the balancing deref, never
+            // the last: the final hop ends the sink here before dropping its ref.
             Self::write_end_request(std::ptr::from_mut(self), Some(reason));
         }
     }
@@ -2611,11 +2586,9 @@ fn on_resolve_request_stream(
 ) -> JsResult<JSValue> {
     let args = callframe.arguments();
     let this: *mut FetchTasklet = args[args.len() - 1].as_promise_ptr::<FetchTasklet>();
-    // SAFETY: `as_promise_ptr` recovers the `*mut FetchTasklet` stashed by
-    // `start_request_stream`; the `ref_()` there keeps it alive until
-    // `write_end_request` below releases it (possibly freeing the tasklet, so
-    // the borrow taken here ends first). Clear `sink.task` so the sink's
-    // `finalize()` fallback does not release a second time.
+    // SAFETY: `start_request_stream` stashed `this` and still holds the ref that
+    // `write_end_request` below releases. Clearing `sink.task` first keeps the
+    // sink's `finalize()` fallback from releasing it again.
     if let Some(sink) = unsafe { (*this).sink_mut() } {
         sink.task = None;
     }

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -21,6 +21,7 @@ use bun_jsc::virtual_machine::VirtualMachine;
 use bun_jsc::{
     self as jsc, GlobalRef, JSGlobalObject, JSValue, JsResult, StringJsc, StrongOptional,
 };
+use bun_ptr::ScopedRef;
 use bun_sys::FdExt;
 use bun_threading::Mutex;
 use bun_url::URL as ZigURL;
@@ -72,7 +73,8 @@ impl Taskable for FetchTasklet {
     /// `on_progress_update` would have dropped. The HTTP thread is parked /
     /// this VM's requests are back, so a 1→0 here deinits against a live heap.
     unsafe fn release_unrun(this: *mut Self) {
-        FetchTasklet::deref(this);
+        // SAFETY: fn contract; the queued hop's ref is the one adopted.
+        drop(unsafe { ScopedRef::adopt(this) });
     }
 }
 
@@ -319,10 +321,11 @@ impl FetchTasklet {
     /// serialised: HTTP-thread writes happen under `mutex.lock()` and
     /// JS-thread access is single-threaded.
     ///
-    /// The entry points above that end by releasing a ref keep the `&mut`
-    /// returned here scoped to the work that precedes the release and release
-    /// through the raw pointer: a release may be the last one, and freeing
-    /// the tasklet through a live `&mut` to it is UB.
+    /// An entry point that owns one of those refs adopts it into a
+    /// [`ScopedRef`] from the raw pointer before calling this, and lets the
+    /// guard drop after the borrow is dead: the release may be the last one,
+    /// and freeing the tasklet while a `&mut` to it is live is UB. There is no
+    /// JS-thread release a `&mut self` method could call instead.
     #[inline]
     fn from_raw_mut<'a>(this: *mut FetchTasklet) -> &'a mut Self {
         // SAFETY: see INVARIANT above.
@@ -400,21 +403,13 @@ impl FetchTasklet {
             .map(|p| unsafe { &mut *p.as_ptr() })
     }
 
+    /// Takes a ref. Each one is released on the JS thread by a `ScopedRef`
+    /// adopted at the entry point that owns it (see `from_raw_mut`), or on the
+    /// HTTP thread by `deref_from_thread`.
     fn ref_(&self) {
         // SAFETY: `self` is live; `ref_` only touches the interior-mutable
         // atomic counter.
         unsafe { bun_ptr::ThreadSafeRefCount::<Self>::ref_(core::ptr::from_ref(self).cast_mut()) };
-    }
-
-    /// # Safety
-    /// Caller holds a ref; `this` must be a live heap allocation from `get()`.
-    // Forwards `this` to ThreadSafeRefCount without dereferencing; signature must stay
-    // `*mut` because the call may drop the last ref and free the allocation, so a `&mut`
-    // here would be UB.
-    #[allow(clippy::not_unsafe_ptr_arg_deref)]
-    pub(crate) fn deref(this: *mut FetchTasklet) {
-        // SAFETY: caller contract.
-        unsafe { bun_ptr::ThreadSafeRefCount::<Self>::deref(this) };
     }
 
     /// # Safety
@@ -926,12 +921,12 @@ impl FetchTasklet {
     /// `task_tag::FetchTasklet` arm: one progress hop posted by `callback`.
     ///
     /// Takes the raw pointer, like `callback` and `resume_request_data_stream`:
-    /// the final hop releases the JS-side ref from `get()`, which is the last
-    /// one once the HTTP thread has dropped its own (the usual order, as
-    /// `callback` derefs right after posting the final hop), so the release
-    /// frees the tasklet and must not run while a `&mut self` to it is live.
-    /// Everything that needs `&mut` runs inside `on_progress_update_locked`,
-    /// which the JS-side ref outlives.
+    /// the final hop owns the JS-side ref from `get()`, which is the last one
+    /// once the HTTP thread has dropped its own (the usual order, as
+    /// `callback` derefs right after posting the final hop), so releasing it
+    /// frees the tasklet. The ref is adopted into a guard here and everything
+    /// that needs `&mut` runs inside `on_progress_update_locked`; the guard
+    /// drops, and the tasklet with it, only after that borrow is gone.
     pub(crate) fn on_progress_update(this: *mut FetchTasklet) -> JsTerminatedResult<()> {
         jsc::mark_binding!();
         bun_output::scoped_log!(FetchTasklet, "onProgressUpdate");
@@ -939,13 +934,11 @@ impl FetchTasklet {
         shared.mutex.lock();
         shared.has_schedule_callback.store(false, Ordering::Relaxed);
         let is_done = !shared.result.has_more;
-        let result = Self::from_raw_mut(this).on_progress_update_locked(is_done);
-        if is_done {
-            // SAFETY: `this` is the live heap tasklet; this releases the
-            // JS-side ref from `get()`, and no borrow of `*this` is live.
-            FetchTasklet::deref(this);
-        }
-        result
+        // SAFETY: `this` is the live heap tasklet and the final hop owns the
+        // JS-side ref from `get()`.
+        let _js_ref = is_done.then(|| unsafe { ScopedRef::adopt(this) });
+        // `_js_ref` drops after this call returns.
+        Self::from_raw_mut(this).on_progress_update_locked(is_done)
     }
 
     /// Body of [`on_progress_update`](Self::on_progress_update). Entered with
@@ -2206,22 +2199,19 @@ impl FetchTasklet {
     /// This is ALWAYS called from the main thread
     // ConcurrentTask::from_callback expects `fn(*mut T) -> bun_event_loop::JsResult<()>`.
     fn resume_request_data_stream(this: *mut FetchTasklet) -> ElJsResult<()> {
-        let this_ref = Self::from_raw_mut(this);
         bun_output::scoped_log!(FetchTasklet, "resumeRequestDataStream");
-        let result = (|| {
-            if this_ref.signal_aborted() {
-                // already aborted; nothing to drain
-                return;
-            }
-            let global_this = this_ref.global_this;
-            if let Some(sink) = this_ref.sink_mut() {
-                sink.on_drain(&global_this);
-            }
-        })();
-        // deref when done because we ref inside onWriteRequestDataDrain
-        // SAFETY: `this` is the live heap tasklet; we hold a ref.
-        FetchTasklet::deref(this);
-        let () = result;
+        // SAFETY: `this` is the live heap tasklet; this hop owns the ref
+        // `on_write_request_data_drain` took.
+        let _drain_ref = unsafe { ScopedRef::adopt(this) };
+        let this_ref = Self::from_raw_mut(this);
+        if this_ref.signal_aborted() {
+            // already aborted; nothing to drain
+            return Ok(());
+        }
+        let global_this = this_ref.global_this;
+        if let Some(sink) = this_ref.sink_mut() {
+            sink.on_drain(&global_this);
+        }
         Ok(())
     }
 
@@ -2312,17 +2302,17 @@ impl FetchTasklet {
     /// JS-side ref, and the pump promise then settles into
     /// `on_resolve_request_stream` / `on_reject_request_stream`, whose release
     /// here frees the tasklet (`FetchRequestBodySink::end_from_stream` releases
-    /// it the same way). Hence the raw pointer: the `&mut` work happens in
-    /// `end_request_body`, and nothing borrows the tasklet when it is
-    /// released. The callers that pass a pointer to their own receiver
+    /// it the same way). Hence the raw pointer: the ref is adopted into a guard
+    /// that drops after `end_request_body`, the `&mut` part, has returned. The
+    /// callers that pass a pointer to their own receiver
     /// (`start_request_stream`, `cancel_request_body_sink`) each say why their
     /// release cannot be the last one.
     pub(crate) fn write_end_request(this: *mut FetchTasklet, err: Option<JSValue>) {
         bun_output::scoped_log!(FetchTasklet, "writeEndRequest hasError? {}", err.is_some());
+        // SAFETY: `this` is the live heap tasklet; the caller owns the
+        // `start_request_stream` ref.
+        let _body_ref = unsafe { ScopedRef::adopt(this) };
         Self::from_raw_mut(this).end_request_body(err);
-        // SAFETY: `this` is the live heap tasklet; this releases the
-        // `start_request_stream` ref, and no borrow of `*this` is live.
-        FetchTasklet::deref(this);
     }
 
     /// The ref-count-neutral part of [`write_end_request`](Self::write_end_request).

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -311,18 +311,25 @@ impl FetchTasklet {
     ///
     /// INVARIANT: every `*mut FetchTasklet` threaded through the HTTP-thread
     /// callback (`callback`), the drain hook (`on_write_request_data_drain` /
-    /// `resume_request_data_stream`), and the JS-thread enqueue
-    /// (`queue` → `node`) was produced by `heap::into_raw(Box<FetchTasklet>)`
-    /// in `get()` and is kept alive by the intrusive `ref_count` until
-    /// `deinit`. Access on either thread is serialised: HTTP-thread writes
-    /// happen under `mutex.lock()` and JS-thread access is single-threaded.
+    /// `resume_request_data_stream`), the progress hop (`on_progress_update`),
+    /// the request-body release (`write_end_request`), and the JS-thread
+    /// enqueue (`queue` → `node`) was produced by
+    /// `heap::into_raw(Box<FetchTasklet>)` in `get()` and is kept alive by the
+    /// intrusive `ref_count` until `deinit`. Access on either thread is
+    /// serialised: HTTP-thread writes happen under `mutex.lock()` and
+    /// JS-thread access is single-threaded.
+    ///
+    /// The entry points above that end by releasing a ref keep the `&mut`
+    /// returned here scoped to the work that precedes the release and release
+    /// through the raw pointer: a release may be the last one, and freeing
+    /// the tasklet through a live `&mut` to it is UB.
     #[inline]
     fn from_raw_mut<'a>(this: *mut FetchTasklet) -> &'a mut Self {
         // SAFETY: see INVARIANT above.
         unsafe { &mut *this }
     }
-    /// Shared variant of [`from_raw_mut`] for paths that only read atomics
-    /// (`ref_count`, `is_shutting_down`) before deciding whether to upgrade.
+    /// Shared variant of [`from_raw_mut`] for the parts of an entry point that
+    /// only need `&self` (atomics, `mutex`, posting a task).
     #[inline]
     fn from_raw_ref<'a>(this: *mut FetchTasklet) -> &'a Self {
         // SAFETY: see [`from_raw_mut`] INVARIANT.
@@ -631,8 +638,12 @@ impl FetchTasklet {
         // +1 on the tasklet; balanced exactly once by `write_end_request` on the
         // assign_to_stream-result side (on_resolve/on_reject or the synchronous
         // Fulfilled/Rejected/undefined branches below), or by the sink's
-        // `finalize` as a fallback if that path never runs.
+        // `finalize` as a fallback if that path never runs. The synchronous
+        // branches release it through `self_ptr` while the progress hop that
+        // called us still holds the JS-side ref, so none of them can free the
+        // tasklet.
         self.ref_();
+        let self_ptr = std::ptr::from_mut::<FetchTasklet>(self);
 
         if stream.is_locked(&global_this) || stream.is_disturbed(&global_this) {
             let err = jsc::SystemError {
@@ -645,11 +656,10 @@ impl FetchTasklet {
             };
             let err_instance = err.to_error_instance(&global_this);
             err_instance.ensure_still_alive();
-            self.write_end_request(Some(err_instance));
+            Self::write_end_request(self_ptr, Some(err_instance));
             return;
         }
 
-        let self_ptr = std::ptr::from_mut::<FetchTasklet>(self);
         // `self_ptr` is the live heap tasklet; the +1 above keeps it alive
         // until `write_end_request`/`finalize` clears `task`.
         let sink: &mut FetchRequestBodySink = Box::leak(Box::new(FetchRequestBodySink {
@@ -683,7 +693,7 @@ impl FetchTasklet {
                     err_js.ensure_still_alive();
                     err_js
                 });
-                self.write_end_request(err_js);
+                Self::write_end_request(self_ptr, err_js);
                 return;
             }
             crate::webcore::readable_stream::NativeWireResult::NotNative => {}
@@ -697,7 +707,7 @@ impl FetchTasklet {
         assignment_result.ensure_still_alive();
 
         if let Some(err) = assignment_result.to_error() {
-            self.write_end_request(Some(err));
+            Self::write_end_request(self_ptr, Some(err));
             self.clear_sink();
             return;
         }
@@ -715,13 +725,13 @@ impl FetchTasklet {
                     }
                     bun_jsc::js_promise::Status::Fulfilled => {
                         sink.task = None;
-                        self.write_end_request(None);
+                        Self::write_end_request(self_ptr, None);
                     }
                     bun_jsc::js_promise::Status::Rejected => {
                         promise.set_handled(global_this.vm());
                         let result = promise.result(global_this.vm());
                         sink.task = None;
-                        self.write_end_request(Some(result));
+                        Self::write_end_request(self_ptr, Some(result));
                     }
                 }
                 return;
@@ -732,7 +742,7 @@ impl FetchTasklet {
         // assignToStream. `end()` no longer calls `write_end_request`, so this
         // path always balances the `+1` itself.
         sink.task = None;
-        self.write_end_request(None);
+        Self::write_end_request(self_ptr, None);
     }
 
     fn on_body_received(&mut self) -> JsTerminatedResult<()> {
@@ -913,13 +923,36 @@ impl FetchTasklet {
         Ok(())
     }
 
-    pub(crate) fn on_progress_update(&mut self) -> JsTerminatedResult<()> {
+    /// `task_tag::FetchTasklet` arm: one progress hop posted by `callback`.
+    ///
+    /// Takes the raw pointer, like `callback` and `resume_request_data_stream`:
+    /// the final hop releases the JS-side ref from `get()`, which is the last
+    /// one once the HTTP thread has dropped its own (the usual order, as
+    /// `callback` derefs right after posting the final hop), so the release
+    /// frees the tasklet and must not run while a `&mut self` to it is live.
+    /// Everything that needs `&mut` runs inside `on_progress_update_locked`,
+    /// which the JS-side ref outlives.
+    pub(crate) fn on_progress_update(this: *mut FetchTasklet) -> JsTerminatedResult<()> {
         jsc::mark_binding!();
         bun_output::scoped_log!(FetchTasklet, "onProgressUpdate");
-        self.mutex.lock();
-        self.has_schedule_callback.store(false, Ordering::Relaxed);
-        let is_done = !self.result.has_more;
+        let shared = Self::from_raw_ref(this);
+        shared.mutex.lock();
+        shared.has_schedule_callback.store(false, Ordering::Relaxed);
+        let is_done = !shared.result.has_more;
+        let result = Self::from_raw_mut(this).on_progress_update_locked(is_done);
+        if is_done {
+            // SAFETY: `this` is the live heap tasklet; this releases the
+            // JS-side ref from `get()`, and no borrow of `*this` is live.
+            FetchTasklet::deref(this);
+        }
+        result
+    }
 
+    /// Body of [`on_progress_update`](Self::on_progress_update). Entered with
+    /// `mutex` held; unlocks it on every path. Does not release the JS-side
+    /// ref, so no release reached from here (`write_end_request` via
+    /// `cancel_request_body_sink`) can be the tasklet's last one.
+    fn on_progress_update_locked(&mut self, is_done: bool) -> JsTerminatedResult<()> {
         let vm = self.global_this.bun_vm();
         // teardown forbade script: we cannot touch JS
         if !vm.script_allowed() {
@@ -932,10 +965,6 @@ impl FetchTasklet {
                 }
             }
             self.mutex.unlock();
-            if is_done {
-                // SAFETY: `self` is the live heap tasklet; we hold a ref.
-                FetchTasklet::deref(std::ptr::from_mut(self));
-            }
             return Ok(());
         }
 
@@ -952,8 +981,6 @@ impl FetchTasklet {
                 this.cancel_request_body_sink(JSValue::UNDEFINED);
                 let mut poll_ref = core::mem::take(&mut this.poll_ref);
                 poll_ref.unref(bun_io::js_vm_ctx());
-                // SAFETY: `this` is the live heap tasklet; we hold a ref.
-                FetchTasklet::deref(std::ptr::from_mut(this));
             }
         };
 
@@ -2277,13 +2304,31 @@ impl FetchTasklet {
         result
     }
 
-    pub(crate) fn write_end_request(&mut self, err: Option<JSValue>) {
+    /// Ends the streamed request body (terminating chunk + End, or an abort
+    /// carrying `err`) and releases the ref `start_request_stream` took for it.
+    ///
+    /// That ref is the tasklet's last one when the response finished before
+    /// the upload did: the final progress hop cancels the sink and drops the
+    /// JS-side ref, and the pump promise then settles into
+    /// `on_resolve_request_stream` / `on_reject_request_stream`, whose release
+    /// here frees the tasklet (`FetchRequestBodySink::end_from_stream` releases
+    /// it the same way). Hence the raw pointer: the `&mut` work happens in
+    /// `end_request_body`, and nothing borrows the tasklet when it is
+    /// released. The callers that pass a pointer to their own receiver
+    /// (`start_request_stream`, `cancel_request_body_sink`) each say why their
+    /// release cannot be the last one.
+    pub(crate) fn write_end_request(this: *mut FetchTasklet, err: Option<JSValue>) {
         bun_output::scoped_log!(FetchTasklet, "writeEndRequest hasError? {}", err.is_some());
-        let this_ptr = std::ptr::from_mut(self);
+        Self::from_raw_mut(this).end_request_body(err);
+        // SAFETY: `this` is the live heap tasklet; this releases the
+        // `start_request_stream` ref, and no borrow of `*this` is live.
+        FetchTasklet::deref(this);
+    }
+
+    /// The ref-count-neutral part of [`write_end_request`](Self::write_end_request).
+    fn end_request_body(&mut self, err: Option<JSValue>) {
         if let Some(js_error) = err {
             if self.signal_store.aborted.load(Ordering::Relaxed) || self.abort_reason.has() {
-                // SAFETY: `this_ptr` derived from live `&mut self`; we hold a ref.
-                FetchTasklet::deref(this_ptr);
                 return;
             }
             if !js_error.is_undefined_or_null() {
@@ -2292,15 +2337,11 @@ impl FetchTasklet {
             self.abort_task();
         } else {
             if self.signal_store.aborted.load(Ordering::Relaxed) {
-                // SAFETY: `this_ptr` derived from live `&mut self`; we hold a ref.
-                FetchTasklet::deref(this_ptr);
                 return;
             }
             if !self.skip_chunked_framing() {
                 // Using chunked transfer encoding, send the terminating chunk
                 let Some(thread_safe_stream_buffer) = self.stream_buffer_mut() else {
-                    // SAFETY: `this_ptr` derived from live `&mut self`; we hold a ref.
-                    FetchTasklet::deref(this_ptr);
                     return;
                 };
                 // Mutex guards `buffer` against the HTTP thread; released when
@@ -2314,8 +2355,6 @@ impl FetchTasklet {
                     .schedule_request_write(http_, http::http_thread::WriteMessageType::End);
             }
         }
-        // SAFETY: `this_ptr` derived from live `&mut self`; we hold a ref.
-        FetchTasklet::deref(this_ptr);
     }
 
     fn abort_task(&mut self) {
@@ -2369,8 +2408,11 @@ impl FetchTasklet {
         if is_native {
             // No pump promise exists to balance the `+1` from
             // `start_request_stream`; `aborted` is set above so
-            // `write_end_request(Some(_))` is just the balancing deref.
-            self.write_end_request(Some(reason));
+            // `write_end_request(Some(_))` is just the balancing deref. Never
+            // the last one: the final progress hop ends the sink (through this
+            // function) before its JS-side ref is released, so an un-ended
+            // sink means that ref is still held.
+            Self::write_end_request(std::ptr::from_mut(self), Some(reason));
         }
     }
 
@@ -2580,15 +2622,14 @@ fn on_resolve_request_stream(
     let args = callframe.arguments();
     let this: *mut FetchTasklet = args[args.len() - 1].as_promise_ptr::<FetchTasklet>();
     // SAFETY: `as_promise_ptr` recovers the `*mut FetchTasklet` stashed by
-    // `start_request_stream`; the `ref_()` there keeps it alive, balanced by
-    // `write_end_request` below. Clear `sink.task` first so the sink's
+    // `start_request_stream`; the `ref_()` there keeps it alive until
+    // `write_end_request` below releases it (possibly freeing the tasklet, so
+    // the borrow taken here ends first). Clear `sink.task` so the sink's
     // `finalize()` fallback does not release a second time.
-    unsafe {
-        if let Some(sink) = (*this).sink_mut() {
-            sink.task = None;
-        }
-        (*this).write_end_request(None);
+    if let Some(sink) = unsafe { (*this).sink_mut() } {
+        sink.task = None;
     }
+    FetchTasklet::write_end_request(this, None);
     Ok(JSValue::UNDEFINED)
 }
 
@@ -2599,16 +2640,11 @@ fn on_reject_request_stream(
     let args = callframe.arguments();
     let this: *mut FetchTasklet = args[args.len() - 1].as_promise_ptr::<FetchTasklet>();
     let err = args[0];
-    // SAFETY: `as_promise_ptr` recovers the `*mut FetchTasklet` stashed by
-    // `start_request_stream`; the `ref_()` there keeps it alive, balanced by
-    // `write_end_request` below. Clear `sink.task` first so the sink's
-    // `finalize()` fallback does not release a second time.
-    unsafe {
-        if let Some(sink) = (*this).sink_mut() {
-            sink.task = None;
-        }
-        (*this).write_end_request(Some(err));
+    // SAFETY: as in `on_resolve_request_stream`.
+    if let Some(sink) = unsafe { (*this).sink_mut() } {
+        sink.task = None;
     }
+    FetchTasklet::write_end_request(this, Some(err));
     Ok(JSValue::UNDEFINED)
 }
 

--- a/src/runtime/webcore/fetch/FetchTasklet.rs
+++ b/src/runtime/webcore/fetch/FetchTasklet.rs
@@ -314,12 +314,13 @@ impl FetchTasklet {
     /// INVARIANT: every `*mut FetchTasklet` threaded through the HTTP-thread
     /// callback (`callback`), the drain hook (`on_write_request_data_drain` /
     /// `resume_request_data_stream`), the progress hop (`on_progress_update`),
-    /// the request-body release (`write_end_request`), and the JS-thread
-    /// enqueue (`queue` → `node`) was produced by
+    /// the stashes `start_request_stream` makes for `write_end_request`, and
+    /// the JS-thread enqueue (`queue` → `node`) was produced by
     /// `heap::into_raw(Box<FetchTasklet>)` in `get()` and is kept alive by the
-    /// intrusive `ref_count` until `deinit`. Access on either thread is
-    /// serialised: HTTP-thread writes happen under `mutex.lock()` and
-    /// JS-thread access is single-threaded.
+    /// intrusive `ref_count` until `deinit`; `write_end_request`'s in-frame
+    /// callers pass a pointer made from the `&mut` the hop currently holds.
+    /// Access on either thread is serialised: HTTP-thread writes happen under
+    /// `mutex.lock()` and JS-thread access is single-threaded.
     ///
     /// An entry point that owns a ref adopts it into a [`ScopedRef`] before
     /// calling this; the guard (which may free the tasklet) drops after the
@@ -609,7 +610,11 @@ impl FetchTasklet {
         self.get_current_response().map(|r| unsafe { &mut *r })
     }
 
-    fn start_request_stream(&mut self) {
+    /// `this` is the allocation pointer the hop was dispatched with; it is what
+    /// gets stashed past this frame (the sink's back-pointer and the promise
+    /// ctx), so the releases made through those later carry the allocation's
+    /// provenance rather than that of a borrow that has long ended.
+    fn start_request_stream(&mut self, this: *mut FetchTasklet) {
         self.is_waiting_request_stream_start = false;
         debug_assert!(matches!(
             self.request_body,
@@ -631,8 +636,8 @@ impl FetchTasklet {
         // assign_to_stream-result side (on_resolve/on_reject or the synchronous
         // Fulfilled/Rejected/undefined branches below), or by the sink's
         // `finalize` as a fallback if that path never runs. The synchronous
-        // branches release it while our caller, the progress hop, still holds
-        // the JS-side ref.
+        // branches release it inside this frame, while our caller, the
+        // progress hop, still holds the JS-side ref; they go through `self`.
         self.ref_();
         let self_ptr = std::ptr::from_mut::<FetchTasklet>(self);
 
@@ -651,10 +656,12 @@ impl FetchTasklet {
             return;
         }
 
-        // `self_ptr` is the live heap tasklet; the +1 above keeps it alive
-        // until `write_end_request`/`finalize` clears `task`.
+        // SAFETY: `this` is this tasklet's allocation pointer (see the fn doc);
+        // the +1 above keeps it live until `write_end_request` / `finalize`
+        // takes `task`.
+        let task = unsafe { bun_ptr::BackRef::from_raw_mut(this) };
         let sink: &mut FetchRequestBodySink = Box::leak(Box::new(FetchRequestBodySink {
-            task: Some(bun_ptr::BackRef::new_mut(self)),
+            task: Some(task),
             high_water_mark: 16384,
             ..Default::default()
         }));
@@ -709,7 +716,7 @@ impl FetchTasklet {
                     bun_jsc::js_promise::Status::Pending => {
                         assignment_result.then(
                             &global_this,
-                            self_ptr,
+                            this,
                             on_resolve_request_stream_shim,
                             on_reject_request_stream_shim,
                         );
@@ -926,12 +933,17 @@ impl FetchTasklet {
         let is_done = !shared.result.has_more;
         // SAFETY: `this` is live; the final hop owns the JS-side ref.
         let _js_ref = is_done.then(|| unsafe { ScopedRef::adopt(this) });
-        Self::from_raw_mut(this).on_progress_update_locked(is_done)
+        Self::from_raw_mut(this).on_progress_update_locked(this, is_done)
     }
 
     /// Entered with `mutex` held; unlocks it on every path. The caller holds
     /// the JS-side ref throughout, so no release reached from here is the last.
-    fn on_progress_update_locked(&mut self, is_done: bool) -> JsTerminatedResult<()> {
+    /// `this` is only passed on to `start_request_stream` for stashing.
+    fn on_progress_update_locked(
+        &mut self,
+        this: *mut FetchTasklet,
+        is_done: bool,
+    ) -> JsTerminatedResult<()> {
         let vm = self.global_this.bun_vm();
         // teardown forbade script: we cannot touch JS
         if !vm.script_allowed() {
@@ -965,7 +977,7 @@ impl FetchTasklet {
 
         if self.is_waiting_request_stream_start && self.result.can_stream {
             // start streaming
-            self.start_request_stream();
+            self.start_request_stream(this);
             // Makes wpt-h2 number-chunk test deterministic.
             // `assign_to_stream` kicks off `await reader.read()`; an invalid
             // chunk type (e.g. a JS number) throws inside `sink.write` and lands in

--- a/test/internal/source-lints/self-receiver-release.test.ts
+++ b/test/internal/source-lints/self-receiver-release.test.ts
@@ -10,7 +10,7 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //   T::deref(std::ptr::from_ref(this).cast_mut());
 //   Self::deref_nn(NonNull::from(self));
 //   drop(ScopedRef::adopt(std::ptr::from_mut(self)));
-//   let p = std::ptr::from_mut(self); ... Self::deref(p);
+//   let p = NonNull::from(self); ... Self::deref_nn(p);
 //
 // is banned. A release may be the object's last one, and then the destructor
 // frees the allocation the reference still points at. While the reference is
@@ -76,23 +76,27 @@ const POINTER_FROM_REFERENCE = [
 // rustfmt line break cannot hide it.
 const DIRECT = new RegExp(RELEASE + String.raw`\s*(?:` + POINTER_FROM_REFERENCE + ")", "g");
 
-// `let p = std::ptr::from_mut(self);` / `let p = self as *mut Self;`, whose
-// binding is then released (`deref(p)`) further down the same function. The
+// The same pointer stored first (`let p = std::ptr::from_mut(self);`,
+// `let p = NonNull::from(self);`, ...) and released (`deref(p)`,
+// `deref_nn(p)`, `deref(p.as_ptr())`) further down the same function. The
 // function ends at the next `fn` item; a closure inside it is still the same
 // function for this purpose.
-const SELF_POINTER_BINDING =
-  /let\s+(?:mut\s+)?(\w+)\s*(?::[^=;]*)?=\s*(?:(?:std::|core::)?ptr::from_mut(?:::<[^>]*>)?\(\s*self\s*\)|self\s+as\s+\*mut\b[^;]*)\s*;/g;
+const POINTER_BINDING = new RegExp(
+  String.raw`let\s+(?:mut\s+)?(\w+)\s*(?::[^=;]*)?=\s*(?:` + POINTER_FROM_REFERENCE + String.raw`)[^;]*;`,
+  "g",
+);
 const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s/m;
 
 function releaseOfBinding(name: string): RegExp {
-  return new RegExp(RELEASE + String.raw`\s*` + name + String.raw`\s*[,)]`);
+  // `name` is a `\w+` capture, so it needs no escaping.
+  return new RegExp(RELEASE + String.raw`\s*` + name + String.raw`(?:\.as_ptr\(\))?\s*[,)]`);
 }
 
 /** Byte offsets (into `stripped`) of every banned release in one file. */
 function findReleases(stripped: string): number[] {
   const hits: number[] = [];
   for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
-  for (const binding of stripped.matchAll(SELF_POINTER_BINDING)) {
+  for (const binding of stripped.matchAll(POINTER_BINDING)) {
     const start = binding.index + binding[0].length;
     const rest = stripped.slice(start);
     const fnEnd = rest.search(FN_ITEM);
@@ -124,8 +128,8 @@ const ALLOW: Record<string, number> = {
   // `finalize(&mut self)`, reached through the generated `JSSink` finalize
   // thunk, releases the wrapper's ref, which is the last one for an idle
   // sink; the second site releases the keep-alive ref while the wrapper's ref
-  // is still held. Needs the thunk to hand over the raw pointer; tracked
-  // separately.
+  // is still held. #37716 converts the thunk and removes both sites: drop
+  // this entry when it lands.
   "src/runtime/webcore/FileSink.rs": 2,
   // Harmless: every `close()` caller releases its own creation ref only after
   // `close()` returns.
@@ -138,6 +142,9 @@ const ALLOW: Record<string, number> = {
   // Harmless: `stmt` is a local reborrow and the queued request holds its own
   // ref on the statement until `release_statement`.
   "src/sql_jsc/postgres/PostgresSQLConnection.rs": 1,
+  // Harmless: `do_run`'s error paths undo the `ref_()` taken a few lines up
+  // while the on-stack JS wrapper holds its own ref.
+  "src/sql_jsc/postgres/PostgresSQLQuery.rs": 1,
 };
 
 const counts: Record<string, number> = {};
@@ -184,8 +191,13 @@ test("the patterns match the banned spellings and nothing else", () => {
     "let this_ptr = std::ptr::from_mut(self);\nif done {\n    FetchTasklet::deref(this_ptr);\n    return;\n}",
     "let this: *mut Self = self as *mut Self;\nSelf::deref(this);",
     "let this = std::ptr::from_mut(self);\nlet _guard = unsafe { ScopedRef::adopt(this) };",
+    "let this = NonNull::from(self);\nSelf::deref_nn(this);",
+    "let this = core::ptr::NonNull::from(self);\nunsafe { T::deref(this.as_ptr()) };",
+    "let p = std::ptr::from_ref::<T>(this).cast_mut();\nunsafe { T::deref(p) };",
+    "let p = &raw mut *self;\nunsafe { RefCount::<Self>::deref(p) };",
   ];
   const allowed = [
+    "let this = NonNull::from(self);\nregister(this);",
     "FetchTasklet::deref_from_thread(task);",
     "let _js_ref = is_done.then(|| unsafe { ScopedRef::adopt(this) });",
     "drop(unsafe { ScopedRef::<FetchTasklet>::adopt(task.as_ptr()) });",

--- a/test/internal/source-lints/self-receiver-release.test.ts
+++ b/test/internal/source-lints/self-receiver-release.test.ts
@@ -9,6 +9,7 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //   FetchTasklet::deref(std::ptr::from_mut(self));
 //   T::deref(std::ptr::from_ref(this).cast_mut());
 //   Self::deref_nn(NonNull::from(self));
+//   drop(ScopedRef::adopt(std::ptr::from_mut(self)));
 //   let p = std::ptr::from_mut(self); ... Self::deref(p);
 //
 // is banned. A release may be the object's last one, and then the destructor
@@ -24,16 +25,19 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //
 // The object was allocated as a raw pointer and every caller of these
 // functions has it (a task arm's `task.ptr`, a callback's ctx, a `BackRef`'s
-// `as_ptr()`), so the fix is structural: the function that ends in a release
-// takes `this: *mut Self`, does its `&mut` work through a call-scoped reborrow
-// (`Self::from_raw_mut(this).body()`), and releases through `this` once that
-// borrow is over. See `on_progress_update` / `write_end_request` in
-// src/runtime/webcore/fetch/FetchTasklet.rs. When the reference is a local
-// reborrow rather than a parameter the release is not UB, but the raw pointer
-// it was made from is in scope; release through that instead.
+// `as_ptr()`), so the fix is structural: the function that owns the ref takes
+// `this: *mut Self`, adopts the ref into a `bun_ptr::ScopedRef` before any
+// reference to `*this` exists, and does its `&mut` work through a call-scoped
+// reborrow (`Self::from_raw_mut(this).body()`); the guard releases when it
+// drops, after that borrow is gone. Once every release of a type is a guard,
+// the type needs no raw release function at all, and a `&mut self` method has
+// nothing left to misuse (src/runtime/webcore/fetch/FetchTasklet.rs). When the
+// reference is a local reborrow rather than a parameter the release is not UB,
+// but the raw pointer it was made from is in scope; adopt that instead.
 //
-// This lint only knows the `deref` family of release names; a release spelled
-// `unref`/`release` is out of its reach. Siblings:
+// This lint knows the `deref` family of release names and `ScopedRef::adopt`
+// (`ScopedRef::new` takes its own ref and is balanced, so it is not a release);
+// a release spelled `unref`/`release` is out of its reach. Siblings:
 // fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
@@ -53,8 +57,9 @@ const tracked: Set<string> | null = (() => {
 })();
 
 // `deref(`, `deref_from_thread(`, `deref_nn(`, `deref_with_context(`,
-// `rc_deref(`, however qualified. `\b` keeps `some_other_deref(` out.
-const RELEASE = String.raw`\b(?:rc_)?deref(?:_from_thread|_nn|_with_context)?\(`;
+// `rc_deref(`, however qualified (`\b` keeps `some_other_deref(` out), and
+// `ScopedRef::adopt(` / `ScopedRef::<T>::adopt(`.
+const RELEASE = String.raw`(?:\b(?:rc_)?deref(?:_from_thread|_nn|_with_context)?|\bScopedRef(?:::<[^>]*>)?::adopt)\(`;
 
 // A pointer spelled from a reference. `ptr::from_mut` / `ptr::from_ref` only
 // accept references, so any argument counts; the remaining spellings are
@@ -174,12 +179,18 @@ test("the patterns match the banned spellings and nothing else", () => {
     "Self::deref_nn(NonNull::from(self));",
     "Self::deref_from_thread(self as *mut Self);",
     "unsafe { T::rc_deref(&raw mut *self) };",
+    "drop(unsafe { ScopedRef::adopt(std::ptr::from_mut(self)) });",
+    "let _ref = unsafe { ScopedRef::<Self>::adopt(\n    std::ptr::from_mut::<Self>(self),\n) };",
     "let this_ptr = std::ptr::from_mut(self);\nif done {\n    FetchTasklet::deref(this_ptr);\n    return;\n}",
     "let this: *mut Self = self as *mut Self;\nSelf::deref(this);",
+    "let this = std::ptr::from_mut(self);\nlet _guard = unsafe { ScopedRef::adopt(this) };",
   ];
   const allowed = [
-    "FetchTasklet::deref(this);",
-    "FetchTasklet::deref(task.as_ptr());",
+    "FetchTasklet::deref_from_thread(task);",
+    "let _js_ref = is_done.then(|| unsafe { ScopedRef::adopt(this) });",
+    "drop(unsafe { ScopedRef::<FetchTasklet>::adopt(task.as_ptr()) });",
+    // `new` takes a ref of its own and releases that one: balanced.
+    "let _guard = unsafe { ScopedRef::new(std::ptr::from_mut::<FileSink>(self)) };",
     "unsafe { ThreadSafeRefCount::<Self>::deref(this) };",
     "let self_ptr = std::ptr::from_mut::<FetchTasklet>(self);\nSelf::write_end_request(self_ptr, None);",
     // The binding is released, but in the next function, where it is a

--- a/test/internal/source-lints/self-receiver-release.test.ts
+++ b/test/internal/source-lints/self-receiver-release.test.ts
@@ -1,0 +1,206 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// An intrusive-refcount release applied to a pointer spelled from a reference
+//
+//   FetchTasklet::deref(std::ptr::from_mut(self));
+//   T::deref(std::ptr::from_ref(this).cast_mut());
+//   Self::deref_nn(NonNull::from(self));
+//   let p = std::ptr::from_mut(self); ... Self::deref(p);
+//
+// is banned. A release may be the object's last one, and then the destructor
+// frees the allocation the reference still points at. While the reference is
+// a function (or closure) parameter, which `self` always is, both aliasing
+// models reject that deallocation: Tree Borrows (what `bun run rust:miri` uses)
+// reports "deallocation through <tag> is forbidden ... the strongly protected
+// tag disallows deallocations", pointing at the `&mut self` receiver, and
+// Stacked Borrows reports "deallocating while item [Unique] is strongly
+// protected". `FetchTasklet::on_progress_update(&mut self)` was the canonical
+// instance: every fetch's final progress hop released the tasklet's last ref
+// from inside its own `&mut self`.
+//
+// The object was allocated as a raw pointer and every caller of these
+// functions has it (a task arm's `task.ptr`, a callback's ctx, a `BackRef`'s
+// `as_ptr()`), so the fix is structural: the function that ends in a release
+// takes `this: *mut Self`, does its `&mut` work through a call-scoped reborrow
+// (`Self::from_raw_mut(this).body()`), and releases through `this` once that
+// borrow is over. See `on_progress_update` / `write_end_request` in
+// src/runtime/webcore/fetch/FetchTasklet.rs. When the reference is a local
+// reborrow rather than a parameter the release is not UB, but the raw pointer
+// it was made from is in scope; release through that instead.
+//
+// This lint only knows the `deref` family of release names; a release spelled
+// `unref`/`release` is out of its reach. Siblings:
+// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `deref(`, `deref_from_thread(`, `deref_nn(`, `deref_with_context(`,
+// `rc_deref(`, however qualified. `\b` keeps `some_other_deref(` out.
+const RELEASE = String.raw`\b(?:rc_)?deref(?:_from_thread|_nn|_with_context)?\(`;
+
+// A pointer spelled from a reference. `ptr::from_mut` / `ptr::from_ref` only
+// accept references, so any argument counts; the remaining spellings are
+// pinned to `self`, where a raw-pointer operand is impossible.
+const POINTER_FROM_REFERENCE = [
+  String.raw`(?:std::|core::)?ptr::from_mut(?:::<[^>]*>)?\(`,
+  String.raw`(?:std::|core::)?ptr::from_ref(?:::<[^>]*>)?\([^()]*\)\s*\.cast_mut\(\)`,
+  String.raw`(?:(?:std|core)::ptr::|ptr::)?NonNull::from\(\s*self\s*\)`,
+  String.raw`self\s+as\s+\*mut\b`,
+  String.raw`&raw\s+mut\s+\*\s*self\b`,
+].join("|");
+
+// Release applied directly to such a pointer. `\s*` between the two so a
+// rustfmt line break cannot hide it.
+const DIRECT = new RegExp(RELEASE + String.raw`\s*(?:` + POINTER_FROM_REFERENCE + ")", "g");
+
+// `let p = std::ptr::from_mut(self);` / `let p = self as *mut Self;`, whose
+// binding is then released (`deref(p)`) further down the same function. The
+// function ends at the next `fn` item; a closure inside it is still the same
+// function for this purpose.
+const SELF_POINTER_BINDING =
+  /let\s+(?:mut\s+)?(\w+)\s*(?::[^=;]*)?=\s*(?:(?:std::|core::)?ptr::from_mut(?:::<[^>]*>)?\(\s*self\s*\)|self\s+as\s+\*mut\b[^;]*)\s*;/g;
+const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s/m;
+
+function releaseOfBinding(name: string): RegExp {
+  return new RegExp(RELEASE + String.raw`\s*` + name + String.raw`\s*[,)]`);
+}
+
+/** Byte offsets (into `stripped`) of every banned release in one file. */
+function findReleases(stripped: string): number[] {
+  const hits: number[] = [];
+  for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
+  for (const binding of stripped.matchAll(SELF_POINTER_BINDING)) {
+    const start = binding.index + binding[0].length;
+    const rest = stripped.slice(start);
+    const fnEnd = rest.search(FN_ITEM);
+    const body = fnEnd === -1 ? rest : rest.slice(0, fnEnd);
+    const release = body.search(releaseOfBinding(binding[1]));
+    if (release !== -1) hits.push(start + release);
+  }
+  return hits.sort((a, b) => a - b);
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape. Every entry is a release that has been read and is either known to be
+// harmless (another ref provably outlives the call) or tracked for its own
+// fix. Lower the count when you convert one; do not add entries.
+const ALLOW: Record<string, number> = {
+  // Harmless: guarded by `ref_count > 1`; the final release goes through
+  // `DeferredDerefTask` precisely because the caller still uses the object.
+  "src/runtime/api/html_rewriter.rs": 1,
+  // Harmless: `write_sync` balances the `ref_()` it took a few lines up while
+  // the JS wrapper (the `this` of the call) holds its own ref.
+  "src/runtime/node/node_zlib_binding.rs": 1,
+  // Harmless: every `disarm` caller (`arm`, `finalize`, `deinit`) holds or
+  // has already consumed its own ref across the call.
+  "src/runtime/valkey_jsc/js_valkey.rs": 1,
+  // `finalize(&mut self)`, reached through the generated `JSSink` finalize
+  // thunk, releases the wrapper's ref, which is the last one for an idle
+  // sink; the second site releases the keep-alive ref while the wrapper's ref
+  // is still held. Needs the thunk to hand over the raw pointer; tracked
+  // separately.
+  "src/runtime/webcore/FileSink.rs": 2,
+  // Harmless: every `close()` caller releases its own creation ref only after
+  // `close()` returns.
+  "src/spawn/process.rs": 1,
+  // `on_write` releases the `start()` ref after `writer.close()` has let the
+  // owner drop the creation ref, so on POSIX it frees the writer from inside
+  // `on_write(&mut self)`; tracked separately. The other three sites run
+  // while the owner's or the in-flight write's ref is held.
+  "src/spawn/static_pipe_writer.rs": 4,
+  // Harmless: `stmt` is a local reborrow and the queued request holds its own
+  // ref on the statement until `release_statement`.
+  "src/sql_jsc/postgres/PostgresSQLConnection.rs": 1,
+};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including doc comments
+  // describing this shape) don't count. `[ \t]*`, not `\s*`, so blank lines
+  // survive and reported line numbers stay right.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const offset of findReleases(stripped)) {
+    counts[source] = (counts[source] ?? 0) + 1;
+    if (counts[source] > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${lineOf(stripped, offset)}`);
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the patterns match the banned spellings and nothing else", () => {
+  const banned = [
+    "FetchTasklet::deref(std::ptr::from_mut(self));",
+    "FetchTasklet::deref(std::ptr::from_mut(this));",
+    "unsafe { FileSink::deref(std::ptr::from_mut::<Self>(self)) };",
+    "unsafe { RefCount::<Self>::deref(\n    std::ptr::from_mut::<Self>(self),\n) };",
+    "unsafe { T::deref(std::ptr::from_ref::<T>(this).cast_mut()) };",
+    "Self::deref_nn(NonNull::from(self));",
+    "Self::deref_from_thread(self as *mut Self);",
+    "unsafe { T::rc_deref(&raw mut *self) };",
+    "let this_ptr = std::ptr::from_mut(self);\nif done {\n    FetchTasklet::deref(this_ptr);\n    return;\n}",
+    "let this: *mut Self = self as *mut Self;\nSelf::deref(this);",
+  ];
+  const allowed = [
+    "FetchTasklet::deref(this);",
+    "FetchTasklet::deref(task.as_ptr());",
+    "unsafe { ThreadSafeRefCount::<Self>::deref(this) };",
+    "let self_ptr = std::ptr::from_mut::<FetchTasklet>(self);\nSelf::write_end_request(self_ptr, None);",
+    // The binding is released, but in the next function, where it is a
+    // raw-pointer parameter of the same name.
+    "let this = std::ptr::from_mut(self);\nregister(this);\n}\n\nfn resume(this: *mut Self) {\n    Self::deref(this);\n}",
+    "signal.clean_native_bindings(std::ptr::from_mut(self).cast::<c_void>());",
+    "let value = strong.deref();",
+    "some_other_deref(std::ptr::from_mut(self));",
+  ];
+  expect(banned.map(s => findReleases(s).length)).toEqual(banned.map(() => 1));
+  expect(allowed.map(s => findReleases(s).length)).toEqual(allowed.map(() => 0));
+});
+
+test("refcount release through a pointer spelled from the receiver is banned", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: when an allowlisted release is converted, lower its entry so the
+  // shape cannot come back into that file.
+  for (const [source, n] of Object.entries(ALLOW)) {
+    expect({ source, count: counts[source] ?? 0 }).toEqual({ source, count: n });
+  }
+});

--- a/test/internal/source-lints/self-receiver-release.test.ts
+++ b/test/internal/source-lints/self-receiver-release.test.ts
@@ -7,6 +7,7 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // An intrusive-refcount release applied to a pointer spelled from a reference
 //
 //   FetchTasklet::deref(std::ptr::from_mut(self));
+//   RefCount::<Self>::deref(self);                 // the same, by coercion
 //   T::deref(std::ptr::from_ref(this).cast_mut());
 //   Self::deref_nn(NonNull::from(self));
 //   drop(ScopedRef::adopt(std::ptr::from_mut(self)));
@@ -35,10 +36,21 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // reference is a local reborrow rather than a parameter the release is not UB,
 // but the raw pointer it was made from is in scope; adopt that instead.
 //
-// This lint knows the `deref` family of release names and `ScopedRef::adopt`
-// (`ScopedRef::new` takes its own ref and is balanced, so it is not a release);
-// a release spelled `unref`/`release` is out of its reach. Siblings:
-// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+// Scope: this is a ratchet over the spellings a grep can see, namely the
+// `deref` family of release names and `ScopedRef::adopt` applied to the
+// receiver spelled as a pointer inline, to the receiver itself (a bare `self`
+// argument to a `*mut` parameter is always a coerced reference; raw-pointer
+// receivers do not exist outside bun_alloc), or to a local bound to one of
+// those. It does not see the same release behind a helper, above all
+// `deref(self.as_ctx_ptr())`, which is how the R-2 `&self` wrappers
+// (Subprocess, sockets, websocket_client, the SQL connections, ...) spell it
+// and which bun_ptr's `AsCtxPtr` doc currently endorses; nor a `&mut`-typed
+// local, a guard (`ScopedRef::new`, `ref_scope`) whose drop happens to be the
+// last release, or a release named `unref`/`release`. Those populations need
+// their own audit; do not read a clean run here as proof that a type is free
+// of the bug. Siblings: self-receiver-reclaim.test.ts (the same shape with a
+// free instead of a release), fn-long-mut-reborrow.test.ts,
+// frozen-nonnull-reborrow.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
@@ -56,10 +68,11 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-// `deref(`, `deref_from_thread(`, `deref_nn(`, `deref_with_context(`,
-// `rc_deref(`, however qualified (`\b` keeps `some_other_deref(` out), and
-// `ScopedRef::adopt(` / `ScopedRef::<T>::adopt(`.
-const RELEASE = String.raw`(?:\b(?:rc_)?deref(?:_from_thread|_nn|_with_context)?|\bScopedRef(?:::<[^>]*>)?::adopt)\(`;
+// A call to `deref(`, `deref_from_thread(`, `deref_nn(`, `deref_with_context(`,
+// `rc_deref(`, however qualified (`\b` keeps `some_other_deref(` out), or to
+// `ScopedRef::adopt(` / `ScopedRef::<T>::adopt(`. The lookbehind keeps the
+// definition `fn deref(self)` of a by-value release from counting as a call.
+const RELEASE = String.raw`(?<!\bfn\s+)(?:\b(?:rc_)?deref(?:_from_thread|_nn|_with_context)?|\bScopedRef(?:::<[^>]*>)?::adopt)\(`;
 
 // A pointer spelled from a reference. `ptr::from_mut` / `ptr::from_ref` only
 // accept references, so any argument counts; the remaining spellings are
@@ -72,17 +85,18 @@ const POINTER_FROM_REFERENCE = [
   String.raw`&raw\s+mut\s+\*\s*self\b`,
 ].join("|");
 
-// Release applied directly to such a pointer. `\s*` between the two so a
-// rustfmt line break cannot hide it.
-const DIRECT = new RegExp(RELEASE + String.raw`\s*(?:` + POINTER_FROM_REFERENCE + ")", "g");
+// Release applied directly to such a pointer, or to `self` itself, which the
+// `*mut` parameter coerces. `\s*` between the two so a rustfmt line break
+// cannot hide it.
+const DIRECT = new RegExp(RELEASE + String.raw`\s*(?:` + POINTER_FROM_REFERENCE + String.raw`|self\s*(?=[,)]))`, "g");
 
 // The same pointer stored first (`let p = std::ptr::from_mut(self);`,
-// `let p = NonNull::from(self);`, ...) and released (`deref(p)`,
-// `deref_nn(p)`, `deref(p.as_ptr())`) further down the same function. The
-// function ends at the next `fn` item; a closure inside it is still the same
-// function for this purpose.
+// `let p = NonNull::from(self);`, `let p: *mut Self = self;`, ...) and
+// released (`deref(p)`, `deref_nn(p)`, `deref(p.as_ptr())`) further down the
+// same function. The function ends at the next `fn` item; a closure inside it
+// is still the same function for this purpose.
 const POINTER_BINDING = new RegExp(
-  String.raw`let\s+(?:mut\s+)?(\w+)\s*(?::[^=;]*)?=\s*(?:` + POINTER_FROM_REFERENCE + String.raw`)[^;]*;`,
+  String.raw`let\s+(?:mut\s+)?(\w+)\s*(?::[^=;]*)?=\s*(?:(?:` + POINTER_FROM_REFERENCE + String.raw`)[^;]*|self\s*);`,
   "g",
 );
 const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s/m;
@@ -116,6 +130,20 @@ function lineOf(text: string, offset: number): number {
 // harmless (another ref provably outlives the call) or tracked for its own
 // fix. Lower the count when you convert one; do not add entries.
 const ALLOW: Record<string, number> = {
+  // `on_close` releases under a `ref_scope` guard (that guard's own drop is
+  // then the last release, still inside `&mut self`); `maybe_release`'s
+  // close branch releases what can be the last ref. Tracked separately.
+  "src/http/h2_client/ClientSession.rs": 2,
+  // Harmless: `detach` drops a per-stream ref while the session's owner holds
+  // its own.
+  "src/http/h3_client/ClientSession.rs": 1,
+  // `detach_and_deref(&mut self)` can drop the tunnel's last ref. Tracked
+  // separately.
+  "src/http/ProxyTunnel.rs": 1,
+  // `on_reader_done` / `on_reader_error(&mut self)` release the reader's own
+  // ref right after `on_close_io` dropped the owner's, so it frees the reader;
+  // the parent macro has the raw pointer to pass instead. Tracked separately.
+  "src/runtime/api/bun/subprocess/SubprocessPipeReader.rs": 2,
   // Harmless: guarded by `ref_count > 1`; the final release goes through
   // `DeferredDerefTask` precisely because the caller still uses the object.
   "src/runtime/api/html_rewriter.rs": 1,
@@ -125,12 +153,6 @@ const ALLOW: Record<string, number> = {
   // Harmless: every `disarm` caller (`arm`, `finalize`, `deinit`) holds or
   // has already consumed its own ref across the call.
   "src/runtime/valkey_jsc/js_valkey.rs": 1,
-  // `finalize(&mut self)`, reached through the generated `JSSink` finalize
-  // thunk, releases the wrapper's ref, which is the last one for an idle
-  // sink; the second site releases the keep-alive ref while the wrapper's ref
-  // is still held. #37716 converts the thunk and removes both sites: drop
-  // this entry when it lands.
-  "src/runtime/webcore/FileSink.rs": 2,
   // Harmless: every `close()` caller releases its own creation ref only after
   // `close()` returns.
   "src/spawn/process.rs": 1,
@@ -195,9 +217,20 @@ test("the patterns match the banned spellings and nothing else", () => {
     "let this = core::ptr::NonNull::from(self);\nunsafe { T::deref(this.as_ptr()) };",
     "let p = std::ptr::from_ref::<T>(this).cast_mut();\nunsafe { T::deref(p) };",
     "let p = &raw mut *self;\nunsafe { RefCount::<Self>::deref(p) };",
+    "unsafe { RefCount::<Self>::deref(self) };",
+    "unsafe { PipeReader::deref(self) }",
+    "drop(unsafe { ScopedRef::adopt(self) });",
+    "let this: *mut Self = self;\nunsafe { Self::deref(this) };",
   ];
   const allowed = [
     "let this = NonNull::from(self);\nregister(this);",
+    // Not seen, by the scope note at the top; listed so the boundary is explicit.
+    "unsafe { Self::deref(self.as_ctx_ptr()) };",
+    "let x = self.field;\nSelf::deref(x);",
+    "self.deref();",
+    // Definitions of by-value releases, not calls.
+    "pub fn deref(self) {\n    dispatch!(self, (), |_T, ctx| ctx.deref())\n}",
+    "unsafe fn rc_deref(self, ctx: ()) {}",
     "FetchTasklet::deref_from_thread(task);",
     "let _js_ref = is_done.then(|| unsafe { ScopedRef::adopt(this) });",
     "drop(unsafe { ScopedRef::<FetchTasklet>::adopt(task.as_ptr()) });",


### PR DESCRIPTION
### Problem

- Every `fetch()` ends with one final progress hop on the JS thread. That hop releases the tasklet's JS-side ref, normally its last, so the release frees the tasklet. The release was made from inside a `&mut self` method, through a pointer spelled from the receiver.
- Freeing an allocation while a `&mut` parameter to it is still live is undefined behaviour under both of Rust's aliasing models, whether or not the reference is touched afterwards. A reduction of the shape fails under Miri with `Undefined Behavior: deallocation through <1642> at alloc786[0x0] is forbidden` (Tree Borrows) and `deallocating while item [Unique for <1663>] is strongly protected` (Stacked Borrows).
- The function that ends a streamed request body had the same shape. Its release is the last ref when the response finishes before the upload does, and it is reached both from the stream's completion promise and from the body sink.
- No crash is known from this today; the contract is what is wrong. The file's other releasing entry points already take a raw pointer for this reason.

### Fix

- Each JS-thread entry point that owns a ref now receives the raw allocation pointer, adopts the ref into a guard before any reference to the tasklet exists, and runs the old `&mut` body through a borrow scoped to that call. The guard releases when it drops, after the borrow is gone, so no reference is live at the free.
- The tasklet's raw release function is deleted, so a `&mut self` method on this type has nothing left to misuse. The HTTP thread's release stays, since it posts the free to the JS thread instead of freeing in place.
- The two pointers kept past the final hop for the body's later release (the sink's back-pointer and the promise context) are now made from the allocation pointer, not from the hop's borrow, because a pointer made from the borrow is dead by the time those releases run. Releases inside the hop's own frame still go through `self`; the hop's guard holds a ref throughout, so none of them can be the last.
- Behaviour is unchanged: releases move, none are added or removed, and each guard drops where the explicit release used to run. Making `&mut self` methods on this type safe to re-enter is out of scope (#31745). The same shape in other files is allowlisted by the new lint, per file at its exact count.
- Verification: the new source lint reports exactly the three sites on main and passes on this branch. The fetch suites, including streamed request bodies, pass on the ASAN build, and a script that streams uploads to a server which answers before the upload finishes (the ordering where the body release is the last ref) ran 20 rounds with GC between rounds without an ASAN report. The undefined behaviour itself is shown only by the standalone Miri reductions in the original below, not by a test in bun.

### Background

- `FetchTasklet` is the per-`fetch()` object shared by the HTTP thread and the JS thread. It is a heap allocation held by raw pointer with an intrusive refcount; the release that takes the count to zero frees it.
- A progress hop is a task the HTTP thread posts to the JS thread whenever a fetch makes progress. The final hop owns the JS-side ref taken when the fetch was created and is responsible for releasing it.
- Under Rust's aliasing models (Stacked Borrows and Tree Borrows, which `bun run rust:miri` checks), a reference passed as a function parameter is protected for the whole call: freeing its allocation during the call is undefined behaviour even if nothing reads it afterwards. A raw pointer parameter carries no such protection.
- Provenance: a raw pointer derived from a `&mut` borrow is only valid while that borrow is. Once the allocation is used through another path, releasing through the stale pointer is also undefined behaviour, so anything stored past the current frame must come from the original allocation pointer.
- `bun_ptr::ScopedRef::adopt` wraps a ref the caller already holds in a guard that releases it, through its own pointer, on drop. One other task arm in the dispatcher already releases this way.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-release.test.ts
bun test v1.4.0 (939b42e00)

test/internal/source-lints/self-receiver-release.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.20ms]
(pass) the patterns match the banned spellings and nothing else [16.71ms]
248 |   expect(banned.map(s => findReleases(s).length)).toEqual(banned.map(() => 1));
249 |   expect(allowed.map(s => findReleases(s).length)).toEqual(allowed.map(() => 0));
250 | });
251 | 
252 | test("refcount release through a pointer spelled from the receiver is banned", () => {
253 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/webcore/fetch/FetchTasklet.rs:937",
+   "src/runtime/webcore/fetch/FetchTasklet.rs:956",
+   "src/runtime/webcore/fetch/FetchTasklet.rs:2286",
+ ]

- Expected  - 1
+ Received  + 5

      at <anonymous> (/workspace/bun/test/internal/source-lints/self-receiver-release.test.ts:253:21)
(fail) refcount release through a pointer spelled from the receiver 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/internal/source-lints/self-receiver-release.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.12ms]
(pass) the patterns match the banned spellings and nothing else [0.40ms]
248 |   expect(banned.map(s => findReleases(s).length)).toEqual(banned.map(() => 1));
249 |   expect(allowed.map(s => findReleases(s).length)).toEqual(allowed.map(() => 0));
250 | });
251 | 
252 | test("refcount release through a pointer spelled from the receiver is banned", () => {
253 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/webcore/fetch/FetchTasklet.rs:937",
+   "src/runtime/webcore/fetch/FetchTasklet.rs:956",
+   "src/runtime/webcore/fetch/FetchTasklet.rs:2286",
+ ]

- Expected  - 1
+ Received  + 5

      at <anonymous> (/workspace/bun/test/internal/source-lints/self-receiver-release.test.ts:253:21)
(fail) refcount release through a pointer spelled from the receiver is banned [0.27ms]
(pass) allowlisted files still carry exactly their documented count [0.17ms]

 3 pass
 1 fail
 15 expect() calls
Ran 4 tests across 1 file. [4.92s]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-release.test.ts
bun test v1.4.0 (939b42e00)

test/internal/source-lints/self-receiver-release.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.19ms]
(pass) the patterns match the banned spellings and nothing else [17.31ms]
(pass) refcount release through a pointer spelled from the receiver is banned [1.27ms]
(pass) allowlisted files still carry exactly their documented count [5.97ms]

 4 pass
 0 fail
 15 expect() calls
Ran 4 tests across 1 file. [26.00s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1051ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_install v0.0.0 (/workspace/bun/src/install)
^[[1m^[[92m   Compiling^[[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
^[[1m^[[92m   Compiling^[[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
^[[1m^[[92m   Compiling^[[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
^[[1m^[[92m   Compiling^[[0m bun_patch_jsc v0.0.0 (/workspace/bun/src/patch_jsc)
^[[1m^[[92m   Compiling^[[0m bun_css_jsc v0.0.0 (/workspace/bun/src/css_jsc)
^[[1m^[[92m   Compiling^[[0m bun_semver_jsc v0.0.0 (/workspace/bun/src/semver_jsc)
^[[1m^[[92m   Compiling^[[0m bun_sys_jsc v0.0.0 (/workspace/bun/src/sys_jsc)
^[[1m^[[92m   Compiling^[[0m bun_sql_jsc v0.0.0 (/workspace/bun/src/sql_jsc)
^[[1m^[[92m   Compiling
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/dispatch.rs                            |   2 +-
 src/runtime/webcore.rs                             |   7 +-
 src/runtime/webcore/fetch/FetchRequestBodySink.rs  |  46 ++--
 src/runtime/webcore/fetch/FetchTasklet.rs          | 188 ++++++++-------
 .../source-lints/self-receiver-release.test.ts     | 262 +++++++++++++++++++++
 5 files changed, 397 insertions(+), 108 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/dispatch.rs                                       2      2      0
src/runtime/webcore.rs                                        1      1      0
src/runtime/webcore/fetch/FetchRequestBodySink.rs             6      7      0
src/runtime/webcore/fetch/FetchTasklet.rs                    31     43      0
test/internal/source-lints/self-receiver-release.test.ts      9     19      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

`FetchTasklet::on_progress_update(&mut self)` (src/runtime/webcore/fetch/FetchTasklet.rs) ended the final progress hop with

```rust
FetchTasklet::deref(std::ptr::from_mut(self));
```

That deref releases the JS-side ref taken in `get()`. `callback` on the HTTP thread derefs its own ref right after posting the final hop, so by the time the hop runs on the JS thread this is normally the tasklet's last ref: `deref` runs `deinit`, which `heap::take`s the box, while the `&mut self` argument (formed by `cast!(FetchTasklet)` in dispatch.rs) is still live. Every `fetch()` goes through this on its final hop.

Freeing an allocation while a reference argument to it is live is rejected by both aliasing models, independent of whether anything touches the reference afterwards. A standalone reduction of exactly this shape (a `&mut self` method whose trailing release drops the count to zero and frees the box) fails under Miri with Tree Borrows, the model `bun run rust:miri` uses, pointing at the receiver:

```
error: Undefined Behavior: deallocation through <1642> at alloc786[0x0] is forbidden
  = help: the allocation of the accessed tag <1642> also contains the strongly protected tag <1622>
  = help: the strongly protected tag <1622> disallows deallocations
help: the strongly protected tag <1622> was created here, in the initial state Reserved
   |     fn on_progress_update_before(&mut self) {
   |                                  ^^^^^^^^^
```

and under Stacked Borrows with `deallocating while item [Unique for <1663>] is strongly protected`. The same reduction with the release performed through the allocation pointer after the method returns passes under both. No crash is known from this today; it is the contract that is wrong, and it is the reason the file's other releasing entry points (`callback`, `resume_request_data_stream`, `deref_from_thread`) already take `*mut` and say so in their comments.

`write_end_request(&mut self, err)` had the same shape (`let this_ptr = ptr::from_mut(self); ... FetchTasklet::deref(this_ptr)` on four exits). Its release is the last ref when the response finishes before a streamed request body does: the final hop's cleanup cancels the sink and drops the JS-side ref, and the pump promise then settles into `on_resolve_request_stream` / `on_reject_request_stream`, which called `(*this).write_end_request(..)` through a `&mut` receiver. `FetchRequestBodySink::end_from_stream` reached it through `task.get_mut()` the same way (its own comment already noted the call may free the tasklet and the sink with it).

<details>
<summary>Reduction run under Miri</summary>

```rust
use std::sync::atomic::{AtomicU32, Ordering};

struct Tasklet { ref_count: AtomicU32, payload: u64 }

impl Tasklet {
    fn deref(this: *mut Tasklet) {
        if unsafe { (*this).ref_count.fetch_sub(1, Ordering::SeqCst) } == 1 {
            drop(unsafe { Box::from_raw(this) });
        }
    }
    // main
    fn on_progress_update_before(&mut self) {
        self.payload += 1;
        Tasklet::deref(std::ptr::from_mut(self));
    }
    // the shape this PR uses (ScopedRef's Drop is the `deref` call)
    fn on_progress_update_after(this: *mut Tasklet) {
        unsafe { &mut *this }.tick();
        Tasklet::deref(this);
    }
    fn tick(&mut self) { self.payload += 1; }
}

fn main() {
    let t = Box::into_raw(Box::new(Tasklet { ref_count: AtomicU32::new(1), payload: 0 }));
    if std::env::args().nth(1).as_deref() == Some("after") {
        Tasklet::on_progress_update_after(t);
    } else {
        unsafe { (*t).on_progress_update_before() };
    }
}
```

`MIRIFLAGS=-Zmiri-tree-borrows cargo miri run -- before` and the default (Stacked Borrows) run both report the errors quoted above; `-- after` exits 0 under both.

</details>

### Fix

The container that rules this out is `bun_ptr::ScopedRef` (already used this way by the `FileResponseStreamEof` arm in dispatch.rs): the entry point that owns a ref receives the allocation pointer, adopts the ref into a guard before any reference to the tasklet exists, and runs the `&mut` body through a call-scoped reborrow; the guard releases through its own pointer when it drops, after that borrow is gone. Every JS-thread release of a tasklet ref is now such a guard, and `FetchTasklet::deref`, the raw release a `&mut self` method could reach for, is deleted, so the file cannot express the bug any more. `deref_from_thread` stays: it is the HTTP thread's release, and it hops the destroy to the JS thread instead of freeing in place.

* `on_progress_update(this: *mut FetchTasklet)`: takes the mutex and reads `is_done` through `from_raw_ref`, adopts the JS-side ref when `is_done` (`Option<ScopedRef>`), and runs the former body as `on_progress_update_locked(&mut self, this, is_done)`. The two derefs inside the body (the script-forbidden exit and the `cleanup` closure) are gone; the deref was already the last thing every path did, so the order of operations is unchanged. The dispatch.rs arm passes `cast_ptr!(FetchTasklet)` instead of forming a `&mut`.
* `write_end_request(this: *mut FetchTasklet, err)`: adopts the `start_request_stream` ref and runs the former body as `end_request_body(&mut self, err)` (the four exit-site derefs collapse into the guard).
* The two pointers `start_request_stream` stores for the deferred releases, the sink's back-pointer and the promise ctx recovered by `on_resolve_request_stream` / `on_reject_request_stream`, are now made from the allocation pointer the hop passes down (`BackRef::from_raw_mut(this)`, `.then(.., this, ..)`) instead of from its own `&mut self`. Self-review of the first version caught this: a pointer made from the hop's borrow is dead by the time those releases run (every later access through the allocation pointer, including the hop's own release, invalidates it), so the last-ref release through it was rejected by both models even after the receiver fix. The second reduction below models exactly that and passes only with the allocation pointer stashed. The releases that happen inside the frame (`start_request_stream`'s six synchronous exits, `cancel_request_body_sink`) keep going through `self`: they run while the hop's guard still holds the JS-side ref, so they never free, and a pointer derived from the live borrow is the right one to use inside it. The ledger for that claim is in the comments below.
* `FetchRequestBodySink::end_from_stream` takes the sink pointer (as its sibling `NetworkSink::end_from_stream` already did; the `SinkHandle::end` arm passes `p.as_ptr()`), because the release it makes can free the tasklet and, through `clear_sink`, the sink itself. The JS-side `end()` calls the non-releasing helper directly and debug-asserts that there was nothing to release, since only JS-pump sinks have a JS object. `finalize` was converted the same way by #37716, which this branch is rebased on.
* `resume_request_data_stream`, `release_unrun` and the sink's `finalize` fallback adopt the ref they own the same way (the first loses the closure it used to reach a single trailing deref).

Behaviour is unchanged: the diff moves releases, it does not add or remove any, and the guards drop at exactly the points the explicit derefs used to run.

What this does not do: make `&mut self` methods of this type safe to re-enter (that is the `&self`/`Cell` conversion #31745 is pursuing for this type), or touch other types. The same shape exists elsewhere; see the lint's allowlist and scope note below.

<details>
<summary>Second reduction: the stashed pointer</summary>

```rust
use std::sync::atomic::{AtomicU32, Ordering};

struct Tasklet { ref_count: AtomicU32, aborted: bool, poll_ref: u32 }

struct Guard(*mut Tasklet); // ScopedRef, reduced
impl Drop for Guard {
    fn drop(&mut self) {
        if unsafe { (*self.0).ref_count.fetch_sub(1, Ordering::SeqCst) } == 1 {
            drop(unsafe { Box::from_raw(self.0) });
        }
    }
}

impl Tasklet {
    fn start_request_stream(&mut self, this: *mut Tasklet, stash_root: bool) -> *mut Tasklet {
        self.ref_count.fetch_add(1, Ordering::SeqCst);
        if stash_root { this } else { std::ptr::from_mut(self) }
    }
    fn on_progress_update(this: *mut Tasklet, stash_root: bool) -> *mut Tasklet {
        let _js_ref = Guard(this);
        let me = unsafe { &mut *this };
        let stash = me.start_request_stream(this, stash_root);
        me.poll_ref = 0;
        stash
    }
    fn write_end_request(this: *mut Tasklet) {
        let _body_ref = Guard(this);
        unsafe { &mut *this }.end_request_body();
    }
    fn end_request_body(&mut self) { self.aborted = true; }
}

fn main() {
    let stash_root = std::env::args().nth(1).as_deref() == Some("root");
    let t = Box::into_raw(Box::new(Tasklet { ref_count: AtomicU32::new(1), aborted: false, poll_ref: 1 }));
    let stash = Tasklet::on_progress_update(t, stash_root);
    Tasklet::write_end_request(stash); // the pump promise settling later
}
```

Stashing `from_mut(self)` (the first version of this PR, and what `main` does): Tree Borrows reports `reborrow through <tag> ... is forbidden ... has state Disabled ... due to a foreign write access`, Stacked Borrows reports `trying to retag from <tag> for Unique permission ... that tag does not exist in the borrow stack`. Stashing the allocation pointer (`-- root`): both exit 0.

</details>

### Tests

* `test/internal/source-lints/self-receiver-release.test.ts` bans a release (`deref` family or `ScopedRef::adopt`) applied to the receiver: spelled as a pointer inline (`deref(ptr::from_mut(x))`, `deref(ptr::from_ref(x).cast_mut())`, `deref_nn(NonNull::from(self))`, `self as *mut`, `&raw mut *self`, `ScopedRef::adopt(ptr::from_mut(self))`), passed as a bare `self` that the `*mut` parameter coerces (`deref(self)`, which the self-review found the first version missed, and which is how six live sites spell it), or stored in a local first and released later in the same function (including via `.as_ptr()`). Definitions such as `fn deref(self)` do not count. It checks its patterns against positive and negative examples and ratchets the remaining instances with their reason. Against `main` it reports exactly

  ```
  src/runtime/webcore/fetch/FetchTasklet.rs:937
  src/runtime/webcore/fetch/FetchTasklet.rs:956
  src/runtime/webcore/fetch/FetchTasklet.rs:2286
  ```

  and passes with this branch. Its header states what it does not see, most importantly `deref(self.as_ctx_ptr())`: that is the spelling bun_ptr's `AsCtxPtr` doc currently recommends and the one most R-2 wrappers (Subprocess, sockets, websocket_client, the SQL connections) use, so it is a decision about the idiom rather than a list of sites, and it has been handed off as such. The allowlist entries were each read. Non-final releases (another ref provably outlives the call): `html_rewriter.rs`, `node_zlib_binding.rs`, `js_valkey.rs`, `process.rs`, `PostgresSQLConnection.rs`, `PostgresSQLQuery.rs`, `h3_client/ClientSession.rs`, three of the four `static_pipe_writer.rs` sites. Real instances of this bug, allowlisted at their exact counts so they cannot multiply, each with its own fix in flight or tracked: `static_pipe_writer.rs` (`on_write`, #37755), `SubprocessPipeReader.rs` (`on_reader_done` / `on_reader_error`), `h2_client/ClientSession.rs` (`on_close`, whose `ref_scope` guard is the final release, and `maybe_release`), `ProxyTunnel.rs` (`detach_and_deref`). The FileSink entry from the first version is gone because #37716 landed. The sibling lints for the unconditional-teardown half of the class (`self-receiver-reclaim` from #37681; `destroy`/`deinit`/`finalize` in #37685, #37693, #37705) state that refcount releases are out of their scope, which is what this one covers.

### Verification

On the debug (ASAN) build, at the current head: test/js/web/fetch/{fetch-abort-stream-body,body,client-fetch,fetch-keepalive,fetch-http2-client,fetch-stream-cancel-leak,fetch-response-finalizer-sweep,exiting}.test.ts, test/js/bun/http/fetch-file-upload.test.ts, test/js/node/http/node-fetch.test.js, test/regression/issue/13696.test.ts and the `used as a request body` test in fetch.test.ts all pass (the one timeout seen was the ITER=100 ended-inline fixture finishing in 3.9 to 5.0 s in this container, where the debug binary's start-up alone is about 2.7 s of that). A script streaming a `Bun.file()` stream and an upstream response body into fetch, both against a server that reads the whole body and against one that answers before the upload finishes (the ordering where `write_end_request`'s release is the last ref, through both the promise handlers and `end_from_stream`), ran 20 rounds with a full GC between rounds without an ASAN report. Earlier heads additionally ran the broader fetch suites listed in the history of this description (fetch, fetch.stream, fetch-leak, fetch-backpressure, abort-signal-leak, fetch.tls and others), with only environment-specific failures. `bun test test/internal/source-lints/` (19 files) passes; `cargo clippy -p bun_runtime` and `cargo fmt --check` are clean.

</details>
