### PR TITLE
http: stop holding &mut HttpThread across code that re-borrows it through http_thread()

### DIFF
--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -770,17 +770,9 @@ impl<'a> AsyncHTTP<'a> {
                 // `ThreadlocalAsyncHTTP::new` (heap::alloc); recover the parent
                 // via field offset and reclaim the Box. This is the LAST access
                 // to `this`/`async_http`; only static state is touched afterward.
-                let threadlocal_http: *mut ThreadlocalAsyncHTTP =
+                let threadlocal_http: *mut ThreadlocalAsyncHTTP<'static> =
                     bun_core::from_field_ptr!(ThreadlocalAsyncHTTP, async_http, async_http);
-                {
-                    let in_flight = &mut crate::http_thread().in_flight;
-                    if let Some(i) = in_flight
-                        .iter()
-                        .position(|n| n.as_ptr() == threadlocal_http)
-                    {
-                        in_flight.swap_remove(i);
-                    }
-                }
+                crate::http_thread().remove_in_flight(threadlocal_http);
                 // Note: reclaiming as `Box<_>` here would drop the
                 // bitwise-shared fields enumerated above and double-free with
                 // the JS-thread original; deallocate the storage directly
@@ -795,13 +787,7 @@ impl<'a> AsyncHTTP<'a> {
             }
         }
 
-        let thread = crate::http_thread();
-        if (!thread.queued_tasks.is_empty() || !thread.deferred_tasks.is_empty())
-            && ACTIVE_REQUESTS_COUNT.load(Ordering::Relaxed)
-                < MAX_SIMULTANEOUS_REQUESTS.load(Ordering::Relaxed)
-        {
-            thread.wakeup();
-        }
+        crate::http_thread().wake_if_tasks_waiting();
     }
 }
 

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -475,8 +475,6 @@ impl<const SSL: bool> HTTPContext<SSL> {
         self.secure.unwrap()
     }
 
-    // `loop_` is a parameter because `init*` runs inside `&mut HttpThread`
-    // methods, which `http::http_thread()` would alias.
     pub(crate) fn init_with_client_config(
         &mut self,
         client: &mut HTTPClient,
@@ -494,6 +492,10 @@ impl<const SSL: bool> HTTPContext<SSL> {
         self.init_with_opts(&opts, loop_)
     }
 
+    // `loop_` is passed in rather than read from `http::http_thread()`: `init`
+    // and `init_with_thread_opts` run inside `&mut HttpThread` methods
+    // (`attach_loop`, `init_https_context`), which that borrow would alias.
+    // `init_with_client_config` (custom contexts) just shares the signature.
     fn init_with_opts(
         &mut self,
         opts: &uws::SocketContext::BunSocketContextOptions,

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -475,10 +475,8 @@ impl<const SSL: bool> HTTPContext<SSL> {
         self.secure.unwrap()
     }
 
-    // The `init*` family takes the uSockets loop as a parameter rather than
-    // reading it back out of `http::http_thread()`: the default contexts are
-    // initialized from inside `&mut HttpThread` methods (`attach_loop`,
-    // `init_https_context`), which a nested `http_thread()` borrow would alias.
+    // `loop_` is a parameter because `init*` runs inside `&mut HttpThread`
+    // methods, which `http::http_thread()` would alias.
     pub(crate) fn init_with_client_config(
         &mut self,
         client: &mut HTTPClient,

--- a/src/http/HTTPContext.rs
+++ b/src/http/HTTPContext.rs
@@ -475,9 +475,14 @@ impl<const SSL: bool> HTTPContext<SSL> {
         self.secure.unwrap()
     }
 
+    // The `init*` family takes the uSockets loop as a parameter rather than
+    // reading it back out of `http::http_thread()`: the default contexts are
+    // initialized from inside `&mut HttpThread` methods (`attach_loop`,
+    // `init_https_context`), which a nested `http_thread()` borrow would alias.
     pub(crate) fn init_with_client_config(
         &mut self,
         client: &mut HTTPClient,
+        loop_: *mut uws::Loop,
     ) -> Result<(), InitError> {
         // Rust cannot reject a const-generic bool branch at compile time on
         // stable, so this is a debug_assert.
@@ -488,12 +493,13 @@ impl<const SSL: bool> HTTPContext<SSL> {
             .unwrap()
             .get()
             .as_usockets_for_client_verification();
-        self.init_with_opts(&opts)
+        self.init_with_opts(&opts, loop_)
     }
 
     fn init_with_opts(
         &mut self,
         opts: &uws::SocketContext::BunSocketContextOptions,
+        loop_: *mut uws::Loop,
     ) -> Result<(), InitError> {
         debug_assert!(SSL, "ssl only");
         let mut err = uws::create_bun_socket_error_t::none;
@@ -516,14 +522,14 @@ impl<const SSL: bool> HTTPContext<SSL> {
         // SAFETY: secure was just set to Some.
         unsafe { ssl_ctx_setup(self.ssl_ctx()) };
         let owner_ptr = std::ptr::from_mut::<Self>(self).cast::<c_void>();
-        self.group
-            .init(http::http_thread().uws_loop(), None, owner_ptr);
+        self.group.init(loop_, None, owner_ptr);
         Ok(())
     }
 
     pub(crate) fn init_with_thread_opts(
         &mut self,
         init_opts: &HTTPThreadInitOpts,
+        loop_: *mut uws::Loop,
     ) -> Result<(), InitError> {
         debug_assert!(SSL, "ssl only");
         let opts = uws::SocketContext::BunSocketContextOptions {
@@ -541,13 +547,12 @@ impl<const SSL: bool> HTTPContext<SSL> {
             request_cert: 1,
             ..Default::default()
         };
-        self.init_with_opts(&opts)
+        self.init_with_opts(&opts, loop_)
     }
 
-    pub(crate) fn init(&mut self) {
+    pub(crate) fn init(&mut self, loop_: *mut uws::Loop) {
         let owner_ptr = std::ptr::from_mut::<Self>(self).cast::<c_void>();
-        self.group
-            .init(http::http_thread().uws_loop(), None, owner_ptr);
+        self.group.init(loop_, None, owner_ptr);
         if SSL {
             let mut err = uws::create_bun_socket_error_t::none;
             self.secure = Some(

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -32,19 +32,26 @@ struct SslContextCacheEntry {
     _config_ref: ssl_config::SharedPtr,
 }
 
+/// Upgrade a custom-SSL context pointer to `&mut` for one use.
+///
+/// INVARIANT: every `NonNull<NewHttpContext<true>>` reaching here is the
+/// pointer `connect` took from the `heap::release`d box before handing it to
+/// anyone (cache entry, `client.custom_ssl_ctx`); the cache holds one strong
+/// intrusive ref until eviction's `deref`, so the pointee is live. All access
+/// is HTTP-thread-only and every caller re-derives per use (the pointer is
+/// what gets stored; a `&mut` is never held across a call into the context),
+/// so the returned `&mut` is the sole live borrow for its scope.
+#[inline]
+fn custom_context_mut<'a>(ctx: NonNull<NewHttpContext<true>>) -> &'a mut NewHttpContext<true> {
+    // SAFETY: see INVARIANT above.
+    unsafe { &mut *ctx.as_ptr() }
+}
+
 impl SslContextCacheEntry {
-    /// Mutable access to the cached `NewHttpContext`.
-    ///
-    /// INVARIANT: `ctx` is set once at insert (in `connect`) to a fresh
-    /// `heap::release`-boxed `NewHttpContext` on which the cache holds one
-    /// strong intrusive ref; it stays live until eviction's `deref` drops it.
-    /// The map and all callers are HTTP-thread-only, so the returned `&mut`
-    /// is the sole live borrow. Centralises the `Option<NonNull>`-style
-    /// `(*entry.ctx.as_ptr()).…` raw deref repeated at every lookup.
+    /// Mutable access to the cached `NewHttpContext`; see [`custom_context_mut`].
     #[inline]
     fn ctx_mut<'a>(&self) -> &'a mut NewHttpContext<true> {
-        // SAFETY: see INVARIANT above.
-        unsafe { &mut *self.ctx.as_ptr() }
+        custom_context_mut(self.ctx)
     }
 
     /// Release the strong intrusive ref the cache holds on `ctx` (taken at
@@ -53,7 +60,7 @@ impl SslContextCacheEntry {
     /// `NewHttpContext::deref(entry.ctx.as_ptr())` open-coded at both eviction
     /// paths so the set-once `NonNull` is dereferenced in one place.
     fn release(self) {
-        // SAFETY: same INVARIANT as [`ctx_mut`] — `ctx` is a
+        // SAFETY: same INVARIANT as [`custom_context_mut`] — `ctx` is a
         // `heap::release`-boxed `NewHttpContext` on which the cache holds one
         // strong ref; this `deref` is its sole release.
         unsafe { NewHttpContext::<true>::deref(self.ctx.as_ptr()) };
@@ -139,12 +146,12 @@ pub struct HttpThread {
 
     /// Every `ThreadlocalAsyncHTTP` box currently in flight on this thread.
     /// Inserted by [`start_queued_task`] right after `heap::release`; removed
-    /// by `AsyncHTTP::on_async_http_callback_raw` immediately before its
-    /// `std::alloc::dealloc`. HTTP-thread-only. Exists so
+    /// by `AsyncHTTP::on_async_http_callback_raw` (via [`Self::remove_in_flight`])
+    /// immediately before its `std::alloc::dealloc`. HTTP-thread-only. Exists so
     /// [`shutdown_for_exit`] can reclaim each clone-owned box at process exit
     /// — the request socket never reaches a terminal state once the JS thread
     /// stops driving the world, so the box would otherwise strand.
-    pub(crate) in_flight: Vec<NonNull<crate::ThreadlocalAsyncHttp<'static>>>,
+    in_flight: Vec<NonNull<crate::ThreadlocalAsyncHttp<'static>>>,
 }
 
 impl HttpThread {
@@ -208,18 +215,6 @@ impl HeapRequestBodyBuffer {
     pub(crate) fn init() -> Box<Self> {
         bun_core::boxed_zeroed()
     }
-
-    pub(crate) fn put(mut self: Box<Self>) {
-        // SAFETY: HTTP-thread-only access to the global.
-        let thread = crate::http_thread_mut();
-        if thread.lazy_request_body_buffer.is_none() {
-            self.cursor = 0; // .reset()
-            thread.lazy_request_body_buffer = Some(self);
-        } else {
-            // This case hypothetically should never happen
-            drop(self);
-        }
-    }
 }
 
 pub enum RequestBodyBuffer {
@@ -233,7 +228,7 @@ impl Drop for RequestBodyBuffer {
     fn drop(&mut self) {
         if let Self::Heap(heap) = self {
             if let Some(h) = heap.take() {
-                h.put();
+                crate::http_thread().put_request_body_send_buffer(h);
             }
         }
     }
@@ -380,13 +375,6 @@ fn on_init_error_noop(err: InitError, opts: &InitOpts) -> ! {
 }
 
 impl HttpThread {
-    /// Raw uSockets loop for `SocketGroup::init`. Split from `loop_` so
-    /// HTTPContext doesn't need to name the higher-tier MiniEventLoop type.
-    #[inline]
-    pub(crate) fn uws_loop(&self) -> *mut uws::Loop {
-        self.uws_loop
-    }
-
     /// Mutable access to the live uSockets event loop.
     ///
     /// INVARIANT: `uws_loop` is set once in [`on_start`] (published via the
@@ -428,6 +416,34 @@ impl HttpThread {
         RequestBodyBuffer::Stack(Box::new([0u8; REQUEST_BODY_SEND_STACK_BUFFER_SIZE]))
     }
 
+    /// Park a heap buffer from [`Self::get_request_body_send_buffer`] for
+    /// reuse. One is kept; a second one (allocated while the parked one was
+    /// checked out by another request) is freed here.
+    fn put_request_body_send_buffer(&mut self, mut buffer: Box<HeapRequestBodyBuffer>) {
+        if self.lazy_request_body_buffer.is_none() {
+            buffer.cursor = 0;
+            self.lazy_request_body_buffer = Some(buffer);
+        }
+    }
+
+    /// Forget a clone `on_async_http_callback_raw` is about to deallocate.
+    pub(crate) fn remove_in_flight(&mut self, http: *mut crate::ThreadlocalAsyncHttp<'static>) {
+        if let Some(i) = self.in_flight.iter().position(|n| n.as_ptr() == http) {
+            self.in_flight.swap_remove(i);
+        }
+    }
+
+    /// A request just finished: if tasks are parked behind the concurrency
+    /// cap and a slot is now free, wake the loop so `drain_events` starts them.
+    pub(crate) fn wake_if_tasks_waiting(&self) {
+        if (!self.queued_tasks.is_empty() || !self.deferred_tasks.is_empty())
+            && ACTIVE_REQUESTS_COUNT.load(Ordering::Relaxed)
+                < MAX_SIMULTANEOUS_REQUESTS.load(Ordering::Relaxed)
+        {
+            self.wakeup();
+        }
+    }
+
     pub(crate) fn deflater(&mut self) -> &mut LibdeflateState {
         if self.lazy_libdeflater.is_none() {
             let decompressor = bun_libdeflate_sys::libdeflate::OwnedDecompressor::new()
@@ -440,16 +456,25 @@ impl HttpThread {
         self.lazy_libdeflater.as_deref_mut().unwrap()
     }
 
-    pub(crate) fn context<const IS_SSL: bool>(&mut self) -> &mut NewHttpContext<IS_SSL> {
-        // Note: const-generic dispatch over two distinct fields — `NewHttpContext<true>`
-        // and `NewHttpContext<IS_SSL>` are the same type when IS_SSL, just spelled
-        // differently. Route through a raw-pointer `.cast()` (identity).
+    /// `*mut` to the default `http_context` / `https_context`, projected
+    /// straight out of the `HTTP_THREAD` static without going through a
+    /// `&mut HttpThread`. It is therefore not tied to any `http_thread()`
+    /// borrow: request code keeps it across calls that re-enter the accessor
+    /// (`HTTPClient::get_ssl_ctx`, the proxy-tunnel callbacks), and
+    /// [`Self::connect`] drives the context through it so no `&mut
+    /// HttpThread` is live while the context runs client code. Upgrade per
+    /// use via `HTTPClient::ssl_ctx_mut`.
+    pub(crate) fn default_context_ptr<const IS_SSL: bool>() -> *mut NewHttpContext<IS_SSL> {
+        let thread = crate::http_thread_ptr();
+        // `NewHttpContext<true>` (resp. `<false>`) is `NewHttpContext<IS_SSL>`
+        // on the branch taken, so the `.cast()` is the identity.
         if IS_SSL {
-            // SAFETY: identical type when IS_SSL == true; pointer is to a live `&mut self` field.
-            unsafe { &mut *(&raw mut self.https_context).cast::<NewHttpContext<IS_SSL>>() }
+            // SAFETY: field projection of the initialized static; nothing is
+            // read and no reference is formed.
+            unsafe { &raw mut (*thread).https_context }.cast::<NewHttpContext<IS_SSL>>()
         } else {
-            // SAFETY: identical type when IS_SSL == false; pointer is to a live `&mut self` field.
-            unsafe { &mut *(&raw mut self.http_context).cast::<NewHttpContext<IS_SSL>>() }
+            // SAFETY: as above.
+            unsafe { &raw mut (*thread).http_context }.cast::<NewHttpContext<IS_SSL>>()
         }
     }
 
@@ -460,19 +485,30 @@ impl HttpThread {
     #[inline]
     fn ensure_https_context_init(&mut self) {
         if let Some(opts) = self.lazy_https_init.take() {
-            self.init_https_context_cold(&opts);
+            self.init_https_context(&opts);
         }
     }
 
+    /// Runs at most once per process: from [`Self::attach_loop`] when the user
+    /// supplied CA config, otherwise from the first `connect::<true>`.
     #[cold]
-    fn init_https_context_cold(&mut self, opts: &InitOpts) {
-        if let Err(err) = self.https_context.init_with_thread_opts(opts) {
+    fn init_https_context(&mut self, opts: &InitOpts) {
+        if let Err(err) = self
+            .https_context
+            .init_with_thread_opts(opts, self.uws_loop)
+        {
             (opts.on_init_error)(err, opts);
         }
     }
 
+    /// Not a method: `HTTPContext::connect` may complete the request
+    /// synchronously (pooled-socket reuse runs `on_open`, a failure runs the
+    /// result callback), and that client code borrows the thread again through
+    /// `crate::http_thread()`. A `&mut self` here would still be live (and, as
+    /// a function argument, protected) under those borrows, so the thread is
+    /// only borrowed a statement at a time and the default context is reached
+    /// through [`Self::default_context_ptr`].
     pub(crate) fn connect<const IS_SSL: bool>(
-        &mut self,
         client: &mut HttpClient,
     ) -> crate::Result<Option<crate::HTTPSocket<IS_SSL>>> {
         if IS_SSL {
@@ -480,8 +516,9 @@ impl HttpThread {
             // socket group now (deferred from `on_start`). Runs once; every
             // SSL request — including unix-socket and proxy paths below —
             // funnels through here before touching `https_context.{group,secure}`.
-            self.ensure_https_context_init();
+            crate::http_thread().ensure_https_context_init();
         }
+        let default_context = || HttpClient::ssl_ctx_mut(Self::default_context_ptr::<IS_SSL>());
         // Note: borrowck — `slice()` borrows `client`; capture into a
         // `bun_ptr::RawSlice` (encapsulated outlives-holder invariant) so the
         // borrow of `client` ends before we hand `&mut client` to
@@ -489,9 +526,7 @@ impl HttpThread {
         // `connect_socket` does not touch.
         let unix_path = bun_ptr::RawSlice::new(client.unix_socket_path.slice());
         if !unix_path.is_empty() {
-            return self
-                .context::<IS_SSL>()
-                .connect_socket(client, unix_path.slice());
+            return default_context().connect_socket(client, unix_path.slice());
         }
 
         if IS_SSL {
@@ -503,14 +538,16 @@ impl HttpThread {
                     break 'custom_ctx;
                 }
                 let requested_config: *const SSLConfig = tls.get();
+                let now = crate::http_thread().timer_read();
+                let uws_loop = crate::http_thread().uws_loop;
 
                 // Evict stale entries from the cache
-                self.evict_stale_ssl_contexts();
+                evict_stale_ssl_contexts(now);
 
                 // Look up by pointer equality (configs are interned)
                 if let Some(entry) = custom_ssl_context_map().get_mut(&requested_config) {
                     // Cache hit - reuse existing SSL context
-                    entry.last_used_ns = self.timer_read();
+                    entry.last_used_ns = now;
                     client.set_custom_ssl_ctx(entry.ctx);
                     let ctx = entry.ctx_mut();
                     // Keepalive is now supported for custom SSL contexts
@@ -524,28 +561,31 @@ impl HttpThread {
                     .map(|o| o.map(|s| s.cast_ssl::<IS_SSL>()));
                 }
 
-                // Cache miss - create new SSL context
-                let custom_context = bun_core::heap::release(Box::new(NewHttpContext::<true> {
-                    ref_count: Cell::new(1),
-                    pending_sockets: bun_collections::HiveArray::init(),
-                    group: uws::SocketGroup::default(),
-                    secure: None,
-                    active_h2_sessions: Vec::new(),
-                    pending_h2_connects: Vec::new(),
-                    session_cache: crate::session_cache::SessionCache::new(),
-                }));
-                if let Err(err) = custom_context.init_with_client_config(client) {
+                // Cache miss - create new SSL context. `ctx_nn` is the one
+                // pointer everything else is derived from: the cache entry
+                // and `client.custom_ssl_ctx` store it, and each use below
+                // re-derives a `&mut` from it (see `custom_context_mut`).
+                let ctx_nn =
+                    NonNull::from(bun_core::heap::release(Box::new(NewHttpContext::<true> {
+                        ref_count: Cell::new(1),
+                        pending_sockets: bun_collections::HiveArray::init(),
+                        group: uws::SocketGroup::default(),
+                        secure: None,
+                        active_h2_sessions: Vec::new(),
+                        pending_h2_connects: Vec::new(),
+                        session_cache: crate::session_cache::SessionCache::new(),
+                    })));
+                if let Err(err) =
+                    custom_context_mut(ctx_nn).init_with_client_config(client, uws_loop)
+                {
                     // `init_with_client_config` fails before `group.init()` runs.
                     // `impl Drop for HTTPContext` tolerates an
                     // uninitialized group (skips close_all/destroy when
                     // `group.loop_` is null), so reclaiming the Box is safe.
-                    // SAFETY: custom_context was just Box::leak'd above and
-                    // has refcount 1; reclaim and drop on error.
-                    drop(unsafe {
-                        bun_core::heap::take(std::ptr::from_mut::<NewHttpContext<true>>(
-                            custom_context,
-                        ))
-                    });
+                    // SAFETY: the box was released just above and nothing
+                    // else has seen `ctx_nn` yet (refcount still 1); reclaim
+                    // and drop it.
+                    drop(unsafe { bun_core::heap::take(ctx_nn.as_ptr()) });
 
                     return Err(match err {
                         InitError::InvalidCRL => crate::Error::InvalidCRL,
@@ -556,8 +596,6 @@ impl HttpThread {
                     });
                 }
 
-                let now = self.timer_read();
-                let ctx_nn = NonNull::from(&mut *custom_context);
                 let _ = custom_ssl_context_map().put(
                     requested_config,
                     SslContextCacheEntry {
@@ -574,6 +612,7 @@ impl HttpThread {
                 }
 
                 client.set_custom_ssl_ctx(ctx_nn);
+                let custom_context = custom_context_mut(ctx_nn);
                 // Keepalive is now supported for custom SSL contexts
                 let result = if let Some(url) = client.http_proxy.clone() {
                     if url.protocol.is_empty() || url.has_http_like_protocol() {
@@ -593,37 +632,21 @@ impl HttpThread {
             if !url.href.is_empty() {
                 // https://github.com/oven-sh/bun/issues/11343
                 if url.protocol.is_empty() || url.has_http_like_protocol() {
-                    return self.context::<IS_SSL>().connect(
-                        client,
-                        url.hostname,
-                        url.get_port_auto(),
-                    );
+                    return default_context().connect(client, url.hostname, url.get_port_auto());
                 }
                 return Err(crate::Error::UnsupportedProxyProtocol);
             }
         }
         let (hn, pt) = (client.url.hostname, client.url.get_port_auto());
-        self.context::<IS_SSL>().connect(client, hn, pt)
+        default_context().connect(client, hn, pt)
     }
 
-    /// Evict SSL context cache entries that haven't been used for ssl_context_cache_ttl_ns.
-    fn evict_stale_ssl_contexts(&mut self) {
-        let now = self.timer_read();
-        let map = custom_ssl_context_map();
-        let mut i: usize = 0;
-        while i < map.count() {
-            let entry_last_used = map.values()[i].last_used_ns;
-            if now.saturating_sub(entry_last_used) > SSL_CONTEXT_CACHE_TTL_NS {
-                let (_k, entry) = map.swap_remove_at(i);
-                entry.release();
-            } else {
-                i += 1;
-            }
-        }
-    }
-
-    fn abort_pending_h2_waiter(&mut self, async_http_id: u32) -> bool {
-        if self.https_context.abort_pending_h2_waiter(async_http_id) {
+    /// Not a method for the same reason as [`Self::connect`]: failing the
+    /// waiter runs its result callback.
+    fn abort_pending_h2_waiter(async_http_id: u32) -> bool {
+        if HttpClient::ssl_ctx_mut(Self::default_context_ptr::<true>())
+            .abort_pending_h2_waiter(async_http_id)
+        {
             return true;
         }
         for entry in custom_ssl_context_map().values_mut() {
@@ -634,14 +657,31 @@ impl HttpThread {
         false
     }
 
-    fn drain_queued_shutdowns(&mut self) {
+    /// Swap one of the JS-thread-fed queues out from under its lock. The
+    /// drain loops below own the returned `Vec`, so they hold no borrow of
+    /// the thread while the request code they dispatch to re-enters
+    /// [`crate::http_thread()`].
+    fn take_queued<T>(
+        &mut self,
+        select: impl FnOnce(&mut Self) -> (&Mutex, &mut Vec<T>),
+    ) -> Vec<T> {
+        let (lock, queue) = select(self);
+        let _guard = lock.lock_guard();
+        core::mem::take(queue)
+    }
+
+    // The `drain_*` functions below have no `self` for the same reason as
+    // `connect`: they dispatch into clients and sessions, which borrow the
+    // thread again through `crate::http_thread()`. Every access here is a
+    // fresh statement-scoped borrow instead.
+
+    fn drain_queued_shutdowns() {
         loop {
             // socket.close() can potentially be slow
             // Let's not block other threads while this runs.
-            let queued_shutdowns = {
-                let _guard = self.queued_shutdowns_lock.lock_guard();
-                core::mem::take(&mut self.queued_shutdowns)
-            };
+            let queued_shutdowns = crate::http_thread().take_queued(|thread| {
+                (&thread.queued_shutdowns_lock, &mut thread.queued_shutdowns)
+            });
 
             for http in &queued_shutdowns {
                 let tracker = abort_tracker();
@@ -682,7 +722,7 @@ impl HttpThread {
                     // leader's in-flight h2 TLS connect (parked in `pc.waiters`
                     // with no abort-tracker entry); scan those first so the abort
                     // doesn't wait for the leader's connect to resolve.
-                    if self.abort_pending_h2_waiter(http.async_http_id) {
+                    if Self::abort_pending_h2_waiter(http.async_http_id) {
                         continue;
                     }
                     // Or it's on an HTTP/3 session, which has no TCP socket to
@@ -695,7 +735,7 @@ impl HttpThread {
                     // Flag it so `drainEvents` knows to scan the queue for
                     // aborted-but-unstarted tasks even when `active >= max`
                     // would otherwise short-circuit.
-                    self.has_pending_queued_abort = true;
+                    crate::http_thread().has_pending_queued_abort = true;
                 }
             }
             let len = queued_shutdowns.len();
@@ -707,12 +747,10 @@ impl HttpThread {
         }
     }
 
-    fn drain_queued_writes(&mut self) {
+    fn drain_queued_writes() {
         loop {
-            let queued_writes = {
-                let _guard = self.queued_writes_lock.lock_guard();
-                core::mem::take(&mut self.queued_writes)
-            };
+            let queued_writes = crate::http_thread()
+                .take_queued(|thread| (&thread.queued_writes_lock, &mut thread.queued_writes));
             for write in &queued_writes {
                 let message = write.kind;
                 let ended = message == WriteMessageType::End;
@@ -767,12 +805,14 @@ impl HttpThread {
         }
     }
 
-    fn drain_queued_cert_check_resumes(&mut self) {
+    fn drain_queued_cert_check_resumes() {
         loop {
-            let queued_cert_check_resumes = {
-                let _guard = self.queued_cert_check_resumes_lock.lock_guard();
-                core::mem::take(&mut self.queued_cert_check_resumes)
-            };
+            let queued_cert_check_resumes = crate::http_thread().take_queued(|thread| {
+                (
+                    &thread.queued_cert_check_resumes_lock,
+                    &mut thread.queued_cert_check_resumes,
+                )
+            });
             for resume in &queued_cert_check_resumes {
                 // Both arms are required: an HTTPS target behind a plaintext
                 // proxy parks behind a SocketTcp tracker entry.
@@ -812,12 +852,14 @@ impl HttpThread {
         }
     }
 
-    fn drain_queued_receive_resumes(&mut self) {
+    fn drain_queued_receive_resumes() {
         loop {
-            let queued = {
-                let _guard = self.queued_receive_resumes_lock.lock_guard();
-                core::mem::take(&mut self.queued_receive_resumes)
-            };
+            let queued = crate::http_thread().take_queued(|thread| {
+                (
+                    &thread.queued_receive_resumes_lock,
+                    &mut thread.queued_receive_resumes,
+                )
+            });
             if queued.is_empty() {
                 return;
             }
@@ -856,22 +898,21 @@ impl HttpThread {
         }
     }
 
-    pub(crate) fn drain_events(&mut self) {
+    fn drain_events() {
         // Process any pending writes **before** aborting.
-        self.drain_queued_receive_resumes();
-        self.drain_queued_writes();
-        self.drain_queued_shutdowns();
+        Self::drain_queued_receive_resumes();
+        Self::drain_queued_writes();
+        Self::drain_queued_shutdowns();
         // After shutdowns: an abort or cert-rejection scheduled in the same JS
         // turn removes the abort-tracker entry first, so the resume becomes a
         // no-op and the request is never transmitted after a same-tick abort.
-        self.drain_queued_cert_check_resumes();
+        Self::drain_queued_cert_check_resumes();
         h3::PendingConnect::drain_resolved();
 
-        for http in self.queued_threadlocal_proxy_derefs.drain(..) {
+        for http in core::mem::take(&mut crate::http_thread().queued_threadlocal_proxy_derefs) {
             // SAFETY: pointer was queued by schedule_proxy_deref on this thread; still live.
             unsafe { ProxyTunnel::deref(http) };
         }
-        // .clearRetainingCapacity() — drain(..) above already cleared while keeping capacity.
 
         let mut count: usize = 0;
         let mut active = ACTIVE_REQUESTS_COUNT.load(Ordering::Relaxed);
@@ -882,8 +923,11 @@ impl HttpThread {
         // which we just drained — `drainQueuedShutdowns` sets
         // `has_pending_queued_abort` for any id it couldn't find in the socket
         // tracker. If that's clear, there's nothing to fail-fast and nothing can
-        // start, so don't walk the lists.
-        if active >= max && !self.has_pending_queued_abort {
+        // start, so don't walk the lists. (The flag is consumed here either
+        // way; when we return early it was already clear.)
+        let has_pending_queued_abort =
+            core::mem::take(&mut crate::http_thread().has_pending_queued_abort);
+        if active >= max && !has_pending_queued_abort {
             return;
         }
 
@@ -907,31 +951,27 @@ impl HttpThread {
         // out before iterating so the field reflects only tasks still waiting, and
         // reload `active` from the atomic after every start rather than tracking
         // it locally.
-        self.has_pending_queued_abort = false;
-        {
-            let pending = core::mem::take(&mut self.deferred_tasks);
-            for http in pending {
-                // AsyncHttp is heap-owned by the caller and alive until its
-                // completion callback; while parked in `deferred_tasks` no other
-                // borrow exists, so a transient `ParentRef` shared deref is sound.
-                let aborted = bun_ptr::ParentRef::from(http)
-                    .client
-                    .signals
-                    .get(crate::signals::Field::Aborted);
-                if aborted || active < max {
-                    start_queued_task(http.as_ptr(), &mut self.in_flight);
-                    if cfg!(debug_assertions) {
-                        count += 1;
-                    }
-                    active = ACTIVE_REQUESTS_COUNT.load(Ordering::Relaxed);
-                } else {
-                    self.deferred_tasks.push(http);
+        for http in core::mem::take(&mut crate::http_thread().deferred_tasks) {
+            // AsyncHttp is heap-owned by the caller and alive until its
+            // completion callback; while parked in `deferred_tasks` no other
+            // borrow exists, so a transient `ParentRef` shared deref is sound.
+            let aborted = bun_ptr::ParentRef::from(http)
+                .client
+                .signals
+                .get(crate::signals::Field::Aborted);
+            if aborted || active < max {
+                start_queued_task(http.as_ptr());
+                if cfg!(debug_assertions) {
+                    count += 1;
                 }
+                active = ACTIVE_REQUESTS_COUNT.load(Ordering::Relaxed);
+            } else {
+                crate::http_thread().deferred_tasks.push(http);
             }
         }
 
         loop {
-            let Some(http) = NonNull::new(self.queued_tasks.pop()) else {
+            let Some(http) = NonNull::new(crate::http_thread().queued_tasks.pop()) else {
                 break;
             };
             // AsyncHttp is heap-owned by the caller and alive until its
@@ -945,10 +985,10 @@ impl HttpThread {
                 // Can't start this one yet. Defer it (preserves FIFO relative to
                 // later pops) and keep draining — there may be aborted tasks
                 // behind it that we can fail-fast right now.
-                self.deferred_tasks.push(http);
+                crate::http_thread().deferred_tasks.push(http);
                 continue;
             }
-            start_queued_task(http.as_ptr(), &mut self.in_flight);
+            start_queued_task(http.as_ptr());
             if cfg!(debug_assertions) {
                 count += 1;
             }
@@ -1151,6 +1191,22 @@ impl HttpThread {
     }
 }
 
+/// Evict SSL context cache entries that haven't been used for
+/// [`SSL_CONTEXT_CACHE_TTL_NS`]. `now` is a [`HttpThread::timer_read`].
+fn evict_stale_ssl_contexts(now: u64) {
+    let map = custom_ssl_context_map();
+    let mut i: usize = 0;
+    while i < map.count() {
+        let entry_last_used = map.values()[i].last_used_ns;
+        if now.saturating_sub(entry_last_used) > SSL_CONTEXT_CACHE_TTL_NS {
+            let (_k, entry) = map.swap_remove_at(i);
+            entry.release();
+        } else {
+            i += 1;
+        }
+    }
+}
+
 /// Evict the least-recently-used SSL context cache entry.
 fn evict_oldest_ssl_context() {
     let map = custom_ssl_context_map();
@@ -1169,10 +1225,7 @@ fn evict_oldest_ssl_context() {
     entry.release();
 }
 
-fn start_queued_task(
-    http: *mut AsyncHttp,
-    in_flight: &mut Vec<NonNull<crate::ThreadlocalAsyncHttp<'static>>>,
-) {
+fn start_queued_task(http: *mut AsyncHttp) {
     // SAFETY: http points to a live AsyncHttp queued by the caller thread.
     let cloned = crate::ThreadlocalAsyncHttp::new(unsafe { core::ptr::read(http) });
     // Note: AsyncHttp is byte-copied here
@@ -1184,7 +1237,12 @@ fn start_queued_task(
     // reborrow would be frozen by the first of them.
     let cloned_ptr = bun_core::heap::into_raw(cloned);
     let cloned_nn = NonNull::new(cloned_ptr).expect("freshly leaked Box is non-null");
-    in_flight.push(cloned_nn.cast::<crate::ThreadlocalAsyncHttp<'static>>());
+    // Statement-scoped `http_thread()` borrow: `on_start` below runs the
+    // request, which re-enters the accessor (and, on a synchronous failure,
+    // removes this very entry again).
+    crate::http_thread()
+        .in_flight
+        .push(cloned_nn.cast::<crate::ThreadlocalAsyncHttp<'static>>());
     // SAFETY: freshly leaked; this thread is its sole owner until the request
     // completes and `in_flight` gives the pointer back.
     let cloned = unsafe { &mut *cloned_ptr };
@@ -1255,8 +1313,8 @@ mod _event_loop_draft {
     fn init_once(opts: &InitOpts) {
         // Initialize the global (with timer
         // started on the calling thread) BEFORE spawning, so `on_start`'s
-        // `crate::http_thread_mut()` finds `Some(..)` and can fill in
-        // `loop_`/`uws_loop`/contexts.
+        // `crate::http_thread()` finds it initialized and `attach_loop` can
+        // fill in `loop_`/`uws_loop`/contexts.
         // SAFETY: `init_once` runs under `Once`; no other thread reads
         // `HTTP_THREAD` until `has_awoken` is set in `on_start`.
         unsafe {
@@ -1324,42 +1382,59 @@ mod _event_loop_draft {
             }
         }
 
-        let thread = crate::http_thread_mut();
-        thread.loop_ = loop_;
-        thread.uws_loop = uws_loop;
-        thread.http_context.init();
-        // `https_context.init_with_thread_opts` eagerly builds the BoringSSL
-        // `SSL_CTX` and parses the bundled root-CA store
-        // (`us_get_default_ca_store`, root_certs.cpp:210), costing ~0.7 ms CPU
-        // and ~400 KB heap whether or not an HTTPS request ever happens. When
-        // there is no user-supplied CA config we stash `opts` and let the first
-        // `connect::<true>` call run it (see `HttpThread::lazy_https_init`) — a
-        // fully-cached `bun install` (which makes zero network requests) then
-        // skips the cost entirely.
-        if !opts.abs_ca_file_name.is_empty() || !opts.ca.is_empty() {
-            // User passed --cafile / --ca: validate now so a bad CA file fails
-            // the process at thread start (test contract:
-            // bun-install-registry.test.ts "non-existent --cafile" /
-            // "invalid cafile"), even if the registry is plain HTTP and no SSL
-            // connect would ever happen.
-            if let Err(err) = thread.https_context.init_with_thread_opts(&opts) {
-                (opts.on_init_error)(err, &opts);
-            }
-        } else {
-            // No CA config — safe to defer the ~0.7 ms / ~400 KB root-cert
-            // parse to the first SSL connect (warm-cache `bun install` makes
-            // none).
-            thread.lazy_https_init = Some(opts);
-        }
-        // Release: publishes `uws_loop`/`loop_` to cross-thread `wakeup()`
-        // readers (which Acquire-load `has_awoken`).
-        thread.has_awoken.store(true, Ordering::Release);
-        thread.process_events();
+        crate::http_thread().attach_loop(loop_, uws_loop, opts);
+        HttpThread::process_events()
     }
 
     impl HttpThread {
-        fn process_events(&mut self) -> ! {
-            let uws_loop = self.uws_loop_mut();
+        /// Bind the singleton to this thread's loop and bring up the
+        /// contexts. Nothing in here reaches back into `crate::http_thread()`
+        /// (the contexts take the loop as a parameter), which is what makes
+        /// holding `&mut self` across it sound; once requests run that stops
+        /// being true, so [`Self::process_events`] has no `self`.
+        fn attach_loop(
+            &mut self,
+            loop_: *const MiniEventLoop,
+            uws_loop: *mut uws::Loop,
+            opts: InitOpts,
+        ) {
+            self.loop_ = loop_;
+            self.uws_loop = uws_loop;
+            self.http_context.init(uws_loop);
+            // `https_context.init_with_thread_opts` eagerly builds the BoringSSL
+            // `SSL_CTX` and parses the bundled root-CA store
+            // (`us_get_default_ca_store`, root_certs.cpp:210), costing ~0.7 ms CPU
+            // and ~400 KB heap whether or not an HTTPS request ever happens. When
+            // there is no user-supplied CA config we stash `opts` and let the first
+            // `connect::<true>` call run it (see `HttpThread::lazy_https_init`) — a
+            // fully-cached `bun install` (which makes zero network requests) then
+            // skips the cost entirely.
+            if !opts.abs_ca_file_name.is_empty() || !opts.ca.is_empty() {
+                // User passed --cafile / --ca: validate now so a bad CA file fails
+                // the process at thread start (test contract:
+                // bun-install-registry.test.ts "non-existent --cafile" /
+                // "invalid cafile"), even if the registry is plain HTTP and no SSL
+                // connect would ever happen.
+                self.init_https_context(&opts);
+            } else {
+                // No CA config — safe to defer the ~0.7 ms / ~400 KB root-cert
+                // parse to the first SSL connect (warm-cache `bun install` makes
+                // none).
+                self.lazy_https_init = Some(opts);
+            }
+            // Release: publishes `uws_loop`/`loop_` to cross-thread `wakeup()`
+            // readers (which Acquire-load `has_awoken`).
+            self.has_awoken.store(true, Ordering::Release);
+        }
+
+        /// The thread's main loop. Every step (draining the queues, the tick)
+        /// runs request code that borrows the singleton through
+        /// `crate::http_thread()`, so this holds no `&mut HttpThread` of its
+        /// own: each access is a fresh statement-scoped borrow. The `&mut
+        /// uws::Loop`s below point into the loop's own allocation, not into
+        /// `HttpThread`, so they are unaffected.
+        fn process_events() -> ! {
+            let uws_loop = crate::http_thread().uws_loop_mut();
             #[cfg(unix)]
             {
                 uws_loop.num_polls = uws_loop.num_polls.max(2);
@@ -1371,7 +1446,7 @@ mod _event_loop_draft {
 
             loop {
                 if SHUTDOWN_REQUESTED.load(Ordering::Acquire) {
-                    self.dealloc_in_flight_for_exit();
+                    crate::http_thread().dealloc_in_flight_for_exit();
                     {
                         let mut done = SHUTDOWN_DONE.0.lock();
                         *done = true;
@@ -1384,23 +1459,24 @@ mod _event_loop_draft {
                         std::thread::park();
                     }
                 }
-                self.drain_events();
+                Self::drain_events();
                 assert_abort_tracker_sockets_alive();
                 Output::flush();
 
-                let uws_loop = self.uws_loop_mut();
+                let uws_loop = crate::http_thread().uws_loop_mut();
                 uws_loop.inc();
                 uws_loop.tick();
                 uws_loop.dec();
                 // Run the deferred-free thunk (`Store::process_deferred_frees`)
                 // like `MiniEventLoop::tick_once` does after its raw tick; the
                 // FilePoll hive slots freed during this tick are reclaimed here.
+                let mini_loop = crate::http_thread().loop_;
                 // SAFETY: `loop_` was born `*mut` (`init_global`), so `cast_mut`
                 // keeps its provenance; it is HTTP-thread-only and disjoint from
                 // the C `us_loop_t` behind `uws_loop`, and no other `&`/`&mut`
                 // to this `MiniEventLoop` is live here (`uws_loop` re-derived
                 // per iteration, last used above).
-                unsafe { (*self.loop_.cast_mut()).on_after_event_loop() };
+                unsafe { (*mini_loop.cast_mut()).on_after_event_loop() };
                 assert_abort_tracker_sockets_alive();
 
                 if cfg!(debug_assertions) {

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -1508,8 +1508,9 @@ pub fn shutdown_for_exit() -> bool {
     // SAFETY: `HTTP_THREAD_INIT == true` ⇒ `HTTP_THREAD` is fully written.
     // `get_unchecked` so the `ThreadCell` owner assert is skipped on this
     // cross-thread caller; `ParentRef` so only a shared `&HttpThread` is
-    // materialised — `process_events(&mut self)` is live on the HTTP thread,
-    // so a `&mut` here would alias. Same shape as `schedule()` above.
+    // materialised — the HTTP thread is forming `&mut HttpThread`s through
+    // `http_thread()` the whole time (`process_events`), so a `&mut` here
+    // would alias them. Same shape as `schedule()` above.
     let thread = unsafe {
         bun_ptr::ParentRef::<HttpThread>::from_raw(
             (*crate::HTTP_THREAD.get_unchecked()).as_mut_ptr(),

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -106,8 +106,9 @@ pub struct HttpThread {
     /// entirely. If `--cafile` / `--ca` *was* passed, `on_start` still runs
     /// init eagerly so a bad CA file crashes at thread start (the long-standing
     /// test contract) and this stays `None`. HTTP-thread-only after `on_start`;
-    /// `Option::take` is the once-guard (no atomics needed — `connect` is never
-    /// reentrant).
+    /// `Option::take` is the once-guard: `ensure_https_context_init` runs no
+    /// request code, so it has returned (leaving `None`) before
+    /// `HTTPContext::connect` can re-enter `connect` (h2 coalescing retries do).
     lazy_https_init: Option<InitOpts>,
 
     pub(crate) queued_tasks: Queue,
@@ -469,10 +470,10 @@ impl HttpThread {
         }
     }
 
-    /// One-shot lazy init of the default HTTPS context. See
-    /// [`HttpThread::lazy_https_init`] for rationale. Called on the HTTP
-    /// thread from [`HttpThread::connect`]`::<true>` only; the `Option::take`
-    /// is the once-guard. On failure, `on_init_error` diverges.
+    /// One-shot lazy init of the default HTTPS context; see
+    /// [`HttpThread::lazy_https_init`]. Must stay free of request code:
+    /// `connect` calls it through `http_thread()`. On failure, `on_init_error`
+    /// diverges.
     #[inline]
     fn ensure_https_context_init(&mut self) {
         if let Some(opts) = self.lazy_https_init.take() {

--- a/src/http/HTTPThread.rs
+++ b/src/http/HTTPThread.rs
@@ -34,13 +34,10 @@ struct SslContextCacheEntry {
 
 /// Upgrade a custom-SSL context pointer to `&mut` for one use.
 ///
-/// INVARIANT: every `NonNull<NewHttpContext<true>>` reaching here is the
-/// pointer `connect` took from the `heap::release`d box before handing it to
-/// anyone (cache entry, `client.custom_ssl_ctx`); the cache holds one strong
-/// intrusive ref until eviction's `deref`, so the pointee is live. All access
-/// is HTTP-thread-only and every caller re-derives per use (the pointer is
-/// what gets stored; a `&mut` is never held across a call into the context),
-/// so the returned `&mut` is the sole live borrow for its scope.
+/// INVARIANT: `ctx` is the pointer `connect` took from the `heap::release`d
+/// box; the cache holds a strong ref on it until eviction, all access is
+/// HTTP-thread-only, and callers re-derive per use instead of holding the
+/// result across a call into the context.
 #[inline]
 fn custom_context_mut<'a>(ctx: NonNull<NewHttpContext<true>>) -> &'a mut NewHttpContext<true> {
     // SAFETY: see INVARIANT above.
@@ -416,9 +413,8 @@ impl HttpThread {
         RequestBodyBuffer::Stack(Box::new([0u8; REQUEST_BODY_SEND_STACK_BUFFER_SIZE]))
     }
 
-    /// Park a heap buffer from [`Self::get_request_body_send_buffer`] for
-    /// reuse. One is kept; a second one (allocated while the parked one was
-    /// checked out by another request) is freed here.
+    /// Keeps one buffer for reuse; a second one (allocated while it was checked
+    /// out) is freed.
     fn put_request_body_send_buffer(&mut self, mut buffer: Box<HeapRequestBodyBuffer>) {
         if self.lazy_request_body_buffer.is_none() {
             buffer.cursor = 0;
@@ -433,8 +429,8 @@ impl HttpThread {
         }
     }
 
-    /// A request just finished: if tasks are parked behind the concurrency
-    /// cap and a slot is now free, wake the loop so `drain_events` starts them.
+    /// Called when a request finishes: a task parked behind the concurrency
+    /// cap can start now.
     pub(crate) fn wake_if_tasks_waiting(&self) {
         if (!self.queued_tasks.is_empty() || !self.deferred_tasks.is_empty())
             && ACTIVE_REQUESTS_COUNT.load(Ordering::Relaxed)
@@ -456,18 +452,13 @@ impl HttpThread {
         self.lazy_libdeflater.as_deref_mut().unwrap()
     }
 
-    /// `*mut` to the default `http_context` / `https_context`, projected
-    /// straight out of the `HTTP_THREAD` static without going through a
-    /// `&mut HttpThread`. It is therefore not tied to any `http_thread()`
-    /// borrow: request code keeps it across calls that re-enter the accessor
-    /// (`HTTPClient::get_ssl_ctx`, the proxy-tunnel callbacks), and
-    /// [`Self::connect`] drives the context through it so no `&mut
-    /// HttpThread` is live while the context runs client code. Upgrade per
-    /// use via `HTTPClient::ssl_ctx_mut`.
+    /// The default context for `IS_SSL`, projected out of the static rather
+    /// than out of an `http_thread()` borrow, so holders (`get_ssl_ctx`
+    /// callers, the proxy tunnel) may keep it across request code. Upgrade
+    /// per use with `HTTPClient::ssl_ctx_mut`.
     pub(crate) fn default_context_ptr<const IS_SSL: bool>() -> *mut NewHttpContext<IS_SSL> {
         let thread = crate::http_thread_ptr();
-        // `NewHttpContext<true>` (resp. `<false>`) is `NewHttpContext<IS_SSL>`
-        // on the branch taken, so the `.cast()` is the identity.
+        // The `.cast()` is the identity: the field picked has type `NewHttpContext<IS_SSL>`.
         if IS_SSL {
             // SAFETY: field projection of the initialized static; nothing is
             // read and no reference is formed.
@@ -489,8 +480,7 @@ impl HttpThread {
         }
     }
 
-    /// Runs at most once per process: from [`Self::attach_loop`] when the user
-    /// supplied CA config, otherwise from the first `connect::<true>`.
+    /// Runs once: from `attach_loop` with user CA config, else from the first `connect::<true>`.
     #[cold]
     fn init_https_context(&mut self, opts: &InitOpts) {
         if let Err(err) = self
@@ -501,13 +491,9 @@ impl HttpThread {
         }
     }
 
-    /// Not a method: `HTTPContext::connect` may complete the request
-    /// synchronously (pooled-socket reuse runs `on_open`, a failure runs the
-    /// result callback), and that client code borrows the thread again through
-    /// `crate::http_thread()`. A `&mut self` here would still be live (and, as
-    /// a function argument, protected) under those borrows, so the thread is
-    /// only borrowed a statement at a time and the default context is reached
-    /// through [`Self::default_context_ptr`].
+    /// Not a method: `HTTPContext::connect` can run the request's client code
+    /// synchronously (pooled reuse, immediate failure), which borrows the thread
+    /// again through [`crate::http_thread()`].
     pub(crate) fn connect<const IS_SSL: bool>(
         client: &mut HttpClient,
     ) -> crate::Result<Option<crate::HTTPSocket<IS_SSL>>> {
@@ -561,10 +547,8 @@ impl HttpThread {
                     .map(|o| o.map(|s| s.cast_ssl::<IS_SSL>()));
                 }
 
-                // Cache miss - create new SSL context. `ctx_nn` is the one
-                // pointer everything else is derived from: the cache entry
-                // and `client.custom_ssl_ctx` store it, and each use below
-                // re-derives a `&mut` from it (see `custom_context_mut`).
+                // Cache miss - create new SSL context. Everything below goes
+                // through `ctx_nn` (see `custom_context_mut`).
                 let ctx_nn =
                     NonNull::from(bun_core::heap::release(Box::new(NewHttpContext::<true> {
                         ref_count: Cell::new(1),
@@ -582,9 +566,7 @@ impl HttpThread {
                     // `impl Drop for HTTPContext` tolerates an
                     // uninitialized group (skips close_all/destroy when
                     // `group.loop_` is null), so reclaiming the Box is safe.
-                    // SAFETY: the box was released just above and nothing
-                    // else has seen `ctx_nn` yet (refcount still 1); reclaim
-                    // and drop it.
+                    // SAFETY: released just above and not yet shared with anyone.
                     drop(unsafe { bun_core::heap::take(ctx_nn.as_ptr()) });
 
                     return Err(match err {
@@ -641,8 +623,7 @@ impl HttpThread {
         default_context().connect(client, hn, pt)
     }
 
-    /// Not a method for the same reason as [`Self::connect`]: failing the
-    /// waiter runs its result callback.
+    /// Not a method (as [`Self::connect`]): failing the waiter runs its result callback.
     fn abort_pending_h2_waiter(async_http_id: u32) -> bool {
         if HttpClient::ssl_ctx_mut(Self::default_context_ptr::<true>())
             .abort_pending_h2_waiter(async_http_id)
@@ -657,10 +638,7 @@ impl HttpThread {
         false
     }
 
-    /// Swap one of the JS-thread-fed queues out from under its lock. The
-    /// drain loops below own the returned `Vec`, so they hold no borrow of
-    /// the thread while the request code they dispatch to re-enters
-    /// [`crate::http_thread()`].
+    /// Swap a JS-thread-fed queue out from under its lock.
     fn take_queued<T>(
         &mut self,
         select: impl FnOnce(&mut Self) -> (&Mutex, &mut Vec<T>),
@@ -670,10 +648,8 @@ impl HttpThread {
         core::mem::take(queue)
     }
 
-    // The `drain_*` functions below have no `self` for the same reason as
-    // `connect`: they dispatch into clients and sessions, which borrow the
-    // thread again through `crate::http_thread()`. Every access here is a
-    // fresh statement-scoped borrow instead.
+    // The `drain_*` functions are not methods (as `connect`): the clients and
+    // sessions they dispatch to borrow the thread again through `http_thread()`.
 
     fn drain_queued_shutdowns() {
         loop {
@@ -923,8 +899,7 @@ impl HttpThread {
         // which we just drained — `drainQueuedShutdowns` sets
         // `has_pending_queued_abort` for any id it couldn't find in the socket
         // tracker. If that's clear, there's nothing to fail-fast and nothing can
-        // start, so don't walk the lists. (The flag is consumed here either
-        // way; when we return early it was already clear.)
+        // start, so don't walk the lists.
         let has_pending_queued_abort =
             core::mem::take(&mut crate::http_thread().has_pending_queued_abort);
         if active >= max && !has_pending_queued_abort {
@@ -1191,8 +1166,7 @@ impl HttpThread {
     }
 }
 
-/// Evict SSL context cache entries that haven't been used for
-/// [`SSL_CONTEXT_CACHE_TTL_NS`]. `now` is a [`HttpThread::timer_read`].
+/// Evict cache entries idle for longer than `SSL_CONTEXT_CACHE_TTL_NS`.
 fn evict_stale_ssl_contexts(now: u64) {
     let map = custom_ssl_context_map();
     let mut i: usize = 0;
@@ -1237,9 +1211,7 @@ fn start_queued_task(http: *mut AsyncHttp) {
     // reborrow would be frozen by the first of them.
     let cloned_ptr = bun_core::heap::into_raw(cloned);
     let cloned_nn = NonNull::new(cloned_ptr).expect("freshly leaked Box is non-null");
-    // Statement-scoped `http_thread()` borrow: `on_start` below runs the
-    // request, which re-enters the accessor (and, on a synchronous failure,
-    // removes this very entry again).
+    // Pushed before `on_start`, which may fail synchronously and remove it again.
     crate::http_thread()
         .in_flight
         .push(cloned_nn.cast::<crate::ThreadlocalAsyncHttp<'static>>());
@@ -1387,11 +1359,8 @@ mod _event_loop_draft {
     }
 
     impl HttpThread {
-        /// Bind the singleton to this thread's loop and bring up the
-        /// contexts. Nothing in here reaches back into `crate::http_thread()`
-        /// (the contexts take the loop as a parameter), which is what makes
-        /// holding `&mut self` across it sound; once requests run that stops
-        /// being true, so [`Self::process_events`] has no `self`.
+        /// Thread-start setup; the last thing that may hold `&mut self` for
+        /// more than a statement (no request code runs yet).
         fn attach_loop(
             &mut self,
             loop_: *const MiniEventLoop,
@@ -1427,12 +1396,8 @@ mod _event_loop_draft {
             self.has_awoken.store(true, Ordering::Release);
         }
 
-        /// The thread's main loop. Every step (draining the queues, the tick)
-        /// runs request code that borrows the singleton through
-        /// `crate::http_thread()`, so this holds no `&mut HttpThread` of its
-        /// own: each access is a fresh statement-scoped borrow. The `&mut
-        /// uws::Loop`s below point into the loop's own allocation, not into
-        /// `HttpThread`, so they are unaffected.
+        /// The main loop. Not a method: every step runs request code, which
+        /// borrows the thread through [`crate::http_thread()`].
         fn process_events() -> ! {
             let uws_loop = crate::http_thread().uws_loop_mut();
             #[cfg(unix)]

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -956,11 +956,14 @@ pub(crate) static HTTP_THREAD: bun_core::ThreadCell<core::mem::MaybeUninit<HTTPT
 static HTTP_THREAD_INIT: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
+/// Raw pointer to the initialized singleton. [`http_thread`] derives its
+/// `&mut` from this per call; `HTTPThread::default_context_ptr` projects the
+/// default contexts out of it without forming a `&mut` at all.
 #[inline]
-pub fn http_thread() -> &'static mut HTTPThread {
+pub(crate) fn http_thread_ptr() -> *mut HTTPThread {
     // Release-mode guard, not `debug_assert!`: `HTTPThread` contains
     // niche-bearing fields (`Box`, `Vec`, `NonNull`, `Option<Arc>` …), so
-    // `assume_init_mut()` on the uninitialized static is *immediate* UB — a
+    // dereferencing the uninitialized static is *immediate* UB — a
     // `debug_assert!` leaves release builds unguarded. The `Acquire` load
     // pairs with `init_once`'s `Release` store on `HTTP_THREAD_INIT`,
     // establishing happens-before for cross-thread callers that did not
@@ -970,15 +973,38 @@ pub fn http_thread() -> &'static mut HTTPThread {
         HTTP_THREAD_INIT.load(core::sync::atomic::Ordering::Acquire),
         "http_thread() called before HTTPThread::init()"
     );
-    // SAFETY: `HTTP_THREAD_INIT == true` (checked above) is set only after
-    // `HTTP_THREAD.write(..)` in `init_once`, so the `MaybeUninit` is fully
-    // written. Thread-affinity is documented (HTTP-thread-only after
-    // `on_start`); the `ThreadCell` owner assert covers debug.
-    unsafe { (*HTTP_THREAD.get()).assume_init_mut() }
+    // `MaybeUninit<T>` is `repr(transparent)`, so this is the `T`'s address;
+    // `HTTP_THREAD_INIT == true` (checked above) is set only after
+    // `HTTP_THREAD.write(..)` in `init_once`, so it points at a fully written
+    // `HTTPThread`.
+    HTTP_THREAD.get().cast::<HTTPThread>()
 }
+
+/// Borrow the HTTP-thread singleton for **one statement**.
+///
+/// Each call is a fresh `&mut` to the whole struct, so it must not be used
+/// while an earlier one (or the `&mut self` of a method reached through an
+/// earlier one) is still live. Nearly everything a request does on this
+/// thread calls back in here (`connect`, `deflater`,
+/// `get_request_body_send_buffer`, the completion callback's
+/// `remove_in_flight`, …), so the result is never bound to a local or
+/// projected into a stored pointer: use it as `http_thread().method()` /
+/// `http_thread().field`, and put anything that needs more than one field
+/// access into a method on `HTTPThread` that itself does not run request
+/// code. The thread's own driver (`HTTPThread::process_events` and the
+/// `drain_*` functions) follows the same rule, which is what makes the
+/// re-entrant borrows sound. Enforced by
+/// `test/internal/source-lints/http-thread-held-borrow.test.ts`. A pointer
+/// that has to survive across request code comes from [`http_thread_ptr`]
+/// instead (`HTTPThread::default_context_ptr`).
 #[inline]
-pub(crate) fn http_thread_mut() -> &'static mut HTTPThread {
-    http_thread()
+pub fn http_thread() -> &'static mut HTTPThread {
+    // SAFETY: `http_thread_ptr` points at the initialized singleton. On this
+    // thread no two of these borrows overlap because every caller keeps its
+    // borrow to one statement (doc above). Thread-affinity is documented
+    // (HTTP-thread-only after `on_start`); the `ThreadCell` owner assert
+    // covers debug.
+    unsafe { &mut *http_thread_ptr() }
 }
 
 // TODO: this needs to be freed when Worker Threads are implemented
@@ -2304,15 +2330,16 @@ impl<'a> HTTPClient<'a> {
     /// Returns the SSL context for this client - either the custom context
     /// (for mTLS/custom TLS) or the default global context.
     pub(crate) fn get_ssl_ctx<const IS_SSL: bool>(&self) -> *mut GenHttpContext<IS_SSL> {
-        // Returns a raw ptr because the global/Arc lifetimes differ.
+        // Returns a raw ptr because the global/Arc lifetimes differ. Callers
+        // carry it through code that re-enters `http_thread()`, so the
+        // default context is projected out of the static
+        // (`default_context_ptr`), not out of an `http_thread()` borrow.
         if IS_SSL {
             if let Some(ctx) = self.custom_ssl_ctx.as_ref() {
                 return ctx.as_ptr().cast::<GenHttpContext<IS_SSL>>();
             }
-            (&raw mut http_thread().https_context).cast::<GenHttpContext<IS_SSL>>()
-        } else {
-            (&raw mut http_thread().http_context).cast::<GenHttpContext<IS_SSL>>()
         }
+        HTTPThread::default_context_ptr::<IS_SSL>()
     }
 
     /// Upgrade a `*mut GenHttpContext<SSL>` (the value [`get_ssl_ctx`]
@@ -2320,8 +2347,8 @@ impl<'a> HTTPClient<'a> {
     /// through as a parameter) to `&mut`.
     ///
     /// INVARIANT: every value reaching here is one of two thread-owned,
-    /// set-once non-null pointers — `&raw mut http_thread().http(s)_context`
-    /// or the heap-boxed `custom_ssl_ctx` on which the client holds a strong
+    /// set-once non-null pointers — `HTTPThread::default_context_ptr()` or
+    /// the heap-boxed `custom_ssl_ctx` on which the client holds a strong
     /// intrusive ref — both live for the call. The context is a separate
     /// allocation from `HTTPClient`, so the returned `&mut` does not alias any
     /// `&self` borrow used to compute the call's other arguments.
@@ -2845,7 +2872,7 @@ impl<'a> HTTPClient<'a> {
             return;
         }
 
-        let socket = match http_thread().connect::<IS_SSL>(self) {
+        let socket = match HTTPThread::connect::<IS_SSL>(self) {
             Ok(Some(s)) => s,
             Ok(None) => {
                 // Coalesced onto an in-flight h2 connect; the leader will attach us

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -956,9 +956,8 @@ pub(crate) static HTTP_THREAD: bun_core::ThreadCell<core::mem::MaybeUninit<HTTPT
 static HTTP_THREAD_INIT: core::sync::atomic::AtomicBool =
     core::sync::atomic::AtomicBool::new(false);
 
-/// Raw pointer to the initialized singleton. [`http_thread`] derives its
-/// `&mut` from this per call; `HTTPThread::default_context_ptr` projects the
-/// default contexts out of it without forming a `&mut` at all.
+/// The initialized singleton, for callers that project a field out of it
+/// without forming a `&mut` (`HTTPThread::default_context_ptr`).
 #[inline]
 pub(crate) fn http_thread_ptr() -> *mut HTTPThread {
     // Release-mode guard, not `debug_assert!`: `HTTPThread` contains
@@ -973,37 +972,27 @@ pub(crate) fn http_thread_ptr() -> *mut HTTPThread {
         HTTP_THREAD_INIT.load(core::sync::atomic::Ordering::Acquire),
         "http_thread() called before HTTPThread::init()"
     );
-    // `MaybeUninit<T>` is `repr(transparent)`, so this is the `T`'s address;
-    // `HTTP_THREAD_INIT == true` (checked above) is set only after
-    // `HTTP_THREAD.write(..)` in `init_once`, so it points at a fully written
-    // `HTTPThread`.
+    // `MaybeUninit<T>` is `repr(transparent)`, so this is the `T`'s address.
     HTTP_THREAD.get().cast::<HTTPThread>()
 }
 
-/// Borrow the HTTP-thread singleton for **one statement**.
+/// Borrow the HTTP-thread singleton for one statement.
 ///
-/// Each call is a fresh `&mut` to the whole struct, so it must not be used
-/// while an earlier one (or the `&mut self` of a method reached through an
-/// earlier one) is still live. Nearly everything a request does on this
-/// thread calls back in here (`connect`, `deflater`,
-/// `get_request_body_send_buffer`, the completion callback's
-/// `remove_in_flight`, …), so the result is never bound to a local or
-/// projected into a stored pointer: use it as `http_thread().method()` /
-/// `http_thread().field`, and put anything that needs more than one field
-/// access into a method on `HTTPThread` that itself does not run request
-/// code. The thread's own driver (`HTTPThread::process_events` and the
-/// `drain_*` functions) follows the same rule, which is what makes the
-/// re-entrant borrows sound. Enforced by
-/// `test/internal/source-lints/http-thread-held-borrow.test.ts`. A pointer
-/// that has to survive across request code comes from [`http_thread_ptr`]
-/// instead (`HTTPThread::default_context_ptr`).
+/// Request code reaches the thread through this (`deflater()`,
+/// `get_request_body_send_buffer()`, the completion callback, ...) and runs
+/// from under the thread's own frames, so a borrow those frames were still
+/// holding would alias it. Hence: use the result as `http_thread().method()`
+/// / `http_thread().field`, never bind it, and keep request code out of the
+/// methods called this way (the frames that do run it, `process_events` /
+/// `drain_*` / `connect`, have no `self`). Enforced by
+/// `test/internal/source-lints/http-thread-held-borrow.test.ts`.
 #[inline]
 pub fn http_thread() -> &'static mut HTTPThread {
-    // SAFETY: `http_thread_ptr` points at the initialized singleton. On this
-    // thread no two of these borrows overlap because every caller keeps its
-    // borrow to one statement (doc above). Thread-affinity is documented
-    // (HTTP-thread-only after `on_start`); the `ThreadCell` owner assert
-    // covers debug.
+    // SAFETY: `HTTP_THREAD_INIT` (asserted in `http_thread_ptr`) is set after
+    // the static is written, so this points at a live `HTTPThread`. Borrows are
+    // statement-scoped (doc above), so none overlaps another on this thread;
+    // thread affinity is HTTP-thread-only after `on_start` (`ThreadCell`
+    // asserts it in debug).
     unsafe { &mut *http_thread_ptr() }
 }
 
@@ -2330,10 +2319,7 @@ impl<'a> HTTPClient<'a> {
     /// Returns the SSL context for this client - either the custom context
     /// (for mTLS/custom TLS) or the default global context.
     pub(crate) fn get_ssl_ctx<const IS_SSL: bool>(&self) -> *mut GenHttpContext<IS_SSL> {
-        // Returns a raw ptr because the global/Arc lifetimes differ. Callers
-        // carry it through code that re-enters `http_thread()`, so the
-        // default context is projected out of the static
-        // (`default_context_ptr`), not out of an `http_thread()` borrow.
+        // Returns a raw ptr because the global/Arc lifetimes differ.
         if IS_SSL {
             if let Some(ctx) = self.custom_ssl_ctx.as_ref() {
                 return ctx.as_ptr().cast::<GenHttpContext<IS_SSL>>();

--- a/test/internal/source-lints/http-thread-held-borrow.test.ts
+++ b/test/internal/source-lints/http-thread-held-borrow.test.ts
@@ -36,9 +36,14 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // `HTTPThread::default_context_ptr()` for a context pointer that has to
 // survive across request code.
 //
-// `HTTPContext` is the struct embedded in `HTTPThread` and is only ever reached
-// through a borrow of it (`attach_loop`, `connect`), so it must not call the
-// accessor at all; it takes the uSockets loop as an `init` parameter instead.
+// The default `HTTPContext`s are fields of `HTTPThread`, and their `init` /
+// `init_with_thread_opts` run inside `&mut HTTPThread` methods (`attach_loop`,
+// `init_https_context`), where calling the accessor aliases the borrow they are
+// running under; that is why they take the uSockets loop as a parameter. A
+// regex cannot single those two functions out, so the whole of HTTPContext.rs
+// is banned from calling the accessor (an over-approximation: its other code
+// runs from socket callbacks or the receiver-less `HTTPThread::connect`, where a
+// statement-scoped call would be fine, but none of it needs one).
 //
 // Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
 
@@ -79,8 +84,8 @@ const SHAPES: { name: string; re: RegExp }[] = [
 ];
 const ACCESSOR_CALL = new RegExp(ACCESSOR, "g");
 
-// Files whose types live inside `HTTPThread` and are therefore always entered
-// through a live borrow of it.
+// Files defining types embedded in `HTTPThread`, some of whose code is entered
+// under a live borrow of it (see the header); banned from the accessor outright.
 const EMBEDDED_IN_HTTP_THREAD = ["src/http/HTTPContext.rs"];
 
 const offenders: string[] = [];

--- a/test/internal/source-lints/http-thread-held-borrow.test.ts
+++ b/test/internal/source-lints/http-thread-held-borrow.test.ts
@@ -22,11 +22,10 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //   - `let thread = crate::http_thread();` in `on_start`, held across the
 //     whole lifetime of the thread (`process_events` never returns).
 //   - `let in_flight = &mut crate::http_thread().in_flight;` and
-//     `let hctx = &raw mut crate::http_thread().https_context;` -- borrows and
-//     raw pointers projected out of one borrow and then carried through code
-//     that takes the next one (`HTTPClient::get_ssl_ctx` did the same in
-//     expression position; it now uses `HTTPThread::default_context_ptr`,
-//     which is projected out of the static instead).
+//     `HTTPClient::get_ssl_ctx` returning `&raw mut http_thread().https_context`
+//     -- a borrow, or a raw pointer, projected out of one borrow and then
+//     carried through code that takes the next one (`get_ssl_ctx` now returns
+//     `HTTPThread::default_context_ptr()`, projected out of the static instead).
 //
 // Replacements: a field read or a single method call on the temporary; a
 // `&mut self` method on `HTTPThread` for anything touching more than one field

--- a/test/internal/source-lints/http-thread-held-borrow.test.ts
+++ b/test/internal/source-lints/http-thread-held-borrow.test.ts
@@ -1,0 +1,128 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// `bun_http::http_thread()` returns `&'static mut HTTPThread` by re-deriving
+// it from the `HTTP_THREAD` static on every call, and nearly everything a
+// request does on the HTTP thread calls it again (`connect`, `deflater`,
+// `get_request_body_send_buffer`, the completion callback's `remove_in_flight`,
+// ...). So one of these borrows is only sound while no request code runs under
+// it: the result is used for a single statement (`http_thread().method()`,
+// `http_thread().field`), and `HTTPThread` methods reached that way do not run
+// request code. Anything held longer is a `&mut` that a nested call
+// invalidates (Stacked Borrows) or that has the nested access happen under it
+// while it is still live (Tree Borrows; for a `&mut self` argument the access
+// is UB on the spot), and anything projected out of it as a raw pointer is
+// stale as soon as the next call happens.
+//
+// The shapes this bans are the ones that existed:
+//
+//   - `let thread = crate::http_thread();` in `on_start`, held across the
+//     whole lifetime of the thread (`process_events` never returns).
+//   - `let in_flight = &mut crate::http_thread().in_flight;` and
+//     `let hctx = &raw mut crate::http_thread().https_context;` -- borrows and
+//     raw pointers projected out of one borrow and then carried through code
+//     that takes the next one (`HTTPClient::get_ssl_ctx` did the same in
+//     expression position; it now uses `HTTPThread::default_context_ptr`,
+//     which is projected out of the static instead).
+//
+// Replacements: a field read or a single method call on the temporary; a
+// `&mut self` method on `HTTPThread` for anything touching more than one field
+// (`take_queued`, `remove_in_flight`, `wake_if_tasks_waiting`); an associated
+// function that borrows per statement when the body runs request code
+// (`HTTPThread::connect`, `process_events`, the `drain_*` family); and
+// `HTTPThread::default_context_ptr()` for a context pointer that has to
+// survive across request code.
+//
+// `HTTPContext` is the struct embedded in `HTTPThread` and is only ever reached
+// through a borrow of it (`attach_loop`, `connect`), so it must not call the
+// accessor at all; it takes the uSockets loop as an `init` parameter instead.
+//
+// Sibling guards: fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// The call itself; `http_thread_timer_read()` and the `http_thread::` module
+// path do not match. `http_thread_mut` was a since-deleted alias of it.
+const ACCESSOR = String.raw`\bhttp_thread(?:_mut)?\(\)`;
+// The call however it is pathed: `crate::`, `http::`, `bun_http::`, bare.
+const PATHED_ACCESSOR = String.raw`(?:\w+::)*` + ACCESSOR;
+// `\s` crosses newlines so a rustfmt-wrapped binding still counts.
+const BINDING_HEAD = String.raw`let\s+(?:mut\s+)?\w+\s*(?::[^=;]*)?=\s*`;
+const SHAPES: { name: string; re: RegExp }[] = [
+  // `let thread = crate::http_thread();`
+  { name: "binding", re: new RegExp(BINDING_HEAD + PATHED_ACCESSOR + String.raw`\s*;`, "g") },
+  // `let x = &mut crate::http_thread().field;` / `let x = &crate::http_thread().field;`
+  {
+    name: "field borrow",
+    re: new RegExp(BINDING_HEAD + String.raw`&(?:mut\s+)?` + PATHED_ACCESSOR + String.raw`\s*\.`, "g"),
+  },
+  // `&raw mut crate::http_thread().field` anywhere: a raw pointer projected
+  // out of a temporary borrow exists only to outlive it.
+  { name: "raw projection", re: new RegExp(String.raw`&raw\s+(?:mut|const)\s+` + PATHED_ACCESSOR, "g") },
+];
+const ACCESSOR_CALL = new RegExp(ACCESSOR, "g");
+
+// Files whose types live inside `HTTPThread` and are therefore always entered
+// through a live borrow of it.
+const EMBEDDED_IN_HTTP_THREAD = ["src/http/HTTPContext.rs"];
+
+const offenders: string[] = [];
+const embeddedOffenders: string[] = [];
+let scanned = 0;
+let scannedEmbedded = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions don't count. `[ \t]*`, not
+  // `\s*`: `\s` crosses newlines and would shift the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  const lineOf = (index: number) => stripped.slice(0, index).split("\n").length;
+  for (const { name, re } of SHAPES) {
+    for (const m of stripped.matchAll(re)) {
+      offenders.push(`${source}:${lineOf(m.index)}: [${name}] ${m[0].replace(/\s+/g, " ")}`);
+    }
+  }
+  if (EMBEDDED_IN_HTTP_THREAD.includes(source)) {
+    scannedEmbedded++;
+    for (const m of stripped.matchAll(ACCESSOR_CALL)) {
+      embeddedOffenders.push(`${source}:${lineOf(m.index)}: ${m[0]}`);
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the bans below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+  expect(scannedEmbedded).toBe(EMBEDDED_IN_HTTP_THREAD.length);
+});
+
+test("an http_thread() borrow is never bound to a local or projected into a pointer", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("types embedded in HTTPThread do not re-borrow it through http_thread()", () => {
+  expect(embeddedOffenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- `http_thread()` returns a fresh `&'static mut HttpThread` on every call, and its SAFETY comment says each result is the only live borrow. On main the frames that drive requests break that: thread start bound one borrow and then entered the never-returning event loop as a `&mut self` method, so that borrow was live for every later `http_thread()` call in the process.
- The event drain and `connect` were also `&mut self` methods that ran client code (which calls `http_thread()` again; pooled keep-alive reuse and connect failures run it synchronously, and h2 coalescing can re-enter `connect` itself) and then kept using `self` afterwards. `get_ssl_ctx` handed out a raw pointer projected from one borrow that callers carried across further calls.
- Under Stacked Borrows every later use of the outer borrow is UB; under Tree Borrows the nested access is UB on the spot; and `&mut` arguments are `noalias` to LLVM. Nothing is known to miscompile today, so there is no runtime repro.
- Same-thread counterpart of #37694, which moves the cross-thread state out of `HttpThread`. The two overlap on a few lines; whichever lands second resolves them.

### Fix
- The frames that run request code (the event loop, the drain functions, `connect`, the h2 waiter abort) lose their `self` and borrow the thread one statement at a time. The pieces that touch several fields but run no request code become small `&mut self` methods; thread start is one such call-scoped method, and the `http_thread_mut` alias is removed.
- The default contexts are reached through a field projection of the static that never forms a `&mut HttpThread`, so `get_ssl_ctx` callers may keep the pointer across request code, and the context init functions take the uSockets loop as a parameter instead of calling the accessor from inside a `&mut HttpThread` method.
- Property to check: no `&mut HttpThread`, and no pointer projected out of one, is alive while client, session or socket callback code runs, so each `http_thread()` borrow ends within its statement. Behaviour is otherwise unchanged apart from two queue bookkeeping details listed in the original; the cost is a few `Acquire` loads per loop tick.
- Verification: a new source lint fails on main at exactly the sites above and passes here, but it cannot see the `&mut self` half, which rests on the argument above and the comments. Beyond that, cargo check/clippy on three targets and the fetch, TLS keep-alive, h2, proxy and SSL-context-eviction suites on an ASAN build, with only failures the container also produces on the released binary.

### Background
- `HttpThread` is the process-wide singleton behind bun's HTTP client: one OS thread owning the uSockets loop, the default HTTP and HTTPS contexts, and the queues other threads push tasks, writes and aborts into. `http_thread()` is how code on that thread reaches it.
- Request code runs synchronously under the thread's own frames: connecting through a pooled keep-alive socket runs `on_open` and the first write inside `connect`, and a failed connect or a preconnect runs the completion callback there. Both call `http_thread()` again.
- Stacked Borrows and Tree Borrows are the aliasing models Miri checks. Creating a new `&mut` to a value invalidates older `&mut`s still in use, and a `&mut self` argument is protected for the whole call, so a nested access to it during the call is UB even when nothing observable goes wrong.
- Turning a `&mut self` method into an associated function removes the borrow that lasted the whole call; each `http_thread().x` inside it is then a temporary that ends with its statement.
- An `HTTPContext` is a uSockets socket context (TLS setup plus connection pool). The two defaults are fields of `HttpThread`; custom-TLS requests get heap-allocated ones held in a cache, and clients carry a raw pointer to whichever they use.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/http-thread-held-borrow.test.ts
bun test v1.4.0 (fe1f3d2e8)

test/internal/source-lints/http-thread-held-borrow.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.64ms]
122 |   expect(scanned).toBeGreaterThan(0);
123 |   expect(scannedEmbedded).toBe(EMBEDDED_IN_HTTP_THREAD.length);
124 | });
125 | 
126 | test("an http_thread() borrow is never bound to a local or projected into a pointer", () => {
127 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/http/AsyncHTTP.rs:798: [binding] let thread = crate::http_thread();",
+   "src/http/AsyncHTTP.rs:776: [field borrow] let in_flight = &mut crate::http_thread().",
+   "src/http/HTTPThread.rs:214: [binding] let thread = crate::http_thread_mut();",
+   "src/http/HTTPThread.rs:1327: [binding] let thread = crate::http_thread_mut();",
+   "src/http/lib.rs:2312: [raw projection] &raw mut http_thread()",
+   "src/http/lib.rs:2314: [raw projection] &raw mut http_thread()",
+ ]

- Expect
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/internal/source-lints/http-thread-held-borrow.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.17ms]
122 |   expect(scanned).toBeGreaterThan(0);
123 |   expect(scannedEmbedded).toBe(EMBEDDED_IN_HTTP_THREAD.length);
124 | });
125 | 
126 | test("an http_thread() borrow is never bound to a local or projected into a pointer", () => {
127 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/http/AsyncHTTP.rs:798: [binding] let thread = crate::http_thread();",
+   "src/http/AsyncHTTP.rs:776: [field borrow] let in_flight = &mut crate::http_thread().",
+   "src/http/HTTPThread.rs:214: [binding] let thread = crate::http_thread_mut();",
+   "src/http/HTTPThread.rs:1327: [binding] let thread = crate::http_thread_mut();",
+   "src/http/lib.rs:2312: [raw projection] &raw mut http_thread()",
+   "src/http/lib.rs:2314: [raw projection] &raw mut http_thread()",
+ ]

- Expected  - 1
+ Received  + 8

      at <anonymous> (/workspace/bun/test/internal/source-lints/http-thread-held-borrow.test.ts:127:21)
(fail) an http_thread() borrow is never bound to a loc
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/http-thread-held-borrow.test.ts
bun test v1.4.0 (fe1f3d2e8)

test/internal/source-lints/http-thread-held-borrow.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.69ms]
(pass) an http_thread() borrow is never bound to a local or projected into a pointer [1.92ms]
(pass) types embedded in HTTPThread do not re-borrow it through http_thread() [1.98ms]

 3 pass
 0 fail
 4 expect() calls
Ran 3 tests across 1 file. [31.97s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     fe1f3d2e80
  features     baseline

22 deps, 107 codegen, 1176 objects in 3929ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] gen .bind.ts → GeneratedBindings.cpp
[4/1238] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[5/1238] gen ZigGlobalObject.lut.h
Generating /workspace/bun/build/release/codegen/ZigGlobalObject.lut.h from /workspace/bun/src/jsc/bindings/ZigGlobalObject.lut.txt
[6/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1238] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[8/1238] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBinding
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/http/AsyncHTTP.rs                              |  20 +-
 src/http/HTTPContext.rs                            |  19 +-
 src/http/HTTPThread.rs                             | 443 +++++++++++----------
 src/http/lib.rs                                    |  43 +-
 .../source-lints/http-thread-held-borrow.test.ts   | 132 ++++++
 5 files changed, 418 insertions(+), 239 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/http/AsyncHTTP.rs                                         2      2      0
src/http/HTTPContext.rs                                       9      8      0
src/http/HTTPThread.rs                                       31     54      0
src/http/lib.rs                                               9     10      0
…t/internal/source-lints/http-thread-held-borrow.test.ts      2      5      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

Same-thread counterpart of #37694. That PR moves the state other threads touch out of `HttpThread`; this one is about code running on the HTTP thread itself re-borrowing the singleton while an earlier borrow of it is still live. Both leave the other's problem alone, and they touch some of the same lines (see the end).

### What does this PR do?

`bun_http::http_thread()` returns `&'static mut HttpThread` by re-deriving it from the `HTTP_THREAD` static on every call, and nearly everything a request does on the HTTP thread calls it: `connect`, `deflater()`, `get_request_body_send_buffer()`, the completion callback's `in_flight` removal and wakeup check, `ProxyTunnel`'s `schedule_proxy_deref`. Its SAFETY comment says the returned `&mut` is the sole live borrow. On main that is false in the frames that drive requests:

- `on_start` did `let thread = crate::http_thread_mut();`, initialised the contexts through it (`HTTPContext::init` / `init_with_opts` reached back into `http::http_thread().uws_loop()` from inside that borrow, the two sites the handoff named), and then called `thread.process_events()`, a `&mut self` method that never returns. So one `&mut HttpThread` spanned every later `http_thread()` call for the life of the process, and `process_events` kept using it (`self.drain_events()`, `self.uws_loop_mut()`, `self.loop_`) after each one.
- `drain_events(&mut self)` and the four `drain_queued_*(&mut self)` methods dispatched into clients and sessions (`start_queued_task`, `close_and_abort`, `flush_stream`, `resume_*`, `fail_from_h2`) and then touched `self` again (`deferred_tasks.push`, `queued_tasks.pop()`, `has_pending_queued_abort`, the next iteration's lock). The existing comment in `drain_events` even describes the re-entrant read of `deferred_tasks` through the singleton that happens underneath it.
- `HttpThread::connect(&mut self)` drove `HTTPContext::connect`, which for a pooled socket runs `on_open` / `first_call` / `on_writable` synchronously (so `get_request_body_send_buffer`, which takes `lazy_request_body_buffer`, runs under it on every keep-alive reuse with a body) and on failure or preconnect runs the result callback (`remove_in_flight`). It can even re-enter `connect` itself on the same stack: `HTTPContext::connect` -> h2 `adopt()` with no headroom -> `h2_retry_after_coalesce` -> `start_::<true>` -> `http_thread().connect()` again, a second `&mut HttpThread` formed while the outer `connect(&mut self)` was still live (the `lazy_https_init` comment claiming `connect` is never re-entered was wrong; fixed here). The custom-context branch also used `self` after `init_with_client_config` had re-entered the accessor, and used the leaked `&mut` it had built `ctx_nn` from after `set_custom_ssl_ctx` had already bumped the refcount through `ctx_nn`.
- `HTTPClient::get_ssl_ctx` projected `&raw mut http_thread().http(s)_context` out of one borrow, and its callers (since #37715 that includes the `ProxyTunnel` callbacks) carried the pointer through `progress_update` / `handle_on_data_headers` / `do_redirect`, which take the next one before `release_socket` finally uses it.

Why this matters: under Stacked Borrows each fresh `&mut` pops the earlier ones, so every later use of the outer borrow is UB. Under Tree Borrows (the model `scripts/rust-miri.ts` uses for this tree) a `&mut self` argument is protected for the duration of the call, so the nested `http_thread()` access to a field the frame has written (`drain_events` had just swapped out `deferred_tasks`; `connect` had just `take()`n `lazy_https_init`) or the nested write to `in_flight` / `lazy_request_body_buffer` under `drain_events` / `connect` is UB at that point, not merely later. These `&mut` arguments also carry `noalias` to LLVM. Nothing is known to miscompile today (the fields the outer frames touch after the nested call are ones the nested code only reads, so there is no stale value for LLVM to forward), which is why the evidence here is the lint and this description rather than a runtime repro.

The change:

- `HTTPContext::{init, init_with_opts, init_with_thread_opts, init_with_client_config}` take the `*mut uws::Loop` as a parameter (`init` and `init_with_thread_opts` run inside `&mut HttpThread` methods, `attach_loop` and `init_https_context`, so they cannot take their own; `init_with_client_config`, used for heap-allocated custom contexts from the receiver-less `connect`, just shares the signature). `HttpThread::uws_loop()` loses its callers and is removed.
- `on_start` sets the thread up through one call-scoped `&mut self` method, `attach_loop` (nothing in it re-enters the accessor, and it absorbs the eager CA-config init, which was a copy of `init_https_context_cold`), then runs `HttpThread::process_events()`, which has no `self` and borrows the thread one statement at a time. `drain_events` and `drain_queued_*` are associated functions on the same pattern; `take_queued` (lock + swap), `remove_in_flight`, `wake_if_tasks_waiting` and `put_request_body_send_buffer` are the `&mut self` / `&self` methods that hold the multi-field pieces and run no request code. `start_queued_task` pushes to `in_flight` through its own statement-scoped borrow instead of a `&mut Vec` passed down from `drain_events`; `HeapRequestBodyBuffer::put` and the `http_thread_mut` alias go away.
- `HttpThread::connect` and `abort_pending_h2_waiter` are associated functions: the thread is borrowed per statement (`ensure_https_context_init()`, `timer_read()`, `uws_loop`) and the default context is reached through the new `HTTPThread::default_context_ptr::<SSL>()`, a field projection of the static made without forming a `&mut HttpThread`, so no borrow of the thread exists while `HTTPContext::connect` runs client code. `get_ssl_ctx` returns the same projection, which is also what makes the pointer its callers carry around survive the `http_thread()` calls in between. `HttpThread::context()` is folded into it. The custom-context branch reads `now` / `uws_loop` before evicting (eviction closes pooled sockets, which runs socket callbacks; `evict_stale_ssl_contexts` becomes a free function over the map like `evict_oldest_ssl_context` already was), takes `ctx_nn` straight from the released box and re-derives `&mut` from it per use (`custom_context_mut`, which `SslContextCacheEntry::ctx_mut` now shares).
- `http_thread()` documents the actual contract (one statement; methods reached through it do not run request code), and `http_thread_ptr()` is the single place that asserts init and casts the static.

Behaviour is unchanged apart from two deliberate details: `drain_events` consumes `has_pending_queued_abort` with one `take` (it was read and then cleared a few lines later with nothing in between; on the early return the flag was already false), and `queued_threadlocal_proxy_derefs` is swapped out with `take` instead of `drain(..)` (one allocation per batch of tunnel closes; the `Drain` would have been a borrow of the thread held across `ProxyTunnel::deref`). The extra cost is a handful of `Acquire` loads per loop tick in `http_thread_ptr`.

Deliberately not changed, because they are a different mechanism (stored back-pointers into a context, the same for custom contexts that never involve `http_thread()`): `PooledSocket.owner` and `h2::ClientSession.ctx` are still derived from a `&mut HTTPContext`, and `HTTPContext::connect` still holds its own `&mut self` while client code runs. (The proxy tunnel pooling custom-TLS sockets into the default context, noticed while reading this, was fixed separately in #37715; this PR is rebased on it and no longer touches `ProxyTunnel.rs`.) `dealloc_in_flight_for_exit` is still a `&mut self` method: the only way request code runs under it is the exit-path context drop, which is a worse (double free) bug of its own and has also been handed off.

### Test

`test/internal/source-lints/http-thread-held-borrow.test.ts`, in the same style as `fn-long-mut-reborrow.test.ts`. It bans binding an `http_thread()` result to a local, binding a `&`/`&mut` of a field of one, and `&raw mut|const http_thread()` anywhere, and bans the call altogether in `HTTPContext.rs` (an over-approximation of the two functions that run under a `&mut HttpThread`, since a regex cannot single them out; nothing else in the file needs the accessor). On main it reports exactly the sites above:

```
src/http/AsyncHTTP.rs:798: [binding] let thread = crate::http_thread();
src/http/AsyncHTTP.rs:776: [field borrow] let in_flight = &mut crate::http_thread().
src/http/HTTPThread.rs:214: [binding] let thread = crate::http_thread_mut();
src/http/HTTPThread.rs:1327: [binding] let thread = crate::http_thread_mut();
src/http/lib.rs:2312: [raw projection] &raw mut http_thread()
src/http/lib.rs:2314: [raw projection] &raw mut http_thread()
src/http/HTTPContext.rs:520, :550: http_thread()
```

and nothing with this change. It cannot see a `&mut self` method that runs request code (the `process_events` / `drain_*` / `connect` half); that half is the argument above plus the comments on those functions.

### How did you verify your code works?

- `cargo check` + `cargo clippy` on `bun_http`, `cargo check -p bun_http` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin`, `cargo fmt --check`, and the whole `test/internal/source-lints/` directory (81 tests).
- Debug (ASAN) build: `fetch-keepalive` and `tls-keepalive` (pooled reuse, i.e. `on_open` running synchronously inside `connect`), `fetch.tls`, `fetch.unix`, `exiting`, `fetch-http2-client`, `fetch-http2-adversarial`, `fetch-abort-socket-close-race`, `fetch-compress`, `fetch-gzip`, `fetch-redirect`, `proxy.test.ts`/`.js`, `fetch-proxy-connect-tunnel-split-envelope`, `proxy-stress-lifecycle`, `fetch-abort-ssl-context-eviction` (61 distinct TLS configs, so the custom-context miss path plus eviction), `fetch-tls-cert`, and `fetch.test.ts`. Everything passes except failures this container also produces with the released binary (`fetch-preconnect` and a few `fetch.test.ts` cases, because `localhost` resolves to `::1` here while the client hardcodes `127.0.0.1`; two `proxy.test.js` cases, because of the ambient `HTTP_PROXY`/`NO_PROXY`; the root-permission cases) and 5 s timeouts on gc-heavy tests in `fetch.test.ts` that pass when run alone (`simultaneous HTTPS fetch`, which is 80 custom-CA fetches, takes 350 ms by itself).

### Relationship to #37694

Once the queues live in that PR's `SHARED` static, `take_queued` here has nothing left to borrow and disappears (`take(&mut *SHARED.x.lock())` already satisfies this PR's rule), `wake_if_tasks_waiting` reads `SHARED` for the queue half, and `attach_loop` publishes the loop the way that PR does; whichever of the two lands second resolves those few lines. The lints are independent (that one checks `claim()`, this one checks how the borrow is used).

</details>
