### PR TITLE
udp: report an unresolvable bind hostname as a getaddrinfo error

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1604,9 +1604,12 @@ int bsd_bind_udp_fd(LIBUS_SOCKET_DESCRIPTOR fd, const struct sockaddr *addr, int
     return 0;
 }
 
-LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int options, int *err) {
+LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int options, int *err, int *dns_error) {
     if (err != NULL) {
         *err = 0;
+    }
+    if (dns_error != NULL) {
+        *dns_error = 0;
     }
 
     struct addrinfo hints, *result;
@@ -1621,8 +1624,10 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
 
     int gai_result = getaddrinfo(host, port_string, &hints, &result);
     if (gai_result != 0) {
-        if (err != NULL) {
-            *err = -gai_result;
+        /* An EAI_* code shares its numeric range with errno values (and is negative on
+         * glibc), so it must not go out through `err`. */
+        if (dns_error != NULL) {
+            *dns_error = gai_result;
         }
         return LIBUS_SOCKET_ERROR;
     }

--- a/packages/bun-usockets/src/internal/networking/bsd.h
+++ b/packages/bun-usockets/src/internal/networking/bsd.h
@@ -234,8 +234,10 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket(const char *host, int port, int
 
 LIBUS_SOCKET_DESCRIPTOR bsd_create_listen_socket_unix(const char *path, size_t pathlen, int options, int* error);
 
-/* Creates an UDP socket bound to the hostname and port */
-LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int options, int *err);
+/* Creates an UDP socket bound to the hostname and port. On failure `err` (optional) holds the errno of
+ * the failing socket call; when `host` itself did not resolve, `dns_error` (optional) holds the
+ * getaddrinfo(3) return code and `err` is 0. */
+LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int options, int *err, int *dns_error);
 int bsd_connect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd, const char *host, int port);
 int bsd_disconnect_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd);
 

--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -225,7 +225,9 @@ struct us_udp_packet_buffer_t *us_create_udp_packet_buffer();
 
 //struct us_udp_socket_t *us_create_udp_socket(us_loop_r loop, void (*data_cb)(struct us_udp_socket_t *, struct us_udp_packet_buffer_t *, int), void (*drain_cb)(struct us_udp_socket_t *), char *host, unsigned short port);
 
-struct us_udp_socket_t *us_create_udp_socket(us_loop_r loop, void (*data_cb)(struct us_udp_socket_t *, void *, int), void (*drain_cb)(struct us_udp_socket_t *), void (*close_cb)(struct us_udp_socket_t *), void (*recv_error_cb)(struct us_udp_socket_t *, int, int), const char *host, unsigned short port, int flags, int *err, void *user);
+/* Returns NULL on failure. `err` (optional) then holds the errno of the failing socket call; when `host`
+ * itself did not resolve, `dns_error` (optional) holds the getaddrinfo(3) return code and `err` is 0. */
+struct us_udp_socket_t *us_create_udp_socket(us_loop_r loop, void (*data_cb)(struct us_udp_socket_t *, void *, int), void (*drain_cb)(struct us_udp_socket_t *), void (*close_cb)(struct us_udp_socket_t *), void (*recv_error_cb)(struct us_udp_socket_t *, int, int), const char *host, unsigned short port, int flags, int *err, int *dns_error, void *user);
 
 void us_udp_socket_close(struct us_udp_socket_t *s);
 

--- a/packages/bun-usockets/src/quic.c
+++ b/packages/bun-usockets/src/quic.c
@@ -862,7 +862,7 @@ us_quic_listen_socket_t *us_quic_socket_context_listen(
     int err = 0;
     ls->udp = us_create_udp_socket(ctx->loop,
         us_quic_udp_on_data, us_quic_udp_on_drain, us_quic_udp_on_close, NULL,
-        host, (unsigned short) port, flags, &err, ls);
+        host, (unsigned short) port, flags, &err, NULL, ls);
     if (!ls->udp) { us_free(ls); return NULL; }
     us_quic_set_dontfrag(ls->udp);
 
@@ -1214,12 +1214,12 @@ static us_quic_listen_socket_t *us_quic_client_endpoint(us_quic_socket_context_t
     int err = 0;
     ls->udp = us_create_udp_socket(ctx->loop,
         us_quic_udp_on_data, us_quic_udp_on_drain, us_quic_udp_on_close, NULL,
-        "::", 0, 0, &err, ls);
+        "::", 0, 0, &err, NULL, ls);
     if (!ls->udp) {
         err = 0;
         ls->udp = us_create_udp_socket(ctx->loop,
             us_quic_udp_on_data, us_quic_udp_on_drain, us_quic_udp_on_close, NULL,
-            "0.0.0.0", 0, 0, &err, ls);
+            "0.0.0.0", 0, 0, &err, NULL, ls);
     }
     if (!ls->udp) { us_free(ls); return NULL; }
     us_quic_set_dontfrag(ls->udp);

--- a/packages/bun-usockets/src/udp.c
+++ b/packages/bun-usockets/src/udp.c
@@ -181,6 +181,7 @@ struct us_udp_socket_t *us_create_udp_socket(
     unsigned short port,
     int flags,
     int *err,
+    int *dns_error,
     void *user
 ) {
 
@@ -188,7 +189,7 @@ struct us_udp_socket_t *us_create_udp_socket(
      * drain the error queue; without one it only poisons subsequent sends. */
     if (recv_error_cb) flags |= LIBUS_UDP_LINUX_RECVERR;
     else flags &= ~LIBUS_UDP_LINUX_RECVERR;
-    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_udp_socket(host, port, flags, err);
+    LIBUS_SOCKET_DESCRIPTOR fd = bsd_create_udp_socket(host, port, flags, err, dns_error);
     if (fd == LIBUS_SOCKET_ERROR) {
         return 0;
     }

--- a/src/runtime/node/quic/endpoint.rs
+++ b/src/runtime/node/quic/endpoint.rs
@@ -1363,6 +1363,7 @@ impl QuicEndpoint {
             return Ok(true);
         }
         let mut err: c_int = 0;
+        let mut dns_error: c_int = 0;
         let cfg = self.bind_config.get();
         let socket = uws::udp::Socket::create(
             uws::Loop::get(),
@@ -1374,6 +1375,7 @@ impl QuicEndpoint {
             cfg.port,
             0,
             Some(&mut err),
+            Some(&mut dns_error),
             core::ptr::from_ref(self).cast_mut().cast::<c_void>(),
         );
         if !socket.is_null() {
@@ -1386,7 +1388,10 @@ impl QuicEndpoint {
                 .with_mut(|r| r.set_strong(this_value, global));
             self.finish_close();
             self.pending_endpoint_close.set(false);
-            self.deliver_endpoint_close(global, CLOSECONTEXT_BIND_FAILURE, err);
+            // `host` is always an IP literal, so `dns_error` is at most
+            // EAI_MEMORY/EAI_SYSTEM; the status only feeds the close message.
+            let status = if err != 0 { err } else { dns_error };
+            self.deliver_endpoint_close(global, CLOSECONTEXT_BIND_FAILURE, status);
             return Ok(false);
         }
         self.socket.set(Some(socket));

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -633,6 +633,7 @@ impl UDPSocket {
             .set(UDPSocketConfig::from_js(global_this, options, this_value)?);
 
         let mut err: c_int = 0;
+        let mut dns_error: c_int = 0;
 
         let config = this.config.get();
         let hostname_z = config.hostname.to_owned_slice_z();
@@ -679,10 +680,10 @@ impl UDPSocket {
                 config.port,
                 config.flags,
                 Some(&mut err),
+                Some(&mut dns_error),
                 this_ptr.cast::<c_void>(),
             )
         };
-        drop(hostname_z);
         this.socket.set(if created.is_null() {
             None
         } else {
@@ -698,6 +699,19 @@ impl UDPSocket {
                 dgram_rollback_adoption(fd, previous);
             }
             this.closed.set(true);
+            // The hostname never resolved: `dns_error` is a raw getaddrinfo(3)
+            // code, not an errno. Report it the way `Bun.connect`/`fetch` do
+            // (`getaddrinfo ENOTFOUND <hostname>`, with `syscall`/`hostname`).
+            if let Some(dns_err) = c_ares::Error::init_eai(dns_error).filter(|_| dns_error != 0) {
+                return Err(global_this.throw_value(
+                    crate::dns_jsc::cares_jsc::system_error_with_syscall_and_hostname(
+                        dns_err,
+                        b"getaddrinfo",
+                        hostname_z.as_bytes(),
+                    )
+                    .to_error_instance(global_this),
+                ));
+            }
             if err != 0 {
                 let code: &'static str = SystemErrno::init(err as i64)
                     .map(Into::into)

--- a/src/uws_sys/udp.rs
+++ b/src/uws_sys/udp.rs
@@ -14,6 +14,10 @@ bun_opaque::opaque_ffi! {
 }
 
 impl Socket {
+    /// Returns null on failure. `err` then receives the errno of the failing
+    /// socket call; if `host` itself did not resolve, `dns_error` receives the
+    /// raw getaddrinfo(3) return code instead (map it with
+    /// `c_ares::Error::init_eai`, never as an errno) and `err` stays 0.
     pub fn create(
         loop_: *mut Loop,
         data_cb: extern "C" fn(*mut Socket, *mut PacketBuffer, c_int),
@@ -24,6 +28,7 @@ impl Socket {
         port: c_ushort,
         options: c_int,
         err: Option<&mut c_int>,
+        dns_error: Option<&mut c_int>,
         user_data: *mut c_void,
     ) -> *mut Socket {
         // SAFETY: thin wrapper over us_create_udp_socket; all pointer args are
@@ -39,6 +44,10 @@ impl Socket {
                 port,
                 options,
                 match err {
+                    Some(e) => std::ptr::from_mut::<c_int>(e),
+                    None => core::ptr::null_mut(),
+                },
+                match dns_error {
                     Some(e) => std::ptr::from_mut::<c_int>(e),
                     None => core::ptr::null_mut(),
                 },
@@ -209,6 +218,7 @@ unsafe extern "C" {
         port: c_ushort,
         options: c_int,
         err: *mut c_int,
+        dns_error: *mut c_int,
         user_data: *mut c_void,
     ) -> *mut Socket;
     fn us_udp_socket_connect(socket: *mut Socket, hostname: *const c_char, port: c_uint) -> c_int;

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -86,6 +86,57 @@ describe("udpSocket()", () => {
     ).toThrow();
   });
 
+  describe("bind failure errors", () => {
+    async function bindError(options: Parameters<typeof udpSocket>[0]): Promise<any> {
+      let socket;
+      try {
+        socket = await udpSocket(options);
+      } catch (error) {
+        return error;
+      }
+      socket.close();
+      throw new Error("expected udpSocket() to fail");
+    }
+
+    function pick({ name, code, syscall, hostname, address, message }: any) {
+      return { name, code, syscall, hostname, address, message };
+    }
+
+    // A DNS label longer than 63 bytes is illegal (RFC 1035 section 2.3.4), so
+    // getaddrinfo rejects it locally without a network round-trip.
+    const UNRESOLVABLE_HOST = Buffer.alloc(64, "a").toString() + ".com";
+
+    test("unresolvable hostname reports the resolver error, not an errno", async () => {
+      // The getaddrinfo return code used to be handed back through the errno
+      // channel, so this surfaced as whichever errno happened to share the
+      // number: `bind ENOENT <host>` on glibc, `bind ENOEXEC <host>` on macOS.
+      expect(pick(await bindError({ hostname: UNRESOLVABLE_HOST, port: 0 }))).toEqual({
+        name: "Error",
+        code: "ENOTFOUND",
+        syscall: "getaddrinfo",
+        hostname: UNRESOLVABLE_HOST,
+        address: undefined,
+        message: `getaddrinfo ENOTFOUND ${UNRESOLVABLE_HOST}`,
+      });
+    });
+
+    test("a failing bind() still reports the errno with the address", async () => {
+      const holder = await udpSocket({ hostname: "127.0.0.1", port: 0 });
+      try {
+        expect(pick(await bindError({ hostname: "127.0.0.1", port: holder.port }))).toEqual({
+          name: "Error",
+          code: "EADDRINUSE",
+          syscall: "bind",
+          hostname: undefined,
+          address: "127.0.0.1",
+          message: "bind EADDRINUSE 127.0.0.1",
+        });
+      } finally {
+        holder.close();
+      }
+    });
+  });
+
   // Out-of-range connect.port used to be silently rewritten to 0, so send()
   // returned true while every datagram was dropped. The bind path already
   // rejected the same values; connect must too. Values beyond the i32 range


### PR DESCRIPTION
### Problem
- `Bun.udpSocket({ hostname })` with a hostname that does not resolve rejects with an errno-shaped error: `bind ENOENT <host>` on glibc, `bind ESRCH <host>` with no resolver reachable, `bind ENOEXEC <host>` on macOS. Node reports `getaddrinfo ENOTFOUND <host>`.
- The name depends on which `EAI_*` value getaddrinfo returned and on the platform's sign for it, so one failure is reported differently per OS and per resolver state.
- Cause: the UDP bind path in usockets returned the getaddrinfo code through the out-parameter every other failure uses for an errno, and the caller named it as whatever errno shares that number.

### Fix
- The getaddrinfo code comes back through a separate `dns_error` out-parameter and the errno parameter stays 0 on that path, so a resolver code can no longer be read as an errno.
- `Bun.udpSocket` maps it the way `Bun.connect` and `fetch()` already map a failed lookup (#32990; #37690 does the same for `Bun.listen` / `Bun.serve`) and throws `getaddrinfo ENOTFOUND <host>` with `syscall` and `hostname` set, as Node does. Real bind failures (`bind EADDRINUSE <host>` with `.address`) and `{ fd }` adoption are unchanged.
- Other callers: quic ignores the new parameter, except `node:quic`, which uses `dns_error` as its close status when the errno is 0. `node:dgram` resolves through `dns.lookup` first, so it only reaches this branch via a custom `lookup` returning a non-IP string.
- Verification: a new test fails on the released build with the `bind ENOENT` shape and passes with this change; a second pins the `EADDRINUSE` shape. CI is green on glibc, musl, macOS and Windows. The numeric `errno` still differs from Node and is deliberately not asserted.

### Background
- `getaddrinfo(3)` returns its own `EAI_*` codes, not errno values; they are negative on glibc (`EAI_NONAME` = -2) and positive on macOS (`EAI_NONAME` = 8), so the same integer in the errno channel names a different errno on each platform.
- usockets (`packages/bun-usockets`) is the C layer under Bun's sockets. It reports failures to Rust through `int *` out-parameters, and Rust turns an errno into the JS `code` string via `SystemErrno`.
- `c_ares::Error::init_eai` is Bun's shared mapping from a raw getaddrinfo code to the lookup error it reports elsewhere (`ENOTFOUND` and friends; on Windows it folds WSA codes into `ENOTFOUND`). A separate `dns_error` channel fed into it is how `Bun.connect` and `fetch()` already report lookup failures.

<details>
<summary>Original description</summary>

### Repro

```js
const host = Buffer.alloc(64, "a").toString() + ".com"; // 64-byte label: getaddrinfo rejects it locally
try {
  await Bun.udpSocket({ hostname: host, port: 0 });
} catch (e) {
  console.log(e.code, e.syscall, e.hostname, e.message);
}
```

Before (Linux, 1.4.0 and main):

```
ENOENT bind undefined bind ENOENT aaaa....com
```

The code depends on which `EAI_*` value getaddrinfo returned: `EAI_NONAME` (-2 on glibc) comes out as `ENOENT`, `EAI_AGAIN` (-3, e.g. no resolver reachable) as `bind ESRCH <host>`. On macOS the constants are positive (`EAI_NONAME` = 8), so the negated value is abs()ed back into `ENOEXEC`.

After:

```
ENOTFOUND getaddrinfo aaaa....com getaddrinfo ENOTFOUND aaaa....com
```

### Cause

`bsd_create_udp_socket()` in `packages/bun-usockets/src/bsd.c` did `*err = -gai_result;` when `getaddrinfo()` failed. Every other write to `err` in that function is an errno, and the consumer (`UDPSocket::udp_socket` in `src/runtime/socket/udp_socket.rs`) maps it with `SystemErrno::init` and reports `syscall: "bind"`, so a resolver return code was being named as whatever errno shares its number.

### Fix

`bsd_create_udp_socket()` / `us_create_udp_socket()` gain a separate `int *dns_error` out-parameter that receives the raw `getaddrinfo()` return code (`err` stays 0 on that path), threaded through `uws::udp::Socket::create`. `udp_socket.rs` maps it with `c_ares::Error::init_eai` and builds the error with `system_error_with_syscall_and_hostname(.., "getaddrinfo", hostname)`. The errno path (`bind EADDRINUSE <host>` with `.address`, `open <code>` for `{ fd }` adoption) is unchanged.

Why this shape: it is the one Bun already uses for a failed lookup everywhere else. `Bun.connect` and `fetch()` carry the raw code on a separate `dns_error` channel and map it with `init_eai` (#32990), #37690 does the same for `Bun.listen` / `Bun.serve`, and this PR is the UDP bind counterpart. It is also what Node reports for the same input: `dgram.createSocket("udp4").bind({ address: host })` on Node 26.3 emits `getaddrinfo ENOTFOUND <host>` with `code: "ENOTFOUND"`, `syscall: "getaddrinfo"`, `hostname` set and no `address`, both for the 64-byte label and for name-shaped strings such as `"256.256.256.256"` (getaddrinfo treats those as names too, so they take the same new branch). The remaining difference from Node is the numeric `errno` (Node uses the libuv code, Bun the same c-ares value `Bun.connect` / `fetch()` report), which the tests deliberately do not pin. Only the errno path is platform-specific on purpose: on Windows `init_eai` folds the raw WSA codes into `ENOTFOUND`, exactly as it already does for `Bun.connect` / `fetch()`.

`node:dgram` is not affected in practice: with the default `lookup` it resolves through `dns.lookup` and hands `Bun.udpSocket` an IP, so this branch is only reachable through a custom `lookup` that yields a non-IP string, and that case now gets the resolver error instead of the mis-named errno.

Other `us_create_udp_socket` callers: the three in `quic.c` never read the error and pass `NULL`; `node:quic`'s `ensure_bound()` always binds an IP literal, and now falls back to `dns_error` for the close status so a (memory/system) resolver failure there still reports a nonzero status instead of 0.

Not changed here: the UDP `connect` path already reports a resolver error (`connect ENOTFOUND <host>`, name `DNSException`); the existing synchronous throw vs. rejection behaviour is #35217's subject.

### Verification

New tests in `test/js/bun/udp/udp_socket.test.ts` (`bind failure errors`): the unresolvable-hostname case fails on the released build with the `bind ENOENT` shape above and passes with this change; the second test pins the `bind EADDRINUSE 127.0.0.1` / `.address` shape of a real bind failure.

```
bun bd test test/js/bun/udp/        # 272 pass
test/js/node/test/parallel/test-dgram-{error-message-address,bind-error-repeat,bind-fd-error,bind,custom-lookup}.js
test/js/node/test/parallel/test-quic-endpoint-bind{,-failure}.mjs
```

CI is green on every lane, so the `ENOTFOUND` expectation holds for the libc `getaddrinfo` on macOS, Windows and musl as well as glibc.


</details>
