### PR TITLE
node:http: deliver a fallback response in full when the connection is torn down right after res.end()

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -147,6 +147,23 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     return length;
   }
 
+  // The pieces above are separate socket.write() calls and a TLS socket completes a write a tick
+  // later, so uncorked only the first piece would be on the transport when something destroys the
+  // socket in the same tick as end() (the idle sweep, res.destroy(), ...). Like Node's write_()/
+  // end(), cork across one tick's pieces and uncork in end(); native writeHeadAndEnd corks the same way.
+  let corkedThisTick = false;
+  function corkThisTick() {
+    if (corkedThisTick) return;
+    corkedThisTick = true;
+    socket.cork();
+    process.nextTick(uncorkThisTick);
+  }
+  function uncorkThisTick() {
+    if (!corkedThisTick) return;
+    corkedThisTick = false;
+    socket.uncork();
+  }
+
   const handle = {
     flags: 0,
     ended: false,
@@ -197,6 +214,7 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     },
     write(chunk, encoding, _callback, _strictContentLength) {
       const buf = toBuffer(chunk, encoding);
+      corkThisTick();
       writeHeadToSocket(null);
       return writeBody(buf);
     },
@@ -204,12 +222,20 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
       if (this.ended) return 0;
       const buf = toBuffer(chunk, encoding);
       const length = buf ? (buf.byteLength ?? buf.length) : 0;
-      writeHeadToSocket(length);
-      writeBody(buf);
-      // Like Node's `_hasBody && chunkedEncoding` gate: a bodiless (HEAD)
-      // response never writes the terminating chunk, even when the user set
-      // Transfer-Encoding: chunked themselves.
-      if (chunked && !noBody) socket.write("0\r\n\r\n");
+      socket.cork();
+      try {
+        writeHeadToSocket(length);
+        writeBody(buf);
+        // Like Node's `_hasBody && chunkedEncoding` gate: a bodiless (HEAD)
+        // response never writes the terminating chunk, even when the user set
+        // Transfer-Encoding: chunked themselves.
+        if (chunked && !noBody) socket.write("0\r\n\r\n");
+      } finally {
+        uncorkThisTick();
+        socket.uncork();
+        // Node's end() releases the user's corks too, so the response is on its way regardless.
+        while (socket.writableCorked) socket.uncork();
+      }
       this.ended = true;
       this.finished = true;
       const onfinished = this.onfinished;
@@ -454,23 +480,29 @@ function connectionListenerHTTP1(server, socket, options) {
 function closeIdleHttp1Connections(server) {
   const connections = server[kHttp1Connections];
   if (!connections) return;
+  // A finished response can still be queued on the socket (a write still completing, a Duplex
+  // without _writev, a peer that stopped reading): let it flush, but only for as long as a
+  // connection may linger after close() anyway; past that the connection is cut as before.
+  const flushTimeout = server.keepAliveTimeout > 0 ? server.keepAliveTimeout : 5000;
   for (const socket of connections) {
     if (socket[kHttp1ActiveRequests] || socket.destroyed || socket[kHttp1Draining]) continue;
     if (!socket.writableLength) {
       socket.destroy();
       continue;
     }
-    // Unlike Node's OutgoingMessage, the handle above hands the response to the transport one
-    // write at a time (a tick apart on TLS), so a response ended this tick may still be queued here.
     socket[kHttp1Draining] = true;
-    destroySoon(socket);
+    destroyAfterFlush(socket, flushTimeout);
   }
 }
 
-// net.Socket#destroySoon(); a Duplex fed in through server.emit("connection") need not have it.
-function destroySoon(socket) {
+// net.Socket#destroySoon() (a Duplex fed in through server.emit("connection") need not have it)
+// with a deadline.
+function destroyAfterFlush(socket, timeout) {
   if (socket.writable) socket.end();
   socket.once("finish", socket.destroy);
+  const timer = setTimeout(() => socket.destroy(), timeout);
+  timer.unref();
+  socket.once("close", () => clearTimeout(timer));
 }
 
 function closeAllHttp1Connections(server) {

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -454,9 +454,18 @@ function closeIdleHttp1Connections(server) {
   const connections = server[kHttp1Connections];
   if (!connections) return;
   for (const socket of connections) {
-    if (!socket[kHttp1ActiveRequests] && !socket.destroyed) {
+    if (socket[kHttp1ActiveRequests] || socket.destroyed) continue;
+    if (!socket.writableLength) {
       socket.destroy();
+      continue;
     }
+    // Node destroys here too, but its OutgoingMessage has uncorked the whole response into the
+    // transport by the time end() returns. This file's handle writes the response piecewise and a
+    // TLS socket completes each write a tick later, so a response ended in this tick is still
+    // queued in the Writable and destroy() would drop it (the client gets the head, no body).
+    // This is net.Socket#destroySoon() spelled out, so it also works on a plain Duplex.
+    if (socket.writable) socket.end();
+    socket.once("finish", socket.destroy);
   }
 }
 

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -147,10 +147,8 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
     return length;
   }
 
-  // The pieces above are separate socket.write() calls and a TLS socket completes a write a tick
-  // later, so uncorked only the first piece would be on the transport when something destroys the
-  // socket in the same tick as end() (the idle sweep, res.destroy(), ...). Like Node's write_()/
-  // end(), cork across one tick's pieces and uncork in end(); native writeHeadAndEnd corks the same way.
+  // A TLS socket completes a write on the next tick, so of the pieces above only the first would be on
+  // the transport when end() returns; cork across a tick's pieces like Node's write_()/end() do.
   let corkedThisTick = false;
   function corkThisTick() {
     if (corkedThisTick) return;
@@ -480,9 +478,8 @@ function connectionListenerHTTP1(server, socket, options) {
 function closeIdleHttp1Connections(server) {
   const connections = server[kHttp1Connections];
   if (!connections) return;
-  // A finished response can still be queued on the socket (a write still completing, a Duplex
-  // without _writev, a peer that stopped reading): let it flush, but only for as long as a
-  // connection may linger after close() anyway; past that the connection is cut as before.
+  // A response still queued on the socket (a write still completing, a Duplex without _writev, a peer
+  // that stopped reading) gets keepAliveTimeout to flush; then the connection is cut as it used to be.
   const flushTimeout = server.keepAliveTimeout > 0 ? server.keepAliveTimeout : 5000;
   for (const socket of connections) {
     if (socket[kHttp1ActiveRequests] || socket.destroyed || socket[kHttp1Draining]) continue;
@@ -495,8 +492,7 @@ function closeIdleHttp1Connections(server) {
   }
 }
 
-// net.Socket#destroySoon() (a Duplex fed in through server.emit("connection") need not have it)
-// with a deadline.
+// net.Socket#destroySoon() with a deadline; a Duplex fed in via emit("connection") need not have it.
 function destroyAfterFlush(socket, timeout) {
   if (socket.writable) socket.end();
   socket.once("finish", socket.destroy);

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -6,6 +6,7 @@ const { SafeSet } = require("internal/primordials");
 
 const kHttp1Connections = Symbol("http1Connections");
 const kHttp1ActiveRequests = Symbol("http1ActiveRequests");
+const kHttp1Draining = Symbol("http1Draining");
 
 function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout) {
   const { _checkInvalidHeaderChar: checkInvalidHeaderChar } = require("node:_http_common");
@@ -454,11 +455,15 @@ function closeIdleHttp1Connections(server) {
   const connections = server[kHttp1Connections];
   if (!connections) return;
   for (const socket of connections) {
-    if (socket[kHttp1ActiveRequests] || socket.destroyed) continue;
+    if (socket[kHttp1ActiveRequests] || socket.destroyed || socket[kHttp1Draining]) continue;
+    if (!socket.writableLength) {
+      socket.destroy();
+      continue;
+    }
     // Unlike Node's OutgoingMessage, the handle above hands the response to the transport one
     // write at a time (a tick apart on TLS), so a response ended this tick may still be queued here.
-    if (socket.writableLength) destroySoon(socket);
-    else socket.destroy();
+    socket[kHttp1Draining] = true;
+    destroySoon(socket);
   }
 }
 

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -455,18 +455,17 @@ function closeIdleHttp1Connections(server) {
   if (!connections) return;
   for (const socket of connections) {
     if (socket[kHttp1ActiveRequests] || socket.destroyed) continue;
-    if (!socket.writableLength) {
-      socket.destroy();
-      continue;
-    }
-    // Node destroys here too, but its OutgoingMessage has uncorked the whole response into the
-    // transport by the time end() returns. This file's handle writes the response piecewise and a
-    // TLS socket completes each write a tick later, so a response ended in this tick is still
-    // queued in the Writable and destroy() would drop it (the client gets the head, no body).
-    // This is net.Socket#destroySoon() spelled out, so it also works on a plain Duplex.
-    if (socket.writable) socket.end();
-    socket.once("finish", socket.destroy);
+    // Unlike Node's OutgoingMessage, the handle above hands the response to the transport one
+    // write at a time (a tick apart on TLS), so a response ended this tick may still be queued here.
+    if (socket.writableLength) destroySoon(socket);
+    else socket.destroy();
   }
+}
+
+// net.Socket#destroySoon(); a Duplex fed in through server.emit("connection") need not have it.
+function destroySoon(socket) {
+  if (socket.writable) socket.end();
+  socket.once("finish", socket.destroy);
 }
 
 function closeAllHttp1Connections(server) {

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,15 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  // Pin one address family: a bare "localhost" can bind ::1 while the client
+  // resolves 127.0.0.1 first (neither Node nor Bun falls back across
+  // families), which fails with ECONNREFUSED on dual-stack hosts.
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -28,7 +28,7 @@ import { connect, createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { duplexPair, PassThrough, Writable } from "node:stream";
-import { connect as tlsConnect, createServer as createTlsServer } from "node:tls";
+import { createServer as createTlsServer, connect as tlsConnect } from "node:tls";
 import tunnel from "tunnel";
 import { run as runHTTPProxyTest } from "./node-http-proxy.js";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll, mock, test } = createTest(import.meta.path);

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4155,22 +4155,25 @@ it("closing the server right after res.end() still delivers the body on an emit(
       closeServer(server);
     });
     const [clientSide, serverSide] = duplexPair();
-    server.emit("connection", serverSide);
-    const body = await new Promise<string>((resolve, reject) => {
-      const req = request({ createConnection: () => clientSide as any, headers: { connection } }, res => {
-        let data = "";
-        res.setEncoding("utf8");
-        res.on("data", chunk => (data += chunk));
-        // A connection destroyed with the body still queued aborts the response after the head:
-        // report whatever body did arrive so the assertion below shows the truncation.
-        res.on("error", () => resolve(data));
-        res.on("end", () => resolve(data));
+    try {
+      server.emit("connection", serverSide);
+      const body = await new Promise<string>((resolve, reject) => {
+        const req = request({ createConnection: () => clientSide as any, headers: { connection } }, res => {
+          let data = "";
+          res.setEncoding("utf8");
+          res.on("data", chunk => (data += chunk));
+          // A connection destroyed with the body still queued aborts the response after the head:
+          // report whatever body did arrive so the assertion below shows the truncation.
+          res.on("error", () => resolve(data));
+          res.on("end", () => resolve(data));
+        });
+        req.on("error", reject);
+        req.end();
       });
-      req.on("error", reject);
-      req.end();
-    });
-    expect({ connection, body }).toEqual({ connection, body: "BODY" });
-    clientSide.destroy();
-    serverSide.destroy();
+      expect({ connection, body }).toEqual({ connection, body: "BODY" });
+    } finally {
+      clientSide.destroy();
+      serverSide.destroy();
+    }
   }
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4145,35 +4145,51 @@ it("closing the server right after res.end() still delivers the body on an emit(
   // and a duplexPair side (like a TLS socket) completes each write asynchronously, so when the
   // handler sweeps idle connections in the same tick the body is still queued in the socket's
   // Writable. The sweep has to flush it rather than drop it, whether the connection is keep-alive
-  // (the sweep ends the socket) or Connection: close (the response already ended it).
-  for (const [closeServer, connection] of [
-    [(server: Server) => server.closeIdleConnections(), "keep-alive"],
-    [(server: Server) => server.close(), "close"],
-  ] as const) {
-    const server = createServer((req, res) => {
-      res.end("BODY");
-      closeServer(server);
-    });
-    const [clientSide, serverSide] = duplexPair();
-    try {
-      server.emit("connection", serverSide);
-      const body = await new Promise<string>((resolve, reject) => {
-        const req = request({ createConnection: () => clientSide as any, headers: { connection } }, res => {
-          let data = "";
-          res.setEncoding("utf8");
-          res.on("data", chunk => (data += chunk));
-          // A connection destroyed with the body still queued aborts the response after the head:
-          // report whatever body did arrive so the assertion below shows the truncation.
-          res.on("error", () => resolve(data));
-          res.on("end", () => resolve(data));
-        });
-        req.on("error", reject);
-        req.end();
+  // (the sweep ends the socket) or Connection: close (the response already ended it). Shutdown code
+  // commonly calls closeIdleConnections() repeatedly; a connection still flushing must not pick up
+  // another 'finish' listener (and a MaxListenersExceededWarning) on every call.
+  const warnings: string[] = [];
+  const onWarning = (warning: Error) => {
+    if (warning.name === "MaxListenersExceededWarning") warnings.push(warning.message);
+  };
+  process.on("warning", onWarning);
+  try {
+    for (const [closeServer, connection] of [
+      [
+        (server: Server) => {
+          for (let i = 0; i < 12; i++) server.closeIdleConnections();
+        },
+        "keep-alive",
+      ],
+      [(server: Server) => server.close(), "close"],
+    ] as const) {
+      const server = createServer((req, res) => {
+        res.end("BODY");
+        closeServer(server);
       });
-      expect({ connection, body }).toEqual({ connection, body: "BODY" });
-    } finally {
-      clientSide.destroy();
-      serverSide.destroy();
+      const [clientSide, serverSide] = duplexPair();
+      try {
+        server.emit("connection", serverSide);
+        const body = await new Promise<string>((resolve, reject) => {
+          const req = request({ createConnection: () => clientSide as any, headers: { connection } }, res => {
+            let data = "";
+            res.setEncoding("utf8");
+            res.on("data", chunk => (data += chunk));
+            // A connection destroyed with the body still queued aborts the response after the head:
+            // report whatever body did arrive so the assertion below shows the truncation.
+            res.on("error", () => resolve(data));
+            res.on("end", () => resolve(data));
+          });
+          req.on("error", reject);
+          req.end();
+        });
+        expect({ connection, body, warnings }).toEqual({ connection, body: "BODY", warnings: [] });
+      } finally {
+        clientSide.destroy();
+        serverSide.destroy();
+      }
     }
+  } finally {
+    process.off("warning", onWarning);
   }
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -28,7 +28,7 @@ import { connect, createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
 import { duplexPair, PassThrough, Writable } from "node:stream";
-import { connect as tlsConnect } from "node:tls";
+import { connect as tlsConnect, createServer as createTlsServer } from "node:tls";
 import tunnel from "tunnel";
 import { run as runHTTPProxyTest } from "./node-http-proxy.js";
 const { describe, expect, it, beforeAll, afterAll, createDoneDotAll, mock, test } = createTest(import.meta.path);
@@ -4191,5 +4191,38 @@ it("closing the server right after res.end() still delivers the body on an emit(
     }
   } finally {
     process.off("warning", onWarning);
+  }
+});
+
+it("closeAllConnections() right after res.end() still delivers the body on an emit('connection') TLS socket", async () => {
+  // closeAllConnections() destroys outright, so this only works if res.end() has handed the whole
+  // response (not just its first piece) to the TLS socket by the time it returns, as Node's
+  // OutgoingMessage does. Feeding a tls.Server's sockets to an http.Server is how a hand-rolled
+  // https server ends up on this path.
+  const httpServer = createServer((req, res) => {
+    res.write("BO");
+    res.end("DY");
+    httpServer.closeAllConnections();
+  });
+  const tlsServer = createTlsServer(tlsCert, socket => httpServer.emit("connection", socket));
+  await new Promise<void>(resolve => tlsServer.listen(0, resolve));
+  // Connection: close so the flow also completes where closeAllConnections() has nothing to do
+  // (Node only tracks connections once the http.Server itself is listening).
+  const client = tlsConnect(
+    { host: "localhost", port: (tlsServer.address() as AddressInfo).port, ca: tlsCert.cert },
+    () => client.write("GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"),
+  );
+  try {
+    const chunks: Buffer[] = [];
+    client.on("data", chunk => chunks.push(chunk));
+    // The destroy may arrive as EOF or as a reset; either way everything written before it arrives first.
+    client.on("error", () => {});
+    await new Promise(resolve => client.on("close", resolve));
+    const raw = Buffer.concat(chunks).toString();
+    expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("2\r\nBO\r\n2\r\nDY\r\n0\r\n\r\n");
+  } finally {
+    client.destroy();
+    tlsServer.close();
   }
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,38 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+it("closing the server right after res.end() still delivers the body on an emit('connection') socket", async () => {
+  // On a socket served through server.emit("connection", ...) the response is written piecewise,
+  // and a duplexPair side (like a TLS socket) completes each write asynchronously, so when the
+  // handler sweeps idle connections in the same tick the body is still queued in the socket's
+  // Writable. The sweep has to flush it rather than drop it, whether the connection is keep-alive
+  // (the sweep ends the socket) or Connection: close (the response already ended it).
+  for (const [closeServer, connection] of [
+    [(server: Server) => server.closeIdleConnections(), "keep-alive"],
+    [(server: Server) => server.close(), "close"],
+  ] as const) {
+    const server = createServer((req, res) => {
+      res.end("BODY");
+      closeServer(server);
+    });
+    const [clientSide, serverSide] = duplexPair();
+    server.emit("connection", serverSide);
+    const body = await new Promise<string>((resolve, reject) => {
+      const req = request({ createConnection: () => clientSide as any, headers: { connection } }, res => {
+        let data = "";
+        res.setEncoding("utf8");
+        res.on("data", chunk => (data += chunk));
+        // A connection destroyed with the body still queued aborts the response after the head:
+        // report whatever body did arrive so the assertion below shows the truncation.
+        res.on("error", () => resolve(data));
+        res.on("end", () => resolve(data));
+      });
+      req.on("error", reject);
+      req.end();
+    });
+    expect({ connection, body }).toEqual({ connection, body: "BODY" });
+    clientSide.destroy();
+    serverSide.destroy();
+  }
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4308,6 +4308,8 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
 // same tick. close() sweeps the idle allowHTTP1 connections while the response bytes are still
 // queued in the TLS socket (each write completes a tick later), which used to destroy the socket
 // with only the head sent. Resolves with the raw bytes after the head once the server has closed.
+// The client keeps its own side open after the server's EOF, so close() only completes if the
+// server destroys the connection once the response has been flushed, rather than waiting on the peer.
 async function bodyReceivedWhenHandlerClosesServer(requestHead, respond) {
   const serverClosed = Promise.withResolvers();
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
@@ -4317,7 +4319,13 @@ async function bodyReceivedWhenHandlerClosesServer(requestHead, respond) {
   await new Promise(resolve => server.listen(0, resolve));
   const { promise, resolve, reject } = Promise.withResolvers();
   const socket = tls.connect(
-    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+    {
+      host: "localhost",
+      port: server.address().port,
+      ca: TLS_CERT.cert,
+      ALPNProtocols: ["http/1.1"],
+      allowHalfOpen: true,
+    },
     () => socket.write(requestHead),
   );
   try {
@@ -4383,6 +4391,7 @@ it("http2 allowHTTP1 fallback close() destroys a keep-alive connection whose res
     const closed = new Promise(resolveClosed => socket.on("close", resolveClosed));
     socket.on("close", () => reject(new Error("connection closed before the response arrived")));
     await promise;
+    expect(serverSocket.destroyed).toBe(false);
     // Nothing is left to flush, so close() tears the idle connection down synchronously, like Node.
     const serverClosed = new Promise(resolveClosed => server.close(resolveClosed));
     expect(serverSocket.destroyed).toBe(true);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4304,6 +4304,82 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+// Serves one HTTP/1.1 request whose handler runs `respond(res)` and then server.close() in the
+// same tick. close() sweeps the idle allowHTTP1 connections while the response bytes are still
+// queued in the TLS socket (each write completes a tick later), which used to destroy the socket
+// with only the head sent. Resolves with the raw bytes after the head once the server has closed.
+async function bodyReceivedWhenHandlerClosesServer(requestHead, respond) {
+  const serverClosed = Promise.withResolvers();
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    respond(res);
+    server.close(serverClosed.resolve);
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const socket = tls.connect(
+    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+    () => socket.write(requestHead),
+  );
+  const chunks = [];
+  socket.on("error", reject);
+  socket.on("data", chunk => chunks.push(chunk));
+  socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
+  const raw = await promise;
+  await serverClosed.promise;
+  expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+  return raw.slice(raw.indexOf("\r\n\r\n") + 4);
+}
+
+it("http2 allowHTTP1 fallback delivers the body when the handler closes the server right after res.end()", async () => {
+  const body = await bodyReceivedWhenHandlerClosesServer("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n", res =>
+    res.end("BODY"),
+  );
+  expect(body).toBe("BODY");
+});
+
+it("http2 allowHTTP1 fallback delivers a Connection: close body when the handler closes the server right after res.end()", async () => {
+  // The response already ended the socket itself when close() sweeps it.
+  const body = await bodyReceivedWhenHandlerClosesServer(
+    "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+    res => res.end("BODY"),
+  );
+  expect(body).toBe("BODY");
+});
+
+it("http2 allowHTTP1 fallback delivers every chunk and the terminator when the handler closes the server right after res.end()", async () => {
+  const body = await bodyReceivedWhenHandlerClosesServer("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n", res => {
+    res.write("BO");
+    res.end("DY");
+  });
+  expect(body).toBe("2\r\nBO\r\n2\r\nDY\r\n0\r\n\r\n");
+});
+
+it("http2 allowHTTP1 fallback close() destroys a keep-alive connection whose response was already delivered", async () => {
+  let serverSocket;
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    serverSocket = req.socket;
+    res.end("BODY");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const socket = tls.connect(
+    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+    () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"),
+  );
+  const chunks = [];
+  socket.on("error", reject);
+  socket.on("data", chunk => {
+    chunks.push(chunk);
+    if (Buffer.concat(chunks).toString().endsWith("\r\n\r\nBODY")) resolve();
+  });
+  const closed = new Promise(resolveClosed => socket.on("close", resolveClosed));
+  await promise;
+  // Nothing is left to flush, so close() tears the idle connection down synchronously, like Node.
+  const serverClosed = new Promise(resolveClosed => server.close(resolveClosed));
+  expect(serverSocket.destroyed).toBe(true);
+  await Promise.all([serverClosed, closed]);
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4325,6 +4325,7 @@ async function bodyReceivedWhenHandlerClosesServer(requestHead, respond) {
     socket.on("error", reject);
     socket.on("data", chunk => chunks.push(chunk));
     socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    socket.on("close", () => reject(new Error("connection closed without EOF")));
     const raw = await promise;
     await serverClosed.promise;
     expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
@@ -4380,6 +4381,7 @@ it("http2 allowHTTP1 fallback close() destroys a keep-alive connection whose res
       if (Buffer.concat(chunks).toString().endsWith("\r\n\r\nBODY")) resolve();
     });
     const closed = new Promise(resolveClosed => socket.on("close", resolveClosed));
+    socket.on("close", () => reject(new Error("connection closed before the response arrived")));
     await promise;
     // Nothing is left to flush, so close() tears the idle connection down synchronously, like Node.
     const serverClosed = new Promise(resolveClosed => server.close(resolveClosed));

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4465,7 +4465,11 @@ it("http2 allowHTTP1 fallback close() gives a connection whose peer stopped read
     },
   );
   try {
+    // The cut itself may surface here as a reset; only a close before the request got through is a failure.
     socket.on("error", () => {});
+    socket.on("close", () => {
+      if (!serverSocket) serverClosed.reject(new Error("connection closed before the request reached the handler"));
+    });
     // Completes once the server gives up on flushing; waiting on the peer would never return.
     await serverClosed.promise;
     expect(serverSocket.destroyed).toBe(true);

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4320,14 +4320,20 @@ async function bodyReceivedWhenHandlerClosesServer(requestHead, respond) {
     { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
     () => socket.write(requestHead),
   );
-  const chunks = [];
-  socket.on("error", reject);
-  socket.on("data", chunk => chunks.push(chunk));
-  socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
-  const raw = await promise;
-  await serverClosed.promise;
-  expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
-  return raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  try {
+    const chunks = [];
+    socket.on("error", reject);
+    socket.on("data", chunk => chunks.push(chunk));
+    socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    const raw = await promise;
+    await serverClosed.promise;
+    expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+    return raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  } finally {
+    socket.destroy();
+    // Only reached while still listening when the request never made it to the handler.
+    if (server.listening) server.close();
+  }
 }
 
 it("http2 allowHTTP1 fallback delivers the body when the handler closes the server right after res.end()", async () => {
@@ -4366,18 +4372,23 @@ it("http2 allowHTTP1 fallback close() destroys a keep-alive connection whose res
     { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
     () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"),
   );
-  const chunks = [];
-  socket.on("error", reject);
-  socket.on("data", chunk => {
-    chunks.push(chunk);
-    if (Buffer.concat(chunks).toString().endsWith("\r\n\r\nBODY")) resolve();
-  });
-  const closed = new Promise(resolveClosed => socket.on("close", resolveClosed));
-  await promise;
-  // Nothing is left to flush, so close() tears the idle connection down synchronously, like Node.
-  const serverClosed = new Promise(resolveClosed => server.close(resolveClosed));
-  expect(serverSocket.destroyed).toBe(true);
-  await Promise.all([serverClosed, closed]);
+  try {
+    const chunks = [];
+    socket.on("error", reject);
+    socket.on("data", chunk => {
+      chunks.push(chunk);
+      if (Buffer.concat(chunks).toString().endsWith("\r\n\r\nBODY")) resolve();
+    });
+    const closed = new Promise(resolveClosed => socket.on("close", resolveClosed));
+    await promise;
+    // Nothing is left to flush, so close() tears the idle connection down synchronously, like Node.
+    const serverClosed = new Promise(resolveClosed => server.close(resolveClosed));
+    expect(serverSocket.destroyed).toBe(true);
+    await Promise.all([serverClosed, closed]);
+  } finally {
+    socket.destroy();
+    if (server.listening) server.close();
+  }
 });
 
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4304,12 +4304,19 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
-// Serves one HTTP/1.1 request whose handler runs `respond(res)` and then server.close() in the
-// same tick. close() sweeps the idle allowHTTP1 connections while the response bytes are still
-// queued in the TLS socket (each write completes a tick later), which used to destroy the socket
-// with only the head sent. Resolves with the raw bytes after the head once the server has closed.
-// The client keeps its own side open after the server's EOF, so close() only completes if the
-// server destroys the connection once the response has been flushed, rather than waiting on the peer.
+function connectOverHttp1(server, requestHead, options) {
+  const socket = tls.connect(
+    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"], ...options },
+    () => socket.write(requestHead),
+  );
+  return socket;
+}
+
+// Serves one HTTP/1.1 request whose handler runs `respond(res)` and then server.close() in the same
+// tick, and resolves with the raw bytes after the response head once close() has completed. The
+// response bytes are still queued on the TLS socket when close() sweeps the connection (used to be
+// destroyed with only the head sent), and the client keeps its own side open after the server's EOF,
+// so close() only completes if the server itself destroys the connection once it has flushed.
 async function bodyReceivedWhenHandlerClosesServer(requestHead, respond) {
   const serverClosed = Promise.withResolvers();
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
@@ -4317,18 +4324,9 @@ async function bodyReceivedWhenHandlerClosesServer(requestHead, respond) {
     server.close(serverClosed.resolve);
   });
   await new Promise(resolve => server.listen(0, resolve));
-  const { promise, resolve, reject } = Promise.withResolvers();
-  const socket = tls.connect(
-    {
-      host: "localhost",
-      port: server.address().port,
-      ca: TLS_CERT.cert,
-      ALPNProtocols: ["http/1.1"],
-      allowHalfOpen: true,
-    },
-    () => socket.write(requestHead),
-  );
+  const socket = connectOverHttp1(server, requestHead, { allowHalfOpen: true });
   try {
+    const { promise, resolve, reject } = Promise.withResolvers();
     const chunks = [];
     socket.on("error", reject);
     socket.on("data", chunk => chunks.push(chunk));
@@ -4369,6 +4367,56 @@ it("http2 allowHTTP1 fallback delivers every chunk and the terminator when the h
   expect(body).toBe("2\r\nBO\r\n2\r\nDY\r\n0\r\n\r\n");
 });
 
+// Serves one HTTP/1.1 request whose handler destroys the connection outright in the same tick as
+// res.end(), and resolves with the raw bytes after the response head once the connection is gone.
+// Like Node's OutgoingMessage, the response has to be handed to the socket in full before end()
+// returns for any of this to arrive; it used to be queued piecemeal and lost.
+async function bodyReceivedWhenHandlerDestroysConnection(respond) {
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => respond(req, res));
+  await new Promise(resolve => server.listen(0, resolve));
+  const socket = connectOverHttp1(server, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+  try {
+    const chunks = [];
+    socket.on("data", chunk => chunks.push(chunk));
+    // An abrupt server-side destroy may reach the client as EOF or as a reset; whatever was written
+    // before it arrives first either way, so just read until the connection is gone.
+    socket.on("error", () => {});
+    await new Promise(resolve => socket.on("close", resolve));
+    const raw = Buffer.concat(chunks).toString();
+    expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+    return raw.slice(raw.indexOf("\r\n\r\n") + 4);
+  } finally {
+    socket.destroy();
+    server.close();
+  }
+}
+
+it("http2 allowHTTP1 fallback delivers the body when the handler destroys the socket right after res.end()", async () => {
+  const body = await bodyReceivedWhenHandlerDestroysConnection((req, res) => {
+    res.end("BODY");
+    req.socket.destroy();
+  });
+  expect(body).toBe("BODY");
+});
+
+it("http2 allowHTTP1 fallback delivers the body when the handler destroys the response right after res.end()", async () => {
+  const body = await bodyReceivedWhenHandlerDestroysConnection((req, res) => {
+    res.end("BODY");
+    res.destroy();
+  });
+  expect(body).toBe("BODY");
+});
+
+it("http2 allowHTTP1 fallback delivers chunks written in the same tick as res.end() when the socket is destroyed right after", async () => {
+  const body = await bodyReceivedWhenHandlerDestroysConnection((req, res) => {
+    res.write("B");
+    res.write("O");
+    res.end("DY");
+    req.socket.destroy();
+  });
+  expect(body).toBe("1\r\nB\r\n1\r\nO\r\n2\r\nDY\r\n0\r\n\r\n");
+});
+
 it("http2 allowHTTP1 fallback close() destroys a keep-alive connection whose response was already delivered", async () => {
   let serverSocket;
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
@@ -4376,12 +4424,9 @@ it("http2 allowHTTP1 fallback close() destroys a keep-alive connection whose res
     res.end("BODY");
   });
   await new Promise(resolve => server.listen(0, resolve));
-  const { promise, resolve, reject } = Promise.withResolvers();
-  const socket = tls.connect(
-    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
-    () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"),
-  );
+  const socket = connectOverHttp1(server, "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
   try {
+    const { promise, resolve, reject } = Promise.withResolvers();
     const chunks = [];
     socket.on("error", reject);
     socket.on("data", chunk => {
@@ -4396,6 +4441,34 @@ it("http2 allowHTTP1 fallback close() destroys a keep-alive connection whose res
     const serverClosed = new Promise(resolveClosed => server.close(resolveClosed));
     expect(serverSocket.destroyed).toBe(true);
     await Promise.all([serverClosed, closed]);
+  } finally {
+    socket.destroy();
+    if (server.listening) server.close();
+  }
+});
+
+it("http2 allowHTTP1 fallback close() gives a connection whose peer stopped reading keepAliveTimeout to flush, then cuts it", async () => {
+  let serverSocket;
+  const serverClosed = Promise.withResolvers();
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true, keepAliveTimeout: 100 }, (req, res) => {
+    serverSocket = req.socket;
+    // Far more than the kernel buffers of a peer that never reads will take.
+    res.end(Buffer.alloc(32 * 1024 * 1024, 120));
+    server.close(serverClosed.resolve);
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const socket = tls.connect(
+    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+    () => {
+      socket.pause();
+      socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    },
+  );
+  try {
+    socket.on("error", () => {});
+    // Completes once the server gives up on flushing; waiting on the peer would never return.
+    await serverClosed.promise;
+    expect(serverSocket.destroyed).toBe(true);
   } finally {
     socket.destroy();
     if (server.listening) server.close();


### PR DESCRIPTION
### Problem
- An `http2.createSecureServer({ allowHTTP1: true })` handler that runs `res.end("BODY")` and then `server.close()` in the same tick sends an HTTP/1.1 client the `200` head with `Content-Length: 4` and an empty body. Node delivers `BODY`.
- Same for `req.socket.destroy()`, `res.destroy()`, and `close()` / `closeIdleConnections()` / `closeAllConnections()` on an `http.Server` given the socket via `emit("connection")`. A chunked response loses every chunk and the terminator.
- Cause: the fallback writes head, framing and body as separate socket writes, and a TLS socket completes a write on the next tick, so when `end()` returns only the first piece is on the transport and a `destroy()` in that tick discards the rest.
- The idle sweep behind `close()` counts a request finished the moment `end()` ran, so it destroys the socket with the body still queued.

### Fix
- The response handle corks the socket across the pieces written in one tick and uncorks in `end()`, as Node's `OutgoingMessage` does. Property to check: when `end()` returns the whole response has been handed to the transport, so a `destroy()` after it loses nothing.
- The idle sweep no longer destroys a socket with bytes queued: it ends the socket and destroys it on `'finish'`, or after the server's `keepAliveTimeout` (5 s default) if the peer stops reading. A socket with nothing queued is still destroyed synchronously and `closeAllConnections()` stays forceful, both as in Node.
- Request accounting is left as is on purpose: counting a request finished only after flush would make the sweep skip the connection, and `close()` would then wait on the client.
- Verification: eight new tests fail on released bun with `Received: ""` and pass with this change; applying only one of the two parts leaves some of them failing. The repro scripts give byte-identical bodies under node v26.3.0. A proxy test helper is also pinned to 127.0.0.1 for an unrelated dual-stack failure.

### Background
- The HTTP/1 fallback: when a `node:http2` secure server has `allowHTTP1` and the client negotiates HTTP/1.1, a JS response handle in `src/js/internal/http1_server_fallback.ts` serves the request. `http.Server#emit("connection", socket)` takes the same path, so the socket can be any Duplex.
- Cork: `socket.cork()` makes a Writable buffer writes instead of passing them down; `uncork()` hands the buffered pieces down together (one `_writev` on net/TLS sockets). Corks nest, so data moves only once every cork is released.
- Duplex writes are asynchronous: TLS sockets and `duplexPair` sides complete a write on a later tick, so `write()` returning does not mean the bytes left the process, and `destroy()` drops whatever `writableLength` still counts.
- Idle sweep: `server.close()` and `closeIdleConnections()` destroy each tracked connection with no request in flight; `closeAllConnections()` destroys all of them regardless.
- `net.Socket#destroySoon()` means "end the socket, destroy it once flushed"; the sweep spells it out because a plain Duplex may not have it.

<details>
<summary>Original description</summary>

### Repro

An `http2.createSecureServer({ allowHTTP1: true })` handler that ends the response and tears the connection down in the same tick:

```js
const server = http2.createSecureServer({ cert, key, allowHTTP1: true }, (req, res) => {
  res.end("BODY");
  server.close(); // likewise req.socket.destroy(), res.destroy(), and on an http.Server that was fed the
}); // socket via emit("connection"): closeIdleConnections(), close(), closeAllConnections()
// HTTP/1.1 client (tls.connect with ALPNProtocols: ["http/1.1"], or any https client):
// node v26.3.0: HTTP/1.1 200 OK ... Content-Length: 4 ... "BODY"
// bun 1.4.0:    HTTP/1.1 200 OK ... Content-Length: 4 ... ""      (connection closed after the head)
```

Same for a `Connection: close` request and for a chunked `res.write("BO"); res.end("DY")`, where the client gets nothing after the head, not even the chunk framing. Node delivers the complete body in every one of these.

### Cause

The fallback's response handle in `src/js/internal/http1_server_fallback.ts` (used by http2's `allowHTTP1` and by `http.Server#emit("connection", socket)`) writes the head, the chunk framing and the body as separate `socket.write()` calls. A TLS socket, like most Duplexes, completes a write on the next tick, so when `res.end()` returns only the first piece has reached the transport and the rest is queued in the socket's Writable. Anything that `destroy()`s the socket in that tick throws the queue away: the idle sweep `closeIdleHttp1Connections()` (reached from `Http2SecureServer#close()` and `http.Server#close()`/`closeIdleConnections()`, and which counts the request as finished the moment `end()` ran), `closeAllConnections()`, `res.destroy()`, `req.socket.destroy()`.

Node does not have this problem because `OutgoingMessage` corks the socket across the pieces written in a tick and uncorks in `end()`: the whole response has been handed to the transport by the time `end()` returns, so a `destroy()` after it loses nothing. Bun's native handle gets the same guarantee by corking inside `writeHeadAndEnd`.

### Fix

1. The handle does what Node's `write_()`/`end()` do: `write()` corks the socket until the next tick, `end()` corks around its pieces and then releases every cork. On a net/TLS socket the response written in one tick leaves as a single `_writev`, so all of the teardown paths above deliver it. The same scripts under node v26.3.0 produce byte-identical bodies for every variant in the repro.

2. The idle sweep no longer destroys a connection that still has bytes queued (a Duplex without `_writev`, a write still completing, a peer that stopped reading). It ends the socket, unless the response already did, and destroys it on `'finish'`: `net.Socket#destroySoon()` written out so a plain Duplex works too. The connection is marked so the repeated `closeIdleConnections()` calls shutdown code tends to make do not stack a listener per call, and the flush is bounded by the server's `keepAliveTimeout` (5 s by default), after which the connection is cut exactly as before, so `close()` cannot be held open indefinitely by a peer that stopped reading. A connection with nothing queued is still destroyed synchronously, and `closeAllConnections()` stays forceful, both as in node.

Keeping the request accounting as it is, instead of only counting the request finished once its bytes are flushed, is deliberate: that variant would make the sweep skip the connection, and since nothing closes a keep-alive fallback connection afterwards, `close()` would then wait on the client instead of losing the body.

### Tests

`test/js/node/http2/node-http2.test.js`, next to the other `allowHTTP1` fallback tests:
- `res.end(); server.close()` delivers the body for a keep-alive request, for a `Connection: close` request (the response ended the socket itself before the sweep) and for a chunked `write()`+`end()` (every chunk plus the terminator), and `close()` completes although the client keeps its side half-open
- `res.end(); req.socket.destroy()`, `res.end(); res.destroy()` and `write(); write(); end(); socket.destroy()` deliver exactly what node sends
- a keep-alive connection whose response was already delivered is still destroyed synchronously by `close()`
- against a peer that never reads a 32 MiB response, `close()` still completes (`keepAliveTimeout: 100`) and the connection is destroyed

`test/js/node/http/node-http.test.ts` (both flows also deliver the body under node): `emit("connection", duplexPairSide)`, whose sides have no `_writev` and therefore exercise the sweep's flush, with twelve `closeIdleConnections()` calls (no `MaxListenersExceededWarning`) and with `close()`; and `closeAllConnections()` right after `res.end()` on a TLS socket fed in from a `tls.Server`.

`test/js/node/http/node-http-proxy.js` (helper for the existing proxy test in the same file) now pins its proxy server and client to 127.0.0.1: on a dual-stack host `listen("localhost")` binds `::1` while the client connects to 127.0.0.1 (node does the same), which made `node-http.test.ts` fail regardless of this change.

On the released bun the six http2 delivery tests and both http tests fail with `Received: ""` (the two guard tests pass, as intended); all pass with this change. With only part 1 applied the duplexPair test still fails, with only part 2 the destroy-after-end tests still fail. `node-http2.test.js`, `node-http.test.ts`, `fetch-http2-client.test.ts` and the ported `test-http2-allow-http1`, `test-http2-https-fallback*`, `test-http2-server-close-idle-connection`, `test-http2-server-http1-client`, `test-http-server-close-idle*`, `test-https-server-close-idle`, `test-http-server-close-all` and `test-http-generic-streams` still pass with the debug build.

</details>
