### PR TITLE
node:http2: drop empty DATA frames that carry no END_STREAM, pass the stream id to frameError

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2893,14 +2893,10 @@ class Http2Stream extends Duplex {
           return;
         }
         this[bunHTTP2StreamStatus] |= StreamState.FinalCalled;
-        // When waitForTrailers is active, writing an empty DATA frame with
-        // close=true emits a bare empty DATA frame (flags=0) to the wire
-        // before the trailer/noTrailers path runs, which then emits ANOTHER
-        // empty DATA (with END_STREAM). Two consecutive empty DATA frames
-        // confuse strict peers (nghttp2 callback failure). Skip the empty
-        // writeStream and drive the wantTrailers path directly — the
-        // eventual `sendTrailers({})` → `noTrailers` call terminates the
-        // stream with a single empty DATA END_STREAM frame, matching Node.
+        // With trailers pending there is no frame for _final to send (END_STREAM rides on the
+        // trailers), so drive the wantTrailers path directly. The eventual `sendTrailers()`, or
+        // `sendTrailers({})` -> `noTrailers` (a single empty DATA END_STREAM frame, as in Node),
+        // terminates the stream.
         if (this[bunHTTP2WaitForTrailers]) {
           this[bunHTTP2WaitForTrailers] = false;
           if ((this[bunHTTP2StreamStatus] & StreamState.WantTrailer) === 0) {
@@ -6760,7 +6756,7 @@ function onErrorSecureServerSession(err, socket) {
 }
 
 function emitFrameErrorEventNT(stream, frameType, errorCode) {
-  stream.emit("frameError", frameType, errorCode);
+  stream.emit("frameError", frameType, errorCode, stream.id);
 }
 class Http2SecureServer extends tls.Server {
   timeout = 0;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1713,21 +1713,22 @@ impl Stream {
             let mut writer = client.to_writer();
 
             if frame_len == 0 {
-                // flush a zero payload frame
                 let Some(frame) = self.data_frame_queue.dequeue() else {
                     return FlushState::NoAction;
                 };
+                // Same rule as send_data: an empty DATA frame is only written to carry END_STREAM.
+                // Otherwise the entry is consumed for its callback / wantTrailers bookkeeping only.
+                let end_stream = frame.end_stream && !self.wait_for_trailers;
+                owned_frame = Some(frame);
+                if !end_stream {
+                    break 'brk true;
+                }
                 let data_header = FrameHeader {
                     type_: FrameType::HTTP_FRAME_DATA as u8,
-                    flags: if frame.end_stream && !self.wait_for_trailers {
-                        DataFrameFlags::END_STREAM as u8
-                    } else {
-                        0
-                    },
+                    flags: DataFrameFlags::END_STREAM as u8,
                     stream_identifier: self.id,
                     length: 0,
                 };
-                owned_frame = Some(frame);
                 break 'brk data_header.write(&mut writer, &client.frames_sent_legacy);
             } else {
                 let max_size = frame_remaining
@@ -7479,21 +7480,22 @@ impl H2FrameParser {
 
         let can_close = close && !stream.wait_for_trailers;
         if payload.is_empty() {
-            // empty payload we still need to send a frame
-            let data_header = FrameHeader {
-                type_: FrameType::HTTP_FRAME_DATA as u8,
-                flags: if can_close {
-                    DataFrameFlags::END_STREAM as u8
-                } else {
-                    0
-                },
-                stream_identifier: stream_id,
-                length: 0,
-            };
             if self.has_backpressure() || self.outbound_queue_size.get() > 0 {
+                // Queued so the END_STREAM / wantTrailers bookkeeping in flush_queue runs after
+                // the frames ahead of it are written.
                 enqueued = true;
                 stream.queue_frame(self, b"", callback, close);
-            } else {
+            } else if can_close {
+                // An empty DATA frame is only sent to carry END_STREAM. Without it the frame says
+                // nothing and receivers (node's maxSessionInvalidFrames, our own engine) count it
+                // as an invalid frame, so an empty write or an end() with trailers still pending
+                // puts nothing on the wire; the callback / wantTrailers dispatch below still runs.
+                let data_header = FrameHeader {
+                    type_: FrameType::HTTP_FRAME_DATA as u8,
+                    flags: DataFrameFlags::END_STREAM as u8,
+                    stream_identifier: stream_id,
+                    length: 0,
+                };
                 let mut writer = self.to_writer();
                 let _ = data_header.write(&mut writer, &self.frames_sent_legacy);
             }

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -890,6 +890,190 @@ describe("SETTINGS ack ordering (RFC 9113 §6.5.3)", () => {
   });
 });
 
+const END_STREAM = 0x1;
+const END_HEADERS = 0x4;
+const TRAILER_TOO_LARGE = { "x-big": Buffer.alloc(64 * 1024 + 1, "x").toString() };
+
+/** `{ type, flags, length }` of every frame the raw peer received on `streamId`, in wire order. */
+function streamFrames(frames: Frame[], streamId: number) {
+  return frames.filter(f => f.streamId === streamId).map(({ type, flags, length }) => ({ type, flags, length }));
+}
+
+describe("outbound request body framing (RFC 9113 §6.1, §8.1)", () => {
+  // node (nghttp2) only ever writes a zero-length DATA frame to carry END_STREAM. One without it
+  // says nothing and is counted against the receiver's invalid-frame allowance (node's
+  // maxSessionInvalidFrames; Bun's own engine does the same), so neither an empty write nor an
+  // end() whose END_STREAM is deferred to the trailers may put one on the wire.
+  async function connectClient() {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    return { raw, client };
+  }
+
+  async function ackPreface(raw: RawH2Server, streamId: number) {
+    await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === streamId);
+    raw.sendFrame(FrameType.SETTINGS, 0, 0); // server SETTINGS
+    raw.sendFrame(FrameType.SETTINGS, 0x1, 0); // ACK the client's
+  }
+
+  test("end() with trailers pending sends no DATA frame: END_STREAM rides on the trailer HEADERS", async () => {
+    const { raw, client } = await connectClient();
+    try {
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      req.on("wantTrailers", () => req.sendTrailers({ "x-trailer": "1" }));
+      await ackPreface(raw, 1);
+      req.end();
+      await raw.waitFor(f => f.streamId === 1 && (f.flags & END_STREAM) !== 0);
+      expect(streamFrames(raw.frames, 1)).toEqual([
+        { type: FrameType.HEADERS, flags: END_HEADERS, length: expect.any(Number) },
+        { type: FrameType.HEADERS, flags: END_HEADERS | END_STREAM, length: expect.any(Number) },
+      ]);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("end() with trailers pending but no wantTrailers listener terminates with a single empty DATA END_STREAM", async () => {
+    const { raw, client } = await connectClient();
+    try {
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      await ackPreface(raw, 1);
+      req.end();
+      await raw.waitFor(f => f.streamId === 1 && (f.flags & END_STREAM) !== 0);
+      expect(streamFrames(raw.frames, 1)).toEqual([
+        { type: FrameType.HEADERS, flags: END_HEADERS, length: expect.any(Number) },
+        { type: FrameType.DATA, flags: END_STREAM, length: 0 },
+      ]);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("empty writes put nothing on the wire", async () => {
+    const { raw, client } = await connectClient();
+    try {
+      const req = client.request({ ":method": "POST", ":path": "/" });
+      req.on("error", () => {});
+      await ackPreface(raw, 1);
+      await new Promise<void>(resolve => req.write("", () => resolve()));
+      await new Promise<void>(resolve => req.write(Buffer.alloc(0), () => resolve()));
+      await new Promise<void>(resolve => req.write("payload", () => resolve()));
+      await new Promise<void>(resolve => req.write("", () => resolve()));
+      req.end();
+      await raw.waitFor(f => f.streamId === 1 && (f.flags & END_STREAM) !== 0);
+      expect(streamFrames(raw.frames, 1)).toEqual([
+        { type: FrameType.HEADERS, flags: END_HEADERS, length: expect.any(Number) },
+        { type: FrameType.DATA, flags: 0, length: "payload".length },
+        { type: FrameType.DATA, flags: END_STREAM, length: 0 },
+      ]);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("an end() with trailers pending that queues behind flow-control-blocked data is not written when it drains", async () => {
+    const { raw, client } = await connectClient();
+    try {
+      // Stream 1 fills both 65535-byte initial send windows; its last byte stays queued, so
+      // every later frame on the session goes through the outbound queue instead of being
+      // written directly.
+      const blocked = client.request({ ":method": "POST", ":path": "/blocked" });
+      blocked.on("error", () => {});
+      await ackPreface(raw, 1);
+      blocked.write(Buffer.alloc(65535 + 1, "a"));
+      const dataBytes = () =>
+        raw.frames.reduce((n, f) => (f.streamId === 1 && f.type === FrameType.DATA ? n + f.length : n), 0);
+      await raw.waitFor(f => f.streamId === 1 && f.type === FrameType.DATA && dataBytes() >= 65535, 10_000);
+      expect(dataBytes()).toBe(65535);
+
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      req.on("wantTrailers", () => req.sendTrailers({ "x-trailer": "1" }));
+      req.end();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 3);
+      // Reopen the connection window (stream 1 stays blocked on its own window) so the queue
+      // drains: stream 3's queued end entry must surface as the trailer HEADERS alone.
+      const increment = Buffer.alloc(4);
+      increment.writeUInt32BE(65535, 0);
+      raw.sendFrame(FrameType.WINDOW_UPDATE, 0, 0, increment);
+      await raw.waitFor(f => f.streamId === 3 && (f.flags & END_STREAM) !== 0);
+      expect(streamFrames(raw.frames, 3)).toEqual([
+        { type: FrameType.HEADERS, flags: END_HEADERS, length: expect.any(Number) },
+        { type: FrameType.HEADERS, flags: END_HEADERS | END_STREAM, length: expect.any(Number) },
+      ]);
+      expect(dataBytes()).toBe(65535);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("a client stream whose trailers cannot be encoded gets frameError(type, code, id) and HEADERS then RST_STREAM on the wire", async () => {
+    const { raw, client } = await connectClient();
+    try {
+      // A first request takes stream 1 so the id reported below is not the default one.
+      const other = client.request({ ":path": "/other" });
+      other.on("error", () => {});
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      req.on("wantTrailers", () => req.sendTrailers(TRAILER_TOO_LARGE));
+      const frameError = new Promise<unknown[]>(resolve => req.on("frameError", (...args) => resolve(args)));
+      await ackPreface(raw, 3);
+      req.end();
+      expect(await frameError).toEqual([FrameType.HEADERS, ErrorCode.FRAME_SIZE_ERROR, 3]);
+      const rst = await raw.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 3);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.FRAME_SIZE_ERROR);
+      expect(streamFrames(raw.frames, 3)).toEqual([
+        { type: FrameType.HEADERS, flags: END_HEADERS, length: expect.any(Number) },
+        { type: FrameType.RST_STREAM, flags: 0, length: 4 },
+      ]);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("a server stream whose trailers cannot be encoded gets frameError(type, code, id)", async () => {
+    const frameError = Promise.withResolvers<unknown[]>();
+    const server = http2.createServer();
+    server.on("session", (session: any) => session.on("error", () => {}));
+    server.on("stream", (stream: any, headers: any) => {
+      stream.on("error", () => {});
+      if (headers[":path"] === "/other") {
+        stream.respond({ ":status": 200 }, { endStream: true });
+        return;
+      }
+      stream.on("frameError", (...args: unknown[]) => frameError.resolve(args));
+      stream.respond({ ":status": 200 }, { waitForTrailers: true });
+      stream.on("wantTrailers", () => stream.sendTrailers(TRAILER_TOO_LARGE));
+      stream.end();
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+    client.on("error", () => {});
+    try {
+      // Stream 1 is taken by a plain request so the failing stream is id 3.
+      const other = client.request({ ":path": "/other" });
+      other.on("error", () => {});
+      other.resume();
+      const req = client.request({ ":path": "/" });
+      req.on("error", () => {});
+      req.resume();
+      expect(await frameError.promise).toEqual([FrameType.HEADERS, ErrorCode.FRAME_SIZE_ERROR, 3]);
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  });
+});
+
 function requestHeaderBlock(method: "GET" | "POST", extra: Buffer = Buffer.alloc(0)): Buffer {
   return Buffer.concat([
     Buffer.from([method === "POST" ? 0x83 : 0x82, 0x86, 0x84, 0x01]),


### PR DESCRIPTION
### Problem
- A `node:http2` stream that calls `end()` with trailers pending, or `write("")` / `write(Buffer.alloc(0))`, puts a zero-length DATA frame with no flags on the wire. Node never sends one.
- That frame carries no information, and receivers (node's `maxSessionInvalidFrames`, Bun's own inbound parser) count it against the session's invalid-frame allowance, so body-less `waitForTrailers` requests slowly burn the peer's budget.
- Cause: the outbound path wrote a DATA header for every empty payload and only chose the flags based on whether trailers were pending, on both the direct write path and the queued (backpressure) path.
- Separately, the stream-level `'frameError'` event was emitted as `(type, code)`; node emits `(type, code, id)`.

### Fix
- An empty payload is written as a DATA frame only when it can carry END_STREAM. Otherwise nothing goes on the wire, and the write callback and `wantTrailers` dispatch still run. The queued path applies the same rule when it drains, so ordering behind earlier frames is unchanged.
- Correct because END_STREAM is the only thing a zero-length DATA frame can convey; `noTrailers()` / `sendTrailers({})` still terminate with a single `DATA(END_STREAM)`, as node does.
- `'frameError'` now passes the stream id as its third argument, node's documented signature.
- Verification: six new wire-level tests (direct path, queued path, client and server `frameError` args) fail on the unfixed binary and pass with the fix. The existing http2 suite and the 256 upstream `test-http2-*` files still pass; the manual repro against node v26.3.0 is in the original.

### Background
- HTTP/2 sends a body as DATA frames on a stream; the END_STREAM flag marks the last frame. A zero-length DATA frame with END_STREAM is the normal way to finish when there is nothing left to send.
- `waitForTrailers`: with this option `end()` does not close the stream. The stream emits `wantTrailers`, and the trailer HEADERS frame written by `sendTrailers()` carries END_STREAM instead; `sendTrailers({})` falls back to an empty `DATA(END_STREAM)`.
- Invalid-frame allowance: HTTP/2 receivers (nghttp2 in node, Bun's own parser) tolerate a bounded number of meaningless or malformed frames per session before tearing it down, and a flagless empty DATA frame counts.
- Outbound queue: when the session has socket backpressure or frames already waiting on flow control, a write is queued and written later by the flush path, so the empty-frame rule has to hold in two places.
- `'frameError'` is the per-stream event fired when a frame cannot be encoded (here, trailers larger than the max frame size); the stream is then reset with `FRAME_SIZE_ERROR`.

<details>
<summary>Original description</summary>

## What

Two node compat fixes on the `node:http2` outbound path, both visible with a `waitForTrailers` request against a raw server that logs the frames it receives:

1. Bun wrote a zero-length DATA frame with no flags whenever the outbound payload was empty but END_STREAM could not be set: `req.end()` with trailers pending (END_STREAM rides on the trailer HEADERS), and every `write("")` / `write(Buffer.alloc(0))`. Node never sends such a frame. An empty DATA frame without END_STREAM carries no information, and receivers count each one against the session's invalid-frame allowance (node's `maxSessionInvalidFrames`; Bun's own inbound engine does the same in `h2/connection.rs`), so a Bun client doing body-less `waitForTrailers` POSTs slowly burns the peer's budget.
2. The stream-level `'frameError'` event was emitted as `(type, code)`. Node emits `(type, code, id)`.

## Repro

Raw `net` server that sends SETTINGS after the preface, ACKs the client's SETTINGS and logs `{type, flags, len}` of every frame on stream 1:

```js
const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
req.on("wantTrailers", () => req.sendTrailers({ "x-big": Buffer.alloc(64 * 1024 + 1, "x").toString() }));
req.on("frameError", (type, code, id) => console.log("frameError", type, code, id));
req.end();
```

| | node v26.3.0 | bun 1.4.0 |
|---|---|---|
| frames on stream 1 | `HEADERS(4)` `RST_STREAM` | `HEADERS(4)` **`DATA(flags=0,len=0)`** `RST_STREAM` |
| `frameError` args | `1 6 1` | `1 6 undefined` |

With a small trailer the stray frame is the same: node sends `HEADERS(4)` then `HEADERS(5)`, bun sent `HEADERS(4)` `DATA(0,0)` `HEADERS(5)`; with no `wantTrailers` listener node sends `HEADERS(4)` `DATA(flags=1,len=0)`, bun sent `HEADERS(4)` `DATA(0,0)` `DATA(1,0)`. `req.write("")` on a plain POST also produced a `DATA(0,0)` per call. After this change every one of these flows produces the same frame sequence as node (the request flows that already carried a body were already identical and are unchanged).

## Cause

`H2FrameParser::send_data` ("empty payload we still need to send a frame") wrote a DATA header for every empty payload and only decided the *flags* based on `wait_for_trailers`; `Stream::flush_queue` did the same for a zero-length queued entry (the path taken when the session already has frames queued behind flow control or socket backpressure). The server-side `_final` in `http2.ts` had grown a JS workaround for this; the client `_final` and plain empty writes went straight to native.

`emitFrameErrorEventNT` in `http2.ts` (shared by the client and server handlers) simply never passed the id.

## Fix

- `send_data`: an empty payload is written only when it can carry END_STREAM. When it cannot (trailers pending, or a plain empty write) nothing goes on the wire; the write callback and the `wantTrailers` dispatch still run exactly as before. The queued branch is unchanged so ordering relative to frames ahead of it is preserved.
- `flush_queue`: a zero-length queued entry is written only when it ends up carrying END_STREAM; otherwise it is consumed for its callback / `wantTrailers` bookkeeping alone.
- `emitFrameErrorEventNT` passes `stream.id`.

Why this is right: END_STREAM is the only thing a zero-length DATA frame can convey, so a frame that will not carry it has no receiver-visible purpose, and both nghttp2 (observed above) and Bun's own receiver treat it as noise to be rate-limited. `noTrailers()` / `sendTrailers({})` still terminate with a single `DATA(END_STREAM, len 0)`, as node does. The `frameError` argument order is the documented node signature.

Not changed here (separate, already tracked): the `ERR_HTTP2_STREAM_CANCEL` vs `ERR_HTTP2_STREAM_ERROR` code on this path (#36389), and a client `endStream` + `waitForTrailers` request, where node puts END_STREAM on the request HEADERS and never asks for trailers.

## Verification

New `outbound empty DATA frames and trailer encode failures` block in `test/js/node/http2/h2-conformance.test.ts`, all wire-level against the file's raw server:

- `end()` with trailers pending: stream frames are exactly `HEADERS`, trailer `HEADERS(END_STREAM)`
- same with no `wantTrailers` listener: exactly `HEADERS`, `DATA(END_STREAM, len 0)`
- `write("")`, `write(Buffer.alloc(0))`, `write("payload")`, `write("")`, `end()`: exactly `HEADERS`, `DATA(7)`, `DATA(END_STREAM, 0)`
- the queued path: stream 1 exhausts both send windows so stream 3's `end()` goes through the outbound queue; after a connection WINDOW_UPDATE stream 3 shows exactly `HEADERS`, trailer `HEADERS(END_STREAM)` (this is the `flush_queue` path; the direct `send_data` branch is not involved while another stream's data is queued)
- client trailers that cannot be encoded: `frameError` args are `[HEADERS, FRAME_SIZE_ERROR, 3]` and the wire is `HEADERS`, `RST_STREAM(FRAME_SIZE_ERROR)` with no DATA
- server trailers that cannot be encoded: `frameError` args are `[HEADERS, FRAME_SIZE_ERROR, 3]`

All six fail on the unfixed binary (the extra `{type: 0, flags: 0, length: 0}` entries / two-element `frameError` args) and pass with the fix. `bun bd test test/js/node/http2/` otherwise passes apart from two tests that only time out under the debug build's 5 s default when the whole directory runs (`node-http2-streams-rehash` forEachStream, and the TLS-over-Duplex "tail" case in `node-http2.test.js`); both pass when run on their own and neither touches the changed paths. All 256 upstream `test-http2-*` files in `test/js/node/test/parallel` exit 0 with the fix (including `test-http2-write-empty-string`, `test-http2-zero-length-write`, `test-http2-write-callbacks`, `test-http2-trailers`, `test-http2-exceeds-server-trailer-size` and the compat trailer tests); `test-http2-forget-closed-streams` needs about 1.5 minutes under the debug build but passes.

</details>
