### PR TITLE
install: resolve deferred `*` peers after their siblings, not on arrival order

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1972,17 +1972,9 @@ fn get_or_put_resolved_package_with_find_result(
 
     // Was this package already allocated? Let's reuse the existing one.
     //
-    // Determinism: passing `version` here lets a peer collapse onto whichever
-    // sibling-appended entry happens to be highest in the index *at this
-    // instant*, which depends on the order the registry's responses arrived
-    // in. The floor guard in `get_package_id` does not cover this case: every
-    // candidate is an exact-pinned same-major sibling. So while peers are
-    // still deferred (`!install_peer`), only an exact `eql(find_result)` may
-    // bind here; anything else falls through to the `is_peer && !install_peer`
-    // defer below and is resolved by phase 2's descending-index scan in
-    // `get_or_put_resolved_package`, once every sibling has been appended.
-    // This includes `*`: it satisfies every sibling, so it is the range most
-    // exposed to arrival order.
+    // A peer that is still deferred may only reuse an exact match: which
+    // siblings exist at this point depends on response arrival order, so the
+    // range match waits for the `install_peer` pass, when all of them exist.
     let suppress_peer_satisfies = behavior.is_peer() && !install_peer;
     if let Some(id) = this.lockfile.get_package_id(
         name_hash,

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1972,23 +1972,18 @@ fn get_or_put_resolved_package_with_find_result(
 
     // Was this package already allocated? Let's reuse the existing one.
     //
-    // Determinism: passing `version` here unconditionally lets a
-    // peer like `>= 1.0.2` collapse onto whichever sibling-appended entry
-    // (e.g. `1.0.9`) happens to be highest in the index *at this instant* — a
-    // network-order artefact that the `^1.0.2` peer-hoisting test already
-    // todoIf's on macOS. The floor guard in `get_package_id` was
-    // meant to close that, but its exact-pinned/same-major exemptions reopen
-    // it when *every* candidate is an exact-pinned same-major sibling
-    // (`uses-a-dep-1..10`). For deferred peers, suppress the satisfies-
-    // fallback so only an exact `eql(find_result)` can bind here; everything
-    // else falls through to the `is_peer && !install_peer` defer below and is
-    // resolved deterministically by phase 2's descending-index scan in
-    // `get_or_put_resolved_package`. `*` is left alone — it expresses no
-    // version preference, and the "peer *" hoisting test depends on it
-    // deduping to whatever sibling pin exists rather than the manifest floor.
-    let suppress_peer_satisfies = behavior.is_peer()
-        && !install_peer
-        && !(version.tag == dependency::version::Tag::Npm && version.npm().version.is_star());
+    // Determinism: passing `version` here lets a peer collapse onto whichever
+    // sibling-appended entry happens to be highest in the index *at this
+    // instant*, which depends on the order the registry's responses arrived
+    // in. The floor guard in `get_package_id` does not cover this case: every
+    // candidate is an exact-pinned same-major sibling. So while peers are
+    // still deferred (`!install_peer`), only an exact `eql(find_result)` may
+    // bind here; anything else falls through to the `is_peer && !install_peer`
+    // defer below and is resolved by phase 2's descending-index scan in
+    // `get_or_put_resolved_package`, once every sibling has been appended.
+    // This includes `*`: it satisfies every sibling, so it is the range most
+    // exposed to arrival order.
+    let suppress_peer_satisfies = behavior.is_peer() && !install_peer;
     if let Some(id) = this.lockfile.get_package_id(
         name_hash,
         if should_update || suppress_peer_satisfies {

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3003,16 +3003,13 @@ pub(crate) fn parse_into_binary_lockfile(
 }
 
 /// True for peer edges the fresh resolver defers to its second phase
-/// (`install_peer`) and binds by version there. Two exemptions, matching
+/// (`install_peer`) and binds by version there. One exemption, matching
 /// `enqueue_dependency_with_main_and_success_fn`: optional peers return
 /// before the deferred phase and are bound to the hoisted-tree sibling by
-/// `process_subtree` instead, and `*` peers express no version preference
-/// and bind to whatever sibling pin existed first. Both of those are
-/// exactly what the printed tree's path walk reproduces, so they keep it.
+/// `process_subtree` instead, which is exactly what the printed tree's path
+/// walk reproduces, so they keep it.
 fn is_deferred_peer(dep: &Dependency) -> bool {
-    dep.behavior.is_peer()
-        && !dep.behavior.is_optional_peer()
-        && !(dep.version.tag == DependencyVersionTag::Npm && dep.version.npm().version.is_star())
+    dep.behavior.is_peer() && !dep.behavior.is_optional_peer()
 }
 
 /// Resolve a peer dependency edge the way the fresh resolver's

--- a/src/install/lockfile/bun.lock.rs
+++ b/src/install/lockfile/bun.lock.rs
@@ -3002,12 +3002,9 @@ pub(crate) fn parse_into_binary_lockfile(
     Ok(())
 }
 
-/// True for peer edges the fresh resolver defers to its second phase
-/// (`install_peer`) and binds by version there. One exemption, matching
-/// `enqueue_dependency_with_main_and_success_fn`: optional peers return
-/// before the deferred phase and are bound to the hoisted-tree sibling by
-/// `process_subtree` instead, which is exactly what the printed tree's path
-/// walk reproduces, so they keep it.
+/// Peer edges the fresh resolver binds by version in its `install_peer`
+/// pass. Optional peers are bound to the hoisted-tree sibling by
+/// `process_subtree` instead, which is what the path walk reproduces.
 fn is_deferred_peer(dep: &Dependency) -> bool {
     dep.behavior.is_peer() && !dep.behavior.is_optional_peer()
 }

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3818,6 +3818,61 @@ describe("hoisting", async () => {
 
       expect(await hoistedADepVersion()).toBe("1.0.10");
     });
+
+    test("peer * binds to the same version when bun.lock is loaded as when it was resolved", async () => {
+      // Nothing above `peer-a-dep-star` provides a-dep, so the isolated linker
+      // installs the peer from the version the edge resolved to and keys the
+      // store entry by it. The root of the printed tree holds a-dep@1.0.1 (from
+      // uses-a-dep-1), while the resolver picks the highest a-dep, 1.0.5. The
+      // second install loads bun.lock and has to arrive at the same 1.0.5, or it
+      // creates a second store entry for peer-a-dep-star.
+      await Promise.all([
+        write(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            workspaces: ["packages/*"],
+            dependencies: { "uses-a-dep-1": "1.0.0", "uses-a-dep-5": "1.0.0" },
+          }),
+        ),
+        write(
+          join(packageDir, "packages", "pkg", "package.json"),
+          JSON.stringify({ name: "pkg", dependencies: { "peer-a-dep-star": "1.0.0" } }),
+        ),
+      ]);
+      const store = join(packageDir, "node_modules", ".bun");
+
+      async function install() {
+        await using proc = spawn({
+          cmd: [bunExe(), "install", "--save-text-lockfile", "--linker", "isolated"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
+        const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+        expect(err).not.toContain("error:");
+        expect(exitCode).toBe(0);
+        return {
+          err,
+          out,
+          entries: (await readdirSorted(store)).filter(entry => entry.startsWith("peer-a-dep-star@")),
+        };
+      }
+
+      const first = await install();
+      expect(first.err).toContain("Saved lockfile");
+      expect(first.entries).toHaveLength(1);
+      expect(await file(join(store, first.entries[0], "node_modules", "a-dep", "package.json")).json()).toMatchObject({
+        version: "1.0.5",
+      });
+
+      const second = await install();
+      expect(second.err).not.toContain("Saved lockfile");
+      expect(second.out).toContain("(no changes)");
+      expect(second.entries).toEqual(first.entries);
+    });
   });
 
   test("hoisting/using incorrect peer dep after install", async () => {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -3732,9 +3732,6 @@ describe("hoisting", async () => {
         expect(err).toContain("Saved lockfile");
         expect(err).not.toContain("not found");
         expect(err).not.toContain("error:");
-        if (out.includes("installed")) {
-          console.log("stdout:", out);
-        }
         expect(out).not.toContain("package installed");
         expect(await exited).toBe(0);
         assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -8,7 +8,6 @@ import {
   bunExe,
   bunEnv as env,
   isFlaky,
-  isMacOS,
   isWindows,
   mergeWindowEnvs,
   readdirSorted,
@@ -3439,6 +3438,11 @@ test("it should install with missing bun.lockb, node_modules, and/or cache", asy
 });
 
 describe("hoisting", async () => {
+  // Compare the exact version: `toContain("1.0.1")` also matches "1.0.10".
+  async function hoistedADepVersion(): Promise<string> {
+    return (await file(join(packageDir, "node_modules", "a-dep", "package.json")).json()).version;
+  }
+
   var tests: any = [
     {
       situation: "1.0.0 - 1.0.10 is in order",
@@ -3548,7 +3552,7 @@ describe("hoisting", async () => {
       expect(await exited).toBe(0);
       assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
 
-      expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).text()).toContain(expected);
+      expect(await hoistedADepVersion()).toBe(expected);
 
       await rm(join(packageDir, "bun.lockb"));
 
@@ -3657,7 +3661,9 @@ describe("hoisting", async () => {
           "uses-a-dep-10": "1.0.0",
           "peer-a-dep-star": "1.0.0",
         },
-        expected: "1.0.1",
+        // `*` is satisfied by every a-dep in the tree, so the peer takes the
+        // highest one, regardless of which manifest the registry returned first.
+        expected: "1.0.10",
       },
       {
         situation: "peer * and peer 1.0.2",
@@ -3679,88 +3685,139 @@ describe("hoisting", async () => {
       },
     ];
     for (const { dependencies, expected, situation } of peerTests) {
-      test.todoIf(isFlaky && isMacOS && situation === "peer ^1.0.2")(
-        `it should hoist ${expected} when ${situation}`,
-        async () => {
-          await writeFile(
-            packageJson,
-            JSON.stringify({
-              name: "foo",
-              dependencies,
-            }),
-          );
+      test(`it should hoist ${expected} when ${situation}`, async () => {
+        await writeFile(
+          packageJson,
+          JSON.stringify({
+            name: "foo",
+            dependencies,
+          }),
+        );
 
-          var { stdout, stderr, exited } = spawn({
-            cmd: [bunExe(), "install"],
-            cwd: packageDir,
-            stdout: "pipe",
-            stdin: "pipe",
-            stderr: "pipe",
-            env,
-          });
+        var { stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        });
 
-          var err = await stderr.text();
-          var out = await stdout.text();
-          expect(err).toContain("Saved lockfile");
-          expect(err).not.toContain("not found");
-          expect(err).not.toContain("error:");
-          for (const dep of Object.keys(dependencies)) {
-            expect(out).toContain(`+ ${dep}@${dependencies[dep]}`);
-          }
-          expect(await exited).toBe(0);
-          assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+        var err = await stderr.text();
+        var out = await stdout.text();
+        expect(err).toContain("Saved lockfile");
+        expect(err).not.toContain("not found");
+        expect(err).not.toContain("error:");
+        for (const dep of Object.keys(dependencies)) {
+          expect(out).toContain(`+ ${dep}@${dependencies[dep]}`);
+        }
+        expect(await exited).toBe(0);
+        assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
 
-          expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).text()).toContain(expected);
+        expect(await hoistedADepVersion()).toBe(expected);
 
-          await rm(join(packageDir, "bun.lockb"));
+        await rm(join(packageDir, "bun.lockb"));
 
-          ({ stdout, stderr, exited } = spawn({
-            cmd: [bunExe(), "install"],
-            cwd: packageDir,
-            stdout: "pipe",
-            stdin: "pipe",
-            stderr: "pipe",
-            env,
-          }));
+        ({ stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        }));
 
-          err = await stderr.text();
-          out = await stdout.text();
-          expect(err).toContain("Saved lockfile");
-          expect(err).not.toContain("not found");
-          expect(err).not.toContain("error:");
-          if (out.includes("installed")) {
-            console.log("stdout:", out);
-          }
-          expect(out).not.toContain("package installed");
-          expect(await exited).toBe(0);
-          assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+        err = await stderr.text();
+        out = await stdout.text();
+        expect(err).toContain("Saved lockfile");
+        expect(err).not.toContain("not found");
+        expect(err).not.toContain("error:");
+        if (out.includes("installed")) {
+          console.log("stdout:", out);
+        }
+        expect(out).not.toContain("package installed");
+        expect(await exited).toBe(0);
+        assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
 
-          expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).text()).toContain(expected);
+        expect(await hoistedADepVersion()).toBe(expected);
 
-          await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+        await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
 
-          ({ stdout, stderr, exited } = spawn({
-            cmd: [bunExe(), "install"],
-            cwd: packageDir,
-            stdout: "pipe",
-            stdin: "pipe",
-            stderr: "pipe",
-            env,
-          }));
+        ({ stdout, stderr, exited } = spawn({
+          cmd: [bunExe(), "install"],
+          cwd: packageDir,
+          stdout: "pipe",
+          stdin: "pipe",
+          stderr: "pipe",
+          env,
+        }));
 
-          err = await stderr.text();
-          out = await stdout.text();
-          expect(err).not.toContain("Saved lockfile");
-          expect(err).not.toContain("not found");
-          expect(err).not.toContain("error:");
-          expect(out).not.toContain("package installed");
-          expect(await exited).toBe(0);
-          assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
+        err = await stderr.text();
+        out = await stdout.text();
+        expect(err).not.toContain("Saved lockfile");
+        expect(err).not.toContain("not found");
+        expect(err).not.toContain("error:");
+        expect(out).not.toContain("package installed");
+        expect(await exited).toBe(0);
+        assertManifestsPopulated(join(packageDir, ".bun-cache"), registryUrl());
 
-          expect(await file(join(packageDir, "node_modules", "a-dep", "package.json")).text()).toContain(expected);
-        },
-      );
+        expect(await hoistedADepVersion()).toBe(expected);
+      });
     }
+
+    test("peer * hoists the same version no matter which manifest the registry answers first", async () => {
+      // Proxy in front of verdaccio that forces the arrival order seen on slow
+      // CI machines: the a-dep manifest gets processed (so a-dep@1.0.1..1.0.9
+      // exist in the lockfile) before peer-a-dep-star's manifest arrives, and
+      // uses-a-dep-10's manifest (the one pinning a-dep@1.0.10) arrives after
+      // peer-a-dep-star has been processed. Each held response is released by
+      // a request bun only makes once the earlier step has happened, so no
+      // timers are involved.
+      const upstream = registryUrl().replace(/\/$/, "");
+      const aDepTarballRequested = Promise.withResolvers<void>();
+      const peerTarballRequested = Promise.withResolvers<void>();
+      using proxy = Bun.serve({
+        port: 0,
+        // The held responses stay open for as long as bun takes to reach the next step.
+        idleTimeout: 0,
+        async fetch(req) {
+          const { pathname } = new URL(req.url);
+          const isTarball = pathname.includes("/-/");
+          if (pathname.startsWith("/a-dep/-/")) aDepTarballRequested.resolve();
+          if (pathname.startsWith("/peer-a-dep-star/-/")) peerTarballRequested.resolve();
+          if (pathname === "/peer-a-dep-star") await aDepTarballRequested.promise;
+          if (pathname === "/uses-a-dep-10") await peerTarballRequested.promise;
+
+          const res = await fetch(upstream + pathname, { headers: { accept: req.headers.get("accept") ?? "*/*" } });
+          if (isTarball) return new Response(await res.arrayBuffer(), { status: res.status });
+          // Tarball urls inside the manifests point at verdaccio; keep every request on the proxy.
+          return new Response((await res.text()).replaceAll(upstream, proxy.url.origin), {
+            status: res.status,
+            headers: { "content-type": "application/json" },
+          });
+        },
+      });
+
+      const dependencies: Record<string, string> = { "peer-a-dep-star": "1.0.0" };
+      for (let i = 1; i <= 10; i++) dependencies[`uses-a-dep-${i}`] = "1.0.0";
+      await writeFile(packageJson, JSON.stringify({ name: "foo", dependencies }));
+
+      await using proc = spawn({
+        cmd: [bunExe(), "install", "--registry", proxy.url.href],
+        cwd: packageDir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const [err, out, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(err).toContain("Saved lockfile");
+      expect(err).not.toContain("error:");
+      expect(out).toContain("21 packages installed");
+      expect(exitCode).toBe(0);
+
+      expect(await hoistedADepVersion()).toBe("1.0.10");
+    });
   });
 
   test("hoisting/using incorrect peer dep after install", async () => {


### PR DESCRIPTION
### Problem
- `bun-install-registry.test.ts` `hoisting > peers > it should hoist 1.0.1 when peer *` goes red on unrelated PRs, mostly on Windows (latest: build 92591, 4/4 attempts): `Expected to contain: "1.0.1"`, received `a-dep` `1.0.9`.
- Cause: which `a-dep` a `peer *` edge binds to depends on registry response order. If the `a-dep` manifest is already in memory when the peer is seen, it binds at once to the highest `a-dep` in the lockfile at that instant; otherwise it waits for the peer pass and gets the highest overall.
- Every other peer range is already protected from this; `*` was exempted because the `peer *` test was believed to need it. It does not: the test normally gets `1.0.10`, which `toContain("1.0.1")` also matches.
- The `bun.lock` loader had the same `*` exemption, so a reloaded `*` peer can bind to a different version than the resolver chose. When it does, the isolated linker adds a second store entry for the dependent on every warm install (`2 packages installed` instead of `(no changes)`). This part is already reachable on main.

### Fix
- Drop the `*` exemption in the resolver: a deferred peer binds early only on an exact match and otherwise waits for the peer pass, like every other range. The result depends only on the full set of siblings, never on arrival order (`1.0.10` here).
- Drop the matching exemption in the `bun.lock` loader, so a reload runs the same version scan as the resolver and the two agree.
- An older `bun.lock` with a `*` peer bound lower rebinds once to the highest version, as non-`*` peers already do; `--frozen-lockfile` still passes on it.
- Verification: a new test forces the CI arrival order through a proxy in front of the registry; it fails without the fix on every run (20/20 locally, same `1.0.9` as CI) and passes 30/30 with it. A second new test fails on main for the reload case. Stopgap until #36476; #33972 can be closed in favour of this.

### Background
- A peer dependency asks the dependent's tree to supply some version of a package. bun binds a peer edge either at once, if a matching package is already in the lockfile when the edge is seen, or in a later `install_peer` pass after every regular dependency has been appended.
- Manifests download concurrently and packages are appended to the lockfile as each response is processed, so what is "already in the lockfile" at a given moment varies between runs and machines.
- Hoisting: root's `node_modules/a-dep` is whichever `a-dep` the first sorted root dependency resolved to. Here `peer-a-dep-star` sorts first, so its binding is what the test reads.
- `bun.lock` records the tree, not peer bindings; on load each peer edge is re-derived, by walking the printed tree or by the resolver's version scan. The isolated linker keys store entries by the peer versions a package resolved to, so both derivations must agree or warm installs churn.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

Fixes the `bun-install-registry.test.ts` flake that has been going red on unrelated PRs for weeks, mostly on the Windows lanes (latest: build 92591, 4/4 attempts):

```
hoisting > peers > it should hoist 1.0.1 when peer *
Expected to contain: "1.0.1"
Received: "{\n    \"name\": \"a-dep\",\n    \"version\": \"1.0.9\"\n}"
```

### Cause

Root depends on `uses-a-dep-1..10` (each pins `a-dep@1.0.N`) and `peer-a-dep-star` (peer `a-dep@*`). `peer-a-dep-star` sorts first among the root dependencies, so whatever its peer resolves to is what gets hoisted to `node_modules/a-dep`.

How the peer resolves depends on what the registry answered first. If the `a-dep` manifest is not in memory yet when `peer-a-dep-star` is processed, the peer is deferred and resolved in the peer pass after every sibling has been appended, where the descending package index gives `1.0.10`. If the manifest is already in memory (slow machine: the `a-dep` manifest, requested after the first `uses-a-dep-*` response, lands before the remaining initial responses), `get_or_put_resolved_package_with_find_result` binds the peer immediately to the highest `a-dep` that exists in the lockfile at that instant. On the failing machines that was `1.0.9`, because `uses-a-dep-10` had not been processed yet.

`suppress_peer_satisfies` already prevents exactly this for every other range (`>=`, `^`, `~`, exact), but `*` was explicitly exempted, with a comment saying the `peer *` test depended on it. It does not: the test normally gets `1.0.10` and only passed because `toContain("1.0.1")` matches `"1.0.10"`.

The text lockfile loader (`is_deferred_peer` in `bun.lock.rs`) carried the same `*` exemption: on reload, a `*` peer edge was rebound by the printed-tree path walk (nearest hoisted `a-dep`) instead of the version scan the resolver uses. Whenever the two differ, the isolated linker keys a second store entry for the dependent on every warm install. That part was already reachable on main, since the resolver usually deferred `*` peers too: with `uses-a-dep-1`, `uses-a-dep-5` and a workspace depending on `peer-a-dep-star`, the second `bun install --linker isolated` reports `2 packages installed` and adds a second `peer-a-dep-star@1.0.0+<hash>` entry to `node_modules/.bun`.

### Fix

- `PackageManagerEnqueue.rs`: drop the `*` exemption, so a deferred peer only binds early on an exact match of the manifest's best version and otherwise waits for the peer pass like every other range. The result no longer depends on arrival order (`1.0.10` here).
- `bun.lock.rs`: drop the matching exemption in `is_deferred_peer`, so loading `bun.lock` binds `*` peers with the same version scan and agrees with the resolver.

Loading a `bun.lock` written before this change whose `*` peer had been bound to a lower version rebinds it to the highest one in the tree, the same one-time adjustment non-`*` peers already get; `--frozen-lockfile` still passes on such a lockfile (checked with a lockfile produced by the forced arrival order below).

This is a stopgap. #36476 reworks resolution so arrival order cannot matter anywhere; #33972 (marks the case todo) can be closed in favour of this.

### Tests

- `hoisting` tests compare the exact `a-dep` version instead of `toContain`, and `peer *` expects `1.0.10`.
- New `peer * hoists the same version no matter which manifest the registry answers first`: a small proxy in front of verdaccio holds `peer-a-dep-star`'s manifest until an `a-dep` tarball has been requested (so the `a-dep` manifest is loaded and `1.0.1..1.0.9` exist) and holds `uses-a-dep-10`'s manifest until the `peer-a-dep-star` tarball has been requested. Each release is triggered by a request bun only makes after the previous step, so there are no timers. Without the fix it fails with `1.0.9` on every run (20/20 locally, the same value CI reports); with it, 30/30 pass.
- New `peer * binds to the same version when bun.lock is loaded as when it was resolved`: the isolated-linker scenario above with `--save-text-lockfile`. On main the second install prints `2 packages installed` instead of `(no changes)`; with the fix the store entry set is unchanged.
- The macOS `todoIf` on the `peer ^1.0.2` case was for the same class of flake and is removed; that range has been covered by `suppress_peer_satisfies` since the rewrite.
- `bun-install-registry.test.ts`, `bun-install.test.ts`, `bun-add.test.ts`, `bun-lock.test.ts`, `isolated-install.test.ts`, `bun-workspaces.test.ts`, `test-dev-peer-dependency-priority.test.ts`, the pnpm/yarn migration suites and `regression/issue/36577.test.ts` pass locally with the debug build (the only failures in `bun-install.test.ts` are the git/tarball tests that need network access and fail identically without this change).

</details>
