### PR TITLE
Declare the "bun" module's ESM exports lazily instead of reifying the whole Bun object

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -1148,56 +1148,41 @@ JSC::JSObject* createBunObject(VM& vm, JSObject* globalObject)
     return JSBunObject::create(vm, uncheckedDowncast<Zig::GlobalObject>(globalObject));
 }
 
-static void exportBunObject(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::JSObject* object, Vector<JSC::Identifier, 4>& exportNames, JSC::MarkedArgumentBuffer& exportValues)
-{
-    exportNames.reserveCapacity(std::size(bunObjectTableValues) + 1);
-    exportValues.ensureCapacity(std::size(bunObjectTableValues) + 1);
-
-    PropertyNameArrayBuilder propertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
-    auto scope = DECLARE_THROW_SCOPE(vm);
-    object->getOwnNonIndexPropertyNames(globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
-    RETURN_IF_EXCEPTION(scope, void());
-
-    exportNames.append(vm.propertyNames->defaultKeyword);
-    exportValues.append(object);
-
-    for (const auto& propertyName : propertyNames) {
-        exportNames.append(propertyName);
-        auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-
-        // Yes, we have to call getters :(
-        JSValue value = object->get(globalObject, propertyName);
-
-        if (topExceptionScope.exception()) {
-            (void)topExceptionScope.tryClearException();
-            value = jsUndefined();
-        }
-        exportValues.append(value);
-    }
-}
-
 } // namespace Bun
 
 namespace Zig {
-void generateNativeModule_BunObject(JSC::JSGlobalObject* lexicalGlobalObject,
+// Every export except `default` is declared without a value: JSC reads `Bun[name]` the first time
+// something binds to it (SyntheticModuleRecord::materializeLazyExport), so importing the module does
+// not run the PropertyCallbacks in bunObjectTable, most of which construct a class or load a builtin.
+JSC::JSObject* generateNativeModule_BunObject(JSC::JSGlobalObject* lexicalGlobalObject,
     JSC::Identifier moduleKey,
     Vector<JSC::Identifier, 4>& exportNames,
     JSC::MarkedArgumentBuffer& exportValues)
 {
     auto& vm = JSC::getVM(lexicalGlobalObject);
     Zig::GlobalObject* globalObject = uncheckedDowncast<Zig::GlobalObject>(lexicalGlobalObject);
-
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* object = globalObject->bunObject();
 
-    // :'(
-    if (object->hasNonReifiedStaticProperties()) [[likely]] {
-        object->reifyAllStaticProperties(lexicalGlobalObject);
+    // Static table entries are listed whether or not they have been reified.
+    PropertyNameArrayBuilder propertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+    object->getOwnNonIndexPropertyNames(globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
+    RETURN_IF_EXCEPTION(scope, nullptr);
+
+    exportNames.reserveCapacity(propertyNames.size() + 1);
+    exportValues.ensureCapacity(propertyNames.size() + 1);
+
+    exportNames.append(vm.propertyNames->defaultKeyword);
+    exportValues.append(object);
+
+    for (const auto& propertyName : propertyNames) {
+        if (propertyName == vm.propertyNames->defaultKeyword) [[unlikely]]
+            continue;
+        exportNames.append(propertyName);
+        exportValues.append(JSValue());
     }
 
-    RETURN_IF_EXCEPTION(scope, void());
-
-    Bun::exportBunObject(vm, globalObject, object, exportNames, exportValues);
+    return object;
 }
 
 } // namespace Zig

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -73,10 +73,13 @@ JSC::JSValue generateModule(JSC::JSGlobalObject* globalObject, JSC::VM& vm, cons
     return result;
 }
 
+// Accepts both generator signatures (BUN_FOREACH_ESM_NATIVE_MODULE and BUN_FOREACH_LAZY_ESM_NATIVE_MODULE);
+// only the default export is used here, and a lazy generator always provides that one eagerly.
+template<typename Generator>
 ALWAYS_INLINE JSC::JSValue generateNativeModule(
     JSC::JSGlobalObject* globalObject,
     JSC::VM& vm,
-    const SyntheticSourceProvider::SyntheticSourceGenerator& generator)
+    Generator generator)
 {
     Vector<JSC::Identifier, 4> propertyNames;
     JSC::MarkedArgumentBuffer arguments;

--- a/src/jsc/bindings/ModuleLoader.cpp
+++ b/src/jsc/bindings/ModuleLoader.cpp
@@ -1046,6 +1046,14 @@ static JSValue fetchESMSourceCode(
             BUN_FOREACH_ESM_NATIVE_MODULE(CASE)
 #undef CASE
 
+#define LAZY_CASE(str, name)                                                                                                                                        \
+    case (SyntheticModuleType::name): {                                                                                                                             \
+        auto source = JSC::SourceCode(JSC::SyntheticSourceProvider::createWithLazyExports(generateNativeModule_##name, JSC::SourceOrigin(), WTF::move(moduleKey))); \
+        RELEASE_AND_RETURN(scope, rejectOrResolve(JSSourceCode::create(vm, WTF::move(source))));                                                                    \
+    }
+            BUN_FOREACH_LAZY_ESM_NATIVE_MODULE(LAZY_CASE)
+#undef LAZY_CASE
+
         // CommonJS modules from src/js/*
         default: {
             if (tag & SyntheticModuleType::InternalModuleRegistryFlag) {

--- a/src/jsc/modules/BunObjectModule.h
+++ b/src/jsc/modules/BunObjectModule.h
@@ -1,6 +1,6 @@
 
 namespace Zig {
-void generateNativeModule_BunObject(JSC::JSGlobalObject* lexicalGlobalObject,
+JSC::JSObject* generateNativeModule_BunObject(JSC::JSGlobalObject* lexicalGlobalObject,
     JSC::Identifier moduleKey,
     Vector<JSC::Identifier, 4>& exportNames,
     JSC::MarkedArgumentBuffer& exportValues);

--- a/src/jsc/modules/NativeModuleList.h
+++ b/src/jsc/modules/NativeModuleList.h
@@ -20,7 +20,13 @@
 #define BUN_FOREACH_ESM_NATIVE_MODULE(macro) \
     BUN_FOREACH_ESM_AND_CJS_NATIVE_MODULE(macro) \
     macro("node:module"_s, NodeModule)  \
-    macro("node:process"_s, NodeProcess) \
+    macro("node:process"_s, NodeProcess)
+
+// Generators with JSC::SyntheticSourceProvider::LazySyntheticSourceGenerator's signature: they may
+// declare exports without a value and return the object JSC reads those exports from on first binding.
+// src/codegen/internal-module-registry-scanner.ts numbers native modules by their order in this file,
+// so these stay after the lists above.
+#define BUN_FOREACH_LAZY_ESM_NATIVE_MODULE(macro) \
     macro("bun"_s, BunObject)
 
 #define BUN_FOREACH_CJS_NATIVE_MODULE(macro) \
@@ -32,6 +38,7 @@ namespace Zig {
 enum class NativeModuleDefaultSlot : unsigned char {
 #define NATIVE_MODULE_SLOT(id, enumName) enumName,
 BUN_FOREACH_ESM_NATIVE_MODULE(NATIVE_MODULE_SLOT)
+BUN_FOREACH_LAZY_ESM_NATIVE_MODULE(NATIVE_MODULE_SLOT)
 #undef NATIVE_MODULE_SLOT
     Count
 };

--- a/src/jsc/modules/_NativeModule.h
+++ b/src/jsc/modules/_NativeModule.h
@@ -127,4 +127,11 @@ void generateNativeModule_##enumName( \
   Vector<JSC::Identifier, 4> &exportNames, \
   JSC::MarkedArgumentBuffer &exportValues);
 BUN_FOREACH_ESM_NATIVE_MODULE(FORWARD_DECL_GENERATOR)
+// Returns the object that exports appended as an empty JSValue are read from on first binding.
+#define FORWARD_DECL_LAZY_GENERATOR(id, enumName) \
+JSC::JSObject* generateNativeModule_##enumName( \
+  JSC::JSGlobalObject *lexicalGlobalObject, JSC::Identifier moduleKey, \
+  Vector<JSC::Identifier, 4> &exportNames, \
+  JSC::MarkedArgumentBuffer &exportValues);
+BUN_FOREACH_LAZY_ESM_NATIVE_MODULE(FORWARD_DECL_LAZY_GENERATOR)
 } // namespace Zig

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -34,12 +34,45 @@ const helper = `
   export { fs };
 `;
 
-async function run(files: Record<string, string>, args: string[] = ["entry.mjs"]) {
-  using dir = tempDir("builtin-esm-lazy-exports", { "helper.mjs": helper, ...files });
+// The "bun" module is generated natively from the Bun object (generateNativeModule_BunObject). Most Bun.* properties
+// are PropertyCallback entries of its static table that construct their value (a class, the shell, the default
+// SQL/S3/Redis clients, ...) the first time they are read, at which point they become own properties of the object.
+// bun:jsc's describe() dumps the object's Structure, i.e. exactly the set of properties that have been constructed,
+// which is the readout used here. WATCHED is a sample of them plus `write`, the plain function the entries below import.
+//
+// Note that a literal `import ... from "bun"` (and `import("bun")` / `require("bun")`) is rewritten by the
+// transpiler into a read of globalThis.Bun and never loads the module; the module is what `export ... from "bun"`
+// and a non-literal import() specifier go through.
+const WATCHED = ["$", "CryptoHasher", "Glob", "S3Client", "SQL", "TOML", "Transpiler", "secrets", "write"] as const;
+
+const bunHelper = `
+  import { describe } from "bun:jsc";
+  const WATCHED = ${JSON.stringify(WATCHED)};
+  /** The WATCHED names that are own properties of the Bun object by now, i.e. whose value has been constructed. */
+  export function constructed() {
+    const properties = /\\{([^}]*)\\}/.exec(describe(Bun))[1];
+    const names = properties.split(",").map(entry => entry.trim().split(":")[0]);
+    return WATCHED.filter(name => names.includes(name));
+  }
+  export function print(result) {
+    console.log(JSON.stringify(result));
+  }
+  // import(specifier) with this really loads the module; a literal (or a const the transpiler can inline) would be
+  // rewritten to globalThis.Bun instead.
+  export const specifier = "bun";
+`;
+
+const bunReexport = `
+  export * from "bun";
+  export { default as BunObject, Glob as RenamedGlob } from "bun";
+`;
+
+async function run(files: Record<string, string>, args: string[] = ["entry.mjs"], env: Record<string, string> = {}) {
+  using dir = tempDir("builtin-esm-lazy-exports", { "helper.mjs": helper, "bun-helper.mjs": bunHelper, ...files });
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
     cwd: String(dir),
-    env: bunEnv,
+    env: { ...bunEnv, ...env },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -47,8 +80,8 @@ async function run(files: Record<string, string>, args: string[] = ["entry.mjs"]
   return { stdout, stderr, exitCode };
 }
 
-async function runEntry(entry: string, extraFiles: Record<string, string> = {}) {
-  const { stdout, stderr, exitCode } = await run({ ...extraFiles, "entry.mjs": entry });
+async function runEntry(entry: string, extraFiles: Record<string, string> = {}, env: Record<string, string> = {}) {
+  const { stdout, stderr, exitCode } = await run({ ...extraFiles, "entry.mjs": entry }, undefined, env);
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
   return JSON.parse(stdout);
@@ -227,6 +260,145 @@ test.concurrent("spyOn and mock.module on an imported builtin", async () => {
     ["test", "lazy.test.ts"],
   );
   expect(stderr).toContain(" 2 pass");
+  expect(stderr).toContain(" 0 fail");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent('"bun": re-exports construct the properties that get bound, not the rest of the object', async () => {
+  const result = await runEntry(
+    `
+      // Linking this import is what constructs Bun.write; nothing else is read.
+      import { write } from "./reexport.mjs";
+      import * as reexported from "./reexport.mjs";
+      import { constructed, print } from "./bun-helper.mjs";
+      const afterLink = constructed();
+      const present = "SQL" in reexported;
+      const afterIn = constructed();
+      const RenamedGlob = reexported.RenamedGlob;
+      const afterRenamedRead = constructed();
+      const SQL = reexported.SQL;
+      print({
+        afterLink,
+        present,
+        afterIn,
+        afterRenamedRead,
+        afterStarRead: constructed(),
+        write: write === Bun.write,
+        renamedGlob: typeof RenamedGlob === "function" && RenamedGlob === Bun.Glob,
+        sql: typeof SQL === "function" && SQL === Bun.SQL,
+        secondReadIsStable: reexported.SQL === SQL,
+        defaultIsBun: reexported.BunObject === Bun,
+      });
+    `,
+    { "reexport.mjs": bunReexport },
+  );
+  expect(result).toEqual({
+    afterLink: ["write"],
+    present: true,
+    afterIn: ["write"],
+    afterRenamedRead: ["Glob", "write"],
+    afterStarRead: ["Glob", "SQL", "write"],
+    write: true,
+    renamedGlob: true,
+    sql: true,
+    secondReadIsStable: true,
+    defaultIsBun: true,
+  });
+});
+
+test.concurrent('"bun": import() namespace has the same export list, and every export is the Bun.* value', async () => {
+  const result = await runEntry(`
+    import { constructed, print, specifier } from "./bun-helper.mjs";
+    const ns = await import(specifier);
+    const afterImport = constructed();
+    // Neither [[OwnPropertyKeys]] of the namespace nor Object.keys of the Bun object reads any of the properties.
+    const exportNames = Reflect.ownKeys(ns).filter(key => typeof key === "string").sort();
+    const exportListMatches = exportNames.join() === [...Object.keys(Bun), "default"].sort().join();
+    const afterListing = constructed();
+    const TOML = ns.TOML;
+    const afterRead = constructed();
+    print({
+      afterImport,
+      exportListMatches,
+      afterListing,
+      toml: typeof TOML === "object" && TOML === Bun.TOML,
+      afterRead,
+      defaultIsBun: ns.default === Bun,
+      everyExportIsTheProperty: Object.keys(Bun).every(name => ns[name] === Bun[name]),
+      afterReadingEverything: constructed(),
+    });
+  `);
+  expect(result).toEqual({
+    afterImport: [],
+    exportListMatches: true,
+    afterListing: [],
+    toml: true,
+    afterRead: ["TOML"],
+    defaultIsBun: true,
+    everyExportIsTheProperty: true,
+    afterReadingEverything: [...WATCHED],
+  });
+});
+
+test.concurrent('"bun": a property whose getter throws only fails the binding that reads it', async () => {
+  // Bun.redis builds the default client from REDIS_URL when it is first read, and throws on an invalid URL. That used
+  // to fail loading the module (and so any module re-exporting from it) up front; now it is the problem of whoever
+  // reads `redis`, and it is the same error a direct read of Bun.redis produces.
+  const result = await runEntry(
+    `
+      import { write } from "./reexport.mjs";
+      import * as reexported from "./reexport.mjs";
+      import { print } from "./bun-helper.mjs";
+      function message(read) {
+        try {
+          read();
+          return "did not throw";
+        } catch (error) {
+          return error.message;
+        }
+      }
+      const viaNamespace = message(() => reexported.redis);
+      print({
+        write: write === Bun.write,
+        viaNamespace,
+        sameErrorAsDirectRead: viaNamespace === message(() => Bun.redis),
+        otherExportsStillWork: reexported.Glob === Bun.Glob,
+      });
+    `,
+    { "reexport.mjs": bunReexport },
+    { REDIS_URL: "http://[::1" },
+  );
+  expect(result).toEqual({
+    write: true,
+    viaNamespace: expect.stringContaining("URL"),
+    sameErrorAsDirectRead: true,
+    otherExportsStillWork: true,
+  });
+});
+
+test.concurrent('"bun": mock.module replaces a binding without constructing the property it shadows', async () => {
+  const { stderr, exitCode } = await run(
+    {
+      "reexport.mjs": bunReexport,
+      "lazy.test.ts": `
+        import { expect, mock, test } from "bun:test";
+        import * as reexported from "./reexport.mjs";
+        import { constructed } from "./bun-helper.mjs";
+
+        test("mock.module('bun')", () => {
+          expect(constructed()).toEqual([]);
+          mock.module("bun", () => ({ SQL: "mocked" }));
+          expect(reexported.SQL).toBe("mocked");
+          expect(reexported.Glob).toBe(Bun.Glob);
+          // The mock went into the module binding; Bun.SQL itself was neither read nor replaced.
+          expect(constructed()).toEqual(["Glob"]);
+          expect(typeof Bun.SQL).toBe("function");
+        });
+      `,
+    },
+    ["test", "lazy.test.ts"],
+  );
+  expect(stderr).toContain(" 1 pass");
   expect(stderr).toContain(" 0 fail");
   expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
Follow-up to #37525, which made the ES module view of the `src/js` builtins declare their accessors lazily. The `"bun"` module is not one of those: it is a native module (`generateNativeModule_BunObject` in `src/jsc/bindings/BunObject.cpp`), and its generator still built the record eagerly:

- `object->reifyAllStaticProperties()` runs every `PropertyCallback` in `bunObjectTable` (about 60 of them: `$`, `SQL`/`sql`/`postgres`, `S3Client`/`s3`, `RedisClient`/`redis`, `Glob`, `TOML`, `WebView`, `secrets`, `stdin`/`stdout`/`stderr`, ...) and stores each result on the object, so that line alone constructs every lazy `Bun.*` property.
- `exportBunObject` then called `get()` on each of them to fill the export values.

Note that the most common forms never reach this code: the transpiler rewrites a literal `import { write } from "bun"`, `import * as b from "bun"`, `import("bun")` and `require("bun")` into reads of `globalThis.Bun` (`src/js_printer/lib.rs`, `ImportRecordTag::Bun`), which is why `import { write } from "bun"` only ever constructed `write`. The generator runs for `export * from "bun"` / `export { x } from "bun"` and for `import()` with a non-literal specifier, and every one of those constructed all 115 static properties.

## Repro

```js
// reexport.mjs
export * from "bun";
// entry.mjs
import { describe } from "bun:jsc";
import { write } from "./reexport.mjs";
// describe() dumps the Structure, i.e. the static-table entries that have been constructed so far.
console.log(describe(Bun).match(/\{[^}]*\}/)[0].split(",").length);
```

Before: 116 entries (`Symbol.toStringTag` plus all 115). After: 2 (`Symbol.toStringTag` and `write`). A non-literal `import(specifier)` of `"bun"` behaves the same way.

A second consequence of the eager path: a property callback that throws fails the whole module. `Bun.redis` builds the default client from `REDIS_URL` and throws on an invalid URL, so with `REDIS_URL='http://[::1'` the entry above died at load with `TypeError: Invalid URL format` even though it only wanted `write`. (The `DECLARE_TOP_EXCEPTION_SCOPE` in `exportBunObject` that turned getter errors into `undefined` never got to run for these, because `reifyAllStaticProperties()` propagated first.)

## Fix

`generateNativeModule_BunObject` now has the `LazySyntheticSourceGenerator` signature from #37525. It lists the object's own property names (`getOwnNonIndexPropertyNames` includes the static table entries that have not been reified, so dropping `reifyAllStaticProperties()` leaves the export list unchanged, `DontEnum` entries excluded as before), provides `default` = the Bun object, appends an empty `JSValue` for every other export, and returns the Bun object as the source. JSC's `materializeLazyExport` then reads `Bun[name]` the first time something binds to that export: when an importer links a named import of it (directly or through `export *` / `export { x as y } from`), or when it is read off a namespace object. Reading it reifies exactly that one property on the Bun object, the same thing a direct `Bun[name]` access does, so the binding is identical to the property (`main`, the one `CustomAccessor`, is read through its getter like before).

Plumbing: the native module list in `NativeModuleList.h` gets a separate `BUN_FOREACH_LAZY_ESM_NATIVE_MODULE` group for generators with this signature (the codegen scanner numbers modules by their order in the file, and `bun` was already last, so the ids do not move); `_NativeModule.h` forward-declares that group with the new return type; `ModuleLoader.cpp` dispatches it through `SyntheticSourceProvider::createWithLazyExports`; and `generateNativeModule` in `InternalModuleRegistry.cpp` (the generated `createInternalModuleById` case, which only needs the default export) becomes a template so it accepts both signatures.

### Behaviour differences

- When a `Bun.*` value is sampled: at first binding rather than at module load. The affected values are constructed on first read and then fixed, so the same object is handed out either way; for `main` (a live getter) a re-export now samples the value when it is first bound rather than when the module loads, which is the same behaviour #37525 gave the builtins' accessors.
- A throwing callback now throws from whatever binds to that export (the import that links it, or the namespace read, including `Object.keys(ns)` / `console.log(ns)` since those read every export), and the other exports keep working. Previously it failed the module. Of the current callbacks, `Bun.redis` throws on an invalid `REDIS_URL` / `VALKEY_URL`, `Bun.embeddedFiles` can throw on OOM, and `Bun.$`, `Bun.sql`, `Bun.postgres`, `Bun.SQL` would throw if their builtin failed to load; `Bun.s3` reports its error as unhandled and yields `undefined` instead. The error surfacing on the `redis` binding is the same error a direct `Bun.redis` read produces, which the new test pins.
- `mock.module("bun", ...)` on an already loaded record writes into the binding with `overrideExportValue`; `materializeLazyExport` is a no-op for a slot that has a value, so the mock wins and the real property is never constructed.
- No bulk reification means nothing here runs callbacks back to back without exception checks, which is what #33150 was fixing in the eager path; this supersedes it. Checked with `BUN_JSC_validateExceptionChecks=1` on the re-export, the non-literal `import()`, the throwing `redis` case, and a full `Object.keys(ns)` materialization.

## Tests

Added to `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts` (the file from #37525), each in its own process. The readout is `bun:jsc`'s `describe(Bun)`, filtered to a sample of the lazy properties plus `write`; `Object.getOwnPropertyDescriptor` cannot be used because it reifies the property it is asked about.

- `export *` / `export { x as y }` / `export { default as ... }` re-exports: linking `import { write }` constructs only `write`; `in` constructs nothing; reading the renamed export constructs `Glob`; reading through the star constructs `SQL`; each is identical to the `Bun.*` value and stable across reads; `default` is the Bun object.
- Non-literal `import()`: nothing constructed on import; `Reflect.ownKeys` of the namespace equals `Object.keys(Bun)` plus `default` and constructs nothing; reading `TOML` constructs only `TOML`; every export is `===` the corresponding `Bun` property (which constructs everything). The specifier is imported from the helper module because a `const` holding it can get inlined into a literal `import("bun")` in some files.
- `REDIS_URL` set to an invalid URL: the module still loads, `reexported.redis` throws the same error as `Bun.redis`, other exports work.
- `mock.module("bun", () => ({ SQL: "mocked" }))` in a `bun test` child after the re-export was imported: the namespace sees the mock, `SQL` is never constructed, `Bun.SQL` is intact.

All four fail on the merge base (everything shows up as constructed after import; the `REDIS_URL` case fails at load), and the eight existing cases in the file pass on both. Also run on this build: `test/js/bun/util/BunObject.test.ts` (which `console.log`s a non-literal `import()` namespace of `"bun"` and compares every property), `test/js/bun/resolve/`, `test/js/bun/test/mock/`, `test/js/node/stubs.test.js`, `node-module-module.test.js`, and `test-process-get-builtin.mjs`; all green apart from `load-same-js-file-a-lot.test.ts`, which times out identically on the unmodified build in this environment.

## Startup

Wall time of `bun file.mjs`, min of 10 runs after a warm-up, debug (ASAN) builds of the merge base and of this branch on the same machine:

| file | before | after |
| --- | ---: | ---: |
| empty module | 273 ms | 264 ms |
| `import { write } from "bun"; write.length` | 277 ms | 251 ms |
| same, but `write` comes from a module doing `export * from "bun"` | 555 ms | 279 ms |

The literal form is rewritten by the transpiler and was already at the floor; the re-export form loses the roughly 280 ms (debug build) it spent constructing the object. Release numbers to follow in a comment.
