### PR TITLE
fetch: pool an https-proxy tunnel in the TLS context its socket was opened in

### DIFF
--- a/src/http/ProxyTunnel.rs
+++ b/src/http/ProxyTunnel.rs
@@ -320,13 +320,17 @@ fn on_data(ctx: *mut HTTPClient, decoded_data: &[u8]) {
         }
         HTTPStage::ProxyHeaders => {
             scoped_log!(http_proxy_tunnel, "ProxyTunnel onData proxy_headers");
+            // `hctx` is the pool the finished tunnel is released into. It must
+            // be the context that owns the outer socket (the per-config custom
+            // context when `tls` needs one, see `HTTPThread::connect`), which
+            // is also the only pool the next request with that config searches.
             match ProxyTunnel::socket_of(proxy_nn) {
                 &Socket::Ssl(socket) => {
-                    let hctx = &raw mut crate::http_thread().https_context;
+                    let hctx = this.get_ssl_ctx::<true>();
                     this.handle_on_data_headers::<true>(decoded_data, hctx, socket);
                 }
                 &Socket::Tcp(socket) => {
-                    let hctx = &raw mut crate::http_thread().http_context;
+                    let hctx = this.get_ssl_ctx::<false>();
                     this.handle_on_data_headers::<false>(decoded_data, hctx, socket);
                 }
                 Socket::None => {}
@@ -551,14 +555,18 @@ fn on_close(ctx: *mut HTTPClient) {
 /// `&mut ProxyTunnel` across this call (they are reborrowed inside via the
 /// module's `client_from_ctx` invariant — see ALIASING NOTE above).
 fn progress_update_for_proxy_socket(ctx: *mut HTTPClient, proxy: NonNull<ProxyTunnel>) {
+    // Same context rule as the ProxyHeaders arm of `on_data`: the tunnel is
+    // pooled into whichever context `progress_update` is handed.
     match ProxyTunnel::socket_of(proxy) {
         &Socket::Ssl(socket) => {
-            let hctx = &raw mut crate::http_thread().https_context;
-            client_from_ctx(ctx).progress_update::<true>(hctx, socket);
+            let client = client_from_ctx(ctx);
+            let hctx = client.get_ssl_ctx::<true>();
+            client.progress_update::<true>(hctx, socket);
         }
         &Socket::Tcp(socket) => {
-            let hctx = &raw mut crate::http_thread().http_context;
-            client_from_ctx(ctx).progress_update::<false>(hctx, socket);
+            let client = client_from_ctx(ctx);
+            let hctx = client.get_ssl_ctx::<false>();
+            client.progress_update::<false>(hctx, socket);
         }
         Socket::None => {}
     }

--- a/test/js/bun/http/proxy-stress-adversarial.test.ts
+++ b/test/js/bun/http/proxy-stress-adversarial.test.ts
@@ -556,14 +556,13 @@ describe("interleaved proxy/direct", () => {
         // option was passed.
         if (!viaProxy) expect(totalBytesUp()).toBe(before);
       }
-      // 3 proxied requests → at least 1 CONNECT, at most 3.
-      expect(proxy.connectCount()).toBeGreaterThanOrEqual(1);
-      expect(proxy.connectCount()).toBeLessThanOrEqual(3);
-      // http-proxy: 3 sequential keepalive proxied requests reuse one
-      // tunnel deterministically. A proxied request that silently
-      // bypassed the proxy would leave this at 0; a direct request that
-      // opened its own CONNECT would push it above 1.
-      if (!proxyTls) expect(proxy.connectCount()).toBe(1);
+      // 3 sequential keepalive proxied requests reuse one tunnel. A proxied
+      // request that silently bypassed the proxy would leave this at 0; a
+      // direct request that opened its own CONNECT, or a tunnel pooled
+      // where the next proxied request does not look (laxTls has a `ca`,
+      // so with an https proxy both the tunnel and the direct sockets live
+      // in that config's own TLS context), would push it above 1.
+      expect(proxy.connectCount()).toBe(1);
     });
   }
 });

--- a/test/js/bun/http/proxy-stress-concurrent.test.ts
+++ b/test/js/bun/http/proxy-stress-concurrent.test.ts
@@ -2,10 +2,12 @@
  * Concurrency, connection-pool, and memory stress for the proxy tunnel.
  *
  * The tunnel pool (HTTPContext::PooledSocket) keys on (proxy addr, target
- * host:port, proxy_auth_hash, established_with_reject_unauthorized). These
- * tests churn that pool: many parallel requests to one target, many targets
- * through one proxy, interleaved aborts, and a subprocess leak probe that
- * watches RSS over thousands of iterations.
+ * host:port, proxy_auth_hash, established_with_reject_unauthorized), and
+ * there is one pool per TLS context: the default one plus one per `tls`
+ * option that needs its own context (ca / cert / key ...). These tests churn
+ * those pools: many parallel requests to one target, many targets through one
+ * proxy, reuse out of both kinds of context, interleaved aborts, and a
+ * subprocess leak probe that watches RSS over thousands of iterations.
  */
 
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
@@ -13,6 +15,7 @@ import { bunEnv, bunExe, isASAN, isCI, isMacOS, isWindows } from "harness";
 import { once } from "node:events";
 import net from "node:net";
 import { join } from "node:path";
+import tls from "node:tls";
 import {
   cartesian,
   clearProxyEnv,
@@ -104,23 +107,18 @@ describe("tunnel reuse", () => {
         expect(await res.text()).toBe("reused");
         expect(res.status).toBe(200);
       }
-      // For an HTTP proxy the outer TCP connection is reused verbatim; a
-      // single CONNECT serves all five requests. For an HTTPS proxy the
-      // outer TLS socket is itself subject to the SSL context's pool
-      // rules; require only that pooling happened at all (fewer CONNECTs
-      // than requests).
-      if (proxyTls) {
-        expect(proxy.connectCount()).toBeLessThanOrEqual(5);
-      } else {
-        expect(proxy.connectCount()).toBe(1);
-      }
+      // laxTls carries a `ca`, so the connection to the proxy lives in that
+      // config's own TLS context. The finished tunnel must be pooled into
+      // that same context (where the next request looks for it), so a
+      // single CONNECT serves all five requests for both proxy flavours.
+      expect(proxy.connectCount()).toBe(1);
     });
 
     test(`${proxyTls ? "https" : "http"}-proxy → https-origin, different auth hashes use separate tunnels`, async () => {
       await using origin = Bun.serve({ port: 0, tls: tlsCert, fetch: () => new Response("ok") });
       await using proxy = await createAdversarialProxy({ tls: proxyTls });
 
-      const creds = ["a:1", "b:2", "a:1"]; // third should reuse first (http-proxy)
+      const creds = ["a:1", "b:2", "a:1"]; // third reuses the first tunnel
       for (const c of creds) {
         const res = await fetch(origin.url, {
           proxy: `${proxyTls ? "https" : "http"}://${c}@127.0.0.1:${proxy.port}`,
@@ -130,16 +128,109 @@ describe("tunnel reuse", () => {
         expect(res.status).toBe(200);
         await res.arrayBuffer();
       }
-      // Different auth hashes must never share a tunnel. That is the
-      // invariant; whether the third (repeat) cred reuses the first
-      // depends on outer-socket pooling for https proxies (see above).
-      const c = proxy.connectCount();
-      expect(c).toBeGreaterThanOrEqual(2);
-      expect(c).toBeLessThanOrEqual(3);
-      // The first two CONNECTs carried different Proxy-Authorization.
+      // Different auth hashes must never share a tunnel; the repeat of the
+      // first credentials must find the first tunnel in the pool.
+      expect(proxy.connectCount()).toBe(2);
+      // The two CONNECTs carried different Proxy-Authorization.
       const auths = proxy.connections.map(r => r.headers["proxy-authorization"]);
       expect(auths[0]).not.toBe(auths[1]);
     });
+  }
+
+  // A `tls` option that needs its own TLS context (`ca` here; cert/key etc.
+  // behave the same) connects to an https proxy inside that context, and the
+  // next request with the same option only searches that context's pool, so
+  // the finished tunnel must be released into it. The client releases a
+  // tunnel from two different places, and each response shape pins one down:
+  //   - "content-length" (head + body in one record) and "204" (no body)
+  //     are released while the response head is being parsed;
+  //   - "chunked" only gets its body after fetch() resolved, i.e. after the
+  //     head was parsed, so it is released from the body path.
+  // The "default" context (rejectUnauthorized alone) is the control.
+  type Shape = "content-length" | "204" | "chunked";
+  const RESPONSES: Record<Shape, { status: number; body: string }> = {
+    "content-length": { status: 200, body: "reused" },
+    "204": { status: 204, body: "" },
+    "chunked": { status: 200, body: "reused" },
+  };
+
+  // Raw HTTP/1.1 keep-alive origin: answers every request on the connection
+  // it arrived on, so end-to-end tunnel reuse shows up as a single accepted
+  // connection serving every request.
+  async function keepAliveOrigin(shape: Shape) {
+    const accepted = new Set<tls.TLSSocket>();
+    let releaseBody: (() => void) | undefined;
+    const server = tls.createServer(tlsCert, sock => {
+      accepted.add(sock);
+      sock.on("error", () => {});
+      let buf = "";
+      sock.on("data", chunk => {
+        buf += chunk.toString("latin1");
+        let end: number;
+        while ((end = buf.indexOf("\r\n\r\n")) !== -1) {
+          buf = buf.slice(end + 4);
+          switch (shape) {
+            case "content-length":
+              sock.write("HTTP/1.1 200 OK\r\nContent-Length: 6\r\n\r\nreused");
+              break;
+            case "204":
+              sock.write("HTTP/1.1 204 No Content\r\n\r\n");
+              break;
+            case "chunked":
+              releaseBody = () => {
+                releaseBody = undefined;
+                sock.write("6\r\nreused\r\n0\r\n\r\n");
+              };
+              sock.write("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n");
+              break;
+          }
+        }
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const port = (server.address() as net.AddressInfo).port;
+    return {
+      url: `https://localhost:${port}/`,
+      get connections() {
+        return accepted.size;
+      },
+      releaseBody() {
+        releaseBody!();
+      },
+      [Symbol.asyncDispose]: async () => {
+        for (const sock of accepted) sock.destroy();
+        server.close();
+      },
+    };
+  }
+
+  for (const { proxyTls, context, shape } of cartesian({
+    proxyTls: [false, true] as const,
+    context: ["custom", "default"] as const,
+    shape: ["content-length", "204", "chunked"] as const,
+  })) {
+    test.concurrent(
+      `${proxyTls ? "https" : "http"}-proxy, ${context} TLS context, ${shape} responses: 3 requests share one tunnel`,
+      async () => {
+        await using origin = await keepAliveOrigin(shape);
+        await using proxy = await createAdversarialProxy({ tls: proxyTls });
+        const tlsOption = context === "custom" ? { ca: tlsCert.cert } : { rejectUnauthorized: false };
+
+        const responses: Array<{ status: number; body: string }> = [];
+        for (let i = 0; i < 3; i++) {
+          const res = await fetch(origin.url, { proxy: proxy.url, keepalive: true, tls: tlsOption });
+          if (shape === "chunked") origin.releaseBody();
+          responses.push({ status: res.status, body: await res.text() });
+        }
+
+        expect(responses).toEqual([RESPONSES[shape], RESPONSES[shape], RESPONSES[shape]]);
+        expect({ connects: proxy.connectCount(), originConnections: origin.connections }).toEqual({
+          connects: 1,
+          originConnections: 1,
+        });
+      },
+    );
   }
 });
 
@@ -168,15 +259,10 @@ describe("many origins, one proxy", () => {
             expect(res.status).toBe(200);
           }
         }
-        // Every request went through the proxy as a CONNECT; none
-        // bypassed. Tunnel reuse across rounds is an optimization —
-        // assert it for the HTTP proxy where it's deterministic.
-        const cc = proxy.connectCount();
-        expect(cc).toBeGreaterThanOrEqual(N_ORIGINS);
-        expect(cc).toBeLessThanOrEqual(2 * N_ORIGINS);
-        if (!proxyTls) {
-          expect(cc).toBe(N_ORIGINS);
-        }
+        // Every request went through the proxy as a CONNECT (none
+        // bypassed it), and round two reused every tunnel round one
+        // pooled, for both proxy flavours.
+        expect(proxy.connectCount()).toBe(N_ORIGINS);
       } finally {
         for (const o of origins) o.stop();
       }
@@ -215,7 +301,9 @@ describe("reject_unauthorized pool gate", () => {
       await res.arrayBuffer();
       expect(proxy.connectCount()).toBe(2);
 
-      // 3: strict again — reuses the strict tunnel (http-proxy).
+      // 3: strict again, reuses the strict tunnel. With an https proxy the
+      // strict tunnel lives in the `ca` config's own TLS context; it must
+      // have been pooled there, not in the default context.
       res = await fetch(origin.url, {
         proxy: proxy.url,
         keepalive: true,
@@ -223,17 +311,7 @@ describe("reject_unauthorized pool gate", () => {
       });
       expect(res.status).toBe(200);
       await res.arrayBuffer();
-      // Invariant: the strict request never reused the lax tunnel
-      // (connectCount grew from 1 to 2 at step 2). For an HTTP proxy,
-      // step 3 deterministically reuses the strict tunnel; HTTPS-proxy
-      // outer-socket pooling can force a third CONNECT (see above).
-      const cc = proxy.connectCount();
-      if (proxyTls) {
-        expect(cc).toBeGreaterThanOrEqual(2);
-        expect(cc).toBeLessThanOrEqual(3);
-      } else {
-        expect(cc).toBe(2);
-      }
+      expect(proxy.connectCount()).toBe(2);
     }, 30_000);
   }
 });


### PR DESCRIPTION
### What does this PR do?

`fetch()` through an `https://` proxy with a `tls` option that needs its own TLS context (`ca`, `cert`, `key`, `ciphers`, ...) never reuses the CONNECT tunnel: every request opens a new connection to the proxy, sends a new CONNECT and runs both TLS handshakes again.

Repro (a local CONNECT proxy with a TLS listener, an https origin, both using the test certificate):

```ts
for (let i = 0; i < 3; i++) {
  const res = await fetch(origin, { proxy: "https://127.0.0.1:" + proxyPort, tls: { ca } });
  await res.text();
}
// proxy saw 3 CONNECTs; with an http:// proxy, or with tls: { rejectUnauthorized: false }, it sees 1
```

Cause: `HTTPThread::connect` opens the socket to an https proxy inside the per-config custom `HTTPContext` when the request's `tls` needs one, and the next request with the same config only searches that context's keep-alive pool. The tunnel's data path did not follow that. `ProxyTunnel::on_data` (the `ProxyHeaders` arm) and `progress_update_for_proxy_socket` always passed `http_thread().https_context` / `http_context` as the `ctx` that `send_progress_update_without_stage_check` hands to `release_socket`, so a finished tunnel was parked in the default context's pool. From there it was never matched again (the custom-config request looks in the other pool; a default-config request never matches an entry keyed with the custom `ssl_config`), so besides the lost reuse each such request left a dead entry in the default pool's 64 slots until the 5 minute idle timeout, and a socket belonging to the custom context's socket group was bookkept by a different context.

Fix: these four sites now ask the client for its context (`get_ssl_ctx`), which is what every other release site in the client already does (`on_close`, `check_server_identity`, the streaming-body and preconnect paths, and the outer socket's `on_data` dispatch). For a plaintext (`http://`) proxy or a request without a custom context `get_ssl_ctx` returns the same default context as before, so those paths are unchanged. Pooling a tunnel inside a custom context needs nothing else: `PooledSocket::release_parked_refs` and `HTTPContext::drop` already handle a parked tunnel, and the pool lookup in `HTTPContext::connect` is the same code that already matches tunnels in the default contexts.

Why this is the right place: `ctx` exists precisely so the release goes into the pool of the context that owns the socket; the tunnel callbacks were the only place in the client that computed it from the global instead of from the client. The custom-context connect path was added later than the tunnel code, and these sites were not updated with it.

#37706 touches the same four lines (it routes them through a `default_context_ptr` helper and keeps the default-context behaviour). Whichever lands second has a trivial conflict: the ProxyTunnel sites should end up calling `get_ssl_ctx`, and `get_ssl_ctx` itself is where that helper belongs.

### How did you verify your code works?

`test/js/bun/http/proxy-stress-concurrent.test.ts`:

- New `tunnel reuse` matrix: http/https proxy x custom (`ca`) / default (`rejectUnauthorized`) context x three response shapes, 3 sequential requests each, asserting exactly one CONNECT at the proxy and one accepted connection at the origin. The shapes cover both changed sites: a content-length response and a 204 are released from the `ProxyHeaders` arm (`handle_on_data_headers`), and the chunked response only gets its body after `fetch()` resolved, so it is released from `progress_update_for_proxy_socket` (confirmed with the `http_proxy_tunnel` / `fetch` debug logs: `onData proxy_headers` -> `release socket` for the first two, `onData body_chunk` -> `release socket` for the third). The https-proxy + custom rows fail on the unfixed build with `{ connects: 3, originConnections: 3 }`; the http-proxy and default-context rows pass before and after.
- The existing https-proxy assertions in `tunnel reuse`, `many origins`, `reject_unauthorized pool gate`, and `interleaved proxy/direct` (proxy-stress-adversarial.test.ts) had been loosened to ranges because of this behaviour (their `laxTls` carries a `ca`); they now assert the exact counts the http-proxy rows already asserted. On the unfixed build they fail with 5/3/24/3/3 CONNECTs respectively.

Locally, `bun bd test` passes for proxy-stress-concurrent, proxy-stress-adversarial, proxy-stress-{protocol,errors,headers,matrix,lifecycle}, proxy.test.ts and fetch-keepalive.test.ts. (proxy.test.js's two Proxy-Authorization tests fail in my container both with and without this change because the container sets `NO_PROXY=localhost`, which fetch honours even for an explicit `proxy` option; unrelated.)
