### PR TITLE
node:http: only treat HTTP/1 fallback connections that are between requests as idle

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -251,9 +251,7 @@ function connectionListenerHTTP1(server, socket, options) {
   const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
 
   // Mirror Node's connectionListenerInternal: carry maxHeaderSize / leniency / maxHeadersCount
-  // into the parser and register it with the server's ConnectionsList, which tracks whether the
-  // connection is idle for closeIdleHttp1Connections.
-  // https://github.com/nodejs/node/blob/main/lib/_http_server.js
+  // into the parser. https://github.com/nodejs/node/blob/main/lib/_http_server.js
   const lenientFlags = calculateLenientFlags(server.httpValidation, server.insecureHTTPParser);
   const connections = (server[kHttp1Connections] ??= new ConnectionsList());
   const parser = new HTTPParser();
@@ -431,8 +429,7 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.end();
     }
   }
-  // Node's freeParser. remove() has to come before close(): a closed parser can no longer take
-  // itself out of the ConnectionsList.
+  // Node's freeParser; a closed parser can no longer remove() itself from the list.
   function freeHttp1Parser() {
     parser.remove();
     parser.close();
@@ -444,12 +441,9 @@ function connectionListenerHTTP1(server, socket, options) {
   socket.once("close", freeHttp1Parser);
 }
 
-// Node's Server#closeIdleConnections. The parser is busy from initialize() until the first
-// request completes and again from each later request's first byte until it completes, so
-// ConnectionsList#idle() only lists connections sitting between requests; a connection that has
-// not sent a request yet, or is still sending one, is not idle. Of those, one whose response is
-// still being written is kept as well.
-// https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js (closeIdleConnections)
+// Node's Server#closeIdleConnections. idle() is the parsers between messages (a parser is busy
+// from initialize() and from each message's first byte until kOnMessageComplete).
+// https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js
 function closeIdleHttp1Connections(server) {
   const connections = server[kHttp1Connections];
   if (!connections) return;

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -441,9 +441,8 @@ function connectionListenerHTTP1(server, socket, options) {
   socket.once("close", freeHttp1Parser);
 }
 
-// Node's Server#closeIdleConnections. idle() is the parsers between messages (a parser is busy
-// from initialize() and from each message's first byte until kOnMessageComplete).
-// https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js
+// Node's Server#closeIdleConnections; a parser is busy from initialize() and from each message's
+// first byte until kOnMessageComplete, so idle() is the connections sitting between requests.
 function closeIdleHttp1Connections(server) {
   const connections = server[kHttp1Connections];
   if (!connections) return;

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -2,10 +2,9 @@
 // Used by http2's `allowHTTP1` ALPN fallback and http's `server.emit("connection", socket)`.
 // See https://github.com/nodejs/node/blob/main/lib/_http_server.js connectionListener.
 const { STATUS_CODES } = require("internal/http");
-const { SafeSet } = require("internal/primordials");
 
+// Node's server[kConnections]: a ConnectionsList holding every fallback connection's parser.
 const kHttp1Connections = Symbol("http1Connections");
-const kHttp1ActiveRequests = Symbol("http1ActiveRequests");
 
 function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout) {
   const { _checkInvalidHeaderChar: checkInvalidHeaderChar } = require("node:_http_common");
@@ -236,7 +235,7 @@ function connectionListenerHTTP1(server, socket, options) {
   const http = require("node:http");
   const { HTTPParser, prepareError, calculateLenientFlags, continueExpression } = require("node:_http_common");
   const { kHandle: kHttp1ResponseHandle } = require("internal/http");
-  const { allMethods } = process.binding("http_parser");
+  const { allMethods, ConnectionsList } = process.binding("http_parser");
 
   const http1Options = options.http1Options || {};
   const IncomingMessageClass = http1Options.IncomingMessage || http.IncomingMessage;
@@ -247,19 +246,18 @@ function connectionListenerHTTP1(server, socket, options) {
   // through req.socket.server (nodejs/node#13435).
   socket.server = server;
 
-  const connections = (server[kHttp1Connections] ??= new SafeSet());
-  connections.add(socket);
-  socket[kHttp1ActiveRequests] = 0;
-
   const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
   const kOnBody = HTTPParser.kOnBody | 0;
   const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
 
   // Mirror Node's connectionListenerInternal: carry maxHeaderSize / leniency / maxHeadersCount
-  // into the parser. https://github.com/nodejs/node/blob/main/lib/_http_server.js
+  // into the parser and register it with the server's ConnectionsList, which tracks whether the
+  // connection is idle for closeIdleHttp1Connections.
+  // https://github.com/nodejs/node/blob/main/lib/_http_server.js
   const lenientFlags = calculateLenientFlags(server.httpValidation, server.insecureHTTPParser);
+  const connections = (server[kHttp1Connections] ??= new ConnectionsList());
   const parser = new HTTPParser();
-  parser.initialize(HTTPParser.REQUEST, {}, server.maxHeaderSize || 0, lenientFlags);
+  parser.initialize(HTTPParser.REQUEST, {}, server.maxHeaderSize || 0, lenientFlags, connections);
   parser.socket = socket;
   socket.parser = parser;
   const { maxHeadersCount } = server;
@@ -281,8 +279,6 @@ function connectionListenerHTTP1(server, socket, options) {
     upgrade,
     shouldKeepAlive,
   ) {
-    socket[kHttp1ActiveRequests]++;
-
     req = new IncomingMessageClass(socket);
     req.socket = socket;
     req.httpVersionMajor = versionMajor;
@@ -320,7 +316,6 @@ function connectionListenerHTTP1(server, socket, options) {
     res._maxRequestsPerSocket = server.maxRequestsPerSocket;
     const handle = createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout);
     handle.onfinished = function () {
-      socket[kHttp1ActiveRequests] = Math.max(0, (socket[kHttp1ActiveRequests] || 1) - 1);
       if (!shouldKeepAlive && !socket.destroyed) {
         socket.end();
       }
@@ -401,11 +396,8 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.removeListener("data", onHttp1SocketData);
       socket.removeListener("error", onHttp1SocketErrorListener);
       socket.removeListener("end", onHttp1SocketEnd);
-      connections.delete(socket);
-      try {
-        parser.close();
-      } catch {}
-      socket.parser = null;
+      socket.removeListener("close", freeHttp1Parser);
+      freeHttp1Parser();
       const eventName = upgradeReq.method === "CONNECT" ? "connect" : "upgrade";
       const bodyHead = typeof ret === "number" ? data.slice(ret) : Buffer.alloc(0);
       if (server.listenerCount(eventName) > 0) {
@@ -439,31 +431,43 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.end();
     }
   }
+  // Node's freeParser. remove() has to come before close(): a closed parser can no longer take
+  // itself out of the ConnectionsList.
+  function freeHttp1Parser() {
+    parser.remove();
+    parser.close();
+    socket.parser = null;
+  }
   socket.on("data", onHttp1SocketData);
   socket.on("error", onHttp1SocketErrorListener);
   socket.once("end", onHttp1SocketEnd);
-  socket.once("close", () => {
-    connections.delete(socket);
-    try {
-      parser.close();
-    } catch {}
-  });
+  socket.once("close", freeHttp1Parser);
 }
 
+// Node's Server#closeIdleConnections. The parser is busy from initialize() until the first
+// request completes and again from each later request's first byte until it completes, so
+// ConnectionsList#idle() only lists connections sitting between requests; a connection that has
+// not sent a request yet, or is still sending one, is not idle. Of those, one whose response is
+// still being written is kept as well.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js (closeIdleConnections)
 function closeIdleHttp1Connections(server) {
   const connections = server[kHttp1Connections];
   if (!connections) return;
-  for (const socket of connections) {
-    if (!socket[kHttp1ActiveRequests] && !socket.destroyed) {
-      socket.destroy();
-    }
+  const idle = connections.idle();
+  for (let i = 0, length = idle.length; i < length; i++) {
+    const socket = idle[i].socket;
+    const httpMessage = socket._httpMessage;
+    if (httpMessage && !httpMessage.finished) continue;
+    if (!socket.destroyed) socket.destroy();
   }
 }
 
 function closeAllHttp1Connections(server) {
   const connections = server[kHttp1Connections];
   if (!connections) return;
-  for (const socket of connections) {
+  const all = connections.all();
+  for (let i = 0, length = all.length; i < length; i++) {
+    const socket = all[i].socket;
     if (!socket.destroyed) socket.destroy();
   }
 }
@@ -472,5 +476,4 @@ export default {
   connectionListenerHTTP1,
   closeIdleHttp1Connections,
   closeAllHttp1Connections,
-  kHttp1Connections,
 };

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6569,11 +6569,7 @@ function closeAllSessions(server: Http2Server | Http2SecureServer) {
   }
 }
 
-const {
-  connectionListenerHTTP1,
-  closeIdleHttp1Connections,
-  kHttp1Connections,
-} = require("internal/http1_server_fallback");
+const { connectionListenerHTTP1, closeIdleHttp1Connections } = require("internal/http1_server_fallback");
 
 function connectionListener(socket: Socket) {
   const options = this[bunSocketServerOptions] || {};
@@ -6797,7 +6793,6 @@ class Http2SecureServer extends tls.Server {
     this.setMaxListeners(0);
     this.on("newListener", setupCompat);
     if (options.allowHTTP1 === true) {
-      this[kHttp1Connections] = new SafeSet();
       const http1Options = { ...options, ...options.http1Options };
       this.keepAliveTimeout = http1Options.keepAliveTimeout ?? 5000;
       this.headersTimeout = http1Options.headersTimeout ?? 60000;

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,14 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  // Bind and connect to one explicit address: on a host whose "localhost" resolves to both ::1 and
+  // 127.0.0.1, the server may bind one family while the client tries the other (ECONNREFUSED).
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4276,6 +4276,66 @@ it("closeIdleConnections() only destroys emitted connections that are between re
   }
 });
 
+// res.end() marks the response finished synchronously while it stays assigned to the socket until
+// 'finish' is emitted; like Node, a connection in that window is already idle.
+it("closeIdleConnections() destroys an emitted connection as soon as its response has ended", async () => {
+  const heldResponse = Promise.withResolvers<ServerResponse>();
+  const server = createServer((req, res) => heldResponse.resolve(res));
+  await listen(server);
+  const [clientSide, serverSide] = duplexPair();
+  try {
+    server.emit("connection", serverSide);
+    clientSide.write("GET /hold HTTP/1.1\r\nHost: x\r\n\r\n");
+    const res = await heldResponse.promise;
+
+    server.closeIdleConnections();
+    const keptWhileResponsePending = !serverSide.destroyed;
+    res.end("done");
+    server.closeIdleConnections();
+    expect({
+      keptWhileResponsePending,
+      responseStillAssigned: (serverSide as any)._httpMessage === res,
+      destroyedOnceEnded: serverSide.destroyed,
+    }).toEqual({ keptWhileResponsePending: true, responseStillAssigned: true, destroyedOnceEnded: true });
+  } finally {
+    clientSide.destroy();
+    serverSide.destroy();
+    if (server.listening) server.close();
+  }
+});
+
+// The request handler runs from the parser's headers-complete callback, i.e. while the request is
+// still being received, so a handler that responds and then sweeps idle connections (the usual
+// "shut down from a request" pattern) does not destroy its own connection; Node leaves it to the
+// keep-alive timeout. Once the request has been fully received the next sweep takes it.
+it("closeIdleConnections() run from inside the request handler keeps the handler's own connection", async () => {
+  const handled = Promise.withResolvers<boolean>();
+  const server = createServer((req, res) => {
+    res.end("body");
+    server.closeIdleConnections();
+    handled.resolve(req.socket.destroyed);
+  });
+  await listen(server);
+  const [clientSide, serverSide] = duplexPair();
+  try {
+    server.emit("connection", serverSide);
+    const body = readResponseBody(clientSide);
+    clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    const destroyedInsideHandler = await handled.promise;
+    expect({ destroyedInsideHandler, destroyedAfterHandler: serverSide.destroyed }).toEqual({
+      destroyedInsideHandler: false,
+      destroyedAfterHandler: false,
+    });
+    expect(await body).toBe("body");
+    server.closeIdleConnections();
+    expect(serverSide.destroyed).toBe(true);
+  } finally {
+    clientSide.destroy();
+    serverSide.destroy();
+    if (server.listening) server.close();
+  }
+});
+
 it("closeAllConnections() destroys an emitted connection that closeIdleConnections() keeps, but not one handed to 'upgrade'", async () => {
   const upgraded = Promise.withResolvers<void>();
   const server = createServer(() => {});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4140,19 +4140,40 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
   }
 });
 
-// Reads one Content-Length framed response off the client half of a duplexPair.
+// Reads one Content-Length framed response off the client half of a duplexPair; rejects if the
+// response is framed any other way or the connection goes away first.
 function readResponseBody(clientSide: ReturnType<typeof duplexPair>[0]): Promise<string> {
-  const { promise, resolve } = Promise.withResolvers<string>();
+  const { promise, resolve, reject } = Promise.withResolvers<string>();
   let raw = "";
-  clientSide.on("data", function onData(chunk) {
+  function settle(body?: string, error?: Error) {
+    clientSide.off("data", onData);
+    clientSide.off("close", onClose);
+    clientSide.off("error", onError);
+    if (error) reject(error);
+    else resolve(body!);
+  }
+  function onData(chunk: Buffer) {
     raw += chunk.toString("latin1");
     const headersEnd = raw.indexOf("\r\n\r\n");
     if (headersEnd === -1) return;
+    const contentLength = /\r\ncontent-length: (\d+)/i.exec(raw.slice(0, headersEnd));
+    if (!contentLength) {
+      settle(undefined, new Error(`expected a Content-Length framed response, got: ${JSON.stringify(raw)}`));
+      return;
+    }
     const body = raw.slice(headersEnd + 4);
-    if (body.length < Number(/\r\ncontent-length: (\d+)/i.exec(raw.slice(0, headersEnd))![1])) return;
-    clientSide.off("data", onData);
-    resolve(body);
-  });
+    if (body.length < Number(contentLength[1])) return;
+    settle(body);
+  }
+  function onClose() {
+    settle(undefined, new Error(`connection closed before the response completed, got: ${JSON.stringify(raw)}`));
+  }
+  function onError(error: Error) {
+    settle(undefined, error);
+  }
+  clientSide.on("data", onData);
+  clientSide.on("close", onClose);
+  clientSide.on("error", onError);
   return promise;
 }
 

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,157 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+// Reads one Content-Length framed response off the client half of a duplexPair.
+function readResponseBody(clientSide: ReturnType<typeof duplexPair>[0]): Promise<string> {
+  const { promise, resolve } = Promise.withResolvers<string>();
+  let raw = "";
+  clientSide.on("data", function onData(chunk) {
+    raw += chunk.toString("latin1");
+    const headersEnd = raw.indexOf("\r\n\r\n");
+    if (headersEnd === -1) return;
+    const body = raw.slice(headersEnd + 4);
+    if (body.length < Number(/\r\ncontent-length: (\d+)/i.exec(raw.slice(0, headersEnd))![1])) return;
+    clientSide.off("data", onData);
+    resolve(body);
+  });
+  return promise;
+}
+
+// Node only considers a connection idle between requests: from the moment it is accepted until
+// its first request has been fully received, and again from the first byte of every later
+// request, it is busy (and left to headersTimeout/requestTimeout instead). A received request
+// whose response has not finished keeps the connection busy too. Sockets handed in through
+// server.emit("connection", ...) are tracked like accepted ones, so closeIdleConnections() and
+// close() must apply the same rules to them.
+it("closeIdleConnections() only destroys emitted connections that are between requests", async () => {
+  const heldResponse = Promise.withResolvers<ServerResponse>();
+  const server = createServer((req, res) => {
+    switch (req.url) {
+      case "/hold":
+        heldResponse.resolve(res);
+        break;
+      case "/body":
+        // Respond before the request body has arrived; the request is still being received.
+        res.end("early");
+        break;
+      default:
+        res.end(`served ${req.url}`);
+    }
+  });
+  // Node tracks connections (including emitted ones) only once the server is listening.
+  await listen(server);
+  const names = ["fresh", "partial", "body", "hold", "reused", "idle"] as const;
+  const pairs = Object.fromEntries(names.map(name => [name, duplexPair()])) as Record<
+    (typeof names)[number],
+    ReturnType<typeof duplexPair>
+  >;
+  const client = (name: (typeof names)[number]) => pairs[name][0];
+  const destroyedFlags = () => Object.fromEntries(names.map(name => [name, pairs[name][1].destroyed]));
+  try {
+    for (const name of names) server.emit("connection", pairs[name][1]);
+
+    const partialHeadArrived = once(pairs.partial[1], "data");
+    client("partial").write("GET /partial HTTP/1.1\r\nHost: x\r\n");
+    await partialHeadArrived;
+    const earlyBody = readResponseBody(client("body"));
+    client("body").write("POST /body HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+    expect(await earlyBody).toBe("early");
+    client("hold").write("GET /hold HTTP/1.1\r\nHost: x\r\n\r\n");
+    const held = await heldResponse.promise;
+    const reusedFirstBody = readResponseBody(client("reused"));
+    client("reused").write("GET /reused-1 HTTP/1.1\r\nHost: x\r\n\r\n");
+    expect(await reusedFirstBody).toBe("served /reused-1");
+    const reusedSecondHeadArrived = once(pairs.reused[1], "data");
+    client("reused").write("GET /reused-2 HTTP/1.1\r\n");
+    await reusedSecondHeadArrived;
+    const idleBody = readResponseBody(client("idle"));
+    client("idle").write("GET /idle HTTP/1.1\r\nHost: x\r\n\r\n");
+    expect(await idleBody).toBe("served /idle");
+
+    server.closeIdleConnections();
+    expect(destroyedFlags()).toEqual({
+      fresh: false,
+      partial: false,
+      body: false,
+      hold: false,
+      reused: false,
+      idle: true,
+    });
+
+    // Every connection that was kept is still fully functional.
+    const freshBody = readResponseBody(client("fresh"));
+    client("fresh").write("GET /fresh HTTP/1.1\r\nHost: x\r\n\r\n");
+    const partialBody = readResponseBody(client("partial"));
+    client("partial").write("\r\n");
+    const bodyNextBody = readResponseBody(client("body"));
+    client("body").write("defghijGET /body-next HTTP/1.1\r\nHost: x\r\n\r\n");
+    const holdBody = readResponseBody(client("hold"));
+    held.end("held");
+    const reusedSecondBody = readResponseBody(client("reused"));
+    client("reused").write("Host: x\r\n\r\n");
+    expect(await Promise.all([freshBody, partialBody, bodyNextBody, holdBody, reusedSecondBody])).toEqual([
+      "served /fresh",
+      "served /partial",
+      "served /body-next",
+      "held",
+      "served /reused-2",
+    ]);
+
+    // Now they are all between requests; close() sweeps idle connections the same way.
+    server.close();
+    expect(destroyedFlags()).toEqual({
+      fresh: true,
+      partial: true,
+      body: true,
+      hold: true,
+      reused: true,
+      idle: true,
+    });
+  } finally {
+    for (const name of names) {
+      pairs[name][0].destroy();
+      pairs[name][1].destroy();
+    }
+    if (server.listening) server.close();
+  }
+});
+
+it("closeAllConnections() destroys an emitted connection that closeIdleConnections() keeps, but not one handed to 'upgrade'", async () => {
+  const upgraded = Promise.withResolvers<void>();
+  const server = createServer(() => {});
+  server.on("upgrade", (req, socket) => {
+    socket.write("HTTP/1.1 101 Switching Protocols\r\n\r\n");
+    upgraded.resolve();
+  });
+  await listen(server);
+  const [clientSide, serverSide] = duplexPair();
+  const [upgradeClientSide, upgradeServerSide] = duplexPair();
+  try {
+    server.emit("connection", serverSide);
+    server.emit("connection", upgradeServerSide);
+    const headArrived = once(serverSide, "data");
+    clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n");
+    await headArrived;
+    upgradeClientSide.write("GET / HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: tcp\r\n\r\n");
+    await upgraded.promise;
+
+    server.closeIdleConnections();
+    expect({ partial: serverSide.destroyed, upgraded: upgradeServerSide.destroyed }).toEqual({
+      partial: false,
+      upgraded: false,
+    });
+    // Like Node, a connection that left HTTP via 'upgrade' is no longer the server's to close.
+    server.closeAllConnections();
+    expect({ partial: serverSide.destroyed, upgraded: upgradeServerSide.destroyed }).toEqual({
+      partial: true,
+      upgraded: false,
+    });
+  } finally {
+    clientSide.destroy();
+    serverSide.destroy();
+    upgradeClientSide.destroy();
+    upgradeServerSide.destroy();
+    if (server.listening) server.close();
+  }
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4304,6 +4304,79 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+// Node's Http2SecureServer#close() runs http's closeIdleConnections() over the allowHTTP1
+// connections, and a connection only counts as idle between requests: one that has not sent a
+// request yet, or is still sending one, is left open (and still served), while one that finished
+// an exchange is destroyed.
+it("http2 allowHTTP1 server.close() only destroys fallback connections that are between requests", async () => {
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) =>
+    res.end(`served ${req.url}`),
+  );
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.address().port;
+
+  // Resolves once the server has accepted the connection too: Http2SecureServer sets the HTTP/1
+  // fallback up in its own 'secureConnection' listener, which runs before this one.
+  async function connectHttp1() {
+    const accepted = new Promise(resolve => server.once("secureConnection", resolve));
+    const client = tls.connect({ host: "localhost", port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] });
+    client.on("error", () => {});
+    await new Promise(resolve => client.once("secureConnect", resolve));
+    return { client, serverSocket: await accepted };
+  }
+  function readHttp1Body(client) {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    let raw = "";
+    client.on("data", function onData(chunk) {
+      raw += chunk.toString("latin1");
+      const headersEnd = raw.indexOf("\r\n\r\n");
+      if (headersEnd === -1) return;
+      const body = raw.slice(headersEnd + 4);
+      if (body.length < Number(/\r\ncontent-length: (\d+)/i.exec(raw.slice(0, headersEnd))[1])) return;
+      client.off("data", onData);
+      resolve(body);
+    });
+    client.once("close", () =>
+      reject(new Error(`connection closed before a response arrived, got: ${JSON.stringify(raw)}`)),
+    );
+    return promise;
+  }
+
+  const fresh = await connectHttp1();
+  const partial = await connectHttp1();
+  const done = await connectHttp1();
+  try {
+    const partialHeadArrived = new Promise(resolve => partial.serverSocket.once("data", resolve));
+    partial.client.write("GET /partial HTTP/1.1\r\nHost: localhost\r\n");
+    await partialHeadArrived;
+    const doneBody = readHttp1Body(done.client);
+    done.client.write("GET /done HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    expect(await doneBody).toBe("served /done");
+
+    const serverClosed = new Promise(resolve => server.once("close", resolve));
+    server.close();
+    expect({
+      fresh: fresh.serverSocket.destroyed,
+      partial: partial.serverSocket.destroyed,
+      done: done.serverSocket.destroyed,
+    }).toEqual({ fresh: false, partial: false, done: true });
+
+    // The connections close() left alone still get their requests served; with Connection: close
+    // the server ends them afterwards, which is what lets the close() above complete.
+    const freshBody = readHttp1Body(fresh.client);
+    fresh.client.write("GET /fresh HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    const partialBody = readHttp1Body(partial.client);
+    partial.client.write("Connection: close\r\n\r\n");
+    expect(await Promise.all([freshBody, partialBody])).toEqual(["served /fresh", "served /partial"]);
+    await serverClosed;
+  } finally {
+    fresh.client.destroy();
+    partial.client.destroy();
+    done.client.destroy();
+    if (server.listening) server.close();
+  }
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4314,12 +4314,14 @@ it("http2 allowHTTP1 server.close() only destroys fallback connections that are 
   );
   await new Promise(resolve => server.listen(0, resolve));
   const port = server.address().port;
+  const clients = [];
 
   // Resolves once the server has accepted the connection too: Http2SecureServer sets the HTTP/1
   // fallback up in its own 'secureConnection' listener, which runs before this one.
   async function connectHttp1() {
     const accepted = new Promise(resolve => server.once("secureConnection", resolve));
     const client = tls.connect({ host: "localhost", port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] });
+    clients.push(client);
     await new Promise((resolve, reject) => {
       client.once("secureConnect", resolve);
       client.once("error", reject);
@@ -4365,10 +4367,10 @@ it("http2 allowHTTP1 server.close() only destroys fallback connections that are 
     return promise;
   }
 
-  const fresh = await connectHttp1();
-  const partial = await connectHttp1();
-  const done = await connectHttp1();
   try {
+    const fresh = await connectHttp1();
+    const partial = await connectHttp1();
+    const done = await connectHttp1();
     const partialHeadArrived = new Promise(resolve => partial.serverSocket.once("data", resolve));
     partial.client.write("GET /partial HTTP/1.1\r\nHost: localhost\r\n");
     await partialHeadArrived;
@@ -4393,9 +4395,7 @@ it("http2 allowHTTP1 server.close() only destroys fallback connections that are 
     expect(await Promise.all([freshBody, partialBody])).toEqual(["served /fresh", "served /partial"]);
     await serverClosed;
   } finally {
-    fresh.client.destroy();
-    partial.client.destroy();
-    done.client.destroy();
+    for (const client of clients) client.destroy();
     if (server.listening) server.close();
   }
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3355,17 +3355,11 @@ describe.concurrent(
       expect(exitCode).toBe(0);
       return JSON.parse(stdout.trim());
     }
-    // Every case here spawns a debug-build subprocess, and the block runs them concurrently, so on a
-    // debug build they land around the default timeout; scale the ceiling like the other slow cases
-    // in this file.
-    const SUBPROCESS_TIMEOUT = 5_000 * ASAN_MULTIPLIER;
 
     // A single-frame write (<= 16374 bytes) corked behind HEADERS straddles the 16 KiB cork;
     // the mid-write cork flush is what runs the Duplex.
-    it.each(["transfer", "resize0"])(
-      "single DATA frame straddling the cork flush (%s)",
-      async mode => {
-        const result = await run(/* js */ `
+    it.each(["transfer", "resize0"])("single DATA frame straddling the cork flush (%s)", async mode => {
+      const result = await run(/* js */ `
       const holder = { src: payload(16374, ${mode === "resize0"}) };
       const snap = Buffer.from(holder.src);
       let armed = false, fired = 0;
@@ -3382,19 +3376,15 @@ describe.concurrent(
       console.log(JSON.stringify({ fired: fired > 0, foreign: foreign(duplex.data(), snap) }));
       process.exit(0);
     `);
-        expect(result).toEqual({ fired: true, foreign: 0 });
-      },
-      SUBPROCESS_TIMEOUT,
-    );
+      expect(result).toEqual({ fired: true, foreign: 0 });
+    });
 
     // HEADERS sized so the cork sits within 8 bytes of full: the 9-byte DATA frame header is
     // what straddles, so the Duplex runs before the payload itself is written at all. The
     // header value uses a character HPACK will not huffman-encode, so the block length tracks
     // N byte for byte; the sweep keeps the case on target if the fixed overhead ever shifts.
-    it(
-      "DATA frame header straddling the cork flush",
-      async () => {
-        const result = await run(/* js */ `
+    it("DATA frame header straddling the cork flush", async () => {
+      const result = await run(/* js */ `
       const results = [];
       for (let n = 16344; n <= 16352; n++) {
         const holder = { src: payload(8000, false) };
@@ -3420,17 +3410,13 @@ describe.concurrent(
       }));
       process.exit(0);
     `);
-        expect(result).toEqual({ hitWindow: true, allFired: true, foreign: 0 });
-      },
-      SUBPROCESS_TIMEOUT,
-    );
+      expect(result).toEqual({ hitWindow: true, allFired: true, foreign: 0 });
+    });
 
     // A write larger than the peer's window: the in-window part is batched and flushed (running
     // the Duplex) and only then is the remainder queued until WINDOW_UPDATE arrives.
-    it(
-      "flow-control-limited tail queued after a flush",
-      async () => {
-        const result = await run(/* js */ `
+    it("flow-control-limited tail queued after a flush", async () => {
+      const result = await run(/* js */ `
       const SZ = 65535 + 32768;
       const holder = { src: payload(SZ, false) };
       const snap = Buffer.from(holder.src);
@@ -3451,17 +3437,13 @@ describe.concurrent(
       console.log(JSON.stringify({ fired: fired > 0, foreign: foreign(duplex.data(), snap) }));
       process.exit(0);
     `);
-        expect(result).toEqual({ fired: true, foreign: 0 });
-      },
-      SUBPROCESS_TIMEOUT,
-    );
+      expect(result).toEqual({ fired: true, foreign: 0 });
+    });
 
     // Two sessions share the thread's cork slot. B's write first flushes A's corked HEADERS
     // through A's Duplex, and it is A's transport JS that detaches B's payload.
-    it(
-      "another session's transport JS running on cork handover",
-      async () => {
-        const result = await run(/* js */ `
+    it("another session's transport JS running on cork handover", async () => {
+      const result = await run(/* js */ `
       const holder = { src: payload(8000, false) };
       const snap = Buffer.from(holder.src);
       let armed = false, fired = 0;
@@ -3480,10 +3462,8 @@ describe.concurrent(
       console.log(JSON.stringify({ fired: fired > 0, foreign: foreign(duplexB.data(), snap) }));
       process.exit(0);
     `);
-        expect(result).toEqual({ fired: true, foreign: 0 });
-      },
-      SUBPROCESS_TIMEOUT,
-    );
+      expect(result).toEqual({ fired: true, foreign: 0 });
+    });
 
     // Same handover, but B is a native TCP connection to a local h2c server: B's own writes
     // never run JS, so the only JS that can touch B's payload mid-send is A's Duplex being
@@ -3532,17 +3512,14 @@ describe.concurrent(
     `);
         expect(result).toEqual({ native: true, firedDuringWrite: true, foreign: 0 });
       },
-      SUBPROCESS_TIMEOUT,
     );
 
     // The session's socket is a native TLSSocket, but one upgraded from a JS Duplex
     // (tls.connect({ socket })), so every TLS record is written through that Duplex's JS.
     // Oracle: the request body a real secure server receives.
-    it.each(["straddle", "tail"])(
-      "TLSSocket over a JS Duplex against a real server (%s)",
-      async face => {
-        const result = await run(
-          /* js */ `
+    it.each(["straddle", "tail"])("TLSSocket over a JS Duplex against a real server (%s)", async face => {
+      const result = await run(
+        /* js */ `
       const net = require("node:net");
       const tls = require("node:tls");
       const SZ = ${face === "tail" ? 65535 + 32768 : 16374};
@@ -3592,12 +3569,10 @@ describe.concurrent(
       console.log(JSON.stringify({ native: !!socket._handle, fired: fired > 0, foreign: foreign(got, snap) }));
       process.exit(0);
     `,
-          { ...bunEnv, TLS_CERT_JSON: JSON.stringify(TLS_CERT) },
-        );
-        expect(result).toEqual({ native: true, fired: true, foreign: 0 });
-      },
-      SUBPROCESS_TIMEOUT,
-    );
+        { ...bunEnv, TLS_CERT_JSON: JSON.stringify(TLS_CERT) },
+      );
+      expect(result).toEqual({ native: true, fired: true, foreign: 0 });
+    });
   },
 );
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3355,11 +3355,17 @@ describe.concurrent(
       expect(exitCode).toBe(0);
       return JSON.parse(stdout.trim());
     }
+    // Every case here spawns a debug-build subprocess, and the block runs them concurrently, so on a
+    // debug build they land around the default timeout; scale the ceiling like the other slow cases
+    // in this file.
+    const SUBPROCESS_TIMEOUT = 5_000 * ASAN_MULTIPLIER;
 
     // A single-frame write (<= 16374 bytes) corked behind HEADERS straddles the 16 KiB cork;
     // the mid-write cork flush is what runs the Duplex.
-    it.each(["transfer", "resize0"])("single DATA frame straddling the cork flush (%s)", async mode => {
-      const result = await run(/* js */ `
+    it.each(["transfer", "resize0"])(
+      "single DATA frame straddling the cork flush (%s)",
+      async mode => {
+        const result = await run(/* js */ `
       const holder = { src: payload(16374, ${mode === "resize0"}) };
       const snap = Buffer.from(holder.src);
       let armed = false, fired = 0;
@@ -3376,15 +3382,19 @@ describe.concurrent(
       console.log(JSON.stringify({ fired: fired > 0, foreign: foreign(duplex.data(), snap) }));
       process.exit(0);
     `);
-      expect(result).toEqual({ fired: true, foreign: 0 });
-    });
+        expect(result).toEqual({ fired: true, foreign: 0 });
+      },
+      SUBPROCESS_TIMEOUT,
+    );
 
     // HEADERS sized so the cork sits within 8 bytes of full: the 9-byte DATA frame header is
     // what straddles, so the Duplex runs before the payload itself is written at all. The
     // header value uses a character HPACK will not huffman-encode, so the block length tracks
     // N byte for byte; the sweep keeps the case on target if the fixed overhead ever shifts.
-    it("DATA frame header straddling the cork flush", async () => {
-      const result = await run(/* js */ `
+    it(
+      "DATA frame header straddling the cork flush",
+      async () => {
+        const result = await run(/* js */ `
       const results = [];
       for (let n = 16344; n <= 16352; n++) {
         const holder = { src: payload(8000, false) };
@@ -3410,13 +3420,17 @@ describe.concurrent(
       }));
       process.exit(0);
     `);
-      expect(result).toEqual({ hitWindow: true, allFired: true, foreign: 0 });
-    });
+        expect(result).toEqual({ hitWindow: true, allFired: true, foreign: 0 });
+      },
+      SUBPROCESS_TIMEOUT,
+    );
 
     // A write larger than the peer's window: the in-window part is batched and flushed (running
     // the Duplex) and only then is the remainder queued until WINDOW_UPDATE arrives.
-    it("flow-control-limited tail queued after a flush", async () => {
-      const result = await run(/* js */ `
+    it(
+      "flow-control-limited tail queued after a flush",
+      async () => {
+        const result = await run(/* js */ `
       const SZ = 65535 + 32768;
       const holder = { src: payload(SZ, false) };
       const snap = Buffer.from(holder.src);
@@ -3437,13 +3451,17 @@ describe.concurrent(
       console.log(JSON.stringify({ fired: fired > 0, foreign: foreign(duplex.data(), snap) }));
       process.exit(0);
     `);
-      expect(result).toEqual({ fired: true, foreign: 0 });
-    });
+        expect(result).toEqual({ fired: true, foreign: 0 });
+      },
+      SUBPROCESS_TIMEOUT,
+    );
 
     // Two sessions share the thread's cork slot. B's write first flushes A's corked HEADERS
     // through A's Duplex, and it is A's transport JS that detaches B's payload.
-    it("another session's transport JS running on cork handover", async () => {
-      const result = await run(/* js */ `
+    it(
+      "another session's transport JS running on cork handover",
+      async () => {
+        const result = await run(/* js */ `
       const holder = { src: payload(8000, false) };
       const snap = Buffer.from(holder.src);
       let armed = false, fired = 0;
@@ -3462,8 +3480,10 @@ describe.concurrent(
       console.log(JSON.stringify({ fired: fired > 0, foreign: foreign(duplexB.data(), snap) }));
       process.exit(0);
     `);
-      expect(result).toEqual({ fired: true, foreign: 0 });
-    });
+        expect(result).toEqual({ fired: true, foreign: 0 });
+      },
+      SUBPROCESS_TIMEOUT,
+    );
 
     // Same handover, but B is a native TCP connection to a local h2c server: B's own writes
     // never run JS, so the only JS that can touch B's payload mid-send is A's Duplex being
@@ -3512,14 +3532,17 @@ describe.concurrent(
     `);
         expect(result).toEqual({ native: true, firedDuringWrite: true, foreign: 0 });
       },
+      SUBPROCESS_TIMEOUT,
     );
 
     // The session's socket is a native TLSSocket, but one upgraded from a JS Duplex
     // (tls.connect({ socket })), so every TLS record is written through that Duplex's JS.
     // Oracle: the request body a real secure server receives.
-    it.each(["straddle", "tail"])("TLSSocket over a JS Duplex against a real server (%s)", async face => {
-      const result = await run(
-        /* js */ `
+    it.each(["straddle", "tail"])(
+      "TLSSocket over a JS Duplex against a real server (%s)",
+      async face => {
+        const result = await run(
+          /* js */ `
       const net = require("node:net");
       const tls = require("node:tls");
       const SZ = ${face === "tail" ? 65535 + 32768 : 16374};
@@ -3569,10 +3592,12 @@ describe.concurrent(
       console.log(JSON.stringify({ native: !!socket._handle, fired: fired > 0, foreign: foreign(got, snap) }));
       process.exit(0);
     `,
-        { ...bunEnv, TLS_CERT_JSON: JSON.stringify(TLS_CERT) },
-      );
-      expect(result).toEqual({ native: true, fired: true, foreign: 0 });
-    });
+          { ...bunEnv, TLS_CERT_JSON: JSON.stringify(TLS_CERT) },
+        );
+        expect(result).toEqual({ native: true, fired: true, foreign: 0 });
+      },
+      SUBPROCESS_TIMEOUT,
+    );
   },
 );
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4320,8 +4320,12 @@ it("http2 allowHTTP1 server.close() only destroys fallback connections that are 
   async function connectHttp1() {
     const accepted = new Promise(resolve => server.once("secureConnection", resolve));
     const client = tls.connect({ host: "localhost", port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] });
+    await new Promise((resolve, reject) => {
+      client.once("secureConnect", resolve);
+      client.once("error", reject);
+    });
+    // From here on the only error this test expects is the reset of the connection close() destroys.
     client.on("error", () => {});
-    await new Promise(resolve => client.once("secureConnect", resolve));
     return { client, serverSocket: await accepted };
   }
   // Reads one Content-Length framed response; rejects if the response is framed any other way or

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4400,6 +4400,43 @@ it("http2 allowHTTP1 server.close() only destroys fallback connections that are 
   }
 });
 
+// The server's connection list holds every fallback parser strongly, so a connection has to be
+// taken out of it when it closes (Node's freeParser), whether the peer or the server closed it.
+it("http2 allowHTTP1 connections leave the server's connection list when they close", async () => {
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => res.end("ok"));
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.address().port;
+  const clients = [];
+  try {
+    const serverSockets = [];
+    for (let i = 0; i < 2; i++) {
+      const accepted = new Promise(resolve => server.once("secureConnection", resolve));
+      const client = tls.connect({ host: "localhost", port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] });
+      clients.push(client);
+      await new Promise((resolve, reject) => {
+        client.once("secureConnect", resolve);
+        client.once("error", reject);
+      });
+      // The connection the server destroys below may surface that as a reset here.
+      client.on("error", () => {});
+      serverSockets.push(await accepted);
+    }
+    const connectionsSymbol = Object.getOwnPropertySymbols(server).find(s => s.description === "http1Connections");
+    const connections = server[connectionsSymbol];
+    expect(connections.all().length).toBe(2);
+
+    const closed = Promise.all(serverSockets.map(socket => new Promise(resolve => socket.once("close", resolve))));
+    // One closed by the peer, one by the server.
+    clients[0].end();
+    serverSockets[1].destroy();
+    await closed;
+    expect(connections.all()).toEqual([]);
+  } finally {
+    for (const client of clients) client.destroy();
+    server.close();
+  }
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4324,21 +4324,40 @@ it("http2 allowHTTP1 server.close() only destroys fallback connections that are 
     await new Promise(resolve => client.once("secureConnect", resolve));
     return { client, serverSocket: await accepted };
   }
+  // Reads one Content-Length framed response; rejects if the response is framed any other way or
+  // the connection goes away first (which is what a wrongly destroyed connection looks like here).
   function readHttp1Body(client) {
     const { promise, resolve, reject } = Promise.withResolvers();
     let raw = "";
-    client.on("data", function onData(chunk) {
+    function settle(body, error) {
+      client.off("data", onData);
+      client.off("close", onClose);
+      client.off("error", onError);
+      if (error) reject(error);
+      else resolve(body);
+    }
+    function onData(chunk) {
       raw += chunk.toString("latin1");
       const headersEnd = raw.indexOf("\r\n\r\n");
       if (headersEnd === -1) return;
+      const contentLength = /\r\ncontent-length: (\d+)/i.exec(raw.slice(0, headersEnd));
+      if (!contentLength) {
+        settle(undefined, new Error(`expected a Content-Length framed response, got: ${JSON.stringify(raw)}`));
+        return;
+      }
       const body = raw.slice(headersEnd + 4);
-      if (body.length < Number(/\r\ncontent-length: (\d+)/i.exec(raw.slice(0, headersEnd))[1])) return;
-      client.off("data", onData);
-      resolve(body);
-    });
-    client.once("close", () =>
-      reject(new Error(`connection closed before a response arrived, got: ${JSON.stringify(raw)}`)),
-    );
+      if (body.length < Number(contentLength[1])) return;
+      settle(body);
+    }
+    function onClose() {
+      settle(undefined, new Error(`connection closed before the response completed, got: ${JSON.stringify(raw)}`));
+    }
+    function onError(error) {
+      settle(undefined, error);
+    }
+    client.on("data", onData);
+    client.on("close", onClose);
+    client.on("error", onError);
     return promise;
   }
 


### PR DESCRIPTION
### Problem
- On the HTTP/1 fallback path, `server.close()` / `closeIdleConnections()` destroy connections that are still mid-exchange, and any request written on them afterwards is lost. Node keeps them and serves that request.
- Affected states: connected but nothing sent yet, request head partly sent, body still arriving after an early response, keep-alive connection that has started its next request, and the handler's own connection when it calls `close()` right after `res.end()`.
- Cause: the fallback counted a connection as idle whenever its number of dispatched requests was zero, so a connection that had not reached headers-complete yet, or had already responded, read as idle.
- Node's rule is different: a connection is busy from the moment it is accepted and from the first byte of every request until that message completes, so only connections sitting between requests are idle.

### Fix
- Each fallback parser is registered with a per-server `ConnectionsList`, replacing the socket set and the counter; the idle and close-all sweeps become node's loops over `idle()` / `all()`, and the parser is removed from the list before it is closed, both on socket close and on the upgrade / CONNECT handoff.
- This is correct because idle-ness is now decided by the same list and the same two checks node uses (between messages, and no unfinished response assigned), and those transitions are already maintained natively, so the classification matches node by construction.
- Behaviour change: node bounds the connections this stops destroying with `headersTimeout` / `requestTimeout` / `keepAliveTimeout`; the fallback path enforces none of these yet (#37739 and #37724 add them), so until then such a connection holds `server.close()` open until the client goes away.
- Verification: the new state-matrix, sweep-from-inside-the-handler, and http2 `allowHTTP1` `close()` tests fail on the unfixed build and pass with the fix, and the same logic passes as a plain script under node v26.3.0. Two neighbouring test tweaks (binding to 127.0.0.1, a scaled timeout) are unrelated to the fix.

### Background
- The HTTP/1 fallback (`src/js/internal/http1_server_fallback.ts`) is a JS port of node's `connectionListener`. Only sockets pushed in via `server.emit("connection", ...)` and HTTP/1.1 clients that land on an `allowHTTP1` http2 server go through it; sockets a listening `http.Server` accepts itself are served by the native uWS server, which this PR does not touch (its own divergence on the early-response case is tracked separately).
- `ConnectionsList` (`process.binding("http_parser")`) is bun's port of node's native list of parsers. A parser passed to `initialize()` joins it as busy, turns idle at message-complete, and turns busy again at the next message-begin; `idle()` / `all()` return the parsers and `remove()` takes one out. Node's `closeIdleConnections()` is a loop over `idle()`.
- A connection that has sent nothing counts as busy on purpose: node governs it with `headersTimeout` rather than treating it as idle.
- `socket._httpMessage` is the response currently assigned to a socket. `res.end()` sets `finished` synchronously but the response stays assigned until `'finish'` fires, so the sweep's second check keeps a connection whose response is still being written and drops one whose response just ended.
- The request handler runs from the parser's headers-complete callback, while the request is still being parsed, so a handler that responds and then sweeps does not destroy its own connection.

<details>
<summary>Original description</summary>

### What

`closeIdleHttp1Connections()` in `src/js/internal/http1_server_fallback.ts` decides which HTTP/1 connections `http.Server#close()` / `closeIdleConnections()` (for sockets handed in through `server.emit("connection", socket)`) and `Http2SecureServer#close()` (`allowHTTP1: true`) are allowed to destroy. It treated every connection without a dispatched request as idle, so it also destroyed connections that were still in the middle of something. Node keeps those.

### Repro

```js
const http = require("http");
const { duplexPair } = require("stream");
const server = http.createServer((req, res) => res.end("served " + req.url));
server.listen(0, () => {
  const [client, conn] = duplexPair();
  server.emit("connection", conn);          // connected, nothing sent yet
  server.closeIdleConnections();
  console.log(conn.destroyed);             // node: false, bun: true
  // a request written now is served by node and lost on bun
});
```

The same thing happens for a connection that has sent part of its request head, for one whose request body is still arriving after the handler already responded, for a keep-alive connection that has started its next request, and for the handler's own connection when the handler responds and then calls `closeIdleConnections()` / `close()` itself (the request is still being parsed at that point). For `http2.createSecureServer({ allowHTTP1: true })`, `server.close()` kills an HTTP/1.1 connection that completed the TLS handshake but has not sent a request yet; node leaves it open and still serves the request that arrives afterwards.

Matrix from a script that puts one connection into each state and calls `closeIdleConnections()` once (node v26.3.0 vs bun 1.4.0; `destroyed` flag of the server side):

| connection state                                              | node      | bun before | bun after |
| ------------------------------------------------------------- | --------- | ---------- | --------- |
| connected, no bytes sent                                      | kept      | destroyed  | kept      |
| partial request head                                          | kept      | destroyed  | kept      |
| request body still arriving, response already sent            | kept      | destroyed  | kept      |
| request received, response not finished                       | kept      | kept       | kept      |
| response ended this tick (`'finish'` not emitted yet)         | destroyed | destroyed  | destroyed |
| sweep run from inside the handler, after `res.end()`          | kept      | destroyed  | kept      |
| one exchange done, next request head partially sent           | kept      | destroyed  | kept      |
| one exchange done, nothing since                              | destroyed | destroyed  | destroyed |

All kept connections are still served afterwards, and a later sweep, once everything has completed, destroys all of them, on both.

### Cause

The helper used a per-socket counter that is incremented at `kOnHeadersComplete` and decremented when the response ends, so anything before headers complete (or after an early response) read as "0 active requests, idle".

Node's `Server.prototype.closeIdleConnections()` asks its `ConnectionsList` instead: the parser is registered at `initialize()` and counts as busy from then on (explicitly so that a connection that never sends anything is governed by `headersTimeout` rather than treated as idle), becomes idle at `on_message_complete`, and busy again at the next `on_message_begin`. `idle()` returns the parsers between messages, and the loop additionally skips a socket whose `_httpMessage` has not `finished`. Bun already has a port of that machinery (`process.binding("http_parser").ConnectionsList`; `NodeHTTPParser.cpp` maintains `m_lastMessageStart` the same way), it just was not wired into this path.

### Fix

- `connectionListenerHTTP1` registers each parser with a per-server `ConnectionsList` (`parser.initialize(..., connections)`), replacing the socket `SafeSet` and the counter.
- `closeIdleHttp1Connections` / `closeAllHttp1Connections` are node's `closeIdleConnections` / `closeAllConnections` loops over `connections.idle()` / `connections.all()`.
- Teardown follows node's `freeParser`: `parser.remove()` before `parser.close()`, both when the socket closes and on the upgrade / CONNECT handoff (which also drops the close listener it no longer needs, as node does). `Http2SecureServer` no longer pre-creates the set; the listener creates the list on first use and the helpers are no-ops without one, as before.

Why this is the right shape: it is the same data structure and the same two checks node uses, so the classification matches node by construction instead of approximating it with a counter, and the state transitions that matter (initialize, message begin, message complete) are already maintained natively. #37739 builds on the same list to add node's `headersTimeout` / `requestTimeout` sweep for these connections.

### Behaviour change worth knowing about

Connections this PR stops destroying are bounded in node by `headersTimeout` / `requestTimeout` (no request or request in progress) and `keepAliveTimeout` (request finished after the sweep ran, e.g. the handler-calls-`close()` row). The fallback path enforces neither today (before or after this PR; the response-in-flight row already behaved this way), so until #37739 and #37724 land, such a connection holds `server.close()` open until the client goes away. Destroying it, and the request on it, was not a substitute for those timeouts, which is why this PR does not keep doing it.

### Intentionally not changed here

- The native path. Sockets accepted by a listening `http.Server` never reach this file (`_http_server.ts` routes `NodeHTTPServerSocket` away from the fallback); their sweep is uWS's `closeIdle`, which classifies via `HttpResponseData::isIdle` (response end) and so still differs from node on the "body still arriving after an early response" row and its inverse. That is a separate, pre-existing divergence and is tracked separately; the matrix test here is written so the native fix can run the same table over a real listening socket.
- Bun tracks emitted sockets whether or not the server is listening (node only creates its list on `'listening'`).
- How an idle connection is destroyed. #37710 flushes queued response bytes before the destroy; that branch belongs inside the `idle()` loop added here, so the two conflict textually at that loop, whichever lands second rebases. Note for #37710: under node's classification a handler that does `res.end(); server.close()` no longer has its own connection swept (the request is still being parsed), so its test for that shape needs the response to be ended asynchronously; the "sweep from inside the handler" test above pins the new behaviour.
- #36991 (pipelining) touches the same upgrade and `'close'` hunks and conflicts textually; semantically a pipelined response in flight keeps the connection busy through `_httpMessage`, so nothing else is needed there. #37724 (keep-alive timeout) reads the counter this PR removes in its `armKeepAliveTimeout()` guard; on top of this PR that guard is simply "another response is still assigned". #37612 (`closeIdleConnections()` method on `Http2SecureServer`) only conflicts where both append tests to the same file, and its tests complete an exchange before expecting a connection to be idle. (All of these also conflict trivially in the appended tests; `git merge-tree` against each was used to check.)

### Tests

- `test/js/node/http/node-http.test.ts`: the matrix above through `closeIdleConnections()` (every kept connection is then served, and `close()` sweeps them once they are between requests); the response-ended-this-tick row on its own (it is the only row where `_httpMessage` is still assigned when the sweep runs, so it is what exercises the `.finished` check: with that check removed, this test fails and the matrix does not); the sweep-from-inside-the-handler row; and `closeAllConnections()` destroying a kept connection but not one handed to `'upgrade'`. The same logic as a plain script passes under node v26.3.0.
- `test/js/node/http2/node-http2.test.js`: `allowHTTP1` `server.close()` keeps the not-yet-used and partially-sent connections, destroys the one that finished an exchange, still serves the two kept ones, and the server's `'close'` fires once they finish (also verified as a plain script under node); and connections closed by either side leave the server's list (the list holds parsers strongly, and this is what the `remove()`-before-`close()` order is for: with the order swapped, this test fails, and on the debug build the matrix test trips UBSan in `idle()` as well).

- One neighbouring test was made hermetic while getting these files green on a dual-stack box: `node-http-proxy.js` now binds and connects to 127.0.0.1 instead of relying on the server and client resolving `localhost` to the same family (it failed with ECONNREFUSED where `localhost` resolves to ::1 first). Unrelated to the fix.

The matrix, handler-sweep and http2 `close()` tests fail on the unfixed build and pass with the fix. Also green locally: the full `node-http.test.ts` and `node-http2.test.js`, `node-http-parser.test.ts`, `node-http2-upgrade.test.mts`, `node-http-connect.test.ts`, and the upstream `test-http2-allow-http1`, `test-http2-https-fallback*`, `test-http-generic-streams`, `test-http-server-unconsume-consume`, `test-http(s)-server-close-idle*`, `test-http(s)-server-close-all`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 5 failed, 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (e127a4e75)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [419.05ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [67.71ms]
(pass) node:http > createServer > request & response body streaming (large) [109.73ms]
(pass) node:http > createServer > request & response body streaming (small) [66.79ms]
(pass) node:http > createServer > listen should return server [26.20ms]
(pass) node:http > createServer > listen callback should be bound to server [27.39ms]
(pass) node:http > createServer > should use the provided port [35.77ms]
(pass) node:http > createServer > should assign a random port when undefined [27.30ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [45.47ms]
(pass) node:http > response > set-cookie works with getHeader [3.48ms]
(pass) node:http > response > set-cookie works with getHeaders [5.87ms]
(pass) node:http > request > should not insert extraneou
... (truncated)

release without fix: 7 skipped
bun test v1.4.0-canary.1 (29a2640f4)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [13.87ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [4.11ms]
(pass) node:http > createServer > request & response body streaming (large) [6.41ms]
(pass) node:http > createServer > request & response body streaming (small) [2.99ms]
(pass) node:http > createServer > listen should return server [1.25ms]
(pass) node:http > createServer > listen callback should be bound to server [2.13ms]
(pass) node:http > createServer > should use the provided port [1.66ms]
(pass) node:http > createServer > should assign a random port when undefined [1.66ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [3.11ms]
(pass) node:http > response > set-cookie works with getHeader [0.11ms]
(pass) node:http > response > set-cookie works with getHeaders [0.17ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [2.97ms]
(pass) node:http > request > multiple Set-Cookie headers works #6810 [16.09ms]
(pass) node:http > request > should make a standard GET request when passed string as first arg [
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (e127a4e75)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [432.74ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [66.78ms]
(pass) node:http > createServer > request & response body streaming (large) [108.70ms]
(pass) node:http > createServer > request & response body streaming (small) [75.97ms]
(pass) node:http > createServer > listen should return server [35.44ms]
(pass) node:http > createServer > listen callback should be bound to server [25.45ms]
(pass) node:http > createServer > should use the provided port [33.77ms]
(pass) node:http > createServer > should assign a random port when undefined [26.43ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [65.96ms]
(pass) node:http > response > set-cookie works with getHeader [3.69ms]
(pass) node:http > response > set-cookie works with getHeaders [6.22ms]
(pass) node:http > request > should not insert extraneou
... (truncated)

release with fix: 7 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1159ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/144] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/144] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/144] gen cpp.rs (cppbind)
[4/144] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/http1_server_fallback.ts |  52 ++++---
 src/js/node/http2.ts                     |   7 +-
 test/js/node/http/node-http-proxy.js     |   6 +-
 test/js/node/http/node-http.test.ts      | 235 +++++++++++++++++++++++++++++++
 test/js/node/http2/node-http2.test.js    | 204 ++++++++++++++++++++++++---
 5 files changed, 445 insertions(+), 59 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/internal/http1_server_fallback.ts      5     17      0
src/js/node/http2.ts                          1      2      0
test/js/node/http/node-http-proxy.js          2      1      0
test/js/node/http/node-http.test.ts           2      9      0
test/js/node/http2/node-http2.test.js         7     10      0
```

</details>

<!-- robobun:evidence:end -->
