### PR TITLE
node:http2: put END_STREAM on the HEADERS frame of an endStream request even with waitForTrailers

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3812,16 +3812,9 @@ class ServerHttp2Stream extends Http2Stream {
       statusCode === HTTP_STATUS_NOT_MODIFIED ||
       this.headRequest === true
     ) {
-      // When endStream is true the HEADERS frame itself carries END_STREAM
-      // and the stream moves to HALF_CLOSED_LOCAL inside native request().
-      // If waitForTrailers is ALSO true the native layer dispatches
-      // onWantTrailers immediately after, whose JS handler calls
-      // noTrailers → sendData("", true) and emits a spurious DATA frame on
-      // the already-half-closed stream (RFC 9113 §5.1 violation). Strip
-      // waitForTrailers here so the native never fires that path; the JS
-      // guard further down (`options?.waitForTrailers && !endStream`) only
-      // covers the `_final` side and runs AFTER the native call.
-      options = { ...options, endStream: true, waitForTrailers: false };
+      // END_STREAM rides on the HEADERS frame itself; native request() ignores waitForTrailers
+      // for a stream ended this way (nothing can follow the HEADERS), as node does.
+      options = { ...options, endStream: true };
       endStream = true;
     }
     const sendDate = options?.sendDate;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -9251,7 +9251,6 @@ impl H2FrameParser {
             if let Some(trailes_js) = options.get(global_object, "waitForTrailers")? {
                 if trailes_js.is_boolean() {
                     wait_for_trailers = trailes_js.as_boolean();
-                    stream.wait_for_trailers = wait_for_trailers;
                 }
             }
 
@@ -9271,10 +9270,7 @@ impl H2FrameParser {
                 if end_stream_js.is_boolean() {
                     if end_stream_js.as_boolean() {
                         end_stream = true;
-                        // will end the stream after trailers
-                        if !wait_for_trailers || this.is_server.get() {
-                            flags |= HeadersFrameFlags::END_STREAM as u8;
-                        }
+                        flags |= HeadersFrameFlags::END_STREAM as u8;
                     }
                 } else {
                     return Err(global_object.throw_invalid_argument_type_value(
@@ -9383,6 +9379,12 @@ impl H2FrameParser {
                 }
             }
         }
+
+        // endStream puts END_STREAM on this HEADERS frame, so neither a body nor trailers can
+        // follow it: waitForTrailers is ignored and onWantTrailers never fires for the stream.
+        // Same as node, where endStream submits the stream without the nghttp2 data provider
+        // that trailers are requested through.
+        stream.wait_for_trailers = wait_for_trailers && !end_stream;
 
         // too much memory being use
         if this.is_over_session_memory_limit() {
@@ -9594,12 +9596,6 @@ impl H2FrameParser {
         if end_stream {
             stream.end_after_headers = true;
 
-            if wait_for_trailers {
-                stream.state = StreamState::HALF_CLOSED_LOCAL;
-                this.dispatch(JSH2FrameParser::Gc::onWantTrailers, stream.get_identifier());
-                return Ok(JSValue::js_number(stream_id as f64));
-            }
-
             // A HEADERS frame carrying END_STREAM half-closes our side; when
             // the peer already half-closed (a server responding after the
             // request body finished) the stream is now fully closed. Mirror
@@ -9621,8 +9617,6 @@ impl H2FrameParser {
                 identifier,
                 JSValue::js_number(stream.state as u8 as f64),
             );
-        } else {
-            stream.wait_for_trailers = wait_for_trailers;
         }
 
         if silent {

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1008,6 +1008,162 @@ describe("request header and body framing (RFC 9113 §8.1)", () => {
   });
 });
 
+describe("endStream with waitForTrailers (RFC 9113 §8.1)", () => {
+  // node submits an endStream request/response without a data provider: END_STREAM rides on the
+  // HEADERS frame and nghttp2 never asks for trailers, so waitForTrailers is ignored and
+  // 'wantTrailers' never fires. A trailer block (or an END_STREAM DATA frame) after such a
+  // HEADERS frame would be a second terminator for the stream.
+  const END_STREAM_END_HEADERS = 0x5;
+
+  type Outcome = {
+    stream1: { type: number; flags: number }[];
+    wantTrailers: number;
+    sendTrailersError: string | undefined;
+    sentTrailers: unknown;
+  };
+  const endedOnHeaders: Outcome = {
+    stream1: [{ type: FrameType.HEADERS, flags: END_STREAM_END_HEADERS }],
+    wantTrailers: 0,
+    sendTrailersError: "ERR_HTTP2_TRAILERS_NOT_READY",
+    sentTrailers: undefined,
+  };
+
+  function observeTrailers(stream: http2.Http2Stream, listen: boolean) {
+    let wantTrailers = 0;
+    if (listen) {
+      stream.on("wantTrailers", () => {
+        wantTrailers++;
+        stream.sendTrailers({ "x-trailer": "1" });
+      });
+    }
+    return () => {
+      let sendTrailersError: string | undefined;
+      try {
+        stream.sendTrailers({ "x-late": "1" });
+      } catch (e: any) {
+        sendTrailersError = e.code;
+      }
+      return { wantTrailers, sendTrailersError, sentTrailers: stream.sentTrailers };
+    };
+  }
+
+  function stream1Frames(frames: Frame[]) {
+    return frames.filter(f => f.streamId === 1).map(f => ({ type: f.type, flags: f.flags }));
+  }
+
+  async function clientRequest(
+    headers: http2.OutgoingHttpHeaders,
+    options: http2.ClientSessionRequestOptions,
+    { listen = true, afterConnect = false } = {},
+  ): Promise<Outcome> {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      // Before 'connect' the request is queued and submitted from the connect handler; after it,
+      // request() submits it directly. Both reach the wire through the same native request().
+      if (afterConnect) await once(client, "connect");
+      const req = client.request(headers, options);
+      req.on("error", () => {});
+      const finished = once(req, "finish");
+      const finishTrailers = observeTrailers(req, listen);
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      // Whatever the client wrote for stream 1 while submitting the request was written before it
+      // could have seen this PING, so it precedes the PING ACK on the wire.
+      raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      // The writable side still finishes even though no frame carried the end separately.
+      await finished;
+      return { stream1: stream1Frames(raw.frames), ...finishTrailers() };
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  }
+
+  test("GET (endStream by default) with waitForTrailers ends the stream on its HEADERS frame", async () => {
+    expect(await clientRequest({ ":method": "GET", ":path": "/" }, { waitForTrailers: true })).toEqual(endedOnHeaders);
+  });
+
+  test("POST with endStream and waitForTrailers ends the stream on its HEADERS frame", async () => {
+    expect(
+      await clientRequest({ ":method": "POST", ":path": "/" }, { endStream: true, waitForTrailers: true }),
+    ).toEqual(endedOnHeaders);
+  });
+
+  test("without a 'wantTrailers' listener no END_STREAM DATA frame follows the HEADERS frame", async () => {
+    expect(
+      await clientRequest({ ":method": "GET", ":path": "/" }, { waitForTrailers: true }, { listen: false }),
+    ).toEqual(endedOnHeaders);
+  });
+
+  test("a request submitted after 'connect' behaves the same", async () => {
+    expect(
+      await clientRequest({ ":method": "GET", ":path": "/" }, { waitForTrailers: true }, { afterConnect: true }),
+    ).toEqual(endedOnHeaders);
+  });
+
+  test("a request that does carry a body still gets to send trailers", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      const finishTrailers = observeTrailers(req, true);
+      req.end("hello");
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1 && (f.flags & 0x1) !== 0);
+      expect({ stream1: stream1Frames(raw.frames), ...finishTrailers() }).toEqual({
+        stream1: [
+          { type: FrameType.HEADERS, flags: 0x4 /* END_HEADERS */ },
+          { type: FrameType.DATA, flags: 0 },
+          { type: FrameType.HEADERS, flags: END_STREAM_END_HEADERS },
+        ],
+        wantTrailers: 1,
+        sendTrailersError: "ERR_HTTP2_TRAILERS_ALREADY_SENT",
+        sentTrailers: { "x-trailer": "1" },
+      });
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("a server response with endStream and waitForTrailers ends the stream on its HEADERS frame", async () => {
+    const closed = Promise.withResolvers<() => Omit<Outcome, "stream1">>();
+    const srv = http2.createServer();
+    srv.on("stream", (stream: any) => {
+      stream.on("error", () => {});
+      const finishTrailers = observeTrailers(stream, true);
+      stream.respond({ ":status": 200 }, { endStream: true, waitForTrailers: true });
+      // The request below is itself END_STREAM, so this response closes the stream outright.
+      stream.on("close", () => closed.resolve(finishTrailers));
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const c = await RawH2.connect((srv.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, END_STREAM_END_HEADERS, 1, requestHeaderBlock("GET"));
+      const finishTrailers = await closed.promise;
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      // Like node, sendTrailers() on the closed stream reports ERR_HTTP2_INVALID_STREAM (it was never
+      // asked for trailers, so it is also not "already sent").
+      expect({ stream1: stream1Frames(c.frames), ...finishTrailers() }).toEqual({
+        ...endedOnHeaders,
+        sendTrailersError: "ERR_HTTP2_INVALID_STREAM",
+      });
+    } finally {
+      c.destroy();
+      srv.close();
+    }
+  });
+});
+
 describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
   // HPACK "literal never indexed, new name" (0x10) so the wire shape is exactly what is written
   // and no client library normalizes it away.


### PR DESCRIPTION
### Problem
- A `node:http2` client request with `endStream` (explicit, or implied for GET/HEAD/DELETE/OPTIONS) plus `waitForTrailers` goes out as `HEADERS(flags=0x4)` and then a second terminating frame: a trailer `HEADERS(flags=0x5)`, or an empty END_STREAM `DATA` frame with no `'wantTrailers'` listener. Node sends one `HEADERS(flags=0x5)`.
- `'wantTrailers'` fires on such a stream (node: never). A later `sendTrailers()` throws `ERR_HTTP2_TRAILERS_ALREADY_SENT` where node throws `ERR_HTTP2_TRAILERS_NOT_READY`; with no listener it does not throw and writes a trailer block after the stream was already ended.
- Cause: on the client, `endStream` with `waitForTrailers` meant "end the stream after the trailers". The HEADERS frame went out without END_STREAM, the stream was marked half-closed although nothing on the wire had closed it, and JS was asked for trailers. The server side already had an exception.

### Fix
- `endStream` now always puts END_STREAM on the HEADERS frame, client and server alike, and a stream only remembers `waitForTrailers` when that frame did not end it. The deferred want-trailers branch is removed.
- Property to check: a stream ended by its HEADERS frame can carry neither a body nor trailers, so trailers are never requested and `sendTrailers()` reports `ERR_HTTP2_TRAILERS_NOT_READY`. Node behaves the same, and its docs place trailers after the final DATA frame, which such a stream does not have.
- Server `respond()` no longer strips `waitForTrailers` itself; the native rule covers it and its wire output is unchanged.
- Verification: wire-level tests against a raw HTTP/2 peer. Four client cases fail on the unfixed binary with the frame lists above; a body-carrying POST and a server `respond({ endStream: true, waitForTrailers: true })` pin the paths that must not change. Outcomes were checked against node v26.3.0; the existing bun, upstream node and grpc-js http2 suites still pass.

### Background
- Each side of an HTTP/2 stream ends its half by setting END_STREAM on a frame. HEADERS flags 0x4 is END_HEADERS alone, 0x5 adds END_STREAM. Anything a side sends on the stream after its END_STREAM is a protocol violation.
- Trailers are a second HEADERS block sent after the body's last DATA frame, and that block is what carries END_STREAM. A stream ended on its first HEADERS frame has nowhere for them to go.
- In the node API, `waitForTrailers` stops the stream from ending by itself after the body: `'wantTrailers'` is emitted and the app calls `sendTrailers()` to send the closing block. `endStream` declares there is no body.
- bun's http2 is split between `src/js/node/http2.ts` (the node-facing API) and a native frame parser that builds frames and tracks per-stream state. One native entry point serves both the client's `request()` and the server's `respond()`, so a rule there covers both sides.

<details>
<summary>Original description</summary>

## What

A `node:http2` client request submitted with `endStream` (explicitly, or by default for GET/HEAD/DELETE/OPTIONS...) together with `waitForTrailers` now goes out the way node sends it: END_STREAM on the request HEADERS frame, no trailers requested, no `'wantTrailers'` event.

## Repro

Raw `net` server that sends SETTINGS after the preface, ACKs the client's SETTINGS and logs every frame it receives on stream 1:

```js
const req = client.request({ ":method": "GET", ":path": "/" }, { waitForTrailers: true }); // GET => endStream
req.on("wantTrailers", () => req.sendTrailers({ "x-t": "1" }));
// later:
try { req.sendTrailers({ "x-late": "1" }); } catch (e) { console.log(e.code); }
```

Same with `{ ":method": "POST" }` and `{ endStream: true, waitForTrailers: true }`.

| | node v26.3.0 | bun 1.4.0 |
|---|---|---|
| frames on stream 1 | `HEADERS(flags=0x5)` | `HEADERS(flags=0x4)`, trailer `HEADERS(flags=0x5)` |
| same, no `'wantTrailers'` listener | `HEADERS(flags=0x5)` | `HEADERS(flags=0x4)`, `DATA(len 0, END_STREAM)` |
| `'wantTrailers'` emitted | no | yes |
| later `sendTrailers()` | throws `ERR_HTTP2_TRAILERS_NOT_READY` | throws `ERR_HTTP2_TRAILERS_ALREADY_SENT` (with a listener); with no listener it does not throw and writes a trailer HEADERS frame after the END_STREAM DATA frame |

## Cause

`H2FrameParser::request()` (`src/runtime/api/bun/h2_frame_parser.rs`) handled `endStream` as "end the stream after the trailers" on the client: it left END_STREAM off the HEADERS frame when `waitForTrailers` was set (the server already had an `is_server` exception), and after writing the frame it set the stream to HALF_CLOSED_LOCAL, although nothing had ended it on the wire yet, and dispatched `onWantTrailers`. The JS `wantTrailers` handler then terminated the stream with a trailer block or an empty END_STREAM DATA frame.

## Fix

`request()` puts END_STREAM on the HEADERS frame whenever `endStream` is set, and only records `waitForTrailers` on the stream when that frame did not end it (`stream.wait_for_trailers = wait_for_trailers && !end_stream`). The deferred `onWantTrailers` branch is gone, so an `endStream` stream takes the same path as one without `waitForTrailers`: state transition plus `onStreamEnd`, the writable side finishes, and `sendTrailers()` reports `ERR_HTTP2_TRAILERS_NOT_READY` because trailers were never requested.

The rule now lives in one place and applies to both sides, so the server-side `respond()` in `src/js/node/http2.ts` no longer has to strip `waitForTrailers` itself before calling into native (its existing `options?.waitForTrailers && !endStream` guard still keeps the JS-side trailers flag off). The wire output of `respond({ endStream: true, waitForTrailers: true })` is unchanged.

## Why this is the right behavior

This is what node does for both `request()` and `respond()`: with `endStream`, `Http2Session::SubmitRequest` / `Http2Stream::SubmitResponse` pass `STREAM_OPTION_EMPTY_PAYLOAD`, which makes the `nghttp2_data_provider` null, so nghttp2 sets END_STREAM on the HEADERS frame and the trailers callback (which hangs off the data provider) can never run. `waitForTrailers` therefore has no effect on such a stream, which also matches its documentation: trailers are sent "after the final DATA frame", and an `endStream` stream has none. Requests that do carry a body keep requesting trailers exactly as before (`stream.wait_for_trailers` is still set for them; the upstream trailer tests cover that path).

## Verification

New `endStream with waitForTrailers` block in `test/js/node/http2/h2-conformance.test.ts`, wire-level against the file's raw server/client. After the client's HEADERS frame arrives the raw server sends a PING; anything the client wrote while submitting the request is ahead of the PING ACK on the wire, so once the ACK arrives the stream-1 frame list is complete.

- GET with `waitForTrailers` (implied `endStream`), POST with `endStream: true, waitForTrailers: true`, the same without a `'wantTrailers'` listener, and a request submitted after `'connect'` (direct submission rather than the queued-until-connect path): the stream-1 frames are exactly `HEADERS(0x5)`, `'wantTrailers'` never fires, `'finish'` still fires, `sendTrailers()` throws `ERR_HTTP2_TRAILERS_NOT_READY`, `sentTrailers` is undefined. These four fail on the unfixed binary with the frame lists from the table above.
- A POST that carries a body still gets `'wantTrailers'` and sends its trailers (`HEADERS`, `DATA`, trailer `HEADERS(0x5)`), pinning the path that is still supposed to request trailers.
- A server `respond({ endStream: true, waitForTrailers: true })` still produces exactly `HEADERS(0x5)` with no `'wantTrailers'`, covering the removed JS strip.

Outcomes of every case were checked against node v26.3.0. Also passing with the fix: `test/js/node/http2/` (all files), all 261 upstream `test-http2-*` tests in `test/js/node/test/{parallel,sequential}`, and the grpc-js `test-server`, `test-end-to-end` and `test-metadata` suites.

Related: #37712 fixes the empty DATA frame emitted on the body-carrying trailers path and lists this flow as out of its scope; #36389's "GET with waitForTrailers still half-closes its side" test accepts END_STREAM on either HEADERS or DATA, so it stays green with this change.


</details>
