### PR TITLE
shell: fail every queued chunk when an IOWriter dies, not one per child

### DIFF
--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -525,7 +525,10 @@ impl IOWriter {
 
     // ── queue management ────────────────────────────────────────────────
 
-    /// Cancel the chunks enqueued by the given child by marking them as dead.
+    /// Cancel the chunks enqueued by the given child by marking them as dead:
+    /// they are skipped without a callback, both when the queue drains and
+    /// when it fails (`fail_pending_writers`), so a child that is about to
+    /// finish with chunks still queued calls this first.
     pub(crate) fn cancel_chunks(&self, ptr: ChildPtr) {
         let s = self.state();
         if s.writers.is_empty() {
@@ -773,11 +776,9 @@ impl IOWriter {
                 if !not_fully_written {
                     return;
                 }
-                // Other end of the socket/pipe closed and we got EPIPE
-                // (e.g. `ls | echo`). Quick hack: have all writers see an
-                // error.
-                s.flags.broken_pipe = true;
-                self.broken_pipe_for_writers();
+                // Other end of the socket/pipe closed (e.g. `ls | echo`):
+                // everything still queued fails with EPIPE.
+                self.fail_pending_writers(&sys::Error::from_code(E::EPIPE, sys::Tag::write), None);
                 return;
             }
             if s.writers[idx].written >= s.writers[idx].len {
@@ -805,86 +806,89 @@ impl IOWriter {
         }
     }
 
-    fn broken_pipe_for_writers(&self) {
-        let s = self.state();
-        debug_assert!(s.flags.broken_pipe);
-        // NOTE: reshaped for borrowck — collect targets first so we don't
-        // hold `&mut s.writers` across `cancel_chunks`/`run_yield`.
-        let mut targets: Vec<ChildPtr> = Vec::new();
-        for w in &s.writers[s.writer_idx..] {
-            if w.is_dead() {
-                continue;
-            }
-            if !targets.contains(&w.ptr) {
-                targets.push(w.ptr);
-            }
-        }
-        for ptr in targets {
-            let err = sys::Error::from_code(E::EPIPE, sys::Tag::write).to_system_error();
-            self.run_yield(Yield::OnIoWriterChunk {
-                child: ptr,
-                written: 0,
-                err: Some(err),
-            });
-            self.cancel_chunks(ptr);
-        }
-        let s = self.state();
-        s.total_bytes_written = 0;
-        s.writers.clear();
-        s.buf.clear();
-        s.writer_idx = 0;
-    }
-
-    /// Shared failure bookkeeping: mark broken pipes, reset the queue, and
-    /// return the still-pending children that have to be told their chunk
-    /// failed. The queue is reset *before* any of them runs so that a child
-    /// re-enqueueing from its callback is not wiped afterwards.
-    fn fail_pending_writers(&self, err: &sys::Error) -> Vec<ChildPtr> {
+    /// Shared failure path: record the error, then fail every chunk that is
+    /// still queued, oldest first, with its own error completion.
+    ///
+    /// One completion per *chunk*, not per child. `rm` and the `OutputTask`
+    /// builtins (`ls`, `mkdir`, `touch`, `cp`) queue one chunk per task under
+    /// the same `ChildPtr` and finish once they have counted a completion for
+    /// each, so a single per-child error left them waiting for the rest
+    /// forever. A child that stops at its first error while more of its
+    /// chunks are queued (`cat`, the subprocess `CapturedWriter`) calls
+    /// `cancel_chunks` from that callback; that is why the queue is walked in
+    /// place, each entry re-checked right before its callback, and only
+    /// cleared after the last completion. Nothing is appended meanwhile:
+    /// `err`/`broken_pipe` are set before the first callback, so a child that
+    /// enqueues from its callback (the next statement, the RHS of `&&`, ...)
+    /// is answered by `handle_dead_writer` instead of being queued onto a
+    /// writer whose handle the error path is tearing down.
+    ///
+    /// `withhold` is the child whose `enqueue` is still on the stack (see
+    /// `on_sync_error`): the first of its chunks is not dispatched here but
+    /// returned, provided it is still live once everything else has run.
+    fn fail_pending_writers(&self, err: &sys::Error, withhold: Option<ChildPtr>) -> Option<Yield> {
+        // A completion may drop the last external `Arc` to this writer.
+        let _keepalive = self.keepalive();
         self.set_writing(false);
         let s = self.state();
         if err.get_errno() == E::EPIPE {
             s.flags.broken_pipe = true;
         }
-        // Mark the writer dead before any completion below runs: a child that
-        // enqueues from its callback (the next statement, the RHS of `&&`, ...)
-        // must be rejected by `handle_dead_writer`, not queued onto a writer
-        // whose handle the error path is tearing down.
         s.err = Some(err.clone());
+        crate::shell_log!(
+            "IOWriter(fd={}) failing {} queued chunk(s): {:?}",
+            s.fd,
+            s.writers.len().saturating_sub(s.writer_idx),
+            err.get_errno()
+        );
         // Writers before writer_idx have already had their callback fired and
-        // may have been freed; only notify the still-pending ones, dedup'd.
-        let mut pending: Vec<ChildPtr> = Vec::new();
-        for w in &s.writers[s.writer_idx..] {
-            if !w.is_dead() && !pending.contains(&w.ptr) {
-                pending.push(w.ptr);
+        // may have been freed; only the still-pending ones are notified.
+        let mut idx = s.writer_idx;
+        let mut withheld: Option<usize> = None;
+        // Re-derived every iteration: a callback may `cancel_chunks`.
+        while let Some(w) = self.state().writers.get(idx) {
+            let (dead, child, this_idx) = (w.is_dead(), w.ptr, idx);
+            idx += 1;
+            if dead {
+                continue;
             }
+            if withheld.is_none() && withhold == Some(child) {
+                withheld = Some(this_idx);
+                continue;
+            }
+            // `SystemError` owns its strings by value, so derive a fresh one
+            // per callee instead of cloning the stored error.
+            self.run_yield(Yield::OnIoWriterChunk {
+                child,
+                written: 0,
+                err: Some(err.to_shell_system_error()),
+            });
         }
+        let withheld = withheld
+            .and_then(|i| self.state().writers.get(i))
+            .filter(|w| !w.is_dead())
+            .map(|w| Yield::OnIoWriterChunk {
+                child: w.ptr,
+                written: 0,
+                err: Some(err.to_shell_system_error()),
+            });
+        let s = self.state();
         s.total_bytes_written = 0;
         s.writer_idx = 0;
         s.buf.clear();
         s.writers.clear();
-        pending
+        withheld
     }
 
     /// Write failure reported by the `bun_io` writer callbacks. Each pending
-    /// child's error completion is driven through its own `Yield::run`; on
+    /// chunk's error completion is driven through its own `Yield::run`; on
     /// POSIX these callbacks only fire from the event loop, with no trampoline
     /// on the stack. On Windows uv can also deliver a synchronous submission
     /// failure from under `write()` (`start_with_current_pipe` returns `Ok`
     /// unconditionally), a re-entry `write()` cannot turn into a
     /// `WriteOutcome::Failed`.
     fn on_error(&self, err: &sys::Error) {
-        let _keepalive = self.keepalive();
-        for ptr in self.fail_pending_writers(err) {
-            // `SystemError` owns `bun_core::String`s by value (no shared
-            // refcount yet), so re-derive a fresh one per callee instead of
-            // cloning the stored error.
-            let ee = err.to_shell_system_error();
-            self.run_yield(Yield::OnIoWriterChunk {
-                child: ptr,
-                written: 0,
-                err: Some(ee),
-            });
-        }
+        self.fail_pending_writers(err, None);
     }
 
     /// Synchronous write failure while `child`'s `enqueue` call (and therefore
@@ -892,31 +896,15 @@ impl IOWriter {
     /// *returned* so that trampoline delivers it after `enqueue` unwinds;
     /// calling `on_error` here instead would re-enter `Yield::run` once per
     /// failing command and fire `child`'s callback from inside its own
-    /// `enqueue`. Usually `child`'s chunk is the only pending one (a
-    /// synchronous failure is the first write attempt of a batch); if a poll
-    /// re-registration fails while other children are still queued, those are
-    /// dispatched the way the async path dispatches them.
+    /// `enqueue`. Usually the chunk `enqueue` just pushed is the only pending
+    /// one (a synchronous failure is the first write attempt of a batch); if a
+    /// poll re-registration fails while other chunks are still queued, those
+    /// are dispatched the way the async path dispatches them. `Yield::done()`
+    /// comes back only if one of those completions made `child` cancel its
+    /// remaining chunks, i.e. it has already finished.
     fn on_sync_error(&self, child: ChildPtr, err: &sys::Error) -> Yield {
-        let _keepalive = self.keepalive();
-        let mut completion = None;
-        for ptr in self.fail_pending_writers(err) {
-            // `SystemError` owns `bun_core::String`s by value (no shared
-            // refcount yet), so re-derive a fresh one per callee.
-            let y = Yield::OnIoWriterChunk {
-                child: ptr,
-                written: 0,
-                err: Some(err.to_shell_system_error()),
-            };
-            if completion.is_none() && ptr == child {
-                completion = Some(y);
-            } else {
-                self.run_yield(y);
-            }
-        }
-        // The writer `enqueue` just pushed for `child` is live and at or past
-        // `writer_idx`, so it is always in the pending list.
-        debug_assert!(completion.is_some());
-        completion.unwrap_or_else(Yield::done)
+        self.fail_pending_writers(err, Some(child))
+            .unwrap_or_else(Yield::done)
     }
 
     fn on_close(&self) {

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -238,7 +238,10 @@ impl Cat {
                 node: cmd,
                 tag: ReaderTag::Cat,
             };
-            // Writing to stdout errored: cancel everything and finish.
+            // Writing to stdout errored: cancel everything and finish. The
+            // writer fails each queued chunk separately, so the chunks still
+            // queued behind this one must not call back into a finished cat.
+            Self::cancel_stdout_chunks(interp, cmd);
             // Pull the reader `Arc` out of
             // state before calling `remove_reader`, then drop it.
             match &mut Self::state_mut(interp, cmd).state {
@@ -389,15 +392,19 @@ impl Cat {
             CatState::WaitingWriteErr | CatState::Idle => Step::Suspend,
         };
         if cancel {
-            let wchild = ChildPtr::new(cmd, WriterTag::Builtin);
-            if let BuiltinIO::Fd(fd) = &Builtin::of(interp, cmd).stdout {
-                fd.writer.cancel_chunks(wchild);
-            }
+            Self::cancel_stdout_chunks(interp, cmd);
         }
         match step {
             Step::Suspend => Yield::suspended(),
             Step::Done(code) => Builtin::done(interp, cmd, code),
             Step::Next => Self::next(interp, cmd),
+        }
+    }
+
+    fn cancel_stdout_chunks(interp: &Interpreter, cmd: NodeId) {
+        if let BuiltinIO::Fd(fd) = &Builtin::of(interp, cmd).stdout {
+            fd.writer
+                .cancel_chunks(ChildPtr::new(cmd, WriterTag::Builtin));
         }
     }
 }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -1656,15 +1656,20 @@ impl CapturedWriter {
             .writer
             .clone()
             .expect("CapturedWriter live without writer");
-        // The CapturedWriter lives outside the NodeId arena (embedded in a
-        // heap-allocated PipeReader), so dispatch is by raw pointer — see
-        // `io_writer::ChildPtr::subproc_capture` / `WriterTag::Subproc`.
-        let child = io_writer::ChildPtr::subproc_capture(std::ptr::from_mut(self).cast::<c_void>());
+        let child = self.child_ptr();
         let y = writer.enqueue(child, None, chunk);
         // `parent()` recovers the enclosing `PipeReader` via the same
         // `from_field_ptr!` projection (encapsulated once there). The `&mut
         // self` access above is finished, so the shared `&PipeReader` is fine.
         self.parent().run_yield(y);
+    }
+
+    /// How this writer's chunks are identified on the IOWriter queue. The
+    /// CapturedWriter lives outside the NodeId arena (embedded in a
+    /// heap-allocated PipeReader), so dispatch is by raw pointer — see
+    /// `io_writer::ChildPtr::subproc_capture` / `WriterTag::Subproc`.
+    fn child_ptr(&mut self) -> io_writer::ChildPtr {
+        io_writer::ChildPtr::subproc_capture(std::ptr::from_mut(self).cast::<c_void>())
     }
 
     pub(crate) fn is_done(&self, just_written: usize) -> bool {
@@ -1709,6 +1714,13 @@ impl CapturedWriter {
                 e.syscall
             );
             self.err = Some(e);
+            // The writer fails each queued chunk separately; the rest of ours
+            // must not call back in here once the Cmd below has released this
+            // PipeReader (`do_write` stops enqueueing now that `err` is set).
+            let child = self.child_ptr();
+            if let Some(writer) = &self.writer {
+                writer.cancel_chunks(child);
+            }
             // SAFETY: `parent_mut` recovers the embedding `PipeReader` via
             // `container_of`; raw-ptr form per `try_signal_done_to_cmd`
             // contract (no `&mut PipeReader` held across the Cmd re-entry).

--- a/test/js/bun/shell/epipe.test.ts
+++ b/test/js/bun/shell/epipe.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { isPosix } from "harness";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
 import { createTestBuilder } from "./test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -18,5 +20,94 @@ describe.if(isPosix)("IOWriter epipe", () => {
     for (const result of results) {
       expect(result).toBe("y\ny\ny\ny\ny\ny\ny\ny\ny\ny\n");
     }
+  });
+});
+
+// The shell echoes command output to the process's stdout. Once nothing reads
+// that stdout anymore, every chunk of output a command queues fails with
+// EPIPE, and the command still has to finish so that the awaited `$` settles.
+// A command with several chunks queued at that point used to be told about the
+// failure once and then wait forever for the rest of them.
+describe.if(isPosix)("command output after the stdout reader went away", () => {
+  const names = Array.from({ length: 16 }, (_, i) => `entry${i}`);
+  const args = names.join(" ");
+
+  // The fixture keeps writing to its own stdout until that fails with EPIPE,
+  // so the command only runs once the test has really closed the read end.
+  //
+  // The output is produced in the background (by one thread pool task per
+  // argument, or by the subprocess). Blocking the main thread right after
+  // starting the command lets all of it pile up, so that it is queued, and
+  // fails, in one batch: the situation that used to hang. The fixed command
+  // has to settle however the output ends up being batched, so nothing below
+  // depends on the length of that pause.
+  function fixture(command: string): string {
+    return `
+import { $ } from "bun";
+import { writeSync } from "node:fs";
+while (true) {
+  try {
+    writeSync(1, "still has a reader\\n");
+  } catch (e) {
+    if (e.code === "EPIPE") break;
+    if (e.code !== "EAGAIN") throw e;
+  }
+  await Bun.sleep(1);
+}
+const running = $\`${command}\`.nothrow().run();
+Bun.sleepSync(100);
+await running;
+console.error("settled");
+`;
+  }
+
+  async function expectFixtureToSettle(dir: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.ts"],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    await proc.stdout.cancel();
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("settled\n");
+    expect(exitCode).toBe(0);
+  }
+
+  function existing(dir: string): string[] {
+    return names.filter(name => existsSync(join(dir, name)));
+  }
+
+  test.concurrent("ls with several arguments", async () => {
+    using dir = tempDir("shell-epipe-ls", {
+      "fixture.ts": fixture(`ls -d ${args}`),
+      ...Object.fromEntries(names.map(name => [name, {}])),
+    });
+    await expectFixtureToSettle(String(dir));
+  });
+
+  test.concurrent("mkdir -v with several arguments", async () => {
+    using dir = tempDir("shell-epipe-mkdir", { "fixture.ts": fixture(`mkdir -v ${args}`) });
+    await expectFixtureToSettle(String(dir));
+    expect(existing(String(dir))).toEqual(names);
+  });
+
+  test.concurrent("rm -v with several arguments", async () => {
+    using dir = tempDir("shell-epipe-rm", {
+      "fixture.ts": fixture(`rm -v ${args}`),
+      ...Object.fromEntries(names.map(name => [name, ""])),
+    });
+    await expectFixtureToSettle(String(dir));
+    expect(existing(String(dir))).toEqual([]);
+  });
+
+  // A subprocess's output is relayed to stdout through the same writer, one
+  // chunk per read. The relay gives up at its first failed chunk and can be
+  // freed along with the subprocess's pipe right there, so the chunks it still
+  // had queued must not be reported to it afterwards.
+  test.concurrent("relayed subprocess output", async () => {
+    using dir = tempDir("shell-epipe-subprocess", { "fixture.ts": fixture("head -c 1048576 /dev/zero") });
+    await expectFixtureToSettle(String(dir));
   });
 });


### PR DESCRIPTION
### Problem
- A Bun Shell builtin that prints several items (`ls -d a b c`, `rm -v`, `mkdir -v`) never finishes once the process's stdout has lost its reader, e.g. `bun script.ts | head -2`. The awaited `$` promise never settles, so the script hangs (bun 1.4.0 too); one item, or `echo`, finishes.
- When a write to the shell's stdout queue failed with EPIPE, the queue reported the failure once per child command and silently dropped that child's other queued chunks.
- `rm` and the `OutputTask` builtins queue one chunk per argument under one child and finish only after counting a completion per chunk, so after the first EPIPE they waited for the other N-1 forever, and those tasks leaked.
- The Zig shell gave each chunk its own child, so one error per child was one per chunk; the Rust port put them under one child without changing the error path.

### Fix
- When the queue fails, every chunk still queued gets its own error completion, oldest first. All three failure paths (async error, synchronous error during enqueue, end of file on the poll) share one function.
- Property to check: every queued chunk either receives exactly one completion or was cancelled by its owner first. Single-chunk children see exactly what they saw before.
- The two children that stop at their first error, `cat` and the subprocess output relay, now cancel their remaining chunks inside that first callback. For the relay this is required: the first completion can free the relay, so a second one is a use-after-free (ASAN report in the original). The `cat` line is covered by review only.
- Verification: new tests close the stdout reader, then run `ls -d` with 16 entries, `mkdir -v`, `rm -v` and a relayed subprocess. Without the fix the three builtins time out in 6/6 runs; with it all pass on a debug ASAN build. Exit codes on EPIPE are deliberately not asserted (#32278 is changing them).

### Background
- Bun Shell (`$`) runs commands such as `ls`, `rm`, `mkdir` and `cat` in-process as builtins; their output reaches the process's stdout through the shell, not directly.
- `IOWriter` is the shell's per-file-descriptor write queue. A child enqueues chunks tagged with its `ChildPtr` and normally gets one completion callback per chunk; `cancel_chunks` marks a child's queued chunks dead, so they are skipped with no callback.
- `rm` and the `OutputTask` builtins produce output on a thread pool, one chunk per argument, all under the builtin's single `ChildPtr`, and finish when completions counted equals chunks queued.
- `CapturedWriter` relays a spawned subprocess's piped output into the same queue, one chunk per read. It is embedded in the subprocess's pipe reader, so finishing the command from its callback can free it.
- EPIPE is the error for writing to a pipe whose reader has closed. The shell learns of it either as a write error or as end of file from the poll, hence more than one failure path.

<details>
<summary>Original description</summary>

### What does this PR do?

A Bun Shell builtin whose output consists of several chunks never finishes when the process's stdout has lost its reader, so the awaited `$` promise never settles and the script hangs:

```ts
// hang.ts (dst_1, dst_2, dst_3 exist)
import { $ } from "bun";
$.nothrow();
for (let i = 0; i < 30; i++) {
  console.log("iteration", i);
  await $`ls -d dst_*`; // same with `rm -v a b c` or `mkdir -v a b c`
}
console.error("finished");
```

```
$ timeout 15 bash -c 'bun hang.ts | head -2 >/dev/null'; echo rc=$?
rc=124      # head exits after two lines; the next ls never finishes, "finished" is never printed (bun 1.4.0 too)
```

With a single entry (`ls -d dst_1`), or with `echo`, the command finishes. `.quiet()` avoids it because nothing is written to stdout at all.

### Cause

`IOWriter` is the per-fd write queue the shell uses to echo command output. When a write fails, `on_error` (and the EndOfFile arm of `on_write_pollable`, via `broken_pipe_for_writers`) delivered **one** error completion per distinct child and dropped the rest of that child's queued chunks.

`rm` and the `OutputTask` builtins (`ls`, `mkdir`, `touch`, `cp`) queue one chunk per argument, all under the same `ChildPtr` (`(cmd, WriterTag::Builtin)`), and finish once they have counted a completion for every chunk (`output_done >= output_waiting`, `output_queue` FIFO). After the first EPIPE they received exactly one completion and waited for the other N-1 forever. The N-1 `OutputTask` boxes leaked as well.

In the Zig implementation each `OutputTask` was its own writer child, so "one error per child" was one error per chunk for these builtins; the Rust port collapsed them onto the builtin's `ChildPtr` (the `output_queue` FIFO is the stopgap for that) without changing the error path.

### Fix

`fail_pending_writers` now gives every chunk that is still queued its own error completion, oldest first, and all three error paths (`on_error`, `on_sync_error`, EndOfFile) go through it; `broken_pipe_for_writers` is gone.

Two children stop at their first error while more of their chunks may still be queued: `cat` and the subprocess output relay (`CapturedWriter`). Both now `cancel_chunks()` their remaining chunks from inside that first error callback, and the queue is walked in place (liveness re-checked before each callback, cleared only at the end) so that the cancellation takes effect. This is the same `cancel_chunks` both already use on their other teardown paths. Nothing can be appended to the queue during the walk: `err`/`broken_pipe` are set before the first callback, so a re-entrant `enqueue` is answered by `handle_dead_writer` as before (#32946).

The `CapturedWriter` cancellation is required, not just tidy: its first error completion can go `try_signal_done_to_cmd` -> `buffered_output_close` -> `close_io` -> `Readable::finalize` -> `detach`, which drops the last `Arc<PipeReader>` and frees the `CapturedWriter` itself, so a second completion for it would be a use-after-free. ASAN confirmed that with the per-chunk delivery but without the cancellation (happens when the subprocess's output was fully read before the writer failed):

<details>
<summary>ASAN report (per-chunk delivery without the CapturedWriter cancellation)</summary>

```
ERROR: AddressSanitizer: heap-use-after-free
    #0 <bun_runtime::shell::subproc::CapturedWriter>::on_iowriter_chunk src/runtime/shell/subproc.rs
    #1 bun_runtime::shell::io_writer::on_io_writer_chunk src/runtime/shell/IOWriter.rs
    #2 <bun_runtime::shell::yield_::Yield>::run src/runtime/shell/Yield.rs
    #3 <IOWriter>::run_yield
    #4 <IOWriter>::fail_pending_writers
    #5 <IOWriter>::on_error
    ...
freed by thread T0 here:
    ...
    #12 <alloc::sync::Arc<bun_runtime::shell::subproc::PipeReader>>::drop_slow
    #15 <bun_runtime::shell::subproc::PipeReader>::detach
    #16 <bun_runtime::shell::subproc::Readable>::finalize
    #17 <bun_runtime::shell::subproc::ShellSubprocess>::close_io
    #18 <Cmd>::buffered_output_close_stdout
    #19 <Cmd>::buffered_output_close
    #20 <PipeReader>::try_signal_done_to_cmd
    #21 <CapturedWriter>::on_iowriter_chunk          <- first completion of the batch
    #25 <IOWriter>::fail_pending_writers
```

</details>

`cat`'s case is the same shape (`Builtin::done` from the first completion retires the Cmd node, so a second completion would dispatch into a freed or reused node); it is the `ExecStdin`/`ExecFilepathArgs` write-error arm, one line away from the cancellation that its read-error arm already did. The builtin is currently behind `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS` on POSIX and I did not find a way to get more than one of its chunks queued at once there, so that line is covered by review rather than by a test.

The alternative of keeping "one error per child" and having the builtins drain their own queues does not work: their `output_queue` FIFO does not know which writer (stdout or stderr) a given chunk went to, so a single notification cannot tell them how many of their chunks just failed. Giving every `OutputTask` its own `ChildPtr` again (what the `output_queue` stopgap stands in for) would fix the `OutputTask` builtins but not `rm`, which counts chunks under the builtin's pointer too, so the contract is fixed at the queue instead and the two early-exit children opt out explicitly.

Other details:

- `on_sync_error` keeps its contract: the enqueuing child's own chunk is withheld and returned so the trampoline that is already on the stack delivers it (#33008); other queued chunks, if any, are dispatched inline. It now comes back as `Yield::done()` only if one of those inline completions made the child cancel its chunks, i.e. the child has already finished.
- The EndOfFile path previously built its EPIPE `SystemError` with `to_system_error()`; it now uses `to_shell_system_error()` like the `on_error` path (which is the one a real EPIPE takes, since the pipe writer reports it as an error). The `handle_dead_writer` rejections are unchanged.
- The keepalive that `on_error`/`on_sync_error` held moved into the shared function, which is where the post-callback state access happens; the EndOfFile path gets it too.
- Single-chunk children see exactly what they saw before (one chunk, one completion), and the exit codes of the affected builtins on EPIPE are unchanged from the single-chunk behavior (`ls`/`mkdir`/`rm` report 0, as `ls -d one_entry` already did; a relayed subprocess reports the errno, as before). What the exit code should be on a write error is a separate question (#32278 is moving these around), so the tests only assert that the command settles.

### How did you verify your code works?

New tests in `test/js/bun/shell/epipe.test.ts`. A fixture waits until writes to its own stdout fail with EPIPE (the test closes the read end right after spawning), starts the command, blocks the main thread briefly so every argument's output is queued in one batch, and awaits it. `ls -d` with 16 entries (OutputTask path), `mkdir -v` (OutputTask path, and the directories must exist afterwards), `rm -v` (the counting path in `rm`, and the files must be gone), and a relayed `head -c 1048576 /dev/zero` subprocess (CapturedWriter; 4 to 6 of its chunks were queued when the writer failed in every local run).

Against the release build without the fix, `ls`, `mkdir` and `rm` time out in 6/6 runs and the subprocess test passes (it guards the cancellation described above, which ASAN catches when the ordering hits); with the fix, all pass on a debug ASAN build (5/5 runs). The rest of `test/js/bun/shell` (bunshell, commands/, yield, shell-write-fault, shell-pipe-read-fault, shelloutput, shell-blocking-pipe, pipeline_stack, throw, exec, shell-hang, file-io, leak) shows no new failures on the debug build; the only failures here are pre-existing in this environment (the `ls` permission-denied tests, which fail as root on the release build too, and leak tests that exceed their 100s budget under ASAN).


</details>
