### PR TITLE
usockets: close the fd and report errno when the UDP IPV6_V6ONLY setsockopt fails

### DIFF
--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1581,6 +1581,17 @@ int bsd_prepare_adopted_udp_socket(LIBUS_SOCKET_DESCRIPTOR fd) {
     return 0;
 }
 
+/* Failure exit of bsd_create_udp_socket once it owns a descriptor. The error is
+ * read before close() / freeaddrinfo() get a chance to overwrite it. */
+static LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket_fail(LIBUS_SOCKET_DESCRIPTOR fd, struct addrinfo *result, int *err) {
+    if (err != NULL) {
+        *err = LIBUS_ERR;
+    }
+    bsd_close_socket(fd);
+    freeaddrinfo(result);
+    return LIBUS_SOCKET_ERROR;
+}
+
 /* Binds a raw datagram descriptor. `flags` uses libuv's UV_UDP_* bits (bit 0
  * IPV6ONLY, bit 2 REUSEADDR). Shared by internal/dgram so it doesn't fork
  * bsd_set_reuseaddr's platform gate. Returns 0 or -1 with the error in errno. */
@@ -1649,23 +1660,18 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
     }
 
     if (bsd_set_reuse(listenFd, options) != 0) {
-        if (err != NULL) {
-#ifdef _WIN32
-            *err = WSAGetLastError();
-#else
-            *err = errno;
-#endif
-        }
-        bsd_close_socket(listenFd);
-        freeaddrinfo(result);
-        return LIBUS_SOCKET_ERROR;
+        return bsd_create_udp_socket_fail(listenFd, result, err);
     }
 
 #ifdef IPV6_V6ONLY
     if (listenAddr->ai_family == AF_INET6) {
         int enabled = (options & LIBUS_SOCKET_IPV6_ONLY) != 0;
-        if (setsockopt(listenFd, IPPROTO_IPV6, IPV6_V6ONLY, &enabled, sizeof(enabled)) != 0) {
-            return LIBUS_SOCKET_ERROR;
+        ssize_t injected = 0; int unused = 0;
+        int failed = US_FAULT_CHECK(US_FAULT_UDP_V6ONLY, listenFd, injected, unused)
+            || setsockopt(listenFd, IPPROTO_IPV6, IPV6_V6ONLY, &enabled, sizeof(enabled)) != 0;
+        (void)injected; (void)unused;
+        if (failed) {
+            return bsd_create_udp_socket_fail(listenFd, result, err);
         }
     }
 #endif
@@ -1674,16 +1680,7 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
 
     /* We bind here as well */
     if (bind(listenFd, listenAddr->ai_addr, (socklen_t) listenAddr->ai_addrlen)) {
-        if (err != NULL) {
-#ifdef _WIN32
-            *err = WSAGetLastError();
-#else
-            *err = errno;
-#endif
-        }
-        bsd_close_socket(listenFd);
-        freeaddrinfo(result);
-        return LIBUS_SOCKET_ERROR;
+        return bsd_create_udp_socket_fail(listenFd, result, err);
     }
 
     freeaddrinfo(result);

--- a/packages/bun-usockets/src/bsd.c
+++ b/packages/bun-usockets/src/bsd.c
@@ -1122,6 +1122,20 @@ static int bsd_set_reuseport(LIBUS_SOCKET_DESCRIPTOR listenFd) {
 #endif
 }
 
+/* Every IPV6_V6ONLY setsockopt in this file (TCP listen, UDP create, raw UDP
+ * bind) goes through here so one fault rule reaches all of them. */
+static int bsd_set_v6only(LIBUS_SOCKET_DESCRIPTOR fd, int enabled) {
+    ssize_t injected = 0; int unused = 0;
+    if (US_FAULT_CHECK(US_FAULT_SETSOCKOPT_V6ONLY, fd, injected, unused)) return (int) injected;
+    (void)injected; (void)unused;
+#ifdef IPV6_V6ONLY
+    return setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (const char *) &enabled, sizeof(enabled));
+#else
+    (void) fd; (void) enabled;
+    return 0;
+#endif
+}
+
 static int bsd_set_reuse(LIBUS_SOCKET_DESCRIPTOR listenFd, int options) {
     int result = 0;
 
@@ -1180,14 +1194,12 @@ inline __attribute__((always_inline)) LIBUS_SOCKET_DESCRIPTOR bsd_bind_listen_fd
     setsockopt(listenFd, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
 #endif
 
-#ifdef IPV6_V6ONLY
     if (listenAddr->ai_family == AF_INET6) {
         int enabled = (options & LIBUS_SOCKET_IPV6_ONLY) != 0;
-        if (setsockopt(listenFd, IPPROTO_IPV6, IPV6_V6ONLY, &enabled, sizeof(enabled)) != 0) {
+        if (bsd_set_v6only(listenFd, enabled) != 0) {
             return LIBUS_SOCKET_ERROR;
         }
     }
-#endif
 
     if (us_internal_bind_and_listen(listenFd, listenAddr->ai_addr, (socklen_t) listenAddr->ai_addrlen, 512, error)) {
         return LIBUS_SOCKET_ERROR;
@@ -1596,14 +1608,11 @@ static LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket_fail(LIBUS_SOCKET_DESCRIPTO
  * IPV6ONLY, bit 2 REUSEADDR). Shared by internal/dgram so it doesn't fork
  * bsd_set_reuseaddr's platform gate. Returns 0 or -1 with the error in errno. */
 int bsd_bind_udp_fd(LIBUS_SOCKET_DESCRIPTOR fd, const struct sockaddr *addr, int addrlen, int flags) {
-#ifdef IPV6_V6ONLY
     if ((flags & 1) && addr->sa_family == AF_INET6) {
-        int on = 1;
-        if (setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, (char *) &on, sizeof(on)) != 0) {
+        if (bsd_set_v6only(fd, 1) != 0) {
             return -1;
         }
     }
-#endif
     if (flags & 4) {
         if (bsd_set_reuseaddr(fd) != 0) {
             return -1;
@@ -1663,18 +1672,12 @@ LIBUS_SOCKET_DESCRIPTOR bsd_create_udp_socket(const char *host, int port, int op
         return bsd_create_udp_socket_fail(listenFd, result, err);
     }
 
-#ifdef IPV6_V6ONLY
     if (listenAddr->ai_family == AF_INET6) {
         int enabled = (options & LIBUS_SOCKET_IPV6_ONLY) != 0;
-        ssize_t injected = 0; int unused = 0;
-        int failed = US_FAULT_CHECK(US_FAULT_UDP_V6ONLY, listenFd, injected, unused)
-            || setsockopt(listenFd, IPPROTO_IPV6, IPV6_V6ONLY, &enabled, sizeof(enabled)) != 0;
-        (void)injected; (void)unused;
-        if (failed) {
+        if (bsd_set_v6only(listenFd, enabled) != 0) {
             return bsd_create_udp_socket_fail(listenFd, result, err);
         }
     }
-#endif
 
     bsd_apply_udp_recv_options(listenFd, listenAddr->ai_family, options);
 

--- a/packages/bun-usockets/src/internal/fault_inject.h
+++ b/packages/bun-usockets/src/internal/fault_inject.h
@@ -54,11 +54,10 @@ enum us_fault_syscall {
      * US_FAULT_ERRNO applies, and the errno value is ignored — the simulated
      * failure is a thrown JS out-of-memory error, not an errno. */
     US_FAULT_SESSION_BUFFER,
-    /* The IPV6_V6ONLY setsockopt in bsd_create_udp_socket. It is issued on a
-     * descriptor socket(2) just returned, so outside of injection it only fails
-     * on kernels / seccomp policies that reject the option. Only US_FAULT_ERRNO
-     * applies. */
-    US_FAULT_UDP_V6ONLY,
+    /* The IPV6_V6ONLY setsockopt (bsd_set_v6only: TCP listen, UDP create and
+     * raw-descriptor UDP bind). Outside of injection it only fails on kernels /
+     * seccomp policies that reject the option. Only US_FAULT_ERRNO applies. */
+    US_FAULT_SETSOCKOPT_V6ONLY,
     US_FAULT_COUNT
 };
 

--- a/packages/bun-usockets/src/internal/fault_inject.h
+++ b/packages/bun-usockets/src/internal/fault_inject.h
@@ -54,6 +54,11 @@ enum us_fault_syscall {
      * US_FAULT_ERRNO applies, and the errno value is ignored — the simulated
      * failure is a thrown JS out-of-memory error, not an errno. */
     US_FAULT_SESSION_BUFFER,
+    /* The IPV6_V6ONLY setsockopt in bsd_create_udp_socket. It is issued on a
+     * descriptor socket(2) just returned, so outside of injection it only fails
+     * on kernels / seccomp policies that reject the option. Only US_FAULT_ERRNO
+     * applies. */
+    US_FAULT_UDP_V6ONLY,
     US_FAULT_COUNT
 };
 

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -596,8 +596,8 @@ export const setSocketOptions: setSocketOptionsFn = $newRustFunction(
 /**
  * The syscalls instrumented in bsd.c, plus non-syscall hooks whose failure
  * paths are otherwise unreachable without injection ("ssl_loop_buffer",
- * "poll_start", "session_buffer"; see fault_inject.h for the per-hook
- * description). Arming anything else is rejected.
+ * "poll_start", "session_buffer", "udp_v6only"; see fault_inject.h for the
+ * per-hook description). Arming anything else is rejected.
  */
 export type SocketFaultSyscall =
   | "recv"
@@ -609,7 +609,8 @@ export type SocketFaultSyscall =
   | "accept"
   | "ssl_loop_buffer"
   | "poll_start"
-  | "session_buffer";
+  | "session_buffer"
+  | "udp_v6only";
 
 export type SocketFaultRule = {
   syscall: SocketFaultSyscall;

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -596,8 +596,8 @@ export const setSocketOptions: setSocketOptionsFn = $newRustFunction(
 /**
  * The syscalls instrumented in bsd.c, plus non-syscall hooks whose failure
  * paths are otherwise unreachable without injection ("ssl_loop_buffer",
- * "poll_start", "session_buffer", "udp_v6only"; see fault_inject.h for the
- * per-hook description). Arming anything else is rejected.
+ * "poll_start", "session_buffer"; see fault_inject.h for the per-hook
+ * description). Arming anything else is rejected.
  */
 export type SocketFaultSyscall =
   | "recv"
@@ -607,10 +607,10 @@ export type SocketFaultSyscall =
   | "recvmsg"
   | "connect"
   | "accept"
+  | "setsockopt_v6only"
   | "ssl_loop_buffer"
   | "poll_start"
-  | "session_buffer"
-  | "udp_v6only";
+  | "session_buffer";
 
 export type SocketFaultRule = {
   syscall: SocketFaultSyscall;

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -5128,19 +5128,19 @@ pub mod testing_apis {
                 fi::CONNECT
             } else if syscall_str.eql_comptime(b"accept") {
                 fi::ACCEPT
+            } else if syscall_str.eql_comptime(b"setsockopt_v6only") {
+                fi::SETSOCKOPT_V6ONLY
             } else if syscall_str.eql_comptime(b"ssl_loop_buffer") {
                 fi::SSL_LOOP_BUFFER
             } else if syscall_str.eql_comptime(b"poll_start") {
                 fi::POLL_START
             } else if syscall_str.eql_comptime(b"session_buffer") {
                 fi::SESSION_BUFFER
-            } else if syscall_str.eql_comptime(b"udp_v6only") {
-                fi::UDP_V6ONLY
             } else {
                 // socket/close/shutdown have enum slots but no bsd.c hooks;
                 // accepting them would arm rules that can never fire.
                 return Err(global.throw(format_args!(
-                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, ssl_loop_buffer, poll_start, session_buffer, udp_v6only"
+                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, setsockopt_v6only, ssl_loop_buffer, poll_start, session_buffer"
                 )));
             };
 

--- a/src/runtime/socket/socket_body.rs
+++ b/src/runtime/socket/socket_body.rs
@@ -5134,11 +5134,13 @@ pub mod testing_apis {
                 fi::POLL_START
             } else if syscall_str.eql_comptime(b"session_buffer") {
                 fi::SESSION_BUFFER
+            } else if syscall_str.eql_comptime(b"udp_v6only") {
+                fi::UDP_V6ONLY
             } else {
                 // socket/close/shutdown have enum slots but no bsd.c hooks;
                 // accepting them would arm rules that can never fire.
                 return Err(global.throw(format_args!(
-                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, ssl_loop_buffer, poll_start, session_buffer"
+                    "rule.syscall must be one of: recv, send, writev, sendmsg, recvmsg, connect, accept, ssl_loop_buffer, poll_start, session_buffer, udp_v6only"
                 )));
             };
 

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -423,8 +423,9 @@ pub mod fault_inject {
     /// Not a syscall: the JS `Buffer` allocated for a TLS session/keylog
     /// payload in the `on_session`/`on_keylog` dispatch.
     pub const SESSION_BUFFER: c_int = 12;
-    /// The `IPV6_V6ONLY` setsockopt in `bsd_create_udp_socket`.
-    pub const UDP_V6ONLY: c_int = 13;
+    /// The `IPV6_V6ONLY` setsockopt (`bsd_set_v6only`: TCP listen, UDP
+    /// create and raw-descriptor UDP bind).
+    pub const SETSOCKOPT_V6ONLY: c_int = 13;
 
     pub const ACTION_NONE: c_int = 0;
     pub const ACTION_ERRNO: c_int = 1;

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -423,6 +423,8 @@ pub mod fault_inject {
     /// Not a syscall: the JS `Buffer` allocated for a TLS session/keylog
     /// payload in the `on_session`/`on_keylog` dispatch.
     pub const SESSION_BUFFER: c_int = 12;
+    /// The `IPV6_V6ONLY` setsockopt in `bsd_create_udp_socket`.
+    pub const UDP_V6ONLY: c_int = 13;
 
     pub const ACTION_NONE: c_int = 0;
     pub const ACTION_ERRNO: c_int = 1;

--- a/src/uws_sys/lib.rs
+++ b/src/uws_sys/lib.rs
@@ -423,8 +423,6 @@ pub mod fault_inject {
     /// Not a syscall: the JS `Buffer` allocated for a TLS session/keylog
     /// payload in the `on_session`/`on_keylog` dispatch.
     pub const SESSION_BUFFER: c_int = 12;
-    /// The `IPV6_V6ONLY` setsockopt (`bsd_set_v6only`: TCP listen, UDP
-    /// create and raw-descriptor UDP bind).
     pub const SETSOCKOPT_V6ONLY: c_int = 13;
 
     pub const ACTION_NONE: c_int = 0;

--- a/test/js/bun/net/socket-syscall-fault.test.ts
+++ b/test/js/bun/net/socket-syscall-fault.test.ts
@@ -96,6 +96,23 @@ describe.skipIf(!fault.available())("poll_start failure is reported, not a crash
   );
 });
 
+// bsd_set_v6only() is shared by the TCP listen, UDP create and raw UDP bind
+// paths; the UDP consumers are covered next to their own suites (udp/,
+// node/quic/), this is the TCP one. getaddrinfo("::1") yields a single
+// AF_INET6 candidate, so a failing IPV6_V6ONLY setsockopt fails the listen.
+describe.skipIf(skip)("setsockopt_v6only failure while listening", () => {
+  afterEach(() => fault.clear());
+
+  test("Bun.listen fails, and the next listen on the same address works", () => {
+    fault.set({ syscall: "setsockopt_v6only", action: "errno", errno: "EINVAL" });
+    expect(() => Bun.listen({ hostname: "::1", port: 0, socket: { data() {} } })).toThrow("Failed to listen at ::1");
+
+    // The one-shot rule is spent: same address, same options, now listening.
+    using server = Bun.listen({ hostname: "::1", port: 0, socket: { data() {} } });
+    expect(server.port).toBeGreaterThan(0);
+  });
+});
+
 // uSockets' TLS low-priority handshake queue (loop->data.low_prio_head)
 // shares its prev/next links with group->head_sockets. A socket already
 // parked in the queue used to be parked a SECOND time whenever a writable

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -372,7 +372,7 @@ describe("bind()", () => {
     const { promise: error, resolve: onError, reject } = Promise.withResolvers<any>();
     socket.on("error", onError);
     socket.on("listening", () => reject(new Error("expected bind() to fail")));
-    fault.set({ syscall: "udp_v6only", action: "errno", errno: osConstants.errno.ENOPROTOOPT });
+    fault.set({ syscall: "setsockopt_v6only", action: "errno", errno: osConstants.errno.ENOPROTOOPT });
     try {
       socket.bind(0, "::1");
       const { name, code, syscall, address, message } = await error;
@@ -417,6 +417,19 @@ test.skipIf(isWindows)("_createSocketHandle() returns a negative errno when the 
   const err = _createSocketHandle("localhost", 0, "udp4");
 
   expect(err).toBe(-22);
+});
+
+// The raw-descriptor bind shares bsd_set_v6only() with the bind() path tested
+// above; flags bit 0 is UV_UDP_IPV6ONLY.
+test.skipIf(!fault.available() || isWindows)("_createSocketHandle() reports a failing IPV6_V6ONLY setsockopt", () => {
+  const { _createSocketHandle } = require("bun:internal-for-testing").exposedInternals["internal/dgram"];
+  const { ENOPROTOOPT } = osConstants.errno;
+  fault.set({ syscall: "setsockopt_v6only", action: "errno", errno: ENOPROTOOPT });
+  try {
+    expect(_createSocketHandle("::1", 0, "udp6", undefined, 1)).toBe(-ENOPROTOOPT);
+  } finally {
+    fault.clear();
+  }
 });
 
 // The duplicate-adoption guard must trip synchronously: libuv reports EEXIST

--- a/test/js/bun/udp/dgram.test.ts
+++ b/test/js/bun/udp/dgram.test.ts
@@ -1,5 +1,7 @@
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { describe, expect, jest, test } from "bun:test";
 import { createSocket } from "dgram";
+import { constants as osConstants } from "node:os";
 import { Worker } from "node:worker_threads";
 
 import { bunEnv, bunExe, bunRun, disableAggressiveGCScope, isWindows } from "harness";
@@ -358,6 +360,32 @@ describe("bind()", () => {
     // The in-flight first bind must still complete normally.
     await listening;
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  // A udp6 bind sets IPV6_V6ONLY inside bsd_create_udp_socket(); when that
+  // failed, 'error' used to carry a code-less "Failed to bind socket"
+  // (udp_socket.test.ts covers the descriptor that leaked along with it). The
+  // option does not fail on its own, so the failure is injected; on Windows
+  // the errno would need to be a WSA code.
+  test.skipIf(!fault.available() || isWindows)("emits the errno of a failing IPV6_V6ONLY setsockopt", async () => {
+    await using socket = createSocket("udp6");
+    const { promise: error, resolve: onError, reject } = Promise.withResolvers<any>();
+    socket.on("error", onError);
+    socket.on("listening", () => reject(new Error("expected bind() to fail")));
+    fault.set({ syscall: "udp_v6only", action: "errno", errno: osConstants.errno.ENOPROTOOPT });
+    try {
+      socket.bind(0, "::1");
+      const { name, code, syscall, address, message } = await error;
+      expect({ name, code, syscall, address, message }).toEqual({
+        name: "Error",
+        code: "ENOPROTOOPT",
+        syscall: "bind",
+        address: "::1",
+        message: "bind ENOPROTOOPT ::1",
+      });
+    } finally {
+      fault.clear();
+    }
   });
 });
 

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -207,7 +207,7 @@ describe("udpSocket()", () => {
     const options = { hostname: "::1", port: 0 } as const;
 
     function injectSetsockoptFailure() {
-      fault.set({ syscall: "udp_v6only", action: "errno", errno: osConstants.errno.ENOPROTOOPT });
+      fault.set({ syscall: "setsockopt_v6only", action: "errno", errno: osConstants.errno.ENOPROTOOPT });
     }
 
     async function creationError(): Promise<any> {

--- a/test/js/bun/udp/udp_socket.test.ts
+++ b/test/js/bun/udp/udp_socket.test.ts
@@ -1,7 +1,9 @@
 import { udpSocket } from "bun";
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { heapStats } from "bun:jsc";
-import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, disableAggressiveGCScope, isWindows, randomPort } from "harness";
+import { afterEach, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, disableAggressiveGCScope, getFDCount, isWindows, randomPort } from "harness";
+import { constants as osConstants } from "node:os";
 import path from "node:path";
 import { dataCases, dataTypes } from "./testdata";
 
@@ -190,6 +192,69 @@ describe("udpSocket()", () => {
       const remaining = await countUDPSocketsAfterGC(5);
       expect(remaining).toBeLessThan(10);
       expect(heapStats().protectedObjectTypeCounts.UDPSocket || 0).toBe(0);
+    });
+  });
+
+  // bsd_create_udp_socket() used to return straight out of a failing
+  // IPV6_V6ONLY setsockopt, leaking the descriptor it had just created and
+  // reporting a code-less "Failed to bind socket". Setting that option on a
+  // brand-new socket does not fail on its own, so the failure is injected.
+  // Windows: getFDCount() cannot see SOCKET handles and the errno would need
+  // to be a WSA code.
+  describe.skipIf(!fault.available() || isWindows)("IPV6_V6ONLY setsockopt failure while binding", () => {
+    afterEach(() => fault.clear());
+
+    const options = { hostname: "::1", port: 0 } as const;
+
+    function injectSetsockoptFailure() {
+      fault.set({ syscall: "udp_v6only", action: "errno", errno: osConstants.errno.ENOPROTOOPT });
+    }
+
+    async function creationError(): Promise<any> {
+      let socket;
+      try {
+        socket = await udpSocket(options);
+      } catch (error) {
+        return error;
+      }
+      socket.close();
+      throw new Error("expected udpSocket() to fail");
+    }
+
+    test("reports the setsockopt errno", async () => {
+      injectSetsockoptFailure();
+      const { name, code, syscall, address, message } = await creationError();
+      expect({ name, code, syscall, address, message }).toEqual({
+        name: "Error",
+        code: "ENOPROTOOPT",
+        syscall: "bind",
+        address: "::1",
+        message: "bind ENOPROTOOPT ::1",
+      });
+
+      // The one-shot rule is spent, so the same options bind normally now.
+      const socket = await udpSocket(options);
+      socket.close();
+    });
+
+    test("closes the descriptor it created", async () => {
+      // Take the baseline after one failure so anything the error path sets
+      // up lazily is not counted against the loop.
+      injectSetsockoptFailure();
+      await creationError();
+
+      const before = getFDCount();
+      const iterations = 8;
+      const codes: string[] = [];
+      for (let i = 0; i < iterations; i++) {
+        injectSetsockoptFailure();
+        codes.push((await creationError()).code);
+      }
+      // Used to leak exactly one descriptor per failed creation.
+      expect({ codes, leakedDescriptors: getFDCount() - before }).toEqual({
+        codes: Array(iterations).fill("ENOPROTOOPT"),
+        leakedDescriptors: 0,
+      });
     });
   });
 

--- a/test/js/bun/util/socket-fault-injection.test.ts
+++ b/test/js/bun/util/socket-fault-injection.test.ts
@@ -22,7 +22,7 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
 
   // Only recv/send have a byte count to clamp; arming "short" on any other
   // syscall used to succeed silently and never fire. ssl_loop_buffer is an
-  // allocation and udp_v6only a setsockopt, so neither has a byte count either.
+  // allocation, so it has no byte count either.
   test("set() rejects 'short' for syscalls that cannot clamp a byte count", () => {
     for (const syscall of [
       "writev",
@@ -30,8 +30,8 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
       "recvmsg",
       "connect",
       "accept",
+      "setsockopt_v6only",
       "ssl_loop_buffer",
-      "udp_v6only",
     ] as const) {
       expect(() => fault.set({ syscall, action: "short", bytes: 1 })).toThrow(/only supported for syscall/);
     }
@@ -42,7 +42,7 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   // A zero return only means something for the data syscalls (EOF on the read
   // side, backpressure on the write side); connect's wrapper returns errno.
   test("set() rejects 'zero' for syscalls with no zero-return semantics", () => {
-    for (const syscall of ["connect", "accept", "ssl_loop_buffer", "udp_v6only"] as const) {
+    for (const syscall of ["connect", "accept", "setsockopt_v6only", "ssl_loop_buffer"] as const) {
       expect(() => fault.set({ syscall, action: "zero" })).toThrow(/only supported for syscall/);
     }
     for (const syscall of ["recv", "send", "writev", "sendmsg", "recvmsg"] as const) {
@@ -52,10 +52,6 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
 
   test("set() accepts ssl_loop_buffer with action 'errno'", () => {
     expect(fault.set({ syscall: "ssl_loop_buffer", action: "errno", errno: "ENOMEM" })).toBe(true);
-  });
-
-  test("set() accepts udp_v6only with action 'errno'", () => {
-    expect(fault.set({ syscall: "udp_v6only", action: "errno", errno: "EINVAL" })).toBe(true);
   });
 
   // ssl_loop_buffer's hook is an allocation, so it checks with fd = -1; a rule
@@ -115,7 +111,16 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   });
 
   test("rules can target each hooked syscall", () => {
-    for (const sc of ["recv", "send", "writev", "sendmsg", "recvmsg", "connect", "accept"] as const) {
+    for (const sc of [
+      "recv",
+      "send",
+      "writev",
+      "sendmsg",
+      "recvmsg",
+      "connect",
+      "accept",
+      "setsockopt_v6only",
+    ] as const) {
       expect(fault.set({ syscall: sc, action: "none" })).toBe(true);
     }
   });

--- a/test/js/bun/util/socket-fault-injection.test.ts
+++ b/test/js/bun/util/socket-fault-injection.test.ts
@@ -22,9 +22,17 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
 
   // Only recv/send have a byte count to clamp; arming "short" on any other
   // syscall used to succeed silently and never fire. ssl_loop_buffer is an
-  // allocation, so it has no byte count either.
+  // allocation and udp_v6only a setsockopt, so neither has a byte count either.
   test("set() rejects 'short' for syscalls that cannot clamp a byte count", () => {
-    for (const syscall of ["writev", "sendmsg", "recvmsg", "connect", "accept", "ssl_loop_buffer"] as const) {
+    for (const syscall of [
+      "writev",
+      "sendmsg",
+      "recvmsg",
+      "connect",
+      "accept",
+      "ssl_loop_buffer",
+      "udp_v6only",
+    ] as const) {
       expect(() => fault.set({ syscall, action: "short", bytes: 1 })).toThrow(/only supported for syscall/);
     }
     expect(fault.set({ syscall: "recv", action: "short", bytes: 1 })).toBe(true);
@@ -34,7 +42,7 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
   // A zero return only means something for the data syscalls (EOF on the read
   // side, backpressure on the write side); connect's wrapper returns errno.
   test("set() rejects 'zero' for syscalls with no zero-return semantics", () => {
-    for (const syscall of ["connect", "accept", "ssl_loop_buffer"] as const) {
+    for (const syscall of ["connect", "accept", "ssl_loop_buffer", "udp_v6only"] as const) {
       expect(() => fault.set({ syscall, action: "zero" })).toThrow(/only supported for syscall/);
     }
     for (const syscall of ["recv", "send", "writev", "sendmsg", "recvmsg"] as const) {
@@ -44,6 +52,10 @@ describe.skipIf(skip)("socketFaultInjection control surface", () => {
 
   test("set() accepts ssl_loop_buffer with action 'errno'", () => {
     expect(fault.set({ syscall: "ssl_loop_buffer", action: "errno", errno: "ENOMEM" })).toBe(true);
+  });
+
+  test("set() accepts udp_v6only with action 'errno'", () => {
+    expect(fault.set({ syscall: "udp_v6only", action: "errno", errno: "EINVAL" })).toBe(true);
   });
 
   // ssl_loop_buffer's hook is an allocation, so it checks with fd = -1; a rule

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -320,7 +320,7 @@ describe("endpoint.close() while a session is live", () => {
 describe("endpoint bind failure", () => {
   test.skipIf(!fault.available() || isWindows)("carries the errno of a failing IPV6_V6ONLY setsockopt", async () => {
     const { ENOPROTOOPT } = osConstants.errno;
-    fault.set({ syscall: "udp_v6only", action: "errno", errno: ENOPROTOOPT });
+    fault.set({ syscall: "setsockopt_v6only", action: "errno", errno: ENOPROTOOPT });
     let endpoint: any;
     try {
       // Like Node, listen() hands back the already-destroyed endpoint and the

--- a/test/js/node/quic/quic-endpoint.test.ts
+++ b/test/js/node/quic/quic-endpoint.test.ts
@@ -1,12 +1,14 @@
 // lsquic fixes HTTP/3-vs-raw framing per client *engine*, set by the first
 // connect() through an endpoint; a later connect in the other mode must fail
 // loudly instead of silently reusing an engine that cannot frame it.
+import { socketFaultInjection as fault } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir } from "harness";
 import { createPrivateKey } from "node:crypto";
 import { createSocket } from "node:dgram";
 import { readFileSync } from "node:fs";
 import { BlockList } from "node:net";
+import { constants as osConstants } from "node:os";
 import { join } from "node:path";
 import { connect, listen, QuicEndpoint } from "node:quic";
 
@@ -308,5 +310,38 @@ describe("endpoint.close() while a session is live", () => {
     held.close();
     await server.closed;
     expect({ announced, resolved }).toEqual({ announced: 1, resolved: true });
+  });
+});
+
+// The endpoint binds through bsd_create_udp_socket(), whose IPV6_V6ONLY
+// setsockopt failure used to report errno 0, so the close reason read
+// "Bind failure (0)". The option does not fail on its own, so the failure is
+// injected; on Windows the errno would need to be a WSA code.
+describe("endpoint bind failure", () => {
+  test.skipIf(!fault.available() || isWindows)("carries the errno of a failing IPV6_V6ONLY setsockopt", async () => {
+    const { ENOPROTOOPT } = osConstants.errno;
+    fault.set({ syscall: "udp_v6only", action: "errno", errno: ENOPROTOOPT });
+    let endpoint: any;
+    try {
+      // Like Node, listen() hands back the already-destroyed endpoint and the
+      // bind error is the rejection reason of its `closed` promise (which is
+      // also why `await using` is not an option here: disposing rethrows it).
+      endpoint = await listen(() => {}, {
+        sni: { "*": { keys: [key], certs: [cert] } },
+        alpn: ["quic-test"],
+        endpoint: { address: { address: "::1", family: "ipv6", port: 0 } },
+      });
+      const closed = await endpoint.closed.then(
+        () => "resolved",
+        (error: any) => ({ code: error.code, message: error.message }),
+      );
+      expect({ destroyed: endpoint.destroyed, closed }).toEqual({
+        destroyed: true,
+        closed: { code: "ERR_QUIC_ENDPOINT_CLOSED", message: `QUIC endpoint closed: Bind failure (${ENOPROTOOPT})` },
+      });
+    } finally {
+      fault.clear();
+      if (endpoint && !endpoint.destroyed) await endpoint.close();
+    }
   });
 });


### PR DESCRIPTION
### Problem
- When the `IPV6_V6ONLY` setsockopt failed while creating a UDP socket, `Bun.udpSocket({ hostname: "::1" })` and a `node:dgram` udp6 `bind()` threw a bare `Error: Failed to bind socket` with no `code`, `syscall`, `errno` or `address`, and `node:quic` reported `ERR_QUIC_ENDPOINT_CLOSED: QUIC endpoint closed: Bind failure (0)`.
- Each failed attempt also leaked the new socket fd and the `addrinfo` list.
- Cause: of the three failure exits after the descriptor exists, this one returned without closing the fd, freeing the list, or writing `*err`, so callers saw an error with errno 0.
- The option only fails on kernels or seccomp policies that reject it; an ordinary machine does not hit this on its own.

### Fix
- All three post-`socket()` failure exits now share one helper: record the errno first, close the fd, free the list. The two exits that were already correct do the same three things in the same order as before.
- Correct because it is the function's existing contract: callers treat an error return as "nothing is owned" and `*err` as the errno of the failing call. The TCP listen path already cleans up in its caller and is left alone (its missing errno write is part of #36710).
- To make the failure reachable, the file's three identical `IPV6_V6ONLY` setsockopts are folded into one function and socket fault injection gets a `setsockopt_v6only` rule that fires inside it. Without fault injection compiled in, the check is a constant 0.
- Verification: with the rule armed, new tests assert the `ENOPROTOOPT` error object from `Bun.udpSocket`, dgram, the raw-descriptor bind and quic, and that eight failed creations leave the fd count unchanged; before the cleanup they showed the code-less message and 8 leaked fds. They skip without fault injection and on Windows; the `addrinfo` leak is not asserted separately.

### Background
- usockets (`packages/bun-usockets`) is bun's C socket layer; `Bun.udpSocket`, `node:dgram` and `node:quic` all create and bind their UDP descriptors through its `bsd.c`.
- `IPV6_V6ONLY` is a socket option set on every AF_INET6 socket between `socket()` and `bind()`; it decides whether the socket also takes IPv4-mapped traffic, and it is one more syscall on that path that can fail.
- `LIBUS_ERR` is usockets' macro for the last error (`errno`, or `WSAGetLastError()` on Windows). `close()` and `freeaddrinfo()` can overwrite it, so it must be read before either runs.
- The JS-facing consumers build a real error (code, syscall, address) only when `*err` is non-zero; errno 0 falls through to a generic message.
- Socket fault injection (`socketFaultInjection` in `bun:internal-for-testing`, absent from release builds) makes the next call of one named operation fail with a chosen errno; a rule is keyed on the operation, so it reaches every call site of a shared function.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/net/socket-syscall-fault.test.ts test/js/bun/udp/dgram.test.ts test/js/bun/udp/udp_socket.test.ts test/js/node/quic/quic-endpoint.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

`bsd_create_udp_socket()` (`packages/bun-usockets/src/bsd.c`) has three failure exits after it has created the descriptor: `bsd_set_reuse()`, the `IPV6_V6ONLY` setsockopt, and `bind()`. The first and the last record the error into `*err`, `bsd_close_socket()` the descriptor and `freeaddrinfo()` the list. The `IPV6_V6ONLY` one did

```c
if (setsockopt(listenFd, IPPROTO_IPV6, IPV6_V6ONLY, &enabled, sizeof(enabled)) != 0) {
    return LIBUS_SOCKET_ERROR;
}
```

so on that path the new socket fd leaked, the `addrinfo` list leaked, and `*err` stayed 0. The consumers only build a real error when `err != 0`, so:

- `Bun.udpSocket({ hostname: "::1" })` and a `node:dgram` udp6 `bind()` produced a bare `Error: Failed to bind socket` (no `code`, `syscall`, `errno` or `address`), plus one leaked fd per attempt
- `node:quic` reported `ERR_QUIC_ENDPOINT_CLOSED: QUIC endpoint closed: Bind failure (0)`

### Fix

The three post-`socket()` exits now go through one static helper, `bsd_create_udp_socket_fail()`, that does what two of them already did: read `LIBUS_ERR` first (so `close()` / `freeaddrinfo()` cannot overwrite it), close the fd, free the list, return `LIBUS_SOCKET_ERROR`. The two exits that were already correct are unchanged in behavior (same three operations in the same order; `LIBUS_ERR` is the existing `errno` / `WSAGetLastError()` macro from `internal.h` that `us_internal_bind_and_listen()` in the same file uses).

This is correct to have because it is the function's existing contract: every caller (`udp_socket.rs` for `Bun.udpSocket` / `node:dgram`, `quic/endpoint.rs`, `quic.c`) treats `LIBUS_SOCKET_ERROR` as "nothing is owned" and `*err` as the errno of the failing call; the `IPV6_V6ONLY` exit was the only one not honoring it. The TCP twin (`bsd_bind_listen_fd()` / `bsd_create_listen_socket()`) already closes the fd and frees the list in the caller on the equivalent failure, so its error handling is left alone here; its missing `*error` write on the same setsockopt failure is part of #36710.

### Making it testable

Setting `IPV6_V6ONLY` on a socket you just created only fails on kernels or seccomp policies that reject the option, so the failure has to be injected. `bsd.c` had three identical `IPV6_V6ONLY` setsockopts (TCP listen, UDP create, and the raw-descriptor UDP bind used by cluster / `_createSocketHandle`); they are folded into one `bsd_set_v6only()` next to `bsd_set_reuseaddr()` / `bsd_set_reuseport()`, and the existing socket fault injection gets a `setsockopt_v6only` rule that fires inside it. Like the other hooks it is keyed on the operation, so one rule covers all three call sites (which also gives #36710 a way to test its TCP change), and it is a constant 0 when `LIBUS_SOCKET_FAULT_INJECTION` is not compiled in. The call sites keep their own error handling; only the setsockopt line moved.

#22796 closes the fd on this branch too, but predates #28084 (which fixed the `bsd_set_reuse()` exit), does not record the errno, and no longer applies to main.

### Tests

- `test/js/bun/udp/udp_socket.test.ts`: with the rule armed, `Bun.udpSocket` fails with `{ code: "ENOPROTOOPT", syscall: "bind", address: "::1", message: "bind ENOPROTOOPT ::1" }` and the next creation with the same options succeeds; eight failed creations leave `getFDCount()` unchanged.
- `test/js/bun/udp/dgram.test.ts`: udp6 `bind()` emits the same error object; `_createSocketHandle("::1", 0, "udp6", undefined, UV_UDP_IPV6ONLY)` (the raw-descriptor site) returns `-ENOPROTOOPT`.
- `test/js/node/quic/quic-endpoint.test.ts`: the endpoint's `closed` rejects with `Bind failure (<ENOPROTOOPT>)`.
- `test/js/bun/net/socket-syscall-fault.test.ts`: `Bun.listen` on `::1` (the TCP site) fails, and the next listen on the same address works.
- `test/js/bun/util/socket-fault-injection.test.ts`: the new rule accepts `errno` / `none` and rejects `short` / `zero` like the other non-data syscalls.

With the hook added but the cleanup not yet applied, the tests showed the bug directly: `message: "Failed to bind socket"` with `code`/`syscall`/`address` undefined, and `leakedDescriptors: 8` for 8 attempts. With the fix, the five files pass under `bun bd test` (305 pass, 2 skip), as do the vendored `test-net-listen-ipv6only.js`, `test-dgram-ipv6only.js` and `test-cluster-dgram-ipv6only.js` (the success path of each of the three sites) and `test-dgram-error-message-address.js` (the `bind()` exit that now also goes through the helper). The new tests skip on builds without fault injection (release, `USE_SYSTEM_BUN=1`) and on Windows, where `getFDCount()` does not observe `SOCKET` handles and the injected errno would have to be a WSA code. The `addrinfo` part of the cleanup is not asserted separately: `test/leaksan.supp` suppresses `getaddrinfo` allocations, so LSan would not see it either way; it is the same helper the fd and errno assertions exercise.

</details>
