### PR TITLE
ci(darwin tart): export RUSTUP_HOME/CARGO_HOME in the guest job environment

### DIFF
--- a/scripts/darwin-ci/guest/job.sh
+++ b/scripts/darwin-ci/guest/job.sh
@@ -2,6 +2,9 @@
 # Runs inside the per-job guest. Expects ~/job.env (exported by the command hook) and the checkout at ~/work.
 set -u
 export PATH=/usr/local/bin:/opt/homebrew/bin:/opt/rust/bin:$PATH
+# bootstrap.sh installs rustup into /opt/rust and only exports these from the login profile, which this script
+# does not source; without them the proxies in /opt/rust/bin look for a toolchain in ~/.rustup and find none.
+export RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/rust
 export BUILDKITE_BUILD_CHECKOUT_PATH=$HOME/work
 set -a; source ~/job.env; set +a
 cd ~/work


### PR DESCRIPTION
`test/js/third_party/grpc-js/test-tonic.test.ts` fails on every run of the `darwin 14 aarch64 - test-bun` lane since the tart agents came online (#37633), e.g. main builds [92687](https://buildkite.com/bun/bun/builds/92687) and [92739](https://buildkite.com/bun/bun/builds/92739):

```
error: tonic server exited (1) before reporting an address:
error: rustup could not choose a version of cargo to run, because one wasn't specified explicitly, and no default is configured.
```

### Cause

That lane is served by the tart guests (`darwin-arm64-{challah,ciabatta,focaccia,sourdough}-tart-15-*`). `scripts/bootstrap.sh` installs rustup into `/opt/rust` (`RUSTUP_HOME=CARGO_HOME=/opt/rust`) and exports those two variables from the login profile. `scripts/darwin-ci/guest/job.sh` is run as a plain `/bin/bash ~/job.sh`, so the profile is never sourced; it puts `/opt/rust/bin` on `PATH` by hand but not the two variables. `Bun.which("cargo")` therefore finds the rustup proxy, and the proxy looks for a toolchain in `~/.rustup`, which does not exist in the guest.

Checked inside a running guest on `darwin-arm64-focaccia`: `/opt/rust/settings.toml` has `default_toolchain = "stable-aarch64-apple-darwin"`, `cargo --version` with job.sh's environment fails with the message above, and the same command with `RUSTUP_HOME=/opt/rust CARGO_HOME=/opt/rust` prints `cargo 1.97.1`. The bare agents are unaffected because `scripts/agent.mjs` runs jobs with `sh -elc`, which sources the profile; that is why the `darwin 26 aarch64` lane passes.

### Fix

Export `RUSTUP_HOME` and `CARGO_HOME` in `job.sh` next to the `PATH` line that already hardcodes `/opt/rust/bin`.

The test itself is left alone: it fails loudly on purpose (#33970), and that is what surfaced this.

### Rollout

The hosts run the copy of `job.sh` installed in `/usr/local/share/darwin-ci` at provision time (`command.ts` pushes it into the guest per job), so this PR's own darwin 14 lane will still show the failure. The four tart hosts need the updated file copied into place (no agent restart needed; the next job picks it up), or a re-run of `main.ts provision`.

cc @alii

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->