### PR TITLE
node:http2: record empty trailers as sent when the stream ends without a 'wantTrailers' listener

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2632,10 +2632,8 @@ class Http2Stream extends Duplex {
     }
   }
 
-  // node's onStreamTrailers: without a 'wantTrailers' listener the stream sends empty trailers itself
-  // (sendTrailers({})), so a later sendTrailers() gets ERR_HTTP2_TRAILERS_ALREADY_SENT. A close()d
-  // stream is not asked either; it is still ended because its writable has to finish for close()'s
-  // RST_STREAM to go out.
+  // node's onStreamTrailers, which sends empty trailers itself when nothing listens. A close()d stream
+  // is ended rather than asked: its writable has to finish for close()'s RST_STREAM to go out.
   [kWantTrailers](native) {
     if ((this[bunHTTP2StreamStatus] & StreamState.Closed) !== 0 || this.listenerCount("wantTrailers") === 0) {
       this.#sentTrailers = {};

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -393,6 +393,8 @@ const kRequestHeaders = Symbol("requestHeaders");
 // set so a second sendTrailers() in the same tick reports ERR_HTTP2_TRAILERS_ALREADY_SENT, not
 // ERR_HTTP2_INVALID_STREAM.
 const kSendingTrailers = Symbol("sendingTrailers");
+// Http2Stream#[kWantTrailers]: the stream's body is on the wire and its trailer block is due.
+const kWantTrailers = Symbol("wantTrailers");
 const kSettingsAckGraceTimer = Symbol("settingsAckGraceTimer");
 // node: a socket can be bound to at most one Http2Session (ERR_HTTP2_SOCKET_BOUND).
 const kBoundSession = Symbol("boundSession");
@@ -2631,6 +2633,22 @@ class Http2Stream extends Duplex {
     }
   }
 
+  // node's onStreamTrailers: with nobody listening for 'wantTrailers' the stream sends empty
+  // trailers itself, i.e. sendTrailers({}): an empty END_STREAM DATA frame, and the trailers count
+  // as sent, so a later sendTrailers() reports ERR_HTTP2_TRAILERS_ALREADY_SENT instead of writing a
+  // trailer HEADERS frame on a stream we already half-closed. A stream close()d while its last DATA
+  // was in flight is ended the same way: node never asks it for trailers (a listener's
+  // sendTrailers() could only throw ERR_HTTP2_INVALID_STREAM), and its writable has to finish for
+  // close()'s RST_STREAM to go out. Callers set StreamState.WantTrailer first.
+  [kWantTrailers](native) {
+    if ((this[bunHTTP2StreamStatus] & StreamState.Closed) !== 0 || this.listenerCount("wantTrailers") === 0) {
+      this.#sentTrailers = {};
+      native.noTrailers(this.#id);
+    } else {
+      this.emit("wantTrailers");
+    }
+  }
+
   setTimeout(timeout, callback) {
     const session = this[bunHTTP2Session];
     if (!session) return;
@@ -2910,22 +2928,7 @@ class Http2Stream extends Duplex {
             // markWritableDone before control returns here: stash the callback there so the
             // writable finishes ('finish' before 'close') instead of being torn down mid-final.
             this[bunHTTP2StreamFinal] = callback;
-            if ((this[bunHTTP2StreamStatus] & StreamState.Closed) !== 0 || this.listenerCount("wantTrailers") === 0) {
-              // No 'wantTrailers' listener — or the stream was close()d while the last write
-              // was still in flight, in which case node never asks for trailers (the compat
-              // onStreamTrailersReady would throw ERR_HTTP2_INVALID_STREAM on a closed
-              // stream): end the writable with the empty END_STREAM DATA frame directly.
-              native.noTrailers(this.#id);
-              // Mark trailers as "sent" so a later stream.sendTrailers()
-              // call hits the ERR_HTTP2_TRAILERS_ALREADY_SENT guard instead
-              // of invoking native noTrailers() a second time on an
-              // already-half-closed stream. The emit("wantTrailers") path
-              // below reaches the same result via sendTrailers({}) which
-              // assigns #sentTrailers itself.
-              this.#sentTrailers = {};
-            } else {
-              this.emit("wantTrailers");
-            }
+            this[kWantTrailers](native);
             // Hand the END_STREAM (or trailer) frame to the socket now: with deferred write
             // completion, _final can run on the program's last live turn and a frame left in
             // the cork for the auto-flusher would strand a generic-streams (duplexPair) peer
@@ -4452,14 +4455,9 @@ class ServerHttp2Session extends Http2Session {
       if (!self || typeof stream !== "object") return;
       const status = stream[bunHTTP2StreamStatus];
       if ((status & StreamState.WantTrailer) !== 0) return;
-
       stream[bunHTTP2StreamStatus] = status | StreamState.WantTrailer;
-
-      if (stream.listenerCount("wantTrailers") === 0) {
-        self[bunHTTP2Native]?.noTrailers(stream.id);
-      } else {
-        stream.emit("wantTrailers");
-      }
+      const native = self[bunHTTP2Native];
+      if (native) stream[kWantTrailers](native);
     },
     goaway(self: ServerHttp2Session, errorCode: number, lastStreamId: number, opaqueData: Buffer) {
       if (!self) return;
@@ -5451,11 +5449,8 @@ class ClientHttp2Session extends Http2Session {
       const status = stream[bunHTTP2StreamStatus];
       if ((status & StreamState.WantTrailer) !== 0) return;
       stream[bunHTTP2StreamStatus] = status | StreamState.WantTrailer;
-      if (stream.listenerCount("wantTrailers") === 0) {
-        self[bunHTTP2Native]?.noTrailers(stream.id);
-      } else {
-        stream.emit("wantTrailers");
-      }
+      const native = self[bunHTTP2Native];
+      if (native) stream[kWantTrailers](native);
     }),
     goaway(self: ClientHttp2Session, errorCode: number, lastStreamId: number, opaqueData: Buffer) {
       if (!self) return;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -393,7 +393,6 @@ const kRequestHeaders = Symbol("requestHeaders");
 // set so a second sendTrailers() in the same tick reports ERR_HTTP2_TRAILERS_ALREADY_SENT, not
 // ERR_HTTP2_INVALID_STREAM.
 const kSendingTrailers = Symbol("sendingTrailers");
-// Http2Stream#[kWantTrailers]: the stream's body is on the wire and its trailer block is due.
 const kWantTrailers = Symbol("wantTrailers");
 const kSettingsAckGraceTimer = Symbol("settingsAckGraceTimer");
 // node: a socket can be bound to at most one Http2Session (ERR_HTTP2_SOCKET_BOUND).
@@ -2633,13 +2632,10 @@ class Http2Stream extends Duplex {
     }
   }
 
-  // node's onStreamTrailers: with nobody listening for 'wantTrailers' the stream sends empty
-  // trailers itself, i.e. sendTrailers({}): an empty END_STREAM DATA frame, and the trailers count
-  // as sent, so a later sendTrailers() reports ERR_HTTP2_TRAILERS_ALREADY_SENT instead of writing a
-  // trailer HEADERS frame on a stream we already half-closed. A stream close()d while its last DATA
-  // was in flight is ended the same way: node never asks it for trailers (a listener's
-  // sendTrailers() could only throw ERR_HTTP2_INVALID_STREAM), and its writable has to finish for
-  // close()'s RST_STREAM to go out. Callers set StreamState.WantTrailer first.
+  // node's onStreamTrailers: without a 'wantTrailers' listener the stream sends empty trailers itself
+  // (sendTrailers({})), so a later sendTrailers() gets ERR_HTTP2_TRAILERS_ALREADY_SENT. A close()d
+  // stream is not asked either; it is still ended because its writable has to finish for close()'s
+  // RST_STREAM to go out.
   [kWantTrailers](native) {
     if ((this[bunHTTP2StreamStatus] & StreamState.Closed) !== 0 || this.listenerCount("wantTrailers") === 0) {
       this.#sentTrailers = {};

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2632,10 +2632,12 @@ class Http2Stream extends Duplex {
     }
   }
 
-  // node's onStreamTrailers, which sends empty trailers itself when nothing listens. A close()d stream
-  // is ended rather than asked: its writable has to finish for close()'s RST_STREAM to go out.
+  // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L484-L493 (onStreamTrailers):
+  // a closed stream is not asked (close()'s RST_STREAM follows on its own); with no listener the
+  // stream sends empty trailers itself, which is what makes a later sendTrailers() fail.
   [kWantTrailers](native) {
-    if ((this[bunHTTP2StreamStatus] & StreamState.Closed) !== 0 || this.listenerCount("wantTrailers") === 0) {
+    if ((this[bunHTTP2StreamStatus] & StreamState.Closed) !== 0) return;
+    if (this.listenerCount("wantTrailers") === 0) {
       this.#sentTrailers = {};
       native.noTrailers(this.#id);
     } else {

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -900,6 +900,141 @@ function requestHeaderBlock(method: "GET" | "POST", extra: Buffer = Buffer.alloc
 
 const CONTENT_LENGTH_5 = Buffer.concat([Buffer.from([0x0f, 0x0d]), hpackLiteral("5")]);
 
+function frameSummary(f: Frame) {
+  return { type: f.type, flags: f.flags, length: f.length };
+}
+
+// A waitForTrailers stream whose body finished without a 'wantTrailers' listener is ended by
+// node itself (onStreamTrailers calls stream.sendTrailers({})): an empty END_STREAM DATA frame
+// goes out and the trailers count as sent, so a later sendTrailers() must fail with
+// ERR_HTTP2_TRAILERS_ALREADY_SENT rather than put a trailer HEADERS frame on the half-closed
+// stream (§8.1: the trailer section is the last frame of the message).
+describe("trailers after the stream was ended without a 'wantTrailers' listener (RFC 9113 §8.1)", () => {
+  test("client: a late sendTrailers() throws ERR_HTTP2_TRAILERS_ALREADY_SENT and sends nothing", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      await raw.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      req.end("hello");
+      await raw.waitFor(f => f.streamId === 1 && f.type === FrameType.DATA && (f.flags & 0x1) !== 0);
+
+      expect(req.sentTrailers).toEqual({});
+      expect(() => req.sendTrailers({ "x-late": "1" })).toThrow(
+        expect.objectContaining({ code: "ERR_HTTP2_TRAILERS_ALREADY_SENT" }),
+      );
+      expect(req.sentTrailers).toEqual({});
+      // Anything the rejected call had written would reach the socket ahead of this PING's ACK.
+      raw.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await raw.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect(raw.frames.filter(f => f.streamId === 1).map(frameSummary)).toEqual([
+        { type: FrameType.HEADERS, flags: 0x4 /* END_HEADERS */, length: expect.any(Number) },
+        { type: FrameType.DATA, flags: 0, length: 5 },
+        { type: FrameType.DATA, flags: 0x1 /* END_STREAM */, length: 0 },
+      ]);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("server: sendTrailers() from 'prefinish' or later throws ERR_HTTP2_TRAILERS_ALREADY_SENT and sends nothing", async () => {
+    const outcome = Promise.withResolvers<{ prefinish: string; finish: string; sentTrailers: unknown }>();
+    const srv = http2.createServer();
+    srv.on("stream", (stream: any) => {
+      stream.on("error", (err: Error) => outcome.reject(err));
+      const attempt = () => {
+        try {
+          stream.sendTrailers({ "x-late": "1" });
+          return "sent";
+        } catch (e: any) {
+          return e.code;
+        }
+      };
+      // 'prefinish' fires from inside the call that writes the END_STREAM frame; 'finish' a tick
+      // later. Both are after the stream ended itself, so both attempts are too late.
+      let prefinish = "not emitted";
+      stream.on("prefinish", () => (prefinish = attempt()));
+      stream.on("finish", () => outcome.resolve({ prefinish, finish: attempt(), sentTrailers: stream.sentTrailers }));
+      stream.respond({ ":status": 200 }, { waitForTrailers: true });
+      stream.end("ok");
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const c = await RawH2.connect((srv.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      // POST without END_STREAM: the request side stays open, so the response's END_STREAM only
+      // half-closes the stream (the stream object stays usable for the late sendTrailers calls).
+      c.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 1, requestHeaderBlock("POST"));
+      expect(await outcome.promise).toEqual({
+        prefinish: "ERR_HTTP2_TRAILERS_ALREADY_SENT",
+        finish: "ERR_HTTP2_TRAILERS_ALREADY_SENT",
+        sentTrailers: {},
+      });
+      c.sendFrame(FrameType.PING, 0, 0, Buffer.alloc(8));
+      await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect(c.frames.filter(f => f.streamId === 1).map(frameSummary)).toEqual([
+        { type: FrameType.HEADERS, flags: 0x4 /* END_HEADERS */, length: expect.any(Number) },
+        { type: FrameType.DATA, flags: 0, length: 2 },
+        { type: FrameType.DATA, flags: 0x1 /* END_STREAM */, length: 0 },
+      ]);
+    } finally {
+      c.destroy();
+      srv.close();
+    }
+  });
+
+  // node's onStreamTrailers returns without emitting when the stream was closed in the meantime
+  // (a listener could only throw ERR_HTTP2_INVALID_STREAM); the stream is ended so close()'s
+  // RST_STREAM, which waits for 'finish', still goes out.
+  test("client: a stream close()d while its final DATA was flow-control blocked is ended without emitting 'wantTrailers'", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      // SETTINGS_INITIAL_WINDOW_SIZE = 0: every new stream starts with no send window.
+      const zeroWindow = Buffer.alloc(6);
+      zeroWindow.writeUInt16BE(0x4, 0);
+      zeroWindow.writeUInt32BE(0, 2);
+      await raw.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0, zeroWindow);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      await once(client, "remoteSettings");
+
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      let wantTrailers = 0;
+      req.on("wantTrailers", () => wantTrailers++);
+      req.end("hello");
+      req.close();
+      await raw.waitFor(f => f.streamId === 1 && f.type === FrameType.HEADERS);
+      expect(raw.frames.filter(f => f.streamId === 1 && f.type === FrameType.DATA)).toEqual([]);
+
+      const windowUpdate = Buffer.alloc(4);
+      windowUpdate.writeUInt32BE(1024, 0);
+      raw.sendFrame(FrameType.WINDOW_UPDATE, 0, 1, windowUpdate);
+      const rst = await raw.waitFor(f => f.streamId === 1 && f.type === FrameType.RST_STREAM);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.NO_ERROR);
+      expect(wantTrailers).toBe(0);
+      expect(raw.frames.filter(f => f.streamId === 1).map(frameSummary)).toEqual([
+        { type: FrameType.HEADERS, flags: 0x4 /* END_HEADERS */, length: expect.any(Number) },
+        { type: FrameType.DATA, flags: 0, length: 5 },
+        { type: FrameType.DATA, flags: 0x1 /* END_STREAM */, length: 0 },
+        { type: FrameType.RST_STREAM, flags: 0, length: 4 },
+      ]);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+});
+
 describe("request header and body framing (RFC 9113 §8.1)", () => {
   let deferredServer: http2.Http2Server;
   let deferredPort: number;

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -993,18 +993,28 @@ describe("trailers after the stream was ended without a 'wantTrailers' listener 
   // node's onStreamTrailers returns without emitting once the stream is closed (a listener could
   // only throw ERR_HTTP2_INVALID_STREAM). Like the _final path, the stream is still ended with the
   // empty END_STREAM DATA frame, and close()'s RST_STREAM (sent once the writable finishes) follows.
-  test("client: 'wantTrailers' is not emitted on a stream close()d before its body reached the wire", async () => {
+  test("client: 'wantTrailers' is not emitted on a stream close()d while its last chunk was still buffered", async () => {
     const raw = await RawH2Server.listen();
     const client = http2.connect(`http://127.0.0.1:${raw.port}`);
     client.on("error", () => {});
+    const connected = once(client, "connect");
     try {
+      await raw.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      await connected;
+
       const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
       req.on("error", () => {});
       let wantTrailers = 0;
       req.on("wantTrailers", () => wantTrailers++);
-      // A new request stream is corked until the next tick, so the body is written (and the
-      // trailer block requested) after close() has already marked the stream closed.
-      req.end("hello");
+      // 'ready' follows the tick that uncorks a new request stream, so the first write below goes
+      // out at once. Its write callback only completes on a later turn, which leaves the chunk
+      // passed to end() buffered behind it: that final chunk (the one that asks for the trailer
+      // block) is written after close() has already marked the stream closed.
+      await once(req, "ready");
+      req.write("a");
+      req.end("b");
       req.close();
       expect(req.closed).toBe(true);
 
@@ -1013,7 +1023,8 @@ describe("trailers after the stream was ended without a 'wantTrailers' listener 
       expect(wantTrailers).toBe(0);
       expect(raw.frames.filter(f => f.streamId === 1).map(frameSummary)).toEqual([
         { type: FrameType.HEADERS, flags: 0x4 /* END_HEADERS */, length: expect.any(Number) },
-        { type: FrameType.DATA, flags: 0, length: 5 },
+        { type: FrameType.DATA, flags: 0, length: 1 },
+        { type: FrameType.DATA, flags: 0, length: 1 },
         { type: FrameType.DATA, flags: 0x1 /* END_STREAM */, length: 0 },
         { type: FrameType.RST_STREAM, flags: 0, length: 4 },
       ]);

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -904,12 +904,14 @@ function frameSummary(f: Frame) {
   return { type: f.type, flags: f.flags, length: f.length };
 }
 
-// A waitForTrailers stream whose body finished without a 'wantTrailers' listener is ended by
-// node itself (onStreamTrailers calls stream.sendTrailers({})): an empty END_STREAM DATA frame
-// goes out and the trailers count as sent, so a later sendTrailers() must fail with
-// ERR_HTTP2_TRAILERS_ALREADY_SENT rather than put a trailer HEADERS frame on the half-closed
-// stream (§8.1: the trailer section is the last frame of the message).
-describe("trailers after the stream was ended without a 'wantTrailers' listener (RFC 9113 §8.1)", () => {
+// node's onStreamTrailers (lib/internal/http2/core.js): once the body of a waitForTrailers stream is
+// out, a stream without a 'wantTrailers' listener is ended by node itself via sendTrailers({}), so an
+// empty END_STREAM DATA frame goes out and the trailers count as sent: a later sendTrailers() must
+// fail with ERR_HTTP2_TRAILERS_ALREADY_SENT rather than put a trailer HEADERS frame on the
+// half-closed stream (§8.1: the trailer section is the last frame of the message). A stream that is
+// closed by then, or that a listener close()s instead of sending trailers, is not completed at all:
+// no END_STREAM frame, nothing recorded as sent, and close()'s RST_STREAM(NO_ERROR) ends it.
+describe("trailer block requests without a listener or on a closing stream (RFC 9113 §8.1)", () => {
   test("client: a late sendTrailers() throws ERR_HTTP2_TRAILERS_ALREADY_SENT and sends nothing", async () => {
     const raw = await RawH2Server.listen();
     const client = http2.connect(`http://127.0.0.1:${raw.port}`);
@@ -990,9 +992,8 @@ describe("trailers after the stream was ended without a 'wantTrailers' listener 
     }
   });
 
-  // node's onStreamTrailers returns without emitting once the stream is closed (a listener could
-  // only throw ERR_HTTP2_INVALID_STREAM). Like the _final path, the stream is still ended with the
-  // empty END_STREAM DATA frame, and close()'s RST_STREAM (sent once the writable finishes) follows.
+  // onStreamTrailers returns without emitting once the stream is closed (a listener could only
+  // throw ERR_HTTP2_INVALID_STREAM); close()'s RST_STREAM goes out once the writable finishes.
   test("client: 'wantTrailers' is not emitted on a stream close()d while its last chunk was still buffered", async () => {
     const raw = await RawH2Server.listen();
     const client = http2.connect(`http://127.0.0.1:${raw.port}`);
@@ -1021,16 +1022,87 @@ describe("trailers after the stream was ended without a 'wantTrailers' listener 
       const rst = await raw.waitFor(f => f.streamId === 1 && f.type === FrameType.RST_STREAM);
       expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.NO_ERROR);
       expect(wantTrailers).toBe(0);
+      expect(req.sentTrailers).toBeUndefined();
       expect(raw.frames.filter(f => f.streamId === 1).map(frameSummary)).toEqual([
         { type: FrameType.HEADERS, flags: 0x4 /* END_HEADERS */, length: expect.any(Number) },
         { type: FrameType.DATA, flags: 0, length: 1 },
         { type: FrameType.DATA, flags: 0, length: 1 },
-        { type: FrameType.DATA, flags: 0x1 /* END_STREAM */, length: 0 },
         { type: FrameType.RST_STREAM, flags: 0, length: 4 },
       ]);
     } finally {
       client.destroy();
       raw.close();
+    }
+  });
+
+  test("client: a 'wantTrailers' listener that close()s the stream ends it with RST_STREAM(NO_ERROR) alone", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      const events: string[] = [];
+      req.on("wantTrailers", () => {
+        events.push("wantTrailers");
+        req.close();
+      });
+      req.on("finish", () => events.push("finish"));
+      const closed = once(req, "close");
+      await raw.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0);
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
+      req.end("hello");
+
+      const rst = await raw.waitFor(f => f.streamId === 1 && f.type === FrameType.RST_STREAM);
+      await closed;
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.NO_ERROR);
+      expect(events).toEqual(["wantTrailers", "finish"]);
+      expect(req.sentTrailers).toBeUndefined();
+      expect(raw.frames.filter(f => f.streamId === 1).map(frameSummary)).toEqual([
+        { type: FrameType.HEADERS, flags: 0x4 /* END_HEADERS */, length: expect.any(Number) },
+        { type: FrameType.DATA, flags: 0, length: 5 },
+        { type: FrameType.RST_STREAM, flags: 0, length: 4 },
+      ]);
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+
+  test("server: a 'wantTrailers' listener that close()s the stream ends it with RST_STREAM(NO_ERROR) alone", async () => {
+    const outcome = Promise.withResolvers<{ events: string[]; sentTrailers: unknown }>();
+    const srv = http2.createServer();
+    srv.on("stream", (stream: any) => {
+      const events: string[] = [];
+      stream.on("error", (err: Error) => outcome.reject(err));
+      stream.on("wantTrailers", () => {
+        events.push("wantTrailers");
+        stream.close();
+      });
+      stream.on("finish", () => events.push("finish"));
+      stream.on("close", () => outcome.resolve({ events, sentTrailers: stream.sentTrailers }));
+      stream.respond({ ":status": 200 }, { waitForTrailers: true });
+      stream.end("ok");
+    });
+    srv.listen(0, "127.0.0.1");
+    await once(srv, "listening");
+    const c = await RawH2.connect((srv.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 1, requestHeaderBlock("POST"));
+      const rst = await c.waitFor(f => f.streamId === 1 && f.type === FrameType.RST_STREAM);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.NO_ERROR);
+      expect(await outcome.promise).toEqual({ events: ["wantTrailers", "finish"], sentTrailers: undefined });
+      expect(c.frames.filter(f => f.streamId === 1).map(frameSummary)).toEqual([
+        { type: FrameType.HEADERS, flags: 0x4 /* END_HEADERS */, length: expect.any(Number) },
+        { type: FrameType.DATA, flags: 0, length: 2 },
+        { type: FrameType.RST_STREAM, flags: 0, length: 4 },
+      ]);
+    } finally {
+      c.destroy();
+      srv.close();
     }
   });
 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -990,35 +990,24 @@ describe("trailers after the stream was ended without a 'wantTrailers' listener 
     }
   });
 
-  // node's onStreamTrailers returns without emitting when the stream was closed in the meantime
-  // (a listener could only throw ERR_HTTP2_INVALID_STREAM); the stream is ended so close()'s
-  // RST_STREAM, which waits for 'finish', still goes out.
-  test("client: a stream close()d while its final DATA was flow-control blocked is ended without emitting 'wantTrailers'", async () => {
+  // node's onStreamTrailers returns without emitting once the stream is closed (a listener could
+  // only throw ERR_HTTP2_INVALID_STREAM). Like the _final path, the stream is still ended with the
+  // empty END_STREAM DATA frame, and close()'s RST_STREAM (sent once the writable finishes) follows.
+  test("client: 'wantTrailers' is not emitted on a stream close()d before its body reached the wire", async () => {
     const raw = await RawH2Server.listen();
     const client = http2.connect(`http://127.0.0.1:${raw.port}`);
     client.on("error", () => {});
     try {
-      // SETTINGS_INITIAL_WINDOW_SIZE = 0: every new stream starts with no send window.
-      const zeroWindow = Buffer.alloc(6);
-      zeroWindow.writeUInt16BE(0x4, 0);
-      zeroWindow.writeUInt32BE(0, 2);
-      await raw.waitFor(f => f.type === FrameType.SETTINGS && (f.flags & 0x1) === 0);
-      raw.sendFrame(FrameType.SETTINGS, 0, 0, zeroWindow);
-      raw.sendFrame(FrameType.SETTINGS, 0x1, 0);
-      await once(client, "remoteSettings");
-
       const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
       req.on("error", () => {});
       let wantTrailers = 0;
       req.on("wantTrailers", () => wantTrailers++);
+      // A new request stream is corked until the next tick, so the body is written (and the
+      // trailer block requested) after close() has already marked the stream closed.
       req.end("hello");
       req.close();
-      await raw.waitFor(f => f.streamId === 1 && f.type === FrameType.HEADERS);
-      expect(raw.frames.filter(f => f.streamId === 1 && f.type === FrameType.DATA)).toEqual([]);
+      expect(req.closed).toBe(true);
 
-      const windowUpdate = Buffer.alloc(4);
-      windowUpdate.writeUInt32BE(1024, 0);
-      raw.sendFrame(FrameType.WINDOW_UPDATE, 0, 1, windowUpdate);
       const rst = await raw.waitFor(f => f.streamId === 1 && f.type === FrameType.RST_STREAM);
       expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.NO_ERROR);
       expect(wantTrailers).toBe(0);


### PR DESCRIPTION
### Problem
- A `waitForTrailers` stream that ends its body with no `'wantTrailers'` listener still accepts a later `sendTrailers()`: a trailer `HEADERS` frame goes out on a stream bun already half-closed with an `END_STREAM` `DATA` frame (RFC 9113 5.1 / 8.1). Node throws `ERR_HTTP2_TRAILERS_ALREADY_SENT` and leaves `sentTrailers` as `{}`.
- Cause, client side (the path hit in practice): with no listener the session handler ended the stream without recording that trailers were sent, so nothing later refused the `sendTrailers()`, and the native send has no stream-state check.
- Cause, server side: the trailers were recorded, but only after the stream was ended, so a `sendTrailers()` issued from `'prefinish'` (which fires inside that call) still reached the wire.
- Also, the session handlers still emitted `'wantTrailers'` on a stream that had been `close()`d before its last chunk went out. Node does not ask a closed stream for trailers.

### Fix
- The three places that ask a stream for its trailer block now share one stream-level helper with the shape of node's `onStreamTrailers`: a closed stream is left alone; with no listener, record `sentTrailers = {}` and then end the stream; otherwise emit `'wantTrailers'`.
- Why that holds: the trailers are recorded as sent before the stream is ended, so every `sendTrailers()` after that point, including one from inside the ending call, hits the existing already-sent guard and writes nothing. No native change.
- Behavior change: a stream that is already closed when its trailer block is due now gets neither the event nor an empty `END_STREAM` frame; the body is followed by `close()`'s `RST_STREAM(NO_ERROR)` alone and `sentTrailers` stays `undefined`, as in node. The server path used to send an `END_STREAM` frame right before the reset.
- Verification: five wire-level tests against a raw peer. Three fail on main (client with no listener, server with no listener, stream closed before it was asked); two pass on both and pin the listener-calls-`close()` contract the helper now routes. The upstream `test-http2-*` suite was also run on a debug build.

### Background
- `waitForTrailers` (an option to `request()` / `respond()`) stops the stream from ending after the last body chunk. Instead it emits `'wantTrailers'` and the app calls `sendTrailers(headers)`, a final `HEADERS` frame carrying `END_STREAM`, or `close()`. With no listener, the stream is expected to end itself with empty trailers.
- Half-closed: once a side has sent a frame with `END_STREAM`, the only thing it may still send on that stream is `RST_STREAM`. A trailer `HEADERS` frame after an `END_STREAM` `DATA` frame is a protocol violation.
- `sentTrailers` is the stream property recording the trailers that went out. It doubles as the guard behind `ERR_HTTP2_TRAILERS_ALREADY_SENT`; `undefined` means the stream was never completed with trailers.
- The trailer block is requested from two places: client streams are asked from a session-level native callback, server streams from the stream's own end-of-writable hook. Before this PR each had its own copy of the no-listener logic (three copies in all).
- `close()` on an `Http2Stream` sends `RST_STREAM(NO_ERROR)` once the writable finishes, so a closed stream needs no `END_STREAM` frame to be torn down.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 3 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (e8c7c682d)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [385.71ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [103.55ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [78.63ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [44.31ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [37.35ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [33.91ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [41.94ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release without fix: 3 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [11.66ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [2.86ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [2.52ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [1.36ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [1.16ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [1.15ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [1.29ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [1.02ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [1.17ms]
(pass) WINDOW_UPDAT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (e8c7c682d)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [386.29ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [103.69ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [78.93ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [43.93ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [38.25ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [35.22ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [83.03ms]
(pass) PING (checklist §3.7) > a PING on a non-zero st
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     e8c7c682dc
  features     baseline

22 deps, 107 codegen, 1176 objects in 1041ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [11.00ms]
[2/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (da3851e57)

Checked 1 install across 2 packages (no changes) [6.00ms]
[3/1238] gen bindgenv2
[4/1238] gen ErrorCode+*.h
[5/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (da3851e57)

Checked 129 installs across 147 packages (no changes) [6.00ms]
[6/1238] fetch picohttpparser
[picohttpparser] up to date
[7/1238] fetch zlib
[zlib] up to date
[8/1238] fetch tinycc
[tinycc] up to date
[9/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[10/1237] gen .bind.ts → GeneratedBindings.cpp
[11/1237] subst deps/zlib/zlib.h
[12/1237] subst deps/zlib/zconf.h
[13/1188] fetch nodejs (prebuilt)
[nodejs] up to date
[14/11
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                      |  47 +++----
 test/js/node/http2/h2-conformance.test.ts | 207 ++++++++++++++++++++++++++++++
 2 files changed, 226 insertions(+), 28 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/http2.ts                          26     10      0
test/js/node/http2/h2-conformance.test.ts      8      9      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

A `waitForTrailers` stream whose body finishes with no `'wantTrailers'` listener, followed by a late `sendTrailers()` (the peer here is a raw server that only completes the SETTINGS handshake, so the stream stays half-closed):

```js
const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
req.end("hello"); // no 'wantTrailers' listener
setTimeout(() => {
  try {
    req.sendTrailers({ "x-late": "1" });
    console.log("no throw", req.sentTrailers);
  } catch (e) {
    console.log(e.code, req.sentTrailers);
  }
}, 300);
```

| | wire (stream 1) | late `sendTrailers()` | `sentTrailers` |
|---|---|---|---|
| node v26.3.0 | `HEADERS`, `DATA(5)`, `DATA(0, END_STREAM)` | throws `ERR_HTTP2_TRAILERS_ALREADY_SENT` | `{}` |
| bun 1.4.0 / main | same three frames, then an extra `HEADERS(END_STREAM)` | returns | `{ "x-late": "1" }` |

That extra trailer `HEADERS` frame is written on a stream we already half-closed with the `END_STREAM` `DATA` frame (RFC 9113 5.1 / 8.1).

### Cause

Node's `onStreamTrailers` handles the no-listener case by calling `stream.sendTrailers({})` itself, which both ends the stream (empty `END_STREAM` `DATA` frame) and records the trailers as sent. Bun's session-level `wantTrailers` handlers (`ClientHttp2Session` and `ServerHttp2Session` in `src/js/node/http2.ts`) called native `noTrailers()` directly without recording anything, so a later `sendTrailers()` passed both the `sentTrailers` and `WantTrailer` guards and native `send_trailers()` (which has no stream-state check) wrote the frame. `Http2Stream#_final` had its own copy of this logic that did record the trailers, but only after the native call returned, so a `sendTrailers()` issued from inside that call (the writable's `'prefinish'` fires there) still went through. The client path is the one hit in practice: client streams always get their `wantTrailers` through the native dispatch, server streams through `_final`.

### Fix

One `Http2Stream#[kWantTrailers]` helper now backs all three sites (both session handlers and `_final`) and has the shape of node's [`onStreamTrailers`](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/http2/core.js#L484-L493): a closed stream is left alone; otherwise, with nothing listening for `'wantTrailers'`, it records `sentTrailers = {}` and then calls `noTrailers()`; otherwise it emits the event.

The closed-stream rule is a small behavior change in its own right. The session handlers previously had no such rule, so a stream `close()`d before its last chunk went out still got `'wantTrailers'` emitted, and a listener's `sendTrailers()` could only throw `ERR_HTTP2_INVALID_STREAM` from inside the native dispatch (the compat layer's `onStreamTrailersReady` is such a listener, attached to every `Http2ServerResponse`). `_final` did have the rule, but ended the stream with an empty `END_STREAM` `DATA` frame instead of asking; that frame was not needed for anything (the writable finishes through `_final`'s own callback, or through the `EndStreamSent` short-circuit on the dispatch path, and `close()` has already arranged for the `RST_STREAM`), and it told the peer the message was complete right before resetting it. Node sends nothing there: the body frames are followed by `RST_STREAM(NO_ERROR)` alone and `sentTrailers` stays `undefined`, which is what both paths do now. The same holds when a listener `close()`s the stream instead of sending trailers (the other half of the documented `'wantTrailers'` contract), which is unchanged here but was untested.

No native change: the JS bookkeeping is the layer node enforces this at, and it is what makes the error code (`ERR_HTTP2_TRAILERS_ALREADY_SENT` rather than a native throw) match.

Related but separate: #37718 (endStream + waitForTrailers on request()) and #37712 (empty DATA frames / frameError stream id) change what happens before the trailer block is requested; this PR is about what happens after the no-listener path has ended the stream, and the handler both of them route through is the one fixed here.

### Verification

Five wire-level tests in `test/js/node/http2/h2-conformance.test.ts` (raw peer on the other side of a `node:http2` client or server). The first three fail on main and pass with the fix; the last two pass on both and pin the listener-calls-`close()` contract the helper now routes:

- client, no listener (the native dispatch path): `sentTrailers` is `{}`, the late `sendTrailers()` throws `ERR_HTTP2_TRAILERS_ALREADY_SENT`, and a PING round trip confirms nothing else reached the wire after the `END_STREAM` `DATA` frame. On main: `sentTrailers` is `undefined`.
- server, no listener (the `_final` path): `sendTrailers()` from `'prefinish'` and from `'finish'` both throw `ERR_HTTP2_TRAILERS_ALREADY_SENT` and the wire ends with the `END_STREAM` `DATA` frame. On main the `'prefinish'` call succeeds and a trailer `HEADERS` frame follows the `END_STREAM` frame.
- client with a listener, `close()`d while the chunk passed to `end()` was still buffered behind an in-flight write: `'wantTrailers'` is not emitted, `sentTrailers` stays `undefined`, and `DATA`, `DATA`, `RST_STREAM(NO_ERROR)` go out with no `END_STREAM` frame, as in node. On main the event fires on the closed stream. (An earlier version of this test issued the request before the session had connected; that variant never saw the `RST_STREAM` on the darwin-14-aarch64 lane, deterministically, while the linux lanes passed. The RST for a queued stream is sent by the pre-existing `sendRstOnReady` path, which this PR does not touch; the current test uses a connected stream and does not depend on it.)
- client and server, a listener that calls `close()`: events are `'wantTrailers'`, `'finish'`, `'close'`, `sentTrailers` is `undefined`, and the body `DATA` is followed by `RST_STREAM(NO_ERROR)` alone.

Also run with the debug build: the rest of `h2-conformance.test.ts`, `node-http2.test.js`, and all 256 upstream `test-http2-*.js` files in `test/js/node/test/parallel` (one of them, `test-http2-forget-closed-streams.js`, a 10,000-request loop, timed out once on a heavily loaded box and passed on rerun; it does not involve trailers).

</details>
