### PR TITLE
bundler: hand a finished Bun.build back through its pointer, not a &mut receiver

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -69,17 +69,14 @@ pub trait CompletionStruct: Node + Send + 'static {
     /// while it was still queued ([`free_released_unstarted`] then frees it).
     fn try_start(&mut self) -> bool;
     fn free_released_unstarted(this: *mut Self);
-    /// Hands the finished build (result and log already stored) back to its
-    /// owner, which may free `*this` the moment it is posted: this is the
-    /// bundle thread's last touch of it. It takes the pointer rather than
-    /// `&mut self` because a reference argument stays protected until the
-    /// call returns, and freeing protected memory is UB under both aliasing
-    /// models; for the same reason the caller must not hold a reference to
-    /// `*this` across the call either.
+    /// Hands the build (result and log stored) back to its owner, which may
+    /// free `*this` as soon as it is posted. Raw pointer, not `&mut self`: no
+    /// reference to `*this`, here or in the caller, may be live when that
+    /// happens.
     ///
     /// # Safety
-    /// `this` is a build that `try_start` accepted and the bundle thread still
-    /// owns; nothing on this thread touches `*this` afterwards.
+    /// `this` is a started build the bundle thread owns; nothing on this
+    /// thread touches `*this` afterwards.
     unsafe fn complete_on_bundle_thread(this: *mut Self);
     fn set_result(&mut self, result: BundleV2Result);
     fn set_log(&mut self, log: bun_ast::Log);
@@ -249,11 +246,8 @@ impl<C: CompletionStruct> BundleThread<C> {
                 // No `catch_unwind` — there is nothing to catch.
                 //
                 // SAFETY: started ⇒ `*completion` is ours until it is handed
-                // back, and handing it back is the last thing either path does
-                // with it. The owner may free it as soon as it is posted, so it
-                // stays a raw pointer: `set_result`'s reborrow ends at the `;`
-                // and no reference to it is live across either hand-back (see
-                // `complete_on_bundle_thread`).
+                // back, which is the last thing either path does with it; the
+                // reborrow for `set_result` ends before that.
                 unsafe {
                     if let Err(err) = Self::generate_in_new_thread(completion, generation) {
                         (*completion).set_result(BundleV2Result::Err(err));
@@ -280,13 +274,9 @@ impl<C: CompletionStruct> BundleThread<C> {
 
     /// This is called from `Bun.build` in JavaScript.
     ///
-    /// On `Ok` the build has been handed back (`complete_on_bundle_thread`)
-    /// and `*completion` may already be gone; on `Err` it is still ours and
-    /// the caller stores the error and hands it back.
-    ///
     /// # Safety
-    /// `completion` is a build that `try_start` accepted and the bundle thread
-    /// still owns.
+    /// `completion` is a started build the bundle thread owns. On `Ok` it has
+    /// been handed back (and may be gone); on `Err` the caller hands it back.
     unsafe fn generate_in_new_thread(
         completion: *mut C,
         generation: bun_core::Generation,
@@ -301,18 +291,16 @@ impl<C: CompletionStruct> BundleThread<C> {
 
         // Allocate + configure folded — see `create_and_configure_transpiler` doc.
         //
-        // SAFETY: fn contract. `*completion` is reborrowed for this one call;
-        // the returned `&'a mut Transpiler` borrows `bump`, not the task.
+        // SAFETY: fn contract; the reborrow ends with the call (the result
+        // borrows `bump`).
         let transpiler = unsafe { (*completion).create_and_configure_transpiler(bump) }?;
 
         transpiler.resolver.generation = generation;
 
-        // Construction + run delegated — see `init_and_run` doc. Keep a raw
-        // ptr to `transpiler`: `init_and_run` consumes the `&'a mut`, and the
-        // log is read (and the struct dropped) through it afterwards.
+        // Construction + run delegated — see `init_and_run` doc. It consumes
+        // the `&'a mut`; the log read and the drop below go through this.
         let transpiler_ptr: *mut Transpiler<'_> = transpiler;
-        // SAFETY: fn contract (reborrowed for this one call, as above);
-        // `transpiler` lives in `bump` for the duration of `heap`.
+        // SAFETY: fn contract; `transpiler` lives in `bump` until `heap` drops.
         let run = unsafe {
             (*completion).init_and_run(
                 &mut *transpiler_ptr,
@@ -329,19 +317,17 @@ impl<C: CompletionStruct> BundleThread<C> {
         // `deinitWithoutFreeingArena` + wait-group drain live inside `init_and_run`
         // (it owns `this`).
         let mut out_log = bun_ast::Log::init();
-        // SAFETY: `transpiler.log` is the `*mut Log` that
-        // `create_and_configure_transpiler` installed (the one impl points it
-        // into the task, which is still ours here). Raw deref so the `&'a mut
-        // Transpiler` consumed by `init_and_run` above is not reborrowed.
+        // SAFETY: `transpiler.log` was installed by `create_and_configure_transpiler`
+        // and is live while the build is ours; raw because `init_and_run`
+        // consumed the `&'a mut`.
         let _ = unsafe { (*(*transpiler_ptr).log).append_to_with_recycled(&mut out_log, true) }; // logger OOM-only
-        // SAFETY: fn contract; reborrowed for this one call.
+        // SAFETY: fn contract; the reborrow ends with the call.
         unsafe { (*completion).set_log(out_log) };
 
         if run.is_ok() {
-            // SAFETY: fn contract; the result and log are stored, the
-            // reborrows above have ended, and nothing below touches
-            // `*completion` (or, through `transpiler.log`, the task's log): the
-            // teardown drops only memory this thread owns.
+            // SAFETY: result and log are stored and no reborrow is live;
+            // nothing below touches `*completion` (the teardown drops only this
+            // thread's memory).
             unsafe { C::complete_on_bundle_thread(completion) };
         }
 

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -69,7 +69,18 @@ pub trait CompletionStruct: Node + Send + 'static {
     /// while it was still queued ([`free_released_unstarted`] then frees it).
     fn try_start(&mut self) -> bool;
     fn free_released_unstarted(this: *mut Self);
-    fn complete_on_bundle_thread(&mut self);
+    /// Hands the finished build (result and log already stored) back to its
+    /// owner, which may free `*this` the moment it is posted: this is the
+    /// bundle thread's last touch of it. It takes the pointer rather than
+    /// `&mut self` because a reference argument stays protected until the
+    /// call returns, and freeing protected memory is UB under both aliasing
+    /// models; for the same reason the caller must not hold a reference to
+    /// `*this` across the call either.
+    ///
+    /// # Safety
+    /// `this` is a build that `try_start` accepted and the bundle thread still
+    /// owns; nothing on this thread touches `*this` afterwards.
+    unsafe fn complete_on_bundle_thread(this: *mut Self);
     fn set_result(&mut self, result: BundleV2Result);
     fn set_log(&mut self, log: bun_ast::Log);
     fn set_transpiler(&mut self, this: *mut BundleV2<'_>);
@@ -225,24 +236,28 @@ impl<C: CompletionStruct> BundleThread<C> {
                     break;
                 }
                 // SAFETY: queue stores non-null *mut C pushed via enqueue(); owner keeps it alive
-                // until complete_on_bundle_thread() signals completion — unless it
+                // until complete_on_bundle_thread() hands it back — unless it
                 // released the build while it sat here (its VM went away).
                 if !unsafe { (*completion).try_start() } {
                     C::free_released_unstarted(completion);
                     continue;
                 }
-                // SAFETY: as above; started ⇒ the owner waits for us.
-                let completion = unsafe { &mut *completion };
                 // SAFETY: `generation` is only read/written on this (bundle) thread.
                 let generation = unsafe { (*instance).generation };
                 // `panic = "abort"` → a Rust panic on this thread enters the
                 // crash-handler hook and aborts the whole process.
                 // No `catch_unwind` — there is nothing to catch.
-                match Self::generate_in_new_thread(completion, generation) {
-                    Ok(()) => {}
-                    Err(err) => {
-                        completion.set_result(BundleV2Result::Err(err));
-                        completion.complete_on_bundle_thread();
+                //
+                // SAFETY: started ⇒ `*completion` is ours until it is handed
+                // back, and handing it back is the last thing either path does
+                // with it. The owner may free it as soon as it is posted, so it
+                // stays a raw pointer: `set_result`'s reborrow ends at the `;`
+                // and no reference to it is live across either hand-back (see
+                // `complete_on_bundle_thread`).
+                unsafe {
+                    if let Err(err) = Self::generate_in_new_thread(completion, generation) {
+                        (*completion).set_result(BundleV2Result::Err(err));
+                        C::complete_on_bundle_thread(completion);
                     }
                 }
                 has_bundled = true;
@@ -264,8 +279,16 @@ impl<C: CompletionStruct> BundleThread<C> {
     }
 
     /// This is called from `Bun.build` in JavaScript.
-    fn generate_in_new_thread(
-        completion: &mut C,
+    ///
+    /// On `Ok` the build has been handed back (`complete_on_bundle_thread`)
+    /// and `*completion` may already be gone; on `Err` it is still ours and
+    /// the caller stores the error and hands it back.
+    ///
+    /// # Safety
+    /// `completion` is a build that `try_start` accepted and the bundle thread
+    /// still owns.
+    unsafe fn generate_in_new_thread(
+        completion: *mut C,
         generation: bun_core::Generation,
     ) -> Result<(), crate::Error> {
         let heap = Arena::new();
@@ -277,22 +300,28 @@ impl<C: CompletionStruct> BundleThread<C> {
         ast_memory_store.push();
 
         // Allocate + configure folded — see `create_and_configure_transpiler` doc.
-        let transpiler = completion.create_and_configure_transpiler(bump)?;
+        //
+        // SAFETY: fn contract. `*completion` is reborrowed for this one call;
+        // the returned `&'a mut Transpiler` borrows `bump`, not the task.
+        let transpiler = unsafe { (*completion).create_and_configure_transpiler(bump) }?;
 
         transpiler.resolver.generation = generation;
 
-        // Construction + run delegated — see
-        // `init_and_run` doc. Reborrow `transpiler` through a raw ptr so
-        // `completion` can be borrowed again below.
+        // Construction + run delegated — see `init_and_run` doc. Keep a raw
+        // ptr to `transpiler`: `init_and_run` consumes the `&'a mut`, and the
+        // log is read (and the struct dropped) through it afterwards.
         let transpiler_ptr: *mut Transpiler<'_> = transpiler;
-        let run = completion.init_and_run(
-            // SAFETY: `transpiler` lives in `bump` for the duration of `heap`.
-            unsafe { &mut *transpiler_ptr },
-            bump,
-            // `WorkPool::get()` returns `&'static ThreadPool`; pass as raw so
-            // the impl can hand it to `BundleV2::init` (which stores `*mut`).
-            std::ptr::from_ref(bun_threading::work_pool::WorkPool::get()).cast_mut(),
-        );
+        // SAFETY: fn contract (reborrowed for this one call, as above);
+        // `transpiler` lives in `bump` for the duration of `heap`.
+        let run = unsafe {
+            (*completion).init_and_run(
+                &mut *transpiler_ptr,
+                bump,
+                // `WorkPool::get()` returns `&'static ThreadPool`; pass as raw so
+                // the impl can hand it to `BundleV2::init` (which stores `*mut`).
+                std::ptr::from_ref(bun_threading::work_pool::WorkPool::get()).cast_mut(),
+            )
+        };
 
         // Straight-line teardown: log copy
         // runs on both paths; `completeOnBundleThread` only on success (the error
@@ -300,14 +329,20 @@ impl<C: CompletionStruct> BundleThread<C> {
         // `deinitWithoutFreeingArena` + wait-group drain live inside `init_and_run`
         // (it owns `this`).
         let mut out_log = bun_ast::Log::init();
-        // SAFETY: `transpiler.log` is the arena-allocated `*mut Log` set up by
-        // `configure_bundler`; valid for the lifetime of `heap`. Raw deref so the
-        // `&'a mut Transpiler` consumed by `init_and_run` above is not reborrowed.
+        // SAFETY: `transpiler.log` is the `*mut Log` that
+        // `create_and_configure_transpiler` installed (the one impl points it
+        // into the task, which is still ours here). Raw deref so the `&'a mut
+        // Transpiler` consumed by `init_and_run` above is not reborrowed.
         let _ = unsafe { (*(*transpiler_ptr).log).append_to_with_recycled(&mut out_log, true) }; // logger OOM-only
-        completion.set_log(out_log);
+        // SAFETY: fn contract; reborrowed for this one call.
+        unsafe { (*completion).set_log(out_log) };
 
         if run.is_ok() {
-            completion.complete_on_bundle_thread();
+            // SAFETY: fn contract; the result and log are stored, the
+            // reborrows above have ended, and nothing below touches
+            // `*completion` (or, through `transpiler.log`, the task's log): the
+            // teardown drops only memory this thread owns.
+            unsafe { C::complete_on_bundle_thread(completion) };
         }
 
         ast_memory_store.pop();

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -561,8 +561,8 @@ impl JSBundleCompletionTask {
 
     pub(crate) fn on_complete_anytask(ctx: *mut Self) -> bun_event_loop::JsResult<()> {
         crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(ctx).expect("completion")).unregister();
-        // For the +1 taken by `complete_on_bundle_thread` enqueue.
-        // SAFETY: `ctx` is the live heap allocation; `adopt` consumes the prior +1 on Drop.
+        // The creation ref, which `complete_on_bundle_thread` posted back to us.
+        // SAFETY: `ctx` is the live heap allocation; `adopt` consumes that ref on Drop.
         let _drop_ref = unsafe { bun_ptr::ScopedRef::<Self>::adopt(ctx) };
         // SAFETY: `ctx` is the heap::alloc allocation registered in `task`,
         // dispatched exactly once per task on the JS thread. Exclusive: the
@@ -1114,13 +1114,21 @@ impl CompletionStruct for JSBundleCompletionTask {
         Ok(())
     }
 
-    fn complete_on_bundle_thread(&mut self) {
+    unsafe fn complete_on_bundle_thread(this: *mut Self) {
         // The bundle thread's last touch of this task and of the VM's memory:
         // hand it back (always queued — the VM waits for it) and stop counting.
-        self.bundle_loop
-            .store(ptr::null_mut(), core::sync::atomic::Ordering::Release);
-        let handle = self.loop_handle.clone();
-        let this = std::ptr::from_mut::<Self>(self);
+        // The post carries the creation ref, which `on_complete_anytask`
+        // releases, so the JS thread may free `*this` as soon as the post
+        // lands: everything needed afterwards is taken out first, through
+        // accesses that end at their `;`.
+        //
+        // SAFETY: trait contract — `this` is the started build, still ours.
+        let handle = unsafe {
+            (*this)
+                .bundle_loop
+                .store(ptr::null_mut(), core::sync::atomic::Ordering::Release);
+            (*this).loop_handle.clone()
+        };
         let ct = jsc::ConcurrentTask::create(jsc::Task::init(this));
         let jsc::vm_handle::Posted::Queued = handle.post_task(ct) else {
             unreachable!("VM handle closed with a Bun.build outstanding");

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1117,10 +1117,8 @@ impl CompletionStruct for JSBundleCompletionTask {
     unsafe fn complete_on_bundle_thread(this: *mut Self) {
         // The bundle thread's last touch of this task and of the VM's memory:
         // hand it back (always queued — the VM waits for it) and stop counting.
-        // The post carries the creation ref, which `on_complete_anytask`
-        // releases, so the JS thread may free `*this` as soon as the post
-        // lands: everything needed afterwards is taken out first, through
-        // accesses that end at their `;`.
+        // The post carries the creation ref (`on_complete_anytask` releases it),
+        // so the JS thread may free `*this` once it lands: take the handle out first.
         //
         // SAFETY: trait contract — `this` is the started build, still ours.
         let handle = unsafe {

--- a/test/internal/source-lints/self-receiver-publish.test.ts
+++ b/test/internal/source-lints/self-receiver-publish.test.ts
@@ -1,0 +1,260 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A method must not post its own receiver as a task. Inside a `&self` /
+// `&mut self` method, a pointer spelled from `self`
+//
+//   ConcurrentTask::create(Task::init(std::ptr::from_mut(self)))
+//   ConcurrentTask::create_from(self)            // `&mut Self` coerces to `*mut Self`
+//   let this = std::ptr::from_mut(self); ... Task::init(this)
+//   let p: *mut Self = self;             ... ConcurrentTask::create_from(p)
+//
+// as the argument of `Task::init(..)` / `..::create_from(..)` /
+// `..::from_callback(..)` is banned.
+//
+// The post is the hand-over. From the moment it lands, the consumer (another
+// thread, for a `ConcurrentTask`) may write to the object or, when the post
+// carries its last ref, free it, and it does so while `self` is still a live
+// argument of the method that posted it. A reference argument is protected
+// for the duration of its call, and writing to or deallocating protected
+// memory is UB under both aliasing models whether or not the method touches
+// `self` again: Tree Borrows (what `bun run rust:miri` uses) reports
+// "deallocation through <tag> is forbidden ... the strongly protected tag
+// disallows deallocations", pointing at the receiver, and Stacked Borrows
+// reports "deallocating while item [Unique] is strongly protected". Codegen
+// relies on the same guarantee: a reference argument is annotated as
+// dereferenceable for the whole call. `JSBundleCompletionTask::
+// complete_on_bundle_thread(&mut self)` was the instance this was written
+// for: every `Bun.build()` ended with the bundle thread posting the task's
+// only ref to the JS thread, which frees it, from inside its own `&mut self`.
+//
+// The object was a raw pointer in the caller's hands before it became `self`
+// (the queue entry, the callback ctx, the backref), so the fix is to keep it
+// one: the function that posts takes `this: *mut Self`, does its own work
+// through accesses that end before the post (`(*this).field` place
+// expressions or a call-scoped reborrow), and posts `this`. Templates:
+// `complete_on_bundle_thread` in src/runtime/api/js_bundle_completion_task.rs
+// (and its caller in src/bundler/BundleThread.rs, which keeps the pointer
+// raw), `async_job_run` in src/runtime/node/node_zlib_binding.rs, `post_job`
+// in src/jsc/VmHandle.rs.
+//
+// Scope: the spellings above, with `self` as the receiver and the three task
+// constructors as the callee. A pointer produced by a helper (`self.as_ptr()`),
+// a `NonNull::from(self)` binding posted through `.as_ptr()`, the intrusive
+// `ConcurrentTask::from(..)` form, and reference *parameters* other than
+// `self` (`fn f(load: &mut Load)` posting `from_mut(load)`) are the same
+// hazard but outside this lint. Siblings: self-receiver-reclaim.test.ts,
+// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `Task::init(`, `ConcurrentTask::create_from(`, `ConcurrentTask::from_callback(`,
+// however the path in front is spelled, optionally turbofished. The `\b`
+// before `Task` keeps `NapiFinalizerTask::init(self)` (a constructor that
+// copies out of `self`) out; `create_from` / `from_callback` require a path
+// in front so a method call of the same name does not count. `\s*` after the
+// paren so a rustfmt-wrapped argument still matches.
+const POST = String.raw`\b(?:Task::init|[\w:]+::create_from|[\w:]+::from_callback)(?:::<[^>]*>)?\(\s*`;
+
+// The ways of spelling "`self`, as a raw pointer" as the first argument. Each
+// is anchored at its front only, so a trailing `.cast_mut()` / `.as_ptr()`
+// still matches; the bare form needs the `,` / `)` so `self.as_ptr()` (a
+// helper, out of scope) does not. `(?!\s*\.)` after the `&raw` form keeps
+// `&raw mut *self.field` (a field the receiver owns) out.
+const SELF_AS_POINTER = [
+  String.raw`self\s*[,)]`,
+  String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
+  String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+  String.raw`self\s+as\s+\*(?:mut|const)\b`,
+  String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
+  String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+].join("|");
+
+const DIRECT = new RegExp(`${POST}(?:${SELF_AS_POINTER})`, "g");
+
+// A local bound to such a pointer: `let this = ptr::from_mut(self);`,
+// `let p = self as *mut Self;`, `let p: *mut Self = self;` (the coercion
+// spelling needs the annotation; without it `let p = self;` is just another
+// reference). The binding is then looked for as a post argument further down
+// the same function, which ends at the next `fn` item (a closure inside it is
+// the same function for this purpose).
+const BINDING_HEAD = String.raw`let\s+(?:mut\s+)?(\w+)\s*`;
+const SELF_POINTER_BINDINGS = [
+  new RegExp(
+    BINDING_HEAD +
+      String.raw`(?::[^=;]*)?=\s*(?:` +
+      [
+        String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)(?:\s*\.cast_mut\(\))?`,
+        String.raw`self\s+as\s+\*(?:mut|const)\b[^;]*`,
+        String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b`,
+        String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+      ].join("|") +
+      String.raw`)\s*;`,
+    "g",
+  ),
+  new RegExp(BINDING_HEAD + String.raw`:\s*\*(?:mut|const)\b[^=;]*=\s*self\s*;`, "g"),
+];
+const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s/m;
+
+function postOfBinding(name: string): RegExp {
+  return new RegExp(POST + name + String.raw`\s*[,)]`);
+}
+
+/** Byte offsets (into `stripped`) of every banned post in one file. */
+function findPosts(stripped: string): number[] {
+  const hits: number[] = [];
+  for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
+  for (const pattern of SELF_POINTER_BINDINGS) {
+    for (const binding of stripped.matchAll(pattern)) {
+      const start = binding.index + binding[0].length;
+      const rest = stripped.slice(start);
+      const fnEnd = rest.search(FN_ITEM);
+      const body = fnEnd === -1 ? rest : rest.slice(0, fnEnd);
+      const post = body.search(postOfBinding(binding[1]));
+      if (post !== -1) hits.push(start + post);
+    }
+  }
+  return hits.sort((a, b) => a - b);
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape. Each has been read; none frees the receiver from the consumer's side,
+// and each needs a change elsewhere before its own receiver can be converted.
+// Lower an entry when you convert one; do not add entries.
+const ALLOW: Record<string, number> = {
+  // `Resolve::dispatch` / `Load::dispatch` (`&mut self`) post the arena-owned
+  // plugin request to the JS thread, which writes its `value` while
+  // `dispatch` is still returning; the arena, not the consumer, frees it.
+  // Converting them means `dispatch(this: *mut Self)` with the arena pointer
+  // the callers already hold; tracked separately.
+  "src/bundler/bundle_v2.rs": 2,
+  // `DeferredBatchTask::schedule` (`&mut self`) posts a task embedded in its
+  // `BundleV2`, whose consumer reaches the surrounding `BundleV2` through it;
+  // the receiver that matters there is the `&mut BundleV2` the bundle thread
+  // holds for the whole pass, not this field's. #37709 reshapes `schedule` to
+  // take the `BundleV2`; delete this entry when that lands.
+  "src/bundler/DeferredBatchTask.rs": 1,
+  // `ThreadSafeFunction::maybe_queue_finalizer` posts to the loop it is
+  // running on, so the task runs after the method has returned.
+  // `schedule_dispatch` posts from addon threads and the JS thread starts
+  // writing the TSFN's atomics at once, but its callers (`call`,
+  // `release_locked`) hold `&mut self` across it too, so it cannot be
+  // converted on its own; tracked separately.
+  "src/runtime/napi/napi_body.rs": 2,
+};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including the in-tree comments
+  // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
+  // newlines and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const offset of findPosts(stripped)) {
+    counts[source] = (counts[source] ?? 0) + 1;
+    if (counts[source] > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${lineOf(stripped, offset)}`);
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the patterns match the banned spellings and nothing else", () => {
+  const banned = [
+    // `complete_on_bundle_thread(&mut self)` as it was.
+    "let this = std::ptr::from_mut::<Self>(self);\nlet ct = jsc::ConcurrentTask::create(jsc::Task::init(this));",
+    // The allowlisted shapes.
+    "ConcurrentTask::create(Task::init(std::ptr::from_mut::<Self>(self)));",
+    "bun_event_loop::ConcurrentTask::ConcurrentTask::create(\n    bun_event_loop::Task::init(std::ptr::from_mut::<Self>(self)),\n);",
+    "let self_ptr: *mut Self = self;\nif done {\n    return;\n}\nlet ct = ConcurrentTask::create_from(self_ptr);",
+    "let self_ptr: *mut Self = self;\nloop_.enqueue_task(Task::init(self_ptr));",
+    // Other spellings of the pointer.
+    "loop_.enqueue_task(Task::init(self));",
+    "let ct = ConcurrentTask::create_from(self);",
+    "ConcurrentTask::from_callback(self, Self::resume);",
+    "ConcurrentTask::from_callback(\n    std::ptr::from_mut(self),\n    Self::resume,\n)",
+    "Task::init(core::ptr::from_ref(self).cast_mut())",
+    "Task::init(NonNull::from(self).as_ptr())",
+    "Task::init(self as *mut Self)",
+    "Task::init(&raw mut *self)",
+    "Task::init(core::ptr::addr_of_mut!(*self))",
+    "jsc::ConcurrentTask::create_from::<Self>(std::ptr::from_mut(self))",
+    "let p = self as *mut Self;\nlet ct = ConcurrentTask::create_from(p);",
+    "let p: *mut Self = std::ptr::from_mut(self);\nlet ct = bun_jsc::ConcurrentTask::create_from(p);",
+    "let p = core::ptr::from_ref(self).cast_mut();\nlet ct = ConcurrentTask::create_from(p);",
+    "let p = &raw mut *self;\nlet task = Task::init(p);",
+  ];
+  const allowed = [
+    // Posting the pointer the caller handed us is the intended shape.
+    "let ct = jsc::ConcurrentTask::create(jsc::Task::init(this));",
+    "let ct = ConcurrentTask::create(Task::init(this));",
+    "ConcurrentTask::create_from(task.as_ptr())",
+    "ConcurrentTask::from_callback(this, FetchTasklet::resume_request_data_stream)",
+    // Something the receiver owns or points at, or a helper's pointer, is
+    // out of scope (see the header).
+    "ConcurrentTask::create(Task::init(self.as_ctx_ptr()))",
+    "Task::init(core::ptr::from_ref(&self.run_pending_later).cast_mut())",
+    "Task::init(&raw mut *self.inner)",
+    "Task::init(self.task)",
+    "ConcurrentTask::from_callback(std::ptr::from_mut(load), on_load_from_js_loop_raw)",
+    // A constructor whose name merely ends in `Task`, and a method call.
+    "NapiFinalizerTask::init(self).schedule();",
+    "state.create_from(index, from, into);",
+    // Producing the pointer is fine when it is not what gets posted.
+    "let this = std::ptr::from_mut::<Self>(self);\nregister(this);",
+    "let this = std::ptr::from_mut(self);\nlet ct = ConcurrentTask::create_from(other);",
+    // Rebinding the reference is not a pointer binding.
+    "let this = self;\nlet ct = ConcurrentTask::create_from(this);",
+    // The binding is posted, but in the next function, where it is a
+    // raw-pointer parameter of the same name.
+    "let this = std::ptr::from_mut(self);\nregister(this);\n}\n\nfn resume(this: *mut Self) {\n    let ct = ConcurrentTask::create_from(this);\n}",
+  ];
+  expect(banned.map(s => findPosts(s).length)).toEqual(banned.map(() => 1));
+  expect(allowed.map(s => findPosts(s).length)).toEqual(allowed.map(() => 0));
+});
+
+test("no method posts its own receiver as a task", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: when an allowlisted site is converted, lower its entry so the
+  // shape cannot come back into that file.
+  for (const [source, n] of Object.entries(ALLOW)) {
+    expect({ source, count: counts[source] ?? 0 }).toEqual({ source, count: n });
+  }
+});

--- a/test/internal/source-lints/self-receiver-publish.test.ts
+++ b/test/internal/source-lints/self-receiver-publish.test.ts
@@ -9,27 +9,42 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //
 //   ConcurrentTask::create(Task::init(std::ptr::from_mut(self)))
 //   ConcurrentTask::create_from(self)            // `&mut Self` coerces to `*mut Self`
+//   loop_.enqueue_task(Task::init(self))          // same loop, drained later
 //   let this = std::ptr::from_mut(self); ... Task::init(this)
 //   let p: *mut Self = self;             ... ConcurrentTask::create_from(p)
 //
-// as the argument of `Task::init(..)` / `..::create_from(..)` /
-// `..::from_callback(..)` is banned.
+// as the argument of `Task::init(..)`, `ConcurrentTask::create_from(..)`,
+// `ConcurrentTask::from_callback(..)` or the intrusive `.from(..)` is banned.
 //
-// The post is the hand-over. From the moment it lands, the consumer (another
-// thread, for a `ConcurrentTask`) may write to the object or, when the post
-// carries its last ref, free it, and it does so while `self` is still a live
-// argument of the method that posted it. A reference argument is protected
-// for the duration of its call, and writing to or deallocating protected
-// memory is UB under both aliasing models whether or not the method touches
-// `self` again: Tree Borrows (what `bun run rust:miri` uses) reports
-// "deallocation through <tag> is forbidden ... the strongly protected tag
-// disallows deallocations", pointing at the receiver, and Stacked Borrows
-// reports "deallocating while item [Unique] is strongly protected". Codegen
-// relies on the same guarantee: a reference argument is annotated as
-// dereferenceable for the whole call. `JSBundleCompletionTask::
-// complete_on_bundle_thread(&mut self)` was the instance this was written
-// for: every `Bun.build()` ended with the bundle thread posting the task's
-// only ref to the JS thread, which frees it, from inside its own `&mut self`.
+// Two things are wrong with it, and which one bites depends on who drains the
+// queue:
+//
+//   - Another thread (a `ConcurrentTask`): the post is the hand-over. From the
+//     moment it lands the consumer may write to the object or, when the post
+//     carries its last ref, free it, while `self` is still a live argument of
+//     the posting method. A reference argument is protected for the duration
+//     of its call, and writing to or deallocating protected memory is UB under
+//     both aliasing models whether or not the method touches `self` again:
+//     Tree Borrows (what `bun run rust:miri` uses) reports "deallocation
+//     through <tag> is forbidden ... the strongly protected tag disallows
+//     deallocations", pointing at the receiver, and Stacked Borrows reports
+//     "deallocating while item [Unique] is strongly protected". Codegen relies
+//     on the same guarantee: a reference argument is annotated as
+//     dereferenceable for the whole call.
+//   - The same thread, later: the queued pointer carries the provenance of the
+//     receiver reborrow it was spelled from, and that reborrow is dead as soon
+//     as anything reaches the object through the owner's own pointer again (the
+//     caller that holds it, the next event, a state CAS on the way out of the
+//     dispatch). When the queue is drained the task is read, or freed, through
+//     a dead pointer: "reborrow through <tag> is forbidden" (Tree Borrows) /
+//     "that tag does not exist in the borrow stack" (Stacked Borrows). This is
+//     why `SendQueue` in src/runtime/ipc.rs keeps its allocation pointer in a
+//     field and posts `root_ptr()`.
+//
+// `JSBundleCompletionTask::complete_on_bundle_thread(&mut self)` was the
+// instance this was written for: every `Bun.build()` ended with the bundle
+// thread posting the task's only ref to the JS thread, which frees it, from
+// inside its own `&mut self`.
 //
 // The object was a raw pointer in the caller's hands before it became `self`
 // (the queue entry, the callback ctx, the backref), so the fix is to keep it
@@ -39,14 +54,23 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // `complete_on_bundle_thread` in src/runtime/api/js_bundle_completion_task.rs
 // (and its caller in src/bundler/BundleThread.rs, which keeps the pointer
 // raw), `async_job_run` in src/runtime/node/node_zlib_binding.rs, `post_job`
-// in src/jsc/VmHandle.rs.
+// in src/jsc/VmHandle.rs, the `(*this).concurrent_task.from(this, ..)` posts
+// in src/runtime/webcore/s3/.
 //
-// Scope: the spellings above, with `self` as the receiver and the three task
-// constructors as the callee. A pointer produced by a helper (`self.as_ptr()`),
-// a `NonNull::from(self)` binding posted through `.as_ptr()`, the intrusive
-// `ConcurrentTask::from(..)` form, and reference *parameters* other than
-// `self` (`fn f(load: &mut Load)` posting `from_mut(load)`) are the same
-// hazard but outside this lint. Siblings: self-receiver-reclaim.test.ts,
+// Scope: the spellings above, with `self` as the receiver and those four
+// callees. The same hand-over spelled some other way is outside the regex and
+// is the same bug; the instances known at the time of writing, each tracked
+// for its own conversion, are `napi_async_work::run` / `post_to_js_thread` in
+// src/runtime/napi/napi_body.rs (posts a `*mut Self` parameter the caller made
+// from its `&mut self`), `FetchTasklet::deref_from_thread` in
+// src/runtime/webcore/fetch/FetchTasklet.rs (posts `this`, but through
+// `post(&self)` and the handle field inside the object it is freeing),
+// `StatWatcher::post_to_js_thread(&self)` in src/runtime/node/
+// node_fs_stat_watcher.rs (a helper's pointer, `self.as_ctx_ptr()`), and
+// `TranspilerJob::dispatch_to_main_thread(&mut self)` in
+// src/jsc/RuntimeTranspilerStore.rs (pushes `NonNull::from(&mut *self)` onto
+// its own queue). Convert anything of that shape on sight; the ratchet below
+// only tracks what the regex can see. Siblings: self-receiver-reclaim.test.ts,
 // fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
@@ -66,12 +90,15 @@ const tracked: Set<string> | null = (() => {
 })();
 
 // `Task::init(`, `ConcurrentTask::create_from(`, `ConcurrentTask::from_callback(`,
-// however the path in front is spelled, optionally turbofished. The `\b`
-// before `Task` keeps `NapiFinalizerTask::init(self)` (a constructor that
-// copies out of `self`) out; `create_from` / `from_callback` require a path
-// in front so a method call of the same name does not count. `\s*` after the
-// paren so a rustfmt-wrapped argument still matches.
-const POST = String.raw`\b(?:Task::init|[\w:]+::create_from|[\w:]+::from_callback)(?:::<[^>]*>)?\(\s*`;
+// however the path in front is spelled (`jsc::`, `bun_event_loop::ConcurrentTask::`,
+// the `ConcurrentTaskItem` alias), optionally turbofished, plus the intrusive
+// `.from(` of an embedded `ConcurrentTask` / `AnyTask` (the tree's only
+// method-call `.from(`). The `\b` before `Task` keeps `NapiFinalizerTask::
+// init(self)` (a constructor that copies out of `self`) out, and pinning the
+// other two to a `ConcurrentTask*` path keeps unrelated `create_from`
+// constructors out. `\s*` after the paren so a rustfmt-wrapped argument still
+// matches.
+const POST = String.raw`(?:\bTask::init|\bConcurrentTask\w*::(?:create_from|from_callback)|\.from)(?:::<[^>]*>)?\(\s*`;
 
 // The ways of spelling "`self`, as a raw pointer" as the first argument. Each
 // is anchored at its front only, so a trailing `.cast_mut()` / `.as_ptr()`
@@ -139,15 +166,16 @@ function lineOf(text: string, offset: number): number {
 }
 
 // Documented, ratcheted exceptions: files allowed to keep exactly N of the
-// shape. Each has been read; none frees the receiver from the consumer's side,
-// and each needs a change elsewhere before its own receiver can be converted.
-// Lower an entry when you convert one; do not add entries.
+// shape. Each has been read and is the bug described above, not a false
+// positive; each is listed because its conversion is a change of its own,
+// tracked separately, not because it is safe. Lower an entry when you convert
+// one; do not add entries.
 const ALLOW: Record<string, number> = {
   // `Resolve::dispatch` / `Load::dispatch` (`&mut self`) post the arena-owned
   // plugin request to the JS thread, which writes its `value` while
-  // `dispatch` is still returning; the arena, not the consumer, frees it.
-  // Converting them means `dispatch(this: *mut Self)` with the arena pointer
-  // the callers already hold; tracked separately.
+  // `dispatch` is still returning (the arena, not the consumer, frees it).
+  // Conversion: `dispatch(this: *mut Self)` with the pointer the callers
+  // already hold.
   "src/bundler/bundle_v2.rs": 2,
   // `DeferredBatchTask::schedule` (`&mut self`) posts a task embedded in its
   // `BundleV2`, whose consumer reaches the surrounding `BundleV2` through it;
@@ -155,12 +183,14 @@ const ALLOW: Record<string, number> = {
   // holds for the whole pass, not this field's. #37709 reshapes `schedule` to
   // take the `BundleV2`; delete this entry when that lands.
   "src/bundler/DeferredBatchTask.rs": 1,
-  // `ThreadSafeFunction::maybe_queue_finalizer` posts to the loop it is
-  // running on, so the task runs after the method has returned.
-  // `schedule_dispatch` posts from addon threads and the JS thread starts
-  // writing the TSFN's atomics at once, but its callers (`call`,
-  // `release_locked`) hold `&mut self` across it too, so it cannot be
-  // converted on its own; tracked separately.
+  // `ThreadSafeFunction::maybe_queue_finalizer` is the same-thread case: it
+  // sets `closing` and posts `self_ptr` to its own loop, `on_dispatch` then
+  // CASes `dispatch_state` through the real pointer on its way out, and the
+  // drained task is what `destroy`s the TSFN, through the dead one.
+  // `schedule_dispatch` is the cross-thread case (addon threads post, the JS
+  // thread writes the atomics at once). Both are reached through `&mut self`
+  // callers (`dispatch_one`; `call` / `release_locked`) that have to be
+  // converted with them.
   "src/runtime/napi/napi_body.rs": 2,
 };
 
@@ -202,7 +232,12 @@ test("the patterns match the banned spellings and nothing else", () => {
     "bun_event_loop::ConcurrentTask::ConcurrentTask::create(\n    bun_event_loop::Task::init(std::ptr::from_mut::<Self>(self)),\n);",
     "let self_ptr: *mut Self = self;\nif done {\n    return;\n}\nlet ct = ConcurrentTask::create_from(self_ptr);",
     "let self_ptr: *mut Self = self;\nloop_.enqueue_task(Task::init(self_ptr));",
-    // Other spellings of the pointer.
+    // The intrusive form.
+    "let ct = self.concurrent_task.from(std::ptr::from_mut(self), AutoDeinit::ManualDeinit);",
+    "let self_ptr: *mut Self = self;\nlet ct = self.concurrent_task.from(self_ptr, AutoDeinit::ManualDeinit);",
+    "at.from(self, Self::run_from_main_thread_mini)",
+    // Other spellings of the pointer; a same-loop post counts too (see the
+    // header).
     "loop_.enqueue_task(Task::init(self));",
     "let ct = ConcurrentTask::create_from(self);",
     "ConcurrentTask::from_callback(self, Self::resume);",
@@ -213,6 +248,8 @@ test("the patterns match the banned spellings and nothing else", () => {
     "Task::init(&raw mut *self)",
     "Task::init(core::ptr::addr_of_mut!(*self))",
     "jsc::ConcurrentTask::create_from::<Self>(std::ptr::from_mut(self))",
+    "let task = ConcurrentTaskItem::create_from(std::ptr::from_mut(self));",
+    "bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(self, on_done)",
     "let p = self as *mut Self;\nlet ct = ConcurrentTask::create_from(p);",
     "let p: *mut Self = std::ptr::from_mut(self);\nlet ct = bun_jsc::ConcurrentTask::create_from(p);",
     "let p = core::ptr::from_ref(self).cast_mut();\nlet ct = ConcurrentTask::create_from(p);",
@@ -224,6 +261,11 @@ test("the patterns match the banned spellings and nothing else", () => {
     "let ct = ConcurrentTask::create(Task::init(this));",
     "ConcurrentTask::create_from(task.as_ptr())",
     "ConcurrentTask::from_callback(this, FetchTasklet::resume_request_data_stream)",
+    "(*this).concurrent_task.from(this, AutoDeinit::ManualDeinit)",
+    "EventLoopTask::Js(ct) => ct.from(this, AutoDeinit::ManualDeinit),",
+    // `From::from` and the like are path calls, not the intrusive method.
+    "let s = String::from(self);",
+    "let v = Vec::from(self.as_slice());",
     // Something the receiver owns or points at, or a helper's pointer, is
     // out of scope (see the header).
     "ConcurrentTask::create(Task::init(self.as_ctx_ptr()))",
@@ -231,8 +273,10 @@ test("the patterns match the banned spellings and nothing else", () => {
     "Task::init(&raw mut *self.inner)",
     "Task::init(self.task)",
     "ConcurrentTask::from_callback(std::ptr::from_mut(load), on_load_from_js_loop_raw)",
-    // A constructor whose name merely ends in `Task`, and a method call.
+    // A constructor whose name merely ends in `Task`, a `create_from` that is
+    // not a task's, and a method call.
     "NapiFinalizerTask::init(self).schedule();",
+    "let headers = FetchHeaders::create_from(self);",
     "state.create_from(index, from, into);",
     // Producing the pointer is fine when it is not what gets posted.
     "let this = std::ptr::from_mut::<Self>(self);\nregister(this);",

--- a/test/internal/source-lints/self-receiver-publish.test.ts
+++ b/test/internal/source-lints/self-receiver-publish.test.ts
@@ -13,8 +13,10 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //   let this = std::ptr::from_mut(self); ... Task::init(this)
 //   let p: *mut Self = self;             ... ConcurrentTask::create_from(p)
 //
-// as the argument of `Task::init(..)`, `ConcurrentTask::create_from(..)`,
-// `ConcurrentTask::from_callback(..)` or the intrusive `.from(..)` is banned.
+// as the argument of `Task::init(..)`, `ConcurrentTask::create_from(..)` or
+// `ConcurrentTask::from_callback(..)`, the heap-task constructors, is banned.
+// (Filling an embedded task with it, `.from(..)`, is the sibling lint
+// self-receiver-intrusive-post.test.ts from #37750.)
 //
 // Two things are wrong with it, and which one bites depends on who drains the
 // queue:
@@ -54,23 +56,22 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // `complete_on_bundle_thread` in src/runtime/api/js_bundle_completion_task.rs
 // (and its caller in src/bundler/BundleThread.rs, which keeps the pointer
 // raw), `async_job_run` in src/runtime/node/node_zlib_binding.rs, `post_job`
-// in src/jsc/VmHandle.rs, the `(*this).concurrent_task.from(this, ..)` posts
-// in src/runtime/webcore/s3/.
+// in src/jsc/VmHandle.rs.
 //
-// Scope: the spellings above, with `self` as the receiver and those four
+// Scope: the spellings above, with `self` as the receiver and those three
 // callees. The same hand-over spelled some other way is outside the regex and
-// is the same bug; the instances known at the time of writing, each tracked
-// for its own conversion, are `napi_async_work::run` / `post_to_js_thread` in
+// is the same bug; the instances known at the time of writing, and where each
+// is being converted, are `napi_async_work::run` / `post_to_js_thread` in
 // src/runtime/napi/napi_body.rs (posts a `*mut Self` parameter the caller made
-// from its `&mut self`), `FetchTasklet::deref_from_thread` in
-// src/runtime/webcore/fetch/FetchTasklet.rs (posts `this`, but through
-// `post(&self)` and the handle field inside the object it is freeing),
-// `StatWatcher::post_to_js_thread(&self)` in src/runtime/node/
-// node_fs_stat_watcher.rs (a helper's pointer, `self.as_ctx_ptr()`), and
-// `TranspilerJob::dispatch_to_main_thread(&mut self)` in
+// from its `&mut self`; #37750), `TranspilerJob::dispatch_to_main_thread` in
 // src/jsc/RuntimeTranspilerStore.rs (pushes `NonNull::from(&mut *self)` onto
-// its own queue). Convert anything of that shape on sight; the ratchet below
-// only tracks what the regex can see. Siblings: self-receiver-reclaim.test.ts,
+// its own queue; #37778), `FetchTasklet::deref_from_thread` in
+// src/runtime/webcore/fetch/FetchTasklet.rs (posts `this`, but through
+// `post(&self)` and the handle field inside the object it is freeing) and
+// `StatWatcher::post_to_js_thread(&self)` in src/runtime/node/
+// node_fs_stat_watcher.rs (a helper's pointer, `self.as_ctx_ptr()`), the last
+// two tracked. Convert anything of that shape on sight; the ratchet below only
+// tracks what the regex can see. Siblings: self-receiver-reclaim.test.ts,
 // fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
@@ -91,14 +92,12 @@ const tracked: Set<string> | null = (() => {
 
 // `Task::init(`, `ConcurrentTask::create_from(`, `ConcurrentTask::from_callback(`,
 // however the path in front is spelled (`jsc::`, `bun_event_loop::ConcurrentTask::`,
-// the `ConcurrentTaskItem` alias), optionally turbofished, plus the intrusive
-// `.from(` of an embedded `ConcurrentTask` / `AnyTask` (the tree's only
-// method-call `.from(`). The `\b` before `Task` keeps `NapiFinalizerTask::
-// init(self)` (a constructor that copies out of `self`) out, and pinning the
-// other two to a `ConcurrentTask*` path keeps unrelated `create_from`
-// constructors out. `\s*` after the paren so a rustfmt-wrapped argument still
-// matches.
-const POST = String.raw`(?:\bTask::init|\bConcurrentTask\w*::(?:create_from|from_callback)|\.from)(?:::<[^>]*>)?\(\s*`;
+// the `ConcurrentTaskItem` alias), optionally turbofished. The `\b` before
+// `Task` keeps `NapiFinalizerTask::init(self)` (a constructor that copies out
+// of `self`) out, and pinning the other two to a `ConcurrentTask*` path keeps
+// unrelated `create_from` constructors out. `\s*` after the paren so a
+// rustfmt-wrapped argument still matches.
+const POST = String.raw`\b(?:Task::init|ConcurrentTask\w*::(?:create_from|from_callback))(?:::<[^>]*>)?\(\s*`;
 
 // The ways of spelling "`self`, as a raw pointer" as the first argument. Each
 // is anchored at its front only, so a trailing `.cast_mut()` / `.as_ptr()`
@@ -167,15 +166,14 @@ function lineOf(text: string, offset: number): number {
 
 // Documented, ratcheted exceptions: files allowed to keep exactly N of the
 // shape. Each has been read and is the bug described above, not a false
-// positive; each is listed because its conversion is a change of its own,
-// tracked separately, not because it is safe. Lower an entry when you convert
-// one; do not add entries.
+// positive; each is listed because its conversion is a change of its own (the
+// PR named on it), not because it is safe. Lower an entry when its conversion
+// lands; do not add entries.
 const ALLOW: Record<string, number> = {
   // `Resolve::dispatch` / `Load::dispatch` (`&mut self`) post the arena-owned
   // plugin request to the JS thread, which writes its `value` while
   // `dispatch` is still returning (the arena, not the consumer, frees it).
-  // Conversion: `dispatch(this: *mut Self)` with the pointer the callers
-  // already hold.
+  // #37732 converts them; delete this entry when it lands.
   "src/bundler/bundle_v2.rs": 2,
   // `DeferredBatchTask::schedule` (`&mut self`) posts a task embedded in its
   // `BundleV2`, whose consumer reaches the surrounding `BundleV2` through it;
@@ -186,11 +184,10 @@ const ALLOW: Record<string, number> = {
   // `ThreadSafeFunction::maybe_queue_finalizer` is the same-thread case: it
   // sets `closing` and posts `self_ptr` to its own loop, `on_dispatch` then
   // CASes `dispatch_state` through the real pointer on its way out, and the
-  // drained task is what `destroy`s the TSFN, through the dead one.
-  // `schedule_dispatch` is the cross-thread case (addon threads post, the JS
-  // thread writes the atomics at once). Both are reached through `&mut self`
-  // callers (`dispatch_one`; `call` / `release_locked`) that have to be
-  // converted with them.
+  // drained task is what `destroy`s the TSFN, through the dead one (#37762,
+  // with its `dispatch_one` caller). `schedule_dispatch` is the cross-thread
+  // case: addon threads post and the JS thread writes the atomics at once
+  // (#37741, with its `call` / `release_locked` callers). One each.
   "src/runtime/napi/napi_body.rs": 2,
 };
 
@@ -232,10 +229,6 @@ test("the patterns match the banned spellings and nothing else", () => {
     "bun_event_loop::ConcurrentTask::ConcurrentTask::create(\n    bun_event_loop::Task::init(std::ptr::from_mut::<Self>(self)),\n);",
     "let self_ptr: *mut Self = self;\nif done {\n    return;\n}\nlet ct = ConcurrentTask::create_from(self_ptr);",
     "let self_ptr: *mut Self = self;\nloop_.enqueue_task(Task::init(self_ptr));",
-    // The intrusive form.
-    "let ct = self.concurrent_task.from(std::ptr::from_mut(self), AutoDeinit::ManualDeinit);",
-    "let self_ptr: *mut Self = self;\nlet ct = self.concurrent_task.from(self_ptr, AutoDeinit::ManualDeinit);",
-    "at.from(self, Self::run_from_main_thread_mini)",
     // Other spellings of the pointer; a same-loop post counts too (see the
     // header).
     "loop_.enqueue_task(Task::init(self));",
@@ -261,11 +254,8 @@ test("the patterns match the banned spellings and nothing else", () => {
     "let ct = ConcurrentTask::create(Task::init(this));",
     "ConcurrentTask::create_from(task.as_ptr())",
     "ConcurrentTask::from_callback(this, FetchTasklet::resume_request_data_stream)",
-    "(*this).concurrent_task.from(this, AutoDeinit::ManualDeinit)",
-    "EventLoopTask::Js(ct) => ct.from(this, AutoDeinit::ManualDeinit),",
-    // `From::from` and the like are path calls, not the intrusive method.
-    "let s = String::from(self);",
-    "let v = Vec::from(self.as_slice());",
+    // The embedded-task form is the sibling lint's (see the header).
+    "let ct = self.concurrent_task.from(self_ptr, AutoDeinit::ManualDeinit);",
     // Something the receiver owns or points at, or a helper's pointer, is
     // out of scope (see the header).
     "ConcurrentTask::create(Task::init(self.as_ctx_ptr()))",


### PR DESCRIPTION
### Problem
- Every `Bun.build()` ends with the bundle thread posting the finished task to the JS thread from inside `complete_on_bundle_thread(&mut self)`. The post carries the task's only ref, so the JS thread can free the task while that `&mut self`, and the `&mut` its caller holds, are still live arguments.
- Freeing memory a live reference argument points at is UB under both of Rust's aliasing models, used again or not. A standalone reduction of this shape fails under Miri with `the strongly protected tag disallows deallocations` (Tree Borrows) and `deallocating while item [Unique] is strongly protected` (Stacked Borrows).
- No crash is known from this today, since nothing reads the task after the post; the contract is what is wrong. Same class as #37703 and #37685, here across threads.

### Fix
- `complete_on_bundle_thread` takes `this: *mut Self` instead of `&mut self`. It reads the two fields it needs through raw accesses that end before the post, then posts `this`, the same shape as the existing zlib and VmHandle posts.
- The bundle thread no longer turns the dequeued task into a `&mut`. Each trait call gets a reborrow that ends with the call, so on both the success and the error path no reference to the task exists on this thread when the post happens. Order of operations is unchanged.
- A new source lint bans posting a pointer spelled from `self` as a heap task. On `main` it reports exactly this one site; five other sites it can see are allowlisted by count, each naming the PR that converts it.
- Verification: the lint fails without the fix and passes with it; the UB itself is shown only by the standalone Miri reduction, not by an in-tree test. The bundler tests (one runs this hand-back thousands of times) and a script hitting the success, `throw: false` and throwing arms 50 times each pass on the ASAN build.

### Background
- `Bun.build()` runs on a dedicated bundle thread. Each build is a heap-allocated completion task: the JS thread enqueues it, the bundle thread dequeues it as a raw pointer, runs the build, stores the result and log on it, and hands it back.
- The hand-back is a `ConcurrentTask` posted to the JS thread's event loop. The task has one ref from creation, the post carries it, and the JS-side handler adopts and releases it, which frees the task. The post is therefore the bundle thread's last legal touch of the object.
- Reference protectors: while a reference is an argument of a call, Rust's aliasing models treat its pointee as protected until the call returns, so freeing it from any thread is UB even if the reference is never used again. Raw pointers carry no protection, hence the fix keeps the task raw and reborrows per call.
- Miri is the interpreter that checks Rust code against those models. Tree Borrows and Stacked Borrows are the two models; `bun run rust:miri` uses Tree Borrows.
- `test/internal/source-lints/` holds bun tests that regex-scan the Rust sources for banned spellings, with a per-file allowlist of exact counts. The count must match exactly, so converting a site forces its entry down and a new site fails outright.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-publish.test.ts
bun test v1.4.0 (2ba088829)

test/internal/source-lints/self-receiver-publish.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.79ms]
(pass) the patterns match the banned spellings and nothing else [23.65ms]
280 |   expect(banned.map(s => findPosts(s).length)).toEqual(banned.map(() => 1));
281 |   expect(allowed.map(s => findPosts(s).length)).toEqual(allowed.map(() => 0));
282 | });
283 | 
284 | test("no method posts its own receiver as a task", () => {
285 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/api/js_bundle_completion_task.rs:1124",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/self-receiver-publish.test.ts:285:21)
(fail) no method posts its own receiver as a task [6.22ms]
(pass) allowlisted files still carry exactly their documented count [5.13ms]

 3 pass
 1 fail
 7 expect() calls
Ran 4 tests across 1 file. [28.78s
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (9008ae7ab)

test/internal/source-lints/self-receiver-publish.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.11ms]
(pass) the patterns match the banned spellings and nothing else [0.55ms]
280 |   expect(banned.map(s => findPosts(s).length)).toEqual(banned.map(() => 1));
281 |   expect(allowed.map(s => findPosts(s).length)).toEqual(allowed.map(() => 0));
282 | });
283 | 
284 | test("no method posts its own receiver as a task", () => {
285 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/api/js_bundle_completion_task.rs:1124",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/self-receiver-publish.test.ts:285:21)
(fail) no method posts its own receiver as a task [0.91ms]
(pass) allowlisted files still carry exactly their documented count [0.16ms]

 3 pass
 1 fail
 7 expect() calls
Ran 4 tests across 1 file. [877.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-publish.test.ts
bun test v1.4.0 (2ba088829)

test/internal/source-lints/self-receiver-publish.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.31ms]
(pass) the patterns match the banned spellings and nothing else [22.99ms]
(pass) no method posts its own receiver as a task [1.43ms]
(pass) allowlisted files still carry exactly their documented count [3.98ms]

 4 pass
 0 fail
 7 expect() calls
Ran 4 tests across 1 file. [28.50s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     2ba0888295
  features     baseline

22 deps, 107 codegen, 1176 objects in 1134ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] install /workspace/bun
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 107 installs across 153 packages (no changes) [127.00ms]
[4/1238] fetch zlib
[zlib] up to date
[5/1238] fetch picohttpparser
[picohttpparser] up to date
[6/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] gen .bind.ts → GeneratedBindings.cpp
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (9008ae7ab)

Checked 1 install across 2 packages (no changes) [33.00ms]
[11/1237]
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/BundleThread.rs                        |  77 ++++--
 src/runtime/api/js_bundle_completion_task.rs       |  20 +-
 .../source-lints/self-receiver-publish.test.ts     | 294 +++++++++++++++++++++
 3 files changed, 356 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/BundleThread.rs                                   5     11      0
src/runtime/api/js_bundle_completion_task.rs                  6      3      0
test/internal/source-lints/self-receiver-publish.test.ts      8     21      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

`JSBundleCompletionTask::complete_on_bundle_thread(&mut self)` (src/runtime/api/js_bundle_completion_task.rs) is how the bundle thread hands a finished `Bun.build()` back:

```rust
let this = std::ptr::from_mut::<Self>(self);
let ct = jsc::ConcurrentTask::create(jsc::Task::init(this));
handle.post_task(ct) ...
handle.embedded_work_finished();
```

The task is created with `ref_count == 1` (`create_and_schedule_completion_task`) and nothing takes another ref, so the post carries the task's only ref. On the JS thread `on_complete_anytask` adopts it (`ScopedRef::adopt`) and releases it on return, which runs `deinit` and `heap::take`s the allocation. The JS thread picks the task up as soon as `post_task` wakes its loop, so on the normal path of every build the allocation can be freed while the bundle thread is still inside `complete_on_bundle_thread(&mut self)`, and inside `BundleThread::generate_in_new_thread(completion: &mut C, ..)` (src/bundler/BundleThread.rs), whose caller in `thread_main` also held the task as `&mut C` and called `completion.complete_on_bundle_thread()` itself on the error arm.

A reference argument is protected for the duration of the call it was passed to, and freeing protected memory is UB under both aliasing models regardless of whether the reference is used again (codegen relies on the same thing: the argument is annotated dereferenceable for the whole call). A standalone reduction of exactly this shape, with the consumer on another thread, fails under Miri with Tree Borrows (the model `bun run rust:miri` uses):

```
error: Undefined Behavior: deallocation through <10104> at alloc1428[0x0] is forbidden
  = help: the allocation of the accessed tag <10104> also contains the strongly protected tag <4692>
  = help: the strongly protected tag <4692> disallows deallocations
help: the strongly protected tag <4692> was created here, in the initial state Reserved
   |     fn complete_on_bundle_thread_before(&mut self, handle: &Handle) {
   |                                         ^^^^^^^^^
```

and under Stacked Borrows with `deallocating while item [Unique for <4874>] is strongly protected`. The same reduction posting through the raw pointer passes under both. No crash is known from this today (nothing reads the task after the post); the contract is what is wrong. Same class as #37703 (FetchTasklet release) and #37685 (`Worker::deinit_soon`, which had the same publish-then-freed-elsewhere shape), here across threads.

<details>
<summary>Reduction run under Miri</summary>

```rust
use std::sync::mpsc;
use std::thread;

struct SendPtr(*mut Completion);
unsafe impl Send for SendPtr {}

struct Completion { bundle_loop: *mut u8 }

struct Handle { post: mpsc::Sender<SendPtr>, freed: mpsc::Receiver<()> }

impl Handle {
    fn post_task(&self, task: SendPtr) { self.post.send(task).unwrap(); }
    // Stands in for `embedded_work_finished()`: by now the JS thread may have
    // run the completion. The channel pins the interleaving the real code allows.
    fn embedded_work_finished(&self) { self.freed.recv().unwrap(); }
}

impl Completion {
    // main
    fn complete_on_bundle_thread_before(&mut self, handle: &Handle) {
        self.bundle_loop = std::ptr::null_mut();
        let this = std::ptr::from_mut::<Self>(self);
        handle.post_task(SendPtr(this));
        handle.embedded_work_finished();
    }
    // this PR
    unsafe fn complete_on_bundle_thread_after(this: *mut Self, handle: &Handle) {
        unsafe { (*this).bundle_loop = std::ptr::null_mut() };
        handle.post_task(SendPtr(this));
        handle.embedded_work_finished();
    }
}

fn main() {
    let (post, queue) = mpsc::channel::<SendPtr>();
    let (freed_tx, freed) = mpsc::channel::<()>();
    // The JS thread: `on_complete_anytask` adopts the ref and frees the task.
    let js_thread = thread::spawn(move || {
        let task = queue.recv().unwrap();
        drop(unsafe { Box::from_raw(task.0) });
        freed_tx.send(()).unwrap();
    });
    let handle = Handle { post, freed };
    let completion = Box::into_raw(Box::new(Completion { bundle_loop: std::ptr::dangling_mut() }));
    if std::env::args().nth(1).as_deref() == Some("after") {
        unsafe { Completion::complete_on_bundle_thread_after(completion, &handle) };
    } else {
        unsafe { (*completion).complete_on_bundle_thread_before(&handle) };
    }
    js_thread.join().unwrap();
}
```

`MIRIFLAGS=-Zmiri-tree-borrows cargo miri run -- before` and the default Stacked Borrows run both exit 1 with the errors quoted above; `-- after` exits 0 under both.

</details>

### Fix

* `CompletionStruct::complete_on_bundle_thread` becomes `unsafe fn complete_on_bundle_thread(this: *mut Self)`, with the contract (last touch of `*this` by the bundle thread; the caller must not hold a reference to it across the call) on the trait. The impl reads `bundle_loop` / `loop_handle` through statement-scoped raw accesses and posts `this` itself, like `async_job_run` in node_zlib_binding.rs and `post_job` in VmHandle.rs already do.
* `BundleThread::thread_main` no longer materializes `&mut C` for the dequeued task; `generate_in_new_thread` takes `*mut C` and reborrows it for each trait call (`create_and_configure_transpiler`, `init_and_run`, `set_log`; the returned `&'a mut Transpiler` borrows the arena, not the task), so no reference to the task is live at either hand-back. The order of operations is unchanged: the success path still posts before the arena teardown (which only drops bundle-thread memory; `Transpiler`/`Resolver` hold `log` as raw pointers with no drop glue), and the error path still posts from `thread_main` after `set_result`.

The rest of the build's lifetime (the build-long `&mut self` trait calls, and the JS-side field writes that happen after the enqueue) is the same family and is #37740, which overlaps this PR on `complete_on_bundle_thread` and the pointer plumbing; whichever lands second has a small rebase. #35312, #35060 and #35158 touch neighbouring lines of `BundleThread.rs` but none of them changes this receiver.

Other sites of this shape were found while writing the lint below and are each their own change rather than part of this one: `Resolve::dispatch` / `Load::dispatch` (#37732), `DeferredBatchTask::schedule` (#37709 reshapes it), the two `ThreadSafeFunction` posts (#37741 addon-thread side, #37762 JS-thread side), `napi_async_work::run` / `post_to_js_thread` (#37750, which also adds the lint for the embedded-task `.from(..)` spelling), `TranspilerJob::dispatch_to_main_thread` (#37778), and `FetchTasklet::deref_from_thread` and `StatWatcher::post_to_js_thread`, which post through `&self` / a helper's pointer and are reported for their own fixes. The lint's header lists the ones its regex cannot see; its allowlist names the PR converting each one it can, and the entry for whichever of those lands before this PR gets dropped here on rebase (the ratchet test fails otherwise, so it cannot be missed in either order).

### Tests

`test/internal/source-lints/self-receiver-publish.test.ts` bans posting a pointer spelled from `self` as a heap task: `Task::init` / `ConcurrentTask*::create_from` / `ConcurrentTask*::from_callback` applied to `from_mut(self)`, `from_ref(self).cast_mut()`, `self as *mut`, `&raw mut *self`, bare `self` (which coerces), or a local bound to one of those (including `let p: *mut Self = self;`) further down the same function. Same-loop `enqueue_task` posts are in scope on purpose: there the hazard is provenance rather than the protector (the queued pointer is a child of the receiver reborrow, and the first access through the owner's pointer before the queue drains kills it; the `maybe_queue_finalizer` case in napi_body.rs is exactly that, and the finalizer it posts is what frees the object), which the header states alongside the cross-thread argument, both checked with Miri reductions. It checks its patterns against positive and negative examples and ratchets the five regex-visible instances with what is wrong at each and the PR converting it (above). Against `main` it reports exactly

```
src/runtime/api/js_bundle_completion_task.rs:1124
```

and passes with this branch.

### Verification

On the debug (ASAN) build: test/bundler/bun-build-api.test.ts (52 pass, including the "thousands of times in one process" test, which runs this hand-back a few thousand times), bundler_plugin.test.ts, bundler_plugin_chain.test.ts, bundler_defer.test.ts, metafile.test.ts, bundler_html_server.test.ts and test/js/bun/http/bun-serve-html.test.ts (the HTMLBundle route path through the same completion), plus a script exercising the success arm, the `throw: false` error arm and the throwing arm 50 times each. `bun test test/internal/source-lints/` (19 files) passes; `cargo clippy -p bun_bundler -p bun_runtime` and `cargo fmt --check` are clean.

Two things seen while running those are unrelated to this change and were reported separately: a DevServer debug assertion when a dev-mode HTML route is started after `process.chdir()` (shows up when bundler_html_server.test.ts and bun-serve-html.test.ts run in one process; the backtrace does not involve this code), and bun-serve-html-entry.test.ts failing to connect to `localhost` in this container with the release binary as well.

</details>
