### PR TITLE
node:http2: enforce keepAliveTimeout and server.timeout on allowHTTP1 fallback connections

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -98,7 +98,7 @@ const serverSymbol = Symbol.for("::bunternal::");
 const kPendingCallbacks = Symbol("pendingCallbacks");
 const kRequest = Symbol("request");
 const kCloseCallback = Symbol("closeCallback");
-// Node's res._last: set by renderNativeHeaders, acted on when the response finishes.
+// Node's res._last: the connection is to be closed once this response has finished.
 const kMustCloseConnection = Symbol("kMustCloseConnection");
 
 const kEmptyObject = Object.freeze(Object.create(null));

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -98,6 +98,10 @@ const serverSymbol = Symbol.for("::bunternal::");
 const kPendingCallbacks = Symbol("pendingCallbacks");
 const kRequest = Symbol("request");
 const kCloseCallback = Symbol("closeCallback");
+// Set on a ServerResponse whose headers commit it to closing the connection (Node's
+// res._last): renderNativeHeaders sets it, the response-finish hooks of both server paths
+// (_http_server.ts's native sockets, http1_server_fallback.ts) end the connection on it.
+const kMustCloseConnection = Symbol("kMustCloseConnection");
 
 const kEmptyObject = Object.freeze(Object.create(null));
 
@@ -635,6 +639,7 @@ export {
   kMaxHeaderSize,
   kMaxHeadersCount,
   kMethod,
+  kMustCloseConnection,
   kNeedDrain,
   kOptions,
   kOutHeaders,

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -98,9 +98,7 @@ const serverSymbol = Symbol.for("::bunternal::");
 const kPendingCallbacks = Symbol("pendingCallbacks");
 const kRequest = Symbol("request");
 const kCloseCallback = Symbol("closeCallback");
-// Set on a ServerResponse whose headers commit it to closing the connection (Node's
-// res._last): renderNativeHeaders sets it, the response-finish hooks of both server paths
-// (_http_server.ts's native sockets, http1_server_fallback.ts) end the connection on it.
+// Node's res._last: set by renderNativeHeaders, acted on when the response finishes.
 const kMustCloseConnection = Symbol("kMustCloseConnection");
 
 const kEmptyObject = Object.freeze(Object.create(null));

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -235,7 +235,7 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
 function connectionListenerHTTP1(server, socket, options) {
   const http = require("node:http");
   const { HTTPParser, prepareError, calculateLenientFlags, continueExpression } = require("node:_http_common");
-  const { kHandle: kHttp1ResponseHandle } = require("internal/http");
+  const { kHandle: kHttp1ResponseHandle, kMustCloseConnection } = require("internal/http");
   const { allMethods } = process.binding("http_parser");
 
   const http1Options = options.http1Options || {};
@@ -341,10 +341,16 @@ function connectionListenerHTTP1(server, socket, options) {
     // node's resOnFinish: release the socket once the response completes so the next
     // keep-alive request's response can attach (assignSocket throws
     // ERR_HTTP_SOCKET_ASSIGNED while a previous response is still assigned), then
-    // start the keep-alive idle clock on the connection.
+    // either end a connection the response headers committed to closing (Node's
+    // res._last; the request-side Connection: close case was already ended by
+    // onfinished above) or start the keep-alive idle clock.
     res.on("finish", function onFallbackResponseFinish() {
       this.detachSocket(socket);
-      armKeepAliveTimeout();
+      if (this[kMustCloseConnection]) {
+        if (!socket.destroyed) socket.end();
+      } else {
+        armKeepAliveTimeout();
+      }
     });
 
     // Node's parserOnIncoming Expect routing (the native dispatcher applies the
@@ -465,8 +471,9 @@ function connectionListenerHTTP1(server, socket, options) {
   // The keep-alive branch of Node's resOnFinish: with no request in flight, the connection may
   // stay idle for the advertised keepAliveTimeout (plus keepAliveTimeoutBuffer, so a client that
   // reuses it right at the advertised deadline is not reset) before onHttp1SocketTimeout closes
-  // it. A response that ended the connection (Connection: close, close-delimited body) and a
-  // Duplex without setTimeout (emit('connection') callers) leave nothing to arm, as in Node.
+  // it. Nothing to arm when onfinished already ended the connection for a request that asked
+  // for Connection: close (writableEnded), or on a Duplex without setTimeout (emit('connection')
+  // callers); Node skips both the same way.
   function armKeepAliveTimeout() {
     if (
       socket[kHttp1ActiveRequests] !== 0 ||

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -445,7 +445,7 @@ function connectionListenerHTTP1(server, socket, options) {
     }
     const httpMessage = socket._httpMessage;
     if (httpMessage) {
-      httpMessage._last = true;
+      httpMessage[kMustCloseConnection] = true;
     } else if (socket.writable) {
       socket.end();
     }

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -241,7 +241,6 @@ function connectionListenerHTTP1(server, socket, options) {
   const http1Options = options.http1Options || {};
   const IncomingMessageClass = http1Options.IncomingMessage || http.IncomingMessage;
   const ServerResponseClass = http1Options.ServerResponse || http.ServerResponse;
-  const keepAliveTimeout = typeof server.keepAliveTimeout === "number" ? server.keepAliveTimeout : 5000;
 
   // Node's connectionListenerInternal sets this so handlers can reach the server
   // through req.socket.server (nodejs/node#13435).
@@ -269,6 +268,9 @@ function connectionListenerHTTP1(server, socket, options) {
 
   let req = null;
   let pendingUpgrade = null;
+  // Node's state.keepAliveTimeoutSet: the socket timeout currently armed is the keep-alive idle
+  // timeout from armKeepAliveTimeout(), not server.timeout.
+  let keepAliveTimeoutSet = false;
 
   parser[kOnHeadersComplete] = function onHttp1HeadersComplete(
     versionMajor,
@@ -281,6 +283,12 @@ function connectionListenerHTTP1(server, socket, options) {
     upgrade,
     shouldKeepAlive,
   ) {
+    // Node's resetSocketTimeout: the connection is busy again, so the keep-alive idle timeout
+    // gives way to server.timeout (none by default) until this request's response finishes.
+    if (keepAliveTimeoutSet) {
+      keepAliveTimeoutSet = false;
+      socket.setTimeout(server.timeout || 0);
+    }
     socket[kHttp1ActiveRequests]++;
 
     req = new IncomingMessageClass(socket);
@@ -316,6 +324,9 @@ function connectionListenerHTTP1(server, socket, options) {
     // The native dispatcher seeds these from the server; renderNativeHeaders
     // reads them to decide the Keep-Alive auto-header bits, so the fallback
     // path must carry them too or keep-alive responses lose their timeout line.
+    // Read per request (Node's parserOnIncoming does too) so the advertised value
+    // is the one armKeepAliveTimeout() enforces once this response finishes.
+    const keepAliveTimeout = typeof server.keepAliveTimeout === "number" ? server.keepAliveTimeout : 5000;
     res._keepAliveTimeout = keepAliveTimeout;
     res._maxRequestsPerSocket = server.maxRequestsPerSocket;
     const handle = createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout);
@@ -329,9 +340,11 @@ function connectionListenerHTTP1(server, socket, options) {
     res.assignSocket(socket);
     // node's resOnFinish: release the socket once the response completes so the next
     // keep-alive request's response can attach (assignSocket throws
-    // ERR_HTTP_SOCKET_ASSIGNED while a previous response is still assigned).
+    // ERR_HTTP_SOCKET_ASSIGNED while a previous response is still assigned), then
+    // start the keep-alive idle clock on the connection.
     res.on("finish", function onFallbackResponseFinish() {
       this.detachSocket(socket);
+      armKeepAliveTimeout();
     });
 
     // Node's parserOnIncoming Expect routing (the native dispatcher applies the
@@ -401,6 +414,7 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.removeListener("data", onHttp1SocketData);
       socket.removeListener("error", onHttp1SocketErrorListener);
       socket.removeListener("end", onHttp1SocketEnd);
+      socket.removeListener("timeout", onHttp1SocketTimeout);
       connections.delete(socket);
       try {
         parser.close();
@@ -439,15 +453,50 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.end();
     }
   }
+  // Node's socketOnTimeout: a 'timeout' listener on the request still being received, on the
+  // response in flight or on the server takes over; otherwise the connection is destroyed.
+  function onHttp1SocketTimeout() {
+    const reqTimeout = req && !req.complete && req.emit("timeout", socket);
+    const res = socket._httpMessage;
+    const resTimeout = res && res.emit("timeout", socket);
+    const serverTimeout = server.emit("timeout", socket);
+    if (!reqTimeout && !resTimeout && !serverTimeout) socket.destroy();
+  }
+  // The keep-alive branch of Node's resOnFinish: with no request in flight, the connection may
+  // stay idle for the advertised keepAliveTimeout (plus keepAliveTimeoutBuffer, so a client that
+  // reuses it right at the advertised deadline is not reset) before onHttp1SocketTimeout closes
+  // it. A response that ended the connection (Connection: close, close-delimited body) and a
+  // Duplex without setTimeout (emit('connection') callers) leave nothing to arm, as in Node.
+  function armKeepAliveTimeout() {
+    if (
+      socket[kHttp1ActiveRequests] !== 0 ||
+      socket.destroyed ||
+      socket.writableEnded ||
+      typeof socket.setTimeout !== "function"
+    ) {
+      return;
+    }
+    const { keepAliveTimeout, keepAliveTimeoutBuffer } = server;
+    if (!(Number.isFinite(keepAliveTimeout) && keepAliveTimeout > 0)) return;
+    const buffer =
+      Number.isFinite(keepAliveTimeoutBuffer) && keepAliveTimeoutBuffer >= 0 ? keepAliveTimeoutBuffer : 1000;
+    socket.setTimeout(keepAliveTimeout + buffer);
+    keepAliveTimeoutSet = true;
+  }
   socket.on("data", onHttp1SocketData);
   socket.on("error", onHttp1SocketErrorListener);
   socket.once("end", onHttp1SocketEnd);
+  socket.on("timeout", onHttp1SocketTimeout);
   socket.once("close", () => {
     connections.delete(socket);
     try {
       parser.close();
     } catch {}
   });
+  // Node's connectionListenerInternal: server.setTimeout() applies from the moment the
+  // connection is accepted, not only once a request is in flight.
+  const { timeout: serverTimeout } = server;
+  if (serverTimeout && typeof socket.setTimeout === "function") socket.setTimeout(serverTimeout);
 }
 
 function closeIdleHttp1Connections(server) {

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -334,8 +334,7 @@ function connectionListenerHTTP1(server, socket, options) {
     };
     res[kHttp1ResponseHandle] = handle;
     res.assignSocket(socket);
-    // Node's resOnFinish: detach (the next response's assignSocket would otherwise throw
-    // ERR_HTTP_SOCKET_ASSIGNED), then the res._last branch or the keep-alive branch.
+    // Node's resOnFinish: detach, then its res._last branch or its keep-alive branch.
     res.on("finish", function onFallbackResponseFinish() {
       this.detachSocket(socket);
       if (this[kMustCloseConnection]) {
@@ -459,8 +458,7 @@ function connectionListenerHTTP1(server, socket, options) {
     const serverTimeout = server.emit("timeout", socket);
     if (!reqTimeout && !resTimeout && !serverTimeout) socket.destroy();
   }
-  // The keep-alive branch of Node's resOnFinish. writableEnded: onfinished already ended the
-  // connection for a request that sent Connection: close.
+  // The keep-alive branch of Node's resOnFinish.
   function armKeepAliveTimeout() {
     if (
       socket[kHttp1ActiveRequests] !== 0 ||

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -268,8 +268,7 @@ function connectionListenerHTTP1(server, socket, options) {
 
   let req = null;
   let pendingUpgrade = null;
-  // Node's state.keepAliveTimeoutSet: the socket timeout currently armed is the keep-alive idle
-  // timeout from armKeepAliveTimeout(), not server.timeout.
+  // Node's state.keepAliveTimeoutSet.
   let keepAliveTimeoutSet = false;
 
   parser[kOnHeadersComplete] = function onHttp1HeadersComplete(
@@ -283,8 +282,7 @@ function connectionListenerHTTP1(server, socket, options) {
     upgrade,
     shouldKeepAlive,
   ) {
-    // Node's resetSocketTimeout: the connection is busy again, so the keep-alive idle timeout
-    // gives way to server.timeout (none by default) until this request's response finishes.
+    // Node's resetSocketTimeout.
     if (keepAliveTimeoutSet) {
       keepAliveTimeoutSet = false;
       socket.setTimeout(server.timeout || 0);
@@ -324,8 +322,6 @@ function connectionListenerHTTP1(server, socket, options) {
     // The native dispatcher seeds these from the server; renderNativeHeaders
     // reads them to decide the Keep-Alive auto-header bits, so the fallback
     // path must carry them too or keep-alive responses lose their timeout line.
-    // Read per request (Node's parserOnIncoming does too) so the advertised value
-    // is the one armKeepAliveTimeout() enforces once this response finishes.
     const keepAliveTimeout = typeof server.keepAliveTimeout === "number" ? server.keepAliveTimeout : 5000;
     res._keepAliveTimeout = keepAliveTimeout;
     res._maxRequestsPerSocket = server.maxRequestsPerSocket;
@@ -338,12 +334,8 @@ function connectionListenerHTTP1(server, socket, options) {
     };
     res[kHttp1ResponseHandle] = handle;
     res.assignSocket(socket);
-    // node's resOnFinish: release the socket once the response completes so the next
-    // keep-alive request's response can attach (assignSocket throws
-    // ERR_HTTP_SOCKET_ASSIGNED while a previous response is still assigned), then
-    // either end a connection the response headers committed to closing (Node's
-    // res._last; the request-side Connection: close case was already ended by
-    // onfinished above) or start the keep-alive idle clock.
+    // Node's resOnFinish: detach (the next response's assignSocket would otherwise throw
+    // ERR_HTTP_SOCKET_ASSIGNED), then the res._last branch or the keep-alive branch.
     res.on("finish", function onFallbackResponseFinish() {
       this.detachSocket(socket);
       if (this[kMustCloseConnection]) {
@@ -459,8 +451,7 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.end();
     }
   }
-  // Node's socketOnTimeout: a 'timeout' listener on the request still being received, on the
-  // response in flight or on the server takes over; otherwise the connection is destroyed.
+  // Node's socketOnTimeout.
   function onHttp1SocketTimeout() {
     const reqTimeout = req && !req.complete && req.emit("timeout", socket);
     const res = socket._httpMessage;
@@ -468,12 +459,8 @@ function connectionListenerHTTP1(server, socket, options) {
     const serverTimeout = server.emit("timeout", socket);
     if (!reqTimeout && !resTimeout && !serverTimeout) socket.destroy();
   }
-  // The keep-alive branch of Node's resOnFinish: with no request in flight, the connection may
-  // stay idle for the advertised keepAliveTimeout (plus keepAliveTimeoutBuffer, so a client that
-  // reuses it right at the advertised deadline is not reset) before onHttp1SocketTimeout closes
-  // it. Nothing to arm when onfinished already ended the connection for a request that asked
-  // for Connection: close (writableEnded), or on a Duplex without setTimeout (emit('connection')
-  // callers); Node skips both the same way.
+  // The keep-alive branch of Node's resOnFinish. writableEnded: onfinished already ended the
+  // connection for a request that sent Connection: close.
   function armKeepAliveTimeout() {
     if (
       socket[kHttp1ActiveRequests] !== 0 ||
@@ -500,8 +487,7 @@ function connectionListenerHTTP1(server, socket, options) {
       parser.close();
     } catch {}
   });
-  // Node's connectionListenerInternal: server.setTimeout() applies from the moment the
-  // connection is accepted, not only once a request is in flight.
+  // Node's connectionListenerInternal: server.timeout applies from accept on.
   const { timeout: serverTimeout } = server;
   if (serverTimeout && typeof socket.setTimeout === "function") socket.setTimeout(serverTimeout);
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -42,6 +42,7 @@ const {
   kPendingCallbacks,
   kRequest,
   kCloseCallback,
+  kMustCloseConnection,
   NodeHTTPResponseFlags,
   emitErrorNextTickIfErrorListenerNT,
   getIsNextIncomingMessageHTTPS,
@@ -2437,7 +2438,6 @@ function renderNativeHeaders(res) {
   return flat;
 }
 
-const kMustCloseConnection = Symbol("kMustCloseConnection");
 function stopServerResponsePerf(this: any) {
   if (this[kServerResponseStatistics] && hasObserver("http")) {
     stopPerf(this, kServerResponseStatistics, {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6800,6 +6800,7 @@ class Http2SecureServer extends tls.Server {
       this[kHttp1Connections] = new SafeSet();
       const http1Options = { ...options, ...options.http1Options };
       this.keepAliveTimeout = http1Options.keepAliveTimeout ?? 5000;
+      this.keepAliveTimeoutBuffer = http1Options.keepAliveTimeoutBuffer ?? 1000;
       this.headersTimeout = http1Options.headersTimeout ?? 60000;
       this.requestTimeout = http1Options.requestTimeout ?? 300000;
       this.maxHeadersCount = http1Options.maxHeadersCount ?? null;

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4070,7 +4070,11 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     const server = createServer(() =>
       unexpectedRequest.reject(new Error("request handler must not run for a handled upgrade")),
     );
+    let timeoutListenersAtHandoff = -1;
     server.on("upgrade", (req, socket, head) => {
+      // Like Node (test-http-connect asserts the same), the listener gets the socket without
+      // the connection listener's 'timeout' handling, which would otherwise destroy the tunnel.
+      timeoutListenersAtHandoff = socket.listenerCount("timeout");
       socket.write("HTTP/1.1 101 Switching Protocols\r\n\r\nHEAD:" + head.toString());
       socket.on("data", d => socket.write("TUNNEL:" + d));
     });
@@ -4097,6 +4101,7 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(out).toStartWith("HTTP/1.1 101 Switching Protocols");
     expect(out).toContain("HEAD:early");
     expect(out).toContain("TUNNEL:more");
+    expect(timeoutListenersAtHandoff).toBe(0);
     clientSide.destroy();
     serverSide.destroy();
   }
@@ -4167,4 +4172,34 @@ it("connectionListener closes a socket fed through emit('connection') once it ha
   } finally {
     netServer.close();
   }
+});
+
+it("connectionListener serves a Duplex that has no setTimeout() even when server.timeout and keepAliveTimeout are set", async () => {
+  // Like Node, the timeouts only apply to sockets that can carry one; a plain stream pair fed
+  // through emit('connection') (test-http-generic-streams style) is served without them.
+  const responseFinished = Promise.withResolvers<void>();
+  const server = createServer((req, res) => {
+    // The connection listener's own 'finish' listener (where keep-alive would be armed) runs
+    // before this one, so reaching it means that path coped with the missing setTimeout too.
+    res.on("finish", () => responseFinished.resolve());
+    res.end("ok");
+  });
+  server.setTimeout(100);
+  const [clientSide, serverSide] = duplexPair();
+  expect(typeof (serverSide as any).setTimeout).toBe("undefined");
+  server.emit("connection", serverSide);
+  const response = await new Promise<string>((resolve, reject) => {
+    let buf = "";
+    clientSide.on("data", d => {
+      buf += d;
+      if (buf.endsWith("\r\n\r\nok")) resolve(buf);
+    });
+    clientSide.on("close", () => reject(new Error("closed before the response arrived: " + buf)));
+    clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+  });
+  await responseFinished.promise;
+  expect(response).toStartWith("HTTP/1.1 200 OK\r\n");
+  expect(serverSide.destroyed).toBe(false);
+  clientSide.destroy();
+  serverSide.destroy();
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,32 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+it("connectionListener closes a socket fed through emit('connection') once it has been idle for keepAliveTimeout", async () => {
+  const httpServer = createServer({ keepAliveTimeout: 100, keepAliveTimeoutBuffer: 0 }, (req, res) => res.end("ok"));
+  const serverSideClosed = Promise.withResolvers<void>();
+  // A plain net.Server accepts the connection and hands it to http's connection listener, so
+  // the request is served by the JS fallback parser rather than the native server.
+  const netServer = createNetServer(socket => {
+    socket.once("close", () => serverSideClosed.resolve());
+    httpServer.emit("connection", socket);
+  });
+  await once(netServer.listen(0), "listening");
+  try {
+    const client = connect((netServer.address() as AddressInfo).port);
+    client.setEncoding("utf8");
+    let received = "";
+    client.on("data", chunk => (received += chunk));
+    const clientClosed = once(client, "close");
+    await once(client, "connect");
+    client.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n");
+    // The client never sends anything else, so only the server can be closing the connection.
+    await serverSideClosed.promise;
+    await clientClosed;
+    expect(received).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(received.toLowerCase()).toContain("\r\nconnection: keep-alive\r\n");
+    expect(received).toEndWith("\r\n\r\nok");
+  } finally {
+    netServer.close();
+  }
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4203,3 +4203,29 @@ it("connectionListener serves a Duplex that has no setTimeout() even when server
   clientSide.destroy();
   serverSide.destroy();
 });
+
+it("connectionListener with httpAllowHalfOpen ends the connection once the response to a half-closed client finishes", async () => {
+  // Node's socketOnEnd marks the in-flight response as the connection's last one instead of
+  // ending the connection under the response; resOnFinish then ends it.
+  const writableEndedAfterFinish = Promise.withResolvers<boolean>();
+  const server = createServer((req, res) => {
+    // The request's own Connection header allows keep-alive; only the half-close says otherwise.
+    req.socket.once("end", () => {
+      res.on("finish", () => writableEndedAfterFinish.resolve(req.socket.writableEnded));
+      res.end("ok");
+    });
+  });
+  server.httpAllowHalfOpen = true;
+  const [clientSide, serverSide] = duplexPair();
+  server.emit("connection", serverSide);
+  const clientSawEnd = once(clientSide, "end");
+  let response = "";
+  clientSide.on("data", d => (response += d));
+  clientSide.end("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+  expect(await writableEndedAfterFinish.promise).toBe(true);
+  await clientSawEnd;
+  expect(response).toStartWith("HTTP/1.1 200 OK\r\n");
+  expect(response).toEndWith("\r\n\r\nok");
+  clientSide.destroy();
+  serverSide.destroy();
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4310,13 +4310,20 @@ async function openHttp1Connection(port) {
   const socket = tls.connect({ host: "localhost", port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] });
   socket.setEncoding("utf8");
   let received = "";
-  let onData = () => {};
+  let lastError;
+  // Resolves whatever waitUntil() is currently waiting on; data and close both wake it.
+  let wake = () => {};
   socket.on("data", chunk => {
     received += chunk;
-    onData();
+    wake();
   });
-  socket.on("error", () => {});
-  const closed = new Promise(resolve => socket.once("close", resolve));
+  socket.on("error", error => (lastError = error));
+  const closed = new Promise(resolve =>
+    socket.once("close", () => {
+      resolve();
+      wake();
+    }),
+  );
   await new Promise((resolve, reject) => {
     socket.once("secureConnect", resolve);
     socket.once("error", reject);
@@ -4332,9 +4339,14 @@ async function openHttp1Connection(port) {
     },
     async waitUntil(predicate) {
       while (!predicate(received)) {
-        await new Promise(resolve => (onData = resolve));
+        if (socket.destroyed) {
+          throw new Error(
+            `connection closed while waiting${lastError ? ` (${lastError.code || lastError.message})` : ""}; received: ${JSON.stringify(received)}`,
+          );
+        }
+        await new Promise(resolve => (wake = resolve));
       }
-      onData = () => {};
+      wake = () => {};
     },
     waitForResponse() {
       const before = responsesReceived();

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4304,6 +4304,198 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+// A raw HTTP/1.1 client for the allowHTTP1 fallback: the tests below drive the connection
+// themselves so they can observe what the server does with it between and after requests.
+async function openHttp1Connection(port) {
+  const socket = tls.connect({ host: "localhost", port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] });
+  socket.setEncoding("utf8");
+  let received = "";
+  let onData = () => {};
+  socket.on("data", chunk => {
+    received += chunk;
+    onData();
+  });
+  socket.on("error", () => {});
+  const closed = new Promise(resolve => socket.once("close", resolve));
+  await new Promise((resolve, reject) => {
+    socket.once("secureConnect", resolve);
+    socket.once("error", reject);
+  });
+  // Every response in these tests is res.end("ok") with a Content-Length, so the number of
+  // complete responses received so far is the number of "ok" bodies in the stream.
+  const responsesReceived = () => received.split("\r\n\r\nok").length - 1;
+  return {
+    socket,
+    closed,
+    get received() {
+      return received;
+    },
+    async waitForResponse() {
+      const before = responsesReceived();
+      while (responsesReceived() === before) {
+        await new Promise(resolve => (onData = resolve));
+      }
+      onData = () => {};
+    },
+    request(path, extraHeaders = "") {
+      socket.write(`GET ${path} HTTP/1.1\r\nHost: localhost\r\n${extraHeaders}\r\n`);
+      return this.waitForResponse();
+    },
+  };
+}
+
+it("http2 allowHTTP1 fallback closes a kept-alive connection once it has been idle for keepAliveTimeout", async () => {
+  const serverSocketClosed = Promise.withResolvers();
+  const server = http2.createSecureServer(
+    { ...TLS_CERT, allowHTTP1: true, keepAliveTimeout: 100, keepAliveTimeoutBuffer: 0 },
+    (req, res) => {
+      req.socket.once("close", serverSocketClosed.resolve);
+      res.end("ok");
+    },
+  );
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const client = await openHttp1Connection(server.address().port);
+    await client.request("/");
+    expect(client.received.toLowerCase()).toContain("\r\nconnection: keep-alive\r\n");
+    // The client sends nothing further: the server has to be the one closing the connection.
+    await serverSocketClosed.promise;
+    await client.closed;
+  } finally {
+    server.close();
+  }
+});
+
+it("http2 allowHTTP1 fallback lets close() finish once a connection busy at close() time goes idle", async () => {
+  const server = http2.createSecureServer(
+    { ...TLS_CERT, allowHTTP1: true, keepAliveTimeout: 100, keepAliveTimeoutBuffer: 0 },
+    (req, res) => {
+      // The connection is busy, so close() cannot sweep it; it has to be closed once its
+      // response has finished and the keep-alive idle period has passed.
+      server.close();
+      res.end("ok");
+    },
+  );
+  const serverClosed = new Promise(resolve => server.once("close", resolve));
+  await new Promise(resolve => server.listen(0, resolve));
+  const client = await openHttp1Connection(server.address().port);
+  try {
+    await client.request("/");
+    await serverClosed;
+    await client.closed;
+  } finally {
+    client.socket.destroy();
+  }
+});
+
+// The arming itself, observed through socket.timeout (what net.Socket#setTimeout records), so
+// no timer has to fire: Node arms keepAliveTimeout + keepAliveTimeoutBuffer when a response
+// finishes with nothing else in flight, puts server.timeout back the moment the next request
+// arrives, and arms nothing after a response that closes the connection.
+it.each([
+  ["no server.timeout", 0],
+  ["server.setTimeout(7000)", 7000],
+])(
+  "http2 allowHTTP1 fallback arms the keep-alive idle timeout between requests (%s)",
+  async (_label, serverTimeout) => {
+    const observed = [];
+    const allFinished = Promise.withResolvers();
+    const server = http2.createSecureServer(
+      { ...TLS_CERT, allowHTTP1: true, keepAliveTimeout: 10_000, keepAliveTimeoutBuffer: 500 },
+      (req, res) => {
+        const entry = { url: req.url, onRequest: req.socket.timeout, afterFinish: undefined };
+        observed.push(entry);
+        res.on("finish", () => {
+          entry.afterFinish = req.socket.timeout;
+          if (observed.length === 3) allFinished.resolve();
+        });
+        res.end("ok");
+      },
+    );
+    if (serverTimeout) server.setTimeout(serverTimeout);
+    await new Promise(resolve => server.listen(0, resolve));
+    try {
+      const client = await openHttp1Connection(server.address().port);
+      await client.request("/1");
+      await client.request("/2");
+      await client.request("/3", "Connection: close\r\n");
+      await allFinished.promise;
+      await client.closed;
+      expect(observed).toEqual([
+        { url: "/1", onRequest: serverTimeout, afterFinish: 10_500 },
+        { url: "/2", onRequest: serverTimeout, afterFinish: 10_500 },
+        { url: "/3", onRequest: serverTimeout, afterFinish: serverTimeout },
+      ]);
+    } finally {
+      server.close();
+    }
+  },
+);
+
+it("http2 allowHTTP1 fallback destroys a connection that stays silent for server.setTimeout()", async () => {
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true });
+  server.setTimeout(100);
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const client = await openHttp1Connection(server.address().port);
+    await client.closed;
+    expect(client.received).toBe("");
+  } finally {
+    server.close();
+  }
+});
+
+it("http2 allowHTTP1 fallback hands a timed-out connection to the server's 'timeout' listener instead of destroying it", async () => {
+  const timedOut = Promise.withResolvers();
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => res.end("ok"));
+  server.setTimeout(100, timedOut.resolve);
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const client = await openHttp1Connection(server.address().port);
+    expect(await timedOut.promise).toBeInstanceOf(tls.TLSSocket);
+    // The listener took responsibility for the connection, so it is still usable.
+    await client.request("/", "Connection: close\r\n");
+    expect(client.received).toStartWith("HTTP/1.1 200 OK\r\n");
+    await client.closed;
+  } finally {
+    server.close();
+  }
+});
+
+it("http2 allowHTTP1 fallback routes a socket timeout to res.setTimeout() and, while a body is still incoming, req.setTimeout()", async () => {
+  const events = [];
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    req.once("timeout", () => events.push(`req ${req.url}`));
+    res.once("timeout", () => events.push(`res ${req.url}`));
+    server.once("timeout", () => events.push(`server ${req.url}`));
+    // Answering from the timeout callback shows the connection survived it: a timeout
+    // nobody listens for destroys the connection instead.
+    if (req.url === "/incomplete-body") {
+      req.setTimeout(50, () => res.end("ok"));
+    } else {
+      res.setTimeout(50, () => res.end("ok"));
+    }
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    // Fully received request: like Node, the request itself is not told about the timeout.
+    const client = await openHttp1Connection(server.address().port);
+    await client.request("/complete", "Connection: close\r\n");
+    await client.closed;
+    expect(events).toEqual(["res /complete", "server /complete"]);
+
+    // Only 3 of the announced 10 body bytes ever arrive: the request is told as well.
+    events.length = 0;
+    const stalled = await openHttp1Connection(server.address().port);
+    stalled.socket.write("POST /incomplete-body HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\nabc");
+    await stalled.waitForResponse();
+    expect(events).toEqual(["req /incomplete-body", "res /incomplete-body", "server /incomplete-body"]);
+    stalled.socket.destroy();
+  } finally {
+    server.close();
+  }
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4330,12 +4330,15 @@ async function openHttp1Connection(port) {
     get received() {
       return received;
     },
-    async waitForResponse() {
-      const before = responsesReceived();
-      while (responsesReceived() === before) {
+    async waitUntil(predicate) {
+      while (!predicate(received)) {
         await new Promise(resolve => (onData = resolve));
       }
       onData = () => {};
+    },
+    waitForResponse() {
+      const before = responsesReceived();
+      return this.waitUntil(() => responsesReceived() > before);
     },
     request(path, extraHeaders = "") {
       socket.write(`GET ${path} HTTP/1.1\r\nHost: localhost\r\n${extraHeaders}\r\n`);
@@ -4391,17 +4394,19 @@ it("http2 allowHTTP1 fallback lets close() finish once a connection busy at clos
 // The arming itself, observed through socket.timeout (what net.Socket#setTimeout records), so
 // no timer has to fire: Node arms keepAliveTimeout + keepAliveTimeoutBuffer when a response
 // finishes with nothing else in flight, puts server.timeout back the moment the next request
-// arrives, and arms nothing after a response that closes the connection.
+// arrives, arms nothing after a response that closes the connection, and arms nothing at all
+// when keepAliveTimeout is 0 (server.timeout, if any, then stays in charge of the connection).
 it.each([
-  ["no server.timeout", 0],
-  ["server.setTimeout(7000)", 7000],
+  { label: "no server.timeout", serverTimeout: 0, keepAliveTimeout: 10_000, afterKeepAliveResponse: 10_500 },
+  { label: "server.setTimeout(7000)", serverTimeout: 7000, keepAliveTimeout: 10_000, afterKeepAliveResponse: 10_500 },
+  { label: "keepAliveTimeout: 0", serverTimeout: 7000, keepAliveTimeout: 0, afterKeepAliveResponse: 7000 },
 ])(
-  "http2 allowHTTP1 fallback arms the keep-alive idle timeout between requests (%s)",
-  async (_label, serverTimeout) => {
+  "http2 allowHTTP1 fallback arms the keep-alive idle timeout between requests ($label)",
+  async ({ serverTimeout, keepAliveTimeout, afterKeepAliveResponse }) => {
     const observed = [];
     const allFinished = Promise.withResolvers();
     const server = http2.createSecureServer(
-      { ...TLS_CERT, allowHTTP1: true, keepAliveTimeout: 10_000, keepAliveTimeoutBuffer: 500 },
+      { ...TLS_CERT, allowHTTP1: true, keepAliveTimeout, keepAliveTimeoutBuffer: 500 },
       (req, res) => {
         const entry = { url: req.url, onRequest: req.socket.timeout, afterFinish: undefined };
         observed.push(entry);
@@ -4422,8 +4427,8 @@ it.each([
       await allFinished.promise;
       await client.closed;
       expect(observed).toEqual([
-        { url: "/1", onRequest: serverTimeout, afterFinish: 10_500 },
-        { url: "/2", onRequest: serverTimeout, afterFinish: 10_500 },
+        { url: "/1", onRequest: serverTimeout, afterFinish: afterKeepAliveResponse },
+        { url: "/2", onRequest: serverTimeout, afterFinish: afterKeepAliveResponse },
         { url: "/3", onRequest: serverTimeout, afterFinish: serverTimeout },
       ]);
     } finally {
@@ -4431,6 +4436,56 @@ it.each([
     }
   },
 );
+
+// Node's res._last: a response whose own headers say the connection closes is followed by the
+// server ending the connection right away, not by a keep-alive idle period.
+it.each([
+  ["res.setHeader('Connection', 'close')", res => res.setHeader("Connection", "close")],
+  ["res.shouldKeepAlive = false", res => (res.shouldKeepAlive = false)],
+])("http2 allowHTTP1 fallback ends the connection after a response that closes it (%s)", async (_label, closeVia) => {
+  let timeoutAfterFinish;
+  const server = http2.createSecureServer(
+    { ...TLS_CERT, allowHTTP1: true, keepAliveTimeout: 10_000, keepAliveTimeoutBuffer: 500 },
+    (req, res) => {
+      res.on("finish", () => (timeoutAfterFinish = req.socket.timeout));
+      closeVia(res);
+      res.end("ok");
+    },
+  );
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const client = await openHttp1Connection(server.address().port);
+    // A keep-alive request: only the response asks for the connection to close.
+    await client.request("/");
+    await client.closed;
+    expect(client.received.toLowerCase()).toContain("\r\nconnection: close\r\n");
+    expect(timeoutAfterFinish).toBe(0);
+  } finally {
+    server.close();
+  }
+});
+
+it("http2 allowHTTP1 fallback stops destroying a connection on timeout once it has been handed to an 'upgrade' listener", async () => {
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true });
+  // server.timeout stays armed on the handed-off socket (as in Node); what must go away with the
+  // handoff is the fallback's own destroy-on-timeout handling, so the protocol now owning the
+  // socket decides what a timeout means. Here it answers the timeout through the tunnel.
+  server.setTimeout(100);
+  server.on("upgrade", (req, socket) => {
+    socket.write("HTTP/1.1 101 Switching Protocols\r\nUpgrade: echo\r\nConnection: Upgrade\r\n\r\n");
+    socket.once("timeout", () => socket.write("still-open-after-timeout"));
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const client = await openHttp1Connection(server.address().port);
+    client.socket.write("GET / HTTP/1.1\r\nHost: localhost\r\nUpgrade: echo\r\nConnection: Upgrade\r\n\r\n");
+    await client.waitUntil(received => received.includes("still-open-after-timeout"));
+    expect(client.received).toStartWith("HTTP/1.1 101 Switching Protocols\r\n");
+    client.socket.destroy();
+  } finally {
+    server.close();
+  }
+});
 
 it("http2 allowHTTP1 fallback destroys a connection that stays silent for server.setTimeout()", async () => {
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true });


### PR DESCRIPTION
### Problem
- On `http2.createSecureServer({ allowHTTP1: true, keepAliveTimeout })`, an HTTP/1.1 keep-alive connection that idles after its response is never closed. Node closes it after `keepAliveTimeout + keepAliveTimeoutBuffer`; bun 1.4.0 keeps it open until the client hangs up.
- Same connections, same gap: `server.setTimeout()` does nothing, `req.setTimeout()` / `res.setTimeout()` callbacks never run, a response that sets `Connection: close` is not followed by a close, and `Http2SecureServer#close()` waits on any connection that was busy when it was called.
- `http.Server#emit("connection", socket)` goes through the same listener and has the same gaps.
- Cause: the JS HTTP/1 fallback listener reads `keepAliveTimeout` only to render the header. It arms no socket timeout, has no `'timeout'` listener, and ignores the close mark already put on responses that must close the connection; the native `http.Server` path does all three.

### Fix
- The fallback listener arms timeouts as Node's `_http_server.js` does: `server.timeout` on accept, `keepAliveTimeout + keepAliveTimeoutBuffer` once a response finishes with nothing else in flight (nothing when `keepAliveTimeout` is 0), and `server.timeout` again when the next request arrives, so a slow handler is not killed by the idle timer.
- A socket `'timeout'` is emitted on the request (only while its body is still incoming), the response and the server; the connection is destroyed only when none of them listens. That handling is removed when the socket is handed to `'upgrade'` / `'connect'`.
- A response marked as the connection's last one ends the connection when it finishes. The mark is the one the native path already sets, moved to a shared module so the fallback can read it; the native path is unchanged. `Http2SecureServer` also stores `keepAliveTimeoutBuffer` now (default 1000), and sockets without `setTimeout` get nothing armed, as in Node.
- Verification: new http2 and http tests wait on events or read `socket.timeout`, with expected values taken from the same scenarios on Node v26.3.0; the behavioral ones hang on bun 1.4.0 and the `socket.timeout` ones read 0 there. 30 runs under 10-way concurrent load on the debug build were green.

### Background
- allowHTTP1 fallback: a client of `http2.createSecureServer({ allowHTTP1: true })` that negotiates `http/1.1` is served by a JS parser loop, not by the native `http.Server`, so per-connection behavior of the native path has to be re-implemented there. `http.Server#emit("connection", socket)` feeds the same loop.
- `keepAliveTimeout` / `keepAliveTimeoutBuffer`: how long the server keeps an idle keep-alive connection open after a response, plus a grace period (default 1000ms) on top of the value advertised to the client. `keepAliveTimeout: 0` disables the idle timer.
- `socket.setTimeout(ms)`: an inactivity timer that only emits `'timeout'`; whoever owns the socket decides whether to destroy it. `socket.timeout` holds the armed value, which is how the tests check arming without waiting for a timer to fire.
- Node's `res._last`: a flag meaning "close the connection once this response is written". Bun sets its equivalent while rendering headers (explicit `Connection: close`, `shouldKeepAlive = false`, close-delimited bodies) and, on `httpAllowHalfOpen` servers, when the client half-closes mid-request.

<details>
<summary>Original description</summary>

### Problem

On `http2.createSecureServer({ allowHTTP1: true, keepAliveTimeout })`, an HTTP/1.1 keep-alive connection that has received its response and then idles is never closed. The response advertises `Keep-Alive: timeout=N`, but nothing enforces it. Node destroys the connection once `keepAliveTimeout` (+ `keepAliveTimeoutBuffer`) has elapsed.

```js
const server = http2.createSecureServer({ cert, key, allowHTTP1: true, keepAliveTimeout: 1000 }, (req, res) => res.end("ok"));
server.listen(0, () => {
  const s = tls.connect({ port: server.address().port, ca: cert, ALPNProtocols: ["http/1.1"] }, () =>
    s.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"));
  s.on("close", () => console.log("closed by server"));
});
// node v26.3.0: "closed by server" after ~2s (1000 + the default 1000 buffer)
// bun 1.4.0:    never; the connection stays open until the client hangs up
```

Consequences of the same gap on that path, also covered by the tests here:

- `Http2SecureServer#close()` only sweeps connections that are idle at the moment of the call; a connection busy at that moment is never closed afterwards, so `close()` completes only when the client disconnects.
- `server.setTimeout()` has no effect on allowHTTP1 connections (a connection that never sends a request is kept forever).
- `req.setTimeout()` / `res.setTimeout()` set the socket timeout, but the socket's `'timeout'` event is never routed anywhere, so the callbacks never run.
- A response that itself closes the connection (`res.setHeader("Connection", "close")`, `res.shouldKeepAlive = false`) advertises `Connection: close` but the fallback never ends the connection either (Node ends it as soon as the response finishes).
- `http.Server#emit("connection", socket)` goes through the same listener and has the same gaps.

### Cause

`connectionListenerHTTP1` in `src/js/internal/http1_server_fallback.ts` reads `server.keepAliveTimeout` only to render the `Keep-Alive` header. It never calls `socket.setTimeout()`, installs no `'timeout'` listener, and does not act on the close mark `renderNativeHeaders` already puts on such responses. The native `http.Server` path has all of this (`onResponseFinishHandleSocket`, `onNodeHTTPServerSocketTimeout`, the reset in the dispatcher); the JS fallback path was missing it.

### Fix

Port the corresponding parts of Node's `lib/_http_server.js` into the fallback listener:

- `connectionListenerInternal`: arm `server.timeout` when the connection is accepted and listen for the socket's `'timeout'`.
- `resOnFinish`, `res._last` branch: a response marked as the connection's last one ends the connection when it finishes. `renderNativeHeaders` already marks these responses (`kMustCloseConnection`: explicit `Connection: close`, `shouldKeepAlive = false`, 204/304 with `Transfer-Encoding`, close-delimited bodies); the symbol moves from `_http_server.ts` to `internal/http` so the fallback can read it too, and the fallback's `socketOnEnd` port (`httpAllowHalfOpen` servers whose client half-closes mid-request) now sets the same mark instead of a `_last` property nothing read. The native path keeps using the symbol exactly as before.
- `resOnFinish`, keep-alive branch: otherwise, when no other request is in flight on the connection, arm `keepAliveTimeout + keepAliveTimeoutBuffer` with Node's sanitizing of both values (so `keepAliveTimeout: 0` arms nothing). A request-side `Connection: close` was already ended by the existing `onfinished` hook, so nothing is armed there either.
- `resetSocketTimeout`: when the next request arrives on a connection whose keep-alive timeout is armed, put `server.timeout || 0` back so a slow handler is not killed by the idle timer.
- `socketOnTimeout`: emit `'timeout'` on the request (only while it is still being received), the in-flight response and the server; destroy the connection when none of them has a listener.
- `onParserExecuteCommon`: remove that `'timeout'` listener when the socket is handed to `'upgrade'` / `'connect'`, so a timeout on the handed-off socket is the new protocol's business (Node leaves `server.timeout` armed on it as well).

`Http2SecureServer` now stores `keepAliveTimeoutBuffer` (from `options` / `options.http1Options`, default 1000) next to the other HTTP/1 options, like Node's `storeHTTPOptions`, so the buffer option is honored on the fallback. Sockets without `setTimeout` (arbitrary Duplex streams fed through `emit("connection")`) keep working: nothing is armed on them, as in Node.

Each of these is what Node v26.3.0 does for the same connections; the expected values in the tests were taken from running the same scenarios against Node (`socket.timeout` sequences, event order of the `'timeout'` routing, which side closes and when).

### Tests

`test/js/node/http2/node-http2.test.js`, next to the other allowHTTP1 fallback tests:

- idle keep-alive connection is closed by the server; `close()` completes once a connection busy at `close()` time goes idle
- `socket.timeout` observed on request arrival and after `'finish'` across three requests, for no `server.timeout`, `server.setTimeout(7000)` and `keepAliveTimeout: 0` (covers the arming, the buffer, the reset and the disabled state without any timer having to fire)
- response-side `Connection: close` / `shouldKeepAlive = false`: connection ended, no idle timeout armed
- `server.setTimeout()` destroys a silent connection; with a `'timeout'` listener the connection survives and still serves a request
- `res.setTimeout()` and, for a request whose body never completes, `req.setTimeout()` receive the event in Node's order
- after an `'upgrade'` handoff the socket's timeout no longer destroys it (the handler answers the timeout through the tunnel)

`test/js/node/http/node-http.test.ts`: an `emit("connection")` net socket is closed after `keepAliveTimeout`; the existing handoff test now also checks the socket reaches the `'upgrade'` listener with no `'timeout'` listener (as upstream `test-http-connect` does); a Duplex without `setTimeout` is still served with `server.timeout` set; with `httpAllowHalfOpen`, a connection whose client half-closed is ended as soon as its response finishes.

The tests wait for events or inspect `socket.timeout`; the only timers involved are the ones under test and nothing in the tests races them. The behavioral ones fail on bun 1.4.0 (hang until the test timeout) and the `socket.timeout` ones report 0 everywhere there; removing the `res._last` branch or the handoff `removeListener` again makes their respective tests fail. 30 runs of the new tests under 10-way concurrent load on the debug build were green.

Also still passing: the rest of `node-http2.test.js` and `node-http.test.ts`, and the upstream `test-http2-https-fallback*.js`, `test-http2-allow-http1.js`, `test-http-generic-streams.js`, `test-http-server-unconsume-consume.js`, plus the upstream keep-alive / connection-close / server-timeout suite for the native path (`test-http-keep-alive*`, `test-http-server-keep-alive-timeout`, `test-http-should-keep-alive`, `test-http-set-timeout-server`, `test-http(s)-server-close-idle`, and friends), which exercises the moved symbol.

</details>
