### PR TITLE
test(shell): run the pwd &> / &>> redirect tests in a temp dir and check the file contents

### DIFF
--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -246,6 +246,11 @@ describe("IOWriter file output redirection", () => {
       .exitCode(0)
       .fileEquals("append_output.txt", "existing line\n$TEMP_DIR\n")
       .runAsTest("builtin pwd with &>> append redirect");
+
+    TestBuilder.command`pwd &>> new_append_output.txt`
+      .exitCode(0)
+      .fileEquals("new_append_output.txt", "$TEMP_DIR\n")
+      .runAsTest("builtin pwd with &>> redirect creates a missing file");
   });
 });
 

--- a/test/js/bun/shell/file-io.test.ts
+++ b/test/js/bun/shell/file-io.test.ts
@@ -225,14 +225,27 @@ describe("IOWriter file output redirection", () => {
     // command caused the same file descriptor to be closed twice, resulting
     // in an EBADF error. The issue was that two separate IOWriter instances
     // were created for the same fd when both stdout and stderr were redirected.
-    TestBuilder.command`pwd &> pwd_output.txt`.exitCode(0).runAsTest("builtin pwd with &> redirect");
+    TestBuilder.command`pwd &> pwd_output.txt`
+      .exitCode(0)
+      .fileEquals("pwd_output.txt", "$TEMP_DIR\n")
+      .runAsTest("builtin pwd with &> redirect");
 
     TestBuilder.command`echo "hello" &> echo_output.txt`
       .exitCode(0)
       .fileEquals("echo_output.txt", "hello\n")
       .runAsTest("builtin echo with &> redirect");
 
-    TestBuilder.command`pwd &>> append_output.txt`.exitCode(0).runAsTest("builtin pwd with &>> append redirect");
+    TestBuilder.command`pwd extra-arg &> stderr_output.txt`
+      .exitCode(1)
+      .stderr("")
+      .fileEquals("stderr_output.txt", "pwd: too many arguments\n")
+      .runAsTest("builtin stderr with &> redirect");
+
+    TestBuilder.command`pwd &>> append_output.txt`
+      .file("append_output.txt", "existing line\n")
+      .exitCode(0)
+      .fileEquals("append_output.txt", "existing line\n$TEMP_DIR\n")
+      .runAsTest("builtin pwd with &>> append redirect");
   });
 });
 

--- a/test/js/bun/shell/test_builder.ts
+++ b/test/js/bun/shell/test_builder.ts
@@ -171,6 +171,10 @@ export function createTestBuilder(path: string) {
       return this;
     }
 
+    /**
+     * Expect a file in the temp directory to have the given contents. Like
+     * `stdout()`, a string `expected` has `$TEMP_DIR` replaced with the temp directory.
+     */
     fileEquals(filename: string, expected: string | (() => string | Promise<string>)): this {
       this.getTempDir();
       this.file_equals[filename] = expected;
@@ -228,7 +232,8 @@ export function createTestBuilder(path: string) {
       } else if (typeof this.expected_exit_code === "function") this.expected_exit_code(exitCode);
 
       for (const [filename, expected_raw] of Object.entries(this.file_equals)) {
-        const expected = typeof expected_raw === "string" ? expected_raw : await expected_raw();
+        const expected =
+          typeof expected_raw === "string" ? expected_raw.replaceAll("$TEMP_DIR", tempdir) : await expected_raw();
         const actual = await Bun.file(join(this.tempdir!, filename)).text();
         expect(actual).toEqual(expected);
       }
@@ -256,7 +261,7 @@ export function createTestBuilder(path: string) {
           if (stdout === undefined || stderr === undefined || exitCode === undefined) {
             throw err_;
           }
-          this.doChecks(stdout, stderr, exitCode);
+          await this.doChecks(stdout, stderr, exitCode);
           return;
         }
         if (this.expected_error === true) return undefined;


### PR DESCRIPTION
### Problem
- `bun test test/js/bun/shell/file-io.test.ts` run from the repo root leaves `pwd_output.txt` and `append_output.txt` untracked in the checkout; the second grows a line per run.
- The two tests that write them redirect `pwd` to a relative path but never ask TestBuilder for a temp dir, so the shell runs in the test runner's cwd.
- The `&>>` test also never checked that anything was appended; a truncating `&>>` would have passed it.

### Fix
- Both tests now assert the redirected file's contents. Asserting on a file is what makes TestBuilder run the command in a temp dir, so nothing lands in the checkout. The append test seeds the file first and checks the cwd was added after the existing line.
- Two cases added: a builtin's stderr goes into the `&>` file, and `&>>` still creates a missing file (seeding the append test would otherwise have removed the only test of that).
- TestBuilder: string `fileEquals()` expectations get the `$TEMP_DIR` substitution `stdout()` already has, and the non-zero-exit path now awaits its checks. Before, a `fileEquals` mismatch there surfaced as "Unhandled error between tests" while the test passed.
- Verification: test-only change, so nothing fails before the fix. The file passes and `git status` is clean afterwards; each new assertion was checked to fail against wrong contents, a truncating `&>>`, and a mismatch on the non-zero-exit path.

### Background
- `TestBuilder` (`test/js/bun/shell/test_builder.ts`) is the shell test harness: a tagged `command` template, chained expectations such as `exitCode()` and `fileEquals()`, then `runAsTest(name)`.
- It only creates a temp dir and runs the shell inside it when an expectation asks for one (`file()`, `fileEquals()`, ...); otherwise the command runs in the test runner's cwd.
- `&>` sends stdout and stderr to one file; `&>>` appends both instead of truncating. This describe block exists because a builtin with both redirected once closed the same fd twice (#25568).
- `$TEMP_DIR` in an expected string is replaced with the temp dir path at check time, so a test can assert on `pwd` output that differs per run.

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/shell/file-io.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/shell/file-io.test.ts
bun test v1.4.0 (f02c937a9)

test/js/bun/shell/file-io.test.ts:
(pass) IOWriter file output redirection > basic file redirection > simple echo to file [62.65ms]
(pass) IOWriter file output redirection > basic file redirection > empty output to file [12.46ms]
(pass) IOWriter file output redirection > basic file redirection > zero-length write should trigger onIOWriterChunk callback [12.82ms]
(pass) IOWriter file output redirection > drainBufferedData edge cases > large single write [13.15ms]
(pass) IOWriter file output redirection > drainBufferedData edge cases > write to subdirectory [13.37ms]
bun: Not a directory: /dev/null/invalid/path(pass) IOWriter file output redirection > file system error conditions > write to invalid path should fail [24.34ms]
bun: No such file or directory: /nonexistent/file.txt(pass) IOWriter file output redirection > file system error conditions > write to non-existent directory should fail [10.16ms]
(pass) IOWriter file output redirection > special file types > write to /dev/null [7.40ms]
(pass) IOWriter file output redirection > special file types > redirect to a FIFO whose reader drains slowly applies backpressure [1153.62ms]
(pass) IOWriter file output redirection > writer queue and bump behavior > single writer completion and cleanup [8.58ms]
(pass) IOWriter file output redirection > writer queue and bump behavior > writer marked as dead during write [7.44ms]
(pass) IOWriter file output redirection > writer queue and bump behavior > bytelist capture during file write [7.72ms]
(pass) IOWriter file output redirection > error handling and unreachable paths > attempt to trigger partial write panic [7.17ms]
(pass) IOWriter file output redirection > error handling and unreachable paths > EAGAIN should never occur for files [6.51ms]
bun: No such file or directory: nonexistent_dir/file.txt(pass) IOWriter file output re
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/shell/file-io.test.ts | 22 ++++++++++++++++++++--
 test/js/bun/shell/test_builder.ts |  9 +++++++--
 2 files changed, 27 insertions(+), 4 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                               reads  edits  tests
test/js/bun/shell/file-io.test.ts      3      2      0
test/js/bun/shell/test_builder.ts      2      4      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

`test/js/bun/shell/file-io.test.ts` has two tests that redirect `pwd` into a relative file without setting up a TestBuilder temp dir:

```ts
TestBuilder.command`pwd &> pwd_output.txt`.exitCode(0).runAsTest("builtin pwd with &> redirect");
TestBuilder.command`pwd &>> append_output.txt`.exitCode(0).runAsTest("builtin pwd with &>> append redirect");
```

TestBuilder only sets the shell's cwd to a temp dir when something asks for one (`ensureTempDir()`, `file()`, `fileEquals()`, ...). These two never do, so the shell runs in the test runner's cwd and the files land there. From the repo root:

```
$ bun test test/js/bun/shell/file-io.test.ts >/dev/null; git status --short
?? append_output.txt
?? pwd_output.txt
```

`append_output.txt` also grows by one line per run, since that test appends to whatever the previous run left behind. Running the whole `test/js/bun/shell/` directory, these two files are the only things left in the checkout.

### Fix

Both tests now assert the redirected file's contents, which gives them a temp dir like every other redirect test in the file:

- `pwd &> pwd_output.txt` checks the file holds the cwd (`$TEMP_DIR\n`, the same convention the existing `pwd` test in `bunshell.test.ts` uses for stdout).
- `pwd &>> append_output.txt` seeds the file first and checks the cwd was appended after the existing line, so it now actually exercises the append half of `&>>` (before, a truncating `&>>` would have passed).
- Added case `pwd extra-arg &> stderr_output.txt` checks the builtin's stderr ends up in the `&>` file and not on the shell's stderr. The describe block is about stdout and stderr sharing one writer (#25568), and until now only the stdout half was checked.
- Added case `pwd &>> new_append_output.txt` keeps `&>>` against a missing file covered, since seeding `append_output.txt` would otherwise have removed the only test doing that.

Two small TestBuilder changes to support this, both in `test_builder.ts`:

- `fileEquals()` string expectations get the same `$TEMP_DIR` substitution `stdout()`/`stderr()` already have. No existing `fileEquals()` call uses that string, so nothing else changes.
- The non-zero-exit path of `run()` (where `Bun.$` throws) called `doChecks()` without awaiting it. Assertions made after the first `await` inside `doChecks()` (`fileEquals`, `doesNotExist`) therefore surfaced as "Unhandled error between tests" while the test itself was reported as passing. The new `exitCode(1)` test goes through that path, so it is now awaited; a mismatch there fails the test it belongs to.

### Verification

`bun bd test test/js/bun/shell/file-io.test.ts` passes (29 tests) and `git status` stays clean afterwards. The full `test/js/bun/shell/` directory has the same results as before the change (the only failures are the two `ls` permission-denied tests, which fail when running as root, and the `shell load` process-limit test, both unrelated), and leaves nothing in the repo root.

Also checked that the new assertions bite: wrong expected contents, a truncating `&>>`, and a `fileEquals` mismatch on the non-zero-exit path each fail the corresponding test.

Test-only change; there is no runtime behavior to fail before the fix, the symptom is the stray files.

</details>
