### PR TITLE
Declare node:process and node:module ESM exports lazily as well

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -42,6 +42,7 @@
 #include "GeneratedBunObject.h"
 #include "JavaScriptCore/BunV8HeapSnapshotBuilder.h"
 #include "BunObjectModule.h"
+#include "_NativeModule.h"
 #include "JSCookie.h"
 #include "JSCookieMap.h"
 #include "Secrets.h"
@@ -1151,9 +1152,6 @@ JSC::JSObject* createBunObject(VM& vm, JSObject* globalObject)
 } // namespace Bun
 
 namespace Zig {
-// Every export except `default` is declared without a value: JSC reads `Bun[name]` the first time
-// something binds to it (SyntheticModuleRecord::materializeLazyExport), so importing the module does
-// not run the PropertyCallbacks in bunObjectTable, most of which construct a class or load a builtin.
 JSC::JSObject* generateNativeModule_BunObject(JSC::JSGlobalObject* lexicalGlobalObject,
     JSC::Identifier moduleKey,
     Vector<JSC::Identifier, 4>& exportNames,
@@ -1164,25 +1162,13 @@ JSC::JSObject* generateNativeModule_BunObject(JSC::JSGlobalObject* lexicalGlobal
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* object = globalObject->bunObject();
 
-    // Static table entries are listed whether or not they have been reified.
+    // Static table entries are listed whether or not they have been reified, so this is the same export
+    // list that reifying them all used to produce, minus the cost of constructing every one of them.
     PropertyNameArrayBuilder propertyNames(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
     object->getOwnNonIndexPropertyNames(globalObject, propertyNames, DontEnumPropertiesMode::Exclude);
     RETURN_IF_EXCEPTION(scope, nullptr);
 
-    exportNames.reserveCapacity(propertyNames.size() + 1);
-    exportValues.ensureCapacity(propertyNames.size() + 1);
-
-    exportNames.append(vm.propertyNames->defaultKeyword);
-    exportValues.append(object);
-
-    for (const auto& propertyName : propertyNames) {
-        if (propertyName == vm.propertyNames->defaultKeyword) [[unlikely]]
-            continue;
-        exportNames.append(propertyName);
-        exportValues.append(JSValue());
-    }
-
-    return object;
+    return exportObjectProperties(vm, object, propertyNames, exportNames, exportValues);
 }
 
 } // namespace Zig

--- a/src/jsc/modules/NativeModuleList.h
+++ b/src/jsc/modules/NativeModuleList.h
@@ -18,15 +18,15 @@
     macro("abort-controller"_s, AbortControllerModule)
 
 #define BUN_FOREACH_ESM_NATIVE_MODULE(macro) \
-    BUN_FOREACH_ESM_AND_CJS_NATIVE_MODULE(macro) \
-    macro("node:module"_s, NodeModule)  \
-    macro("node:process"_s, NodeProcess)
+    BUN_FOREACH_ESM_AND_CJS_NATIVE_MODULE(macro)
 
 // Generators with JSC::SyntheticSourceProvider::LazySyntheticSourceGenerator's signature: they may
-// declare exports without a value and return the object JSC reads those exports from on first binding.
-// src/codegen/internal-module-registry-scanner.ts numbers native modules by their order in this file,
-// so these stay after the lists above.
+// declare exports without a value and return the object JSC reads those exports from on first binding
+// (see exportObjectProperties in _NativeModule.h). src/codegen/internal-module-registry-scanner.ts
+// numbers native modules by their order in this file, so these stay after the list above, in this order.
 #define BUN_FOREACH_LAZY_ESM_NATIVE_MODULE(macro) \
+    macro("node:module"_s, NodeModule)  \
+    macro("node:process"_s, NodeProcess) \
     macro("bun"_s, BunObject)
 
 #define BUN_FOREACH_CJS_NATIVE_MODULE(macro) \

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -1219,48 +1219,22 @@ JSC::JSValue createStreamIterEnabledFlag(Zig::GlobalObject*)
 } // namespace Bun
 
 namespace Zig {
-void generateNativeModule_NodeModule(JSC::JSGlobalObject* lexicalGlobalObject,
+JSC::JSObject* generateNativeModule_NodeModule(JSC::JSGlobalObject* lexicalGlobalObject,
     JSC::Identifier moduleKey,
     Vector<JSC::Identifier, 4>& exportNames,
     JSC::MarkedArgumentBuffer& exportValues)
 {
     Zig::GlobalObject* globalObject = defaultGlobalObject(lexicalGlobalObject);
     auto& vm = JSC::getVM(globalObject);
-    auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
     auto* constructor = globalObject->m_nodeModuleConstructor.getInitializedOnMainThread(globalObject);
-    // Don't bulk-reifyAllStaticProperties here. JSObject::reifyAllStaticProperties
-    // walks every PropertyCallbackAttribute back-to-back without an exception
-    // check between them, and several of our callbacks (getBuiltinModulesObject,
-    // getGlobalPathsObject, …) call constructArray/constructEmptyArray which
-    // open a ThrowScope at the same recursion depth as the next callback's
-    // ThrowScope — that trips the exception-check verifier on the synthetic
-    // ESM path (BUN_JSC_validateExceptionChecks=1). The loop below already
-    // does constructor->get(property) per-export, which lazy-reifies one entry
-    // at a time inside JSObject::get's own ThrowScope and is checked
-    // immediately after.
 
-    exportNames.reserveCapacity(Bun::countof(Bun::nodeModuleObjectTableValues) + 1);
-    exportValues.ensureCapacity(Bun::countof(Bun::nodeModuleObjectTableValues) + 1);
+    // The exports are the static table's entries, not the constructor's own properties (`length`, `name`,
+    // whatever user code assigned onto Module).
+    PropertyNameArrayBuilder properties(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
+    for (const auto& entry : Bun::nodeModuleObjectTableValues)
+        properties.add(Identifier::fromString(vm, entry.m_key));
 
-    exportNames.append(vm.propertyNames->defaultKeyword);
-    exportValues.append(constructor);
-
-    for (unsigned i = 0; i < Bun::countof(Bun::nodeModuleObjectTableValues); ++i) {
-        const auto& entry = Bun::nodeModuleObjectTableValues[i];
-        const auto& property = Identifier::fromString(vm, entry.m_key);
-        JSValue value = constructor->get(globalObject, property);
-
-        if (topExceptionScope.exception()) [[unlikely]] {
-            // A termination (worker terminate() mid-import) cannot be cleared:
-            // stop the walk and leave it pending for the loader.
-            if (!topExceptionScope.tryClearException())
-                return;
-            value = jsUndefined();
-        }
-
-        exportNames.append(property);
-        exportValues.append(value);
-    }
+    return exportObjectProperties(vm, constructor, properties, exportNames, exportValues);
 }
 
 } // namespace Zig

--- a/src/jsc/modules/NodeModuleModule.h
+++ b/src/jsc/modules/NodeModuleModule.h
@@ -36,10 +36,10 @@ JSC::JSValue resolveLookupPaths(JSC::JSGlobalObject* globalObject, String reques
 
 namespace Zig {
 
-void generateNativeModule_NodeModule(                                     
-  JSC::JSGlobalObject *lexicalGlobalObject, JSC::Identifier moduleKey,     
+JSC::JSObject *generateNativeModule_NodeModule(
+  JSC::JSGlobalObject *lexicalGlobalObject, JSC::Identifier moduleKey,
   Vector<JSC::Identifier, 4> &exportNames,
-  JSC::MarkedArgumentBuffer &exportValues);  
+  JSC::MarkedArgumentBuffer &exportValues);
 
 
 } // namespace Zig

--- a/src/jsc/modules/NodeProcessModule.h
+++ b/src/jsc/modules/NodeProcessModule.h
@@ -6,46 +6,19 @@
 
 namespace Zig {
 
-DEFINE_NATIVE_MODULE(NodeProcess)
+DEFINE_LAZY_NATIVE_MODULE(NodeProcess)
 {
     auto& vm = lexicalGlobalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
-
     Bun::Process* process = globalObject->processObject();
-    // Don't bulk-reifyAllStaticProperties here (see generateNativeModule_NodeModule
-    // for the long version). It runs every PropertyCallback back-to-back without an
-    // exception check in between, which trips BUN_JSC_validateExceptionChecks=1.
-    // The per-export get() below lazy-reifies one property at a time inside
-    // JSObject::get's own checked ThrowScope.
 
+    // The whole prototype chain: the EventEmitter methods are exports of this module too.
     PropertyNameArrayBuilder properties(vm, PropertyNameMode::Strings, PrivateSymbolMode::Exclude);
     process->getPropertyNames(globalObject, properties, DontEnumPropertiesMode::Exclude);
-    RETURN_IF_EXCEPTION(scope, );
+    RETURN_IF_EXCEPTION(scope, nullptr);
 
-    exportNames.append(vm.propertyNames->defaultKeyword);
-    exportValues.append(process);
-
-    for (auto& entry : properties.releaseData()->propertyNameVector()) {
-        if (entry == vm.propertyNames->defaultKeyword) {
-            // skip because it's already on the default
-            // export (the Process object itself)
-            continue;
-        }
-
-        auto topExceptionScope = DECLARE_TOP_EXCEPTION_SCOPE(vm);
-        JSValue result = process->get(globalObject, entry);
-        if (topExceptionScope.exception()) {
-            // A getter that throws exports undefined; a termination (worker
-            // terminate() mid-import) cannot be cleared: stop, leave it pending.
-            if (!topExceptionScope.tryClearException())
-                return;
-            result = jsUndefined();
-        }
-
-        exportNames.append(entry);
-        exportValues.append(result);
-    }
+    return exportObjectProperties(vm, process, properties, exportNames, exportValues);
 }
 
 } // namespace Zig

--- a/src/jsc/modules/_NativeModule.h
+++ b/src/jsc/modules/_NativeModule.h
@@ -3,6 +3,7 @@
 #include "JSBuffer.h"
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/ObjectConstructor.h>
+#include <JavaScriptCore/PropertyNameArray.h>
 #include "ZigGlobalObject.h"
 #include "NativeModuleList.h"
 
@@ -54,6 +55,12 @@
       JSC::MarkedArgumentBuffer &exportValues)
 #define DEFINE_NATIVE_MODULE_NOINLINE(name)                                             \
   void generateNativeModule_##name(                                     \
+      JSC::JSGlobalObject *lexicalGlobalObject, JSC::Identifier moduleKey,     \
+      Vector<JSC::Identifier, 4> &exportNames,                                 \
+      JSC::MarkedArgumentBuffer &exportValues)
+// For modules in BUN_FOREACH_LAZY_ESM_NATIVE_MODULE; the body usually ends in exportObjectProperties().
+#define DEFINE_LAZY_NATIVE_MODULE(name)                                        \
+  inline JSC::JSObject *generateNativeModule_##name(                           \
       JSC::JSGlobalObject *lexicalGlobalObject, JSC::Identifier moduleKey,     \
       Vector<JSC::Identifier, 4> &exportNames,                                 \
       JSC::MarkedArgumentBuffer &exportValues)
@@ -134,4 +141,34 @@ JSC::JSObject* generateNativeModule_##enumName( \
   Vector<JSC::Identifier, 4> &exportNames, \
   JSC::MarkedArgumentBuffer &exportValues);
 BUN_FOREACH_LAZY_ESM_NATIVE_MODULE(FORWARD_DECL_LAZY_GENERATOR)
+
+// The lazy modules each mirror an object that already exists (the Bun object, process, the Module
+// constructor): `default` is the object and each of propertyNames is an export. A value that is
+// already stored on the object is exported as is. Anything else, i.e. a static table entry nothing
+// has read yet, an accessor, or an inherited property, is declared without a value, and JSC reads
+// object[name] when something first binds to it, so loading the module does not construct the
+// object's lazy properties. Returns the object, as the LazySyntheticSourceGenerator contract wants.
+inline JSC::JSObject *exportObjectProperties(
+    JSC::VM &vm, JSC::JSObject *object,
+    const JSC::PropertyNameArrayBuilder &propertyNames,
+    Vector<JSC::Identifier, 4> &exportNames,
+    JSC::MarkedArgumentBuffer &exportValues) {
+  exportNames.reserveCapacity(propertyNames.size() + 1);
+  exportValues.ensureCapacity(propertyNames.size() + 1);
+
+  exportNames.append(vm.propertyNames->defaultKeyword);
+  exportValues.append(object);
+
+  for (const auto &propertyName : propertyNames) {
+    if (propertyName == vm.propertyNames->defaultKeyword) [[unlikely]]
+      continue;
+    JSC::JSValue stored = object->getDirect(vm, propertyName);
+    if (stored && (stored.isGetterSetter() || stored.isCustomGetterSetter()))
+      stored = JSC::JSValue();
+    exportNames.append(propertyName);
+    exportValues.append(stored);
+  }
+
+  return object;
+}
 } // namespace Zig

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -34,26 +34,43 @@ const helper = `
   export { fs };
 `;
 
-// The "bun" module is generated natively from the Bun object (generateNativeModule_BunObject). Most Bun.* properties
-// are PropertyCallback entries of its static table that construct their value (a class, the shell, the default
-// SQL/S3/Redis clients, ...) the first time they are read, at which point they become own properties of the object.
-// bun:jsc's describe() dumps the object's Structure, i.e. exactly the set of properties that have been constructed,
-// which is the readout used here. WATCHED is a sample of them plus `write`, the plain function the entries below import.
+// "bun", "node:process" and "node:module" are generated natively from an existing object (the Bun object, process,
+// the Module constructor; see BUN_FOREACH_LAZY_ESM_NATIVE_MODULE). Most of those objects' properties are
+// PropertyCallback entries of a static table that construct their value (a class, the shell, the default
+// SQL/S3/Redis clients, the stdio streams, the builtinModules array, ...) the first time they are read, at which
+// point they become own properties of the object. bun:jsc's describe() dumps the object's Structure, i.e. exactly the
+// set of properties that have been constructed, which is the readout used here. (Object.keys and Reflect.ownKeys list
+// static entries without constructing them; for...in constructs all of them, so the entries below avoid it.) The
+// watched names are a sample of those entries plus the plain function (`write`, `createRequire`) an entry imports.
 //
 // Note that a literal `import ... from "bun"` (and `import("bun")` / `require("bun")`) is rewritten by the
 // transpiler into a read of globalThis.Bun and never loads the module; the module is what `export ... from "bun"`
-// and a non-literal import() specifier go through.
+// and a non-literal import() specifier go through. Imports of node:process and node:module always load the module.
 const WATCHED = ["$", "CryptoHasher", "Glob", "S3Client", "SQL", "TOML", "Transpiler", "secrets", "write"] as const;
+const PROCESS_WATCHED = ["allowedNodeEnvironmentFlags", "config", "release", "stderr", "stdin", "stdout", "versions"];
+const MODULE_WATCHED = [
+  "SourceMap",
+  "_cache",
+  "_extensions",
+  "builtinModules",
+  "constants",
+  "createRequire",
+  "globalPaths",
+];
 
-const bunHelper = `
+const nativeHelper = `
   import { describe } from "bun:jsc";
-  const WATCHED = ${JSON.stringify(WATCHED)};
-  /** The WATCHED names that are own properties of the Bun object by now, i.e. whose value has been constructed. */
-  export function constructed() {
-    const properties = /\\{([^}]*)\\}/.exec(describe(Bun))[1];
+  /** The names out of \`watched\` that are own properties of \`object\` by now, i.e. whose value has been constructed. */
+  function constructedOn(object, watched) {
+    const properties = /\\{([^}]*)\\}/.exec(describe(object))[1];
     const names = properties.split(",").map(entry => entry.trim().split(":")[0]);
-    return WATCHED.filter(name => names.includes(name));
+    return watched.filter(name => names.includes(name));
   }
+  export const constructed = () => constructedOn(Bun, ${JSON.stringify(WATCHED)});
+  export const constructedOnProcess = () => constructedOn(process, ${JSON.stringify(PROCESS_WATCHED)});
+  // getBuiltinModule hands out the constructor itself without going through the ES module.
+  export const constructedOnModule = () =>
+    constructedOn(process.getBuiltinModule("node:module"), ${JSON.stringify(MODULE_WATCHED)});
   export function print(result) {
     console.log(JSON.stringify(result));
   }
@@ -68,7 +85,11 @@ const bunReexport = `
 `;
 
 async function run(files: Record<string, string>, args: string[] = ["entry.mjs"], env: Record<string, string> = {}) {
-  using dir = tempDir("builtin-esm-lazy-exports", { "helper.mjs": helper, "bun-helper.mjs": bunHelper, ...files });
+  using dir = tempDir("builtin-esm-lazy-exports", {
+    "helper.mjs": helper,
+    "native-helper.mjs": nativeHelper,
+    ...files,
+  });
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
     cwd: String(dir),
@@ -270,7 +291,7 @@ test.concurrent('"bun": re-exports construct the properties that get bound, not 
       // Linking this import is what constructs Bun.write; nothing else is read.
       import { write } from "./reexport.mjs";
       import * as reexported from "./reexport.mjs";
-      import { constructed, print } from "./bun-helper.mjs";
+      import { constructed, print } from "./native-helper.mjs";
       const afterLink = constructed();
       const present = "SQL" in reexported;
       const afterIn = constructed();
@@ -308,7 +329,7 @@ test.concurrent('"bun": re-exports construct the properties that get bound, not 
 
 test.concurrent('"bun": import() namespace has the same export list, and every export is the Bun.* value', async () => {
   const result = await runEntry(`
-    import { constructed, print, specifier } from "./bun-helper.mjs";
+    import { constructed, print, specifier } from "./native-helper.mjs";
     const ns = await import(specifier);
     const afterImport = constructed();
     // Neither [[OwnPropertyKeys]] of the namespace nor Object.keys of the Bun object reads any of the properties.
@@ -348,7 +369,7 @@ test.concurrent('"bun": a property whose getter throws only fails the binding th
     `
       import { write } from "./reexport.mjs";
       import * as reexported from "./reexport.mjs";
-      import { print } from "./bun-helper.mjs";
+      import { print } from "./native-helper.mjs";
       function message(read) {
         try {
           read();
@@ -383,7 +404,7 @@ test.concurrent('"bun": mock.module replaces a binding without constructing the 
       "lazy.test.ts": `
         import { expect, mock, test } from "bun:test";
         import * as reexported from "./reexport.mjs";
-        import { constructed } from "./bun-helper.mjs";
+        import { constructed } from "./native-helper.mjs";
 
         test("mock.module('bun')", () => {
           expect(constructed()).toEqual([]);
@@ -401,4 +422,94 @@ test.concurrent('"bun": mock.module replaces a binding without constructing the 
   expect(stderr).toContain(" 1 pass");
   expect(stderr).toContain(" 0 fail");
   expect(exitCode).toBe(0);
+});
+
+test.concurrent("node:process: linking constructs the linked bindings, not the stdio streams", async () => {
+  const result = await runEntry(`
+    import proc, { on, release } from "node:process";
+    import * as ns from "node:process";
+    import { constructedOnProcess, print } from "./native-helper.mjs";
+    const afterLink = constructedOnProcess();
+    // The exports are the enumerable names of process and its prototype chain, as listed when the module loaded.
+    // (Object.keys does not reify anything, unlike for...in, and nothing has changed the chain since loading: that
+    // happens further down, when reading stdout loads node:events.)
+    const enumerable = new Set();
+    for (let object = process; object !== null; object = Object.getPrototypeOf(object)) {
+      for (const name of Object.keys(object)) enumerable.add(name);
+    }
+    const exportNames = Reflect.ownKeys(ns).filter(key => typeof key === "string");
+    const exportListMatches = exportNames.sort().join() === [...enumerable, "default"].sort().join();
+    const afterListing = constructedOnProcess();
+    const stdout = ns.stdout;
+    print({
+      defaultIsProcess: proc === process,
+      afterLink,
+      release: release === process.release,
+      // Inherited from the EventEmitter prototype, so it was never stored on process itself.
+      on: on === process.on && !Object.hasOwn(process, "on"),
+      exportListMatches,
+      afterListing,
+      stdout: stdout === process.stdout && typeof stdout.write === "function",
+      afterStdoutRead: constructedOnProcess(),
+      argv: ns.argv === process.argv,
+    });
+  `);
+  expect(result).toEqual({
+    defaultIsProcess: true,
+    afterLink: ["release"],
+    release: true,
+    on: true,
+    exportListMatches: true,
+    afterListing: ["release"],
+    stdout: true,
+    afterStdoutRead: ["release", "stdout"],
+    argv: true,
+  });
+});
+
+test.concurrent("node:process: a value already stored on the object is exported as it was at load", async () => {
+  const result = await runEntry(`
+    import { print } from "./native-helper.mjs";
+    process.addedBeforeLoad = "at load";
+    const ns = await import("node:process");
+    process.addedBeforeLoad = "after load";
+    process.addedAfterLoad = true;
+    print({ addedBeforeLoad: ns.addedBeforeLoad, exportsAddedAfterLoad: "addedAfterLoad" in ns });
+  `);
+  expect(result).toEqual({ addedBeforeLoad: "at load", exportsAddedAfterLoad: false });
+});
+
+test.concurrent("node:module: linking constructs the linked bindings, not the rest of the table", async () => {
+  const result = await runEntry(`
+    import Module, { createRequire } from "node:module";
+    import * as ns from "node:module";
+    import { constructedOnModule, print } from "./native-helper.mjs";
+    const afterLink = constructedOnModule();
+    const exportNames = Reflect.ownKeys(ns).filter(key => typeof key === "string");
+    // The export list is the static table, which is also exactly what Object.keys of the constructor lists.
+    const exportListMatches = exportNames.sort().join() === [...Object.keys(Module), "default"].sort().join();
+    const afterListing = constructedOnModule();
+    const builtinModules = ns.builtinModules;
+    print({
+      defaultIsTheConstructor: Module === process.getBuiltinModule("node:module"),
+      afterLink,
+      createRequire: typeof createRequire(import.meta.url)("node:path").join === "function",
+      exportListMatches,
+      afterListing,
+      builtinModules: Array.isArray(builtinModules) && builtinModules === Module.builtinModules,
+      afterRead: constructedOnModule(),
+      // Backed by an accessor rather than a constructed value; the binding gets what the accessor returns.
+      resolveFilename: ns._resolveFilename === Module._resolveFilename && typeof ns._resolveFilename === "function",
+    });
+  `);
+  expect(result).toEqual({
+    defaultIsTheConstructor: true,
+    afterLink: ["createRequire"],
+    createRequire: true,
+    exportListMatches: true,
+    afterListing: ["createRequire"],
+    builtinModules: true,
+    afterRead: ["builtinModules", "createRequire"],
+    resolveFilename: true,
+  });
 });


### PR DESCRIPTION
Follow-up to #37714 (the `"bun"` module) and #37525 (the `src/js` builtins): the two remaining native ES modules that mirror an existing object, `node:process` and `node:module`, still built their records eagerly. `generateNativeModule_NodeProcess` called `get()` on every enumerable property of `process` and its prototype chain, and `generateNativeModule_NodeModule` on every entry of the Module constructor's static table. Unlike `"bun"`, these imports are not rewritten by the transpiler, so every `import process from "node:process"` (a very common line in published ESM packages) and every `import { createRequire } from "node:module"` paid for it.

## Repro

```js
// entry.mjs
import { describe } from "bun:jsc";
import process from "node:process";
import { createRequire } from "node:module";
// describe() dumps an object's Structure, i.e. which of its static table entries have been constructed so far.
const entries = object => describe(object).match(/\{[^}]*\}/)[0].split(",").length;
console.log(entries(process), entries(globalThis.process.getBuiltinModule("node:module")));
```

Before: `86 27`. For `process` that is everything in the table that can be reified, including `stdout`, `stderr` and `stdin`, which construct the stdio streams and load `node:tty` / `node:stream` to do it, plus `config`, `release`, `allowedNodeEnvironmentFlags`, `versions`, ...; for `Module` it is `_cache`, `builtinModules`, `globalPaths`, `SourceMap`, the `wrapper` proxy and the rest of the table. After: `2 3`, i.e. only what is there before user code runs (`Symbol.toStringTag` and `_exiting` on `process`, `length` and `name` on `Module`) plus `createRequire`, the one thing the file imported.

On this machine (release build of 1.4.0, min of 20 runs), `import process from "node:process"` added about 18 ms to the startup of an otherwise empty file, about the same as touching `process.stdout` does; with this change the import itself is free and that cost moves to whoever actually reads `stdout`. Measured numbers (release 1.4.0 for the eager cost, a debug build of this branch for the new one) are in a comment below.

## Fix

Both generators move to the `BUN_FOREACH_LAZY_ESM_NATIVE_MODULE` group added in #37714 (the entries keep their position in `NativeModuleList.h`, so the generated ids do not change) and share one helper, `exportObjectProperties()` in `_NativeModule.h`, which the `"bun"` generator now uses too. For each name the caller wants exported it does the split #37525 does for the `src/js` builtins: a value that is already stored on the object (`getDirect()` finds a plain value) is exported as is, anything else is declared without a value and JSC's `materializeLazyExport` reads `object[name]` the first time something binds to it. "Anything else" covers a static table entry nobody has read yet (the expensive case), an accessor (`process.argv`, `process.title`, `Module._resolveFilename`, `Module.wrapper`), and a property inherited from the prototype chain (the EventEmitter methods of `process`). The generators themselves only decide the name list, which is what keeps the export lists identical to before:

- `node:process`: `getPropertyNames()` on `process`, as before, so the inherited EventEmitter methods (`on`, `emit`, ...) stay exports, and a data property assigned onto `process` before the module is loaded is still exported and still snapshotted at load (`process.test.js` has a test for exactly that, with `default` on top, which keeps being skipped in favour of the object).
- `node:module`: the static table, as before, so `length`, `name` and anything user code assigned onto `Module` stay out.
- `"bun"`: `getOwnNonIndexPropertyNames()`, as in #37714. The only difference from #37714 is that a `Bun.*` property something already read before the module loads is now snapshotted instead of declared lazily; it is the same object either way.

The generators no longer run any getters, so the `TopExceptionScope` handling that turned a throwing getter into an `undefined` export (and the comments about not bulk-reifying because of the exception-check verifier) go away with them. A getter that throws now throws from whatever binds to that export, and a termination arriving while a binding is being materialized propagates from there, the same way #37714 describes for `"bun"`. The sampling-time difference is also the same as there: an accessor export is read when it is first bound rather than when the module loads, which for the first importer is the same moment.

## Tests

Added to `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts`, same shape as the `"bun"` cases (each in its own process, readout is `describe()` of the object filtered to a watched sample of names; `Object.keys` / `Reflect.ownKeys` are used for the export-list checks because `for...in` reifies every static property of the object it enumerates):

- `node:process`: linking `import proc, { on, release }` constructs exactly `release`; `on` is the inherited method; the export list equals the enumerable names of `process` and its prototype chain plus `default`; listing it constructs nothing; reading `stdout` off the namespace constructs exactly `stdout` and is the real stream; `argv` (an accessor) binds to `process.argv`.
- `node:process`: a data property assigned before the load is exported with its value at load time, and one assigned afterwards is not exported (the part of the behaviour this keeps from the eager version).
- `node:module`: linking `import Module, { createRequire }` constructs exactly `createRequire` (and it works); the export list equals `Object.keys(Module)` plus `default`; reading `builtinModules` constructs exactly that and is the same array; `_resolveFilename` binds to the accessor's value.

The two "linking constructs ..." cases fail on main (everything watched shows up as constructed after import); the snapshot case and the 12 existing cases in the file pass on both. Also run on this build: `test/js/node/process/` (`process.test.js`, `process-stdio`, `process-on`, `call-constructor`, which imports `node:process` as ESM), `test/js/node/module/`, `test/js/node/events/event-emitter.test.ts`, `test/js/bun/util/BunObject.test.ts`, `test/js/bun/test/mock/`, `stubs.test.js`, `require-esm-transitive-tla` and `import-meta-resolve`; green except for two tests that fail identically without this change in this environment (`process.test.js` "process" wants `$USER` set, and `process-args.test.js` spawns 100 debug processes inside a 5 s timeout). `BUN_JSC_validateExceptionChecks=1` is clean for importing both modules and for reading every export of both namespaces.

