### PR TITLE
bake: return the promise from import() with options in the dev server runtime

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -142,7 +142,7 @@ export class HMRModule {
       return (found as Promise<HMRModule>).then(getEsmExports);
     }
     return opts
-      ? (lazyDynamicImportWithOptions ??= new Function("specifier, opts", "import(specifier, opts)"))(id, opts)
+      ? (lazyDynamicImportWithOptions ??= new Function("specifier, opts", "return import(specifier, opts)"))(id, opts)
       : import(id);
   }
 

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -273,6 +273,48 @@ devTest("ESM <-> CJS (async)", {
     await c.expectMessage("PASS");
   },
 });
+devTest("import() with an options object returns the module namespace", {
+  // Every import() in a dev server module is lowered to hmr.dynamicImport().
+  // Modules the dev server did not bundle (builtins, externals, URLs) fall
+  // through to a real import(), which must be returned to the caller when
+  // import options are present, the same as when they are absent.
+  framework: minimalFramework,
+  files: {
+    "dep.ts": `
+      export const x = 1;
+    `,
+    "routes/index.ts": `
+      export default async function (req, meta) {
+        const builtin = await import("node:path");
+        const builtinWithOptions = import("node:path", { with: {} });
+        const specifier = "node:" + "path";
+        const computedWithOptions = import(specifier, { with: {} });
+        const bundledWithOptions = import("../dep", { with: {} });
+        return Response.json({
+          builtinWithOptions: [
+            builtinWithOptions instanceof Promise,
+            (await builtinWithOptions) === builtin,
+          ],
+          computedWithOptions: [
+            computedWithOptions instanceof Promise,
+            (await computedWithOptions) === builtin,
+          ],
+          bundledWithOptions: [
+            bundledWithOptions instanceof Promise,
+            (await bundledWithOptions).x,
+          ],
+        });
+      }
+    `,
+  },
+  async test(dev) {
+    expect(await dev.fetch("/").json()).toEqual({
+      builtinWithOptions: [true, true],
+      computedWithOptions: [true, true],
+      bundledWithOptions: [true, 1],
+    });
+  },
+});
 devTest("importer tracking survives flipping a module from ESM to CJS", {
   // https://github.com/oven-sh/bun/issues/31942
   files: {

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -273,35 +273,38 @@ devTest("ESM <-> CJS (async)", {
     await c.expectMessage("PASS");
   },
 });
-devTest("import() with an options object returns the module namespace", {
+devTest("import() with an options object returns the namespace and forwards the options", {
   // Every import() in a dev server module is lowered to hmr.dynamicImport().
-  // Modules the dev server did not bundle (builtins, externals, URLs) fall
-  // through to a real import(), which must be returned to the caller when
-  // import options are present, the same as when they are absent.
+  // Modules the dev server did not bundle (builtins, externals, absolute paths)
+  // fall through to a real import(), which must receive the options and whose
+  // promise must be handed back to the caller.
   framework: minimalFramework,
   files: {
     "dep.ts": `
       export const x = 1;
     `,
+    "data.json": `{"a":1}`,
     "routes/index.ts": `
+      import * as path from "node:path";
       export default async function (req, meta) {
-        const builtin = await import("node:path");
         const builtinWithOptions = import("node:path", { with: {} });
-        const specifier = "node:" + "path";
-        const computedWithOptions = import(specifier, { with: {} });
+        // Computed, so the bundler cannot resolve it; type: "text" is only
+        // honored if the options object reaches the real import().
+        const dataFile = path.join(process.cwd(), "data.json");
+        const computedWithOptions = import(dataFile, { with: { type: "text" } });
         const bundledWithOptions = import("../dep", { with: {} });
         return Response.json({
           builtinWithOptions: [
             builtinWithOptions instanceof Promise,
-            (await builtinWithOptions) === builtin,
+            (await builtinWithOptions) === path,
           ],
           computedWithOptions: [
             computedWithOptions instanceof Promise,
-            (await computedWithOptions) === builtin,
+            (await computedWithOptions)?.default,
           ],
           bundledWithOptions: [
             bundledWithOptions instanceof Promise,
-            (await bundledWithOptions).x,
+            (await bundledWithOptions)?.x,
           ],
         });
       }
@@ -310,8 +313,36 @@ devTest("import() with an options object returns the module namespace", {
   async test(dev) {
     expect(await dev.fetch("/").json()).toEqual({
       builtinWithOptions: [true, true],
-      computedWithOptions: [true, true],
+      computedWithOptions: [true, '{"a":1}'],
       bundledWithOptions: [true, 1],
+    });
+  },
+});
+devTest("import() with an options object returns the namespace (client runtime)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      // Computed, so the bundler leaves it to the runtime; a literal data: URL
+      // would be bundled like any other module.
+      const specifier = "data:text/javascript," + encodeURIComponent("export default 1;");
+      const computedWithOptions = import(specifier, { with: {} });
+      const bundledWithOptions = import("./dep", { with: {} });
+      console.log({
+        computedWithOptions: [typeof computedWithOptions?.then, (await computedWithOptions)?.default],
+        bundledWithOptions: [typeof bundledWithOptions?.then, (await bundledWithOptions)?.x],
+      });
+    `,
+    "dep.ts": `
+      export const x = 1;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage({
+      computedWithOptions: ["function", 1],
+      bundledWithOptions: ["function", 1],
     });
   },
 });


### PR DESCRIPTION
### Problem
- In the dev server (`bun ./index.html`, or any Bake app in development), `await import("node:path", { with: {} })` resolves to `undefined`. The same import without the options object returns the namespace.
- Any `import()` that passes options and targets a module the dev server did not bundle (a builtin, a computed specifier) is affected, in both the client and server runtimes.
- Cause: the runtime's fallback for the options form started the real `import()` but never handed its promise back to the caller. It has been this way since the helper was added in #17476.

### Fix
- The fallback now returns the promise from the real `import()`. The source change is one `return`.
- This is the right value because a real `import()` always evaluates to a promise, the no-options branch beside it already returns one, and production `bun build` output yields the promise too, which the dev runtime is meant to match.
- Verification: two dev server tests, one per runtime, fail without the fix and pass with it. The server test also imports a `.json` file with `{ with: { type: "text" } }` and expects raw text, so it fails if the promise comes back but the options stop being forwarded.

### Background
- The dev server rewrites every `import()` in a served module into a call to its own `hmr.dynamicImport(specifier, opts)`, so modules it bundled are looked up in its module registry.
- A specifier that is not in the registry (a builtin, a computed path) falls through to a real `import()`. That fallback is the only code this PR touches.
- The options form of that fallback is built with `new Function` on first use instead of being written in the runtime source, because Firefox does not parse `import(a, b)`. A `new Function` body only yields a value through an explicit `return`.
- `hmr-module.ts` is shared by the client and server dev runtimes, so the one change fixes both.

<details>
<summary>Original description</summary>

### What does this PR do?

In the dev server (`bun ./index.html`, or any Bake app in development), a dynamic `import()` that carries an options object and targets a module the dev server did not bundle resolves to `undefined` instead of the module namespace:

```ts
// routes/index.ts, served by the dev server
const plain = await import("node:path");              // namespace, works
const ns = await import("node:path", { with: {} });   // undefined
const ns2 = await import(specifier, { with: {} });    // undefined when `specifier` is not a bundled module
```

The dev server lowers every `import()` in a module to `hmr.dynamicImport(specifier, opts)` (both the string literal and the computed specifier forms, see the `InternalBakeDev` branches in `src/js_printer/lib.rs`). For ids that are not in the module registry, `HMRModule.dynamicImport` in `src/runtime/bake/hmr-module.ts` falls back to a real `import()`. The no-options branch returns `import(id)`, but the options branch goes through a lazily built function (kept out of the runtime source because Firefox does not parse `import(a, b)`) whose body was:

```js
lazyDynamicImportWithOptions ??= new Function("specifier, opts", "import(specifier, opts)")
```

There is no `return`, so the import is started for its side effects and the caller gets `undefined`. This has been the case since the helper was added in #17476; `hmr-module.ts` is shared by the client and server runtimes, so both are affected.

The fix adds the `return`. A real `import()` always evaluates to a promise, the no-options branch of the same function already returns one, and production `bun build` output prints these imports as a plain `import(path, opts)` expression, which also yields the promise; the dev runtime's stated goal is to match that output.

### How did you verify your code works?

Two dev server tests were added to `test/bake/dev/esm.test.ts`.

The server runtime test (a `minimalFramework` route) covers the ways `hmr.dynamicImport` is reached with options: a string literal builtin specifier, a computed specifier, and a bundled module (the registry branch, which already worked and stays working). The builtin case must resolve to the same namespace object as a static `import * as path from "node:path"`. The computed case imports a `.json` file from the project directory with `{ with: { type: "text" } }` and expects the raw file text, so it also fails if the helper returns the promise but stops forwarding the options (checked by building with `return import(specifier)` as the body: that variant gets the parsed object back and fails the test).

The client runtime test loads an HTML route and does the same through the client bundle, using a computed `data:` URL (a literal one would be bundled). Verified against both Node versions the CI agents run the client harness with (24.3.0 and 26.3.0): passes with the fix, fails without it.

Without the fix (`USE_SYSTEM_BUN=1 bun test test/bake/dev/esm.test.ts`, also with `src/` stashed and `bun bd test`), server test:

```
    "builtinWithOptions": [
-     true,
-     true,
+     false,
+     false,
    ],
    "computedWithOptions": [
-     true,
-     "{"a":1}",
+     false,
+     null,
    ],
```

and client test:

```
      "computedWithOptions": [
-       "function",
-       1,
+       "undefined",
+       null,
      ],
```

With the fix, `bun bd test test/bake/dev/esm.test.ts` passes (19 tests).

</details>
