### PR TITLE
Bump WebKit: InternalFieldTuple cast by JSType; give ErrorCodeCache and InternalModuleRegistry their own JSType

### DIFF
--- a/src/jsc/bindings/ErrorCode.cpp
+++ b/src/jsc/bindings/ErrorCode.cpp
@@ -163,7 +163,7 @@ DEFINE_VISIT_CHILDREN_WITH_MODIFIER(JS_EXPORT_PRIVATE, ErrorCodeCache);
 
 Structure* ErrorCodeCache::createStructure(JSC::VM& vm, JSC::JSGlobalObject* globalObject)
 {
-    return Structure::create(vm, globalObject, jsNull(), TypeInfo(InternalFieldTupleType, StructureFlags), info(), 0, 0);
+    return Structure::create(vm, globalObject, jsNull(), TypeInfo(ObjectType, StructureFlags), info(), 0, 0);
 }
 
 ErrorCodeCache* ErrorCodeCache::create(VM& vm, Structure* structure)

--- a/src/jsc/bindings/InternalModuleRegistry.cpp
+++ b/src/jsc/bindings/InternalModuleRegistry.cpp
@@ -165,7 +165,7 @@ void InternalModuleRegistry::finishCreation(VM& vm)
 
 Structure* InternalModuleRegistry::createStructure(VM& vm, JSGlobalObject* globalObject)
 {
-    return Structure::create(vm, globalObject, jsNull(), TypeInfo(InternalFieldTupleType, StructureFlags), info(), 0, 0);
+    return Structure::create(vm, globalObject, jsNull(), TypeInfo(ObjectType, StructureFlags), info(), 0, 0);
 }
 
 JSValue InternalModuleRegistry::requireId(JSGlobalObject* globalObject, VM& vm, Field id)


### PR DESCRIPTION
### Problem
- oven-sh/WebKit#410 makes `dynamicDowncast<InternalFieldTuple>`, run on every promise reaction and await resumption, trust the JSType byte alone.
- `ErrorCodeCache` and `InternalModuleRegistry` copied their Structure setup from `InternalFieldTuple`, so they carry `InternalFieldTupleType` without being one.
- Nothing is observable today, since neither object reaches such a cast; after the WebKit change both would pass it.

### Fix
- Both objects now create their Structure with `ObjectType`, like Bun's other internal-field objects.
- Safe because nothing in JSC or Bun keys on either object's JSType, and heap snapshots treat both tags alike.
- Verification: built against the current WebKit pin only, no new test. Once repinned to WebKit#410, the debug/ASAN lanes assert on every cast that JSType and ClassInfo agree. Draft until then.

### Background
- JSType is a one-byte tag in each JSC cell header, set by the `TypeInfo` used to create the object's Structure.
- JSC's fast-cast table lists classes whose `dynamicDowncast` reads that byte instead of the ClassInfo chain, so a listed class must own its tag exclusively.
- `InternalFieldTuple` is a small JSC object with internal slots; Bun's async context tracking stores its context in one and casts back to it.

<details>
<summary>Original description</summary>

Bun side of oven-sh/WebKit#410, which adds `InternalFieldTuple` to JSC's JSType fast-cast table so `dynamicDowncast<InternalFieldTuple>` (run by `AsyncContextSwapScope::unwrapContextTuple` on every promise reaction and await resumption) compares the type byte in the cell header instead of loading the Structure and ClassInfo and walking the parent chain.

That cast is only correct if `InternalFieldTupleType` means `InternalFieldTuple` and nothing else. Two classes here copied their Structure setup from `InternalFieldTuple`, type included:

- `ErrorCodeCache::createStructure` (`src/jsc/bindings/ErrorCode.cpp`)
- `InternalModuleRegistry::createStructure` (`src/jsc/bindings/InternalModuleRegistry.cpp`)

Neither object is ever passed to a site that casts to `InternalFieldTuple`, so nothing is observable today, but after the WebKit change they would satisfy that cast. This creates their structures with `ObjectType`, like the other internal-field objects in this directory (`JSNextTickQueue`, `JSSocketHandlers`, `ModuleLoader`, `BunStreamSource`). Heap snapshots classify both types the same way (`isObject()`), and nothing in JSC or Bun keys on either object's JSType.

Plan for this PR:

1. This commit alone, against the current WebKit pin, so the `ObjectType` change is exercised on its own.
2. Pin `WEBKIT_VERSION` to oven-sh/WebKit#410's preview tag once its build finishes, so the whole suite runs against the new cast. Debug/ASAN lanes link a debug JSC, where `inheritsJSTypeImpl` asserts on every cast that the JSType answer matches the ClassInfo answer, so the AsyncLocalStorage, streams and `bun:sqlite` tests check the mapping in both directions.
3. After oven-sh/WebKit#410 merges, repin to the merge commit and mark this ready for review.

Draft until step 3.


</details>
