### PR TITLE
docs: state the onLoad defer() lifetime and the error a stale call throws

### DIFF
--- a/docs/bundler/plugins.mdx
+++ b/docs/bundler/plugins.mdx
@@ -306,7 +306,10 @@ plugin({
 
 </Accordion>
 
-<Warning>You can call the `.defer()` function only once per `onLoad` callback.</Warning>
+<Warning>
+  You can call the `.defer()` function only once per `onLoad` callback, and only while Bun is still loading that module.
+  A `defer` you kept around and call after the callback has settled throws an `ERR_INVALID_STATE` error.
+</Warning>
 
 ### onEnd
 

--- a/docs/runtime/plugins.mdx
+++ b/docs/runtime/plugins.mdx
@@ -299,7 +299,7 @@ plugin({
 });
 ```
 
-You can call the `.defer()` function only once per `onLoad` callback.
+You can call the `.defer()` function only once per `onLoad` callback, and only while Bun is still loading that module. A `defer` you kept around and call after the callback has settled throws an `ERR_INVALID_STATE` error.
 
 ## Native plugins
 

--- a/packages/bun-types/bun.d.ts
+++ b/packages/bun-types/bun.d.ts
@@ -5764,6 +5764,10 @@ declare module "bun" {
     /**
      * Defer the execution of this callback until all other modules have been parsed.
      *
+     * Can only be called once, and only while this module is still being
+     * loaded: a `defer` kept around and called after the callback has
+     * settled throws an `ERR_INVALID_STATE` error.
+     *
      * @returns Promise that resolves when all modules have been parsed
      */
     defer: () => Promise<void>;


### PR DESCRIPTION
### Problem
- Docs and types did not say how long the `defer` function passed to an `onLoad` plugin callback stays usable, or what happens when a plugin keeps it around and calls it late.
- Since #38660, a `defer()` call made after its onLoad callback settled throws an `ERR_INVALID_STATE` error (".defer() called after the onLoad callback settled"). Before that it corrupted the build's deferred-load accounting or, after the build finished, touched freed memory.

### Fix
- `docs/bundler/plugins.mdx`, `docs/runtime/plugins.mdx`: extend the existing ".defer() only once" warning to say it is also only callable while Bun is still loading that module, and that a stale call throws `ERR_INVALID_STATE`.
- `packages/bun-types/bun.d.ts`: same statement on the `defer` JSDoc.
- Verified the documented behavior against a debug build of current main (stale `defer()` from `onEnd` and after `Bun.build()` resolves both throw `ERR_INVALID_STATE`), and ran `test/integration/bun-types/bun-types.test.ts` (15 pass).

### Background
- `args.defer()` in an `onLoad` plugin callback returns a promise that resolves once every other module in the build has been loaded; plugins use it to produce contents that depend on the rest of the graph.
- Each `defer` closes over native per-load state owned by the running build, which is why its usable lifetime ends with the callback.
- This PR originally made a stale `defer()` throw instead of reaching that freed state. #38660 landed a deeper rework of plugin request ownership on main that fixes the same bug (with its own regression tests in `test/bundler/bundler_defer.test.ts`), so the code and test changes here were dropped and only the documentation remains.

<details>
<summary>Original PR description (code fix, superseded by #38660)</summary>

The original change made a retained `onLoad` `args.defer()` throw instead of accessing freed bundler state:

- `src/js/builtins/BundlerPlugin.ts` tracked whether a load request had completed (an `answered` flag set in a `finally` around the onLoad chain) so a stale `defer()` threw at the JS layer.
- `src/jsc/bindings/JSBundlerPlugin.cpp` added a tombstone check to `generateDeferPromise`, matching the existing checks in `addError`/`onLoadAsync`/`onResolveAsync`.
- Seven spawned-fixture tests covered the four onLoad exit shapes, mid-build cross-file stale calls, an uncaught stale call, and `serve.static`; four reproduced as heap-use-after-free under ASAN without the fix.

#38660 ("Worker teardown, round 3") made plugin request ownership linear: `BundlerPlugin` records which requests it holds, answers are forwarded only for held requests, `tombstone()` cancels everything still held, and `generateDeferPromise` refuses un-held loads with `ERR_INVALID_STATE`. That covers every path the original change guarded.

</details>
