### PR TITLE
Stop rewriting a literal import("bun") to Promise.resolve(globalThis.Bun)

### DIFF
--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -2475,31 +2475,17 @@ pub(crate) mod __gated_printer {
             let module_type = self.options.module_type;
 
             if IS_BUN_PLATFORM {
-                // "bun" is not a real module. It's just globalThis.Bun.
-                //
-                //  transform from:
-                //      const foo = await import("bun")
-                //      const bar = require("bun")
-                //
-                //  transform to:
-                //      const foo = await Promise.resolve(globalThis.Bun)
-                //      const bar = globalThis.Bun
-                //
-                if record.tag == ImportRecordTag::Bun {
-                    if record.kind == ImportKind::Dynamic {
-                        self.print(b"Promise.resolve(globalThis.Bun)");
-                        if wrap {
-                            self.print(b")");
-                        }
-                        return;
-                    } else if record.kind == ImportKind::Require || record.kind == ImportKind::Stmt
-                    {
-                        self.print(b"globalThis.Bun");
-                        if wrap {
-                            self.print(b")");
-                        }
-                        return;
+                // import("bun") is excluded: the loader returns the module namespace for it,
+                // and a specifier that escapes const inlining reaches the loader anyway, so
+                // the literal form has to resolve to that same namespace.
+                if record.tag == ImportRecordTag::Bun
+                    && (record.kind == ImportKind::Require || record.kind == ImportKind::Stmt)
+                {
+                    self.print(b"globalThis.Bun");
+                    if wrap {
+                        self.print(b")");
                     }
+                    return;
                 }
             }
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,9 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: a literal `import("bun")` is printed as a dynamic import instead of
+/// `Promise.resolve(globalThis.Bun)`.
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/bundler/bundler_bun.test.ts
+++ b/test/bundler/bundler_bun.test.ts
@@ -3,6 +3,41 @@ import { describe, expect } from "bun:test";
 import { itBundled } from "./expectBundled";
 
 describe("bundler", () => {
+  // import("bun") is left for the runtime, which resolves it to the "bun" module
+  // namespace (default = Bun plus a named export per property), the same thing a
+  // non-literal specifier gets. require("bun") is still inlined to globalThis.Bun,
+  // which is also what the runtime returns for a non-literal require().
+  itBundled("bun/dynamic-import-bun-is-module-namespace", {
+    target: "bun",
+    files: {
+      "/entry.ts": /* js */ `
+        const ns = await import("bun");
+        console.log(Object.prototype.toString.call(ns), ns.default === Bun, ns.serve === Bun.serve);
+        console.log(require("bun") === Bun);
+      `,
+    },
+    run: { stdout: "[object Module] true true\ntrue" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toContain('import("bun")');
+      api.expectFile("out.js").not.toContain("Promise.resolve(globalThis.Bun)");
+    },
+  });
+  // --minify-syntax inlines the const, so the import() reaches the printer as a literal.
+  itBundled("bun/dynamic-import-bun-inlined-const", {
+    target: "bun",
+    minifySyntax: true,
+    files: {
+      "/entry.ts": /* js */ `
+        const specifier = "bun";
+        const ns = await import(specifier);
+        console.log(Object.prototype.toString.call(ns), ns.default === Bun, ns.serve === Bun.serve);
+      `,
+    },
+    run: { stdout: "[object Module] true true" },
+    onAfterBundle(api) {
+      api.expectFile("out.js").toContain('import("bun")');
+    },
+  });
   // https://github.com/oven-sh/bun/issues/18899
   itBundled("bun/import-bun-format-cjs", {
     target: "bun",

--- a/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
+++ b/test/js/bun/resolve/builtin-esm-lazy-exports.test.ts
@@ -43,9 +43,9 @@ const helper = `
 // static entries without constructing them; for...in constructs all of them, so the entries below avoid it.) The
 // watched names are a sample of those entries plus the plain function (`write`, `createRequire`) an entry imports.
 //
-// Note that a literal `import ... from "bun"` (and `import("bun")` / `require("bun")`) is rewritten by the
-// transpiler into a read of globalThis.Bun and never loads the module; the module is what `export ... from "bun"`
-// and a non-literal import() specifier go through. Imports of node:process and node:module always load the module.
+// Note that a static `import ... from "bun"` and `require("bun")` are rewritten by the transpiler into a read of
+// globalThis.Bun and never load the module; the module is what `export ... from "bun"` and import() go through.
+// Imports of node:process and node:module always load the module.
 const WATCHED = ["$", "CryptoHasher", "Glob", "S3Client", "SQL", "TOML", "Transpiler", "secrets", "write"] as const;
 const PROCESS_WATCHED = ["allowedNodeEnvironmentFlags", "config", "release", "stderr", "stdin", "stdout", "versions"];
 const MODULE_WATCHED = [
@@ -74,9 +74,6 @@ const nativeHelper = `
   export function print(result) {
     console.log(JSON.stringify(result));
   }
-  // import(specifier) with this really loads the module; a literal (or a const the transpiler can inline) would be
-  // rewritten to globalThis.Bun instead.
-  export const specifier = "bun";
 `;
 
 const bunReexport = `
@@ -329,8 +326,8 @@ test.concurrent('"bun": re-exports construct the properties that get bound, not 
 
 test.concurrent('"bun": import() namespace has the same export list, and every export is the Bun.* value', async () => {
   const result = await runEntry(`
-    import { constructed, print, specifier } from "./native-helper.mjs";
-    const ns = await import(specifier);
+    import { constructed, print } from "./native-helper.mjs";
+    const ns = await import("bun");
     const afterImport = constructed();
     // Neither [[OwnPropertyKeys]] of the namespace nor Object.keys of the Bun object reads any of the properties.
     const exportNames = Reflect.ownKeys(ns).filter(key => typeof key === "string").sort();

--- a/test/js/bun/resolve/import-meta.test.js
+++ b/test/js/bun/resolve/import-meta.test.js
@@ -1,7 +1,7 @@
 import { spawnSync } from "bun";
 import { isModuleResolveFilenameSlowPathEnabled } from "bun:internal-for-testing";
-import { expect, it, mock } from "bun:test";
-import { bunEnv, bunExe, ospath } from "harness";
+import { describe, expect, it, mock } from "bun:test";
+import { bunEnv, bunExe, ospath, tempDir } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import Module from "node:module";
 import { tmpdir } from "node:os";
@@ -224,8 +224,43 @@ it('require("bun") works', () => {
   expect(require("bun")).toBe(Bun);
 });
 
-it('import("bun") works', async () => {
-  expect(await import("bun")).toBe(Bun);
+it('import("bun") returns the "bun" module namespace', async () => {
+  const ns = await import("bun");
+  expect(ns.default).toBe(Bun);
+  expect(ns.serve).toBe(Bun.serve);
+  // Same module record as a specifier the transpiler cannot see through.
+  expect(ns).toBe(await import(eval("'bun'")));
+});
+
+// Whether `import(specifier)` reaches the printer as a literal depends on const
+// inlining, which only applies to a const declared before any other statement in
+// its scope. What comes back must not depend on that.
+describe.concurrent('import() of "bun" resolves to the same thing however the specifier is written', () => {
+  it.each([
+    ["string literal", `const ns = await import("bun");`],
+    ["const declared first (inlined)", `const specifier = "bun"; const ns = await import(specifier);`],
+    [
+      "const declared after an import (not inlined)",
+      `import "./empty.mjs"; const specifier = "bun"; const ns = await import(specifier);`,
+    ],
+    ["let", `let specifier = "bun"; const ns = await import(specifier);`],
+  ])("%s", async (_, source) => {
+    using dir = tempDir("import-bun", {
+      "empty.mjs": "",
+      "entry.mjs": `${source}\nconsole.log(Object.prototype.toString.call(ns), ns.default === Bun, ns.serve === Bun.serve);\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("[object Module] true true\n");
+    expect(exitCode).toBe(0);
+  });
 });
 
 it("require.resolve with empty options object", () => {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -8,6 +8,7 @@
 // - Write test for import {foo} from "./foo"; export {foo}
 
 import { expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
@@ -165,4 +166,34 @@ test("mocking a builtin", async () => {
 
   const { readFile } = await import("node:fs/promises");
   expect(await readFile("hello.txt", "utf8")).toBe("hello world");
+});
+
+// Runs in a child so the mock of "bun" does not outlive this test. A literal
+// import("bun") used to be rewritten by the transpiler and skip the module
+// registry, so only the non-literal form saw the mock.
+test('mocking "bun" applies to a literal import("bun") like it does to a computed specifier', async () => {
+  using dir = tempDir("mock-bun-module", {
+    "mock-bun.test.ts": `
+      import { expect, mock, test } from "bun:test";
+
+      test("literal and computed import() of bun agree", async () => {
+        mock.module("bun", () => ({ mocked: true }));
+        const literal = await import("bun");
+        const computed = await import(eval("'bun'"));
+        expect(literal.mocked).toBe(true);
+        expect(literal).toBe(computed);
+      });
+    `,
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "mock-bun.test.ts"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+  expect(stderr).toContain(" 1 pass\n");
+  expect(stderr).toContain(" 0 fail\n");
+  expect(exitCode).toBe(0);
 });


### PR DESCRIPTION
### Problem
- `await import("bun")` returns two different things depending on how the specifier is spelled. A literal gives the `Bun` object itself (`[object Bun]`, `ns.default === Bun` is false); `import(s)` with a `let`, or a `const` declared after any other statement, gives a module namespace (`[object Module]`, `ns.default === Bun`).
- Reproduced on bun 1.4.0 and main; `bun build --target=bun --minify-syntax` shows the same split in its output.
- Cause: `import("bun")` has two implementations. The printer rewrites a literal to `Promise.resolve(globalThis.Bun)` (from 2022, before a real `"bun"` module existed); anything the printer cannot see as a literal goes to the loader's `"bun"` module (#4055). Which one a file hits is decided by const inlining, an optimisation that is supposed to be unobservable.
- Because the rewrite skipped the loader, `mock.module("bun", ...)` applied to `import(s)` but not to `import("bun")`, and import options were silently dropped.

### Fix
- The printer stops rewriting the dynamic-import form: a literal `import("bun")` is printed as an ordinary external import and the loader resolves it, in the runtime transpiler and in `bun build --target=bun`. `require("bun")` and static imports are still inlined to `globalThis.Bun`, which is also what the loader returns for a `require` of `"bun"` (their `globalThis` shadowing bug is #8058 / #35739, untouched here).
- Why the namespace is the right single answer: the loader path exists regardless (computed specifiers, re-exports, mocks), and `import()` of a module record can only ever produce a namespace, so the literal has to move to it. `"bun"` then behaves like `import("bun:sqlite")` or `import("node:fs")`.
- Observable change: `(await import("bun")) === Bun` is now false for the literal (it already was for every other spelling); `.default`, named exports and destructuring all work. The literal is now a real module load, cheap only because #37714 made the module's exports lazy, so this PR is stacked on it. The runtime transpiler cache version is bumped so cached output holding the old rewrite is not reused after an upgrade.
- Verification: new tests in the runtime, bundler and `mock.module` suites fail without the printer change and pass with it, including four one-file programs (literal, inlined const, non-inlined const, `let`) that must print identical output. Import options, `.cjs` callers, `--format=cjs`, `--minify`, `--compile` and the Bake dev server path were checked by hand.

### Background
- The `"bun"` module: since #4055 the module loader has a native `"bun"` module, a namespace whose `default` is the `Bun` global with one named export per `Bun.*` property. `export * from "bun"`, `mock.module("bun", ...)` and every computed `import()` already go through it.
- Import record tags: an import record whose specifier is the literal `"bun"` carries a `Bun` tag, and the printer used that tag to emit `globalThis.Bun` in place of the import for all three kinds (require, static import, dynamic import). After this PR only the first two are rewritten.
- Const inlining: the transpiler (and `--minify-syntax` in the bundler) substitutes a `const` string into `import(x)` only when the `const` is in the leading run of const declarations of its scope, the TDZ-safe rule. That is why one extra statement before the `const` flips which path a file takes.
- Runtime transpiler cache: bun stores transpiled output of source files on disk under a version constant; bumping the constant discards entries whose printed text would now differ.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 6 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_bun.test.ts test/js/bun/resolve/builtin-esm-lazy-exports.test.ts test/js/bun/resolve/import-meta.test.js test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.0 (132085efd)

test/bundler/bundler_bun.test.ts:
16 |         console.log(require("bun") === Bun);
17 |       `,
18 |     },
19 |     run: { stdout: "[object Module] true true\ntrue" },
20 |     onAfterBundle(api) {
21 |       api.expectFile("out.js").toContain('import("bun")');
                                    ^
error: expect(received).toContain(expected)

Expected to contain: "import(\"bun\")"
Received: "// @bun\nvar __require = import.meta.require;\n\n// entry.ts\nvar ns = await Promise.resolve(globalThis.Bun);\nconsole.log(Object.prototype.toString.call(ns), ns.default === Bun, ns.serve === Bun.serve);\nconsole.log(globalThis.Bun === Bun);\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_bun.test.ts:21:32)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) bundler > bun/dynamic-import-bun-is-module-namesp
... (truncated)

release without fix: 19 failed, 1 skipped
bun test v1.4.0-canary.1 (9008ae7ab)

test/bundler/bundler_bun.test.ts:
16 |         console.log(require("bun") === Bun);
17 |       `,
18 |     },
19 |     run: { stdout: "[object Module] true true\ntrue" },
20 |     onAfterBundle(api) {
21 |       api.expectFile("out.js").toContain('import("bun")');
                                    ^
error: expect(received).toContain(expected)

Expected to contain: "import(\"bun\")"
Received: "// @bun\nvar __require = import.meta.require;\n\n// entry.ts\nvar ns = await Promise.resolve(globalThis.Bun);\nconsole.log(Object.prototype.toString.call(ns), ns.default === Bun, ns.serve === Bun.serve);\nconsole.log(globalThis.Bun === Bun);\n"

      at onAfterBundle (/workspace/bun/test/bundler/bundler_bun.test.ts:21:32)
      at <anonymous> (/workspace/bun/test/bundler/expectBundled.ts:1591:7)
(fail) bundler > bun/dynamic-import-bun-is-module-namespace [15.32ms]
33 |         console.log(Object.prototype.toString.call(ns), ns.default === Bun, ns.serve === Bun.serve);
34 |       `,
35 |     },
36 |     run: { stdout: "[object Module] true true" },
37 |     onAfterBundle(api) {
38 |       api.expectFile("out.js").toContain('import("bun")'
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/bundler_bun.test.ts test/js/bun/resolve/builtin-esm-lazy-exports.test.ts test/js/bun/resolve/import-meta.test.js test/js/bun/test/mock/mock-module.test.ts
bun test v1.4.0 (132085efd)

test/bundler/bundler_bun.test.ts:
(pass) bundler > bun/dynamic-import-bun-is-module-namespace [924.92ms]
(pass) bundler > bun/dynamic-import-bun-inlined-const [493.41ms]
(pass) bundler > bun/import-bun-format-cjs [548.72ms]
(pass) bundler > bun/embedded-sqlite-file [525.81ms]
(pass) bundler > bun/sqlite-file [544.54ms]
(pass) bundler > bun/TargetBunNoSourcemapMessage [668.32ms]
(pass) bundler > bun/TargetBunSourcemapInline [665.68ms]
(pass) bundler > bun/unicode comment [447.09ms]
(pass) bundler > bun/ExportsConditionsDevelopmentAPI [492.38ms]
(pass) bundler > bun/ExportsConditionsDevelopmentInProductionAPI [499.53ms]
(pass) bundler > bun/ExportsConditionsDevelopmentCLI [1091.81ms]
(pass) bundler > bun/ExportsConditionsDevelopmentInProductionCLI [586.11ms]

test/js/bun/resolve/import-meta.test.js:
(pass) import.meta.require is settable [4.87m
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 771ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_js_printer v0.0.0 (/workspace/bun/src/js_printer)
^[[1m^[[92m   Compiling^[[0m bun_bundler v0.0.0 (/workspace/bun/src/bundler)
^[[1m^[[92m   Compiling^[[0m bun_standalone_graph v0.0.0 (/workspace/bun/src/standalone_graph)
^[[1m^[[92m   Compiling^[[0m bun_transpiler v0.0.0 (/workspace/bun/src/transpiler)
^[[1m^[[92m   Compiling^[[0m bun_bunfig v0.0.0 (/workspace/bun/src/bunfig)
^[[1m^[[92m   Compiling^[[0m bun_install v0.0.0 (/workspace/bun/src/install)
^[[1m^[[92m   Compiling^[[0m bun_jsc v0.0.0 (/workspace/bun/src/jsc)
^[[1m^[[92m   Compiling^[[0m bun_js_parser_jsc v0.0.0 (/workspace/bun/src/js_parser_jsc)
^[[1m^[[92m   Compiling^[[0m bun_ast_jsc v0.0.0 (/workspace/bun/src/ast_jsc)
^[[1m
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js_printer/lib.rs                              | 34 +++++------------
 src/jsc/RuntimeTranspilerCache.rs                  |  4 +-
 test/bundler/bundler_bun.test.ts                   | 35 ++++++++++++++++++
 .../bun/resolve/builtin-esm-lazy-exports.test.ts   | 13 +++----
 test/js/bun/resolve/import-meta.test.js            | 43 ++++++++++++++++++++--
 test/js/bun/test/mock/mock-module.test.ts          | 31 ++++++++++++++++
 6 files changed, 123 insertions(+), 37 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
src/js_printer/lib.rs                                     6      4      0
src/jsc/RuntimeTranspilerCache.rs                         3      3      0
test/bundler/bundler_bun.test.ts                          1      1      0
test/js/bun/resolve/builtin-esm-lazy-exports.test.ts      4      5      0
test/js/bun/resolve/import-meta.test.js                   2      2      0
test/js/bun/test/mock/mock-module.test.ts                 2      4      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

## What

`import()` of `"bun"` returned two different kinds of object depending on how the specifier reached the transpiler:

```js
// a.mjs
const s = "bun"; const ns = await import(s);
console.log(Object.prototype.toString.call(ns), ns.default === Bun);   // [object Bun] false

// b.mjs: identical, plus any statement before the const (empty.mjs is an empty file)
import "./empty.mjs";
const s = "bun"; const ns = await import(s);
console.log(Object.prototype.toString.call(ns), ns.default === Bun);   // [object Module] true
```

`let s = "bun"` behaves like `b.mjs`; a literal `import("bun")` behaves like `a.mjs`. `bun build --target=bun --minify-syntax` shows the same split in its output (`Promise.resolve(globalThis.Bun)` for `a.mjs`, `import(s)` for `b.mjs`). Reproduced on bun 1.4.0 and on main.

## Cause

Two implementations of `import("bun")`:

- The printer (`print_require_or_import_expr`, `ImportRecordTag::Bun`) rewrites a literal `import("bun")` into `Promise.resolve(globalThis.Bun)`. This dates from a97914fff3 (2022), when there was no `"bun"` module in the loader at all and the rewrite was what made `require("bun")` / `import("bun")` work.
- #4055 (2023) added the real `"bun"` module to the loader (`generateNativeModule_BunObject`): a namespace whose `default` is `Bun`, with one named export per `Bun.*` property. Every `import()` whose specifier the printer cannot see as a literal goes there, as do `export * from "bun"` and `mock.module("bun", ...)`.

The runtime transpiler (and `--minify-syntax` in the bundler) inlines a `const` string into `import(s)` only when the `const` is in the leading run of const declarations of its scope, which is the standard TDZ-safe rule for const inlining and is working as intended. Inlining is supposed to be unobservable; the printer rewrite is what made it observable, because a folded specifier took the first implementation and an unfolded one took the second.

## Fix

Remove the dynamic-import half of the rewrite. A literal `import("bun")` is now printed as a normal external `import("bun")` and the loader resolves it, in both the runtime transpiler and `bun build --target=bun`. `require("bun")` is still inlined to `globalThis.Bun`: the loader also returns the `Bun` object for a `require()` of `"bun"`, so the two paths already agree there (the shadowed `globalThis` problem with that inlining is #8058 / #35739, which this PR does not touch). The runtime transpiler cache version is bumped because cached output for files containing a literal `import("bun")` would otherwise keep the old rewrite after an upgrade.

Making the namespace the single answer is the only option that can be consistent: the loader path exists regardless (computed specifiers, re-exports, mocks), and `import()` of a module record can only ever produce a namespace object, so the literal has to move to it rather than the other way around. It also makes `"bun"` behave like every other builtin (`await import("bun:sqlite")` or `await import("node:fs")` return namespaces too), and the old `Promise.resolve(globalThis.Bun)` text was skipping the loader entirely, so `mock.module("bun", ...)` applied to `import(s)` but not to `import("bun")`, and import options were silently dropped. Those now behave the same as for any other module.

### Observable changes

- `await import("bun")` is the module namespace: `ns.default === Bun`, `ns.serve === Bun.serve`, `Object.keys(ns)` lists the `Bun` properties. `(await import("bun")) === Bun` is now false; it was already false for every non-literal form. Destructuring or property access keeps working, and `.default` starts working.
- `import("bun")` is one more module load instead of a resolved promise. This is built on top of #37714, which makes the `"bun"` module's exports lazy, so the load constructs nothing on the `Bun` object up front (before #37714 the generator reified every `Bun.*` property, about 5ms on a release build, and that bulk reification also trips `BUN_JSC_validateExceptionChecks` on the ASAN lane, which is what the first CI run of this PR hit once the literal form started reaching it). Static `import ... from "bun"` and `require("bun")` are unchanged.
- Side effect under `--minify-whitespace`: `return import("bun")` was printed as `returnPromise.resolve(...)` (the dynamic-import case of #30673); the external import path prints the separating space, so that case is fixed here. The `require("bun")` case in #30673 still stands.
- Bake dev server code: a literal `import("bun")` now goes through `hmr.dynamicImport("bun")` like other builtins do, which falls through to the real `import()`; checked manually with a route doing both the literal and a computed import and getting the same namespace.

#35739 (open) drops the runtime half of both rewrites for the `globalThis` shadowing bug; it would fix the runtime side of this as a side effect but leaves the bundler split in place. The two overlap textually in the same hunk and are otherwise compatible: if it lands first, this PR reduces to deleting the dynamic-import branch for the bundler too.

## Tests

All of these fail without the `src/` change and pass with it:

- `test/js/bun/resolve/import-meta.test.js`: the literal `import("bun")` test now asserts the namespace shape and that it is the same record as `import(eval("'bun'"))`; a new concurrent group runs four single-file programs (literal, const that gets inlined, const after an import that does not, `let`) and expects identical output from each.
- `test/bundler/bundler_bun.test.ts`: `bun build --target=bun` of a literal `import("bun")` keeps `import("bun")` in the output and prints the namespace when run, with `require("bun") === Bun` checked alongside; the same through `--minify-syntax` with the specifier in a `const`.
- `test/js/bun/test/mock/mock-module.test.ts`: `mock.module("bun", ...)` in a child `bun test` applies to the literal `import("bun")` and the computed one alike.
- `test/js/bun/resolve/builtin-esm-lazy-exports.test.ts` (from #37714 / #37726): its comments described the literal `import("bun")` as being rewritten, and its `import()` test routed the specifier through the helper module to keep it away from the transpiler. The comments are updated and the test now uses the literal directly, so it exercises the path this PR changes (it fails on the old printer with `defaultIsBun: false`).

Also run on this build: the rest of `import-meta.test.js`, `bundler_bun.test.ts`, `mock-module.test.ts` and `builtin-esm-lazy-exports.test.ts`, `test/js/bun/util/BunObject.test.ts`, `test/cli/run/syntax.test.ts` (includes `await import('bun')`), `test/cli/run/transpiler-cache.test.ts`. Manually checked `import("bun", {...})`, `import("bun")` from a `.cjs` file, `--format=cjs` output, `--minify` output, and a `bun build --compile` binary; all return the namespace.

</details>
