### PR TITLE
bundler: allocate, link and post a plugin request through one pointer instead of a &mut receiver

### DIFF
--- a/src/bundler/Graph.rs
+++ b/src/bundler/Graph.rs
@@ -276,6 +276,8 @@ impl<T> Default for OutstandingLink<T> {
 }
 pub trait OutstandingNode: Sized {
     fn link(&mut self) -> &mut OutstandingLink<Self>;
+    /// The pass's list of outstanding requests of this type.
+    fn outstanding<'g>(graph: &'g mut Graph<'_>) -> &'g mut OutstandingList<Self>;
 }
 /// A bundle pass's outstanding plugin requests; single-threaded (bundle thread).
 pub struct OutstandingList<T: OutstandingNode> {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1092,17 +1092,6 @@ pub mod bv2_impl {
                 /// holds (`Graph::outstanding_resolves`); bundle thread only.
                 pub(crate) outstanding: crate::Graph::OutstandingLink<Resolve>,
             }
-            impl Default for Resolve {
-                fn default() -> Self {
-                    Self {
-                    bv2: core::ptr::null_mut(),
-                    import_record: MiniImportRecord::default(),
-                    value: ResolveValue::Pending,
-                    task: bun_event_loop::AnyTaskWithExtraContext::AnyTaskWithExtraContext::default(),
-                    outstanding: Default::default(),
-                }
-                }
-            }
             impl bun_event_loop::Taskable for Resolve {
                 const TAG: bun_event_loop::TaskTag =
                     bun_event_loop::task_tag::BundleV2PluginResolve;
@@ -1122,15 +1111,33 @@ pub mod bv2_impl {
                     outstanding: Default::default(),
                 }
                 }
-                /// Hops to the JS thread to call the `onResolve` plugin chain —
-                /// unless the pass is already cancelled (that VM is stopping and
-                /// will never answer): then the request fails here and now.
-                pub(crate) fn dispatch(&mut self) {
-                    // SAFETY: `bv2` is a valid backref set by `init`; plugins is
-                    // Some (asserted by `enqueue_on_js_loop_for_plugins`).
+                /// Bundle thread. Hops to the JS thread to call the `onResolve`
+                /// plugin chain, unless the pass is already cancelled (that VM is
+                /// stopping and will never answer): then the request fails here
+                /// and now.
+                ///
+                /// Takes the pointer, not `&mut self`: the same pointer goes into
+                /// `Graph::outstanding_resolves` and into the task, because from
+                /// here on the request is reached through both. The next push
+                /// writes this request's link through the list's pointer and the
+                /// answer comes back through the task's; were those two reborrows
+                /// of a `&mut self`, that write would invalidate the task's
+                /// pointer under the aliasing model (Miri rejects the answer's
+                /// reborrow), and the `&mut self` itself would claim exclusivity
+                /// for a call during which the JS thread may already be writing
+                /// `value`.
+                ///
+                /// # Safety
+                /// `this` is an arena slot holding an `init`ed, not yet dispatched
+                /// request, and the caller does not use it afterwards: the pass
+                /// gets it back through the list or the answer.
+                pub(crate) unsafe fn dispatch(this: *mut Self) {
+                    // SAFETY: `this` is live (fn contract) and this is the thread
+                    // that owns the pass `bv2` (set by `init`) points at; plugins
+                    // is Some (asserted by `enqueue_on_js_loop_for_plugins`).
                     unsafe {
-                        let bv2 = &mut *self.bv2;
-                        bv2.graph.outstanding_resolves.push(self);
+                        let bv2 = &mut *(*this).bv2;
+                        bv2.graph.outstanding_resolves.push(this);
                         if bv2.graph.cancelled {
                             // Failed by `is_done` at the loop's top level (not
                             // here, mid-caller); make sure it runs again.
@@ -1138,7 +1145,7 @@ pub mod bv2_impl {
                             return;
                         }
                         let task = bun_event_loop::ConcurrentTask::ConcurrentTask::create(
-                            bun_event_loop::Task::init(std::ptr::from_mut::<Self>(self)),
+                            bun_event_loop::Task::init(this),
                         );
                         bv2.enqueue_on_js_loop_for_plugins(task);
                     }
@@ -1257,14 +1264,17 @@ pub mod bv2_impl {
                 pub(crate) fn bake_graph(&self) -> crate::bake_types::Graph {
                     self.parse_task().known_target.bake_graph()
                 }
-                /// Hops to the JS thread to call the `onLoad` plugin chain —
-                /// unless the pass is already cancelled: see `Resolve::dispatch`.
-                pub(crate) fn dispatch(&mut self) {
-                    // SAFETY: `bv2` is a valid backref; plugins is Some (asserted
-                    // by `enqueue_on_js_loop_for_plugins`).
+                /// Bundle thread. Hops to the JS thread to call the `onLoad`
+                /// plugin chain, unless the pass is already cancelled. Pointer
+                /// receiver for the reason given on `Resolve::dispatch`.
+                ///
+                /// # Safety
+                /// As `Resolve::dispatch`.
+                pub(crate) unsafe fn dispatch(this: *mut Self) {
+                    // SAFETY: as `Resolve::dispatch`.
                     unsafe {
-                        let bv2 = &mut *self.bv2;
-                        bv2.graph.outstanding_loads.push(self);
+                        let bv2 = &mut *(*this).bv2;
+                        bv2.graph.outstanding_loads.push(this);
                         if bv2.graph.cancelled {
                             // Failed by `is_done` at the loop's top level (not
                             // here, mid-caller); make sure it runs again.
@@ -1273,7 +1283,7 @@ pub mod bv2_impl {
                         }
                         let concurrent_task =
                             bun_event_loop::ConcurrentTask::ConcurrentTask::create(
-                                bun_event_loop::Task::init(std::ptr::from_mut::<Self>(self)),
+                                bun_event_loop::Task::init(this),
                             );
                         bv2.enqueue_on_js_loop_for_plugins(concurrent_task);
                     }
@@ -5628,13 +5638,7 @@ pub mod bv2_impl {
                     );
                     self.increment_scan_counter();
 
-                    // Arena-owned; the dispatch
-                    // chain holds the raw `*mut Resolve` until the JS thread calls
-                    // back, at which point the bundle pass is still alive.
-                    // SAFETY: arena outlives the bundle pass.
-                    let resolve: &mut jsc_api::JSBundler::Resolve =
-                        self.arena_create(jsc_api::JSBundler::Resolve::default());
-                    *resolve = jsc_api::JSBundler::Resolve::init(
+                    let resolve = jsc_api::JSBundler::Resolve::init(
                         self,
                         jsc_api::JSBundler::MiniImportRecord {
                             kind: import_record.kind,
@@ -5647,8 +5651,12 @@ pub mod bv2_impl {
                             original_target,
                         },
                     );
-
-                    resolve.dispatch();
+                    // Arena-owned: the slot lives as long as the pass, which
+                    // holds it in `outstanding_resolves` until the JS thread
+                    // answers (or the pass is cancelled).
+                    let resolve: *mut jsc_api::JSBundler::Resolve = self.arena_create(resolve);
+                    // SAFETY: fresh slot, `init`ed above, not used again here.
+                    unsafe { jsc_api::JSBundler::Resolve::dispatch(resolve) };
                     return true;
                 }
             }
@@ -5671,13 +5679,9 @@ pub mod bv2_impl {
                         bstr::BStr::new(entry_point)
                     );
 
-                    // Arena-owned.
-                    // SAFETY: arena outlives the bundle pass.
-                    let resolve: &mut jsc_api::JSBundler::Resolve =
-                        self.arena_create(jsc_api::JSBundler::Resolve::default());
                     self.increment_scan_counter();
 
-                    *resolve = jsc_api::JSBundler::Resolve::init(
+                    let resolve = jsc_api::JSBundler::Resolve::init(
                         self,
                         jsc_api::JSBundler::MiniImportRecord {
                             kind: ImportKind::EntryPointBuild,
@@ -5690,8 +5694,10 @@ pub mod bv2_impl {
                             original_target: target,
                         },
                     );
-
-                    resolve.dispatch();
+                    // Arena-owned; see `enqueue_on_resolve_plugin_if_needed`.
+                    let resolve: *mut jsc_api::JSBundler::Resolve = self.arena_create(resolve);
+                    // SAFETY: fresh slot, `init`ed above, not used again here.
+                    unsafe { jsc_api::JSBundler::Resolve::dispatch(resolve) };
                     return true;
                 }
             }
@@ -5748,12 +5754,13 @@ pub mod bv2_impl {
                         bstr::BStr::new(&parse.path.namespace),
                         bstr::BStr::new(&parse.path.text)
                     );
-                    // Arena-owned; the dispatch
-                    // chain holds the raw `*mut Load` until the JS thread calls back.
-                    let load_val = jsc_api::JSBundler::Load::init(self, parse);
-                    // SAFETY: arena outlives the bundle pass.
-                    let load: &mut jsc_api::JSBundler::Load = self.arena_create(load_val);
-                    load.dispatch();
+                    let load = jsc_api::JSBundler::Load::init(self, parse);
+                    // Arena-owned: the slot lives as long as the pass, which
+                    // holds it in `outstanding_loads` until the JS thread
+                    // answers (or the pass is cancelled).
+                    let load: *mut jsc_api::JSBundler::Load = self.arena_create(load);
+                    // SAFETY: fresh slot, `init`ed above, not used again here.
+                    unsafe { jsc_api::JSBundler::Load::dispatch(load) };
                     return true;
                 }
             }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1111,33 +1111,9 @@ pub mod bv2_impl {
                     outstanding: Default::default(),
                 }
                 }
-                /// Bundle thread: links the request into the pass and hops to the JS
-                /// thread for the `onResolve` chain (a cancelled pass only links it,
-                /// for `is_done` to fail). Pointer receiver because `this` itself
-                /// has to be what both the list and the task hold; the reasoning is
-                /// in test/internal/source-lints/bundler-plugin-dispatch-raw-request.test.ts.
-                ///
-                /// # Safety
-                /// `this` is a fresh arena slot holding an `init`ed request, and the
-                /// caller does not use it again.
-                pub(crate) unsafe fn dispatch(this: *mut Self) {
-                    // SAFETY: `this` is live (fn contract) and this is the thread
-                    // that owns the pass `bv2` (set by `init`) points at; plugins
-                    // is Some (asserted by `enqueue_on_js_loop_for_plugins`).
-                    unsafe {
-                        let bv2 = &mut *(*this).bv2;
-                        bv2.graph.outstanding_resolves.push(this);
-                        if bv2.graph.cancelled {
-                            // Failed by `is_done` at the loop's top level (not
-                            // here, mid-caller); make sure it runs again.
-                            bv2.wake_own_loop();
-                            return;
-                        }
-                        let task = bun_event_loop::ConcurrentTask::ConcurrentTask::create(
-                            bun_event_loop::Task::init(this),
-                        );
-                        bv2.enqueue_on_js_loop_for_plugins(task);
-                    }
+                /// Bundle thread: hands the request to the `onResolve` plugin chain.
+                pub(crate) fn dispatch(self, bv2: &mut BundleV2<'_>) {
+                    bv2.dispatch_plugin_request(self);
                 }
                 pub fn run_on_js_thread(&mut self) {
                     let kind = self.import_record.kind;
@@ -1253,27 +1229,9 @@ pub mod bv2_impl {
                 pub(crate) fn bake_graph(&self) -> crate::bake_types::Graph {
                     self.parse_task().known_target.bake_graph()
                 }
-                /// Bundle thread: as `Resolve::dispatch`, for the `onLoad` chain.
-                ///
-                /// # Safety
-                /// As `Resolve::dispatch`.
-                pub(crate) unsafe fn dispatch(this: *mut Self) {
-                    // SAFETY: as `Resolve::dispatch`.
-                    unsafe {
-                        let bv2 = &mut *(*this).bv2;
-                        bv2.graph.outstanding_loads.push(this);
-                        if bv2.graph.cancelled {
-                            // Failed by `is_done` at the loop's top level (not
-                            // here, mid-caller); make sure it runs again.
-                            bv2.wake_own_loop();
-                            return;
-                        }
-                        let concurrent_task =
-                            bun_event_loop::ConcurrentTask::ConcurrentTask::create(
-                                bun_event_loop::Task::init(this),
-                            );
-                        bv2.enqueue_on_js_loop_for_plugins(concurrent_task);
-                    }
+                /// Bundle thread: hands the request to the `onLoad` plugin chain.
+                pub(crate) fn dispatch(self, bv2: &mut BundleV2<'_>) {
+                    bv2.dispatch_plugin_request(self);
                 }
                 pub fn run_on_js_thread(&mut self) {
                     let is_server_side = self.bake_graph() != crate::bake_types::Graph::Client;
@@ -1306,10 +1264,20 @@ pub mod bv2_impl {
                 fn link(&mut self) -> &mut crate::Graph::OutstandingLink<Self> {
                     &mut self.outstanding
                 }
+                fn outstanding<'g>(
+                    graph: &'g mut crate::Graph::Graph<'_>,
+                ) -> &'g mut crate::Graph::OutstandingList<Self> {
+                    &mut graph.outstanding_loads
+                }
             }
             impl crate::Graph::OutstandingNode for Resolve {
                 fn link(&mut self) -> &mut crate::Graph::OutstandingLink<Self> {
                     &mut self.outstanding
+                }
+                fn outstanding<'g>(
+                    graph: &'g mut crate::Graph::Graph<'_>,
+                ) -> &'g mut crate::Graph::OutstandingList<Self> {
+                    &mut graph.outstanding_resolves
                 }
             }
         }
@@ -1519,6 +1487,29 @@ pub mod bv2_impl {
     pub use super::{BakeOptions, BundleV2, PendingImport};
 
     impl<'a> BundleV2<'a> {
+        /// Bundle thread: parks an onResolve / onLoad request in the arena, links it
+        /// into the pass and posts it to the plugins' thread (a cancelled pass only
+        /// links it, for `is_done` to fail). Taking the request by value makes the
+        /// pointer created here the only one: the list, the JS thread and the
+        /// answer all hold it. Guarded by bundler-plugin-dispatch-raw-request.test.ts.
+        pub(crate) fn dispatch_plugin_request<T>(&mut self, request: T)
+        where
+            T: bun_event_loop::Taskable + crate::Graph::OutstandingNode,
+        {
+            let request: *mut T = self.arena_create(request);
+            T::outstanding(&mut self.graph).push(request);
+            if self.graph.cancelled {
+                // Failed by `is_done` at the loop's top level (not here,
+                // mid-caller); make sure it runs again.
+                self.wake_own_loop();
+                return;
+            }
+            let task = bun_event_loop::ConcurrentTask::ConcurrentTask::create(
+                bun_event_loop::Task::init(request),
+            );
+            self.enqueue_on_js_loop_for_plugins(task);
+        }
+
         /// Folds the JS-loop lookup + enqueue so the bundler never dereferences
         /// `JSBundleCompletionTask` (its layout lives in `bun_runtime`); the
         /// `completion` handle carries the `&'static` vtable.
@@ -5638,9 +5629,7 @@ pub mod bv2_impl {
                             original_target,
                         },
                     );
-                    let resolve: *mut jsc_api::JSBundler::Resolve = self.arena_create(resolve);
-                    // SAFETY: fresh slot, `init`ed above, not used again here.
-                    unsafe { jsc_api::JSBundler::Resolve::dispatch(resolve) };
+                    resolve.dispatch(self);
                     return true;
                 }
             }
@@ -5678,9 +5667,7 @@ pub mod bv2_impl {
                             original_target: target,
                         },
                     );
-                    let resolve: *mut jsc_api::JSBundler::Resolve = self.arena_create(resolve);
-                    // SAFETY: fresh slot, `init`ed above, not used again here.
-                    unsafe { jsc_api::JSBundler::Resolve::dispatch(resolve) };
+                    resolve.dispatch(self);
                     return true;
                 }
             }
@@ -5737,10 +5724,7 @@ pub mod bv2_impl {
                         bstr::BStr::new(&parse.path.namespace),
                         bstr::BStr::new(&parse.path.text)
                     );
-                    let load = jsc_api::JSBundler::Load::init(self, parse);
-                    let load: *mut jsc_api::JSBundler::Load = self.arena_create(load);
-                    // SAFETY: fresh slot, `init`ed above, not used again here.
-                    unsafe { jsc_api::JSBundler::Load::dispatch(load) };
+                    jsc_api::JSBundler::Load::init(self, parse).dispatch(self);
                     return true;
                 }
             }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1111,26 +1111,15 @@ pub mod bv2_impl {
                     outstanding: Default::default(),
                 }
                 }
-                /// Bundle thread. Hops to the JS thread to call the `onResolve`
-                /// plugin chain, unless the pass is already cancelled (that VM is
-                /// stopping and will never answer): then the request fails here
-                /// and now.
-                ///
-                /// Takes the pointer, not `&mut self`: the same pointer goes into
-                /// `Graph::outstanding_resolves` and into the task, because from
-                /// here on the request is reached through both. The next push
-                /// writes this request's link through the list's pointer and the
-                /// answer comes back through the task's; were those two reborrows
-                /// of a `&mut self`, that write would invalidate the task's
-                /// pointer under the aliasing model (Miri rejects the answer's
-                /// reborrow), and the `&mut self` itself would claim exclusivity
-                /// for a call during which the JS thread may already be writing
-                /// `value`.
+                /// Bundle thread: links the request into the pass and hops to the JS
+                /// thread for the `onResolve` chain (a cancelled pass only links it,
+                /// for `is_done` to fail). Pointer receiver because `this` itself
+                /// has to be what both the list and the task hold; the reasoning is
+                /// in test/internal/source-lints/bundler-plugin-dispatch-raw-request.test.ts.
                 ///
                 /// # Safety
-                /// `this` is an arena slot holding an `init`ed, not yet dispatched
-                /// request, and the caller does not use it afterwards: the pass
-                /// gets it back through the list or the answer.
+                /// `this` is a fresh arena slot holding an `init`ed request, and the
+                /// caller does not use it again.
                 pub(crate) unsafe fn dispatch(this: *mut Self) {
                     // SAFETY: `this` is live (fn contract) and this is the thread
                     // that owns the pass `bv2` (set by `init`) points at; plugins
@@ -1264,9 +1253,7 @@ pub mod bv2_impl {
                 pub(crate) fn bake_graph(&self) -> crate::bake_types::Graph {
                     self.parse_task().known_target.bake_graph()
                 }
-                /// Bundle thread. Hops to the JS thread to call the `onLoad`
-                /// plugin chain, unless the pass is already cancelled. Pointer
-                /// receiver for the reason given on `Resolve::dispatch`.
+                /// Bundle thread: as `Resolve::dispatch`, for the `onLoad` chain.
                 ///
                 /// # Safety
                 /// As `Resolve::dispatch`.
@@ -5651,9 +5638,6 @@ pub mod bv2_impl {
                             original_target,
                         },
                     );
-                    // Arena-owned: the slot lives as long as the pass, which
-                    // holds it in `outstanding_resolves` until the JS thread
-                    // answers (or the pass is cancelled).
                     let resolve: *mut jsc_api::JSBundler::Resolve = self.arena_create(resolve);
                     // SAFETY: fresh slot, `init`ed above, not used again here.
                     unsafe { jsc_api::JSBundler::Resolve::dispatch(resolve) };
@@ -5694,7 +5678,6 @@ pub mod bv2_impl {
                             original_target: target,
                         },
                     );
-                    // Arena-owned; see `enqueue_on_resolve_plugin_if_needed`.
                     let resolve: *mut jsc_api::JSBundler::Resolve = self.arena_create(resolve);
                     // SAFETY: fresh slot, `init`ed above, not used again here.
                     unsafe { jsc_api::JSBundler::Resolve::dispatch(resolve) };
@@ -5755,9 +5738,6 @@ pub mod bv2_impl {
                         bstr::BStr::new(&parse.path.text)
                     );
                     let load = jsc_api::JSBundler::Load::init(self, parse);
-                    // Arena-owned: the slot lives as long as the pass, which
-                    // holds it in `outstanding_loads` until the JS thread
-                    // answers (or the pass is cancelled).
                     let load: *mut jsc_api::JSBundler::Load = self.arena_create(load);
                     // SAFETY: fresh slot, `init`ed above, not used again here.
                     unsafe { jsc_api::JSBundler::Load::dispatch(load) };

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -1488,10 +1488,9 @@ pub mod bv2_impl {
 
     impl<'a> BundleV2<'a> {
         /// Bundle thread: parks an onResolve / onLoad request in the arena, links it
-        /// into the pass and posts it to the plugins' thread (a cancelled pass only
-        /// links it, for `is_done` to fail). Taking the request by value makes the
-        /// pointer created here the only one: the list, the JS thread and the
-        /// answer all hold it. Guarded by bundler-plugin-dispatch-raw-request.test.ts.
+        /// into the pass and posts it to the plugins' thread. By value, so that the
+        /// pointer made here is the only one: the list, the JS thread and the answer
+        /// all hold it.
         pub(crate) fn dispatch_plugin_request<T>(&mut self, request: T)
         where
             T: bun_event_loop::Taskable + crate::Graph::OutstandingNode,

--- a/test/internal/source-lints/bundler-plugin-dispatch-raw-request.test.ts
+++ b/test/internal/source-lints/bundler-plugin-dispatch-raw-request.test.ts
@@ -1,0 +1,227 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// The bundler's plugin requests are handed to the plugins' thread by the
+// pointer the pass keeps, never through a `self` receiver.
+//
+// `Resolve::dispatch` and `Load::dispatch` (src/bundler/bundle_v2.rs) each
+// link one arena-allocated request into `Graph::outstanding_resolves` /
+// `outstanding_loads` and post it to the JS thread that runs the plugins
+// (`enqueue_on_js_loop_for_plugins`). From the moment the post lands, the
+// request is used from two threads through two stored pointers: the JS thread
+// writes its `value` (and posts it back) through the one in the task, while
+// the bundle thread writes its `outstanding` link through the one in the list
+// whenever a neighbouring request is pushed or unlinked, and fails the request
+// through it if the pass is cancelled. Under the aliasing model that only
+// works if the list and the task hold the same pointer. When the two
+// functions took `&mut self`, the list got one reborrow of the receiver
+// (`push(self)`) and the task another (`Task::init(ptr::from_mut(self))`):
+// dispatching the next request wrote this one's link through the list's
+// pointer, which invalidated the task's, and the answer was then consumed
+// through the task's (Miri rejects that reborrow under Tree Borrows and under
+// Stacked Borrows). The `&mut self` argument also asserted exclusive access
+// for a call during which the other thread may already have been writing the
+// request. (The free variant of the same mistake is
+// self-receiver-reclaim.test.ts.)
+//
+// So the two functions take `this: *mut Self`, and the body passes `this`
+// itself both to the list and to `Task::init`. Banned inside them: a `self`
+// receiver, and forming a reference to the request (`&mut *this`, `&*this`,
+// `ptr::from_mut` / `from_ref`), which is the same two-pointer shape spelled
+// differently. The pass itself (`&mut *(*this).bv2`) is not covered: dispatch
+// runs on the thread that owns it.
+//
+// The answer path (`on_resolve_async` / `on_load_async` and the thunks in
+// src/runtime/api/JSBundler.rs) and `DeferredBatchTask::schedule` are
+// separate populations and not covered here.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const bundlerSources = globAllSources().rust.filter(
+  p => p.endsWith(".rs") && path.relative(root, p).replaceAll(path.sep, "/").startsWith("src/bundler/"),
+);
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+const DISPATCH = /\bfn\s+dispatch\s*\(([^)]*)\)/g;
+// `this: *mut Self` (any parameter name; `*mut Resolve` / `*mut Load` would do
+// as well). Captures the name so the body checks can look for it.
+const RAW_REQUEST_PARAM = /^\s*(\w+)\s*:\s*\*\s*mut\s+\w+\s*$/;
+
+function lineOf(text: string, index: number): number {
+  return text.slice(0, index).split("\n").length;
+}
+
+/** The `{ .. }` block starting at the first `{` at or after `from`. */
+function blockAfter(text: string, from: number): { start: number; body: string } | null {
+  const start = text.indexOf("{", from);
+  if (start < 0) return null;
+  let depth = 0;
+  for (let i = start; i < text.length; i++) {
+    const c = text[i];
+    if (c === "{") depth++;
+    else if (c === "}" && --depth === 0) return { start, body: text.slice(start, i + 1) };
+  }
+  return null;
+}
+
+/** Strip comments so prose about the banned shapes (this file's own header
+ * is paraphrased in the doc comments) does not count. Full-line comments
+ * first, keeping the newline so line numbers hold; then trailing ones. The
+ * bodies contain no string literals, which is what this would misread. */
+function stripComments(text: string): string {
+  return text.replace(/^[ \t]*\/\/.*$/gm, "").replace(/[ \t]\/\/.*$/gm, "");
+}
+
+/** Every `fn dispatch` in `text` and what is wrong with each (nothing, for a
+ * conforming one). */
+function audit(text: string): { line: number; complaints: string[] }[] {
+  const stripped = stripComments(text);
+  const out: { line: number; complaints: string[] }[] = [];
+  for (const m of stripped.matchAll(DISPATCH)) {
+    const line = lineOf(stripped, m.index);
+    const complaints: string[] = [];
+    const params = m[1];
+    const raw = RAW_REQUEST_PARAM.exec(params);
+    if (/\bself\b/.test(params)) {
+      complaints.push(`takes a self receiver: \`${params.trim()}\``);
+    } else if (raw === null) {
+      complaints.push(`does not take the request as its one \`*mut\` parameter: \`${params.trim()}\``);
+    }
+    const block = blockAfter(stripped, m.index + m[0].length);
+    if (block === null) {
+      complaints.push("could not find the body");
+    } else {
+      const { body } = block;
+      if (/\bself\b/.test(body)) complaints.push("body uses `self`");
+      if (raw !== null) {
+        const name = raw[1];
+        const reborrow = new RegExp(String.raw`&\s*(?:mut\s+)?\*\s*${name}\b`);
+        if (reborrow.test(body) || /\bfrom_(?:mut|ref)\b/.test(body)) {
+          complaints.push("body forms a reference to the request");
+        }
+        const linked = new RegExp(String.raw`\boutstanding_\w+\s*\.\s*push\(\s*${name}\s*\)`);
+        if (!linked.test(body)) complaints.push(`body does not link \`${name}\` itself into the outstanding list`);
+        const posted = new RegExp(String.raw`\bTask::init\(\s*${name}\s*\)`);
+        if (!posted.test(body)) complaints.push(`body does not post \`${name}\` itself`);
+      }
+    }
+    out.push({ line, complaints });
+  }
+  return out;
+}
+
+const found: string[] = [];
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of bundlerSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  for (const { line, complaints } of audit(await file(abs).text())) {
+    found.push(source);
+    for (const c of complaints) offenders.push(`${source}:${line}: ${c}`);
+  }
+}
+
+test("scans the tracked sources of the bundler crate", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the assertions below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("Resolve::dispatch and Load::dispatch are still where this lint looks for them", () => {
+  // If this changes, a request type was added, removed or moved: update this
+  // list (and the header) rather than the checks below.
+  expect(found).toEqual(["src/bundler/bundle_v2.rs", "src/bundler/bundle_v2.rs"]);
+});
+
+test("the audit recognizes the shapes it claims to", () => {
+  const conforming = `
+    pub(crate) unsafe fn dispatch(this: *mut Self) {
+        // SAFETY: see above; \`&mut *this\` is mentioned here only in prose.
+        unsafe {
+            let bv2 = &mut *(*this).bv2;
+            bv2.graph.outstanding_resolves.push(this);
+            if bv2.graph.cancelled {
+                bv2.wake_own_loop();
+                return;
+            }
+            let task = bun_event_loop::ConcurrentTask::ConcurrentTask::create(
+                bun_event_loop::Task::init(this),
+            );
+            bv2.enqueue_on_js_loop_for_plugins(task);
+        }
+    }`;
+  expect(audit(conforming)).toEqual([{ line: 2, complaints: [] }]);
+  // Another parameter name and a spelled-out type are fine too.
+  expect(audit("unsafe fn dispatch(load: *mut Load) { outstanding_loads.push(load); Task::init(load); }")).toEqual([
+    { line: 1, complaints: [] },
+  ]);
+
+  const complaintsOf = (snippet: string) => audit(snippet).flatMap(f => f.complaints);
+
+  // The shape this lint was written against: the receiver gets reborrowed once
+  // for the list and once for the task.
+  expect(
+    complaintsOf(`
+      pub(crate) fn dispatch(&mut self) {
+          unsafe {
+              let bv2 = &mut *self.bv2;
+              bv2.graph.outstanding_loads.push(self);
+              let task = ConcurrentTask::create(Task::init(std::ptr::from_mut::<Self>(self)));
+              bv2.enqueue_on_js_loop_for_plugins(task);
+          }
+      }`),
+  ).toEqual(["takes a self receiver: `&mut self`", "body uses `self`"]);
+  expect(complaintsOf("fn dispatch(self: &mut Self) {}")).toContain("takes a self receiver: `self: &mut Self`");
+  expect(complaintsOf("fn dispatch(this: &mut Self) {}")).toContain(
+    "does not take the request as its one `*mut` parameter: `this: &mut Self`",
+  );
+  expect(complaintsOf("fn dispatch(this: *mut Self, bv2: &mut BundleV2) {}")).toContain(
+    "does not take the request as its one `*mut` parameter: `this: *mut Self, bv2: &mut BundleV2`",
+  );
+  // Raw receiver, but the body reintroduces a second pointer derivation.
+  expect(
+    complaintsOf(`
+      unsafe fn dispatch(this: *mut Self) {
+          let this_ref = &mut *this;
+          bv2.graph.outstanding_resolves.push(this);
+          Task::init(this);
+      }`),
+  ).toEqual(["body forms a reference to the request"]);
+  expect(
+    complaintsOf(`
+      unsafe fn dispatch(this: *mut Self) {
+          bv2.graph.outstanding_resolves.push(this);
+          Task::init(std::ptr::from_mut::<Self>(&mut *this));
+      }`),
+  ).toEqual(["body forms a reference to the request", "body does not post `this` itself"]);
+  expect(
+    complaintsOf(`
+      unsafe fn dispatch(this: *mut Self) {
+          let node = this.cast::<Self>();
+          bv2.graph.outstanding_resolves.push(node);
+          Task::init(this);
+      }`),
+  ).toEqual(["body does not link `this` itself into the outstanding list"]);
+  expect(complaintsOf("unsafe fn dispatch(this: *mut Self)")).toContain("could not find the body");
+});
+
+test("plugin requests are dispatched through the pointer the pass keeps", () => {
+  expect(offenders).toEqual([]);
+});

--- a/test/internal/source-lints/bundler-plugin-dispatch-raw-request.test.ts
+++ b/test/internal/source-lints/bundler-plugin-dispatch-raw-request.test.ts
@@ -1,42 +1,41 @@
 import { file } from "bun";
 import { expect, test } from "bun:test";
-import { realpathSync } from "fs";
+import { existsSync, realpathSync } from "fs";
 import path from "path";
 import { globAllSources } from "../../../scripts/glob-sources.ts";
 
-// The bundler's plugin requests are handed to the plugins' thread by the
-// pointer the pass keeps, never through a `self` receiver.
+// A bundler plugin request (`Resolve` / `Load` in src/bundler/bundle_v2.rs) is
+// known by exactly one pointer from the moment it is dispatched.
 //
-// `Resolve::dispatch` and `Load::dispatch` (src/bundler/bundle_v2.rs) each
-// link one arena-allocated request into `Graph::outstanding_resolves` /
-// `outstanding_loads` and post it to the JS thread that runs the plugins
-// (`enqueue_on_js_loop_for_plugins`). From the moment the post lands, the
-// request is used from two threads through two stored pointers: the JS thread
-// writes its `value` (and posts it back) through the one in the task, while
-// the bundle thread writes its `outstanding` link through the one in the list
-// whenever a neighbouring request is pushed or unlinked, and fails the request
-// through it if the pass is cancelled. Under the aliasing model that only
-// works if the list and the task hold the same pointer. When the two
-// functions took `&mut self`, the list got one reborrow of the receiver
-// (`push(self)`) and the task another (`Task::init(ptr::from_mut(self))`):
-// dispatching the next request wrote this one's link through the list's
-// pointer, which invalidated the task's, and the answer was then consumed
-// through the task's (Miri rejects that reborrow under Tree Borrows and under
-// Stacked Borrows). The `&mut self` argument also asserted exclusive access
-// for a call during which the other thread may already have been writing the
-// request. (The free variant of the same mistake is
-// self-receiver-reclaim.test.ts.)
+// Once dispatched, a request is linked in `Graph::outstanding_resolves` /
+// `outstanding_loads` and posted to the thread that runs the plugins, and is
+// used through both: the JS thread writes its `value` and posts it back
+// through the task's pointer, while the bundle thread writes its
+// `outstanding` link through the list's pointer whenever a neighbouring
+// request is dispatched or answered, and fails it through the list's pointer
+// if the pass is cancelled. Under the aliasing model the list and the task
+// therefore have to hold the same pointer. `Resolve::dispatch(&mut self)` and
+// `Load::dispatch(&mut self)` used to give them two reborrows of the receiver
+// (`push(self)` and `Task::init(ptr::from_mut(self))`): dispatching the next
+// request wrote this one's link through the first and invalidated the second,
+// and the answer was then consumed through the second. Miri rejects that
+// reborrow under Tree Borrows and under Stacked Borrows.
 //
-// So the two functions take `this: *mut Self`, and the body passes `this`
-// itself both to the list and to `Task::init`. Banned inside them: a `self`
-// receiver, and forming a reference to the request (`&mut *this`, `&*this`,
-// `ptr::from_mut` / `from_ref`), which is the same two-pointer shape spelled
-// differently. The pass itself (`&mut *(*this).bv2`) is not covered: dispatch
-// runs on the thread that owns it.
+// So `BundleV2::dispatch_plugin_request` takes the request by value, parks it
+// in the arena, and passes the one `*mut` it gets back both to the list and to
+// `Task::init`; there is no other pointer for anything to hold. `Resolve::
+// dispatch` / `Load::dispatch` only forward to it. This lint checks both halves:
+// the helper's body has that shape (one `arena_create` binding, the same local
+// into `.push(..)` and `Task::init(..)`, no reference formed to it), and every
+// `fn dispatch` in the crate takes `self` by value and forwards instead of
+// linking or posting anything itself.
 //
-// The answer path (`on_resolve_async` / `on_load_async` and the thunks in
-// src/runtime/api/JSBundler.rs) and `DeferredBatchTask::schedule` are
-// separate populations and not covered here.
+// Not covered: the answer path (`on_resolve_async` / `on_load_async` and the
+// thunks in src/runtime/api/JSBundler.rs) and `DeferredBatchTask::schedule`,
+// which posts a field of the pass rather than an arena request. The tree-wide
+// guard for posting `self` is self-receiver-publish.test.ts, whose ratchet
+// entry for bundle_v2.rs this conversion retires; the last test below keeps
+// the two from landing out of step.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const bundlerSources = globAllSources().rust.filter(
@@ -56,75 +55,110 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-const DISPATCH = /\bfn\s+dispatch\s*\(([^)]*)\)/g;
-// `this: *mut Self` (any parameter name; `*mut Resolve` / `*mut Load` would do
-// as well). Captures the name so the body checks can look for it.
-const RAW_REQUEST_PARAM = /^\s*(\w+)\s*:\s*\*\s*mut\s+\w+\s*$/;
+type Finding = { line: number; complaints: string[] };
 
 function lineOf(text: string, index: number): number {
   return text.slice(0, index).split("\n").length;
 }
 
 /** The `{ .. }` block starting at the first `{` at or after `from`. */
-function blockAfter(text: string, from: number): { start: number; body: string } | null {
+function blockAfter(text: string, from: number): string | null {
   const start = text.indexOf("{", from);
   if (start < 0) return null;
   let depth = 0;
   for (let i = start; i < text.length; i++) {
     const c = text[i];
     if (c === "{") depth++;
-    else if (c === "}" && --depth === 0) return { start, body: text.slice(start, i + 1) };
+    else if (c === "}" && --depth === 0) return text.slice(start, i + 1);
   }
   return null;
 }
 
-/** Strip comments so prose about the banned shapes (this file's own header
- * is paraphrased in the doc comments) does not count. Full-line comments
- * first, keeping the newline so line numbers hold; then trailing ones. The
- * bodies contain no string literals, which is what this would misread. */
+/** Strip comments (full-line ones first, keeping the newline so line numbers
+ * hold; then trailing ones) so the doc comments paraphrasing this header do
+ * not count. The bodies involved contain no string literals. */
 function stripComments(text: string): string {
   return text.replace(/^[ \t]*\/\/.*$/gm, "").replace(/[ \t]\/\/.*$/gm, "");
 }
 
-/** Every `fn dispatch` in `text` and what is wrong with each (nothing, for a
- * conforming one). */
-function audit(text: string): { line: number; complaints: string[] }[] {
+// `fn dispatch_plugin_request<T>(&mut self, request: T)`; the `<..>` may be
+// absent or carry bounds, the `where` clause is outside the parens.
+const HELPER = /\bfn\s+dispatch_plugin_request\b(?:<[^()]*?>)?\s*\(([^)]*)\)/g;
+// `&mut self, <name>: <Type>` where the type is a plain path, i.e. the request
+// is taken by value and not as a pointer or reference.
+const HELPER_PARAMS = /^\s*&mut\s+self\s*,\s*(\w+)\s*:\s*[\w:]+\s*,?\s*$/;
+
+/** Every `dispatch_plugin_request` definition in `text`, audited. */
+function auditHelper(text: string): Finding[] {
   const stripped = stripComments(text);
-  const out: { line: number; complaints: string[] }[] = [];
-  for (const m of stripped.matchAll(DISPATCH)) {
-    const line = lineOf(stripped, m.index);
+  const out: Finding[] = [];
+  for (const m of stripped.matchAll(HELPER)) {
     const complaints: string[] = [];
-    const params = m[1];
-    const raw = RAW_REQUEST_PARAM.exec(params);
-    if (/\bself\b/.test(params)) {
-      complaints.push(`takes a self receiver: \`${params.trim()}\``);
-    } else if (raw === null) {
-      complaints.push(`does not take the request as its one \`*mut\` parameter: \`${params.trim()}\``);
-    }
-    const block = blockAfter(stripped, m.index + m[0].length);
-    if (block === null) {
+    const params = HELPER_PARAMS.exec(m[1]);
+    if (params === null) complaints.push(`does not take the request by value: \`${m[1].trim()}\``);
+    const body = blockAfter(stripped, m.index + m[0].length);
+    if (body === null) {
       complaints.push("could not find the body");
-    } else {
-      const { body } = block;
-      if (/\bself\b/.test(body)) complaints.push("body uses `self`");
-      if (raw !== null) {
-        const name = raw[1];
-        const reborrow = new RegExp(String.raw`&\s*(?:mut\s+)?\*\s*${name}\b`);
-        if (reborrow.test(body) || /\bfrom_(?:mut|ref)\b/.test(body)) {
-          complaints.push("body forms a reference to the request");
+    } else if (params !== null) {
+      const request = params[1];
+      const bindings = [
+        ...body.matchAll(
+          new RegExp(
+            String.raw`\blet\s+(\w+)\s*(?::\s*\*\s*mut\s+[\w:]+\s*)?=\s*self\s*\.\s*arena_create\(\s*${request}\s*\)`,
+            "g",
+          ),
+        ),
+      ];
+      const allocations = body.match(/\barena_create\(/g)?.length ?? 0;
+      if (allocations !== 1) {
+        complaints.push(`expected exactly one arena_create, found ${allocations}`);
+      } else if (bindings.length !== 1) {
+        complaints.push(`does not bind the arena slot of \`${request}\` as a raw pointer`);
+      } else {
+        const slot = bindings[0][1];
+        if (!new RegExp(String.raw`\.push\(\s*${slot}\s*\)`).test(body))
+          complaints.push(`\`${slot}\` is not what gets linked`);
+        if (!new RegExp(String.raw`\bTask::init\(\s*${slot}\s*\)`).test(body))
+          complaints.push(`\`${slot}\` is not what gets posted`);
+        if (new RegExp(String.raw`&\s*(?:mut\s+)?\*\s*${slot}\b`).test(body) || /\bfrom_(?:mut|ref)\b/.test(body)) {
+          complaints.push(`forms a reference to \`${slot}\``);
         }
-        const linked = new RegExp(String.raw`\boutstanding_\w+\s*\.\s*push\(\s*${name}\s*\)`);
-        if (!linked.test(body)) complaints.push(`body does not link \`${name}\` itself into the outstanding list`);
-        const posted = new RegExp(String.raw`\bTask::init\(\s*${name}\s*\)`);
-        if (!posted.test(body)) complaints.push(`body does not post \`${name}\` itself`);
       }
     }
-    out.push({ line, complaints });
+    out.push({ line: lineOf(stripped, m.index), complaints });
   }
   return out;
 }
 
-const found: string[] = [];
+const DISPATCH = /\bfn\s+dispatch\s*\(([^)]*)\)/g;
+
+/** Every `fn dispatch` in `text`, audited: by-value `self`, and a body that
+ * forwards rather than linking or posting. */
+function auditDispatch(text: string): Finding[] {
+  const stripped = stripComments(text);
+  const out: Finding[] = [];
+  for (const m of stripped.matchAll(DISPATCH)) {
+    const complaints: string[] = [];
+    const params = m[1];
+    if (!/^\s*(?:mut\s+)?self\s*(?:,|$)/.test(params)) {
+      complaints.push(`does not take the request by value: \`${params.trim()}\``);
+    }
+    const body = blockAfter(stripped, m.index + m[0].length);
+    if (body === null) {
+      complaints.push("could not find the body");
+    } else {
+      if (!/\.dispatch_plugin_request\(\s*self\s*\)/.test(body))
+        complaints.push("does not forward to dispatch_plugin_request");
+      if (/\.push\(|\bTask::init\(|\barena_create\(/.test(body))
+        complaints.push("links, allocates or posts on its own");
+    }
+    out.push({ line: lineOf(stripped, m.index), complaints });
+  }
+  return out;
+}
+
+const helpers: string[] = [];
+const dispatches: string[] = [];
 const offenders: string[] = [];
 let scanned = 0;
 for (const abs of bundlerSources) {
@@ -132,9 +166,14 @@ for (const abs of bundlerSources) {
   if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
   if (tracked !== null && !tracked.has(source)) continue;
   scanned++;
-  for (const { line, complaints } of audit(await file(abs).text())) {
-    found.push(source);
-    for (const c of complaints) offenders.push(`${source}:${line}: ${c}`);
+  const content = await file(abs).text();
+  for (const { line, complaints } of auditHelper(content)) {
+    helpers.push(source);
+    for (const c of complaints) offenders.push(`${source}:${line}: dispatch_plugin_request ${c}`);
+  }
+  for (const { line, complaints } of auditDispatch(content)) {
+    dispatches.push(source);
+    for (const c of complaints) offenders.push(`${source}:${line}: dispatch ${c}`);
   }
 }
 
@@ -144,41 +183,85 @@ test("scans the tracked sources of the bundler crate", () => {
   expect(scanned).toBeGreaterThan(0);
 });
 
-test("Resolve::dispatch and Load::dispatch are still where this lint looks for them", () => {
-  // If this changes, a request type was added, removed or moved: update this
-  // list (and the header) rather than the checks below.
-  expect(found).toEqual(["src/bundler/bundle_v2.rs", "src/bundler/bundle_v2.rs"]);
+test("the helper and the two request types' dispatch are where this lint looks for them", () => {
+  // If this changes, the helper moved or a request type was added, removed or
+  // moved: update this (and the header) rather than the checks below.
+  expect({ helpers, dispatches }).toEqual({
+    helpers: ["src/bundler/bundle_v2.rs"],
+    dispatches: ["src/bundler/bundle_v2.rs", "src/bundler/bundle_v2.rs"],
+  });
 });
 
-test("the audit recognizes the shapes it claims to", () => {
-  const conforming = `
-    pub(crate) unsafe fn dispatch(this: *mut Self) {
-        // SAFETY: see above; \`&mut *this\` is mentioned here only in prose.
-        unsafe {
-            let bv2 = &mut *(*this).bv2;
-            bv2.graph.outstanding_resolves.push(this);
-            if bv2.graph.cancelled {
-                bv2.wake_own_loop();
-                return;
-            }
-            let task = bun_event_loop::ConcurrentTask::ConcurrentTask::create(
-                bun_event_loop::Task::init(this),
-            );
-            bv2.enqueue_on_js_loop_for_plugins(task);
-        }
-    }`;
-  expect(audit(conforming)).toEqual([{ line: 2, complaints: [] }]);
-  // Another parameter name and a spelled-out type are fine too.
-  expect(audit("unsafe fn dispatch(load: *mut Load) { outstanding_loads.push(load); Task::init(load); }")).toEqual([
-    { line: 1, complaints: [] },
+test("the audits recognize the shapes they claim to", () => {
+  const complaintsOfHelper = (s: string) => auditHelper(s).flatMap(f => f.complaints);
+  const complaintsOfDispatch = (s: string) => auditDispatch(s).flatMap(f => f.complaints);
+
+  const helper = (body: string, params = "&mut self, request: T") =>
+    `pub(crate) fn dispatch_plugin_request<T>(${params})\nwhere\n    T: Taskable + OutstandingNode,\n{\n${body}\n}`;
+  const conformingBody = `
+    // SAFETY-style prose mentioning &mut *request is stripped before auditing.
+    let request: *mut T = self.arena_create(request);
+    T::outstanding(&mut self.graph).push(request);
+    if self.graph.cancelled {
+        self.wake_own_loop();
+        return;
+    }
+    let task = bun_event_loop::ConcurrentTask::ConcurrentTask::create(
+        bun_event_loop::Task::init(request),
+    );
+    self.enqueue_on_js_loop_for_plugins(task);`;
+  expect(auditHelper(helper(conformingBody))).toEqual([{ line: 1, complaints: [] }]);
+  // A different local name and an untyped binding are fine.
+  expect(
+    complaintsOfHelper(
+      helper("let slot = self.arena_create(req); list(self).push(slot); Task::init(slot);", "&mut self, req: R"),
+    ),
+  ).toEqual([]);
+  // The request must arrive by value: a pointer or a reference means someone
+  // else already holds a pointer to it.
+  expect(complaintsOfHelper(helper(conformingBody, "&mut self, request: *mut T"))).toEqual([
+    "does not take the request by value: `&mut self, request: *mut T`",
+  ]);
+  expect(complaintsOfHelper(helper(conformingBody, "&mut self, request: &mut T"))).toEqual([
+    "does not take the request by value: `&mut self, request: &mut T`",
+  ]);
+  // Two derivations of the slot, in the spellings main used.
+  expect(
+    complaintsOfHelper(
+      helper(`
+        let slot: &mut T = self.arena_create(request);
+        T::outstanding(&mut self.graph).push(slot);
+        Task::init(std::ptr::from_mut::<T>(slot));`),
+    ),
+  ).toEqual(["does not bind the arena slot of `request` as a raw pointer"]);
+  expect(
+    complaintsOfHelper(
+      helper(`
+        let slot: *mut T = self.arena_create(request);
+        let again: *mut T = self.arena_create(T::default());
+        T::outstanding(&mut self.graph).push(slot);
+        Task::init(again);`),
+    ),
+  ).toEqual(["expected exactly one arena_create, found 2"]);
+  expect(
+    complaintsOfHelper(
+      helper(`
+        let slot: *mut T = self.arena_create(request);
+        let node = &mut *slot;
+        T::outstanding(&mut self.graph).push(node);
+        Task::init(std::ptr::from_mut::<T>(node));`),
+    ),
+  ).toEqual(["`slot` is not what gets linked", "`slot` is not what gets posted", "forms a reference to `slot`"]);
+  expect(complaintsOfHelper("fn dispatch_plugin_request<T>(&mut self, request: T)")).toEqual([
+    "could not find the body",
   ]);
 
-  const complaintsOf = (snippet: string) => audit(snippet).flatMap(f => f.complaints);
-
-  // The shape this lint was written against: the receiver gets reborrowed once
-  // for the list and once for the task.
   expect(
-    complaintsOf(`
+    auditDispatch("pub(crate) fn dispatch(self, bv2: &mut BundleV2<'_>) {\n    bv2.dispatch_plugin_request(self);\n}"),
+  ).toEqual([{ line: 1, complaints: [] }]);
+  // The shape this lint was written against.
+  expect(
+    complaintsOfDispatch(`
       pub(crate) fn dispatch(&mut self) {
           unsafe {
               let bv2 = &mut *self.bv2;
@@ -187,41 +270,43 @@ test("the audit recognizes the shapes it claims to", () => {
               bv2.enqueue_on_js_loop_for_plugins(task);
           }
       }`),
-  ).toEqual(["takes a self receiver: `&mut self`", "body uses `self`"]);
-  expect(complaintsOf("fn dispatch(self: &mut Self) {}")).toContain("takes a self receiver: `self: &mut Self`");
-  expect(complaintsOf("fn dispatch(this: &mut Self) {}")).toContain(
-    "does not take the request as its one `*mut` parameter: `this: &mut Self`",
-  );
-  expect(complaintsOf("fn dispatch(this: *mut Self, bv2: &mut BundleV2) {}")).toContain(
-    "does not take the request as its one `*mut` parameter: `this: *mut Self, bv2: &mut BundleV2`",
-  );
-  // Raw receiver, but the body reintroduces a second pointer derivation.
-  expect(
-    complaintsOf(`
-      unsafe fn dispatch(this: *mut Self) {
-          let this_ref = &mut *this;
-          bv2.graph.outstanding_resolves.push(this);
-          Task::init(this);
-      }`),
-  ).toEqual(["body forms a reference to the request"]);
-  expect(
-    complaintsOf(`
-      unsafe fn dispatch(this: *mut Self) {
-          bv2.graph.outstanding_resolves.push(this);
-          Task::init(std::ptr::from_mut::<Self>(&mut *this));
-      }`),
-  ).toEqual(["body forms a reference to the request", "body does not post `this` itself"]);
-  expect(
-    complaintsOf(`
-      unsafe fn dispatch(this: *mut Self) {
-          let node = this.cast::<Self>();
-          bv2.graph.outstanding_resolves.push(node);
-          Task::init(this);
-      }`),
-  ).toEqual(["body does not link `this` itself into the outstanding list"]);
-  expect(complaintsOf("unsafe fn dispatch(this: *mut Self)")).toContain("could not find the body");
+  ).toEqual([
+    "does not take the request by value: `&mut self`",
+    "does not forward to dispatch_plugin_request",
+    "links, allocates or posts on its own",
+  ]);
+  // Other receivers that hand out a second pointer.
+  expect(complaintsOfDispatch("fn dispatch(&self, bv2: &mut BundleV2) { bv2.dispatch_plugin_request(self) }")).toEqual([
+    "does not take the request by value: `&self, bv2: &mut BundleV2`",
+  ]);
+  expect(complaintsOfDispatch("unsafe fn dispatch(this: *mut Self) { Task::init(this); }")).toEqual([
+    "does not take the request by value: `this: *mut Self`",
+    "does not forward to dispatch_plugin_request",
+    "links, allocates or posts on its own",
+  ]);
+  // By value, but doing the work inline instead of through the helper.
+  expect(complaintsOfDispatch("fn dispatch(self, bv2: &mut BundleV2) { let p = bv2.arena_create(self); }")).toEqual([
+    "does not forward to dispatch_plugin_request",
+    "links, allocates or posts on its own",
+  ]);
 });
 
-test("plugin requests are dispatched through the pointer the pass keeps", () => {
+test("plugin requests are allocated, linked and posted in one place, through one pointer", () => {
   expect(offenders).toEqual([]);
+});
+
+test("the tree-wide publish lint no longer ratchets bundle_v2.rs", async () => {
+  // self-receiver-publish.test.ts (the tree-wide guard against posting `self`)
+  // was written while Resolve::dispatch / Load::dispatch still did that, and
+  // allowlists bundle_v2.rs with an exact count; this conversion is what
+  // retires that entry. The two changes touch different files, so nothing
+  // else stops them from landing with the entry still in place, which would
+  // fail that lint's ratchet on main. Passes trivially while that lint does
+  // not exist in this checkout.
+  const publishLint = path.join(import.meta.dir, "self-receiver-publish.test.ts");
+  if (!existsSync(publishLint)) return;
+  const entries = stripComments(await file(publishLint).text()).match(
+    /^[ \t]*["']src\/bundler\/bundle_v2\.rs["'][ \t]*:[ \t]*\d+/gm,
+  );
+  expect(entries).toBeNull();
 });

--- a/test/internal/source-lints/bundler-plugin-dispatch-raw-request.test.ts
+++ b/test/internal/source-lints/bundler-plugin-dispatch-raw-request.test.ts
@@ -1,6 +1,6 @@
 import { file } from "bun";
 import { expect, test } from "bun:test";
-import { existsSync, realpathSync } from "fs";
+import { realpathSync } from "fs";
 import path from "path";
 import { globAllSources } from "../../../scripts/glob-sources.ts";
 
@@ -23,19 +23,17 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //
 // So `BundleV2::dispatch_plugin_request` takes the request by value, parks it
 // in the arena, and passes the one `*mut` it gets back both to the list and to
-// `Task::init`; there is no other pointer for anything to hold. `Resolve::
-// dispatch` / `Load::dispatch` only forward to it. This lint checks both halves:
-// the helper's body has that shape (one `arena_create` binding, the same local
-// into `.push(..)` and `Task::init(..)`, no reference formed to it), and every
-// `fn dispatch` in the crate takes `self` by value and forwards instead of
-// linking or posting anything itself.
+// `Task::init`; there is no other pointer for anything to hold. This lint
+// checks that the helper's body has that shape (one `arena_create` binding,
+// the same local into `.push(..)` and `Task::init(..)`, no reference formed to
+// it), and that nothing else in the crate links a request into an outstanding
+// list: linking is what makes something a dispatched request, so a method
+// that links its own receiver again, under whatever name, shows up here.
 //
 // Not covered: the answer path (`on_resolve_async` / `on_load_async` and the
 // thunks in src/runtime/api/JSBundler.rs) and `DeferredBatchTask::schedule`,
-// which posts a field of the pass rather than an arena request. The tree-wide
-// guard for posting `self` is self-receiver-publish.test.ts, whose ratchet
-// entry for bundle_v2.rs this conversion retires; the last test below keeps
-// the two from landing out of step.
+// which posts a field of the pass rather than an arena request; the general
+// "posting `self`" spelling is the tree-wide lint's business (#37723).
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const bundlerSources = globAllSources().rust.filter(
@@ -55,28 +53,26 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-type Finding = { line: number; complaints: string[] };
-
 function lineOf(text: string, index: number): number {
   return text.slice(0, index).split("\n").length;
 }
 
-/** The `{ .. }` block starting at the first `{` at or after `from`. */
-function blockAfter(text: string, from: number): string | null {
+/** Bounds of the `{ .. }` block starting at the first `{` at or after `from`. */
+function blockAfter(text: string, from: number): { start: number; end: number } | null {
   const start = text.indexOf("{", from);
   if (start < 0) return null;
   let depth = 0;
   for (let i = start; i < text.length; i++) {
     const c = text[i];
     if (c === "{") depth++;
-    else if (c === "}" && --depth === 0) return text.slice(start, i + 1);
+    else if (c === "}" && --depth === 0) return { start, end: i + 1 };
   }
   return null;
 }
 
 /** Strip comments (full-line ones first, keeping the newline so line numbers
  * hold; then trailing ones) so the doc comments paraphrasing this header do
- * not count. The bodies involved contain no string literals. */
+ * not count. The code involved contains no string literals. */
 function stripComments(text: string): string {
   return text.replace(/^[ \t]*\/\/.*$/gm, "").replace(/[ \t]\/\/.*$/gm, "");
 }
@@ -87,78 +83,64 @@ const HELPER = /\bfn\s+dispatch_plugin_request\b(?:<[^()]*?>)?\s*\(([^)]*)\)/g;
 // `&mut self, <name>: <Type>` where the type is a plain path, i.e. the request
 // is taken by value and not as a pointer or reference.
 const HELPER_PARAMS = /^\s*&mut\s+self\s*,\s*(\w+)\s*:\s*[\w:]+\s*,?\s*$/;
+// Linking a request: a push onto one of the graph's lists, reached either as
+// the field or through the `OutstandingNode::outstanding` accessor.
+const LINK = /(?:\boutstanding_\w+|::outstanding\([^)]*\))\s*\.\s*push\(/g;
 
-/** Every `dispatch_plugin_request` definition in `text`, audited. */
-function auditHelper(text: string): Finding[] {
+type Audit = {
+  /** Each helper definition and what is wrong with it (nothing, if conforming). */
+  helpers: { line: number; complaints: string[] }[];
+  /** Lines of every link site, and of those outside a helper body. */
+  links: number[];
+  strayLinks: number[];
+};
+
+function audit(text: string): Audit {
   const stripped = stripComments(text);
-  const out: Finding[] = [];
+  const out: Audit = { helpers: [], links: [], strayLinks: [] };
+  const bodies: { start: number; end: number }[] = [];
   for (const m of stripped.matchAll(HELPER)) {
     const complaints: string[] = [];
     const params = HELPER_PARAMS.exec(m[1]);
     if (params === null) complaints.push(`does not take the request by value: \`${m[1].trim()}\``);
-    const body = blockAfter(stripped, m.index + m[0].length);
-    if (body === null) {
+    const bounds = blockAfter(stripped, m.index + m[0].length);
+    if (bounds === null) {
       complaints.push("could not find the body");
-    } else if (params !== null) {
-      const request = params[1];
-      const bindings = [
-        ...body.matchAll(
-          new RegExp(
-            String.raw`\blet\s+(\w+)\s*(?::\s*\*\s*mut\s+[\w:]+\s*)?=\s*self\s*\.\s*arena_create\(\s*${request}\s*\)`,
-            "g",
-          ),
-        ),
-      ];
-      const allocations = body.match(/\barena_create\(/g)?.length ?? 0;
-      if (allocations !== 1) {
-        complaints.push(`expected exactly one arena_create, found ${allocations}`);
-      } else if (bindings.length !== 1) {
-        complaints.push(`does not bind the arena slot of \`${request}\` as a raw pointer`);
-      } else {
-        const slot = bindings[0][1];
-        if (!new RegExp(String.raw`\.push\(\s*${slot}\s*\)`).test(body))
-          complaints.push(`\`${slot}\` is not what gets linked`);
-        if (!new RegExp(String.raw`\bTask::init\(\s*${slot}\s*\)`).test(body))
-          complaints.push(`\`${slot}\` is not what gets posted`);
-        if (new RegExp(String.raw`&\s*(?:mut\s+)?\*\s*${slot}\b`).test(body) || /\bfrom_(?:mut|ref)\b/.test(body)) {
-          complaints.push(`forms a reference to \`${slot}\``);
-        }
-      }
+    } else {
+      bodies.push(bounds);
+      if (params !== null) complaints.push(...auditBody(stripped.slice(bounds.start, bounds.end), params[1]));
     }
-    out.push({ line: lineOf(stripped, m.index), complaints });
+    out.helpers.push({ line: lineOf(stripped, m.index), complaints });
+  }
+  for (const m of stripped.matchAll(LINK)) {
+    const line = lineOf(stripped, m.index);
+    out.links.push(line);
+    if (!bodies.some(b => m.index >= b.start && m.index < b.end)) out.strayLinks.push(line);
   }
   return out;
 }
 
-const DISPATCH = /\bfn\s+dispatch\s*\(([^)]*)\)/g;
-
-/** Every `fn dispatch` in `text`, audited: by-value `self`, and a body that
- * forwards rather than linking or posting. */
-function auditDispatch(text: string): Finding[] {
-  const stripped = stripComments(text);
-  const out: Finding[] = [];
-  for (const m of stripped.matchAll(DISPATCH)) {
-    const complaints: string[] = [];
-    const params = m[1];
-    if (!/^\s*(?:mut\s+)?self\s*(?:,|$)/.test(params)) {
-      complaints.push(`does not take the request by value: \`${params.trim()}\``);
-    }
-    const body = blockAfter(stripped, m.index + m[0].length);
-    if (body === null) {
-      complaints.push("could not find the body");
-    } else {
-      if (!/\.dispatch_plugin_request\(\s*self\s*\)/.test(body))
-        complaints.push("does not forward to dispatch_plugin_request");
-      if (/\.push\(|\bTask::init\(|\barena_create\(/.test(body))
-        complaints.push("links, allocates or posts on its own");
-    }
-    out.push({ line: lineOf(stripped, m.index), complaints });
+function auditBody(body: string, request: string): string[] {
+  const allocations = body.match(/\barena_create\(/g)?.length ?? 0;
+  if (allocations !== 1) return [`expected exactly one arena_create, found ${allocations}`];
+  const binding = new RegExp(
+    String.raw`\blet\s+(\w+)\s*(?::\s*\*\s*mut\s+[\w:]+\s*)?=\s*self\s*\.\s*arena_create\(\s*${request}\s*\)`,
+  ).exec(body);
+  if (binding === null) return [`does not bind the arena slot of \`${request}\` as a raw pointer`];
+  const slot = binding[1];
+  const complaints: string[] = [];
+  if (!new RegExp(String.raw`\.push\(\s*${slot}\s*\)`).test(body))
+    complaints.push(`\`${slot}\` is not what gets linked`);
+  if (!new RegExp(String.raw`\bTask::init\(\s*${slot}\s*\)`).test(body))
+    complaints.push(`\`${slot}\` is not what gets posted`);
+  if (new RegExp(String.raw`&\s*(?:mut\s+)?\*\s*${slot}\b`).test(body) || /\bfrom_(?:mut|ref)\b/.test(body)) {
+    complaints.push(`forms a reference to \`${slot}\``);
   }
-  return out;
+  return complaints;
 }
 
 const helpers: string[] = [];
-const dispatches: string[] = [];
+let links = 0;
 const offenders: string[] = [];
 let scanned = 0;
 for (const abs of bundlerSources) {
@@ -166,15 +148,14 @@ for (const abs of bundlerSources) {
   if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
   if (tracked !== null && !tracked.has(source)) continue;
   scanned++;
-  const content = await file(abs).text();
-  for (const { line, complaints } of auditHelper(content)) {
+  const result = audit(await file(abs).text());
+  links += result.links.length;
+  for (const { line, complaints } of result.helpers) {
     helpers.push(source);
     for (const c of complaints) offenders.push(`${source}:${line}: dispatch_plugin_request ${c}`);
   }
-  for (const { line, complaints } of auditDispatch(content)) {
-    dispatches.push(source);
-    for (const c of complaints) offenders.push(`${source}:${line}: dispatch ${c}`);
-  }
+  for (const line of result.strayLinks)
+    offenders.push(`${source}:${line}: links a request outside dispatch_plugin_request`);
 }
 
 test("scans the tracked sources of the bundler crate", () => {
@@ -183,23 +164,19 @@ test("scans the tracked sources of the bundler crate", () => {
   expect(scanned).toBeGreaterThan(0);
 });
 
-test("the helper and the two request types' dispatch are where this lint looks for them", () => {
-  // If this changes, the helper moved or a request type was added, removed or
-  // moved: update this (and the header) rather than the checks below.
-  expect({ helpers, dispatches }).toEqual({
-    helpers: ["src/bundler/bundle_v2.rs"],
-    dispatches: ["src/bundler/bundle_v2.rs", "src/bundler/bundle_v2.rs"],
-  });
+test("there is one helper, and it is the one place a request gets linked", () => {
+  // If this changes, the helper moved or was split, or linking is spelled in a
+  // way LINK does not see: update this (and the header) rather than the ban
+  // below. `links` counting the helper's own push is what keeps the stray-link
+  // check from going vacuous.
+  expect({ helpers, links }).toEqual({ helpers: ["src/bundler/bundle_v2.rs"], links: 1 });
 });
 
-test("the audits recognize the shapes they claim to", () => {
-  const complaintsOfHelper = (s: string) => auditHelper(s).flatMap(f => f.complaints);
-  const complaintsOfDispatch = (s: string) => auditDispatch(s).flatMap(f => f.complaints);
-
+test("the audit recognizes the shapes it claims to", () => {
   const helper = (body: string, params = "&mut self, request: T") =>
     `pub(crate) fn dispatch_plugin_request<T>(${params})\nwhere\n    T: Taskable + OutstandingNode,\n{\n${body}\n}`;
   const conformingBody = `
-    // SAFETY-style prose mentioning &mut *request is stripped before auditing.
+    // Prose mentioning &mut *request or outstanding_loads.push( is stripped first.
     let request: *mut T = self.arena_create(request);
     T::outstanding(&mut self.graph).push(request);
     if self.graph.cancelled {
@@ -210,24 +187,33 @@ test("the audits recognize the shapes they claim to", () => {
         bun_event_loop::Task::init(request),
     );
     self.enqueue_on_js_loop_for_plugins(task);`;
-  expect(auditHelper(helper(conformingBody))).toEqual([{ line: 1, complaints: [] }]);
+  expect(audit(helper(conformingBody))).toEqual({
+    helpers: [{ line: 1, complaints: [] }],
+    links: [8],
+    strayLinks: [],
+  });
   // A different local name and an untyped binding are fine.
   expect(
-    complaintsOfHelper(
-      helper("let slot = self.arena_create(req); list(self).push(slot); Task::init(slot);", "&mut self, req: R"),
+    audit(
+      helper(
+        "let slot = self.arena_create(req); T::outstanding(&mut self.graph).push(slot); Task::init(slot);",
+        "&mut self, req: R",
+      ),
     ),
-  ).toEqual([]);
+  ).toMatchObject({ helpers: [{ complaints: [] }], strayLinks: [] });
+
+  const complaintsOf = (snippet: string) => audit(snippet).helpers.flatMap(h => h.complaints);
   // The request must arrive by value: a pointer or a reference means someone
   // else already holds a pointer to it.
-  expect(complaintsOfHelper(helper(conformingBody, "&mut self, request: *mut T"))).toEqual([
+  expect(complaintsOf(helper(conformingBody, "&mut self, request: *mut T"))).toEqual([
     "does not take the request by value: `&mut self, request: *mut T`",
   ]);
-  expect(complaintsOfHelper(helper(conformingBody, "&mut self, request: &mut T"))).toEqual([
+  expect(complaintsOf(helper(conformingBody, "&mut self, request: &mut T"))).toEqual([
     "does not take the request by value: `&mut self, request: &mut T`",
   ]);
   // Two derivations of the slot, in the spellings main used.
   expect(
-    complaintsOfHelper(
+    complaintsOf(
       helper(`
         let slot: &mut T = self.arena_create(request);
         T::outstanding(&mut self.graph).push(slot);
@@ -235,16 +221,7 @@ test("the audits recognize the shapes they claim to", () => {
     ),
   ).toEqual(["does not bind the arena slot of `request` as a raw pointer"]);
   expect(
-    complaintsOfHelper(
-      helper(`
-        let slot: *mut T = self.arena_create(request);
-        let again: *mut T = self.arena_create(T::default());
-        T::outstanding(&mut self.graph).push(slot);
-        Task::init(again);`),
-    ),
-  ).toEqual(["expected exactly one arena_create, found 2"]);
-  expect(
-    complaintsOfHelper(
+    complaintsOf(
       helper(`
         let slot: *mut T = self.arena_create(request);
         let node = &mut *slot;
@@ -252,61 +229,62 @@ test("the audits recognize the shapes they claim to", () => {
         Task::init(std::ptr::from_mut::<T>(node));`),
     ),
   ).toEqual(["`slot` is not what gets linked", "`slot` is not what gets posted", "forms a reference to `slot`"]);
-  expect(complaintsOfHelper("fn dispatch_plugin_request<T>(&mut self, request: T)")).toEqual([
-    "could not find the body",
-  ]);
+  expect(
+    complaintsOf(
+      helper(`
+        let slot: *mut T = self.arena_create(request);
+        let again: *mut T = self.arena_create(T::default());
+        T::outstanding(&mut self.graph).push(slot);
+        Task::init(again);`),
+    ),
+  ).toEqual(["expected exactly one arena_create, found 2"]);
+  expect(complaintsOf("fn dispatch_plugin_request<T>(&mut self, request: T)")).toEqual(["could not find the body"]);
 
+  // main's shape: no helper, and each request type links itself.
+  const mainShape = `
+    impl Resolve {
+        pub(crate) fn dispatch(&mut self) {
+            unsafe {
+                let bv2 = &mut *self.bv2;
+                bv2.graph.outstanding_resolves.push(self);
+                let task = ConcurrentTask::create(Task::init(std::ptr::from_mut::<Self>(self)));
+                bv2.enqueue_on_js_loop_for_plugins(task);
+            }
+        }
+    }
+    impl Load {
+        pub(crate) fn dispatch(&mut self) {
+            unsafe { (*self.bv2).graph.outstanding_loads.push(self) }
+        }
+    }`;
+  expect(audit(mainShape)).toEqual({ helpers: [], links: [6, 14], strayLinks: [6, 14] });
+  // The helper present, plus a method of any name linking its receiver again,
+  // through either spelling of the list.
   expect(
-    auditDispatch("pub(crate) fn dispatch(self, bv2: &mut BundleV2<'_>) {\n    bv2.dispatch_plugin_request(self);\n}"),
-  ).toEqual([{ line: 1, complaints: [] }]);
-  // The shape this lint was written against.
+    audit(
+      helper(conformingBody) +
+        `
+    impl Load {
+        fn redispatch(&mut self, bv2: &mut BundleV2) {
+            Load::outstanding(&mut bv2.graph).push(self);
+        }
+        fn relink(&mut self, graph: &mut Graph) {
+            graph.outstanding_loads.push(self);
+        }
+    }`,
+    ),
+  ).toMatchObject({ strayLinks: [20, 23] });
+  // Other uses of the lists are not links.
   expect(
-    complaintsOfDispatch(`
-      pub(crate) fn dispatch(&mut self) {
-          unsafe {
-              let bv2 = &mut *self.bv2;
-              bv2.graph.outstanding_loads.push(self);
-              let task = ConcurrentTask::create(Task::init(std::ptr::from_mut::<Self>(self)));
-              bv2.enqueue_on_js_loop_for_plugins(task);
-          }
-      }`),
-  ).toEqual([
-    "does not take the request by value: `&mut self`",
-    "does not forward to dispatch_plugin_request",
-    "links, allocates or posts on its own",
-  ]);
-  // Other receivers that hand out a second pointer.
-  expect(complaintsOfDispatch("fn dispatch(&self, bv2: &mut BundleV2) { bv2.dispatch_plugin_request(self) }")).toEqual([
-    "does not take the request by value: `&self, bv2: &mut BundleV2`",
-  ]);
-  expect(complaintsOfDispatch("unsafe fn dispatch(this: *mut Self) { Task::init(this); }")).toEqual([
-    "does not take the request by value: `this: *mut Self`",
-    "does not forward to dispatch_plugin_request",
-    "links, allocates or posts on its own",
-  ]);
-  // By value, but doing the work inline instead of through the helper.
-  expect(complaintsOfDispatch("fn dispatch(self, bv2: &mut BundleV2) { let p = bv2.arena_create(self); }")).toEqual([
-    "does not forward to dispatch_plugin_request",
-    "links, allocates or posts on its own",
-  ]);
+    audit(`
+      this.graph.outstanding_resolves.unlink(resolve);
+      while let Some(load) = self.graph.outstanding_loads.pop() {}
+      let mut load = self.outstanding_loads.head;
+      pub(crate) fn push(&mut self, node: *mut T) {}
+      pending.push(self);`),
+  ).toEqual({ helpers: [], links: [], strayLinks: [] });
 });
 
 test("plugin requests are allocated, linked and posted in one place, through one pointer", () => {
   expect(offenders).toEqual([]);
-});
-
-test("the tree-wide publish lint no longer ratchets bundle_v2.rs", async () => {
-  // self-receiver-publish.test.ts (the tree-wide guard against posting `self`)
-  // was written while Resolve::dispatch / Load::dispatch still did that, and
-  // allowlists bundle_v2.rs with an exact count; this conversion is what
-  // retires that entry. The two changes touch different files, so nothing
-  // else stops them from landing with the entry still in place, which would
-  // fail that lint's ratchet on main. Passes trivially while that lint does
-  // not exist in this checkout.
-  const publishLint = path.join(import.meta.dir, "self-receiver-publish.test.ts");
-  if (!existsSync(publishLint)) return;
-  const entries = stripComments(await file(publishLint).text()).match(
-    /^[ \t]*["']src\/bundler\/bundle_v2\.rs["'][ \t]*:[ \t]*\d+/gm,
-  );
-  expect(entries).toBeNull();
 });


### PR DESCRIPTION
### Problem
- Nothing misbehaves today. This is an aliasing-contract fix in the same family as #37723 and #37685.
- When a bundle pass hands an onResolve or onLoad request to the plugin thread, `dispatch(&mut self)` makes two pointers to the request from the same receiver: one kept in the pass's outstanding list, one posted to the JS thread as the task.
- Dispatching the next request writes the previous request's list link through the list's pointer. Under Rust's aliasing model that invalidates the posted pointer, and consuming the answer through it is UB. This happens as soon as two requests are outstanding, the normal state of a build whose plugins answer asynchronously.
- A reduction with the real list shape fails under Miri with both Tree Borrows and Stacked Borrows at the answer's reborrow (`Undefined Behavior: reborrow through <4058> at alloc1960[0x0] is forbidden`), and passes once the list and the task hold one and the same pointer.

### Fix
- The two `dispatch` bodies become one function on the pass that takes the request by value, allocates it in the arena, links the `*mut` the arena hands back, and posts that same `*mut`. The old names stay as one-line forwarders; callers no longer preallocate a default slot.
- Correct because the arena's pointer is now the only pointer to the request that ever exists, so the list, the JS thread and the answer all go through it. Order of operations is unchanged, including the cancelled path, and no `unsafe` remains on this path.
- Verification: a new source lint pins this shape; it reports the two old `push(self)` sites with `src/` at main and passes here. The Miri reduction fails before and passes after. The bundler plugin, bake plugin and worker-terminate suites pass on the ASAN build; none is claimed to fail without the fix.
- Sequencing: lands after #37723, whose lint carries a ratchet entry of 2 for these two sites; on rebase this PR deletes that entry. If this one merges first, #37723 has to drop the entry instead.

### Background
- A plugin request (`Resolve` or `Load`) is a struct the bundle thread allocates in the pass's arena for one onResolve or onLoad call. The JS thread runs the plugin chain, writes the answer into the struct, and posts the same pointer back to the bundle thread.
- The outstanding lists are intrusive doubly linked lists in the pass's `Graph`, one per request type. Each request carries its own link, so pushing or unlinking a neighbour writes into this request's memory, and cancellation walks the list to fail every pending request.
- Under Rust's aliasing model (Stacked Borrows and Tree Borrows, what Miri checks and what the optimizer is allowed to assume), each reborrow of a `&mut` gets its own tag, and a write through one tag invalidates the others. Copies of one raw pointer share a tag, which is why handing the same `*mut` to both places is fine.
- `Task::init` wraps a raw pointer to a `Taskable` so it can be posted to another thread's event loop. `OutstandingNode` is the trait that maps a request type to its link field, and now also to its list.
- Miri interprets a Rust program and reports UB under those models; `bun run rust:miri` uses Tree Borrows.

<details>
<summary>Original description</summary>

Lands after #37723: that PR's publish lint carries an exact-count ratchet entry of 2 for `bundle_v2.rs`, for the two sites converted here. Once it is in, this PR gets rebased and deletes the entry; that lint's own ratchet test fails on the rebase until it is. If this one is merged first instead, #37723 has to drop the entry before it merges.

### Problem

`Resolve::dispatch` and `Load::dispatch` (src/bundler/bundle_v2.rs) are how a bundle pass hands an onResolve / onLoad request to the thread that runs the plugins. Both took `&mut self` and used it twice:

```rust
pub(crate) fn dispatch(&mut self) {
    unsafe {
        let bv2 = &mut *self.bv2;
        bv2.graph.outstanding_resolves.push(self);                        // pointer 1, kept by the list
        ...
        let task = ConcurrentTask::create(Task::init(std::ptr::from_mut::<Self>(self)));  // pointer 2, posted
        bv2.enqueue_on_js_loop_for_plugins(task);
    }
}
```

From then on the request is reached through both pointers. The list's pointer is written through whenever a neighbouring request is dispatched or answered (`OutstandingList::push` sets the previous head's `prev`; `unlink` fixes up both neighbours) and is what `fail_outstanding_plugin_requests` uses on cancellation. The task's pointer is what the JS thread writes `value` through and what comes back to `on_resolve` / `on_load`, which reborrow it and unlink the request. Under the aliasing model the two are separate reborrows of the receiver, so the link write made by dispatching the next request invalidates the posted pointer, and consuming the answer through it is UB. This is deterministic as soon as two requests are outstanding at once, which is the normal state of a build whose plugin answers asynchronously; it does not depend on the JS thread's timing. Separately, `&mut self` is a protected (`noalias`) argument for the whole call, while for `Bun.build` the JS thread may already be writing the request before `dispatch` returns. Nothing misbehaves today (the reads that would be affected are not optimized across the post), so this is a contract fix, same family as #37723 (the completion hand-back, which frees) and #37685.

A reduction with the real `OutstandingList` shape fails under Miri with Tree Borrows (the model `bun run rust:miri` uses) and with Stacked Borrows, in both cases at the answer's reborrow, naming the link write as what invalidated the pointer:

```
error: Undefined Behavior: reborrow through <4058> at alloc1960[0x0] is forbidden
    |     let request = unsafe { &mut *answered };
help: the accessed tag <4058> was created here, in the initial state Reserved
    |         post.send(SendPtr(std::ptr::from_mut::<Self>(self))).unwrap();
help: the accessed tag <4058> later transitioned to Disabled due to a foreign write access at offsets [0x0..0x8]
    |                 (*self.head).outstanding.prev = node;
```

The same program passes under both models when the list and the task are given one and the same pointer.

<details>
<summary>Reduction (<code>cargo miri run -- before</code> fails, <code>-- after</code> passes; <code>MIRIFLAGS=-Zmiri-tree-borrows</code> or default)</summary>

```rust
use std::sync::mpsc;
use std::thread;

struct SendPtr(*mut Request);
unsafe impl Send for SendPtr {}

struct Link { prev: *mut Request, next: *mut Request, linked: bool }
impl Default for Link {
    fn default() -> Self { Link { prev: std::ptr::null_mut(), next: std::ptr::null_mut(), linked: false } }
}

/// `Resolve` / `Load`: the answer lands in `value`; the pass keeps the request
/// in its list through `outstanding`.
#[derive(Default)]
struct Request { value: u32, outstanding: Link }

/// `Graph::OutstandingList`, same shape.
struct OutstandingList { head: *mut Request }
impl OutstandingList {
    fn push(&mut self, node: *mut Request) {
        unsafe {
            let l = &mut (*node).outstanding;
            assert!(!l.linked);
            l.linked = true;
            l.prev = std::ptr::null_mut();
            l.next = self.head;
            if !self.head.is_null() {
                (*self.head).outstanding.prev = node;
            }
        }
        self.head = node;
    }
    fn unlink(&mut self, node: &mut Request) {
        let node_ptr: *mut Request = node;
        let l = &mut node.outstanding;
        if !l.linked { return; }
        l.linked = false;
        let (prev, next) = (l.prev, l.next);
        l.prev = std::ptr::null_mut();
        l.next = std::ptr::null_mut();
        unsafe {
            if prev.is_null() { assert!(std::ptr::eq(self.head, node_ptr)); self.head = next; }
            else { (*prev).outstanding.next = next; }
            if !next.is_null() { (*next).outstanding.prev = prev; }
        }
    }
}

impl Request {
    // main
    fn dispatch_before(&mut self, list: &mut OutstandingList, post: &mpsc::Sender<SendPtr>) {
        list.push(self);
        post.send(SendPtr(std::ptr::from_mut::<Self>(self))).unwrap();
    }
    // this PR: one pointer for both (here the slot's pointer; in the tree it is
    // the one `arena_create` hands back inside `dispatch_plugin_request`)
    unsafe fn dispatch_after(this: *mut Self, list: &mut OutstandingList, post: &mpsc::Sender<SendPtr>) {
        list.push(this);
        post.send(SendPtr(this)).unwrap();
    }
}

/// `on_resolve_from_js_loop_raw` -> `BundleV2::on_resolve`.
fn consume_answer(list: &mut OutstandingList, answered: *mut Request) -> u32 {
    let request = unsafe { &mut *answered };
    list.unlink(request);
    std::mem::take(&mut request.value)
}

fn main() {
    let after = std::env::args().nth(1).as_deref() == Some("after");
    let (post, plugin_queue) = mpsc::channel::<SendPtr>();
    let (answer, answers) = mpsc::channel::<SendPtr>();
    // The plugins' thread writes the answer into the request and posts it back.
    let js_thread = thread::spawn(move || {
        for (i, SendPtr(request)) in plugin_queue.into_iter().enumerate() {
            unsafe { (*request).value = 100 + i as u32 };
            answer.send(SendPtr(request)).unwrap();
        }
    });

    // Bundle thread: two requests outstanding at once. Leaked boxes stand in for the arena.
    let mut list = OutstandingList { head: std::ptr::null_mut() };
    let a: *mut Request = Box::into_raw(Box::default());
    let b: *mut Request = Box::into_raw(Box::default());
    for slot in [a, b] {
        if after { unsafe { Request::dispatch_after(slot, &mut list, &post) } }
        else { unsafe { &mut *slot }.dispatch_before(&mut list, &post) }
    }
    drop(post);
    js_thread.join().unwrap();

    let values: Vec<u32> = answers.into_iter().map(|SendPtr(p)| consume_answer(&mut list, p)).collect();
    assert_eq!(values, [100, 101]);
    assert!(list.head.is_null());
    unsafe { drop(Box::from_raw(a)); drop(Box::from_raw(b)); }
    println!("ok");
}
```

The threads are sequenced through the channels, so the only thing Miri can report is an aliasing violation. Stacked Borrows reports the same site: `trying to retag from <4198> for Unique permission ... <4198> was later invalidated at offsets [0x0..0x8] by a write access` at the same `prev` store.

</details>

### Fix

The two bodies were the same code apart from which list they push to, so they become one function on the pass:

```rust
pub(crate) fn dispatch_plugin_request<T: Taskable + OutstandingNode>(&mut self, request: T) {
    let request: *mut T = self.arena_create(request);
    T::outstanding(&mut self.graph).push(request);
    if self.graph.cancelled { self.wake_own_loop(); return; }
    self.enqueue_on_js_loop_for_plugins(ConcurrentTask::create(Task::init(request)));
}
```

It takes the request by value, so the `*mut` that `arena_create` hands back is the only pointer to it that ever exists, and that one goes both into the list and into the task; `push` and `Task::init` already took raw pointers. `OutstandingNode` (src/bundler/Graph.rs, which already maps a request type to its link) gains `outstanding()`, mapping it to its list. `Resolve::dispatch` / `Load::dispatch` become one-line forwarders taking `self` by value plus the pass the callers already hold; they are kept under those names because the runtime's thunks in src/runtime/api/JSBundler.rs document their pointers as coming from `Resolve::dispatch` / `Load::dispatch`, in comments that #37691 and the consuming-side fix are editing, so rewording them here would only buy conflicts. The callers build the request and hand it over, which also means the two `Resolve` callers no longer pre-allocate a `Resolve::default()` slot to assign into, so that `Default` impl goes away. There is no `unsafe` left on this path (main had two blocks), and nothing the callers can do with the request after dispatching it. Order of operations is unchanged: the scan counter is incremented before the dispatch, and a cancelled pass still links the request and leaves it for `is_done` to fail.

Adjacent work, not changed here: #37709 changes the `run_on_js_thread` bodies next to these and leaves the dispatch side alone; the consuming side, where the JS thread holds the whole request as `&mut Load` / `&mut Resolve` while the bundle thread keeps writing its link through this same pointer, is a different shape (Miri flags it as a foreign write to a protected tag) and has been reported separately.

### Tests

`test/internal/source-lints/bundler-plugin-dispatch-raw-request.test.ts` checks two things across src/bundler/: `dispatch_plugin_request` takes the request by value, binds one `arena_create` result and passes that same local to `.push(..)` and `Task::init(..)` without forming a reference to it; and no other code links a request into an outstanding list (`outstanding_*.push(..)` or `T::outstanding(..).push(..)` outside the helper's body). Linking is what makes something a dispatched request, so this is keyed on the shape rather than on a method name: a method of any name that links its receiver again is reported, and an unrelated `fn dispatch` somewhere in the crate is not. It self-tests the audit against main's shape and against near misses (request taken as `*mut` / `&mut`, a second `arena_create`, the slot reborrowed, a `redispatch(&mut self)` re-adding a push, and non-link uses of the lists), and pins that there is exactly one helper and exactly one link site, so the stray-link check cannot go vacuous. With `src/` at main it reports the two `push(self)` sites (`bundle_v2.rs:1133` and `:1267`, `links a request outside dispatch_plugin_request`) and the missing helper; it passes here.

On the debug (ASAN) build: `test/bundler/bundler_plugin.test.ts` (53 pass), `bundler_plugin_chain.test.ts` (13), `bundler_defer.test.ts` (10), which dispatch both request types from the `Bun.build` bundle thread with several outstanding at once; `test/bake/dev/plugins.test.ts` (3) for the arm where the posting loop is the plugins' own loop; the `pool` family of `test/js/web/workers/worker-terminate-funnels.test.ts`, which terminates a worker with a `Bun.build` onLoad pending (the cancelled path popping the request back out of the list). `bun test test/internal/source-lints/` passes (19 files); `cargo clippy -p bun_bundler` and `cargo fmt --check` are clean.


</details>
