### PR TITLE
bake: make import() reject instead of throwing when a module fails to evaluate in the dev server

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -134,9 +134,7 @@ export class HMRModule {
     }
   }
 
-  /** Lowered from `.e_import` (import(id)). Marked `async` because the loader
-   * throws synchronously when the module (or one of its dependencies) fails to
-   * evaluate, while a real `import()` always returns a promise and rejects it. */
+  /** Lowered from `.e_import` (import(id)). `async` so a failed load rejects instead of throwing, like import() */
   async dynamicImport(id: Id, opts?: ImportCallOptions) {
     const found = loadModuleAsync(id, true, this);
     if (found) {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -134,11 +134,13 @@ export class HMRModule {
     }
   }
 
-  /** Lowered from `.e_import` (import(id)) */
-  dynamicImport(id: Id, opts?: ImportCallOptions) {
+  /** Lowered from `.e_import` (import(id)). Marked `async` because the loader
+   * throws synchronously when the module (or one of its dependencies) fails to
+   * evaluate, while a real `import()` always returns a promise and rejects it. */
+  async dynamicImport(id: Id, opts?: ImportCallOptions) {
     const found = loadModuleAsync(id, true, this);
     if (found) {
-      if ((found as HMRModule).id === id) return Promise.resolve(getEsmExports(found as HMRModule));
+      if ((found as HMRModule).id === id) return getEsmExports(found as HMRModule);
       return (found as Promise<HMRModule>).then(getEsmExports);
     }
     return opts

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -440,6 +440,8 @@ devTest("import() of a module that fails to evaluate rejects instead of throwing
       // First import evaluates the module; the second one hits its recorded failure.
       esm: "rejected: boom esm",
       esmAgain: "rejected: boom esm",
+      // CommonJS failures are not recorded: the module is marked stale and the
+      // second import runs its body again, which throws again.
       cjs: "rejected: boom cjs",
       cjsAgain: "rejected: boom cjs",
       // The failure comes from a static dependency of the imported module.

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -361,6 +361,100 @@ devTest("cannot require a module with top level await", {
     });
   },
 });
+devTest("import() of a module that fails to evaluate rejects instead of throwing", {
+  // In the dev server, `import()` is lowered to `hmr.dynamicImport()`. Like a
+  // native `import()`, it must always hand back a promise: load failures have
+  // to reject it rather than escape as a synchronous exception.
+  framework: minimalFramework,
+  files: {
+    "ok.ts": `
+      export const value = "ok";
+    `,
+    "throws.ts": `
+      export const value = "unreachable";
+      throw new Error("boom esm");
+    `,
+    "throws-cjs.ts": `
+      module.exports = { value: "unreachable" };
+      throw new Error("boom cjs");
+    `,
+    "imports-thrower.ts": `
+      import "./throws-dep";
+      export const value = "unreachable";
+    `,
+    "throws-dep.ts": `
+      export const value = "unreachable";
+      throw new Error("boom dep");
+    `,
+    "imports-tla-thrower.ts": `
+      import "./tla-throws";
+      export const value = "unreachable";
+    `,
+    "tla-throws.ts": `
+      export const value = "unreachable";
+      await 1;
+      throw new Error("boom tla");
+    `,
+    "proxy-cjs.ts": `
+      module.exports = new Proxy({}, {
+        ownKeys() {
+          throw new Error("boom ownKeys");
+        },
+      });
+    `,
+    "routes/index.ts": `
+      async function probe(run) {
+        let promise;
+        try {
+          promise = run();
+        } catch (e) {
+          return "threw synchronously: " + e.message;
+        }
+        if (!(promise instanceof Promise)) return "returned a non-promise";
+        return promise.then(
+          ns => "resolved: " + ns.value,
+          e => "rejected: " + e.message,
+        );
+      }
+      export default async function () {
+        const results = {};
+        results.ok = await probe(() => import("../ok"));
+        results.okAgain = await probe(() => import("../ok"));
+        results.esm = await probe(() => import("../throws"));
+        results.esmAgain = await probe(() => import("../throws"));
+        results.cjs = await probe(() => import("../throws-cjs"));
+        results.cjsAgain = await probe(() => import("../throws-cjs"));
+        results.dep = await probe(() => import("../imports-thrower"));
+        results.tla = await probe(() => import("../imports-tla-thrower"));
+        results.tlaAgain = await probe(() => import("../imports-tla-thrower"));
+        results.cjsProxy = await probe(() => import("../proxy-cjs"));
+        results.builtin = await probe(() => import("node:path").then(m => ({ value: typeof m.join })));
+        return Response.json(results);
+      }
+    `,
+  },
+  async test(dev) {
+    expect(await dev.fetch("/").json()).toEqual({
+      ok: "resolved: ok",
+      okAgain: "resolved: ok",
+      // First import evaluates the module; the second one hits its recorded failure.
+      esm: "rejected: boom esm",
+      esmAgain: "rejected: boom esm",
+      cjs: "rejected: boom cjs",
+      cjsAgain: "rejected: boom cjs",
+      // The failure comes from a static dependency of the imported module.
+      dep: "rejected: boom dep",
+      // The dependency uses top-level await, so the first import already
+      // rejected; the second one hits the recorded failure.
+      tla: "rejected: boom tla",
+      tlaAgain: "rejected: boom tla",
+      // The module evaluates fine; converting its exports to a namespace fails.
+      cjsProxy: "rejected: boom ownKeys",
+      // Not part of the bundle, so this falls through to the runtime's own import().
+      builtin: "resolved: function",
+    });
+  },
+});
 devTest("function that is assigned to should become a live binding", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
### Problem
- In the dev server (`bun ./index.html`, or a Bake app in development), `import()` of a module that fails to evaluate throws synchronously into the caller instead of returning a rejected promise. So `import(x).catch(...)`, `Promise.all([...])` and `Promise.allSettled([...])` work in production and break in development.
- Cause: the dev server rewrites every `import()` into a call on its own module loader, and that loader reports load failures by throwing. Nothing between the loader and the caller turned the throw into a rejection.
- It throws for a module body that throws (ESM or CommonJS), a static dependency that throws, a failure recorded by an earlier import, and CommonJS exports that cannot be converted to a namespace.
- A native `import()` never throws synchronously, and neither does `bun build` output, which the dev runtime is documented to match.

### Fix
- The method that `import()` is rewritten to becomes `async`, so anything it throws becomes a rejection of the promise it returns. The source is shared by the client and server dev runtimes, so both are fixed.
- Why nothing else changes: the method contains no `await`, so the loader still runs synchronously at the call site, and importer tracking and evaluation order are as before. The fallback to the runtime's own `import()` for unbundled modules is untouched (its missing `return` is a separate bug, #37727).
- Verification: a dev server test calls `import()` on each failure shape above and checks that each call returns a promise that rejects with the module's error. Seven shapes throw synchronously without the fix; all pass with it. It runs in a route module, so it covers the server runtime; the client runtime is covered only by existing success-path tests.
- Out of scope: a module whose dependency throws, or whose own top-level await rejects, is left pending, so a second `import()` of it resolves to `null`. Tracked separately.

### Background
- Bake is bun's dev server (`bun ./index.html`, or a framework app in development). It bundles modules on the fly and evaluates them through its own hot-reloading module registry rather than the engine's native module loader.
- In that mode the bundler rewrites each `import(x)` in user code into a method call on the dev runtime, so `import()` in development behaves exactly as that method does. The engine's own `import()` is reached only for modules the dev server did not bundle, such as builtins.
- The registry's runtime source is one TypeScript file compiled into both the browser and the server dev runtimes.
- An `async` function runs synchronously up to its first `await`; with no `await` it runs entirely synchronously and only changes how the outcome is delivered: a return value resolves the returned promise, a throw rejects it, a returned promise is adopted. That property is the whole fix.
- Native `import()` returns a promise in every case, including link and evaluation failures; `bun build` output keeps that by running the module initialiser inside `Promise.resolve().then(...)`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/esm.test.ts
bun test v1.4.0 (973255421)

test/bake/dev/esm.test.ts:
Dev server testing directory: /tmp/bun-dev-test-HYNI1m
^[[0;30mdev|^[[0m Started development server: http://localhost:39783
^[[0;30mdev|^[[0m ^[[32mBundled page in 206ms^[[0m^[[2m:^[[0m routes/index.ts ^[[2m+ 1 more^[[0m
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "routes/index.ts" is a root module that does not self-accept.
^[[0;30mdev|^[[0m ^[[32mReloaded in 76ms^[[0m^[[2m:^[[0m routes/index.ts
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "state.ts" is not accepted by routes/index.ts,
^[[0;30mdev|^[[0m ^[[36m[x2]^[[0m ^[[32mReloaded in
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/bake/dev/esm.test.ts:
Dev server testing directory: /tmp/bun-dev-test-ku6N4H
^[[0;30mdev|^[[0m Started development server: http://localhost:37345
^[[0;30mdev|^[[0m ^[[32mBundled page in 3ms^[[0m^[[2m:^[[0m routes/index.ts ^[[2m+ 1 more^[[0m
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "routes/index.ts" is a root module that does not self-accept.
^[[0;30mdev|^[[0m ^[[32mReloaded in 2ms^[[0m^[[2m:^[[0m routes/index.ts
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "state.ts" is not accepted by routes/index.ts,
^[[0;30mdev|^[[0m ^[[36m[x2]^[[0m ^[[32mReloaded in 2ms^[[0m^[[2m:^[[0m state.ts
(pass)  DEV:esm-1: live bindings with `var` [214.09ms]
^[[0;30mdev|^[[0m Started development server: http://localhost:41789
^[[0;
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/esm.test.ts
bun test v1.4.0 (973255421)

test/bake/dev/esm.test.ts:
Dev server testing directory: /tmp/bun-dev-test-0GMetC
^[[0;30mdev|^[[0m Started development server: http://localhost:34057
^[[0;30mdev|^[[0m ^[[32mBundled page in 172ms^[[0m^[[2m:^[[0m routes/index.ts ^[[2m+ 1 more^[[0m
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "routes/index.ts" is a root module that does not self-accept.
^[[0;30mdev|^[[0m ^[[32mReloaded in 78ms^[[0m^[[2m:^[[0m routes/index.ts
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "state.ts" is not accepted by routes/index.ts,
^[[0;30mdev|^[[0m ^[[36m[x2]^[[0m ^[[32mReloaded in
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9732554217
  features     baseline

22 deps, 107 codegen, 1176 objects in 1350ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [13.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (da3851e57)

Checked 1 install across 2 packages (no changes) [1.00ms]
[4/1238] gen bindgenv2
[5/1238] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (da3851e57)

Checked 129 installs across 147 packages (no changes) [7.00ms]
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] fetch picohttpparser
[picohttpparser] up to date
[8/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] fetch libjpeg-turbo
[libjp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/hmr-module.ts |  6 +--
 test/bake/dev/esm.test.ts      | 96 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 99 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/runtime/bake/hmr-module.ts      3      3      0
test/bake/dev/esm.test.ts           2      4      0
```

</details>

**root cause** · written by the author bot

In the Bake dev server every dynamic import() is lowered to HMRModule.dynamicImport, which invoked the module loader directly and let its synchronous throws (a module body or CommonJS module throwing during evaluation, a missing or failing dependency, a previously recorded failure, or a namespace conversion error) escape into the caller, whereas native import() and bun build output always return a rejected promise. The fix makes dynamicImport an async method, so any failure raised on these paths becomes a rejection of the returned promise and patterns such as import().catch() and Promise.al…

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What does this PR do?

In the dev server (`bun ./index.html`, or a Bake app in development), a dynamic `import()` of a module that fails to evaluate throws synchronously into the caller instead of returning a rejected promise:

```ts
// throws.ts
export const value = 1;
throw new Error("boom");

// routes/index.ts, served by the dev server
import("../throws").catch(handle);        // .catch never runs: the call itself throws "boom"
Promise.all([import("../a"), import("../throws")]); // same, Promise.all is never reached
```

The dev server lowers every `import()` to `hmr.dynamicImport(id)` (`InternalBakeDev` branches in `src/js_printer/lib.rs`). `HMRModule.dynamicImport` in `src/runtime/bake/hmr-module.ts` calls `loadModuleAsync` directly, and the loader throws synchronously in several cases:

- the module is ESM without top-level-await dependencies and its body throws (`finishLoadModuleAsync` rethrows),
- the module is CommonJS and its body throws,
- a statically imported dependency throws while being loaded (`parseEsmDependencies`),
- the module already failed earlier and is in the error state (`throw mod.failure`), which also applies to modules whose top-level-await dependency rejected on a previous import,
- the module loads but converting its CommonJS exports to a namespace throws (`getEsmExports` in the already-loaded branch).

A native `import()` never throws synchronously, and neither does `bun build` output (`Promise.resolve().then(() => (init_x(), exports_x))`, which rejects), which is the behavior the dev runtime is documented to follow (see the header comment of `hmr-module.ts`). So `import(x).catch(...)`, `Promise.all([...])`, `Promise.allSettled([...])` and similar patterns that work in production break in development.

The fix marks `dynamicImport` as `async`, so any of the throws above becomes a rejection of the returned promise. Nothing else moves: the loader is still invoked synchronously when `import()` is called (an async function runs synchronously up to its first `await`, and this one has none), so importer tracking and module evaluation order are unchanged; the already-loaded branch returns the namespace directly instead of wrapping it in `Promise.resolve`; the promise-returning branches are adopted by the async function's promise. The fallback to the runtime's own `import()` for modules the dev server did not bundle is also unchanged (the missing `return` in its with-options variant is a separate bug, fixed in #37727; the two changes touch different lines and compose).

`hmr-module.ts` is shared by the client and server runtimes, so both are fixed.

### How did you verify your code works?

Added a dev server test to `test/bake/dev/esm.test.ts` that calls `import()` on each failure shape listed above (ESM body throws, the same module again, CJS body throws, the same module again, a dependency throws, a top-level-await dependency rejects and the same module again, and a CJS module whose exports cannot be converted), plus two that already worked and must keep working (a module that loads fine, imported twice, and a builtin that falls through to the runtime's `import()`). Each call is checked to return a promise and to settle with the module's error. The imports run in a route module, so the test exercises the server runtime; the client runtime is built from the same `hmr-module.ts` source. Note that "the same module again" means different things for the two module kinds: an ESM failure is recorded and rethrown, while a failed CJS module is marked stale and evaluated again (which throws again); the test comments say which is which.

Without the fix (`USE_SYSTEM_BUN=1 bun test test/bake/dev/esm.test.ts`, and likewise with `src/` stashed):

```
-   "cjs": "rejected: boom cjs",
-   "cjsAgain": "rejected: boom cjs",
-   "cjsProxy": "rejected: boom ownKeys",
-   "dep": "rejected: boom dep",
-   "esm": "rejected: boom esm",
-   "esmAgain": "rejected: boom esm",
+   "cjs": "threw synchronously: boom cjs",
+   "cjsAgain": "threw synchronously: boom cjs",
+   "cjsProxy": "threw synchronously: boom ownKeys",
+   "dep": "threw synchronously: boom dep",
+   "esm": "threw synchronously: boom esm",
+   "esmAgain": "threw synchronously: boom esm",
-   "tlaAgain": "rejected: boom tla",
+   "tlaAgain": "threw synchronously: boom tla",
```

With the fix, `bun bd test test/bake/dev/esm.test.ts` passes (18 tests). `test/bake/dev/bundle.test.ts` and `test/bake/dev/react-spa.test.ts`, which `import()` bundled modules on the client side (the success path of the changed method in the client runtime), and `test/bake/dev/hot.test.ts`, as a general hot-reload regression check, also pass.

While writing the test I noticed a separate loader bookkeeping issue: a module whose dependency throws synchronously (or whose own top-level await rejects) is left in the pending state, so a second `import()` of it resolves to `null`. That is independent of this change and is tracked separately; the new test imports those two shapes only once.

</details>
