### PR TITLE
node:http: deliver all request headers on HTTP/1 fallback connections and enforce requireHostHeader

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -318,9 +318,8 @@ function connectionListenerHTTP1(server, socket, options) {
     // path must carry them too or keep-alive responses lose their timeout line.
     res._keepAliveTimeout = keepAliveTimeout;
     res._maxRequestsPerSocket = server.maxRequestsPerSocket;
-    // Node's parserOnIncoming: an HTTP/1.1 request without a Host header is answered 400 below
-    // instead of being dispatched (RFC 9112 §3.2). That reply advertises Connection: close, and
-    // the handle is what ends the connection after a response, so it must not see keep-alive.
+    // Node's parserOnIncoming (RFC 9112 §3.2): an HTTP/1.1 request without a Host header gets
+    // a 400 below and the connection is closed instead of the request being dispatched.
     const missingHostHeader =
       versionMajor === 1 && versionMinor === 1 && server.requireHostHeader && req.headers.host === undefined;
     if (missingHostHeader) shouldKeepAlive = false;

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -318,8 +318,7 @@ function connectionListenerHTTP1(server, socket, options) {
     // path must carry them too or keep-alive responses lose their timeout line.
     res._keepAliveTimeout = keepAliveTimeout;
     res._maxRequestsPerSocket = server.maxRequestsPerSocket;
-    // Node's parserOnIncoming (RFC 9112 §3.2): an HTTP/1.1 request without a Host header gets
-    // a 400 below and the connection is closed instead of the request being dispatched.
+    // Node's parserOnIncoming (RFC 9112 §3.2): answered with a 400 below and the connection closed.
     const missingHostHeader =
       versionMajor === 1 && versionMinor === 1 && server.requireHostHeader && req.headers.host === undefined;
     if (missingHostHeader) shouldKeepAlive = false;

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -234,7 +234,14 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
 // 'request' with http.IncomingMessage/ServerResponse, like Node's httpConnectionListener routing.
 function connectionListenerHTTP1(server, socket, options) {
   const http = require("node:http");
-  const { HTTPParser, prepareError, calculateLenientFlags, continueExpression } = require("node:_http_common");
+  const {
+    HTTPParser,
+    prepareError,
+    calculateLenientFlags,
+    continueExpression,
+    parserOnHeaders,
+    MAX_HEADER_PAIRS,
+  } = require("node:_http_common");
   const { kHandle: kHttp1ResponseHandle } = require("internal/http");
   const { allMethods } = process.binding("http_parser");
 
@@ -251,6 +258,7 @@ function connectionListenerHTTP1(server, socket, options) {
   connections.add(socket);
   socket[kHttp1ActiveRequests] = 0;
 
+  const kOnHeaders = HTTPParser.kOnHeaders | 0;
   const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
   const kOnBody = HTTPParser.kOnBody | 0;
   const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
@@ -262,10 +270,13 @@ function connectionListenerHTTP1(server, socket, options) {
   parser.initialize(HTTPParser.REQUEST, {}, server.maxHeaderSize || 0, lenientFlags);
   parser.socket = socket;
   socket.parser = parser;
+  // Header blocks past the native parser's 32-field buffer, and trailers, only arrive through
+  // kOnHeaders (a parser without it drops them); collect them like _http_common's pooled parsers.
+  parser._headers = [];
+  parser._url = "";
   const { maxHeadersCount } = server;
-  if (typeof maxHeadersCount === "number") {
-    parser.maxHeaderPairs = maxHeadersCount << 1;
-  }
+  parser.maxHeaderPairs = typeof maxHeadersCount === "number" ? maxHeadersCount << 1 : MAX_HEADER_PAIRS;
+  parser[kOnHeaders] = parserOnHeaders;
 
   let req = null;
   let pendingUpgrade = null;
@@ -281,6 +292,19 @@ function connectionListenerHTTP1(server, socket, options) {
     upgrade,
     shouldKeepAlive,
   ) {
+    // Both are undefined once anything went through kOnHeaders (_http_common's parserOnHeadersComplete).
+    if (rawHeaders === undefined) {
+      rawHeaders = parser._headers;
+      parser._headers = [];
+    }
+    if (url === undefined) {
+      url = parser._url;
+      parser._url = "";
+    }
+    let headersLength = rawHeaders.length;
+    const { maxHeaderPairs } = parser;
+    if (maxHeaderPairs > 0) headersLength = Math.min(headersLength, maxHeaderPairs);
+
     socket[kHttp1ActiveRequests]++;
 
     req = new IncomingMessageClass(socket);
@@ -291,7 +315,7 @@ function connectionListenerHTTP1(server, socket, options) {
     req.url = url;
     req.method = typeof methodNum === "number" ? allMethods[methodNum] : methodNum;
     req.upgrade = upgrade;
-    req._addHeaderLines(rawHeaders, rawHeaders.length);
+    req._addHeaderLines(rawHeaders, headersLength);
 
     // Node's parserOnIncoming: upgrade only sticks for CONNECT or when an 'upgrade' listener
     // exists; otherwise fall through to normal dispatch. Returning 2 makes llhttp stop after
@@ -370,8 +394,14 @@ function connectionListenerHTTP1(server, socket, options) {
     if (req && !req._dumped) req.push(chunk);
   };
   parser[kOnMessageComplete] = function onHttp1MessageComplete() {
+    // What kOnHeaders collected since the header block is this message's trailers
+    // (_http_common's parserOnMessageComplete); _addHeaderLines files them as trailers once complete.
+    const trailers = parser._headers;
+    if (trailers.length !== 0) parser._headers = [];
+    parser._url = "";
     if (req) {
       req.complete = true;
+      if (trailers.length !== 0) req._addHeaderLines(trailers, trailers.length);
       req.push(null);
     }
   };

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -395,11 +395,12 @@ function connectionListenerHTTP1(server, socket, options) {
   parser[kOnMessageComplete] = function onHttp1MessageComplete() {
     // Collected after the header block, so these are trailers (_http_common's parserOnMessageComplete).
     const trailers = parser._headers;
-    if (trailers.length !== 0) parser._headers = [];
+    const trailersLength = trailers.length;
+    if (trailersLength !== 0) parser._headers = [];
     parser._url = "";
     if (req) {
       req.complete = true;
-      if (trailers.length !== 0) req._addHeaderLines(trailers, trailers.length);
+      if (trailersLength !== 0) req._addHeaderLines(trailers, trailersLength);
       req.push(null);
     }
   };

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -270,8 +270,7 @@ function connectionListenerHTTP1(server, socket, options) {
   parser.initialize(HTTPParser.REQUEST, {}, server.maxHeaderSize || 0, lenientFlags);
   parser.socket = socket;
   socket.parser = parser;
-  // Header blocks past the native parser's 32-field buffer, and trailers, only arrive through
-  // kOnHeaders (a parser without it drops them); collect them like _http_common's pooled parsers.
+  // Blocks past the parser's 32-field buffer, and trailers, arrive via kOnHeaders (as in _http_common).
   parser._headers = [];
   parser._url = "";
   const { maxHeadersCount } = server;
@@ -394,8 +393,7 @@ function connectionListenerHTTP1(server, socket, options) {
     if (req && !req._dumped) req.push(chunk);
   };
   parser[kOnMessageComplete] = function onHttp1MessageComplete() {
-    // What kOnHeaders collected since the header block is this message's trailers
-    // (_http_common's parserOnMessageComplete); _addHeaderLines files them as trailers once complete.
+    // Collected after the header block, so these are trailers (_http_common's parserOnMessageComplete).
     const trailers = parser._headers;
     if (trailers.length !== 0) parser._headers = [];
     parser._url = "";

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -318,6 +318,12 @@ function connectionListenerHTTP1(server, socket, options) {
     // path must carry them too or keep-alive responses lose their timeout line.
     res._keepAliveTimeout = keepAliveTimeout;
     res._maxRequestsPerSocket = server.maxRequestsPerSocket;
+    // Node's parserOnIncoming: an HTTP/1.1 request without a Host header is answered 400 below
+    // instead of being dispatched (RFC 9112 §3.2). That reply advertises Connection: close, and
+    // the handle is what ends the connection after a response, so it must not see keep-alive.
+    const missingHostHeader =
+      versionMajor === 1 && versionMinor === 1 && server.requireHostHeader && req.headers.host === undefined;
+    if (missingHostHeader) shouldKeepAlive = false;
     const handle = createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout);
     handle.onfinished = function () {
       socket[kHttp1ActiveRequests] = Math.max(0, (socket[kHttp1ActiveRequests] || 1) - 1);
@@ -333,6 +339,12 @@ function connectionListenerHTTP1(server, socket, options) {
     res.on("finish", function onFallbackResponseFinish() {
       this.detachSocket(socket);
     });
+
+    if (missingHostHeader) {
+      res.writeHead(400, { Connection: "close" });
+      res.end();
+      return 0;
+    }
 
     // Node's parserOnIncoming Expect routing (the native dispatcher applies the
     // same at _http_server.ts's DISPATCH_HAS_EXPECT branch).

--- a/src/js/node/_http_common.ts
+++ b/src/js/node/_http_common.ts
@@ -279,6 +279,8 @@ export default {
   freeParser,
   methods,
   parsers,
+  parserOnHeaders,
+  MAX_HEADER_PAIRS,
   kIncomingMessage,
   kSkipPendingData,
   HTTPParser,

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6804,6 +6804,7 @@ class Http2SecureServer extends tls.Server {
       this.requestTimeout = http1Options.requestTimeout ?? 300000;
       this.maxHeadersCount = http1Options.maxHeadersCount ?? null;
       this.maxRequestsPerSocket = http1Options.maxRequestsPerSocket ?? 0;
+      this.requireHostHeader = http1Options.requireHostHeader ?? true;
       // connectionListenerHTTP1 reads these off the server when initializing
       // the per-connection parser, matching Node's storeHTTP1Options.
       this.maxHeaderSize = http1Options.maxHeaderSize;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6804,7 +6804,9 @@ class Http2SecureServer extends tls.Server {
       this.requestTimeout = http1Options.requestTimeout ?? 300000;
       this.maxHeadersCount = http1Options.maxHeadersCount ?? null;
       this.maxRequestsPerSocket = http1Options.maxRequestsPerSocket ?? 0;
-      this.requireHostHeader = http1Options.requireHostHeader ?? true;
+      const requireHostHeader = http1Options.requireHostHeader;
+      if (requireHostHeader !== undefined) validateBoolean(requireHostHeader, "options.requireHostHeader");
+      this.requireHostHeader = requireHostHeader ?? true;
       // connectionListenerHTTP1 reads these off the server when initializing
       // the per-connection parser, matching Node's storeHTTP1Options.
       this.maxHeaderSize = http1Options.maxHeaderSize;

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4140,6 +4140,15 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
   }
 });
 
+// A GET with exactly `totalHeaders` header fields: Host first, X-* fillers, and optionally
+// Connection: close last.
+function manyHeaderRequest(path: string, totalHeaders: number, { close = false } = {}) {
+  const lines = ["Host: example.test"];
+  while (lines.length < (close ? totalHeaders - 1 : totalHeaders)) lines.push(`X-H${lines.length}: v${lines.length}`);
+  if (close) lines.push("Connection: close");
+  return `GET ${path} HTTP/1.1\r\n${lines.join("\r\n")}\r\n\r\n`;
+}
+
 describe("connectionListener requireHostHeader", () => {
   // Drives one raw request through server.emit("connection", ...) (the JS fallback parser).
   // `head` settles once the first response head arrived, `ended` once the server ended the
@@ -4240,5 +4249,168 @@ describe("connectionListener requireHostHeader", () => {
     expect(await client.ended).toStartWith("HTTP/1.1 200 OK\r\n");
     expect(await client.ended).toEndWith("served:example.test");
     expect(onRequest).toHaveBeenCalledTimes(1);
+  });
+
+  // The native parser hands header blocks to JS 32 fields at a time, so a Host header that is
+  // followed by enough other headers only reaches the request if every block is assembled.
+  for (const totalHeaders of [32, 64]) {
+    it(`dispatches an HTTP/1.1 request whose Host header is one of ${totalHeaders} header fields`, async () => {
+      const onRequest = mock((req, res) => res.end(`served:${req.headers.host}:${req.rawHeaders.length / 2}`));
+      const server = createServer(onRequest);
+      using client = rawRequestOverEmittedConnection(server, manyHeaderRequest("/", totalHeaders, { close: true }));
+      expect(await client.ended).toStartWith("HTTP/1.1 200 OK\r\n");
+      expect(await client.ended).toEndWith(`served:example.test:${totalHeaders}`);
+      expect(onRequest).toHaveBeenCalledTimes(1);
+    });
+  }
+
+  it("rejects a Host-less HTTP/1.1 request only after the Upgrade/CONNECT hand-off declined it", async () => {
+    {
+      // An Upgrade with a listener is handed off, Host or not (Node's parserOnIncoming order).
+      const onRequest = mock(() => {});
+      const onUpgrade = mock((req, socket) =>
+        socket.end(`HTTP/1.1 101 Switching Protocols\r\nX-Host: ${req.headers.host}\r\n\r\n`),
+      );
+      const server = createServer(onRequest);
+      server.on("upgrade", onUpgrade);
+      using client = rawRequestOverEmittedConnection(
+        server,
+        "GET /ws HTTP/1.1\r\nUpgrade: ws\r\nConnection: Upgrade\r\n\r\n",
+      );
+      expect(await client.ended).toBe("HTTP/1.1 101 Switching Protocols\r\nX-Host: undefined\r\n\r\n");
+      expect(onUpgrade).toHaveBeenCalledTimes(1);
+      expect(onRequest).not.toHaveBeenCalled();
+    }
+    {
+      const onRequest = mock(() => {});
+      const onConnect = mock((req, socket) =>
+        socket.end(`HTTP/1.1 200 Connection Established\r\nX-Target: ${req.url}\r\n\r\n`),
+      );
+      const server = createServer(onRequest);
+      server.on("connect", onConnect);
+      using client = rawRequestOverEmittedConnection(server, "CONNECT example.test:443 HTTP/1.1\r\n\r\n");
+      expect(await client.ended).toBe("HTTP/1.1 200 Connection Established\r\nX-Target: example.test:443\r\n\r\n");
+      expect(onConnect).toHaveBeenCalledTimes(1);
+      expect(onRequest).not.toHaveBeenCalled();
+    }
+    {
+      // Without an 'upgrade' listener the request falls through to normal dispatch, where the
+      // Host check applies.
+      const onRequest = mock((req, res) => res.end("served"));
+      const server = createServer(onRequest);
+      using client = rawRequestOverEmittedConnection(
+        server,
+        "GET /ws HTTP/1.1\r\nUpgrade: ws\r\nConnection: Upgrade\r\n\r\n",
+      );
+      expect(await client.head).toStartWith("HTTP/1.1 400 Bad Request\r\n");
+      expect(normalizeDate(await client.ended)).toBe(nodeMissingHostReply);
+      expect(onRequest).not.toHaveBeenCalled();
+    }
+  });
+
+  it("treats a Host header cut off by maxHeadersCount as missing, like Node", async () => {
+    const onRequest = mock((req, res) => res.end("served"));
+    const server = createServer(onRequest);
+    server.maxHeadersCount = 3;
+    using client = rawRequestOverEmittedConnection(
+      server,
+      "GET / HTTP/1.1\r\nX-A: 1\r\nX-B: 2\r\nX-C: 3\r\nHost: example.test\r\n\r\n",
+    );
+    expect(await client.head).toStartWith("HTTP/1.1 400 Bad Request\r\n");
+    expect(normalizeDate(await client.ended)).toBe(nodeMissingHostReply);
+    expect(onRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("connectionListener header assembly", () => {
+  // One kept-alive connection served through server.emit("connection", ...).
+  function keepAliveConnection(server: Server) {
+    const [clientSide, serverSide] = duplexPair();
+    let received = "";
+    clientSide.on("data", (chunk: Buffer) => (received += chunk.toString("latin1")));
+    server.emit("connection", serverSide);
+    return {
+      write(rawRequest: string) {
+        clientSide.write(rawRequest);
+      },
+      get received() {
+        return received;
+      },
+      [Symbol.dispose]() {
+        clientSide.destroy();
+        serverSide.destroy();
+      },
+    };
+  }
+
+  // `served` collects summarize(req) for every request; serve() writes one request and returns
+  // once its response has closed, i.e. once the connection is free for the next one.
+  function recordingServer(summarize: (req: IncomingMessage) => unknown) {
+    const served: unknown[] = [];
+    let responseClosed = Promise.withResolvers<void>();
+    const server = createServer((req, res) => {
+      req.resume();
+      req.on("end", () => {
+        served.push(summarize(req));
+        res.on("close", responseClosed.resolve);
+        res.end("ok");
+      });
+    });
+    return {
+      server,
+      served,
+      async serve(connection: ReturnType<typeof keepAliveConnection>, rawRequest: string) {
+        responseClosed = Promise.withResolvers<void>();
+        connection.write(rawRequest);
+        await responseClosed.promise;
+      },
+    };
+  }
+
+  it("delivers every header of requests larger than the parser's 32-field block, across a kept-alive connection", async () => {
+    const { server, served, serve } = recordingServer(req => [req.url, req.headers.host, req.rawHeaders.length / 2]);
+    using connection = keepAliveConnection(server);
+    await serve(connection, manyHeaderRequest("/first", 40));
+    // Once the parser has delivered a request in blocks it keeps doing so on that connection, so
+    // a small request after a large one goes through the assembled path as well.
+    await serve(connection, manyHeaderRequest("/second", 2));
+    await serve(connection, manyHeaderRequest("/third", 70));
+    expect(served).toEqual([
+      ["/first", "example.test", 40],
+      ["/second", "example.test", 2],
+      ["/third", "example.test", 70],
+    ]);
+    expect(connection.received.match(/HTTP\/1\.1 200 OK/g)).toHaveLength(3);
+  });
+
+  it("files a chunked body's trailers on its own request only", async () => {
+    const { server, served, serve } = recordingServer(req => [req.url, req.trailers, req.rawHeaders.length / 2]);
+    using connection = keepAliveConnection(server);
+    await serve(
+      connection,
+      "POST /with-trailer HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\nTrailer: X-Checksum\r\n\r\n" +
+        "3\r\nabc\r\n0\r\nX-Checksum: 123\r\n\r\n",
+    );
+    await serve(connection, "GET /after HTTP/1.1\r\nHost: a\r\n\r\n");
+    expect(served).toEqual([
+      ["/with-trailer", { "x-checksum": "123" }, 3],
+      ["/after", {}, 1],
+    ]);
+  });
+
+  it("applies server.maxHeadersCount to both the single-block and the assembled header paths", async () => {
+    const { server, served, serve } = recordingServer(req => [
+      req.url,
+      req.headers.host,
+      Object.keys(req.headers).length,
+    ]);
+    server.maxHeadersCount = 3;
+    using connection = keepAliveConnection(server);
+    await serve(connection, manyHeaderRequest("/five", 5));
+    await serve(connection, manyHeaderRequest("/forty", 40));
+    expect(served).toEqual([
+      ["/five", "example.test", 3],
+      ["/forty", "example.test", 3],
+    ]);
   });
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4141,23 +4141,31 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
 });
 
 describe("connectionListener requireHostHeader", () => {
-  // Drives one raw request through server.emit("connection", ...) (the JS fallback parser) and
-  // returns the first response head the client saw plus a promise for the server ending the
-  // connection. A duplexPair does not propagate destroy(), so both halves are torn down.
+  // Drives one raw request through server.emit("connection", ...) (the JS fallback parser).
+  // `head` settles once the first response head arrived, `ended` once the server ended the
+  // connection (with everything received); both reject if the connection errors or the server
+  // destroys it instead.
   function rawRequestOverEmittedConnection(server: Server, rawRequest: string) {
     const [clientSide, serverSide] = duplexPair();
-    const chunks: Buffer[] = [];
-    const ended = new Promise<string>(resolve =>
-      clientSide.on("end", () => resolve(Buffer.concat(chunks).toString("latin1"))),
-    );
-    const head = new Promise<string>((resolve, reject) => {
-      clientSide.on("data", (chunk: Buffer) => {
-        chunks.push(chunk);
-        const received = Buffer.concat(chunks).toString("latin1");
-        if (received.includes("\r\n\r\n")) resolve(received);
-      });
-      clientSide.on("error", reject);
+    let received = "";
+    const { promise: head, resolve: resolveHead, reject: rejectHead } = Promise.withResolvers<string>();
+    const { promise: ended, resolve: resolveEnded, reject: rejectEnded } = Promise.withResolvers<string>();
+    // A test awaits whichever of the two it needs; the other one's rejection must not surface as a
+    // separate unhandled error.
+    head.catch(() => {});
+    ended.catch(() => {});
+    const fail = (err: Error) => {
+      rejectHead(err);
+      rejectEnded(err);
+    };
+    clientSide.on("data", (chunk: Buffer) => {
+      received += chunk.toString("latin1");
+      if (received.includes("\r\n\r\n")) resolveHead(received);
     });
+    clientSide.on("end", () => resolveEnded(received));
+    clientSide.on("error", fail);
+    serverSide.on("error", fail);
+    serverSide.on("close", () => fail(new Error(`server destroyed the connection; received: ${received}`)));
     server.emit("connection", serverSide);
     clientSide.write(rawRequest);
     return {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4323,13 +4323,22 @@ describe("connectionListener requireHostHeader", () => {
 });
 
 describe("connectionListener header assembly", () => {
-  // One kept-alive connection served through server.emit("connection", ...).
+  // One connection served through server.emit("connection", ...) that the server is expected to
+  // keep alive: `failed` rejects (with everything received so far) if it errors or ends instead.
   function keepAliveConnection(server: Server) {
     const [clientSide, serverSide] = duplexPair();
     let received = "";
+    const { promise: failed, reject } = Promise.withResolvers<never>();
+    failed.catch(() => {});
+    const fail = (what: string) => reject(new Error(`${what}; received: ${JSON.stringify(received)}`));
     clientSide.on("data", (chunk: Buffer) => (received += chunk.toString("latin1")));
+    clientSide.on("end", () => fail("server ended the connection"));
+    clientSide.on("error", err => reject(err));
+    serverSide.on("error", err => reject(err));
+    serverSide.on("close", () => fail("server destroyed the connection"));
     server.emit("connection", serverSide);
     return {
+      failed,
       write(rawRequest: string) {
         clientSide.write(rawRequest);
       },
@@ -4362,7 +4371,7 @@ describe("connectionListener header assembly", () => {
       async serve(connection: ReturnType<typeof keepAliveConnection>, rawRequest: string) {
         responseClosed = Promise.withResolvers<void>();
         connection.write(rawRequest);
-        await responseClosed.promise;
+        await Promise.race([responseClosed.promise, connection.failed]);
       },
     };
   }

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,98 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+describe("connectionListener requireHostHeader", () => {
+  // Drives one raw request through server.emit("connection", ...) (the JS fallback parser) and
+  // returns the first response head the client saw plus a promise for the server ending the
+  // connection. A duplexPair does not propagate destroy(), so both halves are torn down.
+  function rawRequestOverEmittedConnection(server: Server, rawRequest: string) {
+    const [clientSide, serverSide] = duplexPair();
+    const chunks: Buffer[] = [];
+    const ended = new Promise<string>(resolve =>
+      clientSide.on("end", () => resolve(Buffer.concat(chunks).toString("latin1"))),
+    );
+    const head = new Promise<string>((resolve, reject) => {
+      clientSide.on("data", (chunk: Buffer) => {
+        chunks.push(chunk);
+        const received = Buffer.concat(chunks).toString("latin1");
+        if (received.includes("\r\n\r\n")) resolve(received);
+      });
+      clientSide.on("error", reject);
+    });
+    server.emit("connection", serverSide);
+    clientSide.write(rawRequest);
+    return {
+      head,
+      ended,
+      [Symbol.dispose]() {
+        clientSide.destroy();
+        serverSide.destroy();
+      },
+    };
+  }
+
+  // Node answers from parserOnIncoming with res.writeHead(400, ["Connection", "close"]); res.end().
+  function normalizeDate(raw: string) {
+    return raw.replace(/^Date: .*$/m, "Date: <date>");
+  }
+  const nodeMissingHostReply =
+    "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nDate: <date>\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
+
+  it("answers an HTTP/1.1 request without a Host header with 400 and closes the connection", async () => {
+    const onRequest = mock((req, res) => res.end("served"));
+    const server = createServer(onRequest);
+    using client = rawRequestOverEmittedConnection(server, "GET / HTTP/1.1\r\n\r\n");
+    expect(await client.head).toStartWith("HTTP/1.1 400 Bad Request\r\n");
+    expect(normalizeDate(await client.ended)).toBe(nodeMissingHostReply);
+    expect(onRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Host-less HTTP/1.1 request before its Expect header is looked at", async () => {
+    const onRequest = mock((req, res) => res.end("served"));
+    const onCheckContinue = mock((req, res) => {
+      res.writeContinue();
+      res.end("served");
+    });
+    const server = createServer(onRequest);
+    server.on("checkContinue", onCheckContinue);
+    using client = rawRequestOverEmittedConnection(
+      server,
+      "POST / HTTP/1.1\r\nExpect: 100-continue\r\nContent-Length: 0\r\n\r\n",
+    );
+    expect(await client.head).toStartWith("HTTP/1.1 400 Bad Request\r\n");
+    expect(normalizeDate(await client.ended)).toBe(nodeMissingHostReply);
+    expect(onCheckContinue).not.toHaveBeenCalled();
+    expect(onRequest).not.toHaveBeenCalled();
+  });
+
+  it("dispatches an HTTP/1.0 request without a Host header", async () => {
+    const onRequest = mock((req, res) => res.end("served:" + req.httpVersion));
+    const server = createServer(onRequest);
+    using client = rawRequestOverEmittedConnection(server, "GET / HTTP/1.0\r\n\r\n");
+    expect(await client.ended).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(await client.ended).toEndWith("served:1.0");
+    expect(onRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches a Host-less HTTP/1.1 request when the server was created with requireHostHeader: false", async () => {
+    const onRequest = mock((req, res) => res.end("served:" + req.headers.host));
+    const server = createServer({ requireHostHeader: false }, onRequest);
+    using client = rawRequestOverEmittedConnection(server, "GET / HTTP/1.1\r\nConnection: close\r\n\r\n");
+    expect(await client.ended).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(await client.ended).toEndWith("served:undefined");
+    expect(onRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches an HTTP/1.1 request that carries a Host header", async () => {
+    const onRequest = mock((req, res) => res.end("served:" + req.headers.host));
+    const server = createServer(onRequest);
+    using client = rawRequestOverEmittedConnection(
+      server,
+      "GET / HTTP/1.1\r\nHost: example.test\r\nConnection: close\r\n\r\n",
+    );
+    expect(await client.ended).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(await client.ended).toEndWith("served:example.test");
+    expect(onRequest).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4365,6 +4365,107 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+// Sends one raw request over an http/1.1 ALPN connection; `head` resolves once the first
+// response head arrived, `ended` once the server ended the connection (with everything received).
+function rawHttp1RequestOverAlpn(server, rawRequest) {
+  const chunks = [];
+  const { promise: head, resolve: resolveHead, reject } = Promise.withResolvers();
+  const { promise: ended, resolve: resolveEnded } = Promise.withResolvers();
+  const socket = tls.connect(
+    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+    () => socket.write(rawRequest),
+  );
+  socket.on("error", reject);
+  socket.on("data", chunk => {
+    chunks.push(chunk);
+    const received = Buffer.concat(chunks).toString("latin1");
+    if (received.includes("\r\n\r\n")) resolveHead(received);
+  });
+  socket.on("end", () => resolveEnded(Buffer.concat(chunks).toString("latin1")));
+  return { head, ended, socket };
+}
+
+// Node answers from parserOnIncoming with res.writeHead(400, ["Connection", "close"]); res.end().
+const nodeMissingHostReply =
+  "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nDate: <date>\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n";
+function normalizeDate(raw) {
+  return raw.replace(/^Date: .*$/m, "Date: <date>");
+}
+
+it("http2 allowHTTP1 fallback answers an HTTP/1.1 request without a Host header with 400 and closes the connection", async () => {
+  let requests = 0;
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    requests++;
+    res.end("served");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const client = rawHttp1RequestOverAlpn(server, "GET / HTTP/1.1\r\n\r\n");
+    try {
+      expect(await client.head).toStartWith("HTTP/1.1 400 Bad Request\r\n");
+      expect(normalizeDate(await client.ended)).toBe(nodeMissingHostReply);
+      expect(requests).toBe(0);
+      // Stored like Node's storeHTTPOptions does for allowHTTP1 servers.
+      expect(server.requireHostHeader).toBe(true);
+    } finally {
+      client.socket.destroy();
+    }
+  } finally {
+    server.close();
+  }
+});
+
+it("http2 allowHTTP1 fallback still dispatches Host-less HTTP/1.0 requests and Host-carrying HTTP/1.1 requests", async () => {
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    res.end(`served:${req.httpVersion}:${req.headers.host}`);
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const bodies = [];
+    for (const rawRequest of [
+      "GET / HTTP/1.0\r\n\r\n",
+      "GET / HTTP/1.1\r\nHost: example.test\r\nConnection: close\r\n\r\n",
+    ]) {
+      const client = rawHttp1RequestOverAlpn(server, rawRequest);
+      try {
+        const raw = await client.ended;
+        expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+        bodies.push(raw.slice(raw.indexOf("served:")));
+      } finally {
+        client.socket.destroy();
+      }
+    }
+    expect(bodies).toEqual(["served:1.0:undefined", "served:1.1:example.test"]);
+  } finally {
+    server.close();
+  }
+});
+
+for (const [description, options] of [
+  ["requireHostHeader: false", { requireHostHeader: false }],
+  ["http1Options: { requireHostHeader: false }", { http1Options: { requireHostHeader: false } }],
+]) {
+  it(`http2 allowHTTP1 fallback dispatches a Host-less HTTP/1.1 request when created with ${description}`, async () => {
+    const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true, ...options }, (req, res) => {
+      res.end(`served:${req.headers.host}`);
+    });
+    await new Promise(resolve => server.listen(0, resolve));
+    try {
+      const client = rawHttp1RequestOverAlpn(server, "GET / HTTP/1.1\r\nConnection: close\r\n\r\n");
+      try {
+        const raw = await client.ended;
+        expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+        expect(raw).toEndWith("served:undefined");
+        expect(server.requireHostHeader).toBe(false);
+      } finally {
+        client.socket.destroy();
+      }
+    } finally {
+      server.close();
+    }
+  });
+}
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4365,23 +4365,32 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
-// Sends one raw request over an http/1.1 ALPN connection; `head` resolves once the first
-// response head arrived, `ended` once the server ended the connection (with everything received).
+// Sends one raw request over an http/1.1 ALPN connection. `head` settles once the first response
+// head arrived, `ended` once the server ended the connection (with everything received); both
+// reject if the connection errors or closes without the server ending it.
 function rawHttp1RequestOverAlpn(server, rawRequest) {
-  const chunks = [];
-  const { promise: head, resolve: resolveHead, reject } = Promise.withResolvers();
-  const { promise: ended, resolve: resolveEnded } = Promise.withResolvers();
+  let received = "";
+  const { promise: head, resolve: resolveHead, reject: rejectHead } = Promise.withResolvers();
+  const { promise: ended, resolve: resolveEnded, reject: rejectEnded } = Promise.withResolvers();
+  // A test awaits whichever of the two it needs; the other one's rejection must not surface as a
+  // separate unhandled error.
+  head.catch(() => {});
+  ended.catch(() => {});
+  const fail = err => {
+    rejectHead(err);
+    rejectEnded(err);
+  };
   const socket = tls.connect(
     { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
     () => socket.write(rawRequest),
   );
-  socket.on("error", reject);
   socket.on("data", chunk => {
-    chunks.push(chunk);
-    const received = Buffer.concat(chunks).toString("latin1");
+    received += chunk.toString("latin1");
     if (received.includes("\r\n\r\n")) resolveHead(received);
   });
-  socket.on("end", () => resolveEnded(Buffer.concat(chunks).toString("latin1")));
+  socket.on("end", () => resolveEnded(received));
+  socket.on("error", fail);
+  socket.on("close", () => fail(new Error(`connection closed before the server ended it; received: ${received}`)));
   return { head, ended, socket };
 }
 
@@ -4465,6 +4474,31 @@ for (const [description, options] of [
     }
   });
 }
+
+it("http2.createSecureServer validates requireHostHeader like Node's storeHTTPOptions, only when allowHTTP1 is set", () => {
+  const codes = [];
+  for (const options of [
+    { requireHostHeader: "yes" },
+    { requireHostHeader: 0 },
+    { http1Options: { requireHostHeader: 1 } },
+    { requireHostHeader: true, http1Options: { requireHostHeader: "no" } },
+  ]) {
+    try {
+      http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true, ...options });
+      codes.push("no error");
+    } catch (err) {
+      codes.push(`${err.code}: ${err.message}`);
+    }
+  }
+  expect(codes).toEqual([
+    `ERR_INVALID_ARG_TYPE: The "options.requireHostHeader" property must be of type boolean. Received type string ('yes')`,
+    `ERR_INVALID_ARG_TYPE: The "options.requireHostHeader" property must be of type boolean. Received type number (0)`,
+    `ERR_INVALID_ARG_TYPE: The "options.requireHostHeader" property must be of type boolean. Received type number (1)`,
+    `ERR_INVALID_ARG_TYPE: The "options.requireHostHeader" property must be of type boolean. Received type string ('no')`,
+  ]);
+  // Without allowHTTP1 there is no HTTP/1 path: Node neither validates nor stores the option.
+  expect(http2.createSecureServer({ ...TLS_CERT, requireHostHeader: "yes" }).requireHostHeader).toBeUndefined();
+});
 
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4424,9 +4424,18 @@ it("http2 allowHTTP1 fallback answers an HTTP/1.1 request without a Host header 
   }
 });
 
+// The native parser hands header blocks to JS 32 fields at a time; 40 fields puts Host in a block
+// the fallback has to assemble before it can look for it.
+function fortyHeaderRequest() {
+  const lines = ["Host: example.test"];
+  while (lines.length < 39) lines.push(`X-H${lines.length}: v${lines.length}`);
+  lines.push("Connection: close");
+  return `GET / HTTP/1.1\r\n${lines.join("\r\n")}\r\n\r\n`;
+}
+
 it("http2 allowHTTP1 fallback still dispatches Host-less HTTP/1.0 requests and Host-carrying HTTP/1.1 requests", async () => {
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
-    res.end(`served:${req.httpVersion}:${req.headers.host}`);
+    res.end(`served:${req.httpVersion}:${req.headers.host}:${req.rawHeaders.length / 2}`);
   });
   await new Promise(resolve => server.listen(0, resolve));
   try {
@@ -4434,6 +4443,7 @@ it("http2 allowHTTP1 fallback still dispatches Host-less HTTP/1.0 requests and H
     for (const rawRequest of [
       "GET / HTTP/1.0\r\n\r\n",
       "GET / HTTP/1.1\r\nHost: example.test\r\nConnection: close\r\n\r\n",
+      fortyHeaderRequest(),
     ]) {
       const client = rawHttp1RequestOverAlpn(server, rawRequest);
       try {
@@ -4444,7 +4454,7 @@ it("http2 allowHTTP1 fallback still dispatches Host-less HTTP/1.0 requests and H
         client.socket.destroy();
       }
     }
-    expect(bodies).toEqual(["served:1.0:undefined", "served:1.1:example.test"]);
+    expect(bodies).toEqual(["served:1.0:undefined:0", "served:1.1:example.test:2", "served:1.1:example.test:40"]);
   } finally {
     server.close();
   }


### PR DESCRIPTION
### Problem

Two gaps in the JS HTTP/1 path in `src/js/internal/http1_server_fallback.ts`, which serves an `http2.createSecureServer({ allowHTTP1: true })` connection that negotiated `http/1.1` and any socket handed to an `http.Server` through `server.emit("connection", socket)`:

1. An HTTP/1.1 request without a `Host` header is dispatched to the `'request'` handler.

   ```js
   const http = require("http");
   const { duplexPair } = require("stream");
   const server = http.createServer((req, res) => res.end("served"));
   const [client, serverSide] = duplexPair();
   server.emit("connection", serverSide);
   client.on("data", d => console.log(JSON.stringify(String(d))));
   client.write("GET / HTTP/1.1\r\n\r\n");
   ```

   ```
   node v26.3.0: "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nDate: ...\r\nTransfer-Encoding: chunked\r\n\r\n0\r\n\r\n"  (then closes the connection)
   bun 1.4.0:    "HTTP/1.1 200 OK\r\nDate: ...\r\nConnection: keep-alive\r\nKeep-Alive: timeout=5\r\nContent-Length: 6\r\n\r\nserved"
   ```

   Same over `allowHTTP1`, where Node also answers 400. A request carrying `Expect: 100-continue` but no `Host` got a `100 Continue` (or a `'checkContinue'` event) instead.

2. A request with 32 or more header fields reaches the handler with only its last few headers. With the request above plus `Host` and 31 `X-*` headers, the handler sees `req.headers.host === undefined` and one header; Node delivers all 32. Chunked request trailers are dropped as well, and `server.maxHeadersCount` has no effect on this path. (This is the bug #33540 was opened for, against the previous location of this code.) Enforcing `Host` on top of this would have turned those requests into 400s, so both are fixed here.

### Cause

* `http.Server` stores `requireHostHeader` (default `true`) and the native listener enforces it (`HTTP_PARSER_ERROR_MISSING_HOST_HEADER` -> `replyMissingHostHeader` in `_http_server.ts`), but the fallback's `kOnHeadersComplete` never looked at it, and `Http2SecureServer` did not store the option at all.
* The native `HTTPParser` (`src/jsc/bindings/node/http/NodeHTTPParser.cpp`, a port of Node's) buffers 32 header fields; each time the buffer fills, and again for a chunked body's trailers, it hands the block to the parser's `kOnHeaders` callback and starts over, and once it has done that it passes `undefined` headers/url to `kOnHeadersComplete`. `_http_common`'s pooled parsers install `parserOnHeaders` for this; the fallback creates a bare `HTTPParser` with no `kOnHeaders`, so `flush()` returns without delivering anything and the buffered fields are discarded. It also set `parser.maxHeaderPairs` but never read it.

### Fix

* `http1_server_fallback.ts`, header assembly: install `_http_common`'s `parserOnHeaders` as `kOnHeaders` (now exported, with `MAX_HEADER_PAIRS`) on the same `_headers` / `_url` / `maxHeaderPairs` fields its pooled parsers use; `kOnHeadersComplete` takes the collected headers and url when its own arguments are `undefined` and applies `maxHeaderPairs` the way `parserOnHeadersComplete` does; `kOnMessageComplete` files whatever was collected after the header block as the request's trailers (`_addHeaderLines` on a completed request) and clears it so nothing carries into the next request on the connection, as `parserOnMessageComplete` does. This is the same logic `node:http`'s own connection listener runs in Node, so the observable results (headers, `rawHeaders`, trailers, `maxHeadersCount` truncation, including the case where truncation removes `Host`) match Node; the tests below were checked against node v26.3.0 on the same inputs.
* `http1_server_fallback.ts`, Host check: port the check from Node's `parserOnIncoming`. For an HTTP/1.1 request (HTTP/1.0 may omit `Host`) on a server with `requireHostHeader` set and `req.headers.host === undefined`, reply through the response object with `writeHead(400, { Connection: "close" }); end()` and return without dispatching. It sits where Node has it: after the upgrade/CONNECT hand-off (exempt in Node and in the native path) and before the `Expect` routing. The reply is the connection's last response, so the response handle is created with keep-alive off and ends the socket once the reply is written, which is what Node's `_last` handling does for the `Connection: close` it sends. No `'clientError'` is emitted, also like Node. The reply is byte for byte the one Node writes; honoring a response-level `Connection: close` in general on fallback connections is part of #36991.
* `http2.ts`: `Http2SecureServer` with `allowHTTP1: true` stores `requireHostHeader` from `options` / `options.http1Options` (default `true`) next to the other HTTP/1 options it already stores there, and type-checks it, so `requireHostHeader: false`, `http1Options: { requireHostHeader: false }` and the `ERR_INVALID_ARG_TYPE` for non-booleans all behave as they do through Node's `storeHTTPOptions`. Without `allowHTTP1` the option is neither validated nor stored, also as in Node.

Why this is correct to have: RFC 9112 section 3.2 requires a server to answer an HTTP/1.1 request without `Host` with 400, and both Node and Bun's native `http.Server` path already do; the fallback was the only server path that did not. The check is only safe once the path sees every header, which is what the assembly change provides, and that change is itself the behavior Node's connection listener has (and what plain `node:http` servers in Bun already have).

### Tests

`test/js/node/http/node-http.test.ts` (`server.emit("connection")` over a `duplexPair`) and `test/js/node/http2/node-http2.test.js` (`allowHTTP1` over a TLS connection negotiating `http/1.1`):

* the 400 reply compared against Node's exact bytes (modulo the `Date` value), the connection being closed, and the handler not running; `Expect: 100-continue` without `Host` getting the 400 rather than `100 Continue`; a `Host`-less Upgrade or CONNECT with a listener still being handed off, and a `Host`-less Upgrade without a listener getting the 400 (the ordering); HTTP/1.0 without `Host` still dispatched; `requireHostHeader: false` on `http.createServer`, and both option spellings on `http2.createSecureServer`, disabling the check; `server.requireHostHeader` stored on the http2 server; non-boolean values rejected with Node's exact error and ignored without `allowHTTP1`.
* `Host` plus 31 or 63 other headers dispatching with every header delivered (both entry points); 40-, 2- and 70-header requests on one kept-alive connection each arriving complete (after the first block-delivered request, the parser delivers every later request on that connection the same way); a chunked request's trailers landing on that request only; `maxHeadersCount` truncating on both the single-block and the assembled path, and a `Host` beyond the cut counting as missing, as in Node.
* The raw-request helpers reject on connection errors and on the connection going away, so a transport failure fails a test immediately.

Without the `src/js` changes, 9 of the 13 `connectionListener` tests and all 5 new http2 tests fail (200 / `100 Continue` where 400 is expected, `host` undefined with 1 of 32 headers delivered, no trailers, no `requireHostHeader` on the http2 server); with them everything passes, as do the full `node-http.test.ts` / `node-http2.test.js` files and the upstream `test-http2-allow-http1`, `test-http2-https-fallback*`, `test-http2-createsecureserver-options`, `test-http-generic-streams`, `test-http-*-per-stream`, `test-http-max-headers-count` and `test-http-request-host-header` tests.

<!-- robobun:evidence:begin -->

---

**[human-review]** gate passed · iteration 0 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 15 failed, 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (b99371011)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [704.92ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [92.07ms]
(pass) node:http > createServer > request & response body streaming (large) [190.54ms]
(pass) node:http > createServer > request & response body streaming (small) [106.56ms]
(pass) node:http > createServer > listen should return server [39.18ms]
(pass) node:http > createServer > listen callback should be bound to server [41.66ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [61.79ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [64.84ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [80.65ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'before
... (truncated)

release without fix: 14 failed, 7 skipped
bun test v1.4.3-canary.1 (b99371011)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [14.88ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [3.79ms]
(pass) node:http > createServer > request & response body streaming (large) [5.74ms]
(pass) node:http > createServer > request & response body streaming (small) [3.26ms]
(pass) node:http > createServer > listen should return server [1.41ms]
(pass) node:http > createServer > listen callback should be bound to server [1.31ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [1.59ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [1.82ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [2.49ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [39.14ms]
(pass) node:http > createServer > https: closing a server listened from 'beforeExit' > re-emits 'beforeExit' [51.82ms]
(pass) node:http > createServer > should use the provided port [1.90ms]
(pa
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/pr_gate.xml" test/js/node/http/node-http.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.3 (b99371011)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [706.59ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [102.81ms]
(pass) node:http > createServer > request & response body streaming (large) [189.28ms]
(pass) node:http > createServer > request & response body streaming (small) [105.68ms]
(pass) node:http > createServer > listen should return server [37.21ms]
(pass) node:http > createServer > listen callback should be bound to server [33.83ms]
(pass) node:http > createServer > emits 'listening' on the next tick, before the event loop polls [60.92ms]
(pass) node:http > createServer > emits a listen() error on the next tick, before the event loop polls [66.55ms]
(pass) node:http > createServer > calls the listen() callback after a retry from the EADDRINUSE 'error' handler [81.06ms]
(pass) node:http > createServer > http: closing a server listened from 'beforeExit' > re-emits 'befor
... (truncated)

release with fix: 7 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 895ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/21] gen JS modules (bundle-modules)
Preprocess modules (13612ms)
Bundle modules (57ms)
Postprocesss modules (184ms)
Bundle Functions (661ms)
Generate Code (36ms)

[14.56s] Bundled "src/js" for production
  2601 kb
  197 internal modules
  13 native modules
  50 internal functions across 16 files
[1/5] cargo bun_runtime → libbun_runtime.a
[1m[92m   Compiling[0m bun_runtime v0.0.0 (/workspace/bun/src/runtime)
[1m[92m    Finished[0m `release` profile [optimized + debuginfo] target(s) in 6m 42s
[2/5] link bun-profile
[4/5] strip bun
[4/5] bun-profile --revision
1.4.3-canary.1+9716d1ee0
[build] done
bun test v1.4.3-canary.1 (9716d1ee0)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [13.38ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [3.16ms]
(pass) node:http > createServer > request & response body streaming (large) [5.26ms]
(pass) node:http > createServer > request & response body streaming (small) [2.86ms]
(pass) node:http > createServer 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/http1_server_fallback.ts |  49 +++++-
 src/js/node/_http_common.ts              |   2 +
 src/js/node/http2.ts                     |   3 +
 test/js/node/http/node-http.test.ts      | 284 +++++++++++++++++++++++++++++++
 test/js/node/http2/node-http2.test.js    | 145 ++++++++++++++++
 5 files changed, 478 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/internal/http1_server_fallback.ts      0      0      0
src/js/node/_http_common.ts                   0      0      0
src/js/node/http2.ts                          0      0      0
test/js/node/http/node-http.test.ts           0      0      0
test/js/node/http2/node-http2.test.js         0      0      0
```

</details>

**root cause** · written by the author bot

The HTTP/1 fallback server did not reassemble headers and URL fragments that the parser delivered across multiple callbacks, and it skipped the validation the main HTTP/1 path performs, so it accepted HTTP/1.1 requests without a Host header, ignored header count limits, and dropped trailers. The fix collects deferred header and URL fragments before dispatching the request, caps the number of parsed header pairs, attaches deferred headers as request trailers, and rejects HTTP/1.1 requests that lack Host with a 400 Bad Request response and Connection: close. The secure HTTP/2 fallback now val…

<!-- robobun:evidence:end -->