### PR TITLE
jsc: use the load-based JIT worklist policy on Linux

### DIFF
--- a/src/jsc/bindings/ZigGlobalObject.cpp
+++ b/src/jsc/bindings/ZigGlobalObject.cpp
@@ -332,6 +332,28 @@ extern "C" void JSCInitialize(const char* envp[], size_t envc, void (*onCrash)(c
             JSC::Options::useWasmMemory64() = false;
             JSC::dangerouslyOverrideJSCBytecodeCacheVersion(getWebKitBytecodeCacheVersion());
 
+#if OS(LINUX)
+            {
+                // JSC only applies its tuned JIT worklist policy under OS(DARWIN) && CPU(ARM64)
+                // (runtime/Options.cpp, overrideDefaults). Everywhere else the defaults are
+                // min = max = 3 worklist threads with a load factor of 1, so
+                // JITWorklist::wakeThreads wakes (or spawns) a compiler thread for every plan
+                // enqueued. Use the Darwin values: one thread handles warm-up and more are only
+                // woken once the weighted queue depth exceeds the load factor.
+                unsigned compilerThreads = std::min<unsigned>(4, WTF::numberOfProcessorCores());
+                JSC::Options::minNumberOfWorklistThreads() = 1;
+                JSC::Options::maxNumberOfWorklistThreads() = compilerThreads;
+                JSC::Options::numberOfBaselineCompilerThreads() = compilerThreads;
+                JSC::Options::numberOfDFGCompilerThreads() = compilerThreads;
+                JSC::Options::numberOfFTLCompilerThreads() = compilerThreads;
+                JSC::Options::worklistLoadFactor() = 20;
+                JSC::Options::worklistBaselineLoadWeight() = 2;
+                JSC::Options::worklistDFGLoadWeight() = 5;
+                // Equal to the load factor so every FTL plan is worth a thread of its own.
+                JSC::Options::worklistFTLLoadWeight() = 20;
+            }
+#endif
+
 #ifdef BUN_DEBUG
             JSC::Options::showPrivateScriptsInStackTraces() = true;
 #endif

--- a/test/js/bun/jsc/bun-jsc.test.ts
+++ b/test/js/bun/jsc/bun-jsc.test.ts
@@ -24,7 +24,7 @@ import {
   totalCompileTime,
 } from "bun:jsc";
 import { describe, expect, it } from "bun:test";
-import { bunEnv, bunExe, isBuildKite, isWindows } from "harness";
+import { bunEnv, bunExe, isBuildKite, isLinux, isWindows } from "harness";
 
 describe("bun:jsc", () => {
   function count() {
@@ -566,4 +566,82 @@ it("deserialize applies the same nesting depth limit to arrays as to objects", a
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect({ stdout, exitCode }).toEqual({ stdout: "rejected\n65\n", exitCode: 0 });
+});
+
+// JSC only ships its tuned JIT worklist policy on Darwin/arm64; JSCInitialize
+// applies the same values on Linux. BUN_JSC_dumpOptions=2 prints every option
+// once they are final, so this reads back exactly what the worklist will use.
+describe.concurrent.skipIf(!isLinux)("JIT worklist options on Linux", () => {
+  const worklistOptionNames = [
+    "minNumberOfWorklistThreads",
+    "maxNumberOfWorklistThreads",
+    "numberOfBaselineCompilerThreads",
+    "numberOfDFGCompilerThreads",
+    "numberOfFTLCompilerThreads",
+    "worklistLoadFactor",
+    "worklistBaselineLoadWeight",
+    "worklistDFGLoadWeight",
+    "worklistFTLLoadWeight",
+  ];
+
+  async function dumpWorklistOptions(extraEnv: Record<string, string>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", "0"],
+      env: { ...bunEnv, BUN_JSC_dumpOptions: "2", ...extraEnv },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    const options: Record<string, number> = {};
+    for (const line of stderr.split("\n")) {
+      // Overridden options print as "   name=value (default: x)".
+      const match = /^\s*(\w+)=(\d+)/.exec(line);
+      if (match && worklistOptionNames.includes(match[1])) options[match[1]] = Number(match[2]);
+    }
+    return options;
+  }
+
+  it("uses the load-based thread wakeup policy, capped at four compiler threads", async () => {
+    expect(await dumpWorklistOptions({ WTF_numberOfProcessorCores: "16" })).toEqual({
+      minNumberOfWorklistThreads: 1,
+      maxNumberOfWorklistThreads: 4,
+      numberOfBaselineCompilerThreads: 4,
+      numberOfDFGCompilerThreads: 4,
+      numberOfFTLCompilerThreads: 4,
+      worklistLoadFactor: 20,
+      worklistBaselineLoadWeight: 2,
+      worklistDFGLoadWeight: 5,
+      worklistFTLLoadWeight: 20,
+    });
+  });
+
+  it("never configures more compiler threads than cores", async () => {
+    expect(await dumpWorklistOptions({ WTF_numberOfProcessorCores: "2" })).toEqual({
+      minNumberOfWorklistThreads: 1,
+      maxNumberOfWorklistThreads: 2,
+      numberOfBaselineCompilerThreads: 2,
+      numberOfDFGCompilerThreads: 2,
+      numberOfFTLCompilerThreads: 2,
+      worklistLoadFactor: 20,
+      worklistBaselineLoadWeight: 2,
+      worklistDFGLoadWeight: 5,
+      worklistFTLLoadWeight: 20,
+    });
+  });
+
+  it("BUN_JSC_ environment overrides still win", async () => {
+    const options = await dumpWorklistOptions({
+      WTF_numberOfProcessorCores: "16",
+      BUN_JSC_worklistLoadFactor: "1",
+      BUN_JSC_maxNumberOfWorklistThreads: "3",
+    });
+    expect(options).toMatchObject({
+      maxNumberOfWorklistThreads: 3,
+      worklistLoadFactor: 1,
+      // Everything not overridden keeps the Linux defaults set by JSCInitialize.
+      minNumberOfWorklistThreads: 1,
+      worklistDFGLoadWeight: 5,
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- On Linux, every bun process that JIT-compiles anything starts three `JITWorker` threads within a few milliseconds, and every compile job queued after that wakes a compiler thread even when the one already running would have drained the queue.
- JSC only ships its tuned worklist policy on macOS/arm64. Everywhere else the defaults are min = max = 3 threads with a load factor of 1, so a thread is woken or spawned per queued job, which is the behaviour the code's own comment says to avoid.
- Visible on any Linux box: `BUN_JSC_dumpOptions=2 bun -e 0` prints `minNumberOfWorklistThreads=3` and `worklistLoadFactor=1`.

### Fix
- On Linux, bun's JSC startup hook now sets the macOS/arm64 values: 1 thread minimum, at most `min(4, cores)`, load factor 20, per-tier weights baseline/DFG/FTL of 2/5/20. One thread handles warm-up and more are woken only when the weighted queue depth exceeds the load factor.
- The values are set before the `BUN_JSC_*` environment variables are read, so user overrides still win, and the prebuilt WebKit is unchanged. Windows and macOS/x64 keep the JSC defaults and were not measured.
- Cost: up to 4 optimizing compiles can now run at once instead of 3, which showed up as +1 to +2 MB max RSS on mid-sized workloads.
- Verification: one `bun-linux-x64` binary, both option sets passed via env, 15 interleaved runs over 15 workloads. Compiler thread wakeups fell 24% summed; wall and CPU time unchanged within noise. Three Linux-only tests read the final options back and fail on the current release.

### Background
- JSC compiles hot JavaScript through three JIT tiers (baseline, DFG, FTL), each slower to compile than the last. Each compile is a "plan" queued on a worklist and run off the main thread by `JITWorker` threads.
- When a plan is queued, the worklist decides whether to wake an idle worker or spawn a new one, bounded by the min and max worklist thread options.
- The load factor and per-tier weights make that decision by weight, not count: each queued plan adds its tier's weight, and another thread is woken only once the total passes the load factor. With factor 1 and weights 1 every plan qualifies; an FTL weight equal to the factor still gives every FTL plan its own thread.
- Every JSC tunable is an "option". bun exposes them as `BUN_JSC_<name>` environment variables, and `BUN_JSC_dumpOptions=2` prints the final values at startup, which is how the tests check the result.

<details>
<summary>Original description</summary>

### What

JSC only applies its tuned `JITWorklist` policy under `OS(DARWIN) && CPU(ARM64)` (`runtime/Options.cpp`, `overrideDefaults()`): 1 worklist thread minimum, up to `min(4, cores)` compiler threads, `worklistLoadFactor=20`, per-tier load weights baseline/DFG/FTL = 2/5/20. Every other platform, including Linux, keeps the `OptionsList.h` defaults: `minNumberOfWorklistThreads = maxNumberOfWorklistThreads = 3`, `worklistLoadFactor = 1`, all weights 1.

With a load factor of 1, `JITWorklist::wakeThreads()` (`jit/JITWorklist.cpp`) wakes, or spawns, a compiler thread for every plan that gets enqueued, which is exactly what the comment above it says not to do. On Linux every bun process that compiles anything spawns three `JITWorker` threads, and each plan enqueued afterwards is a futex wake, even when the thread that is already running would have drained the queue.

Current behaviour is visible on any Linux box:

```sh
$ BUN_JSC_dumpOptions=2 bun -e 0 2>&1 | grep -E 'Worklist|worklist'
   minNumberOfWorklistThreads=3
   maxNumberOfWorklistThreads=3
   worklistLoadFactor=1
   worklistBaselineLoadWeight=1
   worklistDFGLoadWeight=1
   worklistFTLLoadWeight=1
```

and `ls /proc/<pid>/task/*/comm` shows three `JITWorker` threads a few milliseconds into any script.

### Fix

`JSCInitialize` (`src/jsc/bindings/ZigGlobalObject.cpp`) sets the Darwin values under `OS(LINUX)`. It runs inside JSC's options customization callback, before the `BUN_JSC_*` environment loop, so `BUN_JSC_worklistLoadFactor=1` etc. still override it. This goes through the prebuilt WebKit as is; moving the tuple into `Options.cpp` upstream can follow later if we want it there.

Windows and macOS/x64 are left on the JSC defaults; this PR only changes (and only measured) Linux.

### Measurements

Same release binary (`bun-linux-x64`, 12 cores visible to JSC, build of current main), with the two option sets passed via `BUN_JSC_*`, so the only variable is the tuple. 15 runs per configuration, interleaved, medians. `after, max 3 threads` is the same policy with the thread count held at the current 3, to separate the wakeup policy from the fourth thread.

"JITWorker wakeups" is `voluntary_ctxt_switches` summed over the process's `JITWorker` threads at the end of the run (one per futex sleep, i.e. one per wakeup a compiler thread had to be given). Workloads are JetStream2's Octane/cdjs files run as in its CLI driver, `typescript.transpileModule` and `prettier.format` on large inputs, and two `Bun.serve` apps (a JSON handler and a React SSR page) serving 4000/2000 requests from `ab` from a cold start.

| workload | JITWorker wakeups: before | after | after, max 3 threads | JITWorker threads spawned: before / after | wall time after | max RSS after |
|---|---|---|---|---|---|---|
| box2d | 198 | 143 (-28%) | 109 (-45%) | 3 / 4 | +0% | +2% |
| cdjs | 79 | 63 (-20%) | 59 (-25%) | 3 / 4 | +0% | +1% |
| code-load | 16 | 14 (-13%) | 14 (-13%) | 2 / 1 | -0% | +0% |
| crypto | 59 | 43 (-27%) | 43 (-27%) | 3 / 4 | +0% | +0% |
| deltablue | 42 | 47 (+12%) | 28 (-33%) | 3 / 4 | +1% | +0% |
| earley-boyer | 76 | 58 (-24%) | 54 (-29%) | 3 / 4 | -1% | +2% |
| gbemu | 377 | 294 (-22%) | 278 (-26%) | 3 / 4 | -0% | +0% |
| pdfjs | 236 | 162 (-31%) | 163 (-31%) | 3 / 4 | +1% | +2% |
| prettier | 454 | 353 (-22%) | 269 (-41%) | 3 / 4 | -3% | +7% |
| raytrace | 55 | 58 (+5%) | 48 (-13%) | 3 / 4 | +0% | +0% |
| richards | 26 | 27 (+4%) | 19 (-27%) | 3 / 4 | +6% | +0% |
| ts-transpile | 175 | 85 (-51%) | 82 (-53%) | 3 / 3 | -1% | -0% |
| typescript | 763 | 598 (-22%) | 514 (-33%) | 3 / 4 | -2% | +1% |
| serve-warmup | 32 | 21 (-34%) | 22 (-31%) | 3 / 2 | -1% | +2% |
| serve-react | 139 | 115 (-17%) | 99 (-29%) | 3 / 4 | -1% | -5% |

Summed over all workloads, compiler thread wakeups drop 24% with the Darwin tuple and 34% with the thread count held at 3.

What the numbers say:

- Wall and CPU time are unchanged within noise. The box this ran on had a host load average above 40, and the per-workload deltas flip sign between repeated runs (richards was -5% CPU in one run and +9% in the next, with overlapping distributions). The summed wall time is -0.7% / +1.2% for the two variants, which is noise. This is the "modest but free" expectation: it removes thread spawns and wakeups during warm-up, it does not make compiled code faster.
- The three tiny Octane benchmarks (richards, deltablue, raytrace, 20 to 60 wakeups total) come out a few wakeups worse with the Darwin tuple and better with three threads. That is the fourth thread: the FTL weight equals the load factor, so a burst of FTL plans spawns one thread per plan, up to four. Baseline-heavy warm-up (code-load, the JSON server) now spawns one or two threads instead of three.
- Max RSS: +1 to +2 MB on the mid-sized workloads that now spawn a fourth thread (one more thread stack and allocator cache, one more concurrent compile). The prettier +7% is bimodal in all three configurations (runs land either around 170 MB or around 205 MB depending on where the last full GC falls; the high mode is the same height in all three), and serve-react's -5% is the same effect in the other direction. The upper bound on concurrent optimizing compiles goes from 3 to 4, so a large application's warm-up peak can be higher than before by one compile's working memory. If that matters more than the extra FTL parallelism, capping `compilerThreads` at 3 keeps all of the wakeup win (third column); this PR ships the values Safari ships, which are also what every macOS/arm64 bun already runs.

<details>
<summary>Option sets used for "before" and "after"</summary>

before (JSC defaults on a machine with 12 cores, i.e. what Linux runs today):

```
BUN_JSC_minNumberOfWorklistThreads=3 BUN_JSC_maxNumberOfWorklistThreads=3
BUN_JSC_numberOfBaselineCompilerThreads=3 BUN_JSC_numberOfDFGCompilerThreads=2 BUN_JSC_numberOfFTLCompilerThreads=7
BUN_JSC_worklistLoadFactor=1 BUN_JSC_worklistBaselineLoadWeight=1 BUN_JSC_worklistDFGLoadWeight=1 BUN_JSC_worklistFTLLoadWeight=1
```

after (this PR's defaults):

```
BUN_JSC_minNumberOfWorklistThreads=1 BUN_JSC_maxNumberOfWorklistThreads=4
BUN_JSC_numberOfBaselineCompilerThreads=4 BUN_JSC_numberOfDFGCompilerThreads=4 BUN_JSC_numberOfFTLCompilerThreads=4
BUN_JSC_worklistLoadFactor=20 BUN_JSC_worklistBaselineLoadWeight=2 BUN_JSC_worklistDFGLoadWeight=5 BUN_JSC_worklistFTLLoadWeight=20
```

"after, max 3 threads" is the second set with the four thread counts at 3.
</details>

<details>
<summary>Full tables (wakeups, threads, RSS, wall, CPU per workload)</summary>

Octane / library workloads:
**jitVcsw**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| box2d | 198 | 143 (-27.8%) | 109 (-44.9%) |
| cdjs | 79 | 63 (-20.3%) | 59 (-25.3%) |
| code-load | 16 | 14 (-12.5%) | 14 (-12.5%) |
| crypto | 59 | 43 (-27.1%) | 43 (-27.1%) |
| deltablue | 42 | 47 (+11.9%) | 28 (-33.3%) |
| earley-boyer | 76 | 58 (-23.7%) | 54 (-28.9%) |
| gbemu | 377 | 294 (-22.0%) | 278 (-26.3%) |
| pdfjs | 236 | 162 (-31.4%) | 163 (-30.9%) |
| prettier | 454 | 353 (-22.2%) | 269 (-40.7%) |
| raytrace | 55 | 58 (+5.5%) | 48 (-12.7%) |
| richards | 26 | 27 (+3.8%) | 19 (-26.9%) |
| ts-transpile | 175 | 85 (-51.4%) | 82 (-53.1%) |
| typescript | 763 | 598 (-21.6%) | 514 (-32.6%) |
| **sum** | 2556 | 1945 (-23.9%) | 1680 (-34.3%) |

**jitThreadsPeak**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| box2d | 3 | 4 (+33.3%) | 3 (+0.0%) |
| cdjs | 3 | 4 (+33.3%) | 3 (+0.0%) |
| code-load | 2 | 1 (-50.0%) | 1 (-50.0%) |
| crypto | 3 | 4 (+33.3%) | 3 (+0.0%) |
| deltablue | 3 | 4 (+33.3%) | 3 (+0.0%) |
| earley-boyer | 3 | 4 (+33.3%) | 3 (+0.0%) |
| gbemu | 3 | 4 (+33.3%) | 3 (+0.0%) |
| pdfjs | 3 | 4 (+33.3%) | 3 (+0.0%) |
| prettier | 3 | 4 (+33.3%) | 3 (+0.0%) |
| raytrace | 3 | 4 (+33.3%) | 3 (+0.0%) |
| richards | 3 | 4 (+33.3%) | 3 (+0.0%) |
| ts-transpile | 3 | 3 (+0.0%) | 3 (+0.0%) |
| typescript | 3 | 4 (+33.3%) | 3 (+0.0%) |

**maxRssMb**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| box2d | 63.8 | 64.9 (+1.7%) | 63.9 (+0.2%) |
| cdjs | 73.9 | 75.0 (+1.5%) | 74.8 (+1.2%) |
| code-load | 48.9 | 48.9 (+0.0%) | 48.9 (+0.0%) |
| crypto | 48.9 | 48.9 (+0.0%) | 48.9 (+0.0%) |
| deltablue | 57.5 | 57.5 (+0.0%) | 57.5 (+0.0%) |
| earley-boyer | 63.9 | 65.0 (+1.6%) | 64.8 (+1.4%) |
| gbemu | 82.2 | 82.6 (+0.4%) | 83.5 (+1.5%) |
| pdfjs | 111.8 | 113.8 (+1.8%) | 113.6 (+1.6%) |
| prettier | 186.9 | 200.9 (+7.5%) | 203.3 (+8.7%) |
| raytrace | 64.9 | 64.9 (+0.1%) | 64.9 (+0.1%) |
| richards | 63.4 | 63.4 (+0.0%) | 63.4 (+0.0%) |
| ts-transpile | 86.2 | 86.1 (-0.0%) | 87.6 (+1.6%) |
| typescript | 325.2 | 329.8 (+1.4%) | 320.6 (-1.4%) |

**wallMs**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| box2d | 158 | 158 (+0.3%) | 160 (+1.6%) |
| cdjs | 439 | 440 (+0.2%) | 437 (-0.6%) |
| code-load | 79 | 79 (-0.1%) | 79 (+0.1%) |
| crypto | 58 | 58 (+0.4%) | 59 (+1.9%) |
| deltablue | 67 | 67 (+1.3%) | 67 (+1.3%) |
| earley-boyer | 113 | 112 (-1.3%) | 112 (-1.5%) |
| gbemu | 313 | 313 (-0.2%) | 315 (+0.7%) |
| pdfjs | 330 | 332 (+0.5%) | 336 (+1.9%) |
| prettier | 900 | 872 (-3.1%) | 911 (+1.2%) |
| raytrace | 162 | 162 (+0.0%) | 163 (+0.4%) |
| richards | 102 | 108 (+5.9%) | 113 (+11.2%) |
| ts-transpile | 393 | 390 (-0.6%) | 401 (+2.1%) |
| typescript | 1696 | 1663 (-2.0%) | 1723 (+1.5%) |
| **sum** | 4810 | 4754 (-1.2%) | 4875 (+1.4%) |

**cpuMs**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| box2d | 395 | 397 (+0.5%) | 394 (-0.3%) |
| cdjs | 663 | 661 (-0.4%) | 658 (-0.9%) |
| code-load | 83 | 82 (-0.8%) | 83 (+0.2%) |
| crypto | 98 | 96 (-1.5%) | 96 (-1.8%) |
| deltablue | 152 | 155 (+1.7%) | 153 (+0.9%) |
| earley-boyer | 262 | 257 (-1.8%) | 261 (-0.1%) |
| gbemu | 597 | 597 (+0.0%) | 596 (-0.2%) |
| pdfjs | 669 | 671 (+0.3%) | 667 (-0.3%) |
| prettier | 2345 | 2307 (-1.6%) | 2355 (+0.4%) |
| raytrace | 347 | 359 (+3.3%) | 359 (+3.5%) |
| richards | 161 | 176 (+9.0%) | 173 (+7.8%) |
| ts-transpile | 572 | 570 (-0.3%) | 547 (-4.4%) |
| typescript | 4058 | 4108 (+1.2%) | 4044 (-0.4%) |
| **sum** | 10402 | 10436 (+0.3%) | 10387 (-0.1%) |


Server workloads:
**jitVcsw**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| serve-warmup | 32 | 21 (-34.4%) | 22 (-31.3%) |
| serve-react | 139 | 115 (-17.3%) | 99 (-28.8%) |
| **sum** | 171 | 136 (-20.5%) | 121 (-29.2%) |

**jitThreadsPeak**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| serve-warmup | 3 | 2 (-33.3%) | 2 (-33.3%) |
| serve-react | 3 | 4 (+33.3%) | 3 (+0.0%) |

**maxRssMb**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| serve-warmup | 53.9 | 54.8 (+1.8%) | 53.9 (+0.0%) |
| serve-react | 83.9 | 79.6 (-5.1%) | 82.8 (-1.3%) |

**wallMs**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| serve-warmup | 308 | 306 (-0.8%) | 308 (-0.2%) |
| serve-react | 1103 | 1094 (-0.8%) | 1116 (+1.2%) |
| **sum** | 1411 | 1400 (-0.8%) | 1424 (+0.9%) |

**cpuMs**

| workload | before | after (vs before) | after3 (vs before) |
|---|---|---|---|
| serve-warmup | 303 | 300 (-1.0%) | 301 (-0.5%) |
| serve-react | 1404 | 1359 (-3.2%) | 1397 (-0.5%) |
| **sum** | 1707 | 1659 (-2.8%) | 1698 (-0.5%) |


</details>

### Tests

`test/js/bun/jsc/bun-jsc.test.ts` reads the final option values back through `BUN_JSC_dumpOptions=2` (Linux only): the tuple with `WTF_numberOfProcessorCores=16`, the `min(4, cores)` clamp with 2 cores, and that `BUN_JSC_*` overrides still win. The three tests fail on the current release (`minNumberOfWorklistThreads=3`, `worklistLoadFactor=1`) and pass with this change. The debug/ASAN build was also run through the typescript and richards workloads with all four compiler threads engaged.

</details>
