### PR TITLE
test(shell): make TestBuilder fail on expectations that cannot assert anything

### DIFF
--- a/test/js/bun/shell/bunshell-default.test.ts
+++ b/test/js/bun/shell/bunshell-default.test.ts
@@ -1,3 +1,4 @@
+import { expect, test } from "bun:test";
 import { bunEnv } from "harness";
 import { bunExe, createTestBuilder } from "./test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -24,7 +25,7 @@ test("default throw on command failure", async () => {
   await TestBuilder.command`echo ${code} > index.test.ts; ${bunExe()} test index.test.ts`
     .ensureTempDir()
     .stdout(`bun test ${Bun.version_with_sha}\n`)
-    .stderr(s => s.includes("1 pass"))
+    .stderr(s => expect(s).toContain("1 pass"))
     .env(bunEnv)
     .run();
 });
@@ -49,7 +50,7 @@ test("ShellError has .text()", async () => {
   await TestBuilder.command`echo ${code} > index.test.ts; ${bunExe()} test index.test.ts`
     .ensureTempDir()
     .stdout(`bun test ${Bun.version_with_sha}\n`)
-    .stderr(s => s.includes("1 pass"))
+    .stderr(s => expect(s).toContain("1 pass"))
     .env(bunEnv)
     .run();
 });

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -62,7 +62,6 @@ describe("bunshell", () => {
       process.platform === "win32" ? "cat ldkfjsldf" : null,
       "touch -alskdjfakjfhasjfh",
       "mkdir",
-      "export",
       "cd lskfjlsdkjf",
       process.platform !== "win32" ? "echo hi > /dev/full" : null,
       "pwd sldfkj sfks jdflks flksd f",
@@ -83,7 +82,7 @@ describe("bunshell", () => {
     failing_cmds.forEach(cmdstr =>
       !!cmdstr
         ? TestBuilder.command`${{ raw: cmdstr }}`
-            .exitCode(c => c !== 0)
+            .exitCode(c => expect(c).not.toBe(0))
             .stdout(() => {})
             .stderr(() => {})
             .runAsTest(cmdstr)
@@ -1328,6 +1327,12 @@ describe("deno_task", () => {
     TestBuilder.command`export VAR=1 VAR2=testing VAR3="test this out" && echo $VAR $VAR2 $VAR3`
       .stdout("1 testing test this out\n")
       .runAsTest("exported vars 2");
+
+    TestBuilder.command`export FOO=bar; export`
+      .env({ ZED: "2", ALPHA: "1" })
+      .ensureTempDir()
+      .stdout("ALPHA=1\nFOO=bar\nPWD=$TEMP_DIR\nZED=2\n")
+      .runAsTest("export with no arguments prints the exported vars sorted and succeeds");
   });
 
   describe("pipeline", async () => {
@@ -1467,7 +1472,7 @@ describe("deno_task", () => {
       // Test nested pipeline with mixed success/failure
       TestBuilder.command`(echo success | echo works) | (nonexistent | echo backup) || echo final_fallback`
         .stdout("backup\n")
-        .stderr(s => s.includes("command not found"))
+        .stderr("bun: command not found: nonexistent\n")
         .runAsTest("nested pipeline mixed success failure");
 
       TestBuilder.command`echo 0 | echo 1 | echo 2 | echo 3 | echo 4 | echo 5 | echo 6 | echo 7 | echo 8 | echo 9 | echo 10 | echo 11 | echo 12 | echo 13 | echo 14 | echo 15 | echo 16 | echo 17 | echo 18 | echo 19 | echo 20 | echo 21 | echo 22 | echo 23 | echo 24 | echo 25 | echo 26 | echo 27 | echo 28 | echo 29 | echo 30 | echo 31 | echo 32 | echo 33 | echo 34 | echo 35 | echo 36 | echo 37 | echo 38 | echo 39 | echo 40 | echo 41 | echo 42 | echo 43 | echo 44 | echo 45 | echo 46 | echo 47 | echo 48 | echo 49 | BUN_TEST_VAR=1 ${BUN} -e 'process.stdin.pipe(process.stdout)'`
@@ -2394,16 +2399,14 @@ describe("condexprs", () => {
 [[ ! 1 -eq 1 ]]; echo $?
 [[ ! ! 1 -eq 1 ]]; echo $?
 `
-      .stdout("1")
-      .stdout("0")
+      .stdout("1\n0\n")
       .runAsTest("! toggles on and off rather than just setting an 'invert result' flag");
 
     TestBuilder.command`
 [[ ! ! ! 1 -eq 1 ]]; echo $?
 [[ ! ! ! ! 1 -eq 1 ]]; echo $?
 `
-      .stdout("1")
-      .stdout("0")
+      .stdout("1\n0\n")
       .runAsTest("! toggles on and off rather than just setting an 'invert result' flag");
 
     TestBuilder.command`[[ a ]]`.exitCode(0).runAsTest("parenthesized terms didn't work right until post-2.04");
@@ -2624,8 +2627,7 @@ fi
 if [[ "123abc" == *?(a)bc ]]; then echo ok 42; else echo bad 42; fi
 if [[ "123abc" == *?(a)bc ]]; then echo ok 43; else echo bad 43; fi
 `
-      .stdout("ok 42")
-      .stdout("ok 43")
+      .stdout("ok 42\nok 43\n")
       .runAsTest("bug in all versions up to and including bash-2.05b");
 
     // TestBuilder.command`

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -110,10 +110,7 @@ describe.concurrent("bunshell ls", () => {
       await $`touch .hidden regular`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls -A`
         .setTempdir(tempdir)
-        .stdout(s => expect(sortedLsOutput(s)).not.toContain("."))
-        .stdout(s => expect(sortedLsOutput(s)).not.toContain(".."))
-        .stdout(s => expect(sortedLsOutput(s)).toContain(".hidden"))
-        .stdout(s => expect(sortedLsOutput(s)).toContain("regular"))
+        .stdout(s => expect(sortedLsOutput(s)).toEqual([".hidden", "regular"]))
         .run();
     });
 
@@ -205,8 +202,9 @@ describe.concurrent("bunshell ls", () => {
       await $`mkdir sub; touch .hidden sub/.hidden-sub`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls -Ra`
         .setTempdir(tempdir)
-        .stdout(s => expect(sortedLsOutput(s)).toContain(".hidden"))
-        .stdout(s => expect(sortedLsOutput(s)).toContain(".hidden-sub"))
+        .stdout(s =>
+          expect(sortedLsOutput(s)).toEqual([".", "..", ".hidden", "sub", "./sub:", ".", "..", ".hidden-sub"].sort()),
+        )
         .run();
     });
 
@@ -215,9 +213,7 @@ describe.concurrent("bunshell ls", () => {
       await $`mkdir sub; touch .hidden sub/.hidden-sub`.quiet().throws(true).cwd(tempdir);
       await TestBuilder.command`ls -RA`
         .setTempdir(tempdir)
-        .stdout(s => expect(sortedLsOutput(s)).toContain(".hidden"))
-        .stdout(s => expect(sortedLsOutput(s)).toContain(".hidden-sub"))
-        .stdout(s => expect(sortedLsOutput(s)).not.toContain("."))
+        .stdout(s => expect(sortedLsOutput(s)).toEqual([".hidden", "sub", "./sub:", ".hidden-sub"].sort()))
         .run();
     });
 
@@ -327,9 +323,7 @@ describe.concurrent("bunshell ls", () => {
       await TestBuilder.command`ls -R level1`
         .setTempdir(tempdir)
         .exitCode(1)
-        .stdout(s => expect(sortedLsOutput(s)).toContain("file1"))
-        .stdout(s => expect(sortedLsOutput(s)).toContain("file2"))
-        .stdout(s => expect(sortedLsOutput(s)).toContain("file3"))
+        .stdout(s => expect(sortedLsOutput(s)).toEqual(["file1", "file2", "file3", "level2"]))
         .stderr(s => expect(s).toContain("Permission denied"))
         .run();
 

--- a/test/js/bun/shell/pipeline_stack.test.ts
+++ b/test/js/bun/shell/pipeline_stack.test.ts
@@ -75,22 +75,25 @@ describe("pipeline stack edge cases", () => {
 
   describe("cd builtin in pipelines", () => {
     TestBuilder.command`cd / | pwd`
-      .stdout(s => s.includes("$TEMP_DIR"))
+      .stdout("$TEMP_DIR\n")
       .ensureTempDir()
       .runAsTest("cd | pwd - cd doesn't affect next command in pipeline");
 
     TestBuilder.command`mkdir foo; mkdir foo/bar; cd foo | cd foo/bar | pwd`
-      .stdout(s => s.includes("$TEMP_DIR"))
+      .stdout("$TEMP_DIR\n")
       .ensureTempDir()
       .runAsTest("cd | cd | pwd - multiple cd's don't affect");
 
+    // The first pwd writes into the pipe, so only the last one reaches stdout.
     TestBuilder.command`pwd | cd / | pwd`
-      .stdout(s => {
-        const lines = s.trim().split("\n");
-        return lines.length === 2 && lines[0].includes("$TEMP_DIR") && lines[1].includes("$TEMP_DIR");
-      })
+      .stdout("$TEMP_DIR\n")
       .ensureTempDir()
       .runAsTest("pwd | cd | pwd - cd in middle doesn't affect");
+
+    TestBuilder.command`mkdir foo; cd foo | pwd; pwd`
+      .stdout("$TEMP_DIR\n$TEMP_DIR\n")
+      .ensureTempDir()
+      .runAsTest("cd in a pipeline doesn't affect the commands after the pipeline either");
   });
 
   describe("mixed builtin and subprocess pipelines", () => {

--- a/test/js/bun/shell/test_builder.test.ts
+++ b/test/js/bun/shell/test_builder.test.ts
@@ -1,0 +1,106 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { createTestBuilder } from "./test_builder";
+
+const TestBuilder = createTestBuilder(import.meta.path);
+
+// Other shell test files switch the shared `$` to nothrow mode; the ShellError tests below need the default.
+$.throws(true);
+
+describe.concurrent("TestBuilder", () => {
+  describe("an expectation can only be set once per builder", () => {
+    test("stdout", () => {
+      expect(() => TestBuilder.command`echo hi`.stdout("hi\n").stdout("hi\n")).toThrow(
+        "the stdout expectation was set more than once",
+      );
+    });
+
+    test("stderr", () => {
+      expect(() => TestBuilder.command`echo hi`.stderr("").stderr_contains("")).toThrow(
+        "the stderr expectation was set more than once",
+      );
+    });
+
+    test("exitCode", () => {
+      expect(() => TestBuilder.command`echo hi`.exitCode(0).exitCode(0)).toThrow(
+        "the exitCode expectation was set more than once",
+      );
+    });
+
+    test("error", () => {
+      expect(() => TestBuilder.command`echo hi`.error("a").error("b")).toThrow(
+        "the error expectation was set more than once",
+      );
+    });
+
+    test("different expectations on one builder are fine", async () => {
+      await TestBuilder.command`echo hi`.stdout("hi\n").stderr("").exitCode(0).run();
+    });
+  });
+
+  describe("expectation callbacks", () => {
+    test("assert by calling expect()", async () => {
+      await TestBuilder.command`echo hi`
+        .stdout(s => expect(s).toBe("hi\n"))
+        .stderr(s => {
+          expect(s).toBe("");
+        })
+        .exitCode(c => expect(c).toBe(0))
+        .run();
+    });
+
+    test("a failing expect() in a callback fails the run", async () => {
+      await expect(TestBuilder.command`echo hi`.stdout(s => expect(s).toBe("bye\n")).run()).rejects.toThrow();
+    });
+
+    test("stdout callback must not return a value", async () => {
+      await expect(TestBuilder.command`echo hi`.stdout(s => s.includes("hi")).run()).rejects.toThrow(
+        "the .stdout() callback returned a boolean",
+      );
+    });
+
+    test("stderr callback must not return a value", async () => {
+      await expect(TestBuilder.command`true`.stderr(s => s.length).run()).rejects.toThrow(
+        "the .stderr() callback returned a number",
+      );
+    });
+
+    test("exitCode callback must not return a value", async () => {
+      await expect(TestBuilder.command`true`.exitCode(c => c === 0).run()).rejects.toThrow(
+        "the .exitCode() callback returned a boolean",
+      );
+    });
+  });
+
+  describe("error()", () => {
+    test("passes when the command throws the expected error", async () => {
+      await TestBuilder.command`echo hi |`.error("Unexpected EOF").run();
+    });
+
+    test("fails when the command does not throw", async () => {
+      await expect(TestBuilder.command`echo hi`.error("Unexpected EOF").run()).rejects.toThrow(
+        "expected the command to throw, but it completed with exit code 0",
+      );
+    });
+  });
+
+  describe("when the command rejects with a ShellError", () => {
+    test("the expectations are checked against its output", async () => {
+      await TestBuilder.command`echo out; ls does-not-exist`
+        .stdout("out\n")
+        .stderr("ls: does-not-exist: No such file or directory\n")
+        .exitCode(1)
+        .run();
+    });
+
+    test("a failing expectation fails the run", async () => {
+      await expect(
+        TestBuilder.command`echo out; ls does-not-exist`
+          .stdout("something else\n")
+          .stderr_contains("No such file or directory")
+          .exitCode(1)
+          .run(),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/test/js/bun/shell/test_builder.ts
+++ b/test/js/bun/shell/test_builder.ts
@@ -1,9 +1,19 @@
-import { ShellError, ShellExpression } from "bun";
+import { $, ShellError, ShellExpression } from "bun";
 // import { tempDirWithFiles } from "harness";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import { join } from "node:path";
 // import { bunExe } from "harness";
+
+type Expectation = "stdout" | "stderr" | "exitCode" | "error";
+
+function checkCallbackReturnedNothing(kind: Exclude<Expectation, "error">, returned: unknown): void {
+  if (returned !== undefined) {
+    throw new Error(
+      `TestBuilder: the .${kind}() callback returned a ${typeof returned}, but its return value is ignored. The callback must call expect() itself.`,
+    );
+  }
+}
 
 export function createTestBuilder(path: string) {
   var { describe, test, afterAll, beforeAll, expect, beforeEach, afterEach } = Bun.jest(path);
@@ -16,6 +26,7 @@ export function createTestBuilder(path: string) {
     expected_exit_code: number | ((code: number) => void) = 0;
     expected_error: ShellError | string | boolean | undefined = undefined;
     file_equals: { [filename: string]: string | (() => string | Promise<string>) } = {};
+    _expectationsSet: Set<Expectation> = new Set();
     _doesNotExist: string[] = [];
     _timeout: number | undefined = undefined;
 
@@ -121,22 +132,36 @@ export function createTestBuilder(path: string) {
       return this;
     }
 
+    _setExpectation(kind: Expectation): void {
+      if (this._expectationsSet.has(kind)) {
+        throw new Error(
+          `TestBuilder: the ${kind} expectation was set more than once; only the last one would be checked. Put all of the assertions in a single callback.`,
+        );
+      }
+      this._expectationsSet.add(kind);
+    }
+
     /**
      * Expect output from stdout
      *
-     * @param expected - can either be a string or a function which itself calls `expect()`
+     * @param expected - can either be a string (`$TEMP_DIR` is replaced with the temp directory) or
+     * a function which itself calls `expect()`. A function must not return anything: its return
+     * value is not an assertion.
      */
     stdout(expected: string | ((stdout: string, tempDir: string) => void)): this {
+      this._setExpectation("stdout");
       this.expected_stdout = expected;
       return this;
     }
 
     stderr(expected: string | ((stderr: string, tempDir: string) => void)): this {
+      this._setExpectation("stderr");
       this.expected_stderr = expected;
       return this;
     }
 
     stderr_contains(expected: string): this {
+      this._setExpectation("stderr");
       this.expected_stderr = { contains: expected };
       return this;
     }
@@ -155,7 +180,11 @@ export function createTestBuilder(path: string) {
       return this;
     }
 
+    /**
+     * Expect the command to throw (e.g. a parse error). The test fails if it completes instead.
+     */
     error(expected?: ShellError | string | boolean): this {
+      this._setExpectation("error");
       if (expected === undefined || expected === true) {
         this.expected_error = true;
       } else if (expected === false) {
@@ -167,6 +196,7 @@ export function createTestBuilder(path: string) {
     }
 
     exitCode(expected: number | ((code: number) => void)): this {
+      this._setExpectation("exitCode");
       this.expected_exit_code = expected;
       return this;
     }
@@ -211,21 +241,23 @@ export function createTestBuilder(path: string) {
         if (typeof this.expected_stdout === "string") {
           expect(stdout.toString()).toEqual(this.expected_stdout.replaceAll("$TEMP_DIR", tempdir));
         } else {
-          this.expected_stdout(stdout.toString(), tempdir);
+          checkCallbackReturnedNothing("stdout", this.expected_stdout(stdout.toString(), tempdir));
         }
       }
       if (this.expected_stderr !== undefined) {
         if (typeof this.expected_stderr === "string") {
           expect(stderr.toString()).toEqual(this.expected_stderr.replaceAll("$TEMP_DIR", tempdir));
         } else if (typeof this.expected_stderr === "function") {
-          this.expected_stderr(stderr.toString(), tempdir);
+          checkCallbackReturnedNothing("stderr", this.expected_stderr(stderr.toString(), tempdir));
         } else {
           expect(stderr.toString()).toContain(this.expected_stderr.contains);
         }
       }
       if (typeof this.expected_exit_code === "number") {
         expect(exitCode).toEqual(this.expected_exit_code);
-      } else if (typeof this.expected_exit_code === "function") this.expected_exit_code(exitCode);
+      } else {
+        checkCallbackReturnedNothing("exitCode", this.expected_exit_code(exitCode));
+      }
 
       for (const [filename, expected_raw] of Object.entries(this.file_equals)) {
         const expected = typeof expected_raw === "string" ? expected_raw : await expected_raw();
@@ -239,16 +271,14 @@ export function createTestBuilder(path: string) {
     }
 
     async run(): Promise<undefined> {
+      let output: $.ShellOutput;
       try {
         let finalPromise = Bun.$(this._scriptStr, ...this._expresssions);
         if (this.tempdir) finalPromise = finalPromise.cwd(this.tempdir);
         if (this._cwd) finalPromise = finalPromise.cwd(this._cwd);
         if (this._env) finalPromise = finalPromise.env(this._env);
         if (this._quiet) finalPromise = finalPromise.quiet();
-        const output = await finalPromise;
-
-        const { stdout, stderr, exitCode } = output;
-        await this.doChecks(stdout, stderr, exitCode);
+        output = await finalPromise;
       } catch (err_) {
         const err: ShellError = err_ as any;
         const { stdout, stderr, exitCode } = err;
@@ -256,7 +286,7 @@ export function createTestBuilder(path: string) {
           if (stdout === undefined || stderr === undefined || exitCode === undefined) {
             throw err_;
           }
-          this.doChecks(stdout, stderr, exitCode);
+          await this.doChecks(stdout, stderr, exitCode);
           return;
         }
         if (this.expected_error === true) return undefined;
@@ -273,7 +303,12 @@ export function createTestBuilder(path: string) {
         return undefined;
       }
 
-      // return output;
+      if (this.expected_error !== undefined && this.expected_error !== false) {
+        expect.unreachable(
+          `TestBuilder: expected the command to throw, but it completed with exit code ${output.exitCode}`,
+        );
+      }
+      await this.doChecks(output.stdout, output.stderr, output.exitCode);
     }
 
     todo(reason?: string): this {


### PR DESCRIPTION
### Problem
- Several shell tests looked like they checked stdout, stderr or the exit code but checked nothing. On `main`, `echo hi` with `.stdout(s => s.includes("definitely-not-present"))` passes.
- Two causes: an expectation callback's return value was ignored, so a predicate callback asserted nothing; and each expectation is a single slot, so a second `.stdout()` in a chain replaced the first and only the last one ran.
- Affected: the 14-command "exit codes" table (no exit code was checked), the `cd`-in-pipeline tests, two stderr checks, four `ls` chains and three `describe.todo` chains. The table hid that bare `export` has always exited 0, as in bash.
- Separately, `.error(...)` on a command that completed ran the output checks instead of failing, and on the ShellError path a failing expectation escaped as an unhandled rejection instead of failing `run()`.

### Fix
- The builder rejects the two shapes that can never assert anything: setting the same expectation twice throws while the chain is built, and a callback that returns anything other than `undefined` fails the run. `bun:test` matchers return `undefined`, so existing `s => expect(s)...` callbacks are unaffected.
- `run()` fails when `.error()` was set but the command completed, and awaits the checks on the ShellError path, so every failing expectation now rejects `run()`.
- The affected tests become real assertions, one per chain. `export` leaves the failing table and gets a test pinning its output and exit 0; a case for the cwd after a `cd` pipeline is added. The new expectations match current shell behaviour, so none papers over a shell bug.
- Verification: the new builder tests fail 9 of 14 against the builder on `main` and pass here. All 24 files that use the builder were run with the guards on and only the chains rewritten here tripped. Two `ls` permission-denied tests fail as root before and after, and `leak.test.ts` times out under a debug build regardless of this change.

### Background
- `TestBuilder` (`test/js/bun/shell/test_builder.ts`) is the helper behind most shell tests: `` TestBuilder.command`...` `` followed by `.stdout()`, `.stderr()`, `.exitCode()` or `.error()`, then `.run()` or `.runAsTest(name)`.
- Each expectation method takes a literal or a callback. A callback is meant to call `expect()` itself; the builder never looked at what it returned.
- `$TEMP_DIR` in a string expectation is replaced with the test's temp directory. It is not replaced for callbacks, which is why the `cd` predicates could never have matched.
- `.error()` declares that the command should throw (for example a parse error) rather than complete with an exit code.
- The ShellError path: when a command exits non-zero with `Bun.$` in throwing mode, `run()` catches a `ShellError` carrying stdout, stderr and the exit code and checks the expectations against those.

<details>
<summary>Original description</summary>

### What was wrong

Several shell tests built with `TestBuilder` (`test/js/bun/shell/test_builder.ts`) looked like they asserted something about the output but did not. Two builder behaviours made this possible:

1. The callback form of `.stdout(fn)` / `.stderr(fn)` / `.exitCode(fn)` discarded the callback's return value, so a predicate-style callback asserted nothing. `doChecks()` called `this.expected_stdout(...)` and ignored the result.
2. `.stdout()` (and `.stderr()` / `.exitCode()` / `.error()`) assign a single field, so calling one of them twice in a chain silently replaced the earlier expectation and only the last one ran.

Both are easy to demonstrate against `main`; these pass:

```ts
const TestBuilder = createTestBuilder(import.meta.path);
await TestBuilder.command`echo hi`.stdout(s => s.includes("definitely-not-present")).run();
await TestBuilder.command`echo hi`
  .stdout(() => { throw new Error("never runs"); })
  .stdout(s => expect(s).toBe("hi\n"))
  .run();
```

Call sites affected (found by temporarily instrumenting the builder and running every file that uses it, plus a scan of the chains):

- `bunshell.test.ts` "exit codes": `.exitCode(c => c !== 0)` on 14 commands, so none of them checked the exit code. One entry, bare `export`, has in fact always exited 0 (it prints the exported variables, like bash), which the no-op assertion hid.
- `pipeline_stack.test.ts` "cd builtin in pipelines": three `.stdout(s => s.includes("$TEMP_DIR"))`-style predicates. Doubly inert, since `$TEMP_DIR` is only substituted into string expectations and the third predicate expected two lines from `pwd | cd / | pwd`, whose first `pwd` goes into the pipe.
- `bunshell.test.ts` "nested pipeline mixed success failure": `.stderr(s => s.includes("command not found"))`.
- `bunshell-default.test.ts`: two `.stderr(s => s.includes("1 pass"))`.
- `commands/ls.test.ts`: four chains with 2 to 4 `.stdout(...)` calls (`-A`, `-Ra`, `-RA`, permission denied recursive). The `-A` test, for example, only ran `toContain("regular")`; the `.`/`..` exclusion it is named for was never checked.
- `bunshell.test.ts` condexprs (inside `describe.todo`): three chains with `.stdout("1").stdout("0")`-style pairs.

### Fix

`test_builder.ts`:

- Setting the same expectation twice on one builder throws, naming the expectation. This fires at chain construction, so a bad `runAsTest` chain fails the file immediately.
- A `.stdout()` / `.stderr()` / `.exitCode()` callback that returns anything other than `undefined` fails the run with a message saying the callback has to call `expect()` itself. All `bun:test` matchers return `undefined`, so the existing `s => expect(s).toBe(...)` style keeps working.
- `run()` now fails when `.error(...)` was set but the command completed (previously the output checks ran instead, and with `.error()` and no argument any failure was swallowed), and it awaits `doChecks()` on the ShellError path, where a failing expectation used to escape as an unhandled rejection instead of rejecting `run()`. The output checks also moved out of the `try`, so an assertion failure can no longer be reinterpreted as the thrown error.

Call sites: the predicates are replaced with real assertions (exact `$TEMP_DIR\n` strings for the `cd` pipeline tests, `expect(c).not.toBe(0)` for the exit code table, exact stderr for the nested pipeline test) and the chained `.stdout()` calls are folded into single exact `toEqual` assertions, matching the neighbouring `ls` tests. `export` is dropped from the failing-commands table and `env variables` gets a test pinning that bare `export` prints the exported variables sorted and exits 0. A `cd foo | pwd; pwd` case is added to the pipeline describe since none of the existing cases covered the cwd after the pipeline.

`test_builder.test.ts` pins the builder behaviour: each of the set-twice guards, each return-value guard, `.error()` with and without a throw, and the ShellError path both passing and failing.

### Why this is the right fix

Both broken patterns were written independently several times (seven predicate callbacks across four files, seven chains with repeated calls across two files), so the API itself invites them; fixing only the call sites would leave the next one just as silent. The guards reject exactly the two shapes that can never assert anything, and nothing in the suite relies on either: with the guards in place, every file that uses `TestBuilder` was run and the only chains that tripped are the ones rewritten here. The rewritten expectations were checked against the current shell behaviour (`cd` in a pipeline stage does not change the cwd of the other stages or of the commands after the pipeline, same as bash), so none of them is papering over a shell bug. The two shell bugs the exit-code table happens to exercise (`echo hi > /dev/full` exiting with 65508, and `export foo-bar` succeeding) already have open PRs (#32278, #32298); the table only asserts non-zero, so it is unaffected by either.

### Verification

- `test_builder.test.ts` with the builder from `main`: 9 of 14 fail (the four set-twice cases, the three return-value cases, `.error()` without a throw, and the failing ShellError-path expectation). With this change: 14 pass.
- All 24 `TestBuilder`-based files under `test/js/bun/shell` with a debug build: everything passes except the two `ls` permission-denied tests, which fail as root both before and after this change (they pass when run as an unprivileged user, including the rewritten recursive one), and the `leak.test.ts` iteration tests, which time out under the debug build here regardless of this change and pass with a release build.

</details>
