### PR TITLE
thread pool: report a pool that cannot spawn any worker instead of hanging

### DIFF
--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -249,11 +249,14 @@ impl ThreadPool {
         self.io_pool.as_deref()
     }
 
-    pub(crate) fn start(&self) {
-        self.worker_pool().warm(8);
+    /// Fails only when a pool could not get a single worker; parse tasks
+    /// scheduled on it would then never complete (see `ThreadPoolLib::warm`).
+    pub(crate) fn start(&self) -> Result<(), bun_errno::SystemErrno> {
+        self.worker_pool().warm(8)?;
         if let Some(io) = self.io_pool_ref() {
-            io.warm(1);
+            io.warm(1)?;
         }
+        Ok(())
     }
 
     pub(crate) fn uses_io_pool() -> bool {

--- a/src/bundler/ThreadPool.rs
+++ b/src/bundler/ThreadPool.rs
@@ -249,8 +249,7 @@ impl ThreadPool {
         self.io_pool.as_deref()
     }
 
-    /// Fails only when a pool could not get a single worker; parse tasks
-    /// scheduled on it would then never complete (see `ThreadPoolLib::warm`).
+    /// Fails only if a pool got no worker at all; see `ThreadPoolLib::ThreadPool::warm`.
     pub(crate) fn start(&self) -> Result<(), bun_errno::SystemErrno> {
         self.worker_pool().warm(8)?;
         if let Some(io) = self.io_pool_ref() {

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2960,12 +2960,12 @@ pub mod bv2_impl {
             let mut tp = ThreadPool::init(&*this, thread_pool)?;
             if let Err(errno) = tp.start() {
                 tp.deinit();
+                let hint = bun_threading::thread_pool::thread_limit_hint(errno)
+                    .map_or_else(String::new, |hint| format!(". {hint}"));
                 this.transpiler.log_mut().add_error_fmt(
                     None,
                     bun_ast::Loc::EMPTY,
-                    format_args!(
-                        "Failed to create a worker thread for the bundler: {errno}. The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
-                    ),
+                    format_args!("Failed to create a worker thread for the bundler: {errno}{hint}"),
                 );
                 return Err(Error::ThreadSpawnFailed);
             }

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2957,21 +2957,31 @@ pub mod bv2_impl {
 
             this.linker.dev_server = this.dev_server;
 
-            let tp = ThreadPool::init(&*this, thread_pool)?;
+            let mut tp = ThreadPool::init(&*this, thread_pool)?;
+            if let Err(errno) = tp.start() {
+                tp.deinit();
+                this.transpiler.log_mut().add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!(
+                        "Failed to create a worker thread for the bundler: {errno}. The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
+                    ),
+                );
+                return Err(errno.into());
+            }
             // errdefer this.graph.heap.deinit() — Drop handles arena teardown.
             this.graph.pool = bun_ptr::BackRef::new_mut(this.arena().alloc(tp));
-            // Install the watcher only after `ThreadPool::init()` has succeeded —
-            // the `?` above is the last early-return in this fn, so the watcher's
-            // raw `*mut BundleV2` can't outlive the box it points at (the caller
-            // drops the box on every error path until `generate_from_cli` leaks it).
+            // Install the watcher only after the thread pool is up — the
+            // `start()` check above is the last early-return in this fn, so the
+            // watcher's raw `*mut BundleV2` can't outlive the box it points at
+            // (the caller drops the box on every error path until
+            // `generate_from_cli` leaks it).
             if cli_watch_flag {
                 // CYCLEBREAK GENUINE: hot_reloader is T6; runtime constructs the
                 // `dispatch::WatcherHandle` (erased owner + `&'static WatcherVTable`)
                 // via this extern hook and writes `bun_watcher`.
                 dispatch::enable_hot_module_reloading_for_bundler(core::ptr::from_mut(&mut *this));
             }
-            // `Graph::pool` wraps the `BackRef` deref; `start()` takes `&self`.
-            this.graph.pool().start();
             Ok(this)
         }
 

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2971,11 +2971,9 @@ pub mod bv2_impl {
             }
             // errdefer this.graph.heap.deinit() — Drop handles arena teardown.
             this.graph.pool = bun_ptr::BackRef::new_mut(this.arena().alloc(tp));
-            // Install the watcher only after the thread pool is up — the
-            // `start()` check above is the last early-return in this fn, so the
-            // watcher's raw `*mut BundleV2` can't outlive the box it points at
-            // (the caller drops the box on every error path until
-            // `generate_from_cli` leaks it).
+            // Install the watcher only after the last early-return above, so the watcher's
+            // raw `*mut BundleV2` can't outlive the box it points at (the caller
+            // drops the box on every error path until `generate_from_cli` leaks it).
             if cli_watch_flag {
                 // CYCLEBREAK GENUINE: hot_reloader is T6; runtime constructs the
                 // `dispatch::WatcherHandle` (erased owner + `&'static WatcherVTable`)

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2967,7 +2967,7 @@ pub mod bv2_impl {
                         "Failed to create a worker thread for the bundler: {errno}. The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
                     ),
                 );
-                return Err(errno.into());
+                return Err(Error::ThreadSpawnFailed);
             }
             // errdefer this.graph.heap.deinit() — Drop handles arena teardown.
             this.graph.pool = bun_ptr::BackRef::new_mut(this.arena().alloc(tp));

--- a/src/bundler/error.rs
+++ b/src/bundler/error.rs
@@ -38,9 +38,7 @@ pub enum Error {
     FormatError,
     #[error("ResolveMessage")]
     ResolveMessage,
-    /// The bundle's thread pool could not get a single worker; the OS error is
-    /// in the log. `BundleV2::init` raises it before anything else (the CLI's
-    /// watcher included) exists, so callers must not wait on a rebuild.
+    /// The pool got no worker at all (OS error in the log); `BundleV2::init` raises it before the CLI watcher exists.
     #[error("ThreadSpawnFailed")]
     ThreadSpawnFailed,
     #[error("JSError")]

--- a/src/bundler/error.rs
+++ b/src/bundler/error.rs
@@ -38,6 +38,11 @@ pub enum Error {
     FormatError,
     #[error("ResolveMessage")]
     ResolveMessage,
+    /// The bundle's thread pool could not get a single worker; the OS error is
+    /// in the log. `BundleV2::init` raises it before anything else (the CLI's
+    /// watcher included) exists, so callers must not wait on a rebuild.
+    #[error("ThreadSpawnFailed")]
+    ThreadSpawnFailed,
     #[error("JSError")]
     Js(bun_core::JsError),
     #[error(transparent)]
@@ -123,6 +128,7 @@ impl Error {
             Self::EmptyAST => "EmptyAST",
             Self::FormatError => "FormatError",
             Self::ResolveMessage => "ResolveMessage",
+            Self::ThreadSpawnFailed => "ThreadSpawnFailed",
             Self::Js(bun_core::JsError::OutOfMemory) => "OutOfMemory",
             Self::Js(_) => "JSError",
             Self::Sys(e) => <&'static str>::from(e),

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -305,16 +305,12 @@ pub fn from_errno(errno: i32) -> SystemErrno {
 }
 
 impl SystemErrno {
-    /// The OS error behind a `std::io::Error` (e.g. from a failed
-    /// `std::thread::Builder::spawn`). `None` when the error did not come from
-    /// the OS or its code has no `SystemErrno`.
+    /// The OS error behind a `std::io::Error`; `None` if it is not an OS error or its code has no `SystemErrno`.
     pub fn from_io_error(err: &std::io::Error) -> Option<SystemErrno> {
         let code = err.raw_os_error()?;
         #[cfg(windows)]
         {
-            // A `GetLastError()` code: the `u32` entry point maps it through
-            // the Win32 → errno table, whereas `i64` would read it as an errno
-            // discriminant.
+            // A Win32 code: the `u32` entry point maps it, `i64` would read it as an errno discriminant.
             SystemErrno::init(code as u32)
         }
         #[cfg(not(windows))]
@@ -533,9 +529,7 @@ mod errno_name_tests {
         );
         #[cfg(windows)]
         {
-            // `raw_os_error()` holds Win32 codes there: ERROR_NOT_ENOUGH_MEMORY
-            // and ERROR_ACCESS_DENIED, which would read as ENOEXEC and EIO if
-            // taken for errno values.
+            // Win32 ERROR_NOT_ENOUGH_MEMORY and ERROR_ACCESS_DENIED; read as errno values, 8 and 5 would be ENOEXEC and EIO.
             assert_eq!(
                 SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(8)),
                 Some(SystemErrno::ENOMEM)

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -524,6 +524,34 @@ mod errno_name_tests {
     }
 
     #[test]
+    fn io_error_to_errno() {
+        // Deliberately not EAGAIN, which is what the callers fall back to.
+        #[cfg(not(windows))]
+        assert_eq!(
+            SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(libc::ENOMEM)),
+            Some(SystemErrno::ENOMEM)
+        );
+        #[cfg(windows)]
+        {
+            // `raw_os_error()` holds Win32 codes there: ERROR_NOT_ENOUGH_MEMORY
+            // and ERROR_ACCESS_DENIED, which would read as ENOEXEC and EIO if
+            // taken for errno values.
+            assert_eq!(
+                SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(8)),
+                Some(SystemErrno::ENOMEM)
+            );
+            assert_eq!(
+                SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(5)),
+                Some(SystemErrno::EPERM)
+            );
+        }
+        assert_eq!(
+            SystemErrno::from_io_error(&std::io::Error::other("not from the OS")),
+            None
+        );
+    }
+
+    #[test]
     fn coreutils_map() {
         assert_eq!(
             coreutils_error_map::get(2),

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -304,6 +304,26 @@ pub fn from_errno(errno: i32) -> SystemErrno {
     SystemErrno::init(errno as i64).unwrap_or(SystemErrno::EIO)
 }
 
+impl SystemErrno {
+    /// The OS error behind a `std::io::Error` (e.g. from a failed
+    /// `std::thread::Builder::spawn`). `None` when the error did not come from
+    /// the OS or its code has no `SystemErrno`.
+    pub fn from_io_error(err: &std::io::Error) -> Option<SystemErrno> {
+        let code = err.raw_os_error()?;
+        #[cfg(windows)]
+        {
+            // A `GetLastError()` code: the `u32` entry point maps it through
+            // the Win32 → errno table, whereas `i64` would read it as an errno
+            // discriminant.
+            SystemErrno::init(code as u32)
+        }
+        #[cfg(not(windows))]
+        {
+            SystemErrno::init(i64::from(code))
+        }
+    }
+}
+
 #[cfg(not(windows))]
 impl SystemErrno {
     // `i64` covers every concrete call site (errno-range values).

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3202,7 +3202,7 @@ impl DevServer {
         // `server_transpiler` (`&'a mut`) and `client/ssr_transpiler`
         // (NonNull) don't trip the single-`&mut self` rule.
         let self_ptr = std::ptr::from_mut::<Self>(self);
-        let mut bv2: Box<BundleV2<'static>> = BundleV2::init(
+        let bv2 = BundleV2::init(
             // SAFETY: `server_transpiler` outlives `bv2` (held by `self`).
             unsafe { (*self_ptr).server_transpiler.assume_init_mut() },
             Some(bundler::bundle_v2::BakeOptions {
@@ -3228,7 +3228,19 @@ impl DevServer {
             )),
             // SAFETY: see `heap_ptr` note above.
             unsafe { &*heap_ptr },
-        )?;
+        );
+        let mut bv2: Box<BundleV2<'static>> = match bv2 {
+            Ok(bv2) => bv2,
+            // The worker pool could not get a single thread; `init` put the
+            // reason in `self.log`. No bundle can run while that holds, and the
+            // callers of this fn abort on any error, so exit showing the reason
+            // rather than with a crash report.
+            Err(bundler::Error::Sys(_)) => {
+                let _ = self.log.print(std::ptr::from_mut(Output::error_writer()));
+                bun_core::Global::exit(1);
+            }
+            Err(err) => return Err(err.into()),
+        };
         bv2.bun_watcher = Some(::core::ptr::NonNull::from(&mut **self.bun_watcher));
         bv2.asynchronous = true;
         let dev_handle = self.bundler_handle();

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3231,11 +3231,10 @@ impl DevServer {
         );
         let mut bv2: Box<BundleV2<'static>> = match bv2 {
             Ok(bv2) => bv2,
-            // The worker pool could not get a single thread; `init` put the
-            // reason in `self.log`. No bundle can run while that holds, and the
-            // callers of this fn abort on any error, so exit showing the reason
-            // rather than with a crash report.
-            Err(bundler::Error::Sys(_)) => {
+            // `init` put the OS error in `self.log`. No bundle can run while
+            // that holds, and the callers of this fn abort on any error, so exit
+            // showing the reason rather than with a crash report.
+            Err(bundler::Error::ThreadSpawnFailed) => {
                 let _ = self.log.print(std::ptr::from_mut(Output::error_writer()));
                 bun_core::Global::exit(1);
             }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3231,9 +3231,7 @@ impl DevServer {
         );
         let mut bv2: Box<BundleV2<'static>> = match bv2 {
             Ok(bv2) => bv2,
-            // `init` put the OS error in `self.log`. No bundle can run while
-            // that holds, and the callers of this fn abort on any error, so exit
-            // showing the reason rather than with a crash report.
+            // The reason is in `self.log`; the callers abort on any error here, so exit showing it instead of a crash report.
             Err(bundler::Error::ThreadSpawnFailed) => {
                 let _ = self.log.print(std::ptr::from_mut(Output::error_writer()));
                 bun_core::Global::exit(1);

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -655,7 +655,11 @@ impl BuildCommand {
                     }
 
                     Output::flush();
-                    exit_or_watch(1, ctx.debug.hot_reload == HotReload::Watch);
+                    // `BundleV2::init` fails with this before it installs the
+                    // watcher, so there is nothing that could trigger a rebuild.
+                    let watch = ctx.debug.hot_reload == HotReload::Watch
+                        && err != bun_bundler::Error::ThreadSpawnFailed;
+                    exit_or_watch(1, watch);
                 }
             };
 

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -655,8 +655,7 @@ impl BuildCommand {
                     }
 
                     Output::flush();
-                    // `BundleV2::init` fails with this before it installs the
-                    // watcher, so there is nothing that could trigger a rebuild.
+                    // Raised before the watcher is installed, so nothing could ever trigger a rebuild.
                     let watch = ctx.debug.hot_reload == HotReload::Watch
                         && err != bun_bundler::Error::ThreadSpawnFailed;
                     exit_or_watch(1, watch);

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -707,6 +707,12 @@ pub const DEFAULT_THREAD_STACK_SIZE: u32 = {
     }
 };
 
+struct SpawnFailed {
+    errno: SystemErrno,
+    /// Workers (and spawns still in flight) the pool had left once the failed spawn's slot was released.
+    workers_left: u16,
+}
+
 /// Nothing will ever run the queued tasks and `schedule()` has no caller to return an error to, so this is the only way to report it.
 #[cold]
 #[inline(never)]
@@ -748,17 +754,20 @@ impl ThreadPool {
                 sync = current;
                 continue;
             }
-            let pool_was_empty = sync.spawned() == 0;
-            if let Err(errno) = self.spawn_worker(pool_was_empty) {
-                return if pool_was_empty { Err(errno) } else { Ok(()) };
+            if let Err(failed) = self.spawn_worker(sync.spawned() == 0) {
+                return if failed.workers_left == 0 {
+                    Err(failed.errno)
+                } else {
+                    Ok(())
+                };
             }
             sync = new_sync;
         }
         Ok(())
     }
 
-    /// Spawns the worker whose `spawned` slot the caller just took; on failure the slot is released and the OS error returned.
-    fn spawn_worker(&self, pool_was_empty: bool) -> Result<(), SystemErrno> {
+    /// Spawns the worker whose `spawned` slot the caller just took; on failure the slot is released again.
+    fn spawn_worker(&self, pool_was_empty: bool) -> Result<(), SpawnFailed> {
         let stack_size = self.stack_size as usize;
         let spawn = || {
             // `BackRef<ThreadPool>: Send` (ThreadPool is `Sync`); pool's `join()`
@@ -787,7 +796,10 @@ impl ThreadPool {
         if workers_left == 0 && self.wait_group.pending() > 0 {
             exit_with_stranded_tasks(errno);
         }
-        Err(errno)
+        Err(SpawnFailed {
+            errno,
+            workers_left,
+        })
     }
 
     #[inline(never)]

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -32,6 +32,7 @@ use core::sync::atomic::{AtomicBool, AtomicPtr, AtomicU32, AtomicU64, AtomicUsiz
 
 use crate::{Futex, WaitGroup};
 use bun_core::Output;
+use bun_sys::SystemErrno;
 
 /// Debug instrumentation: when `BUN_THREADPOOL_STATS=1`, each pool records
 /// aggregate worker idle/busy nanoseconds and dumps them on drop. Zero-cost
@@ -706,6 +707,21 @@ pub const DEFAULT_THREAD_STACK_SIZE: u32 = {
     }
 };
 
+/// See [`ThreadPool::spawn_worker`].
+#[cold]
+#[inline(never)]
+fn exit_with_stranded_tasks(errno: SystemErrno) -> ! {
+    Output::err(
+        errno,
+        "failed to create a worker thread for the thread pool; the work already queued on it could never run",
+        (),
+    );
+    bun_core::note!(
+        "the process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency"
+    );
+    bun_core::Global::exit(1)
+}
+
 // NOTE: a `prewarm_mimalloc_numa()` helper was tried here to call
 // `_mi_os_numa_node_count()` once on the spawning thread so workers don't race
 // the `/sys/devices/system/node/node%u` slow path, but mimalloc is built as
@@ -716,7 +732,12 @@ pub const DEFAULT_THREAD_STACK_SIZE: u32 = {
 impl ThreadPool {
     /// Warm the thread pool up to the given number of threads.
     /// https://www.youtube.com/watch?v=ys3qcbO5KWw
-    pub fn warm(&self, count: u16) {
+    ///
+    /// Workers only exit at shutdown, so once the pool has one it stays usable
+    /// and a failed spawn merely ends the warm-up. The error is the OS refusing
+    /// the pool its *first* worker: nothing scheduled afterwards could run, and
+    /// a caller that warms before scheduling can still fail cleanly.
+    pub fn warm(&self, count: u16) -> Result<(), SystemErrno> {
         // Thread counts are 14-bit fields in `Sync`; truncate to 14 bits.
         self.is_running.store(true, Ordering::Relaxed);
         let target = count.min((self.max_threads & 0x3FFF) as u16);
@@ -731,26 +752,58 @@ impl ThreadPool {
                 sync = current;
                 continue;
             }
-            let stack_size = self.stack_size as usize;
-            // `BackRef<ThreadPool>: Send` (ThreadPool is `Sync`); pool's `join()`
-            // waits for every worker, so the back-reference invariant holds.
-            let pool = bun_ptr::BackRef::new(self);
-            match std::thread::Builder::new()
-                .stack_size(stack_size)
-                .spawn(move || Thread::run(pool))
-            {
-                Ok(_handle) => {
-                    // Dropping JoinHandle detaches the thread.
-                }
-                Err(_) => {
-                    // SAFETY: `&self` keeps the pool live; `null` thread makes
-                    // `unregister` return right after undoing the `spawned`
-                    // increment CAS'd above (no per-thread wait past notify).
-                    return unsafe { Self::unregister(self, ptr::null_mut()) };
-                }
+            let pool_was_empty = sync.spawned() == 0;
+            if let Err(errno) = self.spawn_worker(pool_was_empty) {
+                return if pool_was_empty { Err(errno) } else { Ok(()) };
             }
             sync = new_sync;
         }
+        Ok(())
+    }
+
+    /// Spawns the worker whose `spawned` slot the caller just CAS'd into
+    /// `sync`; on failure the slot is released again and the OS error returned.
+    ///
+    /// The pool's first worker (`pool_was_empty`) gets one retry, as in
+    /// `Watcher::start`: `EAGAIN` from `pthread_create` is often momentary
+    /// (a fork storm, an exec'd image's threads not reaped yet), and unlike a
+    /// later spawn, whose failure only costs parallelism, this one failing
+    /// leaves the pool unable to run anything.
+    ///
+    /// When that happens with tasks already queued, nothing can ever run them.
+    /// `schedule()` is fire-and-forget, so there is no caller to hand the error
+    /// to; whoever waits on those tasks (`wait_for_all()`, the bundler's or
+    /// `bun install`'s event loop, a `node:fs` promise) would wait forever.
+    /// Exiting with the error is the only way left to report it.
+    fn spawn_worker(&self, pool_was_empty: bool) -> Result<(), SystemErrno> {
+        let stack_size = self.stack_size as usize;
+        let spawn = || {
+            // `BackRef<ThreadPool>: Send` (ThreadPool is `Sync`); pool's `join()`
+            // waits for every worker, so the back-reference invariant holds.
+            let pool = bun_ptr::BackRef::new(self);
+            std::thread::Builder::new()
+                .stack_size(stack_size)
+                .spawn(move || Thread::run(pool))
+        };
+        let spawned = spawn().or_else(|first| {
+            if !pool_was_empty {
+                return Err(first);
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+            spawn().map_err(|_| first)
+        });
+        let err = match spawned {
+            // Dropping the JoinHandle detaches the thread.
+            Ok(_handle) => return Ok(()),
+            Err(err) => err,
+        };
+        let errno = SystemErrno::from_io_error(&err).unwrap_or(SystemErrno::EAGAIN);
+        // SAFETY: `&self` keeps the pool live for the whole call.
+        let workers_left = unsafe { Self::unspawn(self) };
+        if workers_left == 0 && self.wait_group.pending() > 0 {
+            exit_with_stranded_tasks(errno);
+        }
+        Err(errno)
     }
 
     #[inline(never)]
@@ -794,26 +847,12 @@ impl ThreadPool {
                             return self.idle_event.notify();
                         }
 
-                        // We signaled to spawn a new thread
+                        // We signaled to spawn a new thread. A failure needs no
+                        // handling here: either the existing workers drain the
+                        // queue on their own, or `spawn_worker` found the queued
+                        // tasks stranded and did not return.
                         if can_wake && (sync.spawned() as u32) < self.max_threads {
-                            let stack_size = self.stack_size as usize;
-                            // `BackRef<ThreadPool>: Send`; see `warm()`.
-                            let pool = bun_ptr::BackRef::new(self);
-                            match std::thread::Builder::new()
-                                .stack_size(stack_size)
-                                .spawn(move || Thread::run(pool))
-                            {
-                                Ok(_handle) => {
-                                    // detach by dropping
-                                }
-                                Err(_) => {
-                                    // SAFETY: `&self` keeps the pool live; `null` thread makes
-                                    // `unregister` return right after undoing the `spawned`
-                                    // increment CAS'd above (no per-thread wait past notify).
-                                    return unsafe { Self::unregister(self, ptr::null_mut()) };
-                                }
-                            }
-                            return;
+                            let _ = self.spawn_worker(sync.spawned() == 0);
                         }
 
                         return;
@@ -944,41 +983,56 @@ impl ThreadPool {
         }
     }
 
+    /// Un-spawn one thread, either because spawning it failed or because it is
+    /// exiting. Returns the number of workers the pool still counts (running
+    /// ones plus spawns in flight).
+    ///
     /// # Safety
-    /// `pool` is the worker's owning pool. After `(*pool).join_event.notify()`
-    /// the joiner may return and the pool may be **deallocated**, so this fn
-    /// takes `*const Self` (no `&self` protector) and never touches `pool`
-    /// past that point — the shutdown chain follows worker-stack `.next` links.
-    unsafe fn unregister(pool: *const Self, maybe_thread: *mut Thread) {
-        // Un-spawn one thread, either due to a failed OS thread spawning or the thread is exiting.
+    /// `pool` must be live on entry. After `(*pool).join_event.notify()` the
+    /// joiner may return and the pool may be **deallocated**, so this fn takes
+    /// `*const Self` (no `&self` protector), never touches `pool` past that
+    /// point, and callers must not touch it after this returns unless they
+    /// hold a `&self` of their own.
+    unsafe fn unspawn(pool: *const Self) -> u16 {
         let one_spawned = {
             let mut s = Sync::zero();
             s.set_spawned(1);
             s
         };
+        // The Acquire half pairs with the Release of an earlier un-spawn by
+        // another thread: observing its decrement also makes the
+        // `wait_group.add()` its `schedule()` did visible to `spawn_worker`'s
+        // stranded-tasks check.
         // SAFETY: `pool` is live until at least the `join_event.notify()` below
         // wakes the joiner.
-        let sync = unsafe { (*pool).sync.fetch_sub(one_spawned, Ordering::Release) };
+        let sync = unsafe { (*pool).sync.fetch_sub(one_spawned, Ordering::AcqRel) };
         debug_assert!(sync.spawned() > 0);
+        let workers_left = sync.spawned() - 1;
 
         // The last thread to exit must wake up the thread pool join()er
         // who will start the chain to shutdown all the threads.
-        if sync.state() == SyncState::Shutdown && sync.spawned() == 1 {
+        if sync.state() == SyncState::Shutdown && workers_left == 0 {
             // SAFETY: `pool` is live until this notify wakes the joiner (same
             // invariant as the `fetch_sub` above); not touched after this line.
             unsafe { (*pool).join_event.notify() };
         }
+        workers_left
+    }
+
+    /// # Safety
+    /// `pool` is the worker's owning pool; see [`Self::unspawn`] — it may be
+    /// deallocated once that returns, so the shutdown chain below follows
+    /// worker-stack `.next` links only. `thread` is the calling worker's own
+    /// stack-local `Thread` (set in `ThreadRegistration::new`).
+    unsafe fn unregister(pool: *const Self, thread: NonNull<Thread>) {
+        // SAFETY: per the contract above, `pool` is live on entry.
+        unsafe { Self::unspawn(pool) };
         // ── `*pool` may be invalid past this point. ──
 
-        // If this is a thread pool thread, wait for a shutdown signal by the thread pool join()er.
-        let Some(thread) = NonNull::new(maybe_thread) else {
-            return;
-        };
-        // `maybe_thread` is the calling worker's own stack-local `Thread`
-        // (set in `ThreadRegistration::new`); it lives on this OS thread's
-        // stack and outlives the entire `unregister` call. BackRef invariant
-        // — pointee outlives holder — covers the `join_event.wait()` and
-        // `.next` reads below.
+        // Wait for a shutdown signal by the thread pool join()er.
+        // `thread` lives on this OS thread's stack and outlives the entire
+        // `unregister` call. BackRef invariant — pointee outlives holder —
+        // covers the `join_event.wait()` and `.next` reads below.
         let thread = bun_ptr::BackRef::from(thread);
         thread.join_event.wait();
 
@@ -1055,14 +1109,14 @@ thread_local! {
 /// worker, so it strictly outlives this guard.
 struct ThreadRegistration {
     pool: bun_ptr::BackRef<ThreadPool>,
-    thread: *mut Thread,
+    thread: NonNull<Thread>,
 }
 
 impl ThreadRegistration {
     /// SAFETY: `thread` must point to the caller's stack-local `Thread`.
-    unsafe fn new(pool: &ThreadPool, thread: *mut Thread) -> Self {
-        CURRENT.with(|c| c.set(thread));
-        pool.register(thread);
+    unsafe fn new(pool: &ThreadPool, thread: NonNull<Thread>) -> Self {
+        CURRENT.with(|c| c.set(thread.as_ptr()));
+        pool.register(thread.as_ptr());
         Self {
             pool: bun_ptr::BackRef::new(pool),
             thread,
@@ -1185,12 +1239,13 @@ impl Thread {
             run_buffer: node::Buffer::default(),
             thread_pool,
         };
-        let self_ptr: *mut Thread = &raw mut self_;
+        let self_nonnull = NonNull::from(&mut self_);
+        let self_ptr: *mut Thread = self_nonnull.as_ptr();
         // `BackRef` invariant: pool's `join()` waits for every worker, so the
         // pointee outlives this fn. Hoist a single shared ref for the hot loop.
         let pool: &ThreadPool = thread_pool.get();
-        // SAFETY: self_ptr is our stack-local Thread.
-        let _registration = unsafe { ThreadRegistration::new(pool, self_ptr) };
+        // SAFETY: self_nonnull is our stack-local Thread.
+        let _registration = unsafe { ThreadRegistration::new(pool, self_nonnull) };
 
         let stats = stats_enabled();
         let mut is_waking = false;

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -707,7 +707,7 @@ pub const DEFAULT_THREAD_STACK_SIZE: u32 = {
     }
 };
 
-/// See [`ThreadPool::spawn_worker`].
+/// Nothing will ever run the queued tasks and `schedule()` has no caller to return an error to, so this is the only way to report it.
 #[cold]
 #[inline(never)]
 fn exit_with_stranded_tasks(errno: SystemErrno) -> ! {
@@ -731,12 +731,8 @@ fn exit_with_stranded_tasks(errno: SystemErrno) -> ! {
 
 impl ThreadPool {
     /// Warm the thread pool up to the given number of threads.
+    /// Fails only if the pool got no worker at all; workers never exit before shutdown, so a later failure just ends the warm-up.
     /// https://www.youtube.com/watch?v=ys3qcbO5KWw
-    ///
-    /// Workers only exit at shutdown, so once the pool has one it stays usable
-    /// and a failed spawn merely ends the warm-up. The error is the OS refusing
-    /// the pool its *first* worker: nothing scheduled afterwards could run, and
-    /// a caller that warms before scheduling can still fail cleanly.
     pub fn warm(&self, count: u16) -> Result<(), SystemErrno> {
         // Thread counts are 14-bit fields in `Sync`; truncate to 14 bits.
         self.is_running.store(true, Ordering::Relaxed);
@@ -761,20 +757,7 @@ impl ThreadPool {
         Ok(())
     }
 
-    /// Spawns the worker whose `spawned` slot the caller just CAS'd into
-    /// `sync`; on failure the slot is released again and the OS error returned.
-    ///
-    /// The pool's first worker (`pool_was_empty`) gets one retry, as in
-    /// `Watcher::start`: `EAGAIN` from `pthread_create` is often momentary
-    /// (a fork storm, an exec'd image's threads not reaped yet), and unlike a
-    /// later spawn, whose failure only costs parallelism, this one failing
-    /// leaves the pool unable to run anything.
-    ///
-    /// When that happens with tasks already queued, nothing can ever run them.
-    /// `schedule()` is fire-and-forget, so there is no caller to hand the error
-    /// to; whoever waits on those tasks (`wait_for_all()`, the bundler's or
-    /// `bun install`'s event loop, a `node:fs` promise) would wait forever.
-    /// Exiting with the error is the only way left to report it.
+    /// Spawns the worker whose `spawned` slot the caller just took; on failure the slot is released and the OS error returned.
     fn spawn_worker(&self, pool_was_empty: bool) -> Result<(), SystemErrno> {
         let stack_size = self.stack_size as usize;
         let spawn = || {
@@ -786,6 +769,7 @@ impl ThreadPool {
                 .spawn(move || Thread::run(pool))
         };
         let spawned = spawn().or_else(|first| {
+            // EAGAIN is often momentary (as in `Watcher::start`); only the first worker is worth a retry, later ones just add parallelism.
             if !pool_was_empty {
                 return Err(first);
             }
@@ -847,10 +831,7 @@ impl ThreadPool {
                             return self.idle_event.notify();
                         }
 
-                        // We signaled to spawn a new thread. A failure needs no
-                        // handling here: either the existing workers drain the
-                        // queue on their own, or `spawn_worker` found the queued
-                        // tasks stranded and did not return.
+                        // We signaled to spawn a new thread. On failure the existing workers drain the queue; if there were none, `spawn_worker` did not return.
                         if can_wake && (sync.spawned() as u32) < self.max_threads {
                             let _ = self.spawn_worker(sync.spawned() == 0);
                         }
@@ -983,26 +964,15 @@ impl ThreadPool {
         }
     }
 
-    /// Un-spawn one thread, either because spawning it failed or because it is
-    /// exiting. Returns the number of workers the pool still counts (running
-    /// ones plus spawns in flight).
-    ///
-    /// # Safety
-    /// `pool` must be live on entry. After `(*pool).join_event.notify()` the
-    /// joiner may return and the pool may be **deallocated**, so this fn takes
-    /// `*const Self` (no `&self` protector), never touches `pool` past that
-    /// point, and callers must not touch it after this returns unless they
-    /// hold a `&self` of their own.
+    /// Releases one `spawned` slot (failed spawn or exiting worker); returns how many the pool still counts.
+    /// SAFETY: `pool` is live on entry. Once this returns the joiner may have freed it, unless the caller holds a `&self`.
     unsafe fn unspawn(pool: *const Self) -> u16 {
         let one_spawned = {
             let mut s = Sync::zero();
             s.set_spawned(1);
             s
         };
-        // The Acquire half pairs with the Release of an earlier un-spawn by
-        // another thread: observing its decrement also makes the
-        // `wait_group.add()` its `schedule()` did visible to `spawn_worker`'s
-        // stranded-tasks check.
+        // Acquire: seeing another thread's release of its slot must also show the `wait_group.add()` behind it (`spawn_worker`).
         // SAFETY: `pool` is live until at least the `join_event.notify()` below
         // wakes the joiner.
         let sync = unsafe { (*pool).sync.fetch_sub(one_spawned, Ordering::AcqRel) };
@@ -1019,20 +989,13 @@ impl ThreadPool {
         workers_left
     }
 
-    /// # Safety
-    /// `pool` is the worker's owning pool; see [`Self::unspawn`] — it may be
-    /// deallocated once that returns, so the shutdown chain below follows
-    /// worker-stack `.next` links only. `thread` is the calling worker's own
-    /// stack-local `Thread` (set in `ThreadRegistration::new`).
+    /// SAFETY: `pool` as for [`Self::unspawn`]; `thread` is the calling worker's own stack-local `Thread`.
     unsafe fn unregister(pool: *const Self, thread: NonNull<Thread>) {
         // SAFETY: per the contract above, `pool` is live on entry.
         unsafe { Self::unspawn(pool) };
         // ── `*pool` may be invalid past this point. ──
 
-        // Wait for a shutdown signal by the thread pool join()er.
-        // `thread` lives on this OS thread's stack and outlives the entire
-        // `unregister` call. BackRef invariant — pointee outlives holder —
-        // covers the `join_event.wait()` and `.next` reads below.
+        // Wait for the shutdown signal from `join()`; `thread` is our own stack slot, so it outlives this call.
         let thread = bun_ptr::BackRef::from(thread);
         thread.join_event.wait();
 

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -713,6 +713,13 @@ struct SpawnFailed {
     workers_left: u16,
 }
 
+/// Remedy for a failed thread spawn. Only EAGAIN points at a limit; ENOMEM (what Windows reports), EPERM or EINVAL do not.
+pub fn thread_limit_hint(errno: SystemErrno) -> Option<&'static str> {
+    (errno == SystemErrno::EAGAIN).then_some(
+        "The process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency",
+    )
+}
+
 /// Nothing will ever run the queued tasks and `schedule()` has no caller to return an error to, so this is the only way to report it.
 #[cold]
 #[inline(never)]
@@ -722,9 +729,9 @@ fn exit_with_stranded_tasks(errno: SystemErrno) -> ! {
         "failed to create a worker thread for the thread pool; the work already queued on it could never run",
         (),
     );
-    bun_core::note!(
-        "the process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency"
-    );
+    if let Some(hint) = thread_limit_hint(errno) {
+        bun_core::note!("{}", hint);
+    }
     bun_core::Global::exit(1)
 }
 

--- a/src/threading/WaitGroup.rs
+++ b/src/threading/WaitGroup.rs
@@ -42,6 +42,11 @@ impl WaitGroup {
         self.add(1);
     }
 
+    /// `add`s not yet matched by a `finish`.
+    pub(crate) fn pending(&self) -> usize {
+        self.raw_count.load(Ordering::Acquire)
+    }
+
     pub fn finish(&self) {
         // Fast path: decrement lock-free while there are other outstanding
         // tasks. We cannot unconditionally `fetch_sub(1)` and then lock/signal

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -256,20 +256,9 @@ impl Watcher {
         });
         self.thread = Some(handle.map_err(|e| {
             self.watchloop_handle.store(false);
-            // Windows: raw_os_error() is a Win32 GetLastError() code, so
-            // route it through the u32 (Win32Error) mapper rather than
-            // from_errno's i64 discriminant-cast path.
-            #[cfg(windows)]
-            let errno = e
-                .raw_os_error()
-                .and_then(|c| bun_errno::SystemErrno::init(c as u32))
-                .unwrap_or(bun_errno::SystemErrno::EAGAIN);
-            #[cfg(not(windows))]
-            let errno = e
-                .raw_os_error()
-                .map(bun_errno::from_errno)
-                .unwrap_or(bun_errno::SystemErrno::EAGAIN);
-            crate::Error::Sys(errno)
+            crate::Error::Sys(
+                bun_errno::SystemErrno::from_io_error(&e).unwrap_or(bun_errno::SystemErrno::EAGAIN),
+            )
         })?);
         Ok(())
     }

--- a/test/js/bun/sys/thread-pool-spawn-failure.test.ts
+++ b/test/js/bun/sys/thread-pool-spawn-failure.test.ts
@@ -8,6 +8,7 @@
 // only kills a timed-out test's dangling children for non-concurrent tests.
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { constants } from "node:os";
 import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
@@ -21,8 +22,9 @@ const skip = !isLinux || !cc;
 // client thread, which also uses this size; see the install test.
 const POOL_WORKER_STACK_SIZE = 4 * 1024 * 1024;
 
-// POOL_SPAWN_PLAN is one letter per spawn attempt of such a thread, 'f' = fail
-// with EAGAIN, 's' = succeed; the last letter repeats for every further attempt.
+// POOL_SPAWN_PLAN is one letter per spawn attempt of such a thread, 'f' = fail,
+// 's' = succeed; the last letter repeats for every further attempt. Failures
+// return EAGAIN unless POOL_SPAWN_ERRNO names another errno value.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -34,12 +36,15 @@ const SHIM_C = /* c */ `
 static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
 static const char *plan;
 static size_t plan_len;
+static int fail_errno = EAGAIN;
 static int attempts;
 
 __attribute__((constructor)) static void init(void) {
   real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
   plan = getenv("POOL_SPAWN_PLAN");
   plan_len = plan ? strlen(plan) : 0;
+  const char *err = getenv("POOL_SPAWN_ERRNO");
+  if (err) fail_errno = atoi(err);
 }
 
 int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(void *), void *arg) {
@@ -47,7 +52,7 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)
   if (attr) pthread_attr_getstacksize(attr, &stack_size);
   if (stack_size == ${POOL_WORKER_STACK_SIZE} && plan_len > 0) {
     size_t i = __sync_fetch_and_add(&attempts, 1);
-    if (plan[i < plan_len ? i : plan_len - 1] == 'f') return EAGAIN;
+    if (plan[i < plan_len ? i : plan_len - 1] == 'f') return fail_errno;
   }
   return real_pthread_create(thread, attr, start, arg);
 }
@@ -114,12 +119,17 @@ afterAll(() => {
   dir?.[Symbol.dispose]();
 });
 
-function spawnWithPlan(plan: string, ...args: string[]) {
+function spawnWithPlan(plan: string, args: string[], errno?: number) {
   const existing = bunEnv.LD_PRELOAD;
   return Bun.spawn({
     cmd: [bunExe(), ...args],
     cwd: String(dir),
-    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath, POOL_SPAWN_PLAN: plan },
+    env: {
+      ...bunEnv,
+      LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+      POOL_SPAWN_PLAN: plan,
+      ...(errno === undefined ? {} : { POOL_SPAWN_ERRNO: String(errno) }),
+    },
     stdout: "pipe",
     stderr: "pipe",
     // Kill switch: without the fix every 'f'-only run below waits forever for
@@ -129,16 +139,17 @@ function spawnWithPlan(plan: string, ...args: string[]) {
   });
 }
 
-async function runWithPlan(plan: string, ...args: string[]) {
-  await using proc = spawnWithPlan(plan, ...args);
+async function runWithPlan(plan: string, args: string[], errno?: number) {
+  await using proc = spawnWithPlan(plan, args, errno);
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signalCode: proc.signalCode };
 }
 
 // The bundler warms its pool before scheduling anything, so it can report the
 // failure through its own log.
-const BUNDLER_ERROR =
-  "Failed to create a worker thread for the bundler: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).";
+function bundlerError(errno: string) {
+  return `Failed to create a worker thread for the bundler: ${errno}. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).`;
+}
 
 // Pools that are only ever fed through fire-and-forget schedule() calls have
 // nobody to return the error to; the process exits with it instead of hanging.
@@ -148,21 +159,41 @@ const STRANDED_TASKS_STDERR = [
 ].join("\n");
 
 test.skipIf(skip)("bun build reports a bundler pool that cannot spawn any worker and exits", async () => {
-  expect(await runWithPlan("f", "build", "entry.js")).toEqual({
+  expect(await runWithPlan("f", ["build", "entry.js"])).toEqual({
     stdout: "",
-    stderr: `error: ${BUNDLER_ERROR}`,
+    stderr: `error: ${bundlerError("EAGAIN")}`,
+    exitCode: 1,
+    signalCode: null,
+  });
+});
+
+test.skipIf(skip)("the error names the errno the OS returned", async () => {
+  expect(await runWithPlan("f", ["build", "entry.js"], constants.errno.EPERM)).toEqual({
+    stdout: "",
+    stderr: `error: ${bundlerError("EPERM")}`,
+    exitCode: 1,
+    signalCode: null,
+  });
+});
+
+// The failure happens before the watcher exists, so a watch build has nothing
+// left to wait for; it must exit like a plain build instead of parking.
+test.skipIf(skip)("bun build --watch exits too when the pool cannot spawn any worker", async () => {
+  expect(await runWithPlan("f", ["build", "--watch", "entry.js"])).toEqual({
+    stdout: "",
+    stderr: `error: ${bundlerError("EAGAIN")}`,
     exitCode: 1,
     signalCode: null,
   });
 });
 
 test.skipIf(skip)("Bun.build() rejects when the pool cannot spawn any worker", async () => {
-  expect(await runWithPlan("f", "build-api.js")).toEqual({
+  expect(await runWithPlan("f", ["build-api.js"])).toEqual({
     stdout: JSON.stringify({
       settled: "rejected",
       name: "AggregateError",
       message: "Bundle failed",
-      errors: [BUNDLER_ERROR],
+      errors: [bundlerError("EAGAIN")],
     }),
     stderr: "",
     exitCode: 0,
@@ -171,7 +202,7 @@ test.skipIf(skip)("Bun.build() rejects when the pool cannot spawn any worker", a
 });
 
 test.skipIf(skip)("the dev server exits with the error when the pool cannot spawn any worker", async () => {
-  await using proc = spawnWithPlan("f", "dev-server.js");
+  await using proc = spawnWithPlan("f", ["dev-server.js"]);
   const stderr = proc.stderr.text();
   const decoder = new TextDecoder();
   let stdout = "";
@@ -189,14 +220,14 @@ test.skipIf(skip)("the dev server exits with the error when the pool cannot spaw
   const exitCode = await proc.exited;
   expect({ stdout: stdout.trim(), stderr: (await stderr).trim(), exitCode, signalCode: proc.signalCode }).toEqual({
     stdout: expect.stringMatching(/^PORT \d+$/),
-    stderr: `error: ${BUNDLER_ERROR}`,
+    stderr: `error: ${bundlerError("EAGAIN")}`,
     exitCode: 1,
     signalCode: null,
   });
 });
 
 test.skipIf(skip)("a node:fs promise whose WorkPool cannot spawn any worker exits with the error", async () => {
-  expect(await runWithPlan("f", "read-file.js")).toEqual({
+  expect(await runWithPlan("f", ["read-file.js"])).toEqual({
     stdout: "",
     stderr: STRANDED_TASKS_STDERR,
     exitCode: 1,
@@ -207,7 +238,7 @@ test.skipIf(skip)("a node:fs promise whose WorkPool cannot spawn any worker exit
 // bun install starts the HTTP client thread (the 's': it uses the same stack
 // size) before scheduling the tarball extraction on its own, never warmed pool.
 test.skipIf(skip)("bun install exits with the error when its pool cannot spawn any worker", async () => {
-  expect(await runWithPlan("sf", "install", "--cwd", "install")).toEqual({
+  expect(await runWithPlan("sf", ["install", "--cwd", "install"])).toEqual({
     stdout: expect.stringContaining("bun install v1."),
     stderr: STRANDED_TASKS_STDERR,
     exitCode: 1,
@@ -216,7 +247,7 @@ test.skipIf(skip)("bun install exits with the error when its pool cannot spawn a
 });
 
 test.skipIf(skip)("the pool's first worker is retried after a transient spawn failure", async () => {
-  expect(await runWithPlan("fs", "read-file.js")).toEqual({
+  expect(await runWithPlan("fs", ["read-file.js"])).toEqual({
     stdout: "read: export const a = 1;",
     stderr: "",
     exitCode: 0,
@@ -225,7 +256,7 @@ test.skipIf(skip)("the pool's first worker is retried after a transient spawn fa
 });
 
 test.skipIf(skip)("a pool that got one worker keeps working when the remaining spawns fail", async () => {
-  expect(await runWithPlan("sf", "build", "entry.js")).toEqual({
+  expect(await runWithPlan("sf", ["build", "entry.js"])).toEqual({
     stdout: ["// a.js", "var a = 1;", "", "// entry.js", "console.log(a);"].join("\n"),
     stderr: "",
     exitCode: 0,

--- a/test/js/bun/sys/thread-pool-spawn-failure.test.ts
+++ b/test/js/bun/sys/thread-pool-spawn-failure.test.ts
@@ -145,43 +145,48 @@ async function runWithPlan(plan: string, args: string[], errno?: number) {
   return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signalCode: proc.signalCode };
 }
 
+// Only EAGAIN means a limit was hit, so only it gets the remedy appended.
+const THREAD_LIMIT_HINT =
+  "The process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency";
+
 // The bundler warms its pool before scheduling anything, so it can report the
 // failure through its own log.
-function bundlerError(errno: string) {
-  return `Failed to create a worker thread for the bundler: ${errno}. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).`;
-}
+const BUNDLER_ERROR = `Failed to create a worker thread for the bundler: EAGAIN. ${THREAD_LIMIT_HINT}`;
 
 // Pools that are only ever fed through fire-and-forget schedule() calls have
 // nobody to return the error to; the process exits with it instead of hanging.
-const STRANDED_TASKS_STDERR = [
-  "EAGAIN: failed to create a worker thread for the thread pool; the work already queued on it could never run",
-  "note: the process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency",
-].join("\n");
+function strandedTasksError(errno: string) {
+  return `${errno}: failed to create a worker thread for the thread pool; the work already queued on it could never run`;
+}
+const STRANDED_TASKS_STDERR = `${strandedTasksError("EAGAIN")}\nnote: ${THREAD_LIMIT_HINT}`;
 
 test.skipIf(skip)("bun build reports a bundler pool that cannot spawn any worker and exits", async () => {
   expect(await runWithPlan("f", ["build", "entry.js"])).toEqual({
     stdout: "",
-    stderr: `error: ${bundlerError("EAGAIN")}`,
+    stderr: `error: ${BUNDLER_ERROR}`,
     exitCode: 1,
     signalCode: null,
   });
 });
 
-test.skipIf(skip)("the error names the errno the OS returned", async () => {
-  expect(await runWithPlan("f", ["build", "entry.js"], constants.errno.EPERM)).toEqual({
-    stdout: "",
-    stderr: `error: ${bundlerError("EPERM")}`,
-    exitCode: 1,
-    signalCode: null,
-  });
-});
+test.skipIf(skip)(
+  "the error names the errno the OS returned, without the limit hint for errors other than EAGAIN",
+  async () => {
+    expect(await runWithPlan("f", ["build", "entry.js"], constants.errno.EPERM)).toEqual({
+      stdout: "",
+      stderr: "error: Failed to create a worker thread for the bundler: EPERM",
+      exitCode: 1,
+      signalCode: null,
+    });
+  },
+);
 
 // The failure happens before the watcher exists, so a watch build has nothing
 // left to wait for; it must exit like a plain build instead of parking.
 test.skipIf(skip)("bun build --watch exits too when the pool cannot spawn any worker", async () => {
   expect(await runWithPlan("f", ["build", "--watch", "entry.js"])).toEqual({
     stdout: "",
-    stderr: `error: ${bundlerError("EAGAIN")}`,
+    stderr: `error: ${BUNDLER_ERROR}`,
     exitCode: 1,
     signalCode: null,
   });
@@ -193,7 +198,7 @@ test.skipIf(skip)("Bun.build() rejects when the pool cannot spawn any worker", a
       settled: "rejected",
       name: "AggregateError",
       message: "Bundle failed",
-      errors: [bundlerError("EAGAIN")],
+      errors: [BUNDLER_ERROR],
     }),
     stderr: "",
     exitCode: 0,
@@ -220,7 +225,7 @@ test.skipIf(skip)("the dev server exits with the error when the pool cannot spaw
   const exitCode = await proc.exited;
   expect({ stdout: stdout.trim(), stderr: (await stderr).trim(), exitCode, signalCode: proc.signalCode }).toEqual({
     stdout: expect.stringMatching(/^PORT \d+$/),
-    stderr: `error: ${bundlerError("EAGAIN")}`,
+    stderr: `error: ${BUNDLER_ERROR}`,
     exitCode: 1,
     signalCode: null,
   });
@@ -241,6 +246,15 @@ test.skipIf(skip)("bun install exits with the error when its pool cannot spawn a
   expect(await runWithPlan("sf", ["install", "--cwd", "install"])).toEqual({
     stdout: expect.stringContaining("bun install v1."),
     stderr: STRANDED_TASKS_STDERR,
+    exitCode: 1,
+    signalCode: null,
+  });
+});
+
+test.skipIf(skip)("the exit leaves out the limit hint for errors other than EAGAIN", async () => {
+  expect(await runWithPlan("sf", ["install", "--cwd", "install"], constants.errno.EPERM)).toEqual({
+    stdout: expect.stringContaining("bun install v1."),
+    stderr: strandedTasksError("EPERM"),
     exitCode: 1,
     signalCode: null,
   });

--- a/test/js/bun/sys/thread-pool-spawn-failure.test.ts
+++ b/test/js/bun/sys/thread-pool-spawn-failure.test.ts
@@ -1,0 +1,234 @@
+// An LD_PRELOAD shim makes pthread_create fail with EAGAIN (what the kernel
+// returns at the RLIMIT_NPROC / cgroup pids limit) for the thread pool's worker
+// threads. A pool that cannot get a single worker used to leave its tasks
+// queued forever: `bun build`, `Bun.build()`, `bun install` and every node:fs
+// promise hung instead of reporting the error.
+//
+// The tests are sequential on purpose: the regression is a hang, and bun test
+// only kills a timed-out test's dangling children for non-concurrent tests.
+import { afterAll, beforeAll, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+const skip = !isLinux || !cc;
+
+// DEFAULT_THREAD_STACK_SIZE in src/threading/ThreadPool.rs: every bun_threading
+// pool worker (the runtime's WorkPool, the bundler's and bun install's pools) is
+// created with this stack size. Bun's other threads (the "Bundler" thread,
+// allocator and JSC helpers) request other sizes and keep working, so the
+// fixtures below get as far as the pool itself. The one exception is the HTTP
+// client thread, which also uses this size; see the install test.
+const POOL_WORKER_STACK_SIZE = 4 * 1024 * 1024;
+
+// POOL_SPAWN_PLAN is one letter per spawn attempt of such a thread, 'f' = fail
+// with EAGAIN, 's' = succeed; the last letter repeats for every further attempt.
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
+static const char *plan;
+static size_t plan_len;
+static int attempts;
+
+__attribute__((constructor)) static void init(void) {
+  real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
+  plan = getenv("POOL_SPAWN_PLAN");
+  plan_len = plan ? strlen(plan) : 0;
+}
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(void *), void *arg) {
+  size_t stack_size = 0;
+  if (attr) pthread_attr_getstacksize(attr, &stack_size);
+  if (stack_size == ${POOL_WORKER_STACK_SIZE} && plan_len > 0) {
+    size_t i = __sync_fetch_and_add(&attempts, 1);
+    if (plan[i < plan_len ? i : plan_len - 1] == 'f') return EAGAIN;
+  }
+  return real_pthread_create(thread, attr, start, arg);
+}
+`;
+
+const BUILD_API_FIXTURE = /* js */ `
+try {
+  const result = await Bun.build({ entrypoints: [import.meta.dirname + "/entry.js"] });
+  console.log(JSON.stringify({ settled: "resolved", success: result.success, logs: result.logs.map(String) }));
+} catch (e) {
+  console.log(JSON.stringify({ settled: "rejected", name: e.name, message: e.message, errors: e.errors.map(err => err.message) }));
+}
+`;
+
+// fs.promises.readFile runs on the runtime's WorkPool, which is created lazily
+// by its first task; nothing warms it up front.
+const READ_FILE_FIXTURE = /* js */ `
+import { readFile } from "node:fs/promises";
+const text = await readFile(import.meta.dirname + "/a.js", "utf8");
+console.log("read:", text.trim());
+`;
+
+// The dev server bundles a route on its first request, on the shared WorkPool.
+const DEV_SERVER_FIXTURE = /* js */ `
+import index from "./index.html";
+const server = Bun.serve({ port: 0, hostname: "127.0.0.1", development: true, routes: { "/": index } });
+console.log("PORT " + server.port);
+`;
+
+let dir: ReturnType<typeof tempDir> | undefined;
+let shimPath: string;
+
+beforeAll(async () => {
+  if (skip) return;
+  dir = tempDir("thread-pool-spawn-failure", {
+    "shim.c": SHIM_C,
+    "entry.js": `import { a } from "./a.js";\nconsole.log(a);\n`,
+    "a.js": `export const a = 1;\n`,
+    "build-api.js": BUILD_API_FIXTURE,
+    "read-file.js": READ_FILE_FIXTURE,
+    "dev-server.js": DEV_SERVER_FIXTURE,
+    "index.html": `<!doctype html><script type="module" src="./a.js"></script>`,
+    "install/package.json": JSON.stringify({ name: "app", dependencies: { dep: "file:./dep.tgz" } }),
+  });
+  await Bun.Archive.write(
+    join(String(dir), "install", "dep.tgz"),
+    { "package/package.json": JSON.stringify({ name: "dep", version: "1.0.0" }) },
+    { compress: "gzip" },
+  );
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  }
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+function spawnWithPlan(plan: string, ...args: string[]) {
+  const existing = bunEnv.LD_PRELOAD;
+  return Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd: String(dir),
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath, POOL_SPAWN_PLAN: plan },
+    stdout: "pipe",
+    stderr: "pipe",
+    // Kill switch: without the fix every 'f'-only run below waits forever for
+    // tasks that no thread will ever pick up.
+    timeout: 20_000,
+    killSignal: "SIGKILL",
+  });
+}
+
+async function runWithPlan(plan: string, ...args: string[]) {
+  await using proc = spawnWithPlan(plan, ...args);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: stdout.trim(), stderr: stderr.trim(), exitCode, signalCode: proc.signalCode };
+}
+
+// The bundler warms its pool before scheduling anything, so it can report the
+// failure through its own log.
+const BUNDLER_ERROR =
+  "Failed to create a worker thread for the bundler: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).";
+
+// Pools that are only ever fed through fire-and-forget schedule() calls have
+// nobody to return the error to; the process exits with it instead of hanging.
+const STRANDED_TASKS_STDERR = [
+  "EAGAIN: failed to create a worker thread for the thread pool; the work already queued on it could never run",
+  "note: the process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency",
+].join("\n");
+
+test.skipIf(skip)("bun build reports a bundler pool that cannot spawn any worker and exits", async () => {
+  expect(await runWithPlan("f", "build", "entry.js")).toEqual({
+    stdout: "",
+    stderr: `error: ${BUNDLER_ERROR}`,
+    exitCode: 1,
+    signalCode: null,
+  });
+});
+
+test.skipIf(skip)("Bun.build() rejects when the pool cannot spawn any worker", async () => {
+  expect(await runWithPlan("f", "build-api.js")).toEqual({
+    stdout: JSON.stringify({
+      settled: "rejected",
+      name: "AggregateError",
+      message: "Bundle failed",
+      errors: [BUNDLER_ERROR],
+    }),
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+test.skipIf(skip)("the dev server exits with the error when the pool cannot spawn any worker", async () => {
+  await using proc = spawnWithPlan("f", "dev-server.js");
+  const stderr = proc.stderr.text();
+  const decoder = new TextDecoder();
+  let stdout = "";
+  let requested = false;
+  for await (const chunk of proc.stdout) {
+    stdout += decoder.decode(chunk, { stream: true });
+    const port = /^PORT (\d+)$/m.exec(stdout)?.[1];
+    if (port !== undefined && !requested) {
+      requested = true;
+      // Triggers the bundle. The server exits before answering, so the
+      // request itself fails; the server's output is what is asserted.
+      fetch(`http://127.0.0.1:${port}/`).catch(() => {});
+    }
+  }
+  const exitCode = await proc.exited;
+  expect({ stdout: stdout.trim(), stderr: (await stderr).trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: expect.stringMatching(/^PORT \d+$/),
+    stderr: `error: ${BUNDLER_ERROR}`,
+    exitCode: 1,
+    signalCode: null,
+  });
+});
+
+test.skipIf(skip)("a node:fs promise whose WorkPool cannot spawn any worker exits with the error", async () => {
+  expect(await runWithPlan("f", "read-file.js")).toEqual({
+    stdout: "",
+    stderr: STRANDED_TASKS_STDERR,
+    exitCode: 1,
+    signalCode: null,
+  });
+});
+
+// bun install starts the HTTP client thread (the 's': it uses the same stack
+// size) before scheduling the tarball extraction on its own, never warmed pool.
+test.skipIf(skip)("bun install exits with the error when its pool cannot spawn any worker", async () => {
+  expect(await runWithPlan("sf", "install", "--cwd", "install")).toEqual({
+    stdout: expect.stringContaining("bun install v1."),
+    stderr: STRANDED_TASKS_STDERR,
+    exitCode: 1,
+    signalCode: null,
+  });
+});
+
+test.skipIf(skip)("the pool's first worker is retried after a transient spawn failure", async () => {
+  expect(await runWithPlan("fs", "read-file.js")).toEqual({
+    stdout: "read: export const a = 1;",
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+test.skipIf(skip)("a pool that got one worker keeps working when the remaining spawns fail", async () => {
+  expect(await runWithPlan("sf", "build", "entry.js")).toEqual({
+    stdout: ["// a.js", "var a = 1;", "", "// entry.js", "console.log(a);"].join("\n"),
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});


### PR DESCRIPTION
### Problem
- At the process or thread limit (`EAGAIN` from `pthread_create` under a cgroup pids limit or `RLIMIT_NPROC`), `bun build`, `Bun.build()`, `bun install` and the first `fs.promises` / zlib / dns call hang forever with no message. Reproduced on 1.4.0 and on main.
- Cause: when a pool's first worker fails to spawn, the tasks stay queued and the pool's "a spawn was requested" latch stays set, so no later `schedule()` tries to spawn again and nothing ever drains the queue.
- A pool that already has one worker is unaffected: workers never exit before shutdown, so the next idle one drains the queue. The bug is exactly "the pool never got a worker".

### Fix
- Warming a pool now returns the errno if it leaves the pool with no worker. The bundler is the only consumer that warms before scheduling, so `bun build` (with or without `--watch`) and the dev server print `Failed to create a worker thread for the bundler: EAGAIN. The process or thread limit may have been reached (...)` and exit 1, and `Bun.build()` rejects with `AggregateError: Bundle failed` carrying that message.
- Every other pool is fed by fire-and-forget `schedule()` with no error channel, so a failed spawn that leaves no worker while tasks are already queued exits the process with `EAGAIN: failed to create a worker thread for the thread pool; the work already queued on it could never run`. Nothing else can ever run those tasks. The `ulimit -u` / pids hint is added only for `EAGAIN`.
- "No worker left" is the count returned when the failed slot is released, so a worker another thread spawned meanwhile counts. A pool's first worker is retried once after 10ms; later failures only cost parallelism and are not retried.
- Verification, per the original: a new Linux test uses an `LD_PRELOAD` shim that fails `pthread_create` for pool-sized threads; nine of its ten cases hang unfixed, all ten pass fixed. The errno mapping helper has a unit test, its Windows half run under miri only. The evidence block below records that the test did not run in the final check here and is left to CI.

### Background
- `bun_threading::ThreadPool` backs the runtime's `WorkPool`, the bundler's pools and `bun install`'s pool. Workers are spawned lazily: `schedule()` publishes the tasks first, then sets a latch and asks for a thread; once the latch is set, later `schedule()` calls assume someone will drain the queue.
- `warm(n)` pre-spawns up to n workers before any task exists. Only the bundler uses it, which is why the bundler can get a returned error and every other consumer gets a process exit.
- The pool's wait group counts tasks published but not finished; non-zero at the moment a spawn fails means work is already stranded.
- On Windows a `std::io::Error` carries a Win32 code, not an errno, so it needs a different mapper; the file watcher had this mapping inline and now shares the new `SystemErrno::from_io_error` with the pool.
- `bun build --watch` normally reacts to a build error by parking until the file watcher triggers a rebuild. The watcher is installed after the pool is started, so this error has to skip that path or the watch build would hang.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/sys/thread-pool-spawn-failure.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

When the OS refuses to create a thread (`EAGAIN` from `pthread_create` at the cgroup pids limit or `RLIMIT_NPROC`), a `bun_threading::ThreadPool` that has no worker yet hangs whatever is waiting on it, forever and silently:

```sh
# as root in a container with the cgroup v2 pids controller: fill pids.current to
# pids.max - 1 with sleeping threads, then (as a non-root user `ulimit -u` does the same)
bun build entry.js        # hangs: Threads: 1, main thread in epoll_pwait2 with no timeout
```

The same happens to `Bun.build()`, to `bun install` (tarball extraction runs on its pool) and to the first use of the runtime's `WorkPool` (`fs.promises.readFile`, zlib, dns, ...). Reproduced on 1.4.0 and on a debug build of main with an `LD_PRELOAD` shim that fails `pthread_create` for threads asking for the pool's worker stack size; that shim is what the new test uses.

### Cause

`ThreadPool::warm()` and `notify_slow()` (`src/threading/ThreadPool.rs`) handled a failed `std::thread::Builder::spawn` by undoing the `spawned` increment and returning. The batch that triggered the spawn stays in the run queue, and because `notify_slow` had already set the `notified` latch, every later `schedule()` takes the fast path and never tries to spawn again. With at least one worker in the pool this is harmless (workers never exit before shutdown, and the next one to go idle consumes the latch and drains the queue), so the bug is exactly "the pool could not get its first worker". The upstream zap code this is derived from has the same shape.

### Fix

* `warm()` returns the errno when a failed spawn leaves the pool with no worker at all, judged by the count the slot release itself returns (so a worker another thread managed to spawn meanwhile counts; failing to add more workers to a working pool still just ends the warm-up). The bundler is the one consumer that warms before scheduling, so `BundleV2::init` checks it, adds the reason to the log and fails the build with a new `bun_bundler::Error::ThreadSpawnFailed` (same name as the existing variants in `bun_runtime` and `bun_jsc`):
  * `bun build`: `error: Failed to create a worker thread for the bundler: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency`, exit code 1. The second sentence comes from `thread_limit_hint()` and is only added for `EAGAIN`; `ENOMEM` (what a failed `CreateThread` maps to on Windows), `EPERM` or `EINVAL` just name the errno, since the ulimit / pids advice does not apply to them.
  * `bun build --watch`: the same. This failure happens before `init` installs the watcher, so `build_command` must not take its usual "park and let the watcher restart us" path for it; under a real thread limit that would turn the baseline's clean watcher-spawn failure (`Failed to start File Watcher: EAGAIN`, exit 1) into a hang. The dedicated variant is what lets `build_command` tell this apart from the build errors that should keep a watch session alive.
  * `Bun.build()`: rejects with the usual `AggregateError: Bundle failed` carrying that message
  * dev server: its callers treat every `start_async_bundle` error as OOM (`.expect("oom")`), so `DevServer` prints the log message and exits 1 for this variant instead of producing an `oom` crash report with the reason never shown.
* Both spawn sites now share `spawn_worker()`. When a failure leaves the pool with no worker (the count comes from the same `fetch_sub` that releases the slot, so a spawn that succeeded concurrently on another thread is respected) while tasks are already queued (`wait_group` is non-zero), the process exits:
  ```
  EAGAIN: failed to create a worker thread for the thread pool; the work already queued on it could never run
  note: The process or thread limit may have been reached (ulimit -u, or the container's pids limit); raise it or reduce concurrency
  ```
  (the `note:` line again only for `EAGAIN`). This covers `bun install`, `WorkPool` and `each()` / `wait_for_all()` callers.
* The first worker of a pool is retried once after 10ms, the same remedy `Watcher::start` already uses for the same error; later spawns are not retried since their failure only costs parallelism.
* `SystemErrno::from_io_error` holds the `io::Error` -> errno mapping (Win32 code on Windows) that `Watcher::start` had inline, so both users share it. The only behavior difference for the watcher is the fallback for an OS code without a `SystemErrno` mapping (`EIO` before, `EAGAIN` now); `pthread_create` only returns `EAGAIN`, `EINVAL` and `EPERM`, so it is not reachable. It gets a unit test next to the existing `bun_errno` ones (a non-`EAGAIN` errno, a non-OS error, and the Win32 codes on Windows; the Windows half was run with `cargo miri test -p bun_errno --target x86_64-pc-windows-msvc`, since no CI lane executes this crate's `cfg(windows)` tests).
* `unregister()` is split into `unspawn()` (the accounting, now also used by the failed-spawn path and returning the remaining worker count) and the worker-exit wait chain; its `thread` argument becomes `NonNull` since nothing passes null anymore.

### Why exit instead of returning an error from `schedule()`

`schedule()` is fire-and-forget: the tasks are already published when the spawn is attempted, the 40-odd `WorkPool` call sites have no error channel, and the waiters (the bundler's and install's event loops, `wait_for_all()`, a JS promise) are on the other side of a queue nobody will ever drain. Exiting with the errno and the limit named is the same treatment the HTTP client thread and `bun install`'s startup failures already get, and it is what a process in this state does anyway on its next `fetch()` or GC (#36985 covers the crash-report presentation of those). The bundler gets the recoverable path because it is the one consumer that can find out before it schedules anything, and `Bun.build()` in a running process is where a clean rejection matters.

### Tests

`test/js/bun/sys/thread-pool-spawn-failure.test.ts` (Linux, needs a C compiler like the existing `LD_PRELOAD` tests) compiles a shim that fails `pthread_create` (with `EAGAIN`, or an errno the test picks) for threads requesting `DEFAULT_THREAD_STACK_SIZE`, following a per-attempt plan:

* persistent failure: `bun build` and `bun build --watch` (exit 1 + message), `bun build` and `bun install` with `EPERM` injected (the messages name `EPERM`, so the mapping and not the fallback is what is shown, and neither carries the limit hint), `Bun.build()` (rejection carrying the message, process exits 0 on its own), dev server (HTML route requested from the test process: message + exit 1), `fs.promises.readFile` and `bun install` of a local tarball (both: the two stderr lines above, exit 1)
* transient failure: the first spawn fails, the retry succeeds, `readFile` completes
* a pool that got one worker and then loses every further spawn still bundles (guards the "no worker left" condition of the exit)

On the unfixed build the first nine hang and are killed; with the fix all ten pass. The existing watcher spawn-failure test in `test/cli/watch/watch.test.ts` still passes; `cargo check` of the touched crates also passes for the `x86_64-pc-windows-msvc` and `aarch64-apple-darwin` targets.

</details>
