### PR TITLE
node:http: enforce headersTimeout and requestTimeout on HTTP/1 fallback connections

### DIFF
--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -432,6 +432,76 @@ function emitErrorNt(msg, err, callback) {
     msg.emit("error", err);
   }
 }
+
+// Server-side connection error handling shared by the native http.Server connections
+// (_http_server.ts) and the connections parsed in JS (internal/http1_server_fallback.ts:
+// http2 allowHTTP1 and server.emit("connection", socket)).
+// https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js (socketOnError, onRequestTimeout)
+const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
+const badRequestResponse = Buffer.from(`HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n`, "latin1");
+const requestTimeoutResponse = Buffer.from(`HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n`, "latin1");
+const requestHeaderFieldsTooLargeResponse = Buffer.from(
+  `HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n`,
+  "latin1",
+);
+const requestChunkExtensionsTooLargeResponse = Buffer.from(
+  `HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n`,
+  "latin1",
+);
+
+// Default 'error' listener installed on every server connection, like
+// Node.js's socketOnError: route the error to the server's 'clientError'
+// event and, when nothing handles it, answer with a raw error response (only
+// if nothing has been written for the in-flight response yet) and destroy the
+// connection.
+function socketOnError(this: any, err) {
+  // Ignore further errors
+  this.removeListener("error", socketOnError);
+  this.on("error", noopOnError);
+
+  const server = this.server;
+  if (!server || !server.emit("clientError", err, this)) {
+    // Caution must be taken to avoid corrupting the remote peer.
+    // Reply an error segment if there is no in-flight `ServerResponse`,
+    // or no data of the in-flight one has been written yet to this socket.
+    const message = this._httpMessage;
+    // Node checks _headerSent (bytes reached the socket), not headersSent
+    // (writeHead called): after res.writeHead() but before write/end/flush,
+    // no bytes are on the wire yet so the raw error response is still safe.
+    if (this.writable && (!message || message[headerStateSymbol] !== NodeHTTPHeaderState.sent)) {
+      let response;
+      switch (err?.code) {
+        case "HPE_HEADER_OVERFLOW":
+          response = requestHeaderFieldsTooLargeResponse;
+          break;
+        case "HPE_CHUNK_EXTENSIONS_OVERFLOW":
+          response = requestChunkExtensionsTooLargeResponse;
+          break;
+        case "ERR_HTTP_REQUEST_TIMEOUT":
+          response = requestTimeoutResponse;
+          break;
+        default:
+          response = badRequestResponse;
+          break;
+      }
+      // Write through the native handle so the raw error response reaches the
+      // wire before the destroy below, regardless of the duplex's cork state.
+      const handle = this[kHandle];
+      if (handle && !handle.closed) {
+        handle.write(response);
+      } else {
+        this.write(response);
+      }
+    }
+    this.destroy(err);
+  }
+}
+function noopOnError() {}
+
+function onRequestTimeout(socket) {
+  socketOnError.$call(socket, $ERR_HTTP_REQUEST_TIMEOUT("Request timeout"));
+}
+
 const setMaxHTTPHeaderSize = $newRustFunction("node_http_binding.rs", "setMaxHTTPHeaderSize", 1);
 const getMaxHTTPHeaderSize = $newRustFunction("node_http_binding.rs", "getMaxHTTPHeaderSize", 0);
 const kOutHeaders = Symbol("kOutHeaders");
@@ -625,6 +695,7 @@ export {
   kBodyChunks,
   kClearTimeout,
   kCloseCallback,
+  kConnectionsCheckingInterval,
   kDeprecatedReplySymbol,
   kEmitState,
   kEmptyObject,
@@ -657,6 +728,7 @@ export {
   kWaitForProxyTunnel,
   noBodySymbol,
   onDataIncomingMessage,
+  onRequestTimeout,
   optionsSymbol,
   parseProxyConfigFromEnv,
   parseProxyUrl,
@@ -670,6 +742,7 @@ export {
   setServerAppFlags,
   setServerCustomOptions,
   setServerIdleTimeout,
+  socketOnError,
   statusCodeSymbol,
   statusMessageSymbol,
   timeoutTimerSymbol,

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -433,11 +433,9 @@ function emitErrorNt(msg, err, callback) {
   }
 }
 
-// Server-side connection error handling shared by the native http.Server connections
-// (_http_server.ts) and the connections parsed in JS (internal/http1_server_fallback.ts:
-// http2 allowHTTP1 and server.emit("connection", socket)).
-// https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js (socketOnError, onRequestTimeout)
 const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
+
+// https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js (socketOnError)
 const badRequestResponse = Buffer.from(`HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n`, "latin1");
 const requestTimeoutResponse = Buffer.from(`HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n`, "latin1");
 const requestHeaderFieldsTooLargeResponse = Buffer.from(

--- a/src/js/internal/http.ts
+++ b/src/js/internal/http.ts
@@ -455,7 +455,9 @@ const requestChunkExtensionsTooLargeResponse = Buffer.from(
 function socketOnError(this: any, err) {
   // Ignore further errors
   this.removeListener("error", socketOnError);
-  this.on("error", noopOnError);
+  if (this.listenerCount("error", noopOnError) === 0) {
+    this.on("error", noopOnError);
+  }
 
   const server = this.server;
   if (!server || !server.emit("clientError", err, this)) {

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -362,8 +362,7 @@ function connectionListenerHTTP1(server, socket, options) {
   function onHttp1SocketData(data) {
     const ret = parser.execute(data);
     if (ret instanceof Error) {
-      // Node's onParserExecuteCommon: the error carries the offending bytes, then the shared
-      // socketOnError emits 'clientError' (or writes the raw error response) and destroys.
+      // Node's onParserExecuteCommon.
       prepareError(ret, parser, data);
       socketOnError.$call(socket, ret);
       return;
@@ -421,11 +420,7 @@ function connectionListenerHTTP1(server, socket, options) {
   socket.once("close", freeHttp1Parser);
 }
 
-// Node's checkConnections, run from the server's connectionsCheckingInterval sweep in
-// _http_server.ts. expired() measures from the current request's first byte (or from accept, for
-// a connection that has not sent one yet): headersTimeout while the head is incomplete,
-// requestTimeout until kOnMessageComplete. It also drops what it reports from the active set, so
-// a request times out once even if the 'clientError' listener keeps the connection open.
+// Node's checkConnections, run from _http_server.ts's connectionsCheckingInterval sweep.
 function checkHttp1Connections(server, headersTimeout, requestTimeout) {
   const connections = server[kHttp1Connections];
   if (!connections) return;

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -1,7 +1,7 @@
 // JS HTTP/1 server path over an arbitrary Duplex with a JS stand-in for NodeHTTPResponse.
 // Used by http2's `allowHTTP1` ALPN fallback and http's `server.emit("connection", socket)`.
 // See https://github.com/nodejs/node/blob/main/lib/_http_server.js connectionListener.
-const { STATUS_CODES } = require("internal/http");
+const { STATUS_CODES, socketOnError, onRequestTimeout } = require("internal/http");
 
 // Node's server[kConnections]: a ConnectionsList holding every fallback connection's parser.
 const kHttp1Connections = Symbol("http1Connections");
@@ -359,30 +359,13 @@ function connectionListenerHTTP1(server, socket, options) {
     }
   };
 
-  function onHttp1SocketError(err, rawPacket) {
-    // Match Node's http _connectionListener: attach err.rawPacket and, when no
-    // 'clientError' listener is present, write the same raw error response
-    // Node's socketOnError does before destroying.
-    prepareError(err, parser, rawPacket);
-    if (!server.emit("clientError", err, socket)) {
-      if (socket.writable && !socket.destroyed) {
-        const code = err?.code;
-        socket.write(
-          code === "HPE_HEADER_OVERFLOW"
-            ? "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n"
-            : code === "HPE_CHUNK_EXTENSIONS_OVERFLOW"
-              ? "HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n"
-              : "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n",
-          "latin1",
-        );
-      }
-      socket.destroy(err);
-    }
-  }
   function onHttp1SocketData(data) {
     const ret = parser.execute(data);
     if (ret instanceof Error) {
-      onHttp1SocketError(ret, data);
+      // Node's onParserExecuteCommon: the error carries the offending bytes, then the shared
+      // socketOnError emits 'clientError' (or writes the raw error response) and destroys.
+      prepareError(ret, parser, data);
+      socketOnError.$call(socket, ret);
       return;
     }
     if (pendingUpgrade) {
@@ -392,7 +375,7 @@ function connectionListenerHTTP1(server, socket, options) {
       const upgradeReq = pendingUpgrade;
       pendingUpgrade = null;
       socket.removeListener("data", onHttp1SocketData);
-      socket.removeListener("error", onHttp1SocketErrorListener);
+      socket.removeListener("error", socketOnError);
       socket.removeListener("end", onHttp1SocketEnd);
       socket.removeListener("close", freeHttp1Parser);
       freeHttp1Parser();
@@ -406,15 +389,12 @@ function connectionListenerHTTP1(server, socket, options) {
       }
     }
   }
-  function onHttp1SocketErrorListener(err) {
-    onHttp1SocketError(err, undefined);
-  }
   // Node's socketOnEnd: let llhttp detect a message cut short by EOF, then end
   // the connection the way Node does (httpAllowHalfOpen / _last / idle end).
   function onHttp1SocketEnd() {
     const ret = parser.finish();
     if (ret instanceof Error) {
-      onHttp1SocketError(ret, undefined);
+      socketOnError.$call(socket, ret);
       return;
     }
     if (!server.httpAllowHalfOpen) {
@@ -436,9 +416,23 @@ function connectionListenerHTTP1(server, socket, options) {
     socket.parser = null;
   }
   socket.on("data", onHttp1SocketData);
-  socket.on("error", onHttp1SocketErrorListener);
+  socket.on("error", socketOnError);
   socket.once("end", onHttp1SocketEnd);
   socket.once("close", freeHttp1Parser);
+}
+
+// Node's checkConnections, run from the server's connectionsCheckingInterval sweep in
+// _http_server.ts. expired() measures from the current request's first byte (or from accept, for
+// a connection that has not sent one yet): headersTimeout while the head is incomplete,
+// requestTimeout until kOnMessageComplete. It also drops what it reports from the active set, so
+// a request times out once even if the 'clientError' listener keeps the connection open.
+function checkHttp1Connections(server, headersTimeout, requestTimeout) {
+  const connections = server[kHttp1Connections];
+  if (!connections) return;
+  const expired = connections.expired(headersTimeout, requestTimeout);
+  for (let i = 0, length = expired.length; i < length; i++) {
+    onRequestTimeout(expired[i].socket);
+  }
 }
 
 // Node's Server#closeIdleConnections; a parser is busy from initialize() and from each message's
@@ -469,4 +463,5 @@ export default {
   connectionListenerHTTP1,
   closeIdleHttp1Connections,
   closeAllHttp1Connections,
+  checkHttp1Connections,
 };

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -443,8 +443,7 @@ function rethrowUncaught(err) {
 
 // Like Node.js's setupConnectionsTracking: each 'listening' event replaces
 // the connections-checking interval timer (used by the headers/request
-// timeout machinery) and destroys the previous one. Registered by http.Server
-// and, like in Node, by http2's Http2SecureServer when it allows HTTP/1.
+// timeout machinery) and destroys the previous one.
 function setupConnectionsTracking(this: any) {
   if (this[kConnectionsCheckingInterval]) {
     clearInterval(this[kConnectionsCheckingInterval]);
@@ -456,9 +455,7 @@ function setupConnectionsTracking(this: any) {
 
 // Node.js's checkConnections sweep: every connectionsCheckingInterval, expire
 // connections whose in-flight request exceeded headersTimeout/requestTimeout.
-// Connections parsed in JS keep their timing in the server's ConnectionsList
-// like Node's; for the natively parsed ones it lives on the socket handle, so
-// each tracked connection is asked whether it expired.
+// The natively parsed connections keep their timing on the socket handle.
 function checkConnections(this: Server) {
   const headersTimeout = this.headersTimeout;
   const requestTimeout = this.requestTimeout;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -67,6 +67,9 @@ const {
   kOutHeaders,
   onDataIncomingMessage,
   validateMsecs,
+  kConnectionsCheckingInterval,
+  socketOnError,
+  onRequestTimeout,
 } = require("internal/http");
 const { FakeSocket } = require("internal/http/FakeSocket");
 const NumberIsNaN = Number.isNaN;
@@ -89,8 +92,8 @@ const {
   connectionListenerHTTP1,
   closeIdleHttp1Connections,
   closeAllHttp1Connections,
+  checkHttp1Connections,
 } = require("internal/http1_server_fallback");
-const kConnectionsCheckingInterval = Symbol("http.server.connectionsCheckingInterval");
 const kTrackedConnections = Symbol("http.server.trackedConnections");
 const kHttpAllowHalfOpen = Symbol("http.server.httpAllowHalfOpen");
 
@@ -440,7 +443,8 @@ function rethrowUncaught(err) {
 
 // Like Node.js's setupConnectionsTracking: each 'listening' event replaces
 // the connections-checking interval timer (used by the headers/request
-// timeout machinery) and destroys the previous one.
+// timeout machinery) and destroys the previous one. Registered by http.Server
+// and, like in Node, by http2's Http2SecureServer when it allows HTTP/1.
 function setupConnectionsTracking(this: any) {
   if (this[kConnectionsCheckingInterval]) {
     clearInterval(this[kConnectionsCheckingInterval]);
@@ -452,14 +456,17 @@ function setupConnectionsTracking(this: any) {
 
 // Node.js's checkConnections sweep: every connectionsCheckingInterval, expire
 // connections whose in-flight request exceeded headersTimeout/requestTimeout.
-// The per-connection timing lives on the native socket handle (the parser is
-// native), so each tracked connection is asked whether it expired.
+// Connections parsed in JS keep their timing in the server's ConnectionsList
+// like Node's; for the natively parsed ones it lives on the socket handle, so
+// each tracked connection is asked whether it expired.
 function checkConnections(this: Server) {
   const headersTimeout = this.headersTimeout;
   const requestTimeout = this.requestTimeout;
   if (headersTimeout === 0 && requestTimeout === 0) {
     return;
   }
+
+  checkHttp1Connections(this, headersTimeout, requestTimeout);
 
   const connections = this[kTrackedConnections];
   if (!connections || connections.size === 0) {
@@ -472,11 +479,6 @@ function checkConnections(this: Server) {
       onRequestTimeout(socket);
     }
   }
-}
-
-// https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js (onRequestTimeout)
-function onRequestTimeout(socket) {
-  socketOnError.$call(socket, $ERR_HTTP_REQUEST_TIMEOUT("Request timeout"));
 }
 
 Server.prototype.ref = function () {
@@ -1428,67 +1430,6 @@ const kStopParsingOnCloseListener = Symbol("kStopParsingOnCloseListener");
 // Set when the dispatcher already detached a synchronously-finished response,
 // so the 'finish' listener does not detach/advance the pipeline a second time.
 const kDispatcherDetached = Symbol("kDispatcherDetached");
-
-// https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js (socketOnError)
-const badRequestResponse = Buffer.from(`HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n`, "latin1");
-const requestTimeoutResponse = Buffer.from(`HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n`, "latin1");
-const requestHeaderFieldsTooLargeResponse = Buffer.from(
-  `HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\n\r\n`,
-  "latin1",
-);
-const requestChunkExtensionsTooLargeResponse = Buffer.from(
-  `HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\n\r\n`,
-  "latin1",
-);
-
-// Default 'error' listener installed on every server connection, like
-// Node.js's socketOnError: route the error to the server's 'clientError'
-// event and, when nothing handles it, answer with a raw error response (only
-// if nothing has been written for the in-flight response yet) and destroy the
-// connection.
-function socketOnError(this: any, err) {
-  // Ignore further errors
-  this.removeListener("error", socketOnError);
-  this.on("error", noopOnError);
-
-  const server = this.server;
-  if (!server || !server.emit("clientError", err, this)) {
-    // Caution must be taken to avoid corrupting the remote peer.
-    // Reply an error segment if there is no in-flight `ServerResponse`,
-    // or no data of the in-flight one has been written yet to this socket.
-    const message = this._httpMessage;
-    // Node checks _headerSent (bytes reached the socket), not headersSent
-    // (writeHead called): after res.writeHead() but before write/end/flush,
-    // no bytes are on the wire yet so the raw error response is still safe.
-    if (this.writable && (!message || message[headerStateSymbol] !== NodeHTTPHeaderState.sent)) {
-      let response;
-      switch (err?.code) {
-        case "HPE_HEADER_OVERFLOW":
-          response = requestHeaderFieldsTooLargeResponse;
-          break;
-        case "HPE_CHUNK_EXTENSIONS_OVERFLOW":
-          response = requestChunkExtensionsTooLargeResponse;
-          break;
-        case "ERR_HTTP_REQUEST_TIMEOUT":
-          response = requestTimeoutResponse;
-          break;
-        default:
-          response = badRequestResponse;
-          break;
-      }
-      // Write through the native handle so the raw error response reaches the
-      // wire before the destroy below, regardless of the duplex's cork state.
-      const handle = this[kHandle];
-      if (handle && !handle.closed) {
-        handle.write(response);
-      } else {
-        this.write(response);
-      }
-    }
-    this.destroy(err);
-  }
-}
-function noopOnError() {}
 
 function onSocketTimeoutTimerExpired(socket) {
   // The keep-alive idle timer is left armed across the request to avoid a
@@ -4017,4 +3958,6 @@ export default {
   Server,
   ServerResponse,
   kConnectionsCheckingInterval,
+  setupConnectionsTracking,
+  storeHTTPOptions,
 };

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -28,7 +28,7 @@
  */
 const { isTypedArray } = require("node:util/types");
 const { hideFromStack, hasObserver, enqueueNodeEntry, PerformanceNodeEntry } = require("internal/shared");
-const { STATUS_CODES } = require("internal/http");
+const { STATUS_CODES, kConnectionsCheckingInterval } = require("internal/http");
 const { kTimeout, getTimerDuration } = require("internal/timers");
 const tls = require("node:tls");
 const net = require("node:net");
@@ -6793,17 +6793,14 @@ class Http2SecureServer extends tls.Server {
     this.setMaxListeners(0);
     this.on("newListener", setupCompat);
     if (options.allowHTTP1 === true) {
+      // As in node, the HTTP/1 connections get http.Server's option set (connectionListenerHTTP1
+      // reads it off the server) and its headersTimeout / requestTimeout sweep while listening.
+      const { storeHTTPOptions, setupConnectionsTracking } = require("node:_http_server");
       const http1Options = { ...options, ...options.http1Options };
-      this.keepAliveTimeout = http1Options.keepAliveTimeout ?? 5000;
-      this.headersTimeout = http1Options.headersTimeout ?? 60000;
-      this.requestTimeout = http1Options.requestTimeout ?? 300000;
+      storeHTTPOptions.$call(this, http1Options);
       this.maxHeadersCount = http1Options.maxHeadersCount ?? null;
       this.maxRequestsPerSocket = http1Options.maxRequestsPerSocket ?? 0;
-      // connectionListenerHTTP1 reads these off the server when initializing
-      // the per-connection parser, matching Node's storeHTTP1Options.
-      this.maxHeaderSize = http1Options.maxHeaderSize;
-      this.insecureHTTPParser = http1Options.insecureHTTPParser;
-      this.httpValidation = http1Options.httpValidation;
+      this.on("listening", setupConnectionsTracking);
     }
     if (typeof onRequestHandler === "function") {
       this.on("request", onRequestHandler);
@@ -6839,7 +6836,9 @@ class Http2SecureServer extends tls.Server {
   }
   close(callback?: Function) {
     super.close(callback);
+    // Node's httpServerPreClose (allowHTTP1 only; neither exists otherwise).
     closeIdleHttp1Connections(this);
+    clearInterval(this[kConnectionsCheckingInterval]);
     closeAllSessions(this);
   }
 }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6793,8 +6793,7 @@ class Http2SecureServer extends tls.Server {
     this.setMaxListeners(0);
     this.on("newListener", setupCompat);
     if (options.allowHTTP1 === true) {
-      // As in node, the HTTP/1 connections get http.Server's option set (connectionListenerHTTP1
-      // reads it off the server) and its headersTimeout / requestTimeout sweep while listening.
+      // As in node, the HTTP/1 side is configured and swept like an http.Server.
       const { storeHTTPOptions, setupConnectionsTracking } = require("node:_http_server");
       const http1Options = { ...options, ...options.http1Options };
       storeHTTPOptions.$call(this, http1Options);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6758,6 +6758,9 @@ function onErrorSecureServerSession(err, socket) {
 function emitFrameErrorEventNT(stream, frameType, errorCode) {
   stream.emit("frameError", frameType, errorCode);
 }
+function shouldUpgradeHttp1Request(this: Http2SecureServer) {
+  return this.listenerCount("upgrade") > 0;
+}
 class Http2SecureServer extends tls.Server {
   timeout = 0;
   [kSessions] = new SafeSet();
@@ -6797,6 +6800,8 @@ class Http2SecureServer extends tls.Server {
       const { storeHTTPOptions, setupConnectionsTracking } = require("node:_http_server");
       const http1Options = { ...options, ...options.http1Options };
       storeHTTPOptions.$call(this, http1Options);
+      // Node overrides the stored shouldUpgradeCallback option for these servers (nodejs/node#59924).
+      this.shouldUpgradeCallback = shouldUpgradeHttp1Request;
       this.maxHeadersCount = http1Options.maxHeadersCount ?? null;
       this.maxRequestsPerSocket = http1Options.maxRequestsPerSocket ?? 0;
       this.on("listening", setupConnectionsTracking);

--- a/src/jsc/bindings/node/http/JSConnectionsList.cpp
+++ b/src/jsc/bindings/node/http/JSConnectionsList.cpp
@@ -68,6 +68,7 @@ JSArray* JSConnectionsList::all(JSGlobalObject* globalObject)
         }
 
         result->putDirectIndex(globalObject, i++, parser);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     return result;
@@ -95,6 +96,7 @@ JSArray* JSConnectionsList::idle(JSGlobalObject* globalObject)
 
         if (parser->impl()->lastMessageStart() == 0) {
             result->putDirectIndex(globalObject, i++, parser);
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
 
@@ -122,6 +124,7 @@ JSArray* JSConnectionsList::active(JSGlobalObject* globalObject)
         }
 
         result->putDirectIndex(globalObject, i++, parser);
+        RETURN_IF_EXCEPTION(scope, {});
     }
 
     return result;

--- a/src/jsc/bindings/node/http/JSConnectionsList.cpp
+++ b/src/jsc/bindings/node/http/JSConnectionsList.cpp
@@ -149,7 +149,9 @@ JSArray* JSConnectionsList::expired(JSGlobalObject* globalObject, uint64_t heade
 
         if ((!parser->impl()->headersCompleted() && headersDeadline > 0 && parser->impl()->lastMessageStart() < headersDeadline) || (requestDeadline > 0 && parser->impl()->lastMessageStart() < requestDeadline)) {
             result->putDirectIndex(globalObject, i++, item);
+            RETURN_IF_EXCEPTION(scope, {});
             active->remove(globalObject, item);
+            RETURN_IF_EXCEPTION(scope, {});
         }
     }
 

--- a/src/jsc/bindings/node/http/JSConnectionsListPrototype.cpp
+++ b/src/jsc/bindings/node/http/JSConnectionsListPrototype.cpp
@@ -90,8 +90,7 @@ JSC_DEFINE_HOST_FUNCTION(jsConnectionsList_expired, (JSGlobalObject * globalObje
     JSValue headersTimeoutValue = callFrame->argument(0);
     JSValue requestTimeoutValue = callFrame->argument(1);
 
-    // Milliseconds to uv_hrtime() nanoseconds; widen before multiplying, a uint32_t product wraps
-    // for anything above 4294ms (node: static_cast<uint64_t>(...) * 1000000).
+    // ms to uv_hrtime() ns; a uint32_t product would wrap above 4294ms.
     uint64_t headersTimeout = static_cast<uint64_t>(headersTimeoutValue.toUInt32(globalObject)) * 1000000;
     RETURN_IF_EXCEPTION(scope, {});
     uint64_t requestTimeout = static_cast<uint64_t>(requestTimeoutValue.toUInt32(globalObject)) * 1000000;

--- a/src/jsc/bindings/node/http/JSConnectionsListPrototype.cpp
+++ b/src/jsc/bindings/node/http/JSConnectionsListPrototype.cpp
@@ -90,9 +90,11 @@ JSC_DEFINE_HOST_FUNCTION(jsConnectionsList_expired, (JSGlobalObject * globalObje
     JSValue headersTimeoutValue = callFrame->argument(0);
     JSValue requestTimeoutValue = callFrame->argument(1);
 
-    uint64_t headersTimeout = headersTimeoutValue.toUInt32(globalObject) * 1000000;
+    // Milliseconds to uv_hrtime() nanoseconds; widen before multiplying, a uint32_t product wraps
+    // for anything above 4294ms (node: static_cast<uint64_t>(...) * 1000000).
+    uint64_t headersTimeout = static_cast<uint64_t>(headersTimeoutValue.toUInt32(globalObject)) * 1000000;
     RETURN_IF_EXCEPTION(scope, {});
-    uint64_t requestTimeout = requestTimeoutValue.toUInt32(globalObject) * 1000000;
+    uint64_t requestTimeout = static_cast<uint64_t>(requestTimeoutValue.toUInt32(globalObject)) * 1000000;
     RETURN_IF_EXCEPTION(scope, {});
 
     if (headersTimeout == 0 && requestTimeout == 0) {

--- a/test/js/node/http/node-http-parser.test.ts
+++ b/test/js/node/http/node-http-parser.test.ts
@@ -263,6 +263,35 @@ describe("ConnectionsList", () => {
     // to remove it.
     expect(list.all()).toEqual([p1, p4, p3]);
   });
+
+  // expired() takes milliseconds and compares in uv_hrtime() nanoseconds; the conversion has to be
+  // done in 64 bits, as 4295ms * 1e6 already wraps a uint32 (to about 33us), which would make the
+  // http server's default headersTimeout / requestTimeout expire connections within seconds.
+  test("expired() does not truncate timeouts above 4294ms to 32 bits", () => {
+    const list = new ConnectionsList();
+    const parser = new HTTPParser();
+    parser.initialize(HTTPParser.REQUEST, {}, 0, 0, list);
+    try {
+      // Older than any wrapped timeout, far younger than the real ones.
+      while (parser.duration() < 2) {}
+      expect({
+        wrapping: list.expired(4295, 4295),
+        httpDefaults: list.expired(60_000, 300_000),
+        active: list.active(),
+      }).toEqual({ wrapping: [], httpDefaults: [], active: [parser] });
+      // A timeout the parser really has exceeded is still reported, and only once: expired() moves
+      // it out of the active set (until its next message) but keeps it in the list.
+      expect({
+        expired: list.expired(1, 1),
+        expiredAgain: list.expired(1, 1),
+        active: list.active(),
+        all: list.all(),
+      }).toEqual({ expired: [parser], expiredAgain: [], active: [], all: [parser] });
+    } finally {
+      parser.remove();
+      parser.close();
+    }
+  });
 });
 
 describe("parserOnHeaders maxHeaderPairs clamp (nodejs/node#61285)", () => {

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,13 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  // Bound and dialed by literal address: "localhost" can bind ::1 while the client dials 127.0.0.1.
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: address.address,
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4314,3 +4314,231 @@ it("closeAllConnections() destroys an emitted connection that closeIdleConnectio
     if (server.listening) server.close();
   }
 });
+
+const requestTimeoutResponse = "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n";
+
+// One duplexPair per name; emit() hands the server half to the server and everything the client
+// half receives is collected in `received`.
+function connectionPairs<const Name extends string>(server: Server, names: readonly Name[]) {
+  const pairs = Object.fromEntries(names.map(name => [name, duplexPair()])) as Record<
+    Name,
+    ReturnType<typeof duplexPair>
+  >;
+  const received = Object.fromEntries(names.map(name => [name, ""])) as Record<Name, string>;
+  for (const name of names) {
+    pairs[name][0].on("data", chunk => (received[name] += chunk.toString("latin1")));
+  }
+  return {
+    received,
+    emit(...emitted: Name[]) {
+      for (const name of emitted) server.emit("connection", pairs[name][1]);
+    },
+    client: (name: Name) => pairs[name][0],
+    nameOf: (socket: unknown) => names.find(name => pairs[name][1] === socket),
+    destroyed: () => Object.fromEntries(names.map(name => [name, pairs[name][1].destroyed])),
+    // duplexPair does not propagate destroy() to the other half, so watch the server half. Not
+    // events.once(): the halves below get destroyed with an error on purpose, which it would reject on.
+    closed: (...watched: Name[]) =>
+      Promise.all(watched.map(name => new Promise<void>(resolve => pairs[name][1].once("close", resolve)))),
+    destroyAll() {
+      for (const name of names) {
+        pairs[name][0].destroy();
+        pairs[name][1].destroy();
+      }
+    },
+  };
+}
+
+// Node's checkConnections() sweep covers emitted connections too: headersTimeout applies while a
+// request head is pending (including on a connection that has not sent anything yet),
+// requestTimeout while the rest of the request is, and an expired connection is treated like a
+// native one: ERR_HTTP_REQUEST_TIMEOUT through 'clientError', which by default answers with a raw
+// 408 and destroys. A request that has been received in full is subject to neither timeout.
+it("headersTimeout and requestTimeout expire emitted connections", async () => {
+  const heldResponse = Promise.withResolvers<ServerResponse>();
+  const dispatched: string[] = [];
+  const server = createServer(
+    { headersTimeout: 100, requestTimeout: 200, connectionsCheckingInterval: 10 },
+    (req, res) => {
+      dispatched.push(req.url!);
+      // "/body" is left unanswered: its request body never completes, so requestTimeout has to.
+      if (req.url === "/held") heldResponse.resolve(res);
+    },
+  );
+  await listen(server);
+  const connections = connectionPairs(server, ["silent", "partial", "body", "held"]);
+  try {
+    connections.emit("silent", "partial", "body", "held");
+    const expired = connections.closed("silent", "partial", "body");
+    connections.client("partial").write("GET /partial HTTP/1.1\r\nHost: x\r\n");
+    connections.client("body").write("POST /body HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+    connections.client("held").write("GET /held HTTP/1.1\r\nHost: x\r\n\r\n");
+    const held = await heldResponse.promise;
+    await expired;
+    expect({ received: connections.received, destroyed: connections.destroyed(), dispatched }).toEqual({
+      received: {
+        silent: requestTimeoutResponse,
+        partial: requestTimeoutResponse,
+        body: requestTimeoutResponse,
+        held: "",
+      },
+      destroyed: { silent: true, partial: true, body: true, held: false },
+      dispatched: ["/body", "/held"],
+    });
+
+    // Both timeouts have elapsed for the held request too (the other connections expired in the
+    // meantime); it can still be answered.
+    const heldBody = readResponseBody(connections.client("held"));
+    held.end("answered");
+    expect(await heldBody).toBe("answered");
+  } finally {
+    connections.destroyAll();
+    server.close();
+  }
+});
+
+it("a request timeout on an emitted connection is reported to 'clientError' exactly once", async () => {
+  const server = createServer({ headersTimeout: 50, requestTimeout: 50, connectionsCheckingInterval: 10 });
+  await listen(server);
+  const connections = connectionPairs(server, ["destroyed", "kept", "later"]);
+  const reports: { name: string | undefined; code: string; message: string; rawPacket: unknown }[] = [];
+  let awaitingReports: { count: number; resolve: () => void } | undefined;
+  function reportCountReaches(count: number) {
+    if (reports.length >= count) return Promise.resolve();
+    const { promise, resolve } = Promise.withResolvers<void>();
+    awaitingReports = { count, resolve };
+    return promise;
+  }
+  server.on("clientError", (err: any, socket: any) => {
+    const name = connections.nameOf(socket);
+    reports.push({ name, code: err.code, message: err.message, rawPacket: err.rawPacket });
+    switch (name) {
+      case "destroyed":
+        // The listener from Node's docs; destroying with the error emits it on the socket again.
+        socket.destroy(err);
+        break;
+      case "kept":
+        // Answers, but leaves the connection open for the following sweeps to look at again.
+        socket.end("HTTP/1.1 408 handled\r\n\r\n");
+        break;
+      default:
+        socket.destroy();
+    }
+    if (awaitingReports && reports.length >= awaitingReports.count) {
+      awaitingReports.resolve();
+      awaitingReports = undefined;
+    }
+  });
+  try {
+    connections.emit("destroyed", "kept");
+    const destroyedClosed = connections.closed("destroyed");
+    connections.client("kept").write("GET / HTTP/1.1\r\n");
+    await reportCountReaches(2);
+    // The socket's own 'error' event (from destroy(err)) precedes 'close'; it must not be reported.
+    await destroyedClosed;
+    // "later" starts counting only now, so the sweep has run over the still-open "kept"
+    // connection several more times by the time it is reported.
+    connections.emit("later");
+    await reportCountReaches(3);
+
+    const report = (name: string) => ({
+      name,
+      code: "ERR_HTTP_REQUEST_TIMEOUT",
+      message: "Request timeout",
+      rawPacket: undefined,
+    });
+    const firstTwo = reports.slice(0, 2).sort((a, b) => a.name!.localeCompare(b.name!));
+    expect({
+      reports: [...firstTwo, ...reports.slice(2)],
+      received: connections.received,
+      destroyed: connections.destroyed(),
+    }).toEqual({
+      reports: [report("destroyed"), report("kept"), report("later")],
+      received: { destroyed: "", kept: "HTTP/1.1 408 handled\r\n\r\n", later: "" },
+      destroyed: { destroyed: true, kept: false, later: true },
+    });
+  } finally {
+    connections.destroyAll();
+    server.close();
+  }
+});
+
+// Node's socketOnError writes its raw 408 only while nothing of a response has reached the socket
+// (_headerSent): writeHead() alone puts nothing on the wire, the first write() does.
+it("a request timeout does not append a 408 to a response that is already on the wire", async () => {
+  const server = createServer(
+    { headersTimeout: 50, requestTimeout: 50, connectionsCheckingInterval: 10 },
+    (req, res) => {
+      res.writeHead(200, { "content-length": "10" });
+      if (req.url === "/written") res.write("partial");
+    },
+  );
+  await listen(server);
+  const connections = connectionPairs(server, ["written", "headOnly"]);
+  try {
+    connections.emit("written", "headOnly");
+    const expired = connections.closed("written", "headOnly");
+    for (const name of ["written", "headOnly"] as const) {
+      connections.client(name).write(`POST /${name} HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc`);
+    }
+    await expired;
+    const [writtenHead, ...writtenAfterHead] = connections.received.written.split("\r\n\r\n");
+    expect({
+      writtenStatusLine: writtenHead.split("\r\n")[0],
+      writtenAfterHead,
+      headOnly: connections.received.headOnly,
+      destroyed: connections.destroyed(),
+    }).toEqual({
+      writtenStatusLine: "HTTP/1.1 200 OK",
+      writtenAfterHead: ["partial"],
+      headOnly: requestTimeoutResponse,
+      destroyed: { written: true, headOnly: true },
+    });
+  } finally {
+    connections.destroyAll();
+    server.close();
+  }
+});
+
+// Emitted connections use Node's socketOnError, which stops listening to the socket's errors
+// before reporting one, so the error it (or the 'clientError' listener) destroys the socket with
+// is not reported a second time. Like in Node, an error from execute() carries the bytes that
+// caused it and one the parser detects at EOF does not.
+it("a parse error on an emitted connection is reported to 'clientError' exactly once", async () => {
+  const server = createServer(() => {});
+  await listen(server);
+  const connections = connectionPairs(server, ["garbage", "truncated"]);
+  const reports: { name: string | undefined; code: string; message: string; rawPacket: string | undefined }[] = [];
+  server.on("clientError", (err: any, socket: any) => {
+    reports.push({
+      name: connections.nameOf(socket),
+      code: err.code,
+      message: err.message,
+      rawPacket: err.rawPacket?.toString(),
+    });
+    socket.destroy(err);
+  });
+  try {
+    connections.emit("garbage", "truncated");
+    const closed = connections.closed("garbage", "truncated");
+    connections.client("garbage").write("GARBAGE\r\n\r\n");
+    connections.client("truncated").end("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+    await closed;
+    reports.sort((a, b) => a.name!.localeCompare(b.name!));
+    expect({ reports, received: connections.received }).toEqual({
+      reports: [
+        {
+          name: "garbage",
+          code: "HPE_INVALID_METHOD",
+          message: "Parse Error: Invalid method encountered",
+          rawPacket: "GARBAGE\r\n\r\n",
+        },
+        { name: "truncated", code: "HPE_INVALID_EOF_STATE", message: "Parse Error", rawPacket: undefined },
+      ],
+      received: { garbage: "", truncated: "" },
+    });
+  } finally {
+    connections.destroyAll();
+    server.close();
+  }
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4398,6 +4398,58 @@ it("headersTimeout and requestTimeout expire emitted connections", async () => {
   }
 });
 
+// Which of the two timeouts governs a connection depends on whether the head of its current
+// request is complete, and a kept-alive connection is judged afresh for each request. With
+// requestTimeout out of reach, the connections still waiting for a head expire (one that sent
+// nothing, one that sent part of a head, and one that completed a request and then started the
+// next), while the one whose head is complete and whose body is still arriving is left alone.
+it("headersTimeout expires emitted connections whose request head is pending, including the next request on a kept-alive connection", async () => {
+  const server = createServer(
+    { headersTimeout: 50, requestTimeout: 60_000, connectionsCheckingInterval: 10 },
+    (req, res) => {
+      if (req.url !== "/body") {
+        res.end(`served ${req.url}`);
+        return;
+      }
+      let bodyBytes = 0;
+      req.on("data", chunk => (bodyBytes += chunk.length));
+      req.on("end", () => res.end(`body ${bodyBytes}`));
+    },
+  );
+  await listen(server);
+  const connections = connectionPairs(server, ["silent", "partial", "reused", "body"]);
+  try {
+    connections.emit("silent", "partial", "reused", "body");
+    const expired = connections.closed("silent", "partial", "reused");
+    // The /body head is complete before any of the others start their clocks, so every sweep that
+    // expires them has considered it as well.
+    connections.client("body").write("POST /body HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+    connections.client("partial").write("GET /partial HTTP/1.1\r\nHost: x\r\n");
+    const firstReusedBody = readResponseBody(connections.client("reused"));
+    connections.client("reused").write("GET /reused-1 HTTP/1.1\r\nHost: x\r\n\r\n");
+    expect(await firstReusedBody).toBe("served /reused-1");
+    const firstReusedResponse = connections.received.reused;
+    connections.client("reused").write("GET /reused-2 HTTP/1.1\r\n");
+    await expired;
+    expect({ received: connections.received, destroyed: connections.destroyed() }).toEqual({
+      received: {
+        silent: requestTimeoutResponse,
+        partial: requestTimeoutResponse,
+        reused: firstReusedResponse + requestTimeoutResponse,
+        body: "",
+      },
+      destroyed: { silent: true, partial: true, reused: true, body: false },
+    });
+
+    const bodyResponse = readResponseBody(connections.client("body"));
+    connections.client("body").write("defghij");
+    expect(await bodyResponse).toBe("body 10");
+  } finally {
+    connections.destroyAll();
+    server.close();
+  }
+});
+
 it("a request timeout on an emitted connection is reported to 'clientError' exactly once", async () => {
   const server = createServer({ headersTimeout: 50, requestTimeout: 50, connectionsCheckingInterval: 10 });
   await listen(server);

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4334,6 +4334,7 @@ function connectionPairs<const Name extends string>(server: Server, names: reado
       for (const name of emitted) server.emit("connection", pairs[name][1]);
     },
     client: (name: Name) => pairs[name][0],
+    serverSide: (name: Name) => pairs[name][1],
     nameOf: (socket: unknown) => names.find(name => pairs[name][1] === socket),
     destroyed: () => Object.fromEntries(names.map(name => [name, pairs[name][1].destroyed])),
     // duplexPair does not propagate destroy() to the other half, so watch the server half. Not
@@ -4503,11 +4504,11 @@ it("a request timeout does not append a 408 to a response that is already on the
 // Emitted connections use Node's socketOnError, which stops listening to the socket's errors
 // before reporting one, so the error it (or the 'clientError' listener) destroys the socket with
 // is not reported a second time. Like in Node, an error from execute() carries the bytes that
-// caused it and one the parser detects at EOF does not.
-it("a parse error on an emitted connection is reported to 'clientError' exactly once", async () => {
+// caused it; one the parser detects at EOF, or one the socket itself emits, does not.
+it("an error on an emitted connection is reported to 'clientError' exactly once", async () => {
   const server = createServer(() => {});
   await listen(server);
-  const connections = connectionPairs(server, ["garbage", "truncated"]);
+  const connections = connectionPairs(server, ["garbage", "truncated", "reset"]);
   const reports: { name: string | undefined; code: string; message: string; rawPacket: string | undefined }[] = [];
   server.on("clientError", (err: any, socket: any) => {
     reports.push({
@@ -4519,10 +4520,11 @@ it("a parse error on an emitted connection is reported to 'clientError' exactly 
     socket.destroy(err);
   });
   try {
-    connections.emit("garbage", "truncated");
-    const closed = connections.closed("garbage", "truncated");
+    connections.emit("garbage", "truncated", "reset");
+    const closed = connections.closed("garbage", "truncated", "reset");
     connections.client("garbage").write("GARBAGE\r\n\r\n");
     connections.client("truncated").end("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+    connections.serverSide("reset").destroy(Object.assign(new Error("read ECONNRESET"), { code: "ECONNRESET" }));
     await closed;
     reports.sort((a, b) => a.name!.localeCompare(b.name!));
     expect({ reports, received: connections.received }).toEqual({
@@ -4533,10 +4535,69 @@ it("a parse error on an emitted connection is reported to 'clientError' exactly 
           message: "Parse Error: Invalid method encountered",
           rawPacket: "GARBAGE\r\n\r\n",
         },
+        { name: "reset", code: "ECONNRESET", message: "read ECONNRESET", rawPacket: undefined },
         { name: "truncated", code: "HPE_INVALID_EOF_STATE", message: "Parse Error", rawPacket: undefined },
       ],
-      received: { garbage: "", truncated: "" },
+      received: { garbage: "", truncated: "", reset: "" },
     });
+  } finally {
+    connections.destroyAll();
+    server.close();
+  }
+});
+
+it("without a 'clientError' listener, a parse error on an emitted connection gets one 400 and reaches the socket's own 'error' listeners intact", async () => {
+  const server = createServer(() => {});
+  await listen(server);
+  const connections = connectionPairs(server, ["garbage"]);
+  // A 'clientError' listener would turn the default handling off, so count the emits at the source.
+  let clientErrorEmits = 0;
+  const emit = server.emit;
+  server.emit = function (event: string | symbol, ...args: any[]) {
+    if (event === "clientError") clientErrorEmits++;
+    return emit.call(this, event, ...args);
+  };
+  const socketErrors: { code: string; rawPacket: string }[] = [];
+  // Runs after the server's own 'connection' listener has set the connection up.
+  server.on("connection", socket => {
+    socket.on("error", (err: any) => socketErrors.push({ code: err.code, rawPacket: String(err.rawPacket) }));
+  });
+  try {
+    connections.emit("garbage");
+    const closed = connections.closed("garbage");
+    connections.client("garbage").write("GARBAGE\r\n\r\n");
+    await closed;
+    expect({ clientErrorEmits, received: connections.received, socketErrors }).toEqual({
+      clientErrorEmits: 1,
+      received: { garbage: "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n" },
+      socketErrors: [{ code: "HPE_INVALID_METHOD", rawPacket: "GARBAGE\r\n\r\n" }],
+    });
+  } finally {
+    connections.destroyAll();
+    server.close();
+  }
+});
+
+// Node's test-http-socket-error-listeners over an emitted connection: a listener that leaves the
+// connection open gets one 'clientError' per bad chunk, and the stand-in 'error' listener
+// socketOnError installs is installed once, not once per error.
+it("a 'clientError' listener that keeps an emitted connection open does not pile up 'error' listeners", async () => {
+  const server = createServer(() => {});
+  await listen(server);
+  const connections = connectionPairs(server, ["chunks"]);
+  const twelfthError = Promise.withResolvers<{ errors: number; errorListeners: number }>();
+  let errors = 0;
+  server.on("clientError", (_err, socket) => {
+    if (++errors === 12) {
+      twelfthError.resolve({ errors, errorListeners: socket.listenerCount("error") });
+    } else {
+      connections.client("chunks").write("*");
+    }
+  });
+  try {
+    connections.emit("chunks");
+    connections.client("chunks").write("*");
+    expect(await twelfthError.promise).toEqual({ errors: 12, errorListeners: 1 });
   } finally {
     connections.destroyAll();
     server.close();

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4655,3 +4655,88 @@ it("a 'clientError' listener that keeps an emitted connection open does not pile
     server.close();
   }
 });
+
+describe("default 'clientError' reply on a connection served through server.emit('connection')", () => {
+  // Node's socketOnError answers a parse error with a raw 400 only while no
+  // in-flight response has put bytes on the wire ("Caution must be taken to
+  // avoid corrupting the remote peer"); the connection is destroyed either way.
+  const rawBadRequest = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
+  const bodyOf = (raw: string) => raw.slice(raw.indexOf("\r\n\r\n") + 4);
+
+  function serveOneConnection(onRequest: (req: IncomingMessage, res: ServerResponse) => void) {
+    const server = createServer(onRequest);
+    const [clientSide, serverSide] = duplexPair();
+    let received = "";
+    const { promise: bodyArrived, resolve: onBodyArrived } = Promise.withResolvers<void>();
+    clientSide.on("data", chunk => {
+      received += chunk;
+      if (bodyOf(received) === "hello") onBodyArrived();
+    });
+    // The server destroys its own half; wait for that rather than for
+    // duplexPair to propagate it to the client half (Node's never does).
+    const closed = new Promise<string>(resolve => serverSide.on("close", () => resolve(received)));
+    server.emit("connection", serverSide);
+    return { clientSide, serverSide, closed, bodyArrived };
+  }
+
+  function writeHeadAndHalfTheBody(req: IncomingMessage, res: ServerResponse) {
+    res.writeHead(200, { "Content-Length": "10" });
+    res.write("hello");
+  }
+
+  // Let the duplex finish the response writes before the connection goes bad,
+  // so anything the server writes next is pushed to the client immediately
+  // rather than left buffered (and discarded) when it destroys the socket:
+  // a wrongly appended 400 must be observable.
+  const settleWrites = () => new Promise<void>(resolve => setImmediate(resolve));
+
+  it("does not write the raw 400 into a response whose head is already on the wire", async () => {
+    const { clientSide, serverSide, closed, bodyArrived } = serveOneConnection(writeHeadAndHalfTheBody);
+    clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    await bodyArrived;
+    await settleWrites();
+    clientSide.write("GARBAGE\r\n\r\n");
+    const received = await closed;
+    expect(received).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(bodyOf(received)).toBe("hello");
+    expect(serverSide.destroyed).toBe(true);
+  });
+
+  it("does not write the raw 400 when the peer ends mid request body while the response is on the wire", async () => {
+    // socket 'end' -> parser.finish() reports the truncated body as a parse
+    // error, reaching the same default handler as garbage bytes do.
+    const { clientSide, serverSide, closed, bodyArrived } = serveOneConnection(writeHeadAndHalfTheBody);
+    clientSide.write("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+    await bodyArrived;
+    await settleWrites();
+    clientSide.end();
+    const received = await closed;
+    expect(received).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(bodyOf(received)).toBe("hello");
+    expect(serverSide.destroyed).toBe(true);
+  });
+
+  it("still writes the raw 400 when the in-flight response has only called writeHead()", async () => {
+    // writeHead() puts nothing on the wire until the first write/end/flushHeaders
+    // (Node checks _headerSent, not headersSent), so the reply is still safe.
+    const { promise: headAssigned, resolve: onHeadAssigned } = Promise.withResolvers<void>();
+    const { clientSide, serverSide, closed } = serveOneConnection((req, res) => {
+      res.writeHead(200, { "Content-Length": "10" });
+      onHeadAssigned();
+    });
+    clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    await headAssigned;
+    clientSide.write("GARBAGE\r\n\r\n");
+    expect(await closed).toBe(rawBadRequest);
+    expect(serverSide.destroyed).toBe(true);
+  });
+
+  it("still writes the raw 400 when no response is in flight", async () => {
+    const onRequest = mock(() => {});
+    const { clientSide, serverSide, closed } = serveOneConnection(onRequest);
+    clientSide.write("GARBAGE\r\n\r\n");
+    expect(await closed).toBe(rawBadRequest);
+    expect(serverSide.destroyed).toBe(true);
+    expect(onRequest).not.toHaveBeenCalled();
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1,5 +1,6 @@
 import { bunEnv, bunExe, isASAN, isCI, isDebug, nodeExe } from "harness";
 import { createTest } from "node-harness";
+import { kConnectionsCheckingInterval } from "node:_http_server";
 import { AsyncLocalStorage } from "node:async_hooks";
 import dc from "node:diagnostics_channel";
 import fs from "node:fs";
@@ -4393,6 +4394,178 @@ it("http2 allowHTTP1 server.close() only destroys fallback connections that are 
     partial.client.destroy();
     done.client.destroy();
     if (server.listening) server.close();
+  }
+});
+
+// With allowHTTP1, node's Http2SecureServer runs http.Server's checkConnections() sweep over the
+// HTTP/1 connections while it is listening: a connection that has not sent a request within
+// headersTimeout of being accepted, or not all of it within requestTimeout of starting it, gets
+// http's raw 408 and is closed. A request that arrived in full is subject to neither timeout, and
+// HTTP/2 sessions are not looked at.
+it("http2 allowHTTP1 enforces headersTimeout and requestTimeout on fallback connections", async () => {
+  const heldResponse = Promise.withResolvers();
+  const dispatched = [];
+  const server = http2.createSecureServer(
+    { ...TLS_CERT, allowHTTP1: true, headersTimeout: 200, requestTimeout: 400, connectionsCheckingInterval: 10 },
+    (req, res) => {
+      dispatched.push(`HTTP/${req.httpVersion} ${req.url}`);
+      if (req.httpVersion === "2.0") res.end("h2");
+      // "/body" is left unanswered: its request body never completes, so requestTimeout has to.
+      else if (req.url === "/held") heldResponse.resolve(res);
+    },
+  );
+  await new Promise(resolve => server.listen(0, resolve));
+  const port = server.address().port;
+  const connections = [];
+  let h2;
+
+  // headersTimeout starts counting when the server accepts the connection (its 'secureConnection'
+  // listener runs before the one below), so whatever the connection is going to send goes out as
+  // soon as it is up. Everything the server sends back is collected until it closes the connection.
+  async function connectHttp1(requestBytes) {
+    const accepted = new Promise(resolve => server.once("secureConnection", resolve));
+    const client = tls.connect({ host: "localhost", port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] });
+    const connection = {
+      client,
+      serverSocket: null,
+      received: "",
+      closed: new Promise(resolve => client.once("close", resolve)),
+    };
+    connections.push(connection);
+    client.on("error", () => {});
+    client.on("data", chunk => (connection.received += chunk.toString("latin1")));
+    await new Promise(resolve => client.once("secureConnect", resolve));
+    if (requestBytes) client.write(requestBytes);
+    connection.serverSocket = await accepted;
+    return connection;
+  }
+
+  try {
+    const held = await connectHttp1("GET /held HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+    const silent = await connectHttp1();
+    const body = await connectHttp1("POST /body HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\nabc");
+    h2 = http2.connect(`https://localhost:${port}`, { ca: TLS_CERT.cert });
+    h2.on("error", () => {});
+    const heldRes = await heldResponse.promise;
+    await Promise.all([silent.closed, body.closed]);
+
+    const timeoutResponse = "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n";
+    expect({
+      received: { silent: silent.received, body: body.received, held: held.received },
+      destroyed: {
+        silent: silent.serverSocket.destroyed,
+        body: body.serverSocket.destroyed,
+        held: held.serverSocket.destroyed,
+      },
+    }).toEqual({
+      received: { silent: timeoutResponse, body: timeoutResponse, held: "" },
+      destroyed: { silent: true, body: true, held: false },
+    });
+
+    // The held request came in before "body" was even accepted, so both timeouts have elapsed for it
+    // as well; it is still answered (and, having asked for Connection: close, ended by the server).
+    heldRes.end("answered");
+    await held.closed;
+    expect(held.received).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(held.received).toEndWith("\r\n\r\nanswered");
+    // The session that sat through every sweep still serves requests.
+    const h2Status = await new Promise((resolve, reject) => {
+      const stream = h2.request({ ":path": "/h2" });
+      stream.on("response", headers => resolve(headers[":status"]));
+      stream.on("error", reject);
+      stream.end();
+    });
+    expect({ h2Status, dispatched: dispatched.sort() }).toEqual({
+      h2Status: 200,
+      dispatched: ["HTTP/1.1 /body", "HTTP/1.1 /held", "HTTP/2.0 /h2"],
+    });
+  } finally {
+    for (const { client } of connections) client.destroy();
+    h2?.destroy();
+    server.close();
+  }
+});
+
+// The HTTP/1 side of an allowHTTP1 server is configured by http.Server's storeHTTPOptions over
+// { ...options, ...options.http1Options } (same defaults, same validation, headersTimeout capped at
+// requestTimeout), and its connections-checking interval is armed on 'listening' (unref'd) and
+// cleared by close(). Without allowHTTP1 none of it exists, as in node.
+it("http2 allowHTTP1 takes http.Server's timeout options and checks connections while listening", async () => {
+  const timeouts = server => ({
+    headersTimeout: server.headersTimeout,
+    requestTimeout: server.requestTimeout,
+    connectionsCheckingInterval: server.connectionsCheckingInterval,
+    keepAliveTimeout: server.keepAliveTimeout,
+  });
+  const rejectedWith = http1Options => {
+    try {
+      http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true, ...http1Options });
+    } catch (error) {
+      return error.code;
+    }
+  };
+  expect({
+    defaults: timeouts(http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true })),
+    configured: timeouts(
+      http2.createSecureServer({
+        ...TLS_CERT,
+        allowHTTP1: true,
+        requestTimeout: 30_000,
+        connectionsCheckingInterval: 1_000,
+        http1Options: { connectionsCheckingInterval: 250 },
+      }),
+    ),
+    withoutAllowHTTP1: timeouts(http2.createSecureServer({ ...TLS_CERT, headersTimeout: 200, requestTimeout: 100 })),
+    rejected: {
+      headersTimeoutAboveRequestTimeout: rejectedWith({ headersTimeout: 200, requestTimeout: 100 }),
+      negative: rejectedWith({ headersTimeout: -1 }),
+      string: rejectedWith({ requestTimeout: "100" }),
+      fraction: rejectedWith({ connectionsCheckingInterval: 1.5 }),
+    },
+  }).toEqual({
+    defaults: {
+      headersTimeout: 60_000,
+      requestTimeout: 300_000,
+      connectionsCheckingInterval: 30_000,
+      keepAliveTimeout: 5_000,
+    },
+    configured: {
+      headersTimeout: 30_000,
+      requestTimeout: 30_000,
+      connectionsCheckingInterval: 250,
+      keepAliveTimeout: 5_000,
+    },
+    withoutAllowHTTP1: {
+      headersTimeout: undefined,
+      requestTimeout: undefined,
+      connectionsCheckingInterval: undefined,
+      keepAliveTimeout: undefined,
+    },
+    rejected: {
+      headersTimeoutAboveRequestTimeout: "ERR_OUT_OF_RANGE",
+      negative: "ERR_OUT_OF_RANGE",
+      string: "ERR_INVALID_ARG_TYPE",
+      fraction: "ERR_OUT_OF_RANGE",
+    },
+  });
+
+  const withAllowHTTP1 = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true });
+  const withoutAllowHTTP1 = http2.createSecureServer({ ...TLS_CERT });
+  try {
+    await Promise.all(
+      [withAllowHTTP1, withoutAllowHTTP1].map(server => new Promise(resolve => server.listen(0, resolve))),
+    );
+    const interval = withAllowHTTP1[kConnectionsCheckingInterval];
+    expect({
+      armed: interval !== undefined,
+      keepsProcessAlive: interval?.hasRef(),
+      withoutAllowHTTP1: withoutAllowHTTP1[kConnectionsCheckingInterval],
+    }).toEqual({ armed: true, keepsProcessAlive: false, withoutAllowHTTP1: undefined });
+    await new Promise(resolve => withAllowHTTP1.close(resolve));
+    expect(interval._destroyed).toBe(true);
+  } finally {
+    if (withAllowHTTP1.listening) withAllowHTTP1.close();
+    withoutAllowHTTP1.close();
   }
 });
 

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4601,6 +4601,42 @@ it("http2 allowHTTP1 takes http.Server's options and checks connections while li
   }
 });
 
+it("http2 allowHTTP1 fallback does not write the default clientError 400 into a response that is already on the wire", async () => {
+  // Node's socketOnError only writes its raw 400 while no in-flight response
+  // has reached the wire; here it must just drop the connection.
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    res.writeHead(200, { "Content-Length": "10" });
+    res.write("hello");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const { promise: closed, resolve: onClose } = Promise.withResolvers();
+    const socket = tls.connect(
+      { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+      () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"),
+    );
+    let received = "";
+    let sentGarbage = false;
+    socket.on("data", chunk => {
+      received += chunk;
+      if (!sentGarbage && received.endsWith("\r\n\r\nhello")) {
+        sentGarbage = true;
+        socket.write("GARBAGE\r\n\r\n");
+      }
+    });
+    // The server destroys the connection without a TLS close_notify, which the
+    // client may report as an error before 'close'; 'close' is what we wait for.
+    socket.on("error", () => {});
+    socket.on("close", () => onClose(received));
+    const raw = await closed;
+    expect(sentGarbage).toBe(true);
+    expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("hello");
+  } finally {
+    server.close();
+  }
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4488,9 +4488,11 @@ it("http2 allowHTTP1 enforces headersTimeout and requestTimeout on fallback conn
 
 // The HTTP/1 side of an allowHTTP1 server is configured by http.Server's storeHTTPOptions over
 // { ...options, ...options.http1Options } (same defaults, same validation, headersTimeout capped at
-// requestTimeout), and its connections-checking interval is armed on 'listening' (unref'd) and
-// cleared by close(). Without allowHTTP1 none of it exists, as in node.
-it("http2 allowHTTP1 takes http.Server's timeout options and checks connections while listening", async () => {
+// requestTimeout), except that node then replaces shouldUpgradeCallback with its own "is anyone
+// listening for 'upgrade'" check, so a caller-supplied one is validated but not used. The
+// connections-checking interval is armed on 'listening' (unref'd) and cleared by close(). Without
+// allowHTTP1 none of it exists, as in node.
+it("http2 allowHTTP1 takes http.Server's options and checks connections while listening", async () => {
   const timeouts = server => ({
     headersTimeout: server.headersTimeout,
     requestTimeout: server.requestTimeout,
@@ -4504,6 +4506,19 @@ it("http2 allowHTTP1 takes http.Server's timeout options and checks connections 
       return error.code;
     }
   };
+  let callerUpgradeCallbackCalls = 0;
+  const callerUpgradeCallback = () => {
+    callerUpgradeCallbackCalls++;
+    return true;
+  };
+  const withUpgradeCallback = http2.createSecureServer({
+    ...TLS_CERT,
+    allowHTTP1: true,
+    shouldUpgradeCallback: callerUpgradeCallback,
+  });
+  const upgradeBeforeListener = withUpgradeCallback.shouldUpgradeCallback();
+  withUpgradeCallback.on("upgrade", () => {});
+  const upgradeWithListener = withUpgradeCallback.shouldUpgradeCallback();
   expect({
     defaults: timeouts(http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true })),
     configured: timeouts(
@@ -4521,6 +4536,15 @@ it("http2 allowHTTP1 takes http.Server's timeout options and checks connections 
       negative: rejectedWith({ headersTimeout: -1 }),
       string: rejectedWith({ requestTimeout: "100" }),
       fraction: rejectedWith({ connectionsCheckingInterval: 1.5 }),
+      nonFunctionUpgradeCallback: rejectedWith({ shouldUpgradeCallback: 1 }),
+    },
+    shouldUpgradeCallback: {
+      storedCallerCallback: withUpgradeCallback.shouldUpgradeCallback === callerUpgradeCallback,
+      callerCallbackCalls: callerUpgradeCallbackCalls,
+      upgradeBeforeListener,
+      upgradeWithListener,
+      withoutAllowHTTP1: http2.createSecureServer({ ...TLS_CERT, shouldUpgradeCallback: callerUpgradeCallback })
+        .shouldUpgradeCallback,
     },
   }).toEqual({
     defaults: {
@@ -4546,6 +4570,14 @@ it("http2 allowHTTP1 takes http.Server's timeout options and checks connections 
       negative: "ERR_OUT_OF_RANGE",
       string: "ERR_INVALID_ARG_TYPE",
       fraction: "ERR_OUT_OF_RANGE",
+      nonFunctionUpgradeCallback: "ERR_INVALID_ARG_TYPE",
+    },
+    shouldUpgradeCallback: {
+      storedCallerCallback: false,
+      callerCallbackCalls: 0,
+      upgradeBeforeListener: false,
+      upgradeWithListener: true,
+      withoutAllowHTTP1: undefined,
     },
   });
 


### PR DESCRIPTION
Stacked on #37717 (this PR's base branch).

### Problem
- `headersTimeout` / `requestTimeout` never fire for connections served by the JS HTTP/1 fallback: `http2.createSecureServer({ allowHTTP1: true })` connections that negotiated `http/1.1`, and sockets passed to `http.Server` via `server.emit("connection", socket)`. A client that sends nothing, or stalls mid head or mid body, stays open forever; node answers `HTTP/1.1 408 Request Timeout` and closes it.
- Cause: `http.Server`'s periodic sweep only asked the native connection handles, which fallback connections do not have, and `Http2SecureServer` stored the two timeouts but never ran a sweep at all.
- The native `ConnectionsList#expired()` converted milliseconds to nanoseconds in 32 bits, so any timeout above 4294ms wrapped (the defaults would have become about 4.2s and 3.6s). Nothing called it until this PR.
- The fallback's private copy of the error path reported each parse error to `'clientError'` twice and wrote a raw error response even when part of a real response was already on the wire; the timeout path would have inherited both.

### Fix
- The existing `http.Server` sweep now also asks the per-server `ConnectionsList` from #37717 for expired fallback parsers. `Http2SecureServer` with `allowHTTP1` stores its HTTP/1 options through `http.Server`'s own helper (node's defaults and validation over `{ ...options, ...options.http1Options }`), arms the same sweep on `'listening'`, and clears it in `close()`.
- Expired connections and fallback parse errors go through the one `socketOnError` the native connections already use: the error reaches `'clientError'` once; otherwise a raw 408 / 400 is written only if no response bytes are out yet, then the socket is destroyed. The private copy and its two drifts are gone. Property to check: fallback connections now share the native connections' tracking, expiry rule, interval and error listener, with no second implementation.
- `expired()` widens to 64 bits before multiplying and checks for JS exceptions after each per-parser call, as do the other list walks. The `close()`d-parser guard is left to #34223; the native sweep itself is untouched.
- Verification: new tests for emitted connections, `allowHTTP1` connections and the 32-bit wrap; all but one fail before this change (the timeout ones by hanging) and pass with it. The repros and new tests behave identically under node v26.3.0. One unrelated test file now binds and dials `127.0.0.1`; it failed regardless of this PR where `localhost` resolves to `::1`.

### Background
- HTTP/1 fallback: bun's `http.Server` normally parses HTTP/1 natively on the socket handle. Two cases instead run a JS server loop over a plain Duplex with a JS-visible parser (`internal/http1_server_fallback.ts`): an `allowHTTP1` secure http2 server whose client chose `http/1.1`, and a socket the user emits as `'connection'` themselves.
- `headersTimeout` bounds the time from a request's first byte (or from accept, if nothing arrives) until its head is complete; `requestTimeout` bounds the whole request. Node enforces neither with a per-socket timer: a `connectionsCheckingInterval` sweep asks every connection whether it has expired.
- `ConnectionsList` is bun's port of node's native per-server set of parsers. `expired(headersMs, requestMs)` compares each parser's recorded message start and headers-complete flag against `hrtime` deadlines, returns the hits, and drops them from the active set so each request is reported once.
- `socketOnError` is node's default `'error'` listener on server connections: emit `'clientError'`; if nobody listens, write a bare status line (400 / 408 / 413 / 431 by error code) unless response bytes already reached the wire, then destroy. A request timeout is an ordinary `ERR_HTTP_REQUEST_TIMEOUT` on this path.
- `storeHTTPOptions` / `setupConnectionsTracking` are the `http.Server` helpers that validate and default these options and arm the unref'd sweep on `'listening'`; node's `Http2SecureServer` reuses both over the merged `http1Options`.

<details>
<summary>Original description</summary>

Stacked on #37717 (this PR's base branch), which registers every HTTP/1 fallback connection's parser in a per-server `ConnectionsList`; this adds the sweep over that list.

### What

`headersTimeout` / `requestTimeout` were never enforced for the connections served by the JS HTTP/1 path in `src/js/internal/http1_server_fallback.ts`: the `http/1.1` ALPN connections of `http2.createSecureServer({ allowHTTP1: true })`, and the sockets handed to an `http.Server` through `server.emit("connection", socket)`. Node runs its `checkConnections()` sweep over both.

```js
const server = http2.createSecureServer({
  key, cert, allowHTTP1: true,
  headersTimeout: 100, requestTimeout: 200, connectionsCheckingInterval: 50,
});
server.listen(0, () => {
  const client = tls.connect({ port: server.address().port, ca: cert, ALPNProtocols: ["http/1.1"] });
  // ... send nothing
});
// node v26.3.0: closed by the server after ~150ms, client received
//               "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\n\r\n"
// bun 1.4.0:    still open indefinitely, nothing received
```

Same result for a request head that stalls half way, for a request whose body stalls after the handler was dispatched (node answers 408 after `requestTimeout`), and for all three on `http.Server` + `server.emit("connection", duplex)`: bun's `checkConnections` only asked the native handles in `kTrackedConnections`, which these connections do not have, and `Http2SecureServer` stored `headersTimeout` / `requestTimeout` but had no interval at all.

### Fix

- `http1_server_fallback.ts` gets node's `checkConnections` loop (`checkHttp1Connections`): `connections.expired(headersTimeout, requestTimeout)` on the list #37717 introduced, each hit routed through `onRequestTimeout`. `http.Server`'s existing `checkConnections` calls it before walking the native connections.
- `Http2SecureServer` with `allowHTTP1` does what node's constructor does: `storeHTTPOptions` over `{ ...options, ...options.http1Options }` (replacing the hand-copied subset; this is what reads `connectionsCheckingInterval`, applies node's defaults such as `headersTimeout = min(60s, requestTimeout)`, and validates the values the way `http.createServer` does) and `this.on("listening", setupConnectionsTracking)`; `close()` clears the interval like node's `httpServerPreClose`. Node's constructor then replaces the `shouldUpgradeCallback` that `storeHTTPOptions` stored with its own listener-count check (a caller-supplied one is validated but not used on these servers), and so does this, which also keeps the base's behaviour: the fallback consults `server.shouldUpgradeCallback` when present, and before this change the http2 constructor never set it. Both helpers are now exported from `_http_server`, which is where node exports them too. The require is lazy so `require("http2")` still does not load the http server module unless `allowHTTP1` is used.
- The fallback's own copy of the error path is replaced by the `socketOnError` the native connections use (moved from `_http_server.ts` to `internal/http.ts` so both modules can share it; the one change to it is node's `listenerCount('error', noop) === 0` guard around installing the stand-in `'error'` listener, which matters now that the fallback calls it once per rejected chunk and a `'clientError'` listener may keep the connection open). That is what makes an expired connection behave like node's: `ERR_HTTP_REQUEST_TIMEOUT` to `'clientError'`, otherwise the raw 408 and destroy. It also fixes two things the copy had drifted on, both of which the timeout path would otherwise have inherited: it did not stop listening to the socket's `'error'` before destroying it with the error, so every parse error reached `'clientError'` twice (also when the listener did the documented `socket.destroy(err)`), and it wrote its raw error response even when a response was already on the wire. As in node, an EOF-detected parse error (`socketOnEnd`) is now reported as-is (`message: "Parse Error"`, `reason` set, no `rawPacket`); `execute()` errors still go through `prepareError` first.
- `ConnectionsList.prototype.expired` (`JSConnectionsListPrototype.cpp`) computed `toUInt32(ms) * 1000000` in 32 bits, so every timeout above 4294ms wrapped (the defaults would have become ~4.2s and ~3.6s). Nothing called it until now; widen to `uint64_t` before multiplying, as node's `ConnectionsList::Expired` does. `JSConnectionsList::expired` itself also did not check for exceptions after the `putDirectIndex` / `JSSet::remove` calls it makes per expired parser (caught by the exception-check validation now that the function is exercised); it does now, and so do the same `putDirectIndex` loops in `all()` / `idle()` / `active()`. Intentionally not included: the `impl() == nullptr` guard for a parser that was `close()`d while still listed, which `idle()` and `expired()` both lack; #34223 already adds exactly that to both loops, so it is left to that PR rather than duplicated here.

Why this shape: the tracking, the expiry rule (headers deadline while the head is incomplete, request deadline until message complete, measured from the message start or from accept for a connection that never sent anything, each request reported once) and the interval are node's own mechanisms, and the native side of them already existed (`NodeHTTPParser.cpp` keeps `lastMessageStart` / `headersCompleted` exactly like node, `ConnectionsList::expired` is a port of node's). So the fallback connections are now governed by the same code path as node's and, on the JS side, by the same `setupConnectionsTracking` / `checkConnections` / `socketOnError` as bun's native connections, rather than by a second implementation. The repros above, and every new test below run as a plain script, behave identically under node v26.3.0.

Unrelated test change in the same file set: `node-http-proxy.js` (used by `node-http.test.ts`'s "request via http proxy") now binds and dials `127.0.0.1` instead of `localhost`; in environments where `localhost` binds `::1` but is dialed as `127.0.0.1` (node v26 behaves identically there) that test failed regardless of this PR.

Not changed: `http.Server` tracks emitted connections whether or not it is listening (as before; node only creates its list on `'listening'`), and the native path's `isRequestTimedOut` sweep is untouched.

### Tests

- `test/js/node/http/node-http.test.ts` (next to the emitted-connection tests from #37717): silent / partial head / stalled body connections get the exact 408 and are destroyed while a fully received request survives both timeouts and is still answered; with `requestTimeout` out of reach, only the connections still waiting for a head expire (silent, partial head, and a kept-alive connection that completed one request and started the next, i.e. the per-request re-arm), while the one whose head is complete and whose body is still arriving is left alone and then finishes normally, which is what tells the two timeouts apart; `'clientError'` gets `ERR_HTTP_REQUEST_TIMEOUT` exactly once per connection, both when the listener destroys the socket with the error and when it keeps the connection open across further sweeps; no 408 is appended after `res.write()` put a response on the wire, but `writeHead()` alone still gets one; a parse error (from `execute()` and from EOF) and an error emitted by the socket itself each reach `'clientError'` once, with node's error shape; without a listener a parse error gets one 400 and the socket's own `'error'` listeners see the error with its `rawPacket` intact; a listener that keeps the connection open gets one `'clientError'` per bad chunk while the socket keeps a single `'error'` listener (this last one also passes on the base, whose separate copy never installed a stand-in listener; it pins the behaviour the shared implementation has to keep). The last three follow the tests on the standalone branch linked in the comments below. Also folded in, from the standalone fix for the same drift that was closed in favour of this PR (#37751): the 400 counterpart of the 408 case, i.e. a parse error from `execute()` or from `finish()` (peer ends mid body) arriving after `res.write()` on a kept-alive emitted connection gets no raw 400 written into the response, while `writeHead()`-only and no-response still get it.
- `test/js/node/http2/node-http2.test.js` (next to the `allowHTTP1` tests): a silent connection and a stalled-body connection (dispatched first) get the 408 and are closed, a complete request accepted before them is still answered afterwards, and an HTTP/2 session that sat through the sweeps still serves a request; `storeHTTPOptions` semantics (defaults, `http1Options` precedence, `headersTimeout` capped at `requestTimeout`, `ERR_OUT_OF_RANGE` / `ERR_INVALID_ARG_TYPE` validation, a caller's `shouldUpgradeCallback` validated but replaced by the listener-count check, nothing set without `allowHTTP1`) and the interval being armed unref'd on `'listening'` and destroyed by `close()`; plus, from #37751, the no-400-into-an-in-flight-response case over a TLS `allowHTTP1` connection.
- `test/js/node/http/node-http-parser.test.ts`: `expired(4295, 4295)` and `expired(60000, 300000)` report nothing for a parser a few ms old, while `expired(1, 1)` reports it once and leaves it in `all()`.

Apart from the one noted above, all of them fail before this change (the timeout tests by hanging, the others on their assertions) and pass with it. Also run locally: the full `node-http.test.ts`, `node-http2.test.js`, `node-http-server-timeouts.test.ts`, `node-http-connect.test.ts`, `node-http2-upgrade.test.mts`, `fetch-http2-client.test.ts`, and the upstream `test-http2-allow-http1`, `test-http2-https-fallback*`, `test-http2-createsecureserver-options`, `test-http-server-clear-timer`, `test-http(s)-server-connections-checking-leak`, all `test-http-server-{headers,request}-timeout-*`, `test-https-server-{headers,request}-timeout`, `test-http-generic-streams`, `test-http-server-unconsume-consume`, `test-http-socket-error-listeners`, `test-http(s)-server-close-{idle,all}` and `test-http-connect*` (43 files, all passing).




</details>
