### PR TITLE
bundler: run a Bun.build on the bundle thread through the task pointer, not a build-long &mut self

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -334,8 +334,8 @@ impl<C: CompletionStruct> BundleThread<C> {
         //
         // SAFETY: both pointers are the unique `&'a mut` slots returned by
         // `bump.alloc(...)` above; nothing else holds a reference to either
-        // past `init_and_run` (`set_transpiler` was cleared by
-        // `deinit_without_freeing_arena`, `pop()` restored the AST-allocator
+        // past `init_and_run` (the `BundleV2` that borrowed the transpiler
+        // went away inside it, `pop()` restored the AST-allocator
         // thread-local). The arena bytes themselves are bulk-freed afterwards
         // by `heap`'s `Drop` — `drop_in_place` only releases the *embedded
         // global-heap* state, so there is no double free.

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -5,8 +5,7 @@ use bun_core::{self, Output, zstr};
 use bun_io as Async;
 use bun_threading::unbounded_queue::{Node, UnboundedQueue};
 
-use crate::bundle_v2::{FileMap, JSBundlerPlugin, dispatch};
-use crate::{BundleV2, Transpiler};
+use crate::Transpiler;
 
 /// Used to keep the bundle thread from spinning on Windows
 #[cfg(windows)]
@@ -54,58 +53,57 @@ pub(crate) struct BundleThread<C: Node> {
 
 /// Trait capturing the interface a completion task must satisfy.
 ///
-/// The trait accessors keep the generic `BundleThread<C>`
-/// layout-agnostic. The concrete impl lives in T6 (`bun_bundler_jsc`).
+/// The trait keeps the generic `BundleThread<C>` layout-agnostic; the one
+/// impl is `bun_runtime`'s `JSBundleCompletionTask`.
+///
+/// Every method takes the task by pointer, never by reference. From `enqueue`
+/// until the post in `complete_on_bundle_thread` the owner's thread still
+/// reaches into the task through its own pointer (to cancel it, or to release
+/// it while it is still queued), and the bundler writes the task's log through
+/// the pointer `create_and_configure_transpiler` hands it for the whole build.
+/// A reference argument is protected for the duration of its call, so a
+/// `&mut self` receiver (`init_and_run`'s would span the entire build) would
+/// make every one of those accesses UB; the impl projects the fields it needs
+/// out of `this` instead.
+///
+/// # Safety
+/// For every method: `this` is the task `BundleThread` popped off its queue,
+/// live until `complete_on_bundle_thread` posts it back (or
+/// `free_released_unstarted` frees it); bundle thread only.
 pub trait CompletionStruct: Node + Send + 'static {
-    /// `bump` is the per-build mimalloc heap that backs `transpiler`, so the
-    /// two share lifetime `'a` (option fields like `optimize_imports: &'a
-    /// StringSet` borrow from `bump`).
-    fn configure_bundler<'a>(
-        &mut self,
-        transpiler: &mut Transpiler<'a>,
-        bump: &'a Arena,
-    ) -> Result<(), crate::Error>;
-    /// Bundle thread, on dequeue: `false` if the owner released this build
-    /// while it was still queued ([`free_released_unstarted`] then frees it).
-    fn try_start(&mut self) -> bool;
-    fn free_released_unstarted(this: *mut Self);
-    fn complete_on_bundle_thread(&mut self);
-    fn set_result(&mut self, result: BundleV2Result);
-    fn set_log(&mut self, log: bun_ast::Log);
-    fn set_transpiler(&mut self, this: *mut BundleV2<'_>);
-    fn plugins(&self) -> Option<NonNull<JSBundlerPlugin>>;
-    /// Returns the file map if non-empty; a single accessor so the opaque
-    /// `FileMap` layout stays in T6.
-    fn file_map(&mut self) -> Option<NonNull<FileMap>>;
-    /// Returns a §Dispatch handle (erased owner + `&'static` vtable) the impl
-    /// provides, so the bundler can read `result == .err` / `is_cancelled`,
-    /// and post plugin hops to the owning VM, without naming the concrete
-    /// struct.
-    fn as_js_bundle_completion_task(&mut self) -> dispatch::CompletionHandle;
+    /// On dequeue: `false` if the owner released this build while it was
+    /// still queued (`free_released_unstarted` then frees it).
+    unsafe fn try_start(this: *mut Self) -> bool;
+    /// Frees a task `try_start` returned `false` for; the owner is done with it.
+    unsafe fn free_released_unstarted(this: *mut Self);
+    /// Hands the task back to its owner. The bundle thread's last touch of
+    /// it: the owner may free it as soon as this posts.
+    unsafe fn complete_on_bundle_thread(this: *mut Self);
+    unsafe fn set_result(this: *mut Self, result: BundleV2Result);
+    unsafe fn set_log(this: *mut Self, log: bun_ast::Log);
 
     /// `Transpiler<'a>` has borrow-carrying fields (`arena: &'a Arena`,
     /// `resolver: Resolver<'a>`) that cannot be zero-init'd, so the allocate +
     /// configure pair is folded into one trait call returning the
-    /// arena-allocated, fully-configured transpiler.
+    /// arena-allocated, fully-configured transpiler. `bump` is the per-build
+    /// heap that backs it, so the two share lifetime `'a`.
     // The returned `&'a mut Transpiler<'a>` is arena-allocated via `bump.alloc(...)`
     // (bumpalo `Bump`), which hands out `&mut` from `&self` through interior
     // mutability — the standard arena pattern `mut_from_ref` cannot see through.
     #[allow(clippy::mut_from_ref)]
-    fn create_and_configure_transpiler<'a>(
-        &mut self,
+    unsafe fn create_and_configure_transpiler<'a>(
+        this: *mut Self,
         bump: &'a Arena,
     ) -> Result<&'a mut Transpiler<'a>, crate::Error>;
 
     /// Constructs the `BundleV2`, wires `plugins`/`completion`/`file_map`,
-    /// and runs the bundle.
+    /// runs the bundle and stores a successful result.
     ///
-    /// This body is `JSBundleCompletionTask`-specific, so the
-    /// construction + run is delegated to the trait impl in T6, which has
-    /// access to the concrete event-loop / work-pool wiring. The shared
-    /// scaffolding (arena, AST arena push/pop, log copy,
-    /// `completeOnBundleThread`) stays in `generate_in_new_thread` below.
-    fn init_and_run<'a>(
-        &mut self,
+    /// The impl has the concrete event-loop / work-pool wiring; the shared
+    /// scaffolding (arena, AST arena push/pop, log copy, the hand-back) stays
+    /// in `generate_in_new_thread` below.
+    unsafe fn init_and_run<'a>(
+        this: *mut Self,
         transpiler: &'a mut Transpiler<'a>,
         bump: &'a Arena,
         // Raw `*mut` (not `&'static`) because `BundleV2::init` ultimately
@@ -227,22 +225,22 @@ impl<C: CompletionStruct> BundleThread<C> {
                 // SAFETY: queue stores non-null *mut C pushed via enqueue(); owner keeps it alive
                 // until complete_on_bundle_thread() signals completion — unless it
                 // released the build while it sat here (its VM went away).
-                if !unsafe { (*completion).try_start() } {
-                    C::free_released_unstarted(completion);
+                if !unsafe { C::try_start(completion) } {
+                    // SAFETY: as above; `try_start` said the owner is done with it.
+                    unsafe { C::free_released_unstarted(completion) };
                     continue;
                 }
-                // SAFETY: as above; started ⇒ the owner waits for us.
-                let completion = unsafe { &mut *completion };
                 // SAFETY: `generation` is only read/written on this (bundle) thread.
                 let generation = unsafe { (*instance).generation };
                 // `panic = "abort"` → a Rust panic on this thread enters the
                 // crash-handler hook and aborts the whole process.
                 // No `catch_unwind` — there is nothing to catch.
-                match Self::generate_in_new_thread(completion, generation) {
-                    Ok(()) => {}
-                    Err(err) => {
-                        completion.set_result(BundleV2Result::Err(err));
-                        completion.complete_on_bundle_thread();
+                // SAFETY: started ⇒ the owner waits for the hand-back, which
+                // is the last thing either arm does with `completion`.
+                unsafe {
+                    if let Err(err) = Self::generate_in_new_thread(completion, generation) {
+                        C::set_result(completion, BundleV2Result::Err(err));
+                        C::complete_on_bundle_thread(completion);
                     }
                 }
                 has_bundled = true;
@@ -264,8 +262,12 @@ impl<C: CompletionStruct> BundleThread<C> {
     }
 
     /// This is called from `Bun.build` in JavaScript.
-    fn generate_in_new_thread(
-        completion: &mut C,
+    ///
+    /// # Safety
+    /// `completion` was just started (`try_start`); see [`CompletionStruct`].
+    /// On `Err` the caller hands it back; on `Ok` this has already done so.
+    unsafe fn generate_in_new_thread(
+        completion: *mut C,
         generation: bun_core::Generation,
     ) -> Result<(), crate::Error> {
         let heap = Arena::new();
@@ -277,22 +279,26 @@ impl<C: CompletionStruct> BundleThread<C> {
         ast_memory_store.push();
 
         // Allocate + configure folded — see `create_and_configure_transpiler` doc.
-        let transpiler = completion.create_and_configure_transpiler(bump)?;
+        // SAFETY: fn contract.
+        let transpiler = unsafe { C::create_and_configure_transpiler(completion, bump)? };
 
         transpiler.resolver.generation = generation;
 
-        // Construction + run delegated — see
-        // `init_and_run` doc. Reborrow `transpiler` through a raw ptr so
-        // `completion` can be borrowed again below.
+        // `init_and_run` consumes the `&'a mut Transpiler`; the log copy below
+        // reads it back through this pointer.
         let transpiler_ptr: *mut Transpiler<'_> = transpiler;
-        let run = completion.init_and_run(
-            // SAFETY: `transpiler` lives in `bump` for the duration of `heap`.
-            unsafe { &mut *transpiler_ptr },
-            bump,
-            // `WorkPool::get()` returns `&'static ThreadPool`; pass as raw so
-            // the impl can hand it to `BundleV2::init` (which stores `*mut`).
-            std::ptr::from_ref(bun_threading::work_pool::WorkPool::get()).cast_mut(),
-        );
+        // SAFETY: fn contract; `transpiler` lives in `bump` for the duration
+        // of `heap`.
+        let run = unsafe {
+            C::init_and_run(
+                completion,
+                &mut *transpiler_ptr,
+                bump,
+                // `WorkPool::get()` returns `&'static ThreadPool`; pass as raw so
+                // the impl can hand it to `BundleV2::init` (which stores `*mut`).
+                std::ptr::from_ref(bun_threading::work_pool::WorkPool::get()).cast_mut(),
+            )
+        };
 
         // Straight-line teardown: log copy
         // runs on both paths; `completeOnBundleThread` only on success (the error
@@ -300,14 +306,17 @@ impl<C: CompletionStruct> BundleThread<C> {
         // `deinitWithoutFreeingArena` + wait-group drain live inside `init_and_run`
         // (it owns `this`).
         let mut out_log = bun_ast::Log::init();
-        // SAFETY: `transpiler.log` is the arena-allocated `*mut Log` set up by
-        // `configure_bundler`; valid for the lifetime of `heap`. Raw deref so the
-        // `&'a mut Transpiler` consumed by `init_and_run` above is not reborrowed.
+        // SAFETY: `transpiler.log` points at the task's log (set up by
+        // `create_and_configure_transpiler`), live per the fn contract; the
+        // transpiler itself lives in `heap`. Nothing else touches the log now
+        // that the bundle has finished.
         let _ = unsafe { (*(*transpiler_ptr).log).append_to_with_recycled(&mut out_log, true) }; // logger OOM-only
-        completion.set_log(out_log);
-
-        if run.is_ok() {
-            completion.complete_on_bundle_thread();
+        // SAFETY: fn contract; on `Ok` the post is the last use of `completion`.
+        unsafe {
+            C::set_log(completion, out_log);
+            if run.is_ok() {
+                C::complete_on_bundle_thread(completion);
+            }
         }
 
         ast_memory_store.pop();

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -51,33 +51,24 @@ pub(crate) struct BundleThread<C: Node> {
     pub(crate) generation: bun_core::Generation,
 }
 
-/// Trait capturing the interface a completion task must satisfy.
-///
-/// The trait keeps the generic `BundleThread<C>` layout-agnostic; the one
-/// impl is `bun_runtime`'s `JSBundleCompletionTask`.
-///
-/// Every method takes the task by pointer, never by reference. From `enqueue`
-/// until the post in `complete_on_bundle_thread` the owner's thread still
-/// reaches into the task through its own pointer (to cancel it, or to release
-/// it while it is still queued), and the bundler writes the task's log through
-/// the pointer `create_and_configure_transpiler` hands it for the whole build.
-/// A reference argument is protected for the duration of its call, so a
-/// `&mut self` receiver (`init_and_run`'s would span the entire build) would
-/// make every one of those accesses UB; the impl projects the fields it needs
-/// out of `this` instead.
+/// The bundle thread's view of a queued build (`bun_runtime`'s
+/// `JSBundleCompletionTask`), by pointer: until `complete_on_bundle_thread`
+/// posts it back, the owning thread still cancels (or releases) the task
+/// through its own pointer and the bundler writes the task's log through the
+/// one `create_and_configure_transpiler` hands it, so no method may hold a
+/// reference to the whole task (a `&mut self` here is protected for the call,
+/// and `init_and_run`'s call is the whole build).
 ///
 /// # Safety
-/// For every method: `this` is the task `BundleThread` popped off its queue,
-/// live until `complete_on_bundle_thread` posts it back (or
-/// `free_released_unstarted` frees it); bundle thread only.
+/// `this` was popped off the queue and is live until `complete_on_bundle_thread`
+/// posts it back or `free_released_unstarted` frees it; bundle thread only.
 pub trait CompletionStruct: Node + Send + 'static {
-    /// On dequeue: `false` if the owner released this build while it was
-    /// still queued (`free_released_unstarted` then frees it).
+    /// `false` if the owner released this build while it was still queued
+    /// (`free_released_unstarted` then frees it).
     unsafe fn try_start(this: *mut Self) -> bool;
-    /// Frees a task `try_start` returned `false` for; the owner is done with it.
     unsafe fn free_released_unstarted(this: *mut Self);
-    /// Hands the task back to its owner. The bundle thread's last touch of
-    /// it: the owner may free it as soon as this posts.
+    /// The bundle thread's last touch: the owner may free the task as soon as
+    /// this posts it.
     unsafe fn complete_on_bundle_thread(this: *mut Self);
     unsafe fn set_result(this: *mut Self, result: BundleV2Result);
     unsafe fn set_log(this: *mut Self, log: bun_ast::Log);

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -33,12 +33,7 @@ pub enum BundleV2Result {
 
 /// Originally, bake.DevServer required a separate bundling thread, but that was
 /// later removed. The bundling thread's scheduling logic is generalized over
-/// the completion structure.
-///
-/// CompletionStruct's interface:
-///
-/// - `configureBundler` is used to configure `Bundler`.
-/// - `completeOnBundleThread` is used to tell the task that it is done.
+/// the completion structure, [`CompletionStruct`].
 // The trait bound lives on the `impl` (not the struct) so the
 // `singleton` static can name `BundleThread<JSBundleCompletionTask>` before T6
 // provides the `CompletionStruct` impl for the forward-decl.
@@ -252,7 +247,7 @@ impl<C: CompletionStruct> BundleThread<C> {
         }
     }
 
-    /// This is called from `Bun.build` in JavaScript.
+    /// One build, run by `thread_main` for each task it dequeues.
     ///
     /// # Safety
     /// `completion` was just started (`try_start`); see [`CompletionStruct`].
@@ -291,11 +286,9 @@ impl<C: CompletionStruct> BundleThread<C> {
             )
         };
 
-        // Straight-line teardown: log copy
-        // runs on both paths; `completeOnBundleThread` only on success (the error
-        // path's `set_result(Err)` + complete happens in `thread_main`). The
-        // `deinitWithoutFreeingArena` + wait-group drain live inside `init_and_run`
-        // (it owns `this`).
+        // The log copy runs on both paths; the hand-back only on success (on
+        // `Err`, `thread_main` stores the error and hands back). The bundle's
+        // own teardown happened inside `init_and_run`.
         let mut out_log = bun_ast::Log::init();
         // SAFETY: `transpiler.log` points at the task's log (set up by
         // `create_and_configure_transpiler`), live per the fn contract; the

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1370,19 +1370,15 @@ pub mod js_bundler {
         // `crate::api::js_bundle_completion_task` (bun_runtime owns it because its
         // fields name `Config`/`Plugin`/`HTMLBundle::Route`; lower-tier crates
         // cannot depend on those).
-        let completion =
-            crate::api::js_bundle_completion_task::create_and_schedule_completion_task(
-                config,
-                plugins.and_then(core::ptr::NonNull::new),
-                global_this,
-            )
-            .map_err(|_| JsError::OutOfMemory)?;
-        // SAFETY: `completion` is the freshly-boxed allocation returned above;
-        // sole owner on the JS thread until enqueued task runs.
-        unsafe {
-            (*completion).promise = jsc::JSPromiseStrong::init(global_this);
-            Ok((*completion).promise.value())
-        }
+        let promise = jsc::JSPromiseStrong::init(global_this);
+        let promise_value = promise.value();
+        crate::api::js_bundle_completion_task::create_and_schedule_completion_task(
+            config,
+            plugins.and_then(core::ptr::NonNull::new),
+            global_this,
+            crate::api::js_bundle_completion_task::Deliver::Promise(promise),
+        );
+        Ok(promise_value)
     }
 
     /// `Bun.build(config)`

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1070,7 +1070,9 @@ impl CompletionStruct for JSBundleCompletionTask {
         // teardown, written by neither; `config` is ours until the hand-back
         // (see `create_and_configure_transpiler`), and the `&'a FileMap` /
         // entry-point slices borrowed out of it below are only used by this
-        // bundle, which `bv2` ends before this returns.
+        // bundle, which `bv2` ends before this returns. Shared, not `&mut`:
+        // `transpiler.options.optimize_imports` still points into `config`
+        // (`configure_bundler`), and a `&mut` retag here would invalidate it.
         let (config, plugins) = unsafe { (&(*this).config, (*this).plugins) };
         bv2.plugins = plugins;
         bv2.completion = Some(dispatch::CompletionHandle {
@@ -1109,6 +1111,10 @@ impl CompletionStruct for JSBundleCompletionTask {
 /// Port of `JSBundleCompletionTask.configureBundler` — the post-init half
 /// (everything after `transpiler.* = try Transpiler.init(...)`), applying
 /// `config` to the freshly initialized `transpiler`.
+///
+/// `config` is `&mut` because the standalone-HTML case clears
+/// `config.compile`, which `on_complete` reads to decide whether to run
+/// `do_compilation`.
 fn configure_bundler(
     config: &mut JSBundlerConfig,
     transpiler: &mut Transpiler<'_>,
@@ -1270,8 +1276,10 @@ fn configure_bundler(
         Box::from(config.metafile_markdown_path.list.as_slice());
     if config.optimize_imports.count() > 0 {
         // SAFETY: `config` lives in the completion task, which outlives the
-        // transpiler (`bump`), and nothing writes `optimize_imports` during
-        // the bundle; a bump.alloc'd clone would leak (arena never runs Drop).
+        // transpiler (`bump`), and until the build is over `config` is only
+        // borrowed shared again (`init_and_run`) and never written, so this
+        // reference stays valid; a bump.alloc'd clone would leak (arena never
+        // runs Drop).
         transpiler.options.optimize_imports =
             Some(unsafe { &*core::ptr::from_ref(&config.optimize_imports) });
     }

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -61,8 +61,7 @@ pub struct JSBundleCompletionTask {
     promise: jsc::JSPromiseStrong,
     pub poll_ref: KeepAlive,
     pub(crate) env: *mut bun_dotenv::Loader,
-    /// The bundler's log for the whole build (`Transpiler::init` is handed a
-    /// pointer to it); read by the owner once the build is handed back.
+    /// Written by the bundler through a raw pointer for the whole build.
     pub(crate) log: bun_ast::Log,
     /// Set by the owner giving up on the result (HTMLBundle route torn down)
     /// or by the VM's stop phase; read by `on_complete` (skip delivery) and by
@@ -77,8 +76,7 @@ pub struct JSBundleCompletionTask {
     /// is still queued itself instead of waiting behind other VMs' builds.
     pub(crate) stage: core::sync::atomic::AtomicU8,
 
-    /// The route whose HTML this build is for ([`Deliver::HtmlRoute`]); it
-    /// holds a ref on itself until `on_complete` hands it the result.
+    /// [`Deliver::HtmlRoute`]; the route refs itself until `on_complete`.
     html_build_task: Option<NonNull<html_bundle::Route>>,
 
     pub(crate) result: BundleV2Result,
@@ -86,18 +84,17 @@ pub struct JSBundleCompletionTask {
     /// intrusive queue link (UnboundedQueue)
     pub(crate) next: bun_threading::Link<JSBundleCompletionTask>,
     pub(crate) plugins: Option<NonNull<Plugin>>,
-    /// When the build was scheduled; only an HTML route reports it.
+    /// Only an HTML route reports it.
     started_at_ns: u64,
 }
 
-/// Who gets the result when the build comes back. Fixed at construction: once
-/// the task is on the bundle thread's queue the JS thread no longer writes
-/// to it (see [`create_and_schedule_completion_task`]).
+/// Who gets the result. Fixed at construction: nothing writes to the task
+/// from the JS thread once it is enqueued (see [`CompletionStruct`]).
 pub(crate) enum Deliver {
     /// `Bun.build()`: settle this promise.
     Promise(jsc::JSPromiseStrong),
-    /// `Bun.serve` HTML route: `Route::on_complete`. The route must stay
-    /// alive until then (it refs itself while the build runs).
+    /// `Bun.serve` HTML route: `Route::on_complete` (the route refs itself
+    /// while the build runs).
     HtmlRoute(NonNull<html_bundle::Route>),
 }
 
@@ -156,12 +153,9 @@ unsafe impl Send for JSBundleCompletionTask {}
 /// `BundleV2.createAndScheduleCompletionTask` — construct, take a process-keepalive
 /// ref, and hand the task to the bundle-thread singleton.
 ///
-/// Everything the owner wants in the task arrives through `deliver`, and the
-/// enqueue is the last thing the JS thread does to the task: from then until
-/// the bundle thread posts it back (`on_complete_anytask`) the JS thread only
-/// goes near it to cancel it (`stop_for_vm_teardown`, `HTMLBundle::State::
-/// deinit`), which is all the returned pointer is for. `CompletionStruct`'s
-/// doc has the aliasing argument behind this.
+/// The enqueue is the JS thread's last write to the task (`CompletionStruct`
+/// says why); the returned pointer is for cancelling it (`stop_for_vm_teardown`,
+/// `HTMLBundle::State::deinit`) until `on_complete_anytask` gets it back.
 pub(crate) fn create_and_schedule_completion_task(
     config: JSBundlerConfig,
     plugins: Option<NonNull<Plugin>>,
@@ -869,10 +863,8 @@ bun_jsc::jsc_abi_extern! {
 // `dispatch::CompletionHandle` (erased owner + this `&'static` vtable) so the
 // struct layout stays in `bun_runtime`.
 
-/// The owner pointer `init_and_run` put in the handle: the task itself. The
-/// thunks project single fields out of it (see `CompletionStruct`); the task
-/// is live for every dispatch because the bundle it belongs to is still
-/// running.
+/// The handle's owner is the task itself (`init_and_run`), live while its
+/// bundle runs; the thunks project single fields out of it (`CompletionStruct`).
 #[inline]
 fn task_of(c: NonNull<Bv2OpaqueCompletion>) -> *mut JSBundleCompletionTask {
     c.as_ptr().cast::<JSBundleCompletionTask>()
@@ -907,12 +899,8 @@ static COMPLETION_VTABLE: dispatch::CompletionDispatch = dispatch::CompletionDis
 };
 
 // ─── CompletionStruct impl ───────────────────────────────────────────────────
-// What the bundle thread does with the task, without exposing the layout.
-// Every method projects the fields it needs out of `this` and never forms a
-// reference to the whole task: `stop_for_vm_teardown` / `State::deinit` reach
-// into it from the JS thread while these run, and the bundler writes `log`
-// through the pointer `create_and_configure_transpiler` hands it (see the
-// trait's doc).
+// Field projections out of `this` only, never a reference to the whole task;
+// the trait doc says why.
 //
 // SAFETY: `next` is the sole intrusive link for `UnboundedQueue<JSBundleCompletionTask>`.
 unsafe impl bun_threading::Linked for JSBundleCompletionTask {
@@ -958,10 +946,9 @@ impl CompletionStruct for JSBundleCompletionTask {
     unsafe fn complete_on_bundle_thread(this: *mut Self) {
         // The bundle thread's last touch of this task and of the VM's memory:
         // hand it back (always queued — the VM waits for it) and stop counting.
-        // SAFETY: trait contract. The post transfers the task to the VM's
-        // queue, which may run `on_complete_anytask` (and free it) at once, so
-        // the handle is cloned out first and nothing reads `this` after the
-        // post.
+        // SAFETY: trait contract. The VM may free the task as soon as it is
+        // posted, so the handle is cloned out first and nothing reads `this`
+        // afterwards.
         let handle = unsafe {
             (*this)
                 .bundle_loop
@@ -989,11 +976,9 @@ impl CompletionStruct for JSBundleCompletionTask {
         this: *mut Self,
         bump: &'a Arena,
     ) -> bun_bundler::Result<&'a mut Transpiler<'a>> {
-        // SAFETY: trait contract. Field projections only: `config` is the
-        // bundle thread's until the hand-back (the JS side does not touch it
-        // after enqueue), and `log` is handed to the bundler as a pointer and
-        // written through it from here until `set_log`, so no reference to it
-        // is formed.
+        // SAFETY: trait contract. `config` is ours until the hand-back; `log`
+        // stays a raw pointer because the bundler writes through it from here
+        // until `set_log`.
         let (config, log, env) =
             unsafe { (&mut (*this).config, &raw mut (*this).log, (*this).env) };
         let opts = api::TransformOptions {
@@ -1066,13 +1051,10 @@ impl CompletionStruct for JSBundleCompletionTask {
         // `Graph.heap` is a borrow, so reuse the caller-owned `bump`.
         let mut bv2 = BundleV2::init(transpiler, None, bump, event_loop, false, worker_pool, bump)?;
 
-        // SAFETY: trait contract. `plugins` is read here and by the VM's
-        // teardown, written by neither; `config` is ours until the hand-back
-        // (see `create_and_configure_transpiler`), and the `&'a FileMap` /
-        // entry-point slices borrowed out of it below are only used by this
-        // bundle, which `bv2` ends before this returns. Shared, not `&mut`:
-        // `transpiler.options.optimize_imports` still points into `config`
-        // (`configure_bundler`), and a `&mut` retag here would invalidate it.
+        // SAFETY: trait contract. `plugins` is only read (here and by the VM's
+        // teardown); `config` is ours until the hand-back and the borrows taken
+        // out of it below end with `bv2`. Shared, not `&mut`: the transpiler
+        // still holds `configure_bundler`'s `&config.optimize_imports`.
         let (config, plugins) = unsafe { (&(*this).config, (*this).plugins) };
         bv2.plugins = plugins;
         bv2.completion = Some(dispatch::CompletionHandle {
@@ -1109,12 +1091,8 @@ impl CompletionStruct for JSBundleCompletionTask {
 }
 
 /// Port of `JSBundleCompletionTask.configureBundler` — the post-init half
-/// (everything after `transpiler.* = try Transpiler.init(...)`), applying
-/// `config` to the freshly initialized `transpiler`.
-///
-/// `config` is `&mut` because the standalone-HTML case clears
-/// `config.compile`, which `on_complete` reads to decide whether to run
-/// `do_compilation`.
+/// (everything after `transpiler.* = try Transpiler.init(...)`). `&mut` because
+/// the standalone-HTML case clears `config.compile`, which `on_complete` reads.
 fn configure_bundler(
     config: &mut JSBundlerConfig,
     transpiler: &mut Transpiler<'_>,
@@ -1275,11 +1253,9 @@ fn configure_bundler(
     transpiler.options.metafile_markdown_path =
         Box::from(config.metafile_markdown_path.list.as_slice());
     if config.optimize_imports.count() > 0 {
-        // SAFETY: `config` lives in the completion task, which outlives the
-        // transpiler (`bump`), and until the build is over `config` is only
-        // borrowed shared again (`init_and_run`) and never written, so this
-        // reference stays valid; a bump.alloc'd clone would leak (arena never
-        // runs Drop).
+        // SAFETY: the task (and so `config`) outlives the transpiler, and until
+        // the build is over `config` is only borrowed shared again
+        // (`init_and_run`); a bump.alloc'd clone would leak (no Drop in arenas).
         transpiler.options.optimize_imports =
             Some(unsafe { &*core::ptr::from_ref(&config.optimize_imports) });
     }

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -14,8 +14,8 @@ use std::io::Write as _;
 
 use bun_alloc::Arena;
 use bun_bundler::bundle_v2::{
-    BundleV2, BundleV2Result, CompletionStruct, FileMap as Bv2FileMap,
-    JSBundleCompletionTask as Bv2OpaqueCompletion, JSBundlerPlugin, dispatch,
+    BundleV2, BundleV2Result, CompletionStruct, JSBundleCompletionTask as Bv2OpaqueCompletion,
+    dispatch,
 };
 use bun_bundler::options::{self, OutputFile, OutputKind, Side};
 use bun_bundler::output_file::Value as OutputFileValue;
@@ -57,9 +57,12 @@ pub struct JSBundleCompletionTask {
     /// How the bundle thread (and plugin hops) reach the VM that called Bun.build.
     pub(crate) loop_handle: jsc::LoopHandle,
     pub global_this: BackRef<JSGlobalObject>,
-    pub(crate) promise: jsc::JSPromiseStrong,
+    /// `Bun.build()`'s promise; empty for an HTML route's build.
+    promise: jsc::JSPromiseStrong,
     pub poll_ref: KeepAlive,
     pub(crate) env: *mut bun_dotenv::Loader,
+    /// The bundler's log for the whole build (`Transpiler::init` is handed a
+    /// pointer to it); read by the owner once the build is handed back.
     pub(crate) log: bun_ast::Log,
     /// Set by the owner giving up on the result (HTMLBundle route torn down)
     /// or by the VM's stop phase; read by `on_complete` (skip delivery) and by
@@ -74,16 +77,28 @@ pub struct JSBundleCompletionTask {
     /// is still queued itself instead of waiting behind other VMs' builds.
     pub(crate) stage: core::sync::atomic::AtomicU8,
 
-    pub(crate) html_build_task: Option<*mut html_bundle::Route>,
+    /// The route whose HTML this build is for ([`Deliver::HtmlRoute`]); it
+    /// holds a ref on itself until `on_complete` hands it the result.
+    html_build_task: Option<NonNull<html_bundle::Route>>,
 
     pub(crate) result: BundleV2Result,
 
     /// intrusive queue link (UnboundedQueue)
     pub(crate) next: bun_threading::Link<JSBundleCompletionTask>,
-    /// arena-owned by BundleThread heap
-    pub(crate) transpiler: *mut BundleV2<'static>,
     pub(crate) plugins: Option<NonNull<Plugin>>,
-    pub(crate) started_at_ns: u64,
+    /// When the build was scheduled; only an HTML route reports it.
+    started_at_ns: u64,
+}
+
+/// Who gets the result when the build comes back. Fixed at construction: once
+/// the task is on the bundle thread's queue the JS thread no longer writes
+/// to it (see [`create_and_schedule_completion_task`]).
+pub(crate) enum Deliver {
+    /// `Bun.build()`: settle this promise.
+    Promise(jsc::JSPromiseStrong),
+    /// `Bun.serve` HTML route: `Route::on_complete`. The route must stay
+    /// alive until then (it refs itself while the build runs).
+    HtmlRoute(NonNull<html_bundle::Route>),
 }
 
 #[repr(u8)]
@@ -102,6 +117,11 @@ pub(crate) enum Stage {
 }
 
 impl JSBundleCompletionTask {
+    /// When the build was scheduled (`Deliver::HtmlRoute` only).
+    pub(crate) fn started_at_ns(&self) -> u64 {
+        self.started_at_ns
+    }
+
     /// `RefCounted` destructor — last ref dropped.
     ///
     /// Safe fn: only reachable via the `#[ref_count(destroy = …)]` derive,
@@ -135,60 +155,69 @@ unsafe impl Send for JSBundleCompletionTask {}
 
 /// `BundleV2.createAndScheduleCompletionTask` — construct, take a process-keepalive
 /// ref, and hand the task to the bundle-thread singleton.
+///
+/// Everything the owner wants in the task arrives through `deliver`, and the
+/// enqueue is the last thing the JS thread does to the task: from then until
+/// the bundle thread posts it back (`on_complete_anytask`) the JS thread only
+/// goes near it to cancel it (`stop_for_vm_teardown`, `HTMLBundle::State::
+/// deinit`), which is all the returned pointer is for. `CompletionStruct`'s
+/// doc has the aliasing argument behind this.
 pub(crate) fn create_and_schedule_completion_task(
     config: JSBundlerConfig,
     plugins: Option<NonNull<Plugin>>,
     global_this: &JSGlobalObject,
-) -> crate::Result<*mut JSBundleCompletionTask> {
+    deliver: Deliver,
+) -> NonNull<JSBundleCompletionTask> {
     let vm = global_this.bun_vm_ptr();
     let env = global_this.bun_vm().transpiler.env;
-    let completion = bun_core::heap::into_raw(Box::new(JSBundleCompletionTask {
+    let (promise, html_build_task, started_at_ns) = match deliver {
+        Deliver::Promise(promise) => (promise, None, 0),
+        Deliver::HtmlRoute(route) => (
+            jsc::JSPromiseStrong::default(),
+            Some(route),
+            bun_core::util::Timespec::now_allow_mocked_time().ns(),
+        ),
+    };
+    let mut task = Box::new(JSBundleCompletionTask {
         ref_count: RefCount::init(),
         config,
         loop_handle: global_this.bun_vm().loop_handle(),
         global_this: BackRef::new(global_this),
-        promise: jsc::JSPromiseStrong::default(),
+        promise,
         poll_ref: KeepAlive::init(),
         env,
         log: bun_ast::Log::init(),
         cancelled: core::sync::atomic::AtomicBool::new(false),
         bundle_loop: core::sync::atomic::AtomicPtr::new(ptr::null_mut()),
         stage: core::sync::atomic::AtomicU8::new(Stage::Queued as u8),
-        html_build_task: None,
+        html_build_task,
         result: BundleV2Result::Pending,
         next: bun_threading::Link::new(),
-        transpiler: ptr::null_mut(),
         plugins,
-        started_at_ns: 0,
-    }));
-    // SAFETY: freshly-boxed allocation with ref_count == 1; sole handle.
-    unsafe {
-        if let Some(plugin) = (*completion).plugins {
-            (*plugin.as_ptr()).set_config(completion.cast());
-        }
+        started_at_ns,
+    });
+    // SAFETY: `vm` is the live per-thread VM (`global_this.bun_vm_ptr()`); the
+    // ctx is used for this one `loop_ref`.
+    task.poll_ref
+        .ref_(unsafe { jsc::virtual_machine::VirtualMachine::event_loop_ctx(vm) });
+    // Out on the bundle thread from the enqueue below until it posts the
+    // completion: it reads this VM's env loader and the plugin cell, so the VM
+    // cancels it at teardown (registry) and waits for it (embedded work).
+    task.loop_handle.embedded_work_scheduled();
+    let completion = bun_core::heap::into_raw_nn(task);
+    if let Some(plugin) = plugins {
+        // SAFETY: `plugin` is the live handle `Config::from_js` created; the
+        // task owns it from here (`deinit`).
+        unsafe { (*plugin.as_ptr()).set_config(completion.as_ptr().cast()) };
     }
+    crate::jsc_hooks::ActiveHandle::Bundle(completion).register();
 
     // Ensure this exists before we spawn the thread to prevent any race
     // conditions from creating two
     let _ = WorkPool::get();
 
-    // Out on the bundle thread from here until it posts the completion: it
-    // reads this VM's env loader and the plugin cell, so the VM cancels it at
-    // teardown (registry) and waits for it (embedded work).
-    // SAFETY: `completion` is live (refcount==1), JS thread.
-    unsafe { (*completion).loop_handle.embedded_work_scheduled() };
-    crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(completion).expect("completion"))
-        .register();
-    bun_bundler::bundle_v2::singleton::enqueue::<JSBundleCompletionTask>(completion);
-
-    // SAFETY: `completion` is live (refcount==1); `vm` outlives this call.
-    unsafe {
-        (*completion)
-            .poll_ref
-            .ref_(jsc::virtual_machine::VirtualMachine::event_loop_ctx(vm))
-    };
-
-    Ok(completion)
+    bun_bundler::bundle_v2::singleton::enqueue::<JSBundleCompletionTask>(completion.as_ptr());
+    completion
 }
 
 /// `if (s.slice().len > 0) s.slice() else null` for the windows-options block.
@@ -636,10 +665,10 @@ impl JSBundleCompletionTask {
 
         if let Some(html_build_task) = this.html_build_task {
             this.plugins = None;
-            // SAFETY: `html_build_task` is a backref set by `HTMLBundle::Route` which
-            // bumped its own refcount before scheduling and stays alive until this returns.
+            // SAFETY: `Deliver::HtmlRoute` contract — the route refs itself
+            // before scheduling and releases that ref inside `on_complete`.
             // R-2: deref as shared — `on_complete` takes `&self`.
-            unsafe { html_bundle::Route::on_complete(&*html_build_task, this) };
+            unsafe { html_bundle::Route::on_complete(html_build_task.as_ref(), this) };
             return Ok(());
         }
 
@@ -840,35 +869,37 @@ bun_jsc::jsc_abi_extern! {
 // `dispatch::CompletionHandle` (erased owner + this `&'static` vtable) so the
 // struct layout stays in `bun_runtime`.
 
-/// Recover `&JSBundleCompletionTask` from the opaque vtable owner pointer.
-///
-/// Centralises the `NonNull<Bv2OpaqueCompletion> → &JSBundleCompletionTask`
-/// cast+deref so the two `CompletionDispatch` thunks below stay safe at the
-/// call site (one accessor, N safe callers).
+/// The owner pointer `init_and_run` put in the handle: the task itself. The
+/// thunks project single fields out of it (see `CompletionStruct`); the task
+/// is live for every dispatch because the bundle it belongs to is still
+/// running.
 #[inline]
-fn from_completion_handle<'a>(c: NonNull<Bv2OpaqueCompletion>) -> &'a JSBundleCompletionTask {
-    // SAFETY: `c` is the live backref the bundler stashed in
-    // `CompletionHandle.owner` (set from a `Box<JSBundleCompletionTask>` that
-    // outlives every dispatch call). The opaque marker and the concrete struct
-    // are the same allocation; only shared field reads follow.
-    unsafe { &*c.as_ptr().cast::<JSBundleCompletionTask>() }
+fn task_of(c: NonNull<Bv2OpaqueCompletion>) -> *mut JSBundleCompletionTask {
+    c.as_ptr().cast::<JSBundleCompletionTask>()
 }
 
 static COMPLETION_VTABLE: dispatch::CompletionDispatch = dispatch::CompletionDispatch {
-    result_is_err: |c| matches!(from_completion_handle(c).result, BundleV2Result::Err(_)),
+    result_is_err: |c| {
+        // SAFETY: see `task_of`; `result` is only written once the bundle is
+        // over.
+        unsafe { matches!((*task_of(c)).result, BundleV2Result::Err(_)) }
+    },
     is_cancelled: |c| {
-        from_completion_handle(c)
-            .cancelled
-            .load(core::sync::atomic::Ordering::Acquire)
+        // SAFETY: see `task_of`; an atomic, readable from any thread.
+        unsafe {
+            (*task_of(c))
+                .cancelled
+                .load(core::sync::atomic::Ordering::Acquire)
+        }
     },
     enqueue_task_concurrent: |c, task| {
-        // SAFETY: `task` is a fresh non-null `ConcurrentTaskItem` passed through
-        // from the bundler vtable; the queue takes ownership. The VM waits for
-        // this build (embedded work) before closing its handle: always queued.
+        // SAFETY: see `task_of`; `loop_handle` is `Sync`. `task` is a fresh
+        // non-null `ConcurrentTaskItem` passed through from the bundler
+        // vtable; the queue takes ownership. The VM waits for this build
+        // (embedded work) before closing its handle: always queued.
         unsafe {
             let task = core::ptr::NonNull::new_unchecked(task);
-            let c = from_completion_handle(c);
-            let jsc::vm_handle::Posted::Queued = c.loop_handle.post_task(task) else {
+            let jsc::vm_handle::Posted::Queued = (*task_of(c)).loop_handle.post_task(task) else {
                 unreachable!("VM handle closed with a Bun.build outstanding");
             };
         }
@@ -876,7 +907,13 @@ static COMPLETION_VTABLE: dispatch::CompletionDispatch = dispatch::CompletionDis
 };
 
 // ─── CompletionStruct impl ───────────────────────────────────────────────────
-// Hands BundleThread the field accessors it needs without exposing the layout.
+// What the bundle thread does with the task, without exposing the layout.
+// Every method projects the fields it needs out of `this` and never forms a
+// reference to the whole task: `stop_for_vm_teardown` / `State::deinit` reach
+// into it from the JS thread while these run, and the bundler writes `log`
+// through the pointer `create_and_configure_transpiler` hands it (see the
+// trait's doc).
+//
 // SAFETY: `next` is the sole intrusive link for `UnboundedQueue<JSBundleCompletionTask>`.
 unsafe impl bun_threading::Linked for JSBundleCompletionTask {
     #[inline]
@@ -887,20 +924,22 @@ unsafe impl bun_threading::Linked for JSBundleCompletionTask {
 }
 
 impl CompletionStruct for JSBundleCompletionTask {
-    fn try_start(&mut self) -> bool {
+    unsafe fn try_start(this: *mut Self) -> bool {
         use core::sync::atomic::Ordering;
-        self.stage
-            .compare_exchange(
+        // SAFETY: trait contract. `stage` is the handshake with
+        // `stop_for_vm_teardown`, which may be running right now.
+        unsafe {
+            (*this).stage.compare_exchange(
                 Stage::Queued as u8,
                 Stage::Started as u8,
                 Ordering::AcqRel,
                 Ordering::Acquire,
             )
-            .is_ok()
+        }
+        .is_ok()
     }
 
-    #[allow(clippy::not_unsafe_ptr_arg_deref)] // trait contract: dequeued ⇒ sole owner
-    fn free_released_unstarted(this: *mut Self) {
+    unsafe fn free_released_unstarted(this: *mut Self) {
         use core::sync::atomic::Ordering;
         // `try_start` lost to the VM's teardown, which may still be releasing
         // the JS side (`Releasing`): a handful of stores on the JS thread.
@@ -916,250 +955,47 @@ impl CompletionStruct for JSBundleCompletionTask {
         drop(unsafe { bun_core::heap::take(this) });
     }
 
-    /// Port of `JSBundleCompletionTask.configureBundler` — the post-init half
-    /// (everything after `transpiler.* = try Transpiler.init(...)`).
-    /// `Transpiler::init` itself is called by `create_and_configure_transpiler`
-    /// (Rust cannot zero-init `Transpiler<'a>` and write it in place).
-    fn configure_bundler<'a>(
-        &mut self,
-        transpiler: &mut Transpiler<'a>,
-        _bump: &'a Arena,
-    ) -> bun_bundler::Result<()> {
-        let config = &mut self.config;
-
-        transpiler.options.env.behavior = config.env_behavior;
-        transpiler.options.env.prefix = Box::from(config.env_prefix.list.as_slice());
-        // `BundleOptions.bundler_feature_flags: Option<Box<StringSet>>` owns
-        // its set, so clone rather than alias `config.features`.
-        transpiler.options.bundler_feature_flags = Some(Box::new(config.features.clone()?));
-        if config.force_node_env != options::ForceNodeEnv::Unspecified {
-            transpiler.options.force_node_env = config.force_node_env;
-        }
-
-        transpiler.options.entry_points = config.entry_points.keys().to_vec().into_boxed_slice();
-        // Convert API JSX config back to options.JSX.Pragma
-        let jsx_import = &config.jsx.import_source;
-        transpiler.options.jsx = options::jsx::Pragma {
-            factory: if !config.jsx.factory.is_empty() {
-                options::jsx::Pragma::member_list_to_components_if_different(
-                    options::jsx::MemberList::Static(options::jsx::defaults::FACTORY),
-                    &config.jsx.factory,
-                )?
-            } else {
-                options::jsx::MemberList::Static(options::jsx::defaults::FACTORY)
-            },
-            fragment: if !config.jsx.fragment.is_empty() {
-                options::jsx::Pragma::member_list_to_components_if_different(
-                    options::jsx::MemberList::Static(options::jsx::defaults::FRAGMENT),
-                    &config.jsx.fragment,
-                )?
-            } else {
-                options::jsx::MemberList::Static(options::jsx::defaults::FRAGMENT)
-            },
-            runtime: options::jsx::Runtime::from(config.jsx.runtime),
-            development: config.jsx.development,
-            package_name: if !jsx_import.is_empty() {
-                std::borrow::Cow::Owned(jsx_import.to_vec())
-            } else {
-                std::borrow::Cow::Borrowed(b"react".as_slice())
-            },
-            classic_import_source: if !jsx_import.is_empty() {
-                std::borrow::Cow::Owned(jsx_import.to_vec())
-            } else {
-                std::borrow::Cow::Borrowed(b"react".as_slice())
-            },
-            side_effects: config.jsx.side_effects,
-            parse: true,
-            import_source: options::jsx::ImportSource {
-                development: if !jsx_import.is_empty() {
-                    let mut v = Vec::with_capacity(jsx_import.len() + 16);
-                    let _ = write!(&mut v, "{}/jsx-dev-runtime", bstr::BStr::new(jsx_import));
-                    std::borrow::Cow::Owned(v)
-                } else {
-                    std::borrow::Cow::Borrowed(options::jsx::defaults::IMPORT_SOURCE_DEV)
-                },
-                production: if !jsx_import.is_empty() {
-                    let mut v = Vec::with_capacity(jsx_import.len() + 12);
-                    let _ = write!(&mut v, "{}/jsx-runtime", bstr::BStr::new(jsx_import));
-                    std::borrow::Cow::Owned(v)
-                } else {
-                    std::borrow::Cow::Borrowed(options::jsx::defaults::IMPORT_SOURCE)
-                },
-            },
-        };
-        transpiler.options.no_macros = config.no_macros;
-        transpiler.options.loaders =
-            options::loaders_from_transform_options(config.loaders.as_ref(), config.target)?;
-        transpiler
-            .options
-            .entry_naming
-            .clone_from(&config.names.entry_point.data);
-        transpiler
-            .options
-            .chunk_naming
-            .clone_from(&config.names.chunk.data);
-        transpiler
-            .options
-            .asset_naming
-            .clone_from(&config.names.asset.data);
-
-        transpiler.options.output_format = config.format;
-        transpiler.options.bytecode = config.bytecode;
-        transpiler.options.compile_mode = if config.compile.is_some() {
-            options::CompileMode::Executable
-        } else {
-            options::CompileMode::None
-        };
-
-        // For compile mode, set the public_path to the target-specific base path
-        // This ensures embedded resources like yoga.wasm are correctly found
-        if let Some(compile_opts) = &config.compile {
-            let base_public_path =
-                target_base_public_path(compile_opts.compile_target.os, b"root/");
-            transpiler.options.public_path = Box::from(base_public_path);
-        } else {
-            transpiler.options.public_path = Box::from(config.public_path.list.as_slice());
-        }
-
-        transpiler.options.output_dir = Box::from(config.outdir.list.as_slice());
-        transpiler.options.root_dir = Box::from(config.rootdir.list.as_slice());
-        transpiler.options.minify_syntax = config.minify.syntax;
-        transpiler.options.minify_whitespace = config.minify.whitespace;
-        transpiler.options.minify_identifiers = config.minify.identifiers;
-        transpiler.options.keep_names = config.minify.keep_names;
-        transpiler.options.inlining = config.minify.syntax;
-        transpiler.options.source_map = config.source_map;
-        transpiler.options.packages = config.packages;
-        transpiler.options.allow_unresolved = match &config.allow_unresolved {
-            Some(a) => options::AllowUnresolved::from_strings(
-                a.keys().to_vec().into_boxed_slice(),
-                |p, s| bun_glob::r#match(p, s).matches(),
-            ),
-            None => options::AllowUnresolved::All,
-        };
-        transpiler.options.code_splitting = config.code_splitting;
-        transpiler.options.emit_dce_annotations = config
-            .emit_dce_annotations
-            .unwrap_or(!config.minify.whitespace);
-        transpiler.options.ignore_dce_annotations = config.ignore_dce_annotations;
-        transpiler.options.tree_shaking_override = config.tree_shaking;
-        transpiler.options.css_chunking = config.css_chunking;
-        let compile_to_standalone_html = 'brk: {
-            if config.compile.is_none() || config.target != bun_ast::Target::Browser {
-                break 'brk false;
-            }
-            // Only activate standalone HTML when all entrypoints are HTML files
-            for ep in config.entry_points.keys() {
-                if !ep.ends_with(b".html") {
-                    break 'brk false;
-                }
-            }
-            config.entry_points.count() > 0
-        };
-        // When compiling to standalone HTML, don't use the bun executable compile path
-        if compile_to_standalone_html {
-            transpiler.options.compile_mode = options::CompileMode::StandaloneHtml;
-            config.compile = None;
-        }
-        // `BundleOptions.{banner,footer}` are `Cow<'static, [u8]>`; clone into
-        // Owned so the static bound holds without tying `&mut self` to `'a`.
-        transpiler.options.banner = std::borrow::Cow::Owned(config.banner.list.clone());
-        transpiler.options.footer = std::borrow::Cow::Owned(config.footer.list.clone());
-        transpiler.options.react_fast_refresh = config.react_fast_refresh;
-        transpiler.options.react_compiler = if config.react_compiler.is_enabled() {
-            config.react_compiler_output_mode.unwrap_or_else(|| {
-                if config.target.is_server_side() {
-                    bun_ast::runtime::ReactCompilerMode::Ssr
-                } else {
-                    bun_ast::runtime::ReactCompilerMode::Client
-                }
-            })
-        } else {
-            bun_ast::runtime::ReactCompilerMode::Disabled
-        };
-        transpiler.options.react_compiler_parse_test_pragmas =
-            config.react_compiler_parse_test_pragmas;
-        transpiler.options.metafile = config.metafile;
-        transpiler.options.metafile_json_path =
-            Box::from(config.metafile_json_path.list.as_slice());
-        transpiler.options.metafile_markdown_path =
-            Box::from(config.metafile_markdown_path.list.as_slice());
-        if config.optimize_imports.count() > 0 {
-            // SAFETY: `self.config` outlives `bump` and `optimize_imports` is not mutated
-            // during the bundle; a bump.alloc'd clone leaked (arena never runs Drop).
-            transpiler.options.optimize_imports =
-                Some(unsafe { &*core::ptr::from_ref(&config.optimize_imports) });
-        }
-
-        if transpiler.options.compile_mode.is_executable() {
-            // Emitting DCE annotations is nonsensical in --compile.
-            transpiler.options.emit_dce_annotations = false;
-        }
-
-        transpiler.configure_linker();
-        transpiler.configure_defines()?;
-
-        if !transpiler.options.production {
-            transpiler
-                .options
-                .conditions
-                .append_slice(&[b"development"])?;
-        }
-        // `transpiler.env` is the dotenv loader installed by
-        // `Transpiler::init`; non-null and valid for `'a`.
-        transpiler.resolver.env_loader = NonNull::new(transpiler.env);
-        // `Resolver.opts` is the resolver-crate subset
-        // — re-project from the now-mutated `transpiler.options`.
-        transpiler.sync_resolver_opts();
-        Ok(())
-    }
-
-    fn complete_on_bundle_thread(&mut self) {
+    unsafe fn complete_on_bundle_thread(this: *mut Self) {
         // The bundle thread's last touch of this task and of the VM's memory:
         // hand it back (always queued — the VM waits for it) and stop counting.
-        self.bundle_loop
-            .store(ptr::null_mut(), core::sync::atomic::Ordering::Release);
-        let handle = self.loop_handle.clone();
-        let this = std::ptr::from_mut::<Self>(self);
+        // SAFETY: trait contract. The post transfers the task to the VM's
+        // queue, which may run `on_complete_anytask` (and free it) at once, so
+        // the handle is cloned out first and nothing reads `this` after the
+        // post.
+        let handle = unsafe {
+            (*this)
+                .bundle_loop
+                .store(ptr::null_mut(), core::sync::atomic::Ordering::Release);
+            (*this).loop_handle.clone()
+        };
         let ct = jsc::ConcurrentTask::create(jsc::Task::init(this));
         let jsc::vm_handle::Posted::Queued = handle.post_task(ct) else {
             unreachable!("VM handle closed with a Bun.build outstanding");
         };
         handle.embedded_work_finished();
     }
-    fn set_result(&mut self, result: BundleV2Result) {
-        self.result = result;
+    unsafe fn set_result(this: *mut Self, result: BundleV2Result) {
+        // SAFETY: trait contract; the JS side reads `result` only after the
+        // hand-back.
+        unsafe { (*this).result = result };
     }
-    fn set_log(&mut self, log: bun_ast::Log) {
-        self.log = log;
-    }
-    fn set_transpiler(&mut self, this: *mut BundleV2<'_>) {
-        self.transpiler = this.cast();
-    }
-    fn plugins(&self) -> Option<NonNull<JSBundlerPlugin>> {
-        // `Plugin` and `JSBundlerPlugin` are the same `bun_bundler` opaque.
-        self.plugins
-    }
-    fn file_map(&mut self) -> Option<NonNull<Bv2FileMap>> {
-        // `FileMap` and `Bv2FileMap` are the same `bun_bundler` type.
-        if self.config.files.map.is_empty() {
-            None
-        } else {
-            Some(NonNull::from(&mut self.config.files))
-        }
-    }
-    fn as_js_bundle_completion_task(&mut self) -> dispatch::CompletionHandle {
-        dispatch::CompletionHandle {
-            owner: NonNull::from(self).cast::<Bv2OpaqueCompletion>(),
-            vtable: &COMPLETION_VTABLE,
-        }
+    unsafe fn set_log(this: *mut Self, log: bun_ast::Log) {
+        // SAFETY: trait contract; the bundle is over, so nothing is writing
+        // through the transpiler's pointer to the old log any more.
+        unsafe { (*this).log = log };
     }
 
-    fn create_and_configure_transpiler<'a>(
-        &mut self,
+    unsafe fn create_and_configure_transpiler<'a>(
+        this: *mut Self,
         bump: &'a Arena,
     ) -> bun_bundler::Result<&'a mut Transpiler<'a>> {
-        let config = &self.config;
+        // SAFETY: trait contract. Field projections only: `config` is the
+        // bundle thread's until the hand-back (the JS side does not touch it
+        // after enqueue), and `log` is handed to the bundler as a pointer and
+        // written through it from here until `set_log`, so no reference to it
+        // is formed.
+        let (config, log, env) =
+            unsafe { (&mut (*this).config, &raw mut (*this).log, (*this).env) };
         let opts = api::TransformOptions {
             define: if config.define.count() > 0 {
                 Some(api::StringMap {
@@ -1190,24 +1026,14 @@ impl CompletionStruct for JSBundleCompletionTask {
             ..Default::default()
         };
 
-        let log: *mut bun_ast::Log = &raw mut self.log;
-        let t = Transpiler::init(bump, log, opts, Some(self.env))?;
-        let transpiler: &'a mut Transpiler<'a> = bump.alloc(t);
-
-        // Post-init field wiring.
-        // Reborrow through a raw ptr so `&mut self` is usable
-        // again after handing `&'a mut Transpiler` (which is tied to `bump`,
-        // not `self`) to the trait method.
-        let tp: *mut Transpiler<'a> = transpiler;
-        // SAFETY: `tp` aliases nothing in `self`; lives in `bump`.
-        self.configure_bundler(unsafe { &mut *tp }, bump)?;
-        // SAFETY: `tp` was the unique `&'a mut` slot from `bump.alloc`; the
-        // reborrow above has ended.
-        Ok(unsafe { &mut *tp })
+        let transpiler: &'a mut Transpiler<'a> =
+            bump.alloc(Transpiler::init(bump, log, opts, Some(env))?);
+        configure_bundler(config, transpiler)?;
+        Ok(transpiler)
     }
 
-    fn init_and_run<'a>(
-        &mut self,
+    unsafe fn init_and_run<'a>(
+        this: *mut Self,
         transpiler: &'a mut Transpiler<'a>,
         bump: &'a Arena,
         thread_pool: *mut bun_threading::ThreadPool,
@@ -1221,8 +1047,13 @@ impl CompletionStruct for JSBundleCompletionTask {
             Some(NonNull::from(&mut any_loop).cast::<bun_event_loop::AnyEventLoop>());
         if let bun_event_loop::AnyEventLoop::Mini(mini) = &any_loop {
             // So a cancelling VM can wake us out of an idle wait for plugins.
-            self.bundle_loop
-                .store(mini.loop_ptr(), core::sync::atomic::Ordering::Release);
+            // SAFETY: trait contract; `stop_for_vm_teardown` reads this atomic
+            // concurrently.
+            unsafe {
+                (*this)
+                    .bundle_loop
+                    .store(mini.loop_ptr(), core::sync::atomic::Ordering::Release);
+            }
         }
 
         // `thread_pool` is the `WorkPool` singleton (`OnceLock`-backed,
@@ -1235,23 +1066,24 @@ impl CompletionStruct for JSBundleCompletionTask {
         // `Graph.heap` is a borrow, so reuse the caller-owned `bump`.
         let mut bv2 = BundleV2::init(transpiler, None, bump, event_loop, false, worker_pool, bump)?;
 
-        bv2.plugins = self.plugins();
-        bv2.completion = Some(self.as_js_bundle_completion_task());
-        // SAFETY: `file_map` returns a `NonNull` into `self.config.files`,
-        // which outlives `bv2` (both live until `generate_in_new_thread`
-        // returns). `BundleV2.file_map: Option<&'a FileMap>` — erase to `'a`.
-        bv2.file_map = self.file_map().map(|p| unsafe { &*p.as_ptr() });
-
-        self.set_transpiler(&raw mut *bv2);
+        // SAFETY: trait contract. `plugins` is read here and by the VM's
+        // teardown, written by neither; `config` is ours until the hand-back
+        // (see `create_and_configure_transpiler`), and the `&'a FileMap` /
+        // entry-point slices borrowed out of it below are only used by this
+        // bundle, which `bv2` ends before this returns.
+        let (config, plugins) = unsafe { (&(*this).config, (*this).plugins) };
+        bv2.plugins = plugins;
+        bv2.completion = Some(dispatch::CompletionHandle {
+            owner: NonNull::new(this)
+                .expect("completion")
+                .cast::<Bv2OpaqueCompletion>(),
+            vtable: &COMPLETION_VTABLE,
+        });
+        // `FileMap` and `JSBundlerConfig.files` are the same `bun_bundler` type.
+        bv2.file_map = (!config.files.map.is_empty()).then_some(&config.files);
 
         // Snapshot entry points as `&[&[u8]]`.
-        let entry_points: Vec<&[u8]> = self
-            .config
-            .entry_points
-            .keys()
-            .iter()
-            .map(|b| &**b)
-            .collect();
+        let entry_points: Vec<&[u8]> = config.entry_points.keys().iter().map(|b| &**b).collect();
 
         let run = bv2.run_from_js_in_new_thread(&entry_points);
 
@@ -1259,7 +1091,8 @@ impl CompletionStruct for JSBundleCompletionTask {
         // source-map wait-group waits run only on the error path.
         match run {
             Ok(build) => {
-                self.set_result(BundleV2Result::Value(build));
+                // SAFETY: trait contract.
+                unsafe { Self::set_result(this, BundleV2Result::Value(build)) };
                 bv2.deinit_without_freeing_arena();
                 Ok(())
             }
@@ -1271,6 +1104,199 @@ impl CompletionStruct for JSBundleCompletionTask {
             }
         }
     }
+}
+
+/// Port of `JSBundleCompletionTask.configureBundler` — the post-init half
+/// (everything after `transpiler.* = try Transpiler.init(...)`), applying
+/// `config` to the freshly initialized `transpiler`.
+fn configure_bundler(
+    config: &mut JSBundlerConfig,
+    transpiler: &mut Transpiler<'_>,
+) -> bun_bundler::Result<()> {
+    transpiler.options.env.behavior = config.env_behavior;
+    transpiler.options.env.prefix = Box::from(config.env_prefix.list.as_slice());
+    // `BundleOptions.bundler_feature_flags: Option<Box<StringSet>>` owns
+    // its set, so clone rather than alias `config.features`.
+    transpiler.options.bundler_feature_flags = Some(Box::new(config.features.clone()?));
+    if config.force_node_env != options::ForceNodeEnv::Unspecified {
+        transpiler.options.force_node_env = config.force_node_env;
+    }
+
+    transpiler.options.entry_points = config.entry_points.keys().to_vec().into_boxed_slice();
+    // Convert API JSX config back to options.JSX.Pragma
+    let jsx_import = &config.jsx.import_source;
+    transpiler.options.jsx = options::jsx::Pragma {
+        factory: if !config.jsx.factory.is_empty() {
+            options::jsx::Pragma::member_list_to_components_if_different(
+                options::jsx::MemberList::Static(options::jsx::defaults::FACTORY),
+                &config.jsx.factory,
+            )?
+        } else {
+            options::jsx::MemberList::Static(options::jsx::defaults::FACTORY)
+        },
+        fragment: if !config.jsx.fragment.is_empty() {
+            options::jsx::Pragma::member_list_to_components_if_different(
+                options::jsx::MemberList::Static(options::jsx::defaults::FRAGMENT),
+                &config.jsx.fragment,
+            )?
+        } else {
+            options::jsx::MemberList::Static(options::jsx::defaults::FRAGMENT)
+        },
+        runtime: options::jsx::Runtime::from(config.jsx.runtime),
+        development: config.jsx.development,
+        package_name: if !jsx_import.is_empty() {
+            std::borrow::Cow::Owned(jsx_import.to_vec())
+        } else {
+            std::borrow::Cow::Borrowed(b"react".as_slice())
+        },
+        classic_import_source: if !jsx_import.is_empty() {
+            std::borrow::Cow::Owned(jsx_import.to_vec())
+        } else {
+            std::borrow::Cow::Borrowed(b"react".as_slice())
+        },
+        side_effects: config.jsx.side_effects,
+        parse: true,
+        import_source: options::jsx::ImportSource {
+            development: if !jsx_import.is_empty() {
+                let mut v = Vec::with_capacity(jsx_import.len() + 16);
+                let _ = write!(&mut v, "{}/jsx-dev-runtime", bstr::BStr::new(jsx_import));
+                std::borrow::Cow::Owned(v)
+            } else {
+                std::borrow::Cow::Borrowed(options::jsx::defaults::IMPORT_SOURCE_DEV)
+            },
+            production: if !jsx_import.is_empty() {
+                let mut v = Vec::with_capacity(jsx_import.len() + 12);
+                let _ = write!(&mut v, "{}/jsx-runtime", bstr::BStr::new(jsx_import));
+                std::borrow::Cow::Owned(v)
+            } else {
+                std::borrow::Cow::Borrowed(options::jsx::defaults::IMPORT_SOURCE)
+            },
+        },
+    };
+    transpiler.options.no_macros = config.no_macros;
+    transpiler.options.loaders =
+        options::loaders_from_transform_options(config.loaders.as_ref(), config.target)?;
+    transpiler
+        .options
+        .entry_naming
+        .clone_from(&config.names.entry_point.data);
+    transpiler
+        .options
+        .chunk_naming
+        .clone_from(&config.names.chunk.data);
+    transpiler
+        .options
+        .asset_naming
+        .clone_from(&config.names.asset.data);
+
+    transpiler.options.output_format = config.format;
+    transpiler.options.bytecode = config.bytecode;
+    transpiler.options.compile_mode = if config.compile.is_some() {
+        options::CompileMode::Executable
+    } else {
+        options::CompileMode::None
+    };
+
+    // For compile mode, set the public_path to the target-specific base path
+    // This ensures embedded resources like yoga.wasm are correctly found
+    if let Some(compile_opts) = &config.compile {
+        let base_public_path = target_base_public_path(compile_opts.compile_target.os, b"root/");
+        transpiler.options.public_path = Box::from(base_public_path);
+    } else {
+        transpiler.options.public_path = Box::from(config.public_path.list.as_slice());
+    }
+
+    transpiler.options.output_dir = Box::from(config.outdir.list.as_slice());
+    transpiler.options.root_dir = Box::from(config.rootdir.list.as_slice());
+    transpiler.options.minify_syntax = config.minify.syntax;
+    transpiler.options.minify_whitespace = config.minify.whitespace;
+    transpiler.options.minify_identifiers = config.minify.identifiers;
+    transpiler.options.keep_names = config.minify.keep_names;
+    transpiler.options.inlining = config.minify.syntax;
+    transpiler.options.source_map = config.source_map;
+    transpiler.options.packages = config.packages;
+    transpiler.options.allow_unresolved = match &config.allow_unresolved {
+        Some(a) => {
+            options::AllowUnresolved::from_strings(a.keys().to_vec().into_boxed_slice(), |p, s| {
+                bun_glob::r#match(p, s).matches()
+            })
+        }
+        None => options::AllowUnresolved::All,
+    };
+    transpiler.options.code_splitting = config.code_splitting;
+    transpiler.options.emit_dce_annotations = config
+        .emit_dce_annotations
+        .unwrap_or(!config.minify.whitespace);
+    transpiler.options.ignore_dce_annotations = config.ignore_dce_annotations;
+    transpiler.options.tree_shaking_override = config.tree_shaking;
+    transpiler.options.css_chunking = config.css_chunking;
+    let compile_to_standalone_html = 'brk: {
+        if config.compile.is_none() || config.target != bun_ast::Target::Browser {
+            break 'brk false;
+        }
+        // Only activate standalone HTML when all entrypoints are HTML files
+        for ep in config.entry_points.keys() {
+            if !ep.ends_with(b".html") {
+                break 'brk false;
+            }
+        }
+        config.entry_points.count() > 0
+    };
+    // When compiling to standalone HTML, don't use the bun executable compile path
+    if compile_to_standalone_html {
+        transpiler.options.compile_mode = options::CompileMode::StandaloneHtml;
+        config.compile = None;
+    }
+    // `BundleOptions.{banner,footer}` are `Cow<'static, [u8]>`; clone into
+    // Owned so the static bound holds without borrowing `config` for `'a`.
+    transpiler.options.banner = std::borrow::Cow::Owned(config.banner.list.clone());
+    transpiler.options.footer = std::borrow::Cow::Owned(config.footer.list.clone());
+    transpiler.options.react_fast_refresh = config.react_fast_refresh;
+    transpiler.options.react_compiler = if config.react_compiler.is_enabled() {
+        config.react_compiler_output_mode.unwrap_or_else(|| {
+            if config.target.is_server_side() {
+                bun_ast::runtime::ReactCompilerMode::Ssr
+            } else {
+                bun_ast::runtime::ReactCompilerMode::Client
+            }
+        })
+    } else {
+        bun_ast::runtime::ReactCompilerMode::Disabled
+    };
+    transpiler.options.react_compiler_parse_test_pragmas = config.react_compiler_parse_test_pragmas;
+    transpiler.options.metafile = config.metafile;
+    transpiler.options.metafile_json_path = Box::from(config.metafile_json_path.list.as_slice());
+    transpiler.options.metafile_markdown_path =
+        Box::from(config.metafile_markdown_path.list.as_slice());
+    if config.optimize_imports.count() > 0 {
+        // SAFETY: `config` lives in the completion task, which outlives the
+        // transpiler (`bump`), and nothing writes `optimize_imports` during
+        // the bundle; a bump.alloc'd clone would leak (arena never runs Drop).
+        transpiler.options.optimize_imports =
+            Some(unsafe { &*core::ptr::from_ref(&config.optimize_imports) });
+    }
+
+    if transpiler.options.compile_mode.is_executable() {
+        // Emitting DCE annotations is nonsensical in --compile.
+        transpiler.options.emit_dce_annotations = false;
+    }
+
+    transpiler.configure_linker();
+    transpiler.configure_defines()?;
+
+    if !transpiler.options.production {
+        transpiler
+            .options
+            .conditions
+            .append_slice(&[b"development"])?;
+    }
+    // `transpiler.env` is the dotenv loader installed by
+    // `Transpiler::init`; non-null and valid for `'a`.
+    transpiler.resolver.env_loader = NonNull::new(transpiler.env);
+    // `Resolver.opts` is the resolver-crate subset
+    // — re-project from the now-mutated `transpiler.options`.
+    transpiler.sync_resolver_opts();
+    Ok(())
 }
 
 impl bun_event_loop::Taskable for JSBundleCompletionTask {

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -88,8 +88,9 @@ pub struct JSBundleCompletionTask {
     started_at_ns: u64,
 }
 
-/// Who gets the result. Fixed at construction: nothing writes to the task
-/// from the JS thread once it is enqueued (see [`CompletionStruct`]).
+/// Who gets the result. Fixed at construction: once the task is enqueued the
+/// JS thread only cancels it (`cancelled`) or releases it while it is still
+/// queued (the `stage` handshake); see [`CompletionStruct`].
 pub(crate) enum Deliver {
     /// `Bun.build()`: settle this promise.
     Promise(jsc::JSPromiseStrong),
@@ -153,9 +154,10 @@ unsafe impl Send for JSBundleCompletionTask {}
 /// `BundleV2.createAndScheduleCompletionTask` — construct, take a process-keepalive
 /// ref, and hand the task to the bundle-thread singleton.
 ///
-/// The enqueue is the JS thread's last write to the task (`CompletionStruct`
-/// says why); the returned pointer is for cancelling it (`stop_for_vm_teardown`,
-/// `HTMLBundle::State::deinit`) until `on_complete_anytask` gets it back.
+/// After the enqueue the JS thread only cancels or releases the task
+/// (`stop_for_vm_teardown`, `HTMLBundle::State::deinit`; `CompletionStruct`
+/// says why nothing else may touch it) until `on_complete_anytask` gets it
+/// back, and that is what the returned pointer is for.
 pub(crate) fn create_and_schedule_completion_task(
     config: JSBundlerConfig,
     plugins: Option<NonNull<Plugin>>,
@@ -899,9 +901,6 @@ static COMPLETION_VTABLE: dispatch::CompletionDispatch = dispatch::CompletionDis
 };
 
 // ─── CompletionStruct impl ───────────────────────────────────────────────────
-// Field projections out of `this` only, never a reference to the whole task;
-// the trait doc says why.
-//
 // SAFETY: `next` is the sole intrusive link for `UnboundedQueue<JSBundleCompletionTask>`.
 unsafe impl bun_threading::Linked for JSBundleCompletionTask {
     #[inline]
@@ -911,6 +910,8 @@ unsafe impl bun_threading::Linked for JSBundleCompletionTask {
     }
 }
 
+// Field projections out of `this` only, never a reference to the whole task;
+// the trait doc says why.
 impl CompletionStruct for JSBundleCompletionTask {
     unsafe fn try_start(this: *mut Self) -> bool {
         use core::sync::atomic::Ordering;
@@ -1253,9 +1254,11 @@ fn configure_bundler(
     transpiler.options.metafile_markdown_path =
         Box::from(config.metafile_markdown_path.list.as_slice());
     if config.optimize_imports.count() > 0 {
-        // SAFETY: the task (and so `config`) outlives the transpiler, and until
-        // the build is over `config` is only borrowed shared again
-        // (`init_and_run`); a bump.alloc'd clone would leak (no Drop in arenas).
+        // SAFETY: only read while the bundle runs, which ends inside
+        // `init_and_run` before the task is handed back (the transpiler is
+        // dropped without reading it), and until then `config` is only
+        // borrowed shared again; a bump.alloc'd clone would leak (no Drop in
+        // arenas).
         transpiler.options.optimize_imports =
             Some(unsafe { &*core::ptr::from_ref(&config.optimize_imports) });
     }

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -18,7 +18,7 @@ use bun_ptr::{AsCtxPtr, IntrusiveRc, RefCount};
 use bun_uws::{AnyRequest, AnyResponse};
 
 use crate::api::js_bundle_completion_task::{
-    JSBundleCompletionTask, create_and_schedule_completion_task,
+    Deliver, JSBundleCompletionTask, create_and_schedule_completion_task,
 };
 use crate::api::js_bundler::js_bundler::{self as JSBundler, Config as JSBundlerConfig};
 use crate::api::output_file_jsc::OutputFileJsc as _;
@@ -499,20 +499,19 @@ impl Route {
         }
         config.source_map = bundler_options::SourceMapOption::Linked;
 
-        let completion_task = create_and_schedule_completion_task(config, plugins, global)?;
-        // SAFETY: `completion_task` is the freshly-boxed allocation (refcount==1); sole owner.
-        unsafe {
-            (*completion_task).started_at_ns =
-                bun_core::util::Timespec::now_allow_mocked_time().ns();
-            (*completion_task).html_build_task = Some(self.as_ctx_ptr());
-        }
-        self.state.set(State::Building(Some(completion_task)));
-
         // While we're building, ensure this doesn't get freed.
         // SAFETY: `self` is a live IntrusiveRc-managed allocation; matched by the
         // deref at the top of `on_complete`. `RefCount` is `Cell`-backed so the
         // `*const → *mut` cast carries sufficient (UnsafeCell) provenance.
         unsafe { RefCount::<Route>::ref_(self.as_ctx_ptr()) };
+        let completion_task = create_and_schedule_completion_task(
+            config,
+            plugins,
+            global,
+            Deliver::HtmlRoute(NonNull::from(self)),
+        );
+        self.state
+            .set(State::Building(Some(completion_task.as_ptr())));
         Ok(())
     }
 
@@ -532,6 +531,7 @@ impl Route {
         // SAFETY: self is IntrusiveRc-managed; `adopt` consumes the prior +1 on Drop.
         let _drop_build_ref = unsafe { bun_ptr::ScopedRef::<Route>::adopt(self.as_ctx_ptr()) };
 
+        let started_at_ns = completion_task.started_at_ns();
         match &mut completion_task.result {
             BundleV2Result::Err(err) => {
                 if bun_core::Environment::ENABLE_LOGS {
@@ -566,7 +566,7 @@ impl Route {
 
                 if server.config().is_development() {
                     let now = bun_core::util::Timespec::now_allow_mocked_time().ns();
-                    let duration = now.saturating_sub(completion_task.started_at_ns);
+                    let duration = now.saturating_sub(started_at_ns);
                     let duration_f64 = duration as f64 / 1_000_000_000.0;
 
                     bun_output::print_elapsed(duration_f64);

--- a/test/internal/source-lints/bundle-completion-task-handoff.test.ts
+++ b/test/internal/source-lints/bundle-completion-task-handoff.test.ts
@@ -131,7 +131,15 @@ test("CompletionStruct takes the task by pointer in every method", async () => {
 });
 
 test("BundleThread.rs never reborrows the dequeued task", async () => {
-  expect(reborrows(await stripped("src/bundler/BundleThread.rs"))).toEqual([]);
+  const source = await stripped("src/bundler/BundleThread.rs");
+  // `reborrows` is coupled to the binding name. Pin it where the task is
+  // dequeued and where the build runs under it (as a pointer), so a rename
+  // fails here instead of making the scan below vacuous.
+  expect({
+    dequeued_as: /\blet (\w+) = unsafe \{ \(\*instance\)\.queue\.pop\(\) \};/.exec(source)?.[1],
+    build_runs_under: /\bfn generate_in_new_thread\(\s*(\w+): ([^,]+),/.exec(source)?.slice(1),
+  }).toEqual({ dequeued_as: "completion", build_runs_under: ["completion", "*mut C"] });
+  expect(reborrows(source)).toEqual([]);
 });
 
 test("create_and_schedule_completion_task does not touch the task after enqueuing it", async () => {

--- a/test/internal/source-lints/bundle-completion-task-handoff.test.ts
+++ b/test/internal/source-lints/bundle-completion-task-handoff.test.ts
@@ -1,0 +1,162 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import path from "path";
+
+// One `JSBundleCompletionTask` allocation is shared between the JS thread that
+// called `Bun.build()` (or is serving an HTML route) and the bundle thread for
+// as long as the build runs:
+//
+//   - the JS thread hands it over with `singleton::enqueue`, and from then on
+//     may still cancel it (`stop_for_vm_teardown`, `HTMLBundle::State::deinit`)
+//     or release it while it is queued, all through its own pointer;
+//   - the bundler writes the task's `log` for the whole build through the raw
+//     pointer `create_and_configure_transpiler` hands `Transpiler::init`.
+//
+// A reference argument is protected for the duration of its call under both
+// aliasing models (Tree Borrows is what `bun run rust:miri` uses), so every one
+// of those accesses is UB while the bundle thread is inside a method that took
+// the task by `&mut self`; `init_and_run`'s call used to span the entire build.
+// Symmetrically, a JS-side field write after the enqueue lands while the bundle
+// thread may already be inside such a call. Neither shape is something the
+// compiler rejects, so this pins the signatures that rule them out:
+//
+//   1. `CompletionStruct` (src/bundler/BundleThread.rs), the bundle thread's
+//      whole view of the task, takes it as `this: *mut Self` in every method
+//      and projects fields; no `self` receivers, and nothing in BundleThread.rs
+//      reborrows the dequeued task (the dequeue loop used to form
+//      `let completion = unsafe { &mut *completion };` for the whole build;
+//      fn-long-mut-reborrow.test.ts is the tree-wide lint for that shape under
+//      the callback-parameter names it knows about).
+//   2. `create_and_schedule_completion_task` (src/runtime/api/
+//      js_bundle_completion_task.rs) does not touch the task after enqueuing
+//      it, and the per-owner fields its callers used to fill in afterwards
+//      (`promise`, `html_build_task`, `started_at_ns`) are private to the
+//      module, so an owner can only get them in through the `Deliver`
+//      argument, i.e. before the enqueue.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+
+async function stripped(rel: string): Promise<string> {
+  const source = await file(path.join(root, rel)).text();
+  // Full-line comments only (`[ \t]*`, not `\s*`, so blank lines and hence
+  // line numbers survive); the shapes below never share a line with code.
+  return source.replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+/** The first top-level item whose header matches `header`, from that header
+ * to the next `}` at column 0. */
+function topLevelItem(source: string, header: RegExp, what: string): string {
+  const m = header.exec(source);
+  if (m === null) throw new Error(`${what} not found; update this lint if it moved`);
+  const end = source.indexOf("\n}", m.index);
+  if (end === -1) throw new Error(`${what}: unterminated item`);
+  return source.slice(m.index, end + 2);
+}
+
+/** Every `fn` header in `block` with the text of its first parameter: a
+ * receiver shows up as `&mut self` / `&self` / `self` / `mut self`, a
+ * pointer-taking method as `this: *mut Self`, however rustfmt wrapped it. */
+function methodReceivers(block: string): Array<{ name: string; first: string }> {
+  return [...block.matchAll(/\bfn\s+(\w+)\s*(?:<[^>]*>)?\s*\(\s*([^,)]*)/g)].map(m => ({
+    name: m[1],
+    first: m[2].trim(),
+  }));
+}
+
+const THIS_PTR = /^this\s*:\s*\*\s*mut\s+Self$/;
+
+/** Reborrows of a binding named `completion` (`&mut *completion`,
+ * `&*completion`) in `code`, with their line numbers. */
+function reborrows(code: string): string[] {
+  return [...code.matchAll(/&\s*(?:mut\s+)?\*\s*completion\b/g)].map(m => {
+    const line = code.slice(0, m.index).split("\n").length;
+    return `${line}: ${m[0]}`;
+  });
+}
+
+/** Uses of the task binding `task` in `code`: `(*task)` and `task.method(..)`. */
+function taskTouches(code: string, task: string): string[] {
+  const touch = new RegExp(String.raw`\(\s*\*\s*${task}\s*\)|\b${task}\s*\.\s*\w+`, "g");
+  return [...code.matchAll(touch)].map(m => m[0].replace(/\s+/g, " "));
+}
+
+test("the scans recognize the shapes they claim to", () => {
+  const receivers = methodReceivers(
+    [
+      "fn a(&mut self) -> bool;",
+      "fn b(&self) -> u8;",
+      "fn c(self);",
+      "fn d(mut self);",
+      "fn e<'a>(\n        &mut self,\n        bump: &'a Arena,\n    ) -> Result<(), E>;",
+      "fn f(this: *mut Self);",
+      "unsafe fn g<'a>(\n        this: *mut Self,\n        bump: &'a Arena,\n    ) -> Result<&'a mut T<'a>, E>;",
+      "fn h();",
+    ].join("\n"),
+  );
+  expect(receivers.map(r => r.name)).toEqual(["a", "b", "c", "d", "e", "f", "g", "h"]);
+  expect(receivers.filter(r => !THIS_PTR.test(r.first)).map(r => r.name)).toEqual(["a", "b", "c", "d", "e", "h"]);
+
+  expect(reborrows("let x = 1;\nlet completion = unsafe { &mut *completion };")).toEqual(["2: &mut *completion"]);
+  expect(reborrows("Self::run(unsafe { &*completion })")).toEqual(["1: &*completion"]);
+  expect(reborrows("C::try_start(completion);\n(*completion).try_start();\n&mut *completion_task")).toEqual([]);
+
+  // The tail of `create_and_schedule_completion_task` as it used to be.
+  expect(
+    taskTouches(
+      "\n    unsafe {\n        (*completion)\n            .poll_ref\n            .ref_(ctx)\n    };\n\n    Ok(completion)\n}",
+      "completion",
+    ),
+  ).toEqual(["(*completion)"]);
+  expect(taskTouches("\n    completion.as_ptr()\n}", "completion")).toEqual(["completion.as_ptr"]);
+  expect(taskTouches("\n    completion\n}", "completion")).toEqual([]);
+  expect(taskTouches("\n    Ok(completion)\n}", "completion")).toEqual([]);
+  expect(taskTouches("\n    other_completion.ref_()\n}", "completion")).toEqual([]);
+});
+
+test("CompletionStruct takes the task by pointer in every method", async () => {
+  const source = await stripped("src/bundler/BundleThread.rs");
+  const trait = topLevelItem(source, /^pub trait CompletionStruct\b.*\{$/m, "trait CompletionStruct");
+  const receivers = methodReceivers(trait);
+  // The calls that bracket the build. If they are gone the trait has been
+  // reshaped and this lint needs a fresh look, not a vacuous pass.
+  expect(receivers.map(r => r.name)).toEqual(
+    expect.arrayContaining([
+      "try_start",
+      "create_and_configure_transpiler",
+      "init_and_run",
+      "complete_on_bundle_thread",
+    ]),
+  );
+  expect(receivers.filter(r => !THIS_PTR.test(r.first)).map(r => `${r.name}(${r.first})`)).toEqual([]);
+});
+
+test("BundleThread.rs never reborrows the dequeued task", async () => {
+  expect(reborrows(await stripped("src/bundler/BundleThread.rs"))).toEqual([]);
+});
+
+test("create_and_schedule_completion_task does not touch the task after enqueuing it", async () => {
+  const source = await stripped("src/runtime/api/js_bundle_completion_task.rs");
+  const body = topLevelItem(
+    source,
+    /^pub\(crate\) fn create_and_schedule_completion_task\b/m,
+    "fn create_and_schedule_completion_task",
+  );
+  const enqueue = /\benqueue::<JSBundleCompletionTask>\(\s*(\w+)[^;]*\);/.exec(body);
+  if (enqueue === null) throw new Error("enqueue call not found; update this lint if it was reshaped");
+  // From here the task is the bundle thread's; returning the pointer is fine.
+  const tail = body.slice(enqueue.index + enqueue[0].length);
+  expect(taskTouches(tail, enqueue[1])).toEqual([]);
+});
+
+test("the per-owner fields are private, so they can only be set through Deliver", async () => {
+  const source = await stripped("src/runtime/api/js_bundle_completion_task.rs");
+  const struct = topLevelItem(source, /^pub struct JSBundleCompletionTask\b.*\{$/m, "struct JSBundleCompletionTask");
+  const visibility: Record<string, string> = {};
+  for (const name of ["promise", "html_build_task", "started_at_ns"]) {
+    const decl = new RegExp(String.raw`^[ \t]+((?:pub(?:\([^)]*\))?[ \t]+)?)${name}[ \t]*:`, "m").exec(struct);
+    if (decl === null) throw new Error(`field \`${name}\` not found; update this lint if it was renamed`);
+    visibility[name] = decl[1].trim();
+  }
+  expect(visibility).toEqual({ promise: "", html_build_task: "", started_at_ns: "" });
+  expect(source).toMatch(/^pub\(crate\) enum Deliver\b/m);
+});


### PR DESCRIPTION
### Problem
- One `JSBundleCompletionTask` allocation is shared by the JS thread and the bundle thread while a `Bun.build()` or HTML route build runs. On main the bundle thread holds it as `&mut self` for the whole build, so anything the JS thread does to it meanwhile is a write into memory a protected `&mut` covers.
- Three such writes exist: `promise` / `started_at_ns` / `html_build_task` are set after the task is already enqueued (every build); `cancelled` is stored on VM teardown or route deinit mid-build; and the bundler writes the task's `log` through a pointer taken out of one `&mut self` while a later `&mut self` is live.
- A reduction of the three shapes fails under Miri with Tree Borrows and Stacked Borrows (`write access through <..> is forbidden`, `the accessed tag is foreign to the protected tag`) and passes with pointer receivers.
- No crash is known and it is ASAN-clean today, since the bundle thread never reads the fields the JS side writes. The contract is wrong, and `noalias` / `dereferenceable` on the receiver let the compiler assume it. Same family as #37723, which converts the hand-back; this covers the rest of the build.

### Fix
- Every `CompletionStruct` method takes the task as `this: *mut Self` and reaches only the fields it uses; the bundle thread no longer reborrows the dequeued task. Trait methods that existed only for the impl to call on itself go away, as does the `transpiler` field, which nothing read. Order of operations is unchanged.
- Scheduling takes a `Deliver` (a promise for `Bun.build`, a route for `Bun.serve`), fills the per-owner fields at construction, and enqueues as its last statement. Those fields are private now, so the old writes do not compile. Only observable difference: `started_at_ns` is taken a few microseconds earlier.
- Property to check: after the enqueue the JS thread reaches the task only through `cancelled` and the queued-release handshake, and nothing on the bundle thread holds a reference to the whole task. Interior mutability would not do it, since a `&mut self` retag claims `UnsafeCell` bytes too; the racing fields are already atomics.
- Verification: a new source-lint test pins the shape (pointer receivers, no reborrow, nothing after the enqueue, private fields); it fails on main and passes here. The Miri reduction is in the description, not the tree. Existing bundler, HTML-serve and worker-teardown tests pass on a debug (ASAN) build.

### Background
- The bundle thread: `Bun.build()` and `Bun.serve` HTML routes do not bundle on the JS thread. They box a `JSBundleCompletionTask`, push it onto a queue, and one bundle thread pops it, runs the build, and posts it back to the owning event loop. Until that post, both threads can reach the same allocation.
- `CompletionStruct` is the trait the generic bundle thread (in `bun_bundler`) uses to drive a task whose concrete type lives in `bun_runtime`; most of the diff is changing its receivers and the impl behind them.
- Protected references: under Rust's aliasing models (Stacked Borrows and Tree Borrows, which `bun run rust:miri` checks) a `&mut self` argument is protected for the whole call. Any access through another pointer during that call is UB, even an atomic store, even to bytes the callee never touches. A raw `*mut` makes no such claim, and `&raw mut (*this).field` claims only that field.
- Miri is the interpreter that reports these violations. ASAN cannot; it only sees real bad reads and writes, and there are none here.
- `Deliver` is the new enum naming who gets the result (promise or route). It is consumed at construction, so the per-owner fields are set before the task is ever on the queue.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/bundle-completion-task-handoff.test.ts
bun test v1.4.0 (fb842a03b)

test/internal/source-lints/bundle-completion-task-handoff.test.ts:
(pass) the scans recognize the shapes they claim to [38.58ms]
125 |       "create_and_configure_transpiler",
126 |       "init_and_run",
127 |       "complete_on_bundle_thread",
128 |     ]),
129 |   );
130 |   expect(receivers.filter(r => !THIS_PTR.test(r.first)).map(r => `${r.name}(${r.first})`)).toEqual([]);
                                                                                                 ^
error: expect(received).toEqual(expected)

- []
+ [
+   "configure_bundler(&mut self)",
+   "try_start(&mut self)",
+   "complete_on_bundle_thread(&mut self)",
+   "set_result(&mut self)",
+   "set_log(&mut self)",
+   "set_transpiler(&mut self)",
+   "plugins(&self)",
+   "file_map(&mut self)",
+   "as_js_bundle_completion_task(&mut self)",
+   "create_and_configure_transpiler(&mut self)",
+   "init_and_run(&mut self)",
+ ]

- Expected  - 1
+ Received  + 13

      at <ano
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/internal/source-lints/bundle-completion-task-handoff.test.ts:
(pass) the scans recognize the shapes they claim to [0.52ms]
125 |       "create_and_configure_transpiler",
126 |       "init_and_run",
127 |       "complete_on_bundle_thread",
128 |     ]),
129 |   );
130 |   expect(receivers.filter(r => !THIS_PTR.test(r.first)).map(r => `${r.name}(${r.first})`)).toEqual([]);
                                                                                                 ^
error: expect(received).toEqual(expected)

- []
+ [
+   "configure_bundler(&mut self)",
+   "try_start(&mut self)",
+   "complete_on_bundle_thread(&mut self)",
+   "set_result(&mut self)",
+   "set_log(&mut self)",
+   "set_transpiler(&mut self)",
+   "plugins(&self)",
+   "file_map(&mut self)",
+   "as_js_bundle_completion_task(&mut self)",
+   "create_and_configure_transpiler(&mut self)",
+   "init_and_run(&mut self)",
+ ]

- Expected  - 1
+ Received  + 13

      at <anonymous> (/workspace/bun/test/internal/source-lints/bundle-completion-task-handoff.test.ts:130:92)
(fail) CompletionStruct takes the task by pointer in every method [0.75ms]
136 |   // dequeue
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/bundle-completion-task-handoff.test.ts
bun test v1.4.0 (fb842a03b)

test/internal/source-lints/bundle-completion-task-handoff.test.ts:
(pass) the scans recognize the shapes they claim to [37.39ms]
(pass) CompletionStruct takes the task by pointer in every method [22.55ms]
(pass) BundleThread.rs never reborrows the dequeued task [13.08ms]
(pass) create_and_schedule_completion_task does not touch the task after enqueuing it [13.36ms]
(pass) the per-owner fields are private, so they can only be set through Deliver [20.29ms]

 5 pass
 0 fail
 17 expect() calls
Ran 5 tests across 1 file. [2.66s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1085ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/151] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/151] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[3/151] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[4/151] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_r
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/BundleThread.rs                        | 165 +++--
 src/runtime/api/JSBundler.rs                       |  22 +-
 src/runtime/api/js_bundle_completion_task.rs       | 675 +++++++++++----------
 src/runtime/server/HTMLBundle.rs                   |  22 +-
 .../bundle-completion-task-handoff.test.ts         | 170 ++++++
 5 files changed, 613 insertions(+), 441 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/bundler/BundleThread.rs                                   5     11      0
src/runtime/api/JSBundler.rs                                  3      1      0
src/runtime/api/js_bundle_completion_task.rs                 15     42      0
src/runtime/server/HTMLBundle.rs                              5      6      0
…nal/source-lints/bundle-completion-task-handoff.test.ts      2     11      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

One `JSBundleCompletionTask` allocation is shared between the JS thread and the bundle thread for as long as a `Bun.build()` (or an HTML route's build) runs. On `main` the bundle thread holds it as `&mut` for the whole build: `BundleThread::thread_main` (src/bundler/BundleThread.rs) reborrows the dequeued task, and every `CompletionStruct` method takes `&mut self`, `create_and_configure_transpiler` for the option setup and `init_and_run` from before `BundleV2::init` until after `run_from_js_in_new_thread` returns. A reference argument is protected for the duration of its call, so while those calls are running, three things that happen on every build or on every teardown are accesses into protected memory through a pointer that is not derived from the reference:

1. **JS-side writes after the enqueue.** `create_and_schedule_completion_task` (src/runtime/api/js_bundle_completion_task.rs) enqueued the task and only then did `poll_ref.ref_(..)`, and its callers kept writing: `JSBundler::build` set `promise` (the comment there, "sole owner on the JS thread until enqueued task runs", was not true, the enqueue had already happened inside the callee) and `HTMLBundle::Route::schedule_bundle` set `started_at_ns` and `html_build_task`. By then the bundle thread may already be inside `create_and_configure_transpiler(&mut self)`. This is the normal path of every build.
2. **Cancellation.** `stop_for_vm_teardown` reads `plugins` and stores `cancelled` / loads `bundle_loop`, and `HTMLBundle::State::deinit` stores `cancelled`, while `init_and_run(&mut self)` is live on the bundle thread. They are atomics, but under both aliasing models an atomic store through a foreign pointer into memory a protected `&mut` covers is still a foreign write.
3. **The log.** `create_and_configure_transpiler` handed `Transpiler::init` a `&raw mut self.log` taken out of its own `&mut self`, and the bundler writes that log for the whole build, i.e. while the later, sibling `&mut self` of `init_and_run` is protected. This one is single-threaded.

A reduction of exactly these three shapes fails under Miri with Tree Borrows (the model `bun run rust:miri` uses) and with Stacked Borrows, in each case pointing at the `&mut self` receiver, and passes once the methods take the pointer (and, for 1, the field is written before the hand-off):

```
before 1:  write access through <2086> at alloc990[0x0] is forbidden        (*task).promise = 1           on the JS thread
before 2:  write access through <14944> at alloc990[0x20] is forbidden      (*task).cancelled.store(..)   on the JS thread
before 3:  write access through <5544> at alloc990[0x10] is forbidden       *log = 1                      on the bundle thread
    = help: the accessed tag is foreign to the protected tag (i.e., it is not a child)
    = help: this foreign write access would cause the protected tag (currently Reserved) to become Disabled
    = help: protected tags must never be Disabled
help: the protected tag was created here, in the initial state Reserved
    |     fn configure_before(&mut self, ..)          (1)
    |     fn init_and_run_before(&mut self, ..)       (2, 3)
```

Stacked Borrows reports `not granting access to tag .. because that would remove [Unique for ..] which is strongly protected` for 1 and 2 and `that tag does not exist in the borrow stack` for 3. No crash is known from any of this; ASAN-clean today, because nothing on the bundle thread actually reads the fields the JS side writes. It is the contract that is wrong, and it is what `noalias`/`dereferenceable` on the receiver let the compiler assume. Same family as #37723, which converts the hand-back (`complete_on_bundle_thread`) and named the rest of the build's lifetime as a separate change; this is that change. The two overlap on `complete_on_bundle_thread` and on the pointer plumbing in `thread_main` / `generate_in_new_thread`, where both end up with the same shape, so whichever lands second has a small rebase.

<details>
<summary>Reduction run under Miri</summary>

```rust
use std::sync::atomic::{AtomicBool, Ordering};
use std::sync::mpsc::{Receiver, Sender, channel};
use std::thread;

struct SendPtr(*mut Task);
unsafe impl Send for SendPtr {}

struct Task { cancelled: AtomicBool, promise: u64, config: u64, log: u64, result: u64 }

/// Pins the interleaving the real code allows: the JS side acts while the
/// bundle thread is inside the call.
struct Rendezvous { inside: Sender<()>, js_done: Receiver<()> }
impl Rendezvous {
    fn js_turn(&self) { self.inside.send(()).unwrap(); self.js_done.recv().unwrap(); }
}

impl Task {
    // main
    fn configure_before(&mut self, rv: &Rendezvous) -> *mut u64 {
        let _ = self.config;
        rv.js_turn();
        &raw mut self.log
    }
    fn init_and_run_before(&mut self, log: *mut u64, rv: &Rendezvous, write_log: bool) {
        self.result = 1;
        if write_log { unsafe { *log = 1 } }          // the bundler logging during the build
        rv.js_turn();
        let _ = self.cancelled.load(Ordering::Acquire);
    }
    // this PR
    unsafe fn configure_after(this: *mut Task, rv: &Rendezvous) -> *mut u64 {
        let _ = unsafe { (*this).config };
        rv.js_turn();
        unsafe { &raw mut (*this).log }
    }
    unsafe fn init_and_run_after(this: *mut Task, log: *mut u64, rv: &Rendezvous, write_log: bool) {
        unsafe { (*this).result = 1 };
        if write_log { unsafe { *log = 1 } }
        rv.js_turn();
        let _ = unsafe { (*this).cancelled.load(Ordering::Acquire) };
    }
}

fn main() {
    let mut args = std::env::args().skip(1);
    let after = args.next().as_deref() == Some("after");
    let scenario: u32 = args.next().unwrap().parse().unwrap();
    let task = Box::into_raw(Box::new(Task {
        cancelled: AtomicBool::new(false), promise: 0, config: 7, log: 0, result: 0,
    }));
    let (inside_tx, inside_rx) = channel::<()>();
    let (js_done_tx, js_done_rx) = channel::<()>();
    let rv = Rendezvous { inside: inside_tx, js_done: js_done_rx };

    if after && scenario == 1 {
        // The fix for 1 is ordering: the owner's fields go in before the enqueue.
        unsafe { (*task).promise = 1 };
    }
    let ptr = SendPtr(task);
    let bundle_thread = thread::spawn(move || {
        let ptr = ptr;
        let task = ptr.0;
        let write_log = scenario == 3;
        if after {
            let log = unsafe { Task::configure_after(task, &rv) };
            unsafe { Task::init_and_run_after(task, log, &rv, write_log) };
        } else {
            let log = unsafe { (*task).configure_before(&rv) };
            unsafe { (*task).init_and_run_before(log, &rv, write_log) };
        }
    });

    // JS thread. First rendezvous: the bundle thread is inside `configure`.
    inside_rx.recv().unwrap();
    if !after && scenario == 1 {
        // JSBundler::build / HTMLBundle::schedule_bundle on main: writing the
        // task after create_and_schedule_completion_task enqueued it.
        unsafe { (*task).promise = 1 };
    }
    js_done_tx.send(()).unwrap();
    // Second rendezvous: inside `init_and_run`.
    inside_rx.recv().unwrap();
    if scenario == 2 {
        // stop_for_vm_teardown / HTMLBundle::State::deinit, identical in both
        // shapes; what differs is what the bundle thread holds meanwhile.
        unsafe { (*task).cancelled.store(true, Ordering::Release) };
    }
    js_done_tx.send(()).unwrap();
    bundle_thread.join().unwrap();
    drop(unsafe { Box::from_raw(task) });
}
```

`MIRIFLAGS=-Zmiri-tree-borrows cargo miri run -- before {1,2,3}` and the Stacked Borrows default all exit 1 with the errors quoted above; `-- after {1,2,3}` exit 0 under both models.

</details>

### Fix

* `CompletionStruct` (src/bundler/BundleThread.rs) takes the task as `this: *mut Self` in every method (`try_start`, `free_released_unstarted`, `complete_on_bundle_thread`, `set_result`, `set_log`, `create_and_configure_transpiler`, `init_and_run`); the trait doc carries the argument above and the one `# Safety` contract. `thread_main` no longer reborrows the dequeued task and `generate_in_new_thread` takes the pointer. The impl projects the fields it uses: `create_and_configure_transpiler` borrows `config`, takes `&raw mut (*this).log` and reads `env`; `init_and_run` stores `bundle_loop` through the atomic, reads `plugins`, borrows `config` for the file map and entry points, and builds the dispatch handle from `this`; the vtable thunks (`task_of`) project `result` / `cancelled` / `loop_handle` instead of forming a `&JSBundleCompletionTask` to the whole task. Same order of operations as before on both the success and the error path.
* Methods the trait only had because the impl called them on itself are gone from it: `configure_bundler` is a free function over `&mut Config` (its body is unchanged apart from indentation and one SAFETY comment; `git diff -w` shows it), `plugins` / `file_map` / `as_js_bundle_completion_task` are inlined into `init_and_run`, and `set_transpiler` is deleted together with the `transpiler` field it wrote, which nothing read (the C++ plugin's `config` pointer that used to be the other way to reach the task is passed back as `_unused`).
* `create_and_schedule_completion_task` takes a `Deliver` (`Promise(JSPromiseStrong)` from `Bun.build`, `HtmlRoute(NonNull<Route>)` from `Bun.serve`), fills `promise` / `html_build_task` / `started_at_ns` in at construction, takes the keep-alive ref before the enqueue, and the enqueue is its last statement. `JSBundler::build` creates the promise and reads its value before scheduling; `HTMLBundle::schedule_bundle` refs the route before handing its pointer over and only stores the returned pointer (for the cancel in `State::deinit`). `promise`, `html_build_task` and `started_at_ns` are private now (`started_at_ns()` for the dev-mode timing line), so the old writes do not compile. `started_at_ns` is taken a few microseconds earlier than before, that is the only observable difference.

Why pointer receivers rather than interior mutability: the fields the JS thread touches during the build are already atomics, and that does not help, because a `&mut self` retag claims the `UnsafeCell` bytes too (only shared references leave them out). The interior-mutability version of this fix would therefore have to give the bundle thread a `&self` to the whole task and put everything the bundle thread writes (`log`, `result`, the `config.compile` clear, the handle wiring) behind cells, touching every JS-side use of those fields as well. Taking the task by pointer and projecting fields is the smaller change and is the shape the rest of this struct's lifecycle already uses (`free_released_unstarted`, `stop_for_vm_teardown`, `on_complete_anytask`, and #37723's hand-back), as do the other conversions in this family.

### Tests

test/internal/source-lints/bundle-completion-task-handoff.test.ts pins the two signatures the compiler cannot: every method of `CompletionStruct` takes `this: *mut Self` (and the methods that bracket the build are still there, so the check cannot pass vacuously), BundleThread.rs contains no reborrow of the dequeued task, nothing in `create_and_schedule_completion_task` goes through the task after the `enqueue` call, and the three per-owner fields are private. It checks its scans against positive and negative examples. Against `main` it reports the eleven `self` receivers, `BundleThread.rs:235: &mut *completion`, the `(*completion)` after the enqueue, and `pub(crate)` on all three fields; it passes with this branch.

### Verification

Debug (ASAN) build: test/bundler/bun-build-api.test.ts and bundler_plugin.test.ts (105 pass, including the build-thousands-of-times test), bundler_plugin_chain, bundler_html_server, plugin-error-nested-throw, plugin-sync-exception-fallback, test/js/bun/http/bun-serve-html.test.ts, bun-serve-html-405, bun-serve-html-manifest (the `HTMLBundle::Route` path in development and production mode), the two worker tests in test/js/node/worker_threads/worker_threads.test.ts that terminate workers with builds both queued and mid-plugin (both `stop_for_vm_teardown` branches, racing `try_start` / `free_released_unstarted`), and the `counted` family of test/js/web/workers/worker-terminate-funnels.test.ts. `bun test test/internal/source-lints/` (19 files) passes; `cargo clippy -p bun_runtime -p bun_bundler` and `cargo fmt --check` are clean. bun-serve-html-entry.test.ts cannot connect to `localhost` in this container with the release binary either (already noted on #37723).

</details>
