### PR TITLE
napi: drive a threadsafe function's addon-thread entry points off its pointer, not &mut self

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2403,11 +2403,12 @@ extern "C" fn napi_internal_enqueue_finalizer(
 /// it in `destroy`; from `env_teardown_done` on it belongs to the remaining
 /// `thread_count` references, and whoever drops the last one frees it.
 ///
-/// Addon-thread entry points (`push`, `acquire`, `release`) take `*mut Self` and
-/// borrow one field at a time: once a dispatch is posted the JS thread uses the
-/// object (and frees it after the last reference), so no `&Self` / `&mut Self`
-/// of ours may be live then, and the posted pointer must be the addon's own,
-/// not one made from a receiver. The `&mut self` methods are JS-thread only.
+/// `schedule_dispatch` hands its pointer to the JS thread, which locks and may
+/// free through it, so it must be the pointer `new` returned (the addon's
+/// handle), not one made from a `&Self` / `&mut Self`, and no such reference
+/// may be live while that thread uses it. Hence `push` / `acquire` / `release`
+/// and what they call take `*mut Self` and borrow one field at a time; a
+/// `&mut self` caller that merely passes `self` on reintroduces the problem.
 // TODO: generate a compile-time version of this instead of runtime checking
 pub(crate) struct ThreadSafeFunction {
     /// thread-safe functions can be "referenced" and "unreferenced". A
@@ -2759,7 +2760,8 @@ impl ThreadSafeFunction {
     /// Addon thread (Node's `Push`). A `napi_closing` result consumes the
     /// caller's thread reference, so like `release` this can free the function.
     ///
-    /// SAFETY: `this` is live and the caller holds no reference into it.
+    /// SAFETY: `this` is the live pointer `new` returned, and no reference into
+    /// the object is live in the caller.
     pub(crate) unsafe fn push(
         this: *mut ThreadSafeFunction,
         ctx: *mut c_void,
@@ -2781,10 +2783,12 @@ impl ThreadSafeFunction {
         status
     }
 
-    /// Caller must hold `lock`. Returns `(status, caller_must_free)`; the free
-    /// must happen after the lock is dropped.
+    /// Returns `(status, caller_must_free)`; the free must happen after the
+    /// lock is dropped.
     ///
-    /// SAFETY: `this` is live and the caller holds `lock`.
+    /// SAFETY: `this` is the live pointer `new` returned (it is what gets
+    /// posted), no reference into the object is live in any calling frame, and
+    /// the caller holds `lock`.
     unsafe fn push_locked(
         this: *mut ThreadSafeFunction,
         ctx: *mut c_void,
@@ -2829,12 +2833,12 @@ impl ThreadSafeFunction {
         (NapiStatus::ok as napi_status, false)
     }
 
-    /// Caller must hold `lock`. Reached from addon threads (`push_locked`,
-    /// `release_locked`); the VM is reached only through its handle, and the
-    /// task carries `this` itself: the JS thread may be in `on_dispatch` from
-    /// the moment it is queued.
+    /// The VM is reached only through its handle, and the JS thread may be in
+    /// `on_dispatch` from the moment the task is queued.
     ///
-    /// SAFETY: `this` is live and the caller holds `lock`.
+    /// SAFETY: `this` is the live pointer `new` returned (it is what gets
+    /// posted), no reference into the object is live in any calling frame, and
+    /// the caller holds `lock`.
     unsafe fn schedule_dispatch(this: *mut ThreadSafeFunction) {
         // SAFETY: see `push_locked`; `loop_handle` is immutable after creation.
         unsafe {
@@ -2999,7 +3003,8 @@ impl ThreadSafeFunction {
 
     /// Addon thread.
     ///
-    /// SAFETY: `this` is live and the caller holds no reference into it.
+    /// SAFETY: `this` is the live pointer `new` returned, and no reference into
+    /// the object is live in the caller.
     pub(crate) unsafe fn acquire(this: *mut ThreadSafeFunction) -> napi_status {
         // SAFETY: live per fn contract; the guard holds the lock by pointer and
         // the other two accesses each borrow one atomic.
@@ -3016,7 +3021,8 @@ impl ThreadSafeFunction {
     /// Addon thread. Frees an orphaned function when this drops its last
     /// thread reference.
     ///
-    /// SAFETY: `this` is live and the caller holds no reference into it.
+    /// SAFETY: `this` is the live pointer `new` returned, and no reference into
+    /// the object is live in the caller.
     pub(crate) unsafe fn release(
         this: *mut ThreadSafeFunction,
         mode: napi_threadsafe_function_release_mode,
@@ -3037,10 +3043,12 @@ impl ThreadSafeFunction {
         status
     }
 
-    /// Caller must hold `lock`. Returns `(status, caller_must_free)`; the free
-    /// must happen after the lock is dropped.
+    /// Returns `(status, caller_must_free)`; the free must happen after the
+    /// lock is dropped.
     ///
-    /// SAFETY: `this` is live and the caller holds `lock`.
+    /// SAFETY: `this` is the live pointer `new` returned (it is what gets
+    /// posted), no reference into the object is live in any calling frame, and
+    /// the caller holds `lock`.
     unsafe fn release_locked(
         this: *mut ThreadSafeFunction,
         mode: napi_threadsafe_function_release_mode,

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2402,6 +2402,16 @@ extern "C" fn napi_internal_enqueue_finalizer(
 /// Ownership: the JS thread owns this allocation while the env lives and frees
 /// it in `destroy`; from `env_teardown_done` on it belongs to the remaining
 /// `thread_count` references, and whoever drops the last one frees it.
+///
+/// The addon-thread entry points (`push`, `acquire`, `release` and what they
+/// call under `lock`) take `*mut Self` and borrow one field per statement,
+/// never the whole object: the task `schedule_dispatch` posts must carry the
+/// pointer the addon gave us (one made from a receiver is invalidated for the
+/// JS thread by our own unlock right after the post), and from the post on the
+/// JS thread uses the object, and after a last release or `napi_closing` call
+/// frees it, while these frames are still returning, so no `&Self` /
+/// `&mut Self` argument of ours may cover it. The `&mut self` methods are
+/// JS-thread only.
 // TODO: generate a compile-time version of this instead of runtime checking
 pub(crate) struct ThreadSafeFunction {
     /// thread-safe functions can be "referenced" and "unreferenced". A
@@ -2598,7 +2608,7 @@ impl ThreadSafeFunction {
                 {
                     break;
                 }
-                // state was bumped to Pending by enqueue()/release(); re-dispatch.
+                // state was bumped to Pending by push()/release(); re-dispatch.
             }
         }
 
@@ -2608,8 +2618,11 @@ impl ThreadSafeFunction {
         // not add unnecessary event loop ticks.
     }
 
-    pub(crate) fn is_closing(&self) -> bool {
-        self.closing.load(Ordering::SeqCst) != ClosingState::NotClosing as u8
+    /// SAFETY: `this` is a live threadsafe function.
+    unsafe fn is_closing(this: *const ThreadSafeFunction) -> bool {
+        // SAFETY: fn contract; `closing` is atomic, so borrowing just that
+        // field is sound whatever the other threads are doing.
+        unsafe { (*this).closing.load(Ordering::SeqCst) != ClosingState::NotClosing as u8 }
     }
 
     /// The creating VM's event loop, or `None` once its env has been torn down.
@@ -2748,9 +2761,9 @@ impl ThreadSafeFunction {
         Ok(())
     }
 
-    /// Runs on an addon thread. A call that reports `napi_closing` consumes the
-    /// caller's thread reference, so like a release it can free the threadsafe
-    /// function -- hence `*mut Self`, not `&mut self` (Node's `Push`).
+    /// Runs on an addon thread (Node's `Push`). A call that reports
+    /// `napi_closing` consumes the caller's thread reference, so like a release
+    /// it can free the threadsafe function; see the receiver rule on the struct.
     ///
     /// SAFETY: `this` is a live threadsafe function and the caller holds no
     /// reference into it.
@@ -2759,9 +2772,13 @@ impl ThreadSafeFunction {
         ctx: *mut c_void,
         block: bool,
     ) -> napi_status {
-        // SAFETY: live allocation; the borrow is scoped to this call and ends
-        // before the free below.
-        let (status, orphaned) = unsafe { (*this).enqueue(ctx, block) };
+        let (status, orphaned) = {
+            // SAFETY: live allocation. `MutexGuard` holds the lock by raw
+            // pointer, so nothing borrows `*this` past this statement.
+            let _g = unsafe { (*this).lock.lock_guard() };
+            // SAFETY: live, and we hold the lock.
+            unsafe { ThreadSafeFunction::push_locked(this, ctx, block) }
+        };
 
         if orphaned {
             // SAFETY: the lock is dropped, we dropped the last thread reference
@@ -2771,71 +2788,97 @@ impl ThreadSafeFunction {
         status
     }
 
-    /// Returns `(status, caller_must_free)`; the free must happen after the
-    /// lock guard here is dropped, which is why only `push` may call this.
-    fn enqueue(&mut self, ctx: *mut c_void, block: bool) -> (napi_status, bool) {
-        let _g = self.lock.lock_guard();
-        if block {
-            while self.queue.is_blocked() && !self.is_closing() {
-                self.blocking_condvar.wait(&self.lock);
+    /// Caller must hold `lock`. Returns `(status, caller_must_free)`; the free
+    /// must happen after the lock is dropped.
+    ///
+    /// SAFETY: `this` is a live threadsafe function and the caller holds `lock`.
+    unsafe fn push_locked(
+        this: *mut ThreadSafeFunction,
+        ctx: *mut c_void,
+        block: bool,
+    ) -> (napi_status, bool) {
+        // SAFETY: live per fn contract, and it stays live until the caller
+        // drops the lock (every path that frees it takes the lock first). Each
+        // access borrows a single field for a single statement, so the JS
+        // thread, which touches the atomics without the lock once
+        // `schedule_dispatch` has posted, never overlaps a borrow of ours.
+        unsafe {
+            if block {
+                while (*this).queue.is_blocked() && !ThreadSafeFunction::is_closing(this) {
+                    (*this).blocking_condvar.wait(&(*this).lock);
+                }
+            } else if (*this).queue.is_blocked() && !ThreadSafeFunction::is_closing(this) {
+                // A closing threadsafe function reports napi_closing even with a full
+                // queue (node's `Push` skips the queue-full check unless it is open),
+                // so the caller's reference is still consumed and it can finalize.
+                // don't set the error on the env as this is run from another thread
+                return (NapiStatus::queue_full as napi_status, false);
             }
-        } else if self.queue.is_blocked() && !self.is_closing() {
-            // A closing threadsafe function reports napi_closing even with a full
-            // queue (node's `Push` skips the queue-full check unless it is open),
-            // so the caller's reference is still consumed and it can finalize.
-            // don't set the error on the env as this is run from another thread
-            return (NapiStatus::queue_full as napi_status, false);
-        }
 
-        if self.is_closing() {
-            // `env_teardown` sets `closing` under this same lock, so an env that
-            // dies while we wait above lands here, never below.
-            if self.thread_count.load(Ordering::SeqCst) <= 0 {
-                return (NapiStatus::invalid_arg as napi_status, false);
+            if ThreadSafeFunction::is_closing(this) {
+                // `env_teardown` sets `closing` under this same lock, so an env that
+                // dies while we wait above lands here, never below.
+                if (*this).thread_count.load(Ordering::SeqCst) <= 0 {
+                    return (NapiStatus::invalid_arg as napi_status, false);
+                }
+                // Consumes this thread's reference, like Node's `Push`, so a thread
+                // that stops calling after napi_closing does not pin the loop. That
+                // can be the last reference: the caller frees if we say so.
+                let (_, caller_must_free) = ThreadSafeFunction::release_locked(
+                    this,
+                    napi_threadsafe_function_release_mode::release,
+                );
+                return (NapiStatus::closing as napi_status, caller_must_free);
             }
-            // Consumes this thread's reference, like Node's `Push`, so a thread
-            // that stops calling after napi_closing does not pin the loop. That
-            // can be the last reference: the caller frees if we say so.
-            let (_, caller_must_free) =
-                self.release_locked(napi_threadsafe_function_release_mode::release);
-            return (NapiStatus::closing as napi_status, caller_must_free);
-        }
 
-        let _ = self.queue.count.fetch_add(1, Ordering::SeqCst);
-        let _ = self.queue.data.write_item(ctx); // OOM/capacity failures are fire-and-forget
-        self.schedule_dispatch();
+            let _ = (*this).queue.count.fetch_add(1, Ordering::SeqCst);
+            let _ = (*this).queue.data.write_item(ctx); // OOM/capacity failures are fire-and-forget
+            ThreadSafeFunction::schedule_dispatch(this);
+        }
         (NapiStatus::ok as napi_status, false)
     }
 
-    /// Caller must hold `lock`. Reached from addon threads (`enqueue`,
-    /// `release_locked`); the VM is reached only through its handle.
-    fn schedule_dispatch(&mut self) {
-        let prev = self
-            .dispatch_state
-            .swap(DispatchState::Pending as u8, Ordering::SeqCst);
-        match prev {
-            x if x == DispatchState::Idle as u8 => {
-                let self_ptr: *mut Self = self;
-                if self.event_loop.is_none() {
-                    // env torn down: the loop is gone, nothing to schedule onto.
-                    return;
+    /// Caller must hold `lock`. Reached from addon threads (`push_locked`,
+    /// `release_locked`); the VM is reached only through its handle. The
+    /// posted task carries `this` itself, the pointer the JS thread keeps
+    /// using after the caller's unlock (see the receiver rule on the struct),
+    /// and from the moment it is queued the JS thread may be in `on_dispatch`,
+    /// so nothing here borrows the object across the post.
+    ///
+    /// SAFETY: `this` is a live threadsafe function and the caller holds `lock`.
+    unsafe fn schedule_dispatch(this: *mut ThreadSafeFunction) {
+        // SAFETY: see `push_locked`. `loop_handle` is immutable after creation,
+        // so the borrow of it for the post does not overlap anything either.
+        unsafe {
+            let prev = (*this)
+                .dispatch_state
+                .swap(DispatchState::Pending as u8, Ordering::SeqCst);
+            match prev {
+                x if x == DispatchState::Idle as u8 => {
+                    if (*this).event_loop.is_none() {
+                        // env torn down: the loop is gone, nothing to schedule onto.
+                        return;
+                    }
+                    let ct = ConcurrentTask::create_from(this);
+                    if let bun_jsc::vm_handle::Posted::Refused(ct) =
+                        (*this).loop_handle.post_task(ct)
+                    {
+                        // VM torn down before the env cleanup hook ran here: no
+                        // dispatch will happen; the queued calls are released by the
+                        // teardown path. Free the task and fall back to Idle.
+                        // Refused ⇒ we own the task box.
+                        drop(bun_core::heap::take(ct.as_ptr()));
+                        (*this)
+                            .dispatch_state
+                            .store(DispatchState::Idle as u8, Ordering::SeqCst);
+                    }
                 }
-                let ct = ConcurrentTask::create_from(self_ptr);
-                if let bun_jsc::vm_handle::Posted::Refused(ct) = self.loop_handle.post_task(ct) {
-                    // VM torn down before the env cleanup hook ran here: no
-                    // dispatch will happen; the queued calls are released by the
-                    // teardown path. Free the task and fall back to Idle.
-                    // SAFETY: refused ⇒ we own the task box.
-                    unsafe { drop(bun_core::heap::take(ct.as_ptr())) };
-                    self.dispatch_state
-                        .store(DispatchState::Idle as u8, Ordering::SeqCst);
+                x if x == DispatchState::Running as u8 => {
+                    // it will check if it has more work to do
                 }
-            }
-            x if x == DispatchState::Running as u8 => {
-                // it will check if it has more work to do
-            }
-            _ => {
-                // we've already scheduled it to run
+                _ => {
+                    // we've already scheduled it to run
+                }
             }
         }
     }
@@ -2966,18 +3009,26 @@ impl ThreadSafeFunction {
         self.poll_ref.unref(bun_io::js_vm_ctx());
     }
 
-    pub(crate) fn acquire(&mut self) -> napi_status {
-        let _g = self.lock.lock_guard();
-        if self.is_closing() {
-            return NapiStatus::closing as napi_status;
+    /// Runs on an addon thread; see the receiver rule on the struct.
+    ///
+    /// SAFETY: `this` is a live threadsafe function and the caller holds no
+    /// reference into it.
+    pub(crate) unsafe fn acquire(this: *mut ThreadSafeFunction) -> napi_status {
+        // SAFETY: live per fn contract. The guard holds the lock by raw
+        // pointer and the two other accesses each borrow one atomic field.
+        unsafe {
+            let _g = (*this).lock.lock_guard();
+            if ThreadSafeFunction::is_closing(this) {
+                return NapiStatus::closing as napi_status;
+            }
+            let _ = (*this).thread_count.fetch_add(1, Ordering::SeqCst);
         }
-        let _ = self.thread_count.fetch_add(1, Ordering::SeqCst);
         NapiStatus::ok as napi_status
     }
 
-    /// Frees the threadsafe function when this drops the last thread reference
-    /// of an orphaned one, so it dispatches off `*mut Self`: freeing through a
-    /// pointer derived from a live `&mut self` is UB.
+    /// Runs on an addon thread. Frees the threadsafe function when this drops
+    /// the last thread reference of an orphaned one; see the receiver rule on
+    /// the struct.
     ///
     /// SAFETY: `this` is a live threadsafe function and the caller holds no
     /// reference into it.
@@ -2987,11 +3038,10 @@ impl ThreadSafeFunction {
     ) -> napi_status {
         let (status, orphaned) = {
             // SAFETY: live allocation. `MutexGuard` holds the lock by raw
-            // pointer, so it does not keep `*this` borrowed across the call
-            // below; both borrows are scoped and end before the free.
+            // pointer, so nothing borrows `*this` past this statement.
             let _g = unsafe { (*this).lock.lock_guard() };
-            // SAFETY: as above.
-            unsafe { (*this).release_locked(mode) }
+            // SAFETY: live, and we hold the lock.
+            unsafe { ThreadSafeFunction::release_locked(this, mode) }
         };
 
         if orphaned {
@@ -3004,43 +3054,50 @@ impl ThreadSafeFunction {
 
     /// Caller must hold `lock`. Returns `(status, caller_must_free)`; the free
     /// must happen after the lock is dropped.
-    fn release_locked(
-        &mut self,
+    ///
+    /// SAFETY: `this` is a live threadsafe function and the caller holds `lock`.
+    unsafe fn release_locked(
+        this: *mut ThreadSafeFunction,
         mode: napi_threadsafe_function_release_mode,
     ) -> (napi_status, bool) {
-        if self.thread_count.load(Ordering::SeqCst) <= 0 {
-            return (NapiStatus::invalid_arg as napi_status, false);
-        }
+        // SAFETY: see `push_locked`.
+        unsafe {
+            if (*this).thread_count.load(Ordering::SeqCst) <= 0 {
+                return (NapiStatus::invalid_arg as napi_status, false);
+            }
 
-        let prev_remaining = self.thread_count.fetch_sub(1, Ordering::SeqCst);
+            let prev_remaining = (*this).thread_count.fetch_sub(1, Ordering::SeqCst);
 
-        if self.env_dead.load(Ordering::SeqCst) {
-            // The event loop we were created on is gone (`env_teardown` set
-            // this under the lock we hold). Never schedule onto it. Whoever
-            // drops the last reference frees us -- but only once teardown has
-            // released the JS-thread-owned resources; until then it owns us
-            // and will free us itself if we are the last to let go.
-            let orphaned = prev_remaining == 1 && self.env_teardown_done.load(Ordering::SeqCst);
-            return (NapiStatus::ok as napi_status, orphaned);
-        }
+            if (*this).env_dead.load(Ordering::SeqCst) {
+                // The event loop we were created on is gone (`env_teardown` set
+                // this under the lock we hold). Never schedule onto it. Whoever
+                // drops the last reference frees us -- but only once teardown has
+                // released the JS-thread-owned resources; until then it owns us
+                // and will free us itself if we are the last to let go.
+                let orphaned =
+                    prev_remaining == 1 && (*this).env_teardown_done.load(Ordering::SeqCst);
+                return (NapiStatus::ok as napi_status, orphaned);
+            }
 
-        if mode == napi_threadsafe_function_release_mode::abort || prev_remaining == 1 {
-            if !self.is_closing() {
-                if mode == napi_threadsafe_function_release_mode::abort {
-                    self.closing
-                        .store(ClosingState::Closing as u8, Ordering::SeqCst);
-                    if self.queue.max_queue_size > 0 {
-                        // Wake all producers blocked in enqueue()'s bounded
-                        // queue wait so they observe is_closing and release.
-                        self.blocking_condvar.broadcast();
+            if mode == napi_threadsafe_function_release_mode::abort || prev_remaining == 1 {
+                if !ThreadSafeFunction::is_closing(this) {
+                    if mode == napi_threadsafe_function_release_mode::abort {
+                        (*this)
+                            .closing
+                            .store(ClosingState::Closing as u8, Ordering::SeqCst);
+                        if (*this).queue.max_queue_size > 0 {
+                            // Wake all producers blocked in push_locked()'s bounded
+                            // queue wait so they observe is_closing and release.
+                            (*this).blocking_condvar.broadcast();
+                        }
                     }
+                    ThreadSafeFunction::schedule_dispatch(this);
+                } else if prev_remaining == 1 {
+                    // Already closing from an earlier abort. The last release must
+                    // still reach dispatch_one's thread_count==0 path so the
+                    // finalizer runs and the event-loop keepalive is dropped.
+                    ThreadSafeFunction::schedule_dispatch(this);
                 }
-                self.schedule_dispatch();
-            } else if prev_remaining == 1 {
-                // Already closing from an earlier abort. The last release must
-                // still reach dispatch_one's thread_count==0 path so the
-                // finalizer runs and the event-loop keepalive is dropped.
-                self.schedule_dispatch();
             }
         }
 
@@ -3184,7 +3241,7 @@ extern "C" fn napi_call_threadsafe_function(
 extern "C" fn napi_acquire_threadsafe_function(func: napi_threadsafe_function) -> napi_status {
     bun_output::scoped_log!(napi, "napi_acquire_threadsafe_function");
     // SAFETY: func is non-null per N-API contract.
-    unsafe { &mut *func }.acquire()
+    unsafe { ThreadSafeFunction::acquire(func) }
 }
 
 #[unsafe(no_mangle)]

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2403,15 +2403,11 @@ extern "C" fn napi_internal_enqueue_finalizer(
 /// it in `destroy`; from `env_teardown_done` on it belongs to the remaining
 /// `thread_count` references, and whoever drops the last one frees it.
 ///
-/// The addon-thread entry points (`push`, `acquire`, `release` and what they
-/// call under `lock`) take `*mut Self` and borrow one field per statement,
-/// never the whole object: the task `schedule_dispatch` posts must carry the
-/// pointer the addon gave us (one made from a receiver is invalidated for the
-/// JS thread by our own unlock right after the post), and from the post on the
-/// JS thread uses the object, and after a last release or `napi_closing` call
-/// frees it, while these frames are still returning, so no `&Self` /
-/// `&mut Self` argument of ours may cover it. The `&mut self` methods are
-/// JS-thread only.
+/// Addon-thread entry points (`push`, `acquire`, `release`) take `*mut Self` and
+/// borrow one field at a time: once a dispatch is posted the JS thread uses the
+/// object (and frees it after the last reference), so no `&Self` / `&mut Self`
+/// of ours may be live then, and the posted pointer must be the addon's own,
+/// not one made from a receiver. The `&mut self` methods are JS-thread only.
 // TODO: generate a compile-time version of this instead of runtime checking
 pub(crate) struct ThreadSafeFunction {
     /// thread-safe functions can be "referenced" and "unreferenced". A
@@ -2618,10 +2614,9 @@ impl ThreadSafeFunction {
         // not add unnecessary event loop ticks.
     }
 
-    /// SAFETY: `this` is a live threadsafe function.
+    /// SAFETY: `this` is live.
     unsafe fn is_closing(this: *const ThreadSafeFunction) -> bool {
-        // SAFETY: fn contract; `closing` is atomic, so borrowing just that
-        // field is sound whatever the other threads are doing.
+        // SAFETY: fn contract; only the atomic is borrowed.
         unsafe { (*this).closing.load(Ordering::SeqCst) != ClosingState::NotClosing as u8 }
     }
 
@@ -2761,12 +2756,10 @@ impl ThreadSafeFunction {
         Ok(())
     }
 
-    /// Runs on an addon thread (Node's `Push`). A call that reports
-    /// `napi_closing` consumes the caller's thread reference, so like a release
-    /// it can free the threadsafe function; see the receiver rule on the struct.
+    /// Addon thread (Node's `Push`). A `napi_closing` result consumes the
+    /// caller's thread reference, so like `release` this can free the function.
     ///
-    /// SAFETY: `this` is a live threadsafe function and the caller holds no
-    /// reference into it.
+    /// SAFETY: `this` is live and the caller holds no reference into it.
     pub(crate) unsafe fn push(
         this: *mut ThreadSafeFunction,
         ctx: *mut c_void,
@@ -2791,17 +2784,15 @@ impl ThreadSafeFunction {
     /// Caller must hold `lock`. Returns `(status, caller_must_free)`; the free
     /// must happen after the lock is dropped.
     ///
-    /// SAFETY: `this` is a live threadsafe function and the caller holds `lock`.
+    /// SAFETY: `this` is live and the caller holds `lock`.
     unsafe fn push_locked(
         this: *mut ThreadSafeFunction,
         ctx: *mut c_void,
         block: bool,
     ) -> (napi_status, bool) {
-        // SAFETY: live per fn contract, and it stays live until the caller
-        // drops the lock (every path that frees it takes the lock first). Each
-        // access borrows a single field for a single statement, so the JS
-        // thread, which touches the atomics without the lock once
-        // `schedule_dispatch` has posted, never overlaps a borrow of ours.
+        // SAFETY: live per fn contract, and still live when we return, since
+        // every path that frees it takes the lock first. Each access borrows one
+        // field for one statement (see the struct doc).
         unsafe {
             if block {
                 while (*this).queue.is_blocked() && !ThreadSafeFunction::is_closing(this) {
@@ -2839,16 +2830,13 @@ impl ThreadSafeFunction {
     }
 
     /// Caller must hold `lock`. Reached from addon threads (`push_locked`,
-    /// `release_locked`); the VM is reached only through its handle. The
-    /// posted task carries `this` itself, the pointer the JS thread keeps
-    /// using after the caller's unlock (see the receiver rule on the struct),
-    /// and from the moment it is queued the JS thread may be in `on_dispatch`,
-    /// so nothing here borrows the object across the post.
+    /// `release_locked`); the VM is reached only through its handle, and the
+    /// task carries `this` itself: the JS thread may be in `on_dispatch` from
+    /// the moment it is queued.
     ///
-    /// SAFETY: `this` is a live threadsafe function and the caller holds `lock`.
+    /// SAFETY: `this` is live and the caller holds `lock`.
     unsafe fn schedule_dispatch(this: *mut ThreadSafeFunction) {
-        // SAFETY: see `push_locked`. `loop_handle` is immutable after creation,
-        // so the borrow of it for the post does not overlap anything either.
+        // SAFETY: see `push_locked`; `loop_handle` is immutable after creation.
         unsafe {
             let prev = (*this)
                 .dispatch_state
@@ -3009,13 +2997,12 @@ impl ThreadSafeFunction {
         self.poll_ref.unref(bun_io::js_vm_ctx());
     }
 
-    /// Runs on an addon thread; see the receiver rule on the struct.
+    /// Addon thread.
     ///
-    /// SAFETY: `this` is a live threadsafe function and the caller holds no
-    /// reference into it.
+    /// SAFETY: `this` is live and the caller holds no reference into it.
     pub(crate) unsafe fn acquire(this: *mut ThreadSafeFunction) -> napi_status {
-        // SAFETY: live per fn contract. The guard holds the lock by raw
-        // pointer and the two other accesses each borrow one atomic field.
+        // SAFETY: live per fn contract; the guard holds the lock by pointer and
+        // the other two accesses each borrow one atomic.
         unsafe {
             let _g = (*this).lock.lock_guard();
             if ThreadSafeFunction::is_closing(this) {
@@ -3026,12 +3013,10 @@ impl ThreadSafeFunction {
         NapiStatus::ok as napi_status
     }
 
-    /// Runs on an addon thread. Frees the threadsafe function when this drops
-    /// the last thread reference of an orphaned one; see the receiver rule on
-    /// the struct.
+    /// Addon thread. Frees an orphaned function when this drops its last
+    /// thread reference.
     ///
-    /// SAFETY: `this` is a live threadsafe function and the caller holds no
-    /// reference into it.
+    /// SAFETY: `this` is live and the caller holds no reference into it.
     pub(crate) unsafe fn release(
         this: *mut ThreadSafeFunction,
         mode: napi_threadsafe_function_release_mode,
@@ -3055,7 +3040,7 @@ impl ThreadSafeFunction {
     /// Caller must hold `lock`. Returns `(status, caller_must_free)`; the free
     /// must happen after the lock is dropped.
     ///
-    /// SAFETY: `this` is a live threadsafe function and the caller holds `lock`.
+    /// SAFETY: `this` is live and the caller holds `lock`.
     unsafe fn release_locked(
         this: *mut ThreadSafeFunction,
         mode: napi_threadsafe_function_release_mode,

--- a/test/internal/source-lints/self-receiver-publish.test.ts
+++ b/test/internal/source-lints/self-receiver-publish.test.ts
@@ -9,13 +9,14 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //
 //   ConcurrentTask::create(Task::init(std::ptr::from_mut(self)))
 //   ConcurrentTask::create_from(self)            // `&mut Self` coerces to `*mut Self`
+//   ManagedTask::new(&mut *self, Self::run)      // so does a reborrow
 //   let this = std::ptr::from_mut(self); ... Task::init(this)
 //   let p: *mut Self = self;             ... ConcurrentTask::create_from(p)
-//   ThreadSafeFunction::schedule_dispatch(self)  // a helper that posts its argument
+//   ThreadSafeFunction::schedule_dispatch(self)  // a function that posts its argument
 //
-// as the argument of `Task::init(..)` / `..::create_from(..)` /
-// `..::from_callback(..)`, or of one of the helpers in `POSTING_HELPERS` whose
-// contract is to post the pointer they are given, is banned.
+// as the argument of one of the `POSTING_CALLEES` below (the task constructors
+// that take the pointer a task will carry, and the functions whose contract is
+// to post the pointer they are given) is banned.
 //
 // The post is the hand-over, and it goes wrong in two ways. The consumer
 // (another thread, for a `ConcurrentTask`) starts using the object the moment
@@ -50,21 +51,28 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // src/runtime/napi/napi_body.rs, `async_job_run` in
 // src/runtime/node/node_zlib_binding.rs, `post_job` in src/jsc/VmHandle.rs.
 //
-// Scope: the spellings above, with `self` as the receiver and the three task
-// constructors or a listed helper as the callee. The conversion of a posting
-// site moves the post behind a `this: *mut Self` function, and `&mut Self`
-// coerces to `*mut Self` silently, so a `&mut self` caller that passes `self`
-// into that function recreates the bug without any of the spellings above
-// appearing at the post itself: that is what `POSTING_HELPERS` is for, and a
-// function that takes a pointer in order to post it has to be added there when
-// it is introduced (its `SAFETY` contract should say the pointer must be the
-// allocation's own, which is the other half of the guard). A pointer produced
-// by a helper (`self.as_ptr()`), a `NonNull::from(self)` binding posted through
-// `.as_ptr()`, the intrusive `ConcurrentTask::from(..)` form, and reference
-// *parameters* other than `self` (`fn f(load: &mut Load)` posting
-// `from_mut(load)`) are the same hazard but outside this lint. Siblings:
-// self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
-// frozen-nonnull-reborrow.test.ts.
+// Scope: the spellings above, with `self` as the receiver and one of
+// `POSTING_CALLEES` as the callee. The conversion of a posting site moves the
+// post behind a `this: *mut Self` function, and `&mut Self` coerces to
+// `*mut Self` silently, so a `&mut self` caller that passes `self` into that
+// function recreates the bug without any of the spellings above appearing at
+// the post itself: that is why such functions are callees here too, and one
+// that is introduced later has to be added (its `SAFETY` contract should say
+// the pointer must be the allocation's own, which is the other half of the
+// guard). Shapes the patterns cannot see, each the same hazard and tracked on
+// its own: a pointer produced by a helper (`StatWatcher::post_to_js_thread`
+// posting `self.as_ctx_ptr()`, #37857); the intrusive `ConcurrentTask::from(..)`
+// form (`napi_async_work::run` / `post_to_js_thread`, #37750); a receiver
+// pointer handed to a posting method that is not a listed callee
+// (`TranspilerJob::run` -> `dispatch_to_main_thread`, #37778); a `&Self` made
+// from the pointer and still live across the post (`FetchTasklet::
+// deref_from_thread`, tracked separately); and reference *parameters* other
+// than `self` (`fn f(load: &mut Load)` posting `from_mut(load)`). The
+// `SELF_AS_POINTER` list below mirrors self-receiver-reclaim.test.ts; once the
+// in-flight lints of this family (#37703, #37685, #37693, #37705, #37750,
+// #37778) have landed, the list and its fixtures should be shared rather than
+// copied again. Siblings: self-receiver-reclaim.test.ts,
+// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
@@ -82,34 +90,48 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-// Functions whose contract is to post the pointer they are given (see the
-// header): `post_job` in src/jsc/VmHandle.rs, `ThreadSafeFunction::
-// schedule_dispatch` in src/runtime/napi/napi_body.rs. Qualified or not.
-const POSTING_HELPERS = [String.raw`(?:[\w:]+::)?post_job`, String.raw`[\w:]+::schedule_dispatch`];
+// The callees: every constructor in src/event_loop that takes the pointer a
+// task will carry (`Task::init`, `ConcurrentTask::create_from` /
+// `from_callback`, `AnyTaskWithExtraContext::init` / `from_callback_auto_deinit`,
+// `ManagedTask::new` / `new_owned`), plus the functions elsewhere whose contract
+// is to post the pointer they are given (`post_job` in src/jsc/VmHandle.rs,
+// `ThreadSafeFunction::schedule_dispatch` in src/runtime/napi/napi_body.rs).
+// A new one of either kind is added here when it is introduced. The `\b` keeps
+// `NapiFinalizerTask::init(self)` (a constructor that copies out of `self`) out
+// of the `Task::init` entry; the entries that require a path in front are the
+// ones whose bare name is also used as a method elsewhere.
+const POSTING_CALLEES = [
+  String.raw`Task::init`,
+  String.raw`[\w:]+::create_from`,
+  String.raw`[\w:]+::from_callback(?:_auto_deinit)?`,
+  String.raw`(?:[\w:]+::)?AnyTaskWithExtraContext::init`,
+  String.raw`(?:[\w:]+::)?ManagedTask::new(?:_owned)?`,
+  String.raw`(?:[\w:]+::)?post_job`,
+  String.raw`[\w:]+::schedule_dispatch`,
+];
 
-// `Task::init(`, `ConcurrentTask::create_from(`, `ConcurrentTask::from_callback(`,
-// however the path in front is spelled, optionally turbofished, or one of the
-// helpers above. The `\b` before `Task` keeps `NapiFinalizerTask::init(self)` (a
-// constructor that copies out of `self`) out; `create_from` / `from_callback` /
-// `schedule_dispatch` require a path in front so a method call of the same name
-// does not count. `\s*` after the paren so a rustfmt-wrapped argument still
-// matches.
-const POST =
-  String.raw`\b(?:Task::init|[\w:]+::create_from|[\w:]+::from_callback|` +
-  POSTING_HELPERS.join("|") +
-  String.raw`)(?:::<[^>]*>)?\(\s*`;
+// Optionally turbofished; `\s*` after the paren so a rustfmt-wrapped argument
+// still matches.
+const POST = String.raw`\b(?:` + POSTING_CALLEES.join("|") + String.raw`)(?:::<[^>]*>)?\(\s*`;
 
-// The ways of spelling "`self`, as a raw pointer" as the first argument. Each
-// is anchored at its front only, so a trailing `.cast_mut()` / `.as_ptr()`
-// still matches; the bare form needs the `,` / `)` so `self.as_ptr()` (a
-// helper, out of scope) does not. `(?!\s*\.)` after the `&raw` form keeps
-// `&raw mut *self.field` (a field the receiver owns) out.
+// `self` reborrowed in place, which every spelling below may contain: all the
+// callees take `*mut T`, so `&mut *self` coerces exactly like bare `self`.
+const REBORROWED_SELF = String.raw`(?:&\s*mut\s+\*\s*)?self`;
+
+// The ways of spelling "`self`, as a raw pointer" as the first argument: the
+// spellings self-receiver-reclaim.test.ts bans, here also allowing a reborrow
+// inside `from_mut(..)` / `NonNull::from(..)` and a `,` after the bare form,
+// since these callees take further arguments. Each is anchored at its front
+// only, so a trailing `.cast_mut()` / `.as_ptr()` still matches; the bare form
+// needs the `,` / `)` so `self.as_ptr()` (a helper, out of scope) does not, and
+// `(?!\s*\.)` after the `&` forms keeps `&mut *self.field` (a field the
+// receiver owns) out.
 const SELF_AS_POINTER = [
   String.raw`self\s*[,)]`,
-  String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
-  String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+  String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*${REBORROWED_SELF}\s*\)`,
+  String.raw`(?:[\w:]+::)?NonNull::from\(\s*${REBORROWED_SELF}\s*\)`,
   String.raw`self\s+as\s+\*(?:mut|const)\b`,
-  String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
+  String.raw`&\s*(?:raw\s+(?:mut|const)|mut)\s+\*\s*self\b(?!\s*\.)`,
   String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
 ].join("|");
 
@@ -118,24 +140,25 @@ const DIRECT = new RegExp(`${POST}(?:${SELF_AS_POINTER})`, "g");
 // A local bound to such a pointer: `let this = ptr::from_mut(self);`,
 // `let p = self as *mut Self;`, `let p: *mut Self = self;` (the coercion
 // spelling needs the annotation; without it `let p = self;` is just another
-// reference). The binding is then looked for as a post argument further down
-// the same function, which ends at the next `fn` item (a closure inside it is
-// the same function for this purpose).
+// reference), or to a plain reborrow `let p = &mut *self;`, which coerces at
+// the call like bare `self` does. The binding is then looked for as a post
+// argument further down the same function, which ends at the next `fn` item (a
+// closure inside it is the same function for this purpose).
 const BINDING_HEAD = String.raw`let\s+(?:mut\s+)?(\w+)\s*`;
 const SELF_POINTER_BINDINGS = [
   new RegExp(
     BINDING_HEAD +
       String.raw`(?::[^=;]*)?=\s*(?:` +
       [
-        String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)(?:\s*\.cast_mut\(\))?`,
+        String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*${REBORROWED_SELF}\s*\)(?:\s*\.cast_mut\(\))?`,
         String.raw`self\s+as\s+\*(?:mut|const)\b[^;]*`,
-        String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b`,
+        String.raw`&\s*(?:raw\s+(?:mut|const)|mut)\s+\*\s*self\b(?!\s*\.)`,
         String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
       ].join("|") +
       String.raw`)\s*;`,
     "g",
   ),
-  new RegExp(BINDING_HEAD + String.raw`:\s*\*(?:mut|const)\b[^=;]*=\s*self\s*;`, "g"),
+  new RegExp(BINDING_HEAD + String.raw`:\s*\*(?:mut|const)\b[^=;]*=\s*${REBORROWED_SELF}\s*;`, "g"),
 ];
 const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s/m;
 
@@ -145,8 +168,10 @@ function postOfBinding(name: string): RegExp {
 
 /** Byte offsets (into `stripped`) of every banned post in one file. */
 function findPosts(stripped: string): number[] {
-  const hits: number[] = [];
-  for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
+  // A set: `let p: *mut Self = &mut *self;` matches both binding patterns, and
+  // one post is one hit.
+  const hits = new Set<number>();
+  for (const m of stripped.matchAll(DIRECT)) hits.add(m.index);
   for (const pattern of SELF_POINTER_BINDINGS) {
     for (const binding of stripped.matchAll(pattern)) {
       const start = binding.index + binding[0].length;
@@ -154,10 +179,10 @@ function findPosts(stripped: string): number[] {
       const fnEnd = rest.search(FN_ITEM);
       const body = fnEnd === -1 ? rest : rest.slice(0, fnEnd);
       const post = body.search(postOfBinding(binding[1]));
-      if (post !== -1) hits.push(start + post);
+      if (post !== -1) hits.add(start + post);
     }
   }
-  return hits.sort((a, b) => a - b);
+  return [...hits].sort((a, b) => a - b);
 }
 
 function lineOf(text: string, offset: number): number {
@@ -167,7 +192,8 @@ function lineOf(text: string, offset: number): number {
 // Documented, ratcheted exceptions: files allowed to keep exactly N of the
 // shape. Each has been read and each has its conversion in flight or tied to
 // a conversion of its callers. Lower an entry when you convert one; do not
-// add entries.
+// add entries. The counts are of what the patterns above see; the escapes the
+// header lists are not in them.
 const ALLOW: Record<string, number> = {
   // `Resolve::dispatch` / `Load::dispatch` (`&mut self`) post the arena-owned
   // plugin request to the JS thread, which writes its `value` while
@@ -193,6 +219,13 @@ const ALLOW: Record<string, number> = {
   // (`dispatch_one` and what it calls), tracked separately; the addon-thread
   // side is converted.
   "src/runtime/napi/napi_body.rs": 1,
+  // `NewServer::schedule_deinit` (`&mut self`) enqueues `ManagedTask::new(
+  // from_mut(self), deinit)` on its own loop; `deinit` reclaims the allocation
+  // through that pointer (its contract asks for the owning pointer), while
+  // `deinit_if_we_can`, the caller, still writes through its receiver after the
+  // post. Same shape as the napi entry above: the pointer to post is the one
+  // the callers of `deinit_if_we_can` hold; tracked separately.
+  "src/runtime/server/mod.rs": 1,
 };
 
 const counts: Record<string, number> = {};
@@ -257,6 +290,19 @@ test("the patterns match the banned spellings and nothing else", () => {
     "let self_ptr: *mut Self = self;\nunsafe { Self::schedule_dispatch(self_ptr) };",
     "unsafe { bun_jsc::post_job(std::ptr::from_mut(self)) };",
     "unsafe { post_job::<Self>(self as *mut Self) };",
+    // The other pointer-taking task constructors (`NewServer::schedule_deinit`
+    // is the `ManagedTask::new` shape).
+    "enqueue_task(bun_event_loop::ManagedTask::ManagedTask::new(\n    std::ptr::from_mut::<Self>(self),\n    |this| Self::deinit(this),\n));",
+    "ManagedTask::new_owned(self, Self::run)",
+    "AnyTaskWithExtraContext::from_callback_auto_deinit(self, Self::run_mini)",
+    "bun_event_loop::AnyTaskWithExtraContext::AnyTaskWithExtraContext::init(self, Self::run)",
+    // A reborrow coerces exactly like bare `self`.
+    "let ct = ConcurrentTask::create_from(&mut *self);",
+    "unsafe { Self::schedule_dispatch(&mut *self) };",
+    "Task::init(std::ptr::from_mut(&mut *self))",
+    "Task::init(NonNull::from(&mut *self).as_ptr())",
+    "let p = &mut *self;\nlet ct = ConcurrentTask::create_from(p);",
+    "let p: *mut Self = &mut *self;\nunsafe { Self::schedule_dispatch(p) };",
   ];
   const allowed = [
     // Posting the pointer the caller handed us is the intended shape.
@@ -269,13 +315,20 @@ test("the patterns match the banned spellings and nothing else", () => {
     // A method call means the callee takes a receiver; its own body is where
     // the post (and the lint hit) is.
     "self.schedule_dispatch();",
-    // An owned box handed over whole (`NapiFinalizerTask::schedule(self: Box<Self>)`).
+    // An owned box handed over whole (`NapiFinalizerTask::schedule(self: Box<Self>)`,
+    // valkey's `ManagedTask::new(into_raw(self), ..)`).
     "let this = bun_core::heap::into_raw(self);\nlet ct = ConcurrentTask::create(Task::init(this));",
+    "bun_jsc::ManagedTask::ManagedTask::new(bun_core::heap::into_raw(self), run_raw)",
+    // The other constructors with the pointer the caller handed us.
+    "jsc::ManagedTask::ManagedTask::new::<CopyFileWindows>(this, call_erased)",
+    "AnyTaskWithExtraContext::from_callback_auto_deinit(this, |p: *mut Self, ctx| run(p, ctx))",
     // Something the receiver owns or points at, or a helper's pointer, is
     // out of scope (see the header).
     "ConcurrentTask::create(Task::init(self.as_ctx_ptr()))",
     "Task::init(core::ptr::from_ref(&self.run_pending_later).cast_mut())",
     "Task::init(&raw mut *self.inner)",
+    "Task::init(&mut *self.inner)",
+    "ManagedTask::new(std::ptr::from_mut(&mut *self.inner), run)",
     "Task::init(self.task)",
     "ConcurrentTask::from_callback(std::ptr::from_mut(load), on_load_from_js_loop_raw)",
     // A constructor whose name merely ends in `Task`, and a method call.

--- a/test/internal/source-lints/self-receiver-publish.test.ts
+++ b/test/internal/source-lints/self-receiver-publish.test.ts
@@ -11,9 +11,11 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //   ConcurrentTask::create_from(self)            // `&mut Self` coerces to `*mut Self`
 //   let this = std::ptr::from_mut(self); ... Task::init(this)
 //   let p: *mut Self = self;             ... ConcurrentTask::create_from(p)
+//   ThreadSafeFunction::schedule_dispatch(self)  // a helper that posts its argument
 //
 // as the argument of `Task::init(..)` / `..::create_from(..)` /
-// `..::from_callback(..)` is banned.
+// `..::from_callback(..)`, or of one of the helpers in `POSTING_HELPERS` whose
+// contract is to post the pointer they are given, is banned.
 //
 // The post is the hand-over, and it goes wrong in two ways. The consumer
 // (another thread, for a `ConcurrentTask`) starts using the object the moment
@@ -49,12 +51,20 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // src/runtime/node/node_zlib_binding.rs, `post_job` in src/jsc/VmHandle.rs.
 //
 // Scope: the spellings above, with `self` as the receiver and the three task
-// constructors as the callee. A pointer produced by a helper (`self.as_ptr()`),
-// a `NonNull::from(self)` binding posted through `.as_ptr()`, the intrusive
-// `ConcurrentTask::from(..)` form, and reference *parameters* other than
-// `self` (`fn f(load: &mut Load)` posting `from_mut(load)`) are the same
-// hazard but outside this lint. Siblings: self-receiver-reclaim.test.ts,
-// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+// constructors or a listed helper as the callee. The conversion of a posting
+// site moves the post behind a `this: *mut Self` function, and `&mut Self`
+// coerces to `*mut Self` silently, so a `&mut self` caller that passes `self`
+// into that function recreates the bug without any of the spellings above
+// appearing at the post itself: that is what `POSTING_HELPERS` is for, and a
+// function that takes a pointer in order to post it has to be added there when
+// it is introduced (its `SAFETY` contract should say the pointer must be the
+// allocation's own, which is the other half of the guard). A pointer produced
+// by a helper (`self.as_ptr()`), a `NonNull::from(self)` binding posted through
+// `.as_ptr()`, the intrusive `ConcurrentTask::from(..)` form, and reference
+// *parameters* other than `self` (`fn f(load: &mut Load)` posting
+// `from_mut(load)`) are the same hazard but outside this lint. Siblings:
+// self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
+// frozen-nonnull-reborrow.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
@@ -72,13 +82,22 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
+// Functions whose contract is to post the pointer they are given (see the
+// header): `post_job` in src/jsc/VmHandle.rs, `ThreadSafeFunction::
+// schedule_dispatch` in src/runtime/napi/napi_body.rs. Qualified or not.
+const POSTING_HELPERS = [String.raw`(?:[\w:]+::)?post_job`, String.raw`[\w:]+::schedule_dispatch`];
+
 // `Task::init(`, `ConcurrentTask::create_from(`, `ConcurrentTask::from_callback(`,
-// however the path in front is spelled, optionally turbofished. The `\b`
-// before `Task` keeps `NapiFinalizerTask::init(self)` (a constructor that
-// copies out of `self`) out; `create_from` / `from_callback` require a path
-// in front so a method call of the same name does not count. `\s*` after the
-// paren so a rustfmt-wrapped argument still matches.
-const POST = String.raw`\b(?:Task::init|[\w:]+::create_from|[\w:]+::from_callback)(?:::<[^>]*>)?\(\s*`;
+// however the path in front is spelled, optionally turbofished, or one of the
+// helpers above. The `\b` before `Task` keeps `NapiFinalizerTask::init(self)` (a
+// constructor that copies out of `self`) out; `create_from` / `from_callback` /
+// `schedule_dispatch` require a path in front so a method call of the same name
+// does not count. `\s*` after the paren so a rustfmt-wrapped argument still
+// matches.
+const POST =
+  String.raw`\b(?:Task::init|[\w:]+::create_from|[\w:]+::from_callback|` +
+  POSTING_HELPERS.join("|") +
+  String.raw`)(?:::<[^>]*>)?\(\s*`;
 
 // The ways of spelling "`self`, as a raw pointer" as the first argument. Each
 // is anchored at its front only, so a trailing `.cast_mut()` / `.as_ptr()`
@@ -230,6 +249,14 @@ test("the patterns match the banned spellings and nothing else", () => {
     "let p: *mut Self = std::ptr::from_mut(self);\nlet ct = bun_jsc::ConcurrentTask::create_from(p);",
     "let p = core::ptr::from_ref(self).cast_mut();\nlet ct = ConcurrentTask::create_from(p);",
     "let p = &raw mut *self;\nlet task = Task::init(p);",
+    // A `&mut self` caller handing `self` (coerced) or a pointer made from it
+    // to a function that posts its argument: the shape a receiver-taking
+    // `release_locked` would have after this conversion.
+    "unsafe { ThreadSafeFunction::schedule_dispatch(self) };",
+    "unsafe {\n    Self::schedule_dispatch(\n        self,\n    )\n};",
+    "let self_ptr: *mut Self = self;\nunsafe { Self::schedule_dispatch(self_ptr) };",
+    "unsafe { bun_jsc::post_job(std::ptr::from_mut(self)) };",
+    "unsafe { post_job::<Self>(self as *mut Self) };",
   ];
   const allowed = [
     // Posting the pointer the caller handed us is the intended shape.
@@ -237,6 +264,11 @@ test("the patterns match the banned spellings and nothing else", () => {
     "let ct = jsc::ConcurrentTask::create(jsc::Task::init(this));",
     "ConcurrentTask::create_from(task.as_ptr())",
     "ConcurrentTask::from_callback(this, FetchTasklet::resume_request_data_stream)",
+    "unsafe { ThreadSafeFunction::schedule_dispatch(this) };",
+    "unsafe { crate::post_job(job) };",
+    // A method call means the callee takes a receiver; its own body is where
+    // the post (and the lint hit) is.
+    "self.schedule_dispatch();",
     // An owned box handed over whole (`NapiFinalizerTask::schedule(self: Box<Self>)`).
     "let this = bun_core::heap::into_raw(self);\nlet ct = ConcurrentTask::create(Task::init(this));",
     // Something the receiver owns or points at, or a helper's pointer, is

--- a/test/internal/source-lints/self-receiver-publish.test.ts
+++ b/test/internal/source-lints/self-receiver-publish.test.ts
@@ -1,0 +1,275 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A method must not post its own receiver as a task. Inside a `&self` /
+// `&mut self` method, a pointer spelled from `self`
+//
+//   ConcurrentTask::create(Task::init(std::ptr::from_mut(self)))
+//   ConcurrentTask::create_from(self)            // `&mut Self` coerces to `*mut Self`
+//   let this = std::ptr::from_mut(self); ... Task::init(this)
+//   let p: *mut Self = self;             ... ConcurrentTask::create_from(p)
+//
+// as the argument of `Task::init(..)` / `..::create_from(..)` /
+// `..::from_callback(..)` is banned.
+//
+// The post is the hand-over, and it goes wrong in two ways. The consumer
+// (another thread, for a `ConcurrentTask`) starts using the object the moment
+// the post lands, and when the post carries its last reference it frees it,
+// while `self` is still a live argument of the method that posted it; a
+// reference argument is protected for the duration of its call, and writing to
+// or deallocating protected memory is UB under both aliasing models whether or
+// not the method touches `self` again (Tree Borrows, what `bun run rust:miri`
+// uses: "the strongly protected tag disallows deallocations"; Stacked Borrows:
+// "deallocating while item [Unique] is strongly protected"). And the pointer
+// that was posted carries the receiver's provenance, so the first thing the
+// poster does to the object through any other path afterwards, typically
+// dropping the lock it posted under, invalidates the consumer's pointer: its
+// next access is "a child of the conflicting tag <receiver>, which has state
+// Disabled" (TB) / "tag does not exist in the borrow stack" (SB). Codegen
+// relies on the same guarantees: a reference argument is annotated
+// dereferenceable (and, for `&mut`, noalias) for the whole call.
+// `ThreadSafeFunction::schedule_dispatch` in src/runtime/napi/napi_body.rs was
+// the instance this was written for: every `napi_call_threadsafe_function` /
+// `napi_release_threadsafe_function` posted the TSFN to the JS thread from
+// inside a chain of `&mut self` frames on the addon thread and then unlocked
+// it, so every dispatch_one on the JS thread locked through an invalidated
+// pointer, and a call that consumed the last thread reference let the JS
+// thread free the allocation while those frames were still returning.
+//
+// The object was a raw pointer in the caller's hands before it became `self`
+// (the N-API handle, the queue entry, the callback ctx, the backref), so the
+// fix is to keep it one: the function that posts takes `this: *mut Self`,
+// does its own work through accesses that end before the post (`(*this).field`
+// place expressions or a call-scoped reborrow), and posts `this`. Templates:
+// `push` / `release` and what they call under the lock in
+// src/runtime/napi/napi_body.rs, `async_job_run` in
+// src/runtime/node/node_zlib_binding.rs, `post_job` in src/jsc/VmHandle.rs.
+//
+// Scope: the spellings above, with `self` as the receiver and the three task
+// constructors as the callee. A pointer produced by a helper (`self.as_ptr()`),
+// a `NonNull::from(self)` binding posted through `.as_ptr()`, the intrusive
+// `ConcurrentTask::from(..)` form, and reference *parameters* other than
+// `self` (`fn f(load: &mut Load)` posting `from_mut(load)`) are the same
+// hazard but outside this lint. Siblings: self-receiver-reclaim.test.ts,
+// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `Task::init(`, `ConcurrentTask::create_from(`, `ConcurrentTask::from_callback(`,
+// however the path in front is spelled, optionally turbofished. The `\b`
+// before `Task` keeps `NapiFinalizerTask::init(self)` (a constructor that
+// copies out of `self`) out; `create_from` / `from_callback` require a path
+// in front so a method call of the same name does not count. `\s*` after the
+// paren so a rustfmt-wrapped argument still matches.
+const POST = String.raw`\b(?:Task::init|[\w:]+::create_from|[\w:]+::from_callback)(?:::<[^>]*>)?\(\s*`;
+
+// The ways of spelling "`self`, as a raw pointer" as the first argument. Each
+// is anchored at its front only, so a trailing `.cast_mut()` / `.as_ptr()`
+// still matches; the bare form needs the `,` / `)` so `self.as_ptr()` (a
+// helper, out of scope) does not. `(?!\s*\.)` after the `&raw` form keeps
+// `&raw mut *self.field` (a field the receiver owns) out.
+const SELF_AS_POINTER = [
+  String.raw`self\s*[,)]`,
+  String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
+  String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+  String.raw`self\s+as\s+\*(?:mut|const)\b`,
+  String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
+  String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+].join("|");
+
+const DIRECT = new RegExp(`${POST}(?:${SELF_AS_POINTER})`, "g");
+
+// A local bound to such a pointer: `let this = ptr::from_mut(self);`,
+// `let p = self as *mut Self;`, `let p: *mut Self = self;` (the coercion
+// spelling needs the annotation; without it `let p = self;` is just another
+// reference). The binding is then looked for as a post argument further down
+// the same function, which ends at the next `fn` item (a closure inside it is
+// the same function for this purpose).
+const BINDING_HEAD = String.raw`let\s+(?:mut\s+)?(\w+)\s*`;
+const SELF_POINTER_BINDINGS = [
+  new RegExp(
+    BINDING_HEAD +
+      String.raw`(?::[^=;]*)?=\s*(?:` +
+      [
+        String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)(?:\s*\.cast_mut\(\))?`,
+        String.raw`self\s+as\s+\*(?:mut|const)\b[^;]*`,
+        String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b`,
+        String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+      ].join("|") +
+      String.raw`)\s*;`,
+    "g",
+  ),
+  new RegExp(BINDING_HEAD + String.raw`:\s*\*(?:mut|const)\b[^=;]*=\s*self\s*;`, "g"),
+];
+const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s/m;
+
+function postOfBinding(name: string): RegExp {
+  return new RegExp(POST + name + String.raw`\s*[,)]`);
+}
+
+/** Byte offsets (into `stripped`) of every banned post in one file. */
+function findPosts(stripped: string): number[] {
+  const hits: number[] = [];
+  for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
+  for (const pattern of SELF_POINTER_BINDINGS) {
+    for (const binding of stripped.matchAll(pattern)) {
+      const start = binding.index + binding[0].length;
+      const rest = stripped.slice(start);
+      const fnEnd = rest.search(FN_ITEM);
+      const body = fnEnd === -1 ? rest : rest.slice(0, fnEnd);
+      const post = body.search(postOfBinding(binding[1]));
+      if (post !== -1) hits.push(start + post);
+    }
+  }
+  return hits.sort((a, b) => a - b);
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape. Each has been read and each has its conversion in flight or tied to
+// a conversion of its callers. Lower an entry when you convert one; do not
+// add entries.
+const ALLOW: Record<string, number> = {
+  // `Resolve::dispatch` / `Load::dispatch` (`&mut self`) post the arena-owned
+  // plugin request to the JS thread, which writes its `value` while
+  // `dispatch` is still returning; the arena, not the consumer, frees it.
+  // #37732 converts them; delete this entry when it lands.
+  "src/bundler/bundle_v2.rs": 2,
+  // `DeferredBatchTask::schedule` (`&mut self`) posts a task embedded in its
+  // `BundleV2`, whose consumer reaches the surrounding `BundleV2` through it;
+  // the receiver that matters there is the `&mut BundleV2` the bundle thread
+  // holds for the whole pass, not this field's. #37709 reshapes `schedule` to
+  // take the `BundleV2`; delete this entry when that lands.
+  "src/bundler/DeferredBatchTask.rs": 1,
+  // `JSBundleCompletionTask::complete_on_bundle_thread` (`&mut self`) posts
+  // the finished build's only ref to the JS thread, which frees it. #37723
+  // converts it; delete this entry when it lands.
+  "src/runtime/api/js_bundle_completion_task.rs": 1,
+  // `ThreadSafeFunction::maybe_queue_finalizer` posts the finalize task to the
+  // loop it is running on (no other thread is involved by then, and the task
+  // runs after it returns), but the pointer it posts is made from a receiver
+  // that `on_dispatch` then writes past through its own pointer, and `destroy`
+  // later frees through the posted one. The pointer to post is the one
+  // `on_dispatch` holds, so this goes with converting the JS-thread side
+  // (`dispatch_one` and what it calls), tracked separately; the addon-thread
+  // side is converted.
+  "src/runtime/napi/napi_body.rs": 1,
+};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including the in-tree comments
+  // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
+  // newlines and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const offset of findPosts(stripped)) {
+    counts[source] = (counts[source] ?? 0) + 1;
+    if (counts[source] > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${lineOf(stripped, offset)}`);
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the patterns match the banned spellings and nothing else", () => {
+  const banned = [
+    // `ThreadSafeFunction::schedule_dispatch(&mut self)` as it was.
+    "let self_ptr: *mut Self = self;\nif self.event_loop.is_none() {\n    return;\n}\nlet ct = ConcurrentTask::create_from(self_ptr);",
+    // `JSBundleCompletionTask::complete_on_bundle_thread(&mut self)`.
+    "let this = std::ptr::from_mut::<Self>(self);\nlet ct = jsc::ConcurrentTask::create(jsc::Task::init(this));",
+    // The remaining allowlisted shapes.
+    "ConcurrentTask::create(Task::init(std::ptr::from_mut::<Self>(self)));",
+    "bun_event_loop::ConcurrentTask::ConcurrentTask::create(\n    bun_event_loop::Task::init(std::ptr::from_mut::<Self>(self)),\n);",
+    "let self_ptr: *mut Self = self;\nloop_.enqueue_task(Task::init(self_ptr));",
+    // Other spellings of the pointer.
+    "loop_.enqueue_task(Task::init(self));",
+    "let ct = ConcurrentTask::create_from(self);",
+    "ConcurrentTask::from_callback(self, Self::resume);",
+    "ConcurrentTask::from_callback(\n    std::ptr::from_mut(self),\n    Self::resume,\n)",
+    "Task::init(core::ptr::from_ref(self).cast_mut())",
+    "Task::init(NonNull::from(self).as_ptr())",
+    "Task::init(self as *mut Self)",
+    "Task::init(&raw mut *self)",
+    "Task::init(core::ptr::addr_of_mut!(*self))",
+    "jsc::ConcurrentTask::create_from::<Self>(std::ptr::from_mut(self))",
+    "let p = self as *mut Self;\nlet ct = ConcurrentTask::create_from(p);",
+    "let p: *mut Self = std::ptr::from_mut(self);\nlet ct = bun_jsc::ConcurrentTask::create_from(p);",
+    "let p = core::ptr::from_ref(self).cast_mut();\nlet ct = ConcurrentTask::create_from(p);",
+    "let p = &raw mut *self;\nlet task = Task::init(p);",
+  ];
+  const allowed = [
+    // Posting the pointer the caller handed us is the intended shape.
+    "let ct = ConcurrentTask::create_from(this);",
+    "let ct = jsc::ConcurrentTask::create(jsc::Task::init(this));",
+    "ConcurrentTask::create_from(task.as_ptr())",
+    "ConcurrentTask::from_callback(this, FetchTasklet::resume_request_data_stream)",
+    // An owned box handed over whole (`NapiFinalizerTask::schedule(self: Box<Self>)`).
+    "let this = bun_core::heap::into_raw(self);\nlet ct = ConcurrentTask::create(Task::init(this));",
+    // Something the receiver owns or points at, or a helper's pointer, is
+    // out of scope (see the header).
+    "ConcurrentTask::create(Task::init(self.as_ctx_ptr()))",
+    "Task::init(core::ptr::from_ref(&self.run_pending_later).cast_mut())",
+    "Task::init(&raw mut *self.inner)",
+    "Task::init(self.task)",
+    "ConcurrentTask::from_callback(std::ptr::from_mut(load), on_load_from_js_loop_raw)",
+    // A constructor whose name merely ends in `Task`, and a method call.
+    "NapiFinalizerTask::init(self).schedule();",
+    "state.create_from(index, from, into);",
+    // Producing the pointer is fine when it is not what gets posted.
+    "let this = std::ptr::from_mut::<Self>(self);\nregister(this);",
+    "let this = std::ptr::from_mut(self);\nlet ct = ConcurrentTask::create_from(other);",
+    // Rebinding the reference is not a pointer binding.
+    "let this = self;\nlet ct = ConcurrentTask::create_from(this);",
+    // The binding is posted, but in the next function, where it is a
+    // raw-pointer parameter of the same name.
+    "let this = std::ptr::from_mut(self);\nregister(this);\n}\n\nunsafe fn schedule_dispatch(this: *mut Self) {\n    let ct = ConcurrentTask::create_from(this);\n}",
+  ];
+  expect(banned.map(s => findPosts(s).length)).toEqual(banned.map(() => 1));
+  expect(allowed.map(s => findPosts(s).length)).toEqual(allowed.map(() => 0));
+});
+
+test("no method posts its own receiver as a task", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: when an allowlisted site is converted, lower its entry so the
+  // shape cannot come back into that file.
+  for (const [source, n] of Object.entries(ALLOW)) {
+    expect({ source, count: counts[source] ?? 0 }).toEqual({ source, count: n });
+  }
+});


### PR DESCRIPTION
### Problem
- No crash is known from this. Every dispatch that `napi_call_threadsafe_function` or `napi_release_threadsafe_function` posts to the JS thread is UB under both of Rust's aliasing models; Miri reports it as `read access through <tag> is forbidden ... transitioned to Disabled due to a foreign write access` (Tree Borrows) or `tag does not exist in the borrow stack for this location` (Stacked Borrows).
- First cause: the pointer posted to the JS thread was made from a `&mut self` receiver, and the addon thread then unlocked the object through the guard. That unlock invalidates the posted pointer, and the JS thread's next step is to lock through it.
- Second cause: when a call reports `napi_closing` and that consumes the last thread reference, the JS thread may free the object while the addon thread's `&mut self` frames are still returning. Freeing memory a live reference argument covers is UB on its own (`the strongly protected tag disallows deallocations`).
- Same class as #37703, #37685, #37693, #37705, #37723 and #37732. The call and release entry points were already converted to raw pointers; acquire and the functions under the lock were not.

### Fix
- The addon-thread entry points (call, acquire, release) and everything they run under the lock now take the raw pointer the addon handed in, borrow one field for one statement at a time, and post that same pointer. The SAFETY contracts require the pointer `new` returned, so a later `&mut self` caller passing `self` along would break a stated rule.
- Why it is sound: across the post and the unlock the only thing pointing into the object is the guard, which holds the lock by pointer; and the object cannot be freed under a caller holding the lock, because every path that frees a TSFN takes that lock first. Behaviour is unchanged: the lock, the state transitions, the condvar traffic and the `(status, caller_must_free)` protocol are as before.
- A new source lint bans handing a pointer spelled from `self` to a task constructor or to a function that posts its argument. The instances left in the tree are allowlisted with a reason each; one is the JS-thread side of this same object, which has the mirror-image shape and is left out because it overlaps #36831 and #36801.
- Verification: the lint reports exactly the old post site on `main` and passes here. The UB itself was shown on a standalone reduction under Miri (in the original below), not by an in-tree test. The tsfn napi tests and the node-api tsfn, worker-terminate and env-teardown tests pass on a debug ASAN build (two worker tests hit the 5s timeout once on a loaded host and passed 3/3 on rerun); source lints, clippy and fmt are clean.

### Background
- A threadsafe function (TSFN) is the N-API object an addon uses to call into JS from any thread. The addon holds it as a raw pointer; call queues work from an addon thread, acquire and release count the threads using it, and the last release (or a call answered `napi_closing`, which also consumes a reference) can free it.
- Dispatch: an addon-thread call or release posts a task carrying the TSFN pointer to the JS thread's event loop. The JS thread locks the TSFN through that pointer, drains the queue, and once no threads remain runs the finalizer and frees it. The post happens while the addon thread still holds the lock, so the JS thread starts using the object the moment the addon thread unlocks.
- The TSFN's lock is a word inside the object and its guard holds the lock by raw pointer, not by borrowing the object. That is what lets the addon thread hold the lock across the post with no reference into the object live.
- Rust aliasing rules, as Miri checks them: a `&mut self` argument claims the whole object exclusively for the whole call. A pointer derived from it dies as soon as the object is touched by any other route, and the object may not be freed while the call is on the stack, even if the reference is never used again. Raw pointers with per-field, per-statement borrows make neither claim. `bun run rust:miri` uses Tree Borrows; Stacked Borrows is the older model.
- `test/internal/source-lints/` holds bun tests that regex-scan the Rust tree for banned code shapes, each with a per-file allowlist of counts that may only go down. That is how a rule stated in a SAFETY comment gets enforced without a compiler change.

<details>
<summary>Original description</summary>

### Problem

`napi_call_threadsafe_function` and `napi_release_threadsafe_function` (src/runtime/napi/napi_body.rs) already take the TSFN as the raw pointer the addon holds (`push(this)` / `release(this)`), but everything under them did not: `enqueue(&mut self)`, `release_locked(&mut self)` and `schedule_dispatch(&mut self)`, and `napi_acquire_threadsafe_function` went through `acquire(&mut self)`. `schedule_dispatch` did

```rust
let self_ptr: *mut Self = self;
...
let ct = ConcurrentTask::create_from(self_ptr);
self.loop_handle.post_task(ct)
```

so on every dispatch initiated from an addon thread, two things were wrong with the pointer the JS thread received:

* It was made from `schedule_dispatch`'s `&mut self`. The caller then dropped the TSFN lock through the `MutexGuard` (a pointer into the object that is not derived from that receiver), which under both aliasing models invalidates the posted pointer at the lock word. The JS thread's `dispatch_one` takes that lock through the posted pointer on every such dispatch, strictly after the unlock (the post happens under the lock), so every addon-initiated dispatch locked through an invalidated pointer. Tree Borrows (what `bun run rust:miri` uses) reports it as `read access through <tag> is forbidden ... the accessed tag is a child of the conflicting tag <schedule_dispatch's &mut self>, which has state Disabled ... transitioned to Disabled due to a foreign write access` (the unlock); Stacked Borrows as `tag does not exist in the borrow stack for this location`.
* The `&mut self` frames were still returning while the JS thread used the object. Normally that is reads and writes of the atomics; when the call reported `napi_closing` and thereby consumed the last thread reference (`enqueue` -> `release_locked` -> `schedule_dispatch`), the JS thread could also finalize and free the allocation as soon as `enqueue`'s guard dropped, which happens inside `enqueue(&mut self)`. Deallocating memory a protected reference argument covers is UB independently of whether the reference is used again: Tree Borrows reports `deallocation through <tag> ... is forbidden: the strongly protected tag disallows deallocations`, Stacked Borrows `deallocating while item [Unique] is strongly protected`.

No crash is known from this; nothing reads through the references after the post and the compiler does not currently exploit either fact. It is the contract that is wrong, the same class as #37703, #37685, #37693, #37705, #37723 and #37732, and `push` / `release` themselves were already converted for the free-through-receiver half of it.

<details>
<summary>Reduction run under Miri</summary>

The lock, the guard-by-pointer, the pre-lock store in `on_dispatch` and the lock in `dispatch_one` mirror the real code; the channels pin interleavings the real code allows.

```rust
use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU8, Ordering::SeqCst};
use std::sync::mpsc;
use std::thread;

struct SendPtr(*mut Tsfn);
unsafe impl Send for SendPtr {}

/// bun_threading::Mutex: an atomic word inside the object, used through `&self` of that field.
struct Lock(AtomicBool);
impl Lock {
    fn lock(&self) {
        while self.0.swap(true, SeqCst) {
            thread::yield_now();
        }
    }
    fn unlock(&self) {
        self.0.store(false, SeqCst);
    }
}
/// MutexGuard: holds the lock by pointer, not by a borrow of the owner.
struct Guard(*const Lock);
impl Guard {
    fn lock(lock: &Lock) -> Guard {
        lock.lock();
        Guard(lock)
    }
}
impl Drop for Guard {
    fn drop(&mut self) {
        unsafe { (*self.0).unlock() }
    }
}

struct Tsfn {
    lock: Lock,
    thread_count: AtomicI64,
    dispatch_state: AtomicU8,
    queued: usize, // under `lock`
}

struct Js {
    post: mpsc::Sender<SendPtr>,
    touched: mpsc::Receiver<()>, // on_dispatch has done its pre-lock store
    freed: mpsc::Receiver<()>,   // the JS thread has freed the object
}

// ── main ──────────────────────────────────────────────────────────────────
impl Tsfn {
    unsafe fn push_before(this: *mut Tsfn, js: &Js) {
        unsafe { (*this).enqueue_before(js) };
    }
    fn enqueue_before(&mut self, js: &Js) {
        let guard = Guard::lock(&self.lock);
        self.queued += 1;
        self.release_locked_before(js); // the call consumed this thread's reference (napi_closing)
        drop(guard);
        js.freed.recv().unwrap(); // still inside enqueue(&mut self) while the JS thread frees us
    }
    unsafe fn release_before(this: *mut Tsfn, js: &Js) {
        let guard = Guard::lock(unsafe { &(*this).lock });
        unsafe { (*this).release_locked_before(js) };
        drop(guard);
    }
    fn release_locked_before(&mut self, js: &Js) {
        self.thread_count.fetch_sub(1, SeqCst);
        self.schedule_dispatch_before(js);
    }
    fn schedule_dispatch_before(&mut self, js: &Js) {
        self.dispatch_state.store(PENDING, SeqCst);
        let self_ptr: *mut Self = self;
        js.post.send(SendPtr(self_ptr)).unwrap(); // ConcurrentTask::create_from(self_ptr) + post_task
        js.touched.recv().unwrap(); // still inside schedule_dispatch(&mut self) while on_dispatch stores
    }
}

// ── this PR ───────────────────────────────────────────────────────────────
impl Tsfn {
    unsafe fn push_after(this: *mut Tsfn, js: &Js) {
        unsafe {
            let guard = Guard::lock(&(*this).lock);
            (*this).queued += 1;
            Tsfn::release_locked_after(this, js);
            drop(guard);
        }
        js.freed.recv().unwrap();
    }
    unsafe fn release_after(this: *mut Tsfn, js: &Js) {
        unsafe {
            let guard = Guard::lock(&(*this).lock);
            Tsfn::release_locked_after(this, js);
            drop(guard);
        }
    }
    unsafe fn release_locked_after(this: *mut Tsfn, js: &Js) {
        unsafe {
            (*this).thread_count.fetch_sub(1, SeqCst);
            Tsfn::schedule_dispatch_after(this, js);
        }
    }
    unsafe fn schedule_dispatch_after(this: *mut Tsfn, js: &Js) {
        unsafe { (*this).dispatch_state.store(PENDING, SeqCst) };
        js.post.send(SendPtr(this)).unwrap();
        js.touched.recv().unwrap();
    }
}

const PENDING: u8 = 2;
const RUNNING: u8 = 1;

fn main() {
    let scenario = std::env::args().nth(1).unwrap_or_default();
    let frees = scenario.starts_with("push");
    // `*-nolock`: the JS thread goes straight to the free, which isolates the
    // protector half of the bug (the lock it would normally take first trips
    // the provenance half before the free is reached).
    let locks = !scenario.ends_with("-nolock");
    let scenario = scenario.trim_end_matches("-nolock").to_string();
    let (post, inbox) = mpsc::channel::<SendPtr>();
    let (touched_tx, touched) = mpsc::channel::<()>();
    let (freed_tx, freed) = mpsc::channel::<()>();

    // The JS thread: on_dispatch, dispatch_one, and (push scenario: the call
    // consumed the last reference) maybe_queue_finalizer -> destroy.
    let js_thread = thread::spawn(move || {
        let SendPtr(p) = inbox.recv().unwrap();
        unsafe { (*p).dispatch_state.store(RUNNING, SeqCst) }; // on_dispatch, before the lock
        touched_tx.send(()).unwrap();
        if locks {
            let guard = Guard::lock(unsafe { &(*p).lock }); // dispatch_one
            assert!(unsafe { (*p).thread_count.load(SeqCst) } == 0 && unsafe { (*p).queued } <= 1);
            drop(guard);
        }
        if frees {
            drop(unsafe { Box::from_raw(p) }); // destroy
            freed_tx.send(()).unwrap();
        }
    });

    let js = Js { post, touched, freed };
    let tsfn = Box::into_raw(Box::new(Tsfn {
        lock: Lock(AtomicBool::new(false)),
        thread_count: AtomicI64::new(1),
        dispatch_state: AtomicU8::new(0),
        queued: 0,
    }));
    unsafe {
        match scenario.as_str() {
            "push-before" => Tsfn::push_before(tsfn, &js),
            "push-after" => Tsfn::push_after(tsfn, &js),
            "release-before" => Tsfn::release_before(tsfn, &js),
            "release-after" => Tsfn::release_after(tsfn, &js),
            other => panic!("unknown scenario {other:?}"),
        }
    }
    js_thread.join().unwrap();
    if !frees {
        drop(unsafe { Box::from_raw(tsfn) });
    }
}
```

| scenario | Tree Borrows | Stacked Borrows |
| --- | --- | --- |
| `release-before` (shape on main) | UB at the JS thread's lock: posted pointer is a child of `schedule_dispatch_before(&mut self)`'s tag, Disabled by the unlock | UB: tag does not exist in the borrow stack |
| `push-before` (shape on main) | same | same |
| `push-before-nolock` (JS thread frees without locking first, isolating the other half) | UB: `the strongly protected tag disallows deallocations` | UB: `deallocating while item [Unique] is strongly protected` |
| `release-after`, `push-after` (this PR) | passes | passes |

(`push-after-nolock` is a genuine use-after-free in the reduction itself, since that variant frees before the poster has unlocked; the real JS thread has to take the lock first, which is why the `-nolock` variants are only there to surface the second message.)

</details>

### Fix

The addon-thread entry points and what they call under the lock now work on the pointer the addon handed in, borrowing one field for one statement at a time, and the posted task carries that pointer:

* `push(this)` takes the lock itself and calls `push_locked(this, ..)` (was `enqueue(&mut self)`), mirroring how `release(this)` / `release_locked` were already split; `release_locked`, `schedule_dispatch`, `is_closing` and `acquire` take `*mut Self` / `*const Self`. `is_closing` had no other callers; `napi_acquire_threadsafe_function` no longer forms `&mut *func`.
* `schedule_dispatch` posts `ConcurrentTask::create_from(this)`. The SAFETY contracts on it and on everything that reaches it say what `this` has to be: the pointer `new` returned, with no reference into the object live in any calling frame. "Live and holding the lock" alone would be satisfied by a pointer coerced from a `&mut self` receiver, which is the shape being removed (a future `&mut self` caller of `schedule_dispatch` would recreate both halves of the bug just by passing `self` along; see the lint below). The `&LoopHandle` borrowed for the post is of a field that is immutable after creation, and the allocation cannot go away under it because every path that frees a TSFN first takes the lock the caller is holding (the `Closed` transition that leads to `destroy` happens inside `dispatch_one` under it, an orphan's last `release` / `push` takes it, and `env_teardown` decides under it); the struct comment states the rule so the next change keeps it.

Behaviour is unchanged: the lock is taken and dropped at the same points, the state transitions, the condvar waits/wakes and the `(status, caller_must_free)` protocol are the same, and `push`'s free still happens after its guard is dropped. The `MutexGuard` holds the lock by pointer, as before, so it is the only thing pointing into the object across the post and the unlock.

### Not in this PR

The JS-thread side of the same object (`on_dispatch` -> `dispatch_one(&mut self)` -> `call` / `maybe_queue_finalizer`, plus `env_teardown(&mut self)` and the JS-thread-only `ref_` / `unref`, which are `acquire`'s shape without the post) has the mirror-image shape: those receivers cover the lock word while addon threads contend for it, and `maybe_queue_finalizer` posts a receiver-derived pointer that `on_dispatch`'s own later CAS invalidates before `destroy` frees through it. Both are also rejected by Miri (the `dispatch_one` one as `foreign read access would cause the protected tag ... to become Disabled`), but converting them means threading `on_dispatch`'s pointer through `dispatch_one` and what it calls, which overlaps the open tsfn PRs #36831 and #36801; reported separately, and the lint below records the one publish site that belongs to it. `napi_async_work::run` / `run_from_js` in the same file have the same shape for a different object and were reported separately as well.

### Tests

`test/internal/source-lints/self-receiver-publish.test.ts` bans handing a pointer spelled from `self` (`from_mut(self)`, bare `self` or `&mut *self`, which coerce, `self as *mut`, `&raw mut *self`, `addr_of_mut!(*self)`, or a local bound to one of those further down the same function, including `let p: *mut Self = self;`) to any of the task constructors that take the pointer a task will carry (`Task::init`, `ConcurrentTask::create_from` / `from_callback`, `ManagedTask::new` / `new_owned`, `AnyTaskWithExtraContext::init` / `from_callback_auto_deinit`) or to the functions whose contract is to post the pointer they are given (`post_job`, and `ThreadSafeFunction::schedule_dispatch` as of this PR). The last group is what makes the converted callers covered too: reverting one of them to `&mut self` and handing `self` to `schedule_dispatch` compiles silently (`&mut Self` coerces to `*mut Self`) and leaves the post site looking correct, and is reported at the call site. It checks its patterns against positive and negative examples and ratchets the remaining instances with the reason for each: `Resolve::dispatch` / `Load::dispatch` (#37732), `DeferredBatchTask::schedule` (#37709), `complete_on_bundle_thread` (#37723), `maybe_queue_finalizer` (above), and `NewServer::schedule_deinit` (the `ManagedTask::new` shape, same argument as `maybe_queue_finalizer`; reported separately). The header lists the shapes the patterns cannot see and where each is tracked (`StatWatcher::post_to_js_thread`'s helper pointer, #37857; the intrusive form in `napi_async_work`, #37750; `TranspilerJob`'s posting method, #37778; `FetchTasklet::deref_from_thread`'s `&Self` across the post), and notes that the spelling list should become shared with the sibling lints once they have landed instead of being copied a third time. Against `main` it reports exactly

```
src/runtime/napi/napi_body.rs:2823
```

(the `create_from(self_ptr)` in `schedule_dispatch`) and passes with this branch; with the three `schedule_dispatch(this)` call sites changed to `(self)` it reports all three. #37723 adds a lint of the same name from the other side of this class, with this file's two sites allowlisted; whichever of the two lands second only has to drop its copy and adjust the allowlist.

### Verification

Debug (ASAN) build: `test/napi/napi.test.ts -t "threadsafe|tsfn"` (15 tests: blocked producers on a bounded queue, abort with and without queued items, `napi_closing` on a full queue, the last release after abort, microtask ordering, and the orphaned-by-worker paths where the last call / release land on a dead env, including the one that frees from `push`), `test/napi/node-napi-tests/test/node-api/{test_threadsafe_function,test_worker_terminate,test_env_teardown_gc,test_async_cleanup_hook}/do.test.ts`. Two of the worker-based tsfn tests sit at ~3.6s on this build and tipped over the 5s default once while the host was loaded; they pass 3/3 when rerun and do not go through the changed code any differently than the others. `bun test test/internal/source-lints/` (19 files; widening the callee set and the spelling list added exactly the one `schedule_deinit` hit in the tree), `cargo clippy -p bun_runtime --no-deps` and `cargo fmt --check` are clean.




</details>
