### PR TITLE
bake: keep a module that failed to load failing when it is loaded again

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -85,7 +85,7 @@ export class HMRModule {
   /** When a module fails to load, trying to load it again
    *  should throw the same error */
   failure: unknown = null;
-  /** Incremented whenever an ESM evaluation starts; an evaluation a hot update superseded must not publish its outcome. */
+  /** Incremented whenever an evaluation starts; an evaluation a hot update superseded must not publish its outcome. */
   generation = 0;
   /** Two purposes:
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
@@ -309,6 +309,7 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     if (importer) {
       mod.importers.add(importer);
     }
+    mod.generation++;
     try {
       const cjs = mod.cjs;
       loadOrEsmModule(mod, cjs, cjs.exports);
@@ -414,6 +415,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
     if (importer) {
       mod.importers.add(importer);
     }
+    mod.generation++;
     try {
       const cjs = mod.cjs;
       loadOrEsmModule(mod, cjs, cjs.exports);

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -530,10 +530,12 @@ function parseEsmDependencies<T extends GenericModuleLoader<any>>(
     try {
       promiseOrModule = enqueueModuleLoad(dep, false, parent);
     } catch (e) {
-      // A dependency that refused to be loaded synchronously did not fail to
-      // evaluate: `parent` still loads fine through `import()`, so it only
-      // goes back to needing a load instead of recording a failure.
-      if (e instanceof AsyncImportError) {
+      // An AsyncImportError normally means the dependency refused to be loaded
+      // synchronously, not that anything failed to evaluate: `parent` still
+      // loads through `import()`, so it only goes back to needing a load. Not
+      // so when it is the dependency's recorded failure (its body called
+      // `require()` on an async module): that dependency did fail.
+      if (e instanceof AsyncImportError && registry.get(dep)?.state !== State.Error) {
         parent.state = State.Stale;
         throw e;
       }

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -500,10 +500,8 @@ function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HM
   }
 }
 
-/** Every module whose evaluation failed, including each importer that was
- * waiting on it, has to record the failure. A module left in `State.Pending`
- * is handed out as-is by the loaders (that is how circular imports work), so
- * the next load of it would receive its `null` namespace instead of the error. */
+/** Pending modules are handed out as-is (circular imports), so every module a
+ * failed load leaves behind must record the failure, importers included. */
 function throwLoadFailure(mod: HMRModule, e: unknown): never {
   mod.state = State.Error;
   mod.failure = e;
@@ -530,11 +528,8 @@ function parseEsmDependencies<T extends GenericModuleLoader<any>>(
     try {
       promiseOrModule = enqueueModuleLoad(dep, false, parent);
     } catch (e) {
-      // An AsyncImportError normally means the dependency refused to be loaded
-      // synchronously, not that anything failed to evaluate: `parent` still
-      // loads through `import()`, so it only goes back to needing a load. Not
-      // so when it is the dependency's recorded failure (its body called
-      // `require()` on an async module): that dependency did fail.
+      // A dependency refusing to be loaded synchronously (as opposed to having
+      // failed) is not an evaluation failure: `parent` still loads via import().
       if (e instanceof AsyncImportError && registry.get(dep)?.state !== State.Error) {
         parent.state = State.Stale;
         throw e;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -500,8 +500,7 @@ function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HM
   }
 }
 
-/** Pending modules are handed out as-is (circular imports), so every module a
- * failed load leaves behind must record the failure, importers included. */
+/** Importers of a failed module must record the failure too: Pending modules are handed out as-is. */
 function throwLoadFailure(mod: HMRModule, e: unknown): never {
   mod.state = State.Error;
   mod.failure = e;
@@ -528,8 +527,7 @@ function parseEsmDependencies<T extends GenericModuleLoader<any>>(
     try {
       promiseOrModule = enqueueModuleLoad(dep, false, parent);
     } catch (e) {
-      // A dependency refusing to be loaded synchronously (as opposed to having
-      // failed) is not an evaluation failure: `parent` still loads via import().
+      // Refused to load synchronously (as opposed to failed): `parent` still loads via import().
       if (e instanceof AsyncImportError && registry.get(dep)?.state !== State.Error) {
         parent.state = State.Stale;
         throw e;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -349,7 +349,11 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     const { list: depsList } = parseEsmDependencies(mod, deps, loadModuleSync);
     const exportsBefore = mod.exports;
     mod.imports = depsList.map(getEsmExports);
-    load(mod);
+    try {
+      load(mod);
+    } catch (e) {
+      throwLoadFailure(mod, e);
+    }
     mod.imports = depsList;
     if (mod.exports === exportsBefore) mod.exports = {};
     mod.cjs = null;
@@ -457,11 +461,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
     return isAsync
       ? Promise.all(list).then(
           list => finishLoadModuleAsync(mod, load, list),
-          e => {
-            mod.state = State.Error;
-            mod.failure = e;
-            throw e;
-          },
+          e => throwLoadFailure(mod, e),
         )
       : finishLoadModuleAsync(
           mod,
@@ -479,13 +479,16 @@ function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HM
     const p = load(mod);
     mod.imports = modules;
     if (p) {
-      return p.then(() => {
-        mod.state = State.Loaded;
-        if (mod.exports === exportsBefore) mod.exports = {};
-        mod.cjs = null;
-        if (shouldPatchImporters) patchImporters(mod);
-        return mod;
-      });
+      return p.then(
+        () => {
+          mod.state = State.Loaded;
+          if (mod.exports === exportsBefore) mod.exports = {};
+          mod.cjs = null;
+          if (shouldPatchImporters) patchImporters(mod);
+          return mod;
+        },
+        e => throwLoadFailure(mod, e),
+      );
     }
     if (mod.exports === exportsBefore) mod.exports = {};
     mod.cjs = null;
@@ -493,10 +496,18 @@ function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HM
     mod.state = State.Loaded;
     return mod;
   } catch (e) {
-    mod.state = State.Error;
-    mod.failure = e;
-    throw e;
+    throwLoadFailure(mod, e);
   }
+}
+
+/** Every module whose evaluation failed, including each importer that was
+ * waiting on it, has to record the failure. A module left in `State.Pending`
+ * is handed out as-is by the loaders (that is how circular imports work), so
+ * the next load of it would receive its `null` namespace instead of the error. */
+function throwLoadFailure(mod: HMRModule, e: unknown): never {
+  mod.state = State.Error;
+  mod.failure = e;
+  throw e;
 }
 
 type GenericModuleLoader<R> = (id: Id, isUserDynamic: false, importer: HMRModule) => R;
@@ -515,7 +526,19 @@ function parseEsmDependencies<T extends GenericModuleLoader<any>>(
     DEBUG.ASSERT(typeof dep === "string");
     let expectedExportKeyEnd = i + 2 + (deps[i + 1] as number);
     DEBUG.ASSERT(typeof deps[i + 1] === "number");
-    const promiseOrModule = enqueueModuleLoad(dep, false, parent);
+    let promiseOrModule;
+    try {
+      promiseOrModule = enqueueModuleLoad(dep, false, parent);
+    } catch (e) {
+      // A dependency that refused to be loaded synchronously did not fail to
+      // evaluate: `parent` still loads fine through `import()`, so it only
+      // goes back to needing a load instead of recording a failure.
+      if (e instanceof AsyncImportError) {
+        parent.state = State.Stale;
+        throw e;
+      }
+      throwLoadFailure(parent, e);
+    }
     list.push(promiseOrModule);
 
     const unloadedModule = unloadedModuleRegistry[dep];

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -85,6 +85,8 @@ export class HMRModule {
   /** When a module fails to load, trying to load it again
    *  should throw the same error */
   failure: unknown = null;
+  /** Incremented whenever an ESM evaluation starts; an evaluation a hot update superseded must not publish its outcome. */
+  generation = 0;
   /** Two purposes:
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
    * 2. any[] - List of module namespace objects. Read by the ESM module's load function.
@@ -346,13 +348,14 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
       mod.importers.add(importer);
     }
 
+    const generation = ++mod.generation;
     const { list: depsList } = parseEsmDependencies(mod, deps, loadModuleSync);
     const exportsBefore = mod.exports;
     mod.imports = depsList.map(getEsmExports);
     try {
       load(mod);
     } catch (e) {
-      throwLoadFailure(mod, e);
+      throwLoadFailure(mod, generation, e);
     }
     mod.imports = depsList;
     if (mod.exports === exportsBefore) mod.exports = {};
@@ -449,6 +452,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
       mod.importers.add(importer);
     }
 
+    const generation = ++mod.generation;
     const { list, isAsync } = parseEsmDependencies(mod, deps, loadModuleAsync<false>);
     DEBUG.ASSERT(
       isAsync //
@@ -460,18 +464,20 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
     // not a performance optimization but a behavioral correctness issue.
     return isAsync
       ? Promise.all(list).then(
-          list => finishLoadModuleAsync(mod, load, list),
-          e => throwLoadFailure(mod, e),
+          list => finishLoadModuleAsync(mod, generation, load, list),
+          e => throwLoadFailure(mod, generation, e),
         )
       : finishLoadModuleAsync(
           mod,
+          generation,
           load,
           list as HMRModule[], // no promises as by assert above
         );
   }
 }
 
-function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HMRModule[]) {
+function finishLoadModuleAsync(mod: HMRModule, generation: number, load: UnloadedESM[3], modules: HMRModule[]) {
+  if (mod.generation !== generation) return mod;
   try {
     const exportsBefore = mod.exports;
     mod.imports = modules.map(getEsmExports);
@@ -481,13 +487,14 @@ function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HM
     if (p) {
       return p.then(
         () => {
+          if (mod.generation !== generation) return mod;
           mod.state = State.Loaded;
           if (mod.exports === exportsBefore) mod.exports = {};
           mod.cjs = null;
           if (shouldPatchImporters) patchImporters(mod);
           return mod;
         },
-        e => throwLoadFailure(mod, e),
+        e => throwLoadFailure(mod, generation, e),
       );
     }
     if (mod.exports === exportsBefore) mod.exports = {};
@@ -496,14 +503,16 @@ function finishLoadModuleAsync(mod: HMRModule, load: UnloadedESM[3], modules: HM
     mod.state = State.Loaded;
     return mod;
   } catch (e) {
-    throwLoadFailure(mod, e);
+    throwLoadFailure(mod, generation, e);
   }
 }
 
 /** Importers of a failed module must record the failure too: Pending modules are handed out as-is. */
-function throwLoadFailure(mod: HMRModule, e: unknown): never {
-  mod.state = State.Error;
-  mod.failure = e;
+function throwLoadFailure(mod: HMRModule, generation: number, e: unknown): never {
+  if (mod.generation === generation) {
+    mod.state = State.Error;
+    mod.failure = e;
+  }
   throw e;
 }
 
@@ -532,7 +541,7 @@ function parseEsmDependencies<T extends GenericModuleLoader<any>>(
         parent.state = State.Stale;
         throw e;
       }
-      throwLoadFailure(parent, e);
+      throwLoadFailure(parent, parent.generation, e);
     }
     list.push(promiseOrModule);
 

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -565,3 +565,228 @@ devTest("html routes reject requests whose host header does not match the dev se
     expect(normal.status).toBe(200);
   },
 });
+
+devTest("a module that failed to load fails the same way when it is loaded again", {
+  // A failed ESM module must be recorded as failed by every loader path.
+  // Otherwise it stays half-initialized in the registry and the next
+  // `import()` or `require()` of it silently gets a namespace that is `null`
+  // (or empty, through `require`) instead of the error.
+  framework: minimalFramework,
+  files: {
+    "a.ts": `
+      import "./a-dep";
+      export const value = "unreachable";
+    `,
+    "a-dep.ts": `
+      throw new Error("a-dep threw");
+    `,
+    "b.ts": `
+      import "./b-dep";
+      export const value = "unreachable";
+    `,
+    "b-dep.ts": `
+      throw new Error("b-dep threw");
+    `,
+    "c.ts": `
+      import "./c-dep";
+      export const value = "unreachable";
+    `,
+    "c-dep.ts": `
+      throw new Error("c-dep threw");
+    `,
+    "d.ts": `
+      export const value = "unreachable";
+      await 1;
+      throw new Error("d rejected");
+    `,
+    "e.ts": `
+      import "./e-mid";
+      export const value = "unreachable";
+    `,
+    "e-mid.ts": `
+      import "./e-dep";
+      export const value = "unreachable";
+    `,
+    "e-dep.ts": `
+      throw new Error("e-dep threw");
+    `,
+    "f.ts": `
+      export const value = "unreachable";
+      throw new Error("f threw");
+    `,
+    "g.ts": `
+      export { value } from "./g-dep";
+    `,
+    "g-dep.ts": `
+      await 1;
+      export const value = "g loaded";
+    `,
+    "h.ts": `
+      export const value = "unreachable";
+      throw new Error("h threw");
+    `,
+    "i.ts": `
+      import "./i-dep";
+      export const value = "unreachable";
+    `,
+    "i-dep.ts": `
+      await 1;
+      throw new Error("i-dep rejected");
+    `,
+    "routes/index.ts": `
+      // A synchronous throw and a rejection produce the same result, so this
+      // does not depend on which of the two import() reports a failure with.
+      async function attempt(load) {
+        try {
+          return "resolved: " + JSON.stringify(await load());
+        } catch (e) {
+          return "threw: " + e.message;
+        }
+      }
+      export default async function () {
+        const results = {};
+        results.importWithThrowingDep = [
+          await attempt(() => import("../a")),
+          await attempt(() => import("../a")),
+        ];
+        results.requireWithThrowingDep = [
+          await attempt(() => require("../b")),
+          await attempt(() => require("../b")),
+        ];
+        results.importThenRequireWithThrowingDep = [
+          await attempt(() => import("../c")),
+          await attempt(() => require("../c")),
+        ];
+        results.importWithRejectingTopLevelAwait = [
+          await attempt(() => import("../d")),
+          await attempt(() => import("../d")),
+        ];
+        results.importChain = [
+          await attempt(() => import("../e")),
+          await attempt(() => import("../e")),
+          await attempt(() => import("../e-mid")),
+        ];
+        results.requireThrowingModule = [
+          await attempt(() => require("../f")),
+          await attempt(() => require("../f")),
+        ];
+        results.requireWithAsyncDep = [
+          await attempt(() => require("../g")),
+          await attempt(() => require("../g")),
+          await attempt(() => import("../g")),
+        ];
+        results.importThrowingModule = [
+          await attempt(() => import("../h")),
+          await attempt(() => import("../h")),
+        ];
+        results.importWithRejectingDep = [
+          await attempt(() => import("../i")),
+          await attempt(() => import("../i")),
+        ];
+        return Response.json(results);
+      }
+    `,
+  },
+  async test(dev) {
+    const cannotRequireG = `threw: Cannot require "g.ts" because "g-dep.ts" uses top-level await, but 'require' is a synchronous operation.`;
+    expect(await dev.fetch("/").json()).toEqual({
+      // A static dependency throws while the module is being loaded.
+      importWithThrowingDep: ["threw: a-dep threw", "threw: a-dep threw"],
+      requireWithThrowingDep: ["threw: b-dep threw", "threw: b-dep threw"],
+      // The failure recorded by one loader is seen by the other one too.
+      importThenRequireWithThrowingDep: ["threw: c-dep threw", "threw: c-dep threw"],
+      // The module's own top-level await rejects.
+      importWithRejectingTopLevelAwait: ["threw: d rejected", "threw: d rejected"],
+      // Every module between the importer and the throwing dependency fails.
+      importChain: ["threw: e-dep threw", "threw: e-dep threw", "threw: e-dep threw"],
+      // The module's own body throws synchronously during require().
+      requireThrowingModule: ["threw: f threw", "threw: f threw"],
+      // Refusing to require() a module with an async dependency is not an
+      // evaluation failure: it keeps failing under require() and still loads
+      // through import().
+      requireWithAsyncDep: [cannotRequireG, cannotRequireG, 'resolved: {"value":"g loaded"}'],
+      // These two paths already recorded the failure; the ones above now match them.
+      importThrowingModule: ["threw: h threw", "threw: h threw"],
+      importWithRejectingDep: ["threw: i-dep rejected", "threw: i-dep rejected"],
+    });
+  },
+});
+
+devTest("a module that failed to load fails the same way when it is loaded again (client)", {
+  // Same loader as the server test above, running in the browser runtime.
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      async function attempt(load) {
+        try {
+          return "resolved: " + JSON.stringify(await load());
+        } catch (e) {
+          return "threw: " + e.message;
+        }
+      }
+      console.log({
+        importWithThrowingDep: [await attempt(() => import("./a")), await attempt(() => import("./a"))],
+        requireWithThrowingDep: [await attempt(() => require("./b")), await attempt(() => require("./b"))],
+        importWithRejectingTopLevelAwait: [await attempt(() => import("./c")), await attempt(() => import("./c"))],
+      });
+    `,
+    "a.ts": `
+      import "./a-dep";
+      export const value = "unreachable";
+    `,
+    "a-dep.ts": `
+      throw new Error("a-dep threw");
+    `,
+    "b.ts": `
+      import "./b-dep";
+      export const value = "unreachable";
+    `,
+    "b-dep.ts": `
+      throw new Error("b-dep threw");
+    `,
+    "c.ts": `
+      export const value = "unreachable";
+      await 1;
+      throw new Error("c rejected");
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage({
+      importWithThrowingDep: ["threw: a-dep threw", "threw: a-dep threw"],
+      requireWithThrowingDep: ["threw: b-dep threw", "threw: b-dep threw"],
+      importWithRejectingTopLevelAwait: ["threw: c rejected", "threw: c rejected"],
+    });
+  },
+});
+
+devTest("a route whose dependency throws reports that error on every request", {
+  // The server runtime loads the route's modules again for each request. A
+  // route left half-initialized by a failed dependency used to report the real
+  // error once and then "null is not an object" for every later request.
+  framework: minimalFramework,
+  files: {
+    "dep.ts": `
+      export const value = "unreachable";
+      throw new Error("dep threw");
+    `,
+    "routes/index.ts": `
+      import { value } from "../dep";
+      export default function () {
+        return new Response(value);
+      }
+    `,
+  },
+  async test(dev) {
+    // The dev error page embeds its payload as JSON (see src/runtime/server/DevErrorPage.rs).
+    const errorPageJson = /<script id="__bunfallback" type="application\/json">([^<]*)<\/script>/;
+    for (let i = 0; i < 2; i++) {
+      const response = await dev.fetch("/");
+      const payload = JSON.parse(errorPageJson.exec(await response.text())![1]);
+      expect(payload.problems.exceptions.map((exception: any) => exception.message)).toEqual(["dep threw"]);
+      expect(response.status).toBe(500);
+    }
+  },
+});

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -1,6 +1,6 @@
 // ESM tests are about various esm features in development mode.
 import { expect } from "bun:test";
-import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
+import { type Dev, devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 const liveBindingTest = devTest("live bindings with `var`", {
   framework: minimalFramework,
@@ -570,7 +570,10 @@ devTest("a module that failed to load fails the same way when it is loaded again
   // A failed ESM module must be recorded as failed by every loader path.
   // Otherwise it stays half-initialized in the registry and the next
   // `import()` or `require()` of it silently gets a namespace that is `null`
-  // (or empty, through `require`) instead of the error.
+  // (or empty, through `require`) instead of the error. The modules that fail
+  // on their own number their evaluations in the error message, so these
+  // assertions also tell a recorded failure apart from a second evaluation
+  // that happens to fail the same way.
   framework: minimalFramework,
   files: {
     "a.ts": `
@@ -597,7 +600,7 @@ devTest("a module that failed to load fails the same way when it is loaded again
     "d.ts": `
       export const value = "unreachable";
       await 1;
-      throw new Error("d rejected");
+      throw new Error("d rejected #" + (globalThis.dEvaluations = (globalThis.dEvaluations ?? 0) + 1));
     `,
     "e.ts": `
       import "./e-mid";
@@ -612,7 +615,7 @@ devTest("a module that failed to load fails the same way when it is loaded again
     `,
     "f.ts": `
       export const value = "unreachable";
-      throw new Error("f threw");
+      throw new Error("f threw #" + (globalThis.fEvaluations = (globalThis.fEvaluations ?? 0) + 1));
     `,
     "g.ts": `
       export { value } from "./g-dep";
@@ -623,7 +626,7 @@ devTest("a module that failed to load fails the same way when it is loaded again
     `,
     "h.ts": `
       export const value = "unreachable";
-      throw new Error("h threw");
+      throw new Error("h threw #" + (globalThis.hEvaluations = (globalThis.hEvaluations ?? 0) + 1));
     `,
     "i.ts": `
       import "./i-dep";
@@ -644,6 +647,16 @@ devTest("a module that failed to load fails the same way when it is loaded again
     "j-async.ts": `
       await 1;
       export const value = "unreachable";
+    `,
+    "k.ts": `
+      export { value } from "./k-mid";
+    `,
+    "k-mid.ts": `
+      export { value } from "./k-async";
+    `,
+    "k-async.ts": `
+      await 1;
+      export const value = "k loaded";
     `,
     "routes/index.ts": `
       // A synchronous throw and a rejection produce the same result, so this
@@ -700,15 +713,24 @@ devTest("a module that failed to load fails the same way when it is loaded again
           await attempt(() => require("../j")),
           await attempt(() => import("../j")),
         ];
+        results.requireWithAsyncDepTwoLevelsDown = [
+          await attempt(() => require("../k")),
+          await attempt(() => require("../k")),
+          await attempt(() => require("../k-mid")),
+          await attempt(() => import("../k")),
+          await attempt(() => import("../k-mid")),
+        ];
         return Response.json(results);
       }
     `,
   },
   async test(dev) {
-    const cannotRequireG = `threw: Cannot require "g.ts" because "g-dep.ts" uses top-level await, but 'require' is a synchronous operation.`;
+    const cannotRequire = (id: string, asyncId: string) =>
+      `threw: Cannot require "${id}" because "${asyncId}" uses top-level await, but 'require' is a synchronous operation.`;
     const cannotRequireJ = expect.stringMatching(
       /^threw: Cannot require "(j|j-async)\.ts" because "j-async\.ts" uses top-level await, but 'require' is a synchronous operation\.$/,
     );
+    const kLoaded = 'resolved: {"value":"k loaded"}';
     expect(await dev.fetch("/").json()).toEqual({
       // A static dependency throws while the module is being loaded.
       importWithThrowingDep: ["threw: a-dep threw", "threw: a-dep threw"],
@@ -716,23 +738,35 @@ devTest("a module that failed to load fails the same way when it is loaded again
       // The failure recorded by one loader is seen by the other one too.
       importThenRequireWithThrowingDep: ["threw: c-dep threw", "threw: c-dep threw"],
       // The module's own top-level await rejects.
-      importWithRejectingTopLevelAwait: ["threw: d rejected", "threw: d rejected"],
+      importWithRejectingTopLevelAwait: ["threw: d rejected #1", "threw: d rejected #1"],
       // Every module between the importer and the throwing dependency fails.
       importChain: ["threw: e-dep threw", "threw: e-dep threw", "threw: e-dep threw"],
       // The module's own body throws synchronously during require().
-      requireThrowingModule: ["threw: f threw", "threw: f threw"],
+      requireThrowingModule: ["threw: f threw #1", "threw: f threw #1"],
       // Refusing to require() a module with an async dependency is not an
       // evaluation failure: it keeps failing under require() and still loads
       // through import().
-      requireWithAsyncDep: [cannotRequireG, cannotRequireG, 'resolved: {"value":"g loaded"}'],
+      requireWithAsyncDep: [
+        cannotRequire("g.ts", "g-dep.ts"),
+        cannotRequire("g.ts", "g-dep.ts"),
+        'resolved: {"value":"g loaded"}',
+      ],
       // These two paths already recorded the failure; the ones above now match them.
-      importThrowingModule: ["threw: h threw", "threw: h threw"],
+      importThrowingModule: ["threw: h threw #1", "threw: h threw #1"],
       importWithRejectingDep: ["threw: i-dep rejected", "threw: i-dep rejected"],
       // Here the dependency's body itself called require() on an async module,
       // so the same kind of error is a real evaluation failure this time and
       // import() must fail as well. (require() rewrites the message of the
       // error it rethrows, hence the loose match on the module it names.)
       requireWithDepThatFailedToRequire: [cannotRequireJ, cannotRequireJ, cannotRequireJ],
+      // The refusal travels up through k-mid, which has to stay loadable too.
+      requireWithAsyncDepTwoLevelsDown: [
+        cannotRequire("k.ts", "k-async.ts"),
+        cannotRequire("k.ts", "k-async.ts"),
+        cannotRequire("k-mid.ts", "k-async.ts"),
+        kLoaded,
+        kLoaded,
+      ],
     });
   },
 });
@@ -813,5 +847,135 @@ devTest("a route whose dependency throws reports that error on every request", {
       expect(payload.problems.exceptions.map((exception: any) => exception.message)).toEqual(["dep threw"]);
       expect(response.status).toBe(500);
     }
+  },
+});
+
+// Fixture for the two tests below: modules whose top-level await the test
+// settles through the route, so that a module can be hot-updated while an
+// evaluation of it (or of a module importing it) is still waiting.
+const supersededEvaluationFiles = {
+  "slow-1.ts": settledThroughRoute("slow-1"),
+  "slow-2.ts": settledThroughRoute("slow-2"),
+  "reexports-slow-2.ts": `
+    export { value } from "./slow-2";
+  `,
+  "slow-a.ts": settledThroughRoute("slow-a"),
+  "slow-b.ts": settledThroughRoute("slow-b"),
+  "imports-slow-a.ts": `
+    import "./slow-a";
+    export const value = "imports-slow-a v1";
+  `,
+  "imports-slow-b.ts": `
+    import "./slow-b";
+    export const value = "imports-slow-b v1";
+  `,
+  "routes/index.ts": `
+    const loaders = {
+      "slow-1": () => import("../slow-1"),
+      "slow-2": () => import("../slow-2"),
+      "reexports-slow-2": () => import("../reexports-slow-2"),
+      "imports-slow-a": () => import("../imports-slow-a"),
+      "imports-slow-b": () => import("../imports-slow-b"),
+    };
+    async function attempt(load) {
+      try {
+        return "resolved: " + JSON.stringify(await load());
+      } catch (e) {
+        return "threw: " + e.message;
+      }
+    }
+    export default async function (req) {
+      const [op, name, version] = req.headers.get("x-command").split(" ");
+      if (op === "start") {
+        (globalThis.started ??= {})[name] = attempt(loaders[name]);
+        return new Response("started");
+      }
+      if (op === "resolve" || op === "reject") {
+        globalThis.settlers[name + " " + version][op]();
+        return new Response("settled");
+      }
+      return Response.json({
+        first: await globalThis.started[name],
+        again: await attempt(loaders[name]),
+      });
+    }
+  `,
+};
+
+// "start <module>", "resolve <module> <version>", "reject <module> <version>"
+// or "load <module>", see the route above. (Sent as a header because static
+// framework routes currently 404 on query strings in development.)
+function command(dev: Dev, line: string) {
+  return dev.fetch("/", { headers: { "x-command": line } });
+}
+
+function settledThroughRoute(name: string) {
+  return `
+    const version = "v1";
+    const { promise, resolve, reject } = Promise.withResolvers();
+    (globalThis.settlers ??= {})["${name} " + version] = {
+      resolve,
+      reject: () => reject(new Error("${name} " + version + " failed")),
+    };
+    await promise;
+    export const value = "${name} " + version;
+  `;
+}
+
+devTest("an evaluation superseded by a hot update does not publish its outcome", {
+  // Saving a module while its top-level await is still pending starts a second
+  // evaluation of the same registry entry. When the first one settles later,
+  // it must neither record its failure over the new version nor push its
+  // namespace to the importers of the new one.
+  framework: minimalFramework,
+  files: supersededEvaluationFiles,
+  async test(dev) {
+    await command(dev, "start slow-1").equals("started");
+    await command(dev, "start slow-2").equals("started");
+    await dev.patch("slow-1.ts", { find: '"v1"', replace: '"v2"' });
+    await dev.patch("slow-2.ts", { find: '"v1"', replace: '"v2"' });
+    await command(dev, "resolve slow-1 v2").equals("settled");
+    await command(dev, "resolve slow-2 v2").equals("settled");
+    // Imports slow-2 after v2 has loaded, so its binding points at v2.
+    await command(dev, "start reexports-slow-2").equals("started");
+
+    await command(dev, "reject slow-1 v1").equals("settled");
+    await command(dev, "resolve slow-2 v1").equals("settled");
+
+    expect(await command(dev, "load slow-1").json()).toEqual({
+      first: "threw: slow-1 v1 failed",
+      again: 'resolved: {"value":"slow-1 v2"}',
+    });
+    expect(await command(dev, "load reexports-slow-2").json()).toEqual({
+      first: 'resolved: {"value":"slow-2 v2"}',
+      again: 'resolved: {"value":"slow-2 v2"}',
+    });
+  },
+});
+
+devTest("an importer re-evaluated by a hot update ignores the dependencies its previous evaluation waited for", {
+  // While an importer waits for a dependency with top-level await, the importer
+  // itself is saved without that import. Once the dependency settles, the
+  // superseded evaluation must neither run the old body nor record the
+  // dependency's failure over the new version.
+  framework: minimalFramework,
+  files: supersededEvaluationFiles,
+  async test(dev) {
+    await command(dev, "start imports-slow-a").equals("started");
+    await command(dev, "start imports-slow-b").equals("started");
+    await dev.write("imports-slow-a.ts", `export const value = "imports-slow-a v2";`);
+    await dev.write("imports-slow-b.ts", `export const value = "imports-slow-b v2";`);
+
+    await command(dev, "resolve slow-a v1").equals("settled");
+    await command(dev, "reject slow-b v1").equals("settled");
+
+    expect(await command(dev, "load imports-slow-a").json()).toEqual({
+      first: 'resolved: {"value":"imports-slow-a v2"}',
+      again: 'resolved: {"value":"imports-slow-a v2"}',
+    });
+    expect(await command(dev, "load imports-slow-b").json()).toEqual({
+      first: "threw: slow-b v1 failed",
+      again: 'resolved: {"value":"imports-slow-b v2"}',
+    });
   },
 });

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -658,6 +658,18 @@ devTest("a module that failed to load fails the same way when it is loaded again
       await 1;
       export const value = "k loaded";
     `,
+    "l.ts": `
+      import "./l-cjs";
+      export const value = "unreachable";
+    `,
+    "l-cjs.ts": `
+      require("./l-async");
+      module.exports = { value: "unreachable" };
+    `,
+    "l-async.ts": `
+      await 1;
+      export const value = "unreachable";
+    `,
     "routes/index.ts": `
       // A synchronous throw and a rejection produce the same result, so this
       // does not depend on which of the two import() reports a failure with.
@@ -720,6 +732,11 @@ devTest("a module that failed to load fails the same way when it is loaded again
           await attempt(() => import("../k")),
           await attempt(() => import("../k-mid")),
         ];
+        results.requireWithCommonJSDepThatFailedToRequire = [
+          await attempt(() => require("../l")),
+          await attempt(() => require("../l")),
+          await attempt(() => import("../l")),
+        ];
         return Response.json(results);
       }
     `,
@@ -766,6 +783,15 @@ devTest("a module that failed to load fails the same way when it is loaded again
         cannotRequire("k-mid.ts", "k-async.ts"),
         kLoaded,
         kLoaded,
+      ],
+      // Like j, but the dependency is CommonJS. A CommonJS module that throws
+      // is evaluated again on its next load rather than recorded as failed, so
+      // the importer is left loadable as well and fails afresh every time,
+      // through import() too (which only has the inner require() name the module).
+      requireWithCommonJSDepThatFailedToRequire: [
+        cannotRequire("l.ts", "l-async.ts"),
+        cannotRequire("l.ts", "l-async.ts"),
+        cannotRequire("l-async.ts", "l-async.ts"),
       ],
     });
   },

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -850,7 +850,7 @@ devTest("a route whose dependency throws reports that error on every request", {
   },
 });
 
-// Fixture for the two tests below: modules whose top-level await the test
+// Fixture for the three tests below: modules whose top-level await the test
 // settles through the route, so that a module can be hot-updated while an
 // evaluation of it (or of a module importing it) is still waiting.
 const supersededEvaluationFiles = {
@@ -859,6 +859,8 @@ const supersededEvaluationFiles = {
   "reexports-slow-2.ts": `
     export { value } from "./slow-2";
   `,
+  "slow-3.ts": settledThroughRoute("slow-3"),
+  "slow-4.ts": settledThroughRoute("slow-4"),
   "slow-a.ts": settledThroughRoute("slow-a"),
   "slow-b.ts": settledThroughRoute("slow-b"),
   "imports-slow-a.ts": `
@@ -874,6 +876,9 @@ const supersededEvaluationFiles = {
       "slow-1": () => import("../slow-1"),
       "slow-2": () => import("../slow-2"),
       "reexports-slow-2": () => import("../reexports-slow-2"),
+      "slow-3": () => import("../slow-3"),
+      "slow-4": () => import("../slow-4"),
+      "slow-4-require": () => require("../slow-4"),
       "imports-slow-a": () => import("../imports-slow-a"),
       "imports-slow-b": () => import("../imports-slow-b"),
     };
@@ -949,6 +954,32 @@ devTest("an evaluation superseded by a hot update does not publish its outcome",
     expect(await command(dev, "load reexports-slow-2").json()).toEqual({
       first: 'resolved: {"value":"slow-2 v2"}',
       again: 'resolved: {"value":"slow-2 v2"}',
+    });
+  },
+});
+
+devTest("an evaluation superseded by a hot update to CommonJS does not publish its outcome", {
+  // Same as above, except that the new version of the module is CommonJS, which
+  // the loaders evaluate on a different path. The old evaluation settling must
+  // neither mark the CommonJS module as failed nor tear down its module object.
+  framework: minimalFramework,
+  files: supersededEvaluationFiles,
+  async test(dev) {
+    await command(dev, "start slow-3").equals("started");
+    await command(dev, "start slow-4").equals("started");
+    await dev.write("slow-3.ts", `module.exports = { value: "slow-3 cjs" };`);
+    await dev.write("slow-4.ts", `module.exports = { value: "slow-4 cjs" };`);
+
+    await command(dev, "reject slow-3 v1").equals("settled");
+    await command(dev, "resolve slow-4 v1").equals("settled");
+
+    expect(await command(dev, "load slow-3").json()).toEqual({
+      first: "threw: slow-3 v1 failed",
+      again: 'resolved: {"default":{"value":"slow-3 cjs"},"value":"slow-3 cjs"}',
+    });
+    // Nothing was started under this name, so only `again` is reported.
+    expect(await command(dev, "load slow-4-require").json()).toEqual({
+      again: 'resolved: {"value":"slow-4 cjs"}',
     });
   },
 });

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -633,6 +633,18 @@ devTest("a module that failed to load fails the same way when it is loaded again
       await 1;
       throw new Error("i-dep rejected");
     `,
+    "j.ts": `
+      import "./j-mid";
+      export const value = "unreachable";
+    `,
+    "j-mid.ts": `
+      require("./j-async");
+      export const value = "unreachable";
+    `,
+    "j-async.ts": `
+      await 1;
+      export const value = "unreachable";
+    `,
     "routes/index.ts": `
       // A synchronous throw and a rejection produce the same result, so this
       // does not depend on which of the two import() reports a failure with.
@@ -683,12 +695,20 @@ devTest("a module that failed to load fails the same way when it is loaded again
           await attempt(() => import("../i")),
           await attempt(() => import("../i")),
         ];
+        results.requireWithDepThatFailedToRequire = [
+          await attempt(() => require("../j")),
+          await attempt(() => require("../j")),
+          await attempt(() => import("../j")),
+        ];
         return Response.json(results);
       }
     `,
   },
   async test(dev) {
     const cannotRequireG = `threw: Cannot require "g.ts" because "g-dep.ts" uses top-level await, but 'require' is a synchronous operation.`;
+    const cannotRequireJ = expect.stringMatching(
+      /^threw: Cannot require "(j|j-async)\.ts" because "j-async\.ts" uses top-level await, but 'require' is a synchronous operation\.$/,
+    );
     expect(await dev.fetch("/").json()).toEqual({
       // A static dependency throws while the module is being loaded.
       importWithThrowingDep: ["threw: a-dep threw", "threw: a-dep threw"],
@@ -708,6 +728,11 @@ devTest("a module that failed to load fails the same way when it is loaded again
       // These two paths already recorded the failure; the ones above now match them.
       importThrowingModule: ["threw: h threw", "threw: h threw"],
       importWithRejectingDep: ["threw: i-dep rejected", "threw: i-dep rejected"],
+      // Here the dependency's body itself called require() on an async module,
+      // so the same kind of error is a real evaluation failure this time and
+      // import() must fail as well. (require() rewrites the message of the
+      // error it rethrows, hence the loose match on the module it names.)
+      requireWithDepThatFailedToRequire: [cannotRequireJ, cannotRequireJ, cannotRequireJ],
     });
   },
 });


### PR DESCRIPTION
### Problem
- In the dev server (HTML routes, or a Bake app in development) a module that fails to load reports the real error once. The next `import()` of it resolves to `null` and the next `require()` returns `{}`.
- The server runtime loads a route's modules again on every request, so a route that imports a throwing module reports the error on the first request and `TypeError: null is not an object (evaluating 'f.streaming')` (from `handleRequest`) on every request after that.
- Cause: only some loader paths record the failure. A dependency throwing while being imported, a module body throwing under `require()`, and a module's own top-level await rejecting all leave the module Pending, and the loader hands Pending modules out as-is.
- A second gap, exposed by recording rejections: a module saved while its top-level await is still pending is evaluated again, and when the old evaluation settles later it still writes its outcome (its namespace, or now its error) over the new version.

### Fix
- Every path a load can fail on now marks the module, and each module that was importing it, as failed, so loading any of them again throws the same error. The property to check: once a load throws or rejects, nothing involved in it is left Pending.
- One exception: a `require()` refused because the dependency uses top-level await is not a failure, so the importer goes back to Stale (needs a load). `require()` keeps failing with the same message and `import()` of the same module works. The exception does not apply when the dependency is itself recorded as failed.
- Each module counts its evaluations. The asynchronous continuations of an evaluation do nothing to the module once a newer evaluation has started, apart from settling whoever awaited the old one. Synchronous paths always see their own count, so their behavior is unchanged.
- Verification: six new dev-server tests over the server and client runtimes. With `USE_SYSTEM_BUN=1` they fail with `resolved: null` / `resolved: {}`, the `f.streaming` TypeError on the second request, or the old version's namespace; they pass with the fix, along with the rest of the bake dev suite on the debug build.

### Background
- In development, Bake runs modules through its own loader (`hmr-module.ts`) instead of the engine's module system, so a hot update can replace a module in place. Each module is a registry entry with a state: Pending (being evaluated), Loaded, Error (with the recorded `failure`, which later loads rethrow), or Stale (needs a load).
- Loading a module first asks the registry for each dependency. A dependency that is Pending is returned as it is; that is how circular imports resolve, and it is also why a module left Pending after a failure looks like a live module to its next importer.
- A module with top-level await loads through a promise. `require()` of such a module throws `AsyncImportError`, a refusal to load synchronously rather than an evaluation failure.
- A hot update can start a new evaluation of a module while the previous evaluation's promise is still pending; both evaluations act on the same registry entry, so the loader needs a way to tell which one is current.

<details>
<summary>Original description</summary>

### What does this PR do?

In the dev server (HTML routes or a Bake app in development), an ESM module that fails to load is only remembered as failed on some of the loader's paths. On the others it is left in `State.Pending`, and because the loaders hand Pending modules out as-is (that is how circular imports work), the next load of it silently gets a half-initialized module whose namespace is `null`:

```ts
// throws-dep.ts:      throw new Error("boom dep");
// imports-thrower.ts: import "./throws-dep"; export const value = 1;
// tla-throws.ts:      await 1; throw new Error("boom tla");

await import("./imports-thrower"); // fails with "boom dep"
await import("./imports-thrower"); // resolves to null
require("./imports-thrower");      // returns {} (an empty __esModule object)

await import("./tla-throws");      // rejects with "boom tla"
await import("./tla-throws");      // resolves to null
```

The server runtime loads a route's modules again on every request, so a route that imports a throwing module reports the real error once and then `TypeError: null is not an object (evaluating 'f.streaming')` (from `handleRequest` in the server runtime) for every request after that.

The paths that did not record the failure, all in `src/runtime/bake/hmr-module.ts`:

- a dependency throwing out of `parseEsmDependencies`: the dependency itself was marked, but not the module(s) importing it (`loadModuleAsync` and `loadModuleSync`);
- the module's own body throwing under `loadModuleSync` (`require()` of an ESM module);
- the module's own top-level await rejecting: `finishLoadModuleAsync` returned `p.then(...)` with no rejection handler.

`finishLoadModuleAsync`'s synchronous catch and the `Promise.all` rejection arm (a dependency with top-level await rejecting) already set `State.Error` / `failure`; the three paths above now do the same through a shared `throwLoadFailure`. `HMRModule.failure` documents the intended contract ("trying to load it again should throw the same error"), and a module in `State.Error` is re-evaluated like any other when a hot update replaces it, so this does not make failures stickier than the existing paths already were.

One exception: an `AsyncImportError` thrown while requiring a dependency (the dependency uses top-level await) is a refusal to load synchronously, not an evaluation failure. Recording it would make a later `import()` of the same module rethrow it even though the module loads fine asynchronously, so in that case the importer goes back to `State.Stale` (the state the CommonJS failure path already uses for "needs a load"): `require()` keeps failing with the same message and `import()` works. Previously such a module was also left Pending, so the second `require()` returned `{}` and `import()` resolved to `null`. The exception only applies while the dependency is not itself in `State.Error`: if a dependency's recorded failure happens to be an `AsyncImportError` (its body called `require()` on an async module), that dependency did fail, and the importer is marked as failed like for any other error. A CommonJS dependency whose body hits the same refusal takes the Stale branch as well, which matches how CommonJS failures already work here: the dependency is evaluated again on its next load, so the importer has to be too, and both fail again each time (pinned by a test).

#### Superseded evaluations

Recording a rejection from the module's own load promise exposed a second problem: the promise continuations did not check that they still belong to the module's current evaluation. Saving a module while its top-level await is still pending makes `replaceModules` start a second evaluation of the same `HMRModule`, and when the first one settled later it still acted on the module. With the rejection handler added above, a late rejection of the old version would have marked the freshly loaded new version as failed (reproduced during review); the pre-existing variants are a late fulfillment pushing the old namespace to the importers of the new version (`patchImporters`), and an importer's superseded evaluation running its old body once the dependency it had been waiting for settled (`Promise.all(...).then(finishLoadModuleAsync)`), or recording that dependency's failure over the importer's new version.

`HMRModule.generation` now counts the evaluations of a module (ESM and CommonJS, so that a module saved as CommonJS while its ESM evaluation was pending moves on too); each ESM evaluation captures it, and `finishLoadModuleAsync` (when reached asynchronously), the load promise's two continuations and `throwLoadFailure` do nothing to the module when it has moved on, apart from still settling the awaiters of the old evaluation. The synchronous paths always match, so their behavior is unchanged. A counter rather than remembering the in-flight promise because the evaluation that supersedes an old one is often not asynchronous at all (a new version without top-level await, or a CommonJS one), so there would be nothing to compare against. Two things this deliberately leaves as they are: the old version's body still assigns `hmr.exports` itself after its await (the loader just no longer propagates that object anywhere, so importers of the new version keep theirs), and whoever was awaiting the superseded evaluation gets the module as it stands now, normally the new version; if the new version is itself still pending at that moment they see it unfinished, exactly like an importer that runs into an in-flight load today, and the fix for that (#37759) would let these continuations hand out the new evaluation's promise instead.

Not changed here: after the failing file is fixed, a module that failed *because of* that dependency is not re-evaluated by `replaceModules` and keeps rethrowing its recorded failure until it is itself replaced (on the client, the page is fully reloaded anyway). That already happens today on the paths that did record the failure; #37765 fixes it on top of this change, since it needs the failure to be recorded in the first place, and should land after this PR. A second importer of a module whose top-level await is still in flight getting its unfinished namespace is also pre-existing and separate (#37759).

### How did you verify your code works?

Six new tests in `test/bake/dev/esm.test.ts`:

- a route handler that loads each failing shape twice (`import()` twice, `require()` twice, `import()` then `require()`, a three-module chain, the module's own top-level await rejecting, the `AsyncImportError` refusal one and two levels down followed by a successful `import()`, a dependency whose recorded failure is an `AsyncImportError`, and a CommonJS dependency that hit that refusal), plus the two shapes that already worked. The modules that fail on their own number their evaluations in the error message, so a recorded failure is distinguishable from a re-evaluation that fails the same way;
- the same loader in the client runtime (`import()` / `require()` of a module with a throwing dependency, and a rejecting top-level await);
- two requests to a route whose dependency throws, both of which must report the dependency's error on the dev error page;
- two modules whose top-level await the test settles through the route: both are saved while their first evaluation is pending and the new versions load; then the old evaluation of one rejects (the module must stay loaded as the new version) and the old evaluation of the other fulfills (a module that imported the new version must keep its binding);
- the same with the new versions being CommonJS: the one whose old evaluation rejects must still be importable as the CommonJS module, the one whose old evaluation fulfills must still be `require()`-able;
- two importers of such modules, saved without the import while waiting for it; afterwards one dependency fulfills and the other rejects, and both importers must still be their new versions.

With `USE_SYSTEM_BUN=1` the first three fail with `resolved: null` / `resolved: {}` for every affected shape (the `AsyncImportError` variants even have `require()` of the importer succeed on the first try) and with `null is not an object (evaluating 'f.streaming')` on the second request; the last three fail with the old version's namespace (`slow-2 v1`, `imports-slow-a v1`) or with `null is not an object (evaluating 'r.cjs.exports')` where the new version is expected, and the late-rejection halves of the fourth and fifth tests fail against earlier revisions of this PR. With `bun bd test` all of them pass, as do the rest of `test/bake/dev/esm.test.ts` (including "cannot require a module with top level await"), `hot.test.ts`, `bundle.test.ts`, `react-spa.test.ts`, `server-sourcemap.test.ts`, `sourcemap.test.ts` and `react-response.test.ts` on the debug build.

Related, but independent of this change: #37734 (`import()` throwing synchronously instead of rejecting; the tests here accept either) and #37727. #31946 rewrites the same functions; the behavior to carry over is "record the failure on the importer when a dependency load throws, except for an `AsyncImportError` from a dependency that has not itself failed, and on the module when its own body throws or its load promise rejects; bump `generation` whenever an evaluation starts and let the asynchronous continuations act only for the current one". The static framework routes returning 404 for URLs with a query string, which is why the last two tests send their commands in a header, is a separate dev server bug reported on its own.

</details>
