### PR TITLE
shell(cat): finish after a read error instead of cancelling the queued output and hanging

### DIFF
--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -47,6 +47,9 @@ struct State {
     /// in the Rust port yet, so we keep the source error to re-derive a fresh
     /// `SystemError` per callee in `on_reader_done_cb`.
     raw_err: Option<sys::Error>,
+    starting: bool,
+    /// While `starting`, errors are parked here for `start()` to return.
+    start_err: Option<sys::Error>,
     evtloop: EventLoopHandle,
     #[cfg(windows)]
     is_reading: bool,
@@ -128,6 +131,8 @@ impl IOReader {
                 buf: Vec::new(),
                 readers: Readers::new(),
                 raw_err: None,
+                starting: false,
+                start_err: None,
                 evtloop,
                 #[cfg(windows)]
                 is_reading: false,
@@ -193,37 +198,53 @@ impl IOReader {
         let _ = reading;
     }
 
-    /// Idempotent function to start the reading.
-    pub(crate) fn start(&self) -> Yield {
-        #[cfg(not(windows))]
-        {
-            let r = self.reader();
-            let need_start = match &r.handle {
-                bun_io::pipes::PollOrFd::Closed => true,
-                bun_io::pipes::PollOrFd::Poll(p) => !p.is_registered(),
-                bun_io::pipes::PollOrFd::Fd(_) => true,
-            };
-            if need_start {
-                let fd = self.state().fd;
-                if let Err(e) = r.start(fd, true) {
-                    self.on_reader_error(&e);
-                }
-            }
-            return Yield::suspended();
+    /// Idempotent function to start the reading; the listeners are then called
+    /// back from the event loop.
+    ///
+    /// A failure to start is returned, not dispatched: the caller is the
+    /// listener being started, still inside its own trampoline frame, so a
+    /// completion dispatched from here would run nested in that frame (the
+    /// read-side counterpart of `IOWriter::on_sync_error`). `starting` catches
+    /// the failures `bun_io` reports through `on_reader_error` instead of
+    /// returning, such as a refused poll registration.
+    pub(crate) fn start(&self) -> sys::Result<()> {
+        self.state().starting = true;
+        let result = self.start_impl();
+        let s = self.state();
+        s.starting = false;
+        let result = match s.start_err.take() {
+            Some(e) => Err(e),
+            None => result,
+        };
+        if result.is_err() {
+            self.set_reading(false);
         }
-        #[cfg(windows)]
-        {
-            let s = self.state();
-            if s.is_reading {
-                return Yield::suspended();
-            }
-            s.is_reading = true;
-            if let Err(e) = self.reader().start_with_current_pipe() {
-                self.on_reader_error(&e);
-                return Yield::failed();
-            }
-            Yield::suspended()
+        result
+    }
+
+    #[cfg(not(windows))]
+    fn start_impl(&self) -> sys::Result<()> {
+        let r = self.reader();
+        let need_start = match &r.handle {
+            bun_io::pipes::PollOrFd::Closed => true,
+            bun_io::pipes::PollOrFd::Poll(p) => !p.is_registered(),
+            bun_io::pipes::PollOrFd::Fd(_) => true,
+        };
+        if !need_start {
+            return Ok(());
         }
+        let fd = self.state().fd;
+        r.start(fd, true)
+    }
+
+    #[cfg(windows)]
+    fn start_impl(&self) -> sys::Result<()> {
+        let s = self.state();
+        if s.is_reading {
+            return Ok(());
+        }
+        s.is_reading = true;
+        self.reader().start_with_current_pipe()
     }
 
     /// Only adds if not already present.
@@ -296,6 +317,10 @@ impl IOReader {
         let _keepalive = self.keepalive();
         self.set_reading(false);
         let s = self.state();
+        if s.starting {
+            s.start_err = Some(err.clone());
+            return;
+        }
         s.raw_err = Some(err.clone());
         // NOTE: reshaped for borrowck — copy out before dispatching.
         let readers: Vec<ChildPtr> = s.readers.clone();

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -198,8 +198,7 @@ impl IOReader {
         let _ = reading;
     }
 
-    /// Idempotent. A failure to start is returned for the caller to finish itself with;
-    /// dispatching it to the listeners would nest a trampoline (cf. `IOWriter::on_sync_error`).
+    /// Idempotent. A start failure is returned, not dispatched (cf. `IOWriter::on_sync_error`).
     pub(crate) fn start(&self) -> sys::Result<()> {
         self.state().starting = true;
         let result = self.start_impl();

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -198,15 +198,8 @@ impl IOReader {
         let _ = reading;
     }
 
-    /// Idempotent function to start the reading; the listeners are then called
-    /// back from the event loop.
-    ///
-    /// A failure to start is returned, not dispatched: the caller is the
-    /// listener being started, still inside its own trampoline frame, so a
-    /// completion dispatched from here would run nested in that frame (the
-    /// read-side counterpart of `IOWriter::on_sync_error`). `starting` catches
-    /// the failures `bun_io` reports through `on_reader_error` instead of
-    /// returning, such as a refused poll registration.
+    /// Idempotent. A failure to start is returned for the caller to finish itself with;
+    /// dispatching it to the listeners would nest a trampoline (cf. `IOWriter::on_sync_error`).
     pub(crate) fn start(&self) -> sys::Result<()> {
         self.state().starting = true;
         let result = self.start_impl();

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -220,20 +220,15 @@ impl Cat {
                     let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
                     return Builtin::done(interp, cmd, 0);
                 }
-                // Clone the `Arc<IOReader>`
-                // out of `stdin` so we hold no borrow of `interp` across
-                // `start()` (which may re-enter via the raw interp backref).
+                // Clone the `Arc<IOReader>` out of `stdin` so no borrow of the
+                // builtin is held while the reader is started.
                 let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
                 let reader = match &Builtin::of(interp, cmd).stdin {
                     BuiltinInput::Fd(r) => Arc::clone(r),
                     _ => unreachable!("needs_io() returned true"),
                 };
                 reader.set_interp(interp_ptr);
-                reader.add_reader(ReaderChildPtr {
-                    node: cmd,
-                    tag: ReaderTag::Cat,
-                });
-                reader.start()
+                Self::start_reader(interp, cmd, &reader)
             }
             Branch::FileArg { args_start, idx } => {
                 let argc = Builtin::of(interp, cmd).args_slice().len();
@@ -291,14 +286,29 @@ impl Cat {
                     *errno = 0;
                     *slot = Some(Arc::clone(&reader));
                 }
-                reader.add_reader(ReaderChildPtr {
-                    node: cmd,
-                    tag: ReaderTag::Cat,
-                });
-                reader.start()
+                Self::start_reader(interp, cmd, &reader)
             }
             Branch::WaitingErr => Yield::failed(),
         }
+    }
+
+    /// A reader that cannot be started is finished right here, in tail
+    /// position, so the completion is returned to the trampoline instead of
+    /// running from inside `start()` (see `IOReader::start`).
+    fn start_reader(interp: &Interpreter, cmd: NodeId, reader: &IOReader) -> Yield {
+        reader.add_reader(ReaderChildPtr {
+            node: cmd,
+            tag: ReaderTag::Cat,
+        });
+        match reader.start() {
+            Ok(()) => Yield::suspended(),
+            Err(e) => Self::finish_input(interp, cmd, e.get_errno() as ExitCode),
+        }
+    }
+
+    fn finish_input(interp: &Interpreter, cmd: NodeId, errno: ExitCode) -> Yield {
+        let step = Self::state_mut(interp, cmd).state.reader_done(errno);
+        Self::take_step(interp, cmd, step)
     }
 
     pub(crate) fn on_io_writer_chunk(
@@ -384,8 +394,7 @@ impl Cat {
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
         let errno: ExitCode = err.map(|e| e.get_errno() as ExitCode).unwrap_or(0);
-        let step = Self::state_mut(interp, cmd).state.reader_done(errno);
-        Self::take_step(interp, cmd, step)
+        Self::finish_input(interp, cmd, errno)
     }
 }
 

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -42,6 +42,7 @@ pub enum CatState {
 }
 
 /// Internal: what to do after dropping the &mut state borrow.
+#[derive(Clone, Copy)]
 pub(crate) enum Step {
     Suspend,
     Done(ExitCode),

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -14,12 +14,6 @@ pub struct Cat {
     pub(crate) state: CatState,
 }
 
-/// An input is finished once the reader has reported done (`in_done`, with the
-/// read error's errno in `errno`, 0 on EOF) and every stdout chunk queued from
-/// it has completed (`chunks_done >= chunks_queued`); whichever callback
-/// observes both acts on `errno`. Queued chunks are never cancelled on a read
-/// error: a cancelled chunk completes without calling back, so nothing would
-/// be left to finish the command.
 #[derive(Default)]
 pub enum CatState {
     #[default]
@@ -28,7 +22,7 @@ pub enum CatState {
         in_done: bool,
         chunks_queued: usize,
         chunks_done: usize,
-        /// Exit code once the queued chunks have drained.
+        /// Errno the reader finished with (0 on EOF); becomes the exit code.
         errno: ExitCode,
     },
     ExecFilepathArgs {
@@ -41,9 +35,8 @@ pub enum CatState {
         chunks_queued: usize,
         chunks_done: usize,
         in_done: bool,
-        /// Non-zero once the current file failed to read: the command ends
-        /// with it as the exit code once the queued chunks have drained,
-        /// instead of moving on to the next file.
+        /// Errno the current file's reader finished with (0 on EOF); non-zero
+        /// ends the command instead of moving on to the next file.
         errno: ExitCode,
     },
     WaitingWriteErr,
@@ -54,6 +47,80 @@ pub(crate) enum Step {
     Suspend,
     Done(ExitCode),
     Next,
+}
+
+impl CatState {
+    /// A stdout chunk queued from the input completed.
+    fn chunk_done(&mut self) -> Step {
+        match self {
+            CatState::ExecStdin { chunks_done, .. }
+            | CatState::ExecFilepathArgs { chunks_done, .. } => {
+                *chunks_done += 1;
+            }
+            CatState::WaitingWriteErr => return Step::Done(1),
+            CatState::Idle => panic!("Invalid state"),
+        }
+        self.input_step()
+    }
+
+    /// The input's reader finished, with `errno` (0 on EOF). The chunks it
+    /// queued are left to drain: a cancelled chunk never calls back.
+    fn reader_done(&mut self, errno: ExitCode) -> Step {
+        match self {
+            CatState::ExecStdin {
+                in_done,
+                errno: st_errno,
+                ..
+            }
+            | CatState::ExecFilepathArgs {
+                in_done,
+                errno: st_errno,
+                ..
+            } => {
+                *in_done = true;
+                *st_errno = errno;
+            }
+            CatState::WaitingWriteErr | CatState::Idle => return Step::Suspend,
+        }
+        self.input_step()
+    }
+
+    /// The input is over once its reader is done and every chunk it queued
+    /// has completed, whichever of the two happens last.
+    fn input_step(&mut self) -> Step {
+        match self {
+            CatState::ExecStdin {
+                in_done,
+                chunks_queued,
+                chunks_done,
+                errno,
+            } => {
+                if *in_done && *chunks_done >= *chunks_queued {
+                    Step::Done(*errno)
+                } else {
+                    Step::Suspend
+                }
+            }
+            CatState::ExecFilepathArgs {
+                in_done,
+                chunks_queued,
+                chunks_done,
+                errno,
+                reader,
+                ..
+            } => {
+                if !*in_done || *chunks_done < *chunks_queued {
+                    Step::Suspend
+                } else if *errno != 0 {
+                    *reader = None;
+                    Step::Done(*errno)
+                } else {
+                    Step::Next
+                }
+            }
+            CatState::WaitingWriteErr | CatState::Idle => unreachable!("checked by the callers"),
+        }
+    }
 }
 
 impl Cat {
@@ -276,41 +343,11 @@ impl Cat {
             return Builtin::done(interp, cmd, errno);
         }
 
-        let step = match &mut Self::state_mut(interp, cmd).state {
-            CatState::ExecStdin {
-                chunks_queued,
-                chunks_done,
-                in_done,
-                errno,
-            } => {
-                *chunks_done += 1;
-                if *in_done && *chunks_done >= *chunks_queued {
-                    Step::Done(*errno)
-                } else {
-                    Step::Suspend
-                }
-            }
-            CatState::ExecFilepathArgs {
-                chunks_queued,
-                chunks_done,
-                in_done,
-                errno,
-                reader,
-                ..
-            } => {
-                *chunks_done += 1;
-                if !*in_done || *chunks_done < *chunks_queued {
-                    Step::Suspend
-                } else if *errno != 0 {
-                    *reader = None;
-                    Step::Done(*errno)
-                } else {
-                    Step::Next
-                }
-            }
-            CatState::WaitingWriteErr => Step::Done(1),
-            _ => panic!("Invalid state"),
-        };
+        let step = Self::state_mut(interp, cmd).state.chunk_done();
+        Self::take_step(interp, cmd, step)
+    }
+
+    fn take_step(interp: &Interpreter, cmd: NodeId, step: Step) -> Yield {
         match step {
             Step::Suspend => Yield::suspended(),
             Step::Done(code) => Builtin::done(interp, cmd, code),
@@ -349,47 +386,8 @@ impl Cat {
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
         let errno: ExitCode = err.map(|e| e.get_errno() as ExitCode).unwrap_or(0);
-        let step = match &mut Self::state_mut(interp, cmd).state {
-            CatState::ExecStdin {
-                chunks_queued,
-                chunks_done,
-                in_done,
-                errno: st_errno,
-            } => {
-                *st_errno = errno;
-                *in_done = true;
-                if *chunks_done >= *chunks_queued {
-                    Step::Done(errno)
-                } else {
-                    Step::Suspend
-                }
-            }
-            CatState::ExecFilepathArgs {
-                chunks_queued,
-                chunks_done,
-                in_done,
-                errno: st_errno,
-                reader,
-                ..
-            } => {
-                *st_errno = errno;
-                *in_done = true;
-                if *chunks_done < *chunks_queued {
-                    Step::Suspend
-                } else if errno != 0 {
-                    *reader = None;
-                    Step::Done(errno)
-                } else {
-                    Step::Next
-                }
-            }
-            CatState::WaitingWriteErr | CatState::Idle => Step::Suspend,
-        };
-        match step {
-            Step::Suspend => Yield::suspended(),
-            Step::Done(code) => Builtin::done(interp, cmd, code),
-            Step::Next => Self::next(interp, cmd),
-        }
+        let step = Self::state_mut(interp, cmd).state.reader_done(errno);
+        Self::take_step(interp, cmd, step)
     }
 }
 

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::shell::ExitCode;
-use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinInput, BuiltinState, IoKind, Kind};
+use crate::shell::builtin::{Builtin, BuiltinInput, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     FlagParser, Interpreter, NodeId, ParseFlagResult, parse_flags, shell_openat, unsupported_flag,
 };
@@ -14,6 +14,12 @@ pub struct Cat {
     pub(crate) state: CatState,
 }
 
+/// An input is finished once the reader has reported done (`in_done`, with the
+/// read error's errno in `errno`, 0 on EOF) and every stdout chunk queued from
+/// it has completed (`chunks_done >= chunks_queued`); whichever callback
+/// observes both acts on `errno`. Queued chunks are never cancelled on a read
+/// error: a cancelled chunk completes without calling back, so nothing would
+/// be left to finish the command.
 #[derive(Default)]
 pub enum CatState {
     #[default]
@@ -22,6 +28,7 @@ pub enum CatState {
         in_done: bool,
         chunks_queued: usize,
         chunks_done: usize,
+        /// Exit code once the queued chunks have drained.
         errno: ExitCode,
     },
     ExecFilepathArgs {
@@ -33,8 +40,11 @@ pub enum CatState {
         reader: Option<Arc<IOReader>>,
         chunks_queued: usize,
         chunks_done: usize,
-        out_done: bool,
         in_done: bool,
+        /// Non-zero once the current file failed to read: the command ends
+        /// with it as the exit code once the queued chunks have drained,
+        /// instead of moving on to the next file.
+        errno: ExitCode,
     },
     WaitingWriteErr,
 }
@@ -79,8 +89,8 @@ impl Cat {
                 reader: None,
                 chunks_queued: 0,
                 chunks_done: 0,
-                out_done: false,
                 in_done: false,
+                errno: 0,
             }
         };
 
@@ -206,14 +216,14 @@ impl Cat {
                     chunks_done,
                     chunks_queued,
                     in_done,
-                    out_done,
+                    errno,
                     ..
                 } = &mut Self::state_mut(interp, cmd).state
                 {
                     *chunks_done = 0;
                     *chunks_queued = 0;
                     *in_done = false;
-                    *out_done = false;
+                    *errno = 0;
                     *slot = Some(Arc::clone(&reader));
                 }
                 reader.add_reader(ReaderChildPtr {
@@ -271,11 +281,11 @@ impl Cat {
                 chunks_queued,
                 chunks_done,
                 in_done,
-                ..
+                errno,
             } => {
                 *chunks_done += 1;
                 if *in_done && *chunks_done >= *chunks_queued {
-                    Step::Done(0)
+                    Step::Done(*errno)
                 } else {
                     Step::Suspend
                 }
@@ -284,17 +294,18 @@ impl Cat {
                 chunks_queued,
                 chunks_done,
                 in_done,
-                out_done,
+                errno,
+                reader,
                 ..
             } => {
                 *chunks_done += 1;
-                if *chunks_done >= *chunks_queued {
-                    *out_done = true;
-                }
-                if *in_done && *out_done {
-                    Step::Next
-                } else {
+                if !*in_done || *chunks_done < *chunks_queued {
                     Step::Suspend
+                } else if *errno != 0 {
+                    *reader = None;
+                    Step::Done(*errno)
+                } else {
+                    Step::Next
                 }
             }
             CatState::WaitingWriteErr => Step::Done(1),
@@ -338,8 +349,6 @@ impl Cat {
         err: Option<bun_sys::SystemError>,
     ) -> Yield {
         let errno: ExitCode = err.map(|e| e.get_errno() as ExitCode).unwrap_or(0);
-        let stdout_needs_io = Builtin::of(interp, cmd).stdout.needs_io().is_some();
-        let mut cancel = false;
         let step = match &mut Self::state_mut(interp, cmd).state {
             CatState::ExecStdin {
                 chunks_queued,
@@ -349,15 +358,8 @@ impl Cat {
             } => {
                 *st_errno = errno;
                 *in_done = true;
-                if errno != 0 {
-                    if *chunks_done >= *chunks_queued || !stdout_needs_io {
-                        Step::Done(errno)
-                    } else {
-                        cancel = true;
-                        Step::Suspend
-                    }
-                } else if *chunks_done >= *chunks_queued || !stdout_needs_io {
-                    Step::Done(0)
+                if *chunks_done >= *chunks_queued {
+                    Step::Done(errno)
                 } else {
                     Step::Suspend
                 }
@@ -366,34 +368,23 @@ impl Cat {
                 chunks_queued,
                 chunks_done,
                 in_done,
-                out_done,
+                errno: st_errno,
                 reader,
                 ..
             } => {
+                *st_errno = errno;
                 *in_done = true;
-                if errno != 0 {
-                    if *out_done || !stdout_needs_io {
-                        // Drop the reader ref.
-                        *reader = None;
-                        Step::Done(errno)
-                    } else {
-                        cancel = true;
-                        Step::Suspend
-                    }
-                } else if *out_done || *chunks_done >= *chunks_queued || !stdout_needs_io {
-                    Step::Next
-                } else {
+                if *chunks_done < *chunks_queued {
                     Step::Suspend
+                } else if errno != 0 {
+                    *reader = None;
+                    Step::Done(errno)
+                } else {
+                    Step::Next
                 }
             }
             CatState::WaitingWriteErr | CatState::Idle => Step::Suspend,
         };
-        if cancel {
-            let wchild = ChildPtr::new(cmd, WriterTag::Builtin);
-            if let BuiltinIO::Fd(fd) = &Builtin::of(interp, cmd).stdout {
-                fd.writer.cancel_chunks(wchild);
-            }
-        }
         match step {
             Step::Suspend => Yield::suspended(),
             Step::Done(code) => Builtin::done(interp, cmd, code),

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -220,8 +220,7 @@ impl Cat {
                     let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &buf);
                     return Builtin::done(interp, cmd, 0);
                 }
-                // Clone the `Arc<IOReader>` out of `stdin` so no borrow of the
-                // builtin is held while the reader is started.
+                // Cloned out so the builtin is not borrowed while the reader starts.
                 let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
                 let reader = match &Builtin::of(interp, cmd).stdin {
                     BuiltinInput::Fd(r) => Arc::clone(r),
@@ -292,9 +291,7 @@ impl Cat {
         }
     }
 
-    /// A reader that cannot be started is finished right here, in tail
-    /// position, so the completion is returned to the trampoline instead of
-    /// running from inside `start()` (see `IOReader::start`).
+    /// A reader that cannot start is finished here, in tail position (see `IOReader::start`).
     fn start_reader(interp: &Interpreter, cmd: NodeId, reader: &IOReader) -> Yield {
         reader.add_reader(ReaderChildPtr {
             node: cmd,

--- a/src/runtime/shell/builtin/cat.rs
+++ b/src/runtime/shell/builtin/cat.rs
@@ -35,8 +35,7 @@ pub enum CatState {
         chunks_queued: usize,
         chunks_done: usize,
         in_done: bool,
-        /// Errno the current file's reader finished with (0 on EOF); non-zero
-        /// ends the command instead of moving on to the next file.
+        /// Errno the current file's reader finished with; non-zero ends the command.
         errno: ExitCode,
     },
     WaitingWriteErr,
@@ -63,8 +62,7 @@ impl CatState {
         self.input_step()
     }
 
-    /// The input's reader finished, with `errno` (0 on EOF). The chunks it
-    /// queued are left to drain: a cancelled chunk never calls back.
+    /// The reader finished with `errno` (0 on EOF); the chunks it queued still drain.
     fn reader_done(&mut self, errno: ExitCode) -> Step {
         match self {
             CatState::ExecStdin {
@@ -85,8 +83,7 @@ impl CatState {
         self.input_step()
     }
 
-    /// The input is over once its reader is done and every chunk it queued
-    /// has completed, whichever of the two happens last.
+    /// Finishes the input once the reader is done and every chunk it queued completed.
     fn input_step(&mut self) -> Step {
         match self {
             CatState::ExecStdin {

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -1,0 +1,116 @@
+import type { FileSink } from "bun";
+import { dlopen, FFIType } from "bun:ffi";
+import { describe, expect, test } from "bun:test";
+import { closeSync, writeSync } from "node:fs";
+import { bunEnv, bunExe, isLinux, isPosix, libcPathForDlopen, tempDir } from "harness";
+
+// On POSIX the shell only runs its own `cat` when this flag is set (see
+// `Kind::DISABLED_ON_POSIX`); otherwise it spawns the system binary. The
+// scripts run in a child so the flag applies.
+const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+// Unless `quiet` is set, cat's stdout is the shell's IOWriter on the child's
+// stdout pipe: a chunk cat reads stays queued there until the event loop
+// reaches the writable poll, which is the window the read-error paths under
+// test fire in. `r.stdout` is a tee of the same bytes, so the child's stdout
+// ends up as cat's own output followed by the report line. With `quiet`
+// nothing is queued (output goes straight into the capture buffer).
+function spawnReport(command: string, options: { quiet?: boolean; stdin?: number | "pipe"; cwd?: string } = {}) {
+  return Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      /* js */ `
+        import { $ } from "bun";
+        const r = await $\`${command}\`${options.quiet ? ".quiet()" : ""}.nothrow();
+        console.log(JSON.stringify({ exitCode: r.exitCode, stdout: r.stdout.toString(), stderr: r.stderr.toString() }));
+      `,
+    ],
+    env: builtinEnv,
+    cwd: options.cwd,
+    stdin: options.stdin ?? "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function report(exitCode: number, stdout: string): string {
+  return JSON.stringify({ exitCode, stdout, stderr: "" }) + "\n";
+}
+
+const EIO = 5;
+
+// On Linux, once the slave side of a pty is closed, read() on the master
+// returns whatever the slave wrote and then fails with EIO. Handing the master
+// to the child as its stdin is a way to feed the builtin a genuine read error
+// preceded by data: cat gets both in the same poll wake.
+function openptyMasterWithClosedSlave(payload: string): number {
+  const { openpty } = dlopen(libcPathForDlopen(), {
+    openpty: {
+      args: [FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr],
+      returns: FFIType.i32,
+    },
+  }).symbols;
+  const master = new Int32Array(1);
+  const slave = new Int32Array(1);
+  expect(openpty(master, slave, null, null, null)).toBe(0);
+  // No newline: the pty's output processing would turn it into "\r\n".
+  writeSync(slave[0], payload);
+  closeSync(slave[0]);
+  return master[0];
+}
+
+describe.concurrent("cat (builtin)", () => {
+  test.skipIf(!isPosix)("copies stdin to stdout until EOF", async () => {
+    await using proc = spawnReport("cat", { stdin: "pipe" });
+    const stdin = proc.stdin as FileSink;
+    stdin.write("piped in\n");
+    await stdin.end();
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "piped in\n" + report(0, "piped in\n"), stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isLinux)("read error with nothing queued: exits with the errno", async () => {
+    const master = openptyMasterWithClosedSlave("read before the error");
+    await using proc = spawnReport("cat", { quiet: true, stdin: master });
+    // The child holds its own copy of the master.
+    closeSync(master);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: report(EIO, "read before the error"), stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  // Same error, but with the data still queued on stdout. This used to cancel
+  // the queued chunk and suspend; a cancelled chunk completes without calling
+  // back into cat, so the command never finished, the `$` promise never
+  // settled, and the data was dropped.
+  test.skipIf(!isLinux)("read error with data still queued: flushes it, then exits with the errno", async () => {
+    const master = openptyMasterWithClosedSlave("read before the error");
+    await using proc = spawnReport("cat", { stdin: master });
+    closeSync(master);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({
+      stdout: "read before the error" + report(EIO, "read before the error"),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // File-argument state. A directory opens but cannot be read (Linux already
+  // refuses to register it with epoll), so the reader fails before anything is
+  // queued. With stdout on an fd this used to suspend forever too: finishing
+  // was gated on a flag that only a completed chunk could set.
+  test.skipIf(!isPosix)("unreadable file argument exits with the errno instead of hanging", async () => {
+    using dir = tempDir("shell-cat-dir-arg", { "sub/.keep": "" });
+    await using proc = spawnReport("cat sub", { cwd: String(dir) });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const parsed = JSON.parse(stdout);
+    expect({ parsed, stderr }).toEqual({
+      parsed: { exitCode: expect.any(Number), stdout: "", stderr: "" },
+      stderr: "",
+    });
+    expect(parsed.exitCode).toBeGreaterThan(0);
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -1,7 +1,7 @@
 import type { FileSink } from "bun";
 import { dlopen, FFIType } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, isPosix, libcPathForDlopen, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isMusl, isPosix, libcPathForDlopen, tempDir } from "harness";
 import { closeSync, writeSync } from "node:fs";
 
 // On POSIX the shell only runs its own `cat` when this flag is set (see
@@ -45,7 +45,8 @@ const EIO = 5;
 // to the child as its stdin is a way to feed the builtin a genuine read error
 // preceded by data: cat gets both in the same poll wake.
 function openptyMasterWithClosedSlave(payload: string): number {
-  const { openpty } = dlopen(libcPathForDlopen(), {
+  // glibc ships openpty in libutil (merged into libc only in 2.34); musl has it in libc.
+  const { openpty } = dlopen(isMusl ? libcPathForDlopen() : "libutil.so.1", {
     openpty: {
       args: [FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr, FFIType.ptr],
       returns: FFIType.i32,

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -25,6 +25,9 @@ function spawnReport(command: string, options: { quiet?: boolean; stdin?: number
         const r = await $\`${command}\`${options.quiet ? ".quiet()" : ""}.nothrow();
         console.log(JSON.stringify({ exitCode: r.exitCode, stdout: r.stdout.toString(), stderr: r.stderr.toString() }));
       `,
+      // Should the child crash, make the panic line the failure instead of a
+      // slow symbolized backtrace.
+      "--debug-crash-handler-use-trace-string",
     ],
     env: builtinEnv,
     cwd: options.cwd,
@@ -98,20 +101,59 @@ describe.concurrent("cat (builtin)", () => {
     expect(exitCode).toBe(0);
   });
 
-  // File-argument state. A directory opens but cannot be read (Linux already
-  // refuses to register it with epoll), so the reader fails before anything is
-  // queued. With stdout on an fd this used to suspend forever too: finishing
-  // was gated on a flag that only a completed chunk could set.
-  test.skipIf(!isPosix)("unreadable file argument exits with the errno instead of hanging", async () => {
-    using dir = tempDir("shell-cat-dir-arg", { "sub/.keep": "" });
-    await using proc = spawnReport("cat sub", { cwd: String(dir) });
+  // The master hands 8 KiB back as three reads (4095, 4095, 2 bytes) in the
+  // same wake as the error, so three chunks are queued when the error lands
+  // and each of their completions has to be counted.
+  test.skipIf(!isLinux)("read error with several chunks queued: flushes all of them", async () => {
+    const payload = Buffer.alloc(8192, "x").toString();
+    const master = openptyMasterWithClosedSlave(payload);
+    await using proc = spawnReport("cat", { stdin: master });
+    closeSync(master);
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const parsed = JSON.parse(stdout);
+    expect({ stdout, stderr }).toEqual({ stdout: payload + report(EIO, payload), stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  // File-argument state, failing before anything is queued: a directory opens
+  // but cannot be read (Linux refuses to even register it with epoll, so the
+  // failure is reported from inside the start call itself). With stdout on an
+  // fd this used to suspend forever: finishing was gated on a flag only a
+  // completed chunk could set. The pipeline and sequence forms check that the
+  // command finishes through its own trampoline frame: completing it from
+  // inside the start call tore down the pipeline node the trampoline was still
+  // holding, and nested one trampoline per statement otherwise.
+  async function runWithUnreadableArg(command: string, quiet = false) {
+    using dir = tempDir("shell-cat-dir-arg", { "sub/.keep": "" });
+    await using proc = spawnReport(command, { cwd: String(dir), quiet });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test.skipIf(!isPosix).each([
+    ["cat sub", false],
+    ["cat sub | cat sub", false],
+    ["true | cat sub", true],
+  ])("unreadable file argument exits with the errno instead of hanging: %s", async (command, quiet) => {
+    const { stdout, stderr, exitCode } = await runWithUnreadableArg(command, quiet);
+    // Nothing but the report reaches stdout, so it parses as a whole; on a
+    // crash the raw output (and stderr) shows up in the diff instead.
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      parsed = stdout;
+    }
     expect({ parsed, stderr }).toEqual({
       parsed: { exitCode: expect.any(Number), stdout: "", stderr: "" },
       stderr: "",
     });
-    expect(parsed.exitCode).toBeGreaterThan(0);
+    expect((parsed as { exitCode: number }).exitCode).toBeGreaterThan(0);
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isPosix)("unreadable file arguments in consecutive statements", async () => {
+    const { stdout, stderr, exitCode } = await runWithUnreadableArg("cat sub; cat sub; cat sub; cat sub; echo after");
+    expect({ stdout, stderr }).toEqual({ stdout: "after\n" + report(0, "after\n"), stderr: "" });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -1,8 +1,8 @@
 import type { FileSink } from "bun";
 import { dlopen, FFIType } from "bun:ffi";
 import { describe, expect, test } from "bun:test";
-import { closeSync, writeSync } from "node:fs";
 import { bunEnv, bunExe, isLinux, isPosix, libcPathForDlopen, tempDir } from "harness";
+import { closeSync, writeSync } from "node:fs";
 
 // On POSIX the shell only runs its own `cat` when this flag is set (see
 // `Kind::DISABLED_ON_POSIX`); otherwise it spawns the system binary. The

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -9,7 +9,7 @@
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isLinux, tempDir } from "harness";
 import { mkfifo } from "mkfifo";
-import { statSync } from "node:fs";
+import { statSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
@@ -40,12 +40,14 @@ const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 //                            recv guarantees the streaming inner loop's mid-read
 //                            flush (`head_start` past the half-buffer cutoff)
 //                            fires in a single poll wake.
-//   SHELL_FAIL_EPOLL_REARM_INO=N  the first epoll_ctl ADD/MOD on each fd open
-//                            on the FIFO with inode N succeeds; every later one
-//                            (the re-arm after a chunk was read) fails with
-//                            ENOMEM. Keyed by inode so only the named FIFO the
-//                            fixture hands to `cat` is affected, not the
-//                            capture pipes (anonymous pipes are FIFOs too).
+//   SHELL_FAIL_EPOLL_REARM_INO=N  epoll_ctl ADD/MOD on an fd open on the FIFO
+//                            with inode N fails with ENOMEM from the
+//                            SHELL_FAIL_EPOLL_REARM_FROM-th call on (1-based,
+//                            default 2: the first re-arm, i.e. right after the
+//                            first chunk was read; 3 = after the second chunk).
+//                            Keyed by inode so only the named FIFO the fixture
+//                            hands to `cat` is affected, not the capture pipes
+//                            (anonymous pipes are FIFOs too).
 // FilePoll registers the socketpair through the raw syscall(SYS_epoll_ctl,
 // ...) wrapper, not the libc epoll_ctl symbol, so the epoll modes interpose
 // syscall(2).
@@ -78,6 +80,7 @@ static int recv_eagain_first = -1;
 static int fail_epoll_from = -1; /* 0 = off, N >= 1 = 1-based index of the first failing call */
 static int recv_bulk = -1;       /* 0 = off, N >= 1 = number of fabricated full-buffer recvs */
 static unsigned long long rearm_ino; /* 0 = off, otherwise the inode of the FIFO whose re-arms fail */
+static int rearm_from;               /* 1-based index of the first failing epoll_ctl on that FIFO */
 static int rearm_init;
 static unsigned char recv_count[MAX_FD];
 static unsigned char epoll_count[MAX_FD];
@@ -101,6 +104,8 @@ static void init_modes(void) {
   if (!rearm_init) {
     const char *s = getenv("SHELL_FAIL_EPOLL_REARM_INO");
     rearm_ino = s ? strtoull(s, NULL, 10) : 0;
+    const char *from = getenv("SHELL_FAIL_EPOLL_REARM_FROM");
+    rearm_from = from ? atoi(from) : 2;
     rearm_init = 1;
   }
 }
@@ -191,7 +196,7 @@ long syscall(long number, ...) {
         }
       }
       if (target >= 0 && target < MAX_FD && is_rearm_fifo(target)) {
-        if (rearm_count[target]++ >= 1) {
+        if (++rearm_count[target] >= rearm_from) {
           errno = ENOMEM;
           return -1;
         }
@@ -263,17 +268,18 @@ console.log(JSON.stringify({ exitCode: r.exitCode }));
 // For SHELL_FAIL_EPOLL_REARM_INO: the builtin cat reads CAT_FIFO, either as a
 // file argument or through a stdin redirect (the two states of its state
 // machine). The fixture keeps its own read/write descriptor on the FIFO so the
-// reader never sees EOF: cat's first poll wake reads the payload and queues it
-// on stdout (the capture pipe, so the write waits for the event loop), and the
-// re-arm that follows is the call the shim fails. cat has to write the payload
-// out anyway and then finish with the errno. It used to cancel the queued
-// chunk and suspend forever instead.
+// reader never sees EOF: each poll wake reads one chunk and queues it on stdout
+// (the capture pipe, so the write waits for the event loop) and then re-arms,
+// and one of those re-arms is the call the shim fails. cat has to write out
+// whatever it has queued and then finish with the errno. It used to cancel the
+// queued chunk and suspend forever instead. The first chunk is written here;
+// the test writes any further ones into the FIFO itself.
 const CAT_FIFO_FIXTURE = /* js */ `
 import { $ } from "bun";
 import { constants, openSync, writeSync } from "node:fs";
 const fifo = process.env.CAT_FIFO;
 const keepWriterOpen = openSync(fifo, constants.O_RDWR);
-writeSync(keepWriterOpen, "queued before the fault\\n");
+writeSync(keepWriterOpen, "first chunk\\n");
 const r = process.env.CAT_FIFO_VIA === "redirect" ? await $\`cat < \${fifo}\`.nothrow() : await $\`cat \${fifo}\`.nothrow();
 console.log(JSON.stringify({ exitCode: r.exitCode, stdout: r.stdout.toString() }));
 `;
@@ -319,13 +325,21 @@ const MODES = [
   "SHELL_RECV_EAGAIN_FIRST",
 ] as const;
 // Integer-valued fault knobs; cleared alongside MODES and set through `extraEnv`.
-const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM", "SHELL_RECV_BULK", "SHELL_FAIL_EPOLL_REARM_INO"] as const;
+const VALUE_MODES = [
+  "SHELL_FAIL_EPOLL_FROM",
+  "SHELL_RECV_BULK",
+  "SHELL_FAIL_EPOLL_REARM_INO",
+  "SHELL_FAIL_EPOLL_REARM_FROM",
+] as const;
 
+// `onStdout` sees the fixture's stdout as it accumulates, for tests that have
+// to feed the fixture more input once it has visibly got through a step.
 async function expectShellFault(
   script: string,
   modes: (typeof MODES)[number][],
   extraEnv: Record<string, string> = {},
   expected: Record<string, unknown> = { exitCode: ENOMEM },
+  onStdout?: (soFar: string) => void,
 ) {
   const existing = bunEnv.LD_PRELOAD;
   const env: Record<string, string | undefined> = {
@@ -348,7 +362,15 @@ async function expectShellFault(
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const stderrAndExit = Promise.all([proc.stderr.text(), proc.exited]);
+  let stdout = "";
+  const decoder = new TextDecoder();
+  for await (const bytes of proc.stdout) {
+    stdout += decoder.decode(bytes, { stream: true });
+    onStdout?.(stdout);
+  }
+  stdout += decoder.decode();
+  const [stderr, exitCode] = await stderrAndExit;
   const line = stdout.trim().split("\n").pop() ?? "";
   let parsed: unknown;
   try {
@@ -457,7 +479,7 @@ async function expectCatReadFaultAfterChunk(via: "arg" | "redirect") {
       CAT_FIFO: fifo,
       CAT_FIFO_VIA: via,
     },
-    { exitCode: ENOMEM, stdout: "queued before the fault\n" },
+    { exitCode: ENOMEM, stdout: "first chunk\n" },
   );
 }
 
@@ -472,5 +494,40 @@ test.concurrent.skipIf(!isLinux || !cc)(
   "builtin cat finishes when redirected stdin fails to read after a chunk was queued",
   async () => {
     await expectCatReadFaultAfterChunk("redirect");
+  },
+);
+
+// Same fault one wake later. The first chunk has been written out by the time
+// the second one is fed in (it is only written once it shows up on the
+// fixture's stdout), so when the error lands the queue has had one completion
+// and holds one more chunk. The file-argument state used to track "drained"
+// with a flag that the first completion set for good, which would let the
+// error end the command with the second chunk still queued: the report would
+// show only the first chunk.
+test.concurrent.skipIf(!isLinux || !cc)(
+  "builtin cat still waits for a chunk queued after an earlier one completed",
+  async () => {
+    const fifo = join(String(dir), "cat-second-wake.fifo");
+    mkfifo(fifo);
+    let fedSecondChunk = false;
+    await expectShellFault(
+      "cat-fifo.js",
+      [],
+      {
+        BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1",
+        SHELL_FAIL_EPOLL_REARM_INO: statSync(fifo, { bigint: true }).ino.toString(),
+        SHELL_FAIL_EPOLL_REARM_FROM: "3",
+        CAT_FIFO: fifo,
+        CAT_FIFO_VIA: "arg",
+      },
+      { exitCode: ENOMEM, stdout: "first chunk\nsecond chunk\n" },
+      soFar => {
+        if (fedSecondChunk || !soFar.includes("first chunk\n")) return;
+        fedSecondChunk = true;
+        // The fixture holds the FIFO open read/write, so this neither blocks
+        // nor delivers an EOF.
+        writeFileSync(fifo, "second chunk\n");
+      },
+    );
   },
 );

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -453,7 +453,7 @@ async function expectCatReadFaultAfterChunk(via: "arg" | "redirect") {
     [],
     {
       BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1",
-      SHELL_FAIL_EPOLL_REARM_INO: String(statSync(fifo).ino),
+      SHELL_FAIL_EPOLL_REARM_INO: statSync(fifo, { bigint: true }).ino.toString(),
       CAT_FIFO: fifo,
       CAT_FIFO_VIA: via,
     },

--- a/test/js/bun/shell/shell-pipe-read-fault.test.ts
+++ b/test/js/bun/shell/shell-pipe-read-fault.test.ts
@@ -2,8 +2,14 @@
 // on the eager read, or epoll_ctl() registering the pipe) so the reader error
 // surfaces synchronously from inside the spawn call. The command must finish
 // with the syscall errno as its exit code, not tear state down under the spawn.
+//
+// The last group does the same to the builtin `cat`'s own reader (a FIFO it
+// opened itself): the re-registration after the first chunk fails, so the read
+// error lands while that chunk is still queued on stdout.
 import { afterAll, beforeAll, expect, test } from "bun:test";
 import { bunEnv, bunExe, isASAN, isLinux, tempDir } from "harness";
+import { mkfifo } from "mkfifo";
+import { statSync } from "node:fs";
 import { join } from "node:path";
 
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
@@ -34,6 +40,12 @@ const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 //                            recv guarantees the streaming inner loop's mid-read
 //                            flush (`head_start` past the half-buffer cutoff)
 //                            fires in a single poll wake.
+//   SHELL_FAIL_EPOLL_REARM_INO=N  the first epoll_ctl ADD/MOD on each fd open
+//                            on the FIFO with inode N succeeds; every later one
+//                            (the re-arm after a chunk was read) fails with
+//                            ENOMEM. Keyed by inode so only the named FIFO the
+//                            fixture hands to `cat` is affected, not the
+//                            capture pipes (anonymous pipes are FIFOs too).
 // FilePoll registers the socketpair through the raw syscall(SYS_epoll_ctl,
 // ...) wrapper, not the libc epoll_ctl symbol, so the epoll modes interpose
 // syscall(2).
@@ -65,9 +77,12 @@ static int recv_one_chunk = -1;
 static int recv_eagain_first = -1;
 static int fail_epoll_from = -1; /* 0 = off, N >= 1 = 1-based index of the first failing call */
 static int recv_bulk = -1;       /* 0 = off, N >= 1 = number of fabricated full-buffer recvs */
+static unsigned long long rearm_ino; /* 0 = off, otherwise the inode of the FIFO whose re-arms fail */
+static int rearm_init;
 static unsigned char recv_count[MAX_FD];
 static unsigned char epoll_count[MAX_FD];
 static unsigned char bulk_count[MAX_FD];
+static unsigned char rearm_count[MAX_FD];
 
 static void init_modes(void) {
   if (fail_recv < 0) fail_recv = getenv("SHELL_FAIL_RECV") != NULL;
@@ -83,6 +98,16 @@ static void init_modes(void) {
     const char *s = getenv("SHELL_RECV_BULK");
     recv_bulk = s ? atoi(s) : 0;
   }
+  if (!rearm_init) {
+    const char *s = getenv("SHELL_FAIL_EPOLL_REARM_INO");
+    rearm_ino = s ? strtoull(s, NULL, 10) : 0;
+    rearm_init = 1;
+  }
+}
+
+static int is_rearm_fifo(int fd) {
+  struct stat st;
+  return rearm_ino != 0 && fstat(fd, &st) == 0 && S_ISFIFO(st.st_mode) && st.st_ino == rearm_ino;
 }
 
 static int is_unix_sock(int fd) {
@@ -165,6 +190,12 @@ long syscall(long number, ...) {
           return -1;
         }
       }
+      if (target >= 0 && target < MAX_FD && is_rearm_fifo(target)) {
+        if (rearm_count[target]++ >= 1) {
+          errno = ENOMEM;
+          return -1;
+        }
+      }
     }
   }
   return real_syscall(number, a, b, c, d, e, f);
@@ -177,6 +208,7 @@ int close(int fd) {
     recv_count[fd] = 0;
     epoll_count[fd] = 0;
     bulk_count[fd] = 0;
+    rearm_count[fd] = 0;
   }
   return real_close(fd);
 }
@@ -228,6 +260,24 @@ const r = await $\`sh -c 'printf AAAA; exec sleep 5' 2> /dev/null\`.quiet().noth
 console.log(JSON.stringify({ exitCode: r.exitCode }));
 `;
 
+// For SHELL_FAIL_EPOLL_REARM_INO: the builtin cat reads CAT_FIFO, either as a
+// file argument or through a stdin redirect (the two states of its state
+// machine). The fixture keeps its own read/write descriptor on the FIFO so the
+// reader never sees EOF: cat's first poll wake reads the payload and queues it
+// on stdout (the capture pipe, so the write waits for the event loop), and the
+// re-arm that follows is the call the shim fails. cat has to write the payload
+// out anyway and then finish with the errno. It used to cancel the queued
+// chunk and suspend forever instead.
+const CAT_FIFO_FIXTURE = /* js */ `
+import { $ } from "bun";
+import { constants, openSync, writeSync } from "node:fs";
+const fifo = process.env.CAT_FIFO;
+const keepWriterOpen = openSync(fifo, constants.O_RDWR);
+writeSync(keepWriterOpen, "queued before the fault\\n");
+const r = process.env.CAT_FIFO_VIA === "redirect" ? await $\`cat < \${fifo}\`.nothrow() : await $\`cat \${fifo}\`.nothrow();
+console.log(JSON.stringify({ exitCode: r.exitCode, stdout: r.stdout.toString() }));
+`;
+
 let shimPath: string;
 let dir: ReturnType<typeof tempDir> | undefined;
 
@@ -239,6 +289,7 @@ beforeAll(async () => {
     "both-pipes.js": BOTH_PIPES_FIXTURE,
     "quiet-chunk.js": QUIET_CHUNK_FIXTURE,
     "poll-chunk.js": POLL_CHUNK_FIXTURE,
+    "cat-fifo.js": CAT_FIFO_FIXTURE,
   });
   shimPath = join(String(dir), "shim.so");
   await using ccProc = Bun.spawn({
@@ -268,12 +319,13 @@ const MODES = [
   "SHELL_RECV_EAGAIN_FIRST",
 ] as const;
 // Integer-valued fault knobs; cleared alongside MODES and set through `extraEnv`.
-const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM", "SHELL_RECV_BULK"] as const;
+const VALUE_MODES = ["SHELL_FAIL_EPOLL_FROM", "SHELL_RECV_BULK", "SHELL_FAIL_EPOLL_REARM_INO"] as const;
 
 async function expectShellFault(
   script: string,
   modes: (typeof MODES)[number][],
-  extraEnv: Partial<Record<(typeof VALUE_MODES)[number], string>> = {},
+  extraEnv: Record<string, string> = {},
+  expected: Record<string, unknown> = { exitCode: ENOMEM },
 ) {
   const existing = bunEnv.LD_PRELOAD;
   const env: Record<string, string | undefined> = {
@@ -306,7 +358,7 @@ async function expectShellFault(
   }
   // One combined assertion so a crash surfaces stderr and the exit code in the diff.
   expect({ parsed, stderr, exitCode }).toEqual({
-    parsed: { exitCode: ENOMEM },
+    parsed: expected,
     stderr: expect.any(String),
     exitCode: 0,
   });
@@ -386,5 +438,39 @@ test.concurrent.skipIf(!isLinux || !cc || !isASAN)(
       SHELL_FAIL_EPOLL_FROM: "3",
       SHELL_RECV_BULK: "1",
     });
+  },
+);
+
+// Builtin cat (`Cat::on_io_reader_done`), both of its states. The read error
+// arrives with the chunk it just read still queued on stdout; cat must let
+// that chunk drain and then exit with the errno. On POSIX the builtin is only
+// used with BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS set.
+async function expectCatReadFaultAfterChunk(via: "arg" | "redirect") {
+  const fifo = join(String(dir), `cat-${via}.fifo`);
+  mkfifo(fifo);
+  await expectShellFault(
+    "cat-fifo.js",
+    [],
+    {
+      BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1",
+      SHELL_FAIL_EPOLL_REARM_INO: String(statSync(fifo).ino),
+      CAT_FIFO: fifo,
+      CAT_FIFO_VIA: via,
+    },
+    { exitCode: ENOMEM, stdout: "queued before the fault\n" },
+  );
+}
+
+test.concurrent.skipIf(!isLinux || !cc)(
+  "builtin cat finishes when a file argument fails to read after a chunk was queued",
+  async () => {
+    await expectCatReadFaultAfterChunk("arg");
+  },
+);
+
+test.concurrent.skipIf(!isLinux || !cc)(
+  "builtin cat finishes when redirected stdin fails to read after a chunk was queued",
+  async () => {
+    await expectCatReadFaultAfterChunk("redirect");
   },
 );

--- a/test/js/bun/shell/yield.test.ts
+++ b/test/js/bun/shell/yield.test.ts
@@ -14,7 +14,7 @@ describe("yield", async () => {
   // used to re-enter the `Yield::run` trampoline from `IOWriter::on_error`, one
   // nesting level per failing command, tripping the interpreter's re-entrancy
   // guard. Spawn a subprocess so the aborting child stays contained.
-  async function expectShellOutput(script: string, expected: { stdout: string; exitCode: number }) {
+  async function expectShellOutput(script: string, expected: { stdout: string; exitCode: number }, env = bunEnv) {
     await using proc = Bun.spawn({
       cmd: [
         bunExe(),
@@ -29,7 +29,7 @@ describe("yield", async () => {
         // backtrace so the failure is the panic message, not a test timeout.
         "--debug-crash-handler-use-trace-string",
       ],
-      env: bunEnv,
+      env,
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -60,6 +60,19 @@ describe("yield", async () => {
     await expectShellOutput(
       "echo a > /dev/full || echo f1; echo b > /dev/full || echo f2; echo c > /dev/full || echo f3; echo d > /dev/full || echo f4",
       { stdout: "f1\nf2\nf3\nf4\n", exitCode: 0 },
+    );
+  });
+
+  // The read-side counterpart. The builtin cat (opted into on POSIX by the env
+  // var) can open a directory but Linux refuses to register it with epoll, so
+  // the reader fails from inside its start call; that failure used to be
+  // dispatched as a completion right there, starting the next statement from
+  // one more nested trampoline each time.
+  test.if(isLinux)("synchronous read errors in sequential statements", async () => {
+    await expectShellOutput(
+      "cat / || echo f1; cat / || echo f2; cat / || echo f3; cat / || echo f4",
+      { stdout: "f1\nf2\nf3\nf4\n", exitCode: 0 },
+      { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
     );
   });
 });


### PR DESCRIPTION
### Problem
- The shell's builtin `cat` hangs forever when its input fails to read while it still has output queued on stdout: the `$` promise never settles and the bytes already read are dropped. On POSIX the builtin only runs with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`; on Windows it is the `cat` every shell script gets.
- Cause: on a read error `cat` cancelled its queued chunks and waited, but a cancelled chunk completes without calling `cat` back, so nothing ever finished the command. With stdout on a pipe or tty, a chunk read in the same wake as the error is always still queued.
- The file-argument form only finished on error once some chunk had completed, so a read error before any output (`cat some_directory` with stdout on an fd) hung too. The Zig version had the same logic; this is inherited, not a porting bug.
- When the reader cannot start at all (a directory; on Linux today any regular file), the failure was delivered as a completion from inside the start call. `true | cat some_dir` dies with `panic: expected Node::Pipeline at Node#2, got Free`; `cat some_dir; cat some_dir; ...` nests one interpreter frame per statement. `true | cat < regular_file` panics the same way on main today.

### Fix
- A read error now ends the input exactly like EOF, plus an errno: the queued output drains, and whichever of "reader finished" or "last chunk written" happens second finishes the command with that errno. `cat` no longer cancels chunks.
- "Drained" is a count comparison (chunks completed >= chunks queued) in both forms. It replaces a flag that stayed set after the first completion, which let the command move on with a later chunk still in flight.
- Waiting for the drain cannot add a new hang: after EOF `cat` already waits for its output the same way, and if stdout goes away the existing write-error path finishes the command. The exit code stays the errno; making it 1 is #32278.
- A reader that fails to start is now reported back to `cat`, which finishes the input from its own frame instead of from inside the start call, the same shape the write side already uses for synchronous write errors.
- Verification: tests that fail without the change (every error case times out without the first commit; with only the first, the pipeline cases hit the panic above and the sequences trip a re-entrancy assertion). The read errors are real: a pty whose other end closed, directories as arguments, and an LD_PRELOAD shim that fails a poll re-arm with a chunk queued. Run on Linux only; for Windows the crate was compiled, not run.

### Background
- Builtin `cat`: bun's shell (`$`) can run `cat` in-process instead of spawning the system binary. It has two states, one reading stdin and one reading each file argument in turn; a non-zero errno in the file state ends the command instead of moving to the next file.
- IOReader: the shell's async input reader. It hands `cat` data, then either EOF or an error. Some failures (epoll refusing a directory or, on Linux, a regular file) surface synchronously from inside its start call rather than from a later poll wake.
- IOWriter: the shell's shared writer for a builtin's stdout. `cat` queues each chunk it read and is called back once per chunk when written, so it tracks output by counting queued against completed chunks. A cancelled chunk completes without that callback.
- Yield trampoline: a shell step does not complete a command by calling into it; it returns a `Yield` and a driver loop runs the next step. Completing a command from inside another step, as the start-failure path did, frees a node the driver is still holding, which is the panic above.

<details>
<summary>Original description</summary>

### What

The shell's builtin `cat` never finishes when its input fails to read while it still has output queued. The command, and the `$` promise awaiting it, hang forever and the data that was already read is dropped.

On POSIX the builtin is only used with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` (`Kind::DISABLED_ON_POSIX`); on Windows it is the `cat` every shell script gets.

Repro (Linux; the child's stdin is a pty master whose slave wrote some bytes and closed, so `read()` returns the bytes and then `EIO`):

```ts
// parent: openpty(); write(slave, "read before the error"); close(slave);
//         Bun.spawn([bun, "-e", script], { stdin: master, env: { BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" } })
// script:
const r = await $`cat`.nothrow();
console.log(r.exitCode, r.stdout.toString());
```

Before: nothing is printed and the process stays alive until it is killed. With `.quiet()` (no IOWriter involved) the same script prints `5 read before the error`, which is also what the non-quiet form prints after this change.

### Cause

`Cat::on_io_reader_done` (`src/runtime/shell/builtin/cat.rs`), in both the stdin and the file-argument state: when the reader reports an error and `chunks_done < chunks_queued`, it called `cancel_chunks` on stdout and returned `Suspend`. `IOWriter::bump` completes a cancelled chunk with `Yield::done()` and never calls the child's `on_io_writer_chunk`, so `chunks_done` never advanced and `Builtin::done` was never reached. The only read-error path that finished was the one where nothing happened to be queued at that instant; with stdout on a pipe or tty, a chunk read in the same poll wake as the error is always still queued. The file-argument state was worse: its error path checked `out_done`, which only a completed chunk ever sets, so a read error before the first chunk (for example `cat some_directory` with stdout on an fd) hung as well. The same logic was in the Zig version, so this is inherited rather than a porting bug.

### Fix

A read error ends the input exactly like EOF, plus an errno. `on_io_reader_done` records the errno and marks the input done, `on_io_writer_chunk` counts the chunk, and both then run the same `CatState::input_step`: once the reader is done and the queue has drained, whichever callback got there last finishes the command with the recorded errno (`ExecStdin` already had an `errno` field that nothing read; `ExecFilepathArgs` gets one, and a non-zero value ends the command instead of moving on to the next file, as before). `cancel_chunks` is no longer used here.

Both states now use `chunks_done >= chunks_queued` for "drained". The `out_done` flag is removed: besides the zero-chunk hang above, once set it stayed set, so a chunk queued after it could still be in flight when the reader finished and cat moved on to the next file or completed. The exit code stays the errno, which is what this builtin (and `shell-pipe-read-fault.test.ts`) already use for read failures; whether that should become 1 is a separate question (#32278).

Why this is the right shape rather than "cancel and finish immediately": the bytes were read successfully, and `cat` writes what it read before reporting the failure; the drain path also already existed for EOF, so the error path now shares it instead of having its own. Waiting for the drain cannot introduce a new way to get stuck: if stdout stalls, cat waits exactly as it does after EOF today (and as a blocked `write(2)` would), and if stdout goes away, the IOWriter fails the chunk and the existing write-error arm finishes the command. The old path never finished at all in this situation.

**Start-time failures** (second commit, found while reviewing the first). When the reader cannot be started at all, `bun_io` reports the error synchronously from inside `IOReader::start()` (epoll refuses directories, and on Linux today any regular file), and `IOReader` dispatched cat's completion right there, nested inside the trampoline frame that was starting the command. Once a read error finishes cat even with nothing queued, that nested completion tears down the pipeline node the outer trampoline is still holding: `true | cat some_dir` died with `panic: expected Node::Pipeline at Node#2, got Free`, and `cat some_dir; cat some_dir; cat some_dir` nested one trampoline per statement (the debug re-entrancy assertion fires at three). The stdin state already had this on main: `true | cat < regular_file` panics the same way with the released binary. `IOReader::start()` now returns a start failure instead of dispatching it (an error `bun_io` reports through `on_reader_error` while `start()` is on the stack is parked and returned too), and `Cat::start_reader` finishes the input in tail position, so the completion flows back through cat's own frame. This is the read-side version of what `IOWriter::on_sync_error` does for synchronous write failures; `IOReader::start()` has no other callers.

Related open PRs: #37719 changes the write-error side of the same builtin (IOWriter failing every queued chunk) and leaves this read-side path as is; #35337 makes the builtin read regular files synchronously and, in passing, aligns the file-argument zero-chunk condition, but keeps the cancel-and-suspend branch for queued chunks. Neither fixes this hang.

### Tests

`test/js/bun/shell/commands/cat.test.ts` (new): EOF through a pipe; the pty read error with nothing queued (`.quiet()`, exit 5 plus the data, unchanged behavior), with the data still queued (data written out, then exit 5), and with an 8 KiB payload, which the master hands back as three reads in the wake that also delivers the error, so three chunks are queued and each completion has to be counted; `cat <directory>` with stdout on an fd (file-argument state, zero chunks) on its own, inside pipelines (`cat sub | cat sub`, and `true | cat sub` with captured output), and four times in a row followed by `echo`.

`test/js/bun/shell/yield.test.ts`: the read-side counterpart of the existing "synchronous write errors in sequential statements" case (`cat / || echo f1; ...`).

`test/js/bun/shell/shell-pipe-read-fault.test.ts`: the existing LD_PRELOAD shim gains `SHELL_FAIL_EPOLL_REARM_INO` (and `..._REARM_FROM`), which fails the poll re-arm of the one FIFO the fixture hands to `cat`, so the read error lands right after a chunk was queued. `cat fifo` (file-argument state) and `cat < fifo` (redirect reader) must print the chunk and exit with `ENOMEM`. A third case fails the re-arm one wake later: the test feeds the second chunk only after the first has shown up on the fixture's stdout, so when the error lands one chunk has completed and another is queued. A sticky "drained" flag (I checked by temporarily putting one back) ends the command there and reports only the first chunk; the counter waits for the second.

Without the first commit, every error case above times out (the child never exits). With only the first commit, the pipeline cases crash on the panic quoted above and the sequence cases trip the re-entrancy assertion. With both, the three files pass (`bun bd test`, Linux; also looped without flakes), `cargo clippy -p bun_runtime` is clean and the crate checks for `x86_64-pc-windows-msvc`. Running `bunshell.test.ts` with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` gives the same 5 failures before and after (all regular-file reads through the builtin, i.e. #35337), with `redirect Bun.File` turning from a 5 s timeout into an immediate failure.

</details>
