### PR TITLE
node:http2: give pending requests cancelled by session.destroy() node's rstCode

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6008,15 +6008,19 @@ class ClientHttp2Session extends Http2Session {
       {
         // Requests still queued (waiting for connect or for a concurrency slot) never reached the
         // wire; node cancels them with ERR_HTTP2_STREAM_CANCEL (carrying the session error, if any,
-        // as its cause).
+        // as its cause). Their rstCode follows node's Http2Stream._destroy: the session's code (a
+        // received GOAWAY's, else this destroy's) unless the stream already close()d with one;
+        // with no session code _destroy derives NGHTTP2_INTERNAL_ERROR from the cancel error
+        // (NGHTTP2_CANCEL is only for AbortSignal cancellations).
         const pendingRequests = this.#pendingRequests;
         this.#pendingRequests = null;
         if (pendingRequests !== null && pendingRequests.length > 0) {
           const cancelError = createPendingStreamCancelError(error);
+          const sessionCode = this[kGoawayCode] || code;
           for (let i = 0; i < pendingRequests.length; i++) {
             const req = pendingRequests[i].req;
             if (!req.destroyed) {
-              req.rstCode = code !== undefined ? code : constants.NGHTTP2_CANCEL;
+              if (sessionCode && !req.rstCode) req.rstCode = sessionCode;
               req.destroy(cancelError);
             }
           }

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -2614,6 +2614,148 @@ it("http2 request.close() validates input and manages stream state", async done 
   });
 });
 
+// A request that is still pending (no stream id yet) when its client session is destroyed is
+// cancelled with ERR_HTTP2_STREAM_CANCEL. The rstCode it reports is the one node v26.3.0 gives
+// such a stream (Http2Stream._destroy): the session's code when there is one, otherwise
+// NGHTTP2_INTERNAL_ERROR, the fallback for a stream destroyed with a non-abort error.
+// NGHTTP2_CANCEL is reserved for AbortSignal cancellations.
+describe.concurrent("http2 pending requests cancelled by client session.destroy() report node's rstCode", () => {
+  const { NGHTTP2_INTERNAL_ERROR, NGHTTP2_REFUSED_STREAM, NGHTTP2_ENHANCE_YOUR_CALM } = http2.constants;
+  const shapes = {
+    "destroy()": [],
+    "destroy(null)": [null],
+    "destroy(NGHTTP2_NO_ERROR)": [http2.constants.NGHTTP2_NO_ERROR],
+    "destroy(NGHTTP2_REFUSED_STREAM)": [NGHTTP2_REFUSED_STREAM],
+    "destroy(null, NGHTTP2_REFUSED_STREAM)": [null, NGHTTP2_REFUSED_STREAM],
+    "destroy(new Error('boom'))": [new Error("boom")],
+    "destroy(new Error('boom'), NGHTTP2_REFUSED_STREAM)": [new Error("boom"), NGHTTP2_REFUSED_STREAM],
+  };
+  const cancelled = (rstCode, cause) => ({ pending: true, rstCode, error: "ERR_HTTP2_STREAM_CANCEL", cause });
+  const expected = {
+    "destroy()": cancelled(NGHTTP2_INTERNAL_ERROR, undefined),
+    "destroy(null)": cancelled(NGHTTP2_INTERNAL_ERROR, undefined),
+    "destroy(NGHTTP2_NO_ERROR)": cancelled(NGHTTP2_INTERNAL_ERROR, undefined),
+    "destroy(NGHTTP2_REFUSED_STREAM)": cancelled(NGHTTP2_REFUSED_STREAM, "Session closed with error code 7"),
+    "destroy(null, NGHTTP2_REFUSED_STREAM)": cancelled(NGHTTP2_REFUSED_STREAM, undefined),
+    "destroy(new Error('boom'))": cancelled(NGHTTP2_INTERNAL_ERROR, "boom"),
+    "destroy(new Error('boom'), NGHTTP2_REFUSED_STREAM)": cancelled(NGHTTP2_REFUSED_STREAM, "boom"),
+  };
+
+  async function listen(onStream) {
+    const server = http2.createServer({ settings: { maxConcurrentStreams: 1 } });
+    server.on("session", session => session.on("error", () => {}));
+    server.on("stream", stream => {
+      stream.on("error", () => {});
+      onStream?.(stream);
+    });
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    return server;
+  }
+
+  function connect(server) {
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    client.on("error", () => {});
+    return client;
+  }
+
+  // Resolves once `req` closes. A request torn down while queued never gets a stream id, so it is
+  // still `pending` after it closed.
+  function destroyAndObserve(req, destroySession) {
+    const { promise, resolve } = Promise.withResolvers();
+    let error;
+    req.on("error", e => (error = e));
+    req.on("close", () =>
+      resolve({ pending: req.pending, rstCode: req.rstCode, error: error?.code, cause: error?.cause?.message }),
+    );
+    destroySession();
+    return promise;
+  }
+
+  // The request is made while the socket is still connecting and the session is destroyed before
+  // the connect completes.
+  async function destroyBeforeConnect(server, args) {
+    const client = connect(server);
+    try {
+      return await destroyAndObserve(client.request({ ":path": "/" }), () => client.destroy(...args));
+    } finally {
+      client.destroy();
+    }
+  }
+
+  // The first request occupies the server's single SETTINGS_MAX_CONCURRENT_STREAMS slot, so the
+  // second stays queued (no id) on a connected session; `destroySession(client)` then tears it down.
+  async function destroyWithQueuedRequest(server, destroySession) {
+    const client = connect(server);
+    try {
+      await new Promise(resolve => client.once("remoteSettings", resolve));
+      const active = client.request({ ":path": "/active" });
+      active.on("error", () => {});
+      const queued = client.request({ ":path": "/queued" });
+      expect(active.pending).toBe(false);
+      return await destroyAndObserve(queued, () => destroySession(client));
+    } finally {
+      client.destroy();
+    }
+  }
+
+  // Runs destroyPending(server, args) for every destroy() shape against one server.
+  async function everyShape(destroyPending) {
+    const server = await listen();
+    try {
+      const names = Object.keys(shapes);
+      const results = await Promise.all(names.map(name => destroyPending(server, shapes[name])));
+      return Object.fromEntries(names.map((name, i) => [name, results[i]]));
+    } finally {
+      server.close();
+    }
+  }
+
+  it("for a request made before the session connected", async () => {
+    expect(await everyShape(destroyBeforeConnect)).toEqual(expected);
+  });
+
+  it("for a request queued behind the peer's maxConcurrentStreams", async () => {
+    const destroyWith = (server, args) => destroyWithQueuedRequest(server, client => client.destroy(...args));
+    expect(await everyShape(destroyWith)).toEqual(expected);
+  });
+
+  it("keeps the code a pending request was already close()d with", async () => {
+    const server = await listen();
+    const client = connect(server);
+    try {
+      const req = client.request({ ":path": "/" });
+      // close() on a pending stream records the code and waits for the stream id to send the
+      // RST_STREAM, so the request is still queued when the session goes away.
+      req.close(NGHTTP2_REFUSED_STREAM);
+      expect(req.destroyed).toBe(false);
+      expect(await destroyAndObserve(req, () => client.destroy(NGHTTP2_ENHANCE_YOUR_CALM))).toEqual(
+        cancelled(NGHTTP2_REFUSED_STREAM, "Session closed with error code 11"),
+      );
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  });
+
+  it("uses the code of a GOAWAY the session received over the destroy code", async () => {
+    // The server answers the first request with GOAWAY(ENHANCE_YOUR_CALM); the client's 'goaway'
+    // listener destroys the session while the second request is still queued.
+    const server = await listen(stream => stream.session.goaway(NGHTTP2_ENHANCE_YOUR_CALM));
+    try {
+      const destroyFromGoawayListener = args => client => client.once("goaway", () => client.destroy(...args));
+      const results = await Promise.all(
+        [[], [NGHTTP2_REFUSED_STREAM]].map(args => destroyWithQueuedRequest(server, destroyFromGoawayListener(args))),
+      );
+      expect(results).toEqual([
+        cancelled(NGHTTP2_ENHANCE_YOUR_CALM, undefined),
+        cancelled(NGHTTP2_ENHANCE_YOUR_CALM, "Session closed with error code 7"),
+      ]);
+    } finally {
+      server.close();
+    }
+  });
+});
+
 it("http2 client.setNextStreamID validates input", async () => {
   const server = http2.createServer();
 


### PR DESCRIPTION
### Problem
- A `node:http2` client request that is still queued (no stream id yet) when `session.destroy()` is called with no code reports `rstCode` 8 (`NGHTTP2_CANCEL`); node reports 2 (`NGHTTP2_INTERNAL_ERROR`). The error, `ERR_HTTP2_STREAM_CANCEL`, already matches.
- The same path ignores the code of a GOAWAY the session received and overwrites the code of a request that was already `close(code)`d, so both report the destroy code where node reports the GOAWAY or close code.
- Cause: on session destroy, bun assigns every queued request a code unconditionally (the destroy code, else `NGHTTP2_CANCEL`) instead of letting the stream's own teardown pick one.

### Fix
- A queued request now only gets a code pre-set when the session has one (a received GOAWAY's code, else the destroy code) and the request has none yet; otherwise it is left unset.
- Left unset, the stream's own `_destroy` derives `NGHTTP2_INTERNAL_ERROR` from the cancel error, as node does and as bun's `destroy(0)` and `destroy(err)` already did. Active streams already follow this rule on session destroy.
- The reported error is unchanged: every shape still gets `ERR_HTTP2_STREAM_CANCEL` with the session error as its `cause`.
- Verification: four new tests cover both queue reasons across seven `destroy()` shapes plus the `close(code)` and GOAWAY cases; all four fail on current bun and pass with this change. The existing http2 suites and the vendored node teardown tests still pass on a debug build.

### Background
- `rstCode` is the RST_STREAM error code an `Http2Stream` ended with. Codes seen here: 2 `INTERNAL_ERROR`, 7 `REFUSED_STREAM`, 8 `CANCEL`, 11 `ENHANCE_YOUR_CALM`.
- Bun's client session queues requests that have no stream id yet: those made before the socket connected, and those waiting for a `SETTINGS_MAX_CONCURRENT_STREAMS` slot (node hands the latter to nghttp2). Both report `pending === true` and go through the changed path.
- In node, a stream destroyed with an error that is not an `AbortError` gets `NGHTTP2_INTERNAL_ERROR` unless it already has a code; `NGHTTP2_CANCEL` is reserved for AbortSignal cancellations.
- A GOAWAY frame is the peer shutting the connection down with an error code; the session remembers it, and node gives it precedence over a later `destroy(code)`.
- `close(code)` on a pending request records the code and waits for a stream id before sending RST_STREAM, so the request is still queued when the session goes away.

<details>
<summary>Original description</summary>

### Repro

A request that is still pending (no stream id yet) when its client session is destroyed without a code reports `rstCode` 8 (`NGHTTP2_CANCEL`); node reports 2 (`NGHTTP2_INTERNAL_ERROR`). The error object already matches (`ERR_HTTP2_STREAM_CANCEL` on both).

```js
const http2 = require("node:http2"), net = require("node:net");
const server = net.createServer(() => {});
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  client.on("error", () => {});
  const req = client.request({ ":path": "/" }); // still connecting, so the request is queued
  let error;
  req.on("error", e => (error = e.code));
  req.on("close", () => { console.log(req.rstCode, error); server.close(); });
  client.destroy();
});
```

```
bun (main):   8 ERR_HTTP2_STREAM_CANCEL
node v26.3.0: 2 ERR_HTTP2_STREAM_CANCEL
```

Full table for a pending request, bun main vs node v26.3.0 (the same script with the `destroy()` arguments varied; the close()d and GOAWAY rows are separate scripts):

| session teardown | bun main | node | this PR |
| --- | --- | --- | --- |
| `destroy()` | 8 | 2 | 2 |
| `destroy(null)` | 8 | 2 | 2 |
| `destroy(0)` | 2 | 2 | 2 |
| `destroy(7)` / `destroy(null, 7)` / `destroy(err, 7)` | 7 | 7 | 7 |
| `destroy(err)` | 2 | 2 | 2 |
| `req.close(5)` first, then `destroy()` or `destroy(7)` | 8 / 7 | 5 | 5 |
| GOAWAY(11) received, `'goaway'` listener calls `destroy()` or `destroy(7)` | 8 / 7 | 11 | 11 |

### Cause

`ClientHttp2Session#destroy()` (`src/js/node/http2.ts`) cancels the requests still queued in `#pendingRequests` with

```ts
req.rstCode = code !== undefined ? code : constants.NGHTTP2_CANCEL;
req.destroy(cancelError);
```

Node's `closeSession` destroys its pending streams with `new ERR_HTTP2_STREAM_CANCEL(error)` and lets `Http2Stream._destroy` pick the code: the session's code (`goawayCode || destroyCode`) when non-zero, otherwise `NGHTTP2_INTERNAL_ERROR` because the stream is being destroyed with an error that is not an `AbortError` (`NGHTTP2_CANCEL` is reserved for AbortSignal cancellations). It also never overwrites the code of a stream that was already `close()`d. Our unconditional assignment hard-coded `CANCEL` for the no-code case, ignored a received GOAWAY's code, and clobbered a `close(code)`.

### Fix

Only pre-set `rstCode` when there is a session code (`this[kGoawayCode] || code`, the expression the active-stream teardown already uses) and the stream has none yet; otherwise leave it unset so `Http2Stream#_destroy` derives `NGHTTP2_INTERNAL_ERROR` from the cancel error, which is the same derivation node performs (and the one `destroy(0)` and `destroy(err)` were already going through). This is the same `if (rstCode && !stream.rstCode)` rule as `destroyStreamForSessionDestroy`.

The reported error is unchanged: every shape still gets `ERR_HTTP2_STREAM_CANCEL` with the session error as its `cause`. Bun also queues requests that are waiting for a `SETTINGS_MAX_CONCURRENT_STREAMS` slot in `#pendingRequests` (node hands those to nghttp2, where they already have an id); they report `pending === true` and get the cancel error here today, so they follow the same rule. The `rstCode` they get matches what node reports for those streams as well (the table's GOAWAY row was measured that way).

Related open PRs touch neighbouring paths but not this one: #33802 changes how active streams are torn down by the client `destroy()`, and #37698 makes `destroy(undefined, code)` behave like `destroy()`; this change composes with both (once #37698 lands, `destroy(undefined, 7)` also yields 2 here, as in node).

### Verification

New `describe` in `test/js/node/http2/node-http2.test.js` covers both queue reasons (request before connect, request behind `maxConcurrentStreams`) for seven `destroy()` shapes, plus the `close(code)`-then-destroy and GOAWAY-precedence cases. All four tests fail on the current release (`rstCode` 8/7/11 where node gives 2/5/11 as in the table) and pass with this change. `node-http2.test.js` (360 pass), `h2-conformance.test.ts` (61 pass) and the vendored node tests that exercise pending streams and session teardown (`test-http2-client-destroy`, `test-http2-client-stream-destroy-before-connect`, `test-http2-client-rststream-before-connect`, `test-http2-stream-removelisteners-after-close`, `test-http2-propagate-session-destroy-code`, `test-http2-max-concurrent-streams`, `test-http2-goaway-delayed-request`, ...) still pass with a debug build.


</details>
