### PR TITLE
build: keep compile flags as bare argv so compile_commands.json is usable by clangd

### DIFF
--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -119,7 +119,9 @@ Build flags must come before exec args. `bun bd --asan=off test foo.ts` works; `
 { flag: "-fno-foo", when: c => c.linux && c.release, desc: "why this flag" },
 ```
 
-Tables: `cpuTargetFlags` (`-march`/`-mcpu`/`-mtune` — also forwarded to local WebKit via `computeCpuTargetFlags()`), `globalFlags` (bun + all deps), `bunOnlyFlags` (just bun), `linkFlags`, `stripFlags`. Use `lang: "cxx"` to restrict to C++.
+Tables: `cpuTargetFlags` (`-march`/`-mcpu`/`-mtune` — also forwarded to local WebKit via `computeCpuTargetFlags()`), `globalFlags` (bun + all deps), `bunOnlyFlags` (just bun), `defines`, `linkFlags`, `stripFlags`. Use `lang: "cxx"` to restrict to C++.
+
+Compile-side entries (`globalFlags`, `bunOnlyFlags`, `defines`, and a dep's `cflags`/`defines`) are the bare argument the compiler should receive — write `FOO="bar"`, never `FOO=\"bar\"`. `compile.ts` shell-quotes them when it writes `build.ninja`; `compile_commands.json` gets them as-is, and clangd would otherwise pass the backslashes on to clang.
 
 **Bump a dependency** — edit the `commit` in `scripts/build/deps/<name>.ts`. See `deps/README.md` for adding/removing deps.
 

--- a/scripts/build/compile.ts
+++ b/scripts/build/compile.ts
@@ -12,7 +12,7 @@ import type { Config } from "./config.ts";
 import { assert } from "./error.ts";
 import { writeIfChanged } from "./fs.ts";
 import type { BuildNode, Ninja, Rule } from "./ninja.ts";
-import { quote } from "./shell.ts";
+import { quote, quoteArgs } from "./shell.ts";
 import { elfDebugCompressPostlinkCommand, machoPostlinkCommand } from "./shims.ts";
 import { streamPath } from "./stream.ts";
 
@@ -191,7 +191,11 @@ export function registerCompileRules(n: Ninja, cfg: Config): void {
 // ---------------------------------------------------------------------------
 
 export interface CompileOpts {
-  /** Compiler flags (including -I, -D — caller assembles). */
+  /**
+   * Compiler flags (including -I, -D — caller assembles). One argv entry per
+   * element, exactly as the compiler should receive it (`-DFOO="bar"` means
+   * clang sees the quotes) — never shell-quoted, see flagsVar().
+   */
   flags: string[];
   /** PCH to use (absolute path to .pch/.gch output). */
   pch?: string;
@@ -218,6 +222,18 @@ export interface CompileOpts {
   orderOnlyInputs?: string[];
   /** Job pool override. */
   pool?: string;
+}
+
+/**
+ * Render a flags argv as a `$cflags`/`$cxxflags`/`$nasmflags` value. Ninja
+ * splices it into the rule command verbatim, so each argument is quoted for
+ * whatever splits that command line on the build HOST (sh on unix; on
+ * Windows ninja spawns the tool directly and its argv parser does the
+ * splitting). This is the only place compile flags pick up shell quoting:
+ * compile_commands.json `arguments` is an argv, so it gets the flags as-is.
+ */
+function flagsVar(cfg: Config, flags: string[]): string {
+  return quoteArgs(flags, cfg.host.os === "windows");
 }
 
 /**
@@ -271,7 +287,7 @@ export function nasm(
     rule: "nasm",
     inputs: [resolve(cfg.cwd, src)],
     orderOnlyInputs: [objectDirStamp(cfg), ...(opts.orderOnlyInputs ?? [])],
-    vars: { nasmflags: opts.flags.join(" ") },
+    vars: { nasmflags: flagsVar(cfg, opts.flags) },
   });
   return out;
 }
@@ -285,7 +301,7 @@ function compile(n: Ninja, cfg: Config, src: string, opts: CompileOpts, lang: "c
 
   const implicitInputs: string[] = [...(opts.implicitInputs ?? [])];
   const vars: Record<string, string> = {
-    [flagVar]: opts.flags.join(" "),
+    [flagVar]: flagsVar(cfg, opts.flags),
   };
 
   // PCH is always an implicit dep — if it changes, recompile.
@@ -346,6 +362,7 @@ export function pch(
   cfg: Config,
   header: string,
   opts: {
+    /** Same contract as CompileOpts.flags: bare argv, quoted here. */
     flags: string[];
     /**
      * Files whose change must invalidate the PCH. Typically: dep output
@@ -413,7 +430,7 @@ export function pch(
     implicitInputs: [absHeader, wrapperHeader, ...(opts.implicitInputs ?? [])],
     orderOnlyInputs: [pchDirStamp(cfg), ...(opts.orderOnlyInputs ?? [])],
     vars: {
-      cxxflags: opts.flags.join(" "),
+      cxxflags: flagsVar(cfg, opts.flags),
       pch_header: n.rel(wrapperHeader),
     },
   };

--- a/scripts/build/deps/boringssl.ts
+++ b/scripts/build/deps/boringssl.ts
@@ -20,7 +20,6 @@
  *           console.log("nasm\n",f([...j.bcm.nasm,...j.crypto.nasm]))'
  */
 
-import { quote } from "../shell.ts";
 import type { Dependency, DirectBuild } from "../source.ts";
 import { depSourceDir } from "../source.ts";
 
@@ -76,15 +75,10 @@ export const boringssl: Dependency = {
             ...(cfg.linux || cfg.freebsd ? ["-Wa,--noexecstack"] : []),
           ],
       // nasm needs -I with a trailing slash and CodeView debug info to
-      // match cmake's `-gcv8`. Absolute path quoted — a checkout root
-      // with a space (C:\Users\John Doe\bun) would otherwise split argv.
-      // Quote style follows the HOST shell (cmd natively, sh when
-      // cross-compiling win-x64 from linux).
-      nasmflags: [
-        "-fwin64",
-        "-gcv8",
-        `-I${quote(depSourceDir(cfg, "boringssl") + "/gen/", cfg.host.os === "windows")}`,
-      ],
+      // match cmake's `-gcv8`. Bare argv like cflags — nasm() in compile.ts
+      // quotes it for the host, so a checkout root with a space
+      // (C:\Users\John Doe\bun) survives intact.
+      nasmflags: ["-fwin64", "-gcv8", `-I${depSourceDir(cfg, "boringssl")}/gen/`],
     };
     return spec;
   },

--- a/scripts/build/flags.ts
+++ b/scripts/build/flags.ts
@@ -100,7 +100,7 @@ export const globalFlags: Flag[] = [
     // splat laid out like a VS install (VC/Tools/MSVC + Windows Kits/10),
     // covering the MSVC CRT/STL and Windows SDK headers + import libs.
     // The lld-link equivalent (/winsysroot:) is added in linkerFlags below.
-    flag: c => ["/winsysroot", quote(c.winsysroot!, false)],
+    flag: c => ["/winsysroot", c.winsysroot!],
     when: c => c.windows && c.winsysroot !== undefined,
     desc: "Windows cross-compile: MSVC CRT + Windows SDK root (xwin splat)",
   },
@@ -710,9 +710,12 @@ export const defines: Flag[] = [
     desc: "Core bun defines (always on)",
   },
   {
-    // Shell-escaped quotes so clang receives literal quotes in the define
-    // (the preprocessor needs the string to be "26.3.0", not bare 26.3.0).
-    flag: c => `REPORTED_NODEJS_VERSION=\\"${c.nodejsVersion}\\"`,
+    // The quotes are part of the define itself (the macro must expand to the
+    // string literal "26.3.0", not the bare tokens 26.3.0). Like every other
+    // entry here this is the argument clang receives; compile.ts quotes it
+    // for the shell when it writes build.ninja, and compile_commands.json
+    // gets it verbatim.
+    flag: c => `REPORTED_NODEJS_VERSION="${c.nodejsVersion}"`,
     desc: "Node.js version string reported by process.version",
   },
   {
@@ -720,7 +723,7 @@ export const defines: Flag[] = [
     desc: "Node.js ABI version (process.versions.modules)",
   },
   {
-    flag: c => `REPORTED_NODEJS_V8_VERSION=\\"${c.nodejsV8Version}\\"`,
+    flag: c => `REPORTED_NODEJS_V8_VERSION="${c.nodejsV8Version}"`,
     desc: "V8 version string (process.versions.v8)",
   },
   {
@@ -747,7 +750,7 @@ export const defines: Flag[] = [
   },
   {
     // slash(): path becomes a C string literal — `\U` would be a unicode escape.
-    flag: c => `BUN_DYNAMIC_JS_LOAD_PATH=\\"${slash(join(c.buildDir, "js"))}\\"`,
+    flag: c => `BUN_DYNAMIC_JS_LOAD_PATH="${slash(join(c.buildDir, "js"))}"`,
     when: c => c.debug && !c.ci,
     desc: "Hot-reload built-in JS from build dir (dev convenience)",
   },
@@ -1605,15 +1608,25 @@ export const fileOverrides: FileOverride[] = [
 // ═══════════════════════════════════════════════════════════════════════════
 
 export interface ComputedFlags {
-  /** C compiler flags (clang -c for .c files). */
+  /**
+   * C compiler flags (clang -c for .c files). cflags/cxxflags/defines are
+   * bare argv entries — compile.ts quotes them for build.ninja and writes
+   * them as-is to compile_commands.json, so a table entry must never be
+   * pre-escaped for a shell.
+   */
   cflags: string[];
-  /** C++ compiler flags (clang++ -c for .cpp files). */
+  /** C++ compiler flags (clang++ -c for .cpp files). Same contract as cflags. */
   cxxflags: string[];
-  /** Preprocessor defines, without -D prefix. */
+  /** Preprocessor defines, without -D prefix. Same contract as cflags. */
   defines: string[];
-  /** Linker flags for the final bun link. */
+  /**
+   * Linker flags for the final bun link. Unlike the compile flags these are
+   * joined into the link command verbatim (link() in compile.ts), so an
+   * entry that can contain shell metacharacters quotes itself — see the
+   * /libpath: and /winsysroot: entries in linkerFlags.
+   */
   ldflags: string[];
-  /** Strip flags for post-link. */
+  /** Strip flags for post-link. Joined verbatim like ldflags. */
   stripflags: string[];
 }
 

--- a/scripts/build/shell.ts
+++ b/scripts/build/shell.ts
@@ -1,8 +1,10 @@
 /**
  * Shell argument quoting for ninja rule commands.
  *
- * Ninja executes commands via `/bin/sh -c "<command>"` on unix and
- * `cmd /c "<command>"` on windows (when we wrap it that way in rules).
+ * Ninja executes commands via `/bin/sh -c "<command>"` on unix. On windows it
+ * hands the command line to CreateProcess as-is (no shell), and the tool
+ * being run splits it into argv with the Win32 rules; the few rules we wrap
+ * in `cmd /c "..."` pass the text through to the tool unchanged as well.
  * Arguments with spaces/metacharacters need quoting to survive that layer.
  *
  * ## Why this is its own file
@@ -21,19 +23,21 @@
  *   escaped quote, reopen quote). Handles every metachar including `$`, `|`,
  *   backticks, etc.
  *
- * Windows (`cmd /c`):
- *   Double-quote. Embedded `"` becomes `""`. This is cmd's escape convention,
- *   NOT the C argv convention (`\"`). The distinction matters: if the inner
- *   executable parses argv itself (most .exe do), cmd unwraps one layer of
- *   `""` but passes the rest through, so the inner program sees a literal `"`.
- *   Good enough for paths and values; breaks if you need to nest three layers
- *   of quoting (you shouldn't).
+ * Windows (CreateProcess → the tool's own argv parsing):
+ *   Double-quote, with the documented Win32 argv rules: an embedded `"`
+ *   becomes `\"`, and a run of backslashes is doubled when it sits in front
+ *   of a `"` (ours or an embedded one), since only there is `\` an escape.
+ *   This is what the MS CRT, CommandLineToArgvW, LLVM's tokenizer and ninja's
+ *   own $in/$out escaping all implement. The alternative `""` spelling is
+ *   not interpreted consistently: ccache 4.12, for one, ends the quoted span
+ *   at `""`, so an argument holding both a quote and a space (a define whose
+ *   value is a path) splits in two on its way to clang-cl.
  *
- *   Known cmd footguns we DON'T handle: `%VAR%` expansion, `^` escape,
- *   `&`/`|`/`>` redirection. If an argument contains these, double-quoting
- *   protects SOME but not all. In practice our args are paths + flag values;
- *   we'd hit this only with very weird file names. If it happens: switch the
- *   affected rule to invoke via powershell instead of cmd.
+ *   Known cmd footguns we DON'T handle for the `cmd /c`-wrapped rules:
+ *   `%VAR%` expansion, `^` escape, `&`/`|`/`>` redirection. In practice the
+ *   args those rules see are paths + flag values; we'd hit this only with
+ *   very weird file names. If it happens: switch the affected rule to invoke
+ *   via powershell instead of cmd.
  *
  * ## Safe chars (no quoting needed)
  *
@@ -45,21 +49,43 @@
 /**
  * Quote a single argument for a shell command.
  *
- * @param windows If true, use cmd.exe quoting (`""`). If false, posix (`'`).
- *   Pass `cfg.windows` from the build config.
+ * @param windows If true, use Win32 argv quoting (`"..."`, `\"`). If false,
+ *   posix (`'`). Pass the HOST's os: the host is what runs the command.
  */
 export function quote(arg: string, windows: boolean): string {
   // Fast path: safe characters only, no quoting needed. Keeps the .ninja
   // file legible for the common case (paths without spaces, flag values).
-  // `\` is safe in cmd (not a metachar) — and posix paths never contain
-  // it, so including it doesn't affect the posix branch.
+  // `\` is safe on windows outside quotes (it only escapes a following `"`,
+  // and `"` is not in this set) — and posix paths never contain it, so
+  // including it doesn't affect the posix branch.
   if (/^[A-Za-z0-9_@%+=:,./\\\-]+$/.test(arg)) {
     return arg;
   }
   if (windows) {
-    return `"${arg.replace(/"/g, '""')}"`;
+    return quoteWin32(arg);
   }
   return `'${arg.replace(/'/g, `'\\''`)}'`;
+}
+
+function quoteWin32(arg: string): string {
+  let out = '"';
+  let backslashes = 0;
+  for (const ch of arg) {
+    if (ch === "\\") {
+      backslashes++;
+      continue;
+    }
+    if (ch === '"') {
+      // The backslashes now precede a quote, so each one needs escaping
+      // itself, and then the quote does too.
+      out += "\\".repeat(backslashes * 2 + 1) + '"';
+    } else {
+      out += "\\".repeat(backslashes) + ch;
+    }
+    backslashes = 0;
+  }
+  // A trailing run would otherwise escape our closing quote.
+  return out + "\\".repeat(backslashes * 2) + '"';
 }
 
 /**

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -290,7 +290,8 @@ export interface NestedCmakeBuild {
   args: Record<string, string>;
   /**
    * Extra C flags appended to CMAKE_C_FLAGS for this dep (beyond global
-   * dep flags). APPENDED, not replacing globals.
+   * dep flags). APPENDED, not replacing globals. Same unquoted-argv contract
+   * as DirectBuild.cflags; emitNestedCmake quotes them into the cmake value.
    */
   extraCFlags?: string[];
   extraCxxFlags?: string[];
@@ -1191,13 +1192,9 @@ function emitNestedCmake(
   // Compiler flags — GLOBAL flags only. These are the dep-safe subset:
   // CPU target, optimization level, debug info, visibility, sections.
   // NO -Werror, NO bun-specific constexpr limits.
-  //
-  // The tables hold bare argv (see ComputedFlags); CMAKE_<LANG>_FLAGS is a
-  // command-line fragment cmake pastes into the inner build's commands, so
-  // each argument is quoted here for the host that runs them.
   const depFlags = computeDepFlags(cfg);
-  let cflags = quoteArgs(depFlags.cflags, hostWin);
-  let cxxflags = quoteArgs(depFlags.cxxflags, hostWin);
+  const cflags = [...depFlags.cflags];
+  const cxxflags = [...depFlags.cxxflags];
 
   // PIC handling:
   //   spec.pic=true  → add -fPIC (non-windows), also tell cmake
@@ -1208,21 +1205,26 @@ function emitNestedCmake(
   // are guarded — no-op there.
   if (spec.pic) {
     if (!cfg.windows) {
-      cflags += " -fPIC";
-      cxxflags += " -fPIC";
+      cflags.push("-fPIC");
+      cxxflags.push("-fPIC");
     }
     args.push(`-DCMAKE_POSITION_INDEPENDENT_CODE=ON`);
   } else if (cfg.darwin) {
-    cflags += " -fno-pic -fno-pie";
-    cxxflags += " -fno-pic -fno-pie";
+    cflags.push("-fno-pic", "-fno-pie");
+    cxxflags.push("-fno-pic", "-fno-pie");
   }
 
   // Dep-specific extra flags. Appended to globals, not replacing them.
-  if (spec.extraCFlags) cflags += " " + spec.extraCFlags.join(" ");
-  if (spec.extraCxxFlags) cxxflags += " " + spec.extraCxxFlags.join(" ");
+  cflags.push(...(spec.extraCFlags ?? []));
+  cxxflags.push(...(spec.extraCxxFlags ?? []));
 
-  args.push(`-DCMAKE_C_FLAGS=${cflags}`);
-  args.push(`-DCMAKE_CXX_FLAGS=${cxxflags}`);
+  // Everything above is bare argv (see ComputedFlags). CMAKE_<LANG>_FLAGS is
+  // a command-line fragment that cmake pastes into the inner build's compile
+  // commands, so it is quoted here for the host that will run those; the
+  // dep_configure edge below then quotes the whole -D argument once more for
+  // the cmake invocation itself.
+  args.push(`-DCMAKE_C_FLAGS=${quoteArgs(cflags, hostWin)}`);
+  args.push(`-DCMAKE_CXX_FLAGS=${quoteArgs(cxxflags, hostWin)}`);
 
   // Dep-specific -D args go LAST so a dep can override anything above
   // if it really needs to. (Rare — we don't expect deps to fight the

--- a/scripts/build/source.ts
+++ b/scripts/build/source.ts
@@ -220,13 +220,20 @@ export interface DirectBuild {
    * Preprocessor defines. Value type controls the emitted form:
    *   true    → -DNAME
    *   number  → -DNAME=42
-   *   string  → -DNAME=\"value\"  (shell-quoted C string literal)
-   * The shell escaping is handled here; callers pass plain strings.
+   *   string  → -DNAME="value"  (the macro expands to a C string literal)
+   * Callers pass plain strings; shell quoting happens when the compile
+   * edges are emitted, never here.
    */
   defines?: Record<string, string | number | true>;
-  /** Extra C flags beyond computeDepFlags globals. */
+  /**
+   * Extra C flags beyond computeDepFlags globals. One argv entry per
+   * element, unquoted (same contract as CompileOpts.flags in compile.ts).
+   */
   cflags?: string[];
-  /** Flags for `.asm` sources (nasm). Separate because nasm doesn't share clang's argv shape. */
+  /**
+   * Flags for `.asm` sources (nasm). Separate because nasm doesn't share
+   * clang's argv shape; same unquoted-argv contract as cflags.
+   */
   nasmflags?: string[];
   /** Include dirs relative to srcDir (no -I prefix). "." for the root. */
   includes?: string[];
@@ -1184,9 +1191,13 @@ function emitNestedCmake(
   // Compiler flags — GLOBAL flags only. These are the dep-safe subset:
   // CPU target, optimization level, debug info, visibility, sections.
   // NO -Werror, NO bun-specific constexpr limits.
+  //
+  // The tables hold bare argv (see ComputedFlags); CMAKE_<LANG>_FLAGS is a
+  // command-line fragment cmake pastes into the inner build's commands, so
+  // each argument is quoted here for the host that runs them.
   const depFlags = computeDepFlags(cfg);
-  let cflags = depFlags.cflags.join(" ");
-  let cxxflags = depFlags.cxxflags.join(" ");
+  let cflags = quoteArgs(depFlags.cflags, hostWin);
+  let cxxflags = quoteArgs(depFlags.cxxflags, hostWin);
 
   // PIC handling:
   //   spec.pic=true  → add -fPIC (non-windows), also tell cmake
@@ -1499,7 +1510,7 @@ function emitDirect(
     picFlags.push("-fno-pic", "-fno-pie");
   }
 
-  const incFlags = (spec.includes ?? []).map(i => `-I${q(resolve(srcDir, i))}`);
+  const incFlags = (spec.includes ?? []).map(i => `-I${resolve(srcDir, i)}`);
   const defFlags = Object.entries(spec.defines ?? {}).map(([k, v]) => defineFlag(k, v));
   const libFlags = [...baseFlags, ...picFlags, ...incFlags, ...defFlags, ...(spec.cflags ?? [])];
 
@@ -1559,7 +1570,7 @@ function emitDirect(
       rule: "dep_host_cc",
       inputs: [toolSrc],
       orderOnlyInputs: orderOnly,
-      vars: { flags: ["-w", ...toolDefs].join(" ") },
+      vars: { flags: quoteArgs(["-w", ...toolDefs], hostWin) },
     });
     const toolExe = toolOut;
 
@@ -1588,7 +1599,7 @@ function emitDirect(
   // finds literal, subst, and codegen headers alike.
   if (generatedHeader !== undefined) generated.push(generatedHeader);
   const implicit = generated;
-  const genInc = needsBuildDirInc ? [`-I${q(buildDir)}`] : [];
+  const genInc = needsBuildDirInc ? [`-I${buildDir}`] : [];
 
   const objects = spec.sources.map(s => {
     const path = typeof s === "string" ? s : s.path;
@@ -1633,11 +1644,14 @@ function emitDirect(
 }
 
 /**
- * Format a -D flag. String values become shell-escaped C string literals
- * (-DNAME=\"val\" → compiler sees "val"); numbers/true pass through bare.
+ * Format a -D flag as the argument the compiler receives. String values
+ * become C string literals (`-DNAME="val"`); numbers/true pass through bare.
+ * Not shell-escaped: the result goes into compile_commands.json verbatim,
+ * and whoever emits the ninja edge (cc()/cxx(), or the dep_host_cc edge
+ * above) quotes it for build.ninja.
  */
 function defineFlag(name: string, value: string | number | true): string {
   if (value === true) return `-D${name}`;
   if (typeof value === "number") return `-D${name}=${value}`;
-  return `-D${name}=\\"${value}\\"`;
+  return `-D${name}="${value}"`;
 }

--- a/test/internal/build-compile-flags-quoting.test.ts
+++ b/test/internal/build-compile-flags-quoting.test.ts
@@ -13,9 +13,9 @@
  *   <command line>:11:34: error: missing terminating '"' character
  *     #define REPORTED_NODEJS_VERSION \"1.2.3\"
  *
- * These tests run the real flag tables, compile.ts and a direct dep through
- * a Ninja instance and read back both files. Configure-time logic only:
- * nothing is compiled, so they run on every host.
+ * These tests run the real flag tables, compile.ts, a direct dep and a
+ * nested-cmake dep through a Ninja instance and read back both files.
+ * Configure-time logic only: nothing is compiled, so they run on every host.
  */
 import { describe, expect, test } from "bun:test";
 import { isWindows, tempDir } from "harness";
@@ -24,7 +24,7 @@ import { join } from "node:path";
 
 import { cc, cxx, pch, registerCompileRules, registerDirStamps } from "../../scripts/build/compile.ts";
 import { resolveConfig, type Config, type Toolchain } from "../../scripts/build/config.ts";
-import { computeFlags } from "../../scripts/build/flags.ts";
+import { computeDepFlags, computeFlags } from "../../scripts/build/flags.ts";
 import { Ninja, type CompileCommand } from "../../scripts/build/ninja.ts";
 import { registerDepRules, resolveDep, type Dependency } from "../../scripts/build/source.ts";
 
@@ -97,6 +97,21 @@ function syntheticDep(srcDir: string): Dependency {
   };
 }
 
+/**
+ * A nested-cmake dep. Its flags reach the compiler through one more layer:
+ * they are pasted into CMAKE_C_FLAGS, which cmake copies into the inner
+ * build's commands, and that whole -D argument is itself one word of the
+ * outer cmake command line.
+ */
+function syntheticCmakeDep(srcDir: string): Dependency {
+  return {
+    name: "synthcm",
+    source: () => ({ kind: "local", path: srcDir }),
+    build: () => ({ kind: "nested-cmake", args: {}, pic: true, extraCFlags: ['-DSYNTHCM_NAME="a b"'] }),
+    provides: () => ({ libs: ["synthcm"], includes: [] }),
+  };
+}
+
 /** An argv entry that still carries shell syntax: an escaped quote or a posix quote character. */
 const SHELL_SYNTAX = /\\"|'/;
 
@@ -109,16 +124,17 @@ interface Emitted {
 }
 
 /**
- * Emit the PCH, one bun C++ edge using it, one bun C edge and the synthetic
- * dep, then write build.ninja + compile_commands.json like configure does.
- * The build dir (and the dep source tree inside it) contains a space so the
- * paths need quoting too. `hostOs` selects the quoting flavour compile.ts
- * applies; the target stays the test host's so the real tables are used.
+ * Emit the PCH, one bun C++ edge using it, one bun C edge and both synthetic
+ * deps, then write build.ninja + compile_commands.json like configure does.
+ * The build dir (and the dep source trees inside it) contains a space so the
+ * paths need quoting too. `hostOs` selects the quoting flavour the emitters
+ * apply; the target stays the test host's so the real tables are used.
  */
 async function emit(hostOs: "linux" | "windows"): Promise<Emitted> {
   using dir = tempDir("build-flags", {
     "build dir/synth/synth.c": "",
     "build dir/synth/synth-gen.c": "",
+    "build dir/synthcm/CMakeLists.txt": "",
   });
   const resolved = configFor(join(String(dir), "build dir"));
   const cfg: Config = {
@@ -138,6 +154,7 @@ async function emit(hostOs: "linux" | "windows"): Promise<Emitted> {
   cxx(n, cfg, "src/jsc/bindings/BunProcess.cpp", { flags: bunFlags, pch: pchFile, pchHeader: wrapperHeader });
   cc(n, cfg, "src/example.c", { flags: bunFlags });
   resolveDep(n, cfg, syntheticDep(join(cfg.buildDir, "synth")), new Map());
+  resolveDep(n, cfg, syntheticCmakeDep(join(cfg.buildDir, "synthcm")), new Map());
   await n.write();
 
   const ninja = readFileSync(join(cfg.buildDir, "build.ninja"), "utf8");
@@ -228,7 +245,7 @@ describe("compile flags are bare argv in compile_commands.json and quoted only i
   });
 
   test.skipIf(isWindows)("sh splits every build.ninja flags variable back into exactly that argv", async () => {
-    const { ninja, compileCommands, bunFlags } = await emit("linux");
+    const { cfg, ninja, compileCommands, bunFlags } = await emit("linux");
 
     for (const file of ["BunProcess.cpp", "example.c", "synth.c"]) {
       const entry = entryFor(compileCommands, file);
@@ -243,6 +260,11 @@ describe("compile flags are bare argv in compile_commands.json and quoted only i
       "-w",
       '-DGEN_BANNER="gen tool"',
     ]);
+    // Nested cmake: the outer sh yields cmake one -DCMAKE_C_FLAGS=<fragment>
+    // argument, and the inner build's sh later splits <fragment> itself.
+    const cmakeArgs = await shWords(edgeVar(ninja, "deps/synthcm/CMakeCache.txt", "args"));
+    const fragment = cmakeArgs.find(a => a.startsWith("-DCMAKE_C_FLAGS="))!.slice("-DCMAKE_C_FLAGS=".length);
+    expect(await shWords(fragment)).toEqual([...computeDepFlags(cfg).cflags, "-fPIC", '-DSYNTHCM_NAME="a b"']);
   });
 
   test("unix hosts single-quote exactly the arguments that need it", async () => {

--- a/test/internal/build-compile-flags-quoting.test.ts
+++ b/test/internal/build-compile-flags-quoting.test.ts
@@ -1,0 +1,271 @@
+/**
+ * scripts/build writes every compile flag twice: shell-quoted into the
+ * `$cflags`/`$cxxflags` variable of a build.ninja edge, and as one entry of
+ * the `arguments` argv in compile_commands.json. The flag tables therefore
+ * hold the argument exactly as clang receives it (`REPORTED_NODEJS_VERSION="1.2.3"`)
+ * and compile.ts quotes it while writing build.ninja.
+ *
+ * The tables used to hold shell-escaped text (`REPORTED_NODEJS_VERSION=\"1.2.3\"`)
+ * that compile.ts joined verbatim. ninja runs through sh, so the build was
+ * fine, but the same strings landed in compile_commands.json, whose readers
+ * (clangd, clang-tidy, anything replaying an entry) hand argv to clang as-is:
+ *
+ *   <command line>:11:34: error: missing terminating '"' character
+ *     #define REPORTED_NODEJS_VERSION \"1.2.3\"
+ *
+ * These tests run the real flag tables, compile.ts and a direct dep through
+ * a Ninja instance and read back both files. Configure-time logic only:
+ * nothing is compiled, so they run on every host.
+ */
+import { describe, expect, test } from "bun:test";
+import { isWindows, tempDir } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { cc, cxx, pch, registerCompileRules, registerDirStamps } from "../../scripts/build/compile.ts";
+import { resolveConfig, type Config, type Toolchain } from "../../scripts/build/config.ts";
+import { computeFlags } from "../../scripts/build/flags.ts";
+import { Ninja, type CompileCommand } from "../../scripts/build/ninja.ts";
+import { registerDepRules, resolveDep, type Dependency } from "../../scripts/build/source.ts";
+
+/** A fully-populated fake toolchain; nothing in these tests spawns any of it. */
+const toolchain: Toolchain = {
+  cc: "/fake/llvm/bin/clang",
+  cxx: "/fake/llvm/bin/clang++",
+  hostCc: undefined,
+  hostCxx: undefined,
+  clangVersion: "21.1.8",
+  clangResourceDir: "/fake/llvm/lib/clang/21",
+  ar: "/fake/llvm/bin/llvm-ar",
+  ranlib: "/fake/llvm/bin/llvm-ranlib",
+  ld: "/fake/llvm/bin/ld.lld",
+  ld64Lld: undefined,
+  rustLld: undefined,
+  rustLlvmVersion: undefined,
+  rustSysroot: undefined,
+  rustHostTriple: undefined,
+  strip: "/fake/bin/strip",
+  llvmStrip: undefined,
+  dsymutil: undefined,
+  bun: "/fake/bin/bun",
+  jsRuntime: "/fake/bin/bun",
+  esbuild: "/fake/bin/esbuild",
+  ccache: undefined,
+  cmake: "/fake/bin/cmake",
+  cargo: undefined,
+  cargoHome: undefined,
+  rustupHome: undefined,
+  msvcLinker: undefined,
+  rc: undefined,
+  mt: undefined,
+  nasm: undefined,
+};
+
+/** Debug config for the test host with the versions that end up in string defines pinned. */
+function configFor(buildDir: string): Config {
+  return resolveConfig(
+    {
+      buildDir,
+      buildType: "Debug",
+      assertions: true,
+      ci: false,
+      nodejsVersion: "1.2.3",
+      nodejsV8Version: "4.5.6-node.7",
+    },
+    toolchain,
+  );
+}
+
+/**
+ * A direct (compiled in our own graph) dep using every flag shape source.ts
+ * assembles itself: all three `defines` value types, `includes`, the -I for
+ * its generated header, and the host codegen tool's `toolDefines`.
+ */
+function syntheticDep(srcDir: string): Dependency {
+  return {
+    name: "synth",
+    source: () => ({ kind: "local", path: srcDir }),
+    build: () => ({
+      kind: "direct",
+      sources: ["synth.c"],
+      includes: ["inc"],
+      defines: { SYNTH_NAME: "a b", SYNTH_LEVEL: 2, SYNTH_STATIC: true },
+      headers: { "config.h": "#define SYNTH_CONFIG 1\n" },
+      codegen: { tool: "synth-gen.c", toolDefines: { GEN_BANNER: "gen tool" }, args: ["$out"], output: "gen.h" },
+    }),
+    provides: () => ({ libs: [], includes: ["inc"] }),
+  };
+}
+
+/** An argv entry that still carries shell syntax: an escaped quote or a posix quote character. */
+const SHELL_SYNTAX = /\\"|'/;
+
+interface Emitted {
+  cfg: Config;
+  ninja: string;
+  compileCommands: CompileCommand[];
+  /** The argv given to pch()/cxx()/cc() for bun's own sources, assembled the way bun.ts does. */
+  bunFlags: string[];
+}
+
+/**
+ * Emit the PCH, one bun C++ edge using it, one bun C edge and the synthetic
+ * dep, then write build.ninja + compile_commands.json like configure does.
+ * The build dir (and the dep source tree inside it) contains a space so the
+ * paths need quoting too. `hostOs` selects the quoting flavour compile.ts
+ * applies; the target stays the test host's so the real tables are used.
+ */
+async function emit(hostOs: "linux" | "windows"): Promise<Emitted> {
+  using dir = tempDir("build-flags", {
+    "build dir/synth/synth.c": "",
+    "build dir/synth/synth-gen.c": "",
+  });
+  const resolved = configFor(join(String(dir), "build dir"));
+  const cfg: Config = {
+    ...resolved,
+    host: { ...resolved.host, os: hostOs, exeSuffix: hostOs === "windows" ? ".exe" : "" },
+  };
+
+  const flags = computeFlags(cfg);
+  const bunFlags = [...flags.cxxflags, `-I${cfg.buildDir}`, ...flags.defines.map(d => `-D${d}`)];
+
+  const n = new Ninja({ buildDir: cfg.buildDir });
+  registerDirStamps(n, cfg);
+  registerCompileRules(n, cfg);
+  registerDepRules(n, cfg);
+
+  const { pch: pchFile, wrapperHeader } = pch(n, cfg, "src/jsc/bindings/root-pch.h", { flags: bunFlags });
+  cxx(n, cfg, "src/jsc/bindings/BunProcess.cpp", { flags: bunFlags, pch: pchFile, pchHeader: wrapperHeader });
+  cc(n, cfg, "src/example.c", { flags: bunFlags });
+  resolveDep(n, cfg, syntheticDep(join(cfg.buildDir, "synth")), new Map());
+  await n.write();
+
+  const ninja = readFileSync(join(cfg.buildDir, "build.ninja"), "utf8");
+  const compileCommands: CompileCommand[] = JSON.parse(
+    readFileSync(join(cfg.buildDir, "compile_commands.json"), "utf8"),
+  );
+  return { cfg, ninja, compileCommands, bunFlags };
+}
+
+/**
+ * Value of variable `name` on the edge producing `output` (buildDir-relative,
+ * as compile_commands.json records it), unescaped the way ninja substitutes
+ * it into the command. Outputs here contain no characters ninja escapes.
+ */
+function edgeVar(ninja: string, output: string, name: string): string {
+  const lines = ninja.replace(/ \$\n +/g, " ").split("\n");
+  const start = lines.findIndex(l => l.startsWith(`build ${output}:`) || l.startsWith(`build ${output} |`));
+  if (start === -1) throw new Error(`no edge builds ${output}:\n${ninja}`);
+  for (let i = start + 1; i < lines.length && lines[i] !== ""; i++) {
+    const m = /^  (\w+) = (.*)$/.exec(lines[i]!);
+    if (m && m[1] === name) return m[2]!.replaceAll("$$", "$");
+  }
+  throw new Error(`edge for ${output} sets no ${name}:\n${lines.slice(start, start + 8).join("\n")}`);
+}
+
+function entryFor(compileCommands: CompileCommand[], file: string): CompileCommand & { output: string } {
+  const entry = compileCommands.find(e => e.file.endsWith(file));
+  if (entry?.output === undefined) throw new Error(`no compile_commands.json entry with an output for ${file}`);
+  return entry as CompileCommand & { output: string };
+}
+
+/** The flags part of an entry: drop the compiler, the PCH pair compile() appends, and `-c <src> -o <out>`. */
+function entryFlags(entry: CompileCommand): string[] {
+  const args = entry.arguments.slice(1, entry.arguments.lastIndexOf("-c"));
+  const pchAt = args.indexOf("-include-pch");
+  return pchAt === -1 ? args : args.slice(0, pchAt);
+}
+
+/** Word-split a build.ninja variable value exactly as ninja's `sh -c` does. */
+async function shWords(value: string): Promise<string[]> {
+  await using proc = Bun.spawn({ cmd: ["sh", "-c", `printf '%s\\n' ${value}`], stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return stdout.slice(0, -1).split("\n");
+}
+
+describe("compile flags are bare argv in compile_commands.json and quoted only in build.ninja", () => {
+  test("flags.ts holds the string defines as clang receives them", () => {
+    using dir = tempDir("build-flags", {});
+    const cfg = configFor(String(dir));
+    const { cflags, cxxflags, defines } = computeFlags(cfg);
+
+    expect(defines).toContain('REPORTED_NODEJS_VERSION="1.2.3"');
+    expect(defines).toContain('REPORTED_NODEJS_V8_VERSION="4.5.6-node.7"');
+    expect(defines).toContain(`BUN_DYNAMIC_JS_LOAD_PATH="${join(cfg.buildDir, "js").replaceAll("\\", "/")}"`);
+    expect([...cflags, ...cxxflags, ...defines].filter(f => SHELL_SYNTAX.test(f))).toEqual([]);
+  });
+
+  test("compile_commands.json carries the argv verbatim for bun sources and direct deps", async () => {
+    const { cfg, compileCommands, bunFlags } = await emit("linux");
+
+    const bunProcess = entryFor(compileCommands, "BunProcess.cpp");
+    expect(bunProcess.directory).toBe(cfg.buildDir);
+    expect(bunProcess.arguments).toEqual([
+      cfg.cxx,
+      ...bunFlags,
+      "-include-pch",
+      join("pch", "root-pch.h.hxx.pch"),
+      "-c",
+      join(cfg.cwd, "src/jsc/bindings/BunProcess.cpp"),
+      "-o",
+      join(cfg.buildDir, "obj/src/jsc/bindings/BunProcess.cpp" + cfg.objSuffix),
+    ]);
+    expect(bunProcess.arguments).toContain('-DREPORTED_NODEJS_VERSION="1.2.3"');
+    expect(entryFlags(entryFor(compileCommands, "example.c"))).toEqual(bunFlags);
+
+    expect(entryFlags(entryFor(compileCommands, "synth.c"))).toEqual(
+      expect.arrayContaining([
+        `-I${join(cfg.buildDir, "synth/inc")}`,
+        '-DSYNTH_NAME="a b"',
+        "-DSYNTH_LEVEL=2",
+        "-DSYNTH_STATIC",
+        `-I${join(cfg.buildDir, "deps/synth")}`,
+      ]),
+    );
+    expect(compileCommands.flatMap(e => e.arguments).filter(a => SHELL_SYNTAX.test(a))).toEqual([]);
+  });
+
+  test.skipIf(isWindows)("sh splits every build.ninja flags variable back into exactly that argv", async () => {
+    const { ninja, compileCommands, bunFlags } = await emit("linux");
+
+    for (const file of ["BunProcess.cpp", "example.c", "synth.c"]) {
+      const entry = entryFor(compileCommands, file);
+      const words = await shWords(edgeVar(ninja, entry.output, file.endsWith(".cpp") ? "cxxflags" : "cflags"));
+      expect(words).toEqual(entryFlags(entry));
+    }
+    // The PCH has no compile_commands.json entry. It must see the same argv
+    // as the TUs that include it, or clang rejects it over a define mismatch.
+    expect(await shWords(edgeVar(ninja, "pch/root-pch.h.hxx.pch", "cxxflags"))).toEqual(bunFlags);
+    // The dep's codegen tool is compiled by source.ts's own dep_host_cc rule.
+    expect(await shWords(edgeVar(ninja, "deps/synth/codegen-tool", "flags"))).toEqual([
+      "-w",
+      '-DGEN_BANNER="gen tool"',
+    ]);
+  });
+
+  test("unix hosts single-quote exactly the arguments that need it", async () => {
+    const { cfg, ninja, compileCommands } = await emit("linux");
+    const cxxflags = edgeVar(ninja, entryFor(compileCommands, "BunProcess.cpp").output, "cxxflags");
+    const cflags = edgeVar(ninja, entryFor(compileCommands, "synth.c").output, "cflags");
+
+    expect(cxxflags).toContain(` '-I${cfg.buildDir}' `);
+    expect(cxxflags).toContain(` '-DREPORTED_NODEJS_VERSION="1.2.3"' -DREPORTED_NODEJS_ABI_VERSION=`);
+    expect(cflags).toContain(` '-I${join(cfg.buildDir, "synth/inc")}' `);
+    expect(cflags).toContain(` '-DSYNTH_NAME="a b"' -DSYNTH_LEVEL=2 -DSYNTH_STATIC `);
+  });
+
+  test("windows hosts use the doubled-quote form the tool's own argv parser reads", async () => {
+    const { cfg, ninja, compileCommands } = await emit("windows");
+    const cxxflags = edgeVar(ninja, entryFor(compileCommands, "BunProcess.cpp").output, "cxxflags");
+    const cflags = edgeVar(ninja, entryFor(compileCommands, "synth.c").output, "cflags");
+
+    expect(cxxflags).toContain(` "-I${cfg.buildDir}" `);
+    expect(cxxflags).toContain(` "-DREPORTED_NODEJS_VERSION=""1.2.3""" -DREPORTED_NODEJS_ABI_VERSION=`);
+    expect(cflags).toContain(` "-DSYNTH_NAME=""a b""" -DSYNTH_LEVEL=2 -DSYNTH_STATIC `);
+    expect(edgeVar(ninja, join("deps", "synth", "codegen-tool.exe"), "flags")).toBe(`-w "-DGEN_BANNER=""gen tool"""`);
+    // Only the build.ninja side changes with the host.
+    expect(compileCommands.flatMap(e => e.arguments).filter(a => SHELL_SYNTAX.test(a))).toEqual([]);
+  });
+});

--- a/test/internal/build-compile-flags-quoting.test.ts
+++ b/test/internal/build-compile-flags-quoting.test.ts
@@ -14,11 +14,15 @@
  *     #define REPORTED_NODEJS_VERSION \"1.2.3\"
  *
  * These tests run the real flag tables, compile.ts, a direct dep and a
- * nested-cmake dep through a Ninja instance and read back both files.
- * Configure-time logic only: nothing is compiled, so they run on every host.
+ * nested-cmake dep through a Ninja instance and read back both files, then
+ * split the emitted variables with the host's real splitter (sh, or a Win32
+ * argv parser on Windows) and compare against the compile_commands.json
+ * argv. Nothing is compiled, so they run on every host; CI builds Windows
+ * by cross-compiling on Linux, so the Windows test shards are the only place
+ * the Windows-host quoting meets a Windows parser automatically.
  */
 import { describe, expect, test } from "bun:test";
-import { isWindows, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -100,18 +104,33 @@ function syntheticDep(srcDir: string): Dependency {
 
 /**
  * A nested-cmake dep. Its flags reach the compiler through one more layer:
- * they are pasted into CMAKE_C_FLAGS, which cmake copies into the inner
+ * they are pasted into CMAKE_<LANG>_FLAGS, which cmake copies into the inner
  * build's commands, and that whole -D argument is itself one word of the
- * outer cmake command line.
+ * outer cmake command line. The C and C++ extras differ so that the two
+ * languages' lines cannot be swapped without a test noticing.
  */
+const SYNTHCM_EXTRA = { C: '-DSYNTHCM_C="a b"', CXX: '-DSYNTHCM_CXX="c d"' };
+
 function syntheticCmakeDep(srcDir: string): Dependency {
   return {
     name: "synthcm",
     source: () => ({ kind: "local", path: srcDir }),
-    build: () => ({ kind: "nested-cmake", args: {}, pic: true, extraCFlags: ['-DSYNTHCM_NAME="a b"'] }),
+    build: () => ({
+      kind: "nested-cmake",
+      args: {},
+      pic: true,
+      extraCFlags: [SYNTHCM_EXTRA.C],
+      extraCxxFlags: [SYNTHCM_EXTRA.CXX],
+    }),
     provides: () => ({ libs: ["synthcm"], includes: [] }),
   };
 }
+
+/** The dep_configure edge of the nested-cmake dep, as compile_commands.json-style buildDir-relative output. */
+const SYNTHCM_CONFIGURE_OUTPUT = join("deps", "synthcm", "CMakeCache.txt");
+
+/** The quoting flavour of the machine running this test file: what a real configure here would emit. */
+const hostOs = isWindows ? "windows" : "linux";
 
 /** An argv entry that still carries shell syntax: an escaped quote or a posix quote character. */
 const SHELL_SYNTAX = /\\"|'/;
@@ -194,13 +213,30 @@ function entryFlags(entry: CompileCommand): string[] {
   return pchAt === -1 ? args : args.slice(0, pchAt);
 }
 
-/** Word-split a build.ninja variable value exactly as ninja's `sh -c` does. */
-async function shWords(value: string): Promise<string[]> {
-  await using proc = Bun.spawn({ cmd: ["sh", "-c", `printf '%s\\n' ${value}`], stdout: "pipe", stderr: "pipe" });
+/**
+ * Word-split a build.ninja variable value the way the command it is spliced
+ * into gets split on this machine. On unix that is ninja's `sh -c`. On
+ * Windows ninja spawns the tool directly and the tool parses the command
+ * line itself; bun does that with CommandLineToArgvW, so handing it the raw
+ * text via windowsVerbatimArguments runs the variable through a real Win32
+ * argv parser (one of the family that split the `""` spelling this build
+ * system used to emit).
+ */
+async function hostWords(value: string): Promise<string[]> {
+  await using proc = isWindows
+    ? Bun.spawn({
+        // `--` keeps bun from reading the flag words as its own options.
+        cmd: [bunExe(), "-e", "console.log(JSON.stringify(process.argv.slice(1)))", "--", value],
+        windowsVerbatimArguments: true,
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+    : Bun.spawn({ cmd: ["sh", "-c", `printf '%s\\n' ${value}`], stdout: "pipe", stderr: "pipe" });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
-  return stdout.slice(0, -1).split("\n");
+  return isWindows ? JSON.parse(stdout) : stdout.slice(0, -1).split("\n");
 }
 
 describe("compile flags are bare argv in compile_commands.json and quoted only in build.ninja", () => {
@@ -245,27 +281,40 @@ describe("compile flags are bare argv in compile_commands.json and quoted only i
     expect(compileCommands.flatMap(e => e.arguments).filter(a => SHELL_SYNTAX.test(a))).toEqual([]);
   });
 
-  test.skipIf(isWindows)("sh splits every build.ninja flags variable back into exactly that argv", async () => {
-    const { cfg, ninja, compileCommands, bunFlags } = await emit("linux");
+  test("this host splits every build.ninja flags variable back into exactly that argv", async () => {
+    const { cfg, ninja, compileCommands, bunFlags } = await emit(hostOs);
 
     for (const file of ["BunProcess.cpp", "example.c", "synth.c"]) {
       const entry = entryFor(compileCommands, file);
-      const words = await shWords(edgeVar(ninja, entry.output, file.endsWith(".cpp") ? "cxxflags" : "cflags"));
+      const words = await hostWords(edgeVar(ninja, entry.output, file.endsWith(".cpp") ? "cxxflags" : "cflags"));
       expect(words).toEqual(entryFlags(entry));
     }
     // The PCH has no compile_commands.json entry. It must see the same argv
     // as the TUs that include it, or clang rejects it over a define mismatch.
-    expect(await shWords(edgeVar(ninja, "pch/root-pch.h.hxx.pch", "cxxflags"))).toEqual(bunFlags);
+    expect(await hostWords(edgeVar(ninja, join("pch", "root-pch.h.hxx.pch"), "cxxflags"))).toEqual(bunFlags);
     // The dep's codegen tool is compiled by source.ts's own dep_host_cc rule.
-    expect(await shWords(edgeVar(ninja, "deps/synth/codegen-tool", "flags"))).toEqual([
-      "-w",
-      '-DGEN_BANNER="gen tool"',
-    ]);
-    // Nested cmake: the outer sh yields cmake one -DCMAKE_C_FLAGS=<fragment>
-    // argument, and the inner build's sh later splits <fragment> itself.
-    const cmakeArgs = await shWords(edgeVar(ninja, "deps/synthcm/CMakeCache.txt", "args"));
-    const fragment = cmakeArgs.find(a => a.startsWith("-DCMAKE_C_FLAGS="))!.slice("-DCMAKE_C_FLAGS=".length);
-    expect(await shWords(fragment)).toEqual([...computeDepFlags(cfg).cflags, "-fPIC", '-DSYNTHCM_NAME="a b"']);
+    expect(
+      await hostWords(edgeVar(ninja, join("deps", "synth", `codegen-tool${cfg.host.exeSuffix}`), "flags")),
+    ).toEqual(["-w", '-DGEN_BANNER="gen tool"']);
+    // Nested cmake: splitting the configure command yields cmake one
+    // -DCMAKE_<LANG>_FLAGS=<fragment> argument per language, and the inner
+    // build later splits <fragment> itself. (-fPIC: the dep sets pic, which
+    // emitNestedCmake only translates into a flag for non-Windows targets.)
+    const depFlags = computeDepFlags(cfg);
+    const cmakeArgs = await hostWords(edgeVar(ninja, SYNTHCM_CONFIGURE_OUTPUT, "args"));
+    for (const [lang, globals] of [
+      ["C", depFlags.cflags],
+      ["CXX", depFlags.cxxflags],
+    ] as const) {
+      const prefix = `-DCMAKE_${lang}_FLAGS=`;
+      const fragments = cmakeArgs.filter(a => a.startsWith(prefix));
+      expect(fragments).toHaveLength(1);
+      expect(await hostWords(fragments[0]!.slice(prefix.length))).toEqual([
+        ...globals,
+        ...(cfg.windows ? [] : ["-fPIC"]),
+        SYNTHCM_EXTRA[lang],
+      ]);
+    }
   });
 
   test("unix hosts single-quote exactly the arguments that need it", async () => {
@@ -288,6 +337,11 @@ describe("compile flags are bare argv in compile_commands.json and quoted only i
     expect(cxxflags).toContain(` "-DREPORTED_NODEJS_VERSION=\\"1.2.3\\"" -DREPORTED_NODEJS_ABI_VERSION=`);
     expect(cflags).toContain(` "-DSYNTH_NAME=\\"a b\\"" -DSYNTH_LEVEL=2 -DSYNTH_STATIC `);
     expect(edgeVar(ninja, join("deps", "synth", "codegen-tool.exe"), "flags")).toBe(`-w "-DGEN_BANNER=\\"gen tool\\""`);
+    // Nested cmake composes two layers: the fragment's own `\"` escapes are
+    // themselves escaped inside the outer "-DCMAKE_<LANG>_FLAGS=..." word.
+    const cmakeArgs = edgeVar(ninja, SYNTHCM_CONFIGURE_OUTPUT, "args");
+    expect(cmakeArgs).toContain(String.raw` \"-DSYNTHCM_C=\\\"a b\\\"\""`);
+    expect(cmakeArgs).toContain(String.raw` \"-DSYNTHCM_CXX=\\\"c d\\\"\""`);
     // Only the build.ninja side changes with the host; the argv is the same.
     expect(compileCommands.flatMap(e => e.arguments).filter(a => SHELL_SYNTAX.test(a))).toEqual([]);
     expect(entryFlags(entryFor(compileCommands, "synth.c"))).toContain('-DSYNTH_NAME="a b"');

--- a/test/internal/build-compile-flags-quoting.test.ts
+++ b/test/internal/build-compile-flags-quoting.test.ts
@@ -26,6 +26,7 @@ import { cc, cxx, pch, registerCompileRules, registerDirStamps } from "../../scr
 import { resolveConfig, type Config, type Toolchain } from "../../scripts/build/config.ts";
 import { computeDepFlags, computeFlags } from "../../scripts/build/flags.ts";
 import { Ninja, type CompileCommand } from "../../scripts/build/ninja.ts";
+import { quote, quoteArgs } from "../../scripts/build/shell.ts";
 import { registerDepRules, resolveDep, type Dependency } from "../../scripts/build/source.ts";
 
 /** A fully-populated fake toolchain; nothing in these tests spawns any of it. */
@@ -278,16 +279,47 @@ describe("compile flags are bare argv in compile_commands.json and quoted only i
     expect(cflags).toContain(` '-DSYNTH_NAME="a b"' -DSYNTH_LEVEL=2 -DSYNTH_STATIC `);
   });
 
-  test("windows hosts use the doubled-quote form the tool's own argv parser reads", async () => {
+  test("windows hosts use Win32 argv quoting, which every tool's argv parser reads the same way", async () => {
     const { cfg, ninja, compileCommands } = await emit("windows");
     const cxxflags = edgeVar(ninja, entryFor(compileCommands, "BunProcess.cpp").output, "cxxflags");
     const cflags = edgeVar(ninja, entryFor(compileCommands, "synth.c").output, "cflags");
 
     expect(cxxflags).toContain(` "-I${cfg.buildDir}" `);
-    expect(cxxflags).toContain(` "-DREPORTED_NODEJS_VERSION=""1.2.3""" -DREPORTED_NODEJS_ABI_VERSION=`);
-    expect(cflags).toContain(` "-DSYNTH_NAME=""a b""" -DSYNTH_LEVEL=2 -DSYNTH_STATIC `);
-    expect(edgeVar(ninja, join("deps", "synth", "codegen-tool.exe"), "flags")).toBe(`-w "-DGEN_BANNER=""gen tool"""`);
-    // Only the build.ninja side changes with the host.
+    expect(cxxflags).toContain(` "-DREPORTED_NODEJS_VERSION=\\"1.2.3\\"" -DREPORTED_NODEJS_ABI_VERSION=`);
+    expect(cflags).toContain(` "-DSYNTH_NAME=\\"a b\\"" -DSYNTH_LEVEL=2 -DSYNTH_STATIC `);
+    expect(edgeVar(ninja, join("deps", "synth", "codegen-tool.exe"), "flags")).toBe(`-w "-DGEN_BANNER=\\"gen tool\\""`);
+    // Only the build.ninja side changes with the host; the argv is the same.
     expect(compileCommands.flatMap(e => e.arguments).filter(a => SHELL_SYNTAX.test(a))).toEqual([]);
+    expect(entryFlags(entryFor(compileCommands, "synth.c"))).toContain('-DSYNTH_NAME="a b"');
+  });
+});
+
+describe("shell.ts quote()", () => {
+  test("passes plain flags and paths through unquoted on both hosts", () => {
+    for (const arg of ["-O2", "-DFOO=1", "-IC:\\bun\\src", "/clang:-march=armv8-a+crc", "--sysroot=/opt/x"]) {
+      expect(quote(arg, false)).toBe(arg);
+      expect(quote(arg, true)).toBe(arg);
+    }
+  });
+
+  test("posix: single-quotes, escaping embedded single quotes", () => {
+    expect(quoteArgs(['-DX="a b"', "-I/tmp/build dir", "it's", ""], false)).toBe(
+      `'-DX="a b"' '-I/tmp/build dir' 'it'\\''s' ''`,
+    );
+  });
+
+  test('windows: double-quotes, \\" for quotes, and doubles only the backslashes that precede a quote', () => {
+    expect(
+      ['-DX="a b"', '-DEMPTY=""', "-IC:\\build dir\\inc", "-IC:\\build dir\\", '-DP="C:\\x y\\"', ""].map(a =>
+        quote(a, true),
+      ),
+    ).toEqual([
+      `"-DX=\\"a b\\""`,
+      `"-DEMPTY=\\"\\""`,
+      `"-IC:\\build dir\\inc"`,
+      `"-IC:\\build dir\\\\"`,
+      `"-DP=\\"C:\\x y\\\\\\""`,
+      `""`,
+    ]);
   });
 });


### PR DESCRIPTION
### Problem
- `build/<profile>/compile_commands.json` (what `.clangd` and `.vscode/c_cpp_properties.json` point at) does not work in clangd. Replaying the `BunProcess.cpp` entry with no shell gives `error: missing terminating '"' character [-Werror,-Winvalid-pp-token]` three times plus `expected expression` follow-ons, 9 errors in all.
- The entries hold shell-escaped text such as `-DREPORTED_NODEJS_VERSION=\"26.3.0\"`, backslashes included, but the `arguments` form of the file is an argv, so clangd hands the backslashes to clang. Nine distinct arguments in a debug configure are affected, three of them present in every TU.
- Cause: the escaping lived in the flag tables, and the same arrays were both joined into ninja command lines (where the escaping was right) and written into compile_commands.json (where it was wrong). One array cannot be a command-line fragment and an argv at the same time.
- Latent, same cause: a build dir or `-I` path containing a space split on the ninja command line.

### Fix
- Flag arrays are now bare argv, each entry exactly as the compiler receives it (`REPORTED_NODEJS_VERSION="26.3.0"`); the few entries that quoted themselves inline become bare paths. Quoting moves to the points that write a command line: the compile, PCH, nasm and host-tool edges in `build.ninja`, and the `CMAKE_<LANG>_FLAGS` value handed to nested cmake deps. compile_commands.json gets the arrays unchanged.
- Property to check: every argument is quoted at exactly one command-line edge and never in the data, so both files come from one argv. On Linux the new `build.ninja` is byte-identical to main's once the nine defines are mapped back, and the compiler argv is unchanged, so ccache still hits.
- On a Windows host `quote()` now spells an embedded quote as `\"` instead of `""`: the ccache our bootstrap installs ends a quoted span at `""`, so a define holding both a quote and a space reached clang-cl split in two. CI cross-compiles Windows from Linux, so this path was checked by hand.
- Verification: a new test emits real edges through a Ninja instance and splits each emitted variable with the host's real splitter (`sh`, or a Win32 argv parser on Windows) back into the compile_commands.json argv; five of its cases fail on main and pass here on Linux and a Windows host. Full `bun bd` on both, and the `BunProcess.cpp` entry now replays clean. The automated fail-before check cannot cover a change under `scripts/`.

### Background
- `compile_commands.json` (the JSON Compilation Database) is how clangd, clang-tidy and editors learn how each TU is compiled. Its `arguments` form is a literal argv: no shell reads it, so shell escaping in an entry reaches the compiler as literal characters.
- A ninja rule command is the opposite: on unix ninja hands it to `sh`, on Windows to `CreateProcess`, where the tool's own argv parser splits it. Anything containing quotes or spaces has to be quoted for that splitter, and `scripts/build/shell.ts` is the one helper the build scripts use for that.
- `scripts/build` generates `build.ninja` and `compile_commands.json` from the same flag tables and per-dependency specs, so every compile flag is written into both files. A PCH must be built with the same defines as the TUs that include it, which is why the PCH edge has to be quoted the same way as the compile edges.
- String defines such as `-DREPORTED_NODEJS_VERSION="26.3.0"` carry double quotes on purpose: the macro has to expand to a C string literal. They are the only compile-side arguments that contain a quote, which is why they were the only ones that broke.
- Win32 argv rules: inside a double-quoted argument an embedded quote is spelled `\"`, and a backslash is only special in front of a quote. `""` is a cmd.exe spelling that some parsers accept (LLVM's) and others do not (the msvcrt argv parser, `CommandLineToArgvW`).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

## Problem

`build/<profile>/compile_commands.json` (what `.clangd` and `.vscode/c_cpp_properties.json` point at) uses the `arguments` form, but the entries were the same shell-escaped strings that go on the ninja command line:

```
-DREPORTED_NODEJS_VERSION=\"26.3.0\"
-DREPORTED_NODEJS_V8_VERSION=\"14.6.202.34-node.20\"
-DBUN_DYNAMIC_JS_LOAD_PATH=\"/workspace/bun/build/debug/js\"
```

(the backslashes are real characters in the JSON strings). `arguments` is an argv, so clangd, clang-tidy, or anything replaying an entry passes the backslashes straight to clang. Replaying the `BunProcess.cpp` entry with `subprocess.run(entry["arguments"])` (no shell) plus `-fsyntax-only`:

```
<command line>:11:34: error: missing terminating '"' character [-Werror,-Winvalid-pp-token]
<command line>:13:37: error: missing terminating '"' character [-Werror,-Winvalid-pp-token]
<command line>:18:35: error: missing terminating '"' character [-Werror,-Winvalid-pp-token]
src/jsc/bindings/BunProcess.cpp:227:140: error: expected expression
...
9 errors generated.
```

Every TU is affected (the three defines are in every bun compile), and `InternalModuleRegistry.cpp` / `BunProcess.cpp`, which expand the macros, get the follow-on errors in clangd. The direct deps have the same problem through `defineFlag()` in `source.ts`: `TCC_VERSION`, `TCC_GITHASH`, `TCC_LIBTCC1`, `XXH_HEADER_NAME` (zstd, lshpack, lsquic), `LSQPACK_{ENC,DEC}_LOGGER_HEADER`. Nine distinct escaped arguments in a debug configure.

## Cause

The escaping lived in the data. `flags.ts` stored `REPORTED_NODEJS_VERSION=\"...\"` ("shell-escaped quotes so clang receives literal quotes"), `source.ts` `defineFlag()` did the same for string defines, and `compile.ts` joined the arrays into `$cflags`/`$cxxflags` with `join(" ")` while also spreading the same arrays into `addCompileCommand()`. The arrays were therefore command-line fragments for one consumer and argv for the other; they can only be one of those. A few entries had already grown inline `quote()` calls for the same reason (`/winsysroot`, direct-dep `-I` paths, boringssl's nasm `-I`), which have the same mismatch.

## Fix

Flag arrays are argv. The tables and dep specs hold the argument exactly as the compiler receives it (`REPORTED_NODEJS_VERSION="26.3.0"`), and quoting happens at the point where a command line is assembled:

- `compile.ts`: `cc()`/`cxx()`/`pch()`/`nasm()` run the flags through `quoteArgs()` for the host when writing the ninja variable. The PCH edge goes through the same function as the TUs, so they keep seeing identical argv (clang rejects a PCH whose defines differ from the TU). `compile_commands.json` keeps getting the arrays verbatim, which is now correct.
- `source.ts`: `defineFlag()` emits `-DNAME="value"`; the `dep_host_cc` edge quotes its own `$flags`; `emitNestedCmake` assembles the global dep flags, PIC flags and a dep's `extraCFlags`/`extraCxxFlags` as one argv and quotes it once into `CMAKE_<LANG>_FLAGS` (a command-line fragment for the inner build); the inline `-I${q(...)}` quoting is dropped since the emitters quote.
- `flags.ts` / `deps/boringssl.ts`: the pre-quoted `/winsysroot` and nasm `-I` entries become bare paths. `ComputedFlags` documents the contract, and that `ldflags`/`stripflags` are still joined verbatim by `link()`/strip (unchanged in this PR; the two linker entries that quote themselves stay as they are).
- `shell.ts`: on Windows, `quote()` now spells an embedded quote as `\"` (and doubles a backslash run only where it precedes a quote) instead of doubling it to `""`. The compile edges are the first place arguments containing quotes go through `quote()` in volume, and the `""` spelling turned out not to be read consistently: clang-cl (LLVM's tokenizer) accepts it, but the ccache 4.12 build our bootstrap installs on x64 is linked against msvcrt.dll (`__getmainargs`, the pre-UCRT argv rules, same family as `CommandLineToArgvW`, which bun itself uses), and that family ends the quoted span at `""`, so an argument holding both a quote and a space, which is exactly what `BUN_DYNAMIC_JS_LOAD_PATH` is in a checkout whose path contains a space, reached clang-cl split in two (`clang-cl: warning: b": 'linker' input unused`). The `\"` form is the documented Win32 rule implemented by the MS CRT, `CommandLineToArgvW`, LLVM, Go, and ninja's own `$in`/`$out` escaping.

### Why this is the right layer

The JSON Compilation Database spec defines `arguments` as an unescaped argv, and ninja defines a rule command as a line handed to `sh` (or, on Windows, to `CreateProcess`, where the tool's own argv parser splits it). One array cannot satisfy both unless quoting is applied at the command-line edge, which is also what `quoteArgs()` exists for and what the other rule emitters in `source.ts`/`rust.ts`/`codegen.ts` already do. Unescaping at the compile_commands side instead would mean reverse-engineering shell syntax out of the data and would leave the latent bug that a path with a space in `BUN_DYNAMIC_JS_LOAD_PATH`, or any `-I`, split on the ninja command line; those now survive as a side effect (on Windows too, which is what the `shell.ts` change is for).

## Blast radius

I audited every compile-side flag source (`globalFlags`, `bunOnlyFlags`, `defines`, `fileOverrides`, `computeDepFlags`, and the `cflags`/`nasmflags`/`defines`/per-source flags of all direct deps) across linux x64 debug/release/release-ci/release-asan, darwin arm64 debug/release, and windows x64/arm64 cross configs: the nine string defines are the only arguments outside `quote()`'s pass-through set, and no entry contains an embedded space. Checked directly against the generated files:

- Linux debug: after mapping `'-DX="v"'` back to `-DX=\"v\"`, the new `build.ninja` is byte-identical to `main`'s, and `compile_commands.json` differs only in those nine arguments (1735 entries). The posix branch of `quote()` is untouched.
- Windows x64 host (native debug configure): the `shell.ts` change alters exactly twelve distinct tokens relative to the `""` spelling: the same nine defines, plus the three codegen edges that pass `--define:process.env.NODE_ENV="production"` to esbuild / `bun build` (bun-error, runtime.bun.js, react-refresh), which were the only pre-existing quoted arguments containing a quote. Every other line of `build.ninja` is identical; `compile_commands.json` is identical. Note that CI cross-compiles the Windows binaries on Linux, so the Windows-host configure path is not covered by a CI build; the evidence for it is the manual runs below plus the test's Windows round trip, which does run on the Windows test shards.

The nested-cmake change is a no-op today (no dep sets `extraCFlags`, WebKit local mode overrides `CMAKE_<LANG>_FLAGS` itself, and the global flags contain nothing that quotes). Since the edge commands change, existing build dirs recompile once; ccache hits because the compiler argv is unchanged.

## Verification

- Linux: full `bun bd` with the new command lines; `bun bd -p` reports `process.version` `v26.3.0` and `process.versions.v8` `14.6.202.34-node.20`, zstd/lshpack/lsquic (`#include XXH_HEADER_NAME`) and tinycc compile. Replaying the `BunProcess.cpp` entry from `compile_commands.json` with no shell and `-fsyntax-only` failed with the errors above before and exits 0 now; the `InternalModuleRegistry.cpp` entry (expands `BUN_DYNAMIC_JS_LOAD_PATH`) replays cleanly too.
- Windows x64 host: a fresh `bun bd` of the first commit (`""` spelling) built everything through ccache + clang-cl; rebuilding with the final `\"` spelling re-ran the three codegen edges (the define is applied: the bundles contain no `process.env.NODE_ENV` and no bare `production` identifier) and the ~260 compile edges whose command changed, all of which were ccache hits (statslog: 260 direct hits, 2 preprocessed hits, no new misses), i.e. ccache and clang-cl derive the same argv from the new spelling as from the old. `bun-debug.exe` reports the same versions. A minimal `build.ninja` copying our `cc`/`nasm` rules showed the difference between the spellings: through ccache, `"-DX=""a b"""` splits while `"-DX=\"a b\""` compiles (the object contains `a b`), clang-cl alone preprocesses both correctly, and nasm accepts a quoted `-I` containing a space.
- New `test/internal/build-compile-flags-quoting.test.ts` drives the real tables, `compile.ts`, a synthetic direct dep (all three define value types, `includes`, the generated-header `-I`, `toolDefines`, build dir containing a space) and a synthetic nested-cmake dep (`extraCFlags` with a quoted define) through a `Ninja` instance and reads both files back: `compile_commands.json` holds the argv verbatim; the host's real splitter word-splits every emitted `$cflags`/`$cxxflags`/`$flags` (TUs, PCH, `dep_host_cc`) back into exactly that argv (`sh` on unix; on Windows, bun spawned with `windowsVerbatimArguments`, i.e. `CommandLineToArgvW`, the parser family that split the `""` spelling), and the nested dep's `-DCMAKE_C_FLAGS=` and `-DCMAKE_CXX_FLAGS=` fragments (distinct C and C++ extras) split back into their argv through both quoting layers; the unix and windows host flavours emit the expected spelling, including how the two nested-cmake layers compose; and `quote()` itself is pinned for the quote, quote-plus-space, trailing-backslash and empty cases on both hosts. The five emission tests fail against `main`'s `scripts/build` and pass with this branch on Linux and on a Windows host; on the Windows host the round trip also fails against the intermediate `""` spelling (checked by putting the first commit's `shell.ts` back), and mutating the C++ side of `emitNestedCmake` (unquoted, swapped to the C flags, or dropped) fails it too. Neighbouring build-script tests (`build-post-link-ordering`, `windows-cross-config`, `macos-cross-config`, `build-rust-toolchain-probe`) still pass.

Note: the fix is in `scripts/`, not `src/`, so the automated fail-before check (which stashes `src/` and `packages/`) cannot revert it; the before/after runs above are the proof.

</details>
