### PR TITLE
node:http: abort the in-flight request when an HTTP/1 fallback connection closes

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -3,6 +3,7 @@
 // See https://github.com/nodejs/node/blob/main/lib/_http_server.js connectionListener.
 const { STATUS_CODES } = require("internal/http");
 const { SafeSet } = require("internal/primordials");
+const { ConnResetException } = require("internal/shared");
 
 const kHttp1Connections = Symbol("http1Connections");
 const kHttp1ActiveRequests = Symbol("http1ActiveRequests");
@@ -401,6 +402,7 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.removeListener("data", onHttp1SocketData);
       socket.removeListener("error", onHttp1SocketErrorListener);
       socket.removeListener("end", onHttp1SocketEnd);
+      socket.removeListener("close", onHttp1SocketClose);
       connections.delete(socket);
       try {
         parser.close();
@@ -428,7 +430,6 @@ function connectionListenerHTTP1(server, socket, options) {
       return;
     }
     if (!server.httpAllowHalfOpen) {
-      if (req && !req.complete) req.destroy();
       if (socket.writable) socket.end();
       return;
     }
@@ -439,15 +440,26 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.end();
     }
   }
-  socket.on("data", onHttp1SocketData);
-  socket.on("error", onHttp1SocketErrorListener);
-  socket.once("end", onHttp1SocketEnd);
-  socket.once("close", () => {
+  // Node's socketOnClose: free the parser, then abortIncoming(). The request
+  // node would still have in state.incoming is the one whose response is still
+  // assigned to the socket (a finished response detached itself on 'finish');
+  // destroying it emits 'aborted' and 'close', and 'error' (ECONNRESET) when
+  // something listens for it. Registered before any response's assignSocket()
+  // 'close' listener so req 'aborted' precedes res 'close', as in node.
+  function onHttp1SocketClose() {
     connections.delete(socket);
     try {
       parser.close();
     } catch {}
-  });
+    const inflightReq = socket._httpMessage?.req;
+    if (inflightReq && !inflightReq.destroyed) {
+      inflightReq.destroy(new ConnResetException("aborted"));
+    }
+  }
+  socket.on("data", onHttp1SocketData);
+  socket.on("error", onHttp1SocketErrorListener);
+  socket.once("end", onHttp1SocketEnd);
+  socket.once("close", onHttp1SocketClose);
 }
 
 function closeIdleHttp1Connections(server) {

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -440,8 +440,7 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.end();
     }
   }
-  // Node's socketOnClose (freeParser + abortIncoming). Must be registered before
-  // any response's assignSocket() 'close' listener: req 'aborted' precedes res 'close'.
+  // Node's socketOnClose: freeParser, then abortIncoming.
   function onHttp1SocketClose() {
     connections.delete(socket);
     try {
@@ -456,6 +455,7 @@ function connectionListenerHTTP1(server, socket, options) {
   socket.on("data", onHttp1SocketData);
   socket.on("error", onHttp1SocketErrorListener);
   socket.once("end", onHttp1SocketEnd);
+  // Ahead of every response's assignSocket() 'close' listener: req 'aborted' precedes res 'close'.
   socket.once("close", onHttp1SocketClose);
 }
 

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -1,7 +1,7 @@
 // JS HTTP/1 server path over an arbitrary Duplex with a JS stand-in for NodeHTTPResponse.
 // Used by http2's `allowHTTP1` ALPN fallback and http's `server.emit("connection", socket)`.
 // See https://github.com/nodejs/node/blob/main/lib/_http_server.js connectionListener.
-const { STATUS_CODES } = require("internal/http");
+const { STATUS_CODES, NodeHTTPResponseFlags } = require("internal/http");
 const { SafeSet } = require("internal/primordials");
 const { ConnResetException } = require("internal/shared");
 
@@ -148,7 +148,11 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
   }
 
   const handle = {
-    flags: 0,
+    // Like NodeHTTPResponse once the connection is gone: ServerResponse's write()/end()
+    // then emit no 'finish', so the response stays assigned for onHttp1SocketClose to abort.
+    get flags() {
+      return socket.writable ? 0 : NodeHTTPResponseFlags.socket_closed;
+    },
     ended: false,
     finished: false,
     aborted: false,

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -440,17 +440,14 @@ function connectionListenerHTTP1(server, socket, options) {
       socket.end();
     }
   }
-  // Node's socketOnClose: free the parser, then abortIncoming(). The request
-  // node would still have in state.incoming is the one whose response is still
-  // assigned to the socket (a finished response detached itself on 'finish');
-  // destroying it emits 'aborted' and 'close', and 'error' (ECONNRESET) when
-  // something listens for it. Registered before any response's assignSocket()
-  // 'close' listener so req 'aborted' precedes res 'close', as in node.
+  // Node's socketOnClose (freeParser + abortIncoming). Must be registered before
+  // any response's assignSocket() 'close' listener: req 'aborted' precedes res 'close'.
   function onHttp1SocketClose() {
     connections.delete(socket);
     try {
       parser.close();
     } catch {}
+    // Node's state.incoming equivalent: a finished response detached on 'finish'.
     const inflightReq = socket._httpMessage?.req;
     if (inflightReq && !inflightReq.destroyed) {
       inflightReq.destroy(new ConnResetException("aborted"));

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -148,13 +148,15 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
   }
 
   const handle = {
-    // Like NodeHTTPResponse after its connection closed: ServerResponse's write()/end() then emit no 'finish'.
+    // Derived from the connection like NodeHTTPResponse's socket-closed bit; write()/end() then emit no 'finish'.
     get flags() {
       return socket.writable ? 0 : NodeHTTPResponseFlags.socket_closed;
     },
+    get aborted() {
+      return !handle.ended && !socket.writable;
+    },
     ended: false,
     finished: false,
-    aborted: false,
     bufferedAmount: 0,
     shouldKeepAlive,
     onfinished: null,
@@ -227,7 +229,6 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
       return length;
     },
     abort() {
-      this.aborted = true;
       if (!socket.destroyed) socket.destroy();
     },
   };

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -148,8 +148,7 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
   }
 
   const handle = {
-    // Like NodeHTTPResponse once the connection is gone: ServerResponse's write()/end()
-    // then emit no 'finish', so the response stays assigned for onHttp1SocketClose to abort.
+    // Like NodeHTTPResponse after its connection closed: ServerResponse's write()/end() then emit no 'finish'.
     get flags() {
       return socket.writable ? 0 : NodeHTTPResponseFlags.socket_closed;
     },

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4259,6 +4259,91 @@ it("connectionListener aborts the request when its response is destroyed", async
   expect(req.aborted).toBe(true);
 });
 
+const GET = "GET /events HTTP/1.1\r\nHost: x\r\n\r\n";
+// A long-poll / event-stream handler: the request completed with its headers
+// and the response stays open.
+function startStreamingResponse(_req: IncomingMessage, res: ServerResponse) {
+  res.writeHead(200, { "content-type": "text/event-stream" });
+  res.write("data: hi\n\n");
+}
+
+it("connectionListener aborts a completed request with an open response when the peer hangs up", async () => {
+  // The parser has nothing to complain about at EOF, so node's socketOnEnd
+  // just ends the connection; the abort comes from the 'close' that follows.
+  const t = connectionListenerRequest(GET, startStreamingResponse);
+  const { req } = await t.dispatched;
+  t.clientSide.end();
+  await t.connectionClosed();
+  expect(t.events).toEqual(ABORTED_EVENTS);
+  expect({ complete: req.complete, aborted: req.aborted }).toEqual({ complete: true, aborted: true });
+});
+
+it("connectionListener aborts the request when the response is ended after the peer hung up", async () => {
+  // Once the connection stopped being writable, a res.end() cannot reach the
+  // wire. Like node (the bytes are parked, nothing is written) it must not
+  // count as the response finishing, or the request would be left out of the
+  // abort, and it must not surface as a 'clientError' from writing to the
+  // ended connection.
+  const t = connectionListenerRequest(GET, (req, res) => {
+    // Runs after the listener's own 'end' handler has ended the connection.
+    req.socket.once("end", () => res.end("bye"));
+  });
+  const clientErrors: string[] = [];
+  t.server.on("clientError", (err: any, socket) => {
+    clientErrors.push(err.code);
+    socket.destroy();
+  });
+  const { req } = await t.dispatched;
+  t.clientSide.end();
+  await t.connectionClosed();
+  expect({ events: t.events, clientErrors }).toEqual({ events: ABORTED_EVENTS, clientErrors: [] });
+  expect(req.aborted).toBe(true);
+});
+
+const destroyThenEndTriggers: [string, (req: IncomingMessage, server: Server) => void][] = [
+  ["req.socket.destroy()", req => req.socket.destroy()],
+  ["server.closeAllConnections()", (_req, server) => server.closeAllConnections()],
+];
+
+for (const [trigger, destroyConnection] of destroyThenEndTriggers) {
+  it(`connectionListener aborts the request when res.end() follows ${trigger} on a net socket`, async () => {
+    // A net.Socket emits 'close' a turn after destroy(). A res.end() issued in
+    // between cannot reach the wire, and like node (and the native server) it
+    // must not emit 'finish' and release the response, or the close path finds
+    // nothing to abort. A duplexPair emits 'close' too early to exercise this.
+    const events: string[] = [];
+    const connectionClosed = Promise.withResolvers<IncomingMessage>();
+    const httpServer = createServer((req, res) => {
+      req.on("aborted", () => events.push("req-aborted"));
+      req.on("error", (err: any) => events.push("req-error:" + err.code));
+      req.on("close", () => events.push("req-close"));
+      res.on("finish", () => events.push("res-finish"));
+      res.on("close", () => events.push("res-close"));
+      req.socket.on("close", () => connectionClosed.resolve(req));
+      destroyConnection(req, httpServer);
+      res.end("late");
+    });
+    const netServer = createNetServer(socket => httpServer.emit("connection", socket));
+    netServer.listen(0, "127.0.0.1");
+    await once(netServer, "listening");
+    const { port } = netServer.address() as AddressInfo;
+    const client = connect(port, "127.0.0.1", () => {
+      client.write(PARTIAL_POST);
+    });
+    client.on("error", () => {});
+    try {
+      const req = await connectionClosed.promise;
+      // The request's 'error'/'close' are nextTick hops behind the socket's 'close'.
+      await new Promise(resolve => setImmediate(resolve));
+      expect(events).toEqual(ABORTED_EVENTS);
+      expect({ destroyed: req.destroyed, aborted: req.aborted }).toEqual({ destroyed: true, aborted: true });
+    } finally {
+      client.destroy();
+      netServer.close();
+    }
+  });
+}
+
 it("connectionListener does not abort a request whose response already finished when the connection closes", async () => {
   // Node's resOnFinish takes the request out of the abort list: a connection
   // that dies afterwards (here with the request body still unfinished) leaves

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4321,7 +4321,8 @@ for (const [trigger, destroyConnection] of destroyThenEndTriggers) {
       res.on("close", () => events.push("res-close"));
       req.socket.on("close", () => connectionClosed.resolve(req));
       destroyConnection(req, httpServer);
-      res.end("late");
+      // Still chainable, like node's end() (and the native response's on a closed connection).
+      events.push(res.end("late") === res ? "end-returned-res" : "end-returned-other");
     });
     const netServer = createNetServer(socket => httpServer.emit("connection", socket));
     netServer.listen(0, "127.0.0.1");
@@ -4335,7 +4336,7 @@ for (const [trigger, destroyConnection] of destroyThenEndTriggers) {
       const req = await connectionClosed.promise;
       // The request's 'error'/'close' are nextTick hops behind the socket's 'close'.
       await new Promise(resolve => setImmediate(resolve));
-      expect(events).toEqual(ABORTED_EVENTS);
+      expect(events).toEqual(["end-returned-res", ...ABORTED_EVENTS]);
       expect({ destroyed: req.destroyed, aborted: req.aborted }).toEqual({ destroyed: true, aborted: true });
     } finally {
       client.destroy();

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,223 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+// Feeds one request to a server through server.emit("connection", duplex) (the
+// JS connectionListener) and records the request/response lifecycle events in
+// the order they fire. A duplexPair does not propagate destroy() to the other
+// side, so the scenarios close the connection from the server's half, the way
+// a reset TCP connection would surface.
+function connectionListenerRequest(
+  requestBytes: string,
+  handler?: (req: IncomingMessage, res: ServerResponse) => void,
+  { reqErrorListener = true } = {},
+) {
+  const events: string[] = [];
+  const dispatched = Promise.withResolvers<{ req: IncomingMessage; res: ServerResponse }>();
+  const resClosed = Promise.withResolvers<void>();
+  const server = createServer((req, res) => {
+    req.on("aborted", () => events.push("req-aborted"));
+    if (reqErrorListener) req.on("error", (err: any) => events.push("req-error:" + err.code));
+    req.on("close", () => events.push("req-close"));
+    res.on("finish", () => events.push("res-finish"));
+    res.on("close", () => {
+      events.push("res-close");
+      resClosed.resolve();
+    });
+    handler?.(req, res);
+    dispatched.resolve({ req, res });
+  });
+  const [clientSide, serverSide] = duplexPair();
+  const serverSideClosed = new Promise<void>(resolve => serverSide.on("close", resolve));
+  clientSide.resume();
+  server.emit("connection", serverSide);
+  clientSide.write(requestBytes);
+  return {
+    server,
+    events,
+    clientSide,
+    serverSide,
+    dispatched: dispatched.promise,
+    resClosed: resClosed.promise,
+    // Resolves once the connection has closed and the request's deferred
+    // 'error'/'close' (process.nextTick hops behind the socket's 'close') have
+    // had their turn, so `events` is final either way.
+    async connectionClosed() {
+      await serverSideClosed;
+      await new Promise(resolve => setImmediate(resolve));
+    },
+  };
+}
+
+const PARTIAL_POST = "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc";
+
+it("connectionListener aborts the in-flight request when the connection closes, like Node", async () => {
+  // Node's socketOnClose runs abortIncoming(): every request whose response has
+  // not finished is destroyed with an ECONNRESET "aborted" error, so it emits
+  // 'aborted' (before the response's 'close'), then 'error' only if something
+  // listens, then 'close'. The event orders below are Node v26's.
+  const aborted = ["req-aborted", "res-close", "req-error:ECONNRESET", "req-close"];
+
+  // The connection is reset while the request body is still arriving.
+  {
+    const t = connectionListenerRequest(PARTIAL_POST);
+    const { req } = await t.dispatched;
+    t.serverSide.destroy();
+    await t.connectionClosed();
+    expect(t.events).toEqual(aborted);
+    expect({
+      destroyed: req.destroyed,
+      aborted: req.aborted,
+      complete: req.complete,
+      errored: (req.errored as any)?.code,
+    }).toEqual({ destroyed: true, aborted: true, complete: false, errored: "ECONNRESET" });
+  }
+
+  // Without an 'error' listener the error is not emitted (it would otherwise be
+  // an uncaught exception), but req.errored still carries it.
+  {
+    const t = connectionListenerRequest(PARTIAL_POST, undefined, { reqErrorListener: false });
+    const { req } = await t.dispatched;
+    t.serverSide.destroy();
+    await t.connectionClosed();
+    expect(t.events).toEqual(["req-aborted", "res-close", "req-close"]);
+    expect((req.errored as any)?.code).toBe("ECONNRESET");
+  }
+
+  // server.closeAllConnections() destroys the connection from the server side.
+  {
+    const t = connectionListenerRequest(PARTIAL_POST);
+    await t.dispatched;
+    t.server.closeAllConnections();
+    await t.connectionClosed();
+    expect(t.events).toEqual(aborted);
+  }
+
+  // The peer hangs up (FIN) with the body cut short: the parser flags the
+  // truncated message, the connection is torn down, and the request is aborted.
+  {
+    const t = connectionListenerRequest(PARTIAL_POST);
+    await t.dispatched;
+    t.clientSide.end();
+    await t.connectionClosed();
+    expect(t.events).toEqual(aborted);
+  }
+
+  // A body-less request is complete as far as the parser is concerned, but its
+  // response is still pending, so it is aborted too (Node keys this off the
+  // response, not off req.complete).
+  {
+    const t = connectionListenerRequest("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    const { req } = await t.dispatched;
+    t.serverSide.destroy();
+    await t.connectionClosed();
+    expect(t.events).toEqual(aborted);
+    expect({ complete: req.complete, aborted: req.aborted }).toEqual({ complete: true, aborted: true });
+  }
+
+  // res.destroy() tears the connection down, which aborts the request as well.
+  // (The response emits its own 'close' synchronously from destroy(), so only
+  // the request's events are order-checked here.)
+  {
+    const t = connectionListenerRequest(PARTIAL_POST);
+    const { req, res } = await t.dispatched;
+    res.destroy();
+    await t.connectionClosed();
+    expect(t.events.filter(event => event.startsWith("req-"))).toEqual([
+      "req-aborted",
+      "req-error:ECONNRESET",
+      "req-close",
+    ]);
+    expect(t.events).toContain("res-close");
+    expect(req.aborted).toBe(true);
+  }
+});
+
+it("connectionListener does not abort a request whose response already finished when the connection closes", async () => {
+  // Node's resOnFinish takes the request out of the abort list: a connection
+  // that dies afterwards (here with the request body still unfinished) leaves
+  // the request untouched.
+  const t = connectionListenerRequest(PARTIAL_POST, (_req, res) => res.end("answered early"));
+  const { req } = await t.dispatched;
+  await t.resClosed;
+  t.serverSide.destroy();
+  await t.connectionClosed();
+  expect(t.events).toEqual(["res-finish", "res-close"]);
+  expect({ destroyed: req.destroyed, aborted: req.aborted }).toEqual({ destroyed: false, aborted: false });
+});
+
+it("connectionListener aborts only the keep-alive request that is in flight when the connection closes", async () => {
+  // The first exchange completed and released the connection; the second
+  // request's body is still arriving when the connection dies. Node aborts the
+  // second request and does not touch the first.
+  const events: Record<string, string[]> = { "/1": [], "/2": [] };
+  const requests: Record<string, IncomingMessage> = {};
+  const firstReqClosed = Promise.withResolvers<void>();
+  const firstResClosed = Promise.withResolvers<void>();
+  const server = createServer((req, res) => {
+    const tag = req.url!;
+    requests[tag] = req;
+    req.on("aborted", () => events[tag].push("aborted"));
+    req.on("error", (err: any) => events[tag].push("error:" + err.code));
+    req.on("close", () => events[tag].push("close"));
+    res.on("close", () => events[tag].push("res-close"));
+    if (tag === "/1") {
+      req.on("close", () => firstReqClosed.resolve());
+      res.on("close", () => firstResClosed.resolve());
+      res.end("one");
+      return;
+    }
+    serverSide.destroy();
+  });
+  const [clientSide, serverSide] = duplexPair();
+  const serverSideClosed = new Promise<void>(resolve => serverSide.on("close", resolve));
+  let received = "";
+  const firstAnswered = Promise.withResolvers<void>();
+  clientSide.on("data", chunk => {
+    received += chunk;
+    if (received.endsWith("one")) firstAnswered.resolve();
+  });
+  server.emit("connection", serverSide);
+  clientSide.write("GET /1 HTTP/1.1\r\nHost: x\r\n\r\n");
+  await Promise.all([firstAnswered.promise, firstReqClosed.promise, firstResClosed.promise]);
+  const firstEvents = [...events["/1"]];
+  expect([...firstEvents].sort()).toEqual(["close", "res-close"]);
+  clientSide.write("POST /2 HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+  await serverSideClosed;
+  await new Promise(resolve => setImmediate(resolve));
+  expect(events["/2"]).toEqual(["aborted", "res-close", "error:ECONNRESET", "close"]);
+  // Nothing happened to the first request after it ended normally.
+  expect(events["/1"]).toEqual(firstEvents);
+  expect({ first: requests["/1"].aborted, second: requests["/2"].aborted }).toEqual({ first: false, second: true });
+});
+
+it("connectionListener does not abort an upgraded request when the tunnel closes", async () => {
+  // After the Upgrade handoff the connection no longer belongs to HTTP (Node
+  // removes its close listener along with the parser), so closing the tunnel
+  // must not abort the upgrade request, even when the 'upgrade' listener
+  // answered through a ServerResponse it assigned to the socket itself.
+  const events: string[] = [];
+  const upgraded = Promise.withResolvers<IncomingMessage>();
+  const server = createServer(() => upgraded.reject(new Error("request handler must not run for a handled upgrade")));
+  server.on("upgrade", (req, socket) => {
+    req.on("aborted", () => events.push("req-aborted"));
+    req.on("error", (err: any) => events.push("req-error:" + err.code));
+    req.on("close", () => events.push("req-close"));
+    const res = new ServerResponse(req);
+    res.assignSocket(socket as any);
+    res.writeHead(400);
+    res.end();
+    upgraded.resolve(req);
+  });
+  const [clientSide, serverSide] = duplexPair();
+  clientSide.resume();
+  const serverSideClosed = new Promise<void>(resolve => serverSide.on("close", resolve));
+  server.emit("connection", serverSide);
+  clientSide.write("GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: ws\r\nConnection: Upgrade\r\n\r\n");
+  const req = await upgraded.promise;
+  serverSide.destroy();
+  await serverSideClosed;
+  await new Promise(resolve => setImmediate(resolve));
+  expect(events).toEqual([]);
+  expect({ destroyed: req.destroyed, aborted: req.aborted }).toEqual({ destroyed: false, aborted: false });
+});

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4189,86 +4189,74 @@ function connectionListenerRequest(
 
 const PARTIAL_POST = "POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc";
 
-it("connectionListener aborts the in-flight request when the connection closes, like Node", async () => {
-  // Node's socketOnClose runs abortIncoming(): every request whose response has
-  // not finished is destroyed with an ECONNRESET "aborted" error, so it emits
-  // 'aborted' (before the response's 'close'), then 'error' only if something
-  // listens, then 'close'. The event orders below are Node v26's.
-  const aborted = ["req-aborted", "res-close", "req-error:ECONNRESET", "req-close"];
+// Node's socketOnClose runs abortIncoming(): a request whose response has not
+// finished is destroyed with an ECONNRESET "aborted" error when its connection
+// closes, so it emits 'aborted' (before the response's 'close'), then 'error'
+// only if something listens, then 'close'. The event orders asserted below are
+// Node v26's.
+const ABORTED_EVENTS = ["req-aborted", "res-close", "req-error:ECONNRESET", "req-close"];
 
-  // The connection is reset while the request body is still arriving.
-  {
+type ConnectionListenerRequest = ReturnType<typeof connectionListenerRequest>;
+const connectionCloseTriggers: [string, (t: ConnectionListenerRequest) => void][] = [
+  ["the connection is reset while the body is still arriving", t => t.serverSide.destroy()],
+  ["server.closeAllConnections() destroys the connection", t => t.server.closeAllConnections()],
+  // The parser flags the truncated message and the connection is torn down.
+  ["the peer hangs up with the body cut short", t => t.clientSide.end()],
+];
+
+for (const [trigger, closeConnection] of connectionCloseTriggers) {
+  it(`connectionListener aborts the in-flight request when ${trigger}`, async () => {
     const t = connectionListenerRequest(PARTIAL_POST);
     const { req } = await t.dispatched;
-    t.serverSide.destroy();
+    closeConnection(t);
     await t.connectionClosed();
-    expect(t.events).toEqual(aborted);
+    expect(t.events).toEqual(ABORTED_EVENTS);
     expect({
       destroyed: req.destroyed,
       aborted: req.aborted,
       complete: req.complete,
       errored: (req.errored as any)?.code,
     }).toEqual({ destroyed: true, aborted: true, complete: false, errored: "ECONNRESET" });
-  }
+  });
+}
 
-  // Without an 'error' listener the error is not emitted (it would otherwise be
-  // an uncaught exception), but req.errored still carries it.
-  {
-    const t = connectionListenerRequest(PARTIAL_POST, undefined, { reqErrorListener: false });
-    const { req } = await t.dispatched;
-    t.serverSide.destroy();
-    await t.connectionClosed();
-    expect(t.events).toEqual(["req-aborted", "res-close", "req-close"]);
-    expect((req.errored as any)?.code).toBe("ECONNRESET");
-  }
+it("connectionListener abort does not emit 'error' on a request without an error listener", async () => {
+  // Like Node, the error is only emitted when something listens for it (it
+  // would otherwise be an uncaught exception), but req.errored still carries it.
+  const t = connectionListenerRequest(PARTIAL_POST, undefined, { reqErrorListener: false });
+  const { req } = await t.dispatched;
+  t.serverSide.destroy();
+  await t.connectionClosed();
+  expect(t.events).toEqual(["req-aborted", "res-close", "req-close"]);
+  expect((req.errored as any)?.code).toBe("ECONNRESET");
+});
 
-  // server.closeAllConnections() destroys the connection from the server side.
-  {
-    const t = connectionListenerRequest(PARTIAL_POST);
-    await t.dispatched;
-    t.server.closeAllConnections();
-    await t.connectionClosed();
-    expect(t.events).toEqual(aborted);
-  }
+it("connectionListener aborts a body-less request whose response is still pending", async () => {
+  // The request is complete as far as the parser is concerned; Node keys the
+  // abort off the unfinished response, not off req.complete.
+  const t = connectionListenerRequest("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+  const { req } = await t.dispatched;
+  t.serverSide.destroy();
+  await t.connectionClosed();
+  expect(t.events).toEqual(ABORTED_EVENTS);
+  expect({ complete: req.complete, aborted: req.aborted }).toEqual({ complete: true, aborted: true });
+});
 
-  // The peer hangs up (FIN) with the body cut short: the parser flags the
-  // truncated message, the connection is torn down, and the request is aborted.
-  {
-    const t = connectionListenerRequest(PARTIAL_POST);
-    await t.dispatched;
-    t.clientSide.end();
-    await t.connectionClosed();
-    expect(t.events).toEqual(aborted);
-  }
-
-  // A body-less request is complete as far as the parser is concerned, but its
-  // response is still pending, so it is aborted too (Node keys this off the
-  // response, not off req.complete).
-  {
-    const t = connectionListenerRequest("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
-    const { req } = await t.dispatched;
-    t.serverSide.destroy();
-    await t.connectionClosed();
-    expect(t.events).toEqual(aborted);
-    expect({ complete: req.complete, aborted: req.aborted }).toEqual({ complete: true, aborted: true });
-  }
-
-  // res.destroy() tears the connection down, which aborts the request as well.
-  // (The response emits its own 'close' synchronously from destroy(), so only
-  // the request's events are order-checked here.)
-  {
-    const t = connectionListenerRequest(PARTIAL_POST);
-    const { req, res } = await t.dispatched;
-    res.destroy();
-    await t.connectionClosed();
-    expect(t.events.filter(event => event.startsWith("req-"))).toEqual([
-      "req-aborted",
-      "req-error:ECONNRESET",
-      "req-close",
-    ]);
-    expect(t.events).toContain("res-close");
-    expect(req.aborted).toBe(true);
-  }
+it("connectionListener aborts the request when its response is destroyed", async () => {
+  // res.destroy() tears the connection down. The response emits its own
+  // 'close' synchronously from destroy(), so only the request's events are
+  // order-checked here.
+  const t = connectionListenerRequest(PARTIAL_POST);
+  const { req, res } = await t.dispatched;
+  res.destroy();
+  await t.connectionClosed();
+  expect(t.events.filter(event => event.startsWith("req-"))).toEqual([
+    "req-aborted",
+    "req-error:ECONNRESET",
+    "req-close",
+  ]);
+  expect(t.events).toContain("res-close");
+  expect(req.aborted).toBe(true);
 });
 
 it("connectionListener does not abort a request whose response already finished when the connection closes", async () => {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4304,19 +4304,26 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
-it("http2 allowHTTP1 fallback aborts the in-flight request when the HTTP/1.1 client goes away", async () => {
-  // Node's socketOnClose -> abortIncoming() applies to allowHTTP1 connections
-  // too: a request whose body was still arriving when the client disconnected
-  // emits 'aborted', then (after the response's 'close') 'error' ECONNRESET
-  // and 'close', and ends up destroyed. Event order is Node v26's.
+// Node's socketOnClose -> abortIncoming() applies to allowHTTP1 connections too:
+// a request whose response has not finished when the connection closes emits
+// 'aborted', then (after the response's 'close') 'error' ECONNRESET and 'close',
+// and ends up destroyed. Event order is Node v26's.
+const HTTP1_ABORTED_EVENTS = ["req-aborted", "res-close", "req-error:ECONNRESET", "req-close"];
+
+// Sends one HTTP/1.1 POST (body cut short) to an allowHTTP1 server over TLS and
+// records the request/response lifecycle events. `onRequest` runs inside the
+// request handler; `afterDispatch` runs once the request reached the server.
+async function allowHTTP1AbortScenario({ onRequest, afterDispatch }) {
   const events = [];
   const dispatched = Promise.withResolvers();
   const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
     req.on("aborted", () => events.push("req-aborted"));
     req.on("error", err => events.push("req-error:" + err.code));
     req.on("close", () => events.push("req-close"));
+    res.on("finish", () => events.push("res-finish"));
     res.on("close", () => events.push("res-close"));
     const connectionClosed = new Promise(resolve => req.socket.on("close", resolve));
+    onRequest?.(req, res);
     dispatched.resolve({ req, connectionClosed });
   });
   await new Promise(resolve => server.listen(0, resolve));
@@ -4328,21 +4335,40 @@ it("http2 allowHTTP1 fallback aborts the in-flight request when the HTTP/1.1 cli
   try {
     const { req, connectionClosed } = await dispatched.promise;
     expect(req.httpVersion).toBe("1.1");
-    socket.destroy();
+    afterDispatch?.(socket);
     await connectionClosed;
     // The request's 'error'/'close' are process.nextTick hops behind the
     // connection's 'close'; after a macrotask the event list is final.
     await new Promise(resolve => setImmediate(resolve));
-    expect(events).toEqual(["req-aborted", "res-close", "req-error:ECONNRESET", "req-close"]);
-    expect({ destroyed: req.destroyed, aborted: req.aborted, complete: req.complete }).toEqual({
-      destroyed: true,
-      aborted: true,
-      complete: false,
-    });
+    return { events, req };
   } finally {
     socket.destroy();
     server.close();
   }
+}
+
+it("http2 allowHTTP1 fallback aborts the in-flight request when the HTTP/1.1 client goes away", async () => {
+  const { events, req } = await allowHTTP1AbortScenario({ afterDispatch: socket => socket.destroy() });
+  expect(events).toEqual(HTTP1_ABORTED_EVENTS);
+  expect({ destroyed: req.destroyed, aborted: req.aborted, complete: req.complete }).toEqual({
+    destroyed: true,
+    aborted: true,
+    complete: false,
+  });
+});
+
+it("http2 allowHTTP1 fallback aborts the request when the handler ends the response right after destroying the connection", async () => {
+  // A TLS socket emits 'close' a turn after destroy(). The res.end() issued in
+  // between cannot reach the wire; like node it must not count as the response
+  // finishing (no 'finish'), or the request would be left out of the abort.
+  const { events, req } = await allowHTTP1AbortScenario({
+    onRequest: (req, res) => {
+      req.socket.destroy();
+      res.end("late");
+    },
+  });
+  expect(events).toEqual(HTTP1_ABORTED_EVENTS);
+  expect({ destroyed: req.destroyed, aborted: req.aborted }).toEqual({ destroyed: true, aborted: true });
 });
 
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4304,6 +4304,47 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+it("http2 allowHTTP1 fallback aborts the in-flight request when the HTTP/1.1 client goes away", async () => {
+  // Node's socketOnClose -> abortIncoming() applies to allowHTTP1 connections
+  // too: a request whose body was still arriving when the client disconnected
+  // emits 'aborted', then (after the response's 'close') 'error' ECONNRESET
+  // and 'close', and ends up destroyed. Event order is Node v26's.
+  const events = [];
+  const dispatched = Promise.withResolvers();
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    req.on("aborted", () => events.push("req-aborted"));
+    req.on("error", err => events.push("req-error:" + err.code));
+    req.on("close", () => events.push("req-close"));
+    res.on("close", () => events.push("res-close"));
+    const connectionClosed = new Promise(resolve => req.socket.on("close", resolve));
+    dispatched.resolve({ req, connectionClosed });
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const socket = tls.connect(
+    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+    () => socket.write("POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 10\r\n\r\nabc"),
+  );
+  socket.on("error", dispatched.reject);
+  try {
+    const { req, connectionClosed } = await dispatched.promise;
+    expect(req.httpVersion).toBe("1.1");
+    socket.destroy();
+    await connectionClosed;
+    // The request's 'error'/'close' are process.nextTick hops behind the
+    // connection's 'close'; after a macrotask the event list is final.
+    await new Promise(resolve => setImmediate(resolve));
+    expect(events).toEqual(["req-aborted", "res-close", "req-error:ECONNRESET", "req-close"]);
+    expect({ destroyed: req.destroyed, aborted: req.aborted, complete: req.complete }).toEqual({
+      destroyed: true,
+      aborted: true,
+      complete: false,
+    });
+  } finally {
+    socket.destroy();
+    server.close();
+  }
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().


### PR DESCRIPTION
### Problem
- On the JS HTTP/1 fallback path (a socket handed to `http.Server` via `server.emit("connection", socket)`, or an HTTP/1.1 connection on an `allowHTTP1` http2 server), a request whose response has not finished is never told its connection went away. Node emits `aborted`, `error` (ECONNRESET) and `close` on `req` and marks it destroyed; bun emits only the response's `close`, so anything waiting on `req` waits forever.
- Reproduced with a reset mid-body, a peer FIN, `closeAllConnections()`, `res.destroy()` and a server-side `socket.destroy()`. Native `http.Server` connections already match node.
- Cause: the fallback's close handler freed the parser and stopped. Node's close path also destroys every request still waiting on its response.
- Smaller gap: a `res.end()` issued after the connection was destroyed or the peer hung up counted as the response finishing. It emitted `finish` and released the response before the close handler ran, and after a peer FIN also raised a `clientError`. Node writes nothing and never finishes such a response.

### Fix
- When the connection closes, the request whose response is still assigned to the socket is destroyed with node's `ConnResetException("aborted")`. A response detaches when it finishes, so this is exactly node's set of unanswered requests, and an already answered request is left alone. The listener is registered ahead of each response's own, so `req` `aborted` precedes `res` `close` as in node. #36991 rewrites this handler and includes the same abort; whichever lands second rebases one hunk.
- The fallback response handle now reports itself socket-closed as soon as the socket stops being writable, as the native handle does once its connection closed. `ServerResponse` already writes nothing and emits no `finish` in that state, so a late `end()` leaves the response assigned for the close handler to abort, and the stray `finish` and `clientError` go away.
- Two related cleanups: the Upgrade/CONNECT handoff also removes the close listener, so a tunnel closing later does not abort the upgrade request (node removes it too), and a `req.destroy()` in the socket `end` handler is deleted because the parser either rejects a truncated request or completes it first, so that branch never fired.
- Verification: new tests assert node v26's event sequences for reset, FIN, `closeAllConnections()`, `res.destroy()` and end-after-teardown (the last over real net and TLS sockets), plus two negatives (response already answered, upgraded tunnel). The abort tests fail on main with `["res-close"]` as the only event. A scenario script printed the same results on node v26.3.0 and this build, apart from two pre-existing ordering differences noted in the original.

### Background
- The HTTP/1 fallback: bun serves `http.Server` connections natively. Sockets bun did not accept itself (`server.emit("connection", socket)`, or HTTP/1.1 chosen by ALPN on an `allowHTTP1` http2 server) go through a JS port of node's `connectionListener`, with a JS object standing in for the native response handle.
- Node's abort-on-close contract: when a connection closes, every request still waiting on its response is destroyed with an ECONNRESET "aborted" error; `IncomingMessage` then emits `aborted`, `error` only if something listens, then `close`. Requests already answered are not touched.
- `socket._httpMessage` is the `ServerResponse` currently assigned to a socket; the fallback clears it when the response finishes. The native close path uses the same indicator to find the in-flight request.
- Response handle flags: `ServerResponse` reads a socket-closed bit from its handle and returns early from `write()`/`end()` when it is set, so the handle decides whether a late `end()` counts as finishing. The native handle sets the bit when its connection closes; the fallback handle never did.
- Close timing: net and TLS sockets emit `close` a turn after `destroy()`, so a handler can call `res.end()` in between. A `duplexPair` closes at once, which is why the end-after-teardown tests use real sockets.

<details>
<summary>Original description</summary>

### Repro

On a connection served by `src/js/internal/http1_server_fallback.ts` (a socket fed to `http.Server` through `server.emit("connection", socket)`, or an HTTP/1.1 connection on `http2.createSecureServer({ allowHTTP1: true })`), a request whose response has not finished is never told that its connection went away:

```js
const http = require("http");
const { duplexPair } = require("stream");
const server = http.createServer((req, res) => {
  const events = [];
  req.on("aborted", () => events.push("aborted"));
  req.on("error", e => events.push("error:" + e.code));
  req.on("close", () => events.push("close"));
  res.on("close", () => events.push("res-close"));
  setImmediate(() => server.closeAllConnections());
  setTimeout(() => { console.log(JSON.stringify({ events, reqDestroyed: req.destroyed })); server.close(); }, 100);
});
server.listen(0, () => {
  const [client, conn] = duplexPair();
  server.emit("connection", conn);
  client.write("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
});
```

```
node v26.3.0:       {"events":["aborted","res-close","error:ECONNRESET","close"],"reqDestroyed":true}
bun 1.4.0 / main:   {"events":["res-close"],"reqDestroyed":false}
```

Same result when the peer disconnects (TLS client destroyed mid-body on an `allowHTTP1` server, FIN with the body cut short, FIN under an open long-poll/event-stream response), on `res.destroy()`, or on a server-side `socket.destroy()`: anything waiting on `req` ('aborted', 'error', 'close', `stream.finished`, `req.destroyed`) waits forever. Bun's native `http.Server` connections behave like node here; only the fallback path did not.

### Cause

Node's `socketOnClose` (lib/_http_server.js) frees the parser and then runs `abortIncoming()`, which does `req.destroy(new ConnResetException("aborted"))` for every request still waiting for its response. `IncomingMessage._destroy` then emits 'aborted', and 'error' (ECONNRESET) only if something listens, then 'close'. The fallback's socket `'close'` listener only did the first half (`parser.close()`).

A second, smaller gap showed up while reviewing the fix: the fallback's response handle treated every `res.end()` as the response finishing, even one issued after the connection had been destroyed or the peer had hung up, when nothing it writes can reach the wire. On a net or TLS socket `'close'` arrives a turn after `destroy()`, so a `res.end()` in that window (a handler that tears the connection down and then ends the response, or one that ends it after the peer's FIN) emitted `'finish'` and released the response, and an end() after the peer's FIN also surfaced as a `'clientError'` from writing to the ended socket. Node never runs the finish callback for a response whose connection is gone, and the native `NodeHTTPResponse` reports itself closed in that state so `ServerResponse` returns early.

### Fix

- The fallback's close listener destroys the in-flight request with a `ConnResetException("aborted")`, the call node's `abortIncoming` makes. Bun's `IncomingMessage._destroy` (the non-native branch this path uses) is a port of node's, so the event sequence, `req.errored` and the error-listener gating come out the same as node's. The request in flight is the one whose response is still assigned to the socket (`socket._httpMessage.req`): the fallback's responses detach on `'finish'`, where node's `resOnFinish` drops the request from `state.incoming`, and this is the same indicator the native socket's close path (`NodeHTTPServerSocket`) uses. A request whose response already went out is left alone (node does not abort it either), and `res.destroy()` leaves the response assigned, so that request is aborted like in node. The listener is registered when the connection is accepted, before any response's `assignSocket()` adds its own `'close'` listener, so `req` 'aborted' precedes `res` 'close' as in node.
- The handle reports `NodeHTTPResponseFlags.socket_closed` (and, as the native handle derives it from the same bit, `aborted`) once the socket is no longer writable, like the native handle once its connection closed. `ServerResponse`'s `write()`/`end()` already return without writing or emitting `'finish'` in that state (end() still returns the response, as in node), so a response ended after the connection stopped being writable stays assigned and the close listener aborts its request; the stray `'finish'` and the `'clientError'` from the end-after-FIN case go away with it. `aborted` additionally requires the response not to have ended, so a normally completed response keeps reporting a later write()/end() as write-after-end.
- The Upgrade/CONNECT handoff removes the close listener along with the data/end/error listeners, as node's `onParserExecuteCommon` does, so a tunnel closing later does not abort the upgrade request (an 'upgrade' listener may have answered through a `ServerResponse` it assigned to the socket itself, which never detaches).
- The `req.destroy()` in the socket 'end' handler is removed: llhttp's `finish()` either reports `HPE_INVALID_EOF_STATE` for a request cut short or completes the message (EOF-delimited lenient bodies), so that branch was only ever reached with a complete request and never did anything. Node's `socketOnEnd` just ends the socket and lets the close path abort, which is what happens now.

Overlap note: #36991 (pipelining queue for the fallback) adds the in-flight abort inside its larger close-handler change, alongside the queued-response aborts it needs. This PR is the standalone fix for the bug on main; whichever lands second has a one-hunk rebase in that handler.

### Verification

A scenario script run against node v26.3.0 and this build on the fallback path (events in order, then `req.destroyed` / `req.aborted` / `req.errored`) prints identical results for: a reset mid-body with and without an 'error' listener, a body-less request with a pending response, FIN with the body cut short, FIN under an open streaming response, `res.end()` issued after `socket.destroy()` / `closeAllConnections()` on a real net socket and after the peer's FIN, `closeAllConnections()`, a server-side `socket.destroy()`, `req.destroy()` from the handler, a response that finished before the connection died (not aborted), and a completed keep-alive exchange followed by an aborted second request. The remaining differences are pre-existing and unrelated to this change: `res.destroy()` emits the response's 'close' synchronously in bun, and the relative order of `req` 'end' vs `res` 'finish' on a normal exchange.

Tests (`test/js/node/http/node-http.test.ts`, next to the other connectionListener tests, and `test/js/node/http2/node-http2.test.js` next to the allowHTTP1 tests) assert node's event sequences for those scenarios. The end-after-teardown cases run over a real net socket pair and over an allowHTTP1 TLS connection, since a duplexPair emits 'close' too early to reach that window; they fail with the close listener alone and pass with the flag. Without the src change, every abort test fails with `["res-close"]` as the only event; the two negative tests (response already finished, upgraded tunnel) pass both ways and guard the handoff change. The existing fallback coverage (`test-http-generic-streams`, `test-http2-allow-http1`, `test-http2-https-fallback*`, `test-http-server-unconsume-consume`, the `*-per-stream` tests, `node-http-connect`, and the full `node-http` / `node-http2` files) still passes.

</details>
