### PR TITLE
node:http: enforce maxRequestsPerSocket on HTTP/1 fallback connections

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -337,11 +337,10 @@ function connectionListenerHTTP1(server, socket, options) {
       this.detachSocket(socket);
     });
 
-    // Node's parserOnIncoming maxRequestsPerSocket routing (the native dispatcher's
-    // reachedRequestsLimit branch in _http_server.ts). Like the Expect routing below, Node only
-    // counts HTTP/1.1 requests. maxRequestsOnConnectionReached makes renderNativeHeaders
-    // advertise Connection: close on the response that reaches the limit and on every 503 past
-    // it; as in Node, nothing here closes the connection itself.
+    // Node's parserOnIncoming request limit: the upgrades handed off above are never counted and,
+    // like the Expect routing below, only HTTP/1.1 requests are. maxRequestsOnConnectionReached
+    // makes renderNativeHeaders advertise Connection: close on the response that reaches the limit
+    // and on every 503 past it; as in Node, nothing here closes the connection itself.
     if (
       versionMajor === 1 &&
       versionMinor === 1 &&

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -337,10 +337,7 @@ function connectionListenerHTTP1(server, socket, options) {
       this.detachSocket(socket);
     });
 
-    // Node's parserOnIncoming request limit: the upgrades handed off above are never counted and,
-    // like the Expect routing below, only HTTP/1.1 requests are. maxRequestsOnConnectionReached
-    // makes renderNativeHeaders advertise Connection: close on the response that reaches the limit
-    // and on every 503 past it; as in Node, nothing here closes the connection itself.
+    // Like Node's parserOnIncoming: upgrades (handed off above) are not counted, and the socket is never closed here.
     if (
       versionMajor === 1 &&
       versionMinor === 1 &&

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -269,6 +269,8 @@ function connectionListenerHTTP1(server, socket, options) {
 
   let req = null;
   let pendingUpgrade = null;
+  // Node's per-connection state.requestsCount, behind server.maxRequestsPerSocket.
+  let requestsCount = 0;
 
   parser[kOnHeadersComplete] = function onHttp1HeadersComplete(
     versionMajor,
@@ -317,7 +319,8 @@ function connectionListenerHTTP1(server, socket, options) {
     // reads them to decide the Keep-Alive auto-header bits, so the fallback
     // path must carry them too or keep-alive responses lose their timeout line.
     res._keepAliveTimeout = keepAliveTimeout;
-    res._maxRequestsPerSocket = server.maxRequestsPerSocket;
+    const { maxRequestsPerSocket } = server;
+    res._maxRequestsPerSocket = maxRequestsPerSocket;
     const handle = createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout);
     handle.onfinished = function () {
       socket[kHttp1ActiveRequests] = Math.max(0, (socket[kHttp1ActiveRequests] || 1) - 1);
@@ -333,6 +336,27 @@ function connectionListenerHTTP1(server, socket, options) {
     res.on("finish", function onFallbackResponseFinish() {
       this.detachSocket(socket);
     });
+
+    // Node's parserOnIncoming maxRequestsPerSocket routing (the native dispatcher's
+    // reachedRequestsLimit branch in _http_server.ts). Like the Expect routing below, Node only
+    // counts HTTP/1.1 requests. maxRequestsOnConnectionReached makes renderNativeHeaders
+    // advertise Connection: close on the response that reaches the limit and on every 503 past
+    // it; as in Node, nothing here closes the connection itself.
+    if (
+      versionMajor === 1 &&
+      versionMinor === 1 &&
+      typeof maxRequestsPerSocket === "number" &&
+      maxRequestsPerSocket > 0
+    ) {
+      requestsCount++;
+      res.maxRequestsOnConnectionReached = maxRequestsPerSocket <= requestsCount;
+      if (maxRequestsPerSocket < requestsCount) {
+        server.emit("dropRequest", req, socket);
+        res.writeHead(503);
+        res.end();
+        return 0;
+      }
+    }
 
     // Node's parserOnIncoming Expect routing (the native dispatcher applies the
     // same at _http_server.ts's DISPATCH_HAS_EXPECT branch).

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,14 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  // Pinned to 127.0.0.1 on both ends (like the exampleSite it proxies to): on hosts where
+  // localhost resolves to ::1 only, the server would bind ::1 while the client dials 127.0.0.1.
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4281,4 +4281,33 @@ describe("connectionListener maxRequestsPerSocket", () => {
     ).toEqual({ statusCode: 503, connection: "close", keepAlive: undefined, body: "" });
     expect(events).toEqual(["request /1", "dropRequest /2"]);
   });
+
+  it("still hands off an Upgrade request once the limit is reached", async () => {
+    // Node's parserOnIncoming hands upgrades off before it counts requests, so the limit never
+    // turns an upgrade into a 503.
+    const events: string[] = [];
+    const server = createServer((req, res) => {
+      events.push(`request ${req.url}`);
+      res.end("served");
+    });
+    server.maxRequestsPerSocket = 1;
+    server.on("upgrade", (req, socket) => {
+      events.push(`upgrade ${req.url}`);
+      socket.end("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n");
+    });
+    server.on("dropRequest", req => events.push(`dropRequest ${req.url}`));
+    using client = keepAliveClientOverEmittedConnection(server);
+
+    expect(await client.request("GET /1 HTTP/1.1\r\nHost: example.test\r\n\r\n")).toEqual({
+      statusCode: 200,
+      connection: "close",
+      keepAlive: undefined,
+      body: "served",
+    });
+    expect(
+      (await client.request("GET /ws HTTP/1.1\r\nHost: example.test\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n"))
+        .statusCode,
+    ).toBe(101);
+    expect(events).toEqual(["request /1", "upgrade /ws"]);
+  });
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,146 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+describe("connectionListener maxRequestsPerSocket", () => {
+  // Sockets fed in through server.emit("connection", ...) take the JS fallback parser. This
+  // client sends raw keep-alive requests over such a socket one at a time (never pipelined) and
+  // parses each response as it arrives. The servers below only produce Content-Length framed
+  // bodies and the bodiless chunked 503 (a lone terminating chunk), which is all it understands.
+  function keepAliveClientOverEmittedConnection(server: Server) {
+    const [clientSide, serverSide] = duplexPair();
+    server.emit("connection", serverSide);
+    let received = "";
+    let waiter: PromiseWithResolvers<string> | undefined;
+    function takeResponse() {
+      const headEnd = received.indexOf("\r\n\r\n");
+      if (headEnd === -1) return undefined;
+      const head = received.slice(0, headEnd);
+      let bodyEnd = headEnd + 4;
+      const contentLength = /^Content-Length: (\d+)$/m.exec(head);
+      if (contentLength) {
+        bodyEnd += Number(contentLength[1]);
+      } else if (/^Transfer-Encoding: chunked$/m.test(head)) {
+        bodyEnd += "0\r\n\r\n".length;
+      }
+      if (received.length < bodyEnd) return undefined;
+      const response = received.slice(0, bodyEnd);
+      received = received.slice(bodyEnd);
+      return response;
+    }
+    function deliver() {
+      if (waiter === undefined) return;
+      const response = takeResponse();
+      if (response === undefined) return;
+      const { resolve } = waiter;
+      waiter = undefined;
+      resolve(response);
+    }
+    function fail(reason: string) {
+      waiter?.reject(new Error(`${reason} while waiting for a response; received ${JSON.stringify(received)}`));
+      waiter = undefined;
+    }
+    clientSide.on("data", chunk => {
+      received += chunk.toString("latin1");
+      deliver();
+    });
+    clientSide.on("end", () => fail("the server ended the connection"));
+    clientSide.on("close", () => fail("the connection closed"));
+    return {
+      serverSide,
+      async request(rawRequest: string) {
+        waiter = Promise.withResolvers<string>();
+        const { promise } = waiter;
+        clientSide.write(rawRequest);
+        deliver();
+        const raw = await promise;
+        return {
+          statusCode: Number(raw.slice("HTTP/1.1 ".length, "HTTP/1.1 ".length + 3)),
+          connection: /^Connection: (.*)$/m.exec(raw)?.[1],
+          keepAlive: /^Keep-Alive: (.*)$/m.exec(raw)?.[1],
+          body: raw.slice(raw.indexOf("\r\n\r\n") + 4).replace(/^0\r\n\r\n$/, ""),
+        };
+      },
+      [Symbol.dispose]() {
+        clientSide.destroy();
+        serverSide.destroy();
+      },
+    };
+  }
+
+  it("advertises Connection: close at the limit and answers every request past it with 503 and 'dropRequest'", async () => {
+    const served: [string, boolean][] = [];
+    const dropped: [string, boolean][] = [];
+    const server = createServer((req, res) => {
+      // Set before 'request' is emitted, like Node; it is what turns the Connection header into "close".
+      served.push([req.url!, (res as any).maxRequestsOnConnectionReached]);
+      res.end("served");
+    });
+    server.maxRequestsPerSocket = 2;
+    using client = keepAliveClientOverEmittedConnection(server);
+    server.on("dropRequest", (req, socket) => dropped.push([req.url!, socket === client.serverSide]));
+
+    const responses: Awaited<ReturnType<typeof client.request>>[] = [];
+    for (const path of ["/1", "/2", "/3", "/4"]) {
+      responses.push(await client.request(`GET ${path} HTTP/1.1\r\nHost: example.test\r\n\r\n`));
+    }
+    expect(responses).toEqual([
+      { statusCode: 200, connection: "keep-alive", keepAlive: "timeout=5, max=2", body: "served" },
+      { statusCode: 200, connection: "close", keepAlive: undefined, body: "served" },
+      { statusCode: 503, connection: "close", keepAlive: undefined, body: "" },
+      { statusCode: 503, connection: "close", keepAlive: undefined, body: "" },
+    ]);
+    expect(served).toEqual([
+      ["/1", false],
+      ["/2", true],
+    ]);
+    expect(dropped).toEqual([
+      ["/3", true],
+      ["/4", true],
+    ]);
+  });
+
+  it("counts requests per connection", async () => {
+    const dropped: string[] = [];
+    const server = createServer((req, res) => res.end("served"));
+    server.maxRequestsPerSocket = 1;
+    server.on("dropRequest", req => dropped.push(req.url!));
+    using first = keepAliveClientOverEmittedConnection(server);
+    using second = keepAliveClientOverEmittedConnection(server);
+
+    const statusCodes = [
+      (await first.request("GET /first HTTP/1.1\r\nHost: example.test\r\n\r\n")).statusCode,
+      (await second.request("GET /second HTTP/1.1\r\nHost: example.test\r\n\r\n")).statusCode,
+      (await first.request("GET /first-again HTTP/1.1\r\nHost: example.test\r\n\r\n")).statusCode,
+      (await second.request("GET /second-again HTTP/1.1\r\nHost: example.test\r\n\r\n")).statusCode,
+    ];
+    expect(statusCodes).toEqual([200, 200, 503, 503]);
+    expect(dropped).toEqual(["/first-again", "/second-again"]);
+  });
+
+  it("drops an over-limit request before looking at its Expect header", async () => {
+    // Node's parserOnIncoming checks the limit before the Expect routing, so the dropped
+    // request gets its 503 straight away: no 100 Continue, no 'checkContinue'.
+    const events: string[] = [];
+    const server = createServer((req, res) => {
+      events.push(`request ${req.url}`);
+      res.end("served");
+    });
+    server.maxRequestsPerSocket = 1;
+    server.on("checkContinue", (req, res) => {
+      events.push(`checkContinue ${req.url}`);
+      res.writeContinue();
+      res.end("served");
+    });
+    server.on("dropRequest", req => events.push(`dropRequest ${req.url}`));
+    using client = keepAliveClientOverEmittedConnection(server);
+
+    expect((await client.request("GET /1 HTTP/1.1\r\nHost: example.test\r\n\r\n")).statusCode).toBe(200);
+    expect(
+      await client.request(
+        "POST /2 HTTP/1.1\r\nHost: example.test\r\nExpect: 100-continue\r\nContent-Length: 0\r\n\r\n",
+      ),
+    ).toEqual({ statusCode: 503, connection: "close", keepAlive: undefined, body: "" });
+    expect(events).toEqual(["request /1", "dropRequest /2"]);
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4376,68 +4376,34 @@ it("http2 allowHTTP1 fallback enforces maxRequestsPerSocket like http.Server", a
   server.maxRequestsPerSocket = 1;
   server.on("dropRequest", (req, socket) => dropped.push([req.url, socket.encrypted === true]));
   await new Promise(resolve => server.listen(0, resolve));
-  const { promise: connected, resolve: onConnect, reject: onConnectError } = Promise.withResolvers();
-  const socket = tls.connect(
-    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
-    onConnect,
-  );
-  socket.on("error", onConnectError);
+  let socket;
   try {
-    await connected;
-    // Requests go out one at a time (never pipelined) and every response here is either
-    // Content-Length framed or the bodiless chunked 503 (a lone terminating chunk).
-    let received = "";
-    let waiter;
-    function takeResponse() {
-      const headEnd = received.indexOf("\r\n\r\n");
-      if (headEnd === -1) return undefined;
-      const head = received.slice(0, headEnd);
-      let bodyEnd = headEnd + 4;
-      const contentLength = /^Content-Length: (\d+)$/m.exec(head);
-      if (contentLength) {
-        bodyEnd += Number(contentLength[1]);
-      } else if (/^Transfer-Encoding: chunked$/m.test(head)) {
-        bodyEnd += "0\r\n\r\n".length;
-      }
-      if (received.length < bodyEnd) return undefined;
-      const response = received.slice(0, bodyEnd);
-      received = received.slice(bodyEnd);
-      return response;
-    }
-    function deliver() {
-      if (!waiter) return;
-      const response = takeResponse();
-      if (response === undefined) return;
-      const { resolve } = waiter;
-      waiter = undefined;
-      resolve(response);
-    }
+    const { promise, resolve, reject } = Promise.withResolvers();
+    socket = tls.connect(
+      { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+      () => socket.write("GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n"),
+    );
+    const chunks = [];
+    let sentSecond = false;
+    socket.on("error", reject);
     socket.on("data", chunk => {
-      received += chunk.toString("latin1");
-      deliver();
+      chunks.push(chunk);
+      if (!sentSecond && Buffer.concat(chunks).toString("latin1").endsWith("served")) {
+        // The first response is complete; send the over-limit request. Its Connection: close
+        // makes the server end the connection after answering it, which resolves the promise.
+        sentSecond = true;
+        socket.write("GET /2 HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n");
+      }
     });
-    socket.on("close", () => {
-      waiter?.reject(new Error(`connection closed while waiting for a response; received ${JSON.stringify(received)}`));
-      waiter = undefined;
-    });
-    async function request(path) {
-      waiter = Promise.withResolvers();
-      const { promise } = waiter;
-      socket.write(`GET ${path} HTTP/1.1\r\nHost: localhost\r\n\r\n`);
-      const raw = await promise;
-      return {
-        statusCode: Number(raw.slice("HTTP/1.1 ".length, "HTTP/1.1 ".length + 3)),
-        connection: /^Connection: (.*)$/m.exec(raw)?.[1],
-        body: raw.slice(raw.indexOf("\r\n\r\n") + 4).replace(/^0\r\n\r\n$/, ""),
-      };
-    }
-
-    expect(await request("/1")).toEqual({ statusCode: 200, connection: "close", body: "served" });
-    expect(await request("/2")).toEqual({ statusCode: 503, connection: "close", body: "" });
+    socket.on("end", () => resolve(Buffer.concat(chunks).toString("latin1")));
+    const raw = await promise;
+    expect([...raw.matchAll(/HTTP\/1\.1 (\d+) /g)].map(match => match[1])).toEqual(["200", "503"]);
+    // The first response is the one that reaches the limit, so it already advertises close.
+    expect(raw.slice(0, raw.indexOf("\r\n\r\n") + 4)).toContain("\r\nConnection: close\r\n");
     expect(served).toEqual([["/1", true]]);
     expect(dropped).toEqual([["/2", true]]);
   } finally {
-    socket.destroy();
+    socket?.destroy();
     server.close();
   }
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4365,6 +4365,83 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+it("http2 allowHTTP1 fallback enforces maxRequestsPerSocket like http.Server", async () => {
+  const served = [];
+  const dropped = [];
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    served.push([req.url, res.maxRequestsOnConnectionReached]);
+    res.end("served");
+  });
+  // Like http.Server (and Node's Http2SecureServer), the limit is a property on the server.
+  server.maxRequestsPerSocket = 1;
+  server.on("dropRequest", (req, socket) => dropped.push([req.url, socket.encrypted === true]));
+  await new Promise(resolve => server.listen(0, resolve));
+  const { promise: connected, resolve: onConnect, reject: onConnectError } = Promise.withResolvers();
+  const socket = tls.connect(
+    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+    onConnect,
+  );
+  socket.on("error", onConnectError);
+  try {
+    await connected;
+    // Requests go out one at a time (never pipelined) and every response here is either
+    // Content-Length framed or the bodiless chunked 503 (a lone terminating chunk).
+    let received = "";
+    let waiter;
+    function takeResponse() {
+      const headEnd = received.indexOf("\r\n\r\n");
+      if (headEnd === -1) return undefined;
+      const head = received.slice(0, headEnd);
+      let bodyEnd = headEnd + 4;
+      const contentLength = /^Content-Length: (\d+)$/m.exec(head);
+      if (contentLength) {
+        bodyEnd += Number(contentLength[1]);
+      } else if (/^Transfer-Encoding: chunked$/m.test(head)) {
+        bodyEnd += "0\r\n\r\n".length;
+      }
+      if (received.length < bodyEnd) return undefined;
+      const response = received.slice(0, bodyEnd);
+      received = received.slice(bodyEnd);
+      return response;
+    }
+    function deliver() {
+      if (!waiter) return;
+      const response = takeResponse();
+      if (response === undefined) return;
+      const { resolve } = waiter;
+      waiter = undefined;
+      resolve(response);
+    }
+    socket.on("data", chunk => {
+      received += chunk.toString("latin1");
+      deliver();
+    });
+    socket.on("close", () => {
+      waiter?.reject(new Error(`connection closed while waiting for a response; received ${JSON.stringify(received)}`));
+      waiter = undefined;
+    });
+    async function request(path) {
+      waiter = Promise.withResolvers();
+      const { promise } = waiter;
+      socket.write(`GET ${path} HTTP/1.1\r\nHost: localhost\r\n\r\n`);
+      const raw = await promise;
+      return {
+        statusCode: Number(raw.slice("HTTP/1.1 ".length, "HTTP/1.1 ".length + 3)),
+        connection: /^Connection: (.*)$/m.exec(raw)?.[1],
+        body: raw.slice(raw.indexOf("\r\n\r\n") + 4).replace(/^0\r\n\r\n$/, ""),
+      };
+    }
+
+    expect(await request("/1")).toEqual({ statusCode: 200, connection: "close", body: "served" });
+    expect(await request("/2")).toEqual({ statusCode: 503, connection: "close", body: "" });
+    expect(served).toEqual([["/1", true]]);
+    expect(dropped).toEqual([["/2", true]]);
+  } finally {
+    socket.destroy();
+    server.close();
+  }
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().


### PR DESCRIPTION
### Problem
- `server.maxRequestsPerSocket` is ignored on the connections bun parses in JS: the HTTP/1.1 side of `http2.createSecureServer({ allowHTTP1: true })`, and sockets handed to an `http.Server` through `server.emit("connection", socket)`. With the limit set to 1, Node answers the second request on a connection with 503 and emits `'dropRequest'`; bun answers 200, emits nothing, and keeps advertising keep-alive.
- Natively accepted `http.Server` connections already enforce the limit, so only these two entry points diverge from Node.
- Cause: the fallback copied the limit onto each response, which only makes the `Keep-Alive` header advertise `max=N`. Nothing counted the requests on a connection, so the limit was never reached and every request was dispatched.

### Fix
- The fallback now counts requests per connection, as Node does. The request that reaches the limit is served with `Connection: close`; every request past it emits `'dropRequest'` `(req, socket)` and is answered with a bare 503 instead of reaching `'request'`.
- The check sits where Node's does: after Upgrade hand-off (upgrades are not counted), before `Expect` routing (a dropped request gets no `100 Continue`), and only for HTTP/1.1. As in Node, the server does not close the connection itself. Nothing else needed wiring: the response layer already renders the reached flag as `Connection: close`, and the HTTP/2 server already stores the property.
- Verification: five new tests (four over `emit("connection")`, one over `allowHTTP1` with an `http/1.1` ALPN client) fail on the current release build and pass with this change; the same scenarios were run against node v26.3.0 and match. They send requests one at a time because pipelining on these connections still hits the separate #36991.
- Also in here: the http proxy test now binds and dials `127.0.0.1` on both ends. On hosts where `localhost` resolves to `::1` only it failed with `ECONNREFUSED` regardless of the code under test. #33472 carries the same pin; whichever lands second drops it.

### Background
- `internal/http1_server_fallback` is bun's JS HTTP/1 parser. Connections `http.Server` accepts itself are parsed natively; a connection that arrives as a JS stream (an `emit("connection")` socket, or an HTTP/2 server's TLS connection where the client negotiated `http/1.1`) is parsed here. Per-request server behaviour therefore has to exist in both paths, and this one only existed natively.
- `server.maxRequestsPerSocket` is Node's cap on requests served over one keep-alive connection. Node advertises it as `Keep-Alive: timeout=N, max=M`, sends `Connection: close` on the response that reaches it, and answers anything past it with 503 plus a `'dropRequest'` event, without closing the socket itself.
- `res.maxRequestsOnConnectionReached` is the flag Node sets on the response before `'request'` fires; bun's header rendering already turns it into `Connection: close`, so setting it is the whole signal.
- Ordering against Upgrade and `Expect: 100-continue`: Node hands Upgrade requests to `'upgrade'` before counting, and applies the cap before looking at `Expect`. The tests pin both orderings.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 8 failed, 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (f26690a1c)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [445.01ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [72.81ms]
(pass) node:http > createServer > request & response body streaming (large) [113.34ms]
(pass) node:http > createServer > request & response body streaming (small) [69.10ms]
(pass) node:http > createServer > listen should return server [27.72ms]
(pass) node:http > createServer > listen callback should be bound to server [26.55ms]
(pass) node:http > createServer > should use the provided port [35.75ms]
(pass) node:http > createServer > should assign a random port when undefined [28.84ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [46.60ms]
(pass) node:http > response > set-cookie works with getHeader [3.54ms]
(pass) node:http > response > set-cookie works with getHeaders [6.38ms]
(pass) node:http > request > should not insert extraneou
... (truncated)

release without fix: 7 skipped
bun test v1.4.0-canary.1 (cb1fb34dc)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [11.65ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [3.39ms]
(pass) node:http > createServer > request & response body streaming (large) [4.98ms]
(pass) node:http > createServer > request & response body streaming (small) [2.40ms]
(pass) node:http > createServer > listen should return server [0.99ms]
(pass) node:http > createServer > listen callback should be bound to server [1.95ms]
(pass) node:http > createServer > should use the provided port [1.51ms]
(pass) node:http > createServer > should assign a random port when undefined [1.93ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [2.84ms]
(pass) node:http > response > set-cookie works with getHeader [0.12ms]
(pass) node:http > response > set-cookie works with getHeaders [0.15ms]
(pass) node:http > request > should not insert extraneous accept-encoding header [2.58ms]
(pass) node:http > request > multiple Set-Cookie headers works #6810 [11.46ms]
(pass) node:http > request > should make a standard GET request when passed string as first arg [
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 7 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http.test.ts "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (f26690a1c)

test/js/node/http/node-http.test.ts:
(pass) node:http > createServer > hello world [447.17ms]
(pass) node:http > createServer > is not marked encrypted (#5867) [75.63ms]
(pass) node:http > createServer > request & response body streaming (large) [122.59ms]
(pass) node:http > createServer > request & response body streaming (small) [73.05ms]
(pass) node:http > createServer > listen should return server [23.49ms]
(pass) node:http > createServer > listen callback should be bound to server [25.20ms]
(pass) node:http > createServer > should use the provided port [37.19ms]
(pass) node:http > createServer > should assign a random port when undefined [27.87ms]
(pass) node:http > createServer > option method should be uppercase (#7250) [49.52ms]
(pass) node:http > response > set-cookie works with getHeader [3.83ms]
(pass) node:http > response > set-cookie works with getHeaders [7.25ms]
(pass) node:http > request > should not insert extraneou
... (truncated)

release with fix: 7 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 690ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/144] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/144] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/144] gen BunProcess.lut.h
Generating /workspace/bun/build/release/codegen/BunProcess.lut.h from /workspace/bun/src/jsc/bindings/BunProcess.cpp
[4/144] gen JSSink.{cpp,h,lut.h,rs}
generated_jssink.rs: 8 sinks, 96 exported symbols
Generating /workspace/bun/build/release/codegen/JSSink.lut.h from /workspace/bun/build/release/codegen/JSSink.lut.txt
[5/144] gen BunObject.lut.h
Generating /workspace/bun/build/release/codegen/BunObject.lut.h from /workspace/bun/src/jsc/bindings/BunObject.cpp
[6/144] gen cpp.rs (cppbind)
[7/144] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes fro
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/http1_server_fallback.ts |  22 +++-
 test/js/node/http/node-http-proxy.js     |   6 +-
 test/js/node/http/node-http.test.ts      | 172 +++++++++++++++++++++++++++++++
 test/js/node/http2/node-http2.test.js    |  43 ++++++++
 4 files changed, 240 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/js/internal/http1_server_fallback.ts      5     10      0
test/js/node/http/node-http-proxy.js          1      1      0
test/js/node/http/node-http.test.ts           4      3      0
test/js/node/http2/node-http2.test.js         5      3      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

`server.maxRequestsPerSocket` was ignored on the connections served by `internal/http1_server_fallback`: the HTTP/1.1 connections of `http2.createSecureServer({ allowHTTP1: true })` and the sockets handed to an `http.Server` through `server.emit("connection", socket)`. The natively accepted `http.Server` connections already enforce it.

```js
const http = require("http");
const { duplexPair } = require("stream");
const server = http.createServer((req, res) => res.end("served"));
server.maxRequestsPerSocket = 1;
let drops = 0;
server.on("dropRequest", () => drops++);
const [client, conn] = duplexPair();
server.emit("connection", conn);
let out = "";
client.on("data", d => (out += d));
client.write("GET /1 HTTP/1.1\r\nHost: a\r\n\r\n");
setTimeout(() => {
  client.write("GET /2 HTTP/1.1\r\nHost: a\r\n\r\n");
  setTimeout(() => {
    console.log([...out.matchAll(/HTTP\/1\.1 (\d+)/g)].map(m => m[1]), "dropRequest:", drops);
    console.log(out.match(/^Connection: .*$/gm));
  }, 200);
}, 200);
```

```
node v26.3.0:  [ '200', '503' ] dropRequest: 1   [ 'Connection: close', 'Connection: close' ]
bun (before):  [ '200', '200' ] dropRequest: 0   [ 'Connection: keep-alive', 'Connection: keep-alive' ]
bun (after):   [ '200', '503' ] dropRequest: 1   [ 'Connection: close', 'Connection: close' ]
```

The same thing happens over `allowHTTP1` with a TLS client negotiating `http/1.1`.

### Cause

`connectionListenerHTTP1` only copied the limit into `res._maxRequestsPerSocket`, which makes the Keep-Alive header advertise `max=N`. Nothing counted the requests on the connection, so `res.maxRequestsOnConnectionReached` was never set and every request was dispatched.

### Fix

Port the counting from Node's `parserOnIncoming` (`lib/_http_server.js`): a per-connection counter in the listener closure; when the limit is set, the response whose request reaches it gets `maxRequestsOnConnectionReached = true`, and a request past it emits `'dropRequest'` `(req, socket)` and is answered with `res.writeHead(503); res.end()` instead of reaching `'request'`. The check sits where Node has it, before the `Expect` routing, and like Node's block it applies to HTTP/1.1 requests.

Nothing else was needed: `renderNativeHeaders` in `_http_server.ts` already turns `maxRequestsOnConnectionReached` into `Connection: close`, and `ServerResponse#end` already dumps the unread body of the dropped request. With the fix, the response at the limit and the 503 are byte for byte what Node writes (apart from `Date`).

Like Node (documented on `server.maxRequestsPerSocket`: it sets `Connection: close` "but will not actually close the connection", and later requests get 503), the server does not close the connection itself; every further request on it gets its own 503 and `'dropRequest'`. `Http2SecureServer` already stores `maxRequestsPerSocket`, so the allowHTTP1 path needs no further wiring.

### Verification

- `test/js/node/http/node-http.test.ts`, `connectionListener maxRequestsPerSocket` (4 tests over `emit("connection")`): keep-alive `max=` on the response under the limit, `Connection: close` plus `maxRequestsOnConnectionReached` on the one that reaches it, 503 plus `'dropRequest'` (with the right `req.url` and socket) on every request past it; the counter is per connection; an over-limit request carrying `Expect: 100-continue` is dropped without `100 Continue` or `'checkContinue'`; an Upgrade request after the limit is still handed to `'upgrade'`, since Node hands upgrades off before counting (the native dispatcher 503s that case today, which is a separate pre-existing divergence, not changed here).
- `test/js/node/http2/node-http2.test.js`: the limit-reaching 200 and the over-limit 503 plus `'dropRequest'` over an `allowHTTP1` server with an `http/1.1` ALPN client.

All five fail on the current release build and pass with this change; the scenarios they assert were run against node v26.3.0 and match. `node-http.test.ts`, the `allowHTTP1` tests in `node-http2.test.js` and the upstream `test-http-keep-alive-{max-requests,drop-requests,pipeline-max-requests}.js`, `test-http-server-keep-alive-max-requests-null.js`, `test-https-keep-alive-drop-requests.js`, `test-http2-allow-http1.js`, `test-http2-https-fallback*.js` and `test-http2-server-http1-client.js` pass as before.

### Also in here

`test/js/node/http/node-http-proxy.js` (the `request via http proxy, issue#4295` test in `node-http.test.ts`) listened on `localhost` and dialed `localhost`. On hosts where `localhost` resolves to `::1` only, the proxy binds `::1` while the client connects to `127.0.0.1` and the test fails with `ECONNREFUSED` regardless of the code under test (Node fails the same way, so the test was not hermetic). Both ends are now pinned to `127.0.0.1`, which is what the `exampleSite` it proxies to already uses. #33472 carries the same two-line pin; whichever lands second drops it.

Requests are sent one at a time in the tests because pipelined requests on these connections still hit the separate `ERR_HTTP_SOCKET_ASSIGNED` issue (#36991); the 503 reply composes with that PR's response queue like any other response written from the parser callback.

</details>
