### PR TITLE
napi: drive napi_async_work through the addon's pointer instead of &mut self receivers

### DIFF
--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -370,7 +370,10 @@ pub(crate) fn run_task(
 
         // ── napi ─────────────────────────────────────────────────────────
         task_tag::NapiAsyncWork => {
-            cast!(napi_async_work).run_from_js(vm, global);
+            // SAFETY: §Dispatch — tag identifies the pointee; the addon's
+            // `complete` callback usually frees the work, so it takes the raw
+            // pointer (no `&mut` at this boundary).
+            unsafe { napi_async_work::run_from_js(cast_ptr!(napi_async_work), vm, global) };
         }
         task_tag::ThreadSafeFunction => {
             ThreadSafeFunction::on_dispatch(cast_ptr!(ThreadSafeFunction));

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1754,7 +1754,11 @@ pub(super) enum AsyncWorkStatus {
     Cancelled = 3,
 }
 
-/// must be globally allocated
+/// Heap-allocated; owned and freed by the addon. Once queued it is shared with
+/// the pool thread and the event-loop queue (`napi_cancel_async_work` may run
+/// during `execute`, and `complete` usually frees it the moment `run` has
+/// posted), so the entry points below take the addon's pointer and go through
+/// it field by field instead of forming a reference to the whole work.
 pub(crate) struct napi_async_work {
     pub task: WorkPoolTask,
     pub(crate) concurrent_task: ConcurrentTask,
@@ -1811,20 +1815,12 @@ impl napi_async_work {
         drop(unsafe { bun_core::heap::take(this) });
     }
 
-    // The work is shared between the addon (which owns and frees it), the
-    // pool thread and the event-loop queue, so every entry point below takes
-    // the addon's pointer and touches individual fields through it: no frame
-    // holds a reference to the whole work while another party may write to
-    // it (`cancel` racing `run`) or free it (`complete`, which normally calls
-    // `napi_delete_async_work`, runs as soon as `run` has posted).
-
-    /// `napi_queue_async_work`, JS thread.
+    /// `napi_queue_async_work`; JS thread.
     ///
     /// # Safety
-    /// `this` is a live work from [`Self::new`].
+    /// `this` is a live work.
     pub(crate) unsafe fn schedule(this: *mut Self) {
-        // SAFETY: fn contract; the pool only gets the work at the end of this
-        // function, so until then the JS thread is the only one touching it.
+        // SAFETY: fn contract; nothing else sees the work before the last line.
         unsafe {
             if (*this).scheduled {
                 return;
@@ -1835,31 +1831,32 @@ impl napi_async_work {
             // env: counted, so the VM waits for it (Node likewise settles its
             // threadpool requests before an environment is freed).
             (*this).loop_handle.embedded_work_scheduled();
-            // Projected from the work pointer itself, as `from_task_ptr`
-            // requires of the pointer it gets back.
             WorkPool::schedule(&raw mut (*this).task);
         }
     }
 
     pub(crate) unsafe fn run_from_thread_pool(task: *mut WorkPoolTask) {
         // SAFETY: `task` is the field `schedule` handed to the pool, projected
-        // from the work pointer, and the pool runs each task once.
+        // from the work pointer; the pool runs it once.
         unsafe { Self::run(napi_async_work::from_task_ptr(task)) };
     }
 
-    /// Pool thread. Ends by handing the work to the JS thread, which runs
-    /// `complete` (and with it, usually, `napi_delete_async_work`) as soon as
-    /// the post lands, so nothing reads `*this` after the post; the cloned
-    /// `handle` is what the pool thread keeps. `napi_cancel_async_work` may
-    /// write `status` at any point during this function.
+    /// Pool thread. The JS thread may `cancel` at any point, and frees the
+    /// work (`complete`) as soon as the post below lands.
     ///
     /// # Safety
-    /// `this` is the live work `schedule` handed to the pool; called once per
-    /// scheduling.
+    /// `this` is the live work `schedule` handed to the pool.
     unsafe fn run(this: *mut Self) {
-        // SAFETY: fn contract. The JS thread does not touch these fields while
-        // the work is in the pool's hands (`status` only through its atomic).
-        let handle = unsafe { (*this).loop_handle.clone() };
+        // SAFETY: fn contract; the JS thread only touches `status` (atomic)
+        // while the pool has the work.
+        let (handle, execute, env, data) = unsafe {
+            (
+                (*this).loop_handle.clone(),
+                (*this).execute,
+                (*this).env.get(),
+                (*this).data,
+            )
+        };
         // A VM that is already stopping cancels work it has not started, as
         // Node's environment cleanup does (uv_cancel); otherwise `execute` runs
         // with the VM held open.
@@ -1878,42 +1875,33 @@ impl napi_async_work {
                 Err(state) => state != AsyncWorkStatus::Cancelled as u32,
             };
         if started {
-            // SAFETY: as above.
-            let (execute, env, data) =
-                unsafe { ((*this).execute, (*this).env.get(), (*this).data) };
             execute(env, data);
-            // SAFETY: as above.
-            unsafe {
+        }
+        // The queue takes the embedded task (and with it the work) from here
+        // on. Counted work, so the VM has not closed its handle; a VM tearing
+        // down runs `complete` from its queue release (status cancelled if
+        // `execute` never ran), as Node does at environment cleanup.
+        // SAFETY: as above; filling in the task is the pool thread's last
+        // access to `*this`.
+        let ct = unsafe {
+            if started {
                 (*this)
                     .status
-                    .store(AsyncWorkStatus::Completed as u32, Ordering::SeqCst)
-            };
-        } else {
-            // SAFETY: as above.
-            let _ = unsafe { Self::cancel(this) };
-        }
+                    .store(AsyncWorkStatus::Completed as u32, Ordering::SeqCst);
+            } else {
+                let _ = Self::cancel(this);
+            }
+            core::ptr::NonNull::from((*this).concurrent_task.from(this, AutoDeinit::ManualDeinit))
+        };
         drop(vm);
-        // `concurrent_task` is the inline field of this heap work; the queue
-        // takes ownership of its `next` link. Counted work, so the VM has not
-        // closed its handle; a VM tearing down runs `complete` from its queue
-        // release (status cancelled if `execute` never ran), as Node does at
-        // environment cleanup.
-        // SAFETY: as above; this is the pool thread's last access to `*this`.
-        let ct = core::ptr::NonNull::from(unsafe {
-            (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit)
-        });
         let bun_jsc::vm_handle::Posted::Queued = handle.post_task(ct) else {
             unreachable!("VM handle closed with napi async work outstanding");
         };
-        // The JS thread may have freed the work by now; `handle` is ours.
         handle.embedded_work_finished();
     }
 
-    /// `napi_cancel_async_work` (JS thread) and [`Self::run`] (pool thread),
-    /// possibly at the same time: only the atomic is touched.
-    ///
     /// # Safety
-    /// `this` is a live work.
+    /// `this` is a live work (any thread; only the atomic is touched).
     pub(crate) unsafe fn cancel(this: *mut Self) -> bool {
         // SAFETY: fn contract.
         unsafe {
@@ -1927,21 +1915,17 @@ impl napi_async_work {
         .is_ok()
     }
 
-    /// JS thread, once per scheduling: from the task queue, or from its
-    /// release when the VM tears down first. `complete` is the addon's and
-    /// normally calls `napi_delete_async_work` on this very work, so
-    /// everything the call needs is taken out of `*this` first and `this` is
-    /// not used again after `complete` starts.
+    /// JS thread, from the task queue or from its release at VM teardown.
+    /// `complete` usually frees the work, so `this` is not used after it.
     ///
     /// # Safety
-    /// `this` is the live work [`Self::run`] posted; the pool thread is done
-    /// with it.
+    /// `this` is the live work [`Self::run`] posted.
     pub(crate) unsafe fn run_from_js(
         this: *mut Self,
         vm: &mut VirtualMachine,
         global: &JSGlobalObject,
     ) {
-        // SAFETY: fn contract; the JS thread is the only one touching the work now.
+        // SAFETY: fn contract; the pool thread is done with the work.
         let (mut poll_ref, complete, env, status, data) = unsafe {
             (
                 core::mem::take(&mut (*this).poll_ref),
@@ -2265,8 +2249,7 @@ extern "C" fn napi_cancel_async_work(env_: napi_env, work_: *mut napi_async_work
         return env.invalid_arg();
     }
     // SAFETY: non-null `work_` is the work `napi_create_async_work` allocated;
-    // the pool thread may be running it, which is why nothing here forms a
-    // reference to the whole work.
+    // the pool thread may be running it, so only individual fields are touched.
     debug_assert!(core::ptr::eq(env.to_js(), unsafe {
         (*work_).global.as_ptr()
     }));

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -1754,15 +1754,18 @@ pub(super) enum AsyncWorkStatus {
     Cancelled = 3,
 }
 
-/// Heap-allocated; owned and freed by the addon. Once queued it is shared with
-/// the pool thread and the event-loop queue (`napi_cancel_async_work` may run
-/// during `execute`, and `complete` usually frees it the moment `run` has
-/// posted), so the entry points below take the addon's pointer and go through
-/// it field by field instead of forming a reference to the whole work.
+/// Heap-allocated; owned and freed by the addon. While queued it is shared
+/// between the JS thread (which may still cancel or re-queue it, and whose
+/// `complete` usually frees it the moment `run` has posted it) and the pool
+/// thread, so the entry points below take the addon's pointer and go through it
+/// field by field instead of forming a reference to the whole work. The field
+/// docs say which thread writes what; unmarked fields are immutable after
+/// [`Self::new`].
 pub(crate) struct napi_async_work {
+    /// The pool's while the work is queued.
     pub task: WorkPoolTask,
+    /// Written by the pool thread as it hands the work back.
     pub(crate) concurrent_task: ConcurrentTask,
-    // Note: BackRef — `enqueue_task` needs `&mut EventLoop`; reborrowed at use sites.
     /// How the pool thread delivers completion / cancellation to the VM.
     pub(crate) loop_handle: bun_jsc::LoopHandle,
     /// JS thread only.
@@ -1771,8 +1774,11 @@ pub(crate) struct napi_async_work {
     pub(crate) execute: napi_async_execute_callback,
     pub(crate) complete: Option<napi_async_complete_callback>,
     pub(crate) data: *mut c_void,
-    pub(crate) status: AtomicU32, // AsyncWorkStatus
+    /// [`AsyncWorkStatus`]; the one field both threads write.
+    pub(crate) status: AtomicU32,
+    /// JS thread only.
     pub(crate) scheduled: bool,
+    /// JS thread only.
     pub poll_ref: KeepAlive,
 }
 
@@ -1820,7 +1826,10 @@ impl napi_async_work {
     /// # Safety
     /// `this` is a live work.
     pub(crate) unsafe fn schedule(this: *mut Self) {
-        // SAFETY: fn contract; nothing else sees the work before the last line.
+        // SAFETY: fn contract. The first call hands the pool its field on the
+        // last line and touches JS-thread and immutable fields before that
+        // (see the struct); a repeat call while the pool has the work only
+        // reads `scheduled`.
         unsafe {
             if (*this).scheduled {
                 return;
@@ -1847,8 +1856,8 @@ impl napi_async_work {
     /// # Safety
     /// `this` is the live work `schedule` handed to the pool.
     unsafe fn run(this: *mut Self) {
-        // SAFETY: fn contract; the JS thread only touches `status` (atomic)
-        // while the pool has the work.
+        // SAFETY: fn contract; immutable fields here, and below only the pool
+        // thread's fields and the atomic (see the struct).
         let (handle, execute, env, data) = unsafe {
             (
                 (*this).loop_handle.clone(),

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -50,7 +50,7 @@ impl Taskable for napi_async_work {
         let vm = VirtualMachine::get().as_mut();
         let global = vm.global();
         // SAFETY: fn contract — the addon's live work object the pool posted.
-        unsafe { (*this).run_from_js(vm, global) };
+        unsafe { napi_async_work::run_from_js(this, vm, global) };
     }
 }
 impl Taskable for ThreadSafeFunction {
@@ -1811,111 +1811,169 @@ impl napi_async_work {
         drop(unsafe { bun_core::heap::take(this) });
     }
 
-    pub(crate) fn schedule(&mut self) {
-        if self.scheduled {
-            return;
+    // The work is shared between the addon (which owns and frees it), the
+    // pool thread and the event-loop queue, so every entry point below takes
+    // the addon's pointer and touches individual fields through it: no frame
+    // holds a reference to the whole work while another party may write to
+    // it (`cancel` racing `run`) or free it (`complete`, which normally calls
+    // `napi_delete_async_work`, runs as soon as `run` has posted).
+
+    /// `napi_queue_async_work`, JS thread.
+    ///
+    /// # Safety
+    /// `this` is a live work from [`Self::new`].
+    pub(crate) unsafe fn schedule(this: *mut Self) {
+        // SAFETY: fn contract; the pool only gets the work at the end of this
+        // function, so until then the JS thread is the only one touching it.
+        unsafe {
+            if (*this).scheduled {
+                return;
+            }
+            (*this).scheduled = true;
+            (*this).poll_ref.ref_(bun_io::js_vm_ctx());
+            // The work object belongs to the addon and `execute` receives this
+            // env: counted, so the VM waits for it (Node likewise settles its
+            // threadpool requests before an environment is freed).
+            (*this).loop_handle.embedded_work_scheduled();
+            // Projected from the work pointer itself, as `from_task_ptr`
+            // requires of the pointer it gets back.
+            WorkPool::schedule(&raw mut (*this).task);
         }
-        self.scheduled = true;
-        self.poll_ref.ref_(bun_io::js_vm_ctx());
-        // The work object belongs to the addon and `execute` receives this
-        // env: counted, so the VM waits for it (Node likewise settles its
-        // threadpool requests before an environment is freed).
-        self.loop_handle.embedded_work_scheduled();
-        WorkPool::schedule(&raw mut self.task);
     }
 
     pub(crate) unsafe fn run_from_thread_pool(task: *mut WorkPoolTask) {
-        // SAFETY: `task` is the `task` field of a live heap `napi_async_work`,
-        // exclusively owned by the work pool for this callback's duration.
-        unsafe { (*napi_async_work::from_task_ptr(task)).run() };
+        // SAFETY: `task` is the field `schedule` handed to the pool, projected
+        // from the work pointer, and the pool runs each task once.
+        unsafe { Self::run(napi_async_work::from_task_ptr(task)) };
     }
 
-    fn run(&mut self) {
-        let self_ptr: *mut Self = self;
-        let handle = self.loop_handle.clone();
+    /// Pool thread. Ends by handing the work to the JS thread, which runs
+    /// `complete` (and with it, usually, `napi_delete_async_work`) as soon as
+    /// the post lands, so nothing reads `*this` after the post; the cloned
+    /// `handle` is what the pool thread keeps. `napi_cancel_async_work` may
+    /// write `status` at any point during this function.
+    ///
+    /// # Safety
+    /// `this` is the live work `schedule` handed to the pool; called once per
+    /// scheduling.
+    unsafe fn run(this: *mut Self) {
+        // SAFETY: fn contract. The JS thread does not touch these fields while
+        // the work is in the pool's hands (`status` only through its atomic).
+        let handle = unsafe { (*this).loop_handle.clone() };
         // A VM that is already stopping cancels work it has not started, as
         // Node's environment cleanup does (uv_cancel); otherwise `execute` runs
         // with the VM held open.
         let vm = handle.borrow_if_running();
         let started = vm.is_some()
-            && match self.status.compare_exchange(
-                AsyncWorkStatus::Pending as u32,
-                AsyncWorkStatus::Started as u32,
-                Ordering::SeqCst,
-                Ordering::SeqCst,
-            ) {
+            // SAFETY: as above.
+            && match unsafe {
+                (*this).status.compare_exchange(
+                    AsyncWorkStatus::Pending as u32,
+                    AsyncWorkStatus::Started as u32,
+                    Ordering::SeqCst,
+                    Ordering::SeqCst,
+                )
+            } {
                 Ok(_) => true,
                 Err(state) => state != AsyncWorkStatus::Cancelled as u32,
             };
         if started {
-            (self.execute)(self.env.get(), self.data);
-            self.status
-                .store(AsyncWorkStatus::Completed as u32, Ordering::SeqCst);
+            // SAFETY: as above.
+            let (execute, env, data) =
+                unsafe { ((*this).execute, (*this).env.get(), (*this).data) };
+            execute(env, data);
+            // SAFETY: as above.
+            unsafe {
+                (*this)
+                    .status
+                    .store(AsyncWorkStatus::Completed as u32, Ordering::SeqCst)
+            };
         } else {
-            let _ = self.cancel();
+            // SAFETY: as above.
+            let _ = unsafe { Self::cancel(this) };
         }
         drop(vm);
-        self.post_to_js_thread(self_ptr);
-        // `self` may already be freed by the JS thread; the handle is ours.
+        // `concurrent_task` is the inline field of this heap work; the queue
+        // takes ownership of its `next` link. Counted work, so the VM has not
+        // closed its handle; a VM tearing down runs `complete` from its queue
+        // release (status cancelled if `execute` never ran), as Node does at
+        // environment cleanup.
+        // SAFETY: as above; this is the pool thread's last access to `*this`.
+        let ct = core::ptr::NonNull::from(unsafe {
+            (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit)
+        });
+        let bun_jsc::vm_handle::Posted::Queued = handle.post_task(ct) else {
+            unreachable!("VM handle closed with napi async work outstanding");
+        };
+        // The JS thread may have freed the work by now; `handle` is ours.
         handle.embedded_work_finished();
     }
 
-    /// Pool thread → JS thread: run `complete` there. `concurrent_task` is the
-    /// live inline field of this heap work; the queue takes ownership of its
-    /// `next` link. Counted work, so the VM has not closed its handle; a VM
-    /// tearing down runs `complete` from its queue release (status cancelled
-    /// if `execute` never ran), as Node does at environment cleanup.
-    fn post_to_js_thread(&mut self, self_ptr: *mut Self) {
-        let ct = core::ptr::NonNull::from(
-            self.concurrent_task
-                .from(self_ptr, AutoDeinit::ManualDeinit),
-        );
-        let bun_jsc::vm_handle::Posted::Queued = self.loop_handle.post_task(ct) else {
-            unreachable!("VM handle closed with napi async work outstanding");
-        };
-    }
-
-    pub(crate) fn cancel(&mut self) -> bool {
-        self.status
-            .compare_exchange(
+    /// `napi_cancel_async_work` (JS thread) and [`Self::run`] (pool thread),
+    /// possibly at the same time: only the atomic is touched.
+    ///
+    /// # Safety
+    /// `this` is a live work.
+    pub(crate) unsafe fn cancel(this: *mut Self) -> bool {
+        // SAFETY: fn contract.
+        unsafe {
+            (*this).status.compare_exchange(
                 AsyncWorkStatus::Pending as u32,
                 AsyncWorkStatus::Cancelled as u32,
                 Ordering::SeqCst,
                 Ordering::SeqCst,
             )
-            .is_ok()
+        }
+        .is_ok()
     }
 
-    pub(crate) fn run_from_js(&mut self, vm: &mut VirtualMachine, global: &JSGlobalObject) {
-        // Note: the "this" value here may already be freed by the user in `complete`
-        // Note: KeepAlive is not `Copy`, so move it out (the original slot may
-        // be freed under us by `complete`).
-        let mut poll_ref = core::mem::take(&mut self.poll_ref);
+    /// JS thread, once per scheduling: from the task queue, or from its
+    /// release when the VM tears down first. `complete` is the addon's and
+    /// normally calls `napi_delete_async_work` on this very work, so
+    /// everything the call needs is taken out of `*this` first and `this` is
+    /// not used again after `complete` starts.
+    ///
+    /// # Safety
+    /// `this` is the live work [`Self::run`] posted; the pool thread is done
+    /// with it.
+    pub(crate) unsafe fn run_from_js(
+        this: *mut Self,
+        vm: &mut VirtualMachine,
+        global: &JSGlobalObject,
+    ) {
+        // SAFETY: fn contract; the JS thread is the only one touching the work now.
+        let (mut poll_ref, complete, env, status, data) = unsafe {
+            (
+                core::mem::take(&mut (*this).poll_ref),
+                (*this).complete,
+                (*this).env.get(),
+                (*this).status.load(Ordering::SeqCst),
+                (*this).data,
+            )
+        };
         // KeepAlive::unref needs an event-loop ctx so it cannot impl Drop
         // generically; this is a genuine one-off cleanup.
         scopeguard::defer! { poll_ref.unref(bun_io::js_vm_ctx()); }
 
         // https://github.com/nodejs/node/blob/a2de5b9150da60c77144bb5333371eaca3fab936/src/node_api.cc#L1201
-        let Some(complete) = self.complete else {
+        let Some(complete) = complete else {
             return;
         };
 
-        let env = self.env.get();
-        // SAFETY: env is held alive by NapiEnvRef for the duration of this call.
+        // SAFETY: `global` (live for this call) holds a ref on every env made
+        // for it (`GlobalObject::m_napiEnvs`), so `env` outlives the work's own
+        // ref, which `complete` usually drops by freeing the work.
         let env_ref = unsafe { &*env };
         let _hs = NapiHandleScope::open_scoped(env_ref);
 
-        let status: NapiStatus =
-            if self.status.load(Ordering::SeqCst) == AsyncWorkStatus::Cancelled as u32 {
-                NapiStatus::cancelled
-            } else {
-                NapiStatus::ok
-            };
+        let status: NapiStatus = if status == AsyncWorkStatus::Cancelled as u32 {
+            NapiStatus::cancelled
+        } else {
+            NapiStatus::ok
+        };
 
-        complete(env, status as napi_status, self.data);
+        complete(env, status as napi_status, data);
 
-        // SAFETY: env is valid for the duration of this call.
-        let env_ref = unsafe { &*env };
         if let Some(exception) = env_ref.get_and_clear_pending_exception() {
             let _ = vm.uncaught_exception(global, exception, false);
         } else if global.has_exception() {
@@ -2172,11 +2230,13 @@ extern "C" fn napi_create_async_work(
 extern "C" fn napi_delete_async_work(env_: napi_env, work_: *mut napi_async_work) -> napi_status {
     bun_output::scoped_log!(napi, "napi_delete_async_work");
     let env = get_env!(env_);
-    // SAFETY: `work_` is null or the `napi_async_work` we allocated in `napi_create_async_work`.
-    let Some(work) = (unsafe { work_.as_mut() }) else {
+    if work_.is_null() {
         return env.invalid_arg();
-    };
-    debug_assert!(core::ptr::eq(env.to_js(), work.global.as_ptr()));
+    }
+    // SAFETY: non-null `work_` is the work `napi_create_async_work` allocated.
+    debug_assert!(core::ptr::eq(env.to_js(), unsafe {
+        (*work_).global.as_ptr()
+    }));
     napi_async_work::destroy(work_);
     env.ok()
 }
@@ -2185,12 +2245,15 @@ extern "C" fn napi_delete_async_work(env_: napi_env, work_: *mut napi_async_work
 extern "C" fn napi_queue_async_work(env_: napi_env, work_: *mut napi_async_work) -> napi_status {
     bun_output::scoped_log!(napi, "napi_queue_async_work");
     let env = get_env!(env_);
-    // SAFETY: `work_` is null or the `napi_async_work` we allocated in `napi_create_async_work`.
-    let Some(work) = (unsafe { work_.as_mut() }) else {
+    if work_.is_null() {
         return env.invalid_arg();
-    };
-    debug_assert!(core::ptr::eq(env.to_js(), work.global.as_ptr()));
-    work.schedule();
+    }
+    // SAFETY: non-null `work_` is the work `napi_create_async_work` allocated.
+    debug_assert!(core::ptr::eq(env.to_js(), unsafe {
+        (*work_).global.as_ptr()
+    }));
+    // SAFETY: as above.
+    unsafe { napi_async_work::schedule(work_) };
     env.ok()
 }
 
@@ -2198,12 +2261,17 @@ extern "C" fn napi_queue_async_work(env_: napi_env, work_: *mut napi_async_work)
 extern "C" fn napi_cancel_async_work(env_: napi_env, work_: *mut napi_async_work) -> napi_status {
     bun_output::scoped_log!(napi, "napi_cancel_async_work");
     let env = get_env!(env_);
-    // SAFETY: `work_` is null or the `napi_async_work` we allocated in `napi_create_async_work`.
-    let Some(work) = (unsafe { work_.as_mut() }) else {
+    if work_.is_null() {
         return env.invalid_arg();
-    };
-    debug_assert!(core::ptr::eq(env.to_js(), work.global.as_ptr()));
-    if work.cancel() {
+    }
+    // SAFETY: non-null `work_` is the work `napi_create_async_work` allocated;
+    // the pool thread may be running it, which is why nothing here forms a
+    // reference to the whole work.
+    debug_assert!(core::ptr::eq(env.to_js(), unsafe {
+        (*work_).global.as_ptr()
+    }));
+    // SAFETY: as above.
+    if unsafe { napi_async_work::cancel(work_) } {
         return env.ok();
     }
 

--- a/test/internal/source-lints/self-receiver-intrusive-post.test.ts
+++ b/test/internal/source-lints/self-receiver-intrusive-post.test.ts
@@ -46,11 +46,14 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // `ShellAsyncTask` in src/runtime/shell/states/Async.rs.
 //
 // Scope: the `.from(` initializer with the receiver's address as its first
-// argument, where "the receiver's address" is one of the direct spellings
-// below, a local of the same function bound to one, or a `*mut Self` /
-// `*const Self` parameter of a method that also has a reference receiver (the
-// only thing such a parameter can be is the receiver, handed in separately
-// because the reference cannot be posted). The heap-task constructors
+// argument, where "the receiver's address" is one of the spellings below
+// (applied to `self` or to a reborrow of it), a local of the same function
+// bound to one, or a parameter of a method that also has a reference receiver
+// and is typed as a raw pointer to the method's own type, spelled `Self` or by
+// the enclosing impl's name (the only thing such a parameter can be is the
+// receiver, handed in separately because the reference cannot be posted). The
+// spelling list is the same one self-receiver-reclaim.test.ts uses; a change
+// to one belongs in the other too. The heap-task constructors
 // (`Task::init`, `ConcurrentTask::create_from`, `from_callback`) are the same
 // hazard in a different spelling and a separate population (#37723); a
 // pointer produced by a helper (`self.as_ptr()`) and reference parameters
@@ -83,23 +86,33 @@ const POST = String.raw`\.\s*from\s*\(\s*`;
 // `.cast_mut()`, `.as_ptr()` (how a `NonNull` binding is passed).
 const SAME_ADDRESS = String.raw`(?:\s*\.\s*(?:cast(?:_mut|_const)?(?:::<[^>]*>)?|as_ptr)\(\))*`;
 
-// The ways of spelling "`self`, as a raw pointer" inline. The bare form (a
-// `&mut Self` coerces to `*mut Self` at the call) needs the `,` / `)` so
-// `self.field` does not match; `(?!\s*\.)` after the `&raw` form keeps
-// `&raw mut *self.field` (something the receiver owns) out.
-const SELF_AS_POINTER = [
-  String.raw`self\s*[,)]`,
-  String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
-  String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
-  String.raw`self\s+as\s+\*(?:mut|const)\b`,
-  String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
+// `self` or a reborrow of it (`&mut *self`, `&*self`), as the operand of the
+// pointer conversions below. `(?!\s*\.)` keeps `&mut *self.field` (something
+// the receiver owns) out.
+const SELF_OPERAND = String.raw`(?:&\s*(?:mut\s+)?\*\s*)?self\b(?!\s*\.)`;
+
+// The conversions that turn the receiver into its address. Shared between the
+// inline and the `let`-bound forms below; the self-test at the bottom pins
+// each spelling. `(?!\s*\.)` after the reborrow forms keeps `&raw mut
+// *self.field` out, as above.
+const ADDRESS_OF_SELF = [
+  String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*${SELF_OPERAND}\s*\)`,
+  String.raw`(?:[\w:]+::)?NonNull::from\(\s*${SELF_OPERAND}\s*\)`,
   String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
-].join("|");
+  String.raw`&\s*(?:raw\s+(?:mut|const)|mut)\s+\*\s*self\b(?!\s*\.)`,
+];
+
+// Inline: one of the conversions, `self as *mut _`, or bare `self` (a `&mut
+// Self` coerces to `*mut Self` at the call; it needs the `,` / `)` so
+// `self.field` does not match).
+const SELF_AS_POINTER = [...ADDRESS_OF_SELF, String.raw`self\s+as\s+\*(?:mut|const)\b`, String.raw`self\s*[,)]`].join(
+  "|",
+);
 
 const DIRECT = new RegExp(`${POST}(?:${SELF_AS_POINTER})`, "g");
 
 // A local bound to the receiver's address: `let p = ptr::from_mut(self);`,
-// `let p = self as *mut Self;`, `let p = NonNull::from(self);`, or the
+// `let p = NonNull::from(&mut *self);`, `let p = self as *mut Self;`, or the
 // coercion spelling `let p: *mut Self = self;` (which needs the annotation;
 // without it `let p = self;` is just another reference).
 const BINDING_HEAD = String.raw`let\s+(?:mut\s+)?(\w+)\s*`;
@@ -107,13 +120,7 @@ const SELF_POINTER_BINDINGS = [
   new RegExp(
     BINDING_HEAD +
       String.raw`(?::[^=;]*)?=\s*(?:` +
-      [
-        String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
-        String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
-        String.raw`self\s+as\s+\*(?:mut|const)\b[^;.]*`,
-        String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b`,
-        String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
-      ].join("|") +
+      [...ADDRESS_OF_SELF, String.raw`self\s+as\s+\*(?:mut|const)\b[^;.]*`].join("|") +
       String.raw`)${SAME_ADDRESS}\s*;`,
     "g",
   ),
@@ -129,7 +136,19 @@ const FN_ITEM_SOURCE = String.raw`^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|as
 const FN_ITEM = new RegExp(FN_ITEM_SOURCE, "m");
 const FN_ITEMS = new RegExp(FN_ITEM_SOURCE, "gm");
 const RECEIVER_PARAM = /^\s*(?:&(?:'\w+\s+)?(?:mut\s+)?self\b|(?:mut\s+)?self\s*:\s*(?:&|Pin<))/;
-const SELF_POINTER_PARAM = /\b(\w+)\s*:\s*\*(?:mut|const)\s+Self\b(?!\s*::)/g;
+
+// `impl Foo`, `impl<T> Foo<T>`, `impl Trait for Foo`: the type `Self` stands
+// for in the methods that follow, so a parameter typed `*mut Foo` inside them
+// counts like `*mut Self`. A `trait` item starts a region where only `Self`
+// is known.
+const IMPL_OR_TRAIT_ITEMS =
+  /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+)?(?:impl(?:<[^>]*>)?\s+(?:[\w:]+(?:<[^>]*>)?\s+for\s+)?([\w:]+)|trait\s+\w+)/gm;
+
+/** A parameter typed `*mut Self` / `*const Self` (or the enclosing impl's type), capturing its name. */
+function selfPointerParams(implType: string | null): RegExp {
+  const types = implType === null ? String.raw`Self\b(?!\s*::)` : String.raw`(?:Self\b(?!\s*::)|${implType}\b)`;
+  return new RegExp(String.raw`\b(\w+)\s*:\s*\*(?:mut|const)\s+${types}`, "g");
+}
 
 function postOf(name: string): RegExp {
   return new RegExp(POST + String.raw`\b${name}\b${SAME_ADDRESS}\s*[,)]`);
@@ -142,12 +161,23 @@ function restOfFunction(stripped: string, offset: number): string {
   return end === -1 ? rest : rest.slice(0, end);
 }
 
+/** For each `impl` / `trait` item: where it starts and the implementing type's last path segment (null for traits). */
+function implRegions(stripped: string): { start: number; implType: string | null }[] {
+  return [...stripped.matchAll(IMPL_OR_TRAIT_ITEMS)].map(m => ({
+    start: m.index,
+    implType: m[1] === undefined ? null : m[1].slice(m[1].lastIndexOf(":") + 1),
+  }));
+}
+
 /**
- * For every method with a reference receiver and a `*mut Self` parameter:
- * the parameter names and the offset of the method's body.
+ * For every method with a reference receiver and a parameter that is a raw
+ * pointer to its own type: the parameter names and the offset of the
+ * method's body.
  */
 function* receiverTwice(stripped: string): Generator<{ names: string[]; bodyStart: number }> {
+  const regions = implRegions(stripped);
   for (const item of stripped.matchAll(FN_ITEMS)) {
+    const region = regions.findLast(r => r.start < item.index);
     let i = item.index + item[0].length;
     // Skip the generic parameter list, which may itself contain parens
     // (`fn f<F: Fn(u8) -> u8>(`); `->` inside it is not a closing angle.
@@ -177,7 +207,7 @@ function* receiverTwice(stripped: string): Generator<{ names: string[]; bodyStar
     if (close === -1) continue;
     const params = stripped.slice(paramsOpen + 1, close);
     if (!RECEIVER_PARAM.test(params)) continue;
-    const names = [...params.matchAll(SELF_POINTER_PARAM)].map(m => m[1]);
+    const names = [...params.matchAll(selfPointerParams(region?.implType ?? null))].map(m => m[1]);
     if (names.length > 0) yield { names, bodyStart: close + 1 };
   }
 }
@@ -263,8 +293,33 @@ test("the patterns match the banned spellings and nothing else", () => {
       "        let Posted::Queued = self.loop_handle.post_task(ct) else { unreachable!() };",
       "    }",
     ].join("\n"),
+    // The same two methods with the parameter typed by the impl's name
+    // instead of `Self`.
+    [
+      "impl napi_async_work {",
+      "    fn run(&mut self) {",
+      "        let self_ptr: *mut napi_async_work = self;",
+      "        self.post_to_js_thread(self_ptr);",
+      "    }",
+      "",
+      "    fn post_to_js_thread(&mut self, work: *mut napi_async_work) {",
+      "        let ct = NonNull::from(self.concurrent_task.from(work, AutoDeinit::ManualDeinit));",
+      "    }",
+      "}",
+    ].join("\n"),
+    "impl<T: Taskable> Worker<T> {\n    fn post(&mut self, me: *const Worker<T>) {\n        self.ct.from(me.cast_mut(), AutoDeinit::ManualDeinit);\n    }\n}",
+    "unsafe impl crate::Postable for shell::RmTask {\n    fn post(&mut self, me: *mut RmTask) {\n        self.ct.from(me, AutoDeinit::ManualDeinit);\n    }\n}",
     // The same thing inlined into one method.
     "fn run(&mut self) {\n    let self_ptr: *mut Self = self;\n    let ct = NonNull::from(self.concurrent_task.from(self_ptr, AutoDeinit::ManualDeinit));\n}",
+    // Taking the address of a reborrow of the receiver is taking the
+    // receiver's address.
+    "fn run(&mut self) {\n    let self_ptr = NonNull::from(&mut *self);\n    ct.from(self_ptr.as_ptr(), AutoDeinit::ManualDeinit);\n}",
+    "fn run(&mut self) {\n    let p = core::ptr::from_mut(&mut *self);\n    ct.from(p, AutoDeinit::ManualDeinit);\n}",
+    "fn run(&mut self) {\n    let p = std::ptr::from_ref(&*self).cast_mut();\n    ct.from(p, AutoDeinit::ManualDeinit);\n}",
+    "fn run(&mut self) {\n    let p = &mut *self;\n    ct.from(p, AutoDeinit::ManualDeinit);\n}",
+    "ct.from(&mut *self, AutoDeinit::ManualDeinit)",
+    "ct.from(std::ptr::from_mut(&mut *self), AutoDeinit::ManualDeinit)",
+    "ct.from(NonNull::from(&mut *self).as_ptr(), AutoDeinit::ManualDeinit)",
     "fn run(&mut self) {\n    let this = std::ptr::from_mut::<Self>(self);\n    unsafe { (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit) };\n}",
     "fn run(&mut self) {\n    let p = self as *mut Self;\n    self.task.from(p, Self::run_from_main_thread_mini);\n}",
     "fn run(&mut self) {\n    let p = std::ptr::from_ref(self).cast_mut();\n    ct.from(p, AutoDeinit::ManualDeinit);\n}",
@@ -297,7 +352,14 @@ test("the patterns match the banned spellings and nothing else", () => {
     // Posting something the receiver owns or points at is not this shape.
     "self.concurrent_task.from(self.child, AutoDeinit::ManualDeinit)",
     "ct.from(&raw mut *self.inner, AutoDeinit::ManualDeinit)",
+    "ct.from(&mut *self.inner, AutoDeinit::ManualDeinit)",
+    "ct.from(std::ptr::from_mut(&mut *self.inner), AutoDeinit::ManualDeinit)",
+    "fn run(&mut self) {\n    let p = NonNull::from(&mut *self.inner);\n    ct.from(p.as_ptr(), AutoDeinit::ManualDeinit);\n}",
     "ct.from(self.as_ptr(), AutoDeinit::ManualDeinit)",
+    // A pointer to some other type, or to a type that is only the impl's
+    // type by name in a different region of the file.
+    "impl Scheduler {\n    fn post(&mut self, job: *mut Job) {\n        self.ct.from(job, AutoDeinit::ManualDeinit);\n    }\n}",
+    "impl Job {\n    fn id(&self) -> u32 {\n        self.id\n    }\n}\n\ntrait Poster {\n    fn post(&mut self, job: *mut Job) {\n        self.ct().from(job, AutoDeinit::ManualDeinit);\n    }\n}",
     // `from` methods that are not the task initializer, and `From` impls.
     ".reader()\n    .from(buffered_reader, ctx_ptr.cast::<c_void>());",
     "let s = String::from(self.name);",

--- a/test/internal/source-lints/self-receiver-intrusive-post.test.ts
+++ b/test/internal/source-lints/self-receiver-intrusive-post.test.ts
@@ -1,0 +1,337 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A method must not post its own receiver through the intrusive task it
+// embeds. Inside a `&self` / `&mut self` method, the receiver's address
+//
+//   self.concurrent_task.from(std::ptr::from_mut(self), AutoDeinit::ManualDeinit)
+//   let p: *mut Self = self; ... self.concurrent_task.from(p, ..)
+//   fn post(&mut self, p: *mut Self) { self.concurrent_task.from(p, ..) }   // p is self, by contract
+//
+// as the first argument of the intrusive `.from(..)` initializer
+// (`ConcurrentTask::from`, `AnyTaskWithExtraContext::from`: "make the task
+// embedded in this object carry this object") is banned.
+//
+// The `.from(..)` is the start of the hand-over: the task it fills in is
+// posted next, and from the moment the post lands the consumer owns the
+// object. For the pool-thread completions that use this form the consumer is
+// the JS thread, and what it does with the object is usually to free it
+// (`napi_async_work`: the addon's `complete` callback calls
+// `napi_delete_async_work`; the S3 and shell tasks `heap::take` themselves),
+// while the `&mut self` of the method that posted is still a live argument.
+// A reference argument is protected for the duration of its call, and
+// writing to or deallocating protected memory is UB under both aliasing
+// models whether or not the method touches `self` again: Tree Borrows (what
+// `bun run rust:miri` uses) reports "deallocation through <tag> is forbidden
+// ... the strongly protected tag disallows deallocations", pointing at the
+// receiver, and Stacked Borrows reports "deallocating while item [Unique] is
+// strongly protected". Codegen relies on the same thing: the argument is
+// annotated dereferenceable for the whole call. `napi_async_work::run(&mut
+// self)` / `post_to_js_thread(&mut self, self_ptr: *mut Self)` were the
+// instance this was written for: every async work completion posted the work
+// from inside two such frames.
+//
+// The object was a raw pointer before it became `self` (the work-pool task
+// pointer, the callback ctx), so the fix is to keep it one: the function that
+// posts takes `this: *mut Self`, reads what it needs through statement-scoped
+// `(*this).field` accesses, clones the handle it posts through out of the
+// object (posting through `(*this).loop_handle` would protect a reference
+// into the allocation for the duration of the post, the same bug one level
+// down), and ends with `(*this).concurrent_task.from(this, ..)`. Templates:
+// `napi_async_work::run` in src/runtime/napi/napi_body.rs,
+// `S3HttpSimpleTask::http_callback` in src/runtime/webcore/s3/simple_request.rs,
+// `ShellAsyncTask` in src/runtime/shell/states/Async.rs.
+//
+// Scope: the `.from(` initializer with the receiver's address as its first
+// argument, where "the receiver's address" is one of the direct spellings
+// below, a local of the same function bound to one, or a `*mut Self` /
+// `*const Self` parameter of a method that also has a reference receiver (the
+// only thing such a parameter can be is the receiver, handed in separately
+// because the reference cannot be posted). The heap-task constructors
+// (`Task::init`, `ConcurrentTask::create_from`, `from_callback`) are the same
+// hazard in a different spelling and a separate population (#37723); a
+// pointer produced by a helper (`self.as_ptr()`) and reference parameters
+// other than `self` are outside this lint. Siblings:
+// self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
+// frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// The intrusive initializer: a method call, so `Foo::from(x)` (a `From` impl)
+// does not count. `\s*` around the paren so a rustfmt-wrapped call still
+// matches.
+const POST = String.raw`\.\s*from\s*\(\s*`;
+
+// Pointer-to-pointer conversions that keep the address: `.cast()`,
+// `.cast_mut()`, `.as_ptr()` (how a `NonNull` binding is passed).
+const SAME_ADDRESS = String.raw`(?:\s*\.\s*(?:cast(?:_mut|_const)?(?:::<[^>]*>)?|as_ptr)\(\))*`;
+
+// The ways of spelling "`self`, as a raw pointer" inline. The bare form (a
+// `&mut Self` coerces to `*mut Self` at the call) needs the `,` / `)` so
+// `self.field` does not match; `(?!\s*\.)` after the `&raw` form keeps
+// `&raw mut *self.field` (something the receiver owns) out.
+const SELF_AS_POINTER = [
+  String.raw`self\s*[,)]`,
+  String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
+  String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+  String.raw`self\s+as\s+\*(?:mut|const)\b`,
+  String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b(?!\s*\.)`,
+  String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+].join("|");
+
+const DIRECT = new RegExp(`${POST}(?:${SELF_AS_POINTER})`, "g");
+
+// A local bound to the receiver's address: `let p = ptr::from_mut(self);`,
+// `let p = self as *mut Self;`, `let p = NonNull::from(self);`, or the
+// coercion spelling `let p: *mut Self = self;` (which needs the annotation;
+// without it `let p = self;` is just another reference).
+const BINDING_HEAD = String.raw`let\s+(?:mut\s+)?(\w+)\s*`;
+const SELF_POINTER_BINDINGS = [
+  new RegExp(
+    BINDING_HEAD +
+      String.raw`(?::[^=;]*)?=\s*(?:` +
+      [
+        String.raw`(?:[\w:]+::)?from_(?:mut|ref)(?:::<[^>]*>)?\(\s*self\s*\)`,
+        String.raw`(?:[\w:]+::)?NonNull::from\(\s*self\s*\)`,
+        String.raw`self\s+as\s+\*(?:mut|const)\b[^;.]*`,
+        String.raw`&raw\s+(?:mut|const)\s+\*\s*self\b`,
+        String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+      ].join("|") +
+      String.raw`)${SAME_ADDRESS}\s*;`,
+    "g",
+  ),
+  new RegExp(BINDING_HEAD + String.raw`:\s*\*(?:mut|const)\b[^=;]*=\s*self\s*;`, "g"),
+];
+
+// A function item, however qualified. Also where the previous function's
+// body is taken to end (a closure inside a function is part of it for this
+// purpose). Two instances because a `g` regex carries its position between
+// uses: `FN_ITEMS` is only ever iterated with `matchAll`, `FN_ITEM` only used
+// with `search`.
+const FN_ITEM_SOURCE = String.raw`^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s+\w+`;
+const FN_ITEM = new RegExp(FN_ITEM_SOURCE, "m");
+const FN_ITEMS = new RegExp(FN_ITEM_SOURCE, "gm");
+const RECEIVER_PARAM = /^\s*(?:&(?:'\w+\s+)?(?:mut\s+)?self\b|(?:mut\s+)?self\s*:\s*(?:&|Pin<))/;
+const SELF_POINTER_PARAM = /\b(\w+)\s*:\s*\*(?:mut|const)\s+Self\b(?!\s*::)/g;
+
+function postOf(name: string): RegExp {
+  return new RegExp(POST + String.raw`\b${name}\b${SAME_ADDRESS}\s*[,)]`);
+}
+
+/** The text after `offset` up to the next function item. */
+function restOfFunction(stripped: string, offset: number): string {
+  const rest = stripped.slice(offset);
+  const end = rest.search(FN_ITEM);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+/**
+ * For every method with a reference receiver and a `*mut Self` parameter:
+ * the parameter names and the offset of the method's body.
+ */
+function* receiverTwice(stripped: string): Generator<{ names: string[]; bodyStart: number }> {
+  for (const item of stripped.matchAll(FN_ITEMS)) {
+    let i = item.index + item[0].length;
+    // Skip the generic parameter list, which may itself contain parens
+    // (`fn f<F: Fn(u8) -> u8>(`); `->` inside it is not a closing angle.
+    if (/^\s*</.test(stripped.slice(i, i + 16))) {
+      for (let depth = 0; i < stripped.length; i++) {
+        const c = stripped[i];
+        if (c === "<") depth++;
+        else if (c === ">" && stripped[i - 1] !== "-" && --depth === 0) {
+          i++;
+          break;
+        }
+      }
+    }
+    const paramsOpen = stripped.indexOf("(", i);
+    if (paramsOpen === -1 || stripped.slice(i, paramsOpen).trim() !== "") continue;
+    // Parameter types may contain parens too (`cb: fn(*mut Task)`), so find
+    // the list's own closing paren by depth.
+    let close = -1;
+    for (let depth = 0, j = paramsOpen; j < stripped.length; j++) {
+      const c = stripped[j];
+      if (c === "(") depth++;
+      else if (c === ")" && --depth === 0) {
+        close = j;
+        break;
+      }
+    }
+    if (close === -1) continue;
+    const params = stripped.slice(paramsOpen + 1, close);
+    if (!RECEIVER_PARAM.test(params)) continue;
+    const names = [...params.matchAll(SELF_POINTER_PARAM)].map(m => m[1]);
+    if (names.length > 0) yield { names, bodyStart: close + 1 };
+  }
+}
+
+/** Byte offsets (into `stripped`) of every banned post in one file. */
+function findPosts(stripped: string): number[] {
+  const hits = new Set<number>();
+  for (const m of stripped.matchAll(DIRECT)) hits.add(m.index);
+  for (const pattern of SELF_POINTER_BINDINGS) {
+    for (const binding of stripped.matchAll(pattern)) {
+      const start = binding.index + binding[0].length;
+      const post = restOfFunction(stripped, start).search(postOf(binding[1]));
+      if (post !== -1) hits.add(start + post);
+    }
+  }
+  for (const { names, bodyStart } of receiverTwice(stripped)) {
+    const body = restOfFunction(stripped, bodyStart);
+    for (const name of names) {
+      const post = body.search(postOf(name));
+      if (post !== -1) hits.add(bodyStart + post);
+    }
+  }
+  return [...hits].sort((a, b) => a - b);
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape, with a stated reason. Empty by design: the whole tree is at zero.
+// Prefer converting over adding an entry here.
+const ALLOW: Record<string, number> = {};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including the in-tree comments
+  // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
+  // newlines and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const offset of findPosts(stripped)) {
+    counts[source] = (counts[source] ?? 0) + 1;
+    if (counts[source] > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${lineOf(stripped, offset)}`);
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the patterns match the banned spellings and nothing else", () => {
+  const banned = [
+    // `napi_async_work::run` / `post_to_js_thread` as they were: the address
+    // is taken in one method and posted by the other, which receives it next
+    // to its own `&mut self`. One hit, at the post.
+    [
+      "    fn run(&mut self) {",
+      "        let self_ptr: *mut Self = self;",
+      "        let handle = self.loop_handle.clone();",
+      "        (self.execute)(self.env.get(), self.data);",
+      "        self.post_to_js_thread(self_ptr);",
+      "        handle.embedded_work_finished();",
+      "    }",
+      "",
+      "    fn post_to_js_thread(&mut self, self_ptr: *mut Self) {",
+      "        let ct = core::ptr::NonNull::from(",
+      "            self.concurrent_task",
+      "                .from(self_ptr, AutoDeinit::ManualDeinit),",
+      "        );",
+      "        let Posted::Queued = self.loop_handle.post_task(ct) else { unreachable!() };",
+      "    }",
+    ].join("\n"),
+    // The same thing inlined into one method.
+    "fn run(&mut self) {\n    let self_ptr: *mut Self = self;\n    let ct = NonNull::from(self.concurrent_task.from(self_ptr, AutoDeinit::ManualDeinit));\n}",
+    "fn run(&mut self) {\n    let this = std::ptr::from_mut::<Self>(self);\n    unsafe { (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit) };\n}",
+    "fn run(&mut self) {\n    let p = self as *mut Self;\n    self.task.from(p, Self::run_from_main_thread_mini);\n}",
+    "fn run(&mut self) {\n    let p = std::ptr::from_ref(self).cast_mut();\n    ct.from(p, AutoDeinit::ManualDeinit);\n}",
+    "fn run(&mut self) {\n    let p = NonNull::from(self);\n    ct.from(p.as_ptr(), AutoDeinit::ManualDeinit);\n}",
+    "fn run(&mut self) {\n    let p = &raw mut *self;\n    if done {\n        return;\n    }\n    ct.from(p, AutoDeinit::ManualDeinit);\n}",
+    // Spelled inline. `ct` is a task reached some other way, since borrowck
+    // rejects `self.concurrent_task.from(self, ..)`.
+    "ct.from(self, AutoDeinit::ManualDeinit)",
+    "ct.from(std::ptr::from_mut(self), AutoDeinit::ManualDeinit)",
+    "ct.from(core::ptr::from_mut::<Self>(self), AutoDeinit::ManualDeinit)",
+    "ct.from(self as *mut Self, AutoDeinit::ManualDeinit)",
+    "ct.from(&raw mut *self, AutoDeinit::ManualDeinit)",
+    "ct.from(core::ptr::addr_of_mut!(*self), AutoDeinit::ManualDeinit)",
+    "ct.from(NonNull::from(self).as_ptr(), AutoDeinit::ManualDeinit)",
+    "at.from(\n    std::ptr::from_mut(self),\n    Self::run_from_main_thread_mini,\n)",
+    // A reference receiver plus a pointer parameter, in the other receiver
+    // and header spellings, posting the parameter.
+    "fn post(&self, this: *mut Self) {\n    self.task.with_mut(|ct| ct.from(this, AutoDeinit::ManualDeinit));\n}",
+    "pub(crate) unsafe fn post<F: Fn(u8) -> u8>(\n    &mut self,\n    f: F,\n    work: *const Self,\n) -> bool {\n    self.ct.from(work.cast_mut(), AutoDeinit::ManualDeinit);\n    true\n}",
+    "fn post(&'a mut self, cb: fn(*mut Task), this: *mut Self) {\n    self.ct.from(this, cb);\n}",
+    "fn post(self: Pin<&mut Self>, this: *mut Self) {\n    self.ct.from(this, AutoDeinit::AutoDeinit);\n}",
+  ];
+  const allowed = [
+    // The converted shape: the pointer comes in as the only handle on the
+    // object.
+    "unsafe fn run(this: *mut Self) {\n    let handle = unsafe { (*this).loop_handle.clone() };\n    let ct = NonNull::from(unsafe { (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit) });\n    handle.post_task(ct);\n}",
+    "pub(crate) fn http_callback(this: *mut Self, result: Result<'_>) {\n    unsafe { (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit) };\n}",
+    "fn run(task: *mut Self) {\n    let ct = unsafe { (*task).concurrent_task.from(task, AutoDeinit::ManualDeinit) };\n}",
+    "EventLoopTask::Mini(at) => at.from(this, Self::run_from_main_thread_mini),",
+    // Posting something the receiver owns or points at is not this shape.
+    "self.concurrent_task.from(self.child, AutoDeinit::ManualDeinit)",
+    "ct.from(&raw mut *self.inner, AutoDeinit::ManualDeinit)",
+    "ct.from(self.as_ptr(), AutoDeinit::ManualDeinit)",
+    // `from` methods that are not the task initializer, and `From` impls.
+    ".reader()\n    .from(buffered_reader, ctx_ptr.cast::<c_void>());",
+    "let s = String::from(self.name);",
+    "Self::from(self)",
+    '"<script>let error=Uint8Array.from(atob(\\"",',
+    // A pointer parameter next to a receiver that is stored, not posted.
+    "fn adopt_impl(&self, this: *mut Self, fd: Fd) -> bool {\n    self.root.set(this);\n    true\n}",
+    // A pointer parameter without a reference receiver is the intended shape
+    // even when it is named like one.
+    "fn post(self_ptr: *mut Self, ct: &mut ConcurrentTask) {\n    ct.from(self_ptr, AutoDeinit::ManualDeinit);\n}",
+    // `*mut Self::Assoc` is not a pointer to the receiver.
+    "fn retarget(&self, raw: *mut Self::Raw) {\n    self.ct.from(raw, AutoDeinit::ManualDeinit);\n}",
+    // Taking the address for something else, or rebinding the reference.
+    "fn run(&mut self) {\n    let this = std::ptr::from_mut(self);\n    register(this);\n}",
+    "fn run(&mut self) {\n    let this = self;\n    ct.from(this, AutoDeinit::ManualDeinit);\n}",
+    // The binding is posted in the next function, where it is that
+    // function's raw-pointer parameter.
+    "fn run(&mut self) {\n    let this = std::ptr::from_mut(self);\n    register(this);\n}\n\nunsafe fn resume(this: *mut Self) {\n    (*this).ct.from(this, AutoDeinit::ManualDeinit);\n}",
+    // The parameter's name is posted, but by the next function, which owns a
+    // parameter of the same name.
+    "fn adopt(&self, this: *mut Self) {\n    self.root.set(this);\n}\n\nfn resume(this: *mut Self) {\n    unsafe { (*this).ct.from(this, AutoDeinit::ManualDeinit) };\n}",
+  ];
+  expect(banned.map(s => findPosts(s).length)).toEqual(banned.map(() => 1));
+  expect(allowed.map(s => findPosts(s).length)).toEqual(allowed.map(() => 0));
+});
+
+test("no method posts its own receiver through its embedded task", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: when an allowlisted site is converted, delete its entry so the
+  // shape cannot come back into that file.
+  for (const [source, n] of Object.entries(ALLOW)) {
+    expect({ source, count: counts[source] ?? 0 }).toEqual({ source, count: n });
+  }
+});

--- a/test/napi/napi-app/async_tests.cpp
+++ b/test/napi/napi-app/async_tests.cpp
@@ -325,6 +325,77 @@ napi_value test_cancel_async_work(const Napi::CallbackInfo &info) {
   return result;
 }
 
+// napi_cancel_async_work while `execute` is running on the pool thread: the
+// cancellation must fail (napi_generic_failure, as uv_cancel fails on a
+// running request) and `complete` must still run with napi_ok. The JS thread
+// makes the call while the pool thread is inside `execute`, so the two sides
+// are touching the same work object at the same time; `complete` then deletes
+// the work, as addons usually do.
+struct RunningCancelData {
+  napi_ref callback;
+  napi_async_work work;
+  std::atomic<bool> execute_started{false};
+  std::atomic<bool> release_execute{false};
+  napi_status cancel_status;
+};
+
+static void execute_for_running_cancel(napi_env env, void *data) {
+  RunningCancelData *running = reinterpret_cast<RunningCancelData *>(data);
+  running->execute_started = true;
+  while (!running->release_execute) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+}
+
+static void complete_for_running_cancel(napi_env env, napi_status status,
+                                        void *data) {
+  RunningCancelData *running = reinterpret_cast<RunningCancelData *>(data);
+  printf("cancel while running: %s\n",
+         running->cancel_status == napi_generic_failure ? "napi_generic_failure"
+                                                        : "unexpected status");
+  printf("complete status: %s\n", status == napi_ok          ? "napi_ok"
+                                  : status == napi_cancelled ? "napi_cancelled"
+                                                             : "unexpected");
+  fflush(stdout);
+
+  napi_value callback;
+  napi_get_reference_value(env, running->callback, &callback);
+  napi_value global;
+  napi_get_global(env, &global);
+  napi_delete_reference(env, running->callback);
+  napi_delete_async_work(env, running->work);
+  delete running;
+  napi_call_function(env, global, callback, 0, nullptr, nullptr);
+}
+
+napi_value test_cancel_running_async_work(const Napi::CallbackInfo &info) {
+  napi_env env = info.Env();
+
+  RunningCancelData *running = new RunningCancelData;
+  NODE_API_CALL(env,
+                napi_create_reference(env, info[0], 1, &running->callback));
+  napi_value resource_name =
+      Napi::String::New(env, "napitests__test_cancel_running_async_work");
+  NODE_API_CALL(env, napi_create_async_work(env, nullptr, resource_name,
+                                            &execute_for_running_cancel,
+                                            &complete_for_running_cancel,
+                                            running, &running->work));
+  NODE_API_CALL(env, napi_queue_async_work(env, running->work));
+
+  // Wait (bounded) for the pool thread to enter `execute`.
+  for (int i = 0; i < 10000 && !running->execute_started; i++) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1));
+  }
+  if (!running->execute_started) {
+    printf("execute did not start\n");
+    running->cancel_status = napi_ok;
+  } else {
+    running->cancel_status = napi_cancel_async_work(env, running->work);
+  }
+  running->release_execute = true;
+  return info.Env().Undefined();
+}
+
 // An addon whose native threads are process-global (like next-swc's tokio
 // pool) can outlive the worker env that created a threadsafe function: the
 // worker unrefs the tsfn so its event loop can exit, and the addon makes its
@@ -564,6 +635,7 @@ void register_async_tests(Napi::Env env, Napi::Object exports) {
   REGISTER_FUNCTION(env, exports, create_async_work_with_null_execute);
   REGISTER_FUNCTION(env, exports, create_async_work_with_null_complete);
   REGISTER_FUNCTION(env, exports, test_cancel_async_work);
+  REGISTER_FUNCTION(env, exports, test_cancel_running_async_work);
   REGISTER_FUNCTION(env, exports, create_orphaned_threadsafe_functions);
   REGISTER_FUNCTION(env, exports, use_orphaned_threadsafe_functions);
   REGISTER_FUNCTION(env, exports, create_leaked_threadsafe_functions);

--- a/test/napi/napi-app/module.js
+++ b/test/napi/napi-app/module.js
@@ -81,6 +81,12 @@ nativeTests.test_napi_async_work_cancel = () => {
   }
 };
 
+nativeTests.test_napi_async_work_cancel_running = () => {
+  // `complete` prints the cancel status observed while `execute` was running
+  // and its own status, then deletes the work and resolves this.
+  return new Promise(resolve => nativeTests.test_cancel_running_async_work(resolve));
+};
+
 nativeTests.test_promise_with_threadsafe_function = async () => {
   await new Promise(resolve => setTimeout(resolve, 1));
   // create_promise_with_threadsafe_function returns a promise that calls our function from another

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -550,6 +550,12 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(output).toContain("success!");
       expect(output).not.toContain("failure!");
     });
+    it("cannot cancel work whose execute callback is running, and still completes it", async () => {
+      const output = await checkSameOutput("test_napi_async_work_cancel_running", []);
+      expect(output).toBe(
+        ["cancel while running: napi_generic_failure", "complete status: napi_ok", "resolved to undefined"].join("\n"),
+      );
+    });
   });
 
   describe("napi_threadsafe_function", () => {

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -552,9 +552,12 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
     });
     it("cannot cancel work whose execute callback is running, and still completes it", async () => {
       const output = await checkSameOutput("test_napi_async_work_cancel_running", []);
-      expect(output).toBe(
-        ["cancel while running: napi_generic_failure", "complete status: napi_ok", "resolved to undefined"].join("\n"),
-      );
+      // printf() via the Windows CRT emits \r\n, so split on either ending.
+      expect(output.split(/\r?\n/)).toEqual([
+        "cancel while running: napi_generic_failure",
+        "complete status: napi_ok",
+        "resolved to undefined",
+      ]);
     });
   });
 


### PR DESCRIPTION
### Problem
- No crash is known from this and nothing in Bun reads the work after the hand-over today. The contract is what is wrong, the same class as #37681, #37703, #37723 and #37741.
- A `napi_async_work` is freed by the addon, usually from inside its own `complete` callback. On every ordinary completion that free happened while a `&mut self` to the work was still a live argument: the pool thread posted the work from inside two `&mut self` frames, and the JS thread called `complete` from a `&mut self` method on the work itself.
- A standalone reduction of exactly those shapes fails under Miri (`Undefined Behavior: reborrow through <tag> ... is forbidden` on the pool side, `deallocation through <tag> ... is forbidden` on the JS side) and passes in the fixed shape. `bun_runtime` itself cannot run under Miri.
- Two smaller cases of the same kind: `schedule` gave the pool a task pointer derived from the reference instead of from the whole allocation, and `cancel` (JS thread) and `run` (pool thread) each claimed the whole struct exclusively while the other could legitimately be running.

### Fix
- The four entry points on the work now take the addon's raw pointer and read or write one field per statement; no reference to the whole work is formed anywhere. Callers (the three `napi_*_async_work` C functions, the dispatch arm, the teardown release path) pass the pointer through instead of turning it into `&mut`.
- The property to check: on the pool thread, filling in the embedded task is the last access to the work and the post goes through a loop handle cloned out beforehand; on the JS thread, everything needed during and after `complete` is copied out before the call and the pointer is not touched after it.
- The struct docs now say which thread writes each field. Only the atomic `status` is written by both threads, which is what lets `cancel` and `run` overlap and what the per-field accesses rest on. No behaviour change is intended: the same fields are read and written and the post goes to the same loop.
- Verification, as reported in the original: a new source lint flags exactly the old posting site on main and nothing with this change; a new addon test cancels a work while `execute` is running and has `complete` delete it; the napi and node-api async suites were run on the ASAN build. The Miri result is from the reduction, not from Bun. `run_from_js` has no lint and relies on the addon tests.

### Background
- `napi_async_work` is the Node-API object an addon gets from `napi_create_async_work`. Bun heap-allocates it, but the addon owns it and frees it with `napi_delete_async_work`, conventionally from inside `complete` (node-addon-api's `AsyncWorker` does this).
- Lifecycle: `napi_queue_async_work` hands the work to Bun's work pool; a pool thread runs the addon's `execute`, then posts the work back to the JS thread, which runs `complete`. `napi_cancel_async_work` may be called from JS at any time and only succeeds if `execute` has not started.
- Embedded (intrusive) task: the work contains its own queue node (`concurrent_task`), so posting it means filling in a field of the work and linking that field into the JS thread's queue. From the moment the post lands the JS thread owns the allocation, even though the posting function has not returned yet.
- Reference protection: Rust treats a reference argument (`&mut self` included) as valid and exclusive for the whole call (`noalias` and `dereferenceable` in codegen), so another thread writing or freeing that memory during the call is UB even if the callee never touches the reference again. A raw pointer makes no such promise, and a `(*this).field` access only claims that field for that statement.
- Source lints: tests under test/internal/source-lints regex-scan the Rust tree for banned shapes and fail on any hit; this PR adds one for "fill the embedded task with the receiver's address", a sibling of the lint from #37723.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/napi/napi.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

`napi_async_work` (src/runtime/napi/napi_body.rs) is an allocation the addon owns. Its pool-thread side posted it back to the JS thread like this:

```rust
fn run(&mut self) {
    let self_ptr: *mut Self = self;
    ...
    self.post_to_js_thread(self_ptr);
}
fn post_to_js_thread(&mut self, self_ptr: *mut Self) {
    let ct = NonNull::from(self.concurrent_task.from(self_ptr, AutoDeinit::ManualDeinit));
    let Posted::Queued = self.loop_handle.post_task(ct) else { ... };
}
```

As soon as the post lands, the JS thread drains the embedded task and runs `run_from_js`, whose `complete` callback belongs to the addon and normally calls `napi_delete_async_work` on this very work (node-addon-api's `AsyncWorker` does; so do the fixtures in test/napi/napi-app/async_tests.cpp). That can happen before `post_task` has returned, i.e. while three references into the allocation are still live function arguments: `run`'s `&mut self`, `post_to_js_thread`'s `&mut self` (which has just written `concurrent_task` through itself), and the `&self.loop_handle` the post went through. On the JS thread, `run_from_js(&mut self)` called `complete` directly, so on every ordinary completion the work was freed while that receiver was a live argument too. Its own comment said so ("the 'this' value here may already be freed by the user in `complete`") and moved `poll_ref` out beforehand, which handles the later reads but not the receiver itself.

A reference argument is protected for the whole call, and another party reading, writing or freeing memory it covers is UB under both aliasing models whether or not the function touches the reference again (rustc's codegen relies on the same thing: the argument is `noalias` and `dereferenceable` for the whole call). `bun_runtime` cannot run under Miri, so the reduction below has exactly these shapes: the embedded task filled in and posted from two `&mut self` frames, a JS thread that frees the work from the completion callback, and the two receivers the fix replaces. Under Tree Borrows (what `bun run rust:miri` uses) the JS thread's first access to the work is rejected against `post_to_js_thread`'s receiver, and the free is rejected against `run_from_js`'s:

```
pool side:  error: Undefined Behavior: reborrow through <2132> at alloc1240[0x10] is forbidden
            = help: the accessed tag <2132> is foreign to the protected tag <4229>
            = help: this reborrow (acting as a foreign read access) would cause the protected tag <4229> (currently Unique) to become Disabled
            help: the protected tag <4229> was created here  -->  fn post_to_js_thread_before(&mut self, self_ptr: *mut Self)
JS side:    error: Undefined Behavior: deallocation through <8922> at alloc1240[0x0] is forbidden
            help: the protected tag <8894> was created here  -->  fn run_from_js_before(&mut self)
fixed:      ok
```

Stacked Borrows reports the same two sites (`not granting access to tag ... because that would remove [Unique for <..>] which is strongly protected`) and also passes the fixed shape. No crash is known from this; nothing in Bun reads through the references after the hand-over today. It is the contract that is wrong, the same class as #37681, #37703, #37723 and the threadsafe-function conversion in #37741 (a different set of functions in the same file; this PR does not touch them).

Two smaller things of the same kind in the same functions: `schedule(&mut self)` handed the pool `&raw mut self.task`, a pointer projected from the reference, while `IntrusiveWorkTask::from_task_ptr` documents that the pointer it gets back must carry provenance for the whole allocation (`WorkPool::schedule_owned` projects from the raw pointer for exactly this reason); and `cancel(&mut self)` on the JS thread and `run(&mut self)` on the pool thread each claimed the whole struct exclusively while the other was legitimately running (`napi_cancel_async_work` during `execute` is an ordinary, documented call).

<details>
<summary>Reduction run under Miri</summary>

```rust
use std::sync::atomic::{AtomicU32, Ordering};
use std::sync::{Arc, Mutex, mpsc};
use std::thread;

struct SendPtr(*mut ConcurrentTask);
unsafe impl Send for SendPtr {}

// LoopHandle: refcounted, cloneable, posts to the JS thread. Waiting for the
// consumer inside post_task pins the interleaving the real code allows: the JS
// thread runs the completion before the posting call has returned.
#[derive(Clone)]
struct Handle(Arc<HandleInner>);
struct HandleInner { post: Mutex<mpsc::Sender<SendPtr>>, consumed: Mutex<mpsc::Receiver<()>> }
impl Handle {
    fn post_task(&self, task: SendPtr) {
        self.0.post.lock().unwrap().send(task).unwrap();
        self.0.consumed.lock().unwrap().recv().unwrap();
    }
    fn embedded_work_finished(&self) {}
}

#[derive(Default)]
struct ConcurrentTask { of: *mut Work }
impl ConcurrentTask {
    fn from(&mut self, of: *mut Work) -> &mut ConcurrentTask { self.of = of; self }
}

struct AddonData { work: *mut Work }
struct Work {
    concurrent_task: ConcurrentTask,
    loop_handle: Handle,
    status: AtomicU32,
    complete: fn(u32, *mut AddonData),
    data: *mut AddonData,
}

// The addon's complete callback: napi_delete_async_work, then free its data.
fn complete(status: u32, data: *mut AddonData) {
    assert_eq!(status, 2);
    unsafe { drop(Box::from_raw((*data).work)); drop(Box::from_raw(data)); }
}

impl Work {
    // main
    fn run_before(&mut self) {
        let self_ptr: *mut Self = self;
        let handle = self.loop_handle.clone();
        self.status.store(2, Ordering::SeqCst);
        self.post_to_js_thread_before(self_ptr);
        handle.embedded_work_finished();
    }
    fn post_to_js_thread_before(&mut self, self_ptr: *mut Self) {
        let ct: *mut ConcurrentTask = self.concurrent_task.from(self_ptr);
        self.loop_handle.post_task(SendPtr(ct));
    }
    fn run_from_js_before(&mut self) {
        let complete = self.complete;
        complete(self.status.load(Ordering::SeqCst), self.data);
    }
    // this PR
    unsafe fn run_after(this: *mut Self) {
        let handle = unsafe { (*this).loop_handle.clone() };
        unsafe { (*this).status.store(2, Ordering::SeqCst) };
        let ct: *mut ConcurrentTask = unsafe { (*this).concurrent_task.from(this) };
        handle.post_task(SendPtr(ct));
        handle.embedded_work_finished();
    }
    unsafe fn run_from_js_after(this: *mut Self) {
        let (complete, status, data) =
            unsafe { ((*this).complete, (*this).status.load(Ordering::SeqCst), (*this).data) };
        complete(status, data);
    }
}

fn main() {
    let mode = std::env::args().nth(1).unwrap_or_default();
    let (post, queue) = mpsc::channel::<SendPtr>();
    let (consumed_tx, consumed) = mpsc::channel::<()>();
    let handle = Handle(Arc::new(HandleInner { post: Mutex::new(post), consumed: Mutex::new(consumed) }));
    let data = Box::into_raw(Box::new(AddonData { work: std::ptr::null_mut() }));
    let work = Box::into_raw(Box::new(Work {
        concurrent_task: ConcurrentTask::default(),
        loop_handle: handle,
        status: AtomicU32::new(0),
        complete,
        data,
    }));
    unsafe { (*data).work = work };

    let js_mode = mode.clone();
    let js_thread = thread::spawn(move || {
        let task = queue.recv().unwrap();
        let work = unsafe { (*task.0).of };
        if js_mode == "js" { unsafe { (*work).run_from_js_before() } } else { unsafe { Work::run_from_js_after(work) } }
        consumed_tx.send(()).unwrap();
    });
    // The pool thread.
    if mode == "pool" { unsafe { (*work).run_before() } } else { unsafe { Work::run_after(work) } }
    js_thread.join().unwrap();
    println!("{mode}: ok");
}
```

`MIRIFLAGS=-Zmiri-tree-borrows cargo miri run -- pool` and `-- js` fail with the errors quoted above; `-- fixed` prints `fixed: ok`. The default Stacked Borrows run gives the same three results.

</details>

### Fix

The addon, the pool thread and the event-loop queue all hold the work as a raw pointer, so the entry points now keep it one. `schedule`, `run`, `cancel` and `run_from_js` take `this: *mut napi_async_work`; each reads or writes the individual fields it needs through statement-scoped `(*this).field` accesses (the atomic `status` through its own `&AtomicU32`, which is what lets `cancel` and `run` overlap), and nothing forms a reference to the whole work at any point:

* `run` copies the `LoopHandle` (cloned), `execute`, `env` and `data` out of the work first, runs `execute`, then in one last access stores the final status (or cancels) and fills in the embedded task with `(*this).concurrent_task.from(this, ..)`; the post goes through the cloned handle and only the clone is touched afterwards. This is the shape `S3HttpSimpleTask::http_callback` (src/runtime/webcore/s3/simple_request.rs) already uses for its embedded task, and the clone-the-handle-first order `async_job_run` in node_zlib_binding.rs uses; `post_to_js_thread` is folded into it.
* `run_from_js` takes `poll_ref`, `complete`, `env`, `status` and `data` out of the work before calling `complete` and does not use `this` afterwards. The post-`complete` exception check goes through the env pointer, which the global keeps alive (`GlobalObject::m_napiEnvs`) independently of the work's own ref; that was already what the old code relied on, and the comment now says so. The struct's field docs record which thread writes each field (the JS thread still reads `global` and `scheduled`, and CASes `status`, while the pool has the work; the pool writes `status` and `concurrent_task`; the rest is immutable after `new`), which is the invariant the field-by-field accesses rest on.
* `schedule` projects the task pointer from the work pointer (`&raw mut (*this).task`), which is what `from_task_ptr` asks for.
* `napi_queue_async_work`, `napi_cancel_async_work` and `napi_delete_async_work` null-check and pass the pointer through instead of going via `as_mut()`; the `NapiAsyncWork` dispatch arm (src/runtime/dispatch.rs) uses `cast_ptr!`, and `Taskable::release_unrun` calls the associated function.

No behaviour change: the same fields are read and written (`execute`/`env`/`data` are now copied out before the status CAS instead of after it, which is unobservable: nothing else writes them), the status store still happens before the VM borrow is released, the post still goes to the same loop (the clone refers to the same VM handle), refusal is still unreachable for the same reason (counted work), and the teardown path still runs `complete` from the queue release.

### Seen while reviewing, not changed here

Running an addon's `complete` from the queue release at worker teardown is pre-existing behaviour this PR keeps. If that `complete` queues another work (node-addon-api's chaining pattern), `napi_queue_async_work` runs into `embedded_work_scheduled`'s closed-handle assertion on debug builds and, on release builds, `run`'s refusal `unreachable!` on the pool thread. That reproduces identically on main and is being handled separately; it is mentioned because `schedule` and `run` are in this diff.

### Tests

* `test/internal/source-lints/self-receiver-intrusive-post.test.ts` (new) bans filling an embedded task with the receiver's address: `.from(..)` applied to `self` spelled as a pointer (directly or through a reborrow: `from_mut(&mut *self)`, `NonNull::from(&mut *self)`, a bare `&mut *self`; the same spelling list self-receiver-reclaim.test.ts uses), to a local of the same function bound to one, or to a parameter of a method that also has a reference receiver and is typed as a raw pointer to the method's own type, written `Self` or by the enclosing impl's name (the `post_to_js_thread(&mut self, self_ptr: *mut Self)` shape, and the same thing spelled `*mut napi_async_work`). It checks its patterns against positive and negative examples, including the two-function shape as it was on main in both spellings. Against main it reports exactly `src/runtime/napi/napi_body.rs:1871`; with this change it reports nothing and the tree needs no allowlist. The heap-task constructors (`Task::init` / `create_from` / `from_callback`) are the population #37723's lint covers, so the two do not overlap; each lint in this family currently carries its own copy of the spelling list and scan scaffold, and folding those into a shared helper is a separate cleanup once the in-flight siblings have landed. `run_from_js` has no syntactic marker a lint can pin; it is covered by the addon tests below, which delete the work inside `complete` under the ASAN build.
* `test/napi/napi.test.ts`: new case `test_napi_async_work_cancel_running` (addon side in async_tests.cpp) queues a work, waits for `execute` to start on the pool thread, calls `napi_cancel_async_work` from the JS thread while it is running, and checks through `complete` (which then deletes the work) that the cancel reported `napi_generic_failure` and the completion `napi_ok`, comparing against Node's output (compared line by line, since the addon's `printf` goes through the Windows CRT and emits `\r\n` there, which the first revision of this test tripped over on the Windows lanes). This is the `cancel` / `run` overlap the field-scoped accesses exist for; the existing cancel test only cancels work that has not started.

On the debug (ASAN) build: test/napi/napi.test.ts (the `napi_async_work`, handle-scope and async-complete exception cases, plus the whole file: 166 pass, the one failure being the unrelated `bigint conversion` case hitting the 5 s default timeout on this machine, which it also does without this change and passes with a longer timeout), the node-api suites `test_async` (its 500-iteration `test-loop.js` passes; `test.js` and friends are pre-existing todos in that suite), `test_worker_terminate` (passes), and `test_instance_data`, `test_uv_threadpool_size`, `test_async_cleanup_hook` (build, with their pre-existing todo entries unchanged), and `bun test test/internal/source-lints/` (86 pass). `cargo clippy -p bun_runtime` and `rustfmt --check` are clean on the touched files.

</details>
