### PR TITLE
node:http: don't write the default clientError 400 into an in-flight fallback response

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -235,7 +235,7 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
 function connectionListenerHTTP1(server, socket, options) {
   const http = require("node:http");
   const { HTTPParser, prepareError, calculateLenientFlags, continueExpression } = require("node:_http_common");
-  const { kHandle: kHttp1ResponseHandle } = require("internal/http");
+  const { kHandle: kHttp1ResponseHandle, headerStateSymbol, NodeHTTPHeaderState } = require("internal/http");
   const { allMethods } = process.binding("http_parser");
 
   const http1Options = options.http1Options || {};
@@ -372,7 +372,16 @@ function connectionListenerHTTP1(server, socket, options) {
     // Node's socketOnError does before destroying.
     prepareError(err, parser, rawPacket);
     if (!server.emit("clientError", err, socket)) {
-      if (socket.writable && !socket.destroyed) {
+      // Node only replies while the in-flight response has not reached the wire
+      // (_httpMessage._headerSent), or the reply would land inside its body.
+      // `sent` is that state here; headersSent is already true after a bare
+      // writeHead(), which this handle does not write out yet.
+      const message = socket._httpMessage;
+      if (
+        socket.writable &&
+        !socket.destroyed &&
+        (!message || message[headerStateSymbol] !== NodeHTTPHeaderState.sent)
+      ) {
         const code = err?.code;
         socket.write(
           code === "HPE_HEADER_OVERFLOW"

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,88 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+describe("default 'clientError' reply on a connection served through server.emit('connection')", () => {
+  // Node's socketOnError answers a parse error with a raw 400 only while no
+  // in-flight response has put bytes on the wire ("Caution must be taken to
+  // avoid corrupting the remote peer"); the connection is destroyed either way.
+  const rawBadRequest = "HTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n";
+  const bodyOf = (raw: string) => raw.slice(raw.indexOf("\r\n\r\n") + 4);
+
+  function serveOneConnection(onRequest: (req: IncomingMessage, res: ServerResponse) => void) {
+    const server = createServer(onRequest);
+    const [clientSide, serverSide] = duplexPair();
+    let received = "";
+    const { promise: bodyArrived, resolve: onBodyArrived } = Promise.withResolvers<void>();
+    clientSide.on("data", chunk => {
+      received += chunk;
+      if (bodyOf(received) === "hello") onBodyArrived();
+    });
+    // The server destroys its own half; wait for that rather than for
+    // duplexPair to propagate it to the client half (Node's never does).
+    const closed = new Promise<string>(resolve => serverSide.on("close", () => resolve(received)));
+    server.emit("connection", serverSide);
+    return { clientSide, serverSide, closed, bodyArrived };
+  }
+
+  function writeHeadAndHalfTheBody(req: IncomingMessage, res: ServerResponse) {
+    res.writeHead(200, { "Content-Length": "10" });
+    res.write("hello");
+  }
+
+  // Let the duplex finish the response writes before the connection goes bad,
+  // so anything the server writes next is pushed to the client immediately
+  // rather than left buffered (and discarded) when it destroys the socket:
+  // a wrongly appended 400 must be observable.
+  const settleWrites = () => new Promise<void>(resolve => setImmediate(resolve));
+
+  it("does not write the raw 400 into a response whose head is already on the wire", async () => {
+    const { clientSide, serverSide, closed, bodyArrived } = serveOneConnection(writeHeadAndHalfTheBody);
+    clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    await bodyArrived;
+    await settleWrites();
+    clientSide.write("GARBAGE\r\n\r\n");
+    const received = await closed;
+    expect(received).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(bodyOf(received)).toBe("hello");
+    expect(serverSide.destroyed).toBe(true);
+  });
+
+  it("does not write the raw 400 when the peer ends mid request body while the response is on the wire", async () => {
+    // socket 'end' -> parser.finish() reports the truncated body as a parse
+    // error, reaching the same default handler as garbage bytes do.
+    const { clientSide, serverSide, closed, bodyArrived } = serveOneConnection(writeHeadAndHalfTheBody);
+    clientSide.write("POST / HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+    await bodyArrived;
+    await settleWrites();
+    clientSide.end();
+    const received = await closed;
+    expect(received).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(bodyOf(received)).toBe("hello");
+    expect(serverSide.destroyed).toBe(true);
+  });
+
+  it("still writes the raw 400 when the in-flight response has only called writeHead()", async () => {
+    // writeHead() puts nothing on the wire until the first write/end/flushHeaders
+    // (Node checks _headerSent, not headersSent), so the reply is still safe.
+    const { promise: headAssigned, resolve: onHeadAssigned } = Promise.withResolvers<void>();
+    const { clientSide, serverSide, closed } = serveOneConnection((req, res) => {
+      res.writeHead(200, { "Content-Length": "10" });
+      onHeadAssigned();
+    });
+    clientSide.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
+    await headAssigned;
+    clientSide.write("GARBAGE\r\n\r\n");
+    expect(await closed).toBe(rawBadRequest);
+    expect(serverSide.destroyed).toBe(true);
+  });
+
+  it("still writes the raw 400 when no response is in flight", async () => {
+    const onRequest = mock(() => {});
+    const { clientSide, serverSide, closed } = serveOneConnection(onRequest);
+    clientSide.write("GARBAGE\r\n\r\n");
+    expect(await closed).toBe(rawBadRequest);
+    expect(serverSide.destroyed).toBe(true);
+    expect(onRequest).not.toHaveBeenCalled();
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4365,6 +4365,42 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+it("http2 allowHTTP1 fallback does not write the default clientError 400 into a response that is already on the wire", async () => {
+  // Node's socketOnError only writes its raw 400 while no in-flight response
+  // has reached the wire; here it must just drop the connection.
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    res.writeHead(200, { "Content-Length": "10" });
+    res.write("hello");
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const { promise: closed, resolve: onClose } = Promise.withResolvers();
+    const socket = tls.connect(
+      { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+      () => socket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"),
+    );
+    let received = "";
+    let sentGarbage = false;
+    socket.on("data", chunk => {
+      received += chunk;
+      if (!sentGarbage && received.endsWith("\r\n\r\nhello")) {
+        sentGarbage = true;
+        socket.write("GARBAGE\r\n\r\n");
+      }
+    });
+    // The server destroys the connection without a TLS close_notify, which the
+    // client may report as an error before 'close'; 'close' is what we wait for.
+    socket.on("error", () => {});
+    socket.on("close", () => onClose(received));
+    const raw = await closed;
+    expect(sentGarbage).toBe(true);
+    expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("hello");
+  } finally {
+    server.close();
+  }
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().


### PR DESCRIPTION
### Problem

On a connection served by the JS HTTP/1 path in `src/js/internal/http1_server_fallback.ts` (a socket handed to an `http.Server` through `server.emit("connection", socket)`, or an `http2.createSecureServer({ allowHTTP1: true })` connection that negotiated `http/1.1`), a parse error that arrives while a response is already partially written makes the listener-less `'clientError'` default write its raw reply into the middle of that response:

```js
const http = require("http");
const { duplexPair } = require("stream");
const server = http.createServer((req, res) => {
  res.writeHead(200, { "Content-Length": "10" });
  res.write("hello");
  setImmediate(() => c.write("GARBAGE\r\n\r\n")); // junk on the same connection, mid-response
});
const [c, s] = duplexPair();
let received = "";
c.on("data", d => (received += d));
s.on("close", () => setImmediate(() => console.log(JSON.stringify(received))));
server.emit("connection", s);
c.write("GET / HTTP/1.1\r\nHost: x\r\n\r\n");
```

```
node v26.3.0: "HTTP/1.1 200 OK\r\n...\r\n\r\nhello"
bun 1.4.0:    "HTTP/1.1 200 OK\r\n...\r\n\r\nhelloHTTP/1.1 400 Bad Request\r\nConnection: close\r\n\r\n"
```

The peer is reading a `Content-Length: 10` body, so it takes the first bytes of the 400 as body data (with chunked framing it would be a framing error instead). The same thing happens when the peer half-closes in the middle of a request body while the response is already going out (`parser.finish()` reports the truncated message through the same handler), and over `allowHTTP1`. The native `http.Server` path is not affected: its `socketOnError` in `_http_server.ts` already has the guard.

### Cause

`onHttp1SocketError` only checked `socket.writable && !socket.destroyed` before writing the reply. Node's `socketOnError` additionally requires `!this._httpMessage || !this._httpMessage._headerSent` ("Caution must be taken to avoid corrupting the remote peer") and destroys the socket either way.

### Fix

Add the same condition to the fallback, expressed with the state the native path's `socketOnError` already uses: skip the reply when `socket._httpMessage[headerStateSymbol] === NodeHTTPHeaderState.sent`. The fallback's responses are the regular `node:http` `ServerResponse` driving the fallback handle through `res[kHandle]`, and that class flips the state to `sent` exactly when it pushes the head to the handle (first `write()`, `end()`, `flushHeaders()`), which is when this handle writes it to the socket. A bare `writeHead()` leaves the state at `assigned` with nothing on the wire, so, like Node (`_headerSent` is still false there), the raw reply is still written in that case. `socket.destroy(err)` stays unconditional.

This is correct to have because the reply exists to tell a client whose request could not be parsed what went wrong; once another response's bytes are on the wire it cannot be delimited from that response, so Node drops it and just closes, and with this change the fallback produces the same bytes as Node in every case in the tests below.

### Tests

`test/js/node/http/node-http.test.ts` (`server.emit("connection")` over a `duplexPair`): garbage after the head and part of the body leaves the peer with exactly head + `hello` and a destroyed connection; the peer ending mid request body while the response is on the wire (the `parser.finish()` entry into the same handler) does the same; a response that has only called `writeHead()` still gets the raw `400 Bad Request\r\nConnection: close` reply; so does a connection with no response in flight. `test/js/node/http2/node-http2.test.js`: the same first scenario over `allowHTTP1` with a TLS client negotiating `http/1.1`.

Without the fix the two "does not write" tests and the http2 test fail with `helloHTTP/1.1 400 Bad Request...` as the body (deterministic across repeated runs); the two "still writes" tests pass before and after and pin the boundary. With the fix the new tests pass, as do the full `node-http.test.ts` and `node-http2.test.js` files and the upstream `test-http-generic-streams`, `test-http-parser-finish-error`, `test-http-*-per-stream`, `test-http-server-client-error`, `test-http-server-destroy-socket-on-client-error`, `test-http-socket-error-listeners`, `test-http2-allow-http1` and `test-http2-https-fallback*` tests.
