### PR TITLE
shell(cat): restart the shared stdin reader for a later cat, notify each listener once

### DIFF
--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -42,11 +42,8 @@ pub(crate) type ReaderImpl = bun_io::BufferedReader;
 struct State {
     fd: Fd,
     buf: Vec<u8>,
+    /// Listeners of the read cycle currently in flight; see `take_readers`.
     readers: Readers,
-    /// The raw `sys::Error`. `SystemError` is not `Clone`
-    /// in the Rust port yet, so we keep the source error to re-derive a fresh
-    /// `SystemError` per callee in `on_reader_done_cb`.
-    raw_err: Option<sys::Error>,
     evtloop: EventLoopHandle,
     #[cfg(windows)]
     is_reading: bool,
@@ -127,7 +124,6 @@ impl IOReader {
                 fd,
                 buf: Vec::new(),
                 readers: Readers::new(),
-                raw_err: None,
                 evtloop,
                 #[cfg(windows)]
                 is_reading: false,
@@ -198,12 +194,12 @@ impl IOReader {
         #[cfg(not(windows))]
         {
             let r = self.reader();
-            let need_start = match &r.handle {
-                bun_io::pipes::PollOrFd::Closed => true,
-                bun_io::pipes::PollOrFd::Poll(p) => !p.is_registered(),
-                bun_io::pipes::PollOrFd::Fd(_) => true,
-            };
-            if need_start {
+            // A finished cycle (EOF or error) leaves the one-shot poll fired
+            // and not re-armed: still `is_registered()`, but it will never
+            // fire again. `has_pending_read()` is false then, so a listener
+            // added after that cycle gets a new one (which reads EOF again on
+            // a pipe, or whatever the fd has to offer now).
+            if !r.has_pending_read() {
                 let fd = self.state().fd;
                 if let Err(e) = r.start(fd, true) {
                     self.on_reader_error(&e);
@@ -295,12 +291,8 @@ impl IOReader {
         // alive across the loop.
         let _keepalive = self.keepalive();
         self.set_reading(false);
-        let s = self.state();
-        s.raw_err = Some(err.clone());
-        // NOTE: reshaped for borrowck — copy out before dispatching.
-        let readers: Vec<ChildPtr> = s.readers.clone();
-        let interp = s.interp;
-        for r in readers {
+        let interp = self.state().interp;
+        for r in self.take_readers() {
             // Re-derive a fresh SystemError per callee (see
             // IOWriter.on_error note).
             let ee = err.to_shell_system_error();
@@ -315,17 +307,20 @@ impl IOReader {
         // Hold a strong ref across the body.
         let _keepalive = self.keepalive();
         self.set_reading(false);
-        let s = self.state();
-        let readers: Vec<ChildPtr> = s.readers.clone();
-        let interp = s.interp;
-        // `SystemError` isn't `Clone` yet, so we keep the source `sys::Error`
-        // (which IS `Clone`) and re-derive a fresh `SystemError` per callee —
-        // same approach as `on_reader_error`.
-        let raw_err = s.raw_err.clone();
-        for r in readers {
-            let ee = raw_err.as_ref().map(|e| e.to_shell_system_error());
-            self.run_yield(dispatch_reader_done(r, ee, interp));
+        let interp = self.state().interp;
+        for r in self.take_readers() {
+            self.run_yield(dispatch_reader_done(r, None, interp));
         }
+    }
+
+    /// Detaches the listeners of the cycle that just ended before notifying
+    /// them. Notifying one can synchronously run the rest of the script: a
+    /// `cat` started there registers into the emptied list and restarts the
+    /// reader, so it is notified by its own cycle rather than by this one, and
+    /// nothing stays behind to be notified again by a later cycle under a
+    /// `NodeId` that has been freed or recycled by then.
+    fn take_readers(&self) -> Readers {
+        core::mem::take(&mut self.state().readers)
     }
 
     fn run_yield(&self, y: Yield) {

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -86,17 +86,11 @@ impl IOReader {
         // held by the bun_io read loop never overlaps a `&mut State` derived in a
         // vtable callback (see struct doc comment).
         //
-        // The `BufferedReaderParent` callback bodies below (`on_read_chunk_cb`/
-        // `on_reader_done_cb`/`on_reader_error`) must not call this: a `&mut
-        // ReaderImpl` can be live on the stack while they run, always on
-        // Windows (`WindowsBufferedReader::on_read` dispatches them from
-        // `&mut self`) and on POSIX when `PosixBufferedReader::start()`
-        // reports a registration failure synchronously. The poll-driven POSIX
-        // dispatches (`on_poll` read loops, `done()`/`on_error()` in tail
-        // position) go through a copied vtable and a raw pointer with no
-        // borrow of the reader live, which is what lets a command that the
-        // trampoline starts from inside `on_reader_done_cb`/`on_reader_error`
-        // call `start()` and arm the next read.
+        // Not called from the callback bodies below: `WindowsBufferedReader`
+        // (and `PosixBufferedReader::start()` on a synchronous registration
+        // failure) invokes them from under a `&mut ReaderImpl`. The POSIX poll
+        // dispatches hold no borrow (raw pointer, copied vtable), so a command
+        // started from a done/error notification may `start()` a new read.
         unsafe { &mut *self.reader.get() }
     }
 
@@ -199,11 +193,9 @@ impl IOReader {
         #[cfg(not(windows))]
         {
             let r = self.reader();
-            // A finished cycle (EOF or error) leaves the one-shot poll fired
-            // and not re-armed: still `is_registered()`, but it will never
-            // fire again. `has_pending_read()` is false then, so a listener
-            // added after that cycle gets a new one (which reads EOF again on
-            // a pipe, or whatever the fd has to offer now).
+            // Not `is_registered()`: a finished read (EOF or error) leaves the
+            // one-shot poll registered but fired, so a listener added after it
+            // needs a new read, which reads the fd again (EOF again on a pipe).
             if !r.has_pending_read() {
                 let fd = self.state().fd;
                 if let Err(e) = r.start(fd, true) {
@@ -272,20 +264,9 @@ impl IOReader {
         let should_continue = has_more != bun_io::ReadState::Eof;
         if should_continue && !self.state().readers.is_empty() {
             self.set_reading(true);
-            // NOTE: no explicit re-arm (`registerPoll()` on posix /
-            // `startWithCurrentPipe()` on windows) here: on Windows this
-            // callback runs from under `WindowsBufferedReader::on_read`'s
-            // `&mut self` (see `reader()`), and it is not needed anyway.
-            // On posix the read loop re-registers itself after the callback
-            // returns based on the `bool` we return (the `register_poll` calls
-            // at the end of the PipeReader.rs read loops). On Windows the
-            // re-arm is also handled by the caller (`on_file_read`'s epilogue /
-            // `uv_read_start` for streams) — but `startWithCurrentPipe()` had
-            // a SECOND load-bearing side effect: `buffer().clearRetainingCapacity()`,
-            // which keeps `WindowsBufferedReader._buffer` bounded between
-            // chunks. That clear is now performed by
-            // `WindowsBufferedReader::on_read` after the streaming chunk is
-            // consumed, so we still do nothing here.
+            // No re-arm here (none is allowed on Windows, see `reader()`): the
+            // caller re-arms once we return (on posix from the `bool` below),
+            // and `WindowsBufferedReader::on_read` clears the chunk buffer.
         }
         should_continue
     }
@@ -317,12 +298,10 @@ impl IOReader {
         }
     }
 
-    /// Detaches the listeners of the cycle that just ended before notifying
-    /// them. Notifying one can synchronously run the rest of the script: a
-    /// `cat` started there registers into the emptied list and restarts the
-    /// reader, so it is notified by its own cycle rather than by this one, and
-    /// nothing stays behind to be notified again by a later cycle under a
-    /// `NodeId` that has been freed or recycled by then.
+    /// The listeners of the read that just finished. Taken out before they are
+    /// notified: a notification can synchronously start the next `cat`, which
+    /// registers for (and starts) a new read, and a notified entry left behind
+    /// would be notified again later, by then under a recycled `NodeId`.
     fn take_readers(&self) -> Readers {
         core::mem::take(&mut self.state().readers)
     }

--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -86,12 +86,17 @@ impl IOReader {
         // held by the bun_io read loop never overlaps a `&mut State` derived in a
         // vtable callback (see struct doc comment).
         //
-        // MUST NOT be invoked from within a `BufferedReaderParent` vtable
-        // callback (`on_read_chunk_cb`/`on_reader_done_cb`/`on_reader_error`):
-        // the read loop already holds a live `&mut ReaderImpl` on its stack
-        // while the callback runs (PipeReader.rs aliasing contract), so
-        // re-deriving here would create two simultaneous `&mut` to the same
-        // BufferedReader = Stacked-Borrows UB.
+        // The `BufferedReaderParent` callback bodies below (`on_read_chunk_cb`/
+        // `on_reader_done_cb`/`on_reader_error`) must not call this: a `&mut
+        // ReaderImpl` can be live on the stack while they run, always on
+        // Windows (`WindowsBufferedReader::on_read` dispatches them from
+        // `&mut self`) and on POSIX when `PosixBufferedReader::start()`
+        // reports a registration failure synchronously. The poll-driven POSIX
+        // dispatches (`on_poll` read loops, `done()`/`on_error()` in tail
+        // position) go through a copied vtable and a raw pointer with no
+        // borrow of the reader live, which is what lets a command that the
+        // trampoline starts from inside `on_reader_done_cb`/`on_reader_error`
+        // call `start()` and arm the next read.
         unsafe { &mut *self.reader.get() }
     }
 
@@ -268,14 +273,13 @@ impl IOReader {
         if should_continue && !self.state().readers.is_empty() {
             self.set_reading(true);
             // NOTE: no explicit re-arm (`registerPoll()` on posix /
-            // `startWithCurrentPipe()` on windows) here: that would re-derive
-            // a second `&mut ReaderImpl` while the bun_io read loop still
-            // holds one on its stack (PipeReader.rs aliasing contract) —
-            // Stacked-Borrows UB.
-            // On posix the re-arm is redundant: the read loop re-registers
-            // itself after the callback returns based on the `bool` we return
-            // (PipeReader.rs:731/755/846/920/986). On Windows the re-arm is
-            // also handled by the caller (`on_file_read`'s defer block /
+            // `startWithCurrentPipe()` on windows) here: on Windows this
+            // callback runs from under `WindowsBufferedReader::on_read`'s
+            // `&mut self` (see `reader()`), and it is not needed anyway.
+            // On posix the read loop re-registers itself after the callback
+            // returns based on the `bool` we return (the `register_poll` calls
+            // at the end of the PipeReader.rs read loops). On Windows the
+            // re-arm is also handled by the caller (`on_file_read`'s epilogue /
             // `uv_read_start` for streams) — but `startWithCurrentPipe()` had
             // a SECOND load-bearing side effect: `buffer().clearRetainingCapacity()`,
             // which keeps `WindowsBufferedReader._buffer` bounded between

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -121,24 +121,32 @@ describe("cat (builtin) sharing one stdin reader", () => {
       let output = "";
       const separator = Promise.withResolvers<void>();
       const trailer = Promise.withResolvers<void>();
-      await using terminal = new Bun.Terminal({
-        data(_, chunk) {
-          output += Buffer.from(chunk).toString();
-          if (output.includes("---\n")) separator.resolve();
-          if (/exit=\d+\n/.test(output)) trailer.resolve();
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", childCode("cat; echo ---; cat", false)],
+        env: builtinEnv,
+        terminal: {
+          data(_, chunk) {
+            output += Buffer.from(chunk).toString();
+            if (output.includes("---\n")) separator.resolve();
+            if (/exit=\d+\n/.test(output)) trailer.resolve();
+          },
+          // Fires once the exited child's output has all been delivered, so a
+          // child that dies early fails the await below instead of timing out.
+          // (A no-op for whichever promise the output above already resolved.)
+          exit() {
+            const error = new Error(`child exited early, output so far: ${JSON.stringify(output)}`);
+            (output.includes("---\n") ? trailer : separator).reject(error);
+          },
         },
       });
+      await using terminal = proc.terminal!;
       // Same values on Linux and macOS. Without these the typed input would be
       // echoed into `output` and the child's "\n" would come back as "\r\n".
+      // The child has nothing to read yet, so nothing has been output either.
       const ECHO = 0x8;
       const OPOST = 0x1;
       terminal.localFlags &= ~ECHO;
       terminal.outputFlags &= ~OPOST;
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", childCode("cat; echo ---; cat", false)],
-        env: builtinEnv,
-        terminal,
-      });
       terminal.write("hi\n\x04");
       await separator.promise;
       terminal.write("more\n\x04");

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -3,7 +3,8 @@ import { bunEnv, bunExe, isLinux, isWindows } from "harness";
 import { closeSync, openSync } from "node:fs";
 
 // On POSIX the builtin `cat` is only used with this flag set (see
-// `Kind::DISABLED_ON_POSIX`); without it `cat` is the system binary.
+// `Kind::DISABLED_ON_POSIX`); without it `cat` is the system binary. On Windows
+// the builtin is the default and the flag does nothing.
 const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
 
 // Code for a child bun that runs `script` and prints the script's stdout
@@ -48,13 +49,12 @@ async function runScript(script: string, stdin: Stdin, { quiet = true } = {}) {
 
 // Every `cat` reading the script's stdin (or a pipeline stage's stdin)
 // registers on the single IOReader owned by that fd. Once the first `cat` has
-// consumed a read cycle (EOF or error), a later `cat` on the same fd has to
-// start a new one and must be the only listener notified by it.
-//
-// Skipped on Windows, where the reader closes its libuv source at EOF; a second
-// `cat` on the same fd there is covered by the fix in #29986.
-describe.skipIf(isWindows)("cat (builtin) sharing one stdin reader", () => {
-  describe("after the first cat reached EOF", () => {
+// consumed a read (EOF or error), a later `cat` on the same fd has to start a
+// new one and must be the only listener notified by it.
+describe("cat (builtin) sharing one stdin reader", () => {
+  // On Windows the reader closes its libuv source at EOF, so starting a new
+  // read there needs the separate fix in #29986.
+  describe.skipIf(isWindows)("after the first cat reached EOF", () => {
     const scripts: [script: string, stdout: string][] = [
       ["cat; echo ---; cat", "hi\n---\n"],
       ["cat && echo --- && cat", "hi\n---\n"],
@@ -113,24 +113,66 @@ describe.skipIf(isWindows)("cat (builtin) sharing one stdin reader", () => {
       expect({ stdout, stderr, exitCode }).toEqual({ stdout: "hi\n---\nexit=0\n", stderr: "", exitCode: 0 });
     });
 
-    // The first cat fails on its stdout write while the read that delivered the
-    // chunk is still running and unregisters itself. With captured output the
-    // second cat registers right away, while that read is still in flight, and
-    // is served by it. With stdout going through an IOWriter, `echo` completes
-    // later, so the read reaches EOF with nobody listening and the second cat
-    // registers only after that.
+    // On a pipe the new read only reports EOF again, which looks the same as
+    // completing the second cat on the spot. A tty's EOF (^D) is used up by the
+    // read that sees it, so here the second cat only finishes if it really reads
+    // the fd again and gets the input typed after the first cat is done.
+    test.concurrent("stdin is a tty: the second cat reads the input typed for it", async () => {
+      let output = "";
+      const separator = Promise.withResolvers<void>();
+      const trailer = Promise.withResolvers<void>();
+      await using terminal = new Bun.Terminal({
+        data(_, chunk) {
+          output += Buffer.from(chunk).toString();
+          if (output.includes("---\n")) separator.resolve();
+          if (/exit=\d+\n/.test(output)) trailer.resolve();
+        },
+      });
+      // Same values on Linux and macOS. Without these the typed input would be
+      // echoed into `output` and the child's "\n" would come back as "\r\n".
+      const ECHO = 0x8;
+      const OPOST = 0x1;
+      terminal.localFlags &= ~ECHO;
+      terminal.outputFlags &= ~OPOST;
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", childCode("cat; echo ---; cat", false)],
+        env: builtinEnv,
+        terminal,
+      });
+      terminal.write("hi\n\x04");
+      await separator.promise;
+      terminal.write("more\n\x04");
+      await trailer.promise;
+      expect(output).toBe("hi\n---\nmore\nexit=0\n");
+      expect(await proc.exited).toBe(0);
+    });
+
+    // The first cat fails its stdout write from inside the read that delivered
+    // the chunk and unregisters itself. With captured output the rest of the
+    // script runs before that read continues: the second cat attaches to it
+    // (re-registering the poll that is being serviced) and is served by its
+    // EOF; a third cat, started from the second one's EOF notification, is
+    // served by the wakeup that re-registration produces; with a subprocess
+    // after the second cat instead, that wakeup finds nobody to notify. With
+    // stdout going through an IOWriter, `echo` completes later, so the read
+    // reaches EOF with nobody listening and the second cat starts a new read.
     describe.if(isLinux)("first cat unregistering mid-read", () => {
-      test.concurrent.each([true, false])("quiet: %p", async quiet => {
-        const result = await runScript(
-          "cat > /dev/full || echo first-failed; cat && echo second-ok",
-          { input: "hi\n" },
-          { quiet },
-        );
-        expect(result).toEqual({ stdout: "first-failed\nsecond-ok\nexit=0\n", stderr: "", exitCode: 0 });
+      const first = "cat > /dev/full || echo first-failed";
+      test.concurrent.each([
+        [`${first}; cat && echo second-ok`, true, "first-failed\nsecond-ok\n"],
+        [`${first}; cat && echo second-ok; cat && echo third-ok`, true, "first-failed\nsecond-ok\nthird-ok\n"],
+        [`${first}; cat && echo second-ok; /bin/true`, true, "first-failed\nsecond-ok\n"],
+        [`${first}; cat && echo second-ok`, false, "first-failed\nsecond-ok\n"],
+      ])("%s (quiet: %p)", async (script, quiet, expected) => {
+        const result = await runScript(script, { input: "hi\n" }, { quiet });
+        expect(result).toEqual({ stdout: `${expected}exit=0\n`, stderr: "", exitCode: 0 });
       });
     });
   });
 
+  // Starting a new read after a failed one already worked everywhere; what
+  // these pin down is that its failure is reported to the second cat only. This
+  // block runs on Windows too.
   describe("after the first cat failed to read", () => {
     test.concurrent.each([
       "cat || echo first-failed; echo ---; cat || echo second-failed",

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isWindows } from "harness";
+import { closeSync, openSync } from "node:fs";
+
+// On POSIX the builtin `cat` is only used with this flag set (see
+// `Kind::DISABLED_ON_POSIX`); without it `cat` is the system binary.
+const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+// Code for a child bun that runs `script` and prints the script's stdout
+// followed by an `exit=<code>` trailer. A hang or a crash in the child shows up
+// as a missing trailer. (Both go through process.stdout: console.log takes a
+// separate path to fd 1 and can overtake a large pending process.stdout.write.)
+function childCode(script: string, quiet: boolean): string {
+  const run = `Bun.$\`\${{ raw: ${JSON.stringify(script)} }}\`.nothrow()`;
+  const trailer = `process.stdout.write("exit=" + r.exitCode + "\\n");`;
+  return quiet
+    ? `const r = await ${run}.quiet(); process.stdout.write(r.stdout); ${trailer}`
+    : `const r = await ${run}; ${trailer}`;
+}
+
+type Stdin =
+  // Written to a pipe that is closed right away, so stdin reaches EOF.
+  | { input: string }
+  // Reading a directory fails, so every `cat` reading stdin fails.
+  | { directory: string };
+
+function spawnChild(script: string, stdin: Stdin, quiet: boolean) {
+  const cmd = [bunExe(), "-e", childCode(script, quiet)];
+  if ("directory" in stdin) {
+    const fd = openSync(stdin.directory, "r");
+    try {
+      return Bun.spawn({ cmd, env: builtinEnv, stdin: fd, stdout: "pipe", stderr: "pipe" });
+    } finally {
+      closeSync(fd);
+    }
+  }
+  const proc = Bun.spawn({ cmd, env: builtinEnv, stdin: "pipe", stdout: "pipe", stderr: "pipe" });
+  proc.stdin.write(stdin.input);
+  proc.stdin.end();
+  return proc;
+}
+
+async function runScript(script: string, stdin: Stdin, { quiet = true } = {}) {
+  await using proc = spawnChild(script, stdin, quiet);
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
+// Every `cat` reading the script's stdin (or a pipeline stage's stdin)
+// registers on the single IOReader owned by that fd. Once the first `cat` has
+// consumed a read cycle (EOF or error), a later `cat` on the same fd has to
+// start a new one and must be the only listener notified by it.
+//
+// Skipped on Windows, where the reader closes its libuv source at EOF; a second
+// `cat` on the same fd there is covered by the fix in #29986.
+describe.skipIf(isWindows)("cat (builtin) sharing one stdin reader", () => {
+  describe("after the first cat reached EOF", () => {
+    const scripts: [script: string, stdout: string][] = [
+      ["cat; echo ---; cat", "hi\n---\n"],
+      ["cat && echo --- && cat", "hi\n---\n"],
+      // The second restart starts from a reader that was already restarted once.
+      ["cat; cat; cat", "hi\n"],
+      // The subshell / if node is allocated before the second cat, so the second
+      // cat does not reuse the first cat's node id: a listener entry left over
+      // from the first cat would be dispatched to a node that is not a cat.
+      ["cat; (echo ---; cat)", "hi\n---\n"],
+      ["cat; if true; then echo ---; cat; fi", "hi\n---\n"],
+    ];
+
+    // With captured output, the first cat's completion runs the rest of the
+    // script synchronously, so the second cat registers from inside the
+    // reader's EOF callback.
+    describe("captured stdout", () => {
+      test.concurrent.each(scripts)("%s", async (script, expected) => {
+        const result = await runScript(script, { input: "hi\n" });
+        expect(result).toEqual({ stdout: `${expected}exit=0\n`, stderr: "", exitCode: 0 });
+      });
+    });
+
+    // With stdout going through an IOWriter, a command can also complete from a
+    // write callback, after the EOF callback has returned.
+    describe("inherited stdout", () => {
+      test.concurrent.each(scripts)("%s", async (script, expected) => {
+        const result = await runScript(script, { input: "hi\n" }, { quiet: false });
+        expect(result).toEqual({ stdout: `${expected}exit=0\n`, stderr: "", exitCode: 0 });
+      });
+    });
+
+    test.concurrent("input spanning several reads", async () => {
+      const input = Buffer.alloc(300_000, "abcdefghij\n").toString();
+      const result = await runScript("cat; cat", { input });
+      expect(result.stderr).toBe("");
+      expect(result.stdout.length).toBe(input.length + "exit=0\n".length);
+      expect(result.stdout).toBe(`${input}exit=0\n`);
+      expect(result.exitCode).toBe(0);
+    });
+
+    test.concurrent("stdin of a pipeline stage", async () => {
+      const result = await runScript("echo hi | (cat; echo ---; cat)", { input: "" });
+      expect(result).toEqual({ stdout: "hi\n---\nexit=0\n", stderr: "", exitCode: 0 });
+    });
+
+    // Bun.spawn's stdin pipe is a socketpair; this is the same thing over an
+    // actual pipe.
+    test.concurrent("stdin is a pipe", async () => {
+      await using proc = Bun.spawn({
+        cmd: ["sh", "-c", 'printf "hi\\n" | "$0" -e "$1"', bunExe(), childCode("cat; echo ---; cat", true)],
+        env: builtinEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "hi\n---\nexit=0\n", stderr: "", exitCode: 0 });
+    });
+
+    // The first cat fails on its stdout write while the read that delivered the
+    // chunk is still running and unregisters itself. With captured output the
+    // second cat registers right away, while that read is still in flight, and
+    // is served by it. With stdout going through an IOWriter, `echo` completes
+    // later, so the read reaches EOF with nobody listening and the second cat
+    // registers only after that.
+    describe.if(isLinux)("first cat unregistering mid-read", () => {
+      test.concurrent.each([true, false])("quiet: %p", async quiet => {
+        const result = await runScript(
+          "cat > /dev/full || echo first-failed; cat && echo second-ok",
+          { input: "hi\n" },
+          { quiet },
+        );
+        expect(result).toEqual({ stdout: "first-failed\nsecond-ok\nexit=0\n", stderr: "", exitCode: 0 });
+      });
+    });
+  });
+
+  describe("after the first cat failed to read", () => {
+    test.concurrent.each([
+      "cat || echo first-failed; echo ---; cat || echo second-failed",
+      // Second cat in a node id different from the first cat's (see above).
+      "cat || echo first-failed; (echo ---; cat) || echo second-failed",
+    ])("%s", async script => {
+      const result = await runScript(script, { directory: import.meta.dir });
+      expect(result).toEqual({ stdout: "first-failed\n---\nsecond-failed\nexit=0\n", stderr: "", exitCode: 0 });
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- With the builtin `cat` (`BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX, the default on Windows), a script that reads stdin with two cats, such as `cat; echo ---; cat`, prints the first cat's output and then hangs forever. A real shell runs the second cat to immediate EOF and moves on.
- When the first cat's read failed and the second cat is inside a subshell (`cat; (echo ---; cat)`), bun crashes instead: `panic: expected Node::Cmd at Node#2, got Subshell`.
- The hang: the shared stdin reader decided whether to start a new read by asking whether its poll was registered. A finished read (EOF or error) leaves the one-shot poll registered but already fired, so the second cat was left waiting for a wakeup that never comes.
- The panic: a cat that had been notified stayed in the reader's listener list, so the next read notified it again, by then under a node id that had been freed or reused by another node.

### Fix
- The POSIX reader starts a new read whenever no read is armed, so a cat that arrives after a finished read reads the fd again, as a system `cat` inheriting the fd would: EOF again on a pipe, more input on a tty, the same error on a failing fd. Windows is unchanged; a second cat there needs #29986.
- The EOF and error callbacks take the listener list out before notifying it, so each listener is notified exactly once with the outcome of the read it registered for, and a cat started from inside a notification registers into the empty list and gets a read of its own.
- The stored error that a later EOF used to replay to the listeners is removed: a read ends in exactly one of error or EOF, and after an error nobody is left to replay it to.
- Verification: a new test file with 20 cases, each run in a child bun. Before the fix 17 fail on Linux (16 hang, one panics); all 20 pass with it. The read-error subshell case only passes with the listener change and the EOF cases only with the restart change. The read-error cases were also checked on a Windows debug build.

### Background
- `Bun.$` is bun's shell. `cat` can run as a builtin inside the interpreter instead of as a subprocess (behind the flag on POSIX, always on Windows), so every cat in a script reads stdin through the interpreter rather than through its own process.
- `IOReader` (src/runtime/shell/IOReader.rs) wraps one readable fd for a whole script, either the script's stdin or the stdin a pipeline creates for a stage. A builtin that wants input registers as a listener; the reader passes chunks and the final EOF or error to every listener.
- On POSIX the reader is driven by a one-shot poll: it fires once per arm and must be re-registered to fire again, so "registered" does not mean "a read is in flight". `has_pending_read()` (is the poll being watched) means that, and `IOWriter` already uses the same check on its writable poll.
- Listeners are recorded by interpreter node id. Ids are released when a command finishes and can be handed to later nodes, so dispatching to a stale entry reaches whatever node holds that id now.
- Captured stdout (`.quiet()`) versus inherited stdout decides when the next cat registers: with captured output the first cat's completion runs the rest of the script synchronously, inside the reader's callback; with inherited output the next command starts later, from a write callback. The tests cover both.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cat.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

Builtin `cat` (POSIX: `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`), two of them reading the same stdin in one script:

```sh
printf 'hi\n' | BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e 'console.log((await Bun.$`cat; echo ---; cat`.nothrow()).exitCode)'
# prints "hi" and "---", then hangs forever (same with .quiet())

BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e 'await Bun.$`cat; (echo ---; cat)`.nothrow()' < /etc/hostname
# (stdin is a regular file, so the first cat fails with EPERM from epoll and the second one restarts the reader)
# panic: expected Node::Cmd at Node#2, got Subshell
```

A real shell runs the second `cat` to immediate EOF (or to the same read error) and moves on. The subprocess `cat`, and two separate `$` calls, both behave; the bug needs two builtin cats on the one `IOReader` a script has for its stdin (the root stdin reader, or the reader a pipeline creates for a stage's stdin).

### Cause

Two things in `src/runtime/shell/IOReader.rs`:

1. `start()` decided whether to (re)start the read with `FilePoll::is_registered()`. The reader's poll is one-shot; after it fires, `PollReadable` stays set and `NeedsRearm` is set until somebody re-registers. A read that ends in EOF or an error does not re-register, so that is exactly the state a finished read leaves behind: `is_registered()` is true, the poll will never fire again, and the second cat's `start()` returns `suspended` without doing anything. `IOWriter::write()` already documents and avoids the same trap on the writable poll (it uses `is_watching()`).

2. `on_reader_done_cb` / `on_reader_error` iterated a clone of `readers` and left the entries in place, and nothing removed a cat that had been notified. Once a restart does happen (today already on the error path, since a poll that failed to register is not registered; after (1) also on the EOF path), the next read notifies the previous cat's entry again. By then its `NodeId` has been freed, or reused by whatever node was allocated next, hence the panic above (`cat; echo ---; cat` only survived because the second cat happened to get the first one's slot back and `add_reader`'s dedup matched the stale entry).

### Fix

- `start()` keys off `BufferedReader::has_pending_read()` (`handle` is a poll and it `is_watching()`), which is false for a never-registered, failed, or fired-and-not-re-armed poll and true while a read is armed. A listener that arrives after a finished read gets a new read on the same fd, which is what the system `cat` does with the inherited fd: a pipe or socket at EOF reports EOF again right away, a tty waits for more input, a failing fd fails again with its own errno. Listeners that arrive while a read is armed attach to it as before.
- The done/error callbacks take the listener list (`take_readers`) before notifying it. Each listener is notified exactly once, with the outcome of the read it registered for. A cat started synchronously from inside a notification (with captured output the first cat's completion runs the rest of the script on the spot) registers into the emptied list and restarts the reader, so it is served by its own read instead of being completed by the notification loop that is still running; nothing stays behind to be dispatched under a dead `NodeId`. This makes `State::raw_err` dead. It existed so that a `done` following an error could hand the error to the listeners again, but a read reports one or the other: on POSIX every read loop in `PipeReader.rs` ends in exactly one of `on_error()` (registration failure or read error) or `done()` (EOF), both in tail position; on Windows `WindowsBufferedReader::on_read` returns right after `on_error()` for an error and only reaches `close()` / `done()` for EOF. The one way a `done` can still follow an error is a Windows VM teardown closing the source of a reader that already failed, and by then the error notification has detached every listener, so there is nothing to carry the error to (before this change that teardown `done` would have re-notified the already finished cats). A listener added after an error is waiting on a new read whose outcome is its own.

Restarting from inside the EOF notification is safe with respect to the `bun_io` reader: every `done()` / `on_error()` dispatch in `PosixBufferedReader` is in tail position and copies the vtable out first, so nothing in the read loop touches the reader after the callback has re-registered it. When the second cat registers while a read is still running (first cat killed by a stdout write error in the middle of a chunk), `has_pending_read()` is false as well and the poll gets re-registered once more. That read still serves the new listener; the re-registration then produces one more wakeup, which either serves a cat that registered in the meantime (a third cat started from the second one's EOF notification finds `has_pending_read()` true and waits for it) or reads EOF again with nobody to notify. The `/dev/full` cases below cover both outcomes.

`start()` on Windows is unchanged: there the reader closes its libuv source at EOF, so a second cat needs a different answer, which #29986 provides (it currently crashes on `start_with_current_pipe`). Note for whichever of the two lands second: #29986 drains `readers` by popping until empty, which would also complete a listener that registered during the drain; on POSIX that listener now has a read in flight and must be left alone, which is why this change snapshots the list instead. #35337 (regular files are not pollable) is a separate problem; the error-path tests here use a directory as stdin so they do not depend on how that one is resolved.

Not changed here: while no cat is registered (the first one died on a write error and the next command has not started its cat yet), the reader keeps reading and throws the bytes away (`on_read_chunk_cb` returns `should_continue` regardless of whether anyone is listening), where a real shell would leave them for the next cat. Pre-existing and independent of the hang; it is the reason the tests below close stdin up front or use a tty rather than feeding more data into a pipe.

### Tests

`test/js/bun/shell/commands/cat.test.ts` (new; the other builtins have a file here, cat did not. #37743 and #35337 create the same file for their own cat fixes; the helpers are independent, so whichever lands later just appends its cases, and I will rebase this one if it is not first). Each case spawns a child bun with the flag and checks the script's stdout plus an `exit=<code>` trailer:

- second cat after EOF: `cat; echo ---; cat`, `&&` chain, three cats, and the second cat inside `( )` / `if` so it gets a different node id than the first; each with captured stdout (restart happens inside the EOF callback) and with stdout going through an IOWriter (restart happens later, from a write callback)
- 300 KB input spanning several reads, a pipeline stage's stdin (`echo hi | (cat; echo ---; cat)`), and stdin as an actual pipe via `sh -c` (Bun.spawn's pipe is a socketpair)
- stdin as a tty (`Bun.Terminal`): `hi` + ^D, wait for `---`, then `more` + ^D, expecting `hi`, `---`, `more`. On a pipe the new read only reports EOF again, which prints the same thing as completing the second cat on the spot would; a tty's ^D is used up by the read that sees it, so this case only passes if the second cat really reads the fd again (it hangs before the fix and would print no `more` with complete-on-the-spot semantics)
- first cat failing its stdout write (`cat > /dev/full`, Linux), captured output: second cat served by the still-running read; plus a third cat served by the extra wakeup, plus a trailing subprocess so the extra wakeup arrives with nobody to notify while the reader is still alive (debug assertions); and with an IOWriter, where `echo` completes later, so the read ends with nobody listening and the second cat starts a new one (this one hung before)
- first cat failing to read (directory as stdin), second cat flat and inside `( )` (the latter panicked before). This block also runs on Windows, where the builtin cat is the default and a failed read can be retried (only the EOF block is skipped there, see above): on a Windows x64 canary build the `( )` case panics with the same `expected Node::Cmd at Node#3, got Subshell`, and both cases pass with a Windows debug build of this branch

Before the fix 17 of the 20 cases fail on Linux (16 hang, the read-error `( )` case panics; the three that pass, the basic and the trailing-subprocess `/dev/full` cases and the flat read-error case, are guards for paths this touches). The two halves are independently load-bearing: the read-error `( )` case does not involve `start()` at all and only passes with `take_readers`, while the EOF cases only stop hanging with the `start()` change. With the fix all 20 pass on the debug build (also checked: the file fails the same way on a debug build with `src/` stashed). For comparison, with #29986's `IOReader.rs` changes ported onto main instead of this change, the captured-output cases pass as a side effect of its drain loop and every case where the next cat registers after the notification has returned still hangs (see the comment below).

</details>
