### PR TITLE
bundler: fail the build instead of panicking when the bundle thread cannot be started

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -67,6 +67,8 @@ pub trait CompletionStruct: Node + Send + 'static {
     ) -> Result<(), crate::Error>;
     /// Bundle thread, on dequeue: `false` if the owner released this build
     /// while it was still queued ([`free_released_unstarted`] then frees it).
+    /// Also the owner's thread, in [`singleton::enqueue`], for a build that
+    /// could not be handed to a bundle thread at all.
     fn try_start(&mut self) -> bool;
     fn free_released_unstarted(this: *mut Self);
     fn complete_on_bundle_thread(&mut self);
@@ -384,22 +386,11 @@ pub mod singleton {
             Err(err) => {
                 // SAFETY: `spawn` started nothing, so this is still the sole owner.
                 unsafe { bun_core::heap::destroy(bundle_thread.as_ptr()) };
-                return Err(spawn_errno(&err));
+                return Err(SystemErrno::from_io_error(&err).unwrap_or(SystemErrno::EAGAIN));
             }
         }
         *instance = Some(Instance(bundle_thread.cast::<()>()));
         Ok(bundle_thread.as_ptr())
-    }
-
-    fn spawn_errno(err: &std::io::Error) -> SystemErrno {
-        // On Windows the raw code is a Win32 error, which `init(u32)` maps.
-        #[cfg(windows)]
-        let errno = err
-            .raw_os_error()
-            .and_then(|code| SystemErrno::init(code as u32));
-        #[cfg(not(windows))]
-        let errno = err.raw_os_error().map(bun_errno::from_errno);
-        errno.unwrap_or(SystemErrno::EAGAIN)
     }
 
     /// The owner gets exactly one completion, even if the bundle thread cannot be started.
@@ -419,24 +410,25 @@ pub mod singleton {
             Err(errno) => errno,
         };
 
-        // Same steps as the dequeue in `thread_main`, on this thread instead.
-        // SAFETY: the task is live until its completion is posted below.
-        if !unsafe { (*completion.as_ptr()).try_start() } {
-            C::free_released_unstarted(completion.as_ptr());
-            return;
-        }
-        // SAFETY: started ⇒ the owner does not touch the task until its completion runs.
+        // SAFETY: the task is live, and until this returns nothing else uses it:
+        // it never reached the queue. The borrow ends before the caller goes on
+        // setting it up.
         let completion = unsafe { &mut *completion.as_ptr() };
-        let hint = if errno == SystemErrno::EAGAIN {
-            " The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
-        } else {
-            ""
-        };
+        // Started, so a VM torn down before the completion below runs waits for
+        // it (as for a build that failed on the bundle thread) instead of
+        // releasing the task itself.
+        let started = completion.try_start();
+        assert!(
+            started,
+            "a build that was never queued cannot have been released"
+        );
         let mut log = bun_ast::Log::init();
         log.add_error_fmt(
             None,
             bun_ast::Loc::EMPTY,
-            format_args!("Failed to start the bundler thread: {errno}.{hint}"),
+            format_args!(
+                "Failed to start the bundler thread: {errno}. The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
+            ),
         );
         completion.set_log(log);
         completion.set_result(BundleV2Result::Err(errno.into()));

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -370,7 +370,7 @@ pub mod singleton {
     /// # Safety
     /// All calls (across the process) must use the same `C`; the static is
     /// type-erased.
-    pub(crate) fn get<C: CompletionStruct>() -> Result<*mut BundleThread<C>, SystemErrno> {
+    pub(crate) fn get<C: CompletionStruct>() -> std::io::Result<*mut BundleThread<C>> {
         let mut instance = INSTANCE.lock();
         if let Some(instance) = &*instance {
             return Ok(instance.0.as_ptr().cast::<BundleThread<C>>());
@@ -386,7 +386,7 @@ pub mod singleton {
             Err(err) => {
                 // SAFETY: `spawn` started nothing, so this is still the sole owner.
                 unsafe { bun_core::heap::destroy(bundle_thread.as_ptr()) };
-                return Err(SystemErrno::from_io_error(&err).unwrap_or(SystemErrno::EAGAIN));
+                return Err(err);
             }
         }
         *instance = Some(Instance(bundle_thread.cast::<()>()));
@@ -400,43 +400,56 @@ pub mod singleton {
         let completion = NonNull::new(completion).unwrap_or_else(|| {
             Output::panic(format_args!("BundleThread enqueue: null completion"))
         });
-        let errno = match get::<C>() {
+        let err = match get::<C>() {
             Ok(instance) => {
                 // SAFETY: `get()` returned the leaked 'static singleton whose bundle thread is
                 // running; `BundleThread::enqueue` only performs raw-ptr field projections.
                 unsafe { BundleThread::enqueue(instance, completion.as_ptr()) };
                 return;
             }
-            Err(errno) => errno,
+            Err(err) => err,
         };
 
         // SAFETY: the task is live, and until this returns nothing else uses it:
         // it never reached the queue. The borrow ends before the caller goes on
         // setting it up.
         let completion = unsafe { &mut *completion.as_ptr() };
-        // Started, so a VM torn down before the completion below runs waits for
-        // it (as for a build that failed on the bundle thread) instead of
-        // releasing the task itself.
+        // A VM torn down before the posted completion runs then treats this like
+        // any started build (the completion is released with the queue); left
+        // queued, the teardown would instead release it itself and finish the
+        // embedded work a second time.
         let started = completion.try_start();
         assert!(
             started,
             "a build that was never queued cannot have been released"
         );
-        // EAGAIN is what a thread limit produces; Windows reports ENOMEM, where
-        // the advice below would be wrong.
-        let hint = if errno == SystemErrno::EAGAIN {
-            " The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
-        } else {
-            ""
-        };
+        let errno = SystemErrno::from_io_error(&err);
         let mut log = bun_ast::Log::init();
-        log.add_error_fmt(
-            None,
-            bun_ast::Loc::EMPTY,
-            format_args!("Failed to start the bundler thread: {errno}.{hint}"),
-        );
+        match errno {
+            Some(errno) => {
+                // Unix reports an exhausted thread or pid limit as EAGAIN.
+                let hint = if cfg!(not(windows)) && errno == SystemErrno::EAGAIN {
+                    " The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
+                } else {
+                    ""
+                };
+                log.add_error_fmt(
+                    None,
+                    bun_ast::Loc::EMPTY,
+                    format_args!("Failed to start the bundler thread: {errno}.{hint}"),
+                );
+            }
+            // An OS code bun has no errno for: report it the way the OS describes it.
+            None => log.add_error_fmt(
+                None,
+                bun_ast::Loc::EMPTY,
+                format_args!("Failed to start the bundler thread: {err}"),
+            ),
+        }
         completion.set_log(log);
-        completion.set_result(BundleV2Result::Err(errno.into()));
+        completion.set_result(BundleV2Result::Err(
+            errno.map_or(crate::Error::BuildFailed, crate::Error::Sys),
+        ));
         completion.complete_on_bundle_thread();
     }
 }

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -422,13 +422,18 @@ pub mod singleton {
             started,
             "a build that was never queued cannot have been released"
         );
+        // EAGAIN is what a thread limit produces; Windows reports ENOMEM, where
+        // the advice below would be wrong.
+        let hint = if errno == SystemErrno::EAGAIN {
+            " The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
+        } else {
+            ""
+        };
         let mut log = bun_ast::Log::init();
         log.add_error_fmt(
             None,
             bun_ast::Loc::EMPTY,
-            format_args!(
-                "Failed to start the bundler thread: {errno}. The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
-            ),
+            format_args!("Failed to start the bundler thread: {errno}.{hint}"),
         );
         completion.set_log(log);
         completion.set_result(BundleV2Result::Err(errno.into()));

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -135,9 +135,10 @@ impl<C: CompletionStruct> BundleThread<C> {
 
     /// # Safety
     /// `instance` must be valid for `'static` (the spawned thread runs forever and
-    /// accesses it). After this returns the bundle thread concurrently accesses
+    /// accesses it). After this returns `Ok`, the bundle thread concurrently accesses
     /// `*instance`; callers must only touch it via the raw-pointer methods on this
-    /// impl (e.g. `enqueue`) and never materialize a `&mut Self`.
+    /// impl (e.g. `enqueue`) and never materialize a `&mut Self`. On `Err` no thread
+    /// was started and nothing else refers to `*instance`.
     pub(crate) unsafe fn spawn(
         instance: *mut Self,
     ) -> std::io::Result<std::thread::JoinHandle<()>> {
@@ -350,69 +351,124 @@ impl<C: CompletionStruct> BundleThread<C> {
 // erased static is sound. T6 (`bun_bundler_jsc`) calls these with its concrete
 // completion-task type.
 pub mod singleton {
+    use bun_errno::SystemErrno;
+
     use super::*;
 
-    /// `Send + Sync` newtype around the leaked `BundleThread` allocation so it
-    /// can sit inside a `OnceLock`. Type-erased because Rust forbids generic
-    /// statics; see module comment. Stored as a raw pointer (not `&'static`)
-    /// because the bundle thread mutates `*self` concurrently — callers must
-    /// only ever project fields via raw-pointer access.
+    /// `Send` newtype around the leaked `BundleThread` allocation so it can
+    /// sit inside the `Guarded` static. Type-erased because Rust forbids
+    /// generic statics; see module comment. Stored as a raw pointer (not
+    /// `&'static`) because the bundle thread mutates `*self` concurrently —
+    /// callers must only ever project fields via raw-pointer access.
     struct Instance(NonNull<()>);
     // SAFETY: the allocation is a leaked `Box<BundleThread<C>>` valid for
     // `'static`; cross-thread access is mediated entirely through
     // `UnboundedQueue` / `ResetEvent` atomics inside `BundleThread::enqueue`.
     unsafe impl Send for Instance {}
-    // SAFETY: `&Instance` only exposes the raw pointer; every dereference path
-    // goes through `BundleThread::enqueue`'s atomic queue/waker primitives, so
-    // sharing the pointer across threads is sound.
-    unsafe impl Sync for Instance {}
 
-    static INSTANCE: std::sync::OnceLock<Instance> = std::sync::OnceLock::new();
+    // `None` until the bundle thread is running. Holding the lock across the
+    // spawn makes concurrent first callers (workers) wait for one attempt
+    // instead of each starting a thread; a failed attempt leaves `None`, so
+    // the next build retries.
+    static INSTANCE: bun_threading::Guarded<Option<Instance>> = bun_threading::Guarded::new(None);
 
-    // Blocks the calling thread until the bun build thread is created.
-    // OnceLock also blocks other callers of this function until the first caller is done.
-    fn load_once_impl<C: CompletionStruct>() -> Instance {
-        let bundle_thread = bun_core::heap::into_raw(Box::new(BundleThread::<C>::uninitialized()));
-
-        // 2. Spawn the bun build thread.
-        // SAFETY: bundle_thread is a leaked Box, valid for 'static; `spawn` takes the
-        // raw pointer directly so no `&mut` is materialized that would alias the
-        // bundle thread's own access.
-        let os_thread = unsafe { BundleThread::spawn(bundle_thread) }
-            .unwrap_or_else(|_| Output::panic(format_args!("Failed to spawn bun build thread")));
-        // `std.Thread.detach()` — drop the JoinHandle without joining.
-        drop(os_thread);
-
-        // SAFETY: `into_raw` of a `Box` is never null.
-        Instance(unsafe { NonNull::new_unchecked(bundle_thread.cast::<()>()) })
-    }
-
-    /// Returns the raw singleton pointer. The bundle thread runs `thread_main`
-    /// against this allocation for the process lifetime, so callers MUST NOT
-    /// materialize `&mut BundleThread` from it.
-    /// Use `BundleThread::enqueue(get(), ...)` instead.
+    /// Returns the raw singleton pointer, starting the bundle thread on first
+    /// use. The bundle thread runs `thread_main` against this allocation for
+    /// the process lifetime, so callers MUST NOT materialize `&mut BundleThread`
+    /// from it. Use `BundleThread::enqueue(get()?, ...)` instead.
+    ///
+    /// Thread creation fails like any other OS resource (`EAGAIN` at the pids
+    /// or `RLIMIT_NPROC` limit); that is reported to the caller rather than
+    /// cached, and nothing of the failed attempt is kept.
     ///
     /// # Safety
     /// All calls (across the process) must use the same `C`; the static is
     /// type-erased.
-    pub(crate) fn get<C: CompletionStruct>() -> *mut BundleThread<C> {
-        // INSTANCE is a leaked 'static Box of `BundleThread<C>` (same `C` per
-        // the safety contract).
-        INSTANCE
-            .get_or_init(load_once_impl::<C>)
-            .0
-            .as_ptr()
-            .cast::<BundleThread<C>>()
+    pub(crate) fn get<C: CompletionStruct>() -> Result<*mut BundleThread<C>, SystemErrno> {
+        let mut instance = INSTANCE.lock();
+        if let Some(instance) = &*instance {
+            // A leaked 'static Box of `BundleThread<C>` (same `C` per the
+            // safety contract).
+            return Ok(instance.0.as_ptr().cast::<BundleThread<C>>());
+        }
+
+        let bundle_thread =
+            bun_core::heap::into_raw_nn(Box::new(BundleThread::<C>::uninitialized()));
+        // SAFETY: `bundle_thread` is a leaked Box, valid for 'static; `spawn` takes the
+        // raw pointer directly so no `&mut` is materialized that would alias the
+        // bundle thread's own access.
+        match unsafe { BundleThread::spawn(bundle_thread.as_ptr()) } {
+            // `std.Thread.detach()` — drop the JoinHandle without joining.
+            Ok(os_thread) => drop(os_thread),
+            Err(err) => {
+                // SAFETY: no thread was started, so this is still the only
+                // reference to the allocation; the placeholder contents own
+                // nothing that needs the bundle thread to release.
+                unsafe { bun_core::heap::destroy(bundle_thread.as_ptr()) };
+                return Err(spawn_errno(&err));
+            }
+        }
+        *instance = Some(Instance(bundle_thread.cast::<()>()));
+        Ok(bundle_thread.as_ptr())
     }
 
+    fn spawn_errno(err: &std::io::Error) -> SystemErrno {
+        // Windows: `raw_os_error()` is a Win32 `GetLastError()` code, so route
+        // it through the u32 (Win32Error) mapper rather than `from_errno`'s
+        // errno path.
+        #[cfg(windows)]
+        let errno = err
+            .raw_os_error()
+            .and_then(|code| SystemErrno::init(code as u32));
+        #[cfg(not(windows))]
+        let errno = err.raw_os_error().map(bun_errno::from_errno);
+        errno.unwrap_or(SystemErrno::EAGAIN)
+    }
+
+    /// Hands `completion` to the bundle thread. If the bundle thread cannot be
+    /// started, the build is failed right here with the reason in its log,
+    /// through the same hand-back a build failing on the bundle thread takes:
+    /// either way the caller gets exactly one completion for it.
     pub fn enqueue<C: CompletionStruct>(completion: *mut C) {
         // Validate the caller's pointer at the public boundary so the unsafe
         // path below never receives null.
         let completion = NonNull::new(completion).unwrap_or_else(|| {
             Output::panic(format_args!("BundleThread enqueue: null completion"))
         });
-        // SAFETY: `get()` returns the leaked 'static singleton whose bundle thread is
-        // running; `BundleThread::enqueue` only performs raw-ptr field projections.
-        unsafe { BundleThread::enqueue(get::<C>(), completion.as_ptr()) };
+        let errno = match get::<C>() {
+            Ok(instance) => {
+                // SAFETY: `get()` returned the leaked 'static singleton whose bundle thread is
+                // running; `BundleThread::enqueue` only performs raw-ptr field projections.
+                unsafe { BundleThread::enqueue(instance, completion.as_ptr()) };
+                return;
+            }
+            Err(errno) => errno,
+        };
+
+        // The task never reached the queue, so this thread stands in for the
+        // bundle thread and takes the same steps as the dequeue in `thread_main`.
+        // SAFETY: the task is live until its completion is posted (below), and
+        // `try_start` is the atomic handshake for claiming it.
+        if !unsafe { (*completion.as_ptr()).try_start() } {
+            C::free_released_unstarted(completion.as_ptr());
+            return;
+        }
+        // SAFETY: started ⇒ the owner waits for the completion posted below
+        // and does not touch the task until then.
+        let completion = unsafe { &mut *completion.as_ptr() };
+        let hint = if errno == SystemErrno::EAGAIN {
+            " The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
+        } else {
+            ""
+        };
+        let mut log = bun_ast::Log::init();
+        log.add_error_fmt(
+            None,
+            bun_ast::Loc::EMPTY,
+            format_args!("Failed to start the bundler thread: {errno}.{hint}"),
+        );
+        completion.set_log(log);
+        completion.set_result(BundleV2Result::Err(errno.into()));
+        completion.complete_on_bundle_thread();
     }
 }

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -134,11 +134,10 @@ impl<C: CompletionStruct> BundleThread<C> {
     }
 
     /// # Safety
-    /// `instance` must be valid for `'static` (the spawned thread runs forever and
-    /// accesses it). After this returns `Ok`, the bundle thread concurrently accesses
-    /// `*instance`; callers must only touch it via the raw-pointer methods on this
-    /// impl (e.g. `enqueue`) and never materialize a `&mut Self`. On `Err` no thread
-    /// was started and nothing else refers to `*instance`.
+    /// `instance` must be valid for `'static`: after `Ok` the bundle thread accesses it
+    /// forever, so callers must only touch it through the raw-pointer methods on this
+    /// impl (e.g. `enqueue`) and never materialize a `&mut Self`. After `Err` no thread
+    /// exists and the caller still owns it.
     pub(crate) unsafe fn spawn(
         instance: *mut Self,
     ) -> std::io::Result<std::thread::JoinHandle<()>> {
@@ -355,31 +354,20 @@ pub mod singleton {
 
     use super::*;
 
-    /// `Send` newtype around the leaked `BundleThread` allocation so it can
-    /// sit inside the `Guarded` static. Type-erased because Rust forbids
-    /// generic statics; see module comment. Stored as a raw pointer (not
-    /// `&'static`) because the bundle thread mutates `*self` concurrently —
-    /// callers must only ever project fields via raw-pointer access.
+    /// The leaked `BundleThread<C>`, type-erased (see module comment). A raw
+    /// pointer because the bundle thread mutates it concurrently.
     struct Instance(NonNull<()>);
     // SAFETY: the allocation is a leaked `Box<BundleThread<C>>` valid for
     // `'static`; cross-thread access is mediated entirely through
     // `UnboundedQueue` / `ResetEvent` atomics inside `BundleThread::enqueue`.
     unsafe impl Send for Instance {}
 
-    // `None` until the bundle thread is running. Holding the lock across the
-    // spawn makes concurrent first callers (workers) wait for one attempt
-    // instead of each starting a thread; a failed attempt leaves `None`, so
-    // the next build retries.
     static INSTANCE: bun_threading::Guarded<Option<Instance>> = bun_threading::Guarded::new(None);
 
-    /// Returns the raw singleton pointer, starting the bundle thread on first
-    /// use. The bundle thread runs `thread_main` against this allocation for
-    /// the process lifetime, so callers MUST NOT materialize `&mut BundleThread`
-    /// from it. Use `BundleThread::enqueue(get()?, ...)` instead.
-    ///
-    /// Thread creation fails like any other OS resource (`EAGAIN` at the pids
-    /// or `RLIMIT_NPROC` limit); that is reported to the caller rather than
-    /// cached, and nothing of the failed attempt is kept.
+    /// Starts the bundle thread on first use; only `BundleThread::enqueue` may
+    /// be used on the returned pointer. A failed spawn (an OS limit) leaves the
+    /// slot empty, so the next build tries again; the lock is held across the
+    /// attempt, so concurrent first callers wait for it instead of racing it.
     ///
     /// # Safety
     /// All calls (across the process) must use the same `C`; the static is
@@ -387,23 +375,18 @@ pub mod singleton {
     pub(crate) fn get<C: CompletionStruct>() -> Result<*mut BundleThread<C>, SystemErrno> {
         let mut instance = INSTANCE.lock();
         if let Some(instance) = &*instance {
-            // A leaked 'static Box of `BundleThread<C>` (same `C` per the
-            // safety contract).
             return Ok(instance.0.as_ptr().cast::<BundleThread<C>>());
         }
 
         let bundle_thread =
             bun_core::heap::into_raw_nn(Box::new(BundleThread::<C>::uninitialized()));
-        // SAFETY: `bundle_thread` is a leaked Box, valid for 'static; `spawn` takes the
-        // raw pointer directly so no `&mut` is materialized that would alias the
-        // bundle thread's own access.
+        // SAFETY: a leaked Box, valid for 'static; passed as a raw pointer so no
+        // `&mut` aliases the bundle thread's own access.
         match unsafe { BundleThread::spawn(bundle_thread.as_ptr()) } {
             // `std.Thread.detach()` — drop the JoinHandle without joining.
             Ok(os_thread) => drop(os_thread),
             Err(err) => {
-                // SAFETY: no thread was started, so this is still the only
-                // reference to the allocation; the placeholder contents own
-                // nothing that needs the bundle thread to release.
+                // SAFETY: `spawn` started nothing, so this is still the sole owner.
                 unsafe { bun_core::heap::destroy(bundle_thread.as_ptr()) };
                 return Err(spawn_errno(&err));
             }
@@ -413,9 +396,7 @@ pub mod singleton {
     }
 
     fn spawn_errno(err: &std::io::Error) -> SystemErrno {
-        // Windows: `raw_os_error()` is a Win32 `GetLastError()` code, so route
-        // it through the u32 (Win32Error) mapper rather than `from_errno`'s
-        // errno path.
+        // On Windows the raw code is a Win32 error, which `init(u32)` maps.
         #[cfg(windows)]
         let errno = err
             .raw_os_error()
@@ -425,10 +406,8 @@ pub mod singleton {
         errno.unwrap_or(SystemErrno::EAGAIN)
     }
 
-    /// Hands `completion` to the bundle thread. If the bundle thread cannot be
-    /// started, the build is failed right here with the reason in its log,
-    /// through the same hand-back a build failing on the bundle thread takes:
-    /// either way the caller gets exactly one completion for it.
+    /// Hands `completion` to the bundle thread, or fails it right here if that
+    /// thread cannot be started; either way its owner gets exactly one completion.
     pub fn enqueue<C: CompletionStruct>(completion: *mut C) {
         // Validate the caller's pointer at the public boundary so the unsafe
         // path below never receives null.
@@ -445,16 +424,13 @@ pub mod singleton {
             Err(errno) => errno,
         };
 
-        // The task never reached the queue, so this thread stands in for the
-        // bundle thread and takes the same steps as the dequeue in `thread_main`.
-        // SAFETY: the task is live until its completion is posted (below), and
-        // `try_start` is the atomic handshake for claiming it.
+        // Same steps as the dequeue in `thread_main`, on this thread instead.
+        // SAFETY: the task is live until its completion is posted below.
         if !unsafe { (*completion.as_ptr()).try_start() } {
             C::free_released_unstarted(completion.as_ptr());
             return;
         }
-        // SAFETY: started ⇒ the owner waits for the completion posted below
-        // and does not touch the task until then.
+        // SAFETY: started ⇒ the owner does not touch the task until its completion runs.
         let completion = unsafe { &mut *completion.as_ptr() };
         let hint = if errno == SystemErrno::EAGAIN {
             " The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."

--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -354,8 +354,6 @@ pub mod singleton {
 
     use super::*;
 
-    /// The leaked `BundleThread<C>`, type-erased (see module comment). A raw
-    /// pointer because the bundle thread mutates it concurrently.
     struct Instance(NonNull<()>);
     // SAFETY: the allocation is a leaked `Box<BundleThread<C>>` valid for
     // `'static`; cross-thread access is mediated entirely through
@@ -364,10 +362,8 @@ pub mod singleton {
 
     static INSTANCE: bun_threading::Guarded<Option<Instance>> = bun_threading::Guarded::new(None);
 
-    /// Starts the bundle thread on first use; only `BundleThread::enqueue` may
-    /// be used on the returned pointer. A failed spawn (an OS limit) leaves the
-    /// slot empty, so the next build tries again; the lock is held across the
-    /// attempt, so concurrent first callers wait for it instead of racing it.
+    /// Starts the bundle thread on first use; a failed spawn leaves the slot empty
+    /// for the next build to retry.
     ///
     /// # Safety
     /// All calls (across the process) must use the same `C`; the static is
@@ -406,8 +402,7 @@ pub mod singleton {
         errno.unwrap_or(SystemErrno::EAGAIN)
     }
 
-    /// Hands `completion` to the bundle thread, or fails it right here if that
-    /// thread cannot be started; either way its owner gets exactly one completion.
+    /// The owner gets exactly one completion, even if the bundle thread cannot be started.
     pub fn enqueue<C: CompletionStruct>(completion: *mut C) {
         // Validate the caller's pointer at the public boundary so the unsafe
         // path below never receives null.

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -305,16 +305,12 @@ pub fn from_errno(errno: i32) -> SystemErrno {
 }
 
 impl SystemErrno {
-    /// The OS error behind a `std::io::Error` (e.g. from a failed
-    /// `std::thread::Builder::spawn`). `None` when the error did not come from
-    /// the OS or its code has no `SystemErrno`.
+    /// The OS error behind a `std::io::Error`; `None` if it is not an OS error or its code has no `SystemErrno`.
     pub fn from_io_error(err: &std::io::Error) -> Option<SystemErrno> {
         let code = err.raw_os_error()?;
         #[cfg(windows)]
         {
-            // A `GetLastError()` code: the `u32` entry point maps it through
-            // the Win32 → errno table, whereas `i64` would read it as an errno
-            // discriminant.
+            // A Win32 code: the `u32` entry point maps it, `i64` would read it as an errno discriminant.
             SystemErrno::init(code as u32)
         }
         #[cfg(not(windows))]
@@ -521,6 +517,32 @@ mod errno_name_tests {
             assert_eq!(win32_errno_name(2), None);
             assert_eq!(win32_errno_name(u32::MAX), None);
         }
+    }
+
+    #[test]
+    fn io_error_to_errno() {
+        // Deliberately not EAGAIN, which is what the callers fall back to.
+        #[cfg(not(windows))]
+        assert_eq!(
+            SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(libc::ENOMEM)),
+            Some(SystemErrno::ENOMEM)
+        );
+        #[cfg(windows)]
+        {
+            // Win32 ERROR_NOT_ENOUGH_MEMORY and ERROR_ACCESS_DENIED; read as errno values, 8 and 5 would be ENOEXEC and EIO.
+            assert_eq!(
+                SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(8)),
+                Some(SystemErrno::ENOMEM)
+            );
+            assert_eq!(
+                SystemErrno::from_io_error(&std::io::Error::from_raw_os_error(5)),
+                Some(SystemErrno::EPERM)
+            );
+        }
+        assert_eq!(
+            SystemErrno::from_io_error(&std::io::Error::other("not from the OS")),
+            None
+        );
     }
 
     #[test]

--- a/src/errno/lib.rs
+++ b/src/errno/lib.rs
@@ -304,6 +304,26 @@ pub fn from_errno(errno: i32) -> SystemErrno {
     SystemErrno::init(errno as i64).unwrap_or(SystemErrno::EIO)
 }
 
+impl SystemErrno {
+    /// The OS error behind a `std::io::Error` (e.g. from a failed
+    /// `std::thread::Builder::spawn`). `None` when the error did not come from
+    /// the OS or its code has no `SystemErrno`.
+    pub fn from_io_error(err: &std::io::Error) -> Option<SystemErrno> {
+        let code = err.raw_os_error()?;
+        #[cfg(windows)]
+        {
+            // A `GetLastError()` code: the `u32` entry point maps it through
+            // the Win32 → errno table, whereas `i64` would read it as an errno
+            // discriminant.
+            SystemErrno::init(code as u32)
+        }
+        #[cfg(not(windows))]
+        {
+            SystemErrno::init(i64::from(code))
+        }
+    }
+}
+
 #[cfg(not(windows))]
 impl SystemErrno {
     // `i64` covers every concrete call site (errno-range values).

--- a/src/watcher/Watcher.rs
+++ b/src/watcher/Watcher.rs
@@ -256,20 +256,9 @@ impl Watcher {
         });
         self.thread = Some(handle.map_err(|e| {
             self.watchloop_handle.store(false);
-            // Windows: raw_os_error() is a Win32 GetLastError() code, so
-            // route it through the u32 (Win32Error) mapper rather than
-            // from_errno's i64 discriminant-cast path.
-            #[cfg(windows)]
-            let errno = e
-                .raw_os_error()
-                .and_then(|c| bun_errno::SystemErrno::init(c as u32))
-                .unwrap_or(bun_errno::SystemErrno::EAGAIN);
-            #[cfg(not(windows))]
-            let errno = e
-                .raw_os_error()
-                .map(bun_errno::from_errno)
-                .unwrap_or(bun_errno::SystemErrno::EAGAIN);
-            crate::Error::Sys(errno)
+            crate::Error::Sys(
+                bun_errno::SystemErrno::from_io_error(&e).unwrap_or(bun_errno::SystemErrno::EAGAIN),
+            )
         })?);
         Ok(())
     }

--- a/test/bundler/bun-build-thread-spawn-failure.test.ts
+++ b/test/bundler/bun-build-thread-spawn-failure.test.ts
@@ -25,9 +25,14 @@ const skip = !isLinux || !cc;
 // while armed.
 const BUNDLE_THREAD_STACK_SIZE = 2 * 1024 * 1024;
 
+// The highest value Linux reserves for errnos; far beyond the ones bun names.
+// Stands in for what Windows produces for most failed thread creations: an OS
+// code with no errno equivalent.
+const UNNAMED_ERRNO = 4095;
+
 // BUNDLE_THREAD_SPAWN_PLAN has one letter per such attempt: 'f' fails it with
-// EAGAIN (a thread limit), 'n' with ENOMEM, 's' lets it through; the last
-// letter repeats.
+// EAGAIN (a thread limit), 'n' with ENOMEM, 'u' with a code bun has no errno
+// name for, 's' lets it through; the last letter repeats.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -60,6 +65,7 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)
     switch (plan[i < plan_len ? i : plan_len - 1]) {
       case 'f': return EAGAIN;
       case 'n': return ENOMEM;
+      case 'u': return ${UNNAMED_ERRNO};
     }
   }
   return real_pthread_create(thread, attr, start, arg);
@@ -130,6 +136,22 @@ console.log(JSON.stringify({ first: first.status, second: second.status }));
 server.stop(true);
 `;
 
+// Exits while the failed build's completion is still queued. Run with
+// BUN_DESTRUCT_VM_ON_EXIT, the exit tears the VM down the way a finished
+// Worker's is, which has to release that completion like any other build's
+// instead of hanging on it or freeing it twice.
+const EXIT_FIXTURE = /* js */ `
+${ARM_HELPERS}
+arm();
+try {
+  Bun.build({ entrypoints: [import.meta.dirname + "/entry.js"], throw: false });
+} finally {
+  disarm();
+}
+console.log(JSON.stringify({ exiting: true }));
+process.exit(0);
+`;
+
 let dir: ReturnType<typeof tempDir> | undefined;
 let shimPath: string;
 
@@ -141,6 +163,7 @@ beforeAll(async () => {
     "a.js": `export const a = 1;\n`,
     "build.js": BUILD_FIXTURE,
     "serve.js": SERVE_FIXTURE,
+    "exit.js": EXIT_FIXTURE,
     "index.html": `<!doctype html><script type="module" src="./entry.js"></script>`,
   });
   shimPath = join(String(dir), "shim.so");
@@ -162,7 +185,7 @@ afterAll(() => {
 
 let runs = 0;
 
-async function runWithPlan(plan: string, ...args: string[]) {
+async function runWithPlan(plan: string, args: string[], env: Record<string, string> = {}) {
   const existing = bunEnv.LD_PRELOAD;
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
@@ -173,9 +196,14 @@ async function runWithPlan(plan: string, ...args: string[]) {
       BUNDLE_THREAD_SPAWN_PLAN: plan,
       // Per run: a fixture that crashes while armed must not arm the others.
       BUNDLE_THREAD_SPAWN_ARMED_FILE: join(String(dir), `armed-${runs++}`),
+      ...env,
     },
     stdout: "pipe",
     stderr: "pipe",
+    // A teardown that waits for a completion that never comes hangs the fixture;
+    // turn that into a failure the concurrent tests do not leave behind.
+    timeout: 30_000,
+    killSignal: "SIGKILL",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return {
@@ -192,7 +220,7 @@ async function runWithPlan(plan: string, ...args: string[]) {
 
 describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", () => {
   test.concurrent("rejects with the error in the AggregateError", async () => {
-    expect(await runWithPlan("f", "build.js", "throw", "1")).toEqual({
+    expect(await runWithPlan("f", ["build.js", "throw", "1"])).toEqual({
       results: [
         {
           settled: "rejected",
@@ -209,7 +237,7 @@ describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", ()
   });
 
   test.concurrent("resolves with success: false and the error in the logs under throw: false", async () => {
-    expect(await runWithPlan("f", "build.js", "nothrow", "1")).toEqual({
+    expect(await runWithPlan("f", ["build.js", "nothrow", "1"])).toEqual({
       results: [{ settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false }],
       stderr: "",
       exitCode: 0,
@@ -218,7 +246,7 @@ describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", ()
   });
 
   test.concurrent("reports other errors without the thread-limit hint", async () => {
-    expect(await runWithPlan("n", "build.js", "nothrow", "1")).toEqual({
+    expect(await runWithPlan("n", ["build.js", "nothrow", "1"])).toEqual({
       results: [
         { settled: "resolved", success: false, logs: ["Failed to start the bundler thread: ENOMEM."], onEnd: false },
       ],
@@ -228,8 +256,29 @@ describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", ()
     });
   });
 
+  test.concurrent("reports an error bun has no errno name for as the OS describes it", async () => {
+    expect(await runWithPlan("u", ["build.js", "nothrow", "1"])).toEqual({
+      results: [
+        {
+          settled: "resolved",
+          success: false,
+          // The text is the libc's; glibc and musl word it differently.
+          logs: [
+            expect.stringMatching(
+              new RegExp(String.raw`^Failed to start the bundler thread: .+ \(os error ${UNNAMED_ERRNO}\)$`),
+            ),
+          ],
+          onEnd: false,
+        },
+      ],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
   test.concurrent("the next build starts the thread again", async () => {
-    expect(await runWithPlan("fs", "build.js", "nothrow", "2")).toEqual({
+    expect(await runWithPlan("fs", ["build.js", "nothrow", "2"])).toEqual({
       results: [
         { settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false },
         { settled: "resolved", success: true, logs: [], onEnd: true },
@@ -241,7 +290,7 @@ describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", ()
   });
 
   test.concurrent("every build fails while the thread keeps failing to start", async () => {
-    expect(await runWithPlan("f", "build.js", "nothrow", "2")).toEqual({
+    expect(await runWithPlan("f", ["build.js", "nothrow", "2"])).toEqual({
       results: [
         { settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false },
         { settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false },
@@ -252,8 +301,17 @@ describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", ()
     });
   });
 
+  test.concurrent("a VM torn down before the failed build's completion ran releases it", async () => {
+    expect(await runWithPlan("f", ["exit.js"], { BUN_DESTRUCT_VM_ON_EXIT: "1" })).toEqual({
+      results: [{ exiting: true }],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
   test.concurrent("an HTML route in Bun.serve answers 500, then builds once the thread starts", async () => {
-    const { stderr, ...rest } = await runWithPlan("fs", "serve.js");
+    const { stderr, ...rest } = await runWithPlan("fs", ["serve.js"]);
     expect({ ...rest, stderrLines: stderr.split("\n") }).toEqual({
       results: [{ first: 500, second: 200 }],
       // The failed first build's log, then the second request's bundle timing.

--- a/test/bundler/bun-build-thread-spawn-failure.test.ts
+++ b/test/bundler/bun-build-thread-spawn-failure.test.ts
@@ -30,7 +30,7 @@ const SHIM_C = /* c */ `
 static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
 static const char *plan;
 static size_t plan_len;
-static int attempts;
+static size_t attempts;
 
 __attribute__((constructor)) static void init(void) {
   real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");

--- a/test/bundler/bun-build-thread-spawn-failure.test.ts
+++ b/test/bundler/bun-build-thread-spawn-failure.test.ts
@@ -1,0 +1,201 @@
+// Bun.build() (and HTML routes in Bun.serve) run on one lazily started
+// "Bundler" thread. An LD_PRELOAD shim makes pthread_create fail for it with
+// EAGAIN, which is what the kernel returns at the RLIMIT_NPROC / cgroup pids
+// limit. That used to abort the whole process ("panic: Failed to spawn bun
+// build thread"); it has to fail the build like any other build error, and a
+// later build has to try starting the thread again.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { join } from "node:path";
+
+const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
+const skip = !isLinux || !cc;
+
+// The "Bundler" thread is the only thread bun creates with Rust's default
+// 2 MiB stack: JSC's helpers ask for their own sizes, the allocators pass no
+// attributes at all, and bun's thread pools use 4 MiB. So this stack size
+// singles out the bundle thread and everything else keeps working.
+const BUNDLE_THREAD_STACK_SIZE = 2 * 1024 * 1024;
+
+// BUNDLE_THREAD_SPAWN_PLAN has one letter per attempt to create such a thread:
+// 'f' fails it with EAGAIN, 's' lets it through; the last letter repeats.
+const SHIM_C = /* c */ `
+#define _GNU_SOURCE
+#include <dlfcn.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
+static const char *plan;
+static size_t plan_len;
+static int attempts;
+
+__attribute__((constructor)) static void init(void) {
+  real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
+  plan = getenv("BUNDLE_THREAD_SPAWN_PLAN");
+  plan_len = plan ? strlen(plan) : 0;
+}
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(void *), void *arg) {
+  size_t stack_size = 0;
+  if (attr) pthread_attr_getstacksize(attr, &stack_size);
+  if (stack_size == ${BUNDLE_THREAD_STACK_SIZE} && plan_len > 0) {
+    size_t i = __sync_fetch_and_add(&attempts, 1);
+    if (plan[i < plan_len ? i : plan_len - 1] == 'f') return EAGAIN;
+  }
+  return real_pthread_create(thread, attr, start, arg);
+}
+`;
+
+const EXPECTED_ERROR =
+  "Failed to start the bundler thread: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).";
+
+// Prints one JSON line per Bun.build() call; `throw` is taken from argv so the
+// same fixture covers the rejecting and the { success: false } flavors.
+const BUILD_FIXTURE = /* js */ `
+const [, , throwArg, count] = process.argv;
+for (let i = 0; i < Number(count); i++) {
+  let onEnd = "not called";
+  const plugin = { name: "record", setup(build) { build.onEnd(result => { onEnd = result.success; }); } };
+  try {
+    const result = await Bun.build({
+      entrypoints: [import.meta.dirname + "/entry.js"],
+      throw: throwArg === "throw",
+      plugins: [plugin],
+    });
+    console.log(JSON.stringify({ settled: "resolved", success: result.success, logs: result.logs.map(l => l.message), onEnd }));
+  } catch (e) {
+    console.log(JSON.stringify({ settled: "rejected", name: e.name, message: e.message, errors: e.errors.map(err => err.message), onEnd }));
+  }
+}
+`;
+
+// Without HMR an HTML route is bundled by the same bundle thread when it is
+// requested. development: { hmr: false } (rather than false) rebundles on every
+// request and writes a failed build's log to stderr, so the second request
+// shows whether the thread gets started again.
+const SERVE_FIXTURE = /* js */ `
+import index from "./index.html";
+const server = Bun.serve({ port: 0, hostname: "127.0.0.1", development: { hmr: false }, routes: { "/": index } });
+const first = await fetch(server.url);
+const second = await fetch(server.url);
+console.log(JSON.stringify({ first: first.status, second: second.status }));
+server.stop(true);
+`;
+
+let dir: ReturnType<typeof tempDir> | undefined;
+let shimPath: string;
+
+beforeAll(async () => {
+  if (skip) return;
+  dir = tempDir("bundle-thread-spawn-failure", {
+    "shim.c": SHIM_C,
+    "entry.js": `import { a } from "./a.js";\nconsole.log(a);\n`,
+    "a.js": `export const a = 1;\n`,
+    "build.js": BUILD_FIXTURE,
+    "serve.js": SERVE_FIXTURE,
+    "index.html": `<!doctype html><script type="module" src="./entry.js"></script>`,
+  });
+  shimPath = join(String(dir), "shim.so");
+  await using ccProc = Bun.spawn({
+    cmd: [cc!, "-shared", "-fPIC", "-o", shimPath, join(String(dir), "shim.c"), "-ldl"],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [ccOut, ccErr, ccExit] = await Promise.all([ccProc.stdout.text(), ccProc.stderr.text(), ccProc.exited]);
+  if (ccExit !== 0) {
+    throw new Error(`shim compile failed: ${ccErr || ccOut}`);
+  }
+});
+
+afterAll(() => {
+  dir?.[Symbol.dispose]();
+});
+
+async function runWithPlan(plan: string, ...args: string[]) {
+  const existing = bunEnv.LD_PRELOAD;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args],
+    cwd: String(dir),
+    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath, BUNDLE_THREAD_SPAWN_PLAN: plan },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return {
+    results: stdout
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(line => JSON.parse(line)),
+    stderr: stderr.trim(),
+    exitCode,
+    signalCode: proc.signalCode,
+  };
+}
+
+describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", () => {
+  test.concurrent("rejects with the error in the AggregateError", async () => {
+    expect(await runWithPlan("f", "build.js", "throw", "1")).toEqual({
+      results: [
+        {
+          settled: "rejected",
+          name: "AggregateError",
+          message: "Bundle failed",
+          errors: [EXPECTED_ERROR],
+          onEnd: false,
+        },
+      ],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("resolves with success: false and the error in the logs under throw: false", async () => {
+    expect(await runWithPlan("f", "build.js", "nothrow", "1")).toEqual({
+      results: [{ settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false }],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("the next build starts the thread again", async () => {
+    expect(await runWithPlan("fs", "build.js", "nothrow", "2")).toEqual({
+      results: [
+        { settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false },
+        { settled: "resolved", success: true, logs: [], onEnd: true },
+      ],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("every build fails while the thread keeps failing to start", async () => {
+    expect(await runWithPlan("f", "build.js", "nothrow", "2")).toEqual({
+      results: [
+        { settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false },
+        { settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false },
+      ],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("an HTML route in Bun.serve answers 500, then builds once the thread starts", async () => {
+    const { stderr, ...rest } = await runWithPlan("fs", "serve.js");
+    expect({ ...rest, stderrLines: stderr.split("\n") }).toEqual({
+      results: [{ first: 500, second: 200 }],
+      // The failed first build's log, then the second request's bundle timing.
+      stderrLines: [`error: ${EXPECTED_ERROR}`, expect.stringMatching(/^\[[\d.]+m?s\] bundle index\.html /)],
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});

--- a/test/bundler/bun-build-thread-spawn-failure.test.ts
+++ b/test/bundler/bun-build-thread-spawn-failure.test.ts
@@ -26,7 +26,8 @@ const skip = !isLinux || !cc;
 const BUNDLE_THREAD_STACK_SIZE = 2 * 1024 * 1024;
 
 // BUNDLE_THREAD_SPAWN_PLAN has one letter per such attempt: 'f' fails it with
-// EAGAIN, 's' lets it through; the last letter repeats.
+// EAGAIN (a thread limit), 'n' with ENOMEM, 's' lets it through; the last
+// letter repeats.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -56,7 +57,10 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)
   if (stack_size == ${BUNDLE_THREAD_STACK_SIZE} && plan_len > 0 && armed_file &&
       syscall(SYS_gettid) == getpid() && access(armed_file, F_OK) == 0) {
     size_t i = __sync_fetch_and_add(&attempts, 1);
-    if (plan[i < plan_len ? i : plan_len - 1] == 'f') return EAGAIN;
+    switch (plan[i < plan_len ? i : plan_len - 1]) {
+      case 'f': return EAGAIN;
+      case 'n': return ENOMEM;
+    }
   }
   return real_pthread_create(thread, attr, start, arg);
 }
@@ -207,6 +211,17 @@ describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", ()
   test.concurrent("resolves with success: false and the error in the logs under throw: false", async () => {
     expect(await runWithPlan("f", "build.js", "nothrow", "1")).toEqual({
       results: [{ settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false }],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  test.concurrent("reports other errors without the thread-limit hint", async () => {
+    expect(await runWithPlan("n", "build.js", "nothrow", "1")).toEqual({
+      results: [
+        { settled: "resolved", success: false, logs: ["Failed to start the bundler thread: ENOMEM."], onEnd: false },
+      ],
       stderr: "",
       exitCode: 0,
       signalCode: null,

--- a/test/bundler/bun-build-thread-spawn-failure.test.ts
+++ b/test/bundler/bun-build-thread-spawn-failure.test.ts
@@ -13,26 +13,25 @@ const skip = !isLinux || !cc;
 
 // Nothing at pthread_create() time says which thread is being created (the name
 // is set by the thread itself, and under ASAN every thread even gets the same
-// entry point), so the shim narrows it down three ways. The thread has to be
-// created by the main thread, the one running Bun.build() / the request handler,
-// with Rust's default 2 MiB stack (bun's pools and its HTTP client thread use
-// 4 MiB, the allocators pass no attributes), and only while the fixture has the
-// BUNDLE_THREAD_SPAWN_ARMED_FILE in place, which it is exactly around the calls
-// that start the bundle thread. JSC's on-demand threads also use 2 MiB on ASAN
-// builds; the fixtures run a GC right before arming so those are already up.
-// Other std-spawned 2 MiB threads (file watchers, the Bun.file() IO thread)
-// would be caught too, so the fixtures must not use fs.watch or Bun.file()
-// while armed.
-const BUNDLE_THREAD_STACK_SIZE = 2 * 1024 * 1024;
+// entry point), so the shim goes by the requested stack size, and the fixtures
+// are run with RUST_MIN_STACK set to a size nothing else asks for. Rust's std
+// applies it to the threads spawned without an explicit size, and in these
+// fixtures the bundle thread is the only one: bun's pools, its HTTP client
+// thread and the Bun.file() IO thread pass explicit sizes, and JSC's and the
+// allocators' threads are not created through std. (Matching std's default
+// 2 MiB instead is ambiguous: JSC's threads use the attr default, which glibc
+// derives from RLIMIT_STACK, and that is 2 MiB on agents running with an
+// unlimited stack.) A multiple of 64 KiB so std's page rounding leaves it as is.
+const BUNDLE_THREAD_STACK_SIZE = 35 * 64 * 1024;
 
 // The highest value Linux reserves for errnos; far beyond the ones bun names.
 // Stands in for what Windows produces for most failed thread creations: an OS
 // code with no errno equivalent.
 const UNNAMED_ERRNO = 4095;
 
-// BUNDLE_THREAD_SPAWN_PLAN has one letter per such attempt: 'f' fails it with
-// EAGAIN (a thread limit), 'n' with ENOMEM, 'u' with a code bun has no errno
-// name for, 's' lets it through; the last letter repeats.
+// BUNDLE_THREAD_SPAWN_PLAN has one letter per attempt to create the thread: 'f'
+// fails it with EAGAIN (a thread limit), 'n' with ENOMEM, 'u' with a code bun has
+// no errno name for, 's' lets it through; the last letter repeats.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -40,18 +39,14 @@ const SHIM_C = /* c */ `
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/syscall.h>
-#include <unistd.h>
 
 static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
-static const char *armed_file;
 static const char *plan;
 static size_t plan_len;
 static size_t attempts;
 
 __attribute__((constructor)) static void init(void) {
   real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
-  armed_file = getenv("BUNDLE_THREAD_SPAWN_ARMED_FILE");
   plan = getenv("BUNDLE_THREAD_SPAWN_PLAN");
   plan_len = plan ? strlen(plan) : 0;
 }
@@ -59,8 +54,7 @@ __attribute__((constructor)) static void init(void) {
 int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(void *), void *arg) {
   size_t stack_size = 0;
   if (attr) pthread_attr_getstacksize(attr, &stack_size);
-  if (stack_size == ${BUNDLE_THREAD_STACK_SIZE} && plan_len > 0 && armed_file &&
-      syscall(SYS_gettid) == getpid() && access(armed_file, F_OK) == 0) {
+  if (stack_size == ${BUNDLE_THREAD_STACK_SIZE} && plan_len > 0) {
     size_t i = __sync_fetch_and_add(&attempts, 1);
     switch (plan[i < plan_len ? i : plan_len - 1]) {
       case 'f': return EAGAIN;
@@ -75,40 +69,19 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)
 const EXPECTED_ERROR =
   "Failed to start the bundler thread: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).";
 
-// The sync fs calls arm and disarm the shim without creating threads themselves.
-const ARM_HELPERS = /* js */ `
-import { unlinkSync, writeFileSync } from "node:fs";
-function arm() {
-  Bun.gc(true);
-  writeFileSync(process.env.BUNDLE_THREAD_SPAWN_ARMED_FILE, "");
-}
-function disarm() {
-  unlinkSync(process.env.BUNDLE_THREAD_SPAWN_ARMED_FILE);
-}
-`;
-
 // Prints one JSON line per Bun.build() call; `throw` is taken from argv so the
 // same fixture covers the rejecting and the { success: false } flavors.
-// Bun.build() starts the bundle thread before it returns its promise.
 const BUILD_FIXTURE = /* js */ `
-${ARM_HELPERS}
 const [, , throwArg, count] = process.argv;
 for (let i = 0; i < Number(count); i++) {
   let onEnd = "not called";
   const plugin = { name: "record", setup(build) { build.onEnd(result => { onEnd = result.success; }); } };
-  arm();
-  let build;
   try {
-    build = Bun.build({
+    const result = await Bun.build({
       entrypoints: [import.meta.dirname + "/entry.js"],
       throw: throwArg === "throw",
       plugins: [plugin],
     });
-  } finally {
-    disarm();
-  }
-  try {
-    const result = await build;
     console.log(JSON.stringify({ settled: "resolved", success: result.success, logs: result.logs.map(l => l.message), onEnd }));
   } catch (e) {
     console.log(JSON.stringify({ settled: "rejected", name: e.name, message: e.message, errors: e.errors.map(err => err.message), onEnd }));
@@ -121,33 +94,21 @@ for (let i = 0; i < Number(count); i++) {
 // request and writes a failed build's log to stderr, so the second request
 // shows whether the thread gets started again.
 const SERVE_FIXTURE = /* js */ `
-${ARM_HELPERS}
 import index from "./index.html";
 const server = Bun.serve({ port: 0, hostname: "127.0.0.1", development: { hmr: false }, routes: { "/": index } });
-arm();
-let first, second;
-try {
-  first = await fetch(server.url);
-  second = await fetch(server.url);
-} finally {
-  disarm();
-}
+const first = await fetch(server.url);
+const second = await fetch(server.url);
 console.log(JSON.stringify({ first: first.status, second: second.status }));
 server.stop(true);
 `;
 
-// Exits while the failed build's completion is still queued. Run with
+// Bun.build() tries to start the thread before returning its promise; this
+// exits while the failed build's completion is still queued. Run with
 // BUN_DESTRUCT_VM_ON_EXIT, the exit tears the VM down the way a finished
 // Worker's is, which has to release that completion like any other build's
 // instead of hanging on it or freeing it twice.
 const EXIT_FIXTURE = /* js */ `
-${ARM_HELPERS}
-arm();
-try {
-  Bun.build({ entrypoints: [import.meta.dirname + "/entry.js"], throw: false });
-} finally {
-  disarm();
-}
+Bun.build({ entrypoints: [import.meta.dirname + "/entry.js"], throw: false });
 console.log(JSON.stringify({ exiting: true }));
 process.exit(0);
 `;
@@ -183,8 +144,6 @@ afterAll(() => {
   dir?.[Symbol.dispose]();
 });
 
-let runs = 0;
-
 async function runWithPlan(plan: string, args: string[], env: Record<string, string> = {}) {
   const existing = bunEnv.LD_PRELOAD;
   await using proc = Bun.spawn({
@@ -193,9 +152,8 @@ async function runWithPlan(plan: string, args: string[], env: Record<string, str
     env: {
       ...bunEnv,
       LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+      RUST_MIN_STACK: String(BUNDLE_THREAD_STACK_SIZE),
       BUNDLE_THREAD_SPAWN_PLAN: plan,
-      // Per run: a fixture that crashes while armed must not arm the others.
-      BUNDLE_THREAD_SPAWN_ARMED_FILE: join(String(dir), `armed-${runs++}`),
       ...env,
     },
     stdout: "pipe",

--- a/test/bundler/bun-build-thread-spawn-failure.test.ts
+++ b/test/bundler/bun-build-thread-spawn-failure.test.ts
@@ -11,14 +11,22 @@ import { join } from "node:path";
 const cc = Bun.which("cc") || Bun.which("gcc") || Bun.which("clang");
 const skip = !isLinux || !cc;
 
-// The "Bundler" thread is the only thread bun creates with Rust's default
-// 2 MiB stack: JSC's helpers ask for their own sizes, the allocators pass no
-// attributes at all, and bun's thread pools use 4 MiB. So this stack size
-// singles out the bundle thread and everything else keeps working.
+// Nothing at pthread_create() time says which thread is being created (the name
+// is set by the thread itself, and under ASAN every thread even gets the same
+// entry point), so the shim narrows it down three ways. The thread has to be
+// created by the main thread, the one running Bun.build() / the request handler,
+// with Rust's default 2 MiB stack (bun's pools and its HTTP client thread use
+// 4 MiB, the allocators pass no attributes), and only while the fixture has the
+// BUNDLE_THREAD_SPAWN_ARMED_FILE in place, which it is exactly around the calls
+// that start the bundle thread. JSC's on-demand threads also use 2 MiB on ASAN
+// builds; the fixtures run a GC right before arming so those are already up.
+// Other std-spawned 2 MiB threads (file watchers, the Bun.file() IO thread)
+// would be caught too, so the fixtures must not use fs.watch or Bun.file()
+// while armed.
 const BUNDLE_THREAD_STACK_SIZE = 2 * 1024 * 1024;
 
-// BUNDLE_THREAD_SPAWN_PLAN has one letter per attempt to create such a thread:
-// 'f' fails it with EAGAIN, 's' lets it through; the last letter repeats.
+// BUNDLE_THREAD_SPAWN_PLAN has one letter per such attempt: 'f' fails it with
+// EAGAIN, 's' lets it through; the last letter repeats.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -26,14 +34,18 @@ const SHIM_C = /* c */ `
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 
 static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
+static const char *armed_file;
 static const char *plan;
 static size_t plan_len;
 static size_t attempts;
 
 __attribute__((constructor)) static void init(void) {
   real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
+  armed_file = getenv("BUNDLE_THREAD_SPAWN_ARMED_FILE");
   plan = getenv("BUNDLE_THREAD_SPAWN_PLAN");
   plan_len = plan ? strlen(plan) : 0;
 }
@@ -41,7 +53,8 @@ __attribute__((constructor)) static void init(void) {
 int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(void *), void *arg) {
   size_t stack_size = 0;
   if (attr) pthread_attr_getstacksize(attr, &stack_size);
-  if (stack_size == ${BUNDLE_THREAD_STACK_SIZE} && plan_len > 0) {
+  if (stack_size == ${BUNDLE_THREAD_STACK_SIZE} && plan_len > 0 && armed_file &&
+      syscall(SYS_gettid) == getpid() && access(armed_file, F_OK) == 0) {
     size_t i = __sync_fetch_and_add(&attempts, 1);
     if (plan[i < plan_len ? i : plan_len - 1] == 'f') return EAGAIN;
   }
@@ -52,19 +65,40 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)
 const EXPECTED_ERROR =
   "Failed to start the bundler thread: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).";
 
+// The sync fs calls arm and disarm the shim without creating threads themselves.
+const ARM_HELPERS = /* js */ `
+import { unlinkSync, writeFileSync } from "node:fs";
+function arm() {
+  Bun.gc(true);
+  writeFileSync(process.env.BUNDLE_THREAD_SPAWN_ARMED_FILE, "");
+}
+function disarm() {
+  unlinkSync(process.env.BUNDLE_THREAD_SPAWN_ARMED_FILE);
+}
+`;
+
 // Prints one JSON line per Bun.build() call; `throw` is taken from argv so the
 // same fixture covers the rejecting and the { success: false } flavors.
+// Bun.build() starts the bundle thread before it returns its promise.
 const BUILD_FIXTURE = /* js */ `
+${ARM_HELPERS}
 const [, , throwArg, count] = process.argv;
 for (let i = 0; i < Number(count); i++) {
   let onEnd = "not called";
   const plugin = { name: "record", setup(build) { build.onEnd(result => { onEnd = result.success; }); } };
+  arm();
+  let build;
   try {
-    const result = await Bun.build({
+    build = Bun.build({
       entrypoints: [import.meta.dirname + "/entry.js"],
       throw: throwArg === "throw",
       plugins: [plugin],
     });
+  } finally {
+    disarm();
+  }
+  try {
+    const result = await build;
     console.log(JSON.stringify({ settled: "resolved", success: result.success, logs: result.logs.map(l => l.message), onEnd }));
   } catch (e) {
     console.log(JSON.stringify({ settled: "rejected", name: e.name, message: e.message, errors: e.errors.map(err => err.message), onEnd }));
@@ -77,10 +111,17 @@ for (let i = 0; i < Number(count); i++) {
 // request and writes a failed build's log to stderr, so the second request
 // shows whether the thread gets started again.
 const SERVE_FIXTURE = /* js */ `
+${ARM_HELPERS}
 import index from "./index.html";
 const server = Bun.serve({ port: 0, hostname: "127.0.0.1", development: { hmr: false }, routes: { "/": index } });
-const first = await fetch(server.url);
-const second = await fetch(server.url);
+arm();
+let first, second;
+try {
+  first = await fetch(server.url);
+  second = await fetch(server.url);
+} finally {
+  disarm();
+}
 console.log(JSON.stringify({ first: first.status, second: second.status }));
 server.stop(true);
 `;
@@ -115,12 +156,20 @@ afterAll(() => {
   dir?.[Symbol.dispose]();
 });
 
+let runs = 0;
+
 async function runWithPlan(plan: string, ...args: string[]) {
   const existing = bunEnv.LD_PRELOAD;
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
     cwd: String(dir),
-    env: { ...bunEnv, LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath, BUNDLE_THREAD_SPAWN_PLAN: plan },
+    env: {
+      ...bunEnv,
+      LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
+      BUNDLE_THREAD_SPAWN_PLAN: plan,
+      // Per run: a fixture that crashes while armed must not arm the others.
+      BUNDLE_THREAD_SPAWN_ARMED_FILE: join(String(dir), `armed-${runs++}`),
+    },
     stdout: "pipe",
     stderr: "pipe",
   });


### PR DESCRIPTION
### Problem
- `Bun.build()` (and HTML routes in `Bun.serve` without HMR) run on one lazily started bundler thread. When the OS refuses to create it, the first build in the process aborts bun (exit 134) with `panic: Failed to spawn bun build thread` instead of failing that build.
- `pthread_create` returns `EAGAIN` at the cgroup pids limit or `ulimit -u`, so this is an ordinary resource error, not a broken invariant. Reproduces on 1.4.0 and on a debug build of main.
- Cause: the thread was started inside a `OnceLock`, which can neither report a failed spawn nor be retried later, so the spawn error was turned into a panic.
- Same family as #37738 (the bundler's pool workers failing to spawn); after that PR the bundle thread itself still panicked.

### Fix
- The singleton becomes a lock around an `Option`. A failed spawn frees the allocation and leaves the slot empty, so the next build tries again; the lock is held across the spawn, so concurrent first callers still wait for one attempt.
- When the thread cannot start, `enqueue()` fails the task on the calling thread: marks it started, puts the error in the build's log, posts the usual completion. Property to check: every task still gets exactly one completion, so both callers take their existing failed-build paths (`success: false` with the message in `logs`, `AggregateError: Bundle failed`, HTML route `500`) unchanged.
- The message is `Failed to start the bundler thread: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).` The hint is Unix-only and `EAGAIN`-only; a code bun has no errno name for (most Windows thread failures) is reported with the OS's own text and `(os error N)`. The errno mapping is shared with the watcher, byte-identical to #37738.
- Verification: a new Linux-only test builds an `LD_PRELOAD` shim that fails `pthread_create` for the bundle thread. Its eight cases (rejection, `throw: false`, other errnos, retry on the next build, VM teardown with the completion still queued, HTML route `500` then `200`) all hit the panic on the unfixed binary and pass with the fix.

### Background
- Bundler thread: `Bun.build()` and non-HMR HTML routes hand a completion task to one process-wide bundler thread, started on first use, which bundles and posts the result back to the owning VM's event loop.
- Completion task: carries the build's log and result and goes queued, then started (`try_start`), then completed. A VM torn down while a task is still queued releases it itself; a started task is released when its completion runs. So the failure path must mark the task started before posting, or teardown releases it a second time and hangs.
- `OnceLock::get_or_init` must return a value and never runs again, so a failed initializer can only panic; a mutex around an `Option` can be left empty and retried on the next call.
- Build failures reach users through the build's log: `throw: false` resolves with `success: false` and `logs`, the default rejects with `AggregateError` whose `errors` hold the log, and an HTML route serves `500`. Reporting this failure the same way means callers need no second error shape.
- `SystemErrno` is bun's errno enum. `std::io::Error::raw_os_error()` is an errno on Unix but a Win32 code on Windows, so one shared mapping picks the right table and returns `None` for a code with no entry.

<details>
<summary>Original description</summary>

### What

`Bun.build()` (and HTML routes in `Bun.serve` without HMR) run on one lazily started "Bundler" thread. When the OS refuses to create that thread, the first build in the process aborts bun instead of failing the build:

```
panic: Failed to spawn bun build thread
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

`pthread_create` returns `EAGAIN` at the cgroup pids limit / `RLIMIT_NPROC` (`ulimit -u`), so this is an ordinary resource error, not an invariant of ours. It is the same family as #37738 (the bundler's pool workers failing to spawn), which leaves this path alone: after that PR the pool failure is reported through the build's log, while the bundle thread itself still panicked.

Repro (Linux): an `LD_PRELOAD` shim that fails `pthread_create` for the bundle thread. Nothing at `pthread_create` time names the thread, so the fixtures run with `RUST_MIN_STACK` set to a size nothing else asks for: std applies it to threads spawned without an explicit stack size, which in these fixtures is only the bundle thread (the pools, the HTTP thread and the IO thread pass explicit sizes; JSC's and the allocators' threads do not go through std), and the shim fails the thread created with exactly that size. Matching std's default 2 MiB instead turned out to be ambiguous on CI: JSC's threads use the attr default, which glibc derives from the stack rlimit, and that is 2 MiB on the agents. With it:

```js
try {
  await Bun.build({ entrypoints: ["./entry.js"] });
} catch (e) {
  console.log("rejected:", e.errors[0].message);
}
```

exits 134 with the panic above on 1.4.0 and on a debug build of main. The test in this PR is that shim.

### Cause

`singleton::load_once_impl` in `src/bundler/BundleThread.rs` ran inside a `OnceLock::get_or_init`, which has no way to report failure, so the `io::Error` from `Builder::spawn` was turned into `Output::panic`. A `OnceLock` also could not have represented "try again later".

### Fix

* The singleton is a `bun_threading::Guarded<Option<Instance>>`. `get()` returns `Result<_, SystemErrno>`: on a failed spawn it frees the `BundleThread` allocation (no thread ever saw it) and leaves the slot empty, so the next build attempts the spawn again; a successful spawn is stored as before. The lock is held across the spawn, so concurrent first callers (workers) still wait for one attempt instead of starting several threads.
* `singleton::enqueue()` keeps its fire-and-forget contract (every task handed to it gets exactly one completion). When the thread cannot be started it fails the task right there: `try_start` (asserted to succeed: the task never reached a queue, so nothing else can have claimed it; marking it started is what makes a VM teardown that happens before the completion runs wait for it instead of releasing the task itself), a log with the error, `set_result(Err(errno))`, `complete_on_bundle_thread()`. That last call only posts the completion to the owning VM's loop and balances the embedded-work count, so it is thread-agnostic; `JSBundleCompletionTask` and `HTMLBundle::Route` then take their normal failed-build paths (`on_complete` -> `to_js_error` / `Route::on_complete`), including `onEnd` plugin callbacks, active-handle unregistration and VM teardown, exactly like a build that failed on the bundle thread. Neither caller changes.
* The `io::Error` -> `SystemErrno` mapping (Win32 code vs errno) becomes `SystemErrno::from_io_error` in `bun_errno` (with a unit test), and `Watcher::start()`, which had its own copy of it, uses it too (the one observable difference there: an errno outside bun's table now falls back to EAGAIN like the Windows arm always did, instead of EIO; thread creation does not produce such codes). The helper and the `Watcher.rs` change are byte-identical to the ones in #37738, so whichever of the two PRs lands second merges cleanly. The remaining spawn sites that report differently (`path_watcher`'s fixed ENOMEM, the HTTP client thread's panic, which #32245 handles) are deliberately left alone here.

Why report it through the build's log rather than rejecting with a separate error: that is how every other failure of the build machinery reaches the user (and how #37738 reports the pool), so `throw: false` callers get `success: false` with the message in `logs`, default callers get the usual `AggregateError: Bundle failed` with it in `errors`, and an HTML route answers `500` instead of taking the server down. Splitting this one failure into a different shape would leave `throw: false` callers with an unhandled rejection for one of two variants of the same condition.

The message is `Failed to start the bundler thread: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).` The second sentence is only added on Unix and only for `EAGAIN`, which is what a thread or pid limit produces; any other errno bun has a name for is reported as just `Failed to start the bundler thread: ENOMEM.`, and an OS code bun has no errno name for (on Windows that is most failed thread creations: `ERROR_COMMITMENT_LIMIT`, `ERROR_MAX_THRDS_REACHED`, ... are not in the Win32 table, only `ERROR_NOT_ENOUGH_MEMORY`/`ERROR_OUTOFMEMORY` map to ENOMEM) is reported with the OS's own description, e.g. `Failed to start the bundler thread: <text> (os error 1455)`, rather than being collapsed into a made-up EAGAIN. `get()` therefore returns the `io::Error` and `enqueue()` does the mapping; the errno, when there is one, also becomes the `BundleV2Result::Err` payload. The pool message in #37738 currently appends the hint for every errno; noted there.

### Tests

`test/bundler/bun-build-thread-spawn-failure.test.ts` (Linux with a C compiler, like `serve-epoll-add-fail.test.ts`). The shim takes a plan of one letter per spawn attempt, which covers:

* default `Bun.build()` rejects with the message in `AggregateError.errors`, `onEnd` ran, exit 0
* `throw: false` resolves with `success: false` and the message in `logs`
* plan `n` (the shim fails with `ENOMEM`): the message carries that errno and no thread-limit hint
* plan `u` (the shim fails with errno 4095, which bun has no name for): the message carries the OS description and `(os error 4095)`
* `exit.js` under `BUN_DESTRUCT_VM_ON_EXIT=1`: `Bun.build()` whose thread fails to start, then `process.exit(0)` in the same tick, so the VM is torn down while the failed build's completion is still queued; exits 0. This is what the `try_start()` call in `enqueue()` is for: with it removed, this fixture hangs in teardown (the task is still `Queued`, so the teardown releases it itself and balances the embedded-work count a second time, and then waits forever for the count to reach zero); verified locally both ways.
* plan `fs`: the first build fails, the second one starts the thread and succeeds (nothing cached from the failed attempt)
* plan `f` twice: every build fails, each one catchable
* `Bun.serve` HTML route (`development: { hmr: false }`): first request `500` with the error on stderr, second request `200`

All eight fail on the unfixed binary with the panic above (exit 134) and pass with the fix. `bun-build-api.test.ts` still passes, as does the watcher's existing spawn-failure test in `test/cli/watch/watch.test.ts`, which now goes through `from_io_error`; `cargo check` for the Windows target passes as well (the errno mapping has a Win32 branch).








</details>
