### PR TITLE
spawnSync: keep event-loop ref counts on the loop they were taken on

### DIFF
--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -282,14 +282,9 @@ impl Drop for SpawnSyncEventLoop {
 impl SpawnSyncEventLoop {
     /// Configure the event loop for a specific VM context and point the VM's
     /// event loop handle at this loop. Returns the handle that was current, for
-    /// [`cleanup`](Self::cleanup).
-    ///
-    /// The caller keeps that value rather than this struct: spawnSync can nest
-    /// (a test timing out inside spawnSync makes the test runner carry on with
-    /// the following tests, which may spawnSync again), and both levels share
-    /// the one loop stored in the VM's rare data. A single saved slot here
-    /// would be overwritten by the inner call and leave the VM pointing at this
-    /// loop for good after the outer call returned.
+    /// [`cleanup`](Self::cleanup); it lives on the caller's frame because
+    /// spawnSync calls nest (the test runner's timeout path runs further tests
+    /// inside a wait) and every level shares this one struct.
     #[must_use = "pass this to cleanup() or the VM keeps running on the spawnSync loop"]
     pub fn prepare(
         &mut self,

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -100,10 +100,6 @@ pub struct SpawnSyncEventLoop {
     // stored back into `internal_loop_data` (self-referential w.r.t. `event_loop`).
     uws_loop: NonNull<uws::Loop>,
 
-    /// On POSIX, we need to temporarily override the VM's event_loop_handle
-    /// Store the original so we can restore it
-    original_event_loop_handle: VmEventLoopHandle,
-
     #[cfg(windows)]
     uv_timer: Option<NonNull<libuv::Timer>>,
     // ALIASING: `Cell` because on Windows the libuv timer callback (`on_uv_timer`) writes this
@@ -162,7 +158,6 @@ impl SpawnSyncEventLoop {
 
         this.write(Self {
             uws_loop: loop_,
-            original_event_loop_handle: None, // overwritten in `prepare`
             #[cfg(windows)]
             uv_timer: None,
             did_timeout: Cell::new(false),
@@ -286,13 +281,26 @@ impl Drop for SpawnSyncEventLoop {
 }
 
 impl SpawnSyncEventLoop {
-    /// Configure the event loop for a specific VM context
-    pub fn prepare(&mut self, vm: *mut () /* SAFETY: erased *mut VirtualMachine */) {
+    /// Configure the event loop for a specific VM context and point the VM's
+    /// event loop handle at this loop. Returns the handle that was current, for
+    /// [`cleanup`](Self::cleanup).
+    ///
+    /// The caller keeps that value rather than this struct: spawnSync can nest
+    /// (a test timing out inside spawnSync makes the test runner carry on with
+    /// the following tests, which may spawnSync again), and both levels share
+    /// the one loop stored in the VM's rare data. A single saved slot here
+    /// would be overwritten by the inner call and leave the VM pointing at this
+    /// loop for good after the outer call returned.
+    #[must_use = "pass this to cleanup() or the VM keeps running on the spawnSync loop"]
+    pub fn prepare(
+        &mut self,
+        vm: *mut (), /* SAFETY: erased *mut VirtualMachine */
+    ) -> VmEventLoopHandle {
         __bun_spawn_sync_event_loop_set_vm(self.event_loop, vm);
         self.did_timeout.set(false);
         self.vm = vm;
 
-        self.original_event_loop_handle = __bun_spawn_sync_vm_get_event_loop_handle(vm);
+        let previous = __bun_spawn_sync_vm_get_event_loop_handle(vm);
         #[cfg(unix)]
         let new_handle: VmEventLoopHandle = Some(self.uws_loop);
         #[cfg(windows)]
@@ -301,15 +309,18 @@ impl SpawnSyncEventLoop {
                 .expect("uv_loop is set by us_create_loop for the loop's lifetime"),
         );
         __bun_spawn_sync_vm_set_event_loop_handle(vm, new_handle);
+        previous
     }
 
-    /// Restore the original event loop handle after spawnSync completes
+    /// Restore the event loop handle that [`prepare`](Self::prepare) returned
+    /// after spawnSync completes.
     pub fn cleanup(
         &mut self,
-        vm: *mut (),              /* SAFETY: erased *mut VirtualMachine */
+        vm: *mut (), /* SAFETY: erased *mut VirtualMachine */
+        previous_handle: VmEventLoopHandle,
         prev_event_loop: *mut (), /* SAFETY: erased *mut jsc::EventLoop */
     ) {
-        __bun_spawn_sync_vm_set_event_loop_handle(vm, self.original_event_loop_handle);
+        __bun_spawn_sync_vm_set_event_loop_handle(vm, previous_handle);
         __bun_spawn_sync_vm_set_event_loop(vm, prev_event_loop);
 
         #[cfg(windows)]

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -8,9 +8,9 @@
 //!
 //! Implementation approach:
 //! - Creates a separate uws.Loop instance with its own kqueue/epoll fd (POSIX) or libuv loop (Windows)
-//! - Wraps it in a full jsc.EventLoop instance
-//! - On POSIX: temporarily overrides vm.event_loop_handle to point to isolated loop
-//! - On Windows: stores isolated loop pointer in EventLoop.uws_loop
+//! - Wraps it in a full jsc.EventLoop instance, whose `uws_loop` is the isolated loop
+//! - Temporarily overrides vm.event_loop_handle to point to the isolated loop, so the
+//!   subprocess' own polls register on it
 //! - Minimal handler callbacks (wakeup/pre/post are no-ops)
 //!
 //! Similar to Node.js's approach in vendor/node/src/spawn_sync.cc but adapted for Bun's architecture.
@@ -46,7 +46,7 @@ pub type VmEventLoopHandle = Option<NonNull<libuv::Loop>>;
 // no caller-side `unsafe { }` needed.
 unsafe extern "Rust" {
     /// Heap-allocate and zero-init a `jsc::EventLoop` bound to `vm`, with
-    /// `uws_loop` as its loop on Windows. Returns erased `*mut jsc::EventLoop`.
+    /// `uws_loop` as its loop. Returns erased `*mut jsc::EventLoop`.
     safe fn __bun_spawn_sync_create_event_loop(vm: *mut (), uws_loop: *mut uws::Loop) -> *mut ();
     safe fn __bun_spawn_sync_destroy_event_loop(el: *mut ());
     /// Re-bind `event_loop.{global, virtual_machine}` to `vm` (prepare path).
@@ -152,8 +152,7 @@ impl SpawnSyncEventLoop {
         let loop_ =
             NonNull::new(loop_).expect("uws::Loop::create never returns null (asserts on OOM)");
 
-        // Initialize the JSC EventLoop with empty state.
-        // CRITICAL: On Windows, the impl stores our isolated loop pointer in `uws_loop`.
+        // Initialize the JSC EventLoop with empty state, driven by our isolated loop.
         let event_loop = __bun_spawn_sync_create_event_loop(vm, loop_.as_ptr());
 
         this.write(Self {

--- a/src/io/ParentDeathWatchdog.rs
+++ b/src/io/ParentDeathWatchdog.rs
@@ -327,9 +327,9 @@ pub fn install_on_event_loop(handle: EventLoopCtx) {
             Owner::new(poll_tag::PARENT_DEATH_WATCHDOG, instance_ptr.cast()),
         );
         // SAFETY: `poll` was just allocated by `FilePoll::init`; sole `&mut`
-        // borrow; `register` does not re-derive the loop.
+        // borrow.
         match unsafe { &mut *poll }.register(
-            handle.loop_mut(),
+            handle.loop_(),
             crate::file_poll::Pollable::Process,
             true,
         ) {

--- a/src/io/keep_alive.rs
+++ b/src/io/keep_alive.rs
@@ -14,10 +14,8 @@ use bun_uws_sys::Loop;
 /// event loop alive. This is not reference counted — only Active / Inactive.
 pub struct KeepAlive {
     status: Status,
-    /// The loop `ref_()` counted this on, null while inactive. The ctx passed
-    /// to `unref()` names whichever loop is current at that moment, which
-    /// during `Bun.spawnSync` is its private loop; the ref has to come off the
-    /// loop it was put on (see `FilePoll::counted_loop`).
+    /// The loop `ref_()` counted this on, null while inactive; the unref has to
+    /// come off the same loop (see `FilePoll::counted_loop`).
     #[cfg(not(windows))]
     loop_: *mut Loop,
 }
@@ -61,11 +59,9 @@ impl KeepAlive {
     fn take_refd_loop(&mut self) -> &'static mut Loop {
         let loop_ = core::mem::replace(&mut self.loop_, core::ptr::null_mut());
         debug_assert!(!loop_.is_null(), "KeepAlive active without a loop");
-        // SAFETY: set from a live loop in `ref_()` when `status` became
-        // `Active`; both the thread's loop and spawnSync's private loop (owned
-        // by the VM's RareData) outlive everything ref'd on them. Single
-        // event-loop thread, and the callers consume the borrow with one
-        // counter adjustment before anything else can reach the loop.
+        // SAFETY: set in `ref_()` from a loop that outlives everything ref'd on
+        // it; single event-loop thread, and the callers drop the borrow after
+        // one counter update.
         unsafe { &mut *loop_ }
     }
 
@@ -93,9 +89,7 @@ impl KeepAlive {
         #[cfg(not(windows))]
         {
             let loop_ = self.take_refd_loop();
-            // The pending counter is drained by the thread's own loop when it
-            // next ticks; a ref that sits on any other loop (spawnSync's
-            // private one) has no next tick to wait for.
+            // Only the thread's loop drains the pending counter on its next tick.
             if core::ptr::eq(loop_, Loop::get()) {
                 event_loop_ctx.increment_pending_unref_counter();
             } else {

--- a/src/io/keep_alive.rs
+++ b/src/io/keep_alive.rs
@@ -7,12 +7,29 @@
 
 use crate::EventLoopCtx;
 use crate::posix_event_loop::js_vm_ctx;
+#[cfg(not(windows))]
+use bun_uws_sys::Loop;
 
 /// Track if an object whose file descriptor is being watched should keep the
 /// event loop alive. This is not reference counted — only Active / Inactive.
-#[derive(Default)]
 pub struct KeepAlive {
     status: Status,
+    /// The loop `ref_()` counted this on, null while inactive. The ctx passed
+    /// to `unref()` names whichever loop is current at that moment, which
+    /// during `Bun.spawnSync` is its private loop; the ref has to come off the
+    /// loop it was put on (see `FilePoll::counted_loop`).
+    #[cfg(not(windows))]
+    loop_: *mut Loop,
+}
+
+impl Default for KeepAlive {
+    fn default() -> Self {
+        Self {
+            status: Status::default(),
+            #[cfg(not(windows))]
+            loop_: core::ptr::null_mut(),
+        }
+    }
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
@@ -39,6 +56,19 @@ impl KeepAlive {
         KeepAlive::default()
     }
 
+    /// The loop `ref_()` used, handed back exactly once per activation.
+    #[cfg(not(windows))]
+    fn take_refd_loop(&mut self) -> &'static mut Loop {
+        let loop_ = core::mem::replace(&mut self.loop_, core::ptr::null_mut());
+        debug_assert!(!loop_.is_null(), "KeepAlive active without a loop");
+        // SAFETY: set from a live loop in `ref_()` when `status` became
+        // `Active`; both the thread's loop and spawnSync's private loop (owned
+        // by the VM's RareData) outlive everything ref'd on them. Single
+        // event-loop thread, and the callers consume the borrow with one
+        // counter adjustment before anything else can reach the loop.
+        unsafe { &mut *loop_ }
+    }
+
     /// Prevent a poll from keeping the process alive.
     pub fn unref(&mut self, event_loop_ctx: EventLoopCtx) {
         if self.status != Status::Active {
@@ -46,7 +76,10 @@ impl KeepAlive {
         }
         self.status = Status::Inactive;
         #[cfg(not(windows))]
-        event_loop_ctx.loop_unref();
+        {
+            let _ = event_loop_ctx;
+            self.take_refd_loop().unref();
+        }
         #[cfg(windows)]
         event_loop_ctx.loop_sub_active(1);
     }
@@ -57,9 +90,18 @@ impl KeepAlive {
             return;
         }
         self.status = Status::Inactive;
-        // vm.pending_unref_counter +|= 1;
         #[cfg(not(windows))]
-        event_loop_ctx.increment_pending_unref_counter();
+        {
+            let loop_ = self.take_refd_loop();
+            // The pending counter is drained by the thread's own loop when it
+            // next ticks; a ref that sits on any other loop (spawnSync's
+            // private one) has no next tick to wait for.
+            if core::ptr::eq(loop_, Loop::get()) {
+                event_loop_ctx.increment_pending_unref_counter();
+            } else {
+                loop_.unref();
+            }
+        }
         #[cfg(windows)]
         event_loop_ctx.loop_dec();
     }
@@ -70,6 +112,10 @@ impl KeepAlive {
             return;
         }
         self.status = Status::Active;
+        #[cfg(not(windows))]
+        {
+            self.loop_ = event_loop_ctx.loop_();
+        }
         event_loop_ctx.loop_ref();
     }
 

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -403,11 +403,6 @@ impl EventLoopCtx {
         self.loop_mut().ref_();
     }
     #[inline]
-    #[cfg(not(windows))]
-    pub(crate) fn loop_unref(&self) {
-        self.loop_mut().unref();
-    }
-    #[inline]
     #[cfg(windows)]
     pub(crate) fn loop_dec(&self) {
         self.loop_mut().dec();

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -331,33 +331,18 @@ bun_dispatch::link_interface! {
 }
 
 impl EventLoopCtx {
-    /// SAFETY: caller must not hold another live `&mut` to the same loop
-    /// across this borrow (resolver-style accessor; the loop is per-thread).
-    #[inline]
-    pub unsafe fn platform_event_loop(&self) -> &'static mut bun_uws_sys::Loop {
-        // Route through the single nonnull-asref accessor below; the `unsafe`
-        // on this fn's signature is the caller-side aliasing contract — the
-        // body itself needs no extra `unsafe`.
-        self.loop_mut()
-    }
-
     // ── safe leaf wrappers (nonnull-asref) ──────────────────────────────
     // The platform loop / poll store are per-thread, set-once back-pointers
-    // (`BackRef`-shaped). [`platform_event_loop`] cannot be a safe fn because
-    // handing out `&mut Loop` from `&self` would let a caller alias two
-    // copies; these wrappers instead perform one counter adjustment and drop
-    // the borrow before returning, so no `&mut` escapes. Collapses N
-    // identical `ctx.platform_event_loop().op()` call sites into the single
-    // deref inside [`loop_mut`].
+    // (`BackRef`-shaped). Handing out `&mut Loop` from `&self` would let a
+    // caller alias two copies; these wrappers instead perform one counter
+    // adjustment and drop the borrow before returning, so no `&mut` escapes.
+    // Anything that needs the loop for longer (`FilePoll`, `KeepAlive`) takes
+    // the raw pointer from [`loop_`](Self::loop_) instead.
     //
-    // `loop_mut` is the single nonnull-asref accessor: `pub(crate)`,
-    // `&self → &mut` (so it must NOT be called twice with overlapping live
-    // results). Every in-crate caller is a leaf op — counter bump,
-    // `FilePoll::activate`/`deactivate`, `unregister` — that consumes the
-    // borrow before returning and never re-enters `EventLoopCtx`, so no two
-    // `&mut Loop` ever coexist. Widened from impl-private to crate-private so
-    // `posix_event_loop`/`windows_event_loop` route their N identical
-    // `ctx.platform_event_loop()` derefs through this single accessor.
+    // `loop_mut` is the single nonnull-asref accessor: `&self → &mut` (so it
+    // must NOT be called twice with overlapping live results). Every caller
+    // is a counter bump that consumes the borrow before returning and never
+    // re-enters `EventLoopCtx`, so no two `&mut Loop` ever coexist.
     #[inline]
     fn loop_mut(&self) -> &'static mut bun_uws_sys::Loop {
         // SAFETY: per-thread set-once pointer (the uws loop singleton); the
@@ -408,10 +393,12 @@ impl EventLoopCtx {
         self.loop_mut().dec();
     }
     #[inline]
+    #[cfg(windows)]
     pub(crate) fn loop_add_active(&self, n: u32) {
         self.loop_mut().add_active(n);
     }
     #[inline]
+    #[cfg(windows)]
     pub(crate) fn loop_sub_active(&self, n: u32) {
         self.loop_mut().sub_active(n);
     }
@@ -1817,15 +1804,14 @@ impl FilePollRef {
     pub(crate) fn deinit_force_unregister(self) {
         self.inner().deinit_force_unregister();
     }
-    /// Single nonnull-asref accessor for the process-global uWS loop pointer.
+    /// Single nonnull-asref accessor for the uWS loop pointer.
     ///
     /// Type invariant (encapsulated `unsafe`): every caller of
-    /// [`unregister`](Self::unregister) / [`register_with_fd`](Self::register_with_fd)
-    /// passes `Loop::get()` (the per-thread uWS loop singleton), which is
-    /// non-null after init and lives for the program. The event loop is
+    /// [`unregister`](Self::unregister) passes its event loop's live uWS loop,
+    /// which outlives every poll registered on it. The event loop is
     /// single-threaded so the returned `&mut` is the sole live borrow at the
-    /// point of use. Collapses the two identical `&mut *loop_` deref blocks in
-    /// those wrappers into one.
+    /// point of use. (On POSIX `FilePoll` takes the pointer itself.)
+    #[cfg(windows)]
     #[inline(always)]
     fn uws_loop_mut<'a>(loop_: *mut bun_uws_sys::Loop) -> &'a mut bun_uws_sys::Loop {
         debug_assert!(!loop_.is_null());
@@ -1834,7 +1820,6 @@ impl FilePollRef {
     }
     #[inline]
     pub(crate) fn unregister(self, loop_: *mut bun_uws_sys::Loop, force: bool) -> sys::Result<()> {
-        let loop_ = Self::uws_loop_mut(loop_);
         #[cfg(not(windows))]
         {
             self.inner().unregister(loop_, force)
@@ -1844,7 +1829,7 @@ impl FilePollRef {
             let _ = force;
             // The windows `FilePoll::unregister` always returns true — the
             // bool is vestigial, so there is no error path to surface here.
-            let _ = self.inner().unregister(loop_);
+            let _ = self.inner().unregister(Self::uws_loop_mut(loop_));
             Ok(())
         }
     }
@@ -1861,12 +1846,8 @@ impl FilePollRef {
         };
         #[cfg(not(windows))]
         {
-            self.inner().register_with_fd(
-                Self::uws_loop_mut(loop_),
-                flag,
-                OneShotFlag::Dispatch,
-                fd,
-            )
+            self.inner()
+                .register_with_fd(loop_, flag, OneShotFlag::Dispatch, fd)
         }
         #[cfg(windows)]
         {

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -299,6 +299,21 @@ pub struct FilePoll {
     pub(crate) next_to_free: *mut FilePoll,
 
     pub(crate) allocator_type: AllocatorType,
+
+    /// The loop whose `num_polls`/`active` this poll is counted in (and whose
+    /// epoll/kqueue fd it is registered with), null while not registered.
+    ///
+    /// Callers hand every register/unregister the loop that is *current*
+    /// (`EventLoopCtx::platform_event_loop`), and `Bun.spawnSync` points that
+    /// at its private loop for the duration of the call. A poll torn down
+    /// while the private loop is current (a GC sweep finalizing a reader, a
+    /// test body run by the test runner's timeout path) must still be
+    /// removed from, and uncounted on, the loop it was registered with:
+    /// decrementing the private loop instead lets its `num_polls` reach 0
+    /// while a child's pidfd is still registered, and `us_loop_run_bun_tick`
+    /// then returns without polling, so that spawnSync spins and never sees
+    /// the child exit.
+    counted_loop: *mut Loop,
 }
 
 #[cfg(not(windows))]
@@ -311,6 +326,7 @@ impl Default for FilePoll {
             generation_number: 0,
             next_to_free: ptr::null_mut(),
             allocator_type: AllocatorType::Js,
+            counted_loop: ptr::null_mut(),
         }
     }
 }
@@ -459,11 +475,32 @@ impl FilePoll {
                 || self.flags.contains(Flags::PollProcess))
     }
 
+    /// The loop a register/unregister must act on: the one this poll is
+    /// already counted on (see `counted_loop`), otherwise the current one the
+    /// caller passed.
+    fn counted_or<'a>(&self, current: &'a mut Loop) -> &'a mut Loop {
+        let counted = self.counted_loop;
+        if counted.is_null() || ptr::eq(counted, current) {
+            return current;
+        }
+        // SAFETY: `counted_loop` is set from a live loop in `activate` and
+        // cleared in `deactivate`; both the thread's loop and spawnSync's
+        // private loop (owned by the VM's RareData) outlive every poll counted
+        // on them. It is a different allocation from `current`, so the two
+        // `&mut` do not alias.
+        unsafe { &mut *counted }
+    }
+
     /// This decrements the active counter if it was previously incremented
     /// "active" controls whether or not the event loop should potentially idle
     pub fn disable_keeping_process_alive(&mut self, event_loop_ctx: EventLoopCtx) {
-        event_loop_ctx
-            .loop_sub_active(self.flags.contains(Flags::HasIncrementedActiveCount) as u32);
+        let count = self.flags.contains(Flags::HasIncrementedActiveCount) as u32;
+        if self.counted_loop.is_null() {
+            event_loop_ctx.loop_sub_active(count);
+        } else {
+            // SAFETY: see `counted_or`.
+            loop_sub_active(unsafe { &mut *self.counted_loop }, count);
+        }
 
         self.flags.remove(Flags::KeepsEventLoopAlive);
         self.flags.remove(Flags::HasIncrementedActiveCount);
@@ -474,8 +511,13 @@ impl FilePoll {
             return;
         }
 
-        event_loop_ctx
-            .loop_add_active((!self.flags.contains(Flags::HasIncrementedActiveCount)) as u32);
+        let count = (!self.flags.contains(Flags::HasIncrementedActiveCount)) as u32;
+        if self.counted_loop.is_null() {
+            event_loop_ctx.loop_add_active(count);
+        } else {
+            // SAFETY: see `counted_or`.
+            loop_add_active(unsafe { &mut *self.counted_loop }, count);
+        }
 
         self.flags.insert(Flags::KeepsEventLoopAlive);
         self.flags.insert(Flags::HasIncrementedActiveCount);
@@ -483,6 +525,7 @@ impl FilePoll {
 
     /// Only intended to be used from EventLoop.Pollable
     fn deactivate(&mut self, loop_: &mut Loop) {
+        let loop_ = self.counted_or(loop_);
         if self.flags.contains(Flags::HasIncrementedPollCount) {
             loop_.dec();
         }
@@ -494,6 +537,7 @@ impl FilePoll {
         );
         self.flags.remove(Flags::KeepsEventLoopAlive);
         self.flags.remove(Flags::HasIncrementedActiveCount);
+        self.counted_loop = ptr::null_mut();
     }
 
     /// Only intended to be used from EventLoop.Pollable
@@ -504,6 +548,7 @@ impl FilePoll {
             loop_.inc();
         }
         self.flags.insert(Flags::HasIncrementedPollCount);
+        self.counted_loop = loop_;
 
         if self.flags.contains(Flags::KeepsEventLoopAlive) {
             loop_add_active(
@@ -537,6 +582,7 @@ impl FilePoll {
                 .wrapping_add(1),
             #[cfg(not(all(target_os = "macos", debug_assertions)))]
             generation_number: 0,
+            counted_loop: ptr::null_mut(),
         }
     }
 
@@ -580,7 +626,10 @@ impl FilePoll {
             target_os = "macos",
             target_os = "freebsd"
         ))]
-        return self.register_with_fd_impl(loop_, flag, one_shot, fd);
+        {
+            let loop_ = self.counted_or(loop_);
+            return self.register_with_fd_impl(loop_, flag, one_shot, fd);
+        }
         #[cfg(not(any(
             target_os = "linux",
             target_os = "android",
@@ -880,6 +929,7 @@ impl FilePoll {
         fd: Fd,
         force_unregister: bool,
     ) -> sys::Result<()> {
+        let loop_ = self.counted_or(loop_);
         // Note: compute the syscall result first, then unconditionally
         // deactivate. Avoids a raw-pointer scopeguard.
         #[cfg(any(

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -27,24 +27,15 @@ fn loop_sub_active(loop_: &mut Loop, value: u32) {
     loop_.active = loop_.active.saturating_sub(value);
 }
 
-/// The one place a loop pointer handed to (or retained by) a `FilePoll` is
-/// dereferenced.
-///
-/// `FilePoll` takes loops as `*mut Loop` rather than `&mut Loop` because it
-/// keeps the pointer in `counted_loop` until the poll is unregistered: a
-/// pointer derived from a caller's `&mut` reborrow would be invalidated by the
-/// next `&mut Loop` anyone forms in between, whereas the handles callers pass
-/// (`EventLoopCtx::loop_` and the like) are the loop's own pointer.
+/// Single deref site for the loop pointers `FilePoll` is given (see
+/// [`FilePoll::register`]) and keeps in `counted_loop`.
 #[cfg(not(windows))]
 #[inline]
 fn loop_mut<'a>(loop_: *mut Loop) -> &'a mut Loop {
     debug_assert!(!loop_.is_null());
-    // SAFETY: `loop_` is the thread's loop or `Bun.spawnSync`'s private loop
-    // (owned by the VM's rare data); both outlive every poll registered on
-    // them, and the pointer carries the handle's own provenance (see above).
-    // The event loop is single-threaded, and every caller consumes the borrow
-    // with a counter adjustment or a field read before anything else can reach
-    // the loop.
+    // SAFETY: a loop outlives every poll registered on it, and the event loop
+    // is single-threaded; every caller drops the borrow after one counter
+    // update or field read.
     unsafe { &mut *loop_ }
 }
 
@@ -321,19 +312,14 @@ pub struct FilePoll {
 
     pub(crate) allocator_type: AllocatorType,
 
-    /// The loop whose `num_polls`/`active` this poll is counted in (and whose
-    /// epoll/kqueue fd it is registered with), null while not registered.
-    ///
-    /// Callers hand every register/unregister the loop that is *current*
-    /// (`EventLoopCtx::loop_`), and `Bun.spawnSync` points that at its
-    /// private loop for the duration of the call. A poll torn down
-    /// while the private loop is current (a GC sweep finalizing a reader, a
-    /// test body run by the test runner's timeout path) must still be
-    /// removed from, and uncounted on, the loop it was registered with:
-    /// decrementing the private loop instead lets its `num_polls` reach 0
-    /// while a child's pidfd is still registered, and `us_loop_run_bun_tick`
-    /// then returns without polling, so that spawnSync spins and never sees
-    /// the child exit.
+    /// The loop this poll is registered with and counted on; null while not
+    /// registered. Callers pass whichever loop is current, and while
+    /// `Bun.spawnSync` waits that is its private loop, so a poll torn down
+    /// during the wait (GC, or tests the runner moves on to after a timeout)
+    /// has to be taken off this loop rather than the current one: a count
+    /// taken off the private loop makes `us_loop_run_bun_tick` stop polling
+    /// and spawnSync spin. `KeepAlive`, `timer::All` and
+    /// `jsc::EventLoop::uws_loop` record their loop for the same reason.
     counted_loop: *mut Loop,
 }
 
@@ -493,9 +479,7 @@ impl FilePoll {
                 || self.flags.contains(Flags::PollProcess))
     }
 
-    /// The loop a register/unregister must act on: the one this poll is
-    /// already counted on (see `counted_loop`), otherwise the current one the
-    /// caller passed.
+    /// `counted_loop` while registered, otherwise the loop the caller passed.
     fn counted_or(&self, current: *mut Loop) -> *mut Loop {
         if self.counted_loop.is_null() {
             current

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -27,6 +27,27 @@ fn loop_sub_active(loop_: &mut Loop, value: u32) {
     loop_.active = loop_.active.saturating_sub(value);
 }
 
+/// The one place a loop pointer handed to (or retained by) a `FilePoll` is
+/// dereferenced.
+///
+/// `FilePoll` takes loops as `*mut Loop` rather than `&mut Loop` because it
+/// keeps the pointer in `counted_loop` until the poll is unregistered: a
+/// pointer derived from a caller's `&mut` reborrow would be invalidated by the
+/// next `&mut Loop` anyone forms in between, whereas the handles callers pass
+/// (`EventLoopCtx::loop_` and the like) are the loop's own pointer.
+#[cfg(not(windows))]
+#[inline]
+fn loop_mut<'a>(loop_: *mut Loop) -> &'a mut Loop {
+    debug_assert!(!loop_.is_null());
+    // SAFETY: `loop_` is the thread's loop or `Bun.spawnSync`'s private loop
+    // (owned by the VM's rare data); both outlive every poll registered on
+    // them, and the pointer carries the handle's own provenance (see above).
+    // The event loop is single-threaded, and every caller consumes the borrow
+    // with a counter adjustment or a field read before anything else can reach
+    // the loop.
+    unsafe { &mut *loop_ }
+}
+
 #[cfg(not(windows))]
 use bun_sys::syslog;
 
@@ -304,8 +325,8 @@ pub struct FilePoll {
     /// epoll/kqueue fd it is registered with), null while not registered.
     ///
     /// Callers hand every register/unregister the loop that is *current*
-    /// (`EventLoopCtx::platform_event_loop`), and `Bun.spawnSync` points that
-    /// at its private loop for the duration of the call. A poll torn down
+    /// (`EventLoopCtx::loop_`), and `Bun.spawnSync` points that at its
+    /// private loop for the duration of the call. A poll torn down
     /// while the private loop is current (a GC sweep finalizing a reader, a
     /// test body run by the test runner's timeout path) must still be
     /// removed from, and uncounted on, the loop it was registered with:
@@ -360,8 +381,8 @@ impl FilePoll {
 
     // Note: these handlers take no loop parameter: holding a
     // protected `&mut Loop` across `on_update` would alias the fresh `&mut Loop`
-    // that downstream `__bun_run_file_poll` handlers conjure via
-    // `EventLoopCtx::platform_event_loop()` when they re-enter the loop
+    // that downstream `__bun_run_file_poll` handlers conjure (via `loop_mut`
+    // here or `EventLoopCtx`) when they re-enter the loop
     // (`register_with_fd`/`unregister`/`deinit`).
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     pub(crate) fn on_kqueue_event(&mut self, kqueue_event: &KQueueEvent) {
@@ -413,10 +434,7 @@ impl FilePoll {
     }
 
     fn deinit_possibly_defer(&mut self, vm: EventLoopCtx, force_unregister: bool) {
-        // `loop_mut()` is the crate-private nonnull-asref accessor (single
-        // deref in `EventLoopCtx`); the `&mut Loop` is consumed by `unregister`
-        // and dropped before any `&mut Store` is materialised.
-        let _ = self.unregister(vm.loop_mut(), force_unregister);
+        let _ = self.unregister(vm.loop_(), force_unregister);
 
         self.owner.clear();
         let was_ever_registered = self.flags.contains(Flags::WasEverRegistered);
@@ -478,29 +496,21 @@ impl FilePoll {
     /// The loop a register/unregister must act on: the one this poll is
     /// already counted on (see `counted_loop`), otherwise the current one the
     /// caller passed.
-    fn counted_or<'a>(&self, current: &'a mut Loop) -> &'a mut Loop {
-        let counted = self.counted_loop;
-        if counted.is_null() || ptr::eq(counted, current) {
-            return current;
+    fn counted_or(&self, current: *mut Loop) -> *mut Loop {
+        if self.counted_loop.is_null() {
+            current
+        } else {
+            self.counted_loop
         }
-        // SAFETY: `counted_loop` is set from a live loop in `activate` and
-        // cleared in `deactivate`; both the thread's loop and spawnSync's
-        // private loop (owned by the VM's RareData) outlive every poll counted
-        // on them. It is a different allocation from `current`, so the two
-        // `&mut` do not alias.
-        unsafe { &mut *counted }
     }
 
     /// This decrements the active counter if it was previously incremented
     /// "active" controls whether or not the event loop should potentially idle
     pub fn disable_keeping_process_alive(&mut self, event_loop_ctx: EventLoopCtx) {
-        let count = self.flags.contains(Flags::HasIncrementedActiveCount) as u32;
-        if self.counted_loop.is_null() {
-            event_loop_ctx.loop_sub_active(count);
-        } else {
-            // SAFETY: see `counted_or`.
-            loop_sub_active(unsafe { &mut *self.counted_loop }, count);
-        }
+        loop_sub_active(
+            loop_mut(self.counted_or(event_loop_ctx.loop_())),
+            self.flags.contains(Flags::HasIncrementedActiveCount) as u32,
+        );
 
         self.flags.remove(Flags::KeepsEventLoopAlive);
         self.flags.remove(Flags::HasIncrementedActiveCount);
@@ -511,21 +521,18 @@ impl FilePoll {
             return;
         }
 
-        let count = (!self.flags.contains(Flags::HasIncrementedActiveCount)) as u32;
-        if self.counted_loop.is_null() {
-            event_loop_ctx.loop_add_active(count);
-        } else {
-            // SAFETY: see `counted_or`.
-            loop_add_active(unsafe { &mut *self.counted_loop }, count);
-        }
+        loop_add_active(
+            loop_mut(self.counted_or(event_loop_ctx.loop_())),
+            (!self.flags.contains(Flags::HasIncrementedActiveCount)) as u32,
+        );
 
         self.flags.insert(Flags::KeepsEventLoopAlive);
         self.flags.insert(Flags::HasIncrementedActiveCount);
     }
 
     /// Only intended to be used from EventLoop.Pollable
-    fn deactivate(&mut self, loop_: &mut Loop) {
-        let loop_ = self.counted_or(loop_);
+    fn deactivate(&mut self, loop_: *mut Loop) {
+        let loop_ = loop_mut(self.counted_or(loop_));
         if self.flags.contains(Flags::HasIncrementedPollCount) {
             loop_.dec();
         }
@@ -541,14 +548,15 @@ impl FilePoll {
     }
 
     /// Only intended to be used from EventLoop.Pollable
-    fn activate(&mut self, loop_: &mut Loop) {
+    fn activate(&mut self, loop_: *mut Loop) {
         self.flags.remove(Flags::Closed);
+        self.counted_loop = loop_;
+        let loop_ = loop_mut(loop_);
 
         if !self.flags.contains(Flags::HasIncrementedPollCount) {
             loop_.inc();
         }
         self.flags.insert(Flags::HasIncrementedPollCount);
-        self.counted_loop = loop_;
 
         if self.flags.contains(Flags::KeepsEventLoopAlive) {
             loop_add_active(
@@ -600,7 +608,9 @@ impl FilePoll {
         poll
     }
 
-    pub fn register(&mut self, loop_: &mut Loop, flag: Flags, one_shot: bool) -> sys::Result<()> {
+    /// `loop_` is retained in `counted_loop` until the poll is unregistered, so
+    /// it has to be the loop's own handle, not a pointer to a borrow of it.
+    pub fn register(&mut self, loop_: *mut Loop, flag: Flags, one_shot: bool) -> sys::Result<()> {
         self.register_with_fd(
             loop_,
             flag,
@@ -613,9 +623,10 @@ impl FilePoll {
         )
     }
 
+    /// See [`register`](Self::register) for what `loop_` may be.
     pub fn register_with_fd(
         &mut self,
-        loop_: &mut Loop,
+        loop_: *mut Loop,
         flag: Flags,
         one_shot: OneShotFlag,
         fd: Fd,
@@ -627,8 +638,7 @@ impl FilePoll {
             target_os = "freebsd"
         ))]
         {
-            let loop_ = self.counted_or(loop_);
-            return self.register_with_fd_impl(loop_, flag, one_shot, fd);
+            return self.register_with_fd_impl(self.counted_or(loop_), flag, one_shot, fd);
         }
         #[cfg(not(any(
             target_os = "linux",
@@ -650,12 +660,12 @@ impl FilePoll {
     ))]
     fn register_with_fd_impl(
         &mut self,
-        loop_: &mut Loop,
+        loop_: *mut Loop,
         flag: Flags,
         one_shot: OneShotFlag,
         fd: Fd,
     ) -> sys::Result<()> {
-        let watcher_fd = loop_.fd;
+        let watcher_fd = loop_mut(loop_).fd;
 
         syslog!(
             "register: FilePoll(0x{:x}, generation_number={}) {} ({})",
@@ -919,13 +929,13 @@ impl FilePoll {
         sys::Result::Ok(())
     }
 
-    pub fn unregister(&mut self, loop_: &mut Loop, force_unregister: bool) -> sys::Result<()> {
+    pub fn unregister(&mut self, loop_: *mut Loop, force_unregister: bool) -> sys::Result<()> {
         self.unregister_with_fd(loop_, self.fd, force_unregister)
     }
 
     pub(crate) fn unregister_with_fd(
         &mut self,
-        loop_: &mut Loop,
+        loop_: *mut Loop,
         fd: Fd,
         force_unregister: bool,
     ) -> sys::Result<()> {
@@ -961,7 +971,7 @@ impl FilePoll {
     ))]
     fn unregister_with_fd_impl(
         &mut self,
-        loop_: &mut Loop,
+        loop_: *mut Loop,
         fd: Fd,
         force_unregister: bool,
     ) -> sys::Result<()> {
@@ -978,7 +988,7 @@ impl FilePoll {
         }
 
         debug_assert!(fd != INVALID_FD);
-        let watcher_fd = loop_.fd;
+        let watcher_fd = loop_mut(loop_).fd;
         let both_directions =
             self.flags.contains(Flags::PollReadable) && self.flags.contains(Flags::PollWritable);
         let flag: Flags = 'brk: {
@@ -1551,7 +1561,7 @@ unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
 
     // SAFETY: `loop_` is the live uws loop. Do *not* materialize `&mut *loop_`
     // here — `on_update` (via `__bun_run_file_poll`) re-enters the loop and conjures
-    // a fresh `&mut Loop` through `EventLoopCtx::platform_event_loop()`; a
+    // a fresh `&mut Loop` through `loop_mut` / `EventLoopCtx`; a
     // protected `&mut Loop` spanning that call would be SB-UB. Take a short-lived
     // `&*loop_` only to copy the POD event onto the stack (the `BackRef`-style
     // accessor returns by value), then drop the borrow before dispatching so the

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -87,11 +87,14 @@ pub struct EventLoop {
     #[cfg(not(windows))]
     pub holds_forever_poll: bool,
     pub deferred_tasks: DeferredTaskQueue::DeferredTaskQueue,
-    #[cfg(windows)]
-    // `?*uws.Loop` FFI handle.
+    /// The uws loop this `EventLoop` instance drives: the thread's loop for the
+    /// VM's embedded loops (set by `ensure_waker`), the private loop for a
+    /// `Bun.spawnSync` loop. `concurrent_ref` is folded into this loop, not into
+    /// `vm.event_loop_handle`: spawnSync points the latter at its private loop
+    /// while it waits, and a `MessagePort`/`BroadcastChannel` torn down during
+    /// that wait (a GC sweep, the test runner moving on after a timeout) has to
+    /// release its ref on the loop that holds it.
     pub uws_loop: Option<NonNull<uws::Loop>>,
-    #[cfg(not(windows))]
-    pub uws_loop: (),
 
     pub entered_event_loop_count: isize,
     pub concurrent_ref: AtomicI32,
@@ -132,10 +135,7 @@ impl Default for EventLoop {
             #[cfg(not(windows))]
             holds_forever_poll: false,
             deferred_tasks: DeferredTaskQueue::DeferredTaskQueue::default(),
-            #[cfg(windows)]
             uws_loop: None,
-            #[cfg(not(windows))]
-            uws_loop: (),
             entered_event_loop_count: 0,
             concurrent_ref: AtomicI32::new(0),
             imminent_gc_timer: AtomicPtr::new(core::ptr::null_mut()),
@@ -563,13 +563,8 @@ impl EventLoop {
     /// ports/channels/sockets on a loop that no longer ticks) so the loop is not
     /// torn down still believing something keeps it alive.
     pub(crate) fn apply_concurrent_ref_delta(&self) {
-        // Do NOT silently drop the swapped delta when the handle is
-        // missing — queued refs would be lost forever.
         let delta = self.concurrent_ref.swap(0, Ordering::SeqCst);
-        let loop_ = self
-            .vm_ref()
-            .platform_loop_opt()
-            .expect("event_loop_handle");
+        let loop_ = self.own_uws_loop();
         #[cfg(windows)]
         {
             if delta > 0 {
@@ -625,6 +620,23 @@ impl EventLoop {
                 "usockets_loop: event_loop_handle not initialized (call ensure_waker first)",
             )
         }
+    }
+
+    /// The loop this instance's keep-alive refs are counted on (see
+    /// [`Self::uws_loop`]). Unlike [`Self::usockets_loop`] this does not follow
+    /// `vm.event_loop_handle`, which `Bun.spawnSync` repoints while it waits.
+    /// An embedded loop that has not run `ensure_waker` yet is driven by the
+    /// thread's loop.
+    #[inline]
+    #[allow(clippy::mut_from_ref)]
+    fn own_uws_loop(&self) -> &mut uws::Loop {
+        let loop_ = self.uws_loop.map_or_else(uws::Loop::get, NonNull::as_ptr);
+        // SAFETY: the thread's loop lives as long as the thread; a spawnSync
+        // loop's private uws loop is destroyed together with its `EventLoop`
+        // (`SpawnSyncEventLoop::drop`). The loop is a separate allocation, so the
+        // `&mut` aliases no field of `self`, and it is only reborrowed from the
+        // owning JS thread, for the duration of one counter update.
+        unsafe { &mut *loop_ }
     }
 
     #[inline]
@@ -909,10 +921,6 @@ impl EventLoop {
     pub fn ensure_waker(&mut self) {
         jsc::mark_binding();
         if self.vm_ref().event_loop_handle.is_none() {
-            #[cfg(windows)]
-            {
-                self.uws_loop = NonNull::new(uws::Loop::get());
-            }
             let vm = self.vm();
             // SAFETY: `vm` is the live owning VM.
             unsafe { (*vm).event_loop_handle = Some(Async::Loop::get()) };
@@ -925,11 +933,8 @@ impl EventLoop {
                 (*gc).init(&mut *vm);
             }
         }
-        #[cfg(windows)]
-        {
-            if self.uws_loop.is_none() {
-                self.uws_loop = NonNull::new(uws::Loop::get());
-            }
+        if self.uws_loop.is_none() {
+            self.uws_loop = NonNull::new(uws::Loop::get());
         }
         // Note: `EventLoopHandle` lives in `bun_event_loop` (lower tier),
         // which cannot name `jsc::EventLoop`, so it stores `*mut ()`.
@@ -1375,22 +1380,15 @@ fn vm_from_ptr<'a>(vm: *mut ()) -> &'a mut VirtualMachine {
     unsafe { &mut *vm.cast::<VirtualMachine>() }
 }
 
-/// Heap-allocate a fresh `EventLoop` bound to `vm`; on Windows, store
-/// `uws_loop` in `event_loop.uws_loop`.
+/// Heap-allocate a fresh `EventLoop` bound to `vm` and driven by `uws_loop`
+/// (spawnSync's private loop).
 #[unsafe(no_mangle)]
 pub(crate) fn __bun_spawn_sync_create_event_loop(vm: *mut (), uws_loop: *mut uws::Loop) -> *mut () {
     let vm = vm_from_ptr(vm);
     let mut el = Box::new(EventLoop::default());
     el.global = NonNull::new(vm.global);
     el.virtual_machine = NonNull::new(std::ptr::from_mut(vm));
-    #[cfg(windows)]
-    {
-        el.uws_loop = NonNull::new(uws_loop);
-    }
-    #[cfg(not(windows))]
-    {
-        let _ = uws_loop;
-    }
+    el.uws_loop = NonNull::new(uws_loop);
     let el = bun_core::heap::into_raw(el);
     // SAFETY: `el` is the stable heap address the poster targets until destroy.
     unsafe { (*el).isolated_poster = Some(crate::vm_handle::IsolatedPosterInner::new(el)) };

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -87,13 +87,10 @@ pub struct EventLoop {
     #[cfg(not(windows))]
     pub holds_forever_poll: bool,
     pub deferred_tasks: DeferredTaskQueue::DeferredTaskQueue,
-    /// The uws loop this `EventLoop` instance drives: the thread's loop for the
-    /// VM's embedded loops (set by `ensure_waker`), the private loop for a
-    /// `Bun.spawnSync` loop. `concurrent_ref` is folded into this loop, not into
-    /// `vm.event_loop_handle`: spawnSync points the latter at its private loop
-    /// while it waits, and a `MessagePort`/`BroadcastChannel` torn down during
-    /// that wait (a GC sweep, the test runner moving on after a timeout) has to
-    /// release its ref on the loop that holds it.
+    /// The uws loop this instance drives (the thread's, set by `ensure_waker`;
+    /// the private one for a `Bun.spawnSync` loop), which `concurrent_ref` is
+    /// folded into. `vm.event_loop_handle` is not used for that because
+    /// spawnSync repoints it while it waits (see `bun_io::FilePoll::counted_loop`).
     pub uws_loop: Option<NonNull<uws::Loop>>,
 
     pub entered_event_loop_count: isize,
@@ -622,20 +619,17 @@ impl EventLoop {
         }
     }
 
-    /// The loop this instance's keep-alive refs are counted on (see
-    /// [`Self::uws_loop`]). Unlike [`Self::usockets_loop`] this does not follow
-    /// `vm.event_loop_handle`, which `Bun.spawnSync` repoints while it waits.
-    /// An embedded loop that has not run `ensure_waker` yet is driven by the
-    /// thread's loop.
+    /// [`Self::uws_loop`], or the thread's loop before `ensure_waker` has run.
+    /// Unlike [`Self::usockets_loop`] this does not follow `vm.event_loop_handle`.
     #[inline]
     #[allow(clippy::mut_from_ref)]
     fn own_uws_loop(&self) -> &mut uws::Loop {
         let loop_ = self.uws_loop.map_or_else(uws::Loop::get, NonNull::as_ptr);
-        // SAFETY: the thread's loop lives as long as the thread; a spawnSync
-        // loop's private uws loop is destroyed together with its `EventLoop`
-        // (`SpawnSyncEventLoop::drop`). The loop is a separate allocation, so the
-        // `&mut` aliases no field of `self`, and it is only reborrowed from the
-        // owning JS thread, for the duration of one counter update.
+        // SAFETY: the loop is live at every call site: `VirtualMachine::teardown`
+        // folds for the last time before freeing the thread's loop, and
+        // `SpawnSyncEventLoop` destroys its `EventLoop` before its uws loop. It
+        // is a separate allocation from `self`, reborrowed on the owning thread
+        // for one counter update.
         unsafe { &mut *loop_ }
     }
 

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1063,9 +1063,6 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     // also pass `jsc_vm` into `spawn_sync_event_loop`/`prepare`/`cleanup` while
     // holding it. Route through a raw `*mut VirtualMachineRef` for the duration.
     let jsc_vm_ptr: *mut jsc::VirtualMachineRef = jsc_vm;
-    // The handle that was current before `prepare()` is kept on this frame
-    // (not in the shared `SpawnSyncEventLoop`) so that a spawnSync nested
-    // inside this one's wait restores the right handle at each level.
     let mut previous_loop_handle: VmEventLoopHandle = None;
     // For IS_SYNC, use the isolated loop's `event_loop` (created by
     // `SpawnSyncEventLoop::init`) so stdio readers/writers register on it

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -8,7 +8,7 @@ use crate::ipc as IPC;
 use bun_core::StackCheck;
 use bun_core::{Output, Timespec, TimespecMockMode, ZBox, fmt as bun_fmt};
 use bun_core::{String as BunString, ZStr, strings};
-use bun_event_loop::SpawnSyncEventLoop::TickState;
+use bun_event_loop::SpawnSyncEventLoop::{TickState, VmEventLoopHandle};
 use bun_io::max_buf::MaxBuf;
 use bun_jsc::{
     self as jsc, EventLoopHandle, JSGlobalObject, JSObject, JSPropertyIterator, JSValue, JsError,
@@ -1063,6 +1063,10 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     // also pass `jsc_vm` into `spawn_sync_event_loop`/`prepare`/`cleanup` while
     // holding it. Route through a raw `*mut VirtualMachineRef` for the duration.
     let jsc_vm_ptr: *mut jsc::VirtualMachineRef = jsc_vm;
+    // The handle that was current before `prepare()` is kept on this frame
+    // (not in the shared `SpawnSyncEventLoop`) so that a spawnSync nested
+    // inside this one's wait restores the right handle at each level.
+    let mut previous_loop_handle: VmEventLoopHandle = None;
     // For IS_SYNC, use the isolated loop's `event_loop` (created by
     // `SpawnSyncEventLoop::init`) so stdio readers/writers register on it
     // instead of the main loop.
@@ -1073,7 +1077,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             let sync_loop = (*jsc_vm_ptr)
                 .rare_data()
                 .spawn_sync_event_loop(&mut *jsc_vm_ptr);
-            sync_loop.prepare(jsc_vm_ptr.cast());
+            previous_loop_handle = sync_loop.prepare(jsc_vm_ptr.cast());
             // `SpawnSyncEventLoop.event_loop` is type-erased to `*mut ()`
             // (bun_event_loop is below bun_jsc); the accessor returns the
             // concrete `jsc::EventLoop` allocation created via the runtime
@@ -1099,7 +1103,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 (*jsc_vm_ptr_cleanup)
                     .rare_data()
                     .spawn_sync_event_loop(&mut *jsc_vm_ptr_cleanup)
-                    .cleanup(jsc_vm_ptr_cleanup.cast(), main_loop.cast());
+                    .cleanup(jsc_vm_ptr_cleanup.cast(), previous_loop_handle, main_loop.cast());
             }
         }
     }

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4901,8 +4901,7 @@ impl Resolver {
                 Async::posix_event_loop::poll_tag::DNS_RESOLVER,
                 self.as_ctx_ptr().cast::<()>(),
             );
-            // SAFETY: `event_loop_handle` is set once VM is initialized; live for VM lifetime.
-            let loop_ = unsafe { &mut *self.vm().event_loop_handle.unwrap() };
+            let loop_ = ctx.loop_();
             // SAFETY: single-JS-thread; the `&mut PollsMap` borrow does not span
             // any re-entrant call (`FilePoll::register` is a syscall wrapper).
             let polls = unsafe { self.polls.get_mut() };

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -374,10 +374,8 @@ impl SharedConnection {
         );
         // SAFETY: `FilePoll::init` returned a live pool slot; exclusive here.
         let poll = unsafe { &mut *poll_ptr };
-        // SAFETY: the event loop outlives every lookup made on it.
-        let loop_ = unsafe { ctx.platform_event_loop() };
         let rc = poll.register_with_fd(
-            loop_,
+            ctx.loop_(),
             Async::PollKind::Readable,
             Async::posix_event_loop::OneShotFlag::None,
             fd,

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -191,10 +191,8 @@ mod posix {
                     NonNull::<()>::dangling().as_ptr(),
                 ),
             );
-            // SAFETY: `poll` is the fresh hive slot; `platform_event_loop` is the live uws loop.
-            let result = unsafe {
-                (*poll).register(ctx.platform_event_loop(), Flags::MemoryPressure, false)
-            };
+            // SAFETY: `poll` is the fresh hive slot.
+            let result = unsafe { (*poll).register(ctx.loop_(), Flags::MemoryPressure, false) };
             if result.is_err() {
                 // SAFETY: fresh hive slot never handed out.
                 deinit_poll(unsafe { &mut *poll });

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -609,6 +609,12 @@ pub(crate) struct All {
     pub(crate) thread_id: std::thread::ThreadId,
     pub(crate) timers: TimerHeap,
     pub(crate) active_timer_count: i32,
+    /// The loop `active_timer_count` going positive ref'd; the matching unref
+    /// has to land on the same loop even if the caller's `vm.uws_loop()` has
+    /// since been pointed at `Bun.spawnSync`'s private loop (a timer being
+    /// cancelled or swept by GC while a spawnSync is in progress).
+    #[cfg(not(windows))]
+    timer_refd_loop: *mut bun_uws_sys::Loop,
     #[cfg(windows)]
     pub(crate) uv_timer: bun_sys::windows::libuv::Timer,
     /// Whether we have emitted a warning for passing a negative timeout duration
@@ -619,6 +625,9 @@ pub(crate) struct All {
     /// TimerObjectInternals.epoch. Masked to 25 bits on increment.
     pub(crate) epoch: u32,
     pub(crate) immediate_ref_count: i32,
+    /// Same as `timer_refd_loop`, for `immediate_ref_count`.
+    #[cfg(not(windows))]
+    immediate_refd_loop: *mut bun_uws_sys::Loop,
     #[cfg(windows)]
     pub(crate) uv_idle: bun_sys::windows::libuv::uv_idle_t,
     pub(crate) event_loop_delay: EventLoopDelayMonitor,
@@ -628,6 +637,29 @@ pub(crate) struct All {
     pub(crate) wtf_timers: Guarded<TimerHeap>,
 }
 
+/// Drop the loop ref recorded by the matching `ref_()` in
+/// `increment_timer_ref` / `increment_immediate_ref`. `current` is the loop the
+/// caller would have used; it only differs from the recorded one while
+/// `Bun.spawnSync` has the VM pointed at its private loop.
+#[cfg(not(windows))]
+fn unref_refd_loop(refd: &mut *mut bun_uws_sys::Loop, current: *mut bun_uws_sys::Loop) {
+    let recorded = core::mem::replace(refd, core::ptr::null_mut());
+    debug_assert!(
+        !recorded.is_null(),
+        "timer ref count went positive without a loop ref"
+    );
+    let loop_ = if recorded.is_null() {
+        current
+    } else {
+        recorded
+    };
+    // SAFETY: `recorded` was the VM's live uws loop when the ref was taken
+    // (the thread's loop, or spawnSync's private loop owned by the VM's
+    // RareData), and both outlive this per-thread timer state; `current` is
+    // the caller's live loop.
+    unsafe { &mut *loop_ }.unref();
+}
+
 impl All {
     pub(crate) fn init() -> Self {
         Self {
@@ -635,12 +667,16 @@ impl All {
             thread_id: std::thread::current().id(),
             timers: TimerHeap::default(),
             active_timer_count: 0,
+            #[cfg(not(windows))]
+            timer_refd_loop: core::ptr::null_mut(),
             #[cfg(windows)]
             uv_timer: bun_core::ffi::zeroed(),
             warned_negative_number: false,
             warned_not_number: false,
             epoch: 0,
             immediate_ref_count: 0,
+            #[cfg(not(windows))]
+            immediate_refd_loop: core::ptr::null_mut(),
             #[cfg(windows)]
             uv_idle: bun_core::ffi::zeroed(),
             event_loop_delay: EventLoopDelayMonitor::default(),
@@ -1122,8 +1158,11 @@ impl All {
         self.immediate_ref_count = new;
         if old <= 0 && new > 0 {
             #[cfg(not(windows))]
-            // SAFETY: caller passes the VM's live uws loop
-            unsafe { &mut *uws_loop }.ref_();
+            {
+                self.immediate_refd_loop = uws_loop;
+                // SAFETY: caller passes the VM's live uws loop
+                unsafe { &mut *uws_loop }.ref_();
+            }
             #[cfg(windows)]
             {
                 // Lazy-init the idle handle and start
@@ -1140,8 +1179,7 @@ impl All {
             }
         } else if old > 0 && new <= 0 {
             #[cfg(not(windows))]
-            // SAFETY: caller passes the VM's live uws loop
-            unsafe { &mut *uws_loop }.unref();
+            unref_refd_loop(&mut self.immediate_refd_loop, uws_loop);
             #[cfg(windows)]
             if !self.uv_idle.data.is_null() {
                 self.uv_idle.stop();
@@ -1173,8 +1211,11 @@ impl All {
         self.active_timer_count = new;
         if old <= 0 && new > 0 {
             #[cfg(not(windows))]
-            // SAFETY: caller passes the VM's live uws loop
-            unsafe { &mut *uws_loop }.ref_();
+            {
+                self.timer_refd_loop = uws_loop;
+                // SAFETY: caller passes the VM's live uws loop
+                unsafe { &mut *uws_loop }.ref_();
+            }
             // `uv_timer.ref()` is intentionally unconditional (no `data !=
             // null` guard). Invariant: every path that reaches a positive
             // `active_timer_count` first inserts a timer, and `insert`
@@ -1184,8 +1225,7 @@ impl All {
             self.uv_timer.ref_();
         } else if old > 0 && new <= 0 {
             #[cfg(not(windows))]
-            // SAFETY: caller passes the VM's live uws loop
-            unsafe { &mut *uws_loop }.unref();
+            unref_refd_loop(&mut self.timer_refd_loop, uws_loop);
             #[cfg(windows)]
             self.uv_timer.unref();
         }

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -609,10 +609,8 @@ pub(crate) struct All {
     pub(crate) thread_id: std::thread::ThreadId,
     pub(crate) timers: TimerHeap,
     pub(crate) active_timer_count: i32,
-    /// The loop `active_timer_count` going positive ref'd; the matching unref
-    /// has to land on the same loop even if the caller's `vm.uws_loop()` has
-    /// since been pointed at `Bun.spawnSync`'s private loop (a timer being
-    /// cancelled or swept by GC while a spawnSync is in progress).
+    /// The loop ref'd when `active_timer_count` went positive; the unref has
+    /// to come off the same loop (see `FilePoll::counted_loop`).
     #[cfg(not(windows))]
     timer_refd_loop: *mut bun_uws_sys::Loop,
     #[cfg(windows)]
@@ -637,27 +635,15 @@ pub(crate) struct All {
     pub(crate) wtf_timers: Guarded<TimerHeap>,
 }
 
-/// Drop the loop ref recorded by the matching `ref_()` in
-/// `increment_timer_ref` / `increment_immediate_ref`. `current` is the loop the
-/// caller would have used; it only differs from the recorded one while
-/// `Bun.spawnSync` has the VM pointed at its private loop.
+/// Balance the `ref_()` taken when a ref count went positive, on the loop it
+/// was taken on.
 #[cfg(not(windows))]
-fn unref_refd_loop(refd: &mut *mut bun_uws_sys::Loop, current: *mut bun_uws_sys::Loop) {
-    let recorded = core::mem::replace(refd, core::ptr::null_mut());
-    debug_assert!(
-        !recorded.is_null(),
-        "timer ref count went positive without a loop ref"
-    );
-    let loop_ = if recorded.is_null() {
-        current
-    } else {
-        recorded
-    };
-    // SAFETY: `recorded` was the VM's live uws loop when the ref was taken
-    // (the thread's loop, or spawnSync's private loop owned by the VM's
-    // RareData), and both outlive this per-thread timer state; `current` is
-    // the caller's live loop.
-    unsafe { &mut *loop_ }.unref();
+fn unref_refd_loop(refd: &mut *mut bun_uws_sys::Loop) {
+    let mut loop_ = core::ptr::NonNull::new(core::mem::replace(refd, core::ptr::null_mut()))
+        .expect("timer ref count went positive without ref'ing a loop");
+    // SAFETY: recorded from the VM's live loop when the ref was taken, and
+    // `VirtualMachine::teardown` cancels all timers before it frees any loop.
+    unsafe { loop_.as_mut() }.unref();
 }
 
 impl All {
@@ -1179,7 +1165,7 @@ impl All {
             }
         } else if old > 0 && new <= 0 {
             #[cfg(not(windows))]
-            unref_refd_loop(&mut self.immediate_refd_loop, uws_loop);
+            unref_refd_loop(&mut self.immediate_refd_loop);
             #[cfg(windows)]
             if !self.uv_idle.data.is_null() {
                 self.uv_idle.stop();
@@ -1225,7 +1211,7 @@ impl All {
             self.uv_timer.ref_();
         } else if old > 0 && new <= 0 {
             #[cfg(not(windows))]
-            unref_refd_loop(&mut self.timer_refd_loop, uws_loop);
+            unref_refd_loop(&mut self.timer_refd_loop);
             #[cfg(windows)]
             self.uv_timer.unref();
         }

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -415,11 +415,10 @@ impl Process {
             // Borrow scoped to the call.
             unsafe { (*poll).enable_keeping_process_alive(ctx) };
 
-            // SAFETY: poll is live and `platform_event_loop` returns the live
-            // uws loop; both `&mut`s are scoped to the `register` call.
+            // SAFETY: poll is live; borrow scoped to the `register` call.
             match unsafe {
                 (*poll).register(
-                    &mut *self.event_loop.platform_event_loop(),
+                    self.event_loop.platform_event_loop(),
                     bun_io::PollKind::Process,
                     PROCESS_POLL_ONE_SHOT,
                 )
@@ -453,10 +452,8 @@ impl Process {
         }
 
         if let Some(fd) = self.poller.fd_poll_mut() {
-            // SAFETY: `platform_event_loop` returns the live uws loop; borrow
-            // scoped to the `register` call.
             let maybe = fd.register(
-                unsafe { &mut *self.event_loop.platform_event_loop() },
+                self.event_loop.platform_event_loop(),
                 bun_io::PollKind::Process,
                 PROCESS_POLL_ONE_SHOT,
             );

--- a/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
+++ b/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
 
 describe.concurrent("spawnSync isolated event loop", () => {
   test("JavaScript timers should not fire during spawnSync", async () => {
@@ -157,5 +157,95 @@ describe.concurrent("spawnSync isolated event loop", () => {
     expect(stdout).toContain("SUCCESS");
     expect(stdout).not.toContain("FAIL");
     expect(exitCode).toBe(0);
+  });
+
+  // While spawnSync waits, the VM's "current" uws loop is spawnSync's private
+  // loop. Event-loop refs that were taken on the main loop (JS timers, fs.watch
+  // and every other KeepAlive, registered FilePolls) and then released during
+  // that wait used to be subtracted from the private loop instead, so its
+  // num_polls could read 0 while a child's pidfd was still registered. Once that
+  // happens us_loop_run_bun_tick returns without polling and spawnSync spins
+  // forever, never observing the exit (seen in CI as `bun test --parallel`
+  // workers stuck in spawnSync of a local bun child until the batch is killed).
+  //
+  // The test runner's timeout path is the one place that runs JS inside a
+  // spawnSync wait: when a test whose callback is no longer on the stack times
+  // out inside spawnSync, the runner carries on with the following tests right
+  // there. Test `a` gets the runner into that state, `b` releases four main-loop
+  // refs while the private loop is current, and `c` runs a spawnSync that needs
+  // the private loop to actually poll.
+  //
+  // Arithmetic on an unfixed build: `a`'s pipeless spawnSync holds one poll on
+  // the private loop (the child's pidfd), `b` wrongly subtracts 4 (1 for the
+  // last JS timer going away, 3 for the watchers), `c` adds 3 (pidfd + two
+  // pipes) => 0, so `c` spins without ever reading the child's output or
+  // noticing its exit until a timeout (bun test's per-test timeout, or the
+  // `timeout` option) fires inside the spin; closing the two pipe readers then
+  // makes the count non-zero, the loop finally polls, and `c` comes back with
+  // empty stdout after several seconds and fails. Fixed, the refs come off the
+  // main loop and `c` completes normally.
+  test.skipIf(isWindows)("refs released during a spawnSync wait come off the loop they were taken on", async () => {
+    using dir = tempDir("spawnsync-loop-refs", {
+      "loop-refs.test.ts": `
+        import { expect, test } from "bun:test";
+        import { watch } from "node:fs";
+
+        const cmd = (code: string) => [process.execPath, "-e", code];
+        let timer: ReturnType<typeof setTimeout>;
+        const watchers: ReturnType<typeof watch>[] = [];
+        let aIsInsideSpawnSync = false;
+
+        // The per-test timeout is the mechanism here: it has to fire while
+        // spawnSync is waiting and after the callback has left the stack.
+        test("a", async () => {
+          timer = setTimeout(() => {}, 1e9);
+          for (let i = 0; i < 3; i++) watchers.push(watch(import.meta.dir));
+          await Bun.sleep(1);
+          aIsInsideSpawnSync = true;
+          Bun.spawnSync({ cmd: cmd("setTimeout(() => {}, 1e9)"), env: process.env, stdout: "ignore", stderr: "ignore" });
+          aIsInsideSpawnSync = false;
+        }, 1000);
+
+        test("b", () => {
+          expect(aIsInsideSpawnSync).toBe(true);
+          clearTimeout(timer);
+          for (const w of watchers) w.unref();
+        });
+
+        test("c", () => {
+          expect(aIsInsideSpawnSync).toBe(true);
+          const result = Bun.spawnSync({
+            cmd: cmd("console.log('from c')"),
+            env: process.env,
+            stdout: "pipe",
+            stderr: "pipe",
+            timeout: 10_000,
+          });
+          expect({
+            exitedDueToTimeout: result.exitedDueToTimeout,
+            exitCode: result.exitCode,
+            stdout: result.stdout.toString(),
+          }).toEqual({ exitedDueToTimeout: false, exitCode: 0, stdout: "from c\\n" });
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "./loop-refs.test.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const output = stdout + stderr;
+
+    // `a` is the deliberate casualty; `b` and `c` are the assertions.
+    expect(output).toContain("(fail) a");
+    expect(output).toContain("(pass) b");
+    expect(output).toContain("(pass) c");
+    expect(output).toContain(" 2 pass");
+    expect(output).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
   });
 });

--- a/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
+++ b/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
@@ -158,48 +158,40 @@ describe.concurrent("spawnSync isolated event loop", () => {
     expect(stdout).not.toContain("FAIL");
     expect(exitCode).toBe(0);
   });
+});
 
-  // While spawnSync waits, the VM's "current" uws loop is spawnSync's private
-  // loop. Event-loop refs that were taken on the main loop (JS timers, fs.watch
-  // and every other KeepAlive, registered FilePolls) and then released during
-  // that wait used to be subtracted from the private loop instead, so its
-  // num_polls could read 0 while a child's pidfd was still registered. Once that
-  // happens us_loop_run_bun_tick returns without polling and spawnSync spins
-  // forever, never observing the exit (seen in CI as `bun test --parallel`
-  // workers stuck in spawnSync of a local bun child until the batch is killed).
-  //
-  // The test runner's timeout path is the one place that runs JS inside a
-  // spawnSync wait: when a test whose callback is no longer on the stack times
-  // out inside spawnSync, the runner carries on with the following tests right
-  // there. Test `a` gets the runner into that state, `b` releases four main-loop
-  // refs while the private loop is current, and `c` runs a spawnSync that needs
-  // the private loop to actually poll.
-  //
-  // Arithmetic on an unfixed build: `a`'s pipeless spawnSync holds one poll on
-  // the private loop (the child's pidfd), `b` wrongly subtracts 4 (1 for the
-  // last JS timer going away, 3 for the watchers), `c` adds 3 (pidfd + two
-  // pipes) => 0, so `c` spins without ever reading the child's output or
-  // noticing its exit until a timeout (bun test's per-test timeout, or the
-  // `timeout` option) fires inside the spin; closing the two pipe readers then
-  // makes the count non-zero, the loop finally polls, and `c` comes back with
-  // empty stdout after several seconds and fails. Fixed, the refs come off the
-  // main loop and `c` completes normally.
-  test.skipIf(isWindows)("refs released during a spawnSync wait come off the loop they were taken on", async () => {
+// While Bun.spawnSync waits, the VM's "current" uws loop is spawnSync's private
+// loop. A ref that was taken on the main loop and released during that wait
+// used to be subtracted from the private loop instead, so the private loop's
+// poll count could read 0 while the child's pidfd was still registered;
+// us_loop_run_bun_tick then returns without polling and spawnSync spins
+// forever, never observing the exit (seen as `bun test --parallel` workers
+// stuck inside spawnSync of a local bun child until the batch is killed, and
+// as #34069).
+//
+// The test runner's timeout path is the one place that runs JS inside a
+// spawnSync wait: when a test whose callback has already left the stack times
+// out inside spawnSync, the runner carries on with the following tests right
+// there. In each fixture below, test `a` enters a spawnSync that its per-test
+// timeout interrupts (bun test kills the dangling child, which is what lets the
+// spawnSync return once the private loop gets polled) and the tests after it
+// run inside that wait. `a`'s spawnSync holds exactly one poll on the private
+// loop, so a single misdirected release in `b` zeroes the count and `a` never
+// returns: the inner `bun test` then spins instead of exiting and this test
+// times out. These tests are deliberately not concurrent: bun test only kills
+// the processes of a timed-out test when that test is not sharing a concurrent
+// group, and that is what cleans up such a spinning child.
+describe.skipIf(isWindows)("refs taken on the main loop and a spawnSync wait", () => {
+  async function runFixture(setup: string, insideWait: string, extraTests = "") {
     using dir = tempDir("spawnsync-loop-refs", {
       "loop-refs.test.ts": `
         import { expect, test } from "bun:test";
-        import { watch } from "node:fs";
 
         const cmd = (code: string) => [process.execPath, "-e", code];
-        let timer: ReturnType<typeof setTimeout>;
-        const watchers: ReturnType<typeof watch>[] = [];
         let aIsInsideSpawnSync = false;
+        ${setup}
 
-        // The per-test timeout is the mechanism here: it has to fire while
-        // spawnSync is waiting and after the callback has left the stack.
         test("a", async () => {
-          timer = setTimeout(() => {}, 1e9);
-          for (let i = 0; i < 3; i++) watchers.push(watch(import.meta.dir));
           await Bun.sleep(1);
           aIsInsideSpawnSync = true;
           Bun.spawnSync({ cmd: cmd("setTimeout(() => {}, 1e9)"), env: process.env, stdout: "ignore", stderr: "ignore" });
@@ -208,25 +200,10 @@ describe.concurrent("spawnSync isolated event loop", () => {
 
         test("b", () => {
           expect(aIsInsideSpawnSync).toBe(true);
-          clearTimeout(timer);
-          for (const w of watchers) w.unref();
+          ${insideWait}
         });
 
-        test("c", () => {
-          expect(aIsInsideSpawnSync).toBe(true);
-          const result = Bun.spawnSync({
-            cmd: cmd("console.log('from c')"),
-            env: process.env,
-            stdout: "pipe",
-            stderr: "pipe",
-            timeout: 10_000,
-          });
-          expect({
-            exitedDueToTimeout: result.exitedDueToTimeout,
-            exitCode: result.exitCode,
-            stdout: result.stdout.toString(),
-          }).toEqual({ exitedDueToTimeout: false, exitCode: 0, stdout: "from c\\n" });
-        });
+        ${extraTests}
       `,
     });
 
@@ -238,9 +215,63 @@ describe.concurrent("spawnSync isolated event loop", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const output = stdout + stderr;
+    return { output: stdout + stderr, exitCode };
+  }
 
-    // `a` is the deliberate casualty; `b` and `c` are the assertions.
+  // One case per kind of ref, each released on its own. The child in the
+  // FilePoll case exits by itself as a fallback, in case `b` never runs.
+  test.each([
+    ["a JS timer", `const timer = setTimeout(() => {}, 1e9);`, `clearTimeout(timer);`],
+    [
+      "a KeepAlive (Bun.serve)",
+      `const server = Bun.serve({ port: 0, fetch: () => new Response() });`,
+      `server.unref();`,
+    ],
+    [
+      "a registered FilePoll (subprocess stdout)",
+      `const child = Bun.spawn({ cmd: cmd("setTimeout(() => {}, 20_000)"), env: process.env, stdout: "pipe", stderr: "ignore" });`,
+      `child.stdout.cancel(); child.kill();`,
+    ],
+    [
+      "an event loop keep-alive ref (BroadcastChannel)",
+      `const channel = new BroadcastChannel("spawnsync-loop-refs");`,
+      `channel.unref();`,
+    ],
+  ])("%s released during the wait comes off the main loop", async (_, setup, release) => {
+    const { output, exitCode } = await runFixture(setup, release);
+
+    // `a` is the deliberate casualty; `b` passing and the process exiting are
+    // the assertions.
+    expect(output).toContain("(fail) a");
+    expect(output).toContain("(pass) b");
+    expect(output).toContain(" 1 pass");
+    expect(output).toContain(" 1 fail");
+    expect(exitCode).toBe(1);
+  });
+
+  // A spawnSync nested inside the wait (what the runner's timeout path does
+  // whenever a following test spawns something) has to leave the main loop as
+  // the current loop once the outer spawnSync returns too: the saved "previous
+  // loop" used to be a single slot that the nested call overwrote. `c` starts
+  // inside the wait like `b`, but its await can only complete once `a`'s
+  // spawnSync has returned and the loop being polled is the main loop, where
+  // the child's pidfd is registered.
+  test("a spawnSync nested inside the wait restores the main loop afterwards", async () => {
+    const { output, exitCode } = await runFixture(
+      `const child = Bun.spawn({ cmd: cmd("setTimeout(() => {}, 20_000)"), env: process.env, stdout: "ignore", stderr: "ignore" });`,
+      `
+        const nested = Bun.spawnSync({ cmd: cmd("console.log('nested')"), env: process.env, stdout: "pipe", stderr: "pipe" });
+        expect(nested.stdout.toString()).toBe("nested\\n");
+      `,
+      `
+        test("c", async () => {
+          child.kill();
+          await child.exited;
+          expect(aIsInsideSpawnSync).toBe(false);
+        });
+      `,
+    );
+
     expect(output).toContain("(fail) a");
     expect(output).toContain("(pass) b");
     expect(output).toContain("(pass) c");

--- a/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
+++ b/test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts
@@ -160,27 +160,22 @@ describe.concurrent("spawnSync isolated event loop", () => {
   });
 });
 
-// While Bun.spawnSync waits, the VM's "current" uws loop is spawnSync's private
-// loop. A ref that was taken on the main loop and released during that wait
-// used to be subtracted from the private loop instead, so the private loop's
-// poll count could read 0 while the child's pidfd was still registered;
-// us_loop_run_bun_tick then returns without polling and spawnSync spins
-// forever, never observing the exit (seen as `bun test --parallel` workers
-// stuck inside spawnSync of a local bun child until the batch is killed, and
-// as #34069).
+// While Bun.spawnSync waits, the VM's current uws loop is spawnSync's private
+// loop. A ref taken on the main loop and released during the wait used to come
+// off the private loop instead; once that loop's poll count reads 0 it is never
+// polled again and spawnSync spins without ever seeing the child exit (CI
+// workers stuck in spawnSync of a local bun child, #34069).
 //
-// The test runner's timeout path is the one place that runs JS inside a
-// spawnSync wait: when a test whose callback has already left the stack times
-// out inside spawnSync, the runner carries on with the following tests right
-// there. In each fixture below, test `a` enters a spawnSync that its per-test
-// timeout interrupts (bun test kills the dangling child, which is what lets the
-// spawnSync return once the private loop gets polled) and the tests after it
-// run inside that wait. `a`'s spawnSync holds exactly one poll on the private
-// loop, so a single misdirected release in `b` zeroes the count and `a` never
-// returns: the inner `bun test` then spins instead of exiting and this test
-// times out. These tests are deliberately not concurrent: bun test only kills
-// the processes of a timed-out test when that test is not sharing a concurrent
-// group, and that is what cleans up such a spinning child.
+// JS only runs inside a spawnSync wait through the test runner's timeout path:
+// when a test times out inside spawnSync after its callback left the stack, the
+// runner carries on with the following tests right there. So in each fixture
+// test `a` enters a spawnSync that its per-test timeout interrupts (bun test
+// kills the dangling child, which lets the spawnSync return once its loop gets
+// polled) and the following tests run inside the wait. That spawnSync holds
+// exactly one poll on the private loop, so a single misdirected release in `b`
+// makes `a` spin forever and this test time out. Not concurrent on purpose:
+// bun test only kills a timed-out test's processes when the test is not in a
+// concurrent group, and that is what cleans up a spinning inner `bun test`.
 describe.skipIf(isWindows)("refs taken on the main loop and a spawnSync wait", () => {
   async function runFixture(setup: string, insideWait: string, extraTests = "") {
     using dir = tempDir("spawnsync-loop-refs", {


### PR DESCRIPTION
### Problem
- `bun test --parallel` workers intermittently hang inside `Bun.spawnSync` of a local bun child: CI prints `Interrupted while still running: <file>` after 4 minutes, or a run of tests in one worker fails with `killed 1 dangling process` and `this test timed out after 90000ms` with empty child stdout. The files pass alone. Also reported on macOS (worker at 100% CPU, child a zombie) and reproduced locally in 3 of about 73 CI-shaped batches.
- Cause: while spawnSync waits, the VM's loop handle points at spawnSync's private loop, and every keep-alive counter released on whichever loop was current. So a ref taken on the main loop and released during the wait (GC sweeping dead objects, or the runner moving on after a timeout) came off the private loop.
- Once the private loop's count reads 0 it is never polled again, so spawnSync spins without seeing the exit. The private loop is reused, so the worker stays broken for the rest of its life.
- A second bug in the same code: the saved "previous loop handle" was one slot shared by nested spawnSync calls, so after a nested call returned the VM stayed on the private loop for good.
- Fixes #34069

### Fix
- Each of the four counters (file polls, KeepAlive refs, the timer and immediate counts, and each JS event loop's keep-alive counter) records the loop it counted on and releases on that same loop, instead of resolving the loop at release time.
- The previous loop handle is returned to the caller and lives on its stack frame, so nested spawnSync calls restore in the right order.
- The property to check: every increment and its matching decrement now hit the same loop. The handle swap itself stays, since spawnSync's own polls rely on it, and each recorded loop outlives what was counted on it (the thread's loop is freed at VM teardown after timers and the heap, the private loop after that).
- Verification: five new test cases fail on the unfixed build (the inner `bun test` spins until killed) and pass with the fix; four release one kind of ref each during a wait, and the nesting case alone still fails with only the counter fix applied. Related suites were also run and the remaining failures judged unrelated. The new tests are skipped on Windows, where three of the counters do not go through the swapped handle.

### Background
- `Bun.spawnSync` waits on a private uws loop with its own epoll/kqueue fd, not the main loop, so main-loop work such as JS timers does not run during the wait. While it waits, `vm.event_loop_handle` is repointed at that private loop so the child's pidfd and pipe polls register there.
- A uws loop tracks how many polls and refs are keeping it alive; `us_loop_run_bun_tick` returns at once without polling when that count is 0. That is why an off-by-one shows up as a busy spin, not a blocked wait.
- The four counters the diff touches: `FilePoll` (one per fd registered on a loop: pipes, pidfds, sockets), `KeepAlive` (the on/off ref used by servers, sockets, fetch, fs, dns and similar), `timer::All` (refs the loop while any JS timer or immediate is pending), and `jsc::EventLoop`'s `concurrent_ref` (refs from MessagePort, BroadcastChannel and similar, folded into a uws loop).
- JS runs inside a spawnSync wait through one path: when a bun:test test times out inside spawnSync after its callback has left the stack, the runner continues with the following tests inside the wait. The new tests use that path to release refs during a wait.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

## Problem

`bun test --parallel` workers intermittently stop inside `Bun.spawnSync` of a local bun child. In CI this is the `flaky` annotation "failed in the parallel batch ... passed alone": the batch goes quiet, the runner kills it after 4 minutes and prints `Interrupted while still running: <file> (24xs)`, and the file passes in ~100ms on its own. The victims are whatever spawn-heavy files land in the batch (napi `do.test.ts` files, `resolve.test.ts`, `child_process.test.ts`, `ctrl-c.test.ts`, `text-loader.test.ts`, `malformed-integrity-base64.test.ts`, ...), across ubuntu, debian and alpine lanes (for example builds 92307, 92340, 92426, 92160). A second shape of the same failure is a run of consecutive tests in one worker each failing with `killed 1 dangling process` + `this test timed out after 90000ms`, with the spawned child's stdout coming back empty (build 92426, `resolve.test.ts`, six in a row).

#34069 describes the same state outside our CI, on macOS (kqueue): a `bun test --parallel` (or plain `--isolate`) worker pegged at 100% CPU inside `spawnMaybeSync`, the child a zombie, the pipes already closed, `tickWithTimeout` returning immediately, and the same nested-spawnSync escalation through the bun:test timeout path once the per-test timeout fires inside the spin. The accounting below is shared by the epoll and kqueue backends, and the new tests run on both.

Reproduced locally by running CI-shaped batches (`bun test --parallel=3 --timeout=90000`, CI's `BUN_GARBAGE_COLLECTOR_LEVEL=1` environment, pinned to 4 CPUs): 3 of ~73 batches stalled or timed out the same way, and the stalled worker's main thread was busy-spinning inside `BunObject_callback_spawnSync` with its child already a zombie.

## Cause

`spawn_maybe_sync` points `vm.event_loop_handle` at spawnSync's private uws loop for the duration of the call, so that the child's pidfd and pipe polls register on that loop. Everything that maintains a loop's keep-alive bookkeeping resolved that handle at the moment it ran, so it acted on whichever loop happened to be current:

- `FilePoll::activate/deactivate` (`num_polls` and `active`, plus the epoll/kqueue fd used to register and unregister),
- `KeepAlive::ref_/unref` (`Loop::ref_/unref`), used by servers, sockets, fetch, node:fs, dns, zlib, napi async work, ...
- `timer::All::increment_timer_ref / increment_immediate_ref`, which ref the loop when the first JS timer or immediate appears and unref it when the last one goes away,
- `jsc::EventLoop::apply_concurrent_ref_delta`, which folds the `refKeepAlive` counter used by `MessagePort`, `BroadcastChannel` and `ScriptExecutionContext` into `vm.platform_loop_opt()`, immediately on every JS-thread ref/unref.

So a ref taken on the main loop and released while a spawnSync is waiting was subtracted from the private loop instead. That happens whenever teardown runs during the wait: JSC sweeping a dead `Timeout`, port or pipe reader while spawnSync allocates its result (very frequent under `--isolate` + `BUN_GARBAGE_COLLECTOR_LEVEL=1`, where the previous file's leftovers are swept during the next file), or the test runner carrying on with the following tests after a test times out inside spawnSync. The private loop is reused for every spawnSync in the process, so the error persists for the rest of the worker's life.

`us_loop_run_bun_tick` returns immediately when `loop->num_polls == 0`. With the private loop's count off by one, a pipeless spawnSync (the napi harness) starts at 0 and spins from the first tick; a piped one reaches 0 as soon as its pipes hit EOF, before the pidfd event is dispatched. Either way the wait loop spins without polling and never observes the exit. The per-test timeout still fires inside the spin: it prints `killed 1 dangling process` into the worker's captured output, and if nothing is left to close the spin continues forever (the silent 240s variant); if pipe readers are still open, closing them makes the count non-zero, the loop polls once, and spawnSync returns the long-exited child with empty stdout (the timed-out variant), leaving the count wrong for the next call, hence the consecutive failures. The main loop is left with counts that are too high, which in a plain script also keeps the process from exiting.

A second problem in the same code: `SpawnSyncEventLoop` kept the saved handle in the struct that both levels of a nested spawnSync share (the timeout path above nests), so after the inner call returned, the outer call restored the private loop's handle and the VM stayed on the private loop for good.

## Fix

Each counter records the loop it counted on and uncounts that one:

- `FilePoll` gets a `counted_loop`, used for unregister/deactivate, re-registration and the active-count adjustments (this also makes the unregister hit the epoll/kqueue instance the fd is actually registered with). Because the poll keeps the pointer, `FilePoll::register/unregister` and friends now take `*mut Loop` instead of `&mut Loop` and the callers pass the loop handle they already hold; the `&'static mut` accessor `EventLoopCtx::platform_event_loop` goes away with that.
- `KeepAlive` records the loop it ref'd. `unref_on_next_tick` keeps deferring through the pending counter when that is the thread's loop and unrefs directly otherwise, since only the thread's loop drains that counter.
- `timer::All` records the loop for each of its two counts.
- Every `jsc::EventLoop` records the uws loop it drives (`uws_loop`, previously a Windows-only field; the VM's loops get the thread's loop in `ensure_waker`, a spawnSync loop gets the private one) and folds its keep-alive counter into that.
- The handle returned by `SpawnSyncEventLoop::prepare` lives on the calling frame and is passed back to `cleanup`, so nesting restores correctly.

Why this is the right shape: the invariant that broke is "an increment and its matching decrement hit the same loop", and the handle swap itself is what spawnSync's own polls rely on to find the private loop, so the swap stays and each counter remembers its loop instead. That is independent of when or why the release happens (GC, the runner, user code), and the recorded pointers are always live when used: the thread's loop is freed by `VirtualMachine::teardown` only after timers are cancelled and the heap is destroyed (which is also when the last fold happens), and the private loop, owned by `RareData`, is freed after that. On Windows the first three counters go through the thread's loop regardless of the handle, so their new fields are `cfg(not(windows))`; the `EventLoop` counter did follow the swapped handle there too and is fixed on every platform.

## Tests

`test/js/bun/spawn/spawnsync-isolated-event-loop.test.ts` gets a block of five cases. Each runs a small file under `bun test` in which test `a` enters a spawnSync after leaving its synchronous section and times out, so the runner executes the following tests while the private loop is current. `a`'s spawnSync holds exactly one poll on the private loop, so one misdirected release is enough to make it spin forever; on the fixed build the release comes off the main loop, `a`'s (killed) child is observed, and the file finishes with everything but `a` passing.

- four cases release one ref each of a different kind inside the wait: a JS timer (`clearTimeout`), a `KeepAlive` (`Bun.serve().unref()`), a registered `FilePoll` (cancelling a subprocess's stdout), and an event-loop keep-alive ref (`BroadcastChannel.unref()`);
- the fifth nests a spawnSync inside the wait and then checks that the main loop is polled again afterwards (a child whose pidfd is registered on the main loop has its exit observed).

On the unfixed build all five fail (the inner `bun test` spins, the outer test times out and bun test kills it). On a build with the counter fixes but without the nested-handle fix, the four release cases pass and only the nesting case fails, so the cases are independent. Each case takes ~1.4s on a debug build; the block is deliberately sequential because bun test only kills a timed-out test's dangling processes when the test is not in a concurrent group, and that is what cleans up a spinning inner process on a regressed build.

Also ran the spawn, spawnSync, maxBuffer, pidfd, child_process, BroadcastChannel, MessagePort/worker, dns, macro, fs.watch, timers and setImmediate suites on the debug build, plus `bun test --parallel=3` over the CI victim files with `BUN_GARBAGE_COLLECTOR_LEVEL=1`. The failures left in those runs are unrelated to this change: network-dependent dns lookups, RSS and throughput tests over their budget under ASAN, a pre-existing LSan report in `worker-terminate-lifetime` that reproduces with a plain `require("fs")`, and container-specific process/uid cases; the ones that were checked against an unfixed debug build fail identically there.

Fixes #34069

</details>
