### PR TITLE
io: report to pipe writer parents through raw pointers, release StaticPipeWriter through its backref

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -282,12 +282,16 @@ crashes that only reproduce under load or in CI.
 If a callback may free `self` (close, error, GC finalize), do **not**
 materialize `&self`/`&mut self` at the boundary — a `&self`-derived raw
 pointer carries `SharedReadOnly` provenance, and `Box::from_raw`/dealloc
-through it is UB. Pass and dispatch off `*mut Self` until the body proves
-ownership. `src/io/PipeWriter.rs`'s `impl_streaming_writer_parent!` macro
-encodes the three modes:
+through it is UB; and any reference that is a live argument of a frame on the
+stack is protected, so releasing the last ref from inside a `&mut self` method
+(`deref(ptr::from_mut(self))`) is UB under both aliasing models even when
+nothing touches `self` afterwards. Pass and dispatch off `*mut Self` until the
+body proves ownership, do the `&mut` work through call-scoped reborrows, and
+release through the raw pointer. `src/io/PipeWriter.rs`'s
+`impl_streaming_writer_parent!` / `impl_buffered_writer_parent!` macros encode
+the two modes (there is deliberately no `&mut` mode):
 
-- `borrow = mut` — body forms `&mut *this`; safe when nothing re-enters
-- `borrow = shared` — body forms `&*this`; safe when re-entrant code only needs `&Self`
+- `borrow = shared` — body forms `&*this`; for parents whose re-entrant code only needs `&Self` and whose writer lives in a `JsCell`/`UnsafeCell`
 - `borrow = ptr` — body calls `Self::method(this, ..)` with `this: *mut Self`; required when the callback may free `self`
 
 ### `Strong` / `Weak` JS handles

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -3,7 +3,8 @@ use core::mem;
 
 use bun_collections::ByteVecExt;
 use bun_core::OOM;
-use bun_ptr::LaunderedSelf; // brings `Self::r` into scope for the writers that launder
+#[cfg(windows)]
+use bun_ptr::LaunderedSelf; // brings `Self::r` into scope for the Windows writers
 #[cfg(windows)]
 use bun_sys::ReturnCodeExt as _;
 #[cfg(windows)]
@@ -57,20 +58,33 @@ pub trait PosixPipeWriter {
     /// releases its last ref there): freeing an allocation while a reference to
     /// it is a live argument of some frame is rejected by both aliasing models,
     /// so every frame between the poll dispatch and that release holds the
-    /// writer as a raw pointer.
+    /// writer as a raw pointer. The same goes for [`on_error`](Self::on_error)
+    /// and [`register_poll`](Self::register_poll), which end in the `on_close`
+    /// a parent may free itself from.
     ///
     /// # Safety
     /// `this` must point to the live writer. After a `Drained` or `EndOfFile`
     /// report the caller must not touch `this` again; a `Pending` report leaves
     /// the writer alive (see the `*WriterParent::on_write` contracts).
     unsafe fn on_write(this: *mut Self, written: usize, status: WriteStatus);
-    /// Optional. Implement as no-op when not needed and set
-    /// `HAS_REGISTER_POLL = false`.
-    fn register_poll(&mut self);
+    /// Re-arms the poll after a `Pending` report. Optional: implement as a
+    /// no-op when not needed and set `HAS_REGISTER_POLL = false`.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer. A failed registration is reported
+    /// to the parent like a write error, after which the parent may have freed
+    /// the object embedding the writer, so the caller must not touch `this`
+    /// afterwards.
+    unsafe fn register_poll(this: *mut Self);
     const HAS_REGISTER_POLL: bool = true;
-    /// The parent's error handler may end or detach the writer but must leave
-    /// it alive: the writer closes itself right after reporting.
-    fn on_error(&mut self, err: sys::Error);
+    /// Reports a write error to the parent and closes the writer. The parent's
+    /// error handler must leave the writer alive for that close; the `on_close`
+    /// the close delivers may free the parent, and the writer with it.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer; the caller must not touch it
+    /// afterwards.
+    unsafe fn on_error(this: *mut Self, err: sys::Error);
     fn get_file_type(&self) -> FileType;
     fn get_force_sync(&self) -> bool;
 
@@ -158,8 +172,9 @@ pub trait PosixPipeWriter {
 
                 if Self::HAS_REGISTER_POLL {
                     // SAFETY: caller contract, plus the `Pending` contract on
-                    // `on_write`; the borrow is scoped to the call.
-                    unsafe { (*this).register_poll() };
+                    // `on_write`. Last use of `this`: a failed re-arm ends in
+                    // an error report.
+                    unsafe { Self::register_poll(this) };
                 }
             }
             // `Drained`: the buffer was fully written before the report. If
@@ -171,9 +186,11 @@ pub trait PosixPipeWriter {
             // SAFETY: as for `Drained`; the writer closes itself (and so may be
             // freed by its parent's `on_close`) before this returns.
             WriteResult::Done(amt) => unsafe { Self::on_write(this, amt, WriteStatus::EndOfFile) },
-            // SAFETY: caller contract; the error report leaves the writer
-            // alive (see `on_error`) and this is the last use of `this`.
-            WriteResult::Err(err) => unsafe { (*this).on_error(err) },
+            // SAFETY: caller contract. Last use of `this`: the writer closes
+            // itself after the report, and the parent may free the object
+            // embedding it from that `on_close` (the security scanner's
+            // `StaticPipeWriter` always does).
+            WriteResult::Err(err) => unsafe { Self::on_error(this, err) },
         }
     }
 
@@ -210,8 +227,18 @@ pub trait PosixPipeWriter {
 
     /// Re-derives the slice from `self.get_buffer()` each iteration.
     /// `try_write` only needs `&self`, so the shared borrow of the buffer
-    /// coexists with it, and the `&mut self` for `on_error` is taken after
-    /// the temporary slice borrow has ended — no raw-pointer escape needed.
+    /// coexists with it.
+    ///
+    /// An error with nothing drained is returned to [`on_poll`](Self::on_poll),
+    /// which reports it with nothing borrowed. An error after a partial drain
+    /// is reported from in here, under this frame's `&mut self`, and the caller
+    /// then reports the drained bytes through `on_write` as well; both of those
+    /// assume the parent does not free itself from that error's `on_close`,
+    /// which the security scanner's `StaticPipeWriter` does. Closing that gap
+    /// means changing what the partial case reports (`StaticPipeWriter`
+    /// currently relies on the trailing `on_write` to release its `start()`
+    /// ref), not how it is dispatched, so it is not part of the dispatch fixes
+    /// made here.
     fn drain_buffered_data(&mut self, max_write_size: usize, received_hup: bool) -> WriteResult {
         let _ = received_hup; // autofix
 
@@ -241,7 +268,15 @@ pub trait PosixPipeWriter {
                 }
                 WriteResult::Err(err) => {
                     if drained > 0 {
-                        self.on_error(err);
+                        // SAFETY: `self` is live; see the doc comment for why
+                        // this report is made from under this frame's borrow.
+                        // Laundered (PORT_NOTES_PLAN R-2) so the close inside
+                        // sees what the parent's handler wrote re-entrantly
+                        // rather than values cached under this `noalias`
+                        // receiver.
+                        unsafe {
+                            Self::on_error(core::hint::black_box(core::ptr::from_mut(self)), err)
+                        };
                         return WriteResult::Wrote(drained);
                     } else {
                         return WriteResult::Err(err);
@@ -311,6 +346,13 @@ pub trait PosixBufferedWriterParent {
     /// `this` must point to a live `Self`.
     unsafe fn on_error(this: *mut Self, err: sys::Error);
     const HAS_ON_CLOSE: bool;
+    /// The writer's last access to itself on every path that reaches this (a
+    /// report from the poll, an error, or the parent's own `close()`), so the
+    /// parent may release its last ref from here. On the `close()` path the
+    /// caller's `&mut` to the writer is still live, so the parent, and whatever
+    /// it calls from here (an owner's `on_close_io`), must not form references
+    /// that cover the writer; reach the allocation's other fields by projection.
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_close(_this: *mut Self) {}
@@ -357,11 +399,15 @@ impl<Parent: PosixBufferedWriterParent> PosixPipeWriter for PosixBufferedWriter<
         // SAFETY: forwarded caller contract.
         unsafe { Self::_on_write(this, written, status) }
     }
-    fn register_poll(&mut self) {
-        Self::register_poll(self);
+    unsafe fn register_poll(this: *mut Self) {
+        // SAFETY: caller contract. This writer's registration failure is only
+        // reported (`Parent::on_error`, which must leave the parent alive); it
+        // does not close, so nothing can be freed while the borrow is live.
+        unsafe { (*this).register_poll() }
     }
-    fn on_error(&mut self, err: sys::Error) {
-        self._on_error(err);
+    unsafe fn on_error(this: *mut Self, err: sys::Error) {
+        // SAFETY: forwarded caller contract.
+        unsafe { Self::_on_error(this, err) }
     }
     fn get_file_type(&self) -> FileType {
         Self::get_file_type(self)
@@ -435,12 +481,23 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         self.handle.get_fd()
     }
 
-    fn _on_error(&mut self, err: sys::Error) {
+    /// Raw like [`_on_write`](Self::_on_write): the error report must leave
+    /// the parent alive (`PosixBufferedWriterParent::on_error`), but the
+    /// `on_close` that [`close_raw`](Self::close_raw) delivers right after it
+    /// may free the parent, and `*this` with it, so neither dispatch runs with
+    /// a borrow of `*this` live.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer; it may be freed when this returns.
+    unsafe fn _on_error(this: *mut Self, err: sys::Error) {
         debug_assert!(!err.is_retry());
 
-        self.parent_on_error(err);
-
-        self.close();
+        // SAFETY: caller contract; the borrow ends at the `;`.
+        let parent = unsafe { (*this).parent() };
+        // SAFETY: parent BACKREF valid.
+        unsafe { Parent::on_error(parent, err) };
+        // SAFETY: caller contract; last use of `this`.
+        unsafe { Self::close_raw(this) };
     }
 
     /// Raw (not `&mut self`): `Parent::on_write` re-enters this writer through
@@ -466,28 +523,39 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         unsafe { Parent::on_write(parent, written, status) };
         if eof {
             // SAFETY: the `EndOfFile` contract on `PosixBufferedWriterParent::
-            // on_write` keeps `*this` alive until here.
-            unsafe { Self::report_close(this) };
+            // on_write` keeps `*this` alive until here; this delivers the
+            // `on_close` deferred by `close_without_reporting` above.
+            unsafe { Self::close_raw(this) };
         }
     }
 
-    /// Delivers the `on_close` that [`close_without_reporting`](Self::
-    /// close_without_reporting) deferred, unless the parent's `on_write` already
-    /// had it delivered by calling [`close`](Self::close) itself. Raw like
-    /// [`_on_write`](Self::_on_write): the parent may release its last ref from
-    /// `on_close` and free itself, `*this` with it, so the dispatch holds no
-    /// borrow of `*this` and is the last use of `this`.
+    /// Closes the handle (unless that already happened without reporting) and
+    /// delivers `on_close` for a handle that was open. The parent may release
+    /// its last ref from `on_close` and free itself, `*this` with it, so the
+    /// handle is closed through a statement-scoped borrow first and the report
+    /// is dispatched with nothing borrowed, as the last use of `this`.
+    /// [`close`](Self::close) is this for callers that themselves keep the
+    /// parent alive across the call.
     ///
     /// # Safety
-    /// `this` must point to the live writer.
-    unsafe fn report_close(this: *mut Self) {
+    /// `this` must point to the live writer; it may be freed when this returns.
+    unsafe fn close_raw(this: *mut Self) {
         if !Parent::HAS_ON_CLOSE {
             return;
         }
         // SAFETY: caller contract; borrows end at each `;`.
         let parent = unsafe {
             if !mem::replace(&mut (*this).closed_without_reporting, false) {
-                return;
+                // `close_impl` would only report for a handle that is still
+                // open; close it without a callback and report below instead.
+                let was_open = (*this).get_fd() != Fd::INVALID;
+                let close_fd = (*this).close_fd;
+                (*this)
+                    .handle
+                    .close_impl(None, None::<fn(*mut c_void)>, close_fd);
+                if !was_open {
+                    return;
+                }
             }
             (*this).parent()
         };
@@ -540,22 +608,15 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         }
     }
 
+    /// For the parent's own code paths (and `end()`): the `on_close` this
+    /// delivers runs while the caller's `&mut` to this writer is live, so such
+    /// callers have to be holding the parent alive across the call (the owners
+    /// of `StaticPipeWriter` claim its `start()` ref before closing it for that
+    /// reason). The poll chain uses [`close_raw`](Self::close_raw) directly.
     pub fn close(&mut self) {
-        if Parent::HAS_ON_CLOSE {
-            if self.closed_without_reporting {
-                self.closed_without_reporting = false;
-                // SAFETY: parent BACKREF valid.
-                unsafe { Parent::on_close(self.parent()) };
-            } else {
-                let parent = self.parent();
-                self.handle.close_impl(
-                    Some(parent.cast()),
-                    // SAFETY: parent was set via set_parent with a *mut Parent.
-                    Some(|ctx: *mut c_void| unsafe { Parent::on_close(ctx.cast::<Parent>()) }),
-                    self.close_fd,
-                );
-            }
-        }
+        // SAFETY: `self` is live; the caller keeps its allocation alive across
+        // the call (see above).
+        unsafe { Self::close_raw(core::ptr::from_mut(self)) }
     }
 
     pub fn update_ref(&self, event_loop: EventLoopHandle, value: bool) {
@@ -657,6 +718,12 @@ pub trait PosixStreamingWriterParent {
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_ready(_this: *mut Self) {}
+    /// The writer's last access to itself on every path that reaches this (an
+    /// error or a failed re-arm from the poll, or the parent's own `close()`),
+    /// so the parent may release its last ref from here. On the `close()` path
+    /// the caller's `&mut` to the writer is still live, so the parent must not
+    /// form references that cover the writer from in here.
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_close(this: *mut Self);
@@ -704,11 +771,13 @@ impl<Parent: PosixStreamingWriterParent> PosixPipeWriter for PosixStreamingWrite
         // SAFETY: forwarded caller contract.
         unsafe { Self::_on_write(this, written, status) }
     }
-    fn register_poll(&mut self) {
-        Self::register_poll(self);
+    unsafe fn register_poll(this: *mut Self) {
+        // SAFETY: forwarded caller contract.
+        unsafe { Self::register_poll_raw(this) }
     }
-    fn on_error(&mut self, err: sys::Error) {
-        self._on_error(err);
+    unsafe fn on_error(this: *mut Self, err: sys::Error) {
+        // SAFETY: forwarded caller contract.
+        unsafe { Self::_on_error(this, err) }
     }
     fn get_file_type(&self) -> FileType {
         Self::get_file_type(self)
@@ -719,15 +788,6 @@ impl<Parent: PosixStreamingWriterParent> PosixPipeWriter for PosixStreamingWrite
     fn handle(&self) -> &PollOrFd {
         &self.handle
     }
-}
-
-// SAFETY: writer is an intrusive field of `Parent`. The one laundered site is
-// `register_poll`'s error arm, and the `Parent::on_error` it spans may end the
-// writer but must leave it alive (`PosixStreamingWriterParent::on_error`);
-// single JS thread.
-unsafe impl<Parent: PosixStreamingWriterParent> bun_ptr::LaunderedSelf
-    for PosixStreamingWriter<Parent>
-{
 }
 
 impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
@@ -817,16 +877,32 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.outgoing.slice()
     }
 
-    fn _on_error(&mut self, err: sys::Error) {
+    /// Raw like [`_on_write`](Self::_on_write): the error report must leave
+    /// the parent alive (`PosixStreamingWriterParent::on_error`), but the
+    /// `on_close` that [`close_raw`](Self::close_raw) delivers right after it
+    /// may free the parent (`FileSink` drops its keep-alive ref there), and
+    /// `*this` with it, so neither dispatch runs with a borrow of `*this` live.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer; it may be freed when this returns.
+    unsafe fn _on_error(this: *mut Self, err: sys::Error) {
         debug_assert!(!err.is_retry());
 
+        // SAFETY: caller contract; the borrow ends when `fail` returns.
+        let parent = unsafe { (*this).fail() };
+        // SAFETY: parent BACKREF valid.
+        unsafe { Parent::on_error(parent, err) };
+        // SAFETY: caller contract; last use of `this`.
+        unsafe { Self::close_raw(this) };
+    }
+
+    /// Tears the writer down after a write error; returns the parent to report
+    /// to.
+    fn fail(&mut self) -> *mut Parent {
         self.close_without_reporting();
         self.is_done = true;
         self.outgoing.reset();
-
-        // SAFETY: parent BACKREF set via set_parent; outlives this writer.
-        unsafe { Parent::on_error(self.parent(), err) };
-        self.close();
+        self.parent()
     }
 
     /// Poll-path report. Raw (not `&mut self`): per the contract on
@@ -880,27 +956,48 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         }
     }
 
+    /// Write-path form of [`register_poll_raw`](Self::register_poll_raw): the
+    /// caller is the parent's own `write*()`, so the parent outlives the error
+    /// dispatch. The pointer is laundered (PORT_NOTES_PLAN R-2) because
+    /// `Parent::on_error` (e.g. `FileSink::on_error`) may re-enter and write
+    /// `is_done` / `handle` through the parent's field, and the close that
+    /// follows has to see that rather than values cached under this receiver's
+    /// `noalias`.
     fn register_poll(&mut self) {
-        let Some(poll) = self.get_poll() else { return };
+        // SAFETY: `self` is live, and the parent is on the stack below us.
+        unsafe { Self::register_poll_raw(core::hint::black_box(core::ptr::from_mut(self))) }
+    }
+
+    /// Arms the poll; a failed registration is reported like a write error,
+    /// after which the writer closes itself. Raw like [`_on_error`](Self::
+    /// _on_error): the report must leave the parent alive, but the `on_close`
+    /// delivered by [`close_raw`](Self::close_raw) may free it, and `*this`
+    /// with it, so neither dispatch runs with a borrow of `*this` live.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer; it may be freed when this returns.
+    unsafe fn register_poll_raw(this: *mut Self) {
+        // SAFETY: caller contract; the borrow ends when `try_register_poll`
+        // returns.
+        let err = match unsafe { (*this).try_register_poll() } {
+            sys::Result::Ok(()) => return,
+            sys::Result::Err(err) => err,
+        };
+        // SAFETY: caller contract; the borrow ends at the `;`.
+        let parent = unsafe { (*this).parent() };
+        // SAFETY: parent BACKREF valid.
+        unsafe { Parent::on_error(parent, err) };
+        // SAFETY: caller contract; last use of `this`.
+        unsafe { Self::close_raw(this) };
+    }
+
+    fn try_register_poll(&self) -> sys::Result<()> {
+        let Some(poll) = self.get_poll() else {
+            return sys::Result::Ok(());
+        };
         // SAFETY: parent BACKREF set via set_parent; outlives this writer.
         let loop_ = unsafe { Parent::loop_(self.parent()) }.cast();
-        match poll.register_with_fd(loop_, FilePollKind::Writable, poll.fd()) {
-            sys::Result::Err(err) => {
-                // PORT_NOTES_PLAN R-2: `&mut self` carries LLVM `noalias`, but
-                // `Parent::on_error` (e.g. `FileSink::on_error`) re-enters via
-                // a fresh `&mut Self` from the parent's intrusive `writer`
-                // field and may write `self.is_done` / `self.handle`.
-                // ASM-verified PROVEN_CACHED on the `self.close()` path's
-                // field reads. Launder so `close()` sees fresh state.
-                let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
-                // SAFETY: parent BACKREF valid.
-                unsafe { Parent::on_error(Self::r(this).parent(), err) };
-                // `this` is still live (parent owns this writer; an on_error
-                // handler may end/detach but never frees mid-call).
-                Self::r(this).close();
-            }
-            sys::Result::Ok(()) => {}
-        }
+        poll.register_with_fd(loop_, FilePollKind::Writable, poll.fd())
     }
 
     pub fn write_utf16(&mut self, buf: &[u16]) -> WriteResult {
@@ -1128,21 +1225,43 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.close();
     }
 
+    /// For the parent's own code paths (`end()`, `start()`, `FileSink`'s
+    /// handlers): the `on_close` this delivers runs while the caller's `&mut`
+    /// to this writer is live, so such callers have to be holding the parent
+    /// alive across the call (`FileSink` holds a guard ref in its handlers).
+    /// The poll chain uses [`close_raw`](Self::close_raw) directly.
     pub fn close(&mut self) {
-        if self.closed_without_reporting {
-            self.closed_without_reporting = false;
-            debug_assert!(self.get_fd() == Fd::INVALID);
-            // SAFETY: parent BACKREF valid.
-            unsafe { Parent::on_close(self.parent()) };
-            return;
-        }
+        // SAFETY: `self` is live; the caller keeps its allocation alive across
+        // the call (see above).
+        unsafe { Self::close_raw(core::ptr::from_mut(self)) }
+    }
 
-        let parent = self.parent;
-        self.handle.close(
-            Some(parent.cast()),
-            // SAFETY: parent was set via set_parent with a *mut Parent.
-            Some(|ctx: *mut c_void| unsafe { Parent::on_close(ctx.cast::<Parent>()) }),
-        );
+    /// Closes the handle (unless that already happened without reporting) and
+    /// delivers `on_close` for a handle that was open. The parent may release
+    /// its last ref from `on_close` and free itself, `*this` with it, so the
+    /// handle is closed through a statement-scoped borrow first and the report
+    /// is dispatched with nothing borrowed, as the last use of `this`.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer; it may be freed when this returns.
+    unsafe fn close_raw(this: *mut Self) {
+        // SAFETY: caller contract; borrows end at each `;`.
+        let parent = unsafe {
+            if mem::replace(&mut (*this).closed_without_reporting, false) {
+                debug_assert!((*this).get_fd() == Fd::INVALID);
+            } else {
+                // `PollOrFd::close` would only report for a handle that is
+                // still open; close it without a callback and report below.
+                let was_open = (*this).get_fd() != Fd::INVALID;
+                (*this).handle.close(None, None::<fn(*mut c_void)>);
+                if !was_open {
+                    return;
+                }
+            }
+            (*this).parent()
+        };
+        // SAFETY: parent BACKREF valid; no borrow of `*this` is live.
+        unsafe { Parent::on_close(parent) };
     }
 
     pub fn start(&mut self, fd: Fd, is_pollable: bool) -> sys::Result<()> {

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -3,7 +3,7 @@ use core::mem;
 
 use bun_collections::ByteVecExt;
 use bun_core::OOM;
-use bun_ptr::LaunderedSelf; // brings `Self::r` into scope for all 4 writers
+use bun_ptr::LaunderedSelf; // brings `Self::r` into scope for the writers that launder
 #[cfg(windows)]
 use bun_sys::ReturnCodeExt as _;
 #[cfg(windows)]
@@ -50,11 +50,26 @@ pub enum WriteStatus {
 pub trait PosixPipeWriter {
     fn get_fd(&self) -> Fd;
     fn get_buffer(&self) -> &[u8];
-    fn on_write(&mut self, written: usize, status: WriteStatus);
+    /// Reports the outcome of a poll-driven drain to the parent.
+    ///
+    /// Raw rather than `&mut self` because the writer is a field of its parent
+    /// and a `Drained` report may free the parent (`StaticPipeWriter::on_write`
+    /// releases its last ref there): freeing an allocation while a reference to
+    /// it is a live argument of some frame is rejected by both aliasing models,
+    /// so every frame between the poll dispatch and that release holds the
+    /// writer as a raw pointer.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer. After a `Drained` or `EndOfFile`
+    /// report the caller must not touch `this` again; a `Pending` report leaves
+    /// the writer alive (see the `*WriterParent::on_write` contracts).
+    unsafe fn on_write(this: *mut Self, written: usize, status: WriteStatus);
     /// Optional. Implement as no-op when not needed and set
     /// `HAS_REGISTER_POLL = false`.
     fn register_poll(&mut self);
     const HAS_REGISTER_POLL: bool = true;
+    /// The parent's error handler may end or detach the writer but must leave
+    /// it alive: the writer closes itself right after reporting.
     fn on_error(&mut self, err: sys::Error);
     fn get_file_type(&self) -> FileType;
     fn get_force_sync(&self) -> bool;
@@ -119,8 +134,52 @@ pub trait PosixPipeWriter {
         WriteResult::Wrote(offset)
     }
 
-    fn on_poll(&mut self, size_hint: isize, received_hup: bool) {
-        // reshaped for borrowck — capture buffer.len() before further &mut self calls.
+    /// Poll-dispatch entry (`__bun_run_file_poll`). Raw for the reason given on
+    /// [`on_write`](Self::on_write): the `&mut` work is confined to
+    /// [`drain_on_poll`](Self::drain_on_poll), and the reports below run with
+    /// no borrow of `*this` live.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer registered as the poll's owner.
+    unsafe fn on_poll(this: *mut Self, size_hint: isize, received_hup: bool) {
+        // SAFETY: caller contract; the borrow ends when `drain_on_poll` returns.
+        let Some(result) = (unsafe { (*this).drain_on_poll(size_hint, received_hup) }) else {
+            return;
+        };
+
+        match result {
+            WriteResult::Pending(wrote) => {
+                // Bytes are still buffered, so the parent keeps the writer
+                // alive and it gets re-armed.
+                if wrote > 0 {
+                    // SAFETY: caller contract.
+                    unsafe { Self::on_write(this, wrote, WriteStatus::Pending) };
+                }
+
+                if Self::HAS_REGISTER_POLL {
+                    // SAFETY: caller contract, plus the `Pending` contract on
+                    // `on_write`; the borrow is scoped to the call.
+                    unsafe { (*this).register_poll() };
+                }
+            }
+            // `Drained`: the buffer was fully written before the report. If
+            // the parent buffers more data via `write()`, that path already
+            // calls `register_poll()`.
+            // SAFETY: caller contract. Last use of `this`: the parent may free
+            // the object embedding the writer from inside this report.
+            WriteResult::Wrote(amt) => unsafe { Self::on_write(this, amt, WriteStatus::Drained) },
+            // SAFETY: as for `Drained`; the writer closes itself (and so may be
+            // freed by its parent's `on_close`) before this returns.
+            WriteResult::Done(amt) => unsafe { Self::on_write(this, amt, WriteStatus::EndOfFile) },
+            // SAFETY: caller contract; the error report leaves the writer
+            // alive (see `on_error`) and this is the last use of `this`.
+            WriteResult::Err(err) => unsafe { (*this).on_error(err) },
+        }
+    }
+
+    /// The `&mut` half of [`on_poll`](Self::on_poll): attempts the write and
+    /// returns what to report, or `None` when there is nothing to do.
+    fn drain_on_poll(&mut self, size_hint: isize, received_hup: bool) -> Option<WriteResult> {
         let buffer_len = self.get_buffer().len();
         log!("onPoll({})", buffer_len);
         if buffer_len == 0 && !received_hup {
@@ -137,7 +196,7 @@ pub trait PosixPipeWriter {
                     poll.is_registered()
                 );
             }
-            return;
+            return None;
         }
 
         let max_write = if size_hint > 0 && self.get_file_type().is_blocking() {
@@ -146,33 +205,7 @@ pub trait PosixPipeWriter {
             usize::MAX
         };
 
-        match self.drain_buffered_data(max_write, received_hup) {
-            WriteResult::Pending(wrote) => {
-                if wrote > 0 {
-                    self.on_write(wrote, WriteStatus::Pending);
-                }
-
-                if Self::HAS_REGISTER_POLL {
-                    self.register_poll();
-                }
-            }
-            WriteResult::Wrote(amt) => {
-                // `.drained`: the buffer was fully written before the
-                // callback. If the callback buffers more data via
-                // `write()`, that path already calls `register_poll()`.
-                // Don't touch `self` after the callback returns — the
-                // `.drained` callback is allowed to close/free the writer
-                // (e.g. `FileSink.onWrite` → `writer.end()` → `onClose`
-                // may drop the last ref).
-                self.on_write(amt, WriteStatus::Drained);
-            }
-            WriteResult::Err(err) => {
-                self.on_error(err);
-            }
-            WriteResult::Done(amt) => {
-                self.on_write(amt, WriteStatus::EndOfFile);
-            }
-        }
+        Some(self.drain_buffered_data(max_write, received_hup))
     }
 
     /// Re-derives the slice from `self.get_buffer()` each iteration.
@@ -258,9 +291,22 @@ pub trait PosixBufferedWriterParent {
     /// per-tag dispatch in `bun_runtime::dispatch::__bun_run_file_poll`
     /// recovers `*mut PosixBufferedWriter<Self>` from this.
     const POLL_OWNER_TAG: PollTag;
+    /// Dispatched with no borrow of the writer live. On `Drained` the parent
+    /// may release its last ref and free itself (the writer with it); the
+    /// writer touches nothing afterwards. On `Pending` the writer re-arms its
+    /// poll afterwards, so the parent must stay alive. On `EndOfFile` the
+    /// writer has already closed the fd and delivers `on_close` (again with no
+    /// borrow live, and as its last access) once this returns, so the parent
+    /// must stay alive through the report itself and may free itself from that
+    /// `on_close`.
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus);
+    /// Must leave `*this` alive: the writer closes itself right after this
+    /// returns (and, on a partially drained buffer, still reports the drained
+    /// bytes through `on_write`).
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_error(this: *mut Self, err: sys::Error);
@@ -307,8 +353,9 @@ impl<Parent: PosixBufferedWriterParent> PosixPipeWriter for PosixBufferedWriter<
     fn get_buffer(&self) -> &[u8] {
         self.get_buffer_internal()
     }
-    fn on_write(&mut self, written: usize, status: WriteStatus) {
-        self._on_write(written, status);
+    unsafe fn on_write(this: *mut Self, written: usize, status: WriteStatus) {
+        // SAFETY: forwarded caller contract.
+        unsafe { Self::_on_write(this, written, status) }
     }
     fn register_poll(&mut self) {
         Self::register_poll(self);
@@ -325,13 +372,6 @@ impl<Parent: PosixBufferedWriterParent> PosixPipeWriter for PosixBufferedWriter<
     fn handle(&self) -> &PollOrFd {
         &self.handle
     }
-}
-
-// SAFETY: writer is an intrusive field of `Parent`; `Parent::on_write`
-// re-entry writes `is_done`/`handle` but never frees it; single JS thread.
-unsafe impl<Parent: PosixBufferedWriterParent> bun_ptr::LaunderedSelf
-    for PosixBufferedWriter<Parent>
-{
 }
 
 impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
@@ -403,33 +443,56 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         self.close();
     }
 
-    fn _on_write(&mut self, written: usize, status: WriteStatus) {
-        // PORT_NOTES_PLAN R-2: `&mut self` carries LLVM `noalias`, but
-        // `Parent::on_write` (e.g. `IOWriter::on_write`) re-enters via a fresh
-        // `&mut Self` from the parent's intrusive `writer` field and may write
-        // `self.handle` / `self.is_done`. ASM-verified PROVEN_CACHED in the
-        // `IOWriter` monomorphization: `self.handle.{tag,poll,fd}` were loaded
-        // once, spilled to `[rbp-48/-120/-44]`, and reused by the trailing
-        // `self.close()` without reload. Launder so post-call accesses see
-        // fresh state.
-        let this: *mut Self = core::hint::black_box(core::ptr::from_mut(self));
-        let was_done = Self::r(this).is_done;
-        let parent = Self::r(this).parent();
+    /// Raw (not `&mut self`): `Parent::on_write` re-enters this writer through
+    /// the parent's field (`close()`, `register_poll()`), and the parent may
+    /// free itself, and `*this` inside it, from a `Drained` report or from the
+    /// `on_close` that follows an `EndOfFile` one; see the contract on
+    /// [`PosixBufferedWriterParent::on_write`]. Every borrow of `*this` here is
+    /// scoped to one statement, and none is live across either dispatch.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer.
+    unsafe fn _on_write(this: *mut Self, written: usize, status: WriteStatus) {
+        // SAFETY: caller contract; borrows end at each `;`.
+        let (parent, eof) = unsafe {
+            let eof = status == WriteStatus::EndOfFile && !(*this).is_done;
+            if eof {
+                (*this).close_without_reporting();
+            }
+            ((*this).parent(), eof)
+        };
 
-        if status == WriteStatus::EndOfFile && !was_done {
-            Self::r(this).close_without_reporting();
-        }
-
-        // SAFETY: parent BACKREF valid.
+        // SAFETY: parent BACKREF valid; no borrow of `*this` is live.
         unsafe { Parent::on_write(parent, written, status) };
-        // Re-escape so the trailing `close()` cannot reuse the spilled
-        // `self.handle` from before `on_write`.
-        core::hint::black_box(this);
-        if status == WriteStatus::EndOfFile && !was_done {
-            // `close()` reads `is_done`/`handle` which may have been written
-            // re-entrantly above; `r()` reborrows fresh from the laundered ptr.
-            Self::r(this).close();
+        if eof {
+            // SAFETY: the `EndOfFile` contract on `PosixBufferedWriterParent::
+            // on_write` keeps `*this` alive until here.
+            unsafe { Self::report_close(this) };
         }
+    }
+
+    /// Delivers the `on_close` that [`close_without_reporting`](Self::
+    /// close_without_reporting) deferred, unless the parent's `on_write` already
+    /// had it delivered by calling [`close`](Self::close) itself. Raw like
+    /// [`_on_write`](Self::_on_write): the parent may release its last ref from
+    /// `on_close` and free itself, `*this` with it, so the dispatch holds no
+    /// borrow of `*this` and is the last use of `this`.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer.
+    unsafe fn report_close(this: *mut Self) {
+        if !Parent::HAS_ON_CLOSE {
+            return;
+        }
+        // SAFETY: caller contract; borrows end at each `;`.
+        let parent = unsafe {
+            if !mem::replace(&mut (*this).closed_without_reporting, false) {
+                return;
+            }
+            (*this).parent()
+        };
+        // SAFETY: parent BACKREF valid; no borrow of `*this` is live.
+        unsafe { Parent::on_close(parent) };
     }
 
     pub fn register_poll(&mut self) {
@@ -572,9 +635,21 @@ pub trait PosixStreamingWriterParent {
     /// per-tag dispatch in `bun_runtime::dispatch::__bun_run_file_poll`
     /// recovers `*mut PosixStreamingWriter<Self>` from this.
     const POLL_OWNER_TAG: PollTag;
+    /// From the poll (`PosixPipeWriter::on_poll`) this is dispatched with no
+    /// borrow of the writer live, and a `Drained` or `EndOfFile` report is the
+    /// writer's last access to itself, so the parent may release its last ref
+    /// there (e.g. `FileSink::on_write` ending the sink) and free itself, the
+    /// writer with it. After a `Pending` report the writer re-arms its poll, so
+    /// the parent must stay alive. Reports made from the parent's own `write()`
+    /// calls run while the parent is on the stack and may be followed by a
+    /// re-arm as well.
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus);
+    /// Must leave `*this` alive: the writer closes itself right after this
+    /// returns.
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_error(this: *mut Self, err: sys::Error);
@@ -625,8 +700,9 @@ impl<Parent: PosixStreamingWriterParent> PosixPipeWriter for PosixStreamingWrite
     fn get_buffer(&self) -> &[u8] {
         self.outgoing.slice()
     }
-    fn on_write(&mut self, written: usize, status: WriteStatus) {
-        self._on_write(written, status);
+    unsafe fn on_write(this: *mut Self, written: usize, status: WriteStatus) {
+        // SAFETY: forwarded caller contract.
+        unsafe { Self::_on_write(this, written, status) }
     }
     fn register_poll(&mut self) {
         Self::register_poll(self);
@@ -645,7 +721,10 @@ impl<Parent: PosixStreamingWriterParent> PosixPipeWriter for PosixStreamingWrite
     }
 }
 
-// SAFETY: see `PosixBufferedWriter`'s `LaunderedSelf` impl — identical shape.
+// SAFETY: writer is an intrusive field of `Parent`. The one laundered site is
+// `register_poll`'s error arm, and the `Parent::on_error` it spans may end the
+// writer but must leave it alive (`PosixStreamingWriterParent::on_error`);
+// single JS thread.
 unsafe impl<Parent: PosixStreamingWriterParent> bun_ptr::LaunderedSelf
     for PosixStreamingWriter<Parent>
 {
@@ -669,24 +748,32 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.parent
     }
 
-    /// Single nonnull-asref dispatch for the set-once `parent` backref.
+    /// Records what is about to be reported and returns the parent to report
+    /// it to.
     ///
     /// Type invariant (encapsulated `unsafe`): `self.parent` is populated by
     /// [`set_parent`](Self::set_parent) before any write path is reached, and
     /// the writer is an intrusive field of `*parent` so the pointee strictly
-    /// outlives `self`. Collapses the N identical
-    /// `unsafe { Parent::on_write(self.parent(), ..) }` blocks (one per
-    /// `WriteResult` arm) into one. `on_write` may re-enter via the parent's
-    /// intrusive `writer` field; callers that read `self` afterwards must
-    /// launder (R-2 noalias) — the existing laundered sites in `_on_write` /
-    /// `register_poll` keep their raw-pointer dispatch and do **not** route
-    /// through this accessor.
+    /// outlives `self`.
     #[inline]
-    fn parent_on_write(&self, amount: usize, status: WriteStatus) {
+    fn report_target(&self, status: WriteStatus) -> *mut Parent {
         // on_write may re-enter write(); record first so re-entry leaves the newer value.
         self.backed_up.set(status == WriteStatus::Pending);
-        // SAFETY: type invariant — set-once parent backref outlives writer.
-        unsafe { Parent::on_write(self.parent(), amount, status) }
+        self.parent()
+    }
+
+    /// `Parent::on_write` for the synchronous `write*()` paths, whose caller is
+    /// the parent itself (so it is alive for the duration; see the contract on
+    /// [`PosixStreamingWriterParent::on_write`]). The poll path reports through
+    /// [`_on_write`](Self::_on_write) instead, which holds no borrow of the
+    /// writer across the report. Collapses the N identical
+    /// `unsafe { Parent::on_write(self.parent(), ..) }` blocks (one per
+    /// `WriteResult` arm) into one.
+    #[inline]
+    fn parent_on_write(&self, amount: usize, status: WriteStatus) {
+        let parent = self.report_target(status);
+        // SAFETY: `report_target`'s type invariant.
+        unsafe { Parent::on_write(parent, amount, status) }
     }
 
     pub fn memory_cost(&self) -> usize {
@@ -742,7 +829,24 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.close();
     }
 
-    fn _on_write(&mut self, written: usize, status: WriteStatus) {
+    /// Poll-path report. Raw (not `&mut self`): per the contract on
+    /// [`PosixStreamingWriterParent::on_write`] the report may free the parent,
+    /// and `*this` inside it, so the bookkeeping borrow ends in
+    /// [`consume_written`](Self::consume_written) and nothing here touches
+    /// `this` once the parent has been called.
+    ///
+    /// # Safety
+    /// `this` must point to the live writer.
+    unsafe fn _on_write(this: *mut Self, written: usize, status: WriteStatus) {
+        // SAFETY: caller contract; the borrow ends when `consume_written` returns.
+        let parent = unsafe { (*this).consume_written(written, status) };
+        // SAFETY: `report_target`'s type invariant; no borrow of `*this` is
+        // live, and this is the last use of `this`.
+        unsafe { Parent::on_write(parent, written, status) };
+    }
+
+    /// Bookkeeping for bytes the poll wrote; returns the parent to report to.
+    fn consume_written(&mut self, written: usize, status: WriteStatus) -> *mut Parent {
         self.outgoing.wrote(written);
 
         if status == WriteStatus::EndOfFile && !self.is_done {
@@ -757,7 +861,7 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
             self.outgoing.list.clear();
         }
 
-        self.parent_on_write(written, status);
+        self.report_target(status)
     }
 
     pub fn set_parent(&mut self, parent: *mut Parent) {
@@ -2562,24 +2666,33 @@ pub type StreamingWriter<P> = WindowsStreamingWriter<P>;
 // (POSIX + WindowsWriterParent + Windows{Streaming,Buffered}WriterParent),
 // differing only in:
 //   (a) the inherent-method names the vtable forwards to,
-//   (b) how the callback is dispatched off `*mut Self` — as `&mut`, `&`, or
-//       a raw-ptr method call (re-entrancy under Stacked/Tree Borrows — see
+//   (b) how the callback is dispatched off `*mut Self` — as `&` or as a
+//       raw-ptr call (re-entrancy under Stacked/Tree Borrows — see the
 //       `borrow = shared` / `borrow = ptr` callers),
 //   (c) the `event_loop` / `loop_` / refcount accessor expressions.
 // These macros stamp that triple once per parent.
 //
-// `borrow = mut`    → bodies form `&mut *this` (unique access for the
-//                     callback's duration; the writer never holds
-//                     `&mut Parent` itself).
 // `borrow = shared` → bodies form `&*this` (callback may re-enter JS or
 //                     `enqueue(&self)` and observe a fresh `&Self`; aliased
-//                     `&Self` is sound where `&mut Self` is not).
+//                     `&Self` is sound where `&mut Self` is not). Requires the
+//                     parent to keep its writer in a `JsCell`/`UnsafeCell`:
+//                     the callback runs underneath the writer's own frames,
+//                     and a plain `&Parent` would cover the writer's bytes too.
 // `borrow = ptr`    → bodies call `Self::method(this, ..)` — no reference is
-//                     materialized at the boundary; for parents that must
-//                     keep full write/dealloc provenance through a re-entrant,
-//                     freeing callback (the callback may run `Box::from_raw`
-//                     on `this`, so a `&self`-derived ptr would carry only
-//                     SharedReadOnly provenance and dealloc through it is UB).
+//                     materialized at the boundary. Required when a callback
+//                     can release the parent's last ref: a reference argument
+//                     is protected for the duration of the call, and both
+//                     aliasing models reject freeing the allocation it points
+//                     into while it is live (besides which a `&self`-derived
+//                     pointer carries no dealloc provenance). The parent's
+//                     handlers take `this: *mut Self` and do their `&mut` work
+//                     through call-scoped reborrows, releasing through `this`.
+//
+// There is deliberately no `&mut` mode: a `&mut Parent` formed here would
+// assert unique access to the whole parent, writer field included, while the
+// writer that is making the call may itself be borrowed further up the stack,
+// and it would be protected across the very callback that may free it. See
+// test/internal/source-lints/writer-parent-mut-borrow.test.ts.
 //
 // Accessor args use closure-literal syntax (`|this| expr`) purely as a binder
 // for the macro — no actual closure is created; `expr` is pasted into an
@@ -2600,7 +2713,6 @@ pub mod __parent_macro {
 #[macro_export]
 macro_rules! impl_streaming_writer_parent {
     // Internal: dispatch a callback off the raw-ptr backref per `borrow` mode.
-    (@call mut    $p:expr; $m:ident($($a:tt)*)) => { (&mut *$p).$m($($a)*) };
     (@call shared $p:expr; $m:ident($($a:tt)*)) => { (&*$p).$m($($a)*) };
     (@call ptr    $p:expr; $m:ident($($a:tt)*)) => { <Self>::$m($p, $($a)*) };
 
@@ -2627,9 +2739,9 @@ macro_rules! impl_streaming_writer_parent {
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: `this` is the BACKREF set via `set_parent`; the
                 // StreamingWriter never materializes `&mut Parent`. The handler
-                // is dispatched per the `borrow` mode (`mut`/`shared`/`ptr` —
-                // see the module comment); `ptr` keeps full write/dealloc
-                // provenance through re-entrant, freeing callbacks.
+                // is dispatched per the `borrow` mode (`shared`/`ptr` — see the
+                // module comment); `ptr` keeps full write/dealloc provenance
+                // through re-entrant, freeing callbacks.
                 unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_write(amount, status)) }
             }
             #[inline]
@@ -2738,8 +2850,9 @@ macro_rules! impl_streaming_writer_parent {
 /// `WindowsBufferedWriterParent` for a parent type. See module comment above.
 #[macro_export]
 macro_rules! impl_buffered_writer_parent {
-    (@borrow mut    $p:expr) => { &mut *$p };
-    (@borrow shared $p:expr) => { &*$p };
+    // Internal: dispatch a callback off the raw-ptr backref per `borrow` mode.
+    (@call shared $p:expr; $m:ident($($a:tt)*)) => { (&*$p).$m($($a)*) };
+    (@call ptr    $p:expr; $m:ident($($a:tt)*)) => { <Self>::$m($p, $($a)*) };
 
     (@emit
         [$($gen:tt)*] $Ty:ty;
@@ -2760,20 +2873,22 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: `this` is the BACKREF set via `set_parent`; the
-                // BufferedWriter never materializes `&mut Parent`, so this is
-                // the unique access path for the callback's duration.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_write(amount, status) };
+                // BufferedWriter never materializes `&mut Parent`. The handler
+                // is dispatched per the `borrow` mode (`shared`/`ptr` — see the
+                // module comment); `ptr` lets the handler release the parent's
+                // last ref with no reference to it live.
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_write(amount, status)) }
             }
             #[inline]
             unsafe fn on_error(this: *mut Self, err: $crate::pipe_writer::__parent_macro::SysError) {
                 // SAFETY: see on_write.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_error(&err) };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_error(&err)) }
             }
             const HAS_ON_CLOSE: bool = true;
             #[inline]
             unsafe fn on_close(this: *mut Self) {
                 // SAFETY: see on_write.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_close() };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_close()) }
             }
             #[inline]
             unsafe fn get_buffer<'a>(this: *mut Self) -> &'a [u8] {
@@ -2821,18 +2936,18 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: BACKREF set via `set_parent`; see borrow-mode note.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_write(amount, status) };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_write(amount, status)) }
             }
             #[inline]
             unsafe fn on_error(this: *mut Self, err: $crate::pipe_writer::__parent_macro::SysError) {
                 // SAFETY: see on_write.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_error(&err) };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_error(&err)) }
             }
             const HAS_ON_CLOSE: bool = true;
             #[inline]
             unsafe fn on_close(this: *mut Self) {
                 // SAFETY: see on_write.
-                unsafe { ($crate::impl_buffered_writer_parent!(@borrow $borrow this)).$on_close() };
+                unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_close()) }
             }
             #[inline]
             unsafe fn get_buffer<'a>(this: *mut Self) -> &'a [u8] {

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -48,42 +48,32 @@ pub enum WriteStatus {
 
 /// The hooks a writer supplies are the required trait methods; the shared
 /// write machinery is the provided trait methods.
+///
+/// The writer is a field of its parent, and the parent may release its last
+/// ref (freeing both) from a report. Freeing an allocation while a reference
+/// into it is a live argument is UB under both aliasing models, so the poll
+/// chain (`on_poll` and the hooks it dispatches) passes the writer as `*mut`,
+/// takes `&mut` only for statement-scoped work, and makes each report that may
+/// free the parent its last access. The `*WriterParent` docs say which reports
+/// those are.
 pub trait PosixPipeWriter {
     fn get_fd(&self) -> Fd;
     fn get_buffer(&self) -> &[u8];
-    /// Reports the outcome of a poll-driven drain to the parent.
-    ///
-    /// Raw rather than `&mut self` because the writer is a field of its parent
-    /// and a `Drained` report may free the parent (`StaticPipeWriter::on_write`
-    /// releases its last ref there): freeing an allocation while a reference to
-    /// it is a live argument of some frame is rejected by both aliasing models,
-    /// so every frame between the poll dispatch and that release holds the
-    /// writer as a raw pointer. The same goes for [`on_error`](Self::on_error)
-    /// and [`register_poll`](Self::register_poll), which end in the `on_close`
-    /// a parent may free itself from.
-    ///
     /// # Safety
-    /// `this` must point to the live writer. After a `Drained` or `EndOfFile`
-    /// report the caller must not touch `this` again; a `Pending` report leaves
-    /// the writer alive (see the `*WriterParent::on_write` contracts).
+    /// `this` must be the live writer. Only a `Pending` report leaves it
+    /// usable afterwards.
     unsafe fn on_write(this: *mut Self, written: usize, status: WriteStatus);
-    /// Re-arms the poll after a `Pending` report. Optional: implement as a
-    /// no-op when not needed and set `HAS_REGISTER_POLL = false`.
+    /// Re-arms the poll after a `Pending` report (optional: no-op and
+    /// `HAS_REGISTER_POLL = false`). A failure is reported like a write error.
     ///
     /// # Safety
-    /// `this` must point to the live writer. A failed registration is reported
-    /// to the parent like a write error, after which the parent may have freed
-    /// the object embedding the writer, so the caller must not touch `this`
-    /// afterwards.
+    /// `this` must be the live writer; it may be gone when this returns.
     unsafe fn register_poll(this: *mut Self);
     const HAS_REGISTER_POLL: bool = true;
-    /// Reports a write error to the parent and closes the writer. The parent's
-    /// error handler must leave the writer alive for that close; the `on_close`
-    /// the close delivers may free the parent, and the writer with it.
+    /// Reports a write error, then closes the writer (delivering `on_close`).
     ///
     /// # Safety
-    /// `this` must point to the live writer; the caller must not touch it
-    /// afterwards.
+    /// `this` must be the live writer; it may be gone when this returns.
     unsafe fn on_error(this: *mut Self, err: sys::Error);
     fn get_file_type(&self) -> FileType;
     fn get_force_sync(&self) -> bool;
@@ -148,49 +138,36 @@ pub trait PosixPipeWriter {
         WriteResult::Wrote(offset)
     }
 
-    /// Poll-dispatch entry (`__bun_run_file_poll`). Raw for the reason given on
-    /// [`on_write`](Self::on_write): the `&mut` work is confined to
-    /// [`drain_on_poll`](Self::drain_on_poll), and the reports below run with
-    /// no borrow of `*this` live.
+    /// Poll-dispatch entry (`__bun_run_file_poll`); see the trait docs for why
+    /// it is raw.
     ///
     /// # Safety
-    /// `this` must point to the live writer registered as the poll's owner.
+    /// `this` must be the live writer registered as the poll's owner.
     unsafe fn on_poll(this: *mut Self, size_hint: isize, received_hup: bool) {
         // SAFETY: caller contract; the borrow ends when `drain_on_poll` returns.
         let Some(result) = (unsafe { (*this).drain_on_poll(size_hint, received_hup) }) else {
             return;
         };
 
-        match result {
-            WriteResult::Pending(wrote) => {
-                // Bytes are still buffered, so the parent keeps the writer
-                // alive and it gets re-armed.
-                if wrote > 0 {
-                    // SAFETY: caller contract.
-                    unsafe { Self::on_write(this, wrote, WriteStatus::Pending) };
+        // SAFETY: caller contract. Every arm's final dispatch is the last use of
+        // `this`; `Pending` keeps the writer alive (bytes are still buffered),
+        // so it can be re-armed after its report.
+        unsafe {
+            match result {
+                WriteResult::Pending(wrote) => {
+                    if wrote > 0 {
+                        Self::on_write(this, wrote, WriteStatus::Pending);
+                    }
+                    if Self::HAS_REGISTER_POLL {
+                        Self::register_poll(this);
+                    }
                 }
-
-                if Self::HAS_REGISTER_POLL {
-                    // SAFETY: caller contract, plus the `Pending` contract on
-                    // `on_write`. Last use of `this`: a failed re-arm ends in
-                    // an error report.
-                    unsafe { Self::register_poll(this) };
-                }
+                // A parent that buffers more data from this report re-arms
+                // through `write()` itself.
+                WriteResult::Wrote(amt) => Self::on_write(this, amt, WriteStatus::Drained),
+                WriteResult::Done(amt) => Self::on_write(this, amt, WriteStatus::EndOfFile),
+                WriteResult::Err(err) => Self::on_error(this, err),
             }
-            // `Drained`: the buffer was fully written before the report. If
-            // the parent buffers more data via `write()`, that path already
-            // calls `register_poll()`.
-            // SAFETY: caller contract. Last use of `this`: the parent may free
-            // the object embedding the writer from inside this report.
-            WriteResult::Wrote(amt) => unsafe { Self::on_write(this, amt, WriteStatus::Drained) },
-            // SAFETY: as for `Drained`; the writer closes itself (and so may be
-            // freed by its parent's `on_close`) before this returns.
-            WriteResult::Done(amt) => unsafe { Self::on_write(this, amt, WriteStatus::EndOfFile) },
-            // SAFETY: caller contract. Last use of `this`: the writer closes
-            // itself after the report, and the parent may free the object
-            // embedding it from that `on_close` (the security scanner's
-            // `StaticPipeWriter` always does).
-            WriteResult::Err(err) => unsafe { Self::on_error(this, err) },
         }
     }
 
@@ -229,16 +206,13 @@ pub trait PosixPipeWriter {
     /// `try_write` only needs `&self`, so the shared borrow of the buffer
     /// coexists with it.
     ///
-    /// An error with nothing drained is returned to [`on_poll`](Self::on_poll),
-    /// which reports it with nothing borrowed. An error after a partial drain
-    /// is reported from in here, under this frame's `&mut self`, and the caller
-    /// then reports the drained bytes through `on_write` as well; both of those
-    /// assume the parent does not free itself from that error's `on_close`,
-    /// which the security scanner's `StaticPipeWriter` does. Closing that gap
-    /// means changing what the partial case reports (`StaticPipeWriter`
-    /// currently relies on the trailing `on_write` to release its `start()`
-    /// ref), not how it is dispatched, so it is not part of the dispatch fixes
-    /// made here.
+    /// An error with nothing drained is returned for `on_poll` to report. An
+    /// error after a partial drain is still reported from here, under this
+    /// frame's `&mut self`, and followed by an `on_write` for the drained bytes
+    /// (which `StaticPipeWriter` relies on to release its `start()` ref); that
+    /// is only sound while no parent frees itself from the error's `on_close`,
+    /// which the security scanner's writer does. Changing what this returns for
+    /// that case is a protocol change, separate from the dispatch here.
     fn drain_buffered_data(&mut self, max_write_size: usize, received_hup: bool) -> WriteResult {
         let _ = received_hup; // autofix
 
@@ -268,12 +242,9 @@ pub trait PosixPipeWriter {
                 }
                 WriteResult::Err(err) => {
                     if drained > 0 {
-                        // SAFETY: `self` is live; see the doc comment for why
-                        // this report is made from under this frame's borrow.
-                        // Laundered (PORT_NOTES_PLAN R-2) so the close inside
-                        // sees what the parent's handler wrote re-entrantly
-                        // rather than values cached under this `noalias`
-                        // receiver.
+                        // SAFETY: `self` is live (see the doc comment). Laundered
+                        // (R-2) so the close inside sees what the parent's handler
+                        // wrote re-entrantly, not values cached under `noalias`.
                         unsafe {
                             Self::on_error(core::hint::black_box(core::ptr::from_mut(self)), err)
                         };
@@ -326,32 +297,24 @@ pub trait PosixBufferedWriterParent {
     /// per-tag dispatch in `bun_runtime::dispatch::__bun_run_file_poll`
     /// recovers `*mut PosixBufferedWriter<Self>` from this.
     const POLL_OWNER_TAG: PollTag;
-    /// Dispatched with no borrow of the writer live. On `Drained` the parent
-    /// may release its last ref and free itself (the writer with it); the
-    /// writer touches nothing afterwards. On `Pending` the writer re-arms its
-    /// poll afterwards, so the parent must stay alive. On `EndOfFile` the
-    /// writer has already closed the fd and delivers `on_close` (again with no
-    /// borrow live, and as its last access) once this returns, so the parent
-    /// must stay alive through the report itself and may free itself from that
-    /// `on_close`.
+    /// The parent may free itself from a `Drained` report. After `Pending` the
+    /// writer re-arms, and after `EndOfFile` (fd already closed) it delivers
+    /// `on_close`, so the parent has to survive those two reports themselves.
     ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus);
-    /// Must leave `*this` alive: the writer closes itself right after this
-    /// returns (and, on a partially drained buffer, still reports the drained
-    /// bytes through `on_write`).
+    /// Must leave the parent alive: the writer closes itself afterwards (and,
+    /// after a partial drain, still reports the drained bytes).
     ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_error(this: *mut Self, err: sys::Error);
     const HAS_ON_CLOSE: bool;
-    /// The writer's last access to itself on every path that reaches this (a
-    /// report from the poll, an error, or the parent's own `close()`), so the
-    /// parent may release its last ref from here. On the `close()` path the
-    /// caller's `&mut` to the writer is still live, so the parent, and whatever
-    /// it calls from here (an owner's `on_close_io`), must not form references
-    /// that cover the writer; reach the allocation's other fields by projection.
+    /// The writer's last access to itself, so the parent may free itself from
+    /// here. When reached through the parent's own `close()` the caller's
+    /// `&mut` to the writer is live, so nothing called from here (an owner's
+    /// `on_close_io` included) may borrow the struct the writer is a field of.
     ///
     /// # Safety
     /// `this` must point to a live `Self`.
@@ -400,9 +363,9 @@ impl<Parent: PosixBufferedWriterParent> PosixPipeWriter for PosixBufferedWriter<
         unsafe { Self::_on_write(this, written, status) }
     }
     unsafe fn register_poll(this: *mut Self) {
-        // SAFETY: caller contract. This writer's registration failure is only
-        // reported (`Parent::on_error`, which must leave the parent alive); it
-        // does not close, so nothing can be freed while the borrow is live.
+        // SAFETY: caller contract. A failure here is only reported, not closed
+        // on, and `on_error` must leave the parent alive, so the call-scoped
+        // borrow is fine.
         unsafe { (*this).register_poll() }
     }
     unsafe fn on_error(this: *mut Self, err: sys::Error) {
@@ -481,64 +444,47 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         self.handle.get_fd()
     }
 
-    /// Raw like [`_on_write`](Self::_on_write): the error report must leave
-    /// the parent alive (`PosixBufferedWriterParent::on_error`), but the
-    /// `on_close` that [`close_raw`](Self::close_raw) delivers right after it
-    /// may free the parent, and `*this` with it, so neither dispatch runs with
-    /// a borrow of `*this` live.
-    ///
     /// # Safety
-    /// `this` must point to the live writer; it may be freed when this returns.
+    /// `this` must be the live writer; the parent may free it from the
+    /// `on_close` this ends with.
     unsafe fn _on_error(this: *mut Self, err: sys::Error) {
         debug_assert!(!err.is_retry());
 
-        // SAFETY: caller contract; the borrow ends at the `;`.
-        let parent = unsafe { (*this).parent() };
-        // SAFETY: parent BACKREF valid.
-        unsafe { Parent::on_error(parent, err) };
-        // SAFETY: caller contract; last use of `this`.
-        unsafe { Self::close_raw(this) };
+        // SAFETY: caller contract; `on_error` must leave the parent alive, and
+        // the final close is the last use of `this`.
+        unsafe {
+            let parent = (*this).parent();
+            Parent::on_error(parent, err);
+            Self::close_raw(this);
+        }
     }
 
-    /// Raw (not `&mut self`): `Parent::on_write` re-enters this writer through
-    /// the parent's field (`close()`, `register_poll()`), and the parent may
-    /// free itself, and `*this` inside it, from a `Drained` report or from the
-    /// `on_close` that follows an `EndOfFile` one; see the contract on
-    /// [`PosixBufferedWriterParent::on_write`]. Every borrow of `*this` here is
-    /// scoped to one statement, and none is live across either dispatch.
-    ///
     /// # Safety
-    /// `this` must point to the live writer.
+    /// `this` must be the live writer; the parent may free it from the report
+    /// (`Drained`) or from the `on_close` that follows an `EndOfFile` one.
     unsafe fn _on_write(this: *mut Self, written: usize, status: WriteStatus) {
-        // SAFETY: caller contract; borrows end at each `;`.
-        let (parent, eof) = unsafe {
+        // SAFETY: caller contract; borrows end at each `;`, and nothing touches
+        // `*this` after a report except the EOF close, which the parent has to
+        // survive until (`PosixBufferedWriterParent::on_write`).
+        unsafe {
             let eof = status == WriteStatus::EndOfFile && !(*this).is_done;
             if eof {
                 (*this).close_without_reporting();
             }
-            ((*this).parent(), eof)
-        };
-
-        // SAFETY: parent BACKREF valid; no borrow of `*this` is live.
-        unsafe { Parent::on_write(parent, written, status) };
-        if eof {
-            // SAFETY: the `EndOfFile` contract on `PosixBufferedWriterParent::
-            // on_write` keeps `*this` alive until here; this delivers the
-            // `on_close` deferred by `close_without_reporting` above.
-            unsafe { Self::close_raw(this) };
+            let parent = (*this).parent();
+            Parent::on_write(parent, written, status);
+            if eof {
+                Self::close_raw(this);
+            }
         }
     }
 
     /// Closes the handle (unless that already happened without reporting) and
-    /// delivers `on_close` for a handle that was open. The parent may release
-    /// its last ref from `on_close` and free itself, `*this` with it, so the
-    /// handle is closed through a statement-scoped borrow first and the report
-    /// is dispatched with nothing borrowed, as the last use of `this`.
-    /// [`close`](Self::close) is this for callers that themselves keep the
-    /// parent alive across the call.
+    /// delivers `on_close` if it was open, with nothing borrowed: the parent
+    /// may free itself, and this writer, from it.
     ///
     /// # Safety
-    /// `this` must point to the live writer; it may be freed when this returns.
+    /// `this` must be the live writer; it may be gone when this returns.
     unsafe fn close_raw(this: *mut Self) {
         if !Parent::HAS_ON_CLOSE {
             return;
@@ -546,8 +492,8 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         // SAFETY: caller contract; borrows end at each `;`.
         let parent = unsafe {
             if !mem::replace(&mut (*this).closed_without_reporting, false) {
-                // `close_impl` would only report for a handle that is still
-                // open; close it without a callback and report below instead.
+                // Closed without `close_impl`'s callback so the report below is
+                // made with no borrow live; like it, only report an open handle.
                 let was_open = (*this).get_fd() != Fd::INVALID;
                 let close_fd = (*this).close_fd;
                 (*this)
@@ -608,14 +554,10 @@ impl<Parent: PosixBufferedWriterParent> PosixBufferedWriter<Parent> {
         }
     }
 
-    /// For the parent's own code paths (and `end()`): the `on_close` this
-    /// delivers runs while the caller's `&mut` to this writer is live, so such
-    /// callers have to be holding the parent alive across the call (the owners
-    /// of `StaticPipeWriter` claim its `start()` ref before closing it for that
-    /// reason). The poll chain uses [`close_raw`](Self::close_raw) directly.
+    /// For callers that hold the parent alive across the call (its own code
+    /// paths, `end()`); the poll chain uses [`close_raw`](Self::close_raw).
     pub fn close(&mut self) {
-        // SAFETY: `self` is live; the caller keeps its allocation alive across
-        // the call (see above).
+        // SAFETY: `self` is live, and the caller keeps it so (see above).
         unsafe { Self::close_raw(core::ptr::from_mut(self)) }
     }
 
@@ -696,20 +638,15 @@ pub trait PosixStreamingWriterParent {
     /// per-tag dispatch in `bun_runtime::dispatch::__bun_run_file_poll`
     /// recovers `*mut PosixStreamingWriter<Self>` from this.
     const POLL_OWNER_TAG: PollTag;
-    /// From the poll (`PosixPipeWriter::on_poll`) this is dispatched with no
-    /// borrow of the writer live, and a `Drained` or `EndOfFile` report is the
-    /// writer's last access to itself, so the parent may release its last ref
-    /// there (e.g. `FileSink::on_write` ending the sink) and free itself, the
-    /// writer with it. After a `Pending` report the writer re-arms its poll, so
-    /// the parent must stay alive. Reports made from the parent's own `write()`
-    /// calls run while the parent is on the stack and may be followed by a
-    /// re-arm as well.
+    /// From the poll, the parent may free itself from a `Drained` or
+    /// `EndOfFile` report but has to survive a `Pending` one (the writer
+    /// re-arms). Reports made from its own `write*()` calls run under its own
+    /// frames and may be followed by a re-arm too.
     ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus);
-    /// Must leave `*this` alive: the writer closes itself right after this
-    /// returns.
+    /// Must leave the parent alive: the writer closes itself afterwards.
     ///
     /// # Safety
     /// `this` must point to a live `Self`.
@@ -718,11 +655,10 @@ pub trait PosixStreamingWriterParent {
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_ready(_this: *mut Self) {}
-    /// The writer's last access to itself on every path that reaches this (an
-    /// error or a failed re-arm from the poll, or the parent's own `close()`),
-    /// so the parent may release its last ref from here. On the `close()` path
-    /// the caller's `&mut` to the writer is still live, so the parent must not
-    /// form references that cover the writer from in here.
+    /// The writer's last access to itself, so the parent may free itself from
+    /// here. When reached through the parent's own `close()` the caller's
+    /// `&mut` to the writer is live, so nothing called from here may borrow the
+    /// struct the writer is a field of.
     ///
     /// # Safety
     /// `this` must point to a live `Self`.
@@ -808,13 +744,9 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.parent
     }
 
-    /// Records what is about to be reported and returns the parent to report
-    /// it to.
-    ///
-    /// Type invariant (encapsulated `unsafe`): `self.parent` is populated by
-    /// [`set_parent`](Self::set_parent) before any write path is reached, and
-    /// the writer is an intrusive field of `*parent` so the pointee strictly
-    /// outlives `self`.
+    /// Records what is about to be reported; returns the parent to report to
+    /// (set once by [`set_parent`](Self::set_parent), and it outlives the
+    /// writer embedded in it).
     #[inline]
     fn report_target(&self, status: WriteStatus) -> *mut Parent {
         // on_write may re-enter write(); record first so re-entry leaves the newer value.
@@ -822,17 +754,12 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.parent()
     }
 
-    /// `Parent::on_write` for the synchronous `write*()` paths, whose caller is
-    /// the parent itself (so it is alive for the duration; see the contract on
-    /// [`PosixStreamingWriterParent::on_write`]). The poll path reports through
-    /// [`_on_write`](Self::_on_write) instead, which holds no borrow of the
-    /// writer across the report. Collapses the N identical
-    /// `unsafe { Parent::on_write(self.parent(), ..) }` blocks (one per
-    /// `WriteResult` arm) into one.
+    /// The report for the `write*()` paths, whose caller is the parent itself;
+    /// the poll path reports through [`_on_write`](Self::_on_write).
     #[inline]
     fn parent_on_write(&self, amount: usize, status: WriteStatus) {
         let parent = self.report_target(status);
-        // SAFETY: `report_target`'s type invariant.
+        // SAFETY: see `report_target`.
         unsafe { Parent::on_write(parent, amount, status) }
     }
 
@@ -877,23 +804,20 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.outgoing.slice()
     }
 
-    /// Raw like [`_on_write`](Self::_on_write): the error report must leave
-    /// the parent alive (`PosixStreamingWriterParent::on_error`), but the
-    /// `on_close` that [`close_raw`](Self::close_raw) delivers right after it
-    /// may free the parent (`FileSink` drops its keep-alive ref there), and
-    /// `*this` with it, so neither dispatch runs with a borrow of `*this` live.
-    ///
     /// # Safety
-    /// `this` must point to the live writer; it may be freed when this returns.
+    /// `this` must be the live writer; the parent (`FileSink` drops its
+    /// keep-alive ref in `on_close`) may free it from the close this ends with.
     unsafe fn _on_error(this: *mut Self, err: sys::Error) {
         debug_assert!(!err.is_retry());
 
-        // SAFETY: caller contract; the borrow ends when `fail` returns.
-        let parent = unsafe { (*this).fail() };
-        // SAFETY: parent BACKREF valid.
-        unsafe { Parent::on_error(parent, err) };
-        // SAFETY: caller contract; last use of `this`.
-        unsafe { Self::close_raw(this) };
+        // SAFETY: caller contract; `fail`'s borrow ends before the report,
+        // `on_error` must leave the parent alive, and the close is the last
+        // use of `this`.
+        unsafe {
+            let parent = (*this).fail();
+            Parent::on_error(parent, err);
+            Self::close_raw(this);
+        }
     }
 
     /// Tears the writer down after a write error; returns the parent to report
@@ -905,20 +829,15 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.parent()
     }
 
-    /// Poll-path report. Raw (not `&mut self`): per the contract on
-    /// [`PosixStreamingWriterParent::on_write`] the report may free the parent,
-    /// and `*this` inside it, so the bookkeeping borrow ends in
-    /// [`consume_written`](Self::consume_written) and nothing here touches
-    /// `this` once the parent has been called.
-    ///
     /// # Safety
-    /// `this` must point to the live writer.
+    /// `this` must be the live writer; the parent may free it from the report.
     unsafe fn _on_write(this: *mut Self, written: usize, status: WriteStatus) {
-        // SAFETY: caller contract; the borrow ends when `consume_written` returns.
-        let parent = unsafe { (*this).consume_written(written, status) };
-        // SAFETY: `report_target`'s type invariant; no borrow of `*this` is
-        // live, and this is the last use of `this`.
-        unsafe { Parent::on_write(parent, written, status) };
+        // SAFETY: caller contract; `consume_written`'s borrow ends before the
+        // report, which is the last use of `this`.
+        unsafe {
+            let parent = (*this).consume_written(written, status);
+            Parent::on_write(parent, written, status);
+        }
     }
 
     /// Bookkeeping for bytes the poll wrote; returns the parent to report to.
@@ -956,39 +875,32 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         }
     }
 
-    /// Write-path form of [`register_poll_raw`](Self::register_poll_raw): the
-    /// caller is the parent's own `write*()`, so the parent outlives the error
-    /// dispatch. The pointer is laundered (PORT_NOTES_PLAN R-2) because
-    /// `Parent::on_error` (e.g. `FileSink::on_error`) may re-enter and write
-    /// `is_done` / `handle` through the parent's field, and the close that
-    /// follows has to see that rather than values cached under this receiver's
-    /// `noalias`.
+    /// For the `write*()` paths, whose caller is the parent itself. Laundered
+    /// (R-2): `on_error` may re-enter and write `is_done`/`handle`, which the
+    /// close after it must see rather than values cached under `noalias`.
     fn register_poll(&mut self) {
         // SAFETY: `self` is live, and the parent is on the stack below us.
         unsafe { Self::register_poll_raw(core::hint::black_box(core::ptr::from_mut(self))) }
     }
 
-    /// Arms the poll; a failed registration is reported like a write error,
-    /// after which the writer closes itself. Raw like [`_on_error`](Self::
-    /// _on_error): the report must leave the parent alive, but the `on_close`
-    /// delivered by [`close_raw`](Self::close_raw) may free it, and `*this`
-    /// with it, so neither dispatch runs with a borrow of `*this` live.
+    /// Arms the poll; a failure is reported like a write error.
     ///
     /// # Safety
-    /// `this` must point to the live writer; it may be freed when this returns.
+    /// `this` must be the live writer; on failure the parent may free it from
+    /// the close this ends with.
     unsafe fn register_poll_raw(this: *mut Self) {
-        // SAFETY: caller contract; the borrow ends when `try_register_poll`
-        // returns.
-        let err = match unsafe { (*this).try_register_poll() } {
-            sys::Result::Ok(()) => return,
-            sys::Result::Err(err) => err,
-        };
-        // SAFETY: caller contract; the borrow ends at the `;`.
-        let parent = unsafe { (*this).parent() };
-        // SAFETY: parent BACKREF valid.
-        unsafe { Parent::on_error(parent, err) };
-        // SAFETY: caller contract; last use of `this`.
-        unsafe { Self::close_raw(this) };
+        // SAFETY: caller contract; each borrow ends before the next call,
+        // `on_error` must leave the parent alive, and the close is the last use
+        // of `this`.
+        unsafe {
+            let err = match (*this).try_register_poll() {
+                sys::Result::Ok(()) => return,
+                sys::Result::Err(err) => err,
+            };
+            let parent = (*this).parent();
+            Parent::on_error(parent, err);
+            Self::close_raw(this);
+        }
     }
 
     fn try_register_poll(&self) -> sys::Result<()> {
@@ -1225,33 +1137,29 @@ impl<Parent: PosixStreamingWriterParent> PosixStreamingWriter<Parent> {
         self.close();
     }
 
-    /// For the parent's own code paths (`end()`, `start()`, `FileSink`'s
-    /// handlers): the `on_close` this delivers runs while the caller's `&mut`
-    /// to this writer is live, so such callers have to be holding the parent
-    /// alive across the call (`FileSink` holds a guard ref in its handlers).
-    /// The poll chain uses [`close_raw`](Self::close_raw) directly.
+    /// For callers that hold the parent alive across the call (its own
+    /// handlers, `end()`, `start()`); the poll chain uses
+    /// [`close_raw`](Self::close_raw).
     pub fn close(&mut self) {
-        // SAFETY: `self` is live; the caller keeps its allocation alive across
-        // the call (see above).
+        // SAFETY: `self` is live, and the caller keeps it so (see above).
         unsafe { Self::close_raw(core::ptr::from_mut(self)) }
     }
 
     /// Closes the handle (unless that already happened without reporting) and
-    /// delivers `on_close` for a handle that was open. The parent may release
-    /// its last ref from `on_close` and free itself, `*this` with it, so the
-    /// handle is closed through a statement-scoped borrow first and the report
-    /// is dispatched with nothing borrowed, as the last use of `this`.
+    /// delivers `on_close` if it was open, with nothing borrowed: the parent
+    /// may free itself, and this writer, from it.
     ///
     /// # Safety
-    /// `this` must point to the live writer; it may be freed when this returns.
+    /// `this` must be the live writer; it may be gone when this returns.
     unsafe fn close_raw(this: *mut Self) {
         // SAFETY: caller contract; borrows end at each `;`.
         let parent = unsafe {
             if mem::replace(&mut (*this).closed_without_reporting, false) {
                 debug_assert!((*this).get_fd() == Fd::INVALID);
             } else {
-                // `PollOrFd::close` would only report for a handle that is
-                // still open; close it without a callback and report below.
+                // Closed without `PollOrFd::close`'s callback so the report
+                // below is made with no borrow live; like it, only report an
+                // open handle.
                 let was_open = (*this).get_fd() != Fd::INVALID;
                 (*this).handle.close(None, None::<fn(*mut c_void)>);
                 if !was_open {
@@ -2791,27 +2699,14 @@ pub type StreamingWriter<P> = WindowsStreamingWriter<P>;
 //   (c) the `event_loop` / `loop_` / refcount accessor expressions.
 // These macros stamp that triple once per parent.
 //
-// `borrow = shared` → bodies form `&*this` (callback may re-enter JS or
-//                     `enqueue(&self)` and observe a fresh `&Self`; aliased
-//                     `&Self` is sound where `&mut Self` is not). Requires the
-//                     parent to keep its writer in a `JsCell`/`UnsafeCell`:
-//                     the callback runs underneath the writer's own frames,
-//                     and a plain `&Parent` would cover the writer's bytes too.
-// `borrow = ptr`    → bodies call `Self::method(this, ..)` — no reference is
-//                     materialized at the boundary. Required when a callback
-//                     can release the parent's last ref: a reference argument
-//                     is protected for the duration of the call, and both
-//                     aliasing models reject freeing the allocation it points
-//                     into while it is live (besides which a `&self`-derived
-//                     pointer carries no dealloc provenance). The parent's
-//                     handlers take `this: *mut Self` and do their `&mut` work
-//                     through call-scoped reborrows, releasing through `this`.
-//
-// There is deliberately no `&mut` mode: a `&mut Parent` formed here would
-// assert unique access to the whole parent, writer field included, while the
-// writer that is making the call may itself be borrowed further up the stack,
-// and it would be protected across the very callback that may free it. See
-// test/internal/source-lints/writer-parent-mut-borrow.test.ts.
+// `borrow = shared` → bodies form `&*this`. For parents that keep the writer
+//                     in a `JsCell`/`UnsafeCell` (the callback runs under the
+//                     writer's own frames, and the `&Parent` covers it too).
+// `borrow = ptr`    → bodies call `Self::method(this, ..)`, materializing no
+//                     reference. Required when a callback can release the
+//                     parent's last ref (see the `PosixPipeWriter` docs).
+// No `&mut` mode: it would be a protected, whole-parent borrow across the very
+// callbacks that may free the parent (writer-parent-mut-borrow source lint).
 //
 // Accessor args use closure-literal syntax (`|this| expr`) purely as a binder
 // for the macro — no actual closure is created; `expr` is pasted into an
@@ -2857,10 +2752,8 @@ macro_rules! impl_streaming_writer_parent {
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: `this` is the BACKREF set via `set_parent`; the
-                // StreamingWriter never materializes `&mut Parent`. The handler
-                // is dispatched per the `borrow` mode (`shared`/`ptr` — see the
-                // module comment); `ptr` keeps full write/dealloc provenance
-                // through re-entrant, freeing callbacks.
+                // StreamingWriter never materializes `&mut Parent`. Dispatched
+                // per the `borrow` mode (module comment above).
                 unsafe { $crate::impl_streaming_writer_parent!(@call $borrow this; $on_write(amount, status)) }
             }
             #[inline]
@@ -2992,10 +2885,8 @@ macro_rules! impl_buffered_writer_parent {
             #[inline]
             unsafe fn on_write(this: *mut Self, amount: usize, status: $crate::WriteStatus) {
                 // SAFETY: `this` is the BACKREF set via `set_parent`; the
-                // BufferedWriter never materializes `&mut Parent`. The handler
-                // is dispatched per the `borrow` mode (`shared`/`ptr` — see the
-                // module comment); `ptr` lets the handler release the parent's
-                // last ref with no reference to it live.
+                // BufferedWriter never materializes `&mut Parent`. Dispatched
+                // per the `borrow` mode (module comment above).
                 unsafe { $crate::impl_buffered_writer_parent!(@call $borrow this; $on_write(amount, status)) }
             }
             #[inline]

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -495,10 +495,8 @@ impl Subprocess<'_> {
                     else {
                         unreachable!()
                     };
-                    // Reached only from `StaticPipeWriter::on_close`, which has
-                    // already detached the source and is running inside the
-                    // writer's own `close()`, so the writer must not be
-                    // borrowed here (`buffer_writer_mut`): just drop the ref.
+                    // Called from inside the writer's own close (it detached the
+                    // source already), so no `buffer_writer_mut` here.
                     buffer.deref();
                 }
                 _ => {}

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -495,7 +495,10 @@ impl Subprocess<'_> {
                     else {
                         unreachable!()
                     };
-                    Writable::buffer_writer_mut(&buffer).source.detach();
+                    // Reached only from `StaticPipeWriter::on_close`, which has
+                    // already detached the source and is running inside the
+                    // writer's own `close()`, so the writer must not be
+                    // borrowed here (`buffer_writer_mut`): just drop the ref.
                     buffer.deref();
                 }
                 _ => {}

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -72,20 +72,24 @@ impl<'a> Writable<'a> {
     /// Mutable borrow of the `Buffer` payload's `StaticPipeWriter`.
     ///
     /// Centralises the `RefPtr → &mut T` deref so the per-match-arm `unsafe`
-    /// blocks (`ref`/`unref`/`close`/`finalize` and `Subprocess::on_close_io`/
-    /// `on_process_exit`) collapse to this one site. `RefPtr` deliberately has
-    /// no `DerefMut` (shared ownership); the invariant that makes `&mut` sound
-    /// here is that `Writable::Buffer` holds the *only* strong ref for the
-    /// variant's lifetime (created by `StaticPipeWriter::create`, released by
-    /// `buffer.deref()` only after the variant is overwritten), the writer
-    /// lives in its own heap allocation disjoint from `Writable`/`Subprocess`,
-    /// and access is single-JS-mutator-thread.
+    /// blocks (`ref`/`unref`/`close`/`finalize`, `take_pending_start_writer`
+    /// and `on_process_exit`) collapse to this one site. `RefPtr` deliberately
+    /// has no `DerefMut` (shared ownership). What makes the `&mut` sound is
+    /// that every caller is entered from JS, from GC or from the process-exit
+    /// callback, i.e. never from underneath the writer's own frames, so no
+    /// borrow of the writer is live: the writer's callbacks (`on_write`,
+    /// `on_error`, `on_close` → `on_close_io`) run inside `BufferedWriter`
+    /// methods that hold `&mut` to the `writer` field embedded in this very
+    /// allocation, and must not use this accessor. The writer lives in its own
+    /// heap allocation, pinned by the ref this variant holds, and access is
+    /// single-JS-mutator-thread.
     #[inline]
     #[allow(clippy::mut_from_ref)]
     pub(in crate::api) fn buffer_writer_mut<'b>(
         buffer: &'b RefPtr<StaticPipeWriter<'a>>,
     ) -> &'b mut StaticPipeWriter<'a> {
-        // SAFETY: see fn doc — sole-owning RefPtr, heap-disjoint, single-thread.
+        // SAFETY: see fn doc — no caller runs under the writer's frames, the
+        // variant's ref pins the allocation, single-thread.
         unsafe { &mut *buffer.as_ptr() }
     }
 

--- a/src/runtime/api/bun/subprocess/Writable.rs
+++ b/src/runtime/api/bun/subprocess/Writable.rs
@@ -69,27 +69,18 @@ impl<'a> Writable<'a> {
         unsafe { FileSink::deref(pipe.as_ptr()) };
     }
 
-    /// Mutable borrow of the `Buffer` payload's `StaticPipeWriter`.
+    /// Mutable borrow of the `Buffer` payload's `StaticPipeWriter`, pinned by
+    /// the ref this variant holds (`RefPtr` deliberately has no `DerefMut`).
     ///
-    /// Centralises the `RefPtr → &mut T` deref so the per-match-arm `unsafe`
-    /// blocks (`ref`/`unref`/`close`/`finalize`, `take_pending_start_writer`
-    /// and `on_process_exit`) collapse to this one site. `RefPtr` deliberately
-    /// has no `DerefMut` (shared ownership). What makes the `&mut` sound is
-    /// that every caller is entered from JS, from GC or from the process-exit
-    /// callback, i.e. never from underneath the writer's own frames, so no
-    /// borrow of the writer is live: the writer's callbacks (`on_write`,
-    /// `on_error`, `on_close` → `on_close_io`) run inside `BufferedWriter`
-    /// methods that hold `&mut` to the `writer` field embedded in this very
-    /// allocation, and must not use this accessor. The writer lives in its own
-    /// heap allocation, pinned by the ref this variant holds, and access is
-    /// single-JS-mutator-thread.
+    /// Only for paths entered from JS, GC or process exit. The writer's own
+    /// callbacks (`on_close` → `on_close_io` included) run under a `&mut` to
+    /// its embedded `writer` field and must not use this.
     #[inline]
     #[allow(clippy::mut_from_ref)]
     pub(in crate::api) fn buffer_writer_mut<'b>(
         buffer: &'b RefPtr<StaticPipeWriter<'a>>,
     ) -> &'b mut StaticPipeWriter<'a> {
-        // SAFETY: see fn doc — no caller runs under the writer's frames, the
-        // variant's ref pins the allocation, single-thread.
+        // SAFETY: see fn doc; single JS thread.
         unsafe { &mut *buffer.as_ptr() }
     }
 

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -679,9 +679,7 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
         ($Ty:ty) => {
             poll_arm!($Ty, |h| {
                 // SAFETY: tag matched, so `owner.ptr` was stored as `*mut $Ty` at
-                // `FilePoll::init` and is live on entry. Passed raw: the drain
-                // report may free the object embedding the writer (see
-                // `PosixPipeWriter::on_poll`).
+                // `FilePoll::init` and is live on entry; `on_poll` may free it.
                 unsafe { <$Ty>::on_poll(h, size_or_offset as isize, hup) }
             })
         };
@@ -734,8 +732,7 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
         // `bun.shell.Interpreter.IOWriter.Poll`
         poll_tag::SHELL_BUFFERED_WRITER => poll_arm!(ShellBufferedWriterPoll, |h| {
             // SAFETY: tag matched, so `owner.ptr` is a live `*mut ShellBufferedWriterPoll`
-            // set at `FilePoll::init`. Passed raw: the entry's keepalive may be
-            // the last ref to the `IOWriter` embedding it (see that fn).
+            // set at `FilePoll::init`; the entry may free it on the way out.
             unsafe { crate::shell::io_writer::on_poll(h, size_or_offset as isize, hup) }
         }),
         poll_tag::DNS_RESOLVER => {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -673,14 +673,16 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
     /// One match-arm body of the poll-tag dispatch. Recovers the typed owner as
     /// a RAW `*mut $Ty` (never `&mut` — re-entrant callees like `DNSResolver`
     /// pick their own deref mode without aliasing UB) then runs `$body`. The
-    /// 1-arg form is the plain `on_poll(size_or_offset, hup)` call that
-    /// covers most tags.
+    /// 1-arg form is the plain `PosixPipeWriter::on_poll` call that covers the
+    /// pipe writers.
     macro_rules! poll_arm {
         ($Ty:ty) => {
             poll_arm!($Ty, |h| {
                 // SAFETY: tag matched, so `owner.ptr` was stored as `*mut $Ty` at
-                // `FilePoll::init` and the owner outlives this dispatch (caller contract).
-                unsafe { (*h).on_poll(size_or_offset as isize, hup) }
+                // `FilePoll::init` and is live on entry. Passed raw: the drain
+                // report may free the object embedding the writer (see
+                // `PosixPipeWriter::on_poll`).
+                unsafe { <$Ty>::on_poll(h, size_or_offset as isize, hup) }
             })
         };
         ($Ty:ty, |$h:ident| $body:expr) => {{
@@ -732,8 +734,9 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
         // `bun.shell.Interpreter.IOWriter.Poll`
         poll_tag::SHELL_BUFFERED_WRITER => poll_arm!(ShellBufferedWriterPoll, |h| {
             // SAFETY: tag matched, so `owner.ptr` is a live `*mut ShellBufferedWriterPoll`
-            // set at `FilePoll::init`; exclusive for this dispatch.
-            unsafe { crate::shell::io_writer::on_poll(&mut *h, size_or_offset as isize, hup) }
+            // set at `FilePoll::init`. Passed raw: the entry's keepalive may be
+            // the last ref to the `IOWriter` embedding it (see that fn).
+            unsafe { crate::shell::io_writer::on_poll(h, size_or_offset as isize, hup) }
         }),
         poll_tag::DNS_RESOLVER => {
             // R-2: deref as shared (`&*const`) — `on_dns_poll` takes `&self` and

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -164,11 +164,9 @@ pub(crate) type Poll = WriterImpl;
 
 /// Poll-dispatch entry for `SHELL_BUFFERED_WRITER`. Holds an extra Arc strong
 /// ref across `on_poll` so child `onIOWriterChunk` callbacks (via `bump()`)
-/// can drop the last external ref without freeing the `IOWriter` while
-/// PipeWriter is still on the stack. When they do, dropping `_keepalive` frees
-/// it, and `*writer` inside it, on the way out of this function, which is why
-/// `writer` is passed raw: a `&mut Poll` argument would still be live (and
-/// protected) at that point.
+/// can drop the last external ref without freeing the `IOWriter` under
+/// PipeWriter; when they do, `_keepalive`'s drop frees it (`*writer` included)
+/// on the way out, which a `&mut Poll` argument would still be covering.
 ///
 /// # Safety
 /// `writer` must be the live poll owner registered by `IOWriter::init`.

--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -164,17 +164,26 @@ pub(crate) type Poll = WriterImpl;
 
 /// Poll-dispatch entry for `SHELL_BUFFERED_WRITER`. Holds an extra Arc strong
 /// ref across `on_poll` so child `onIOWriterChunk` callbacks (via `bump()`)
-/// can drop the last external ref without freeing `self` while PipeWriter is
-/// still on the stack.
+/// can drop the last external ref without freeing the `IOWriter` while
+/// PipeWriter is still on the stack. When they do, dropping `_keepalive` frees
+/// it, and `*writer` inside it, on the way out of this function, which is why
+/// `writer` is passed raw: a `&mut Poll` argument would still be live (and
+/// protected) at that point.
+///
+/// # Safety
+/// `writer` must be the live poll owner registered by `IOWriter::init`.
 #[cfg(not(windows))]
-pub(crate) fn on_poll(writer: &mut Poll, size_hint: isize, hup: bool) {
+pub(crate) unsafe fn on_poll(writer: *mut Poll, size_hint: isize, hup: bool) {
     use bun_io::pipe_writer::PosixPipeWriter;
-    let parent = writer.parent.expect("IOWriter writer.parent unset");
+    // SAFETY: caller contract; the borrow ends at the `;`.
+    let parent = unsafe { (*writer).parent }.expect("IOWriter writer.parent unset");
     // `parent` is the backref stashed via `set_parent` in `IOWriter::init`;
-    // `writer` is a field of `*parent`, so the pointee is live. Re-enter via
+    // `*writer` is a field of `*parent`, so the pointee is live. Re-enter via
     // `&self` (UnsafeCell aliasing model). `ParentRef::Deref → &IOWriter`.
     let _keepalive = parent.keepalive();
-    writer.on_poll(size_hint, hup);
+    // SAFETY: caller contract, and `_keepalive` keeps `*writer` allocated until
+    // this call has returned.
+    unsafe { Poll::on_poll(writer, size_hint, hup) };
 }
 
 /// Mutable state. Wrapped in `UnsafeCell` so `Arc<IOWriter>`-shared callers can

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -90,12 +90,15 @@ mod __pipe_reader_thread_confined {
 /// Mutably borrow a `RefPtr<StaticPipeWriter>` payload.
 ///
 /// `RefPtr` only exposes `&T` via `Deref`; the shell is single-threaded.
-/// Localises the `(*buffer.as_ptr()).method()` pattern at the five
+/// Localises the `(*buffer.as_ptr()).method()` pattern at the
 /// `Writable::Buffer` callsites.
 ///
 /// # Safety
 /// Caller must ensure no other `&`/`&mut StaticPipeWriter` to the same
-/// payload is live for the returned borrow. The `(&RefPtr<T>) -> &mut T`
+/// payload is live for the returned borrow. In particular this must not be
+/// reached from underneath the writer's own callbacks (`on_close` →
+/// `on_close_io`): those run inside `BufferedWriter` methods holding `&mut` to
+/// the `writer` field of the same allocation. The `(&RefPtr<T>) -> &mut T`
 /// shape cannot encode this; `unsafe fn` keeps the obligation at the callsite.
 #[inline]
 #[allow(clippy::mut_from_ref)]
@@ -409,8 +412,10 @@ impl ShellSubprocess {
                     if let Writable::Buffer(buffer) =
                         core::mem::replace(&mut self.stdin, Writable::Ignore)
                     {
-                        // SAFETY: single-threaded; sole borrow of the payload.
-                        unsafe { buffer_mut(&buffer) }.source.detach();
+                        // Reached only from `StaticPipeWriter::on_close`, which
+                        // has already detached the source and is running inside
+                        // the writer's own `close()`, so `buffer_mut` must not be
+                        // used here: just drop the ref.
                         buffer.deref();
                     }
                 }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -95,11 +95,10 @@ mod __pipe_reader_thread_confined {
 ///
 /// # Safety
 /// Caller must ensure no other `&`/`&mut StaticPipeWriter` to the same
-/// payload is live for the returned borrow. In particular this must not be
-/// reached from underneath the writer's own callbacks (`on_close` →
-/// `on_close_io`): those run inside `BufferedWriter` methods holding `&mut` to
-/// the `writer` field of the same allocation. The `(&RefPtr<T>) -> &mut T`
-/// shape cannot encode this; `unsafe fn` keeps the obligation at the callsite.
+/// payload is live for the returned borrow; the writer's own callbacks
+/// (`on_close` → `on_close_io`) run under one, so they must not use this.
+/// The `(&RefPtr<T>) -> &mut T` shape cannot encode this; `unsafe fn` keeps
+/// the obligation at the callsite.
 #[inline]
 #[allow(clippy::mut_from_ref)]
 unsafe fn buffer_mut(buf: &RefPtr<StaticPipeWriter>) -> &mut StaticPipeWriter {
@@ -412,10 +411,8 @@ impl ShellSubprocess {
                     if let Writable::Buffer(buffer) =
                         core::mem::replace(&mut self.stdin, Writable::Ignore)
                     {
-                        // Reached only from `StaticPipeWriter::on_close`, which
-                        // has already detached the source and is running inside
-                        // the writer's own `close()`, so `buffer_mut` must not be
-                        // used here: just drop the ref.
+                        // Called from inside the writer's own close (it detached
+                        // the source already), so no `buffer_mut` here.
                         buffer.deref();
                     }
                 }

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -201,18 +201,14 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         }
     }
 
-    /// Once the write is finished this closes the writer and releases the ref
-    /// that was holding it open. On POSIX, `writer.close()` runs `on_close` →
-    /// `P::on_close_io`, where the owner drops the ref it got from `create()`,
-    /// so the release at the end is normally the writer's last one and frees
-    /// `*this`. That is why this takes the raw backref: freeing an allocation
-    /// while a reference to it is a live argument is rejected by both aliasing
-    /// models, so no `&mut Self` is formed here (each borrow is scoped to one
-    /// statement) and nothing above this frame holds one either
-    /// (`PosixPipeWriter::on_poll`).
+    /// Once the write is finished, closes the writer (on POSIX `on_close` →
+    /// `on_close_io` is where the owner drops its `create()` ref) and then
+    /// releases the ref that held it open, normally the last one. Raw, with
+    /// statement-scoped borrows only, so that final release frees `*this` with
+    /// no reference to it live (see `PosixPipeWriter`).
     ///
     /// # Safety
-    /// `this` must be the live writer; it may have been freed when this returns.
+    /// `this` must be the live writer; it may be gone when this returns.
     pub(crate) unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus) {
         bun_output::scoped_log!(
             StaticPipeWriter,
@@ -234,33 +230,28 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
             if status != WriteStatus::EndOfFile && !remaining.is_empty() {
                 return;
             }
-            // `started` is the token for start()'s outstanding +1. Claiming it
-            // here makes the release below mutually exclusive with the owners'
-            // close-time release (`Subprocess::take_pending_start_writer` and
-            // friends clear it the same way).
+            // `started` is the token for start()'s outstanding +1; claiming it
+            // excludes the owners' close-time release (`take_pending_start_writer`).
             core::mem::replace(&mut (*this).started, false)
         };
 
         if status == WriteStatus::EndOfFile {
-            // The writer closed the fd before reporting EOF and delivers
-            // `on_close` itself once this returns (`PosixBufferedWriterParent::
-            // on_write`), so the owner still holds `create()`'s ref and this
-            // release cannot be the last one; closing here instead would let
-            // the owner free `*this` underneath the writer's pending close.
+            // The writer delivers `on_close` itself after this report (the fd
+            // is already closed), so the owner's ref is still held and this
+            // release is not the last one; closing here would free `*this`
+            // under the writer's pending close instead.
             if claimed_start_ref {
-                // SAFETY: caller contract; `started` was claimed above, so this
-                // is the only release of start()'s ref.
+                // SAFETY: caller contract; `started` was claimed above.
                 unsafe { RefCount::<Self>::deref(this) };
             }
             return;
         }
 
-        // SAFETY: caller contract. `*this` has to be held across `close()`,
-        // which lets the owner drop `create()`'s ref: start()'s ref does that
-        // when it is still outstanding, otherwise (the owner already released
-        // it, as `SecurityScanSubprocess` does right after `start()`) a ref
-        // taken here does. Either way the trailing release balances it, goes
-        // through `this`, and is the last use of `this`.
+        // SAFETY: caller contract. Something must hold `*this` across `close()`
+        // (the owner drops its ref in there): start()'s ref if still
+        // outstanding, else one taken here (the security scanner releases
+        // start()'s right after `start()`). The trailing release balances it
+        // and is the last use of `this`.
         unsafe {
             if !claimed_start_ref {
                 RefCount::<Self>::ref_(this);
@@ -279,12 +270,11 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
             this as usize,
             err
         );
-        // Nothing is released here: the writer closes itself after this (so
-        // `on_close` runs), and after a partially drained buffer it still
-        // reports the drained bytes through `on_write`, which does the release.
-        // SAFETY: caller contract; borrows end at each `;`. `buffer` aliases
-        // `source`'s storage, which `detach()` frees, so it is cleared first:
-        // that later `on_write` re-slices it.
+        // No release here: the writer closes itself next, and after a partial
+        // drain still reports through `on_write`, which releases.
+        // SAFETY: caller contract; borrows end at each `;`. `buffer` aliases the
+        // storage `detach()` frees, and that `on_write` re-slices it, so it is
+        // cleared first.
         unsafe {
             (*this).buffer = RawSlice::EMPTY;
             (*this).source.detach();
@@ -292,27 +282,23 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
     }
 
     /// # Safety
-    /// `this` must be the live writer. On POSIX, `P::on_close_io` may drop the
-    /// owner's ref, and when nothing else holds one (`SecurityScanSubprocess`,
-    /// or the EOF path of `on_write`) that frees `*this`; it is the last thing
-    /// done with `this` here.
+    /// `this` must be the live writer. On POSIX the owner's release in
+    /// `on_close_io` may be the last one (security scanner, EOF path); it is
+    /// the last thing done with `this` here.
     pub(crate) unsafe fn on_close(this: *mut Self) {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) onClose()",
             this as usize
         );
-        // On Windows the error arm of `WindowsBufferedWriter::on_write_complete`
-        // reaches here via `close()` without ever calling `Parent::on_write`, so
-        // this is the last point `started` can be claimed for that path.
-        // `write()`'s +1 (held by that callback's scopeguard) keeps the writer
-        // live past the release. POSIX must not release here: `drain_buffered_data`
-        // may call `on_error()` -> `close()` -> here and then `on_write()` on
-        // the same object, with no extra ref held.
-        // SAFETY: caller contract; borrows end at each `;`. `buffer` aliases
-        // `source`'s storage, so it is cleared before `detach()` frees that.
-        // `process` is a backref to the owning process, which outlives its
-        // stdio writers; it is copied out before the call that may free `*this`.
+        // Windows: the error arm of `WindowsBufferedWriter::on_write_complete`
+        // reaches here without an `on_write`, so start()'s ref is released here
+        // (write()'s ref, held by that callback, keeps the writer alive).
+        // POSIX: not here, because `drain_buffered_data` may reach here via
+        // `on_error()` and then still call `on_write()` on the same object.
+        // SAFETY: caller contract; borrows end at each `;`. `buffer` aliases the
+        // storage `detach()` frees; `process` (outlives its stdio writers) is
+        // copied out before the call that may free `*this`.
         unsafe {
             #[cfg(windows)]
             let release_start_ref = core::mem::replace(&mut (*this).started, false);

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -63,10 +63,12 @@ pub type Poll<P> = IOWriter<P>;
 // BufferedWriter parent vtable — wires bun_io callbacks to inherent methods
 // ──────────────────────────────────────────────────────────────────────────
 
+// `borrow = ptr`: `on_write` ends by releasing what is normally the writer's
+// last ref, so the handlers take the raw backref (see `on_write`).
 bun_io::impl_buffered_writer_parent! {
     for<P: StaticPipeWriterProcess> StaticPipeWriter<P>;
     poll_tag   = P::POLL_OWNER_TAG,
-    borrow     = mut,
+    borrow     = ptr,
     on_write   = on_write,
     on_error   = on_error,
     on_close   = on_close,
@@ -199,11 +201,23 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         }
     }
 
-    pub(crate) fn on_write(&mut self, amount: usize, status: WriteStatus) {
+    /// Once the write is finished this closes the writer and releases the ref
+    /// that was holding it open. On POSIX, `writer.close()` runs `on_close` →
+    /// `P::on_close_io`, where the owner drops the ref it got from `create()`,
+    /// so the release at the end is normally the writer's last one and frees
+    /// `*this`. That is why this takes the raw backref: freeing an allocation
+    /// while a reference to it is a live argument is rejected by both aliasing
+    /// models, so no `&mut Self` is formed here (each borrow is scoped to one
+    /// statement) and nothing above this frame holds one either
+    /// (`PosixPipeWriter::on_poll`).
+    ///
+    /// # Safety
+    /// `this` must be the live writer; it may have been freed when this returns.
+    pub(crate) unsafe fn on_write(this: *mut Self, amount: usize, status: WriteStatus) {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) onWrite(amount={} {})",
-            std::ptr::from_ref(self) as usize,
+            this as usize,
             amount,
             // Local stringify — `WriteStatus` (upstream bun_io) has no `Debug` impl.
             match status {
@@ -212,72 +226,104 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
                 WriteStatus::Pending => "pending",
             }
         );
-        let len = self.buffer.len();
-        self.buffer = RawSlice::new(&self.buffer.slice()[amount.min(len)..]);
-        if status == WriteStatus::EndOfFile || self.buffer.is_empty() {
-            // `started` is the token for start()'s outstanding +1. Clearing it
-            // before the deref makes this release mutually exclusive with the
-            // owner's close-time release (`Subprocess::take_pending_start_writer`,
-            // which also clears `started`). On POSIX, `writer.close()` →
-            // `Parent::on_close` may drop `create()`'s +1, so keep start()'s +1
-            // across it. `EndOfFile` is skipped because `PosixBufferedWriter::
-            // _on_write` still touches `self` after this returns on that status.
-            let release_start_ref = self.started && status != WriteStatus::EndOfFile;
-            if release_start_ref {
-                self.started = false;
+        // SAFETY: caller contract; borrows end at each `;`.
+        let claimed_start_ref = unsafe {
+            let buffer = (*this).buffer;
+            let remaining = RawSlice::new(&buffer.slice()[amount.min(buffer.len())..]);
+            (*this).buffer = remaining;
+            if status != WriteStatus::EndOfFile && !remaining.is_empty() {
+                return;
             }
-            self.writer.close();
-            if release_start_ref {
-                // SAFETY: start()'s +1 was still outstanding; `started` cleared above so no other site re-derefs.
-                unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
+            // `started` is the token for start()'s outstanding +1. Claiming it
+            // here makes the release below mutually exclusive with the owners'
+            // close-time release (`Subprocess::take_pending_start_writer` and
+            // friends clear it the same way).
+            core::mem::replace(&mut (*this).started, false)
+        };
+
+        if status == WriteStatus::EndOfFile {
+            // The writer closed the fd before reporting EOF and delivers
+            // `on_close` itself once this returns (`PosixBufferedWriterParent::
+            // on_write`), so the owner still holds `create()`'s ref and this
+            // release cannot be the last one; closing here instead would let
+            // the owner free `*this` underneath the writer's pending close.
+            if claimed_start_ref {
+                // SAFETY: caller contract; `started` was claimed above, so this
+                // is the only release of start()'s ref.
+                unsafe { RefCount::<Self>::deref(this) };
             }
+            return;
+        }
+
+        // SAFETY: caller contract. `*this` has to be held across `close()`,
+        // which lets the owner drop `create()`'s ref: start()'s ref does that
+        // when it is still outstanding, otherwise (the owner already released
+        // it, as `SecurityScanSubprocess` does right after `start()`) a ref
+        // taken here does. Either way the trailing release balances it, goes
+        // through `this`, and is the last use of `this`.
+        unsafe {
+            if !claimed_start_ref {
+                RefCount::<Self>::ref_(this);
+            }
+            (*this).writer.close();
+            RefCount::<Self>::deref(this);
         }
     }
 
-    pub(crate) fn on_error(&mut self, err: &bun_sys::Error) {
+    /// # Safety
+    /// `this` must be the live writer.
+    pub(crate) unsafe fn on_error(this: *mut Self, err: &bun_sys::Error) {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) onError(err={})",
-            std::ptr::from_ref(self) as usize,
+            this as usize,
             err
         );
-        // Clear the buffer before detaching: `buffer` aliases `self.source`'s
-        // storage, and `detach()` frees it. `drain_buffered_data` calls
-        // on_error() then Parent::on_write(), which would otherwise re-slice
-        // the freed allocation.
-        self.buffer = RawSlice::EMPTY;
-        self.source.detach();
-        // Can't release start()'s +1 here: `drain_buffered_data` calls on_error() then
-        // Parent::on_write(); freeing here would UAF.
+        // Nothing is released here: the writer closes itself after this (so
+        // `on_close` runs), and after a partially drained buffer it still
+        // reports the drained bytes through `on_write`, which does the release.
+        // SAFETY: caller contract; borrows end at each `;`. `buffer` aliases
+        // `source`'s storage, which `detach()` frees, so it is cleared first:
+        // that later `on_write` re-slices it.
+        unsafe {
+            (*this).buffer = RawSlice::EMPTY;
+            (*this).source.detach();
+        }
     }
 
-    pub(crate) fn on_close(&mut self) {
+    /// # Safety
+    /// `this` must be the live writer. On POSIX, `P::on_close_io` may drop the
+    /// owner's ref, and when nothing else holds one (`SecurityScanSubprocess`,
+    /// or the EOF path of `on_write`) that frees `*this`; it is the last thing
+    /// done with `this` here.
+    pub(crate) unsafe fn on_close(this: *mut Self) {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) onClose()",
-            std::ptr::from_ref(self) as usize
+            this as usize
         );
         // On Windows the error arm of `WindowsBufferedWriter::on_write_complete`
         // reaches here via `close()` without ever calling `Parent::on_write`, so
         // this is the last point `started` can be claimed for that path.
-        // `write()`'s +1 (held by that callback's scopeguard) keeps `self` live
-        // past the deref. POSIX must not release here: `drain_buffered_data`
+        // `write()`'s +1 (held by that callback's scopeguard) keeps the writer
+        // live past the release. POSIX must not release here: `drain_buffered_data`
         // may call `on_error()` -> `close()` -> here and then `on_write()` on
         // the same object, with no extra ref held.
-        #[cfg(windows)]
-        let release_start_ref = core::mem::replace(&mut self.started, false);
-        // `buffer` aliases `self.source`'s storage; clear it before detach()
-        // frees that storage so no dangling slice survives the close.
-        self.buffer = RawSlice::EMPTY;
-        self.source.detach();
-        // SAFETY: `process` is a backref to the owning process, guaranteed alive
-        // for the lifetime of this writer (the process owns/outlives its stdio writers).
-        unsafe { P::on_close_io(self.process, StdioKind::Stdin) };
-        #[cfg(windows)]
-        if release_start_ref {
-            // SAFETY: `started` was the token for start()'s outstanding +1;
-            // cleared above so no other site re-derefs. Last use of `self`.
-            unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
+        // SAFETY: caller contract; borrows end at each `;`. `buffer` aliases
+        // `source`'s storage, so it is cleared before `detach()` frees that.
+        // `process` is a backref to the owning process, which outlives its
+        // stdio writers; it is copied out before the call that may free `*this`.
+        unsafe {
+            #[cfg(windows)]
+            let release_start_ref = core::mem::replace(&mut (*this).started, false);
+            (*this).buffer = RawSlice::EMPTY;
+            (*this).source.detach();
+            let process = (*this).process;
+            P::on_close_io(process, StdioKind::Stdin);
+            #[cfg(windows)]
+            if release_start_ref {
+                RefCount::<Self>::deref(this);
+            }
         }
     }
 

--- a/test/cli/install/bun-install-security-provider.test.ts
+++ b/test/cli/install/bun-install-security-provider.test.ts
@@ -27,6 +27,14 @@ function test(
     packageJson?: object;
     customRegistry?: (urls: string[], ctx: TestContext) => any;
     concurrent?: boolean;
+    /** Extra files written into the project directory. */
+    files?: Record<string, string>;
+    /**
+     * Top-level `preload` for the project's bunfig.toml. `bun install` ignores
+     * it; the scanner subprocess, which runs in the project directory, runs it
+     * before scanner-entry does anything else.
+     */
+    bunfigPreload?: string;
   },
 ) {
   const itFn = options.concurrent === false ? it : it.concurrent;
@@ -55,7 +63,16 @@ function test(
           await write(scannerPath, s);
         }
 
-        const bunfig = await Bun.file(join(ctx.package_dir, "bunfig.toml")).text();
+        for (const [path, content] of Object.entries(options.files ?? {})) {
+          await write(path, content);
+        }
+
+        let bunfig = await Bun.file(join(ctx.package_dir, "bunfig.toml")).text();
+        if (options.bunfigPreload !== undefined) {
+          // Top-level keys have to precede the first table.
+          bunfig = `preload = ${JSON.stringify([options.bunfigPreload])}\n${bunfig}`;
+          await write("./bunfig.toml", bunfig);
+        }
         if (options.bunfigScanner !== false) {
           const scannerPath = options.bunfigScanner ?? "./scanner.ts";
           await write("./bunfig.toml", `${bunfig}\n[install.security]\nscanner = "${scannerPath}"`);
@@ -725,6 +742,48 @@ describe("Large payload via ipc pipe", () => {
     barTarballBytes = await Bun.file(`${import.meta.dir}/bar-0.0.2.tgz`).bytes();
   });
 
+  const packageJson = (() => {
+    const dependencies: Record<string, string> = {};
+
+    for (let i = 0; i < PKG_COUNT; i++) {
+      dependencies[pkgName(i)] = "0.0.2";
+    }
+    return {
+      name: "my-app",
+      version: "1.0.0",
+      dependencies,
+    };
+  })();
+
+  const customRegistry = (_urls: string[], ctx: TestContext) => {
+    return async (request: Request) => {
+      const url = request.url.replaceAll("%2f", "/");
+      expect(request.method).toBe("GET");
+      if (new URL(url).pathname.endsWith(".tgz")) {
+        return new Response(barTarballBytes);
+      }
+      expect(request.headers.get("accept")).toBe(
+        "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
+      );
+      expect(request.headers.get("npm-auth-type")).toBe(null);
+      expect(await request.text()).toBe("");
+      const name = new URL(url).pathname.replace(`/${ctx.id}/`, "");
+      return new Response(
+        JSON.stringify({
+          name,
+          versions: {
+            "0.0.2": {
+              name,
+              version: "0.0.2",
+              dist: { tarball: `${ctx.registry_url}${name}-0.0.2.tgz?pad=${URL_PAD}` },
+            },
+          },
+          "dist-tags": { latest: "0.0.2" },
+        }),
+      );
+    };
+  };
+
   test("handles packages JSON larger than max arg length (>1MB)", {
     testTimeout: 60_000,
     scanner: async ({ packages }) => {
@@ -743,49 +802,10 @@ describe("Large payload via ipc pipe", () => {
       // hundreds of packages into node_modules is not what is under test here.
       return [{ package: packages[0].name, description: "abort after IPC payload check", level: "fatal", url: null }];
     },
-
-    packageJson: (() => {
-      const dependencies: Record<string, string> = {};
-
-      for (let i = 0; i < PKG_COUNT; i++) {
-        dependencies[pkgName(i)] = "0.0.2";
-      }
-      return {
-        name: "my-app",
-        version: "1.0.0",
-        dependencies,
-      };
-    })(),
+    packageJson,
     packages: [],
     fails: true,
-    customRegistry: (_urls, ctx) => {
-      return async (request: Request) => {
-        const url = request.url.replaceAll("%2f", "/");
-        expect(request.method).toBe("GET");
-        if (new URL(url).pathname.endsWith(".tgz")) {
-          return new Response(barTarballBytes);
-        }
-        expect(request.headers.get("accept")).toBe(
-          "application/vnd.npm.install-v1+json; q=1.0, application/json; q=0.8, */*",
-        );
-        expect(request.headers.get("npm-auth-type")).toBe(null);
-        expect(await request.text()).toBe("");
-        const name = new URL(url).pathname.replace(`/${ctx.id}/`, "");
-        return new Response(
-          JSON.stringify({
-            name,
-            versions: {
-              "0.0.2": {
-                name,
-                version: "0.0.2",
-                dist: { tarball: `${ctx.registry_url}${name}-0.0.2.tgz?pad=${URL_PAD}` },
-              },
-            },
-            "dist-tags": { latest: "0.0.2" },
-          }),
-        );
-      };
-    },
+    customRegistry,
     expect: ({ out }) => {
       const match = out.match(/Received JSON payload of (\d+) bytes from (\d+) packages/);
       expect(match).not.toBeNull();
@@ -794,6 +814,27 @@ describe("Large payload via ipc pipe", () => {
       expect(bytes).toBeGreaterThan(1024 * 1024);
       expect(count).toBe(PKG_COUNT);
       expect(out).toContain("abort after IPC payload check");
+    },
+  });
+
+  // The scanner process runs in the project directory, so a bunfig preload
+  // runs before scanner-entry reads its input: the child exits with most of
+  // the same >1MB payload as above (the test above asserts its size) still
+  // unwritten, and bun's next write to it fails with EPIPE. That is the
+  // writer's error path, as opposed to the drained path above; on it the
+  // scanner subprocess drops its last reference to the writer from inside the
+  // error's close notification.
+  test("scanner that exits before reading a >1MB payload is reported, not crashed on", {
+    testTimeout: 60_000,
+    scanner: async () => [],
+    files: { "exit-before-reading.ts": "process.exit(42);" },
+    bunfigPreload: "./exit-before-reading.ts",
+    packageJson,
+    packages: [],
+    customRegistry,
+    expectedExitCode: 1,
+    expect: ({ err }) => {
+      expect(err).toContain("Security scanner exited with code 42 without sending data");
     },
   });
 });

--- a/test/internal/source-lints/writer-parent-mut-borrow.test.ts
+++ b/test/internal/source-lints/writer-parent-mut-borrow.test.ts
@@ -1,0 +1,201 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// The PipeWriter parent vtables (`impl_streaming_writer_parent!` /
+// `impl_buffered_writer_parent!` in src/io/PipeWriter.rs) must not dispatch a
+// callback through `&mut Parent`: `borrow = mut` is banned at every invocation,
+// and the macros must not grow a dispatch arm for it again.
+//
+// A parent's callbacks run underneath the writer that reports to it, and the
+// writer is a field of the parent. Forming `&mut *this` over the parent at the
+// vtable therefore
+//
+//   - asserts unique access to the writer's own bytes while the writer may
+//     still be borrowed further up the stack (the Windows write-complete
+//     callbacks and the synchronous `write()` paths report from `&mut self`),
+//     and
+//   - leaves a protected reference to the parent live for the whole callback,
+//     and a callback is exactly where a parent releases refs: when the release
+//     is the last one, the allocation the protected reference points into is
+//     freed underneath it, which both aliasing models reject (Tree Borrows,
+//     the model `bun run rust:miri` uses: "deallocation through <tag> ... is
+//     forbidden"; Stacked Borrows: "would remove [Unique for <tag>] which is
+//     strongly protected"; both point at the reference argument).
+//     `StaticPipeWriter::on_write` was the instance: on POSIX its trailing
+//     release of the `start()` ref is normally the writer's last one.
+//
+// `borrow = shared` is sound only for parents that keep the writer in a
+// `JsCell`/`UnsafeCell` (shell `IOWriter`, `WindowsNamedPipe`); `borrow = ptr`
+// hands the callback the raw backref, so it can do its `&mut` work through
+// call-scoped reborrows and release through the pointer (`FileSink`,
+// `StaticPipeWriter`). The module comment above the macros has the details.
+//
+// Hand-written `*WriterParent` impls are outside this lint; they have the same
+// obligations. Siblings: self-receiver-reclaim.test.ts (freeing the receiver's
+// own allocation), fn-long-mut-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// Start of a brace-delimited invocation of either macro. The macros' internal
+// helper arms are invoked with parentheses (`!(@call ..)`), so they never
+// match; their brace-delimited `@emit` recursion does, and is skipped below
+// because it carries no `borrow =` setting.
+const INVOCATION = /\bimpl_(?:streaming|buffered)_writer_parent!\s*\{/g;
+const BORROW_SETTING = /\bborrow\s*=\s*(\w+)\s*,/;
+const KNOWN_MODES = new Set(["shared", "ptr"]);
+
+// A dispatch arm in either macro's definition for a `mut` mode
+// (`(@call mut $p:expr; ..)`, or the older `(@borrow mut $p:expr)` spelling).
+const MUT_DISPATCH_ARM = /@(?:call|borrow)\s+mut\b/g;
+
+interface Invocation {
+  /** Offset of the `borrow =` setting (of the opening brace when there is none). */
+  offset: number;
+  /** The `borrow =` mode, or `null` for a body without one (`@emit` recursion). */
+  mode: string | null;
+}
+
+/** Every brace-delimited invocation in `text`, with its `borrow =` mode. */
+function invocations(text: string): Invocation[] {
+  const out: Invocation[] = [];
+  for (const m of text.matchAll(INVOCATION)) {
+    const open = m.index + m[0].length - 1;
+    let depth = 0;
+    let close = open;
+    for (; close < text.length; close++) {
+      const c = text[close];
+      if (c === "{") depth++;
+      else if (c === "}" && --depth === 0) break;
+    }
+    const setting = BORROW_SETTING.exec(text.slice(open + 1, close));
+    out.push(setting === null ? { offset: open, mode: null } : { offset: open + 1 + setting.index, mode: setting[1] });
+  }
+  return out;
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+/** `file:line: <reason>` for every violation in one (comment-stripped) file. */
+function violations(source: string, stripped: string): string[] {
+  const out: string[] = [];
+  for (const { offset, mode } of invocations(stripped)) {
+    if (mode === null || KNOWN_MODES.has(mode)) continue;
+    const reason =
+      mode === "mut"
+        ? "borrow = mut dispatches through &mut Parent"
+        : `unknown borrow mode \`${mode}\`; document its aliasing story here first`;
+    out.push(`${source}:${lineOf(stripped, offset)}: ${reason}`);
+  }
+  for (const m of stripped.matchAll(MUT_DISPATCH_ARM)) {
+    out.push(`${source}:${lineOf(stripped, m.index)}: macro offers a \`mut\` dispatch mode`);
+  }
+  return out;
+}
+
+const modesSeen: string[] = [];
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose (including the macros' own module
+  // comment) does not count. `[ \t]*`, not `\s*`, so blank lines survive and
+  // reported line numbers stay right.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const { mode } of invocations(stripped)) {
+    if (mode !== null) modesSeen.push(`${source}: ${mode}`);
+  }
+  offenders.push(...violations(source, stripped));
+}
+
+test("scans a non-empty set of tracked Rust sources, including vtable invocations", () => {
+  // Guards against the filters above over-firing, or the macros being renamed
+  // out from under `INVOCATION`, which would make the ban pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+  expect(modesSeen.length).toBeGreaterThan(0);
+});
+
+test("the scanner reads invocations and definitions the way it claims to", () => {
+  const staticPipeWriterBefore = [
+    "bun_io::impl_buffered_writer_parent! {",
+    "    for<P: StaticPipeWriterProcess> StaticPipeWriter<P>;",
+    "    poll_tag   = P::POLL_OWNER_TAG,",
+    "    borrow     = mut,",
+    "    on_write   = on_write,",
+    "    get_buffer = |this| &*(*this).buffer.as_ptr(),",
+    "    deref      = |this| RefCount::<Self>::deref(this),",
+    "}",
+  ].join("\n");
+  const fileSink = [
+    "bun_io::impl_streaming_writer_parent! {",
+    "    FileSink;",
+    "    poll_tag   = bun_io::posix_event_loop::poll_tag::FILE_SINK,",
+    "    borrow     = ptr,",
+    "    uws_loop   = |this| (*this).event_loop_handle.r#loop(),",
+    "}",
+  ].join("\n");
+  // An accessor expression containing braces must not end the body early.
+  const bracesInAccessor = [
+    "bun_io::impl_buffered_writer_parent! {",
+    "    IOWriter;",
+    "    event_loop = |this| { let s = &*this; s.io_evtloop() },",
+    "    borrow     = shared,",
+    "}",
+  ].join("\n");
+  const emitRecursion = ["$crate::impl_streaming_writer_parent! {", "    @emit [] $Ty; $($rest)*", "}"].join("\n");
+
+  expect(invocations(staticPipeWriterBefore).map(i => i.mode)).toEqual(["mut"]);
+  expect(invocations(fileSink).map(i => i.mode)).toEqual(["ptr"]);
+  expect(invocations(bracesInAccessor).map(i => i.mode)).toEqual(["shared"]);
+  expect(invocations(emitRecursion).map(i => i.mode)).toEqual([null]);
+
+  expect(violations("a.rs", staticPipeWriterBefore)).toEqual(["a.rs:4: borrow = mut dispatches through &mut Parent"]);
+  expect(violations("a.rs", fileSink + "\n" + bracesInAccessor + "\n" + emitRecursion)).toEqual([]);
+  expect(violations("a.rs", fileSink.replace("ptr", "owned"))).toEqual([
+    "a.rs:4: unknown borrow mode `owned`; document its aliasing story here first",
+  ]);
+
+  const definitionBefore = [
+    "    (@call mut    $p:expr; $m:ident($($a:tt)*)) => { (&mut *$p).$m($($a)*) };",
+    "    (@call shared $p:expr; $m:ident($($a:tt)*)) => { (&*$p).$m($($a)*) };",
+    "    (@borrow mut    $p:expr) => { &mut *$p };",
+  ].join("\n");
+  expect(violations("m.rs", definitionBefore)).toEqual([
+    "m.rs:1: macro offers a `mut` dispatch mode",
+    "m.rs:3: macro offers a `mut` dispatch mode",
+  ]);
+  const definitionAfter = [
+    "    (@call shared $p:expr; $m:ident($($a:tt)*)) => { (&*$p).$m($($a)*) };",
+    "    (@call ptr    $p:expr; $m:ident($($a:tt)*)) => { <Self>::$m($p, $($a)*) };",
+    "    borrow     = $borrow:tt,",
+  ].join("\n");
+  expect(violations("m.rs", definitionAfter)).toEqual([]);
+});
+
+test("no writer-parent vtable dispatches through &mut Parent", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- Draining a buffer or Blob into a child's stdin (`Bun.spawn` when memfd is not used, always on macOS, and every shell `$` command with a buffer on stdin) frees the `StaticPipeWriter` from inside its own `on_write(&mut self)`: the owner drops its ref during `writer.close()`, so the trailing `deref` is normally the last one.
- Every frame below it, from the poll dispatch down to the vtable shim, held the embedded writer by `&mut` too, and that writer is a field of the object being freed. Freeing an allocation while a reference into it is a live argument is UB under both Rust aliasing models, even if nothing touches it afterwards.
- A reduction of the chain fails under Miri: `error: Undefined Behavior: deallocation through <1716> at alloc239[0x0] is forbidden` (Tree Borrows), and at the `Box::from_raw` under Stacked Borrows. `FileSink` and the install security scanner's writer release through the same chain.
- No crash is known from this: the free is the last thing any of these frames do. The contract is what is wrong, the same one #36571 moved `PipeReader` off.

### Fix
- The POSIX poll chain passes the writer as `*mut` end to end: each frame takes `&mut` only for statement-scoped work, and the report or close that may free the parent is its last use of the pointer (a raw close entry delivers `on_close` with nothing borrowed). Property to check: at every call that may free the parent, no reference into the parent or its writer is live.
- `StaticPipeWriter` moves to the raw dispatch mode and the `&mut` mode is deleted from both parent macros (it was the only user). Its `on_write` takes a ref of its own across `writer.close()` when `start()`'s is already gone (the scanner) and releases through the raw pointer last; on EOF it no longer closes the writer itself, which used to leak it. The subprocess owners stop borrowing the whole writer from `on_close_io` and only drop their ref.
- Verification: nothing observable changes, so no test fails without the fix. A new source lint rejects `main` (3 hits) and passes here; the Miri reductions pass once converted; refcount logs on the ASAN debug build show `Bun.spawn`, the shell and `bun pm scan` ending in the same order; a new scanner test covers the EPIPE path (passes before and after); the spawn, shell, filesink and security-provider suites pass under ASAN; Windows `cargo check` passes.
- Left alone on purpose: the zero-drain error path still leaks `start()`'s ref on POSIX (pre-existing, tracked separately), and the partial-drain error is still reported under `&mut self` (that is the #34697 protocol change).

### Background
- `StaticPipeWriter` writes one fixed buffer or Blob into a spawned child's stdin; `Bun.spawn`, the shell and `bun pm scan`'s security scanner all use it. It is refcounted: `create()` hands the owner a ref, `start()` takes another, and whoever drops the last one frees it.
- `PosixBufferedWriter` is the generic fd-draining machinery, embedded as a field of that parent with a raw backref to it. It reports `on_write` (`Pending`, `Drained` or `EndOfFile`), `on_error` and `on_close` through a vtable the `impl_*_writer_parent!` macros generate; the macro's `borrow` mode decides whether the parent's handlers get `&*this`, `&mut *this` or the bare `*mut`.
- Because the writer is a field of the parent, freeing the parent frees the writer, so a frame entered through `&mut writer` still points into memory the parent's handler may free.
- Stacked Borrows and Tree Borrows (the aliasing models Miri checks) protect a reference for as long as it is an argument of a running function: deallocating what it points into during that time is UB whether or not the reference is used again. Raw pointers have no protector, which is why `*mut` plus short reborrows is the sound shape.
- `on_close_io` is the owner's callback for one of its stdio pipes closing; for stdin it is where the owner drops its `create()` ref, which is why the final free normally lands inside `writer.close()`.

<details>
<summary>Original description</summary>

### Problem

`StaticPipeWriter::on_write(&mut self, ..)` (src/spawn/static_pipe_writer.rs) ended with

```rust
unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
```

releasing the ref `start()` took. Just before it, `self.writer.close()` runs `on_close` -> `P::on_close_io`, where the owner (`Subprocess`, `ShellSubprocess`) drops the ref it got from `create()`, so on POSIX that release is normally the writer's last one: `deref` runs the destructor and frees the `StaticPipeWriter` while `&mut self` is still a live argument. Every buffer/Blob stdin that drains goes through this (on Linux once memfd is not used, e.g. `stdin: Bun.file(..)` or `BUN_FEATURE_FLAG_DISABLE_MEMFD=1`; always on macOS; every shell `$` command with a buffer redirected to its stdin).

The receiver is not the only reference involved. The writer is a field of the `StaticPipeWriter`, and every frame between the poll dispatch and the release held it by reference: `PosixPipeWriter::on_poll(&mut self)` -> `on_write(&mut self)` -> `PosixBufferedWriter::_on_write(&mut self)` -> the vtable shim, which with `borrow = mut` formed `&mut *this` over the whole parent. A reference argument is protected for the duration of its call, and both aliasing models reject freeing the allocation it points into while it is live, whether or not anything touches it afterwards. So converting `on_write` alone would not have been enough; the chain had to go. A reduction of the chain (writer embedded in a refcounted parent, the poll entry holding `&mut writer`, the parent's report releasing the last ref) fails under Miri with Tree Borrows, the model `bun run rust:miri` uses, at the deallocation:

```
error: Undefined Behavior: deallocation through <1716> at alloc239[0x0] is forbidden
  = help: this deallocation (acting as a foreign write access) would cause the protected tag <1707> ... to become Disabled
help: the protected tag <1707> was created here, in the initial state Reserved
   |     fn on_poll_before(&mut self) {
```

and under Stacked Borrows at the `Box::from_raw` (`not granting access to tag <398> because that would remove [Unique for <1748>] which is strongly protected`, `<1748>` being the same `&mut self`). The same program with the entry taking `*mut Writer` passes under both.

The same chain sits under two other final releases today: `FileSink::on_write` / `on_close` drop the sink's refs from the poll path through the streaming writer's `&mut` frames, and `SecurityScanSubprocess` releases the `start()` ref right after `start()`, so for it the owner's release inside `writer.close()` was the last one, freeing the writer underneath `on_write(&mut self)`, `close(&mut self)` and `close_impl(&mut self)`.

No crash is known from this; the destructor is the last thing any of these frames do. It is the contract that is wrong, and it is the same contract #36571 moved `PipeReader`'s `read`/`on_poll`/`done` entries onto.

<details>
<summary>Reduction run under Miri</summary>

```rust
struct Writer { parent: *mut Parent }
struct Parent { refs: u32, writer: Writer }

impl Parent {
    // `StaticPipeWriter::on_write`: may free the parent, and so the writer.
    unsafe fn on_write(this: *mut Parent) {
        unsafe {
            (*this).refs -= 1;
            if (*this).refs == 0 { drop(Box::from_raw(this)); }
        }
    }
}

impl Writer {
    // main
    fn on_poll_before(&mut self) {
        let parent = self.parent;
        unsafe { Parent::on_write(parent) }
    }
    // this PR
    unsafe fn on_poll_after(this: *mut Writer) {
        let parent = unsafe { (*this).parent };
        unsafe { Parent::on_write(parent) }
    }
}

fn main() {
    let parent = Box::into_raw(Box::new(Parent { refs: 1, writer: Writer { parent: std::ptr::null_mut() } }));
    let writer: *mut Writer = unsafe { &raw mut (*parent).writer };
    unsafe { (*writer).parent = parent };
    if std::env::args().nth(1).as_deref() == Some("after") {
        unsafe { Writer::on_poll_after(writer) }
    } else {
        unsafe { (*writer).on_poll_before() }
    }
}
```

`MIRIFLAGS=-Zmiri-tree-borrows cargo miri run -- before` and the default Stacked Borrows run report the errors quoted above; `-- after` exits 0 under both.

</details>

### Fix

Each frame now holds the writer as a raw pointer, does its `&mut` work through a call-scoped reborrow, and makes the report (or release) with nothing borrowed:

* `PosixPipeWriter` (src/io/PipeWriter.rs): `on_poll(this: *mut Self, ..)` is the poll entry; its `&mut` half is `drain_on_poll`, and every arm's final dispatch is the last thing done with `this`. The `on_write`, `on_error` and `register_poll` hooks take `*mut Self` too. In both writers `_on_write` and `_on_error` are raw, and the `on_close` they end with (the error path's close, the buffered writer's deferred EOF close, the streaming writer's failed re-arm) is delivered by a raw `close_raw`, which closes the handle through a statement-scoped borrow and then dispatches `on_close` with nothing borrowed. `close_raw` reports exactly when the old code did (a pending unreported close, or a handle that was still open), so `close()` and the streaming `register_poll()` are now thin wrappers over the raw entries for the parent's own call paths, which hold the parent alive. The R-2 `black_box` laundering in the buffered `_on_write` and both POSIX `LaunderedSelf` impls go away (the write-path `register_poll` wrapper still launders, since its receiver is a real `&mut self`). The parent traits' `on_write` / `on_error` / `on_close` docs state the liveness contract: the parent may free itself from a `Drained` report, from the `on_close` after an `EndOfFile` one, or from the `on_close` after an error; it has to survive a `Pending` report and the `on_error` report itself. One place is deliberately left as it was: `drain_buffered_data` still reports an error that follows a partial drain from under its own `&mut self` and is then followed by an `on_write` for the drained bytes (which is where `StaticPipeWriter` releases its `start()` ref on that path). Making that sound for a parent that frees itself from the error's `on_close` means changing what the partial case reports, i.e. the error-protocol rework that #34697 is about, not the dispatch; the comment there says so.
* `impl_buffered_writer_parent!` gains the `ptr` dispatch mode the streaming macro already had. The `mut` mode is removed from both macros: this was its only user, and besides the protector it asserted unique access to the writer's own bytes from underneath the writer's frames. The remaining `shared` users (shell `IOWriter`, `WindowsNamedPipe`) keep their writer in an `UnsafeCell`/`JsCell`, which the module comment now spells out. src/CLAUDE.md's description of the modes is updated.
* `StaticPipeWriter`: `borrow = ptr`; `on_write` / `on_error` / `on_close` take `this: *mut Self` and access fields one statement at a time. `on_write` now says explicitly what was implicit: the writer has to be held across `writer.close()`. It claims `start()`'s ref for that when it is still outstanding, takes one of its own otherwise, and releases through `this` as its last action. The "otherwise" covers the security scanner, which releases `start()`'s ref right after `start()`, so before this its free happened inside `close()`; on its error path (every write error, e.g. EPIPE) the free still happens from `on_close`, which is what the raw `close_raw` dispatch is for. The Windows-only release in `on_close` goes through `this` as well. `start()`'s two failure-path releases are unchanged: the caller holds the creation ref across `start()`, so they are never final (the ref is taken before `writer.start()` on purpose, a synchronous close on Windows relies on it).
* `EndOfFile` is handled differently from before, on purpose. The buffered writer reports EOF after closing the fd and delivers `on_close` itself once the report returns, so `on_write` no longer closes the writer there; it releases `start()`'s ref (not final: the owner's ref is dropped by the `on_close` that follows) and returns. Before, it closed the writer itself and deliberately kept `start()`'s ref, which leaked the writer on EOF, and for the scanner the owner's release inside that close freed the writer before the buffered writer's trailing `close()` read it. The Windows writer never reports EOF, so this is POSIX-only behaviour; EOF itself needs `write(2)` to return 0 on a pipe, which is why it is reasoned about here rather than tested.
* `shell::io_writer::on_poll` takes `*mut Poll`: it holds an `Arc` keepalive precisely because the child callbacks may drop the last external ref, and when they do, dropping the keepalive on the way out frees the `IOWriter` while a `&mut Poll` argument into it would still be live. dispatch.rs passes the owner raw to both entries.
* `Subprocess::on_close_io` and `ShellSubprocess::on_close_io` no longer borrow the whole `StaticPipeWriter` (`buffer_writer_mut` / `buffer_mut`) to detach its source: they are only ever reached from `StaticPipeWriter::on_close`, which has already detached it (and `Drop` detaches again), and they run underneath the writer's own `close()`, whose `&mut` to the embedded writer such a borrow would overlap. They just drop the ref now; the two accessors' docs and the `on_close` contracts say why. The scanner already used a field projection.

The zero-drain error path (`on_poll`'s `Err` arm, e.g. EPIPE with nothing written in that round) still leaks `start()`'s ref on POSIX; that is pre-existing, independent of this change (this PR changes how the error path is dispatched, not what it releases) and tracked separately. Once this and #37703 both land, its `self-receiver-release` allowlist entry for `static_pipe_writer.rs` drops from 4 to the two `start()` sites.

### Tests

`test/internal/source-lints/writer-parent-mut-borrow.test.ts` bans `borrow = mut` at every `impl_*_writer_parent!` invocation and bans a `mut` dispatch arm in the macro definitions, checks its scanner against the old `StaticPipeWriter` invocation, the current `FileSink` one, a body with braces in an accessor and the macros' own `@emit` recursion, and requires that it actually found invocations. Against `main` it reports

```
src/io/PipeWriter.rs:2603: macro offers a `mut` dispatch mode
src/io/PipeWriter.rs:2741: macro offers a `mut` dispatch mode
src/spawn/static_pipe_writer.rs:69: borrow = mut dispatches through &mut Parent
```

and passes with this branch. The rest of `test/internal/source-lints/` (19 files) passes.

`test/cli/install/bun-install-security-provider.test.ts` gets a test for the error path: with the same >1MB payload as the existing large-payload test, a bunfig `preload` makes the scanner process exit before scanner-entry reads its input, so bun's next write fails with EPIPE after one `Pending` round. On the debug build that is deterministically `onWrite(219264 pending)` -> `onError(EPIPE)` -> `onClose()` -> `deref 1 -> 0` (3/3 runs), i.e. the scanner freeing its writer from the error's `on_close`, now dispatched by `close_raw`; the install reports `Security scanner exited with code 42 without sending data`. It passes before and after (nothing observable changes), so it is coverage for the converted path under ASAN rather than the gate test.

### Verification

With `BUN_DEBUG_StaticPipeWriter=1 BUN_DEBUG_ref_count=1` on the debug (ASAN) build, the three owners now end the same way: `onWrite(drained)` -> `onClose()` -> owner's `deref 2 -> 1` -> trailing `deref 1 -> 0` for `Bun.spawn` (`BUN_FEATURE_FLAG_DISABLE_MEMFD=1`, 1 MiB buffer into `cat`) and for the shell (`cat` with the same buffer redirected to stdin); for `bun pm scan` it is `ref 1 -> 2` (the ref taken in `on_write`) -> `onClose()` -> `deref 2 -> 1` -> `deref 1 -> 0`. A second reduction, one level deeper (the parent's report calls the embedded writer's `close(&mut self)`, whose `close_impl(&mut self)` writes the handle and then delivers `on_close`, from which the owner forms a `&mut` over the whole parent the way `on_close_io` did), fails under Tree Borrows at that reborrow (`reborrow through <tag> ... is forbidden ... would cause the protected tag ... (currently Unique) to become Disabled`) and under Stacked Borrows (`would remove [Unique for <tag>] which is strongly protected`); with the owner touching its field by projection instead, as the owners now do, it passes under both.

On the debug (ASAN) build: test/js/bun/spawn/{spawn,spawnSync,spawn-empty-arrayBufferOrBlob,spawn-stdin-destroy,spawn-pipe-start-error,spawn-many-teardown,spawn-stdin-pipe-fd-leak,spawn-streaming-stdin}.test.ts, test/js/bun/memfd-disabled.test.ts, test/js/bun/shell/{bunshell,shell-blocking-pipe,epipe,shell-write-fault}.test.ts (bunshell: 418 pass), test/js/bun/util/filesink.test.ts, test/js/bun/terminal/terminal.test.ts and test/cli/install/bun-install-security-provider.test.ts all pass. `cargo check --target x86_64-pc-windows-msvc` for bun_io, bun_spawn, bun_install and bun_runtime passes (the Windows vtable impls and the `cfg(windows)` branch in `on_close` are exercised by it); `cargo clippy` on bun_io, bun_spawn and bun_runtime and `cargo fmt --check` are clean.

</details>
