### PR TITLE
install: key npm cache entries by their integrity, derive URL-based cache names with SHA-256

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -354,7 +354,7 @@ Environment variables take priority over `bunfig.toml`.
 
 Bun uses the fastest installation method available on the target platform: `clonefile` on macOS and `hardlink` on Linux. You can change the installation method with the `--backend` flag. When unavailable or on error, `clonefile` and `hardlink` fall back to a platform-specific implementation of copying files.
 
-Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}@@@2`, followed by `.` and a short fingerprint of the tarball's integrity hash when one is known. If the semver version has a `build` or a `pre` tag, Bun replaces it with a hash of that value. This reduces the chances of errors from long file paths, but complicates figuring out where a package was installed on disk.
+Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}@@@2`, followed by `.` and a short fingerprint of the tarball's integrity hash when the registry or lockfile provides one and integrity verification is enabled (it is omitted with `--no-verify`, and for the rare package name long enough that the folder name would exceed the filesystem's name-length limit). If the semver version has a `build` or a `pre` tag, Bun replaces it with a hash of that value. This reduces the chances of errors from long file paths, but complicates figuring out where a package was installed on disk.
 
 When the `node_modules` folder exists, Bun decides whether to install a package by checking that the `"name"` and `"version"` in its `package.json` at the expected `node_modules` location match the expected name and version. It uses a custom JSON parser which stops parsing as soon as it finds `"name"` and `"version"`.
 

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -354,7 +354,7 @@ Environment variables take priority over `bunfig.toml`.
 
 Bun uses the fastest installation method available on the target platform: `clonefile` on macOS and `hardlink` on Linux. You can change the installation method with the `--backend` flag. When unavailable or on error, `clonefile` and `hardlink` fall back to a platform-specific implementation of copying files.
 
-Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}`, followed by a fingerprint of the tarball's integrity hash when one is known. If the semver version has a `build` or a `pre` tag, Bun replaces it with a hash of that value. This reduces the chances of errors from long file paths, but complicates figuring out where a package was installed on disk.
+Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}`, followed by a short fingerprint of the tarball's integrity hash when one is known. If the semver version has a `build` or a `pre` tag, Bun replaces it with a hash of that value. This reduces the chances of errors from long file paths, but complicates figuring out where a package was installed on disk.
 
 When the `node_modules` folder exists, Bun decides whether to install a package by checking that the `"name"` and `"version"` in its `package.json` at the expected `node_modules` location match the expected name and version. It uses a custom JSON parser which stops parsing as soon as it finds `"name"` and `"version"`.
 

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -354,7 +354,7 @@ Environment variables take priority over `bunfig.toml`.
 
 Bun uses the fastest installation method available on the target platform: `clonefile` on macOS and `hardlink` on Linux. You can change the installation method with the `--backend` flag. When unavailable or on error, `clonefile` and `hardlink` fall back to a platform-specific implementation of copying files.
 
-Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}`. If the semver version has a `build` or a `pre` tag, Bun replaces it with a hash of that value. This reduces the chances of errors from long file paths, but complicates figuring out where a package was installed on disk.
+Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}`, followed by a fingerprint of the tarball's integrity hash when one is known. If the semver version has a `build` or a `pre` tag, Bun replaces it with a hash of that value. This reduces the chances of errors from long file paths, but complicates figuring out where a package was installed on disk.
 
 When the `node_modules` folder exists, Bun decides whether to install a package by checking that the `"name"` and `"version"` in its `package.json` at the expected `node_modules` location match the expected name and version. It uses a custom JSON parser which stops parsing as soon as it finds `"name"` and `"version"`.
 

--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -354,7 +354,7 @@ Environment variables take priority over `bunfig.toml`.
 
 Bun uses the fastest installation method available on the target platform: `clonefile` on macOS and `hardlink` on Linux. You can change the installation method with the `--backend` flag. When unavailable or on error, `clonefile` and `hardlink` fall back to a platform-specific implementation of copying files.
 
-Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}`, followed by a short fingerprint of the tarball's integrity hash when one is known. If the semver version has a `build` or a `pre` tag, Bun replaces it with a hash of that value. This reduces the chances of errors from long file paths, but complicates figuring out where a package was installed on disk.
+Bun stores installed packages from npm in `~/.bun/install/cache/${name}@${version}@@@2`, followed by `.` and a short fingerprint of the tarball's integrity hash when one is known. If the semver version has a `build` or a `pre` tag, Bun replaces it with a hash of that value. This reduces the chances of errors from long file paths, but complicates figuring out where a package was installed on disk.
 
 When the `node_modules` folder exists, Bun decides whether to install a package by checking that the `"name"` and `"version"` in its `package.json` at the expected `node_modules` location match the expected name and version. It uses a custom JSON parser which stops parsing as soon as it finds `"name"` and `"version"`.
 

--- a/docs/pm/global-cache.mdx
+++ b/docs/pm/global-cache.mdx
@@ -3,7 +3,7 @@ title: "Global cache"
 description: "How Bun stores and manages packages in its global cache"
 ---
 
-Bun stores every package downloaded from the registry in a global cache at `~/.bun/install/cache`, or the path set by the `BUN_INSTALL_CACHE_DIR` environment variable. Packages live in subdirectories named like `${name}@${version}`, so multiple versions of a package can be cached.
+Bun stores every package downloaded from the registry in a global cache at `~/.bun/install/cache`, or the path set by the `BUN_INSTALL_CACHE_DIR` environment variable. Packages live in subdirectories named like `${name}@${version}`, followed by a fingerprint of the tarball's integrity hash when the registry or lockfile provides one, so multiple versions of a package can be cached.
 
 <Accordion title="Configuring cache behavior">
 

--- a/docs/pm/global-cache.mdx
+++ b/docs/pm/global-cache.mdx
@@ -3,7 +3,7 @@ title: "Global cache"
 description: "How Bun stores and manages packages in its global cache"
 ---
 
-Bun stores every package downloaded from the registry in a global cache at `~/.bun/install/cache`, or the path set by the `BUN_INSTALL_CACHE_DIR` environment variable. Packages live in subdirectories named like `${name}@${version}`, followed by a fingerprint of the tarball's integrity hash when the registry or lockfile provides one, so multiple versions of a package can be cached.
+Bun stores every package downloaded from the registry in a global cache at `~/.bun/install/cache`, or the path set by the `BUN_INSTALL_CACHE_DIR` environment variable. Packages live in subdirectories named like `${name}@${version}`, so multiple versions of a package can be cached side by side. When the registry or lockfile provides an integrity hash for the tarball, a fingerprint of it is appended to the directory name as well, so entries for the same name and version whose tarballs have different digests are kept apart.
 
 <Accordion title="Configuring cache behavior">
 

--- a/docs/pm/global-cache.mdx
+++ b/docs/pm/global-cache.mdx
@@ -3,7 +3,7 @@ title: "Global cache"
 description: "How Bun stores and manages packages in its global cache"
 ---
 
-Bun stores every package downloaded from the registry in a global cache at `~/.bun/install/cache`, or the path set by the `BUN_INSTALL_CACHE_DIR` environment variable. Packages live in subdirectories named like `${name}@${version}`, so multiple versions of a package can be cached side by side. When the registry or lockfile provides an integrity hash for the tarball, a fingerprint of it is appended to the directory name as well, so entries for the same name and version whose tarballs have different digests are kept apart.
+Bun stores every package downloaded from the registry in a global cache at `~/.bun/install/cache`, or the path set by the `BUN_INSTALL_CACHE_DIR` environment variable. Packages live in subdirectories named like `${name}@${version}`, so multiple versions of a package can be cached side by side. When the registry or lockfile provides an integrity hash for the tarball, a short fingerprint of it is appended to the directory name as well, so entries for the same name and version whose tarballs have different digests are kept apart.
 
 <Accordion title="Configuring cache behavior">
 

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -86,7 +86,7 @@ The on-disk layout adds one level of indirection compared to [isolated installs]
 
 ```bash tree layout icon="list-tree"
 ~/.bun/install/cache/
-├── react@18.3.1@@@1/                     # Package cache (unchanged)
+├── react@18.3.1@@@1_integrity=<hex>/     # Package cache (unchanged)
 │   └── ...package files...
 └── links/                                # Global virtual store
     └── react@18.3.1-5664d3cd670b3205/    # <storepath>-<entry hash>

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -86,7 +86,7 @@ The on-disk layout adds one level of indirection compared to [isolated installs]
 
 ```bash tree layout icon="list-tree"
 ~/.bun/install/cache/
-├── react@18.3.1@@@1_integrity=<hex>/     # Package cache (unchanged)
+├── react@18.3.1@@@2.<fingerprint>/       # Package cache (unchanged)
 │   └── ...package files...
 └── links/                                # Global virtual store
     └── react@18.3.1-5664d3cd670b3205/    # <storepath>-<entry hash>

--- a/docs/pm/global-store.mdx
+++ b/docs/pm/global-store.mdx
@@ -86,7 +86,7 @@ The on-disk layout adds one level of indirection compared to [isolated installs]
 
 ```bash tree layout icon="list-tree"
 ~/.bun/install/cache/
-├── react@18.3.1@@@2.<fingerprint>/       # Package cache (unchanged)
+├── react@18.3.1@@@2.<fingerprint>/       # Package cache
 │   └── ...package files...
 └── links/                                # Global virtual store
     └── react@18.3.1-5664d3cd670b3205/    # <storepath>-<entry hash>

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1429,6 +1429,7 @@ impl<'a> PackageInstaller<'a> {
                     self.manager_mut(),
                     pkg_name.slice(string_buf!()),
                     resolution.npm().version,
+                    &self.metas[package_id as usize].integrity,
                     patch_contents_hash,
                 );
                 installer.cache_dir = package_manager::get_cache_directory(self.manager_mut());

--- a/src/install/PackageInstaller.rs
+++ b/src/install/PackageInstaller.rs
@@ -1425,6 +1425,7 @@ impl<'a> PackageInstaller<'a> {
 
         match resolution.tag {
             resolution::Tag::Npm => {
+                installer.cache_dir = package_manager::get_cache_directory(self.manager_mut());
                 installer.cache_dir_subpath = package_manager::cached_npm_package_folder_name(
                     self.manager_mut(),
                     pkg_name.slice(string_buf!()),
@@ -1432,7 +1433,6 @@ impl<'a> PackageInstaller<'a> {
                     &self.metas[package_id as usize].integrity,
                     patch_contents_hash,
                 );
-                installer.cache_dir = package_manager::get_cache_directory(self.manager_mut());
             }
             resolution::Tag::Git => {
                 installer.cache_dir_subpath = package_manager::cached_git_folder_name(

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -279,6 +279,7 @@ bun_output::declare_scope!(PackageManager, hidden);
 pub struct PackageManager {
     pub(crate) cache_directory: Option<bun_sys::Dir>,
     pub(crate) cache_directory_path: ZBox, // owned; process lifetime via the leaked singleton
+    pub(crate) cache_directory_id: crate::integrity::CacheDirId,
     pub root_dir: &'static mut fs::DirEntry,
     // allocator dropped per §Allocators (was `bun.default_allocator`). For the
     // handful of sites that allocated AST nodes via `Expr.allocate(manager.allocator, …)`
@@ -1857,6 +1858,7 @@ pub fn init(
 
         wr!(cache_directory, None);
         wr!(cache_directory_path, ZBox::from_bytes(b""));
+        wr!(cache_directory_id, [0; 16]);
         wr!(options, options);
         wr!(
             active_lifecycle_scripts,
@@ -2284,6 +2286,7 @@ fn init_with_runtime_once(
 
         wr!(cache_directory, None);
         wr!(cache_directory_path, ZBox::from_bytes(b""));
+        wr!(cache_directory_id, [0; 16]);
         wr!(
             options,
             Options {

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -7,6 +7,7 @@ use crate::bun_fs::FileSystem;
 use crate::lockfile_real::package::PackageColumns;
 use crate::repository::Repository;
 use bun_core::ZStr;
+use bun_core::strings;
 use bun_core::{Global, Output, ZBox, env_var, fmt as bun_fmt};
 use bun_dotenv::Loader as DotEnvLoader;
 use bun_install::integrity::{self, Integrity};
@@ -338,7 +339,11 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
             unsafe { (*this).cache_directory_path = ZBox::from_bytes(&cache_dir.path) };
 
             match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
-                Ok(d) => return d,
+                Ok(d) => {
+                    // SAFETY: see fn safety contract.
+                    unsafe { (*this).cache_directory_id = read_or_create_cache_directory_id(&d) };
+                    return d;
+                }
                 Err(_) => {
                     // SAFETY: narrow `&mut enable` projection; disjoint from
                     // any `&options.{registries,scope}` the caller may hold.
@@ -360,7 +365,11 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
         };
 
         match Dir::cwd().make_open_path(b"node_modules/.cache", Default::default()) {
-            Ok(d) => return d,
+            Ok(d) => {
+                // SAFETY: see fn safety contract.
+                unsafe { (*this).cache_directory_id = read_or_create_cache_directory_id(&d) };
+                return d;
+            }
             Err(err) => {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: bun is unable to write files: {}",
@@ -370,6 +379,36 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
             }
         }
     }
+}
+
+/// `<cache>/.id`: 16 random bytes created once per cache directory; npm cache
+/// entry fingerprints are keyed with it. An unreadable file is replaced,
+/// which only means fingerprinted entries are fetched again.
+fn read_or_create_cache_directory_id(cache_dir: &Dir) -> integrity::CacheDirId {
+    let name = bun_core::zstr!(".id");
+    let read = |id: &mut integrity::CacheDirId| -> bool {
+        File::openat(cache_dir.fd(), name.as_bytes(), sys::O::RDONLY, 0)
+            .and_then(|file| file.read_all(id))
+            .is_ok_and(|len| len == id.len())
+    };
+    let mut id: integrity::CacheDirId = [0; 16];
+    for _ in 0..2 {
+        if read(&mut id) {
+            return id;
+        }
+        bun_boringssl_sys::rand_bytes(&mut id);
+        let _ = sys::unlinkat(cache_dir.fd(), name);
+        match File::openat(
+            cache_dir.fd(),
+            name.as_bytes(),
+            sys::O::WRONLY | sys::O::CREAT | sys::O::EXCL,
+            0o600,
+        ) {
+            Ok(file) if file.write_all(&id).is_ok() => return id,
+            _ => continue,
+        }
+    }
+    id
 }
 
 pub struct CacheDir {
@@ -434,7 +473,7 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
 /// Append-only cursor over a caller-owned `&mut [u8]`. All writers are
 /// infallible: the destination is always a `PathBuffer` (`MAX_PATH_BYTES`,
 /// asserted ≥ 1024 elsewhere) and the longest possible payload here —
-/// `name@u64.u64.u64-16hex+16HEX@@@<ver>_integrity=24hex_patch_hash=16hex\0`
+/// `name@u64.u64.u64-16hex+16HEX@@@<ver>.13base32_patch_hash=16hex\0`
 /// plus an `@@host__16hex` scope suffix — is bounded well under that. Debug builds
 /// keep the bounds check; release elides it so no panic-format code is
 /// reachable from this module.
@@ -497,13 +536,15 @@ impl<'a> ByteCursor<'a> {
         }
     }
 
-    /// `_integrity=<hex>` — leading bytes of the digest the entry was fetched
-    /// for, so entries fetched for different digests of one version coexist.
+    /// `.` + 13 chars of lowercase base32: a keyed fingerprint of the digest
+    /// the entry was fetched for, so entries fetched for different digests of
+    /// one version coexist.
     #[inline(always)]
-    fn put_integrity(&mut self, integrity: &Integrity) {
-        if let Some(fingerprint) = integrity.fingerprint() {
-            self.put(b"_integrity=");
-            self.at += bun_fmt::bytes_to_hex_lower(fingerprint, &mut self.buf[self.at..]);
+    fn put_fingerprint(&mut self, fingerprint: u64) {
+        const CHARS: &[u8; 32] = b"0123456789abcdefghjkmnpqrstvwxyz";
+        self.put_byte(b'.');
+        for i in 0..13 {
+            self.put_byte(CHARS[((fingerprint >> (60 - 5 * i)) & 31) as usize]);
         }
     }
 
@@ -657,7 +698,22 @@ pub fn cached_npm_package_folder_name_print<'a>(
         }
     }
     w.put_cache_version(Some(CacheVersion::CURRENT));
-    w.put_integrity(integrity);
+    debug_assert!(this.cache_directory.is_some());
+    // With verification off nothing vouches for the digest, so such entries
+    // share the digest-less name and a verifying install fetches its own copy.
+    if this.options.do_.contains(options::Do::VERIFY_INTEGRITY)
+        && let Some(fingerprint) = integrity.fingerprint(&this.cache_directory_id)
+    {
+        // NAME_MAX: leave the fingerprint off rather than produce a component
+        // the filesystem rejects (only reachable with ~200-byte package names).
+        // Decided on the unpatched name so both shapes share the same prefix.
+        const SUFFIXES_LEN: usize = ".".len() + 13 + "_patch_hash=".len() + 16;
+        let component_start =
+            strings::last_index_of_char(&w.buf[..w.at], b'/').map_or(0, |i| i + 1);
+        if w.at - component_start + SUFFIXES_LEN <= 255 {
+            w.put_fingerprint(fingerprint);
+        }
+    }
     w.put_patch_hash(patch_hash);
     w.finish_z()
 }
@@ -738,7 +794,7 @@ pub fn cached_tarball_folder_name_print<'a>(
 ) -> &'a ZStr {
     let mut w = ByteCursor::new(buf);
     w.put(b"@T@");
-    w.put_u64_hex16::<true>(integrity::sha256_prefix_u64(url));
+    w.put_u64_hex16::<true>(integrity::sha256_prefix_u64(&[url]));
     w.put_cache_version(Some(CacheVersion::CURRENT));
     w.put_patch_hash(patch_hash);
     w.finish_z()
@@ -844,6 +900,7 @@ pub fn path_for_cached_npm_path<'a>(
     version: Semver::Version,
     integrity: &Integrity,
 ) -> Result<&'a mut [u8], Error> {
+    let cache_dir: Fd = get_cache_directory(this);
     let mut cache_path_buf = PathBuffer::uninit();
 
     let cache_path = cached_npm_package_folder_name_print(
@@ -860,8 +917,6 @@ pub fn path_for_cached_npm_path<'a>(
     debug_assert!(cache_path_buf[package_name.len()] == b'@');
 
     cache_path_buf[package_name.len()] = SEP;
-
-    let cache_dir: Fd = get_cache_directory(this);
 
     #[cfg(windows)]
     {
@@ -944,9 +999,9 @@ pub fn compute_cache_dir_and_subpath<'a>(
     match resolution.tag {
         ResolutionTag::Npm => {
             let version = resolution.npm().version;
+            cache_dir = get_cache_directory(manager);
             cache_dir_subpath =
                 cached_npm_package_folder_name(manager, name, version, integrity, patch_hash);
-            cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::Git => {
             let git = resolution.git();
@@ -1276,7 +1331,7 @@ pub fn write_yarn_lock(this: &mut PackageManager) -> Result<(), Error> {
 
 pub(crate) struct CacheVersion;
 impl CacheVersion {
-    pub(crate) const CURRENT: usize = 1;
+    pub(crate) const CURRENT: usize = 2;
 }
 
 // ────────────────────────────── helpers ───────────────────────────────────────

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -386,18 +386,23 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
 /// which only means fingerprinted entries are fetched again.
 fn read_or_create_cache_directory_id(cache_dir: &Dir) -> integrity::CacheDirId {
     let name = bun_core::zstr!(".id");
-    let read = |id: &mut integrity::CacheDirId| -> bool {
-        File::openat(cache_dir.fd(), name.as_bytes(), sys::O::RDONLY, 0)
-            .and_then(|file| file.read_all(id))
-            .is_ok_and(|len| len == id.len())
-    };
     let mut id: integrity::CacheDirId = [0; 16];
-    for _ in 0..2 {
-        if read(&mut id) {
-            return id;
+    for attempt in 0..3 {
+        match File::openat(cache_dir.fd(), name.as_bytes(), sys::O::RDONLY, 0) {
+            Ok(file) => {
+                if file.read_all(&mut id).is_ok_and(|len| len == id.len()) {
+                    return id;
+                }
+                if attempt < 2 {
+                    // possibly being written by a concurrent install; read again
+                    continue;
+                }
+                let _ = sys::unlinkat(cache_dir.fd(), name);
+            }
+            Err(err) if err.get_errno() != sys::E::ENOENT => break,
+            Err(_) => {}
         }
         bun_boringssl_sys::rand_bytes(&mut id);
-        let _ = sys::unlinkat(cache_dir.fd(), name);
         match File::openat(
             cache_dir.fd(),
             name.as_bytes(),
@@ -405,9 +410,11 @@ fn read_or_create_cache_directory_id(cache_dir: &Dir) -> integrity::CacheDirId {
             0o600,
         ) {
             Ok(file) if file.write_all(&id).is_ok() => return id,
-            _ => continue,
+            // created concurrently by another install: read theirs
+            _ => {}
         }
     }
+    bun_boringssl_sys::rand_bytes(&mut id);
     id
 }
 

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -86,7 +86,7 @@ pub fn get_cache_directory(this: &mut PackageManager) -> Fd {
 /// borrow (see `PackageManifestMap::by_name_hash_allow_expired`). Never
 /// materializes a `&mut PackageManager` covering the whole struct — only the
 /// disjoint `cache_directory`, `cache_directory_id`, `cache_directory_path`,
-/// `options.enable`, and `env` fields are projected, so an outstanding `&mut manifests` derived
+/// `options.enable`, `options.log_level`, and `env` fields are projected, so an outstanding `&mut manifests` derived
 /// from the same provenance root stays valid under Stacked Borrows.
 ///
 /// # Safety
@@ -105,8 +105,8 @@ pub(crate) unsafe fn get_cache_directory_raw(this: *mut PackageManager) -> Fd {
     let fd = d.fd();
     let (id, id_err) = read_or_create_cache_directory_id(&d);
     if let Some(err) = id_err {
-        // SAFETY: as above; `options` and `cache_directory_path` are covered by
-        // the caller contract and only read here.
+        // SAFETY: as above; `options.log_level` and `cache_directory_path` are
+        // covered by the caller contract and only read here.
         let (log_level, cache_directory_path) = unsafe {
             (
                 (*this).options.log_level,
@@ -115,7 +115,7 @@ pub(crate) unsafe fn get_cache_directory_raw(this: *mut PackageManager) -> Fd {
         };
         if log_level != LogLevel::Silent {
             bun_core::pretty_errorln!(
-                "<r><yellow>warn<r>: {} saving {}{}.id; packages fetched by this install will not be reused from the cache",
+                "<r><yellow>warn<r>: {} accessing {}{}.id; packages fetched by this install will not be reused from the cache",
                 bun_fmt::s(err.name()),
                 bun_fmt::s(cache_directory_path),
                 bun_fmt::s(path::SEP_STR.as_bytes()),

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -103,7 +103,25 @@ pub(crate) unsafe fn get_cache_directory_raw(this: *mut PackageManager) -> Fd {
     // `options.enable`/`options.cache_directory`/`env`/`cache_directory_path`.
     let d = unsafe { ensure_cache_directory(this) };
     let fd = d.fd();
-    let id = read_or_create_cache_directory_id(&d);
+    let (id, id_err) = read_or_create_cache_directory_id(&d);
+    if let Some(err) = id_err {
+        // SAFETY: as above; `options` and `cache_directory_path` are covered by
+        // the caller contract and only read here.
+        let (log_level, cache_directory_path) = unsafe {
+            (
+                (*this).options.log_level,
+                (*this).cache_directory_path.as_bytes(),
+            )
+        };
+        if log_level != LogLevel::Silent {
+            bun_core::pretty_errorln!(
+                "<r><yellow>warn<r>: {} saving {}{}.id; packages fetched by this install will not be reused from the cache",
+                bun_fmt::s(err.name()),
+                bun_fmt::s(cache_directory_path),
+                bun_fmt::s(path::SEP_STR.as_bytes()),
+            );
+        }
+    }
     // SAFETY: as above; single writer of `cache_directory` / `cache_directory_id`.
     unsafe {
         (*this).cache_directory_id = id;
@@ -382,35 +400,46 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
 /// fresh key written into it (its fingerprinted entries are then fetched
 /// again); if the file cannot be read or created at all, a per-process random
 /// key is used and this run does not reuse fingerprinted entries.
-fn read_or_create_cache_directory_id(cache_dir: &Dir) -> integrity::CacheDirId {
+fn read_or_create_cache_directory_id(
+    cache_dir: &Dir,
+) -> (integrity::CacheDirId, Option<sys::Error>) {
     let name = bun_core::zstr!(".id");
     let mut id: integrity::CacheDirId = [0; 16];
+    let mut last_err: Option<sys::Error> = None;
     for attempt in 0..3 {
         match File::openat(cache_dir.fd(), name.as_bytes(), sys::O::RDONLY, 0) {
             Ok(file) => match file.read_all(&mut id) {
-                Ok(len) if len == id.len() => return id,
+                Ok(len) if len == id.len() => return (id, None),
                 // empty: another install may be between creating and writing it
                 Ok(0) if attempt < 2 => continue,
                 // still empty, or a wrong length: write a fresh key in place
                 Ok(_) => {
                     bun_boringssl_sys::rand_bytes(&mut id);
-                    if File::openat(
+                    match File::openat(
                         cache_dir.fd(),
                         name.as_bytes(),
                         sys::O::WRONLY | sys::O::TRUNC,
                         0,
                     )
                     .and_then(|file| file.write_all(&id))
-                    .is_ok()
                     {
-                        return id;
+                        Ok(()) => return (id, None),
+                        Err(err) => {
+                            last_err = Some(err);
+                            break;
+                        }
                     }
+                }
+                Err(err) => {
+                    last_err = Some(err);
                     break;
                 }
-                Err(_) => break,
             },
             Err(err) if err.get_errno() == sys::E::ENOENT => {}
-            Err(_) => break,
+            Err(err) => {
+                last_err = Some(err);
+                break;
+            }
         }
         bun_boringssl_sys::rand_bytes(&mut id);
         match File::openat(
@@ -418,14 +447,17 @@ fn read_or_create_cache_directory_id(cache_dir: &Dir) -> integrity::CacheDirId {
             name.as_bytes(),
             sys::O::WRONLY | sys::O::CREAT | sys::O::EXCL,
             0o600,
-        ) {
-            Ok(file) if file.write_all(&id).is_ok() => return id,
+        )
+        .and_then(|file| file.write_all(&id))
+        {
+            Ok(()) => return (id, None),
             // created concurrently by another install: read theirs
-            _ => {}
+            Err(err) if err.get_errno() == sys::E::EEXIST => {}
+            Err(err) => last_err = Some(err),
         }
     }
     bun_boringssl_sys::rand_bytes(&mut id);
-    id
+    (id, last_err)
 }
 
 pub struct CacheDir {

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -85,8 +85,8 @@ pub fn get_cache_directory(this: &mut PackageManager) -> Fd {
 /// Raw-pointer entry for callers that hold a disjoint `&mut this.manifests`
 /// borrow (see `PackageManifestMap::by_name_hash_allow_expired`). Never
 /// materializes a `&mut PackageManager` covering the whole struct — only the
-/// disjoint `cache_directory`, `cache_directory_path`, `options.enable`, and
-/// `env` fields are projected, so an outstanding `&mut manifests` derived
+/// disjoint `cache_directory`, `cache_directory_id`, `cache_directory_path`,
+/// `options.enable`, and `env` fields are projected, so an outstanding `&mut manifests` derived
 /// from the same provenance root stays valid under Stacked Borrows.
 ///
 /// # Safety
@@ -103,8 +103,12 @@ pub(crate) unsafe fn get_cache_directory_raw(this: *mut PackageManager) -> Fd {
     // `options.enable`/`options.cache_directory`/`env`/`cache_directory_path`.
     let d = unsafe { ensure_cache_directory(this) };
     let fd = d.fd();
-    // SAFETY: as above; single writer.
-    unsafe { (*this).cache_directory = Some(d) };
+    let id = read_or_create_cache_directory_id(&d);
+    // SAFETY: as above; single writer of `cache_directory` / `cache_directory_id`.
+    unsafe {
+        (*this).cache_directory_id = id;
+        (*this).cache_directory = Some(d);
+    }
     fd
 }
 
@@ -339,11 +343,7 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
             unsafe { (*this).cache_directory_path = ZBox::from_bytes(&cache_dir.path) };
 
             match Dir::cwd().make_open_path(&cache_dir.path, Default::default()) {
-                Ok(d) => {
-                    // SAFETY: see fn safety contract.
-                    unsafe { (*this).cache_directory_id = read_or_create_cache_directory_id(&d) };
-                    return d;
-                }
+                Ok(d) => return d,
                 Err(_) => {
                     // SAFETY: narrow `&mut enable` projection; disjoint from
                     // any `&options.{registries,scope}` the caller may hold.
@@ -365,11 +365,7 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
         };
 
         match Dir::cwd().make_open_path(b"node_modules/.cache", Default::default()) {
-            Ok(d) => {
-                // SAFETY: see fn safety contract.
-                unsafe { (*this).cache_directory_id = read_or_create_cache_directory_id(&d) };
-                return d;
-            }
+            Ok(d) => return d,
             Err(err) => {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: bun is unable to write files: {}",
@@ -382,32 +378,32 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
 }
 
 /// `<cache>/.id`: 16 random bytes created once per cache directory; npm cache
-/// entry fingerprints are keyed with it. An unreadable file is replaced,
-/// which only means fingerprinted entries are fetched again.
+/// entry fingerprints are keyed with it. A truncated file is replaced (its
+/// fingerprinted entries are then fetched again); if the file cannot be read
+/// or created at all the key falls back to zeroes so names stay stable.
 fn read_or_create_cache_directory_id(cache_dir: &Dir) -> integrity::CacheDirId {
     let name = bun_core::zstr!(".id");
     let mut id: integrity::CacheDirId = [0; 16];
-    for attempt in 0..3 {
+    for _ in 0..3 {
         match File::openat(cache_dir.fd(), name.as_bytes(), sys::O::RDONLY, 0) {
-            Ok(file) => {
-                if file.read_all(&mut id).is_ok_and(|len| len == id.len()) {
-                    return id;
+            Ok(file) => match file.read_all(&mut id) {
+                Ok(len) if len == id.len() => return id,
+                // just created by a concurrent install that has not written it yet
+                Ok(0) => continue,
+                Ok(_) => {
+                    let _ = sys::unlinkat(cache_dir.fd(), name);
                 }
-                if attempt < 2 {
-                    // possibly being written by a concurrent install; read again
-                    continue;
-                }
-                let _ = sys::unlinkat(cache_dir.fd(), name);
-            }
-            Err(err) if err.get_errno() != sys::E::ENOENT => break,
-            Err(_) => {}
+                Err(_) => return [0; 16],
+            },
+            Err(err) if err.get_errno() == sys::E::ENOENT => {}
+            Err(_) => return [0; 16],
         }
         bun_boringssl_sys::rand_bytes(&mut id);
         match File::openat(
             cache_dir.fd(),
             name.as_bytes(),
             sys::O::WRONLY | sys::O::CREAT | sys::O::EXCL,
-            0o600,
+            0o644,
         ) {
             Ok(file) if file.write_all(&id).is_ok() => return id,
             // created concurrently by another install: read theirs

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -378,21 +378,34 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
 }
 
 /// `<cache>/.id`: 16 random bytes created once per cache directory; npm cache
-/// entry fingerprints are keyed with it. A truncated file is replaced (its
-/// fingerprinted entries are then fetched again); if the file cannot be read
-/// or created at all, a per-process random key is used and this run does not
-/// reuse fingerprinted entries.
+/// entry fingerprints are keyed with it. A file left empty or truncated gets a
+/// fresh key written into it (its fingerprinted entries are then fetched
+/// again); if the file cannot be read or created at all, a per-process random
+/// key is used and this run does not reuse fingerprinted entries.
 fn read_or_create_cache_directory_id(cache_dir: &Dir) -> integrity::CacheDirId {
     let name = bun_core::zstr!(".id");
     let mut id: integrity::CacheDirId = [0; 16];
-    for _ in 0..3 {
+    for attempt in 0..3 {
         match File::openat(cache_dir.fd(), name.as_bytes(), sys::O::RDONLY, 0) {
             Ok(file) => match file.read_all(&mut id) {
                 Ok(len) if len == id.len() => return id,
-                // just created by a concurrent install that has not written it yet
-                Ok(0) => continue,
+                // empty: another install may be between creating and writing it
+                Ok(0) if attempt < 2 => continue,
+                // still empty, or a wrong length: write a fresh key in place
                 Ok(_) => {
-                    let _ = sys::unlinkat(cache_dir.fd(), name);
+                    bun_boringssl_sys::rand_bytes(&mut id);
+                    if File::openat(
+                        cache_dir.fd(),
+                        name.as_bytes(),
+                        sys::O::WRONLY | sys::O::TRUNC,
+                        0,
+                    )
+                    .and_then(|file| file.write_all(&id))
+                    .is_ok()
+                    {
+                        return id;
+                    }
+                    break;
                 }
                 Err(_) => break,
             },

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -380,7 +380,8 @@ unsafe fn ensure_cache_directory(this: *mut PackageManager) -> Dir {
 /// `<cache>/.id`: 16 random bytes created once per cache directory; npm cache
 /// entry fingerprints are keyed with it. A truncated file is replaced (its
 /// fingerprinted entries are then fetched again); if the file cannot be read
-/// or created at all the key falls back to zeroes so names stay stable.
+/// or created at all, a per-process random key is used and this run does not
+/// reuse fingerprinted entries.
 fn read_or_create_cache_directory_id(cache_dir: &Dir) -> integrity::CacheDirId {
     let name = bun_core::zstr!(".id");
     let mut id: integrity::CacheDirId = [0; 16];
@@ -393,17 +394,17 @@ fn read_or_create_cache_directory_id(cache_dir: &Dir) -> integrity::CacheDirId {
                 Ok(_) => {
                     let _ = sys::unlinkat(cache_dir.fd(), name);
                 }
-                Err(_) => return [0; 16],
+                Err(_) => break,
             },
             Err(err) if err.get_errno() == sys::E::ENOENT => {}
-            Err(_) => return [0; 16],
+            Err(_) => break,
         }
         bun_boringssl_sys::rand_bytes(&mut id);
         match File::openat(
             cache_dir.fd(),
             name.as_bytes(),
             sys::O::WRONLY | sys::O::CREAT | sys::O::EXCL,
-            0o644,
+            0o600,
         ) {
             Ok(file) if file.write_all(&id).is_ok() => return id,
             // created concurrently by another install: read theirs

--- a/src/install/PackageManager/PackageManagerDirectories.rs
+++ b/src/install/PackageManager/PackageManagerDirectories.rs
@@ -9,6 +9,7 @@ use crate::repository::Repository;
 use bun_core::ZStr;
 use bun_core::{Global, Output, ZBox, env_var, fmt as bun_fmt};
 use bun_dotenv::Loader as DotEnvLoader;
+use bun_install::integrity::{self, Integrity};
 use bun_install::lockfile::{Format as LockfileFormat, LoadResult, Lockfile};
 use bun_install::resolution::Tag as ResolutionTag;
 use bun_install::{PackageID, Resolution};
@@ -433,8 +434,8 @@ pub fn fetch_cache_directory_path(env: &mut DotEnvLoader, options: Option<&Optio
 /// Append-only cursor over a caller-owned `&mut [u8]`. All writers are
 /// infallible: the destination is always a `PathBuffer` (`MAX_PATH_BYTES`,
 /// asserted ≥ 1024 elsewhere) and the longest possible payload here —
-/// `name@u64.u64.u64-16hex+16HEX@@@<ver>_patch_hash=16hex\0` plus an
-/// `@@host__16hex` scope suffix — is bounded well under that. Debug builds
+/// `name@u64.u64.u64-16hex+16HEX@@@<ver>_integrity=24hex_patch_hash=16hex\0`
+/// plus an `@@host__16hex` scope suffix — is bounded well under that. Debug builds
 /// keep the bounds check; release elides it so no panic-format code is
 /// reachable from this module.
 struct ByteCursor<'a> {
@@ -493,6 +494,16 @@ impl<'a> ByteCursor<'a> {
         if let Some(v) = v {
             self.put(b"@@@");
             self.put_u64_dec(v as u64);
+        }
+    }
+
+    /// `_integrity=<hex>` — leading bytes of the digest the entry was fetched
+    /// for, so entries fetched for different digests of one version coexist.
+    #[inline(always)]
+    fn put_integrity(&mut self, integrity: &Integrity) {
+        if let Some(fingerprint) = integrity.fingerprint() {
+            self.put(b"_integrity=");
+            self.at += bun_fmt::bytes_to_hex_lower(fingerprint, &mut self.buf[self.at..]);
         }
     }
 
@@ -615,20 +626,10 @@ pub fn cached_npm_package_folder_name_print<'a>(
     buf: &'a mut [u8],
     name: &[u8],
     version: Semver::Version,
+    integrity: &Integrity,
     patch_hash: Option<u64>,
 ) -> &'a ZStr {
     let scope = this.scope_for_package_name(name);
-
-    if scope.name.is_empty() && !this.options.did_override_default_scope {
-        let include_version_number = true;
-        return cached_npm_package_folder_print_basename(
-            buf,
-            name,
-            version,
-            patch_hash,
-            include_version_number,
-        );
-    }
 
     let include_version_number = false;
     let spanned_len =
@@ -637,23 +638,26 @@ pub fn cached_npm_package_folder_name_print<'a>(
             .len();
     // reshaped for borrowck — resume the cursor at the basename's
     // tail instead of holding the returned `&ZStr` across the re-borrow.
-    let scope_url = scope.url.url();
     let mut w = ByteCursor {
         buf,
         at: spanned_len,
     };
-    let available = w.buf.len() - spanned_len;
-    if scope_url.hostname.len() > 32 || available < 64 {
-        let visible_hostname = &scope_url.hostname[..scope_url.hostname.len().min(12)];
-        w.put(b"@@");
-        w.put(visible_hostname);
-        w.put(b"__");
-        w.put_u64_hex16::<true>(Semver::semver_string::Builder::string_hash(scope_url.href));
-    } else {
-        w.put(b"@@");
-        w.put(scope_url.hostname);
+    if !scope.name.is_empty() || this.options.did_override_default_scope {
+        let scope_url = scope.url.url();
+        let available = w.buf.len() - spanned_len;
+        if scope_url.hostname.len() > 32 || available < 64 {
+            let visible_hostname = &scope_url.hostname[..scope_url.hostname.len().min(12)];
+            w.put(b"@@");
+            w.put(visible_hostname);
+            w.put(b"__");
+            w.put_u64_hex16::<true>(Semver::semver_string::Builder::string_hash(scope_url.href));
+        } else {
+            w.put(b"@@");
+            w.put(scope_url.hostname);
+        }
     }
     w.put_cache_version(Some(CacheVersion::CURRENT));
+    w.put_integrity(integrity);
     w.put_patch_hash(patch_hash);
     w.finish_z()
 }
@@ -680,6 +684,7 @@ pub fn cached_npm_package_folder_name(
     this: &PackageManager,
     name: &[u8],
     version: Semver::Version,
+    integrity: &Integrity,
     patch_hash: Option<u64>,
 ) -> &'static ZStr {
     cached_npm_package_folder_name_print(
@@ -687,6 +692,7 @@ pub fn cached_npm_package_folder_name(
         cached_package_folder_name_buf(),
         name,
         version,
+        integrity,
         patch_hash,
     )
 }
@@ -732,7 +738,7 @@ pub fn cached_tarball_folder_name_print<'a>(
 ) -> &'a ZStr {
     let mut w = ByteCursor::new(buf);
     w.put(b"@T@");
-    w.put_u64_hex16::<true>(Semver::semver_string::Builder::string_hash(url));
+    w.put_u64_hex16::<true>(integrity::sha256_prefix_u64(url));
     w.put_cache_version(Some(CacheVersion::CURRENT));
     w.put_patch_hash(patch_hash);
     w.finish_z()
@@ -836,6 +842,7 @@ pub fn path_for_cached_npm_path<'a>(
     buf: &'a mut PathBuffer,
     package_name: &[u8],
     version: Semver::Version,
+    integrity: &Integrity,
 ) -> Result<&'a mut [u8], Error> {
     let mut cache_path_buf = PathBuffer::uninit();
 
@@ -844,6 +851,7 @@ pub fn path_for_cached_npm_path<'a>(
         &mut cache_path_buf.0[..],
         package_name,
         version,
+        integrity,
         None,
     );
     let cache_path_len = cache_path.as_bytes().len();
@@ -904,8 +912,9 @@ pub fn path_for_resolution<'a>(
             // mutably (for `get_cache_directory`), so the `&this.lockfile`
             // borrow can't be held across it. Copy the name out first.
             let package_name = this.lockfile.str(&package_name_).to_vec();
+            let integrity = this.lockfile.packages.items_meta()[package_id as usize].integrity;
 
-            path_for_cached_npm_path(this, buf, &package_name, npm.version)
+            path_for_cached_npm_path(this, buf, &package_name, npm.version, &integrity)
         }
         _ => Ok(&mut buf.0[..0]),
     }
@@ -924,6 +933,7 @@ pub fn compute_cache_dir_and_subpath<'a>(
     manager: &mut PackageManager,
     pkg_name: &[u8],
     resolution: &Resolution,
+    integrity: &Integrity,
     folder_path_buf: &'a mut PathBuffer,
     patch_hash: Option<u64>,
 ) -> CacheDirAndSubpath<'a> {
@@ -934,7 +944,8 @@ pub fn compute_cache_dir_and_subpath<'a>(
     match resolution.tag {
         ResolutionTag::Npm => {
             let version = resolution.npm().version;
-            cache_dir_subpath = cached_npm_package_folder_name(manager, name, version, patch_hash);
+            cache_dir_subpath =
+                cached_npm_package_folder_name(manager, name, version, integrity, patch_hash);
             cache_dir = get_cache_directory(manager);
         }
         ResolutionTag::Git => {

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -362,7 +362,11 @@ pub fn enqueue_package_for_download(
     task_context: TaskCallbackContext,
     patch_name_and_version_hash: Option<u64>,
 ) -> Result<(), EnqueuePackageForDownloadError> {
-    let task_id = Task::Id::for_npm_package(name, version);
+    let task_id = Task::Id::for_npm_package(
+        name,
+        version,
+        &this.lockfile.packages.items_meta()[package_id as usize].integrity,
+    );
     if this.network_task_has_failed(task_id) {
         return Err(EnqueuePackageForDownloadError::AlreadyFailed);
     }
@@ -2097,6 +2101,7 @@ fn get_or_put_resolved_package_with_find_result(
             let task_id = Task::Id::for_npm_package(
                 this.lockfile.str(&name),
                 package.resolution.npm().version,
+                &package.meta.integrity,
             );
             debug_assert!(!this.network_dedupe_map.contains(&task_id));
 

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -156,6 +156,7 @@ impl PackageManager {
                             self,
                             name,
                             pkg.resolution.npm().version,
+                            &pkg.meta.integrity,
                             patch_hash,
                         )
                     }

--- a/src/install/PackageManager/PackageManagerLifecycle.rs
+++ b/src/install/PackageManager/PackageManagerLifecycle.rs
@@ -133,6 +133,8 @@ impl PackageManager {
                     break 'brk Some(patched_dep.patchfile_hash().unwrap());
                 };
 
+                let _ = directories::get_cache_directory(self);
+
                 // SAFETY: each arm reads the union variant that matches the
                 // `pkg.resolution.tag` just dispatched on; `Resolution` is
                 // zero-initialised (`Value::zero()`) so even a stale tag yields

--- a/src/install/PackageManager/PackageManagerResolution.rs
+++ b/src/install/PackageManager/PackageManagerResolution.rs
@@ -207,6 +207,7 @@ impl PackageManager {
                     &mut buf,
                     package_name,
                     installed_version,
+                    &crate::Integrity::default(),
                 ) {
                     Ok(p) => p,
                     Err(err) => {

--- a/src/install/PackageManager/patchPackage.rs
+++ b/src/install/PackageManager/patchPackage.rs
@@ -252,6 +252,7 @@ pub fn do_patch_commit(
                     manager,
                     &name,
                     &resolution_clone,
+                    &actual_package.meta.integrity,
                     &mut folder_path_buf,
                     None,
                 );
@@ -289,6 +290,7 @@ pub fn do_patch_commit(
                     manager,
                     &pkg_name_slice,
                     &resolution_clone,
+                    &pkg.meta.integrity,
                     &mut folder_path_buf,
                     None,
                 );
@@ -889,6 +891,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                     manager,
                     &name,
                     &actual_package.resolution,
+                    &actual_package.meta.integrity,
                     &mut folder_path_buf,
                     existing_patchfile_hash,
                 );
@@ -949,6 +952,7 @@ pub fn prepare_patch(manager: &mut PackageManager) -> Result<(), crate::Error> {
                     manager,
                     &pkg_name,
                     &pkg_resolution,
+                    &pkg.meta.integrity,
                     &mut folder_path_buf,
                     existing_patchfile_hash,
                 );

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -121,8 +121,9 @@ impl Id {
                 core::mem::size_of::<semver::Version>(),
             )
         });
-        if let Some(fingerprint) = integrity.fingerprint() {
-            hasher.update(fingerprint);
+        if integrity.tag.is_supported() {
+            hasher.update(&[integrity.tag.0]);
+            hasher.update(integrity.slice());
         }
         Id(hasher.final_())
     }
@@ -144,7 +145,7 @@ impl Id {
     // Persisted to the filesystem: this is the name of the bare clone in the cache directory.
     pub(crate) fn for_git_clone(url: &[u8]) -> Id {
         // @truncate to u61 then widen to u64 — keep low 61 bits
-        Id((4u64 << 61) | (crate::integrity::sha256_prefix_u64(url) & ((1u64 << 61) - 1)))
+        Id((4u64 << 61) | (crate::integrity::sha256_prefix_u64(&[url]) & ((1u64 << 61) - 1)))
     }
 
     pub(crate) fn for_git_checkout(url: &[u8], resolved: &[u8]) -> Id {

--- a/src/install/PackageManagerTask.rs
+++ b/src/install/PackageManagerTask.rs
@@ -105,7 +105,11 @@ impl Id {
         self.0
     }
 
-    pub(crate) fn for_npm_package(package_name: &[u8], package_version: semver::Version) -> Id {
+    pub(crate) fn for_npm_package(
+        package_name: &[u8],
+        package_version: semver::Version,
+        integrity: &crate::Integrity,
+    ) -> Id {
         let mut hasher = Wyhash11::init(0);
         hasher.update(b"npm-package:");
         hasher.update(package_name);
@@ -117,6 +121,9 @@ impl Id {
                 core::mem::size_of::<semver::Version>(),
             )
         });
+        if let Some(fingerprint) = integrity.fingerprint() {
+            hasher.update(fingerprint);
+        }
         Id(hasher.final_())
     }
 
@@ -134,13 +141,10 @@ impl Id {
         Id(hasher.final_())
     }
 
-    // These cannot change:
-    // We persist them to the filesystem.
+    // Persisted to the filesystem: this is the name of the bare clone in the cache directory.
     pub(crate) fn for_git_clone(url: &[u8]) -> Id {
-        let mut hasher = Wyhash11::init(0);
-        hasher.update(url);
         // @truncate to u61 then widen to u64 — keep low 61 bits
-        Id((4u64 << 61) | (hasher.final_() & ((1u64 << 61) - 1)))
+        Id((4u64 << 61) | (crate::integrity::sha256_prefix_u64(url) & ((1u64 << 61) - 1)))
     }
 
     pub(crate) fn for_git_checkout(url: &[u8], resolved: &[u8]) -> Id {

--- a/src/install/extract_tarball.rs
+++ b/src/install/extract_tarball.rs
@@ -476,6 +476,7 @@ impl ExtractTarball {
                         &mut bufs.folder_name_buf,
                         name,
                         self.resolution.npm().version,
+                        &self.integrity,
                         None,
                     )
                     .as_bytes()

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -33,6 +33,17 @@ impl Default for Integrity {
 
 const EMPTY_DIGEST_BUF: [u8; DIGEST_BUF_LEN] = [0u8; DIGEST_BUF_LEN];
 
+pub const FINGERPRINT_LEN: usize = 12;
+
+/// First 8 bytes of SHA-256 over `bytes`, for naming cache entries after a URL.
+pub fn sha256_prefix_u64(bytes: &[u8]) -> u64 {
+    let mut hasher = Crypto::SHA256::init();
+    hasher.update(bytes);
+    let mut digest = [0u8; SHA256_DIGEST_LEN];
+    hasher.r#final(&mut digest);
+    u64::from_be_bytes(digest[..8].try_into().expect("infallible: size matches"))
+}
+
 const DIGEST_BUF_LEN: usize = {
     let mut m = SHA1_DIGEST_LEN;
     if SHA512_DIGEST_LEN > m {
@@ -169,6 +180,15 @@ impl Integrity {
 
     pub(crate) fn slice(&self) -> &[u8] {
         &self.value[0..self.tag.digest_len()]
+    }
+
+    /// Leading digest bytes used to tell cache entries for the same
+    /// name@version apart; `None` when there is no supported digest.
+    pub fn fingerprint(&self) -> Option<&[u8]> {
+        if !self.tag.is_supported() {
+            return None;
+        }
+        Some(&self.value[..FINGERPRINT_LEN])
     }
 
     /// Compute a sha512 integrity hash from raw bytes (e.g. a downloaded tarball).

--- a/src/install/integrity.rs
+++ b/src/install/integrity.rs
@@ -33,12 +33,16 @@ impl Default for Integrity {
 
 const EMPTY_DIGEST_BUF: [u8; DIGEST_BUF_LEN] = [0u8; DIGEST_BUF_LEN];
 
-pub const FINGERPRINT_LEN: usize = 12;
+/// Random per-cache-directory key stored in `<cache>/.id`; cache entry
+/// fingerprints are derived from it so they cannot be predicted off-machine.
+pub type CacheDirId = [u8; 16];
 
-/// First 8 bytes of SHA-256 over `bytes`, for naming cache entries after a URL.
-pub fn sha256_prefix_u64(bytes: &[u8]) -> u64 {
+/// First 8 bytes of SHA-256 over the concatenation of `parts`.
+pub fn sha256_prefix_u64(parts: &[&[u8]]) -> u64 {
     let mut hasher = Crypto::SHA256::init();
-    hasher.update(bytes);
+    for part in parts {
+        hasher.update(part);
+    }
     let mut digest = [0u8; SHA256_DIGEST_LEN];
     hasher.r#final(&mut digest);
     u64::from_be_bytes(digest[..8].try_into().expect("infallible: size matches"))
@@ -182,13 +186,17 @@ impl Integrity {
         &self.value[0..self.tag.digest_len()]
     }
 
-    /// Leading digest bytes used to tell cache entries for the same
-    /// name@version apart; `None` when there is no supported digest.
-    pub fn fingerprint(&self) -> Option<&[u8]> {
+    /// 64-bit keyed fingerprint of (algorithm, digest) used to tell cache
+    /// entries for the same name@version apart; `None` without a digest.
+    pub fn fingerprint(&self, cache_dir_id: &CacheDirId) -> Option<u64> {
         if !self.tag.is_supported() {
             return None;
         }
-        Some(&self.value[..FINGERPRINT_LEN])
+        Some(sha256_prefix_u64(&[
+            cache_dir_id,
+            &[self.tag.0],
+            self.slice(),
+        ]))
     }
 
     /// Compute a sha512 integrity hash from raw bytes (e.g. a downloaded tarball).

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -1990,6 +1990,7 @@ pub(crate) fn install_isolated_packages(
         let pkg_names = pkgs.items_name();
         let pkg_name_hashes = pkgs.items_name_hash();
         let pkg_resolutions = pkgs.items_resolution();
+        let pkg_metas = pkgs.items_meta();
 
         let mut seen_entry_ids: HashMap<store::entry::Id, ()> = HashMap::default();
         seen_entry_ids.reserve(store.entries.len());
@@ -2318,6 +2319,7 @@ pub(crate) fn install_isolated_packages(
                             installer.manager(),
                             pkg_name.slice(string_buf),
                             pkg_res.npm().version,
+                            &pkg_metas[pkg_id as usize].integrity,
                             patch_info.contents_hash(),
                         ),
                         ResolutionTag::Git => package_manager::cached_git_folder_name(

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2312,6 +2312,10 @@ pub(crate) fn install_isolated_packages(
                         continue;
                     }
 
+                    let (cache_dir, cache_dir_path) =
+                        installer.manager_mut().get_cache_directory_and_abs_path();
+                    let _ = &cache_dir_path; // dropped at scope exit
+
                     // SAFETY: each arm reads the union field that `pkg_res_tag`
                     // (== `pkg_res.tag`) names as active.
                     let cache_subpath_z: &bun_core::ZStr = match pkg_res_tag {
@@ -2349,10 +2353,6 @@ pub(crate) fn install_isolated_packages(
                     };
                     let mut pkg_cache_dir_subpath: AutoRelPath =
                         AutoRelPath::from(cache_subpath_z.as_bytes()).assume_ok();
-
-                    let (cache_dir, cache_dir_path) =
-                        installer.manager_mut().get_cache_directory_and_abs_path();
-                    let _ = &cache_dir_path; // dropped at scope exit
 
                     let missing_from_cache = match installer.manager().get_preinstall_state(pkg_id)
                     {

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -1088,6 +1088,7 @@ impl Task {
                                     manager,
                                     pkg_name.slice(string_buf),
                                     pkg_res.npm().version,
+                                    &pkg_metas[pkg_id as usize].integrity,
                                     patch_info.contents_hash(),
                                 ),
                                 ResolutionTag::Git => directories::cached_git_folder_name(

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -340,8 +340,11 @@ impl PatchTask {
                             .npm
                             .version
                     };
-                    let task_id =
-                        TaskId::for_npm_package(manager.lockfile.str(&pkg_name), pkg_npm_version);
+                    let task_id = TaskId::for_npm_package(
+                        manager.lockfile.str(&pkg_name),
+                        pkg_npm_version,
+                        &manager.lockfile.packages.items_meta()[pkg_id as usize].integrity,
+                    );
                     debug_assert!(!manager.network_dedupe_map.contains_key(&task_id));
 
                     let is_required = manager.lockfile.buffers.dependencies[dep_id as usize]
@@ -787,12 +790,14 @@ impl PatchTask {
         // before `compute_cache_dir_and_subpath` reborrows `pkg_manager` mutably.
         let resolution_clone: Resolution =
             pkg_manager.lockfile.packages.items_resolution()[pkg_id as usize];
+        let integrity = pkg_manager.lockfile.packages.items_meta()[pkg_id as usize].integrity;
 
         let mut folder_path_buf = PathBuffer::uninit();
         let stuff = package_manager::compute_cache_dir_and_subpath(
             pkg_manager,
             &pkg_name_slice,
             &resolution_clone,
+            &integrity,
             &mut folder_path_buf,
             Some(patch_hash),
         );

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1659,7 +1659,7 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
-  expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("9d05c118f06c3b4c.git");
+  expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("89529d5f052b327e.git");
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",

--- a/test/cli/install/bun-add.test.ts
+++ b/test/cli/install/bun-add.test.ts
@@ -1048,7 +1048,10 @@ it("should add dependency (GitHub)", async () => {
   expect(requested).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+    ".id",
+    "@GH@mishoo-UglifyJS-e219a9a@@@2",
+  ]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -1277,15 +1280,16 @@ it("should add aliased dependency (GitHub)", async () => {
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
-    "@GH@mishoo-UglifyJS-e219a9a@@@1",
+    ".id",
+    "@GH@mishoo-UglifyJS-e219a9a@@@2",
     "uglify",
   ]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".cache", "uglify"))).toEqual([
-    "mishoo-UglifyJS-e219a9a@@@1",
+    "mishoo-UglifyJS-e219a9a@@@2",
   ]);
   expect(
-    resolve(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1"))),
-  ).toBe(join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
+    resolve(await readlink(join(package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@2"))),
+  ).toBe(join(package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@2"));
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -1659,7 +1663,9 @@ it("should handle Git URL in dependencies (SCP-style)", async () => {
   expect(join(package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
     join("..", "uglify-js", "bin", "uglifyjs"),
   );
-  expect((await readdirSorted(join(package_dir, "node_modules", ".cache")))[0]).toBe("89529d5f052b327e.git");
+  expect(
+    (await readdirSorted(join(package_dir, "node_modules", ".cache"))).filter(entry => entry.endsWith(".git")),
+  ).toEqual(["89529d5f052b327e.git"]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2020,7 +2026,10 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited1).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+    ".id",
+    "@GH@mishoo-UglifyJS-e219a9a@@@2",
+  ]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",
@@ -2081,7 +2090,10 @@ it("should add dependency without duplication (GitHub)", async () => {
   expect(await exited2).toBe(0);
   expect(await readdirSorted(join(package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify-js"]);
   expect(await readdirSorted(join(package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
-  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual(["@GH@mishoo-UglifyJS-e219a9a@@@1"]);
+  expect(await readdirSorted(join(package_dir, "node_modules", ".cache"))).toEqual([
+    ".id",
+    "@GH@mishoo-UglifyJS-e219a9a@@@2",
+  ]);
   expect(await readdirSorted(join(package_dir, "node_modules", "uglify-js"))).toEqual([
     ".bun-tag",
     ".gitattributes",

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -7,6 +7,7 @@ import {
   assertManifestsPopulated,
   bunExe,
   bunEnv as env,
+  installCacheFolderName,
   isFlaky,
   isMacOS,
   isWindows,
@@ -26,10 +27,9 @@ import {
 import { join, resolve } from "path";
 const { parseLockfile } = install_test_helpers;
 
-/** Folder name of an npm cache entry: `<name>@<version>@@localhost@@@1_integrity=<first 12 digest bytes as hex>` */
-function cacheFolderName(name: string, version: string, integrity: string) {
-  const digest = Buffer.from(integrity.replace(/^sha\d+-/, ""), "base64");
-  return `${name}@${version}@@localhost@@@1_integrity=${digest.subarray(0, 12).toString("hex")}`;
+/** Folder name of an npm cache entry served by the test registry. */
+function cacheFolderName(cacheDir: string, name: string, version: string, integrity: string) {
+  return installCacheFolderName(cacheDir, name, version, integrity, "localhost");
 }
 async function fixtureIntegrity(name: string, version: string): Promise<string> {
   const manifest = await file(join(import.meta.dir, "registry", "packages", name, "package.json")).json();
@@ -125,7 +125,12 @@ describe("auto-install", () => {
     expect(err).not.toContain("error:");
     expect(await exited).toBe(0);
 
-    const folderName = cacheFolderName("is-number", "2.0.0", await fixtureIntegrity("is-number", "2.0.0"));
+    const folderName = cacheFolderName(
+      join(packageDir, ".bun-cache"),
+      "is-number",
+      "2.0.0",
+      await fixtureIntegrity("is-number", "2.0.0"),
+    );
     expect(
       resolve(await readlink(join(packageDir, ".bun-cache", "is-number", folderName.slice("is-number@".length)))),
     ).toBe(join(packageDir, ".bun-cache", folderName));
@@ -133,12 +138,14 @@ describe("auto-install", () => {
 
   test("does not run a cached package that was stored for a different integrity", async () => {
     const cacheDir = join(packageDir, ".bun-cache");
-    // an entry (and its version index link) as stored without a recorded integrity
-    const otherEntry = join(cacheDir, "is-number@2.0.0@@localhost@@@1");
+    // entries (and version index links) stored by an earlier version / without an integrity
+    const otherEntries = ["is-number@2.0.0@@localhost@@@1", "is-number@2.0.0@@localhost@@@2"];
     await mkdir(join(cacheDir, "is-number"), { recursive: true });
-    await write(join(otherEntry, "package.json"), JSON.stringify({ name: "is-number", version: "2.0.0" }));
-    await write(join(otherEntry, "index.js"), "module.exports = { version: 'not from the registry' };");
-    await symlink(otherEntry, join(cacheDir, "is-number", "2.0.0@@localhost@@@1"), "junction");
+    for (const entry of otherEntries) {
+      await write(join(cacheDir, entry, "package.json"), JSON.stringify({ name: "is-number", version: "2.0.0" }));
+      await write(join(cacheDir, entry, "index.js"), "module.exports = { version: 'not from the registry' };");
+      await symlink(join(cacheDir, entry), join(cacheDir, "is-number", entry.slice("is-number@".length)), "junction");
+    }
 
     await using proc = spawn({
       cmd: [bunExe(), "--install=fallback", "--print", "require('is-number').version"],
@@ -153,11 +160,23 @@ describe("auto-install", () => {
     expect(exitCode).toBe(0);
 
     expect(
-      await exists(join(cacheDir, cacheFolderName("is-number", "2.0.0", await fixtureIntegrity("is-number", "2.0.0")))),
+      await exists(
+        join(
+          cacheDir,
+          cacheFolderName(
+            join(packageDir, ".bun-cache"),
+            "is-number",
+            "2.0.0",
+            await fixtureIntegrity("is-number", "2.0.0"),
+          ),
+        ),
+      ),
     ).toBeTrue();
-    expect(await file(join(otherEntry, "index.js")).text()).toBe(
-      "module.exports = { version: 'not from the registry' };",
-    );
+    for (const entry of otherEntries) {
+      expect(await file(join(cacheDir, entry, "index.js")).text()).toBe(
+        "module.exports = { version: 'not from the registry' };",
+      );
+    }
   });
 });
 
@@ -3215,7 +3234,7 @@ test("it should invalid cached package if package.json is missing", async () => 
   const cacheEntry = join(
     packageDir,
     ".bun-cache",
-    cacheFolderName("no-deps", "2.0.0", await fixtureIntegrity("no-deps", "2.0.0")),
+    cacheFolderName(join(packageDir, ".bun-cache"), "no-deps", "2.0.0", await fixtureIntegrity("no-deps", "2.0.0")),
   );
   await Promise.all([
     write(
@@ -3278,12 +3297,13 @@ describe.each(["hoisted", "isolated"] as const)("cache entry identity (%s linker
     const cacheDir = join(packageDir, ".bun-cache");
     const testEnv = { ...env, BUN_INSTALL_CACHE_DIR: cacheDir };
     const integrity = await fixtureIntegrity("no-deps", "2.0.0");
-    const cacheEntry = join(cacheDir, cacheFolderName("no-deps", "2.0.0", integrity));
+    const cacheEntry = join(cacheDir, cacheFolderName(cacheDir, "no-deps", "2.0.0", integrity));
 
     // entries for the same name@version stored without / for another integrity
     const otherEntries = [
       join(cacheDir, "no-deps@2.0.0@@localhost@@@1"),
-      join(cacheDir, cacheFolderName("no-deps", "2.0.0", "sha512-" + Buffer.alloc(64, 7).toString("base64"))),
+      join(cacheDir, "no-deps@2.0.0@@localhost@@@2"),
+      join(cacheDir, cacheFolderName(cacheDir, "no-deps", "2.0.0", "sha512-" + Buffer.alloc(64, 7).toString("base64"))),
     ];
     for (const entry of otherEntries) {
       await write(join(entry, "package.json"), JSON.stringify({ name: "no-deps", version: "2.0.0" }));

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -2,7 +2,7 @@ import { file, spawn, write } from "bun";
 import { install_test_helpers, npm_manifest_test_helpers } from "bun:internal-for-testing";
 import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { copyFileSync, mkdirSync } from "fs";
-import { cp, exists, lstat, mkdir, readlink, rm, writeFile } from "fs/promises";
+import { cp, exists, lstat, mkdir, readlink, rm, symlink, writeFile } from "fs/promises";
 import {
   assertManifestsPopulated,
   bunExe,
@@ -25,6 +25,16 @@ import {
 } from "harness";
 import { join, resolve } from "path";
 const { parseLockfile } = install_test_helpers;
+
+/** Folder name of an npm cache entry: `<name>@<version>@@localhost@@@1_integrity=<first 12 digest bytes as hex>` */
+function cacheFolderName(name: string, version: string, integrity: string) {
+  const digest = Buffer.from(integrity.replace(/^sha\d+-/, ""), "base64");
+  return `${name}@${version}@@localhost@@@1_integrity=${digest.subarray(0, 12).toString("hex")}`;
+}
+async function fixtureIntegrity(name: string, version: string): Promise<string> {
+  const manifest = await file(join(import.meta.dir, "registry", "packages", name, "package.json")).json();
+  return manifest.versions[version].dist.integrity;
+}
 
 expect.extend({
   toBeValidBin,
@@ -115,9 +125,43 @@ describe("auto-install", () => {
     expect(err).not.toContain("error:");
     expect(await exited).toBe(0);
 
-    expect(resolve(await readlink(join(packageDir, ".bun-cache", "is-number", "2.0.0@@localhost@@@1")))).toBe(
-      join(packageDir, ".bun-cache", "is-number@2.0.0@@localhost@@@1"),
+    const folderName = cacheFolderName("is-number", "2.0.0", await fixtureIntegrity("is-number", "2.0.0"));
+    expect(
+      resolve(await readlink(join(packageDir, ".bun-cache", "is-number", folderName.slice("is-number@".length)))),
+    ).toBe(join(packageDir, ".bun-cache", folderName));
+  });
+
+  test("does not run a cached package that was stored for a different integrity", async () => {
+    const cacheDir = join(packageDir, ".bun-cache");
+    // an entry (and its version index link) as stored without a recorded integrity
+    const otherEntry = join(cacheDir, "is-number@2.0.0@@localhost@@@1");
+    await mkdir(join(cacheDir, "is-number"), { recursive: true });
+    await write(
+      join(otherEntry, "package.json"),
+      JSON.stringify({ name: "is-number", version: "0.0.0-not-from-registry" }),
     );
+    await write(join(otherEntry, "index.js"), "module.exports = require('./package.json');");
+    await symlink(otherEntry, join(cacheDir, "is-number", "2.0.0@@localhost@@@1"), "junction");
+
+    await using proc = spawn({
+      cmd: [bunExe(), "--install=fallback", "--print", "require('is-number').version"],
+      cwd: packageDir,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...env, BUN_INSTALL_CACHE_DIR: cacheDir },
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(out.trim()).toBe("2.0.0");
+    expect(exitCode).toBe(0);
+
+    expect(
+      await exists(join(cacheDir, cacheFolderName("is-number", "2.0.0", await fixtureIntegrity("is-number", "2.0.0")))),
+    ).toBeTrue();
+    expect(await file(join(otherEntry, "package.json")).json()).toEqual({
+      name: "is-number",
+      version: "0.0.0-not-from-registry",
+    });
   });
 });
 
@@ -3172,6 +3216,11 @@ test("--config cli flag works", async () => {
 });
 
 test("it should invalid cached package if package.json is missing", async () => {
+  const cacheEntry = join(
+    packageDir,
+    ".bun-cache",
+    cacheFolderName("no-deps", "2.0.0", await fixtureIntegrity("no-deps", "2.0.0")),
+  );
   await Promise.all([
     write(
       packageJson,
@@ -3189,10 +3238,7 @@ test("it should invalid cached package if package.json is missing", async () => 
 
   // node_modules and cache should be populated
   expect(
-    await Promise.all([
-      readdirSorted(join(packageDir, "node_modules", "no-deps")),
-      readdirSorted(join(packageDir, ".bun-cache", "no-deps@2.0.0@@localhost@@@1")),
-    ]),
+    await Promise.all([readdirSorted(join(packageDir, "node_modules", "no-deps")), readdirSorted(cacheEntry)]),
   ).toEqual([
     ["index.js", "package.json"],
     ["index.js", "package.json"],
@@ -3208,14 +3254,11 @@ test("it should invalid cached package if package.json is missing", async () => 
   expect(out).not.toContain("+ no-deps@2.0.0");
 
   // with cache package.json deleted, install is a no-op and cache is untouched
-  await rm(join(packageDir, ".bun-cache", "no-deps@2.0.0@@localhost@@@1", "package.json"));
+  await rm(join(cacheEntry, "package.json"));
   ({ out } = await runBunInstall(env, packageDir, { savesLockfile: false }));
   expect(out).not.toContain("+ no-deps@2.0.0");
   expect(
-    await Promise.all([
-      readdirSorted(join(packageDir, "node_modules", "no-deps")),
-      readdirSorted(join(packageDir, ".bun-cache", "no-deps@2.0.0@@localhost@@@1")),
-    ]),
+    await Promise.all([readdirSorted(join(packageDir, "node_modules", "no-deps")), readdirSorted(cacheEntry)]),
   ).toEqual([["index.js", "package.json"], ["index.js"]]);
 
   // now with node_modules package.json deleted, the package AND the cache should
@@ -3224,14 +3267,54 @@ test("it should invalid cached package if package.json is missing", async () => 
   ({ out } = await runBunInstall(env, packageDir, { savesLockfile: false }));
   expect(out).toContain("+ no-deps@2.0.0");
   expect(
-    await Promise.all([
-      readdirSorted(join(packageDir, "node_modules", "no-deps")),
-      readdirSorted(join(packageDir, ".bun-cache", "no-deps@2.0.0@@localhost@@@1")),
-    ]),
+    await Promise.all([readdirSorted(join(packageDir, "node_modules", "no-deps")), readdirSorted(cacheEntry)]),
   ).toEqual([
     ["index.js", "package.json"],
     ["index.js", "package.json"],
   ]);
+});
+
+describe.each(["hoisted", "isolated"] as const)("cache entry identity (%s linker)", linker => {
+  test("a cache entry stored for a different integrity is not used", async () => {
+    const { packageDir, packageJson } = await registry.createTestDir({
+      bunfigOpts: { saveTextLockfile: false, linker },
+    });
+    const cacheDir = join(packageDir, ".bun-cache");
+    const testEnv = { ...env, BUN_INSTALL_CACHE_DIR: cacheDir };
+    const integrity = await fixtureIntegrity("no-deps", "2.0.0");
+    const cacheEntry = join(cacheDir, cacheFolderName("no-deps", "2.0.0", integrity));
+
+    // entries for the same name@version stored without / for another integrity
+    const otherEntries = [
+      join(cacheDir, "no-deps@2.0.0@@localhost@@@1"),
+      join(cacheDir, cacheFolderName("no-deps", "2.0.0", "sha512-" + Buffer.alloc(64, 7).toString("base64"))),
+    ];
+    for (const entry of otherEntries) {
+      await write(join(entry, "package.json"), JSON.stringify({ name: "no-deps", version: "2.0.0" }));
+      await write(join(entry, "index.js"), "module.exports = 'not from the registry';");
+    }
+
+    await write(packageJson, JSON.stringify({ name: "foo", dependencies: { "no-deps": "2.0.0" } }));
+
+    let { out } = await runBunInstall(testEnv, packageDir);
+    expect(out).toContain("+ no-deps@2.0.0");
+    const installedIndexJs = await file(join(packageDir, "node_modules", "no-deps", "index.js")).text();
+    expect(installedIndexJs).toStartWith("module.exports = require(`./package.json`);");
+    expect(await file(join(cacheEntry, "index.js")).text()).toBe(installedIndexJs);
+    expect(await readdirSorted(join(packageDir, "node_modules", "no-deps"))).toEqual(["index.js", "package.json"]);
+    for (const entry of otherEntries) {
+      expect(await file(join(entry, "index.js")).text()).toBe("module.exports = 'not from the registry';");
+    }
+
+    // the matching entry is reused as-is
+    await rm(join(packageDir, "node_modules"), { recursive: true, force: true });
+    await write(join(cacheEntry, "index.js"), "module.exports = 'from cache';");
+    ({ out } = await runBunInstall(testEnv, packageDir, { savesLockfile: false }));
+    expect(out).toContain("+ no-deps@2.0.0");
+    expect(await file(join(packageDir, "node_modules", "no-deps", "index.js")).text()).toBe(
+      "module.exports = 'from cache';",
+    );
+  });
 });
 
 test("it should install with missing bun.lockb, node_modules, and/or cache", async () => {

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -136,11 +136,8 @@ describe("auto-install", () => {
     // an entry (and its version index link) as stored without a recorded integrity
     const otherEntry = join(cacheDir, "is-number@2.0.0@@localhost@@@1");
     await mkdir(join(cacheDir, "is-number"), { recursive: true });
-    await write(
-      join(otherEntry, "package.json"),
-      JSON.stringify({ name: "is-number", version: "0.0.0-not-from-registry" }),
-    );
-    await write(join(otherEntry, "index.js"), "module.exports = require('./package.json');");
+    await write(join(otherEntry, "package.json"), JSON.stringify({ name: "is-number", version: "2.0.0" }));
+    await write(join(otherEntry, "index.js"), "module.exports = { version: 'not from the registry' };");
     await symlink(otherEntry, join(cacheDir, "is-number", "2.0.0@@localhost@@@1"), "junction");
 
     await using proc = spawn({
@@ -158,10 +155,9 @@ describe("auto-install", () => {
     expect(
       await exists(join(cacheDir, cacheFolderName("is-number", "2.0.0", await fixtureIntegrity("is-number", "2.0.0")))),
     ).toBeTrue();
-    expect(await file(join(otherEntry, "package.json")).json()).toEqual({
-      name: "is-number",
-      version: "0.0.0-not-from-registry",
-    });
+    expect(await file(join(otherEntry, "index.js")).text()).toBe(
+      "module.exports = { version: 'not from the registry' };",
+    );
   });
 });
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -3772,17 +3772,18 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
-        "@GH@mishoo-UglifyJS-e219a9a@@@1",
+        ".id",
+        "@GH@mishoo-UglifyJS-e219a9a@@@2",
         "uglify",
       ]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache", "uglify"))).toEqual([
-        "mishoo-UglifyJS-e219a9a@@@1",
+        "mishoo-UglifyJS-e219a9a@@@2",
       ]);
       expect(
         resolve(
-          await readlink(join(ctx.package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1")),
+          await readlink(join(ctx.package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@2")),
         ),
-      ).toBe(join(ctx.package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
+      ).toBe(join(ctx.package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@2"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -3842,17 +3843,18 @@ describe.concurrent("bun-install", () => {
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".bin", ".cache", "uglify"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".bin"))).toHaveBins(["uglifyjs"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
-        "@GH@mishoo-UglifyJS-e219a9a@@@1",
+        ".id",
+        "@GH@mishoo-UglifyJS-e219a9a@@@2",
         "uglify",
       ]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache", "uglify"))).toEqual([
-        "mishoo-UglifyJS-e219a9a@@@1",
+        "mishoo-UglifyJS-e219a9a@@@2",
       ]);
       expect(
         resolve(
-          await readlink(join(ctx.package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1")),
+          await readlink(join(ctx.package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@2")),
         ),
-      ).toBe(join(ctx.package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
+      ).toBe(join(ctx.package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@2"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -4080,17 +4082,18 @@ describe.concurrent("bun-install", () => {
         join("..", "uglify", "bin", "uglifyjs"),
       );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
-        "@GH@mishoo-UglifyJS-e219a9a@@@1",
+        ".id",
+        "@GH@mishoo-UglifyJS-e219a9a@@@2",
         "uglify",
       ]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache", "uglify"))).toEqual([
-        "mishoo-UglifyJS-e219a9a@@@1",
+        "mishoo-UglifyJS-e219a9a@@@2",
       ]);
       expect(
         resolve(
-          await readlink(join(ctx.package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1")),
+          await readlink(join(ctx.package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@2")),
         ),
-      ).toBe(join(ctx.package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
+      ).toBe(join(ctx.package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@2"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -4212,17 +4215,18 @@ describe.concurrent("bun-install", () => {
         join("..", "uglify", "bin", "uglifyjs"),
       );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
-        "@GH@mishoo-UglifyJS-e219a9a@@@1",
+        ".id",
+        "@GH@mishoo-UglifyJS-e219a9a@@@2",
         "uglify",
       ]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache", "uglify"))).toEqual([
-        "mishoo-UglifyJS-e219a9a@@@1",
+        "mishoo-UglifyJS-e219a9a@@@2",
       ]);
       expect(
         resolve(
-          await readlink(join(ctx.package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@1")),
+          await readlink(join(ctx.package_dir, "node_modules", ".cache", "uglify", "mishoo-UglifyJS-e219a9a@@@2")),
         ),
-      ).toBe(join(ctx.package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@1"));
+      ).toBe(join(ctx.package_dir, "node_modules", ".cache", "@GH@mishoo-UglifyJS-e219a9a@@@2"));
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5099,7 +5103,9 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify-js", "bin", "uglifyjs"),
       );
-      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("8b781131fcb82ac5.git");
+      expect(
+        (await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).filter(entry => entry.endsWith(".git")),
+      ).toEqual(["8b781131fcb82ac5.git"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify-js"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5131,6 +5137,7 @@ describe.concurrent("bun-install", () => {
         version: "1.0.0",
         dependencies: { a: "git+https://example.invalid/a.git" },
       }),
+      "gitconfig": "",
     });
     const repoA = join(String(dir), "repo-a");
     const repoB = join(String(dir), "repo-b");
@@ -5145,6 +5152,10 @@ describe.concurrent("bun-install", () => {
     // A bare clone of a different repository, stored under the name earlier
     // versions derived for this dependency's URL.
     await Bun.$`git clone -q --bare ${repoB} ${join(cacheDir, "9a422e910b76550b.git")}`.env(env).quiet();
+    // route the dependency URL to the local repository for the git that bun spawns
+    await Bun.$`git config --file ${join(String(dir), "gitconfig")} url.${repoA}.insteadOf https://example.invalid/a.git`
+      .env(env)
+      .quiet();
 
     await using proc = spawn({
       cmd: [bunExe(), "install"],
@@ -5156,9 +5167,8 @@ describe.concurrent("bun-install", () => {
         ...env,
         BUN_INSTALL_CACHE_DIR: cacheDir,
         GIT_TERMINAL_PROMPT: "0",
-        GIT_CONFIG_COUNT: "1",
-        GIT_CONFIG_KEY_0: `url.${repoA.replaceAll("\\", "/")}.insteadOf`,
-        GIT_CONFIG_VALUE_0: "https://example.invalid/a.git",
+        GIT_CONFIG_NOSYSTEM: "1",
+        GIT_CONFIG_GLOBAL: join(String(dir), "gitconfig"),
       },
     });
     const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -5214,7 +5224,9 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("803d84def89a6418.git");
+      expect(
+        (await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).filter(entry => entry.endsWith(".git")),
+      ).toEqual(["803d84def89a6418.git"]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5276,6 +5288,7 @@ describe.concurrent("bun-install", () => {
         join("..", "uglify", "bin", "uglifyjs"),
       );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+        ".id",
         "8b781131fcb82ac5.git",
         "@G@e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
       ]);
@@ -5464,6 +5477,7 @@ describe.concurrent("bun-install", () => {
         join("..", "uglify-hash", "bin", "uglifyjs"),
       );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
+        ".id",
         "8b781131fcb82ac5.git",
         "@G@e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
       ]);

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -5099,7 +5099,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify-js", "bin", "uglifyjs"),
       );
-      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("9694c5fe9c41ad51.git");
+      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("8b781131fcb82ac5.git");
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify-js"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5118,6 +5118,58 @@ describe.concurrent("bun-install", () => {
       expect(package_json.name).toBe("uglify-js");
       await access(join(ctx.package_dir, "bun.lockb"));
     });
+  });
+
+  it("does not use a cached git repository stored under a differently derived name", async () => {
+    using dir = tempDir("git-cache-identity", {
+      "repo-a/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+      "repo-a/index.js": "module.exports = 'a';",
+      "repo-b/package.json": JSON.stringify({ name: "a", version: "1.0.0" }),
+      "repo-b/index.js": "module.exports = 'b';",
+      "project/package.json": JSON.stringify({
+        name: "project",
+        version: "1.0.0",
+        dependencies: { a: "git+https://example.invalid/a.git" },
+      }),
+    });
+    const repoA = join(String(dir), "repo-a");
+    const repoB = join(String(dir), "repo-b");
+    const projectDir = join(String(dir), "project");
+    const cacheDir = join(String(dir), "cache");
+    for (const repo of [repoA, repoB]) {
+      await Bun.$`git init -q -b main . && git add . && git -c user.name=test -c user.email=test@example.com commit -q -m init`
+        .cwd(repo)
+        .env(env)
+        .quiet();
+    }
+    // A bare clone of a different repository, stored under the name earlier
+    // versions derived for this dependency's URL.
+    await Bun.$`git clone -q --bare ${repoB} ${join(cacheDir, "9a422e910b76550b.git")}`.env(env).quiet();
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: projectDir,
+      stdout: "pipe",
+      stdin: "ignore",
+      stderr: "pipe",
+      env: {
+        ...env,
+        BUN_INSTALL_CACHE_DIR: cacheDir,
+        GIT_TERMINAL_PROMPT: "0",
+        GIT_CONFIG_COUNT: "1",
+        GIT_CONFIG_KEY_0: `url.${repoA.replaceAll("\\", "/")}.insteadOf`,
+        GIT_CONFIG_VALUE_0: "https://example.invalid/a.git",
+      },
+    });
+    const [out, err, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(err).not.toContain("error:");
+    expect(out).toContain("+ a@git+https://example.invalid/a.git");
+    expect(exitCode).toBe(0);
+    expect(await file(join(projectDir, "node_modules", "a", "index.js")).text()).toBe("module.exports = 'a';");
+    expect((await readdirSorted(cacheDir)).filter(entry => entry.endsWith(".git"))).toEqual([
+      "9856be5c1989976d.git",
+      "9a422e910b76550b.git",
+    ]);
   });
 
   it("should handle Git URL in dependencies (SCP-style)", async () => {
@@ -5162,7 +5214,7 @@ describe.concurrent("bun-install", () => {
       expect(join(ctx.package_dir, "node_modules", ".bin", "uglifyjs")).toBeValidBin(
         join("..", "uglify", "bin", "uglifyjs"),
       );
-      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("87d55589eb4217d2.git");
+      expect((await readdirSorted(join(ctx.package_dir, "node_modules", ".cache")))[0]).toBe("803d84def89a6418.git");
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
         ".bun-tag",
         ".gitattributes",
@@ -5224,7 +5276,7 @@ describe.concurrent("bun-install", () => {
         join("..", "uglify", "bin", "uglifyjs"),
       );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
-        "9694c5fe9c41ad51.git",
+        "8b781131fcb82ac5.git",
         "@G@e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
       ]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify"))).toEqual([
@@ -5412,7 +5464,7 @@ describe.concurrent("bun-install", () => {
         join("..", "uglify-hash", "bin", "uglifyjs"),
       );
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", ".cache"))).toEqual([
-        "9694c5fe9c41ad51.git",
+        "8b781131fcb82ac5.git",
         "@G@e219a9a78a0d2251e4dcbd4bb9034207eb484fe8",
       ]);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules", "uglify-hash"))).toEqual([

--- a/test/cli/install/bun-run-dir.test.ts
+++ b/test/cli/install/bun-run-dir.test.ts
@@ -33,8 +33,12 @@ console.log(minify("print(6 * 7)").code);
   expect(err1).toBe("");
   expect(await readdirSorted(run_dir)).toEqual([".cache", "test.js"]);
   expect(await readdirSorted(join(run_dir, ".cache"))).toContain("uglify-js");
-  expect(await readdirSorted(join(run_dir, ".cache", "uglify-js"))).toEqual(["3.17.4@@@1"]);
-  expect(await exists(join(run_dir, ".cache", "uglify-js", "3.17.4@@@1", "package.json"))).toBeTrue();
+  expect(await readdirSorted(join(run_dir, ".cache", "uglify-js"))).toEqual([
+    "3.17.4@@@1_integrity=4fdabcd93248f5efc2d53031",
+  ]);
+  expect(
+    await exists(join(run_dir, ".cache", "uglify-js", "3.17.4@@@1_integrity=4fdabcd93248f5efc2d53031", "package.json")),
+  ).toBeTrue();
   const out1 = await new Response(stdout1).text();
   expect(out1.split(/\r?\n/)).toEqual(["print(42);", ""]);
   expect(await exited1).toBe(0);
@@ -58,7 +62,9 @@ console.log(minify("print(6 * 7)").code);
   expect(err2).toBe("");
   expect(await readdirSorted(run_dir)).toEqual([".cache", "test.js"]);
   expect(await readdirSorted(join(run_dir, ".cache"))).toContain("uglify-js");
-  expect(await readdirSorted(join(run_dir, ".cache", "uglify-js"))).toEqual(["3.17.4@@@1"]);
+  expect(await readdirSorted(join(run_dir, ".cache", "uglify-js"))).toEqual([
+    "3.17.4@@@1_integrity=4fdabcd93248f5efc2d53031",
+  ]);
   const out2 = await new Response(stdout2).text();
   expect(out2.split(/\r?\n/)).toEqual(["print(42);", ""]);
   expect(await exited2).toBe(0);
@@ -98,11 +104,17 @@ for (const entry of await decompress(Buffer.from(buffer))) {
   expect(err1).toBe("");
   expect(await readdirSorted(run_dir)).toEqual([".cache", "test.js"]);
   expect(await readdirSorted(join(run_dir, ".cache"))).toContain("decompress");
-  expect(await readdirSorted(join(run_dir, ".cache", "decompress"))).toEqual(["4.2.1@@@1"]);
-  expect(await exists(join(run_dir, ".cache", "decompress", "4.2.1@@@1", "package.json"))).toBeTrue();
-  expect(await file(join(run_dir, ".cache", "decompress", "4.2.1@@@1", "index.js")).text()).toContain(
-    "\nmodule.exports = ",
-  );
+  expect(await readdirSorted(join(run_dir, ".cache", "decompress"))).toEqual([
+    "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713",
+  ]);
+  expect(
+    await exists(join(run_dir, ".cache", "decompress", "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713", "package.json")),
+  ).toBeTrue();
+  expect(
+    await file(
+      join(run_dir, ".cache", "decompress", "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713", "index.js"),
+    ).text(),
+  ).toContain("\nmodule.exports = ");
   const out1 = await new Response(stdout1).text();
   expect(out1.split(/\r?\n/)).toEqual([
     "directory: package/",
@@ -131,11 +143,17 @@ for (const entry of await decompress(Buffer.from(buffer))) {
   expect(err2).toBe("");
   expect(await readdirSorted(run_dir)).toEqual([".cache", "test.js"]);
   expect(await readdirSorted(join(run_dir, ".cache"))).toContain("decompress");
-  expect(await readdirSorted(join(run_dir, ".cache", "decompress"))).toEqual(["4.2.1@@@1"]);
-  expect(await exists(join(run_dir, ".cache", "decompress", "4.2.1@@@1", "package.json"))).toBeTrue();
-  expect(await file(join(run_dir, ".cache", "decompress", "4.2.1@@@1", "index.js")).text()).toContain(
-    "\nmodule.exports = ",
-  );
+  expect(await readdirSorted(join(run_dir, ".cache", "decompress"))).toEqual([
+    "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713",
+  ]);
+  expect(
+    await exists(join(run_dir, ".cache", "decompress", "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713", "package.json")),
+  ).toBeTrue();
+  expect(
+    await file(
+      join(run_dir, ".cache", "decompress", "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713", "index.js"),
+    ).text(),
+  ).toContain("\nmodule.exports = ");
   const out2 = await new Response(stdout2).text();
   expect(out2.split(/\r?\n/)).toEqual([
     "directory: package/",

--- a/test/cli/install/bun-run-dir.test.ts
+++ b/test/cli/install/bun-run-dir.test.ts
@@ -1,8 +1,20 @@
 import { file, spawn } from "bun";
 import { expect, it } from "bun:test";
 import { exists, writeFile } from "fs/promises";
-import { bunExe, bunEnv as env, readdirSorted, tmpdirSync } from "harness";
+import { bunExe, bunEnv as env, installCacheFolderName, readdirSorted, tmpdirSync } from "harness";
 import { join } from "path";
+
+// registry.npmjs.org dist.integrity of the versions these tests install
+const uglifyIntegrity =
+  "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==";
+const decompressIntegrity =
+  "sha512-e48kc2IjU+2Zw8cTb6VZcJQ3lgVbS4uuB1TfCHbiZIP/haNXm+SVyhu+87jts5/3ROpd82GSVCoNs/z8l4ZOaQ==";
+const uglifyCacheEntry = (run_dir: string) =>
+  installCacheFolderName(join(run_dir, ".cache"), "uglify-js", "3.17.4", uglifyIntegrity).slice("uglify-js@".length);
+const decompressCacheEntry = (run_dir: string) =>
+  installCacheFolderName(join(run_dir, ".cache"), "decompress", "4.2.1", decompressIntegrity).slice(
+    "decompress@".length,
+  );
 
 it.concurrent("should download dependency to run local file", async () => {
   const run_dir = tmpdirSync();
@@ -33,12 +45,8 @@ console.log(minify("print(6 * 7)").code);
   expect(err1).toBe("");
   expect(await readdirSorted(run_dir)).toEqual([".cache", "test.js"]);
   expect(await readdirSorted(join(run_dir, ".cache"))).toContain("uglify-js");
-  expect(await readdirSorted(join(run_dir, ".cache", "uglify-js"))).toEqual([
-    "3.17.4@@@1_integrity=4fdabcd93248f5efc2d53031",
-  ]);
-  expect(
-    await exists(join(run_dir, ".cache", "uglify-js", "3.17.4@@@1_integrity=4fdabcd93248f5efc2d53031", "package.json")),
-  ).toBeTrue();
+  expect(await readdirSorted(join(run_dir, ".cache", "uglify-js"))).toEqual([uglifyCacheEntry(run_dir)]);
+  expect(await exists(join(run_dir, ".cache", "uglify-js", uglifyCacheEntry(run_dir), "package.json"))).toBeTrue();
   const out1 = await new Response(stdout1).text();
   expect(out1.split(/\r?\n/)).toEqual(["print(42);", ""]);
   expect(await exited1).toBe(0);
@@ -62,9 +70,7 @@ console.log(minify("print(6 * 7)").code);
   expect(err2).toBe("");
   expect(await readdirSorted(run_dir)).toEqual([".cache", "test.js"]);
   expect(await readdirSorted(join(run_dir, ".cache"))).toContain("uglify-js");
-  expect(await readdirSorted(join(run_dir, ".cache", "uglify-js"))).toEqual([
-    "3.17.4@@@1_integrity=4fdabcd93248f5efc2d53031",
-  ]);
+  expect(await readdirSorted(join(run_dir, ".cache", "uglify-js"))).toEqual([uglifyCacheEntry(run_dir)]);
   const out2 = await new Response(stdout2).text();
   expect(out2.split(/\r?\n/)).toEqual(["print(42);", ""]);
   expect(await exited2).toBe(0);
@@ -104,17 +110,11 @@ for (const entry of await decompress(Buffer.from(buffer))) {
   expect(err1).toBe("");
   expect(await readdirSorted(run_dir)).toEqual([".cache", "test.js"]);
   expect(await readdirSorted(join(run_dir, ".cache"))).toContain("decompress");
-  expect(await readdirSorted(join(run_dir, ".cache", "decompress"))).toEqual([
-    "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713",
-  ]);
-  expect(
-    await exists(join(run_dir, ".cache", "decompress", "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713", "package.json")),
-  ).toBeTrue();
-  expect(
-    await file(
-      join(run_dir, ".cache", "decompress", "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713", "index.js"),
-    ).text(),
-  ).toContain("\nmodule.exports = ");
+  expect(await readdirSorted(join(run_dir, ".cache", "decompress"))).toEqual([decompressCacheEntry(run_dir)]);
+  expect(await exists(join(run_dir, ".cache", "decompress", decompressCacheEntry(run_dir), "package.json"))).toBeTrue();
+  expect(await file(join(run_dir, ".cache", "decompress", decompressCacheEntry(run_dir), "index.js")).text()).toContain(
+    "\nmodule.exports = ",
+  );
   const out1 = await new Response(stdout1).text();
   expect(out1.split(/\r?\n/)).toEqual([
     "directory: package/",
@@ -143,17 +143,11 @@ for (const entry of await decompress(Buffer.from(buffer))) {
   expect(err2).toBe("");
   expect(await readdirSorted(run_dir)).toEqual([".cache", "test.js"]);
   expect(await readdirSorted(join(run_dir, ".cache"))).toContain("decompress");
-  expect(await readdirSorted(join(run_dir, ".cache", "decompress"))).toEqual([
-    "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713",
-  ]);
-  expect(
-    await exists(join(run_dir, ".cache", "decompress", "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713", "package.json")),
-  ).toBeTrue();
-  expect(
-    await file(
-      join(run_dir, ".cache", "decompress", "4.2.1@@@1_integrity=7b8f2473622353ed99c3c713", "index.js"),
-    ).text(),
-  ).toContain("\nmodule.exports = ");
+  expect(await readdirSorted(join(run_dir, ".cache", "decompress"))).toEqual([decompressCacheEntry(run_dir)]);
+  expect(await exists(join(run_dir, ".cache", "decompress", decompressCacheEntry(run_dir), "package.json"))).toBeTrue();
+  expect(await file(join(run_dir, ".cache", "decompress", decompressCacheEntry(run_dir), "index.js")).text()).toContain(
+    "\nmodule.exports = ",
+  );
   const out2 = await new Response(stdout2).text();
   expect(out2.split(/\r?\n/)).toEqual([
     "directory: package/",

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2032,6 +2032,53 @@ export async function readdirSorted(path: string): Promise<string[]> {
 }
 
 /**
+ * Folder name `bun install` uses for an npm package in its cache directory:
+ * `<name>@<version>[@@<registryHost>]@@@2[.<fingerprint>]`. The fingerprint is
+ * present when the package has an integrity value and is derived from the
+ * per-cache-directory key in `<cacheDir>/.id`, which this helper reads (or
+ * creates the same way `bun install` would, so it may be called before the
+ * first install into `cacheDir`).
+ */
+export function installCacheFolderName(
+  cacheDir: string,
+  name: string,
+  version: string,
+  integrity?: string,
+  registryHost?: string,
+): string {
+  let folder = `${name}@${version}${registryHost ? "@@" + registryHost : ""}@@@2`;
+  const match = integrity && /^(sha1|sha256|sha384|sha512)-([A-Za-z0-9+/=]+)$/.exec(integrity);
+  if (!match) return folder;
+  const idPath = join(cacheDir, ".id");
+  let id: Buffer;
+  try {
+    id = fs.readFileSync(idPath);
+    if (id.length !== 16) throw new Error("short");
+  } catch {
+    fs.mkdirSync(cacheDir, { recursive: true });
+    id = require("node:crypto").randomBytes(16);
+    try {
+      fs.writeFileSync(idPath, id, { flag: "wx", mode: 0o600 });
+    } catch {
+      id = fs.readFileSync(idPath);
+    }
+  }
+  const tag = { sha1: 1, sha256: 2, sha384: 3, sha512: 4 }[match[1] as "sha1" | "sha256" | "sha384" | "sha512"];
+  const digest = Buffer.from(match[2], "base64");
+  const bits = require("node:crypto")
+    .createHash("sha256")
+    .update(id)
+    .update(Buffer.from([tag]))
+    .update(digest)
+    .digest()
+    .readBigUInt64BE(0);
+  const alphabet = "0123456789abcdefghjkmnpqrstvwxyz";
+  folder += ".";
+  for (let i = 0; i < 13; i++) folder += alphabet[Number((bits >> BigInt(60 - 5 * i)) & 31n)];
+  return folder;
+}
+
+/**
  * Helper function for making automatically lazily-executed promises.
  *
  * The difference is that the promise has not already started to be evaluated when it is created,

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -11,6 +11,7 @@ import { heapStats } from "bun:jsc";
 import { beforeAll, describe, expect } from "bun:test";
 import { ChildProcess, execSync, fork } from "child_process";
 import { readdir, rm, writeFile } from "fs/promises";
+import { createHash, randomBytes } from "node:crypto";
 import fs, { closeSync, openSync, rmSync } from "node:fs";
 import os from "node:os";
 import { dirname, isAbsolute, join } from "path";
@@ -2048,7 +2049,10 @@ export function installCacheFolderName(
 ): string {
   let folder = `${name}@${version}${registryHost ? "@@" + registryHost : ""}@@@2`;
   const match = integrity && /^(sha1|sha256|sha384|sha512)-([A-Za-z0-9+/=]+)$/.exec(integrity);
-  if (!match) return folder;
+  // same NAME_MAX rule as `bun install`: no fingerprint when it and a
+  // `_patch_hash=<16 hex>` suffix would not fit in a 255-byte component
+  const component = folder.slice(folder.lastIndexOf("/") + 1);
+  if (!match || Buffer.byteLength(component) + 1 + 13 + "_patch_hash=".length + 16 > 255) return folder;
   const idPath = join(cacheDir, ".id");
   let id: Buffer;
   try {
@@ -2056,7 +2060,7 @@ export function installCacheFolderName(
     if (id.length !== 16) throw new Error("short");
   } catch {
     fs.mkdirSync(cacheDir, { recursive: true });
-    id = require("node:crypto").randomBytes(16);
+    id = randomBytes(16);
     try {
       fs.writeFileSync(idPath, id, { flag: "wx", mode: 0o600 });
     } catch {
@@ -2065,8 +2069,7 @@ export function installCacheFolderName(
   }
   const tag = { sha1: 1, sha256: 2, sha384: 3, sha512: 4 }[match[1] as "sha1" | "sha256" | "sha384" | "sha512"];
   const digest = Buffer.from(match[2], "base64");
-  const bits = require("node:crypto")
-    .createHash("sha256")
+  const bits = createHash("sha256")
     .update(id)
     .update(Buffer.from([tag]))
     .update(digest)

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2048,11 +2048,17 @@ export function installCacheFolderName(
   registryHost?: string,
 ): string {
   let folder = `${name}@${version}${registryHost ? "@@" + registryHost : ""}@@@2`;
-  const match = integrity && /^(sha1|sha256|sha384|sha512)-([A-Za-z0-9+/=]+)$/.exec(integrity);
+  if (!integrity) return folder;
+  const match = /^(sha1|sha256|sha384|sha512)-([A-Za-z0-9+/]+={0,2})$/.exec(integrity);
+  const digestLengths = { sha1: 20, sha256: 32, sha384: 48, sha512: 64 };
+  const digest = match && Buffer.from(match[2], "base64");
+  if (!match || !digest || digest.length !== digestLengths[match[1] as keyof typeof digestLengths]) {
+    throw new Error(`installCacheFolderName: not a supported integrity value: ${integrity}`);
+  }
   // same NAME_MAX rule as `bun install`: no fingerprint when it and a
   // `_patch_hash=<16 hex>` suffix would not fit in a 255-byte component
   const component = folder.slice(folder.lastIndexOf("/") + 1);
-  if (!match || Buffer.byteLength(component) + 1 + 13 + "_patch_hash=".length + 16 > 255) return folder;
+  if (Buffer.byteLength(component) + 1 + 13 + "_patch_hash=".length + 16 > 255) return folder;
   const idPath = join(cacheDir, ".id");
   let id: Buffer;
   try {
@@ -2067,8 +2073,7 @@ export function installCacheFolderName(
       id = fs.readFileSync(idPath);
     }
   }
-  const tag = { sha1: 1, sha256: 2, sha384: 3, sha512: 4 }[match[1] as "sha1" | "sha256" | "sha384" | "sha512"];
-  const digest = Buffer.from(match[2], "base64");
+  const tag = { sha1: 1, sha256: 2, sha384: 3, sha512: 4 }[match[1] as keyof typeof digestLengths];
   const bits = createHash("sha256")
     .update(id)
     .update(Buffer.from([tag]))

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -2050,10 +2050,16 @@ export function installCacheFolderName(
   let folder = `${name}@${version}${registryHost ? "@@" + registryHost : ""}@@@2`;
   if (!integrity) return folder;
   const match = /^(sha1|sha256|sha384|sha512)-([A-Za-z0-9+/]+={0,2})$/.exec(integrity);
+  if (!match) {
+    throw new Error(`installCacheFolderName: expected "<sha1|sha256|sha384|sha512>-<base64>", got ${integrity}`);
+  }
   const digestLengths = { sha1: 20, sha256: 32, sha384: 48, sha512: 64 };
-  const digest = match && Buffer.from(match[2], "base64");
-  if (!match || !digest || digest.length !== digestLengths[match[1] as keyof typeof digestLengths]) {
-    throw new Error(`installCacheFolderName: not a supported integrity value: ${integrity}`);
+  const digest = Buffer.from(match[2], "base64");
+  const expectedLength = digestLengths[match[1] as keyof typeof digestLengths];
+  if (digest.length !== expectedLength) {
+    throw new Error(
+      `installCacheFolderName: ${match[1]} digest decodes to ${digest.length} bytes, expected ${expectedLength}: ${integrity}`,
+    );
   }
   // same NAME_MAX rule as `bun install`: no fingerprint when it and a
   // `_patch_hash=<16 hex>` suffix would not fit in a 255-byte component


### PR DESCRIPTION
### What does this PR do?

npm packages in the global install cache are now stored under a folder name that ends in a short fingerprint of the integrity value the registry manifest or the lockfile provides for them:

```
~/.bun/install/cache/lodash@4.17.21@@@2.0gwamgzgacdck
                                     └── '.' + 13 chars (lowercase base32, the alphabet
                                         bundler chunk hashes use): the first 64 bits of
                                         SHA-256(<cache-dir key> ‖ <hash algorithm> ‖ <digest>)
```

`<cache-dir key>` is 16 random bytes kept in `<cache dir>/.id`. It is created (`O_EXCL`) the first time a cache directory is used and read once per process when the cache directory is opened, so it adds no per-package work; because it lives inside the cache directory it travels with saved/restored CI caches. Keying the fingerprint means that which two digests would share a name cannot be worked out ahead of time, so 64 bits are enough and the name stays short.

An entry that was extracted for one digest is therefore never reused by an install whose lockfile pins a different digest for the same `name@version`; that install fetches and verifies its own copy, and both entries coexist. The cache-hit check is unchanged: it is still a single existence probe on the folder. Packages without an integrity value, and everything installed with `--no-verify` (where nothing vouches for the digest), use the plain `name@version@@@2` name, so a later verifying install fetches its own copy rather than trusting them. In-flight download tasks are keyed by the digest as well, so two lockfile entries for the same `name@version` with different digests are fetched separately. For package names long enough that the fingerprinted component would not fit in 255 bytes, the fingerprint is left off.

The cache layout version is bumped from `@@@1` to `@@@2`, and remote/local tarball entries (`@T@…`) and cached bare git clones (`<hex>.git`) now derive their folder names from a SHA-256 prefix of the URL rather than a Wyhash of it (same width as before).

Consequences worth calling out: every existing cache entry is fetched (git repositories: cloned) again once after upgrading, and the old `@@@1` entries are left in place. A cache directory that was populated by an earlier Bun therefore does not satisfy installs on its own until it has been repopulated once — air-gapped setups and CI images with a baked-in cache need one online install (or a re-bake) with this version. This is deliberate (adopting the old entries would keep serving exactly the entries whose origin is unknown) and easy to reverse if preferred.

### How did you verify your code works?

New tests in `test/cli/install/bun-install-registry.test.ts` (hoisted and isolated linkers, plus auto-install) pre-populate cache folders under the previous layout's name, under the digest-less name and under a name for a different digest, and check that `bun install` / `bun --print "require(...)"` fetch and use the registry contents instead, and that the matching entry is reused as-is on the next install. A new test in `test/cli/install/bun-install.test.ts` pre-populates a bare clone of an unrelated repository under the previously derived clone directory name and checks that the dependency is cloned from its own URL. Tests derive expected cache folder names through one helper in `test/harness.ts` (`installCacheFolderName`, which reads `<cache>/.id`); existing tests that assert exact cache folder / clone directory names were updated.

`bun-install-registry.test.ts` (232 pass), `bun-install.test.ts` (195), `bun-add` (54), `isolated-install`, `bun-patch`, `bun-install-patch`, `bun-pm`, `npmrc`, `bun-lock`, `lockfile-only`, `lockfile-version-2`, `migrate-bun-lockb-v2`, `bun-run-dir` and `test/internal/source-lints` pass locally with a debug build; the new tests fail against the current release.

Release-build numbers (`bun run build:release` of this branch vs the installed `1.4.0-canary.1` release; Linux x64, shared machine):

Syscalls per install (`strace -f -c`, 68-package express fixture, two runs each):

| scenario | 1.4.0-canary.1 | this branch |
| --- | --- | --- |
| warm cache, `node_modules` removed | 2024 / 2027 | 2014 / 2017 |
| warm cache, `node_modules` present (no-op) | 640 | 618 |

The install-path syscalls (`faccessat2`, `mkdirat`, `linkat`, `getdents64`, `readlink`) are identical in count; reading `.id` is one `openat`/`read`/`close` per process, and the remaining differences are startup noise (`mmap`, `futex`, …).

`hyperfine` on a 552-package project (`--warmup 3 --runs 30`, both orders):

| scenario | 1.4.0-canary.1 | this branch |
| --- | --- | --- |
| warm cache, `rm -rf node_modules` before each run | 136.8 ms ± 7.0 / 141.1 ms ± 12.8 | 142.0 ms ± 8.1 / 139.5 ms ± 9.6 |
| warm cache and `node_modules` present | 19.8 ms ± 2.7 / 22.0 ms ± 3.7 | 23.8 ms ± 6.1 / 22.5 ms ± 4.9 |

(minimums: 125.9/125.4 ms vs 130.0/127.0 ms and 16.4/17.3 ms vs 16.9/16.3 ms — within run-to-run noise on this machine.)
