### PR TITLE
bake: make importers found during an in-flight top-level await load wait for it

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -70,6 +70,14 @@ interface CJSModule {
   require: (id: Id) => unknown;
 }
 
+interface InFlightLoad {
+  promise: Promise<HMRModule>;
+  /** The module whose top-level await the load is suspended on: the loading
+   *  module itself, or else the first of its dependencies that was suspended.
+   *  Same module `loadModuleSync` would name if it were loading the graph. */
+  asyncId: Id;
+}
+
 /** Implementation details must remain in sync with the parser (src/js_parser) and bundler (src/bundler/bundle_v2.rs) */
 export class HMRModule {
   /** Key in `registry` */
@@ -85,11 +93,12 @@ export class HMRModule {
   /** When a module fails to load, trying to load it again
    *  should throw the same error */
   failure: unknown = null;
-  /** Set while this module's load is suspended on top-level await (its own or
-   *  a dependency's). Distinguishes that from a `State.Pending` module that is
-   *  merely part of an import cycle: importers found in the meantime must wait
-   *  for this promise instead of reading the not-yet-assigned namespace. */
-  loading: Promise<HMRModule> | null = null;
+  /** Set while this module's load is suspended on top-level await. Distinguishes
+   *  that from a `State.Pending` module that is merely part of an import cycle:
+   *  importers found in the meantime wait for the promise instead of reading the
+   *  not-yet-assigned namespace, and `require` refuses the module the same way
+   *  it does before the load has started. */
+  loading: InFlightLoad | null = null;
   /** Two purposes:
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
    * 2. any[] - List of module namespace objects. Read by the ESM module's load function.
@@ -287,7 +296,7 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
       mod.loading = null;
       isUserDynamic = false;
     } else {
-      if (mod.loading) throw new AsyncImportError(id);
+      if (mod.loading) throw new AsyncImportError(mod.loading.asyncId);
       if (importer) {
         mod.importers.add(importer);
       }
@@ -389,7 +398,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
       if (importer) {
         mod.importers.add(importer);
       }
-      return mod.loading ?? mod;
+      return mod.loading ? mod.loading.promise : mod;
     }
   }
   const loadOrEsmModule = unloadedModuleRegistry[id];
@@ -439,7 +448,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
         throw e;
       }
     }
-    const [deps /* exports */ /* stars */, , , load /* isAsync */] = loadOrEsmModule;
+    const [deps /* exports */ /* stars */, , , load, isAsync] = loadOrEsmModule;
 
     if (!mod) {
       mod = new HMRModule(id, false);
@@ -453,16 +462,17 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
       mod.importers.add(importer);
     }
 
-    const { list, isAsync } = parseEsmDependencies(mod, deps, loadModuleAsync<false>);
+    const { list, asyncId: depAsyncId } = parseEsmDependencies(mod, deps, loadModuleAsync<false>);
+    const hasAsyncDep = depAsyncId !== null;
     DEBUG.ASSERT(
-      isAsync //
+      hasAsyncDep //
         ? list.some(x => x instanceof Promise)
         : list.every(x => x instanceof HMRModule),
     );
 
     // Running finishLoadModuleAsync synchronously when there are no promises is
     // not a performance optimization but a behavioral correctness issue.
-    const result = isAsync
+    const result = hasAsyncDep
       ? Promise.all(list).then(
           list => finishLoadModuleAsync(mod, load, list),
           e => {
@@ -477,10 +487,14 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
           list as HMRModule[], // no promises as by assert above
         );
     if (result instanceof Promise) {
-      mod.loading = result;
+      // `load` only returns a promise for a module flagged `isAsync`, so one of
+      // the two is always set. Checked in the same order as loadModuleSync does.
+      DEBUG.ASSERT(isAsync || hasAsyncDep);
+      const loading: InFlightLoad = { promise: result, asyncId: isAsync ? id : depAsyncId! };
+      mod.loading = loading;
       const settled = () => {
         // A hot reload that started while this load was in flight owns the field now.
-        if (mod.loading === result) mod.loading = null;
+        if (mod.loading === loading) mod.loading = null;
       };
       result.then(settled, settled);
     }
@@ -525,7 +539,8 @@ function parseEsmDependencies<T extends GenericModuleLoader<any>>(
 ) {
   let i = 0;
   let list: ReturnType<T>[] = [];
-  let isAsync = false;
+  /** Set if any dependency came back as a promise: what the first one of those is suspended on. */
+  let asyncId: Id | null = null;
   const { length } = deps;
   while (i < length) {
     const dep = deps[i] as string;
@@ -557,7 +572,10 @@ function parseEsmDependencies<T extends GenericModuleLoader<any>>(
         // }
         i++;
       }
-      isAsync ||= promiseOrModule instanceof Promise;
+      if (promiseOrModule instanceof Promise) {
+        // The loader only hands out a promise for a module whose `loading` is set.
+        asyncId ??= registry.get(dep)!.loading!.asyncId;
+      }
     } else {
       DEBUG.ASSERT(!registry.get(dep)?.esm);
       i = expectedExportKeyEnd;
@@ -567,7 +585,7 @@ function parseEsmDependencies<T extends GenericModuleLoader<any>>(
       }
     }
   }
-  return { list, isAsync };
+  return { list, asyncId };
 }
 
 function hasExportStar(starImports: Id[], key: string) {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -72,9 +72,7 @@ interface CJSModule {
 
 interface InFlightLoad {
   promise: Promise<HMRModule>;
-  /** The module whose top-level await the load is suspended on: the loading
-   *  module itself, or else the first of its dependencies that was suspended.
-   *  Same module `loadModuleSync` would name if it were loading the graph. */
+  /** The module whose top-level await this load is suspended on, as `loadModuleSync` would name it. */
   asyncId: Id;
 }
 
@@ -93,11 +91,7 @@ export class HMRModule {
   /** When a module fails to load, trying to load it again
    *  should throw the same error */
   failure: unknown = null;
-  /** Set while this module's load is suspended on top-level await. Distinguishes
-   *  that from a `State.Pending` module that is merely part of an import cycle:
-   *  importers found in the meantime wait for the promise instead of reading the
-   *  not-yet-assigned namespace, and `require` refuses the module the same way
-   *  it does before the load has started. */
+  /** Set while the load is suspended on top-level await; a `Pending` module without it is in an import cycle. */
   loading: InFlightLoad | null = null;
   /** Two purposes:
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
@@ -487,8 +481,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
           list as HMRModule[], // no promises as by assert above
         );
     if (result instanceof Promise) {
-      // `load` only returns a promise for a module flagged `isAsync`, so one of
-      // the two is always set. Checked in the same order as loadModuleSync does.
+      // Same blame order as loadModuleSync: the module's own await before a dependency's.
       DEBUG.ASSERT(isAsync || hasAsyncDep);
       const loading: InFlightLoad = { promise: result, asyncId: isAsync ? id : depAsyncId! };
       mod.loading = loading;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -85,6 +85,11 @@ export class HMRModule {
   /** When a module fails to load, trying to load it again
    *  should throw the same error */
   failure: unknown = null;
+  /** Set while this module's load is suspended on top-level await (its own or
+   *  a dependency's). Distinguishes that from a `State.Pending` module that is
+   *  merely part of an import cycle: importers found in the meantime must wait
+   *  for this promise instead of reading the not-yet-assigned namespace. */
+  loading: Promise<HMRModule> | null = null;
   /** Two purposes:
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
    * 2. any[] - List of module namespace objects. Read by the ESM module's load function.
@@ -279,8 +284,10 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     if (mod.state === State.Error) throw mod.failure;
     if (mod.state === State.Stale) {
       mod.state = State.Pending;
+      mod.loading = null;
       isUserDynamic = false;
     } else {
+      if (mod.loading) throw new AsyncImportError(id);
       if (importer) {
         mod.importers.add(importer);
       }
@@ -376,12 +383,13 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
     if (state === State.Error) throw mod.failure;
     if (state === State.Stale) {
       mod.state = State.Pending;
+      mod.loading = null;
       isUserDynamic = false as IsUserDynamic;
     } else {
       if (importer) {
         mod.importers.add(importer);
       }
-      return mod;
+      return mod.loading ?? mod;
     }
   }
   const loadOrEsmModule = unloadedModuleRegistry[id];
@@ -454,7 +462,7 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
 
     // Running finishLoadModuleAsync synchronously when there are no promises is
     // not a performance optimization but a behavioral correctness issue.
-    return isAsync
+    const result = isAsync
       ? Promise.all(list).then(
           list => finishLoadModuleAsync(mod, load, list),
           e => {
@@ -468,6 +476,15 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
           load,
           list as HMRModule[], // no promises as by assert above
         );
+    if (result instanceof Promise) {
+      mod.loading = result;
+      const settled = () => {
+        // A hot reload that started while this load was in flight owns the field now.
+        if (mod.loading === result) mod.loading = null;
+      };
+      result.then(settled, settled);
+    }
+    return result;
   }
 }
 

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -427,15 +427,19 @@ devTest("import() and require() of a module whose top-level await is in flight",
   files: {
     ...tlaAndFirstImporter,
     "probes.ts": `
-      let requireResult;
-      try {
-        requireResult = "returned " + JSON.stringify(require("./tla"));
-      } catch (e) {
-        requireResult = "threw: " + e.message;
+      function tryRequire(load) {
+        try {
+          return "returned " + JSON.stringify(load());
+        } catch (e) {
+          return "threw: " + e.message;
+        }
       }
+      const requireTla = tryRequire(() => require("./tla"));
+      const requireA = tryRequire(() => require("./a"));
       export const probes = import("./tla").then(ns => ({
         dynamicImport: ns === null ? "resolved to null" : "resolved to v=" + ns.v,
-        require: requireResult,
+        requireTla,
+        requireA,
       }));
     `,
     "routes/index.ts": `
@@ -452,11 +456,135 @@ devTest("import() and require() of a module whose top-level await is in flight",
       a: "a:tla",
       duringLoad: {
         dynamicImport: "resolved to v=tla",
-        // Same error as requiring it before it started loading.
-        require: `threw: Cannot require "tla.ts" because "tla.ts" uses top-level await, but 'require' is a synchronous operation.`,
+        // Same errors as requiring them before anything started loading: the
+        // module that contains the await is the one named, whether it is the
+        // required module itself or a dependency it is waiting on.
+        requireTla: `threw: Cannot require "tla.ts" because "tla.ts" uses top-level await, but 'require' is a synchronous operation.`,
+        requireA: `threw: Cannot require "a.ts" because "tla.ts" uses top-level await, but 'require' is a synchronous operation.`,
       },
       // Once the load has settled, synchronous access works again.
       requireAfterLoad: "tla",
+    });
+  },
+});
+devTest("an in-flight load that rejects fails the importers waiting on it", {
+  // "a" and "b" both wait on "tla", whose load rejects. Each of them, and the
+  // route, must fail with that error. (When "b" was instead evaluated right
+  // away, the rejection "a" was waiting on ended up unhandled and took the
+  // whole dev server process down.)
+  framework: minimalFramework,
+  files: {
+    "tla.ts": `
+      await 1;
+      throw new Error("boom tla");
+      export const v = "unreachable";
+    `,
+    "a.ts": `
+      import { v } from "./tla";
+      export const a = "a:" + v;
+    `,
+    "b.ts": `
+      import { v } from "./tla";
+      export const b = "b:" + v;
+    `,
+    "routes/index.ts": `
+      import { a } from "../a";
+      import { b } from "../b";
+      export default function () {
+        return new Response(a + " " + b);
+      }
+    `,
+    "routes/other.ts": `
+      export default function () {
+        return new Response("other route still works");
+      }
+    `,
+  },
+  async test(dev) {
+    // The dev error page embeds its payload as JSON (see src/runtime/server/DevErrorPage.rs).
+    const errorPageJson = /<script id="__bunfallback" type="application\/json">([^<]*)<\/script>/;
+    for (let i = 0; i < 2; i++) {
+      const response = await dev.fetch("/");
+      const payload = JSON.parse(errorPageJson.exec(await response.text())![1]);
+      expect(payload.problems.exceptions.map((exception: any) => exception.message)).toEqual(["boom tla"]);
+      expect(response.status).toBe(500);
+    }
+    await dev.fetch("/other").equals("other route still works");
+  },
+});
+devTest("a hot update replacing a module whose load is still in flight supersedes that load", {
+  // Version 1 of each module never finishes loading. Replacing it with a
+  // version that loads synchronously must make the module usable again: the
+  // pending load is forgotten when the reload starts, whether the reload is
+  // started by the update itself (x, y; y also switches to CommonJS) or by a
+  // require() that arrives while the update is parked on a dispose callback (z).
+  framework: minimalFramework,
+  files: {
+    "x.ts": `
+      await new Promise(() => {});
+      export const version = "unreachable";
+    `,
+    "y.ts": `
+      await new Promise(() => {});
+      export const version = "unreachable";
+    `,
+    "z.ts": `
+      import.meta.hot.accept();
+      import.meta.hot.dispose(() => new Promise(() => {}));
+      await new Promise(() => {});
+      export const version = "unreachable";
+    `,
+    "probe.ts": `
+      export function tryRequire(load) {
+        try {
+          return "returned " + JSON.stringify(load());
+        } catch (e) {
+          return "threw: " + e.message;
+        }
+      }
+    `,
+    "routes/index.ts": `
+      import { tryRequire } from "../probe";
+      export default function () {
+        // Version 1 of these never settles, so nothing awaits them.
+        import("../x");
+        import("../y");
+        import("../z");
+        return Response.json({
+          x: tryRequire(() => require("../x")),
+          y: tryRequire(() => require("../y")),
+          z: tryRequire(() => require("../z")),
+        });
+      }
+    `,
+    "routes/z.ts": `
+      import { tryRequire } from "../probe";
+      export default function () {
+        return Response.json([tryRequire(() => require("../z")), tryRequire(() => require("../z"))]);
+      }
+    `,
+  },
+  async test(dev) {
+    const refused = (id: string) =>
+      `threw: Cannot require "${id}" because "${id}" uses top-level await, but 'require' is a synchronous operation.`;
+    // Nothing has started loading z yet, so this is the plain refusal (and it
+    // gets this route bundled before the updates below).
+    expect(await dev.fetch("/z").json()).toEqual([refused("z.ts"), refused("z.ts")]);
+    // Now every version 1 is in flight.
+    expect(await dev.fetch("/").json()).toEqual({ x: refused("x.ts"), y: refused("y.ts"), z: refused("z.ts") });
+
+    await dev.write("x.ts", `export const version = "x2";`);
+    await dev.write("y.ts", `module.exports = { version: "y2" };`);
+    // z self-accepts and its dispose callback never settles, so this update
+    // marks z stale and then stays parked; the first require() below performs
+    // the reload, the second one sees the reloaded module.
+    await dev.write("z.ts", `export const version = "z2";`);
+
+    expect(await dev.fetch("/z").json()).toEqual(['returned {"version":"z2"}', 'returned {"version":"z2"}']);
+    expect(await dev.fetch("/").json()).toEqual({
+      x: 'returned {"version":"x2"}',
+      y: 'returned {"version":"y2"}',
+      z: 'returned {"version":"z2"}',
     });
   },
 });

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -325,6 +325,141 @@ devTest("importer tracking survives flipping a module from ESM to CJS", {
     await c.expectMessage("leaf 2", "index run 3");
   },
 });
+// Loading an entry point discovers its whole graph synchronously. "tla" starts
+// evaluating, and suspends at its await, while "a" is being visited, so any
+// module visited after "a" finds "tla" and "a" still in flight.
+const tlaAndFirstImporter = {
+  "tla.ts": `
+    await 1;
+    export const v = "tla";
+  `,
+  "a.ts": `
+    import { v } from "./tla";
+    export const a = "a:" + v;
+  `,
+};
+// "b" and "c" must wait instead of being evaluated against a namespace that
+// does not exist yet ("TypeError: null is not an object (evaluating
+// 'import_tla.v')" thrown from b.ts).
+const inFlightDiamond = {
+  ...tlaAndFirstImporter,
+  // Second importer of a module that itself uses top-level await.
+  "b.ts": `
+    import { v } from "./tla";
+    export const b = "b:" + v;
+  `,
+  // Second importer of a module that is only waiting on a dependency.
+  "c.ts": `
+    import { a } from "./a";
+    export const c = "c:" + a;
+  `,
+};
+devTest("importers found while a module's top-level await is in flight wait for it (server)", {
+  framework: minimalFramework,
+  files: {
+    ...inFlightDiamond,
+    "routes/index.ts": `
+      import { a } from "../a";
+      import { b } from "../b";
+      import { c } from "../c";
+      export default function () {
+        return new Response(a + " " + b + " " + c);
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("a:tla b:tla c:a:tla");
+    // The second request reuses the loaded graph.
+    await dev.fetch("/").equals("a:tla b:tla c:a:tla");
+  },
+});
+devTest("importers found while a module's top-level await is in flight wait for it (client)", {
+  files: {
+    ...inFlightDiamond,
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { a } from "./a";
+      import { b } from "./b";
+      import { c } from "./c";
+      console.log(a + " " + b + " " + c);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client();
+    await c.expectMessage("a:tla b:tla c:a:tla");
+  },
+});
+devTest("route loader waits for a layout whose load the page already started", {
+  // The server runtime loads the page module and then its layouts. The page
+  // imports the layout, so by the time the layout itself is requested its
+  // top-level await is in flight, and the loader must hand back that pending
+  // load rather than the module's unfinished namespace.
+  framework: {
+    ...minimalFramework,
+    fileSystemRouterTypes: [{ ...minimalFramework.fileSystemRouterTypes![0], layouts: true }],
+  },
+  files: {
+    "routes/_layout.ts": `
+      // A module handed out without waiting has its namespace read one
+      // microtask later. \`await 1\` would have resumed within that window; a
+      // timer keeps this module suspended across it.
+      await new Promise(resolve => setTimeout(resolve, 0));
+      export const name = "layout";
+    `,
+    "routes/index.ts": `
+      import { name } from "./_layout";
+      export default function (req, meta) {
+        const seenByLoader = meta.layouts.map(layout => (layout === null ? "null" : layout.name));
+        return new Response("page saw " + name + ", loader saw " + seenByLoader);
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("page saw layout, loader saw layout");
+  },
+});
+devTest("import() and require() of a module whose top-level await is in flight", {
+  // "probes" has no static dependencies, so it is evaluated synchronously
+  // while "tla" (started by "a" just before) is still suspended at its await.
+  framework: minimalFramework,
+  files: {
+    ...tlaAndFirstImporter,
+    "probes.ts": `
+      let requireResult;
+      try {
+        requireResult = "returned " + JSON.stringify(require("./tla"));
+      } catch (e) {
+        requireResult = "threw: " + e.message;
+      }
+      export const probes = import("./tla").then(ns => ({
+        dynamicImport: ns === null ? "resolved to null" : "resolved to v=" + ns.v,
+        require: requireResult,
+      }));
+    `,
+    "routes/index.ts": `
+      import { a } from "../a";
+      import { probes } from "../probes";
+      export default async function () {
+        const duringLoad = await probes;
+        return Response.json({ a, duringLoad, requireAfterLoad: require("../tla").v });
+      }
+    `,
+  },
+  async test(dev) {
+    expect(await dev.fetch("/").json()).toEqual({
+      a: "a:tla",
+      duringLoad: {
+        dynamicImport: "resolved to v=tla",
+        // Same error as requiring it before it started loading.
+        require: `threw: Cannot require "tla.ts" because "tla.ts" uses top-level await, but 'require' is a synchronous operation.`,
+      },
+      // Once the load has settled, synchronous access works again.
+      requireAfterLoad: "tla",
+    });
+  },
+});
 devTest("cannot require a module with top level await", {
   // TODO: after the module-loader rewrite the dev server's /_bun/report_error
   // handler can hang (never responds), so the client overlay never mounts and


### PR DESCRIPTION
### Problem
- In the dev server (HTML routes or a Bake app), when two modules import the same module that uses top-level await, the second importer is evaluated before that module has finished loading and its import is `null`: `TypeError: null is not an object (evaluating 'import_x2.v')`. That is a 500 on the server and an error overlay in the browser; `bun build` and `bun run` handle the same graph fine.
- The same window makes `import()` of a module whose load is in flight resolve to `null`, makes `require()` of one return an empty object instead of the usual top-level-await error, and hands the route loader `null` in `meta.layouts` when a page imports its own layout.
- If the suspended module ends up rejecting, the importer that ran early leaves that rejection unhandled, which takes the dev server process down.
- Cause: the module registry hands out a module that is suspended on an await as if it were loaded. Its state alone cannot tell that apart from a module that is pending because it is in an import cycle, which must be handed out as-is.

### Fix
- While a module's load is in flight, the module records that load: the promise, plus which module's top-level await it is stuck on. Later static importers, `import()`, and the route loader get the promise and wait; `require()` throws the same "uses top-level await" error it throws before loading starts, naming the module that contains the await.
- The record is only set after a module's dependencies have been collected, so a cycle back edge still finds no record and gets the module itself, exactly as before. Waiting is also what `bun build` output and native ESM do, and the loader is meant to match `bun build` output.
- The record is cleared when the load settles and when a hot reload replaces the module, so a replacement that loads synchronously becomes usable again. One behavior carried over from `bun build`: a module that, after its own await, dynamically imports something that imports it back now waits forever instead of seeing `null`.
- Verification: six new dev-server tests (server route, browser entry point, layout, `import()`/`require()` probes, a rejecting load, hot updates over suspended loads). They fail on the unfixed build with the errors above and pass with the fix; the other bake dev suites still pass on the debug build.

### Background
- The dev server does not run bundled output. A small runtime loader (`src/runtime/bake/hmr-module.ts`, compiled into both the browser and server runtimes) keeps a registry of modules and runs each module's generated load function on demand.
- A module that uses top-level await has an async load function, and its exports are stored only when that function finishes, so its namespace is `null` until then. A module that imports such a module is itself in flight (waiting on a `Promise.all` of its dependencies) until it finishes.
- The registry also reports a module as pending while its dependencies are still being collected. That is how import cycles work: a back edge receives the half-built module. Before this change, "pending in a cycle" and "suspended on an await" looked identical to the registry.
- Loading an entry point discovers its whole import graph synchronously, before any suspended module can resume, so every module visited after the first importer of an awaiting module sees it mid-load. This is what makes the tests deterministic.
- A hot update marks the old module stale; the next load of a stale module starts over from scratch, which is why the in-flight record has to be forgotten at that point.

<details>
<summary>Original description</summary>

### What does this PR do?

In the dev server (HTML routes or a Bake app in development), when two modules import the same module that uses top-level await, the second importer is evaluated before that module has finished loading, with its import bound to `null`:

```ts
// x.ts
await 1;
export const v = "x";
// a.ts
import { v } from "./x"; export const a = "a:" + v;
// b.ts
import { v } from "./x"; export const b = "b:" + v;
// routes/index.ts (or an HTML entry point), imports both a and b
```

```
TypeError: null is not an object (evaluating 'import_x2.v')
    at b.ts:1:1
```

On the server that is a 500 for the route; in the browser it is an error overlay. `bun build` and `bun run` handle the same graph fine. The same window also affects `import()` of a module whose load is in flight (it resolves to `null`), `require()` of one (it returns an empty `__esModule` object instead of the usual top-level-await error), and the server runtime's route loader when a page imports its own layout (`meta.layouts` contains `null`). If the suspended module ends up rejecting, the importer that was evaluated early leaves the rejection the other importer was waiting on unhandled, which takes the dev server process down.

#### Cause

`src/runtime/bake/hmr-module.ts`. The first importer's `loadModuleAsync(x)` registers `x`, calls its load function, which returns a promise because the module is `async`, and returns `p.then(...)`; `x` stays in `State.Pending` until that promise settles, because the module's `hmr.exports = ...` store is the last statement of the generated load function. When the second importer's `parseEsmDependencies` asks for `x`, the registry fast path at the top of `loadModuleAsync` returns the `HMRModule` itself rather than the in-flight promise. So the second importer's dependency list contains no promise, it is not considered async, and `finishLoadModuleAsync` evaluates it synchronously with `getEsmExports(x) === null`. The same applies to a module that is itself synchronous but is waiting on such a dependency (its in-flight value is the `Promise.all(...)` chain), and `loadModuleSync` has the same fast path, which is why `require()` hands out a module with a `null` namespace.

The fast path exists for import cycles: a module that is `Pending` because its dependencies are still being collected must be handed out as-is. The state alone cannot tell that apart from "the load is suspended on an await".

#### Fix

`HMRModule` gets a `loading` field, set while the load is in flight. It holds the in-flight promise plus the id of the module whose top-level await the load is suspended on (the module itself if it is flagged async, otherwise what the first in-flight dependency is suspended on; `parseEsmDependencies` now reports that instead of a plain boolean). `loadModuleAsync` sets it when the value it is about to return is a promise, which covers both shapes, and the registry fast path returns the promise when the field is set. That is the fixing line; later static importers, `import()`, `loadExports` (the route loader) and `replaceModules` (for a module that an earlier module's reload already started) all go through it, and every caller already handles a promise coming back from `loadModuleAsync`. `loadModuleSync`'s fast path throws `AsyncImportError` with the recorded id when the field is set, so `require()` of such a module fails with the same message as requiring it before anything started loading (`Cannot require "a.ts" because "x.ts" uses top-level await, ...`, naming the module that actually contains the await, which is what the cold path and the bundler's own error do), instead of returning an empty object.

Why this is the right behavior rather than a different one:

- Waiting is what both production and the engine do. `bun build` output makes a later importer await the shared module's init promise, and native ESM does not run a module until its async dependencies have evaluated. The header comment of this file states that the dev loader is meant to behave like `bun build` output. (This also means a module that, after its own `await`, dynamically imports something that statically imports it back now waits forever, exactly as the same code does under `bun build` or plain ESM. Previously it got a `null` namespace.)
- Cycles keep working unchanged: `loading` is only assigned after `parseEsmDependencies` has returned, so a back edge reached while collecting a module's dependencies still sees `loading === null` and receives the module itself, as before. Synthetic modules (`bun:wrap`, `bun:bake/*`), which live in `State.Pending` permanently, are unaffected for the same reason.
- The field is cleared when the load settles either way (a `then(settled, settled)` side branch on the returned promise, so callers' own reactions are unchanged and run after it), and when a reload moves the module out of `State.Stale`, in both loaders. The clear on reload is what makes a module usable again when a hot update replaces it while version 1 is still suspended: without it, a replacement that loads synchronously would keep handing out version 1's promise and keep refusing `require()` (and a replacement that switched to CommonJS would hand a promise to `parseEsmDependencies`' CommonJS branch). The clear on settle is guarded by identity so that the settlement of a superseded load cannot clear a newer load's record. All of these paths are covered by the tests below.

Relation to other open changes in the same file: #37742 (recording failures) and #37734 (`import()` rejecting instead of throwing) fix different bookkeeping problems in these functions; this change composes with both (a rejected in-flight promise clears `loading` and, with #37742, leaves the module in `State.Error`; an in-flight `AsyncImportError` from `require()` takes #37742's "refused, not failed" path). #37742 edits the same `Promise.all` block, so there will be a textual conflict with whichever lands second, nothing semantic. #31946 rewrites these functions and documents this exact limitation in its doc comment; the behavior to carry over is the `loading` record, the two fast-path checks, and the two clears on reload.

### How did you verify your code works?

Six new tests in `test/bake/dev/esm.test.ts`. They are deterministic because the whole graph of an entry point is discovered synchronously, before a suspended module can resume, and the hot-update ones use an await that never resumes:

- the diamond above plus a third module importing `a` (covers both promise shapes: a module suspended on its own await, and one waiting on a dependency), once through a server route and once through an HTML entry point in the browser, since the client and server runtimes are built from this file;
- a page that imports its own `_layout`, so the route loader asks for the layout while its load is in flight (`meta.layouts` must contain the namespace, not `null`); this one uses a zero-delay timer as the await because a route loader handed the module without waiting reads the namespace one microtask later, which `await 1` would satisfy by accident;
- a module evaluated while the load is in flight that calls `import()` (must resolve to the namespace), `require()` of the suspended module and of a module waiting on it (both must throw, naming the suspended module), and a `require()` after the load has settled (must work, which checks the clear on settle);
- the diamond with a suspended module whose load rejects: both requests to the route must report that error and the dev server must still serve another route afterwards;
- three modules whose version 1 never finishes loading, replaced by versions that load synchronously (one stays ESM, one becomes CommonJS, one self-accepts with a dispose callback that never settles so that the update stays parked and the reload is performed by the next `require()`): `require()` must refuse all three before the update and return the new versions after it. Removing either clear on reload fails this test (the first two modules, or the second `require()` of the third one, keep being refused).

On the unfixed build (`USE_SYSTEM_BUN=1 bun test test/bake/dev/esm.test.ts`, and likewise with `src/` stashed under `bun bd test`) they fail with the `TypeError` above (server and client), `loader saw null`, `"resolved to null"` / `"returned {}"` for the probes, the `TypeError` instead of the module's own error for the rejecting case, and `"returned {}"` for the modules that should have been refused. With the fix, `bun bd test test/bake/dev/esm.test.ts` passes (23 tests), as do `test/bake/dev/{bundle,hot,react-spa,react-response,ssg-pages-router,html}.test.ts` and `test/bake/dev-and-prod.test.ts` on the debug build.

</details>
