### PR TITLE
build: 16 codegen units for the asan cargo build

### DIFF
--- a/scripts/build/rust.ts
+++ b/scripts/build/rust.ts
@@ -686,6 +686,8 @@ export function cargoBuildInvocation(cfg: Config): CargoInvocation {
     // cargo step vs 4m36s for the linker-plugin-lto build (which defers
     // codegen to lld). ASAN builds don't need intra-Rust LTO; turn it off.
     env.CARGO_PROFILE_RELEASE_LTO = "off";
+    // With LTO off, `codegen-units = 1` only serializes each crate's LLVM pass over the doubled IR; nothing built with ASAN ships, so take cargo's release default instead.
+    env.CARGO_PROFILE_RELEASE_CODEGEN_UNITS = "16";
   }
   if (cfg.assertions) {
     // Turn `debug_assert!()` / `#[cfg(debug_assertions)]` on in the release


### PR DESCRIPTION
The asan build already runs with `CARGO_PROFILE_RELEASE_LTO=off` (rust.ts — fat LTO over ASAN-instrumented IR was a 15-minute cargo step), so the workspace's `codegen-units = 1` no longer feeds an LTO step there; it only makes each crate's LLVM pass over the ~2× IR single-threaded, and `bun_runtime`'s is most of the asan lane's ~4.5-minute cargo step. For reference, `cargo --timings` on the non-LTO configuration shows 137s of a 159s build with at most two units running.

Nothing built with ASAN ships, so that profile uses cargo's release default of 16 codegen units (`-Zbuild-std`'s std gets the same). Every other configuration is untouched — the env var is only set inside the existing asan branch; a `release-asan` configure shows `CODEGEN_UNITS=16` alongside `LTO=off`, and the release/LTO configurations set neither. Local `release-asan` builds get the same speedup.

The trade is intra-crate inlining of non-`#[inline]` functions in the asan binary — the stock cgu=1 vs cgu=16 difference — so the two numbers to look at on this PR's build are the `linux-x64-asan-build-bun` time (baseline ~5m20–5m35) and the asan test lane's wall clock, which should not move meaningfully. Will fill both in from CI.