### PR TITLE
test: measure spawn_waiter_thread idle CPU in-process instead of whole-process rusage

### DIFF
--- a/test/js/bun/spawn/spawn_waiter_thread-fixture.js
+++ b/test/js/bun/spawn/spawn_waiter_thread-fixture.js
@@ -1,4 +1,4 @@
-// Spawns a child that never exits, then reports how much CPU this process (every
+// Spawns a child that stays blocked, then reports how much CPU this process (every
 // thread, so the waiter thread counts) burns over a window spent doing nothing but
 // waiting on that child. Measured in-process rather than via the parent's
 // resourceUsage() so startup and module loading, which cost over a second of CPU
@@ -11,11 +11,14 @@ if (!process.env.WITHOUT_WAITER_THREAD) {
   }
 }
 
-const child = spawn(process.argv0, ["-e", "Bun.sleepSync(999999999)"]);
+// Outlives any per-test timeout, so the child is still alive for the whole window,
+// but bounded: a run that dies before the kill() below must not leave it behind.
+const child = spawn(process.argv0, ["-e", "Bun.sleepSync(10 * 60 * 1000)"]);
 
 child.once("spawn", () => {
-  // The stdio streams finish wiring themselves up in the tick that emits "spawn";
-  // start the window once that tick is over.
+  // "spawn" is emitted while the entrypoint's microtasks drain. The GC bun runs after
+  // evaluating the entrypoint and the first turn of the event loop both come after it,
+  // so start the window once the loop has been around once.
   setImmediate(() => {
     const wall0 = process.hrtime.bigint();
     const cpu0 = process.cpuUsage();
@@ -24,8 +27,8 @@ child.once("spawn", () => {
       const { user, system } = process.cpuUsage(cpu0);
       const wallUs = Number((process.hrtime.bigint() - wall0) / 1000n);
       const childAlive = child.exitCode === null && child.signalCode === null;
-      console.log(JSON.stringify({ cpuUs: user + system, wallUs, childAlive }));
       child.kill();
+      console.log(JSON.stringify({ cpuUs: user + system, wallUs, childAlive }));
     }, 500);
   });
 });

--- a/test/js/bun/spawn/spawn_waiter_thread-fixture.js
+++ b/test/js/bun/spawn/spawn_waiter_thread-fixture.js
@@ -1,3 +1,8 @@
+// Spawns a child that never exits, then reports how much CPU this process (every
+// thread, so the waiter thread counts) burns over a window spent doing nothing but
+// waiting on that child. Measured in-process rather than via the parent's
+// resourceUsage() so startup and module loading, which cost over a second of CPU
+// on a debug build, stay out of the number.
 const { spawn } = require("child_process");
 
 if (!process.env.WITHOUT_WAITER_THREAD) {
@@ -6,4 +11,21 @@ if (!process.env.WITHOUT_WAITER_THREAD) {
   }
 }
 
-spawn(process.argv0, ["-e", "Bun.sleepSync(999999999)"]);
+const child = spawn(process.argv0, ["-e", "Bun.sleepSync(999999999)"]);
+
+child.once("spawn", () => {
+  // The stdio streams finish wiring themselves up in the tick that emits "spawn";
+  // start the window once that tick is over.
+  setImmediate(() => {
+    const wall0 = process.hrtime.bigint();
+    const cpu0 = process.cpuUsage();
+
+    setTimeout(() => {
+      const { user, system } = process.cpuUsage(cpu0);
+      const wallUs = Number((process.hrtime.bigint() - wall0) / 1000n);
+      const childAlive = child.exitCode === null && child.signalCode === null;
+      console.log(JSON.stringify({ cpuUs: user + system, wallUs, childAlive }));
+      child.kill();
+    }, 500);
+  });
+});

--- a/test/js/bun/spawn/spawn_waiter_thread.test.ts
+++ b/test/js/bun/spawn/spawn_waiter_thread.test.ts
@@ -39,5 +39,7 @@ async function run(withWaiterThread: boolean) {
 // ~50% and could both slip under the limit.
 test.serial("issue #9404: default process watcher", () => run(false));
 
-// The waiter thread is the fallback for kernels without pidfd. Forcing it is Linux only.
+// Bun only falls back to the waiter thread on its own on Linux (kernels without pidfd);
+// macOS always has EVFILT_PROC. The flag forces the thread there too, but that exercises
+// a non-Linux idle loop nothing ships with, so it is only asserted on Linux.
 test.serial.skipIf(!isLinux)("issue #9404: waiter thread", () => run(true));

--- a/test/js/bun/spawn/spawn_waiter_thread.test.ts
+++ b/test/js/bun/spawn/spawn_waiter_thread.test.ts
@@ -1,47 +1,39 @@
 import { spawn } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isLinux } from "harness";
 import { join } from "path";
 
+// https://github.com/oven-sh/bun/issues/9404: a process with a live child used a
+// full core while waiting on it. The fixture spawns such a child and reports the
+// CPU it used over a window spent only waiting: spinning puts cpuUs at ~100% of
+// wallUs, while a process that sleeps properly measures ~0.2% on a release build
+// and ~5% on a debug build.
 async function run(withWaiterThread: boolean) {
-  const proc = spawn({
+  await using proc = spawn({
+    cmd: [bunExe(), join(__dirname, "spawn_waiter_thread-fixture.js")],
     env: {
       ...bunEnv,
       ...(withWaiterThread
         ? { BUN_GARBAGE_COLLECTOR_LEVEL: "1", BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" }
         : { WITHOUT_WAITER_THREAD: "1" }),
     },
-    stderr: "inherit",
-    stdout: "inherit",
     stdin: "ignore",
-    cmd: [bunExe(), join(__dirname, "spawn_waiter_thread-fixture.js")],
+    stdout: "pipe",
+    stderr: "pipe",
   });
 
-  setTimeout(
-    () => {
-      proc.kill(process.platform !== "win32" ? "SIGKILL" : undefined);
-    },
-    isWindows ? 5000 : 1000,
-  ).unref();
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  await proc.exited;
-
-  const resourceUsage = proc.resourceUsage();
-
-  // Assert we didn't use 100% of CPU time
-  console.log(resourceUsage.cpuTime);
-  expect(resourceUsage?.cpuTime.total).toBeLessThan(750_000n * (isWindows ? 5n : 1n));
+  expect(stdout, stderr).toMatch(/^\{.*\}\n$/);
+  const { cpuUs, wallUs, childAlive } = JSON.parse(stdout);
+  expect(childAlive).toBe(true);
+  expect(wallUs).toBeGreaterThan(400_000);
+  const cpuPercent = (cpuUs / wallUs) * 100;
+  expect(cpuPercent, `cpuUs=${cpuUs} wallUs=${wallUs}`).toBeLessThan(50);
+  expect(exitCode).toBe(0);
 }
 
-test(
-  "issue #9404",
-  async () => {
-    const promises = [run(false)];
-    if (process.platform === "linux") {
-      promises.push(run(true));
-    }
+test.concurrent("issue #9404: default process watcher", () => run(false));
 
-    await Promise.all(promises);
-  },
-  isWindows ? 6_000 : 5_000,
-);
+// The waiter thread is the fallback for kernels without pidfd. Forcing it is Linux only.
+test.concurrent.skipIf(!isLinux)("issue #9404: waiter thread", () => run(true));

--- a/test/js/bun/spawn/spawn_waiter_thread.test.ts
+++ b/test/js/bun/spawn/spawn_waiter_thread.test.ts
@@ -25,15 +25,18 @@ async function run(withWaiterThread: boolean) {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
   expect(stdout, stderr).toMatch(/^\{.*\}\n$/);
-  const { cpuUs, wallUs, childAlive } = JSON.parse(stdout);
-  expect(childAlive).toBe(true);
+  const report = JSON.parse(stdout);
+  expect(report).toEqual({ cpuUs: expect.any(Number), wallUs: expect.any(Number), childAlive: true });
+  const { cpuUs, wallUs } = report;
   expect(wallUs).toBeGreaterThan(400_000);
   const cpuPercent = (cpuUs / wallUs) * 100;
   expect(cpuPercent, `cpuUs=${cpuUs} wallUs=${wallUs}`).toBeLessThan(50);
   expect(exitCode).toBe(0);
 }
 
-test.concurrent("issue #9404: default process watcher", () => run(false));
+// One fixture at a time: two spinning fixtures sharing a core would each measure
+// ~50% and could both slip under the limit.
+test.serial("issue #9404: default process watcher", () => run(false));
 
 // The waiter thread is the fallback for kernels without pidfd. Forcing it is Linux only.
-test.concurrent.skipIf(!isLinux)("issue #9404: waiter thread", () => run(true));
+test.serial.skipIf(!isLinux)("issue #9404: waiter thread", () => run(true));

--- a/test/js/bun/spawn/spawn_waiter_thread.test.ts
+++ b/test/js/bun/spawn/spawn_waiter_thread.test.ts
@@ -24,7 +24,8 @@ async function run(withWaiterThread: boolean) {
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stdout, stderr).toMatch(/^\{.*\}\n$/);
+  expect(stderr).toBe("");
+  expect(stdout).toMatch(/^\{.*\}\n$/);
   const report = JSON.parse(stdout);
   expect(report).toEqual({ cpuUs: expect.any(Number), wallUs: expect.any(Number), childAlive: true });
   const { cpuUs, wallUs } = report;


### PR DESCRIPTION
### Problem
- `test/js/bun/spawn/spawn_waiter_thread.test.ts` (the test for #9404) fails on a debug build: `expect(received).toBeLessThan(expected)`, `Expected: < 750000n`, `Received: 1020033n`.
- Nothing is spinning. Sampled from `/proc`, the fixture is busy for about 1.4s of startup and module loading (ordinary debug-build cost), then sleeps in epoll, using ~10ms over the next 3.5s. Nothing in `src/` needs to change.
- The test SIGKILLs the fixture at t=1s and asserts total process CPU under 750ms, so on a debug build it measures module loading, not the idle behaviour #9404 was about.
- The fixture also left its `Bun.sleepSync` grandchild orphaned on every run.

### Fix
- Test only. The fixture measures its own `process.cpuUsage()` over a 500ms window that opens once the child has spawned and the event loop has turned once, then kills the child and prints CPU, wall time and whether the child was still alive.
- The test asserts the child stayed alive and CPU stayed under 50% of wall time. A spinning process reads ~100%, a sleeping one ~0.2% on release and ~4% on debug, so one limit works on either build.
- The two variants (default watcher, forced waiter thread) become separate serial tests, since two spinning fixtures sharing a core would each read ~50%. The child sleeps 10 minutes instead of 11 days, so an aborted run no longer leaves it behind for good. The waiter-thread variant stays Linux-only, as before.
- Verification: the new tests pass on debug and release; a negative control (a `Worker` running `for(;;){}` added to the fixture) fails both at ~104%; no children are left behind after a passing run.

### Background
- #9404 was a bun process using a full core while idle with a live child. This test is the regression guard for it.
- Waiter thread: on Linux kernels without pidfd, bun watches child exits from a dedicated thread instead of the event loop. `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1` forces that path; macOS always has `EVFILT_PROC` and never falls back on its own.
- `process.cpuUsage()` is RUSAGE_SELF, so it counts every thread in the process; a spinning waiter thread shows up even though the main thread takes the reading.
- Debug builds run startup and module loading many times slower than release (about 1.4s versus 32ms here), so a CPU budget that includes startup depends on the build type; a CPU-to-wall ratio over an idle window does not.
- The child's `spawn` event fires while the entrypoint's microtasks are still draining; the post-entrypoint GC and first event-loop turn come after it, so the window opens on a `setImmediate` after `spawn` (opening at `spawn` reads ~28% on debug).

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

## Problem

`test/js/bun/spawn/spawn_waiter_thread.test.ts` (the test for #9404) fails on a debug build:

```
$ bun bd test test/js/bun/spawn/spawn_waiter_thread.test.ts
error: expect(received).toBeLessThan(expected)
Expected: < 750000n
Received: 1020033n
```

It was reported as the main thread spinning at 100% CPU while idling with a live child. That is not what is happening. Per-thread CPU sampled from `/proc` while the fixture runs (debug build, both `WITHOUT_WAITER_THREAD=1` and `BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1`):

```
t=500ms:  main thread R  utime=410ms
t=1000ms: main thread R  utime=980ms
t=1500ms: main thread S  utime=1370ms  wchan=ep_poll
t=5000ms: main thread S  utime=1380ms  wchan=ep_poll
```

The process is busy until about t=1.4s and then sleeps in epoll, using ~10ms over the next 3.5s. The busy part is startup (~280ms), `require("child_process")` (~300ms), and spawning with stdio pipes, which pulls in `node:stream`, `node:net` and the stream wiring (~550ms), all ordinary debug-build cost (the same script costs ~32ms of CPU on a release build; a plain script that defines a few hundred classes is ~100x slower on debug too). With `stdio: "ignore"` the spawn itself is ~190ms. Measured in-process after setup, the idle window is 29-32ms of CPU over 2s on debug and 3-4ms on release, on both process-watcher paths. There is nothing to fix in `src/`.

The test is red because it SIGKILLs the fixture at t=1s and asserts the whole process used under 750ms of CPU, so on a debug build it is measuring module loading, not the idle behaviour #9404 was about. It also left the `Bun.sleepSync` grandchild orphaned on every run.

## Fix

Test only. The fixture now measures `process.cpuUsage()` (RUSAGE_SELF, so a spinning waiter thread counts) over a 500ms window that starts once the child's `spawn` event has fired and the event loop has been around once, kills its child, and reports `{ cpuUs, wallUs, childAlive }`. The child sleeps for 10 minutes instead of 11 days, so a run that dies before the fixture gets to `kill()` (per-test timeout, crash) no longer leaves it behind for good. The test asserts the child was alive for the whole window and that CPU stayed under 50% of wall time. This is the same shape as the epoll busy-spin test in `test/js/web/timers/setTimeout.test.js`.

Measured values for the window: ~0.2% release, ~4% debug (stable across 5 serial runs per mode and 4 concurrent runs, 3.7-4.3%). Starting the window at the `spawn` event (or synchronously after `spawn()`) instead measures ~28% on debug: `spawn` is emitted while the entrypoint's microtasks drain, and the GC bun runs after evaluating the entrypoint, plus the first event-loop turn, land after it (verified with `BUN_JSC_logGC=1`). Waiting for a `setImmediate` after the `spawn` event puts both before the window.

The two variants (default watcher, forced waiter thread) are now separate `test.serial` tests: two spinning fixtures sharing a core would each measure ~50% and could both slip under the limit, so they must not overlap. The test also checks the report's shape with `toEqual`, so a missing field fails instead of coercing to 0%. The explicit per-test timeout is gone.

The waiter-thread variant stays Linux-only, as before. The flag itself is honoured on any unix, but bun only falls back to the waiter thread on its own on Linux (macOS always has `EVFILT_PROC`), and the non-Linux idle wait in `src/spawn/process.rs` (`sigwait` on an empty signal set) is not something that ships, so it is not asserted here; that loop is being looked at separately.

## Verification

- Old test: fails on `bun bd` (above), passes on release.
- New test: passes on `bun bd` (2 pass) and on a release build (`USE_SYSTEM_BUN=1`).
- Negative control: with a `new Worker` running `for(;;){}` added to the fixture to stand in for a spinning waiter thread, both new tests fail with `Received: 103.9` / `104.6`.
- No `Bun.sleepSync` children are left behind after a passing run; after a run that times out, the ones left behind exit on their own within 10 minutes (checked with `bun test --timeout=300`).

Since nothing in `src/` changes, there is no src-level fail-before for this PR; the three runs above are the evidence that the rewritten test measures the right thing.

</details>
