### PR TITLE
napi: drive a threadsafe function's JS-thread side off its pointer, not &mut self

### DIFF
--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2403,15 +2403,9 @@ extern "C" fn napi_internal_enqueue_finalizer(
 /// it in `destroy`; from `env_teardown_done` on it belongs to the remaining
 /// `thread_count` references, and whoever drops the last one frees it.
 ///
-/// Addon threads use `lock`, `blocking_condvar`, the atomics and (under `lock`)
-/// `queue` for as long as they hold references, including while the JS thread
-/// is inside `dispatch_one` or `env_teardown`, and after `env_teardown_done`
-/// one of them may free the allocation. So the JS-thread entry points take
-/// `*mut Self` and borrow one field per statement (a `&mut self` argument
-/// would claim the whole object for the duration of the call), and the
-/// finalize task `maybe_queue_finalizer` posts carries that pointer itself: one
-/// made from a receiver is dead by the time `destroy` frees through it, since
-/// `on_dispatch` keeps using the object after the receiver's call returns.
+/// Addon threads use this object (and may free it) while the JS thread is inside
+/// `dispatch_one` / `env_teardown`, so those take `*mut Self` and borrow one
+/// field per statement; the finalize task carries that same pointer.
 // TODO: generate a compile-time version of this instead of runtime checking
 pub(crate) struct ThreadSafeFunction {
     /// thread-safe functions can be "referenced" and "unreferenced". A
@@ -2980,9 +2974,8 @@ impl ThreadSafeFunction {
         // allocation over: `env_teardown_done` is what lets another thread free
         // it, so it is published in the same critical section that reads
         // thread_count (Node's ReleaseResources + MaybeDelete).
-        // SAFETY: fn contract; until `env_teardown_done` is published below
-        // nothing frees us, and once the guard drops nothing here touches
-        // `*this` again.
+        // SAFETY: fn contract; freeing needs `lock`, which the guard holds, and
+        // nothing here outlives the guard.
         unsafe {
             let _g = (*this).lock.lock_guard();
             (*this).callback = TsfnCallback::Js(StrongOptional::empty());
@@ -3250,9 +3243,8 @@ extern "C" fn napi_unref_threadsafe_function(
     }
     #[cfg(not(debug_assertions))]
     let _ = env_;
-    // SAFETY: `func` was null-checked above; `poll_ref` is JS-thread-only, like
-    // this entry point (as in Node). Only that field is borrowed: addon threads
-    // may be using the rest of the object right now.
+    // SAFETY: `func` was null-checked above; `poll_ref` belongs to the JS thread,
+    // like this entry point (as in Node), and only that field is borrowed.
     unsafe { (*func).poll_ref.unref(bun_io::js_vm_ctx()) };
     NapiStatus::ok as napi_status
 }

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2402,6 +2402,16 @@ extern "C" fn napi_internal_enqueue_finalizer(
 /// Ownership: the JS thread owns this allocation while the env lives and frees
 /// it in `destroy`; from `env_teardown_done` on it belongs to the remaining
 /// `thread_count` references, and whoever drops the last one frees it.
+///
+/// Addon threads use `lock`, `blocking_condvar`, the atomics and (under `lock`)
+/// `queue` for as long as they hold references, including while the JS thread
+/// is inside `dispatch_one` or `env_teardown`, and after `env_teardown_done`
+/// one of them may free the allocation. So the JS-thread entry points take
+/// `*mut Self` and borrow one field per statement (a `&mut self` argument
+/// would claim the whole object for the duration of the call), and the
+/// finalize task `maybe_queue_finalizer` posts carries that pointer itself: one
+/// made from a receiver is dead by the time `destroy` frees through it, since
+/// `on_dispatch` keeps using the object after the receiver's call returns.
 // TODO: generate a compile-time version of this instead of runtime checking
 pub(crate) struct ThreadSafeFunction {
     /// thread-safe functions can be "referenced" and "unreferenced". A
@@ -2564,9 +2574,8 @@ impl ThreadSafeFunction {
                     .dispatch_state
                     .store(DispatchState::Running as u8, Ordering::SeqCst)
             };
-            // SAFETY: as above. `dispatch_one` runs JS that can re-enter other
-            // TSFN entry points, so the exclusive borrow is scoped to this call.
-            if unsafe { (*this).dispatch_one(is_first) } {
+            // SAFETY: as above.
+            if unsafe { Self::dispatch_one(this, is_first) } {
                 is_first = false;
                 // SAFETY: as above.
                 unsafe {
@@ -2612,87 +2621,84 @@ impl ThreadSafeFunction {
         self.closing.load(Ordering::SeqCst) != ClosingState::NotClosing as u8
     }
 
-    /// The creating VM's event loop, or `None` once its env has been torn down.
-    ///
-    /// JS-thread only. Its callers (`call`, `maybe_queue_finalizer`) run from
-    /// the loop's own dispatch, so no other `&mut EventLoop` is live. Paths
-    /// reachable from an addon thread must use the shared `&EventLoop` that
-    /// `BackRef` derefs to, never this.
-    #[inline]
-    fn loop_mut(&mut self) -> Option<&mut EventLoop> {
-        let back_ref = self.event_loop.as_mut()?;
-        // SAFETY: BackRef invariant while `Some`; JS thread, outside tick().
-        Some(unsafe { back_ref.get_mut() })
-    }
-
-    fn maybe_queue_finalizer(&mut self) {
-        let prev = self
-            .closing
-            .swap(ClosingState::Closed as u8, Ordering::SeqCst);
-        match prev {
-            x if x == ClosingState::Closing as u8 || x == ClosingState::NotClosing as u8 => {
-                // TODO: is this boolean necessary? Can we rely just on the closing value?
-                if !self.has_queued_finalizer {
-                    // Note: replace callback with a no-op variant to drop Strong now.
-                    self.callback = TsfnCallback::Js(StrongOptional::empty());
-                    self.poll_ref.disable();
-                    let self_ptr: *mut Self = self;
-                    let Some(loop_) = self.loop_mut() else {
-                        // env torn down: `env_teardown` owns the finalize + free.
-                        return;
-                    };
-                    loop_.enqueue_task(Task::init(self_ptr));
-                    self.has_queued_finalizer = true;
-                }
-            }
-            _ => {
-                // already scheduled.
-            }
+    /// SAFETY: `this` is a live threadsafe function; JS thread.
+    unsafe fn maybe_queue_finalizer(this: *mut ThreadSafeFunction) {
+        // SAFETY: fn contract.
+        let prev = unsafe {
+            (*this)
+                .closing
+                .swap(ClosingState::Closed as u8, Ordering::SeqCst)
+        };
+        if prev == ClosingState::Closed as u8 {
+            // already scheduled.
+            return;
         }
+        // SAFETY: fn contract; these fields are the JS thread's.
+        unsafe {
+            if (*this).has_queued_finalizer {
+                return;
+            }
+            // Drop the callback's Strong now rather than at finalize.
+            (*this).callback = TsfnCallback::Js(StrongOptional::empty());
+            (*this).poll_ref.disable();
+        }
+        // SAFETY: fn contract; only the JS thread writes `event_loop`, and the
+        // `BackRef` is copied out.
+        let Some(mut loop_) = (unsafe { (*this).event_loop }) else {
+            // env torn down: `env_teardown` owns the finalize + free.
+            return;
+        };
+        // SAFETY: BackRef invariant while `Some`; JS thread, outside tick().
+        unsafe { loop_.get_mut() }.enqueue_task(Task::init(this));
+        // SAFETY: fn contract.
+        unsafe { (*this).has_queued_finalizer = true };
     }
 
-    pub(crate) fn dispatch_one(&mut self, is_first: bool) -> bool {
+    /// SAFETY: `this` is a live threadsafe function; JS thread.
+    unsafe fn dispatch_one(this: *mut ThreadSafeFunction, is_first: bool) -> bool {
         let mut queue_finalizer_after_call = false;
-        let task = 'brk: {
-            // `MutexGuard` holds the lock by raw pointer, so it does not borrow
-            // `*self` across the `&mut self` calls below.
-            let _g = self.lock.lock_guard();
-            let was_blocked = self.queue.is_blocked();
-            let Some(t) = self.queue.data.read_item() else {
+        // SAFETY: fn contract; `queue.data` is only touched under `lock`, which
+        // the guard holds by pointer.
+        let task = unsafe {
+            let _g = (*this).lock.lock_guard();
+            let was_blocked = (*this).queue.is_blocked();
+            let Some(t) = (*this).queue.data.read_item() else {
                 // When there are no tasks and the number of threads that have
                 // references reaches zero, we prepare to finalize the
                 // ThreadSafeFunction.
-                if self.thread_count.load(Ordering::SeqCst) == 0 {
-                    if self.queue.max_queue_size > 0 {
-                        self.blocking_condvar.signal();
+                if (*this).thread_count.load(Ordering::SeqCst) == 0 {
+                    if (*this).queue.max_queue_size > 0 {
+                        (*this).blocking_condvar.signal();
                     }
-                    self.maybe_queue_finalizer();
+                    Self::maybe_queue_finalizer(this);
                 }
                 return false;
             };
 
-            if self.queue.count.fetch_sub(1, Ordering::SeqCst) == 1
-                && self.thread_count.load(Ordering::SeqCst) == 0
+            if (*this).queue.count.fetch_sub(1, Ordering::SeqCst) == 1
+                && (*this).thread_count.load(Ordering::SeqCst) == 0
             {
-                self.closing
+                (*this)
+                    .closing
                     .store(ClosingState::Closing as u8, Ordering::SeqCst);
-                if self.queue.max_queue_size > 0 {
-                    self.blocking_condvar.signal();
+                if (*this).queue.max_queue_size > 0 {
+                    (*this).blocking_condvar.signal();
                 }
                 queue_finalizer_after_call = true;
-            } else if was_blocked && !self.queue.is_blocked() {
-                self.blocking_condvar.signal();
+            } else if was_blocked && !(*this).queue.is_blocked() {
+                (*this).blocking_condvar.signal();
             }
-
-            break 'brk t;
+            t
         };
 
-        if self.call(task, is_first).is_err() {
+        // SAFETY: fn contract.
+        if unsafe { Self::call(this, task, is_first) }.is_err() {
             return false;
         }
 
         if queue_finalizer_after_call {
-            self.maybe_queue_finalizer();
+            // SAFETY: fn contract.
+            unsafe { Self::maybe_queue_finalizer(this) };
         }
 
         // An item was dequeued: keep on_dispatch looping so remaining queued
@@ -2703,48 +2709,64 @@ impl ThreadSafeFunction {
     /// This function can be called multiple times in one tick of the event loop.
     /// See: https://github.com/nodejs/node/pull/38506
     /// In that case, we need to drain microtasks.
-    fn call(&mut self, task: *mut c_void, is_first: bool) -> Result<(), bun_jsc::JsTerminated> {
-        let Some(env) = self.env.as_ref().map(NapiEnvRef::get) else {
+    ///
+    /// The callback's inputs are copied out before it runs: it can re-enter this
+    /// object (`napi_unref_threadsafe_function`).
+    ///
+    /// SAFETY: `this` is a live threadsafe function; JS thread.
+    unsafe fn call(
+        this: *mut ThreadSafeFunction,
+        task: *mut c_void,
+        is_first: bool,
+    ) -> Result<(), bun_jsc::JsTerminated> {
+        // SAFETY: fn contract; `env` is the JS thread's, and the raw pointer is
+        // copied out.
+        let Some(env) = (unsafe { (*this).env.as_ref() }).map(NapiEnvRef::get) else {
             // env torn down; nothing to call into.
             return Ok(());
         };
         if !is_first {
-            let Some(loop_) = self.loop_mut() else {
+            // SAFETY: as in `maybe_queue_finalizer`.
+            let Some(mut loop_) = (unsafe { (*this).event_loop }) else {
                 return Ok(());
             };
-            loop_.drain_microtasks()?;
+            // SAFETY: BackRef invariant while `Some`; JS thread, outside tick().
+            unsafe { loop_.get_mut() }.drain_microtasks()?;
         }
-        // SAFETY: env is valid while the TSF is live.
-        let global_object = unsafe { &*env }.to_js();
+        // SAFETY: `env` is held alive by `(*this).env` (`NapiEnvRef`) for the TSF's lifetime.
+        let env_ref = unsafe { &*env };
+        let global_object = env_ref.to_js();
 
-        let _dispatch = self.tracker.dispatch(global_object);
+        // SAFETY: fn contract; `tracker` is `Copy`, the scope borrows `global_object`.
+        let _dispatch = unsafe { (*this).tracker }.dispatch(global_object);
 
-        match &self.callback {
-            TsfnCallback::Js(strong) => {
-                let js: JSValue = strong.get().unwrap_or(JSValue::UNDEFINED);
-                if js.is_empty_or_undefined_or_null() {
-                    return Ok(());
-                }
-
-                let _ = js
-                    .call(global_object, JSValue::UNDEFINED, &[])
-                    .map_err(|err| global_object.report_active_exception_as_unhandled(err));
-            }
+        // SAFETY: fn contract; `callback` is the JS thread's.
+        let (js, call_js) = match unsafe { &(*this).callback } {
+            TsfnCallback::Js(js) => (js.get(), None),
             TsfnCallback::C {
-                js: cb_js,
+                js,
                 napi_threadsafe_function_call_js,
-            } => {
-                // SAFETY: `env` is held alive by `self.env` (`NapiEnvRef`) for the TSF's lifetime.
-                let env_ref = unsafe { &*env };
-                let _hs = NapiHandleScope::open_scoped(env_ref);
-                // No func at creation => null js_callback (Node), not encoded undefined.
-                let js = match cb_js.get() {
-                    Some(v) => napi_value::create(env_ref, v),
-                    None => napi_value(0),
-                };
-                napi_threadsafe_function_call_js(env, js, self.ctx, task);
+            } => (js.get(), Some(*napi_threadsafe_function_call_js)),
+        };
+        let Some(call_js) = call_js else {
+            let js = js.unwrap_or(JSValue::UNDEFINED);
+            if js.is_empty_or_undefined_or_null() {
+                return Ok(());
             }
-        }
+            let _ = js
+                .call(global_object, JSValue::UNDEFINED, &[])
+                .map_err(|err| global_object.report_active_exception_as_unhandled(err));
+            return Ok(());
+        };
+        let _hs = NapiHandleScope::open_scoped(env_ref);
+        // No func at creation => null js_callback (Node), not encoded undefined.
+        let js = match js {
+            Some(v) => napi_value::create(env_ref, v),
+            None => napi_value(0),
+        };
+        // SAFETY: fn contract; `ctx` is immutable.
+        let ctx = unsafe { (*this).ctx };
+        call_js(env, js, ctx, task);
         Ok(())
     }
 
@@ -2848,7 +2870,7 @@ impl ThreadSafeFunction {
         // the sole owner; reclaim the Box up front so the body works on owned
         // state and the drop at scope end frees it.
         let mut self_ = unsafe { bun_core::heap::take(this) };
-        self_.unref();
+        self_.poll_ref.unref(bun_io::js_vm_ctx());
 
         if let Some(env) = self_.env.as_ref() {
             // SAFETY: env is live (we hold a ref); drops our registry entry so
@@ -2888,53 +2910,68 @@ impl ThreadSafeFunction {
     /// ThreadSafeFunction::Cleanup -> Finalize -> MaybeDelete.
     ///
     /// Returns true if the caller must free the allocation.
-    fn env_teardown(&mut self) -> bool {
+    ///
+    /// SAFETY: `this` is a live threadsafe function; JS thread.
+    unsafe fn env_teardown(this: *mut ThreadSafeFunction) -> bool {
         // Phase 1: publish "the loop is going away". From here no other thread
         // schedules onto it, but none may free us either -- the JS resources
         // below are still live and only this thread may touch them.
-        let drained: Vec<*mut c_void> = {
-            let _g = self.lock.lock_guard();
-            self.env_dead.store(true, Ordering::SeqCst);
-            if self.closing.load(Ordering::SeqCst) == ClosingState::NotClosing as u8 {
-                self.closing
+        // SAFETY: fn contract; `queue.data` is only touched under `lock`, which
+        // the guard holds by pointer.
+        let drained: Vec<*mut c_void> = unsafe {
+            let _g = (*this).lock.lock_guard();
+            (*this).env_dead.store(true, Ordering::SeqCst);
+            if (*this).closing.load(Ordering::SeqCst) == ClosingState::NotClosing as u8 {
+                (*this)
+                    .closing
                     .store(ClosingState::Closing as u8, Ordering::SeqCst);
             }
-            if self.queue.max_queue_size > 0 {
+            if (*this).queue.max_queue_size > 0 {
                 // Wake producers blocked on the bounded queue; they observe
                 // is_closing and release.
-                self.blocking_condvar.broadcast();
+                (*this).blocking_condvar.broadcast();
             }
             let mut drained = Vec::new();
-            while let Some(item) = self.queue.data.read_item() {
+            while let Some(item) = (*this).queue.data.read_item() {
                 drained.push(item);
             }
-            self.queue.count.store(0, Ordering::SeqCst);
+            (*this).queue.count.store(0, Ordering::SeqCst);
             drained
         };
 
         // Phase 2: addon callbacks, so no lock is held. Node hands queued items
         // back with a null env (ThreadSafeFunction::EmptyQueue) so the addon can
         // free them, then runs the finalizer.
-        if let TsfnCallback::C {
-            napi_threadsafe_function_call_js,
-            ..
-        } = &self.callback
-        {
-            let call_js = *napi_threadsafe_function_call_js;
+        // SAFETY: fn contract; `callback`, `finalizer_*` and `env` are the JS
+        // thread's, `ctx` is immutable.
+        let (call_js, ctx) = unsafe {
+            let call_js = match &(*this).callback {
+                TsfnCallback::C {
+                    napi_threadsafe_function_call_js,
+                    ..
+                } => Some(*napi_threadsafe_function_call_js),
+                TsfnCallback::Js(_) => None,
+            };
+            (call_js, (*this).ctx)
+        };
+        if let Some(call_js) = call_js {
             for item in drained {
-                call_js(ptr::null_mut(), napi_value(0), self.ctx, item);
+                call_js(ptr::null_mut(), napi_value(0), ctx, item);
             }
         }
-        let finalizer = self
-            .finalizer_fun
-            .take()
-            .zip(self.env.as_ref())
-            .map(|(fun, env)| Finalizer {
-                env: env.clone(),
-                fun,
-                data: self.finalizer_data,
-                hint: self.ctx,
-            });
+        // SAFETY: as above.
+        let finalizer = unsafe {
+            (*this)
+                .finalizer_fun
+                .take()
+                .zip((*this).env.as_ref())
+                .map(|(fun, env)| Finalizer {
+                    env: env.clone(),
+                    fun,
+                    data: (*this).finalizer_data,
+                    hint: ctx,
+                })
+        };
         if let Some(mut finalizer) = finalizer {
             finalizer.run();
         }
@@ -2943,27 +2980,22 @@ impl ThreadSafeFunction {
         // allocation over: `env_teardown_done` is what lets another thread free
         // it, so it is published in the same critical section that reads
         // thread_count (Node's ReleaseResources + MaybeDelete).
-        let _g = self.lock.lock_guard();
-        self.callback = TsfnCallback::Js(StrongOptional::empty());
-        self.poll_ref.disable();
-        self.event_loop = None;
-        drop(self.env.take());
-        self.env_teardown_done.store(true, Ordering::SeqCst);
-        // Cleanup hooks are the loop's last tick: a task still queued for this
-        // TSFN will never run (and its `release_unrun` does not dereference it).
-        // With no thread_count reference left, nobody else can reach this, so
-        // free it here.
-        self.thread_count.load(Ordering::SeqCst) <= 0
-    }
-
-    /// `napi_ref_threadsafe_function` — JS thread only (as in Node).
-    pub(crate) fn ref_(&mut self) {
-        self.poll_ref.ref_(bun_io::js_vm_ctx());
-    }
-
-    /// `napi_unref_threadsafe_function` — JS thread only (as in Node).
-    pub(crate) fn unref(&mut self) {
-        self.poll_ref.unref(bun_io::js_vm_ctx());
+        // SAFETY: fn contract; until `env_teardown_done` is published below
+        // nothing frees us, and once the guard drops nothing here touches
+        // `*this` again.
+        unsafe {
+            let _g = (*this).lock.lock_guard();
+            (*this).callback = TsfnCallback::Js(StrongOptional::empty());
+            (*this).poll_ref.disable();
+            (*this).event_loop = None;
+            drop((*this).env.take());
+            (*this).env_teardown_done.store(true, Ordering::SeqCst);
+            // Cleanup hooks are the loop's last tick: a task still queued for this
+            // TSFN will never run (and its `release_unrun` does not dereference it).
+            // With no thread_count reference left, nobody else can reach this, so
+            // the caller frees it.
+            (*this).thread_count.load(Ordering::SeqCst) <= 0
+        }
     }
 
     pub(crate) fn acquire(&mut self) -> napi_status {
@@ -3054,9 +3086,8 @@ impl ThreadSafeFunction {
 extern "C" fn napi_internal_threadsafe_function_env_teardown(tsfn: *mut c_void) {
     let this = tsfn.cast::<ThreadSafeFunction>();
     // SAFETY: the registry only holds live TSFN pointers — `destroy` and
-    // `env_teardown` both remove the entry before freeing. Exclusive borrow
-    // scoped to this call.
-    if unsafe { (*this).env_teardown() } {
+    // `env_teardown` both remove the entry before freeing.
+    if unsafe { ThreadSafeFunction::env_teardown(this) } {
         // SAFETY: no other thread holds a reference (thread_count == 0) and no
         // event-loop task will run again.
         unsafe { ThreadSafeFunction::free_orphaned(this) };
@@ -3148,7 +3179,7 @@ extern "C" fn napi_create_threadsafe_function(
 
     // nodejs by default keeps the event loop alive until the thread-safe function is unref'd
     // SAFETY: function is non-null (just allocated) and not yet handed out.
-    unsafe { (*function).ref_() };
+    unsafe { (*function).poll_ref.ref_(bun_io::js_vm_ctx()) };
     // SAFETY: as above.
     unsafe { (*function).tracker.did_schedule(vm.global()) };
 
@@ -3219,8 +3250,10 @@ extern "C" fn napi_unref_threadsafe_function(
     }
     #[cfg(not(debug_assertions))]
     let _ = env_;
-    // SAFETY: `func` was null-checked above; exclusive borrow scoped to this call.
-    unsafe { (*func).unref() };
+    // SAFETY: `func` was null-checked above; `poll_ref` is JS-thread-only, like
+    // this entry point (as in Node). Only that field is borrowed: addon threads
+    // may be using the rest of the object right now.
+    unsafe { (*func).poll_ref.unref(bun_io::js_vm_ctx()) };
     NapiStatus::ok as napi_status
 }
 
@@ -3245,8 +3278,8 @@ extern "C" fn napi_ref_threadsafe_function(
     }
     #[cfg(not(debug_assertions))]
     let _ = env_;
-    // SAFETY: `func` was null-checked above; exclusive borrow scoped to this call.
-    unsafe { (*func).ref_() };
+    // SAFETY: as in `napi_unref_threadsafe_function`.
+    unsafe { (*func).poll_ref.ref_(bun_io::js_vm_ctx()) };
     NapiStatus::ok as napi_status
 }
 

--- a/src/runtime/napi/napi_body.rs
+++ b/src/runtime/napi/napi_body.rs
@@ -2402,10 +2402,6 @@ extern "C" fn napi_internal_enqueue_finalizer(
 /// Ownership: the JS thread owns this allocation while the env lives and frees
 /// it in `destroy`; from `env_teardown_done` on it belongs to the remaining
 /// `thread_count` references, and whoever drops the last one frees it.
-///
-/// Addon threads use this object (and may free it) while the JS thread is inside
-/// `dispatch_one` / `env_teardown`, so those take `*mut Self` and borrow one
-/// field per statement; the finalize task carries that same pointer.
 // TODO: generate a compile-time version of this instead of runtime checking
 pub(crate) struct ThreadSafeFunction {
     /// thread-safe functions can be "referenced" and "unreferenced". A

--- a/test/internal/source-lints/napi-tsfn-receivers.test.ts
+++ b/test/internal/source-lints/napi-tsfn-receivers.test.ts
@@ -4,7 +4,7 @@ import path from "path";
 import { globAllSources } from "../../../scripts/glob-sources.ts";
 
 // `ThreadSafeFunction` (src/runtime/napi/napi_body.rs) is reached through a
-// raw pointer from every side, never through a `self` receiver.
+// raw pointer from every side, never through a reference to the whole object.
 //
 // The object is shared for its whole life: addon threads take `lock`, wait on
 // `blocking_condvar` and write `thread_count` / `queue` / `closing` from
@@ -12,46 +12,77 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // `napi_release_threadsafe_function` at any time, including while the JS
 // thread is inside `dispatch_one` running the user's callback, or inside
 // `env_teardown`, after whose last phase an addon thread may even free the
-// allocation. A `&self` / `&mut self` argument claims the object for the
-// duration of the call: a write to any byte of it from anywhere else while
-// the call is running (or, for `env_teardown`, freeing it) is rejected by both
-// aliasing models (Tree Borrows, which `bun run rust:miri` uses: "foreign read
-// access would cause the protected tag ... to become Disabled; protected tags
-// must never be Disabled", naming the `&mut self` method; Stacked Borrows:
-// "would remove [Unique for <tag>] which is strongly protected"), and it is
-// what rustc's `noalias` on the argument tells LLVM to rely on. The callback
-// also re-enters the object from the same thread: `napi_unref_threadsafe_
-// function` called from inside it used to form a second `&mut Self` under the
-// `&mut self` of `call`, which fails the same way with one thread.
+// allocation. A reference argument (a `&mut self` / `&self` receiver, or a
+// `this: &mut ThreadSafeFunction` parameter, which is the same thing under a
+// different name) claims the object for the duration of the call: a write to
+// any byte of it from anywhere else while the call is running (or, for
+// `env_teardown`, freeing it) is rejected by both aliasing models (Tree
+// Borrows, which `bun run rust:miri` uses: "foreign read access would cause
+// the protected tag ... to become Disabled; protected tags must never be
+// Disabled", naming the method; Stacked Borrows: "would remove [Unique for
+// <tag>] which is strongly protected"), and it is what rustc's `noalias` on
+// the argument tells LLVM to rely on. The callback also re-enters the object
+// from the same thread: `napi_unref_threadsafe_function` called from inside it
+// used to form a second `&mut Self` under the `&mut self` of `call`, which
+// fails the same way with one thread. `&self` is not exempt with the current
+// layout: `queue.data` (written by addon threads under `lock`) and the JS
+// thread's plain fields (`poll_ref`, `callback`, ..., written by
+// `maybe_queue_finalizer`, `env_teardown` and the re-entrant unref) are
+// ordinary bytes, so a shared reference covering them is invalidated by those
+// writes too. If those fields are ever moved into `Guarded` / `JsCell`, `&self`
+// becomes sound for everything except the functions that post or free the
+// object, and this lint should be narrowed to `&mut` then; until that layout
+// change, no reference to the whole object is right.
 //
-// So the methods take `this: *mut ThreadSafeFunction` and borrow one field per
-// statement (`(*this).lock.lock_guard()`, `(*this).queue.data.read_item()`),
+// So the functions take `this: *mut ThreadSafeFunction` and borrow one field
+// per statement (`(*this).lock.lock_guard()`, `(*this).queue.data.read_item()`),
 // and the `extern "C"` entry points project the field they need straight off
-// the handle (`(*func).poll_ref.ref_(..)`) instead of reborrowing the whole
-// object. This lint holds that shape:
+// the handle (`(*func).poll_ref.ref_(..)`). This lint holds that shape for the
+// inherent `impl ThreadSafeFunction` and the `*threadsafe_function*` entry
+// points:
 //
-//   1. no method of the inherent `impl ThreadSafeFunction` takes a reference
-//      receiver, except the ratcheted list below;
-//   2. neither those methods nor the `*threadsafe_function*` entry points
-//      reborrow the whole object from the pointer (`&mut *this`, `&*func`,
-//      `func.as_mut()`), which is the same claim spelled differently.
+//   1. the functions named in PINNED take the object as `this: *mut ..`;
+//   2. no other parameter whose type names the object is anything but a raw
+//      pointer, a by-value move or a `Box` (so `this: &mut ThreadSafeFunction`,
+//      `Option<&mut Self>`, `NonNull<Self>` are all out);
+//   3. no method takes a reference receiver, except the ratcheted list below;
+//   4. no body reborrows the whole object from the handle (`&mut *this`,
+//      `&*func`, `func.as_mut()`), except the ratcheted count below.
 //
-// Trait impls (`Drop`, `Taskable`) are not covered: their receivers are
-// dictated by the trait and they run once nothing else can reach the object.
-// `TsfnQueue::is_blocked(&self)` borrows only the queue, under `lock`.
-// Siblings: fn-long-mut-reborrow.test.ts (the fn-long `let x = &mut *ptr`
-// form of the same claim, tree-wide), self-receiver-reclaim.test.ts.
+// Out of scope, knowingly: a reborrow through a local alias of the handle
+// (`let p = this; .. &mut *p`), a reference formed by a caller outside
+// src/runtime/napi/ (the `task_tag::ThreadSafeFunction` arm in
+// src/runtime/dispatch.rs passes `cast_ptr!`, not `cast!`), and trait impls
+// (`Drop`, `Taskable`), whose receivers the trait dictates and which run once
+// nothing else can reach the object. `TsfnQueue::is_blocked(&self)` borrows
+// only the queue, under `lock`. Siblings: fn-long-mut-reborrow.test.ts (the
+// fn-long `let x = &mut *ptr` form, tree-wide), self-receiver-reclaim.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const napiSources = globAllSources().rust.filter(
   p => p.endsWith(".rs") && path.relative(root, p).replaceAll(path.sep, "/").startsWith("src/runtime/napi/"),
 );
 
+// Functions that must take the object as their first parameter, as a raw
+// pointer. The JS-thread side plus the two addon-thread roots that already had
+// the shape; append the rest of the addon-thread side as it is converted.
+const PINNED = [
+  "on_dispatch",
+  "dispatch_one",
+  "call",
+  "maybe_queue_finalizer",
+  "env_teardown",
+  "push",
+  "release",
+  "destroy",
+  "free_orphaned",
+];
+
 // Methods of `impl ThreadSafeFunction` still taking a reference receiver.
 // These are the addon-thread half of the same hazard (`push` and `release`
 // reach `enqueue` / `release_locked` through an autoref of `*this`; the entry
 // point for `acquire` reborrows the whole object, see below); #37741 converts
-// them, after which both lists below are empty. Delete each name as it is
+// them, after which both lists are empty. Delete each name as it is
 // converted; do not add any.
 const REFERENCE_RECEIVERS_STILL_TO_CONVERT = [
   "acquire",
@@ -76,11 +107,19 @@ const WHOLE_OBJECT_REBORROW = new RegExp(
 );
 
 const INHERENT_IMPL = /^impl\s+ThreadSafeFunction\s*\{/gm;
-const TSFN_ENTRY_POINT = /^extern\s+"C"\s+fn\s+(\w*threadsafe_function\w*)\s*\(/gm;
-// `fn name(params)`: the receiver, if any, is the first parameter. `[^)]*`
-// cannot cross a nested paren, but a receiver never follows one.
-const FN_ITEM = /\bfn\s+(\w+)\s*\(\s*([^)]*)\)/g;
-const REFERENCE_RECEIVER = /^(?:&\s*(?:mut\s+)?self\b|self\s*:\s*&)/;
+// A file-level `extern "C" fn` whose name mentions the object, however it is
+// qualified. The parameter list is parsed from the `(` by `parseFn`.
+const TSFN_ENTRY_POINT =
+  /^(?:pub(?:\([^)]*\))?\s+)?(?:unsafe\s+)?extern\s+"C"\s+fn\s+(\w*threadsafe_function\w*)\s*\(/gm;
+// Every fn item inside an impl block (generics included); the parameter list
+// is parsed from the `(` by `parseFn`.
+const FN_HEAD = /\bfn\s+(\w+)\s*(?:<[^()]*>)?\s*\(/g;
+const REFERENCE_RECEIVER = /^(?:&\s*(?:'\w+\s+)?(?:mut\s+)?self\b|(?:mut\s+)?self\s*:\s*&)/;
+const NAMES_THE_OBJECT = /\b(?:Self|ThreadSafeFunction)\b/;
+// The three ways a parameter may take the object: raw pointer, by value, boxed.
+const ALLOWED_OBJECT_PARAM =
+  /^(?:\*\s*(?:mut|const)\s+(?:Self|ThreadSafeFunction)|(?:Self|ThreadSafeFunction)|Box\s*<\s*(?:Self|ThreadSafeFunction)\s*>)$/;
+const PINNED_FIRST_PARAM = /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/;
 
 function lineOf(text: string, index: number): number {
   return text.slice(0, index).split("\n").length;
@@ -92,76 +131,126 @@ function stripComments(text: string): string {
   return text.replace(/^[ \t]*\/\/.*$/gm, "").replace(/[ \t]\/\/.*$/gm, "");
 }
 
-/** The `{ .. }` block whose opening brace is at `open`, or null if unbalanced. */
-function blockAt(text: string, open: number): string | null {
+/** Index one past the bracket closing the one at `open`, or -1 if unbalanced. */
+function closeOf(text: string, open: number, openCh: string, closeCh: string): number {
   let depth = 0;
   for (let i = open; i < text.length; i++) {
     const c = text[i];
-    if (c === "{") depth++;
-    else if (c === "}" && --depth === 0) return text.slice(open, i + 1);
+    if (c === openCh) depth++;
+    else if (c === closeCh && --depth === 0) return i + 1;
   }
-  return null;
+  return -1;
+}
+
+/** Splits a parameter list on its top-level commas (generics and parens may
+ * contain commas of their own). */
+function splitParams(params: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < params.length; i++) {
+    const c = params[i];
+    if (c === "<" || c === "(" || c === "[") depth++;
+    else if (c === ">" || c === ")" || c === "]") depth--;
+    else if (c === "," && depth === 0) {
+      out.push(params.slice(start, i));
+      start = i + 1;
+    }
+  }
+  out.push(params.slice(start));
+  return out.map(p => p.trim().replace(/\s+/g, " ")).filter(Boolean);
+}
+
+interface Fn {
+  name: string;
+  params: string[];
+  /** Offsets into the text `parseFn` was given: the `fn` keyword and one past the body's `}`. */
+  start: number;
+  end: number;
+}
+
+/** The fn item whose head regex match is `head`, in `text`. */
+function parseFn(text: string, head: RegExpMatchArray, source: string): Fn {
+  const name = head[1];
+  const paramsOpen = head.index + head[0].length - 1;
+  const paramsEnd = closeOf(text, paramsOpen, "(", ")");
+  if (paramsEnd === -1) throw new Error(`${source}:${lineOf(text, head.index)}: unbalanced parameter list in ${name}`);
+  const params = splitParams(text.slice(paramsOpen + 1, paramsEnd - 1));
+  // `fn f(..) -> T where ..;` (a declaration) has no body; every fn this lint
+  // looks at has one, so a missing body is a parse failure worth hearing about.
+  const bodyOpen = text.indexOf("{", paramsEnd);
+  const end = bodyOpen === -1 ? -1 : closeOf(text, bodyOpen, "{", "}");
+  if (end === -1) throw new Error(`${source}:${lineOf(text, head.index)}: could not find the body of ${name}`);
+  return { name, params, start: head.index, end };
 }
 
 interface Audit {
   /** Inherent impl blocks found (normally one). */
   impls: number;
-  /** Every method of those impls, in source order. */
-  methods: string[];
+  /** `name -> first parameter` of every method of those impls, in source order. */
+  methods: Record<string, string>;
   /** Methods whose receiver is a reference. */
   referenceReceivers: string[];
   /** `*threadsafe_function*` entry points found. */
   entryPoints: string[];
+  /** `file:line: function: param` for every non-receiver parameter that names the object other than as allowed. */
+  referenceParams: string[];
   /** `function name -> count` of whole-object reborrows, impl methods and entry points alike. */
   reborrows: Record<string, number>;
   /** `file:line: function: text` of every reborrow, for the failure message. */
   reborrowSites: string[];
 }
 
+function emptyAudit(): Audit {
+  return {
+    impls: 0,
+    methods: {},
+    referenceReceivers: [],
+    entryPoints: [],
+    referenceParams: [],
+    reborrows: {},
+    reborrowSites: [],
+  };
+}
+
 function audit(source: string, text: string, into: Audit): void {
   const stripped = stripComments(text);
   for (const m of stripped.matchAll(INHERENT_IMPL)) {
-    const body = blockAt(stripped, m.index + m[0].length - 1);
-    if (body === null) throw new Error(`${source}:${lineOf(stripped, m.index)}: unbalanced impl block`);
+    const open = m.index + m[0].length - 1;
+    const end = closeOf(stripped, open, "{", "}");
+    if (end === -1) throw new Error(`${source}:${lineOf(stripped, m.index)}: unbalanced impl block`);
     into.impls++;
-    const base = m.index + m[0].length - 1;
-    // Split the impl into per-method regions so reborrows are attributed to
-    // the method containing them.
-    const items = [...body.matchAll(FN_ITEM)];
-    items.forEach((item, i) => {
-      const name = item[1];
-      into.methods.push(name);
-      if (REFERENCE_RECEIVER.test(item[2].trim())) into.referenceReceivers.push(name);
-      const end = i + 1 < items.length ? items[i + 1].index : body.length;
-      countReborrows(source, stripped, base, body.slice(item.index, end), item.index, name, into);
-    });
+    const body = stripped.slice(0, end);
+    FN_HEAD.lastIndex = open;
+    for (let head = FN_HEAD.exec(body); head !== null; head = FN_HEAD.exec(body)) {
+      const fn = parseFn(body, head, source);
+      into.methods[fn.name] = fn.params[0] ?? "";
+      if (REFERENCE_RECEIVER.test(fn.params[0] ?? "")) into.referenceReceivers.push(fn.name);
+      check(source, stripped, fn, into);
+      // Skip the body so a nested closure or item does not count as a method.
+      FN_HEAD.lastIndex = fn.end;
+    }
   }
   for (const m of stripped.matchAll(TSFN_ENTRY_POINT)) {
-    const open = stripped.indexOf("{", m.index);
-    const body = open === -1 ? null : blockAt(stripped, open);
-    if (body === null) throw new Error(`${source}:${lineOf(stripped, m.index)}: could not find the body of ${m[1]}`);
-    into.entryPoints.push(m[1]);
-    countReborrows(source, stripped, open, body, 0, m[1], into);
+    const fn = parseFn(stripped, m, source);
+    into.entryPoints.push(fn.name);
+    check(source, stripped, fn, into);
   }
 }
 
-function countReborrows(
-  source: string,
-  stripped: string,
-  base: number,
-  region: string,
-  regionOffset: number,
-  fn: string,
-  into: Audit,
-): void {
-  for (const r of region.matchAll(WHOLE_OBJECT_REBORROW)) {
-    into.reborrows[fn] = (into.reborrows[fn] ?? 0) + 1;
-    into.reborrowSites.push(`${source}:${lineOf(stripped, base + regionOffset + r.index)}: ${fn}: ${r[0]}`);
+function check(source: string, stripped: string, fn: Fn, into: Audit): void {
+  const where = `${source}:${lineOf(stripped, fn.start)}: ${fn.name}`;
+  for (const param of fn.params) {
+    if (REFERENCE_RECEIVER.test(param) || /^(?:mut\s+)?self\b/.test(param)) continue; // the receiver check's job
+    const type = param.slice(param.indexOf(":") + 1).trim();
+    if (NAMES_THE_OBJECT.test(type) && !ALLOWED_OBJECT_PARAM.test(type))
+      into.referenceParams.push(`${where}: ${param}`);
   }
-}
-
-function emptyAudit(): Audit {
-  return { impls: 0, methods: [], referenceReceivers: [], entryPoints: [], reborrows: {}, reborrowSites: [] };
+  const body = stripped.slice(fn.start, fn.end);
+  for (const r of body.matchAll(WHOLE_OBJECT_REBORROW)) {
+    into.reborrows[fn.name] = (into.reborrows[fn.name] ?? 0) + 1;
+    into.reborrowSites.push(`${source}:${lineOf(stripped, fn.start + r.index)}: ${fn.name}: ${r[0]}`);
+  }
 }
 
 const tree = emptyAudit();
@@ -181,14 +270,24 @@ impl ThreadSafeFunction {
     unsafe fn dispatch_one(this: *mut ThreadSafeFunction, is_first: bool) -> bool {
         let _g = unsafe { (*this).lock.lock_guard() }; // nor does &*this here
         let env = unsafe { &*env };
+        let f = |x: &mut Self| x.poll_ref.disable();
         unsafe { (*this).queue.data.read_item() }.is_some()
+    }
+    unsafe fn call(
+        this: *mut Self,
+        cb: Option<extern "C" fn(*mut c_void, *mut c_void)>,
+        pair: (u32, u32),
+    ) {
     }
     pub(crate) unsafe fn destroy(this: *mut ThreadSafeFunction) {
         drop(unsafe { bun_core::heap::take(this) });
     }
+    fn consume(boxed: Box<Self>) {}
     fn is_closing(&self) -> bool { true }
     fn enqueue(&mut self, ctx: *mut c_void) {}
     fn by_ref(self: &Self) {}
+    fn with_lifetime<'a>(&'a mut self) -> &'a Mutex { &self.lock }
+    fn by_param(this: &mut ThreadSafeFunction, other: &Self, maybe: Option<&mut Self>, nn: NonNull<ThreadSafeFunction>) {}
     unsafe fn reborrows(this: *mut Self) {
         unsafe { &mut *this }.tick();
         let shared = unsafe { & *this };
@@ -201,7 +300,7 @@ impl Drop for ThreadSafeFunction {
 extern "C" fn napi_acquire_threadsafe_function(func: napi_threadsafe_function) -> napi_status {
     unsafe { &mut *func }.acquire()
 }
-extern "C" fn napi_ref_threadsafe_function(env_: napi_env, func: napi_threadsafe_function) -> napi_status {
+pub(crate) unsafe extern "C" fn napi_ref_threadsafe_function(env_: napi_env, func: napi_threadsafe_function) -> napi_status {
     // SAFETY: prose about &mut *func.
     unsafe { (*func).poll_ref.ref_(bun_io::js_vm_ctx()) };
     NapiStatus::ok as napi_status
@@ -212,35 +311,58 @@ extern "C" fn napi_internal_threadsafe_function_env_teardown(tsfn: *mut c_void) 
         unsafe { ThreadSafeFunction::free_orphaned(this) };
     }
 }
+extern "C" fn napi_internal_threadsafe_function_by_ref(func: &mut ThreadSafeFunction) -> napi_status {
+    func.poll_ref.disable();
+    NapiStatus::ok as napi_status
+}
 extern "C" fn napi_create_async_work(env: napi_env) -> napi_status { unsafe { &mut *env }.ok() }
 `,
     a,
   );
   expect(a).toEqual({
     impls: 1,
-    methods: ["new", "dispatch_one", "destroy", "is_closing", "enqueue", "by_ref", "reborrows"],
-    referenceReceivers: ["is_closing", "enqueue", "by_ref"],
+    methods: {
+      new: "init: ThreadSafeFunction",
+      dispatch_one: "this: *mut ThreadSafeFunction",
+      call: "this: *mut Self",
+      destroy: "this: *mut ThreadSafeFunction",
+      consume: "boxed: Box<Self>",
+      is_closing: "&self",
+      enqueue: "&mut self",
+      by_ref: "self: &Self",
+      with_lifetime: "&'a mut self",
+      by_param: "this: &mut ThreadSafeFunction",
+      reborrows: "this: *mut Self",
+    },
+    referenceReceivers: ["is_closing", "enqueue", "by_ref", "with_lifetime"],
     entryPoints: [
       "napi_acquire_threadsafe_function",
       "napi_ref_threadsafe_function",
       "napi_internal_threadsafe_function_env_teardown",
+      "napi_internal_threadsafe_function_by_ref",
+    ],
+    referenceParams: [
+      "x.rs:25: by_param: this: &mut ThreadSafeFunction",
+      "x.rs:25: by_param: other: &Self",
+      "x.rs:25: by_param: maybe: Option<&mut Self>",
+      "x.rs:25: by_param: nn: NonNull<ThreadSafeFunction>",
+      "x.rs:49: napi_internal_threadsafe_function_by_ref: func: &mut ThreadSafeFunction",
     ],
     reborrows: { reborrows: 3, napi_acquire_threadsafe_function: 1 },
     reborrowSites: [
-      "x.rs:17: reborrows: &mut *this",
-      "x.rs:18: reborrows: & *this",
-      "x.rs:19: reborrows: this.as_mut(",
-      "x.rs:26: napi_acquire_threadsafe_function: &mut *func",
+      "x.rs:27: reborrows: &mut *this",
+      "x.rs:28: reborrows: & *this",
+      "x.rs:29: reborrows: this.as_mut(",
+      "x.rs:36: napi_acquire_threadsafe_function: &mut *func",
     ],
   });
 });
 
 test("ThreadSafeFunction is still where this lint looks for it", () => {
   // If this fails, the impl or the entry points moved or were renamed: update
-  // the patterns above rather than the assertions below.
+  // the patterns and lists above rather than the assertions below.
   expect(tree.impls).toBe(1);
-  expect(tree.methods).toContain("on_dispatch");
-  expect(tree.methods).toContain("env_teardown");
+  expect(Object.keys(tree.methods)).toEqual(expect.arrayContaining(PINNED));
   expect(tree.entryPoints).toEqual(
     expect.arrayContaining([
       "napi_create_threadsafe_function",
@@ -252,6 +374,17 @@ test("ThreadSafeFunction is still where this lint looks for it", () => {
       "napi_internal_threadsafe_function_env_teardown",
     ]),
   );
+});
+
+test("the pinned functions take the object as `this: *mut`", () => {
+  const firstParams = Object.fromEntries(PINNED.map(name => [name, tree.methods[name]]));
+  expect(firstParams).toEqual(
+    Object.fromEntries(PINNED.map(name => [name, expect.stringMatching(PINNED_FIRST_PARAM)])),
+  );
+});
+
+test("no other parameter takes the object by reference", () => {
+  expect(tree.referenceParams).toEqual([]);
 });
 
 test("no ThreadSafeFunction method takes a reference receiver, beyond the ones still being converted", () => {

--- a/test/internal/source-lints/napi-tsfn-receivers.test.ts
+++ b/test/internal/source-lints/napi-tsfn-receivers.test.ts
@@ -1,0 +1,268 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// `ThreadSafeFunction` (src/runtime/napi/napi_body.rs) is reached through a
+// raw pointer from every side, never through a `self` receiver.
+//
+// The object is shared for its whole life: addon threads take `lock`, wait on
+// `blocking_condvar` and write `thread_count` / `queue` / `closing` from
+// `napi_call_threadsafe_function`, `napi_acquire_threadsafe_function` and
+// `napi_release_threadsafe_function` at any time, including while the JS
+// thread is inside `dispatch_one` running the user's callback, or inside
+// `env_teardown`, after whose last phase an addon thread may even free the
+// allocation. A `&self` / `&mut self` argument claims the object for the
+// duration of the call: a write to any byte of it from anywhere else while
+// the call is running (or, for `env_teardown`, freeing it) is rejected by both
+// aliasing models (Tree Borrows, which `bun run rust:miri` uses: "foreign read
+// access would cause the protected tag ... to become Disabled; protected tags
+// must never be Disabled", naming the `&mut self` method; Stacked Borrows:
+// "would remove [Unique for <tag>] which is strongly protected"), and it is
+// what rustc's `noalias` on the argument tells LLVM to rely on. The callback
+// also re-enters the object from the same thread: `napi_unref_threadsafe_
+// function` called from inside it used to form a second `&mut Self` under the
+// `&mut self` of `call`, which fails the same way with one thread.
+//
+// So the methods take `this: *mut ThreadSafeFunction` and borrow one field per
+// statement (`(*this).lock.lock_guard()`, `(*this).queue.data.read_item()`),
+// and the `extern "C"` entry points project the field they need straight off
+// the handle (`(*func).poll_ref.ref_(..)`) instead of reborrowing the whole
+// object. This lint holds that shape:
+//
+//   1. no method of the inherent `impl ThreadSafeFunction` takes a reference
+//      receiver, except the ratcheted list below;
+//   2. neither those methods nor the `*threadsafe_function*` entry points
+//      reborrow the whole object from the pointer (`&mut *this`, `&*func`,
+//      `func.as_mut()`), which is the same claim spelled differently.
+//
+// Trait impls (`Drop`, `Taskable`) are not covered: their receivers are
+// dictated by the trait and they run once nothing else can reach the object.
+// `TsfnQueue::is_blocked(&self)` borrows only the queue, under `lock`.
+// Siblings: fn-long-mut-reborrow.test.ts (the fn-long `let x = &mut *ptr`
+// form of the same claim, tree-wide), self-receiver-reclaim.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const napiSources = globAllSources().rust.filter(
+  p => p.endsWith(".rs") && path.relative(root, p).replaceAll(path.sep, "/").startsWith("src/runtime/napi/"),
+);
+
+// Methods of `impl ThreadSafeFunction` still taking a reference receiver.
+// These are the addon-thread half of the same hazard (`push` and `release`
+// reach `enqueue` / `release_locked` through an autoref of `*this`; the entry
+// point for `acquire` reborrows the whole object, see below); #37741 converts
+// them, after which both lists below are empty. Delete each name as it is
+// converted; do not add any.
+const REFERENCE_RECEIVERS_STILL_TO_CONVERT = [
+  "acquire",
+  "enqueue",
+  "is_closing",
+  "release_locked",
+  "schedule_dispatch",
+];
+
+// Functions allowed exactly N whole-object reborrows of the handle, for the
+// same reason. Lower when converted; do not add entries.
+const REBORROWS_STILL_TO_CONVERT: Record<string, number> = {
+  napi_acquire_threadsafe_function: 1,
+};
+
+// The names the handle goes by in the functions this lint covers. A new name
+// must be added here for the reborrow check to see it.
+const HANDLE = String.raw`(?:this|func|function|tsfn)`;
+const WHOLE_OBJECT_REBORROW = new RegExp(
+  [String.raw`&\s*(?:mut\s+)?\*\s*${HANDLE}\b`, String.raw`\b${HANDLE}\s*\.\s*as_(?:mut|ref)\s*\(`].join("|"),
+  "g",
+);
+
+const INHERENT_IMPL = /^impl\s+ThreadSafeFunction\s*\{/gm;
+const TSFN_ENTRY_POINT = /^extern\s+"C"\s+fn\s+(\w*threadsafe_function\w*)\s*\(/gm;
+// `fn name(params)`: the receiver, if any, is the first parameter. `[^)]*`
+// cannot cross a nested paren, but a receiver never follows one.
+const FN_ITEM = /\bfn\s+(\w+)\s*\(\s*([^)]*)\)/g;
+const REFERENCE_RECEIVER = /^(?:&\s*(?:mut\s+)?self\b|self\s*:\s*&)/;
+
+function lineOf(text: string, index: number): number {
+  return text.slice(0, index).split("\n").length;
+}
+
+/** Comments out (full-line and trailing), newlines kept so line numbers hold.
+ * The covered code has no string literals containing `//`. */
+function stripComments(text: string): string {
+  return text.replace(/^[ \t]*\/\/.*$/gm, "").replace(/[ \t]\/\/.*$/gm, "");
+}
+
+/** The `{ .. }` block whose opening brace is at `open`, or null if unbalanced. */
+function blockAt(text: string, open: number): string | null {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if (c === "{") depth++;
+    else if (c === "}" && --depth === 0) return text.slice(open, i + 1);
+  }
+  return null;
+}
+
+interface Audit {
+  /** Inherent impl blocks found (normally one). */
+  impls: number;
+  /** Every method of those impls, in source order. */
+  methods: string[];
+  /** Methods whose receiver is a reference. */
+  referenceReceivers: string[];
+  /** `*threadsafe_function*` entry points found. */
+  entryPoints: string[];
+  /** `function name -> count` of whole-object reborrows, impl methods and entry points alike. */
+  reborrows: Record<string, number>;
+  /** `file:line: function: text` of every reborrow, for the failure message. */
+  reborrowSites: string[];
+}
+
+function audit(source: string, text: string, into: Audit): void {
+  const stripped = stripComments(text);
+  for (const m of stripped.matchAll(INHERENT_IMPL)) {
+    const body = blockAt(stripped, m.index + m[0].length - 1);
+    if (body === null) throw new Error(`${source}:${lineOf(stripped, m.index)}: unbalanced impl block`);
+    into.impls++;
+    const base = m.index + m[0].length - 1;
+    // Split the impl into per-method regions so reborrows are attributed to
+    // the method containing them.
+    const items = [...body.matchAll(FN_ITEM)];
+    items.forEach((item, i) => {
+      const name = item[1];
+      into.methods.push(name);
+      if (REFERENCE_RECEIVER.test(item[2].trim())) into.referenceReceivers.push(name);
+      const end = i + 1 < items.length ? items[i + 1].index : body.length;
+      countReborrows(source, stripped, base, body.slice(item.index, end), item.index, name, into);
+    });
+  }
+  for (const m of stripped.matchAll(TSFN_ENTRY_POINT)) {
+    const open = stripped.indexOf("{", m.index);
+    const body = open === -1 ? null : blockAt(stripped, open);
+    if (body === null) throw new Error(`${source}:${lineOf(stripped, m.index)}: could not find the body of ${m[1]}`);
+    into.entryPoints.push(m[1]);
+    countReborrows(source, stripped, open, body, 0, m[1], into);
+  }
+}
+
+function countReborrows(
+  source: string,
+  stripped: string,
+  base: number,
+  region: string,
+  regionOffset: number,
+  fn: string,
+  into: Audit,
+): void {
+  for (const r of region.matchAll(WHOLE_OBJECT_REBORROW)) {
+    into.reborrows[fn] = (into.reborrows[fn] ?? 0) + 1;
+    into.reborrowSites.push(`${source}:${lineOf(stripped, base + regionOffset + r.index)}: ${fn}: ${r[0]}`);
+  }
+}
+
+function emptyAudit(): Audit {
+  return { impls: 0, methods: [], referenceReceivers: [], entryPoints: [], reborrows: {}, reborrowSites: [] };
+}
+
+const tree = emptyAudit();
+for (const abs of napiSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  audit(source, await file(abs).text(), tree);
+}
+
+test("the audit recognizes the shapes it claims to", () => {
+  const a = emptyAudit();
+  audit(
+    "x.rs",
+    `
+impl ThreadSafeFunction {
+    pub(crate) fn new(init: ThreadSafeFunction) -> *mut ThreadSafeFunction { heap::into_raw(Box::new(init)) }
+    // A comment mentioning &mut *this does not count.
+    unsafe fn dispatch_one(this: *mut ThreadSafeFunction, is_first: bool) -> bool {
+        let _g = unsafe { (*this).lock.lock_guard() }; // nor does &*this here
+        let env = unsafe { &*env };
+        unsafe { (*this).queue.data.read_item() }.is_some()
+    }
+    pub(crate) unsafe fn destroy(this: *mut ThreadSafeFunction) {
+        drop(unsafe { bun_core::heap::take(this) });
+    }
+    fn is_closing(&self) -> bool { true }
+    fn enqueue(&mut self, ctx: *mut c_void) {}
+    fn by_ref(self: &Self) {}
+    unsafe fn reborrows(this: *mut Self) {
+        unsafe { &mut *this }.tick();
+        let shared = unsafe { & *this };
+        unsafe { this.as_mut() }.unwrap().tick();
+    }
+}
+impl Drop for ThreadSafeFunction {
+    fn drop(&mut self) { let _ = &mut *self; }
+}
+extern "C" fn napi_acquire_threadsafe_function(func: napi_threadsafe_function) -> napi_status {
+    unsafe { &mut *func }.acquire()
+}
+extern "C" fn napi_ref_threadsafe_function(env_: napi_env, func: napi_threadsafe_function) -> napi_status {
+    // SAFETY: prose about &mut *func.
+    unsafe { (*func).poll_ref.ref_(bun_io::js_vm_ctx()) };
+    NapiStatus::ok as napi_status
+}
+extern "C" fn napi_internal_threadsafe_function_env_teardown(tsfn: *mut c_void) {
+    let this = tsfn.cast::<ThreadSafeFunction>();
+    if unsafe { ThreadSafeFunction::env_teardown(this) } {
+        unsafe { ThreadSafeFunction::free_orphaned(this) };
+    }
+}
+extern "C" fn napi_create_async_work(env: napi_env) -> napi_status { unsafe { &mut *env }.ok() }
+`,
+    a,
+  );
+  expect(a).toEqual({
+    impls: 1,
+    methods: ["new", "dispatch_one", "destroy", "is_closing", "enqueue", "by_ref", "reborrows"],
+    referenceReceivers: ["is_closing", "enqueue", "by_ref"],
+    entryPoints: [
+      "napi_acquire_threadsafe_function",
+      "napi_ref_threadsafe_function",
+      "napi_internal_threadsafe_function_env_teardown",
+    ],
+    reborrows: { reborrows: 3, napi_acquire_threadsafe_function: 1 },
+    reborrowSites: [
+      "x.rs:17: reborrows: &mut *this",
+      "x.rs:18: reborrows: & *this",
+      "x.rs:19: reborrows: this.as_mut(",
+      "x.rs:26: napi_acquire_threadsafe_function: &mut *func",
+    ],
+  });
+});
+
+test("ThreadSafeFunction is still where this lint looks for it", () => {
+  // If this fails, the impl or the entry points moved or were renamed: update
+  // the patterns above rather than the assertions below.
+  expect(tree.impls).toBe(1);
+  expect(tree.methods).toContain("on_dispatch");
+  expect(tree.methods).toContain("env_teardown");
+  expect(tree.entryPoints).toEqual(
+    expect.arrayContaining([
+      "napi_create_threadsafe_function",
+      "napi_call_threadsafe_function",
+      "napi_acquire_threadsafe_function",
+      "napi_release_threadsafe_function",
+      "napi_ref_threadsafe_function",
+      "napi_unref_threadsafe_function",
+      "napi_internal_threadsafe_function_env_teardown",
+    ]),
+  );
+});
+
+test("no ThreadSafeFunction method takes a reference receiver, beyond the ones still being converted", () => {
+  // Exact: a new `&self` / `&mut self` method fails this, and so does leaving
+  // a converted one in the list.
+  expect([...tree.referenceReceivers].sort()).toEqual([...REFERENCE_RECEIVERS_STILL_TO_CONVERT].sort());
+});
+
+test("neither the methods nor the entry points reborrow the whole object from its pointer", () => {
+  const over = Object.keys(tree.reborrows).filter(fn => tree.reborrows[fn] > (REBORROWS_STILL_TO_CONVERT[fn] ?? 0));
+  expect(tree.reborrowSites.filter(site => over.some(fn => site.includes(`: ${fn}: `)))).toEqual([]);
+  // Ratchet the other way too.
+  expect(tree.reborrows).toEqual(REBORROWS_STILL_TO_CONVERT);
+});


### PR DESCRIPTION
### Problem
- The JS-thread half of napi's `ThreadSafeFunction` (dispatching queued calls, ref/unref, env teardown) ran as `&mut self` methods on the shared object.
- A `&mut self` argument claims the whole object for the length of the call, but addon threads take its lock and bump its counters the whole time the user's callback runs, the callback can unref the same function re-entrantly (`test_issue_11949`), and after teardown's last phase an addon thread may free it while the method is still returning.
- The finalize task was posted with a pointer derived from that receiver; the caller's next use of its own pointer invalidates it before `destroy` frees through it.
- A reduction of these four shapes fails Miri under both Tree Borrows (`protected tags must never be Disabled`) and Stacked Borrows, and passes in this PR's shape. No crash is known and the compiler does not exploit it today. Same class as #37703, #37685, #37693, #37705, #37723, #37732; the mirror image of #37741, which converts the addon-thread half.

### Fix
- The four JS-thread functions take `this: *mut ThreadSafeFunction` and borrow one field per statement, as `push` / `release` already do; the `loop_mut`, `ref_` and `unref` wrappers go away and their callers touch `poll_ref` or a copied `BackRef` directly.
- Sound because no borrow of the object is live across the callback, a lock release, or a call into another method (`call` copies its inputs out first; the finalize task carries the pointer the object was dispatched with, the one `destroy` frees). The lock is taken and dropped at the same points as before and the finalize / free decisions are unchanged.
- The new lint ratchets the five methods #37741 converts and one reborrow in `napi_acquire_threadsafe_function`; whichever PR lands second drops the other's allowlist entry.
- Verification: the lint fails on `main` (listing the seven old receivers) and passes here, but it checks signatures only; there is no runtime repro since nothing crashes. The existing napi addon tests, including unref from inside the callback and worker teardown, pass on the ASAN build; clippy and fmt are clean.

### Background
- A threadsafe function is the Node-API object addon threads use to queue calls (`napi_call_threadsafe_function`) that the JS thread later runs; addon threads acquire and release it, and the last release, the JS-thread finalizer, or env teardown frees it. One allocation is shared between the JS thread and any number of addon threads for its whole life.
- In Rust a `&mut self` (or `&self`) argument is a promise, passed to LLVM as `noalias`, that nothing else reads or writes the object while the call is on the stack; holding a lock around each field access does not change that. Going through `(*this).field` claims only that field for that statement.
- Miri is rustc's interpreter that checks those aliasing rules; Tree Borrows (what `bun run rust:miri` uses) and Stacked Borrows are its two models. A "protected tag" in its errors is the reference argument of a call that has not returned yet.
- `poll_ref` is the object's keep-the-event-loop-alive handle and is touched only by the JS thread (ref/unref are JS-thread-only in Node as well), so borrowing that one field is fine while addon threads are in the rest of the object.
- Tests under test/internal/source-lints/ read the source tree and assert a shape; a ratchet is an allowlist of remaining violations that may shrink but not grow.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/napi-tsfn-receivers.test.ts
bun test v1.4.0 (4ddfdae64)

test/internal/source-lints/napi-tsfn-receivers.test.ts:
(pass) the audit recognizes the shapes it claims to [41.00ms]
(pass) ThreadSafeFunction is still where this lint looks for it [3.53ms]
376 |   );
377 | });
378 | 
379 | test("the pinned functions take the object as `this: *mut`", () => {
380 |   const firstParams = Object.fromEntries(PINNED.map(name => [name, tree.methods[name]]));
381 |   expect(firstParams).toEqual(
                            ^
error: expect(received).toEqual(expected)

  {
-   "call": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "destroy": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "dispatch_one": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "env_teardown": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "free_orphaned": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "maybe_queue_finalize
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/internal/source-lints/napi-tsfn-receivers.test.ts:
(pass) the audit recognizes the shapes it claims to [0.54ms]
(pass) ThreadSafeFunction is still where this lint looks for it [0.08ms]
376 |   );
377 | });
378 | 
379 | test("the pinned functions take the object as `this: *mut`", () => {
380 |   const firstParams = Object.fromEntries(PINNED.map(name => [name, tree.methods[name]]));
381 |   expect(firstParams).toEqual(
                            ^
error: expect(received).toEqual(expected)

  {
-   "call": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "destroy": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "dispatch_one": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "env_teardown": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "free_orphaned": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "maybe_queue_finalizer": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "on_dispatch": StringMatching /^this\s*:\s*\*\s*mut\s+(?:Self|ThreadSafeFunction)$/,
-   "push": Strin
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/napi-tsfn-receivers.test.ts
bun test v1.4.0 (4ddfdae64)

test/internal/source-lints/napi-tsfn-receivers.test.ts:
(pass) the audit recognizes the shapes it claims to [48.94ms]
(pass) ThreadSafeFunction is still where this lint looks for it [3.63ms]
(pass) the pinned functions take the object as `this: *mut` [12.22ms]
(pass) no other parameter takes the object by reference [1.37ms]
(pass) no ThreadSafeFunction method takes a reference receiver, beyond the ones still being converted [2.14ms]
(pass) neither the methods nor the entry points reborrow the whole object from its pointer [6.93ms]

 6 pass
 0 fail
 9 expect() calls
Ran 6 tests across 1 file. [21.22s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 816ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/144] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/144] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2FrameParser 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/napi/napi_body.rs                      | 315 ++++++++--------
 .../source-lints/napi-tsfn-receivers.test.ts       | 401 +++++++++++++++++++++
 2 files changed, 569 insertions(+), 147 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/runtime/napi/napi_body.rs                              14     24      0
test/internal/source-lints/napi-tsfn-receivers.test.ts      2      7      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

The JS-thread side of `ThreadSafeFunction` (src/runtime/napi/napi_body.rs) still went through whole-object receivers: `on_dispatch(this)` called `(*this).dispatch_one(&mut self)`, which called `call(&mut self)` and `maybe_queue_finalizer(&mut self)`, and `napi_internal_threadsafe_function_env_teardown` called `(*this).env_teardown(&mut self)`. `napi_ref_threadsafe_function` / `napi_unref_threadsafe_function` went through `ref_(&mut self)` / `unref(&mut self)`.

A reference argument claims the object for the duration of the call (it is what rustc's `noalias` on the argument promises LLVM), and this object is shared for its whole life:

* `dispatch_one` takes `lock` and then runs the user's callback in `call`, for as long as that takes. Any `napi_call_threadsafe_function` / `napi_acquire_threadsafe_function` / `napi_release_threadsafe_function` arriving from an addon thread in that time does a read-modify-write on the lock word and then on `thread_count` / `queue.count`, i.e. writes inside the range the protected `&mut self` covers. This is the steady state of every threadsafe function with a producer thread, not a race window.
* The callback run by `call(&mut self)` can re-enter the object from the same thread: `napi_unref_threadsafe_function` on the TSFN being dispatched (what the `test_issue_11949` addon in test/napi does) formed a second `&mut Self` under the protected one.
* `maybe_queue_finalizer` posted `let self_ptr: *mut Self = self` as the finalize task. `on_dispatch` goes on using the object through its own pointer after `dispatch_one` returns (the `Running -> Idle` CAS), which invalidates that receiver-derived pointer, and the next `on_dispatch` then frees through it in `destroy`.
* `env_teardown` coordinates with live addon threads through `lock` across its three phases, and its last phase publishes `env_teardown_done`: from the moment its guard drops, a thread dropping the last reference frees the allocation, while the `&mut self` frame is still returning.

A reduction of these four shapes (below) fails under both aliasing models and passes with the shape this PR uses. Tree Borrows, the model `bun run rust:miri` uses, reports the first, second and fourth as `foreign read access would cause the protected tag <N> (currently Unique) to become Disabled; protected tags must never be Disabled`, with `<N>` pointing at the `&mut self` of `dispatch_one` / `env_teardown`, and the third as the posted pointer having `state Disabled which forbids this reborrow` when it is freed; Stacked Borrows reports `would remove [Unique for <N>] which is strongly protected` and `tag does not exist in the borrow stack`. No crash is known from any of this; the compiler does not currently exploit it. It is the contract that is wrong, the same class as #37703, #37685, #37693, #37705, #37723 and #37732, and the mirror image of #37741, which converts the addon-thread side of this same object and lists this side as reported separately.

<details>
<summary>Reduction run under Miri</summary>

`HANDLE` is the addon's copy of the `napi_threadsafe_function` pointer; `POSTED` is what `maybe_queue_finalizer` put in the finalize task. `<scenario>-before` is the shape on `main`, `<scenario>-after` the shape in this PR.

```rust
use std::sync::atomic::{AtomicI64, AtomicPtr, AtomicU8, AtomicU32, Ordering::SeqCst};

struct Tsfn {
    lock: AtomicU32,
    thread_count: AtomicI64,
    dispatch_state: AtomicU8,
    // The JS thread's plain fields.
    has_queued_finalizer: bool,
    poll_ref: u32,
}

static HANDLE: AtomicPtr<Tsfn> = AtomicPtr::new(std::ptr::null_mut());
static POSTED: AtomicPtr<Tsfn> = AtomicPtr::new(std::ptr::null_mut());

/// An addon thread calling napi_call/acquire/release_threadsafe_function
/// while the JS thread is inside its method: takes the lock, touches a counter.
fn addon_thread_uses_it() {
    std::thread::scope(|s| {
        s.spawn(|| {
            let h = HANDLE.load(SeqCst);
            unsafe {
                (*h).lock.swap(1, SeqCst);
                (*h).thread_count.fetch_sub(1, SeqCst);
                (*h).lock.swap(0, SeqCst);
            }
        });
    });
}

/// The last release of an orphaned TSFN: frees it once it gets the lock.
fn addon_thread_frees_it() {
    std::thread::scope(|s| {
        s.spawn(|| {
            let h = HANDLE.load(SeqCst);
            unsafe {
                (*h).lock.swap(1, SeqCst);
                (*h).thread_count.fetch_sub(1, SeqCst);
                drop(Box::from_raw(h));
            }
        });
    });
}

// main
impl Tsfn {
    fn dispatch_one_before(&mut self, scenario: &str) {
        self.lock.swap(1, SeqCst); // dispatch_one's lock_guard
        let _ = self.thread_count.load(SeqCst);
        self.lock.swap(0, SeqCst);
        match scenario {
            // call(): the user's callback runs here, for as long as it takes.
            "js" => addon_thread_uses_it(),
            // ... and it may napi_unref_threadsafe_function this very TSFN.
            "reenter" => unsafe { (*HANDLE.load(SeqCst)).unref_before() },
            "finalize" => self.maybe_queue_finalizer_before(),
            _ => unreachable!(),
        }
    }
    fn unref_before(&mut self) {
        self.poll_ref -= 1;
    }
    fn maybe_queue_finalizer_before(&mut self) {
        self.has_queued_finalizer = true;
        let self_ptr: *mut Self = self;
        POSTED.store(self_ptr, SeqCst); // loop.enqueue_task(Task::init(self_ptr))
    }
    fn env_teardown_before(&mut self) -> bool {
        self.lock.swap(1, SeqCst); // phase 3
        self.poll_ref = 0;
        let caller_frees = self.thread_count.load(SeqCst) <= 0;
        self.lock.swap(0, SeqCst); // guard dropped: the addon thread may free us now
        if !caller_frees {
            addon_thread_frees_it();
        }
        caller_frees
    }
}

// this PR
impl Tsfn {
    unsafe fn dispatch_one_after(this: *mut Tsfn, scenario: &str) {
        unsafe {
            (*this).lock.swap(1, SeqCst);
            let _ = (*this).thread_count.load(SeqCst);
            (*this).lock.swap(0, SeqCst);
        }
        match scenario {
            "js" => addon_thread_uses_it(),
            "reenter" => unsafe { Tsfn::unref_after(HANDLE.load(SeqCst)) },
            "finalize" => unsafe { Tsfn::maybe_queue_finalizer_after(this) },
            _ => unreachable!(),
        }
    }
    unsafe fn unref_after(this: *mut Tsfn) {
        unsafe { (*this).poll_ref -= 1 };
    }
    unsafe fn maybe_queue_finalizer_after(this: *mut Tsfn) {
        unsafe { (*this).has_queued_finalizer = true };
        POSTED.store(this, SeqCst);
    }
    unsafe fn env_teardown_after(this: *mut Tsfn) -> bool {
        let caller_frees = unsafe {
            (*this).lock.swap(1, SeqCst);
            (*this).poll_ref = 0;
            let caller_frees = (*this).thread_count.load(SeqCst) <= 0;
            (*this).lock.swap(0, SeqCst);
            caller_frees
        };
        if !caller_frees {
            addon_thread_frees_it();
        }
        caller_frees
    }
}

fn main() {
    let arg = std::env::args().nth(1).unwrap_or_default();
    let (scenario, after) = match arg.rsplit_once('-') {
        Some((s, "before")) => (s.to_string(), false),
        Some((s, "after")) => (s.to_string(), true),
        _ => panic!("usage: {{js,reenter,finalize,teardown}}-{{before,after}}"),
    };
    let t = Box::into_raw(Box::new(Tsfn {
        lock: AtomicU32::new(0),
        thread_count: AtomicI64::new(1),
        dispatch_state: AtomicU8::new(0),
        has_queued_finalizer: false,
        poll_ref: 1,
    }));
    HANDLE.store(t, SeqCst);
    if scenario == "teardown" {
        // napi_internal_threadsafe_function_env_teardown
        let caller_frees = unsafe {
            if after { Tsfn::env_teardown_after(t) } else { (*t).env_teardown_before() }
        };
        if caller_frees {
            unsafe { drop(Box::from_raw(t)) };
        }
        return;
    }
    // on_dispatch(this): one dispatch_one, then the Running -> Idle CAS.
    unsafe {
        if after { Tsfn::dispatch_one_after(t, &scenario) } else { (*t).dispatch_one_before(&scenario) }
    }
    let _ = unsafe { (*t).dispatch_state.compare_exchange(0, 1, SeqCst, SeqCst) };
    // The next on_dispatch sees Closed and runs destroy() on the posted pointer.
    let posted = POSTED.load(SeqCst);
    unsafe { drop(Box::from_raw(if posted.is_null() { t } else { posted })) };
}
```

| scenario | Tree Borrows (`-Zmiri-tree-borrows`) | Stacked Borrows (default) |
| --- | --- | --- |
| `js-before` | UB: `foreign read access would cause the protected tag ... to become Disabled`, tag created at `fn dispatch_one_before(&mut self, ..)` | UB: `would remove [Unique for <dispatch_one_before>] which is strongly protected` |
| `reenter-before` | UB: same, at the reborrow for `unref_before` | UB: same, naming `unref_before` and `dispatch_one_before` |
| `finalize-before` | UB: the posted tag `has state Disabled which forbids this reborrow`, created at `fn maybe_queue_finalizer_before(&mut self)` | UB: `trying to retag from <posted> for Unique permission ..., but that tag does not exist in the borrow stack` |
| `teardown-before` | UB: `foreign read access would cause the protected tag ... to become Disabled`, tag created at `fn env_teardown_before(&mut self)` | UB: `would remove [Unique for <env_teardown_before>] which is strongly protected` |
| all four `-after` | pass | pass |

</details>

### Fix

`dispatch_one`, `call`, `maybe_queue_finalizer` and `env_teardown` take `this: *mut ThreadSafeFunction` and borrow one field per statement, the way `push` / `release` already do on the other side of the object: `(*this).lock.lock_guard()` (the guard holds the lock by pointer, so nothing points into the object across the callback except that), `(*this).queue.data.read_item()` under it, and so on. Concretely:

* `on_dispatch` passes its pointer down: `Self::dispatch_one(this, is_first)`.
* `call` copies what the callback needs out of the object first (the env pointer, the `Copy` tracker, the JS value or `call_js` function pointer, `ctx`), so no borrow of the threadsafe function exists while the microtask drain or the callback runs. The JS and C paths do the same things in the same order as before; they are just no longer two arms of one `match` on a borrowed field.
* `maybe_queue_finalizer` posts `Task::init(this)`, the pointer `on_dispatch` was dispatched with, which is the one `destroy` later frees.
* `env_teardown` keeps its three phases, with the phase 1 and phase 3 critical sections as single blocks; `env_teardown_done` is still published, and `thread_count` still read, under the lock, and nothing touches the object after the guard drops. Its caller already had the pointer.
* `loop_mut`, `ref_` and `unref` are deleted: the two loop users copy the `Copy` `BackRef` out of the field and call `get_mut()` on the copy, and `napi_ref_threadsafe_function`, `napi_unref_threadsafe_function`, `napi_create_threadsafe_function` and `destroy` call `poll_ref.ref_()` / `unref()` on the field directly, which is all the wrappers did. `poll_ref` is the JS thread's (as `napi_ref/unref_threadsafe_function` are JS-thread-only in Node too), so a borrow of that one field is sound while addon threads are in the rest of the object.
* The rule itself is stated and enforced by the lint below rather than by a comment on the struct (an earlier revision had one; it said nothing the signatures and the lint do not).

Behaviour is unchanged: the lock is taken and dropped at the same points, the condvar signals, state transitions and the finalize / free decisions are the same, and `call` runs the same code in the same order.

### Why raw pointers rather than `&self` plus interior mutability

The other way to make this object sound is to change its layout: put `queue.data` behind a `Guarded`, the JS thread's plain fields (`poll_ref`, `callback`, `env`, `finalizer_fun`, `has_queued_finalizer`) into `JsCell`, and then give everything that does not post or free the object a `&self` receiver, keeping `*mut` only for `on_dispatch`, the two posting functions and the freeing ones. That is the better end state and nothing here is in its way: every function this PR converts would keep working unchanged under that layout (a raw pointer is sound wherever a shared reference is), so it is a later simplification on top of this, not a reversal of it. It is not done here because it rewrites both halves of the object at once (the addon-thread half is #37741, in flight, and #36831 / #36801 are open against the same functions), while this PR is a behaviour-preserving change to one half. With the current layout, `&self` is not a sound receiver either (a shared reference covering `queue.data` and the plain fields is invalidated by the writes the other party makes to them), which is why the lint bans both kinds of reference for now; its header says that the `&self` half of the ban is what to lift when the layout changes.

### Relationship to other open PRs

* #37741 converts the addon-thread methods of this object (`enqueue` -> `push_locked`, `release_locked`, `schedule_dispatch`, `is_closing`, `acquire`); this PR converts the JS-thread methods. The two are independent (each removes its own side's receivers); a three-way merge of the two branches' napi_body.rs against their common base applies cleanly, and the merged file passes the lint below once its two ratchets are emptied. The lint below ratchets #37741's five methods and the one `&mut *func` in `napi_acquire_threadsafe_function` by name, so when it lands its entries are deleted and both lists are empty; conversely #37741's `self-receiver-publish` lint allowlists `maybe_queue_finalizer`'s post, which this PR removes, so whichever lands second drops that allowlist entry (this PR, if it is the second one).
* #36831 and #36801 rewrite parts of `on_dispatch` / `dispatch_one` / `call` for other reasons and will conflict with this; #36831 already moves `dispatch_one` and `call` to `*mut Self` as part of its change, so the shapes are compatible.

### Tests

`test/internal/source-lints/napi-tsfn-receivers.test.ts` parses the signature and body of every method of the inherent `impl ThreadSafeFunction` and of every `*threadsafe_function*` `extern "C"` entry point under src/runtime/napi/ (brace- and paren-matched, so rustfmt-wrapped parameter lists, generics, lifetimes and qualified `pub(crate) unsafe extern "C"` items are all seen) and asserts four things:

1. the converted functions (`on_dispatch`, `dispatch_one`, `call`, `maybe_queue_finalizer`, `env_teardown`, plus `push`, `release`, `destroy`, `free_orphaned`, which already had the shape) take the object as `this: *mut ..`;
2. no other parameter of any of these functions takes the object as anything but a raw pointer, a move or a `Box` (so renaming the receiver to a `this: &mut ThreadSafeFunction` parameter, or `Option<&mut Self>` / `NonNull<Self>`, fails; zero today, so there is no ratchet);
3. the set of methods with a reference receiver is exactly the ratcheted list of the five #37741 converts;
4. neither the methods nor the entry points reborrow the whole object from the handle (`&mut *this`, `&*func`, `func.as_mut()`), with `napi_acquire_threadsafe_function`'s one site ratcheted.

It checks its own parser and patterns against an inline fixture (including the lines it reports), anchors itself on the pinned names and the seven entry points so it cannot pass vacuously if the code moves, and its header lists what it knowingly does not see (a reborrow through a local alias of the handle, and callers outside src/runtime/napi/ such as the dispatch.rs arm, which passes `cast_ptr!`). Against `main`'s napi_body.rs assertions 1 and 3 fail, the latter listing

```
+   "call",
+   "dispatch_one",
+   "env_teardown",
+   "loop_mut",
+   "maybe_queue_finalizer",
+   "ref_",
+   "unref",
```

beyond the allowed list; with this branch all four pass. I also applied seven single-site regressions to this branch's napi_body.rs (`dispatch_one(this: &mut ThreadSafeFunction)` with the caller coercing, `env_teardown(this: &mut Self)` reached through a local alias, `on_dispatch(this: &mut ThreadSafeFunction)`, an entry point with a `&mut ThreadSafeFunction` parameter, a new `&self` helper, a lifetime-annotated `&'a self` helper, and a qualified entry point reborrowing `&mut *func`); each one fails the lint.

The behaviour the converted functions implement is covered by the existing addon tests, all run on the debug (ASAN) build of this branch: `test/napi/napi.test.ts` (166 pass; the threadsafe-function ones exercise the empty-queue and after-call finalize paths, abort with and without queued items, blocked producers on a bounded queue, microtask draining between callbacks, `napi_unref_threadsafe_function` from inside the callback being dispatched (`test_issue_11949`), `napi_ref/unref_threadsafe_function` with a NULL env, and the worker-teardown paths through all three phases of `env_teardown`, including the ones where an addon thread's later call or release frees the orphan and where the caller frees it), and `test/napi/node-napi-tests/test/node-api/{test_threadsafe_function,test_worker_terminate,test_worker_terminate_finalization,test_env_teardown_gc}/do.test.ts` (10 pass; `test_threadsafe_function/test.js` is a pre-existing todo, it crashes in `uv_thread_create`). `bun test test/internal/source-lints/` (19 files, 88 tests), `cargo clippy -p bun_runtime --no-deps` and `cargo fmt --check` are clean.

</details>
