### PR TITLE
inspect: clear exceptions left behind by the slow property walk

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5596,10 +5596,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
-                // Ignore exceptions from "Get" proxy traps.
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
+                // Ignore exceptions from "Get" proxy traps and lazy property initializers.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5671,7 +5672,10 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            iterating = prototype ? prototype.getObject() : nullptr;
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,72 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe.concurrent("property lookups that throw while formatting", () => {
+  async function run(fixture) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("skips a lazy property whose initializer throws and keeps walking", async () => {
+    const fixture = `
+      // These initializers need Symbol too; reify them up front so that Bun.$
+      // is the only property whose initializer throws during the walk.
+      Bun.sql; Bun.postgres; Bun.SQL;
+      globalThis.Symbol = [];
+      let threw = false;
+      try { Bun.$; } catch { threw = true; }
+      console.log("initializer throws:", threw);
+      const out = Bun.inspect(Bun);
+      // Archive and allocUnsafe are the static properties right after $ in
+      // Bun's table; write is near the end.
+      console.log(JSON.stringify(["$", "Archive", "allocUnsafe", "write"].filter(k => out.includes("\\n  " + k + ": "))));
+    `;
+    expect(await run(fixture)).toEqual({
+      stdout: 'initializer throws: true\n["Archive","allocUnsafe","write"]\n',
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("skips an inherited property whose Proxy get trap throws", async () => {
+    const fixture = `
+      const proto = new Proxy({ first: 1, second: 2 }, {
+        get(target, key, receiver) {
+          if (key === "first") throw new Error("get trap");
+          return Reflect.get(target, key, receiver);
+        },
+      });
+      const obj = Object.create(proto);
+      obj.own = 0;
+      console.log(Bun.inspect(obj));
+    `;
+    expect(await run(fixture)).toEqual({
+      stdout: "{\n  own: 0,\n  second: 2,\n}\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  it("stops walking at a Proxy whose getPrototypeOf trap throws", async () => {
+    const fixture = `
+      const proto = new Proxy({}, {
+        getPrototypeOf() { throw new Error("getPrototypeOf trap"); },
+      });
+      const obj = Object.create(proto);
+      obj.own = 0;
+      console.log(Bun.inspect(obj));
+    `;
+    expect(await run(fixture)).toEqual({
+      stdout: "{\n  own: 0,\n}\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found assertion failure in debug builds and a segfault in release builds, both in the slow path of `JSC__JSValue__forEachPropertyImpl` (the property walk behind `Bun.inspect` / `console.log`).

When `object->getPropertySlot()` returned `false` with an exception pending, the loop hit `continue` before reaching `CLEAR_IF_EXCEPTION`, so the exception stayed pending while the walk went on. That happens when:

- a lazy static property's initializer throws (`setUpStaticFunctionSlot` in our JSC fork reports the slot as not found and leaves the exception pending). The fuzzer got there with `Symbol` replaced by an array, which makes the `Bun.$` initializer throw.
- a Proxy on the prototype chain throws from its `get` trap.

Consequences of the stale exception:

- every following static-table lookup also reports "not found", so `Bun.inspect(Bun)` silently drops most of the object (with `Symbol` replaced, the current release build prints 30 of the 115 properties)
- in debug/ASAN builds, the next host lazy property callback (`Bun.Archive`) asserts `releaseAssertNoException()` because an exception is pending that it did not throw
- when the loop then calls `getPrototype()` on a Proxy, the proxy bails out on the stale exception and returns empty, and `.getObject()` on an empty `JSValue` dereferences a null cell. This is a segfault at address 0x5 in the current release build, reachable from plain JS: `console.log(Object.create(proxyWhoseGetTrapThrows))`.

The fix is the reordering in the first hunk: call `getPropertySlot`, clear, then decide whether to skip, which is what `forEachPropertyOrdered` already does. The second hunk handles the remaining way `getPrototype()` can return empty (a `getPrototypeOf` trap that throws itself), which segfaulted the same way regardless of the first hunk. Both sites keep the function's existing policy of ignoring exceptions raised while fetching properties; only exceptions from the callback are propagated.

Not changed here: in debug builds, `Bun.sql` / `Bun.postgres` / `Bun.SQL` trip a different assertion (`Structure::storedPrototype`) when their module fails to load, because the `#if BUN_DEBUG` block in `defaultBunSQLObject` runs the uncaught exception machinery while the exception is still pending. That reproduces with a bare `Bun.sql` access and no inspect involved, so it is being handled separately; the new test reifies those three properties up front to stay out of its way.

### How did you verify your code works?

Three new tests in `test/js/bun/util/inspect.test.js`, each spawning a fixture:

- `skips a lazy property whose initializer throws and keeps walking`: unfixed debug build aborts with the fuzzer's assertion; unfixed release build prints `["write"]` instead of `["Archive","allocUnsafe","write"]`.
- `skips an inherited property whose Proxy get trap throws`: unfixed release build exits 139; with only the second hunk applied it prints `{ own: 0 }` without `second`.
- `stops walking at a Proxy whose getPrototypeOf trap throws`: unfixed release build exits 139; with only the first hunk applied, UBSan reports the null cell call.

I also built each hunk on its own to confirm the above split, and ran the fixtures under `BUN_JSC_validateExceptionChecks=1`. The original fuzzer script passes on a debug build when run after a script that replaces `Symbol`, which is the state leak between REPRL iterations that made the crash look flaky. `test/js/bun/util/inspect.test.js` passes in full with `bun bd test`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->