### PR TITLE
bun:test: print 'serializes to the same string' instead of an empty diff

### DIFF
--- a/src/runtime/test_runner/diff/printDiff.rs
+++ b/src/runtime/test_runner/diff/printDiff.rs
@@ -431,9 +431,7 @@ fn print_truncation_notice(
     Ok(())
 }
 
-/// The rendering is all unchanged context, so once it is longer than
-/// `truncate_threshold` only `chunk_context_lines` at each end are kept, the
-/// way `print_truncated_line` keeps `truncate_context` bytes at each end.
+/// Past `truncate_threshold` only `chunk_context_lines` at each end are kept.
 fn print_identical_rendering(
     rendering: &[u8],
     writer: &mut impl Write,

--- a/src/runtime/test_runner/diff/printDiff.rs
+++ b/src/runtime/test_runner/diff/printDiff.rs
@@ -58,6 +58,26 @@ pub(crate) fn print_diff_main(
         return Ok(());
     }
 
+    // The values compared unequal but render to the same text (distinct
+    // symbols, a hole vs an explicit undefined, ...), so a diff would be empty.
+    if received_slice == expected_slice {
+        match config.enable_ansi_colors {
+            true => write!(
+                writer,
+                "Expected: {GREEN}{}{RESET}\nReceived: serializes to the same string",
+                BStr::new(expected_slice),
+                GREEN = colors::GREEN,
+                RESET = colors::RESET,
+            )?,
+            false => write!(
+                writer,
+                "Expected: {}\nReceived: serializes to the same string",
+                BStr::new(expected_slice)
+            )?,
+        }
+        return Ok(());
+    }
+
     // check if the diffs are single-line
     if strings::index_of_char(received_slice, b'\n').is_none()
         && strings::index_of_char(expected_slice, b'\n').is_none()

--- a/src/runtime/test_runner/diff/printDiff.rs
+++ b/src/runtime/test_runner/diff/printDiff.rs
@@ -58,8 +58,7 @@ pub(crate) fn print_diff_main(
         return Ok(());
     }
 
-    // The values compared unequal but render to the same text (distinct
-    // symbols, a hole vs an explicit undefined, ...), so a diff would be empty.
+    // Unequal values can still render identically (distinct symbols, a hole vs undefined).
     if received_slice == expected_slice {
         print_line_prefix(writer, config, prefix_styles::SINGLE_LINE_REMOVED)?;
         for (i, line) in strings::split(expected_slice, b"\n").enumerate() {

--- a/src/runtime/test_runner/diff/printDiff.rs
+++ b/src/runtime/test_runner/diff/printDiff.rs
@@ -60,17 +60,7 @@ pub(crate) fn print_diff_main(
 
     // Unequal values can still render identically (distinct symbols, a hole vs undefined).
     if received_slice == expected_slice {
-        print_line_prefix(writer, config, prefix_styles::SINGLE_LINE_REMOVED)?;
-        for (i, line) in strings::split(expected_slice, b"\n").enumerate() {
-            if i > 0 {
-                writer.write_str("\n")?;
-            }
-            print_truncated_line(line, writer, config, styles::REMOVED_LINE)?;
-        }
-        writer.write_str("\n")?;
-        print_line_prefix(writer, config, prefix_styles::SINGLE_LINE_INSERTED)?;
-        writer.write_str("serializes to the same string")?;
-        return Ok(());
+        return print_identical_rendering(expected_slice, writer, config);
     }
 
     // check if the diffs are single-line
@@ -402,18 +392,15 @@ fn print_truncated_line(
         writer.write_str(colors::RESET)?;
     }
 
-    if config.enable_ansi_colors {
-        writer.write_str(colors::BRIGHT_WHITE)?; // preserve SGR 97
-    }
     // The context is shown on both sides, so we truncate line.len - 2 * context
-    write!(
+    print_truncation_notice(
         writer,
-        "... ({} bytes truncated) ...",
-        line.len() - 2 * config.truncate_context
+        config,
+        format_args!(
+            "... ({} bytes truncated) ...",
+            line.len() - 2 * config.truncate_context
+        ),
     )?;
-    if config.enable_ansi_colors {
-        writer.write_str(colors::RESET)?;
-    }
 
     if config.enable_ansi_colors {
         writer.write_str(style.text_color)?;
@@ -427,6 +414,61 @@ fn print_truncated_line(
         writer.write_str(colors::RESET)?;
     }
     Ok(())
+}
+
+fn print_truncation_notice(
+    writer: &mut impl Write,
+    config: &DiffConfig,
+    notice: std::fmt::Arguments<'_>,
+) -> std::fmt::Result {
+    if config.enable_ansi_colors {
+        writer.write_str(colors::BRIGHT_WHITE)?; // preserve SGR 97
+    }
+    writer.write_fmt(notice)?;
+    if config.enable_ansi_colors {
+        writer.write_str(colors::RESET)?;
+    }
+    Ok(())
+}
+
+/// The rendering is all unchanged context, so once it is longer than
+/// `truncate_threshold` only `chunk_context_lines` at each end are kept, the
+/// way `print_truncated_line` keeps `truncate_context` bytes at each end.
+fn print_identical_rendering(
+    rendering: &[u8],
+    writer: &mut impl Write,
+    config: &DiffConfig,
+) -> std::fmt::Result {
+    let line_count = strings::count_char(rendering, b'\n') + 1;
+    let context = config.chunk_context_lines;
+    let truncate = rendering.len() > config.truncate_threshold && line_count > 2 * context;
+    let truncated_lines = if truncate {
+        context..line_count - context
+    } else {
+        0..0
+    };
+
+    print_line_prefix(writer, config, prefix_styles::SINGLE_LINE_REMOVED)?;
+    for (i, line) in strings::split(rendering, b"\n").enumerate() {
+        if truncated_lines.contains(&i) {
+            if i == truncated_lines.start {
+                writer.write_str("\n")?;
+                print_truncation_notice(
+                    writer,
+                    config,
+                    format_args!("... ({} lines truncated) ...", truncated_lines.len()),
+                )?;
+            }
+            continue;
+        }
+        if i > 0 {
+            writer.write_str("\n")?;
+        }
+        print_truncated_line(line, writer, config, styles::REMOVED_LINE)?;
+    }
+    writer.write_str("\n")?;
+    print_line_prefix(writer, config, prefix_styles::SINGLE_LINE_INSERTED)?;
+    writer.write_str("serializes to the same string")
 }
 
 fn print_segment(

--- a/src/runtime/test_runner/diff/printDiff.rs
+++ b/src/runtime/test_runner/diff/printDiff.rs
@@ -61,20 +61,16 @@ pub(crate) fn print_diff_main(
     // The values compared unequal but render to the same text (distinct
     // symbols, a hole vs an explicit undefined, ...), so a diff would be empty.
     if received_slice == expected_slice {
-        match config.enable_ansi_colors {
-            true => write!(
-                writer,
-                "Expected: {GREEN}{}{RESET}\nReceived: serializes to the same string",
-                BStr::new(expected_slice),
-                GREEN = colors::GREEN,
-                RESET = colors::RESET,
-            )?,
-            false => write!(
-                writer,
-                "Expected: {}\nReceived: serializes to the same string",
-                BStr::new(expected_slice)
-            )?,
+        print_line_prefix(writer, config, prefix_styles::SINGLE_LINE_REMOVED)?;
+        for (i, line) in strings::split(expected_slice, b"\n").enumerate() {
+            if i > 0 {
+                writer.write_str("\n")?;
+            }
+            print_truncated_line(line, writer, config, styles::REMOVED_LINE)?;
         }
+        writer.write_str("\n")?;
+        print_line_prefix(writer, config, prefix_styles::SINGLE_LINE_INSERTED)?;
+        writer.write_str("serializes to the same string")?;
         return Ok(());
     }
 

--- a/test/js/bun/test/printing/diffexample-color.fixture.ts
+++ b/test/js/bun/test/printing/diffexample-color.fixture.ts
@@ -120,3 +120,10 @@ try {
 } catch (e) {
   console.log(e.message);
 }
+
+try {
+  const items = Array.from({ length: 600 }, (_, i) => i);
+  expect({ items, id: Symbol("a") }).toEqual({ items, id: Symbol("a") });
+} catch (e) {
+  console.log(e.message);
+}

--- a/test/js/bun/test/printing/diffexample-color.fixture.ts
+++ b/test/js/bun/test/printing/diffexample-color.fixture.ts
@@ -107,3 +107,16 @@ try {
 } catch (e) {
   console.log(e.message);
 }
+
+// Unequal values that render to the same text: single-line and multi-line.
+try {
+  expect(Symbol("a")).toEqual(Symbol("a"));
+} catch (e) {
+  console.log(e.message);
+}
+
+try {
+  expect([1, , 3]).toStrictEqual([1, undefined, 3]);
+} catch (e) {
+  console.log(e.message);
+}

--- a/test/js/bun/test/printing/diffexample.fixture.ts
+++ b/test/js/bun/test/printing/diffexample.fixture.ts
@@ -379,3 +379,8 @@ test("serializes to the same string - toHaveBeenCalledWith", () => {
 test("serializes to the same string - toHaveProperty", () => {
   expect({ id: Symbol("a") }).toHaveProperty("id", Symbol("a"));
 });
+
+test("serializes to the same string - long line is truncated", () => {
+  const description = Buffer.alloc(3000, "a").toString();
+  expect(Symbol(description)).toEqual(Symbol(description));
+});

--- a/test/js/bun/test/printing/diffexample.fixture.ts
+++ b/test/js/bun/test/printing/diffexample.fixture.ts
@@ -389,3 +389,8 @@ test("serializes to the same string - long rendering keeps only the first and la
   const items = Array.from({ length: 600 }, (_, i) => i);
   expect({ items, id: Symbol("a") }).toEqual({ items, id: Symbol("a") });
 });
+
+test("serializes to the same string - short multi-line rendering is printed in full", () => {
+  const items = Array.from({ length: 10 }, (_, i) => i);
+  expect({ items, id: Symbol("a") }).toEqual({ items, id: Symbol("a") });
+});

--- a/test/js/bun/test/printing/diffexample.fixture.ts
+++ b/test/js/bun/test/printing/diffexample.fixture.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "bun:test";
+import { test, expect, mock } from "bun:test";
 
 function normalizeInspectError(e: any) {
   let str = Bun.inspect(e, { colors: true });
@@ -354,4 +354,28 @@ test.skipIf(!Bun.enableANSIColors)("mix of whitespace-only and non-whitespace-on
       "
     `);
   }
+});
+
+// Values that compare unequal but render to the same text. The diff would be
+// empty, so the message says so instead.
+test("serializes to the same string - toStrictEqual, hole vs undefined", () => {
+  expect([1, , 3]).toStrictEqual([1, undefined, 3]);
+});
+
+test("serializes to the same string - toEqual, single line", () => {
+  expect(Symbol("a")).toEqual(Symbol("a"));
+});
+
+test("serializes to the same string - toMatchObject", () => {
+  expect({ id: Symbol("a") }).toMatchObject({ id: Symbol("a") });
+});
+
+test("serializes to the same string - toHaveBeenCalledWith", () => {
+  const fn = mock();
+  fn(Symbol("a"));
+  expect(fn).toHaveBeenCalledWith(Symbol("a"));
+});
+
+test("serializes to the same string - toHaveProperty", () => {
+  expect({ id: Symbol("a") }).toHaveProperty("id", Symbol("a"));
 });

--- a/test/js/bun/test/printing/diffexample.fixture.ts
+++ b/test/js/bun/test/printing/diffexample.fixture.ts
@@ -384,3 +384,8 @@ test("serializes to the same string - long line is truncated", () => {
   const description = Buffer.alloc(3000, "a").toString();
   expect(Symbol(description)).toEqual(Symbol(description));
 });
+
+test("serializes to the same string - long rendering keeps only the first and last lines", () => {
+  const items = Array.from({ length: 600 }, (_, i) => i);
+  expect({ items, id: Symbol("a") }).toEqual({ items, id: Symbol("a") });
+});

--- a/test/js/bun/test/printing/diffexample.test.ts
+++ b/test/js/bun/test/printing/diffexample.test.ts
@@ -3,7 +3,7 @@ import { bunEnv, bunExe } from "harness";
 
 function cleanOutput(output: string) {
   return output
-    .replaceAll(/ \[[0-9\.]+ms\]/g, "")
+    .replaceAll(/ \[[0-9\.]+m?s\]/g, "")
     .replaceAll(/at <anonymous> \(.*\)/g, "at <anonymous> (FILE:LINE)")
     .replaceAll(
       "test\\js\\bun\\test\\printing\\diffexample.fixture.ts:",
@@ -16,6 +16,16 @@ function cleanAnsiEscapes(output: string) {
 
 test("no color", async () => {
   const noColorSpawn = Bun.spawn({
+    cmd: [bunExe(), "test", import.meta.dir + "/diffexample.fixture.ts"],
+    stdio: ["inherit", "pipe", "pipe"],
+    env: {
+      ...bunEnv,
+      FORCE_COLOR: "0",
+    },
+  });
+  // Started before the first run is awaited: two sequential runs of the
+  // fixture exceed the default test timeout with a debug build.
+  const colorSpawn = Bun.spawn({
     cmd: [bunExe(), "test", import.meta.dir + "/diffexample.fixture.ts"],
     stdio: ["inherit", "pipe", "pipe"],
     env: {
@@ -714,25 +724,95 @@ test("no color", async () => {
           at <anonymous> (FILE:LINE)
     (fail) mix of whitespace-only and non-whitespace-only differences
     (skip) mix of whitespace-only and non-whitespace-only differences (ANSI)
+    357 | });
+    358 | 
+    359 | // Values that compare unequal but render to the same text. The diff would be
+    360 | // empty, so the message says so instead.
+    361 | test("serializes to the same string - toStrictEqual, hole vs undefined", () => {
+    362 |   expect([1, , 3]).toStrictEqual([1, undefined, 3]);
+                             ^
+    error: expect(received).toStrictEqual(expected)
+
+    Expected: [
+      1,
+      undefined,
+      3,
+    ]
+    Received: serializes to the same string
+
+          at <anonymous> (FILE:LINE)
+    (fail) serializes to the same string - toStrictEqual, hole vs undefined
+    361 | test("serializes to the same string - toStrictEqual, hole vs undefined", () => {
+    362 |   expect([1, , 3]).toStrictEqual([1, undefined, 3]);
+    363 | });
+    364 | 
+    365 | test("serializes to the same string - toEqual, single line", () => {
+    366 |   expect(Symbol("a")).toEqual(Symbol("a"));
+                                ^
+    error: expect(received).toEqual(expected)
+
+    Expected: Symbol(a)
+    Received: serializes to the same string
+
+          at <anonymous> (FILE:LINE)
+    (fail) serializes to the same string - toEqual, single line
+    365 | test("serializes to the same string - toEqual, single line", () => {
+    366 |   expect(Symbol("a")).toEqual(Symbol("a"));
+    367 | });
+    368 | 
+    369 | test("serializes to the same string - toMatchObject", () => {
+    370 |   expect({ id: Symbol("a") }).toMatchObject({ id: Symbol("a") });
+                                        ^
+    error: expect(received).toMatchObject(expected)
+
+    Expected: {
+      "id": Symbol(a),
+    }
+    Received: serializes to the same string
+
+          at <anonymous> (FILE:LINE)
+    (fail) serializes to the same string - toMatchObject
+    371 | });
+    372 | 
+    373 | test("serializes to the same string - toHaveBeenCalledWith", () => {
+    374 |   const fn = mock();
+    375 |   fn(Symbol("a"));
+    376 |   expect(fn).toHaveBeenCalledWith(Symbol("a"));
+                       ^
+    error: expect(received).toHaveBeenCalledWith(...expected)
+
+    Expected: [
+      Symbol(a),
+    ]
+    Received: serializes to the same string
+
+          at <anonymous> (FILE:LINE)
+    (fail) serializes to the same string - toHaveBeenCalledWith
+    375 |   fn(Symbol("a"));
+    376 |   expect(fn).toHaveBeenCalledWith(Symbol("a"));
+    377 | });
+    378 | 
+    379 | test("serializes to the same string - toHaveProperty", () => {
+    380 |   expect({ id: Symbol("a") }).toHaveProperty("id", Symbol("a"));
+                                        ^
+    error: expect(received).toHaveProperty(path, value)
+
+    Expected: Symbol(a)
+    Received: serializes to the same string
+
+          at <anonymous> (FILE:LINE)
+    (fail) serializes to the same string - toHaveProperty
 
      0 pass
      2 skip
      1 todo
-     16 fail
-     16 expect() calls
-    Ran 19 tests across 1 file.
+     21 fail
+     21 expect() calls
+    Ran 24 tests across 1 file.
     "
   `);
   expect(noColorSpawn.exitCode).toBe(1);
 
-  const colorSpawn = Bun.spawn({
-    cmd: [bunExe(), "test", import.meta.dir + "/diffexample.fixture.ts"],
-    stdio: ["inherit", "pipe", "pipe"],
-    env: {
-      ...bunEnv,
-      FORCE_COLOR: "0",
-    },
-  });
   await colorSpawn.exited;
   const colorStderr = cleanOutput(cleanAnsiEscapes(await colorSpawn.stderr.text()));
   const colorStdout = cleanAnsiEscapes(await colorSpawn.stdout.text());
@@ -877,6 +957,20 @@ test("color", async () => {
 
     \x1B[32m- Expected  - 1\x1B[0m
     \x1B[31m+ Received  + 1\x1B[0m
+
+    \x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoEqual\x1B[2m(\x1B[0m\x1B[32mexpected\x1B[0m\x1B[2m)\x1B[0m
+
+    Expected: \x1B[32mSymbol(a)\x1B[0m
+    Received: serializes to the same string
+
+    \x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoStrictEqual\x1B[2m(\x1B[0m\x1B[32mexpected\x1B[0m\x1B[2m)\x1B[0m
+
+    Expected: \x1B[32m[
+      1,
+      undefined,
+      3,
+    ]\x1B[0m
+    Received: serializes to the same string
 
     "
   `);

--- a/test/js/bun/test/printing/diffexample.test.ts
+++ b/test/js/bun/test/printing/diffexample.test.ts
@@ -10,10 +10,6 @@ function cleanOutput(output: string) {
       "test/js/bun/test/printing/diffexample.fixture.ts:",
     );
 }
-function cleanAnsiEscapes(output: string) {
-  return output.replaceAll(/\x1B\[[0-9;]*m/g, "");
-}
-
 test("no color", async () => {
   const noColorSpawn = Bun.spawn({
     cmd: [bunExe(), "test", import.meta.dir + "/diffexample.fixture.ts"],
@@ -23,19 +19,8 @@ test("no color", async () => {
       FORCE_COLOR: "0",
     },
   });
-  // Started before the first run is awaited: two sequential runs of the
-  // fixture exceed the default test timeout with a debug build.
-  const colorSpawn = Bun.spawn({
-    cmd: [bunExe(), "test", import.meta.dir + "/diffexample.fixture.ts"],
-    stdio: ["inherit", "pipe", "pipe"],
-    env: {
-      ...bunEnv,
-      FORCE_COLOR: "0",
-    },
-  });
   await noColorSpawn.exited;
   const noColorStderr = cleanOutput(await noColorSpawn.stderr.text());
-  const noColorStdout = await noColorSpawn.stdout.text();
   expect(noColorStderr).toMatchInlineSnapshot(`
     "
     test/js/bun/test/printing/diffexample.fixture.ts:
@@ -816,31 +801,41 @@ test("no color", async () => {
 
           at <anonymous> (FILE:LINE)
     (fail) serializes to the same string - long line is truncated
+    385 |   expect(Symbol(description)).toEqual(Symbol(description));
+    386 | });
+    387 | 
+    388 | test("serializes to the same string - long rendering keeps only the first and last lines", () => {
+    389 |   const items = Array.from({ length: 600 }, (_, i) => i);
+    390 |   expect({ items, id: Symbol("a") }).toEqual({ items, id: Symbol("a") });
+                                               ^
+    error: expect(received).toEqual(expected)
+
+    Expected: {
+      "id": Symbol(a),
+      "items": [
+        0,
+        1,
+    ... (595 lines truncated) ...
+        597,
+        598,
+        599,
+      ],
+    }
+    Received: serializes to the same string
+
+          at <anonymous> (FILE:LINE)
+    (fail) serializes to the same string - long rendering keeps only the first and last lines
 
      0 pass
      2 skip
      1 todo
-     22 fail
-     22 expect() calls
-    Ran 25 tests across 1 file.
+     23 fail
+     23 expect() calls
+    Ran 26 tests across 1 file.
     "
   `);
   expect(noColorSpawn.exitCode).toBe(1);
-
-  await colorSpawn.exited;
-  const colorStderr = cleanOutput(cleanAnsiEscapes(await colorSpawn.stderr.text()));
-  const colorStdout = cleanAnsiEscapes(await colorSpawn.stdout.text());
-  expect(colorStderr).toEqual(noColorStderr);
-  expect(colorStdout).toEqual(noColorStdout);
 });
-
-function getDiffPart(stderr: string): string {
-  stderr = stderr.split("a\\nd\\nc\\nd\\ne")[1];
-  const split = stderr.split("\n\n");
-  split.pop();
-  stderr = split.join("\n\n");
-  return stderr;
-}
 
 test("color", async () => {
   const spawn = Bun.spawn({
@@ -984,6 +979,21 @@ test("color", async () => {
     \x1B[32m  undefined,\x1B[0m
     \x1B[32m  3,\x1B[0m
     \x1B[32m]\x1B[0m
+    Received: \x1B[0mserializes to the same string
+
+    \x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoEqual\x1B[2m(\x1B[0m\x1B[32mexpected\x1B[0m\x1B[2m)\x1B[0m
+
+    Expected: \x1B[0m\x1B[32m{\x1B[0m
+    \x1B[32m  "id": Symbol(a),\x1B[0m
+    \x1B[32m  "items": [\x1B[0m
+    \x1B[32m    0,\x1B[0m
+    \x1B[32m    1,\x1B[0m
+    \x1B[97m... (595 lines truncated) ...\x1B[0m
+    \x1B[32m    597,\x1B[0m
+    \x1B[32m    598,\x1B[0m
+    \x1B[32m    599,\x1B[0m
+    \x1B[32m  ],\x1B[0m
+    \x1B[32m}\x1B[0m
     Received: \x1B[0mserializes to the same string
 
     "

--- a/test/js/bun/test/printing/diffexample.test.ts
+++ b/test/js/bun/test/printing/diffexample.test.ts
@@ -825,13 +825,41 @@ test("no color", async () => {
 
           at <anonymous> (FILE:LINE)
     (fail) serializes to the same string - long rendering keeps only the first and last lines
+    390 |   expect({ items, id: Symbol("a") }).toEqual({ items, id: Symbol("a") });
+    391 | });
+    392 | 
+    393 | test("serializes to the same string - short multi-line rendering is printed in full", () => {
+    394 |   const items = Array.from({ length: 10 }, (_, i) => i);
+    395 |   expect({ items, id: Symbol("a") }).toEqual({ items, id: Symbol("a") });
+                                               ^
+    error: expect(received).toEqual(expected)
+
+    Expected: {
+      "id": Symbol(a),
+      "items": [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6,
+        7,
+        8,
+        9,
+      ],
+    }
+    Received: serializes to the same string
+
+          at <anonymous> (FILE:LINE)
+    (fail) serializes to the same string - short multi-line rendering is printed in full
 
      0 pass
      2 skip
      1 todo
-     23 fail
-     23 expect() calls
-    Ran 26 tests across 1 file.
+     24 fail
+     24 expect() calls
+    Ran 27 tests across 1 file.
     "
   `);
   expect(noColorSpawn.exitCode).toBe(1);

--- a/test/js/bun/test/printing/diffexample.test.ts
+++ b/test/js/bun/test/printing/diffexample.test.ts
@@ -802,13 +802,27 @@ test("no color", async () => {
 
           at <anonymous> (FILE:LINE)
     (fail) serializes to the same string - toHaveProperty
+    380 |   expect({ id: Symbol("a") }).toHaveProperty("id", Symbol("a"));
+    381 | });
+    382 | 
+    383 | test("serializes to the same string - long line is truncated", () => {
+    384 |   const description = Buffer.alloc(3000, "a").toString();
+    385 |   expect(Symbol(description)).toEqual(Symbol(description));
+                                        ^
+    error: expect(received).toEqual(expected)
+
+    Expected: Symbol(aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... (2808 bytes truncated) ...aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa)
+    Received: serializes to the same string
+
+          at <anonymous> (FILE:LINE)
+    (fail) serializes to the same string - long line is truncated
 
      0 pass
      2 skip
      1 todo
-     21 fail
-     21 expect() calls
-    Ran 24 tests across 1 file.
+     22 fail
+     22 expect() calls
+    Ran 25 tests across 1 file.
     "
   `);
   expect(noColorSpawn.exitCode).toBe(1);
@@ -960,17 +974,17 @@ test("color", async () => {
 
     \x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoEqual\x1B[2m(\x1B[0m\x1B[32mexpected\x1B[0m\x1B[2m)\x1B[0m
 
-    Expected: \x1B[32mSymbol(a)\x1B[0m
-    Received: serializes to the same string
+    Expected: \x1B[0m\x1B[32mSymbol(a)\x1B[0m
+    Received: \x1B[0mserializes to the same string
 
     \x1B[2mexpect(\x1B[0m\x1B[31mreceived\x1B[0m\x1B[2m).\x1B[0mtoStrictEqual\x1B[2m(\x1B[0m\x1B[32mexpected\x1B[0m\x1B[2m)\x1B[0m
 
-    Expected: \x1B[32m[
-      1,
-      undefined,
-      3,
-    ]\x1B[0m
-    Received: serializes to the same string
+    Expected: \x1B[0m\x1B[32m[\x1B[0m
+    \x1B[32m  1,\x1B[0m
+    \x1B[32m  undefined,\x1B[0m
+    \x1B[32m  3,\x1B[0m
+    \x1B[32m]\x1B[0m
+    Received: \x1B[0mserializes to the same string
 
     "
   `);


### PR DESCRIPTION
### Problem
- When `toEqual`, `toStrictEqual`, `toMatchObject`, `toHaveBeenCalledWith`, `toHaveProperty(path, value)` or another diff-rendering matcher fails on two values that pretty-print to the same text, the message is an empty diff: `expect([1, , 3]).toStrictEqual([1, undefined, 3])` prints the value once, then `- Expected  - 0` / `+ Received  + 0`.
- Single-line values print the same text twice (`Expected: Symbol(a)` / `Received: Symbol(a)`). Past the 2 KiB chunking threshold every line is elided as context and only the `- 0` / `+ 0` footer is left.
- Cause: the printer diffs the two renderings without checking whether they are identical, so any difference the formatter does not show (a hole vs `undefined`, two distinct symbols, two functions) comes out as an empty diff.

### Fix
- Before diffing, the shared printer checks whether the two rendered sides are byte-identical and, if so, prints `Expected: <value>` then `Received: serializes to the same string`. Same wording `toBe` already uses, and what jest prints when its diff shows nothing.
- Property to check: the check sits in the one printer every diff-rendering matcher uses, after the `.not` branch, so `Expected: not ...` is unchanged; `toBe` and `toHaveReturnedWith` only reach it for two strings and are left alone. Pass or fail does not change, only the message.
- The printed value is bounded like the printer's existing context: long lines are truncated per line, and past 2 KiB only a few lines at each end are kept around a `... (N lines truncated) ...` notice. Making the formatter show the differences themselves (holes, the `URL` case in #7253 and #36645) is separate work.
- Verification: the printer's snapshot test gains eight plain and three colored failing cases, including both truncation paths and a short value that must print in full; without the printer change only the new snapshot blocks fail. The test also strips `s` as well as `ms` run times and drops a second fixture run that compared output with itself.

### Background
- Diff printer: when an equality-style matcher fails, bun:test pretty-prints both values with the console formatter and hands the two strings to one shared printer, which emits the `Expected` / `Received` line diff. Matchers do not build these messages themselves.
- The formatter distinguishes less than equality does: an array hole and `undefined`, or two different `Symbol("a")` values, render to identical text even though the matcher rejects them.
- Context bounding: the printer truncates long lines to a few bytes at each end, and once the rendering passes a 2 KiB threshold it prints only a few lines around each changed hunk. With no hunks, nothing was printed.
- Snapshot test: a fixture file is run under `bun test` and its whole stderr (plain and ANSI) is compared with an inline snapshot, so each new case is one more block in the snapshot.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/printing/diffexample.test.ts
bun test v1.4.0 (faa493cd6)

test/js/bun/test/printing/diffexample.test.ts:
19 |       FORCE_COLOR: "0",
20 |     },
21 |   });
22 |   await noColorSpawn.exited;
23 |   const noColorStderr = cleanOutput(await noColorSpawn.stderr.text());
24 |   expect(noColorStderr).toMatchInlineSnapshot(`
                             ^
error: expect(received).toMatchInlineSnapshot(expected)

@@ -693,16 +693,18 @@
  361 | test("serializes to the same string - toStrictEqual, hole vs undefined", () => {
  362 |   expect([1, , 3]).toStrictEqual([1, undefined, 3]);
                           ^
  error: expect(received).toStrictEqual(expected)
  
- Expected: [
-   1,
-   undefined,
-   3,
- ]
- Received: serializes to the same string
+   [
+     1,
+     undefined,
+     3,
+   ]
+ 
+ - Expected  - 0
+ + Received  + 0
  
        at <anonymous> (FILE:LINE)
  (fail) serializes to the same string - toStrictEqual, hole vs undefined
  361 | test("serializes to the same string - toStrictEqual, hole vs undefined", () =
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/bun/test/printing/diffexample.test.ts:
19 |       FORCE_COLOR: "0",
20 |     },
21 |   });
22 |   await noColorSpawn.exited;
23 |   const noColorStderr = cleanOutput(await noColorSpawn.stderr.text());
24 |   expect(noColorStderr).toMatchInlineSnapshot(`
                             ^
error: expect(received).toMatchInlineSnapshot(expected)

@@ -693,16 +693,18 @@
  361 | test("serializes to the same string - toStrictEqual, hole vs undefined", () => {
  362 |   expect([1, , 3]).toStrictEqual([1, undefined, 3]);
                           ^
  error: expect(received).toStrictEqual(expected)
  
- Expected: [
-   1,
-   undefined,
-   3,
- ]
- Received: serializes to the same string
+   [
+     1,
+     undefined,
+     3,
+   ]
+ 
+ - Expected  - 0
+ + Received  + 0
  
        at <anonymous> (FILE:LINE)
  (fail) serializes to the same string - toStrictEqual, hole vs undefined
  361 | test("serializes to the same string - toStrictEqual, hole vs undefined", () => {
  362 |   expect([1, , 3]).toStrictEqual([1, undefined, 3]);
@@ -712,11 +714,11 @@
  366 |   expect(Symbol("a")).toEqual(Symbol("a"));
                              ^
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/printing/diffexample.test.ts
bun test v1.4.0 (faa493cd6)

test/js/bun/test/printing/diffexample.test.ts:
(pass) no color [2554.50ms]
(pass) color [1620.47ms]

 2 pass
 0 fail
 3 snapshots, 5 expect() calls
Ran 2 tests across 1 file. [6.75s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 977ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/144] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[2/144] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/144] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspa
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/test_runner/diff/printDiff.rs          |  73 +++++++-
 .../bun/test/printing/diffexample-color.fixture.ts |  20 ++
 test/js/bun/test/printing/diffexample.fixture.ts   |  41 +++-
 test/js/bun/test/printing/diffexample.test.ts      | 208 ++++++++++++++++++---
 4 files changed, 301 insertions(+), 41 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/runtime/test_runner/diff/printDiff.rs                   7      9      0
test/js/bun/test/printing/diffexample-color.fixture.ts      1      1      0
test/js/bun/test/printing/diffexample.fixture.ts            1      1      0
test/js/bun/test/printing/diffexample.test.ts               5      5      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

When `toEqual`, `toStrictEqual`, `toMatchObject`, `toHaveBeenCalledWith`, `toHaveProperty(path, value)` and the other matchers that render a diff fail on two values that pretty-print to the same text, the failure message is a diff with nothing in it:

```ts
import { expect, test } from "bun:test";
test("hole vs undefined", () => {
  expect([1, , 3]).toStrictEqual([1, undefined, 3]);
});
```

```
error: expect(received).toStrictEqual(expected)

  [
    1,
    undefined,
    3,
  ]

- Expected  - 0
+ Received  + 0
```

Single-line values print the same text twice (`Expected: Symbol(a)` / `Received: Symbol(a)`), and once the rendered value is larger than the chunking threshold (2 KiB) every line is elided as unchanged context, so the message is just the `- 0` / `+ 0` footer. Any pair of values whose difference the formatter does not show ends up here: a hole vs an explicit `undefined`, two distinct symbols, two functions, etc.

### Fix

`print_diff_main` (`src/runtime/test_runner/diff/printDiff.rs`) now checks whether the two rendered sides are byte-identical before diffing them, and prints

```
Expected: [
  1,
  undefined,
  3,
]
Received: serializes to the same string
```

instead. The check sits after the `.not` branch, which keeps printing `Expected: not ...` as before. The value is all unchanged context, so it is bounded the way the rest of the printer bounds context: each line goes through `print_truncated_line`, and once the whole rendering is longer than `truncate_threshold` (2 KiB) only `chunk_context_lines` at each end are printed around a `... (N lines truncated) ...` notice, which reuses the rendering of the existing per-line `... (N bytes truncated) ...` notice. Before this change such a value printed either in full (under the chunking threshold) or not at all. The `.not` branch prints its value unbounded as before; that is pre-existing and left alone here. The wording is the one `toBe` already uses for the same situation, and it is also what jest prints: `printDiffOrStringify` falls back to `Received: serializes to the same string` whenever `jest-diff` reports no visual difference. Putting the check in the shared diff printer means every matcher that renders a diff gets the same message. `toBe` and the `toHaveReturnedWith` family only use the diff printer for two strings; for other values they print `Expected:` / `Received:` through the console formatter (`toBe` with its own deep-equality hint), and they are intentionally unchanged here.

This does not change what the matchers accept or reject, only the message printed for a failure that was already being reported. Making the formatter show the differences themselves (array holes, the fields of a `URL` as in #7253, which currently prints `{}` on both sides and then this empty diff) is separate formatter work; #36645 covers the `URL` case. This PR only makes sure the message says something useful whenever the two renderings end up identical.

### Tests

`test/js/bun/test/printing/diffexample.test.ts` is the snapshot test for this printer. The fixture gains eight failing cases (`toStrictEqual` with a hole vs `undefined`, `toEqual` on a single-line value, `toMatchObject`, `toHaveBeenCalledWith`, `toHaveProperty`, a 3000 byte symbol description for the per-line truncation, a 605-line object for the line truncation, and a 15-line object under the size threshold that must print in full), and the color fixture gains a single-line, a multi-line and a truncated case, so both the plain and the ANSI rendering are snapshotted. The pre-existing `not` case in the fixture covers the ordering with `.not`, and the pre-existing long-string case covers the shared notice helper. Without the `printDiff.rs` change, the only snapshot hunks that fail are the new blocks.

Two changes to the outer test itself. The run-time suffix is now stripped whether it is printed in `ms` or `s`: with a debug build one run of the fixture takes about 2.5s and the summary switches to seconds after 1.5s, which made the snapshot fail locally. And the test used to run the fixture a second time with the same environment and compare that output with the first run, which could not fail; that run is removed together with the `cleanAnsiEscapes` helper it used and the unused `getDiffPart` helper. Colored output is covered by the separate `color` test.

</details>
