### PR TITLE
bake: evaluate failed modules again when a module they import is hot-updated

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -82,8 +82,9 @@ export class HMRModule {
   /** For ESM, this is the converted CJS exports.
    *  For CJS, this is the `module` object. */
   cjs: CJSModule | any | null;
-  /** When a module fails to load, trying to load it again
-   *  should throw the same error */
+  /** When a module fails to load, trying to load it again should throw the
+   *  same error, until a hot update replaces it or a module it imports
+   *  (`replaceModules` then has it evaluated again). */
   failure: unknown = null;
   /** Two purposes:
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
@@ -332,6 +333,10 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     }
     const { [ESMProps.imports]: deps, [ESMProps.load]: load, [ESMProps.isAsync]: isAsync } = loadOrEsmModule;
     if (isAsync) {
+      // `mod` is only set here if it was stale. Put it back: a refused
+      // require() does not evaluate it, and a Pending module would be handed
+      // out as-is by the next load.
+      if (mod) mod.state = State.Stale;
       throw new AsyncImportError(id);
     }
     if (!mod) {
@@ -619,7 +624,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   const toDispose: HMRModule[] = [];
 
   // Discover all HMR boundaries
-  outer: for (const key of Object.keys(modules)) {
+  for (const key of Object.keys(modules)) {
     // Unref old source maps, and track new ones
     if (side === "client") {
       DEBUG.ASSERT(sourceMapId);
@@ -641,9 +646,22 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
       const mod = queue.shift();
       if (!mod) break;
 
-      // Stop propagation if the module is self-accepting
       let hadSelfAccept = true;
-      if (mod.selfAccept) {
+      if (mod.state === State.Error) {
+        // A failed evaluation left no import bindings to patch, and nothing it
+        // registered can accept the update: the module is evaluated again by
+        // its next load (for a replaced module, the reload below). Not doing
+        // that here reports a repeated failure to whatever loads the module,
+        // and does not evaluate it while a replaced dependency with top-level
+        // await is still loading. Its importers failed along with it, so the
+        // walk continues through it.
+        mod.state = State.Stale;
+        mod.failure = null;
+        mod.selfAccept = null;
+        mod.depAccepts = null;
+      }
+      // Stop propagation if the module is self-accepting
+      else if (mod.selfAccept) {
         toReload.add(mod);
         visited.add(mod);
         hadSelfAccept = false;
@@ -662,15 +680,18 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         }
       }
 
-      // All importers will be visited
+      // A root that does not accept the update. The rest of the queue is still
+      // walked: the boundaries and failed modules behind the other importers
+      // are needed by the server, which applies the update regardless.
       if (hadSelfAccept && mod.importers.size === 0) {
         failures ??= new Set();
         failures.add(key);
-        continue outer;
       }
 
       for (const importer of mod.importers) {
-        const cb = importer.depAccepts?.[key];
+        // A failed importer is queued to be evaluated again (above) rather
+        // than asked to accept the update.
+        const cb = importer.state === State.Error ? null : importer.depAccepts?.[key];
         if (cb) {
           toAccept.push({ cb, key });
         } else if (hadSelfAccept) {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -275,7 +275,11 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
   // First, try and re-use an existing module.
   let mod = registry.get(id);
   if (mod) {
-    if (mod.state === State.Error) throw mod.failure;
+    if (mod.state === State.Error) {
+      // The importer fails too; `replaceModules` only finds it through `importers` once this module is replaced.
+      if (importer) mod.importers.add(importer);
+      throw mod.failure;
+    }
     if (mod.state === State.Stale) {
       mod.state = State.Pending;
       isUserDynamic = false;
@@ -374,7 +378,11 @@ export function loadModuleAsync<IsUserDynamic extends boolean>(
   let mod = registry.get(id)!;
   if (mod) {
     const { state } = mod;
-    if (state === State.Error) throw mod.failure;
+    if (state === State.Error) {
+      // Same as in loadModuleSync: the importer has to be reachable from here when this module is replaced.
+      if (importer) mod.importers.add(importer);
+      throw mod.failure;
+    }
     if (state === State.Stale) {
       mod.state = State.Pending;
       isUserDynamic = false as IsUserDynamic;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -82,9 +82,8 @@ export class HMRModule {
   /** For ESM, this is the converted CJS exports.
    *  For CJS, this is the `module` object. */
   cjs: CJSModule | any | null;
-  /** When a module fails to load, trying to load it again should throw the
-   *  same error, until a hot update reaches it (see `replaceModules`) and has
-   *  it evaluated again. */
+  /** Loading a module that failed to load rethrows this, until a hot update
+   *  has it evaluated again. */
   failure: unknown = null;
   /** Two purposes:
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
@@ -333,9 +332,7 @@ export function loadModuleSync(id: Id, isUserDynamic: boolean, importer: HMRModu
     }
     const { [ESMProps.imports]: deps, [ESMProps.load]: load, [ESMProps.isAsync]: isAsync } = loadOrEsmModule;
     if (isAsync) {
-      // `mod` is only set here if it was stale. Put it back: a refused
-      // require() does not evaluate it, and a Pending module would be handed
-      // out as-is by the next load.
+      // Only set when it was stale; refusing it must not leave it Pending.
       if (mod) mod.state = State.Stale;
       throw new AsyncImportError(id);
     }
@@ -666,21 +663,16 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
           toDispose.push(mod);
         }
       }
-      // A module that failed to evaluate has no import bindings to patch, so
-      // it is evaluated again by its next load (a replaced module: the reload
-      // below). Leaving that to the next load reports a repeated failure to
-      // whatever loads the module, and does not evaluate it while a replaced
-      // dependency with top-level await is still loading. Its importers failed
-      // along with it, so the walk continues through it like through any
-      // other module that does not accept the update.
+      // A module that failed to evaluate has no bindings to patch: its next
+      // load evaluates it again and reports any new failure (a replaced module
+      // is reloaded below). Its importers failed with it, so the walk goes on.
       else if (mod.state === State.Error) {
         mod.state = State.Stale;
         mod.failure = null;
       }
 
       // A root that does not accept the update. The rest of the queue is still
-      // walked: the boundaries and failed modules behind the other importers
-      // are needed by the server, which applies the update regardless.
+      // walked; the server applies the update regardless and needs all of it.
       if (hadSelfAccept && mod.importers.size === 0) {
         failures ??= new Set();
         failures.add(key);

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -662,8 +662,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
           toDispose.push(mod);
         }
       }
-      // Nothing to patch in a module that failed to evaluate: its next load evaluates it again.
-      // Its importers failed along with it, so the walk continues through it.
+      // Nothing to patch in a failed module: its next load evaluates it again. Its importers failed with it.
       else if (mod.state === State.Error) {
         mod.state = State.Stale;
         mod.failure = null;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -82,8 +82,7 @@ export class HMRModule {
   /** For ESM, this is the converted CJS exports.
    *  For CJS, this is the `module` object. */
   cjs: CJSModule | any | null;
-  /** Loading a module that failed to load rethrows this, until a hot update
-   *  has it evaluated again. */
+  /** Rethrown by later loads, until a hot update has the module evaluated again */
   failure: unknown = null;
   /** Two purposes:
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
@@ -663,16 +662,14 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
           toDispose.push(mod);
         }
       }
-      // A module that failed to evaluate has no bindings to patch: its next
-      // load evaluates it again and reports any new failure (a replaced module
-      // is reloaded below). Its importers failed with it, so the walk goes on.
+      // Nothing to patch in a module that failed to evaluate: its next load evaluates it again.
+      // Its importers failed along with it, so the walk continues through it.
       else if (mod.state === State.Error) {
         mod.state = State.Stale;
         mod.failure = null;
       }
 
-      // A root that does not accept the update. The rest of the queue is still
-      // walked; the server applies the update regardless and needs all of it.
+      // Root that does not accept the update. The server applies it regardless, so keep walking.
       if (hadSelfAccept && mod.importers.size === 0) {
         failures ??= new Set();
         failures.add(key);

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -83,8 +83,8 @@ export class HMRModule {
    *  For CJS, this is the `module` object. */
   cjs: CJSModule | any | null;
   /** When a module fails to load, trying to load it again should throw the
-   *  same error, until a hot update replaces it or a module it imports
-   *  (`replaceModules` then has it evaluated again). */
+   *  same error, until a hot update reaches it (see `replaceModules`) and has
+   *  it evaluated again. */
   failure: unknown = null;
   /** Two purposes:
    * 1. HMRModule[] - List of parsed imports. indexOf is used to go from HMRModule -> updater function
@@ -646,22 +646,9 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
       const mod = queue.shift();
       if (!mod) break;
 
-      let hadSelfAccept = true;
-      if (mod.state === State.Error) {
-        // A failed evaluation left no import bindings to patch, and nothing it
-        // registered can accept the update: the module is evaluated again by
-        // its next load (for a replaced module, the reload below). Not doing
-        // that here reports a repeated failure to whatever loads the module,
-        // and does not evaluate it while a replaced dependency with top-level
-        // await is still loading. Its importers failed along with it, so the
-        // walk continues through it.
-        mod.state = State.Stale;
-        mod.failure = null;
-        mod.selfAccept = null;
-        mod.depAccepts = null;
-      }
       // Stop propagation if the module is self-accepting
-      else if (mod.selfAccept) {
+      let hadSelfAccept = true;
+      if (mod.selfAccept) {
         toReload.add(mod);
         visited.add(mod);
         hadSelfAccept = false;
@@ -679,6 +666,17 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
           toDispose.push(mod);
         }
       }
+      // A module that failed to evaluate has no import bindings to patch, so
+      // it is evaluated again by its next load (a replaced module: the reload
+      // below). Leaving that to the next load reports a repeated failure to
+      // whatever loads the module, and does not evaluate it while a replaced
+      // dependency with top-level await is still loading. Its importers failed
+      // along with it, so the walk continues through it like through any
+      // other module that does not accept the update.
+      else if (mod.state === State.Error) {
+        mod.state = State.Stale;
+        mod.failure = null;
+      }
 
       // A root that does not accept the update. The rest of the queue is still
       // walked: the boundaries and failed modules behind the other importers
@@ -689,9 +687,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
       }
 
       for (const importer of mod.importers) {
-        // A failed importer is queued to be evaluated again (above) rather
-        // than asked to accept the update.
-        const cb = importer.state === State.Error ? null : importer.depAccepts?.[key];
+        const cb = importer.depAccepts?.[key];
         if (cb) {
           toAccept.push({ cb, key });
         } else if (hadSelfAccept) {

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -753,6 +753,31 @@ class DevFetchPromise extends Promise<Response> {
     });
   }
 
+  /**
+   * Expect the dev error page (a 500 for a server-side failure), carrying
+   * exactly these exception messages.
+   * @example await dev.fetch("/").expectErrorPage("dep threw");
+   */
+  expectErrorPage(...messages: string[]) {
+    return withAnnotatedStack(snapshotCallerLocation(), async () => {
+      try {
+        const res = await this;
+        const text = await res.text();
+        // The page embeds its payload as JSON (see src/runtime/server/DevErrorPage.rs).
+        const match = /<script id="__bunfallback" type="application\/json">([^<]*)<\/script>/.exec(text);
+        if (!match) throw new Error(`Expected a dev error page, got ${res.status}: ${text}`);
+        const payload = JSON.parse(match[1]);
+        expect(payload.problems.exceptions.map((exception: any) => exception.message)).toEqual(messages);
+        expect(res.status).toBe(500);
+      } catch (err) {
+        if (this.dev.panicked) {
+          throw new Error("DevServer crashed");
+        }
+        throw err;
+      }
+    });
+  }
+
   expectFile(expected: Buffer) {
     return withAnnotatedStack(snapshotCallerLocation(), async () => {
       const res = await this;

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -540,17 +540,6 @@ devTest("error report endpoint tolerates a browser url whose normalized origin i
   },
 });
 
-/** The dev error page embeds its payload as JSON (see src/runtime/server/DevErrorPage.rs). */
-async function expectErrorPage(response: Promise<Response>, ...messages: string[]) {
-  const res = await response;
-  const text = await res.text();
-  const match = /<script id="__bunfallback" type="application\/json">([^<]*)<\/script>/.exec(text);
-  if (!match) throw new Error(`Expected a dev error page, got ${res.status}: ${text}`);
-  const payload = JSON.parse(match[1]);
-  expect(payload.problems.exceptions.map((exception: any) => exception.message)).toEqual(messages);
-  expect(res.status).toBe(500);
-}
-
 devTest("a route that failed because its dependency rejected is loaded again once the dependency is fixed", {
   // The route fails together with its dependency and remembers that failure.
   // Fixing the dependency only replaces the dependency; the route, whose body
@@ -571,8 +560,8 @@ devTest("a route that failed because its dependency rejected is loaded again onc
     `,
   },
   async test(dev) {
-    await expectErrorPage(dev.fetch("/"), "dep rejected");
-    await expectErrorPage(dev.fetch("/"), "dep rejected");
+    await dev.fetch("/").expectErrorPage("dep rejected");
+    await dev.fetch("/").expectErrorPage("dep rejected");
     await dev.write(
       "dep.ts",
       `
@@ -647,11 +636,11 @@ devTest("a route that threw because of its dependency's exports is evaluated aga
     `,
   },
   async test(dev) {
-    await expectErrorPage(dev.fetch("/"), "invalid port: not a number");
+    await dev.fetch("/").expectErrorPage("invalid port: not a number");
     // Still broken: the route is evaluated against the new dependency and
     // reports the new failure, not the remembered one.
     await dev.write("config.ts", `export const port = "still not a number";`);
-    await expectErrorPage(dev.fetch("/"), "invalid port: still not a number");
+    await dev.fetch("/").expectErrorPage("invalid port: still not a number");
     await dev.write("config.ts", `export const port = 3000;`);
     await dev.fetch("/").equals("port: 3000");
     // Once loaded, the route takes further updates as a regular importer.
@@ -689,11 +678,43 @@ devTest("every route that failed because of a dependency is evaluated again when
     `,
   },
   async test(dev) {
-    await expectErrorPage(dev.fetch("/"), "index: dep is broken");
-    await expectErrorPage(dev.fetch("/other"), "other: dep is broken");
+    await dev.fetch("/").expectErrorPage("index: dep is broken");
+    await dev.fetch("/other").expectErrorPage("other: dep is broken");
     await dev.write("dep.ts", `export const value = "fixed";`);
     await dev.fetch("/").equals("index: fixed");
     await dev.fetch("/other").equals("other: fixed");
+  },
+});
+
+devTest("a route that loaded an already failed module is evaluated again once that module is fixed", {
+  // `dep` is already recorded as failed (by /first) when the route loads it.
+  // Loading a failed module rethrows its failure right away; the route still
+  // has to be recorded as one of its importers, or fixing `dep` cannot find it.
+  framework: minimalFramework,
+  files: {
+    "dep.ts": `
+      export const value = "unreachable";
+      throw new Error("dep threw");
+    `,
+    "routes/first.ts": `
+      export default async function () {
+        const { value } = await import("../dep");
+        return new Response("first: " + value);
+      }
+    `,
+    "routes/index.ts": `
+      const { value } = require("../dep");
+      export default function () {
+        return new Response("index: " + value);
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/first").expectErrorPage("dep threw");
+    await dev.fetch("/").expectErrorPage("dep threw");
+    await dev.write("dep.ts", `export const value = "fixed";`);
+    await dev.fetch("/").equals("index: fixed");
+    await dev.fetch("/first").equals("first: fixed");
   },
 });
 

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -544,7 +544,9 @@ devTest("error report endpoint tolerates a browser url whose normalized origin i
 async function expectErrorPage(response: Promise<Response>, ...messages: string[]) {
   const res = await response;
   const text = await res.text();
-  const payload = JSON.parse(/<script id="__bunfallback" type="application\/json">([^<]*)<\/script>/.exec(text)![1]);
+  const match = /<script id="__bunfallback" type="application\/json">([^<]*)<\/script>/.exec(text);
+  if (!match) throw new Error(`Expected a dev error page, got ${res.status}: ${text}`);
+  const payload = JSON.parse(match[1]);
   expect(payload.problems.exceptions.map((exception: any) => exception.message)).toEqual(messages);
   expect(res.status).toBe(500);
 }

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -540,6 +540,208 @@ devTest("error report endpoint tolerates a browser url whose normalized origin i
   },
 });
 
+/** The dev error page embeds its payload as JSON (see src/runtime/server/DevErrorPage.rs). */
+async function expectErrorPage(response: Promise<Response>, ...messages: string[]) {
+  const res = await response;
+  const text = await res.text();
+  const payload = JSON.parse(/<script id="__bunfallback" type="application\/json">([^<]*)<\/script>/.exec(text)![1]);
+  expect(payload.problems.exceptions.map((exception: any) => exception.message)).toEqual(messages);
+  expect(res.status).toBe(500);
+}
+
+devTest("a route that failed because its dependency rejected is loaded again once the dependency is fixed", {
+  // The route fails together with its dependency and remembers that failure.
+  // Fixing the dependency only replaces the dependency; the route, whose body
+  // never ran, has no import bindings to patch, so it has to be evaluated
+  // again on the next request instead of rethrowing the old failure.
+  framework: minimalFramework,
+  files: {
+    "dep.ts": `
+      await 1;
+      export const value = "unreachable";
+      throw new Error("dep rejected");
+    `,
+    "routes/index.ts": `
+      import { value } from "../dep";
+      export default function () {
+        return new Response("value: " + value);
+      }
+    `,
+  },
+  async test(dev) {
+    await expectErrorPage(dev.fetch("/"), "dep rejected");
+    await expectErrorPage(dev.fetch("/"), "dep rejected");
+    await dev.write(
+      "dep.ts",
+      `
+        await 1;
+        export const value = "fixed";
+      `,
+    );
+    await dev.fetch("/").equals("value: fixed");
+  },
+});
+
+devTest("a failed module with top-level await is loaded again by import() once its dependency is fixed", {
+  // `async-mod` fails along with `dep` and is marked for another evaluation
+  // when `dep` is fixed. require() still refuses it (it has top-level await),
+  // which must not consume that mark: the import() after it has to evaluate
+  // it instead of getting back the never-evaluated module.
+  framework: minimalFramework,
+  files: {
+    "dep.ts": `
+      await 1;
+      export const value = "unreachable";
+      throw new Error("dep rejected");
+    `,
+    "async-mod.ts": `
+      import { value } from "./dep";
+      await 1;
+      export const result = "async-mod: " + value;
+    `,
+    "routes/index.ts": `
+      export default async function () {
+        const results = [];
+        try {
+          results.push("require: " + require("../async-mod").result);
+        } catch (e) {
+          results.push("require threw: " + e.message);
+        }
+        try {
+          results.push("import: " + (await import("../async-mod")).result);
+        } catch (e) {
+          results.push("import threw: " + e.message);
+        }
+        return Response.json(results);
+      }
+    `,
+  },
+  async test(dev) {
+    const cannotRequire = `require threw: Cannot require "async-mod.ts" because "async-mod.ts" uses top-level await, but 'require' is a synchronous operation.`;
+    expect(await dev.fetch("/").json()).toEqual([cannotRequire, "import threw: dep rejected"]);
+    await dev.write(
+      "dep.ts",
+      `
+        await 1;
+        export const value = "fixed";
+      `,
+    );
+    expect(await dev.fetch("/").json()).toEqual([cannotRequire, "import: async-mod: fixed"]);
+  },
+});
+
+devTest("a route that threw because of its dependency's exports is evaluated again when the dependency changes", {
+  framework: minimalFramework,
+  files: {
+    "config.ts": `
+      export const port = "not a number";
+    `,
+    "routes/index.ts": `
+      import { port } from "../config";
+      if (typeof port !== "number") throw new Error("invalid port: " + port);
+      export default function () {
+        return new Response("port: " + port);
+      }
+    `,
+  },
+  async test(dev) {
+    await expectErrorPage(dev.fetch("/"), "invalid port: not a number");
+    // Still broken: the route is evaluated against the new dependency and
+    // reports the new failure, not the remembered one.
+    await dev.write("config.ts", `export const port = "still not a number";`);
+    await expectErrorPage(dev.fetch("/"), "invalid port: still not a number");
+    await dev.write("config.ts", `export const port = 3000;`);
+    await dev.fetch("/").equals("port: 3000");
+    // Once loaded, the route takes further updates as a regular importer.
+    await dev.write("config.ts", `export const port = 3001;`);
+    await dev.fetch("/").equals("port: 3001");
+  },
+});
+
+devTest("every route that failed because of a dependency is evaluated again when the dependency changes", {
+  // `dep` is imported by one route directly and by the other one through
+  // `shared`. Discovering the failed modules must walk all of `dep`'s
+  // importers, including the ones behind a root that does not accept the
+  // update, rather than stopping at the first such root.
+  framework: minimalFramework,
+  files: {
+    "dep.ts": `
+      export const value = "broken";
+    `,
+    "shared.ts": `
+      export { value } from "./dep";
+    `,
+    "routes/index.ts": `
+      import { value } from "../dep";
+      if (value === "broken") throw new Error("index: dep is broken");
+      export default function () {
+        return new Response("index: " + value);
+      }
+    `,
+    "routes/other.ts": `
+      import { value } from "../shared";
+      if (value === "broken") throw new Error("other: dep is broken");
+      export default function () {
+        return new Response("other: " + value);
+      }
+    `,
+  },
+  async test(dev) {
+    await expectErrorPage(dev.fetch("/"), "index: dep is broken");
+    await expectErrorPage(dev.fetch("/other"), "other: dep is broken");
+    await dev.write("dep.ts", `export const value = "fixed";`);
+    await dev.fetch("/").equals("index: fixed");
+    await dev.fetch("/other").equals("other: fixed");
+  },
+});
+
+devTest("a module that failed because its dependency rejected is loaded again once the dependency is fixed (client)", {
+  // Same as the server tests above, in the browser runtime. The failure is
+  // reached through import() so that it does not take the page down; the
+  // entry point accepts the update so that it is applied without a reload.
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      globalThis.loadLazy = async () => {
+        try {
+          return (await import("./lazy")).value;
+        } catch (e) {
+          return "failed: " + e.message;
+        }
+      };
+      console.log("ready");
+      import.meta.hot.accept();
+    `,
+    "lazy.ts": `
+      import { value } from "./dep";
+      export { value };
+    `,
+    "dep.ts": `
+      await 1;
+      export const value = "unreachable";
+      throw new Error("dep rejected");
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("ready");
+    expect(await c.js`loadLazy()`).toBe("failed: dep rejected");
+    expect(await c.js`loadLazy()`).toBe("failed: dep rejected");
+    await dev.write(
+      "dep.ts",
+      `
+        await 1;
+        export const value = "fixed";
+      `,
+    );
+    // The self-accepting entry point is evaluated again by the update.
+    await c.expectMessage("ready");
+    expect(await c.js`loadLazy()`).toBe("fixed");
+  },
+});
+
 devTest("html routes reject requests whose host header does not match the dev server", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
### Problem
- In the dev server (a Bake app or HTML routes in development), a module that failed to load because of a dependency keeps failing after the dependency is fixed, until it is edited itself or the dev server restarts.
- Repro: `dep.ts` throws `dep rejected` at top level, a route imports it, `GET /` answers 500. Fixing `dep.ts` prints `Reloaded in 2ms: dep.ts`, but `GET /` still answers 500 with `dep rejected` instead of 200. Same on the client through `import()`.
- Cause: a failed module records its failure and every later load rethrows it. A hot update re-evaluates only the replaced modules and those that accept the update; a failed importer is walked past and left failed.
- Some failed importers were not even reached: the walk stopped at the first importer root that did not accept the update (so on the server the result depended on importer order), and a load that hit an already recorded failure was not recorded as an importer.

### Fix
- While walking the importers of a replaced module, a failed module is put back into the stale state (already used for "evaluate on the next load") and its failure is dropped. It is evaluated on the next request or `import()`, not inside the update, so a module that still fails reports the new error to that load and the dev error page instead of rejecting the update.
- The walk no longer stops at the first non-accepting root, and a load that rethrows a recorded failure records itself as an importer first, so every module that failed with a dependency is reachable when the dependency is replaced. Modules with accept handlers are checked before the failed state and behave as before.
- Land after #37742: alone, a failure rethrown synchronously through an intermediate module leaves the re-evaluated route pending and unrecoverable; #37742 makes the loaders record it. Two tests that need both changes wait on a side branch. Also here: `require()` refusing a stale top-level-await module leaves it stale, so a following `import()` evaluates it.
- Verification: six new dev-server tests (five server, one client) fail on the released bun with the stale failure and pass with this change; the bake `esm` and `hot` suites pass, alone and with #37742 merged in locally.

### Background
- The dev server (Bake) loads app modules through its own registry in `src/runtime/bake/hmr-module.ts`; each module carries a state (pending, stale, error, ...) and the set of modules that imported it.
- A hot update re-evaluates the replaced modules, then walks their importers: importers that ran get their import bindings patched, importers that called `import.meta.hot.accept()` are re-run. A root that accepts nothing makes the client reload the page; the server applies the update regardless.
- Failed state: a module whose evaluation threw (its own body or a dependency's) keeps the error and rethrows it to every later load, so an unchanged broken graph reports the same error each time.
- Stale state: the module is evaluated afresh the next time anything loads it; hot-reloaded modules and CommonJS modules that threw already pass through it.
- A module with top-level await cannot be loaded synchronously: `require()` of it is refused, only `import()` can evaluate it.

<details>
<summary>Original description</summary>

### What does this PR do?

In the dev server (a Bake app or HTML routes in development), a module that failed to load because of one of its dependencies keeps failing after that dependency is fixed. It only recovers when it is edited itself or the dev server is restarted.

```ts
// dep.ts
await 1;
export const value = "unreachable";
throw new Error("dep rejected");
// routes/index.ts
import { value } from "../dep";
export default () => new Response("value: " + value);
```

1. `GET /` answers 500 with `dep rejected` (correct).
2. `dep.ts` is changed to `await 1; export const value = "fixed";`. The dev server prints `Reloaded in 2ms: dep.ts`.
3. `GET /` still answers 500 with `dep rejected`. Expected: 200 `value: fixed`.

The same happens when the route itself threw while evaluating because of what the dependency exported (a config module exporting a bad value, a dependency's function throwing when the route calls it at top level), and on the client for a module reached through `import()` whose rejection the page handled.

#### Cause

`src/runtime/bake/hmr-module.ts`. When `dep.ts` fails, `routes/index.ts` is put into `State.Error` with `failure` set, and every later load of it rethrows that (`loadModuleAsync` / `loadModuleSync`: `if (state === State.Error) throw mod.failure`). That is intended for repeated loads of an unchanged graph. But `replaceModules()` only re-evaluates the replaced modules and the self-accepting modules it finds while walking their importers; a failed importer is walked past like any other module, and `patchImporters(dep)` has nothing to update in it because its body never ran (no `updateImport`). So after step 2 the route is still in `State.Error` with the old failure.

The importer walk also gave up on a replaced module as soon as it reached one root that does not accept the update (`continue outer`). On the client that is followed by a full reload, so it did not matter there; on the server, which applies the update regardless, it meant that whatever was behind the replaced module's other importers (failed modules, but also self-accepting modules and `accept(dep)` callbacks) was found or not depending on the order in which the importers had been registered.

#### Fix

While walking the importers of a replaced module, a module in `State.Error` that the walk passes through is put back into `State.Stale`, which is the state the loaders already use for "evaluate on the next load" (hot-reloaded modules and CommonJS modules that threw go through it), and its `failure` is dropped. The walk continues through it as it did before, because its importers failed along with it. The walk no longer stops at the first non-accepting root; `failures` is a set, so the message and the full-reload decision are unchanged.

The walk can only reach what is in `importers`, and both loaders rethrew a recorded failure before adding the importer, so only the module that made a module fail in the first place was recorded as its importer; anything that loaded it afterwards (a second route, a second `import()`) failed with it but was invisible to the walk and stayed failed after the fix. The two fast paths now add the importer before rethrowing. `patchImporters()` skips importers without bindings, so the extra edges change nothing else.

The state is flipped during the walk rather than after the update has been applied so that, when a root and the module it failed on are saved together, the root's eager reload re-evaluates the failed modules in between instead of hitting their recorded failures. The price is that a load which races the update itself (a request arriving while a replaced dependency with top-level await is still being reloaded) is evaluated against the in-flight dependency; that is the existing in-flight-load limitation that #37759 removes (the load then waits), and without it such a module ends up where it was before this change.

Accept handlers are checked before the failed state, so a module whose failed evaluation had already registered them behaves exactly as before: a self-accepting one is still disposed and reloaded eagerly by this update, and an `accept("./dep", cb)` callback still runs (and that module is still not re-evaluated). Only modules the walk already passed through without doing anything are affected. Treating a failed module's registrations as void instead would change which updates count as accepted (and so when the client reloads the page), which is a separate decision from this fix.

Re-evaluating lazily (on the next request on the server, the next `import()` on the client) rather than inside `replaceModules()` is deliberate, and on the server it is required: a module that still fails then reports the new failure to the request or `import()` that loaded it, where the dev error page shows it. A module that throws inside `replaceModules()` instead rejects the promise that `registerUpdate()` does not await, and today that takes the dev server process down (reproducible on main by saving a server module that still throws at top level; tracked separately), while the client answers it with a full reload. Re-evaluating the second test below eagerly would hit exactly that. Lazy evaluation also means the module is not evaluated while a replaced dependency with top-level await is still loading, which with the current loader would hand it the unfinished namespace. The replaced module itself is still reloaded eagerly as before.

Because stale modules can now be observed outside the reload loop, `loadModuleSync()` puts a stale module back into `State.Stale` when it refuses it because of its own top-level await. It used to leave it `Pending`, which the loaders hand out as-is, so a refused `require()` of such a module made the `import()` after it resolve to a module whose namespace is `null`. This is the one throw site in `loadModuleSync()` that only a stale module can reach: a fresh module is refused before it is registered. The two later throw sites (a dependency being refused or failing inside `parseEsmDependencies()`, and the module's own body throwing) leave a fresh module `Pending` today just the same, and #37742 handles them for fresh and stale modules alike (stale on a refused dependency, `State.Error` on a failure), so they are not duplicated here.

#### Land this after #37742

The re-evaluation goes through the loaders, and today they only record a failure on some paths (#37742): a module whose dependency's recorded failure is rethrown synchronously is left in `State.Pending`, which the loaders hand out as-is. That matters for this change in one common flow. With `tla.ts` (rejecting) imported by `service.ts`, imported by a route that also imports an unrelated `other.ts`:

- main: every request reports `tla rejected`, including after `other.ts` is edited; fixing `tla.ts` never recovers the route (this bug).
- this change alone: editing `other.ts` re-evaluates the route on the next request, which correctly reports `tla rejected` again but leaves the route `Pending`; from the request after that it reports `null is not an object (evaluating 'pageModule.streaming')` (the error #37742 fixes for fresh loads), and since it is no longer in `State.Error`, fixing `tla.ts` afterwards does not recover it either.
- this change with #37742 merged in locally: `tla rejected` on every request until `tla.ts` is fixed, 200 right after, and later edits to `service.ts` and the route apply normally.

So this should land after #37742 (they merge cleanly; the combination passes both PRs' tests, see below). Two tests that need both changes (the scenario above, and two routes statically importing a module that throws, which also covers the `loadModuleAsync()` importer edge) are ready on the branch `farm/10f9a3e7/bake-failed-importers-recover-with-37742` (this PR + #37742 + one test commit, 1cc1afeb00); they cannot be part of this PR alone because they only pass with both changes. I will rebase them in here once #37742 is merged.

What this does not change: the walk still stops at modules that accept the update, as it always has, so a failed importer of a self-accepting module is not reached (editing that importer re-evaluates it, as today). This composes with #37759 (importers wait for in-flight top-level await loads) and #37734 (`import()` rejects instead of throwing); #31944 and #31946 change the reload loop further down in `replaceModules()`, not the importer walk. #31946 also rewrites `loadModuleSync()`: the behavior to carry over there is that refusing a stale module leaves it stale.

### How did you verify your code works?

Six new tests in `test/bake/dev/esm.test.ts` (the error page assertion they share is `DevFetchPromise.expectErrorPage()` in the harness, next to `equals()` / `expect404()`):

- the repro above (server, dependency with top-level await rejecting);
- a route whose own body throws because of a dependency's export: after the dependency changes it reports the new failure, after it is fixed it serves, and a further change to the dependency then reaches it as a regular live binding update;
- `dep` imported by one route directly and by another route through a re-exporting module, both of which must recover; this one fails if only the `State.Error` handling is added and the walk still stops at the first root;
- a route that loads a module which another route had already made fail (`require()` of it, so that the route's own failure is recorded on today's loader); this one fails if the importer is not added on the failed fast path;
- a failed module with top-level await that `require()` refuses after the fix, followed by an `import()` that must evaluate it; without the `loadModuleSync()` change the `import()` reports `null is not an object`;
- the client runtime: an `import()` that rejected because of the dependency resolves after the dependency is fixed, with the update applied through a self-accepting entry point (no reload).

With `USE_SYSTEM_BUN=1` all six fail with the stale failure (`dep rejected` / `invalid port: not a number` / `dep threw` / 500 after the fix / `failed: dep rejected`); with `bun bd test` they pass, as do `esm.test.ts` and `hot.test.ts` as a whole. Before the last two commits, `test/bake/dev/{react-spa,bundle,html,css,sourcemap,server-sourcemap,react-response,incremental-graph-edge-deletion}.test.ts` passed on the debug build as well (the `ASSERTION FAILED` trace printed during `css url resolve error on hot reload is recoverable` is the pre-existing #31908, noted in that test); the harness change since then only adds a method.

Combined with #37742 (its branch merged into this one locally, no conflicts): `esm.test.ts` with both PRs' tests plus the two tests from the branch named above, and `hot.test.ts`, pass on a debug build.


</details>
