### PR TITLE
node:http: end HTTP/1 fallback connections after a response that must close them

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -234,6 +234,8 @@ function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTim
 // 'request' with http.IncomingMessage/ServerResponse, like Node's httpConnectionListener routing.
 function connectionListenerHTTP1(server, socket, options) {
   const http = require("node:http");
+  const { kMustCloseConnection } = require("node:_http_server");
+  const { kReqShouldKeepAlive } = require("node:_http_incoming");
   const { HTTPParser, prepareError, calculateLenientFlags, continueExpression } = require("node:_http_common");
   const { kHandle: kHttp1ResponseHandle } = require("internal/http");
   const { allMethods } = process.binding("http_parser");
@@ -292,6 +294,11 @@ function connectionListenerHTTP1(server, socket, options) {
     req.method = typeof methodNum === "number" ? allMethods[methodNum] : methodNum;
     req.upgrade = upgrade;
     req._addHeaderLines(rawHeaders, rawHeaders.length);
+    // Same stamp as the native dispatcher (renderNativeHeaders derives the Connection header
+    // from it): this server never keeps HTTP/1.0 alive; otherwise llhttp's verdict, which
+    // unlike req.headers saw every header field.
+    const keepAlive = versionMajor === 1 && versionMinor === 0 ? false : shouldKeepAlive;
+    req[kReqShouldKeepAlive] = keepAlive;
 
     // Node's parserOnIncoming: upgrade only sticks for CONNECT or when an 'upgrade' listener
     // exists; otherwise fall through to normal dispatch. Returning 2 makes llhttp stop after
@@ -318,20 +325,23 @@ function connectionListenerHTTP1(server, socket, options) {
     // path must carry them too or keep-alive responses lose their timeout line.
     res._keepAliveTimeout = keepAliveTimeout;
     res._maxRequestsPerSocket = server.maxRequestsPerSocket;
-    const handle = createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout);
+    // Node's res._last; renderNativeHeaders and onHttp1SocketEnd set it too.
+    if (!keepAlive) res[kMustCloseConnection] = true;
+    const handle = createHttp1FallbackResponseHandle(socket, keepAlive, keepAliveTimeout);
     handle.onfinished = function () {
       socket[kHttp1ActiveRequests] = Math.max(0, (socket[kHttp1ActiveRequests] || 1) - 1);
-      if (!shouldKeepAlive && !socket.destroyed) {
-        socket.end();
-      }
     };
     res[kHttp1ResponseHandle] = handle;
     res.assignSocket(socket);
     // node's resOnFinish: release the socket once the response completes so the next
     // keep-alive request's response can attach (assignSocket throws
-    // ERR_HTTP_SOCKET_ASSIGNED while a previous response is still assigned).
+    // ERR_HTTP_SOCKET_ASSIGNED while a previous response is still assigned), and end
+    // the connection after its last response.
     res.on("finish", function onFallbackResponseFinish() {
       this.detachSocket(socket);
+      if (this[kMustCloseConnection] && !socket.destroyed) {
+        socket.end();
+      }
     });
 
     // Node's parserOnIncoming Expect routing (the native dispatcher applies the
@@ -434,7 +444,7 @@ function connectionListenerHTTP1(server, socket, options) {
     }
     const httpMessage = socket._httpMessage;
     if (httpMessage) {
-      httpMessage._last = true;
+      httpMessage[kMustCloseConnection] = true;
     } else if (socket.writable) {
       socket.end();
     }

--- a/src/js/node/_http_incoming.ts
+++ b/src/js/node/_http_incoming.ts
@@ -28,9 +28,9 @@ const ObjectDefineProperty = Object.defineProperty;
 const ArrayPrototypeSlice = Array.prototype.slice;
 
 const kHeaders = Symbol("kHeaders");
-// Cache slot for the server dispatcher's keep-alive decision (stamped once
-// per request in _http_server.ts); declared in the constructor so the stamp
-// never shape-transitions the request.
+// Cache slot for the server dispatchers' keep-alive decision (stamped once
+// per request in _http_server.ts / http1_server_fallback.ts); declared in the
+// constructor so the stamp never shape-transitions the request.
 const kReqShouldKeepAlive = Symbol("kReqShouldKeepAlive");
 const kHeadersDistinct = Symbol("kHeadersDistinct");
 const kHeadersCount = Symbol("kHeadersCount");

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -4024,4 +4024,5 @@ export default {
   Server,
   ServerResponse,
   kConnectionsCheckingInterval,
+  kMustCloseConnection,
 };

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,171 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+describe("connectionListener closes the connection like Node's resOnFinish", () => {
+  // A connection is ended after a response when the request forbade reuse, the
+  // response itself did, or (httpAllowHalfOpen) the peer half-closed while the
+  // response was in flight: Node's res._last. The server.emit("connection") path
+  // used to go by the parser's keep-alive flag alone, so an HTTP/1.0 request
+  // asking for keep-alive kept being served on a connection whose every response
+  // said Connection: close, and none of the response-level reasons closed anything.
+  type Handler = (req: IncomingMessage, res: ServerResponse) => void;
+  type Outcome = { connection: string | undefined; responses: number; ended: boolean; served: string[] };
+  type Case = {
+    name: string;
+    version?: string;
+    requestHeaders?: string;
+    handler?: Handler;
+    // httpAllowHalfOpen server; the client half-closes right after its request.
+    peerEndsFirst?: boolean;
+    expected: Outcome;
+  };
+
+  async function serve({
+    version = "1.1",
+    requestHeaders = "",
+    handler = endBody,
+    peerEndsFirst = false,
+  }: Case): Promise<Outcome> {
+    const requestFor = (path: string) => `GET ${path} HTTP/${version}\r\nHost: x\r\n${requestHeaders}\r\n`;
+    const served: string[] = [];
+    const server = createServer((req, res) => {
+      served.push(req.url!);
+      handler(req, res);
+    });
+    if (peerEndsFirst) server.httpAllowHalfOpen = true;
+    const [clientSide, serverSide] = duplexPair();
+    server.emit("connection", serverSide);
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers<void>();
+      let wire = "";
+      let responses = 0;
+      let ended = false;
+      let firstResponseSeen = false;
+      clientSide.on("error", reject);
+      clientSide.on("end", () => {
+        ended = true;
+        resolve();
+      });
+      clientSide.on("data", chunk => {
+        wire += chunk;
+        responses = wire.match(/HTTP\/1\.1 \d{3} /g)?.length ?? 0;
+        if (responses >= 2) {
+          resolve();
+        } else if (responses === 1 && !firstResponseSeen) {
+          firstResponseSeen = true;
+          // A server that ends the connection does so as the first response
+          // finishes, so its 'end' settles this before the immediate runs. One
+          // that keeps it open is sent a second request and answers it (or, once
+          // the client has half-closed, is simply observed to still be open).
+          setImmediate(() => {
+            if (ended) return;
+            if (peerEndsFirst) resolve();
+            else clientSide.write(requestFor("/2"));
+          });
+        }
+      });
+      if (peerEndsFirst) clientSide.end(requestFor("/1"));
+      else clientSide.write(requestFor("/1"));
+      await promise;
+      return { connection: wire.match(/^connection: ([^\r\n]*)/im)?.[1], responses, ended, served };
+    } finally {
+      clientSide.destroy();
+      serverSide.destroy();
+    }
+  }
+
+  function endBody(_req: IncomingMessage, res: ServerResponse) {
+    res.end("served");
+  }
+  const closes: Outcome = { connection: "close", responses: 1, ended: true, served: ["/1"] };
+  const closesAdvertisingKeepAlive: Outcome = { ...closes, connection: "keep-alive" };
+  let manyOtherHeaders = "";
+  for (let i = 0; i < 40; i++) manyOtherHeaders += `X-Filler-${i}: ${i}\r\n`;
+
+  const cases: Case[] = [
+    {
+      name: "ends it after answering an HTTP/1.0 request that asked for keep-alive",
+      version: "1.0",
+      requestHeaders: "Connection: keep-alive\r\n",
+      expected: closes,
+    },
+    { name: "ends it after answering an HTTP/1.0 request", version: "1.0", expected: closes },
+    {
+      name: "ends it after answering an HTTP/1.1 request that sent Connection: close",
+      requestHeaders: "Connection: close\r\n",
+      expected: closes,
+    },
+    {
+      // The parser's verdict must drive both the header and the close: req.headers
+      // does not necessarily retain every header field of a large request.
+      name: "ends it after answering a Connection: close request that carried many other headers",
+      requestHeaders: "Connection: close\r\n" + manyOtherHeaders,
+      expected: closes,
+    },
+    {
+      name: "ends it after a response the handler gave a Connection: close header",
+      handler: (_req, res) => {
+        res.setHeader("Connection", "close");
+        res.end("served");
+      },
+      expected: closes,
+    },
+    {
+      name: "ends it after a response the handler cleared shouldKeepAlive on",
+      handler: (_req, res) => {
+        res.shouldKeepAlive = false;
+        res.end("served");
+      },
+      expected: closes,
+    },
+    {
+      // Node's _removedConnection branch: nothing advertised, still the last response.
+      name: "ends it after a response with shouldKeepAlive cleared and the Connection header removed",
+      handler: (_req, res) => {
+        res.removeHeader("Connection");
+        res.shouldKeepAlive = false;
+        res.end("served");
+      },
+      expected: { ...closes, connection: undefined },
+    },
+    {
+      name: "ends it after a 204 response carrying a Transfer-Encoding header",
+      handler: (_req, res) => {
+        res.writeHead(204, { "Transfer-Encoding": "chunked" });
+        res.end();
+      },
+      expected: closes,
+    },
+    {
+      // This server never reuses an HTTP/1.0 connection (same as its native
+      // listener), whatever Connection header the handler writes itself.
+      name: "ends an HTTP/1.0 connection even when the handler advertised keep-alive",
+      version: "1.0",
+      requestHeaders: "Connection: keep-alive\r\n",
+      handler: (_req, res) => {
+        res.setHeader("Connection", "keep-alive");
+        res.end("served");
+      },
+      expected: closesAdvertisingKeepAlive,
+    },
+    {
+      name: "ends it after the response when the peer half-closed before the handler answered (httpAllowHalfOpen)",
+      peerEndsFirst: true,
+      handler: (req, res) => req.socket.once("end", () => res.end("served")),
+      expected: closesAdvertisingKeepAlive,
+    },
+    {
+      name: "ends it after a synchronous response to a request that arrived together with the peer's FIN (httpAllowHalfOpen)",
+      peerEndsFirst: true,
+      expected: closesAdvertisingKeepAlive,
+    },
+    {
+      name: "keeps a kept-alive HTTP/1.1 connection open for the next request",
+      expected: { connection: "keep-alive", responses: 2, ended: false, served: ["/1", "/2"] },
+    },
+  ];
+  it.each(cases)("$name", async testCase => {
+    expect(await serve(testCase)).toEqual(testCase.expected);
+  });
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4365,6 +4365,35 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+it("http2 allowHTTP1 fallback ends the connection after answering an HTTP/1.0 keep-alive request with Connection: close", async () => {
+  // HTTP/1.0 responses are always answered with Connection: close (like
+  // node:http's own server); the fallback used to leave the connection open
+  // anyway when the request had asked for keep-alive.
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+    res.end(`served ${req.httpVersion} ${req.url}`);
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  const { promise, resolve, reject } = Promise.withResolvers();
+  const socket = tls.connect(
+    { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+    () => socket.write("GET /first HTTP/1.0\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n"),
+  );
+  try {
+    const chunks = [];
+    socket.on("error", reject);
+    socket.on("data", chunk => chunks.push(chunk));
+    // Never arrives while the server keeps the connection open.
+    socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    const raw = await promise;
+    expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+    expect(raw.slice(0, raw.indexOf("\r\n\r\n") + 4).toLowerCase()).toContain("\r\nconnection: close\r\n");
+    expect(raw.slice(raw.indexOf("\r\n\r\n") + 4)).toBe("served 1.0 /first");
+  } finally {
+    socket.destroy();
+    server.close();
+  }
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().


### PR DESCRIPTION
### Problem
- A socket handed to `http.Server` with `server.emit("connection", socket)`, or the HTTP/1 side of `http2.createSecureServer({ allowHTTP1: true })`, answers an HTTP/1.0 request that sent `Connection: keep-alive` with `Connection: close` but leaves the connection open and keeps serving requests on it. Node and bun's native `http.Server` end it after the response.
- The same path ignores close reasons recorded on the response: a handler's `res.setHeader("Connection", "close")`, `res.shouldKeepAlive = false`, a `204`/`304` with `Transfer-Encoding`, or a peer half-close under `server.httpAllowHalfOpen` all leave the connection open. Node and the native path end it in every one of these cases.
- Cause: this path decided whether to end the connection from the parser's keep-alive flag alone, while the `Connection` header it sent was computed by a different rule, and the flag on which the response records its own close reasons was never read. The peer-FIN handler set a field nothing reads.

### Fix
- The fallback stamps each request with the same keep-alive verdict the native server uses (the parser's verdict, forced off for HTTP/1.0), so the advertised `Connection` header and the close decision come from one value. The parser's verdict is used instead of `req.headers` because `req.headers` can drop fields of a large request (#33540).
- That verdict seeds the response's must-close flag, response-level close reasons and a peer FIN set the same flag, and the socket is ended in one place, when the response finishes, if the flag is set. The property to check: the connection is ended exactly when the response was marked as the last one, which is how Node's `resOnFinish` consumes `_last`.
- Known consequence: an HTTP/1.0 response whose handler writes `Connection: keep-alive` is still ended, as on the native path; Node would keep it open when a `Content-Length` is present. `maxRequestsPerSocket` (#37749) and pipelining (#36991) are not touched.
- Verification: a table test over a `duplexPair`, nine rows failing on main and three passing as guards, each expected outcome also checked against Node v26.3.0; an `allowHTTP1` TLS test that times out on main; the upstream node http tests listed in the original run against a debug build.

### Background
- The HTTP/1 fallback: bun's `http.Server` is normally backed by a native server, but a socket given to it directly (or the `http/1.1` ALPN branch of an `allowHTTP1` http2 server) is parsed in JS with llhttp and dispatched to the same `IncomingMessage` / `ServerResponse` classes.
- The parser's `shouldKeepAlive` verdict counts HTTP/1.0 plus `Connection: keep-alive` as keep-alive. This server never reuses HTTP/1.0 connections, so the native dispatcher overrides the verdict for 1.0 and this PR makes the fallback do the same.
- `kReqShouldKeepAlive` is stamped on the request and drives the rendered `Connection` header; `kMustCloseConnection` is set on the response by anything that decides the connection must close and is consumed when the response finishes. Together they are bun's equivalent of Node's `res._last`.
- `httpAllowHalfOpen` keeps the connection open after the peer sends FIN so an in-flight response can still be written; Node ends the connection once that response finishes.

<details>
<summary>Original description</summary>

### Problem

Connections served by the JS HTTP/1 fallback (`src/js/internal/http1_server_fallback.ts`: sockets fed into an `http.Server` with `server.emit("connection", socket)`, and the `http/1.1` ALPN side of `http2.createSecureServer({ allowHTTP1: true })`) answer every HTTP/1.0 request with `Connection: close`, but keep the connection open when the request carried `Connection: keep-alive`, and go on serving further requests on it:

```js
const http = require("http");
const { duplexPair } = require("stream");
const server = http.createServer((req, res) => res.end("served"));
const [c, s] = duplexPair();
server.emit("connection", s);
let out = "";
c.on("data", d => (out += d));
c.on("end", () => console.log("server ended connection"));
c.write("GET /1 HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n");
setTimeout(() => {
  console.log(JSON.stringify(out)); out = "";
  c.write("GET /2 HTTP/1.0\r\nHost: a\r\nConnection: keep-alive\r\n\r\n");
  setTimeout(() => { console.log(JSON.stringify(out)); c.destroy(); s.destroy(); }, 200);
}, 200);
```

bun 1.4.0 / main prints two `200` responses, both carrying `Connection: close`, and never ends the connection. Node v26.3.0 (and this branch) print `server ended connection`, the first response, and `""` for the second request. Bun's native `http.Server` path also ends HTTP/1.0 connections after the response.

The fallback also ignores every close reason recorded on the response itself. With an HTTP/1.1 request, `res.setHeader("Connection", "close")`, `res.shouldKeepAlive = false` (with or without the `Connection` header removed), or a `204`/`304` carrying a `Transfer-Encoding` header all leave the connection open, and with `server.httpAllowHalfOpen = true` a peer that half-closes while a response is in flight never gets the connection ended after that response. Node and the native path end the connection in all of these cases.

### Cause

`connectionListenerHTTP1` decided whether to end the connection from one input only: llhttp's `shouldKeepAlive` argument, which is true for HTTP/1.0 + `Connection: keep-alive`, and `handle.onfinished` ended the socket only when it was false. Meanwhile `renderNativeHeaders` renders the `Connection` header from `requestShouldKeepAlive()` (HTTP/1.0 is never kept alive on this server) and records the response-level close reasons in `res[kMustCloseConnection]`, which the native dispatcher seeds from its request-level decision and acts on when the response finishes; the fallback never read or seeded that flag. Its `onHttp1SocketEnd` ported Node's `socketOnEnd` by setting `res._last`, which nothing in the handle-backed `ServerResponse` reads.

### Fix

Give the fallback the native dispatcher's structure:

- Stamp `req[kReqShouldKeepAlive]` at dispatch from llhttp's verdict, forced off for HTTP/1.0 exactly like the native stamp in `_http_server.ts`. `renderNativeHeaders` already reads the stamp back through `requestShouldKeepAlive()`, so the advertised `Connection` header and the close decision come from one value. The stamp is taken from the parser rather than by re-reading `req.headers` because the parser saw every header field: `req.headers` on this path does not keep all of them for large requests (#33540), and a `Connection: close` among the dropped fields must still close the connection (and is now also advertised as `close`; on main the transport closed but the header said `keep-alive`).
- Seed `res[kMustCloseConnection]` from that stamp, let `onHttp1SocketEnd` set the same flag instead of the unread `_last`, and end the socket from the response's `'finish'` listener whenever the flag is set, which is where Node's `resOnFinish` consumes `_last`. That one consumer covers the request-level reasons, everything `renderNativeHeaders` records, and a FIN that lands before or during the response. `kMustCloseConnection` is added to `node:_http_server`'s exports for this.

This is correct to have because the transport now follows the header the response actually advertised, both derived from one decision, and because a peer FIN under `httpAllowHalfOpen` now reaches the same consumer as in Node. One consequence to be aware of: a handler that writes its own `Connection: keep-alive` header on a response to an HTTP/1.0 request still gets the connection ended on the fallback, as it does on the native path (this server never reuses HTTP/1.0 connections); Node would keep it open when the response also has a `Content-Length`. Not touched here: `maxRequestsPerSocket`, which like Node only advertises close (#37749), and how the connection is ended (`socket.end()`, as before). #36991 adds a similar `kMustCloseConnection` check to this listener as part of its pipelining work; this PR is the standalone fix for the close decision and is independent of it.

### Tests

`test/js/node/http/node-http.test.ts`: a `server.emit("connection")` table over a `duplexPair` recording the advertised `Connection` header, the number of responses received, whether the server ended the connection, and the requests that reached the handler (a second request is sent once the first response is in, unless the client half-closed). Failing on main: HTTP/1.0 + keep-alive; `Connection: close` carried among 40 other request headers (main advertises `keep-alive`); handler-set `Connection: close`; `shouldKeepAlive = false`, with and without the `Connection` header removed (the latter pins the no-header wire shape); `204` + `Transfer-Encoding`; HTTP/1.0 with a handler-set `Connection: keep-alive` (pins the consequence above); and the two `httpAllowHalfOpen` cases (handler answers after the peer's FIN, and a synchronous answer to a request that arrived together with the FIN). Passing on main as guards: HTTP/1.0 without keep-alive and HTTP/1.1 + `Connection: close` (the cases that moved off the llhttp flag), and a plain HTTP/1.1 request whose connection must stay open and serve the second request. Every row's expected outcome is also what Node v26.3.0 produces for the same scenario.

`test/js/node/http2/node-http2.test.js`: an `allowHTTP1` server answering an HTTP/1.0 keep-alive request over TLS must send `Connection: close` and end the connection (times out waiting for `'end'` on main).

Also ran the full `node-http.test.ts` / `node-http2.test.js` files and the upstream `test-http-generic-streams`, `test-http-server`, `test-http(s)-*-per-stream`, `test-http-server-unconsume-consume`, `test-http2-allow-http1` and `test-http2-https-fallback*` tests against the debug build; the only failure was the pre-existing `localhost` proxy test in this container.

</details>
