### PR TITLE
Hand intrusive work-pool tasks to the pool through the object's pointer, not a reference

### DIFF
--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -589,11 +589,9 @@ impl TranspilerJob {
         )
     }
 
-    /// JS thread. Takes the pointer, not `&mut self`: the pool owns the job
-    /// from the `schedule` onwards, before this returns.
-    ///
     /// # Safety
-    /// `this` is a fully initialised job that has not been scheduled yet.
+    /// `this` is a fully initialised, unscheduled job; the pool owns it once
+    /// this returns.
     unsafe fn schedule(this: *mut Self) {
         // SAFETY: fn contract; no reference into `*this` outlives its statement.
         unsafe {

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -589,19 +589,13 @@ impl TranspilerJob {
         )
     }
 
-    /// JS thread: hand a freshly initialised job to the pool, which may be
-    /// running it before this returns. Takes the slot pointer `transpile`
-    /// holds rather than a `&mut self` that would stay live (and protected)
-    /// across the hand-off.
+    /// JS thread. Takes the pointer, not `&mut self`: the pool owns the job
+    /// from the `schedule` onwards, before this returns.
     ///
     /// # Safety
-    /// `this` is a fully initialised job in this VM's store that nothing else
-    /// is using yet.
+    /// `this` is a fully initialised job that has not been scheduled yet.
     unsafe fn schedule(this: *mut Self) {
-        // SAFETY: fn contract. Both accesses end at their statement, so no
-        // reference into the slot is live once the pool has the task, and the
-        // task pointer is projected from `this` itself, as `from_field_ptr!`
-        // in `run_from_worker_thread` requires.
+        // SAFETY: fn contract; no reference into `*this` outlives its statement.
         unsafe {
             // Note: the KeepAlive takes an
             // `EventLoopCtx` vtable; resolve it via the `get_vm_ctx` hook (registered by

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -371,8 +371,8 @@ impl RuntimeTranspilerStore {
                 <&'static str>::from(unsafe { (*job).loader })
             );
         }
-        // SAFETY: job fully initialized above
-        unsafe { (*job).schedule() };
+        // SAFETY: job fully initialized above and not yet handed to anyone.
+        unsafe { TranspilerJob::schedule(job) };
         promise.cast::<c_void>()
     }
 }
@@ -589,15 +589,29 @@ impl TranspilerJob {
         )
     }
 
-    fn schedule(&mut self) {
-        // Note: the KeepAlive takes an
-        // `EventLoopCtx` vtable; resolve it via the `get_vm_ctx` hook (registered by
-        // `bun_runtime::init`).
-        self.poll_ref.ref_(get_vm_ctx(AllocatorType::Js));
-        // The job is a slot inside this VM: counted, so teardown waits for it
-        // (see `VmHandle::embedded_work_scheduled`).
-        self.loop_handle.embedded_work_scheduled();
-        WorkPool::schedule(&raw mut self.work_task);
+    /// JS thread: hand a freshly initialised job to the pool, which may be
+    /// running it before this returns. Takes the slot pointer `transpile`
+    /// holds rather than a `&mut self` that would stay live (and protected)
+    /// across the hand-off.
+    ///
+    /// # Safety
+    /// `this` is a fully initialised job in this VM's store that nothing else
+    /// is using yet.
+    unsafe fn schedule(this: *mut Self) {
+        // SAFETY: fn contract. Both accesses end at their statement, so no
+        // reference into the slot is live once the pool has the task, and the
+        // task pointer is projected from `this` itself, as `from_field_ptr!`
+        // in `run_from_worker_thread` requires.
+        unsafe {
+            // Note: the KeepAlive takes an
+            // `EventLoopCtx` vtable; resolve it via the `get_vm_ctx` hook (registered by
+            // `bun_runtime::init`).
+            (*this).poll_ref.ref_(get_vm_ctx(AllocatorType::Js));
+            // The job is a slot inside this VM: counted, so teardown waits for it
+            // (see `VmHandle::embedded_work_scheduled`).
+            (*this).loop_handle.embedded_work_scheduled();
+            WorkPool::schedule(&raw mut (*this).work_task);
+        }
     }
 
     unsafe fn run_from_worker_thread(work_task: *mut WorkPoolTask) {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -780,7 +780,9 @@ use crate::webcore::blob::read_file::ReadFile;
 use crate::webcore::blob::write_file::WriteFile;
 
 /// `bun_io::__bun_io_pollable_on_ready` body — declared `extern "Rust"` in
-/// `bun_io`. The owner is recovered from the embedded `io_poll` field.
+/// `bun_io`. The owner is recovered from the embedded `io_poll` field and
+/// stays a raw pointer: the handlers hand it to the work pool, which may be
+/// running it before they return, so no reference to it may be live here.
 ///
 /// # Safety
 /// `poll` is the `io_poll` field of a live owner of type `tag`.
@@ -788,14 +790,12 @@ use crate::webcore::blob::write_file::WriteFile;
 unsafe fn __bun_io_pollable_on_ready(tag: bun_io::PollableTag, poll: *mut bun_io::Poll) {
     match tag {
         bun_io::PollableTag::ReadFile => {
-            // SAFETY: per fn contract.
-            let this = unsafe { &mut *bun_core::from_field_ptr!(ReadFile, io_poll, poll) };
-            this.on_ready();
+            // SAFETY: per fn contract; the owner is not touched after the call.
+            unsafe { ReadFile::on_ready(bun_core::from_field_ptr!(ReadFile, io_poll, poll)) };
         }
         bun_io::PollableTag::WriteFile => {
-            // SAFETY: per fn contract.
-            let this = unsafe { &mut *bun_core::from_field_ptr!(WriteFile, io_poll, poll) };
-            this.on_ready();
+            // SAFETY: as above.
+            unsafe { WriteFile::on_ready(bun_core::from_field_ptr!(WriteFile, io_poll, poll)) };
         }
         bun_io::PollableTag::Empty => {
             // Waker / unblock-only — caller already filtered this out.
@@ -805,7 +805,8 @@ unsafe fn __bun_io_pollable_on_ready(tag: bun_io::PollableTag, poll: *mut bun_io
 }
 
 /// `bun_io::__bun_io_pollable_on_io_error` body — declared `extern "Rust"` in
-/// `bun_io`.
+/// `bun_io`. Same hand-off as [`__bun_io_pollable_on_ready`]: the owner stays
+/// a raw pointer.
 ///
 /// # Safety
 /// `poll` is the `io_poll` field of a live owner of type `tag`.
@@ -817,16 +818,16 @@ unsafe fn __bun_io_pollable_on_io_error(
 ) {
     match tag {
         bun_io::PollableTag::ReadFile => {
-            // SAFETY: per fn contract.
-            let this = unsafe { &mut *bun_core::from_field_ptr!(ReadFile, io_poll, poll) };
-            this.on_io_error(err);
+            // SAFETY: per fn contract; the owner is not touched after the call.
+            unsafe {
+                ReadFile::on_io_error(bun_core::from_field_ptr!(ReadFile, io_poll, poll), err)
+            };
         }
         bun_io::PollableTag::WriteFile => {
             // SAFETY: per fn contract.
             let this = unsafe { bun_core::from_field_ptr!(WriteFile, io_poll, poll) };
-            // WriteFile::on_io_error already takes `*mut ()` (it
-            // self-recovers via the io_request path elsewhere); reuse that
-            // shape rather than reborrowing `&mut`.
+            // `WriteFile::on_io_error` is shaped as the io action's error hook
+            // (`fn(*mut (), ..)`), so it takes the erased pointer.
             WriteFile::on_io_error(this.cast(), err);
         }
         bun_io::PollableTag::Empty => {
@@ -993,8 +994,9 @@ pub(crate) unsafe fn __bun_fire_timer(t: *mut EventLoopTimer, now: *const ElTime
             })
         }
         EventLoopTimerTag::StatWatcherScheduler => {
-            timer_arm!(StatWatcherScheduler, event_loop_timer, |c, _now, _vm| (*c)
-                .timer_callback())
+            timer_arm!(StatWatcherScheduler, event_loop_timer, |c, _now, _vm| {
+                StatWatcherScheduler::timer_callback(c)
+            })
         }
         EventLoopTimerTag::UpgradedDuplex => {
             timer_arm!(UpgradedDuplex, event_loop_timer, |c, _now, _vm| (*c)

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -780,9 +780,7 @@ use crate::webcore::blob::read_file::ReadFile;
 use crate::webcore::blob::write_file::WriteFile;
 
 /// `bun_io::__bun_io_pollable_on_ready` body — declared `extern "Rust"` in
-/// `bun_io`. The owner is recovered from the embedded `io_poll` field and
-/// stays a raw pointer: the handlers hand it to the work pool, which may be
-/// running it before they return, so no reference to it may be live here.
+/// `bun_io`. The owner is recovered from the embedded `io_poll` field.
 ///
 /// # Safety
 /// `poll` is the `io_poll` field of a live owner of type `tag`.
@@ -790,11 +788,11 @@ use crate::webcore::blob::write_file::WriteFile;
 unsafe fn __bun_io_pollable_on_ready(tag: bun_io::PollableTag, poll: *mut bun_io::Poll) {
     match tag {
         bun_io::PollableTag::ReadFile => {
-            // SAFETY: per fn contract; the owner is not touched after the call.
+            // SAFETY: per fn contract.
             unsafe { ReadFile::on_ready(bun_core::from_field_ptr!(ReadFile, io_poll, poll)) };
         }
         bun_io::PollableTag::WriteFile => {
-            // SAFETY: as above.
+            // SAFETY: per fn contract.
             unsafe { WriteFile::on_ready(bun_core::from_field_ptr!(WriteFile, io_poll, poll)) };
         }
         bun_io::PollableTag::Empty => {
@@ -805,8 +803,7 @@ unsafe fn __bun_io_pollable_on_ready(tag: bun_io::PollableTag, poll: *mut bun_io
 }
 
 /// `bun_io::__bun_io_pollable_on_io_error` body — declared `extern "Rust"` in
-/// `bun_io`. Same hand-off as [`__bun_io_pollable_on_ready`]: the owner stays
-/// a raw pointer.
+/// `bun_io`.
 ///
 /// # Safety
 /// `poll` is the `io_poll` field of a live owner of type `tag`.
@@ -818,7 +815,7 @@ unsafe fn __bun_io_pollable_on_io_error(
 ) {
     match tag {
         bun_io::PollableTag::ReadFile => {
-            // SAFETY: per fn contract; the owner is not touched after the call.
+            // SAFETY: per fn contract.
             unsafe {
                 ReadFile::on_io_error(bun_core::from_field_ptr!(ReadFile, io_poll, poll), err)
             };
@@ -826,8 +823,6 @@ unsafe fn __bun_io_pollable_on_io_error(
         bun_io::PollableTag::WriteFile => {
             // SAFETY: per fn contract.
             let this = unsafe { bun_core::from_field_ptr!(WriteFile, io_poll, poll) };
-            // `WriteFile::on_io_error` is shaped as the io action's error hook
-            // (`fn(*mut (), ..)`), so it takes the erased pointer.
             WriteFile::on_io_error(this.cast(), err);
         }
         bun_io::PollableTag::Empty => {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1605,11 +1605,8 @@ mod _async_tasks {
             // the JS heap: counted, so the VM waits for it (embedded work).
             task.poster.embedded_work_scheduled();
 
-            // The task is projected from the box's own pointer, not from a
-            // `&mut` into it, so what the pool hands back to `from_task_ptr`
-            // covers the whole allocation (the `schedule_owned` shape).
             let raw = bun_core::heap::into_raw(task);
-            // SAFETY: `raw` is the live box just released above.
+            // SAFETY: `raw` is the box just released; the pool owns it from here.
             WorkPool::schedule(unsafe { &raw mut (*raw).task });
             raw
         }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1605,8 +1605,12 @@ mod _async_tasks {
             // the JS heap: counted, so the VM waits for it (embedded work).
             task.poster.embedded_work_scheduled();
 
-            let raw = bun_core::heap::release(task);
-            WorkPool::schedule(&raw mut raw.task);
+            // The task is projected from the box's own pointer, not from a
+            // `&mut` into it, so what the pool hands back to `from_task_ptr`
+            // covers the whole allocation (the `schedule_owned` shape).
+            let raw = bun_core::heap::into_raw(task);
+            // SAFETY: `raw` is the live box just released above.
+            WorkPool::schedule(unsafe { &raw mut (*raw).task });
             raw
         }
 

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -308,14 +308,29 @@ impl StatWatcherScheduler {
         }
     }
 
-    pub(crate) fn timer_callback(&mut self) {
-        let has_been_cleared = self.event_loop_timer.state == EventLoopTimerState::CANCELLED
-            || self.vm().script_execution_status() != jsc::ScriptExecutionStatus::Running;
-
-        self.event_loop_timer.state = EventLoopTimerState::FIRED;
-        self.event_loop_timer.heap = Default::default();
-
-        if has_been_cleared || self.is_shutdown.load(Ordering::Relaxed) {
+    /// JS thread, from the event-loop timer: hand the queued watchers to the
+    /// pool for one round of stats. The pool may be running `work_pool_callback`
+    /// on this scheduler before this returns, so it takes the pointer the timer
+    /// dispatch recovered rather than a `&mut self` that would stay live (and
+    /// protected) across the hand-off; `event_loop_timer` is only ever touched
+    /// on this thread and everything else is atomic.
+    ///
+    /// # Safety
+    /// `this` is the live scheduler whose `event_loop_timer` fired (`RareData`
+    /// holds a ref on it until `shutdown_for_exit`, which disarms the timer).
+    pub(crate) unsafe fn timer_callback(this: *mut Self) {
+        // SAFETY: fn contract; the timer state is this thread's to write. Here
+        // and below, every access ends at its own statement, so no reference
+        // into the scheduler is live once the pool has the task.
+        let cleared_or_shutting_down = unsafe {
+            let timer = &raw mut (*this).event_loop_timer;
+            let has_been_cleared = (*timer).state == EventLoopTimerState::CANCELLED
+                || (*this).vm().script_execution_status() != jsc::ScriptExecutionStatus::Running;
+            (*timer).state = EventLoopTimerState::FIRED;
+            (*timer).heap = Default::default();
+            has_been_cleared || (*this).is_shutdown.load(Ordering::Relaxed)
+        };
+        if cleared_or_shutting_down {
             return;
         }
 
@@ -338,9 +353,12 @@ impl StatWatcherScheduler {
         // that landed after its `pop_batch()`, which would otherwise leave a
         // live watcher with the timer disarmed. `.max(5)` matches the clamp
         // applied to every watcher interval in `StatWatcher::init`.
-        if self.work_pool_in_flight.swap(true, Ordering::AcqRel) {
-            let this = core::ptr::from_mut(self);
-            Self::set_timer(this, self.get_interval().max(5));
+        // SAFETY: fn contract; both fields are atomics.
+        let already_in_flight = unsafe { (*this).work_pool_in_flight.swap(true, Ordering::AcqRel) };
+        if already_in_flight {
+            // SAFETY: as above.
+            let interval = unsafe { (*this).get_interval() };
+            Self::set_timer(this, interval.max(5));
             return;
         }
 
@@ -348,12 +366,16 @@ impl StatWatcherScheduler {
         // `SchedulerRefGuard` in `work_pool_callback`). Taken here — not in
         // `set_interval` — so the count exactly tracks "task in flight" instead
         // of accumulating one leak per `set_interval(0)` / re-arm.
-        // SAFETY: `self` is live (`&mut self`).
-        Self::ref_(core::ptr::from_mut(self));
+        Self::ref_(this);
         // The task is a field of this per-VM scheduler: counted, so the VM
         // waits for it (see `VmHandle::embedded_work_scheduled`).
-        self.loop_handle.embedded_work_scheduled();
-        WorkPool::schedule(&raw mut self.task);
+        // SAFETY: fn contract. The hand-off is the last thing this function does
+        // with the scheduler, and the task pointer is projected from `this`
+        // itself, as `work_pool_callback`'s `from_field_ptr!` requires.
+        unsafe {
+            (*this).loop_handle.embedded_work_scheduled();
+            WorkPool::schedule(&raw mut (*this).task);
+        }
     }
 
     /// Thread-pool callback (safe fn — coerces to the `WorkPoolTask.callback`

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -308,20 +308,16 @@ impl StatWatcherScheduler {
         }
     }
 
-    /// JS thread, from the event-loop timer: hand the queued watchers to the
-    /// pool for one round of stats. The pool may be running `work_pool_callback`
-    /// on this scheduler before this returns, so it takes the pointer the timer
-    /// dispatch recovered rather than a `&mut self` that would stay live (and
-    /// protected) across the hand-off; `event_loop_timer` is only ever touched
-    /// on this thread and everything else is atomic.
+    /// JS thread, from the event-loop timer. Takes the pointer, not `&mut self`:
+    /// the pool shares the scheduler from the `schedule` onwards, before this
+    /// returns.
     ///
     /// # Safety
-    /// `this` is the live scheduler whose `event_loop_timer` fired (`RareData`
-    /// holds a ref on it until `shutdown_for_exit`, which disarms the timer).
+    /// `this` is the live scheduler whose `event_loop_timer` fired.
     pub(crate) unsafe fn timer_callback(this: *mut Self) {
-        // SAFETY: fn contract; the timer state is this thread's to write. Here
-        // and below, every access ends at its own statement, so no reference
-        // into the scheduler is live once the pool has the task.
+        // SAFETY: fn contract; `event_loop_timer` is JS-thread-only and the rest
+        // is atomic. Here and below, no reference into `*this` outlives its
+        // statement.
         let cleared_or_shutting_down = unsafe {
             let timer = &raw mut (*this).event_loop_timer;
             let has_been_cleared = (*timer).state == EventLoopTimerState::CANCELLED
@@ -353,10 +349,10 @@ impl StatWatcherScheduler {
         // that landed after its `pop_batch()`, which would otherwise leave a
         // live watcher with the timer disarmed. `.max(5)` matches the clamp
         // applied to every watcher interval in `StatWatcher::init`.
-        // SAFETY: fn contract; both fields are atomics.
+        // SAFETY: fn contract.
         let already_in_flight = unsafe { (*this).work_pool_in_flight.swap(true, Ordering::AcqRel) };
         if already_in_flight {
-            // SAFETY: as above.
+            // SAFETY: fn contract.
             let interval = unsafe { (*this).get_interval() };
             Self::set_timer(this, interval.max(5));
             return;
@@ -369,9 +365,7 @@ impl StatWatcherScheduler {
         Self::ref_(this);
         // The task is a field of this per-VM scheduler: counted, so the VM
         // waits for it (see `VmHandle::embedded_work_scheduled`).
-        // SAFETY: fn contract. The hand-off is the last thing this function does
-        // with the scheduler, and the task pointer is projected from `this`
-        // itself, as `work_pool_callback`'s `from_field_ptr!` requires.
+        // SAFETY: fn contract.
         unsafe {
             (*this).loop_handle.embedded_work_scheduled();
             WorkPool::schedule(&raw mut (*this).task);

--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -308,16 +308,11 @@ impl StatWatcherScheduler {
         }
     }
 
-    /// JS thread, from the event-loop timer. Takes the pointer, not `&mut self`:
-    /// the pool shares the scheduler from the `schedule` onwards, before this
-    /// returns.
-    ///
     /// # Safety
-    /// `this` is the live scheduler whose `event_loop_timer` fired.
+    /// `this` is the live scheduler whose `event_loop_timer` fired, on the JS
+    /// thread.
     pub(crate) unsafe fn timer_callback(this: *mut Self) {
-        // SAFETY: fn contract; `event_loop_timer` is JS-thread-only and the rest
-        // is atomic. Here and below, no reference into `*this` outlives its
-        // statement.
+        // SAFETY: fn contract; `event_loop_timer` is JS-thread-only.
         let cleared_or_shutting_down = unsafe {
             let timer = &raw mut (*this).event_loop_timer;
             let has_been_cleared = (*timer).state == EventLoopTimerState::CANCELLED

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -7138,7 +7138,10 @@ macro_rules! impl_file_closer {
                     // here finishes; the io thread does not touch it after this
                     // call, and each access ends at its own statement.
                     unsafe {
-                        (*this).io_poll.flags.remove(::bun_io::Flags::WasEverRegistered);
+                        (*this)
+                            .io_poll
+                            .flags
+                            .remove(::bun_io::Flags::WasEverRegistered);
                         (*this).task = ::bun_jsc::WorkPoolTask {
                             node: Default::default(),
                             callback: on_close_io_request,

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -7042,11 +7042,9 @@ pub trait FileCloser: Sized {
     #[cfg(windows)]
     fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t;
 
-    /// The io thread's half of a deferred close (see `do_close`): close the fd,
-    /// then hand the task back to the pool to finish. Both steps touch fields
-    /// by name (`offset_of!` cannot name fields on a trait `Self`), so the
-    /// whole round trip is supplied per impl by [`impl_file_closer!`], with
-    /// no default body here.
+    /// The deferred close started by `do_close`, including its hand-back to the
+    /// pool. Supplied per impl by [`impl_file_closer!`]: `offset_of!` cannot
+    /// name fields on a trait `Self`.
     fn schedule_close(request: &mut bun_io::Request) -> bun_io::Action<'_>;
 
     fn do_close(&mut self, is_allowed_to_close_fd: bool) -> bool {
@@ -7125,18 +7123,12 @@ macro_rules! impl_file_closer {
             fn schedule_close(request: &mut ::bun_io::Request) -> ::bun_io::Action<'_> {
                 use ::bun_io::IntrusiveIoRequest as _;
 
-                // io thread: the fd is closed. Hands the job back to the pool,
-                // which may be running `on_close_io_request` before this
-                // returns, so the job stays a raw pointer throughout: no
-                // reference into it is live at the hand-off, and the work-pool
-                // task is projected from the job's own pointer, as
-                // `from_task_ptr` requires.
+                // io thread: the fd is closed. Stays a raw pointer, as the pool
+                // owns the job again from the `schedule` onwards.
                 fn on_done(ctx: *mut ()) {
                     let this = ctx.cast::<$T>();
-                    // SAFETY: `ctx` is the `*mut $T` registered as the close
-                    // action's ctx below, live until the pool task scheduled
-                    // here finishes; the io thread does not touch it after this
-                    // call, and each access ends at its own statement.
+                    // SAFETY: `ctx` is the live `*mut $T` registered below; no
+                    // reference into `*this` outlives its statement.
                     unsafe {
                         (*this)
                             .io_poll
@@ -7153,9 +7145,8 @@ macro_rules! impl_file_closer {
                 // Pool thread: finish the job now that its fd is closed.
                 fn on_close_io_request(task: *mut ::bun_jsc::WorkPoolTask) {
                     use ::bun_threading::IntrusiveWorkTask as _;
-                    // SAFETY: only reached via `WorkPoolTask::callback` with the
-                    // `task` field `on_done` projected from the live parent's own
-                    // pointer; recover parent.
+                    // SAFETY: `task` is the field `on_done` scheduled, projected
+                    // from the live parent's pointer; recover parent.
                     let this = unsafe { $T::from_task_ptr(task) };
                     // SAFETY: `this` is the live parent (see above); scoped access.
                     unsafe { (*this).close_after_io = false };

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -7042,9 +7042,9 @@ pub trait FileCloser: Sized {
     #[cfg(windows)]
     fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t;
 
-    /// The deferred close started by `do_close`, including its hand-back to the
-    /// pool. Supplied per impl by [`impl_file_closer!`]: `offset_of!` cannot
-    /// name fields on a trait `Self`.
+    /// Intrusive backref: Rust `offset_of!` cannot name
+    /// fields on a trait `Self`, so each concrete impl supplies its own
+    /// container_of recovery (no default body).
     fn schedule_close(request: &mut bun_io::Request) -> bun_io::Action<'_>;
 
     fn do_close(&mut self, is_allowed_to_close_fd: bool) -> bool {
@@ -7092,7 +7092,7 @@ pub trait FileCloser: Sized {
 /// an inherent `update()`, and a [`bun_io::Tag`] variant named after the type.
 /// The type must also carry `bun_threading::intrusive_work_task!` and
 /// `bun_io::intrusive_io_request!`, which provide the parent-pointer recovery
-/// used by the close round trip's trampolines.
+/// used by the two trampolines.
 macro_rules! impl_file_closer {
     ($T:ident) => {
         impl crate::webcore::blob::FileCloser for $T {
@@ -7123,12 +7123,10 @@ macro_rules! impl_file_closer {
             fn schedule_close(request: &mut ::bun_io::Request) -> ::bun_io::Action<'_> {
                 use ::bun_io::IntrusiveIoRequest as _;
 
-                // io thread: the fd is closed. Stays a raw pointer, as the pool
-                // owns the job again from the `schedule` onwards.
+                // io thread: the fd is closed; the pool finishes the job.
                 fn on_done(ctx: *mut ()) {
                     let this = ctx.cast::<$T>();
-                    // SAFETY: `ctx` is the live `*mut $T` registered below; no
-                    // reference into `*this` outlives its statement.
+                    // SAFETY: `ctx` is the live `*mut $T` registered below.
                     unsafe {
                         (*this)
                             .io_poll
@@ -7142,11 +7140,9 @@ macro_rules! impl_file_closer {
                     }
                 }
 
-                // Pool thread: finish the job now that its fd is closed.
                 fn on_close_io_request(task: *mut ::bun_jsc::WorkPoolTask) {
                     use ::bun_threading::IntrusiveWorkTask as _;
-                    // SAFETY: `task` is the field `on_done` scheduled, projected
-                    // from the live parent's pointer; recover parent.
+                    // SAFETY: `task` is the live parent's field that `on_done` scheduled.
                     let this = unsafe { $T::from_task_ptr(task) };
                     // SAFETY: `this` is the live parent (see above); scoped access.
                     unsafe { (*this).close_after_io = false };

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -7038,35 +7038,16 @@ pub trait FileCloser: Sized {
     fn close_after_io(&self) -> bool;
     fn state(&self) -> &core::sync::atomic::AtomicU8;
     fn io_request(&mut self) -> Option<&mut bun_io::Request>;
-    fn io_poll(&mut self) -> &mut bun_io::Poll;
-    fn task(&mut self) -> &mut bun_jsc::WorkPoolTask;
     fn update(&mut self);
     #[cfg(windows)]
     fn loop_(&self) -> *mut bun_libuv_sys::uv_loop_t;
 
-    /// Intrusive backref: Rust `offset_of!` cannot name
-    /// fields on a trait `Self`, so each concrete impl supplies its own
-    /// container_of recovery (no default body).
+    /// The io thread's half of a deferred close (see `do_close`): close the fd,
+    /// then hand the task back to the pool to finish. Both steps touch fields
+    /// by name (`offset_of!` cannot name fields on a trait `Self`), so the
+    /// whole round trip is supplied per impl by [`impl_file_closer!`], with
+    /// no default body here.
     fn schedule_close(request: &mut bun_io::Request) -> bun_io::Action<'_>;
-
-    fn on_io_request_closed(this: &mut Self) {
-        this.io_poll()
-            .flags
-            .remove(bun_io::Flags::WasEverRegistered);
-        *this.task() = bun_jsc::WorkPoolTask {
-            node: Default::default(),
-            callback: Self::on_close_io_request,
-        };
-        bun_jsc::WorkPool::schedule(this.task());
-    }
-
-    /// Intrusive backref: concrete impl supplies its own
-    /// container_of recovery (no default body).
-    ///
-    /// Stored in `WorkPoolTask::callback` (raw fn-pointer slot — safe `fn`
-    /// coerces). Never called directly; the impl guards its single
-    /// `container_of` deref locally, so a fn-level qualifier is redundant.
-    fn on_close_io_request(task: *mut bun_jsc::WorkPoolTask);
 
     fn do_close(&mut self, is_allowed_to_close_fd: bool) -> bool {
         // Check `close_after_io()` before `io_request()` so the immutable
@@ -7113,7 +7094,7 @@ pub trait FileCloser: Sized {
 /// an inherent `update()`, and a [`bun_io::Tag`] variant named after the type.
 /// The type must also carry `bun_threading::intrusive_work_task!` and
 /// `bun_io::intrusive_io_request!`, which provide the parent-pointer recovery
-/// used by the two trampolines.
+/// used by the close round trip's trampolines.
 macro_rules! impl_file_closer {
     ($T:ident) => {
         impl crate::webcore::blob::FileCloser for $T {
@@ -7133,12 +7114,6 @@ macro_rules! impl_file_closer {
             fn io_request(&mut self) -> Option<&mut ::bun_io::Request> {
                 Some(&mut self.io_request)
             }
-            fn io_poll(&mut self) -> &mut ::bun_io::Poll {
-                &mut self.io_poll
-            }
-            fn task(&mut self) -> &mut ::bun_jsc::WorkPoolTask {
-                &mut self.task
-            }
             fn update(&mut self) {
                 $T::update(self)
             }
@@ -7149,13 +7124,44 @@ macro_rules! impl_file_closer {
 
             fn schedule_close(request: &mut ::bun_io::Request) -> ::bun_io::Action<'_> {
                 use ::bun_io::IntrusiveIoRequest as _;
+
+                // io thread: the fd is closed. Hands the job back to the pool,
+                // which may be running `on_close_io_request` before this
+                // returns, so the job stays a raw pointer throughout: no
+                // reference into it is live at the hand-off, and the work-pool
+                // task is projected from the job's own pointer, as
+                // `from_task_ptr` requires.
+                fn on_done(ctx: *mut ()) {
+                    let this = ctx.cast::<$T>();
+                    // SAFETY: `ctx` is the `*mut $T` registered as the close
+                    // action's ctx below, live until the pool task scheduled
+                    // here finishes; the io thread does not touch it after this
+                    // call, and each access ends at its own statement.
+                    unsafe {
+                        (*this).io_poll.flags.remove(::bun_io::Flags::WasEverRegistered);
+                        (*this).task = ::bun_jsc::WorkPoolTask {
+                            node: Default::default(),
+                            callback: on_close_io_request,
+                        };
+                        ::bun_jsc::WorkPool::schedule(&raw mut (*this).task);
+                    }
+                }
+
+                // Pool thread: finish the job now that its fd is closed.
+                fn on_close_io_request(task: *mut ::bun_jsc::WorkPoolTask) {
+                    use ::bun_threading::IntrusiveWorkTask as _;
+                    // SAFETY: only reached via `WorkPoolTask::callback` with the
+                    // `task` field `on_done` projected from the live parent's own
+                    // pointer; recover parent.
+                    let this = unsafe { $T::from_task_ptr(task) };
+                    // SAFETY: `this` is the live parent (see above); scoped access.
+                    unsafe { (*this).close_after_io = false };
+                    // SAFETY: as above; exclusive borrow scoped to the call.
+                    $T::update(unsafe { &mut *this });
+                }
+
                 // SAFETY: `request` is `&mut self.io_request` (intrusive); recover parent.
                 let this = unsafe { $T::from_io_request(::core::ptr::from_mut(request)) };
-                fn on_done(ctx: *mut ()) {
-                    // SAFETY: ctx is `self as *mut Self` set below.
-                    let this = unsafe { ::bun_ptr::callback_ctx::<$T>(ctx.cast()) };
-                    <$T as crate::webcore::blob::FileCloser>::on_io_request_closed(this);
-                }
                 // SAFETY: `request` is `&mut self.io_request` (intrusive), so `this` is the
                 // live parent; the `fd` copy and the `io_poll` field borrow are the only
                 // borrows formed.
@@ -7167,23 +7173,6 @@ macro_rules! impl_file_closer {
                     tag: <Self as crate::webcore::blob::FileCloser>::IO_TAG,
                     on_done,
                 })
-            }
-
-            // `FileCloser` fixes `on_close_io_request` to take `*mut WorkPoolTask`;
-            // the trait method cannot be marked `unsafe fn`, so the lint is
-            // unsatisfiable here. The pointer is the intrusive `&mut self.task` set
-            // in `on_io_request_closed` and is guaranteed live.
-            #[allow(clippy::not_unsafe_ptr_arg_deref)]
-            fn on_close_io_request(task: *mut ::bun_jsc::WorkPoolTask) {
-                use ::bun_threading::IntrusiveWorkTask as _;
-                // SAFETY: only reached via `WorkPoolTask::callback` with `task` =
-                // `&mut self.task` (intrusive) registered in `on_io_request_closed`;
-                // recover parent.
-                let this = unsafe { $T::from_task_ptr(task) };
-                // SAFETY: `this` is the live parent (see above); scoped access.
-                unsafe { (*this).close_after_io = false };
-                // SAFETY: as above; exclusive borrow scoped to the call.
-                $T::update(unsafe { &mut *this });
             }
         }
     };

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -389,11 +389,9 @@ impl ReadFile {
     #[cfg(not(windows))]
     pub(crate) const IO_TAG: io::Tag = io::Tag::ReadFile;
 
-    /// io thread. Takes the pointer, not `&mut self`: the pool owns the read
-    /// again from the `schedule` onwards, before this returns.
-    ///
     /// # Safety
-    /// `this` is the live `ReadFile` whose `io_poll` fired.
+    /// `this` is the live `ReadFile` whose `io_poll` fired; the pool owns it
+    /// again once this returns.
     pub(crate) unsafe fn on_ready(this: *mut Self) {
         bloblog!("ReadFile.onReady");
         // SAFETY: fn contract; no reference into `*this` outlives its statement.
@@ -415,8 +413,6 @@ impl ReadFile {
         }
     }
 
-    /// io thread; same hand-off as [`on_ready`](Self::on_ready).
-    ///
     /// # Safety
     /// As for [`on_ready`](Self::on_ready).
     pub(crate) unsafe fn on_io_error(this: *mut Self, err: &bun_sys::Error) {

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -389,48 +389,71 @@ impl ReadFile {
     #[cfg(not(windows))]
     pub(crate) const IO_TAG: io::Tag = io::Tag::ReadFile;
 
-    pub fn on_ready(&mut self) {
+    /// io thread: the fd the read is waiting on became readable. Hands the
+    /// read back to the pool, which may be running it again before this
+    /// returns, so this takes the pointer the io thread holds rather than a
+    /// `&mut self` that would stay live (and protected) across the hand-off.
+    ///
+    /// # Safety
+    /// `this` is the live `ReadFile` whose `io_poll` fired; nothing on this
+    /// thread touches it after the call.
+    pub(crate) unsafe fn on_ready(this: *mut Self) {
         bloblog!("ReadFile.onReady");
-        self.task = WorkPoolTask {
-            node: Default::default(),
-            callback: Self::do_read_loop_task,
-        };
-        // On macOS, we use one-shot mode, so:
-        // - we don't need to unregister
-        // - we don't need to delete from kqueue
-        #[cfg(target_os = "macos")]
-        {
-            // unless pending IO has been scheduled in-between.
-            self.close_after_io = self.io_request.scheduled;
-        }
+        // SAFETY: fn contract. Every access ends at its statement, so no
+        // reference into the read is live when the pool gets it, and the task
+        // pointer is projected from `this` itself, as `from_task_ptr` requires.
+        unsafe {
+            (*this).task = WorkPoolTask {
+                node: Default::default(),
+                callback: Self::do_read_loop_task,
+            };
+            // On macOS, we use one-shot mode, so:
+            // - we don't need to unregister
+            // - we don't need to delete from kqueue
+            #[cfg(target_os = "macos")]
+            {
+                // unless pending IO has been scheduled in-between.
+                (*this).close_after_io = (*this).io_request.scheduled;
+            }
 
-        WorkPool::schedule(&raw mut self.task);
+            WorkPool::schedule(&raw mut (*this).task);
+        }
     }
 
-    pub(crate) fn on_io_error(&mut self, err: &bun_sys::Error) {
+    /// io thread: registering or polling the fd failed. Records the error and
+    /// hands the read back to the pool to finish; same hand-off as
+    /// [`on_ready`](Self::on_ready).
+    ///
+    /// # Safety
+    /// As for [`on_ready`](Self::on_ready).
+    pub(crate) unsafe fn on_io_error(this: *mut Self, err: &bun_sys::Error) {
         bloblog!("ReadFile.onIOError");
-        self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
-        self.system_error = Some(err.to_system_error().into());
-        self.task = WorkPoolTask {
-            node: Default::default(),
-            callback: Self::do_read_loop_task,
-        };
-        // On macOS, we use one-shot mode, so:
-        // - we don't need to unregister
-        // - we don't need to delete from kqueue
-        #[cfg(target_os = "macos")]
-        {
-            // unless pending IO has been scheduled in-between.
-            self.close_after_io = self.io_request.scheduled;
+        // SAFETY: see `on_ready`.
+        unsafe {
+            (*this).errno = Some(bun_errno::from_errno(err.errno as i32).into());
+            (*this).system_error = Some(err.to_system_error().into());
+            (*this).task = WorkPoolTask {
+                node: Default::default(),
+                callback: Self::do_read_loop_task,
+            };
+            // On macOS, we use one-shot mode, so:
+            // - we don't need to unregister
+            // - we don't need to delete from kqueue
+            #[cfg(target_os = "macos")]
+            {
+                // unless pending IO has been scheduled in-between.
+                (*this).close_after_io = (*this).io_request.scheduled;
+            }
+            WorkPool::schedule(&raw mut (*this).task);
         }
-        WorkPool::schedule(&raw mut self.task);
     }
 
     /// Thunk matching `io::FileAction::on_error`'s `fn(*mut (), &sys::Error)` shape.
     #[cfg(not(windows))]
     fn on_io_error_thunk(ctx: *mut (), err: &bun_sys::Error) {
-        // SAFETY: ctx is `self as *mut ReadFile` set in on_request_readable below.
-        unsafe { (*ctx.cast::<ReadFile>()).on_io_error(err) }
+        // SAFETY: `ctx` is the `*mut ReadFile` registered in `on_request_readable`
+        // below; the io thread does not touch it after the action's error hook.
+        unsafe { Self::on_io_error(ctx.cast::<ReadFile>(), err) }
     }
 
     #[cfg(not(windows))]
@@ -764,9 +787,9 @@ impl ReadFile {
     }
 
     fn do_read_loop_task(task: *mut WorkPoolTask) {
-        // SAFETY: only reached via `WorkPoolTask::callback` with `task` =
-        // `&mut self.task` (intrusive) registered in `on_writable`/`init`;
-        // recover parent.
+        // SAFETY: only reached via `WorkPoolTask::callback` with the `task`
+        // field that `on_ready` / `on_io_error` projected from the live
+        // `ReadFile`'s own pointer; recover parent.
         let this = unsafe { &mut *ReadFile::from_task_ptr(task) };
 
         this.update();
@@ -984,19 +1007,10 @@ impl<'a> FileCloser for ReadFileUV<'a> {
     fn io_request(&mut self) -> Option<&mut bun_io::Request> {
         None
     }
-    fn io_poll(&mut self) -> &mut bun_io::Poll {
-        unreachable!("@hasField(ReadFileUV, \"io_request\") == false")
-    }
-    fn task(&mut self) -> &mut bun_jsc::WorkPoolTask {
-        unreachable!("@hasField(ReadFileUV, \"io_request\") == false")
-    }
     fn update(&mut self) {
         unreachable!("@hasField(ReadFileUV, \"io_request\") == false")
     }
     fn schedule_close(_: &mut bun_io::Request) -> bun_io::Action<'_> {
-        unreachable!("@hasField(ReadFileUV, \"io_request\") == false")
-    }
-    fn on_close_io_request(_: *mut bun_jsc::WorkPoolTask) {
         unreachable!("@hasField(ReadFileUV, \"io_request\") == false")
     }
 }

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -389,19 +389,14 @@ impl ReadFile {
     #[cfg(not(windows))]
     pub(crate) const IO_TAG: io::Tag = io::Tag::ReadFile;
 
-    /// io thread: the fd the read is waiting on became readable. Hands the
-    /// read back to the pool, which may be running it again before this
-    /// returns, so this takes the pointer the io thread holds rather than a
-    /// `&mut self` that would stay live (and protected) across the hand-off.
+    /// io thread. Takes the pointer, not `&mut self`: the pool owns the read
+    /// again from the `schedule` onwards, before this returns.
     ///
     /// # Safety
-    /// `this` is the live `ReadFile` whose `io_poll` fired; nothing on this
-    /// thread touches it after the call.
+    /// `this` is the live `ReadFile` whose `io_poll` fired.
     pub(crate) unsafe fn on_ready(this: *mut Self) {
         bloblog!("ReadFile.onReady");
-        // SAFETY: fn contract. Every access ends at its statement, so no
-        // reference into the read is live when the pool gets it, and the task
-        // pointer is projected from `this` itself, as `from_task_ptr` requires.
+        // SAFETY: fn contract; no reference into `*this` outlives its statement.
         unsafe {
             (*this).task = WorkPoolTask {
                 node: Default::default(),
@@ -420,15 +415,13 @@ impl ReadFile {
         }
     }
 
-    /// io thread: registering or polling the fd failed. Records the error and
-    /// hands the read back to the pool to finish; same hand-off as
-    /// [`on_ready`](Self::on_ready).
+    /// io thread; same hand-off as [`on_ready`](Self::on_ready).
     ///
     /// # Safety
     /// As for [`on_ready`](Self::on_ready).
     pub(crate) unsafe fn on_io_error(this: *mut Self, err: &bun_sys::Error) {
         bloblog!("ReadFile.onIOError");
-        // SAFETY: see `on_ready`.
+        // SAFETY: as in `on_ready`.
         unsafe {
             (*this).errno = Some(bun_errno::from_errno(err.errno as i32).into());
             (*this).system_error = Some(err.to_system_error().into());
@@ -451,8 +444,7 @@ impl ReadFile {
     /// Thunk matching `io::FileAction::on_error`'s `fn(*mut (), &sys::Error)` shape.
     #[cfg(not(windows))]
     fn on_io_error_thunk(ctx: *mut (), err: &bun_sys::Error) {
-        // SAFETY: `ctx` is the `*mut ReadFile` registered in `on_request_readable`
-        // below; the io thread does not touch it after the action's error hook.
+        // SAFETY: `ctx` is the `*mut ReadFile` registered in `on_request_readable` below.
         unsafe { Self::on_io_error(ctx.cast::<ReadFile>(), err) }
     }
 

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -179,26 +179,51 @@ impl WriteFile {
     #[cfg(not(windows))]
     pub(crate) const IO_TAG: io::Tag = io::Tag::WriteFile;
 
-    pub fn on_ready(&mut self) {
+    /// io thread: the fd the write is waiting on became writable. Hands the
+    /// write back to the pool, which may be running it again before this
+    /// returns, so this takes the pointer the io thread holds rather than a
+    /// `&mut self` that would stay live (and protected) across the hand-off.
+    ///
+    /// # Safety
+    /// `this` is the live `WriteFile` whose `io_poll` fired; nothing on this
+    /// thread touches it after the call.
+    pub(crate) unsafe fn on_ready(this: *mut Self) {
         bun_output::scoped_log!(WriteFile, "WriteFile.onReady()");
-        self.task = WorkPoolTask {
-            node: Default::default(),
-            callback: Self::do_write_loop_task,
-        };
-        WorkPool::schedule(&raw mut self.task);
+        // SAFETY: fn contract. The write of `task` ends at its statement, so no
+        // reference into the write is live when the pool gets it, and the task
+        // pointer is projected from `this` itself, as `from_task_ptr` requires.
+        unsafe {
+            (*this).task = WorkPoolTask {
+                node: Default::default(),
+                callback: Self::do_write_loop_task,
+            };
+            WorkPool::schedule(&raw mut (*this).task);
+        }
     }
 
+    /// io thread: registering or polling the fd failed. Records the error and
+    /// hands the write back to the pool to finish; same hand-off as
+    /// [`on_ready`](Self::on_ready). Shaped as `io::FileAction::on_error`
+    /// (`fn(*mut (), &sys::Error)`), which is how `on_request_writable`
+    /// registers it; the poll error dispatch calls it with the same pointer.
     pub(crate) fn on_io_error(this: *mut (), err: &sys::Error) {
         bun_output::scoped_log!(WriteFile, "WriteFile.onIOError()");
-        // SAFETY: ctx was set to `self as *mut WriteFile` in `on_request_writable`.
-        let this = unsafe { bun_ptr::callback_ctx::<WriteFile>(this.cast()) };
-        this.errno = Some(bun_errno::from_errno(err.errno as i32).into());
-        this.system_error = Some(err.to_system_error().into());
-        this.task = WorkPoolTask {
-            node: Default::default(),
-            callback: Self::do_write_loop_task,
-        };
-        WorkPool::schedule(&raw mut this.task);
+        let this = this.cast::<WriteFile>();
+        // SAFETY: `this` is the `*mut WriteFile` registered as the action's ctx
+        // in `on_request_writable` (or recovered from its `io_poll` by the
+        // dispatch), live until the pool task scheduled here finishes, and the
+        // io thread does not touch it after this call. See `on_ready` for why
+        // the accesses are statement-scoped and the task is projected from
+        // `this`.
+        unsafe {
+            (*this).errno = Some(bun_errno::from_errno(err.errno as i32).into());
+            (*this).system_error = Some(err.to_system_error().into());
+            (*this).task = WorkPoolTask {
+                node: Default::default(),
+                callback: Self::do_write_loop_task,
+            };
+            WorkPool::schedule(&raw mut (*this).task);
+        }
     }
 
     #[cfg(not(windows))]
@@ -473,8 +498,9 @@ impl WriteFile {
     }
 
     fn do_write_loop_task(task: *mut WorkPoolTask) {
-        // SAFETY: only reached via `WorkPoolTask::callback` with `task` = `&mut self.task`
-        // (intrusive) registered in `on_writable`/`init`; recover parent.
+        // SAFETY: only reached via `WorkPoolTask::callback` with the `task` field
+        // that `on_ready` / `on_io_error` projected from the live `WriteFile`'s
+        // own pointer; recover parent.
         let this = unsafe { WriteFile::from_task_ptr(task) };
         // On macOS, we use one-shot mode, so we don't need to unregister.
         #[cfg(target_os = "macos")]

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -179,11 +179,9 @@ impl WriteFile {
     #[cfg(not(windows))]
     pub(crate) const IO_TAG: io::Tag = io::Tag::WriteFile;
 
-    /// io thread. Takes the pointer, not `&mut self`: the pool owns the write
-    /// again from the `schedule` onwards, before this returns.
-    ///
     /// # Safety
-    /// `this` is the live `WriteFile` whose `io_poll` fired.
+    /// `this` is the live `WriteFile` whose `io_poll` fired; the pool owns it
+    /// again once this returns.
     pub(crate) unsafe fn on_ready(this: *mut Self) {
         bun_output::scoped_log!(WriteFile, "WriteFile.onReady()");
         // SAFETY: fn contract; no reference into `*this` outlives its statement.
@@ -196,13 +194,11 @@ impl WriteFile {
         }
     }
 
-    /// io thread; same hand-off as [`on_ready`](Self::on_ready), in the
-    /// `io::FileAction::on_error` shape `on_request_writable` registers.
     pub(crate) fn on_io_error(this: *mut (), err: &sys::Error) {
         bun_output::scoped_log!(WriteFile, "WriteFile.onIOError()");
         let this = this.cast::<WriteFile>();
-        // SAFETY: `this` is the live `*mut WriteFile` registered as the action's
-        // ctx (or recovered from its `io_poll` by the dispatch); as in `on_ready`.
+        // SAFETY: `this` is the live `WriteFile` the io thread handed to this
+        // hook; otherwise as in `on_ready`.
         unsafe {
             (*this).errno = Some(bun_errno::from_errno(err.errno as i32).into());
             (*this).system_error = Some(err.to_system_error().into());

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -179,19 +179,14 @@ impl WriteFile {
     #[cfg(not(windows))]
     pub(crate) const IO_TAG: io::Tag = io::Tag::WriteFile;
 
-    /// io thread: the fd the write is waiting on became writable. Hands the
-    /// write back to the pool, which may be running it again before this
-    /// returns, so this takes the pointer the io thread holds rather than a
-    /// `&mut self` that would stay live (and protected) across the hand-off.
+    /// io thread. Takes the pointer, not `&mut self`: the pool owns the write
+    /// again from the `schedule` onwards, before this returns.
     ///
     /// # Safety
-    /// `this` is the live `WriteFile` whose `io_poll` fired; nothing on this
-    /// thread touches it after the call.
+    /// `this` is the live `WriteFile` whose `io_poll` fired.
     pub(crate) unsafe fn on_ready(this: *mut Self) {
         bun_output::scoped_log!(WriteFile, "WriteFile.onReady()");
-        // SAFETY: fn contract. The write of `task` ends at its statement, so no
-        // reference into the write is live when the pool gets it, and the task
-        // pointer is projected from `this` itself, as `from_task_ptr` requires.
+        // SAFETY: fn contract; no reference into `*this` outlives its statement.
         unsafe {
             (*this).task = WorkPoolTask {
                 node: Default::default(),
@@ -201,20 +196,13 @@ impl WriteFile {
         }
     }
 
-    /// io thread: registering or polling the fd failed. Records the error and
-    /// hands the write back to the pool to finish; same hand-off as
-    /// [`on_ready`](Self::on_ready). Shaped as `io::FileAction::on_error`
-    /// (`fn(*mut (), &sys::Error)`), which is how `on_request_writable`
-    /// registers it; the poll error dispatch calls it with the same pointer.
+    /// io thread; same hand-off as [`on_ready`](Self::on_ready), in the
+    /// `io::FileAction::on_error` shape `on_request_writable` registers.
     pub(crate) fn on_io_error(this: *mut (), err: &sys::Error) {
         bun_output::scoped_log!(WriteFile, "WriteFile.onIOError()");
         let this = this.cast::<WriteFile>();
-        // SAFETY: `this` is the `*mut WriteFile` registered as the action's ctx
-        // in `on_request_writable` (or recovered from its `io_poll` by the
-        // dispatch), live until the pool task scheduled here finishes, and the
-        // io thread does not touch it after this call. See `on_ready` for why
-        // the accesses are statement-scoped and the task is projected from
-        // `this`.
+        // SAFETY: `this` is the live `*mut WriteFile` registered as the action's
+        // ctx (or recovered from its `io_poll` by the dispatch); as in `on_ready`.
         unsafe {
             (*this).errno = Some(bun_errno::from_errno(err.errno as i32).into());
             (*this).system_error = Some(err.to_system_error().into());

--- a/test/internal/source-lints/work-pool-schedule-projection.test.ts
+++ b/test/internal/source-lints/work-pool-schedule-projection.test.ts
@@ -43,11 +43,13 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // converted versions are the templates.
 //
 // Scope: the argument of a call spelled `..WorkPool::schedule(..)`, when it is
-// a field path through a binding (`&raw mut x.f`, `&mut x.f`, `addr_of_mut!(
-// x.f)`, `ptr::from_mut(&mut x.f)`) or one of the tree's reference-returning
-// task accessors (`x.task()`, `x.task_mut()`, `x.field_mut()`). A raw pointer
-// projected through `(*p).f`, a local holding the projected pointer, and
-// `schedule_owned` / `schedule_new` are the intended shapes. Whether the
+// a field path through a binding (`&raw mut x.f`, `&raw mut (*self).f`,
+// `&mut x.f`, `addr_of_mut!(x.f)`, `ptr::from_mut(&mut x.f)`) or one of the
+// tree's reference-returning task accessors (`x.task()`, `x.task_mut()`,
+// `x.field_mut()`). A raw pointer projected through `(*p).f`, a local holding
+// the projected pointer, and `schedule_owned` / `schedule_new` are the intended
+// shapes; `(*r).f` through a reference parameter not named `self` looks the
+// same as the intended shape and is not caught. Whether the
 // pointer the function was handed is itself whole-object is that function's
 // caller's business (the io thread's `FileAction.poll: &mut Poll` and
 // `Request` hand-offs narrow one level up; tracked separately). The same
@@ -82,9 +84,13 @@ const tracked: Set<string> | null = (() => {
 const CALL = String.raw`\bWorkPool::schedule\(\s*(?:unsafe\s*\{\s*)?`;
 const END = String.raw`\s*\}?\s*[,)]`;
 
-// `x.f`, `x.a.f`: a field path whose base is a binding. A raw pointer projects
-// as `(*x).f`, which starts with `(` and so never matches.
-const FIELD_PATH = String.raw`\w+(?:\.\w+)+`;
+// `x.f`, `x.a.f`: a field path whose base is a binding; also `(*self).f`,
+// since `self` is a reference (or the value) in every position it can appear
+// in, so dereferencing it explicitly is the same projection. A raw pointer
+// projects as `(*p).f`; whether `p` is a raw pointer or a reference parameter
+// is not visible here, so only the `self` spelling of that form is matched.
+const BASE = String.raw`(?:\w+|\(\s*\*\s*self\s*\))`;
+const FIELD_PATH = String.raw`${BASE}(?:\.\w+)+`;
 
 const BANNED_ARGS = [
   String.raw`&raw\s+mut\s+${FIELD_PATH}`,
@@ -95,7 +101,7 @@ const BANNED_ARGS = [
   // was), `IntrusiveWorkTask::task_mut`, `IntrusiveField::field_mut`. A
   // trailing `.as_ptr()` or similar does not reach the closing paren, so a
   // helper returning a raw pointer is not matched.
-  String.raw`\w+(?:\.\w+)*\.(?:task|task_mut|field_mut)\(\s*\)`,
+  String.raw`${BASE}(?:\.\w+)*\.(?:task|task_mut|field_mut)\(\s*\)`,
 ].join("|");
 
 const BANNED = new RegExp(`${CALL}(?:${BANNED_ARGS})${END}`, "g");
@@ -164,6 +170,11 @@ test("the pattern recognizes the spellings it claims to", () => {
     "WorkPool::schedule(self.field_mut());",
     "WorkPool::schedule(this.inner.task());",
     "WorkPool::schedule(unsafe { &raw mut this.task });",
+    // `self` dereferenced explicitly is still a projection through `self`.
+    "WorkPool::schedule(&raw mut (*self).task);",
+    "WorkPool::schedule(addr_of_mut!((*self).task));",
+    "WorkPool::schedule(&mut (* self).inner.task);",
+    "WorkPool::schedule((*self).task_mut());",
     // rustfmt-wrapped.
     "WorkPool::schedule(\n    &raw mut self.task,\n);",
     "bun_jsc::WorkPool::schedule(\n    this.task(),\n);",

--- a/test/internal/source-lints/work-pool-schedule-projection.test.ts
+++ b/test/internal/source-lints/work-pool-schedule-projection.test.ts
@@ -1,0 +1,201 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// The task handed to `WorkPool::schedule` must be projected from the raw
+// pointer to the object that embeds it, never through a reference to that
+// object. Inside a `&mut self` method (or any function holding a reference),
+//
+//   WorkPool::schedule(&raw mut self.task);
+//   WorkPool::schedule(&raw mut this.task);        // `this` a `&mut T` local
+//   bun_jsc::WorkPool::schedule(this.task());      // accessor returning `&mut Task`
+//
+// is banned; the accepted spelling is the one `WorkPool::schedule_owned`
+// (src/threading/work_pool.rs) and the tree's other schedulers use:
+//
+//   WorkPool::schedule(&raw mut (*this).task);
+//
+// where `this: *mut T` is the pointer the caller already held (the io action's
+// ctx, the timer's container, the hive slot, the box just released).
+//
+// Two things are wrong with the banned shape. `schedule` is the hand-over: a
+// pool thread may be running the object's callback before the call returns,
+// and when the argument is a reference (`&mut self`, `this: &mut Self`) that
+// reference stays live, and protected, until the method returns. Under the
+// aliasing models (Tree Borrows is what `bun run rust:miri` uses) a protected
+// reference is released with an implicit read of everything it touched, which
+// conflicts with the pool thread's writes and retires every reference the pool
+// thread derived from the pointer it was given; rustc's codegen makes the same
+// assumption (`noalias` + `dereferenceable` for the whole call). Separately, a
+// `&mut Task` accessor hands the pool a pointer whose provenance covers the
+// task field alone, while `IntrusiveWorkTask::from_task_ptr` (the pool-side
+// recovery) documents that it needs the whole allocation; `bun_core::
+// container_of` says the same ("a `&mut field` reborrow does not suffice").
+// `ReadFile::on_ready` / `on_io_error`, `WriteFile::on_ready`, the close
+// round trip in `impl_file_closer!`, `StatWatcherScheduler::timer_callback`
+// and `TranspilerJob::schedule` were the instances this was written for; the
+// converted versions are the templates.
+//
+// Scope: the argument of a call spelled `..WorkPool::schedule(..)`, when it is
+// a field path through a binding (`&raw mut x.f`, `&mut x.f`, `addr_of_mut!(
+// x.f)`, `ptr::from_mut(&mut x.f)`) or one of the tree's reference-returning
+// task accessors (`x.task()`, `x.task_mut()`, `x.field_mut()`). A raw pointer
+// projected through `(*p).f`, a local holding the projected pointer, and
+// `schedule_owned` / `schedule_new` are the intended shapes. The same hazard
+// in other spellings is outside this lint: `Batch::from(&raw mut self.task)`
+// pushed onto a batch that is scheduled later (bundler, install, http), a
+// helper that returns a raw pointer (`x.task().as_ptr()` in the zlib binding),
+// and `IoRequestLoop::schedule(&mut self.io_request)`, which is the io-thread
+// twin of this hand-over. Siblings: self-receiver-reclaim.test.ts,
+// self-receiver-publish.test.ts, self-receiver-intrusive-post.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `WorkPool::schedule(`, however the path in front of `WorkPool` is spelled
+// (`bun_jsc::`, `bun_threading::work_pool::`, bare). `schedule_owned` and
+// `schedule_new` have a different name and do not match. `\s*` after the paren
+// so a rustfmt-wrapped argument still matches; the argument may be wrapped in
+// an `unsafe { .. }` block.
+const CALL = String.raw`\bWorkPool::schedule\(\s*(?:unsafe\s*\{\s*)?`;
+const END = String.raw`\s*\}?\s*[,)]`;
+
+// `x.f`, `x.a.f`: a field path whose base is a binding. A raw pointer projects
+// as `(*x).f`, which starts with `(` and so never matches.
+const FIELD_PATH = String.raw`\w+(?:\.\w+)+`;
+
+const BANNED_ARGS = [
+  String.raw`&raw\s+mut\s+${FIELD_PATH}`,
+  String.raw`&mut\s+${FIELD_PATH}`,
+  String.raw`(?:[\w:]+::)?addr_of_mut!\s*\(\s*${FIELD_PATH}\s*\)`,
+  String.raw`(?:[\w:]+::)?from_mut(?:::<[^>]*>)?\(\s*&mut\s+${FIELD_PATH}\s*\)`,
+  // The tree's accessors that return `&mut Task`: `FileCloser::task` (as it
+  // was), `IntrusiveWorkTask::task_mut`, `IntrusiveField::field_mut`. A
+  // trailing `.as_ptr()` or similar does not reach the closing paren, so a
+  // helper returning a raw pointer is not matched.
+  String.raw`\w+(?:\.\w+)*\.(?:task|task_mut|field_mut)\(\s*\)`,
+].join("|");
+
+const BANNED = new RegExp(`${CALL}(?:${BANNED_ARGS})${END}`, "g");
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape. Prefer converting over adding an entry here.
+const ALLOW: Record<string, number> = {
+  // `napi_async_work::schedule(&mut self)` is being converted separately
+  // (#37750, together with the rest of that type's receivers); delete this
+  // entry when that lands.
+  "src/runtime/napi/napi_body.rs": 1,
+};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including the in-tree comments
+  // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
+  // newlines and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const m of stripped.matchAll(BANNED)) {
+    const line = stripped.slice(0, m.index).split("\n").length;
+    counts[source] = (counts[source] ?? 0) + 1;
+    if ((counts[source] ?? 0) > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${line}: ${m[0].replace(/\s+/g, " ")}`);
+    }
+  }
+}
+
+function matches(snippet: string): boolean {
+  BANNED.lastIndex = 0;
+  return BANNED.test(snippet);
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the pattern recognizes the spellings it claims to", () => {
+  const banned = [
+    // The instances this was written for, as they were.
+    "WorkPool::schedule(&raw mut self.task);",
+    "WorkPool::schedule(&raw mut this.task);",
+    "WorkPool::schedule(&raw mut raw.task);",
+    "WorkPool::schedule(&raw mut self.work_task);",
+    "bun_jsc::WorkPool::schedule(this.task());",
+    // Other paths to the pool, and other spellings of the projection.
+    "bun_threading::work_pool::WorkPool::schedule(&raw mut self.task);",
+    "WorkPool::schedule(&raw mut self.inner.task);",
+    "WorkPool::schedule(&mut self.task);",
+    "WorkPool::schedule(addr_of_mut!(self.task));",
+    "WorkPool::schedule(core::ptr::addr_of_mut!(this.task));",
+    "WorkPool::schedule(ptr::from_mut(&mut self.task));",
+    "WorkPool::schedule(std::ptr::from_mut::<WorkPoolTask>(&mut self.task));",
+    "WorkPool::schedule(self.task_mut());",
+    "WorkPool::schedule(self.field_mut());",
+    "WorkPool::schedule(this.inner.task());",
+    "WorkPool::schedule(unsafe { &raw mut this.task });",
+    // rustfmt-wrapped.
+    "WorkPool::schedule(\n    &raw mut self.task,\n);",
+    "bun_jsc::WorkPool::schedule(\n    this.task(),\n);",
+  ];
+  const allowed = [
+    // The converted shapes: projected from the object's raw pointer.
+    "WorkPool::schedule(&raw mut (*this).task);",
+    "WorkPool::schedule(&raw mut (*this).work_task);",
+    "WorkPool::schedule(unsafe { &raw mut (*job).task });",
+    "WorkPool::schedule(&raw mut (*st).task);",
+    "bun_threading::work_pool::WorkPool::schedule(&raw mut (*subtask).work_task);",
+    "::bun_jsc::WorkPool::schedule(&raw mut (*this).task);",
+    "WorkPool::schedule(unsafe {\n    &raw mut (*raw).task\n});",
+    // A local already holding the projected pointer, and the typed schedulers.
+    "WorkPool::schedule(task);",
+    "Self::schedule(unsafe { T::field_of(raw) });",
+    "WorkPool::schedule_owned(task);",
+    "WorkPool::schedule_new(ReaddirSubtask { .. });",
+    // Out of scope (see the header): a helper that returns a raw pointer, the
+    // batch and io-loop spellings.
+    "WorkPool::schedule(this.task().as_ptr());",
+    "batch.push(Batch::from(&raw mut self.task));",
+    "io::IoRequestLoop::schedule(&mut self.io_request);",
+    // A pointer the object owns is not a projection through it.
+    "WorkPool::schedule(self.task_ptr);",
+    "WorkPool::schedule(&raw mut *self.task);",
+  ];
+  expect(banned.filter(s => !matches(s))).toEqual([]);
+  expect(allowed.filter(matches)).toEqual([]);
+});
+
+test("no WorkPool::schedule call projects the task through a reference", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: once an allowlisted instance is converted, delete its entry so
+  // a new one cannot take its place.
+  for (const [f, n] of Object.entries(ALLOW)) {
+    expect({ file: f, count: counts[f] ?? 0 }).toEqual({ file: f, count: n });
+  }
+});

--- a/test/internal/source-lints/work-pool-schedule-projection.test.ts
+++ b/test/internal/source-lints/work-pool-schedule-projection.test.ts
@@ -4,15 +4,15 @@ import { realpathSync } from "fs";
 import path from "path";
 import { globAllSources } from "../../../scripts/glob-sources.ts";
 
-// The task handed to `WorkPool::schedule` must be projected from the raw
-// pointer to the object that embeds it, never through a reference to that
-// object. Inside a `&mut self` method (or any function holding a reference),
+// The task handed to `WorkPool::schedule` must be projected from a raw pointer
+// to the object that embeds it, never through a reference:
 //
-//   WorkPool::schedule(&raw mut self.task);
+//   WorkPool::schedule(&raw mut self.task);        // `self: &mut Self`
 //   WorkPool::schedule(&raw mut this.task);        // `this` a `&mut T` local
+//   WorkPool::schedule(&raw mut raw.task);         // `raw` a leaked `&mut T`
 //   bun_jsc::WorkPool::schedule(this.task());      // accessor returning `&mut Task`
 //
-// is banned; the accepted spelling is the one `WorkPool::schedule_owned`
+// are banned; the accepted spelling is the one `WorkPool::schedule_owned`
 // (src/threading/work_pool.rs) and the tree's other schedulers use:
 //
 //   WorkPool::schedule(&raw mut (*this).task);
@@ -20,22 +20,26 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // where `this: *mut T` is the pointer the caller already held (the io action's
 // ctx, the timer's container, the hive slot, the box just released).
 //
-// Two things are wrong with the banned shape. `schedule` is the hand-over: a
-// pool thread may be running the object's callback before the call returns,
-// and when the argument is a reference (`&mut self`, `this: &mut Self`) that
-// reference stays live, and protected, until the method returns. Under the
-// aliasing models (Tree Borrows is what `bun run rust:miri` uses) a protected
-// reference is released with an implicit read of everything it touched, which
-// conflicts with the pool thread's writes and retires every reference the pool
-// thread derived from the pointer it was given; rustc's codegen makes the same
-// assumption (`noalias` + `dereferenceable` for the whole call). Separately, a
-// `&mut Task` accessor hands the pool a pointer whose provenance covers the
-// task field alone, while `IntrusiveWorkTask::from_task_ptr` (the pool-side
-// recovery) documents that it needs the whole allocation; `bun_core::
-// container_of` says the same ("a `&mut field` reborrow does not suffice").
-// `ReadFile::on_ready` / `on_io_error`, `WriteFile::on_ready`, the close
-// round trip in `impl_file_closer!`, `StatWatcherScheduler::timer_callback`
-// and `TranspilerJob::schedule` were the instances this was written for; the
+// The pool calls back with exactly the pointer it was given, and the callback
+// (`IntrusiveWorkTask::from_task_ptr`, `from_field_ptr!`) recovers the whole
+// object from it and then reads and writes the object's other fields through
+// the result. `from_task_ptr` and `bun_core::container_of` document that this
+// needs a pointer whose provenance covers the whole object ("a `&mut field`
+// reborrow does not suffice"). A projection taken through a reference does not
+// reliably give one: an accessor's `&mut Task` covers the field by definition,
+// and under Stacked Borrows so does `&raw mut self.task` (Miri: the callback's
+// write to a sibling field is "using <tag> ... created by a SharedReadWrite
+// retag at offsets [<the task field>]"). The raw projection `&raw mut
+// (*p).task` keeps `p`'s provenance and is accepted by Stacked and Tree
+// Borrows alike. Tree Borrows, which is what `bun run rust:miri` runs, accepts
+// the banned spellings too, and none of the crates involved are in its crate
+// set, so nothing but this lint reports a regression; keeping the argument a
+// raw projection also means no `&mut` to the object is a live function
+// argument (`noalias`, `dereferenceable`) while a pool thread may already be
+// running it. `ReadFile::on_ready` / `on_io_error`, `WriteFile::on_ready` /
+// `on_io_error`, the close round trip in `impl_file_closer!`,
+// `StatWatcherScheduler::timer_callback`, `TranspilerJob::schedule` and
+// `AsyncCpTask::schedule_new` were the instances this was written for; the
 // converted versions are the templates.
 //
 // Scope: the argument of a call spelled `..WorkPool::schedule(..)`, when it is
@@ -43,13 +47,16 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // x.f)`, `ptr::from_mut(&mut x.f)`) or one of the tree's reference-returning
 // task accessors (`x.task()`, `x.task_mut()`, `x.field_mut()`). A raw pointer
 // projected through `(*p).f`, a local holding the projected pointer, and
-// `schedule_owned` / `schedule_new` are the intended shapes. The same hazard
-// in other spellings is outside this lint: `Batch::from(&raw mut self.task)`
-// pushed onto a batch that is scheduled later (bundler, install, http), a
-// helper that returns a raw pointer (`x.task().as_ptr()` in the zlib binding),
-// and `IoRequestLoop::schedule(&mut self.io_request)`, which is the io-thread
-// twin of this hand-over. Siblings: self-receiver-reclaim.test.ts,
-// self-receiver-publish.test.ts, self-receiver-intrusive-post.test.ts.
+// `schedule_owned` / `schedule_new` are the intended shapes. Whether the
+// pointer the function was handed is itself whole-object is that function's
+// caller's business (the io thread's `FileAction.poll: &mut Poll` and
+// `Request` hand-offs narrow one level up; tracked separately). The same
+// defect in other spellings is outside this lint and tracked separately:
+// tasks that go into `Batch::from(..)` (bundler, install, http), and
+// `IoRequestLoop::schedule(&mut self.io_request)`, the io-thread twin of this
+// hand-over; #37772 adds a sibling lint for method calls in the argument, such
+// as the zlib binding's `x.task().as_ptr()`. Siblings: self-receiver-reclaim.
+// test.ts, self-receiver-publish.test.ts, self-receiver-intrusive-post.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));


### PR DESCRIPTION
### Problem
- Nothing is known to break: no crash is known and none is expected from the code as compiled today. This is a contract fix in the same series as #37681, #37703, #37723 and #37750 (#37772 covers the zlib binding).
- Six places hand an embedded `WorkPoolTask` to the pool through a `&mut` to the object that owns it: `Bun.file` reads and writes and their close round trip, the `fs.watchFile` scheduler, the runtime transpiler job, and `fs.cp`. They spell it `WorkPool::schedule(&raw mut self.task)`, or pass an accessor's `&mut WorkPoolTask`.
- The pool calls back with exactly the pointer it was given, and each callback recovers the whole object from it and writes the object's other fields. `from_task_ptr` and `container_of` document that this needs a pointer whose provenance covers the whole object; one derived from a reference does not reliably give that.
- No checker reports it: Miri under Stacked Borrows flags the callback's first sibling-field write (reduction in the original), but `bun run rust:miri` uses Tree Borrows, which accepts both spellings, and these crates are not in its crate set anyway.

### Fix
- Each scheduling function now takes the `*mut Self` its caller already held (the io callback ctx, the timer container, the transpiler slot, the box being released), touches fields as `(*this).field`, and schedules `&raw mut (*this).task`. Same statements in the same order; no behaviour change.
- This is correct because every caller already had the whole-object raw pointer and only formed the reference to make the call, so the pointer the pool receives now carries the whole object's provenance. It is the spelling `schedule_owned` already uses, and both borrow models accept it.
- The `FileCloser` trait loses its `task()` and `io_poll()` accessors and the default close round trip; the per-type macro now generates the round trip against concrete fields, and the Windows impl drops the stubs that only satisfied the removed methods. `napi_async_work` has the same shape, is left for #37750, and is allowlisted with an exact count.
- Verification: a new source lint fails on main, listing exactly the eight converted sites, and passes on this branch. Behaviour is unchanged, so the existing `Bun.write`, file read, `fs.watchFile`, `fs.cp` and dynamic import suites were run against a debug build; clippy is clean and `cargo check` passes for the Windows and macOS targets.

### Background
- Intrusive work-pool task: instead of allocating a job, an object embeds a `WorkPoolTask` field. `WorkPool::schedule` takes a pointer to that field, a pool thread later calls the task's callback with the same pointer, and the callback subtracts the field offset (`from_task_ptr`, `container_of`) to get the object back and use its other fields.
- Provenance: under Rust's aliasing rules a pointer carries a record of which bytes it may touch, separate from its address. `&raw mut (*p).task` keeps `p`'s whole-object range; a `&mut WorkPoolTask` covers only that field, so reaching sibling fields through it is undefined behaviour even though the address arithmetic works.
- Stacked Borrows and Tree Borrows are Miri's two aliasing models. Stacked (Miri's default) also narrows `&raw mut self.task` to the field; Tree Borrows does not. bun's Miri job runs Tree Borrows, so this class of bug is enforced by a source lint rather than a checker.
- Source lints (`test/internal/source-lints/`) are `bun test` files that regex-scan the Rust tree for a banned spelling, with a self-test of what they do and do not match and a per-file allowlist of exact counts, so a converted instance cannot be quietly replaced by a new one.
- Close round trip: when a `Bun.file` read or write finishes, the fd close is sent to the io thread, and when that completes the object schedules itself onto the pool once more to finish up. `impl_file_closer!` generates this per type, which is what let the trait methods go.

<details>
<summary>Original description</summary>

### Problem

Several objects that embed an intrusive `WorkPoolTask` handed it to the pool through a projection taken from a reference to the object:

| site | shape |
| --- | --- |
| `ReadFile::on_ready(&mut self)`, `ReadFile::on_io_error(&mut self, ..)` (src/runtime/webcore/blob/read_file.rs) | `WorkPool::schedule(&raw mut self.task)` |
| `WriteFile::on_ready(&mut self)`; `WriteFile::on_io_error`, through a `&mut WriteFile` local (src/runtime/webcore/blob/write_file.rs) | `WorkPool::schedule(&raw mut self.task)` / `(&raw mut this.task)` |
| `StatWatcherScheduler::timer_callback(&mut self)` (src/runtime/node/node_fs_stat_watcher.rs) | `WorkPool::schedule(&raw mut self.task)` |
| `TranspilerJob::schedule(&mut self)` (src/jsc/RuntimeTranspilerStore.rs) | `WorkPool::schedule(&raw mut self.work_task)` |
| `AsyncCpTask::schedule_new` (src/runtime/node/node_fs.rs), through the `&mut` that `heap::release` returns | `WorkPool::schedule(&raw mut raw.task)` |
| `FileCloser::on_io_request_closed(this: &mut Self)` (src/runtime/webcore/Blob.rs, the close round trip of `ReadFile`/`WriteFile`) | `WorkPool::schedule(this.task())`, where `task()` returns `&mut WorkPoolTask` |

The pool calls back with exactly the pointer it was given, and every callback behind these sites (`do_read_loop_task`, `do_write_loop_task`, `on_close_io_request`, `work_pool_callback`, `run_from_worker_thread`, `AsyncCpTask::work_pool_callback`) recovers the object from it with `from_task_ptr` / `from_field_ptr!` and then reads and writes the object's other fields through the result. `IntrusiveWorkTask::from_task_ptr` (src/threading/work_pool.rs) and `bun_core::container_of` document that this requires a pointer whose provenance covers the whole object ("a `&mut field` reborrow does not suffice"), and `WorkPool::schedule_owned` projects the task from the raw `Box` pointer for exactly that reason. The accessor form violates that contract outright: a `&mut WorkPoolTask` covers the field. The `&raw mut self.task` form violates it under Stacked Borrows, which ranges a raw projection taken through a reference to the projected field; Miri attributes the callback's first sibling-field write to it directly (reduction below). Tree Borrows, which is what `bun run rust:miri` runs, accepts both banned forms, and none of the crates involved are in its crate set, so no checker reports these or would report a regression; that is what the lint is for. The raw projection `&raw mut (*this).task` is accepted by both models. A secondary benefit of the same change is that no `&mut` to the object is a live function argument (`noalias`, `dereferenceable`) at the point where a pool thread may already be running the object; that is hygiene rather than something a checker flags.

In every case the caller already had the object as a raw pointer (the io action's ctx, the `io_poll` container recovered in `dispatch.rs`, the timer container, the hive slot, the box being released) and formed the reference only to make the call. No crash is known and none is expected from the code as compiled today: none of these functions touch the object after the hand-over. It is the contract that was not being met, in the one population of `WorkPool::schedule` callers that still spelled it this way (same series as #37681, #37703, #37723, #37750; #37772 handles the zlib binding's `task().as_ptr()` spelling).

<details>
<summary>Reduction under Miri (miri 0.1.0 9f36de775b)</summary>

```rust
// cargo miri run -- field | accessor | fixed
use std::thread;

#[repr(C)]
struct Job { state: u32, task: u32 }

struct SendPtr(*mut u32);
unsafe impl Send for SendPtr {}

// IntrusiveWorkTask::from_task_ptr + the callback's field accesses.
fn pool_thread(task: SendPtr) {
    thread::spawn(move || {
        let task = task;
        let job: *mut Job = unsafe { task.0.byte_sub(core::mem::offset_of!(Job, task)).cast() };
        unsafe { (*job).state = 1 };
    }).join().unwrap();
}

impl Job {
    fn schedule_field(&mut self) {                       // WorkPool::schedule(&raw mut self.task)
        self.task = 0;
        pool_thread(SendPtr(&raw mut self.task));
    }
    fn task(&mut self) -> &mut u32 { &mut self.task }
    fn schedule_accessor(this: &mut Self) {              // WorkPool::schedule(this.task())
        *this.task() = 0;
        pool_thread(SendPtr(this.task()));
    }
    unsafe fn schedule_fixed(this: *mut Self) {          // WorkPool::schedule(&raw mut (*this).task)
        unsafe {
            (*this).task = 0;
            pool_thread(SendPtr(&raw mut (*this).task));
        }
    }
}

fn main() {
    let mode = std::env::args().nth(1).unwrap_or_default();
    let job: *mut Job = Box::into_raw(Box::new(Job { state: 0, task: 0 }));
    match mode.as_str() {
        "field" => unsafe { (*job).schedule_field() },
        "accessor" => Job::schedule_accessor(unsafe { &mut *job }),
        "fixed" => unsafe { Job::schedule_fixed(job) },
        _ => panic!(),
    }
    let state = unsafe { (*job).state };
    drop(unsafe { Box::from_raw(job) });
    println!("{mode}: state = {state}");
}
```

Stacked Borrows (Miri's default), `field` and `accessor`:

```
error: Undefined Behavior: attempting a write access using <1642> at alloc786[0x0], but that tag does not exist in the borrow stack for this location
  --> src/bin/reduction.rs:25:18          (*job).state = 1      // the callback
help: <1642> was created by a SharedReadWrite retag at offsets [0x4..0x8]
  --> src/bin/reduction.rs:34:29          &raw mut self.task    // (this.task() for `accessor`)
```

`fixed` prints `fixed: state = 1` under Stacked Borrows. With `-Zmiri-tree-borrows` all three modes run clean, which is the point made above: the tree's chosen model does not catch this shape, the contract and the lint do.

</details>

### Fix

Each scheduling function takes the `*mut Self` its caller holds, does its field writes through statement-scoped `(*this).field` accesses, and ends with `WorkPool::schedule(&raw mut (*this).task)`. Same statements in the same order everywhere; no behaviour change.

* `ReadFile::on_ready` / `on_io_error` and `WriteFile::on_ready` become `unsafe fn(this: *mut Self)`; `WriteFile::on_io_error` keeps its `fn(*mut (), &Error)` shape (it is stored as the io action's error hook) and works through the pointer instead of a `callback_ctx` reborrow. The two io dispatch entry points in `src/runtime/dispatch.rs` pass the recovered pointer straight through. This makes the work-pool layer of the blob read/write correct given a whole-object pointer; the pointer the io layer hands back is itself taken from `FileAction.poll: &mut Poll` / the `&mut Request` one level up, which is the io-thread twin of this change and is tracked separately.
* `StatWatcherScheduler::timer_callback` becomes `unsafe fn(this: *mut Self)`; the timer dispatch already had the container pointer (the timer is inserted with `addr_of_mut!((*this).event_loop_timer)`, so it covers the scheduler).
* `TranspilerJob::schedule` becomes `unsafe fn(this: *mut Self)`; `transpile()` already had the slot pointer, which comes from the hive buffer and covers the slot. `transpile(&mut self)` itself does not need to change for this: the pool gets the slot pointer, not a projection through that receiver. (The store being stored inline in the VM while slots are in flight is a pre-existing property of the hive design that the tree accepts, see the note in scripts/rust-miri.ts; it is unrelated to which function does the projection.)
* The `FileCloser` trait loses `task()`, `io_poll()`, the default `on_io_request_closed` and `on_close_io_request`: both halves of the close round trip need the concrete field names, so `impl_file_closer!` now generates them next to the `schedule_close` that registers them (`on_done` schedules through `&raw mut (*this).task`). The Windows `ReadFileUV` impl drops the three `unreachable!()` stubs that only existed to satisfy the removed items; the `#[allow(clippy::not_unsafe_ptr_arg_deref)]` goes away with the trait method.
* `AsyncCpTask::schedule_new` takes the box's raw pointer (`heap::into_raw`) and projects from it; it returned that pointer already.

`napi_async_work::schedule` has the same shape and is converted by #37750 together with the rest of that type's receivers; this PR leaves it alone and allowlists it.

### Verification

`test/internal/source-lints/work-pool-schedule-projection.test.ts` bans the argument shapes above for any `..WorkPool::schedule(..)` call (a field path through a binding: `&raw mut x.f`, `&mut x.f`, `addr_of_mut!(x.f)`, `from_mut(&mut x.f)`; or one of the tree's `&mut Task` accessors: `.task()`, `.task_mut()`, `.field_mut()`), with a self-test of the spellings it does and does not match and an exact-count ratchet for the allowlist. Against main it reports exactly the sites this PR converts:

```
src/jsc/RuntimeTranspilerStore.rs:600: WorkPool::schedule(&raw mut self.work_task)
src/runtime/node/node_fs_stat_watcher.rs:356: WorkPool::schedule(&raw mut self.task)
src/runtime/node/node_fs.rs:1609: WorkPool::schedule(&raw mut raw.task)
src/runtime/webcore/Blob.rs:7060: WorkPool::schedule(this.task())
src/runtime/webcore/blob/read_file.rs:407: WorkPool::schedule(&raw mut self.task)
src/runtime/webcore/blob/read_file.rs:426: WorkPool::schedule(&raw mut self.task)
src/runtime/webcore/blob/write_file.rs:188: WorkPool::schedule(&raw mut self.task)
src/runtime/webcore/blob/write_file.rs:201: WorkPool::schedule(&raw mut this.task)
```

and passes with this branch. Out of scope and tracked separately: the same defect in the `Batch::from(..)` spelling (bundler, install, http), the io-thread hand-offs (`IoRequestLoop::schedule(&mut self.io_request)` and the `&mut Poll` / `&mut Request` the io thread recovers owners from), and the zlib binding (#37772).

Behaviour is unchanged, so the existing coverage is what exercises the converted paths, all run against the debug build: `test/js/bun/io/bun-write.test.js` (50 pass; includes the pipe copy that goes through `on_ready` on both the read and the write side and the deferred close round trip), `test/js/bun/util/bun-file-fd-read.test.ts`, `test/js/node/watch/fs.watchFile.test.ts` plus the node `test-fs-watchfile*.js` / `test-worker-fs-stat-watcher.js` suites, `test/js/node/fs/cp.test.ts`, and the dynamic-import tests under `test/js/bun/resolve/`. `cargo clippy -p bun_runtime -p bun_jsc` is clean, and `cargo check` of the two crates passes for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin` (the `ReadFileUV` impl and the macOS-only branches are the cfg-gated surfaces this touches).

</details>
