### PR TITLE
bundler: fail the build instead of panicking when the bundle thread cannot create its waker

### DIFF
--- a/src/bundler/BundleThread.rs
+++ b/src/bundler/BundleThread.rs
@@ -45,6 +45,11 @@ pub enum BundleV2Result {
 // provides the `CompletionStruct` impl for the forward-decl.
 pub(crate) struct BundleThread<C: Node> {
     pub(crate) waker: Async::Waker,
+    /// Set by the bundle thread instead of `waker` when `Waker::init()` fails
+    /// (`eventfd`/`kqueue` at the open-files limit). Published by
+    /// `ready_event`, read once by `spawn()`, which then reports it and the
+    /// allocation is freed.
+    pub(crate) waker_error: Option<Async::Error>,
     pub(crate) ready_event: ResetEvent,
     // `bun.UnboundedQueue(CompletionStruct, .next)` — intrusive over `C.next`;
     // the field offset is encoded via the `Node` supertrait on `CompletionStruct`.
@@ -125,10 +130,13 @@ impl<C: CompletionStruct> BundleThread<C> {
     // Windows), so zeroing them is *language-level* UB even if never read.
     // `placeholder()` yields a fully-initialized inert value instead.
     // `ready_event.wait()` in `spawn()` blocks until `thread_main` overwrites
-    // it via `ptr::write`, so the placeholder is never observed live.
+    // it via `ptr::write`, so the placeholder is never observed live; if
+    // `thread_main` fails instead, the whole struct is freed and dropping the
+    // placeholder is harmless (it owns nothing).
     pub(crate) fn uninitialized() -> Self {
         Self {
             waker: Async::Waker::placeholder(),
+            waker_error: None,
             queue: UnboundedQueue::new(),
             generation: 0,
             ready_event: ResetEvent::default(),
@@ -138,11 +146,11 @@ impl<C: CompletionStruct> BundleThread<C> {
     /// # Safety
     /// `instance` must be valid for `'static`: after `Ok` the bundle thread accesses it
     /// forever, so callers must only touch it through the raw-pointer methods on this
-    /// impl (e.g. `enqueue`) and never materialize a `&mut Self`. After `Err` no thread
-    /// exists and the caller still owns it.
-    pub(crate) unsafe fn spawn(
-        instance: *mut Self,
-    ) -> std::io::Result<std::thread::JoinHandle<()>> {
+    /// impl (e.g. `enqueue`) and never materialize a `&mut Self`. After `Err` nothing
+    /// refers to `*instance` any more and the caller still owns it: either no thread
+    /// was started, or the one that was has been joined without ever looking at the
+    /// queue.
+    pub(crate) unsafe fn spawn(instance: *mut Self) -> std::io::Result<()> {
         // `std::thread::Builder` (not `std::thread::spawn`) so the spawn error
         // is surfaced to the caller.
         struct SendPtr<T>(*mut T);
@@ -156,15 +164,32 @@ impl<C: CompletionStruct> BundleThread<C> {
                 let ptr = ptr;
                 // SAFETY: caller guarantees `instance` is valid for 'static; `thread_main`
                 // accesses fields only via raw-ptr projection (never `&Self`/`&mut Self`)
-                // and is the sole writer of `waker`/`generation`, so concurrent `enqueue()`
-                // from other threads is sound.
+                // and is the sole writer of `waker`/`waker_error`/`generation`, so
+                // concurrent `enqueue()` from other threads is sound.
                 unsafe { Self::thread_main(ptr.0) }
             })?;
-        // SAFETY: field projection via raw ptr — the spawned thread is concurrently
-        // writing `waker`, so we must not hold `&Self`/`&mut Self` here. `ready_event`
-        // itself is a sync primitive safe to wait on from this thread.
-        unsafe { (*instance).ready_event.wait() };
-        Ok(thread)
+        // SAFETY: field projections via raw ptr — the spawned thread is concurrently
+        // writing `waker` / `waker_error`, so we must not hold `&Self`/`&mut Self` here.
+        // `ready_event` itself is a sync primitive safe to wait on from this thread, and
+        // the bundle thread writes `waker_error` before `set()`, so the read after
+        // `wait()` observes it.
+        let waker_error = unsafe {
+            (*instance).ready_event.wait();
+            (*instance).waker_error
+        };
+        match waker_error {
+            None => {
+                // `std.Thread.detach()` — drop the JoinHandle without joining.
+                drop(thread);
+                Ok(())
+            }
+            Some(err) => {
+                // `thread_main` returns right after `set()`; wait for the thread to be
+                // gone so the caller can free `*instance`.
+                let _ = thread.join();
+                Err(waker_error_to_io(err))
+            }
+        }
     }
 
     /// # Safety
@@ -189,12 +214,27 @@ impl<C: CompletionStruct> BundleThread<C> {
     unsafe fn thread_main(instance: *mut Self) {
         Output::Source::configure_named_thread(zstr!("Bundler"));
 
+        // The waker has to be created on this thread (on Windows it is this
+        // thread's libuv loop), which is why `spawn()` cannot create it up front
+        // and instead learns of a failure through `waker_error`.
+        let waker = match Async::Waker::init() {
+            Ok(waker) => waker,
+            Err(err) => {
+                // SAFETY: `spawn()` is blocked in `ready_event.wait()` and reads
+                // `waker_error` only once that returns; `set()` is this thread's last
+                // access to `*instance`, and `spawn()` joins this thread before the
+                // allocation is freed.
+                unsafe {
+                    core::ptr::addr_of_mut!((*instance).waker_error).write(Some(err));
+                    (*instance).ready_event.set();
+                }
+                return;
+            }
+        };
+
         // SAFETY: `waker` is written exactly once here, before `ready_event.set()`
         // releases any thread that could call `enqueue` (which reads `waker`).
-        unsafe {
-            core::ptr::addr_of_mut!((*instance).waker)
-                .write(Async::Waker::init().unwrap_or_else(|_| panic!("Failed to create waker")));
-        }
+        unsafe { core::ptr::addr_of_mut!((*instance).waker).write(waker) };
 
         // Unblock the calling thread so it can continue.
         // SAFETY: raw-ptr field projection; spawning thread is blocked in `ready_event.wait()`.
@@ -343,6 +383,23 @@ impl<C: CompletionStruct> BundleThread<C> {
     }
 }
 
+/// Carries a failed waker creation out of `spawn()` in the form `singleton::get`
+/// reports: `SystemErrno::from_io_error` recovers the errno for the named
+/// message, the rest fall through to the OS-description path.
+fn waker_error_to_io(err: Async::Error) -> std::io::Error {
+    match err {
+        // The POSIX wakers store the OS's errno and `SystemErrno`'s
+        // discriminants are those values, so the code round-trips. (Windows'
+        // waker cannot fail; its `raw_os_error` space is Win32 codes, so a
+        // `Sys` from it must not take this path.)
+        Async::Error::Sys(errno) => std::io::Error::from_raw_os_error(errno as i32),
+        // No OS code to carry; the log then shows the variant's Display.
+        Async::Error::MachportCreationFailed | Async::Error::Unexpected => {
+            std::io::Error::other(err)
+        }
+    }
+}
+
 /// Lazily-initialized singleton. This is used for `Bun.build` since the
 /// bundle thread may not be needed.
 // Rust forbids generic statics, so the storage is
@@ -364,8 +421,9 @@ pub mod singleton {
 
     static INSTANCE: bun_threading::Guarded<Option<Instance>> = bun_threading::Guarded::new(None);
 
-    /// Starts the bundle thread on first use; a failed spawn leaves the slot empty
-    /// for the next build to retry.
+    /// Starts the bundle thread on first use; a failed start (`pthread_create`,
+    /// or the thread's waker at the open-files limit) leaves the slot empty for
+    /// the next build to retry.
     ///
     /// # Safety
     /// All calls (across the process) must use the same `C`; the static is
@@ -380,14 +438,11 @@ pub mod singleton {
             bun_core::heap::into_raw_nn(Box::new(BundleThread::<C>::uninitialized()));
         // SAFETY: a leaked Box, valid for 'static; passed as a raw pointer so no
         // `&mut` aliases the bundle thread's own access.
-        match unsafe { BundleThread::spawn(bundle_thread.as_ptr()) } {
-            // `std.Thread.detach()` — drop the JoinHandle without joining.
-            Ok(os_thread) => drop(os_thread),
-            Err(err) => {
-                // SAFETY: `spawn` started nothing, so this is still the sole owner.
-                unsafe { bun_core::heap::destroy(bundle_thread.as_ptr()) };
-                return Err(err);
-            }
+        if let Err(err) = unsafe { BundleThread::spawn(bundle_thread.as_ptr()) } {
+            // SAFETY: per `spawn`'s contract no thread refers to the allocation
+            // after `Err`, so this is the sole owner again.
+            unsafe { bun_core::heap::destroy(bundle_thread.as_ptr()) };
+            return Err(err);
         }
         *instance = Some(Instance(bundle_thread.cast::<()>()));
         Ok(bundle_thread.as_ptr())
@@ -427,9 +482,13 @@ pub mod singleton {
         let mut log = bun_ast::Log::init();
         match errno {
             Some(errno) => {
-                // Unix reports an exhausted thread or pid limit as EAGAIN.
+                // Unix reports an exhausted thread or pid limit as EAGAIN;
+                // EMFILE/ENFILE is the waker's eventfd/kqueue at the open-files
+                // limit.
                 let hint = if cfg!(not(windows)) && errno == SystemErrno::EAGAIN {
                     " The process or thread limit may have been reached (ulimit -u, or the container's pids limit)."
+                } else if matches!(errno, SystemErrno::EMFILE | SystemErrno::ENFILE) {
+                    " The open file limit may have been reached (ulimit -n, or the system-wide limit)."
                 } else {
                     ""
                 };

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -2108,10 +2108,10 @@ pub mod waker {
     #[cfg(windows)]
     pub struct WindowsWaker {
         /// The `WindowsLoop` of the thread that called [`init`] (uws keeps one
-        /// per thread). `BackRef` invariant (pointee outlives holder) holds as
-        /// long as that thread does; the only user, the bundle thread, never
-        /// exits once it holds a waker. `None`
-        /// only between [`placeholder`] and [`init`]; every dispatch path
+        /// per thread, freed when that thread exits). `BackRef` invariant
+        /// (pointee outlives holder) holds because the only user, the bundle
+        /// thread, never exits once it holds a waker. `None` only between
+        /// [`placeholder`] and [`init`]; every dispatch path
         /// (`wake`/`wait`/`uv_loop`) unwraps and would have UB-derefed the old
         /// raw null anyway.
         ///
@@ -2153,15 +2153,14 @@ pub mod waker {
 
         pub fn wait(&self) {
             // Do NOT route through `WindowsLoop::wait(&mut self)`: that would
-            // materialize a `&mut WindowsLoop` over the process-global
-            // singleton for the entire duration of `us_loop_run`/`uv_run`,
-            // and a concurrent `wake()` from a worker thread (BundleThread,
-            // HTTPThread) would alias it — two live `&mut T` to one
+            // materialize a `&mut WindowsLoop` over the loop for the entire
+            // duration of `us_loop_run`/`uv_run`, and a concurrent `wake()`
+            // from another thread would alias it — two live `&mut T` to one
             // allocation is UB under Stacked/Tree Borrows. Call the C entry
             // point with the raw pointer directly so no Rust reference is
             // ever formed.
-            // SAFETY: `loop_` is the live `WindowsLoop::get()` singleton,
-            // non-null after `init()`.
+            // SAFETY: `loop_` is live for as long as this waker is (see the
+            // field doc) and non-null after `init()`.
             unsafe { bun_uws_sys::loop_::us_loop_run(self.loop_ref().as_const_ptr().cast_mut()) };
         }
 
@@ -2170,23 +2169,22 @@ pub mod waker {
             // `&mut WindowsLoop` here would alias the event-loop thread's
             // borrow held across `us_loop_run`. Pass the raw pointer to the
             // thread-safe C wake (`uv_async_send`) instead.
-            // SAFETY: `loop_` is the live `WindowsLoop::get()` singleton;
-            // `us_wakeup_loop` → `uv_async_send` is documented thread-safe.
+            // SAFETY: `loop_` is live for as long as this waker is (see the
+            // field doc); `us_wakeup_loop` → `uv_async_send` is documented
+            // thread-safe.
             unsafe {
                 bun_uws_sys::loop_::us_wakeup_loop(self.loop_ref().as_const_ptr().cast_mut())
             };
         }
 
-        /// Raw libuv `uv_loop_t*` underlying this waker's `WindowsLoop`.
-        ///
-        /// `loop_` is the process-global singleton from `WindowsLoop::get()`
-        /// (set in [`init`]), so the returned pointer has process lifetime —
-        /// safe to hand to `uv::Timer::init` and friends without an `unsafe`
-        /// block at the call site.
+        /// Raw libuv `uv_loop_t*` underlying this waker's `WindowsLoop`. It
+        /// lives as long as `loop_` does (see the field doc), so it is safe to
+        /// hand to `uv::Timer::init` and friends without an `unsafe` block at
+        /// the call site.
         #[inline]
         pub fn uv_loop(&self) -> *mut bun_sys::windows::libuv::Loop {
-            // `BackRef` deref is safe (process-lifetime singleton); `uv_loop`
-            // is a `Copy` field set once by C `us_create_loop`.
+            // `BackRef` deref is safe for the same reason; `uv_loop` is a
+            // `Copy` field set once by C `us_create_loop`.
             self.loop_ref().uv_loop
         }
     }

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -2107,8 +2107,10 @@ pub mod waker {
 
     #[cfg(windows)]
     pub struct WindowsWaker {
-        /// Process-global `WindowsLoop` singleton. `BackRef` invariant (pointee
-        /// outlives holder) holds trivially: the loop is never freed. `None`
+        /// The `WindowsLoop` of the thread that called [`init`] (uws keeps one
+        /// per thread). `BackRef` invariant (pointee outlives holder) holds as
+        /// long as that thread does; the only user, the bundle thread, never
+        /// exits once it holds a waker. `None`
         /// only between [`placeholder`] and [`init`]; every dispatch path
         /// (`wake`/`wait`/`uv_loop`) unwraps and would have UB-derefed the old
         /// raw null anyway.
@@ -2130,7 +2132,9 @@ pub mod waker {
             Self { loop_: None }
         }
 
-        pub fn init() -> crate::Result<Self> {
+        /// Binds the calling thread's loop, so call it on the thread that will
+        /// `wait()`. Same signature as the POSIX wakers; cannot fail today.
+        pub fn init() -> crate::error::Result<Self> {
             Ok(Self {
                 loop_: Some(bun_ptr::BackRef::from(
                     core::ptr::NonNull::new(bun_uws_sys::WindowsLoop::get())

--- a/src/uws_sys/Loop.rs
+++ b/src/uws_sys/Loop.rs
@@ -397,7 +397,8 @@ impl WindowsLoop {
     }
 
     pub fn get() -> *mut WindowsLoop {
-        // SAFETY: uv::Loop::get() returns the libuv default loop; uws wraps it
+        // SAFETY: uv::Loop::get() returns this thread's live libuv loop; uws
+        // wraps it in a per-thread loop of its own.
         unsafe { c::uws_get_loop_with_native(uv::Loop::get() as *mut c_void) }
     }
 

--- a/test/bundler/bun-build-thread-spawn-failure.test.ts
+++ b/test/bundler/bun-build-thread-spawn-failure.test.ts
@@ -1,9 +1,11 @@
 // Bun.build() (and HTML routes in Bun.serve) run on one lazily started
-// "Bundler" thread. An LD_PRELOAD shim makes pthread_create fail for it with
-// EAGAIN, which is what the kernel returns at the RLIMIT_NPROC / cgroup pids
-// limit. That used to abort the whole process ("panic: Failed to spawn bun
-// build thread"); it has to fail the build like any other build error, and a
-// later build has to try starting the thread again.
+// "Bundler" thread. Starting it takes two OS resources, and an LD_PRELOAD shim
+// fails either one: pthread_create with EAGAIN (what the kernel returns at the
+// RLIMIT_NPROC / cgroup pids limit), or the eventfd the thread wakes up on with
+// EMFILE (the open-files limit). Both used to abort the whole process ("panic:
+// Failed to spawn bun build thread" / "panic: Failed to create waker"); they
+// have to fail the build like any other build error, and a later build has to
+// try starting the thread again.
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { join } from "node:path";
@@ -22,6 +24,9 @@ const skip = !isLinux || !cc;
 // 2 MiB instead is ambiguous: JSC's threads use the attr default, which glibc
 // derives from RLIMIT_STACK, and that is 2 MiB on agents running with an
 // unlimited stack.) A multiple of 64 KiB so std's page rounding leaves it as is.
+//
+// eventfd() is easier to attribute: the bundle thread names itself "Bundler"
+// before creating its waker, and no other thread with that name calls it.
 const BUNDLE_THREAD_STACK_SIZE = 35 * 64 * 1024;
 
 // The highest value Linux reserves for errnos; far beyond the ones bun names.
@@ -29,9 +34,12 @@ const BUNDLE_THREAD_STACK_SIZE = 35 * 64 * 1024;
 // code with no errno equivalent.
 const UNNAMED_ERRNO = 4095;
 
-// BUNDLE_THREAD_SPAWN_PLAN has one letter per attempt to create the thread: 'f'
-// fails it with EAGAIN (a thread limit), 'n' with ENOMEM, 'u' with a code bun has
-// no errno name for, 's' lets it through; the last letter repeats.
+// A plan has one letter per intercepted attempt: 'f' fails it with the
+// resource-limit errno (EAGAIN for pthread_create, EMFILE for eventfd), 'n'
+// with ENOMEM, 'u' with a code bun has no errno name for, 's' lets it through;
+// the last letter repeats. BUNDLE_THREAD_SPAWN_PLAN applies to pthread_create
+// calls for the bundle thread, BUNDLE_THREAD_WAKER_PLAN to eventfd() calls
+// made by the bundle thread.
 const SHIM_C = /* c */ `
 #define _GNU_SOURCE
 #include <dlfcn.h>
@@ -39,24 +47,34 @@ const SHIM_C = /* c */ `
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/prctl.h>
 
 static int (*real_pthread_create)(pthread_t *, const pthread_attr_t *, void *(*)(void *), void *);
-static const char *plan;
-static size_t plan_len;
-static size_t attempts;
+static int (*real_eventfd)(unsigned int, int);
+static const char *spawn_plan, *waker_plan;
+static size_t spawn_attempts, waker_attempts;
 
 __attribute__((constructor)) static void init(void) {
   real_pthread_create = dlsym(RTLD_NEXT, "pthread_create");
-  plan = getenv("BUNDLE_THREAD_SPAWN_PLAN");
-  plan_len = plan ? strlen(plan) : 0;
+  real_eventfd = dlsym(RTLD_NEXT, "eventfd");
+  spawn_plan = getenv("BUNDLE_THREAD_SPAWN_PLAN");
+  waker_plan = getenv("BUNDLE_THREAD_WAKER_PLAN");
+}
+
+// 0 when the plan is unset or the step is 's' (let it through).
+static char plan_step(const char *plan, size_t *attempts) {
+  size_t len = plan ? strlen(plan) : 0;
+  if (len == 0) return 0;
+  size_t i = __sync_fetch_and_add(attempts, 1);
+  char step = plan[i < len ? i : len - 1];
+  return step == 's' ? 0 : step;
 }
 
 int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)(void *), void *arg) {
   size_t stack_size = 0;
   if (attr) pthread_attr_getstacksize(attr, &stack_size);
-  if (stack_size == ${BUNDLE_THREAD_STACK_SIZE} && plan_len > 0) {
-    size_t i = __sync_fetch_and_add(&attempts, 1);
-    switch (plan[i < plan_len ? i : plan_len - 1]) {
+  if (stack_size == ${BUNDLE_THREAD_STACK_SIZE}) {
+    switch (plan_step(spawn_plan, &spawn_attempts)) {
       case 'f': return EAGAIN;
       case 'n': return ENOMEM;
       case 'u': return ${UNNAMED_ERRNO};
@@ -64,10 +82,33 @@ int pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start)
   }
   return real_pthread_create(thread, attr, start, arg);
 }
+
+int eventfd(unsigned int initval, int flags) {
+  char name[16] = {0};
+  if (prctl(PR_GET_NAME, name) == 0 && strcmp(name, "Bundler") == 0) {
+    switch (plan_step(waker_plan, &waker_attempts)) {
+      case 'f': errno = EMFILE; return -1;
+      case 'n': errno = ENOMEM; return -1;
+    }
+  }
+  return real_eventfd(initval, flags);
+}
 `;
 
-const EXPECTED_ERROR =
-  "Failed to start the bundler thread: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).";
+const MODES = [
+  {
+    name: "pthread_create fails",
+    planEnv: "BUNDLE_THREAD_SPAWN_PLAN",
+    error:
+      "Failed to start the bundler thread: EAGAIN. The process or thread limit may have been reached (ulimit -u, or the container's pids limit).",
+  },
+  {
+    name: "creating its waker fails",
+    planEnv: "BUNDLE_THREAD_WAKER_PLAN",
+    error:
+      "Failed to start the bundler thread: EMFILE. The open file limit may have been reached (ulimit -n, or the system-wide limit).",
+  },
+];
 
 // Prints one JSON line per Bun.build() call; `throw` is taken from argv so the
 // same fixture covers the rejecting and the { success: false } flavors.
@@ -144,7 +185,7 @@ afterAll(() => {
   dir?.[Symbol.dispose]();
 });
 
-async function runWithPlan(plan: string, args: string[], env: Record<string, string> = {}) {
+async function runWithPlan(planEnv: string, plan: string, args: string[], env: Record<string, string> = {}) {
   const existing = bunEnv.LD_PRELOAD;
   await using proc = Bun.spawn({
     cmd: [bunExe(), ...args],
@@ -153,7 +194,7 @@ async function runWithPlan(plan: string, args: string[], env: Record<string, str
       ...bunEnv,
       LD_PRELOAD: existing ? `${shimPath}:${existing}` : shimPath,
       RUST_MIN_STACK: String(BUNDLE_THREAD_STACK_SIZE),
-      BUNDLE_THREAD_SPAWN_PLAN: plan,
+      [planEnv]: plan,
       ...env,
     },
     stdout: "pipe",
@@ -176,46 +217,94 @@ async function runWithPlan(plan: string, args: string[], env: Record<string, str
   };
 }
 
-describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", () => {
-  test.concurrent("rejects with the error in the AggregateError", async () => {
-    expect(await runWithPlan("f", ["build.js", "throw", "1"])).toEqual({
-      results: [
-        {
-          settled: "rejected",
-          name: "AggregateError",
-          message: "Bundle failed",
-          errors: [EXPECTED_ERROR],
-          onEnd: false,
-        },
-      ],
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
+describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started because", () => {
+  describe.each(MODES)("$name", ({ planEnv, error }) => {
+    test.concurrent("rejects with the error in the AggregateError", async () => {
+      expect(await runWithPlan(planEnv, "f", ["build.js", "throw", "1"])).toEqual({
+        results: [
+          {
+            settled: "rejected",
+            name: "AggregateError",
+            message: "Bundle failed",
+            errors: [error],
+            onEnd: false,
+          },
+        ],
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    });
+
+    test.concurrent("resolves with success: false and the error in the logs under throw: false", async () => {
+      expect(await runWithPlan(planEnv, "f", ["build.js", "nothrow", "1"])).toEqual({
+        results: [{ settled: "resolved", success: false, logs: [error], onEnd: false }],
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    });
+
+    test.concurrent("reports other errors without the resource-limit hint", async () => {
+      expect(await runWithPlan(planEnv, "n", ["build.js", "nothrow", "1"])).toEqual({
+        results: [
+          { settled: "resolved", success: false, logs: ["Failed to start the bundler thread: ENOMEM."], onEnd: false },
+        ],
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    });
+
+    test.concurrent("the next build starts the thread again", async () => {
+      expect(await runWithPlan(planEnv, "fs", ["build.js", "nothrow", "2"])).toEqual({
+        results: [
+          { settled: "resolved", success: false, logs: [error], onEnd: false },
+          { settled: "resolved", success: true, logs: [], onEnd: true },
+        ],
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    });
+
+    test.concurrent("every build fails while the thread keeps failing to start", async () => {
+      expect(await runWithPlan(planEnv, "f", ["build.js", "nothrow", "2"])).toEqual({
+        results: [
+          { settled: "resolved", success: false, logs: [error], onEnd: false },
+          { settled: "resolved", success: false, logs: [error], onEnd: false },
+        ],
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    });
+
+    test.concurrent("a VM torn down before the failed build's completion ran releases it", async () => {
+      expect(await runWithPlan(planEnv, "f", ["exit.js"], { BUN_DESTRUCT_VM_ON_EXIT: "1" })).toEqual({
+        results: [{ exiting: true }],
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    });
+
+    test.concurrent("an HTML route in Bun.serve answers 500, then builds once the thread starts", async () => {
+      const { stderr, ...rest } = await runWithPlan(planEnv, "fs", ["serve.js"]);
+      expect({ ...rest, stderrLines: stderr.split("\n") }).toEqual({
+        results: [{ first: 500, second: 200 }],
+        // The failed first build's log, then the second request's bundle timing.
+        stderrLines: [`error: ${error}`, expect.stringMatching(/^\[[\d.]+m?s\] bundle index\.html /)],
+        exitCode: 0,
+        signalCode: null,
+      });
     });
   });
 
-  test.concurrent("resolves with success: false and the error in the logs under throw: false", async () => {
-    expect(await runWithPlan("f", ["build.js", "nothrow", "1"])).toEqual({
-      results: [{ settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false }],
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
-
-  test.concurrent("reports other errors without the thread-limit hint", async () => {
-    expect(await runWithPlan("n", ["build.js", "nothrow", "1"])).toEqual({
-      results: [
-        { settled: "resolved", success: false, logs: ["Failed to start the bundler thread: ENOMEM."], onEnd: false },
-      ],
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
-
+  // pthread_create only: an eventfd error always comes from the OS with an
+  // errno, so the unnamed-code path is reachable just for the thread spawn.
   test.concurrent("reports an error bun has no errno name for as the OS describes it", async () => {
-    expect(await runWithPlan("u", ["build.js", "nothrow", "1"])).toEqual({
+    expect(await runWithPlan("BUNDLE_THREAD_SPAWN_PLAN", "u", ["build.js", "nothrow", "1"])).toEqual({
       results: [
         {
           settled: "resolved",
@@ -230,50 +319,6 @@ describe.skipIf(skip)("Bun.build() when the bundle thread cannot be started", ()
         },
       ],
       stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
-
-  test.concurrent("the next build starts the thread again", async () => {
-    expect(await runWithPlan("fs", ["build.js", "nothrow", "2"])).toEqual({
-      results: [
-        { settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false },
-        { settled: "resolved", success: true, logs: [], onEnd: true },
-      ],
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
-
-  test.concurrent("every build fails while the thread keeps failing to start", async () => {
-    expect(await runWithPlan("f", ["build.js", "nothrow", "2"])).toEqual({
-      results: [
-        { settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false },
-        { settled: "resolved", success: false, logs: [EXPECTED_ERROR], onEnd: false },
-      ],
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
-
-  test.concurrent("a VM torn down before the failed build's completion ran releases it", async () => {
-    expect(await runWithPlan("f", ["exit.js"], { BUN_DESTRUCT_VM_ON_EXIT: "1" })).toEqual({
-      results: [{ exiting: true }],
-      stderr: "",
-      exitCode: 0,
-      signalCode: null,
-    });
-  });
-
-  test.concurrent("an HTML route in Bun.serve answers 500, then builds once the thread starts", async () => {
-    const { stderr, ...rest } = await runWithPlan("fs", ["serve.js"]);
-    expect({ ...rest, stderrLines: stderr.split("\n") }).toEqual({
-      results: [{ first: 500, second: 200 }],
-      // The failed first build's log, then the second request's bundle timing.
-      stderrLines: [`error: ${EXPECTED_ERROR}`, expect.stringMatching(/^\[[\d.]+m?s\] bundle index\.html /)],
       exitCode: 0,
       signalCode: null,
     });


### PR DESCRIPTION
### Problem
- At the open-files limit (`EMFILE`/`ENFILE`), the first `Bun.build()` in a process, or the first non-HMR HTML route request in `Bun.serve`, aborts bun with `panic: Failed to create waker` / `oh no: Bun has crashed`. Reproduced on 1.4.0 and on #37753's branch.
- The bundle thread creates the handle it sleeps on only after it has started, and a failure there was unwrapped with a panic while the thread that requested the build was still blocked waiting for it to come up, so no error could reach the build.
- Running out of descriptors is an OS resource condition, and every other `EMFILE` a build or a server hits (opening a source file, accept) is already reported as an error; this was the one spot that took the process down.
- Stacked on #37753, which does the same for a failed `pthread_create` of this thread; the diff here is only this PR's commits.

### Fix
- The bundle thread stores the waker error in the shared struct and signals ready as usual. The spawner reads it, joins the thread, frees the struct, and fails the build through the exact path #37753 uses for a failed spawn: `spawn()` returns it as a `std::io::Error` (an errno round-trips through `SystemErrno::from_io_error` into the named message, the macOS mach-port failure takes the OS-description path), so `singleton::get()` has a single error path for both failure kinds.
- The message is `Failed to start the bundler thread: EMFILE.` plus an open-files hint for `EMFILE`/`ENFILE`, next to #37753's `EAGAIN` thread-limit hint.
- Why it is right: after a failure nothing of the attempt survives (thread joined, allocation freed, singleton slot still empty), so the next build starts the thread from scratch, and a build has an error channel every other resource failure already uses.
- The waker is still created on the bundle thread, because on Windows it binds the calling thread's loop. The Windows waker's `init()` now returns the same `Result` type as the POSIX ones so the shared call site compiles on every target; on Windows it cannot fail and the new branch is never taken.
- Verification: the `LD_PRELOAD` test from #37753 now also fails `eventfd()` on the "Bundler" thread and runs its seven scenarios for both failure kinds (plus #37753's unnamed-errno case, which only the spawn can hit). The waker cases hit the panic without this change and pass with it on a debug (ASAN) build. Linux only; Windows and macOS targets are `cargo check` only.

### Background
- Bundle thread: `Bun.build()` and HTML routes in `Bun.serve` run on one lazily started, process-wide "Bundler" thread. The first build starts it and later builds enqueue work onto it; starting it needs two OS resources, the thread (#37753) and its waker (this PR).
- Waker: the handle the bundle thread sleeps on until work is queued. It is an `eventfd` on Linux and a `kqueue` plus a mach port on macOS, so creating it costs a file descriptor and can fail with `EMFILE`/`ENFILE`; on Windows it wraps the thread's libuv loop and cannot fail.
- Ready event: the spawner blocks on a one-shot event until the bundle thread sets it. Anything the bundle thread writes to the shared struct before `set()` is visible to the spawner after `wait()`; that is the channel the error travels through.
- Windows loops are per thread: `uWS::Loop::get()` is `thread_local` and the loop dies with its thread, so a waker created on the JS thread before the spawn would bind the wrong loop. That is why the waker is created on the bundle thread and the failure reported back.
- Test shim: an `LD_PRELOAD` library overriding `pthread_create` and `eventfd`, driven by a plan string with one letter per intercepted call (`f` fails with the limit errno, `n` with `ENOMEM`, `u` with a code bun has no errno name for, `s` lets it through). It recognises the bundle thread by a `RUST_MIN_STACK` stack size nothing else requests for the spawn, and by the thread name "Bundler" (set before the waker is created) for the eventfd.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bun-build-thread-spawn-failure.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Earlier iterations (superseded by rebases onto #37753's branch)</summary>

Two shapes this PR had before #37753's branch moved under it:

- The waker error was first carried as a new `bun_bundler::Error::Io(bun_io::Error)` variant. #37753 later switched its own reporting to `std::io::Error` end to end (so an OS code bun has no errno name for is reported as the OS describes it); this PR now converts the waker's `bun_io::Error` into a `std::io::Error` inside `spawn()` instead, and the extra enum variant and the `bun_io::Error::name()` visibility change are gone.
- The test shim originally identified the bundle thread by Rust's default 2 MiB stack request, which on ASAN agents collided with JSC's threads (caught in CI), then by an arm/disarm marker file around the calls that start the thread. #37753 replaced that with running the fixtures under a `RUST_MIN_STACK` value nothing else asks for; the eventfd override was keyed on the thread name from the start and keeps working unchanged.

Original description:

Stacked on #37753 (this PR's base is that branch, so the diff here is only this PR's own commits). #37753 makes a failed `pthread_create` for the "Bundler" thread fail the build; this does the same for the other resource the thread needs to start.

### What

Once the bundle thread is running it creates the handle it sleeps on (`eventfd` on Linux, `kqueue` plus a mach port on macOS). When that fails, which is what happens at the open-files limit (`EMFILE`/`ENFILE`), the first `Bun.build()` (or the first non-HMR HTML route request in `Bun.serve`) in the process aborts bun:

```
panic: Failed to create waker
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

Repro (Linux): an `LD_PRELOAD` shim that makes `eventfd()` return `EMFILE` on the thread named "Bundler" (the name is set before the waker is created, and no other thread with that name creates an eventfd), then

```js
try {
  await Bun.build({ entrypoints: ["./entry.js"] });
} catch (e) {
  console.log("rejected:", e.errors[0].message);
}
```

exits 134 with the panic above on 1.4.0 and on a debug build of #37753's branch. The test in this PR is that shim.

### Cause

`BundleThread::thread_main` unwrapped `Waker::init()` with a panic. At that point the spawning thread is blocked in `ready_event.wait()` inside `singleton::get()`, so nothing could turn the failure into an error.

Why this should be a build error rather than stay an abort: running out of descriptors is an OS resource condition, not a broken invariant, and `Bun.build()` has an error channel that every other resource failure inside a build already uses (a source file that cannot be opened at the same fd limit is a build error; #37738 and #37753 route the pool and the thread itself through it). The same holds for a server bundling an HTML route on demand: every other `EMFILE` it hits (accept, open) is an error it recovers from once descriptors are freed, and this one spot took the process down. It is the same shape as #35185 (a helper thread that cannot start fails the operation that asked for it), and unlike #33850 it does not try to keep going without process-level infrastructure: nothing of the failed attempt is kept and the next build starts from scratch.

### Fix (original shape)

* `BundleThread` gets a `waker_error` slot. When `Waker::init()` fails, `thread_main` writes the error there, sets `ready_event` as usual and returns; that `set()` is its last access to the struct.
* `spawn()` reads the slot after `ready_event.wait()`. On success it detaches the thread as before; on failure it joins the thread (so the allocation can be freed) and returns the error, so `singleton::get()` has a single error path: free the allocation, leave the slot empty so the next build tries again, and hand the error to `singleton::enqueue()`, which fails the build through its normal completion exactly as #37753 does for a failed spawn.
* `WindowsWaker::init()` returned a different `Result` alias than the Linux and macOS wakers (`bun_core::Error` instead of `bun_io::Error`), which nothing noticed while the result was only ever unwrapped. It now returns the same type, so the shared call site compiles on every target. Its docs and SAFETY comments (and `WindowsLoop::get()`'s) also called the `WindowsLoop` a process-global or default loop; it is per thread (`uWS::Loop::get()` is `thread_local`, wrapping the thread's libuv loop, and it is freed when that thread exits), so those comments now say that and derive the pointer's lifetime from the bundle thread never exiting. The per-thread loop is also why the waker cannot simply be created on the spawning thread before the spawn: on Windows it would bind the JS thread's loop. Creating it on the bundle thread and reporting back keeps one code path for all platforms.

Not changed: when the mach port cannot be created on macOS, `KEventWaker::init_with_file_descriptor` leaks the kqueue it had already opened. That is pre-existing (until now the process died right after) and #33845 fixes it in `bun_io`.

</details>
