### PR TITLE
bundler: record the ESM module record's TLA flag from the awaits the printer emits

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7645,10 +7645,10 @@ pub mod bv2_impl {
         Javascript {
             source_index: IndexInt,
             result: bun_js_printer::PrintResult,
-            /// The imports/exports the printer emitted for this part range.
-            /// Only present when `LinkerOptions::generates_module_info()`;
-            /// `post_process_js_chunk` appends these to the chunk's
-            /// `ModuleInfo` in output order.
+            /// The imports/exports (and top-level await) the printer emitted for
+            /// this part range. Only present when
+            /// `LinkerOptions::generates_module_info()`; `post_process_js_chunk`
+            /// appends these to the chunk's `ModuleInfo` in output order.
             module_info: Option<Box<crate::analyze_transpiled_module::ModuleInfo>>,
         },
         Css {

--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -97,6 +97,11 @@ pub(crate) fn post_process_js_chunk(
     // the cross-chunk prefix imports below, then the per-part-range results
     // (printed in parallel into their own ModuleInfo) are appended, then the
     // cross-chunk suffix and entry point tail exports are printed into it.
+    // The printer also sets `flags.has_tla` on whichever of these records it
+    // prints a top-level `await` into, including the `await init_foo()` /
+    // `await init_entry()` the linker synthesizes for async wrapped files; JSC
+    // evaluates the bytecode on the sync path and abandons the body at its
+    // first `await` if the chunk's record does not carry that flag.
     // Stored on chunk.content.javascript.module_info — owned `Box<ModuleInfo>`.
     let mut module_info: Option<Box<ModuleInfo>> = c.options.generates_module_info().then(|| {
         let loader =
@@ -248,31 +253,6 @@ pub(crate) fn post_process_js_chunk(
             }],
             chunk.renamer.as_renamer(),
         );
-    }
-
-    // The printer does not know about top-level await, so derive that flag from
-    // the AST. The JSC module loader decides sync vs async evaluation from
-    // JSModuleRecord::hasTLA(), which is set from this bit when the record is
-    // constructed from module_info (BunAnalyzeTranspiledModule). Without it, a
-    // bytecode-compiled module that contains TLA gets evaluated on the sync path
-    // and the suspended generator is dropped — the entry promise resolves
-    // immediately and the process exits before the awaited value lands.
-    if let Some(mi) = module_info.as_deref_mut() {
-        let tla_keywords = c.parse_graph().ast.items_top_level_await_keyword();
-        let wraps = c.graph.meta.items_flags();
-        for part_range in chunk.content.javascript().parts_in_chunk_in_order.iter() {
-            let idx = part_range.source_index.get() as usize;
-            if idx >= tla_keywords.len() {
-                continue;
-            }
-            if wraps[idx].wrap != crate::WrapKind::None {
-                continue;
-            }
-            if !tla_keywords[idx].is_empty() {
-                mi.flags.has_tla = true;
-                break;
-            }
-        }
     }
 
     // Generate the exports for the entry point, if there are any.

--- a/src/js_printer/lib.rs
+++ b/src/js_printer/lib.rs
@@ -1669,6 +1669,10 @@ pub(crate) mod __gated_printer {
         pub(crate) was_lazy_export: bool,
         // Always carried; gated at call sites with MAY_HAVE_MODULE_INFO.
         pub(crate) module_info: Option<&'a mut analyze_transpiled_module::ModuleInfo>,
+        /// Number of function (or arrow) bodies currently being printed. An
+        /// `await` printed at depth 0 is a top-level await of the module,
+        /// which `module_info` records; see `record_top_level_await`.
+        pub(crate) fn_depth: u32,
 
         /// Arena for transient allocations during printing (rope flattening,
         /// UTF-16→UTF-8 transcoding).
@@ -1732,6 +1736,24 @@ pub(crate) mod __gated_printer {
                 return None;
             }
             self.module_info.as_deref_mut()
+        }
+
+        /// Called wherever an `await` is printed (`await x`, `for await`, and the
+        /// `await using` keyword in `print_decls`, which also covers
+        /// `for (await using ...)`). Outside of every function body it marks the module
+        /// record as having top-level await, which decides whether JSC evaluates
+        /// code it never parses itself (bytecode builds, the isolation source
+        /// cache) as an async module. This is derived from the printed output
+        /// rather than the parser's `top_level_await_keyword` so that it also
+        /// holds when the only `await` was eliminated as dead code, and so that
+        /// the `await init_foo()` the bundler synthesizes is counted.
+        #[inline]
+        fn record_top_level_await(&mut self) {
+            if self.fn_depth == 0 {
+                if let Some(mi) = self.module_info() {
+                    mi.flags.has_tla = true;
+                }
+            }
         }
 
         // BinaryExpressionVisitor::checkAndPrepare
@@ -2194,7 +2216,10 @@ pub(crate) mod __gated_printer {
                 S::Kind::KLet => b"let",
                 S::Kind::KConst => b"const",
                 S::Kind::KUsing => b"using",
-                S::Kind::KAwaitUsing => b"await using",
+                S::Kind::KAwaitUsing => {
+                    self.record_top_level_await();
+                    b"await using"
+                }
             };
             self.print(keyword);
             self.print_space();
@@ -2463,6 +2488,7 @@ pub(crate) mod __gated_printer {
         }
 
         pub(crate) fn print_func(&mut self, func: &G::Fn) {
+            self.fn_depth += 1;
             self.print_fn_args(
                 Some(func.open_parens_loc),
                 slice_of(func.args),
@@ -2471,6 +2497,7 @@ pub(crate) mod __gated_printer {
             );
             self.print_space();
             self.print_block(func.body.loc, slice_of(func.body.stmts), None);
+            self.fn_depth -= 1;
         }
 
         pub(crate) fn print_class(&mut self, class: &G::Class) {
@@ -3743,6 +3770,7 @@ pub(crate) mod __gated_printer {
                         self.print_space();
                     }
 
+                    self.fn_depth += 1;
                     self.print_fn_args(
                         if e.is_async { None } else { Some(expr.loc) },
                         &e.args,
@@ -3765,6 +3793,7 @@ pub(crate) mod __gated_printer {
                     if !was_printed {
                         self.print_block(e.body.loc, slice_of(e.body.stmts), None);
                     }
+                    self.fn_depth -= 1;
 
                     if wrap {
                         self.print(b")");
@@ -4306,6 +4335,7 @@ pub(crate) mod __gated_printer {
 
                     self.print_space_before_identifier();
                     self.add_source_mapping(expr.loc);
+                    self.record_top_level_await();
                     self.print(b"await");
                     self.print_space();
                     self.print_expr(e.value, Level::Prefix.sub(1), ExprFlag::none());
@@ -5729,6 +5759,7 @@ pub(crate) mod __gated_printer {
                     self.add_source_mapping(stmt.loc);
                     self.print(b"for");
                     if s.is_await {
+                        self.record_top_level_await();
                         self.print(b" await");
                     }
                     self.print_space();
@@ -6764,6 +6795,7 @@ pub(crate) mod __gated_printer {
                 stack_overflowed: false,
                 was_lazy_export: false,
                 module_info: None,
+                fn_depth: 0,
             }
         }
 

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -55,7 +55,10 @@ bun_core::declare_scope!(cache, visible);
 /// offsets picked by a header byte) plus a body of tagged records with
 /// u8/u16/u32 ids and implied slots dropped, instead of fixed u32 arrays.
 /// Version 27: ModuleInfo string table holds Latin-1 / UTF-16 bodies, not WTF-8.
-const EXPECTED_VERSION: u32 = 27;
+/// Version 28: The ESM record's `has_tla` comes from the awaits the printer
+/// emitted rather than the parser's await keyword, so a module whose only
+/// top-level await was eliminated as dead code no longer records one.
+const EXPECTED_VERSION: u32 = 28;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -1062,15 +1062,6 @@ impl TranspilerJob {
             } else {
                 None
             };
-        // Propagate top-level-await to the cached
-        // module record. Without this, modules cached via the isolation source
-        // provider (used under --isolate / --parallel) are reported to JSC as
-        // having no TLA, so the module's evaluation promise resolves before the
-        // top-level-await actually completes — causing the caller's
-        // `wait_for_promise` on the preload to return early.
-        if let Some(mi) = module_info.as_deref_mut() {
-            mi.flags.has_tla = !parse_result.ast.top_level_await_keyword.is_empty();
-        }
         // Note: derive `*mut` from a `&mut` borrow (not `&x as *const _ as
         // *mut _`, which is Stacked-Borrows UB). The `&mut` borrow ends when the
         // closure returns; the raw pointer stays valid until `module_info` is

--- a/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
+++ b/src/jsc/bindings/BunAnalyzeTranspiledModule.cpp
@@ -290,6 +290,10 @@ String dumpRecordInfo(JSModuleRecord* moduleRecord)
 
     stream.print("\nAnalyzing ModuleRecord key(", moduleRecord->moduleKey().impl(), ")\n");
 
+    // Selects the sync or async path in JSModuleRecord::execute; a false for a
+    // body that does contain a top-level await abandons the body at that await.
+    stream.print("    hasTLA: ", moduleRecord->hasTLA(), "\n");
+
     stream.print("    Dependencies: ", moduleRecord->requestedModules().size(), " modules\n");
     {
         Vector<String> sortedDeps;

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -3067,13 +3067,6 @@ fn transpile_source_code_inner(
                 } else {
                     None
                 };
-                // Propagate top-level-await to the
-                // cached module record (see the matching note in
-                // RuntimeTranspilerStore.rs for why this matters under
-                // --isolate / --parallel).
-                if let Some(mi) = module_info.as_deref_mut() {
-                    mi.flags.has_tla = !parse_result.ast.top_level_await_keyword.is_empty();
-                }
                 // Derive the `*mut` from a `&mut` borrow (not `&x as *const _
                 // as *mut _`, which is Stacked-Borrows UB). The borrow ends
                 // here; the raw pointer stays valid until `module_info` is

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -382,6 +382,24 @@ describe("bundler", () => {
       stdout: "no await printed",
     },
     {
+      // Same cross-check, for awaits that are printed but all sit inside a
+      // function body of some shape: the record must still say no top-level
+      // await.
+      name: "AwaitOnlyInsideFunctions",
+      files: {
+        "/entry.ts": `
+          const arrow = async () => { await null; return "arrow"; };
+          const expr = async function () { await null; return (async x => await x)("expression"); };
+          async function decl() { await null; return "declaration"; }
+          const obj = { async method() { await null; return "method"; } };
+          class K { async method() { await null; return "class method"; } }
+          console.log("sync module");
+          Promise.all([arrow(), expr(), decl(), obj.method(), new K().method()]).then(r => console.log(r.join(", ")));
+        `,
+      },
+      stdout: "sync module\narrow, expression, declaration, method, class method",
+    },
+    {
       // The other spellings of a top-level await. Each lives in its own
       // dynamically imported module, so each gets its own record: a module
       // whose record misses its await is abandoned at that await and its

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -186,8 +186,10 @@ describe("bundler", () => {
     });
   }
   // ESM bytecode test matrix: each scenario × {default, minified} = 2 tests per scenario.
-  // With --compile, static imports are inlined into one chunk, but dynamic imports
-  // create separate modules in the standalone graph — each with its own bytecode + ModuleInfo.
+  // Without --splitting everything lands in one chunk with one bytecode blob and
+  // one ModuleInfo: dynamically imported files are inlined as async __esm
+  // wrappers, not emitted as separate modules (see bundler_compile_splitting for
+  // per-chunk records).
   const esmBytecodeScenarios: Array<{
     name: string;
     files: Record<string, string>;
@@ -398,43 +400,6 @@ describe("bundler", () => {
         `,
       },
       stdout: "sync module\narrow, expression, declaration, method, class method",
-    },
-    {
-      // The other spellings of a top-level await. Each lives in its own
-      // dynamically imported module, so each gets its own record: a module
-      // whose record misses its await is abandoned at that await and its
-      // output (or, for `await using`, its disposal) never happens.
-      name: "TopLevelAwaitForms",
-      files: {
-        "/entry.ts": `
-          await import("./for-await.ts");
-          await import("./await-using.ts");
-          await import("./for-await-using.ts");
-          console.log("entry done");
-        `,
-        "/for-await.ts": `
-          for await (const v of [Promise.resolve("a"), Promise.resolve("b")]) console.log("for await:", v);
-        `,
-        "/await-using.ts": `
-          await using res = { async [Symbol.asyncDispose]() { console.log("await using: disposed"); } };
-          console.log("await using: body");
-        `,
-        "/for-await-using.ts": `
-          const make = (n: string) => ({ async [Symbol.asyncDispose]() { console.log("for await using: disposed", n); } });
-          for (await using r of [make("x"), make("y")]) console.log("for await using: body");
-        `,
-      },
-      stdout: [
-        "for await: a",
-        "for await: b",
-        "await using: body",
-        "await using: disposed",
-        "for await using: body",
-        "for await using: disposed x",
-        "for await using: body",
-        "for await using: disposed y",
-        "entry done",
-      ].join("\n"),
     },
   ];
 

--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -320,6 +320,104 @@ describe("bundler", () => {
       },
       stdout: "function",
     },
+    {
+      // dep.ts is both imported statically and import()ed, so (without
+      // splitting) it is inlined as an async __esm wrapper and the entry's
+      // import of it is printed as a top-level `await init_dep()`. No input
+      // file has a top-level await at the chunk's top level, but the chunk
+      // does; if the module record does not say so, JSC evaluates the chunk
+      // synchronously and everything after that await never runs (the binary
+      // used to print only "dep evaluated" and exit 0).
+      name: "AwaitInitOfAsyncWrappedDependency",
+      files: {
+        "/entry.ts": `
+          import { value } from "./dep.ts";
+          import { lazy } from "./helper.ts";
+          console.log("entry:", value);
+          lazy().then(m => console.log("lazy:", m.value));
+        `,
+        "/dep.ts": `
+          export const value = await Promise.resolve("tla value");
+          console.log("dep evaluated");
+        `,
+        "/helper.ts": `export const lazy = () => import("./dep.ts");`,
+      },
+      stdout: "dep evaluated\nentry: tla value\nlazy: tla value",
+    },
+    {
+      // The entry point itself is import()ed, so it becomes an async __esm
+      // wrapper and the chunk ends with the entry point tail's
+      // `await init_entry()`. With the record claiming no top-level await,
+      // JSC never observes that promise, so a rejected top-level await in the
+      // entry surfaced as an unhandled rejection. It has to be the entry
+      // module's evaluation error (an uncaught exception), which is what the
+      // same build without --bytecode and `bun run` report.
+      name: "AwaitInitOfAsyncWrappedEntryPoint",
+      files: {
+        "/entry.ts": `
+          import { lazy } from "./helper.ts";
+          process.on("uncaughtException", err => console.log("uncaughtException:", err.message));
+          process.on("unhandledRejection", err => console.log("unhandledRejection:", err.message));
+          console.log("entry:", typeof lazy);
+          await Promise.reject(new Error("tla rejected"));
+        `,
+        "/helper.ts": `export const lazy = () => import("./entry.ts");`,
+      },
+      stdout: "entry: function\nuncaughtException: tla rejected",
+    },
+    {
+      // The only top-level await in the input is dead code, so the printed
+      // chunk has none and JSC's own analysis of it says no top-level await.
+      // The record is built from the printed output, not from the parser's
+      // await keyword, so it must agree; debug builds cross-check the two and
+      // refuse to start the binary if the record claims an await that was
+      // never printed.
+      name: "DeadTopLevelAwait",
+      files: {
+        "/entry.ts": `
+          if (false) await Promise.resolve();
+          console.log("no await printed");
+        `,
+      },
+      stdout: "no await printed",
+    },
+    {
+      // The other spellings of a top-level await. Each lives in its own
+      // dynamically imported module, so each gets its own record: a module
+      // whose record misses its await is abandoned at that await and its
+      // output (or, for `await using`, its disposal) never happens.
+      name: "TopLevelAwaitForms",
+      files: {
+        "/entry.ts": `
+          await import("./for-await.ts");
+          await import("./await-using.ts");
+          await import("./for-await-using.ts");
+          console.log("entry done");
+        `,
+        "/for-await.ts": `
+          for await (const v of [Promise.resolve("a"), Promise.resolve("b")]) console.log("for await:", v);
+        `,
+        "/await-using.ts": `
+          await using res = { async [Symbol.asyncDispose]() { console.log("await using: disposed"); } };
+          console.log("await using: body");
+        `,
+        "/for-await-using.ts": `
+          const make = (n: string) => ({ async [Symbol.asyncDispose]() { console.log("for await using: disposed", n); } });
+          for (await using r of [make("x"), make("y")]) console.log("for await using: body");
+        `,
+      },
+      stdout: [
+        "for await: a",
+        "for await: b",
+        "await using: body",
+        "await using: disposed",
+        "for await using: body",
+        "for await using: disposed x",
+        "for await using: body",
+        "for await using: disposed y",
+        "entry done",
+      ].join("\n"),
+    },
   ];
 
   for (const scenario of esmBytecodeScenarios) {

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -377,6 +377,54 @@ describe("bundler", () => {
       });
     }
 
+    // The other spellings of a top-level await. With splitting, each import()
+    // target is its own chunk with its own module record (without splitting
+    // they would be inlined as async __esm wrappers, so their awaits would not
+    // be at the chunk's top level), so each spelling is pinned by its own
+    // record: a chunk whose record misses its await is abandoned at that
+    // await and its output (or, for `await using`, its disposal) never happens.
+    for (const minify of [false, true]) {
+      itBundled(`compile/splitting/TopLevelAwaitForms${minify ? "+minify" : ""}`, {
+        compile: true,
+        splitting: true,
+        bytecode: true,
+        format: "esm",
+        ...(minify ? { minifySyntax: true, minifyIdentifiers: true, minifyWhitespace: true } : {}),
+        files: {
+          "/entry.ts": /* js */ `
+            await import("./for-await.ts");
+            await import("./await-using.ts");
+            await import("./for-await-using.ts");
+            console.log("entry done");
+          `,
+          "/for-await.ts": /* js */ `
+            for await (const v of [Promise.resolve("a"), Promise.resolve("b")]) console.log("for await:", v);
+          `,
+          "/await-using.ts": /* js */ `
+            await using res = { async [Symbol.asyncDispose]() { console.log("await using: disposed"); } };
+            console.log("await using: body");
+          `,
+          "/for-await-using.ts": /* js */ `
+            const make = (n: string) => ({ async [Symbol.asyncDispose]() { console.log("for await using: disposed", n); } });
+            for (await using r of [make("x"), make("y")]) console.log("for await using: body");
+          `,
+        },
+        run: {
+          stdout: [
+            "for await: a",
+            "for await: b",
+            "await using: body",
+            "await using: disposed",
+            "for await using: body",
+            "for await using: disposed x",
+            "for await using: body",
+            "for await using: disposed y",
+            "entry done",
+          ].join("\n"),
+        },
+      });
+    }
+
     // The shared chunk contains a require()d (so __esm-wrapped) module with an
     // unused import of a node builtin. Builtins are side-effect free, so that
     // import is tree-shaken out of the printed chunk, but the module record

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -343,6 +343,40 @@ describe("bundler", () => {
       });
     }
 
+    // shared.ts has a top-level await and ends up in its own chunk. Only that
+    // chunk's module record may carry the top-level-await flag: the entry and
+    // page chunks depend on it (the linker marks both files async because of
+    // it) but contain no `await` of their own, and JSC sequences the async
+    // dependency through the module graph. Debug builds cross-check every
+    // record against JSC's own analysis of the chunk, so a flag derived from
+    // the files' async-dependency bit instead of the printed code fails here.
+    for (const minify of [false, true]) {
+      itBundled(`compile/splitting/TopLevelAwaitOnlyInSharedChunk${minify ? "+minify" : ""}`, {
+        compile: true,
+        splitting: true,
+        bytecode: true,
+        format: "esm",
+        ...(minify ? { minifySyntax: true, minifyIdentifiers: true, minifyWhitespace: true } : {}),
+        files: {
+          "/entry.ts": /* js */ `
+            import { value } from "./shared.ts";
+            console.log("entry:", value);
+            import("./page.ts").then(m => console.log("page:", m.page));
+          `,
+          "/page.ts": /* js */ `
+            import { value } from "./shared.ts";
+            export const page = "page sees " + value;
+          `,
+          "/shared.ts": /* js */ `
+            export const value = await Promise.resolve("shared tla");
+          `,
+        },
+        run: {
+          stdout: "entry: shared tla\npage: page sees shared tla",
+        },
+      });
+    }
+
     // The shared chunk contains a require()d (so __esm-wrapped) module with an
     // unused import of a node builtin. Builtins are side-effect free, so that
     // import is tree-shaken out of the printed chunk, but the module record

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -907,6 +907,43 @@ test("t2", () => {
   },
 );
 
+test.concurrent("--isolate: cached module_info's top-level await flag describes the printed output", async () => {
+  // The record decides whether JSC evaluates the module as an async module.
+  // tla.test.ts registers its test after a real top-level await: with the
+  // flag missing, the body is abandoned at that await and no test runs.
+  // dead.test.ts's only await is eliminated as dead code before printing, so
+  // its record must not carry the flag; the debug build's fallbackParse diff
+  // (see the test above) catches a record that still derives it from the
+  // source's await keyword.
+  using dir = tempDir("isolate-tla-flag", {
+    "tla.test.ts": `import { test, expect } from "bun:test";
+const value = await Promise.resolve("awaited");
+test("tla", () => {
+  expect(value).toBe("awaited");
+});
+`,
+    "dead.test.ts": `import { test, expect } from "bun:test";
+if (false) await Promise.resolve();
+test("dead", () => {
+  expect(1).toBe(1);
+});
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "--isolate", "./tla.test.ts", "./dead.test.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stderr: "pipe",
+    stdout: "pipe",
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).not.toContain("BEGIN analyzeTranspiledModule");
+  expect(stderr).toContain("2 pass");
+  expect(stderr).toContain("0 fail");
+  expect(exitCode).toBe(0);
+});
+
 test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next file", async () => {
   using dir = tempDir("isolate-abort-timeout", {
     "a-leak.test.ts": `


### PR DESCRIPTION
### Problem
- `bun build --compile --bytecode --format=esm` can produce a binary that runs only part of the entry point and exits 0. In the repro below, a dependency with a top-level await that is also `import()`ed prints `dep evaluated` and nothing else; the same build without `--bytecode` prints all three lines.
- Second shape: when the entry point itself is `import()`ed, a rejected top-level await in it is reported as `unhandledRejection` in the bytecode binary but as `uncaughtException` without bytecode and under `bun run`.
- Cause: with bytecode, JSC never parses the chunk. It picks sync or async evaluation from the TLA flag in the record bun hands it, while the bytecode is compiled from the printed text. When the record says no TLA but the text awaits, JSC runs the body on the sync path, the body suspends at its first `await`, and nothing resumes it.
- The flag came from `await` keywords in the input files. The awaits the bundler itself prints (`await init_foo()`, `await init_entry()`) were not counted, and an `await` removed as dead code still was. The `bun test --isolate` records used the same keyword, and the debug cross-check did not compare this flag.

### Fix
- The printer sets the flag itself: each of the four places it prints an `await` marks the record it is printing into, unless a function or arrow body is being printed. The keyword-based assignments in the bundler and in the two runtime (`--isolate`) paths are removed, so the flag has one producer.
- Why this is right: the flag is derived from the same text the bytecode is compiled from, counting the constructs JSC's parser counts, so record and bytecode agree by construction. Synthesized awaits count; dead awaits, awaits inside a wrapper, and a `--splitting` chunk that merely depends on a TLA chunk do not.
- The debug cross-check now includes `hasTLA`, so a debug binary or `--isolate` module whose record disagrees with JSC's analysis in either direction refuses to load. The on-disk transpiler cache version is bumped 25 to 26 because the serialized record can differ (only for the dead-await case).
- Verification: two new compiled-binary tests reproduce the two shapes above and fail on a release build without the fix. Further tests (dead await, awaits inside functions, each `await` form, splitting, `--isolate`) pass on main's release build and pin the new producer under the debug cross-check.

### Background
- Module record: the metadata JSC needs to link and evaluate an ES module (imports, exports, whether it has top-level await). Normally JSC builds it by parsing the source; for `--bytecode` builds and the `--isolate` source cache, bun builds it and JSC never parses the text.
- TLA flag: JSC evaluates a module marked as having top-level await as an async body, and one not marked on a synchronous path. On the sync path a body that awaits anyway suspends and is never resumed, with no error.
- Wrapped files: a file that is both imported and `import()`ed (with splitting off) has its body wrapped in an `init_foo()` function run on demand. If that body has TLA the wrapper is async and each importer gets `await init_foo()` printed at the chunk's top level. This await exists only in the printed output, not in any input file.
- Debug cross-check: debug builds compare bun's record with JSC's own parse of the same text and refuse to run on a mismatch. It only compares the fields it dumps, and TLA was not one of them.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/bundler/bundler_compile.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

## Repro

```js
// entry.js
import { value } from "./dep.js";
import { lazy } from "./helper.js";
console.log("entry:", value);
lazy().then(m => console.log("lazy:", m.value));
// dep.js
export const value = await Promise.resolve("tla-value");
console.log("dep evaluated");
// helper.js
export const lazy = () => import("./dep.js");
```

```
$ bun build --compile --bytecode --format=esm ./entry.js --outfile=app && ./app
dep evaluated
$ echo $?
0
```

Without `--bytecode` the same binary prints `dep evaluated`, `entry: tla-value`, `lazy: tla-value`. The rest of the entry point is silently skipped.

Second shape (the one from the review of #37677): the entry point itself is `import()`ed, so it becomes an async `__esm` wrapper and the chunk ends in `await init_entry()`. A rejected top-level await in that entry is reported through `process.on("unhandledRejection")` in the bytecode binary, but through `uncaughtException` (the entry module's evaluation error) in the non-bytecode binary and under `bun run`.

## Cause

With `--compile --bytecode --format=esm`, JSC does not parse the chunk; its `JSModuleRecord` comes from the `ModuleInfo` the linker assembles, and `JSModuleRecord::execute` chooses between synchronous and async module evaluation purely from that record's TLA flag. The bytecode, on the other hand, is compiled from the printed chunk text, so it is generator-style whenever the text contains a top-level `await`. When the record says no TLA but the text has one, JSC runs the body on the sync path, the body yields at its first `await`, and nothing ever resumes it (`JSModuleRecord.cpp`, the `!hasTLA()` branch): the remaining statements never run and the awaited promise is never observed.

`post_process_js_chunk` derived the flag from `top_level_await_keyword` of the unwrapped files in the chunk, which only covers awaits written in the input files. The linker prints two more kinds of top-level await:

- `convert_stmts_for_chunk` turns an unwrapped file's import of an async wrapped file into `await init_foo()` (or `await __promiseAll([...])`) at the chunk's top level (repro above: `dep.js` is wrapped because it is also `import()`ed and splitting is off).
- `generate_entry_point_tail_js` emits `await init_entry()` when the entry point is an async ESM wrapper.

The keyword also errs in the other direction: `if (false) await x` (or `if (__DEV__) await import(...)` with a define) sets it, but dead code elimination removes the `await` before printing, so the record claims a TLA the chunk text does not have. JSC tolerates that at runtime (the async path handles a body that finishes synchronously), but it is still a record that does not describe the bytecode, and the same thing happens to the records the runtime builds for `bun test --isolate`, which set the flag from the same keyword.

Debug builds cross-check the record against JSC's own analysis of the chunk (`error: Imports different between parseFromSourceCode and fallbackParse`), but `dumpRecordInfo` did not include `hasTLA`, so none of this was caught.

## Fix

The printer sets `has_tla` itself. There are exactly three places it prints an `await` (`await x`, `for await`, and the `await using` keyword in `print_decls`, which serves both the statement form and `for (await using ...)`); each calls `record_top_level_await`, which sets the flag on the `ModuleInfo` being printed into unless a function or arrow body is being printed (`print_func` and the `EArrow` arm keep a depth counter). That is the same set of constructs JSC's parser counts for a module's `usesAwait()`, evaluated on the same text, so the record matches the bytecode by construction: the `await init_foo()` statements of an unwrapped file are printed at depth 0 into that part range's record (which `ModuleInfo::append` already ORs into the chunk's, since #37677), a wrapped file's statements sit inside its wrapper arrow and are not counted, the entry point tail prints `await init_entry()` straight into the chunk's record, and a dead `await` is never printed at all. Under `--splitting` a chunk that merely depends on a TLA chunk prints no `await` of its own and so does not claim one.

With the printer owning the flag, the keyword scan in `post_process_js_chunk` and the keyword assignments in `RuntimeTranspilerStore.rs` / `jsc_hooks.rs` (the `--isolate` records, which are built by the same printer pass) are removed; the flag now has one producer, like the import and export entries. Nothing changes for builds that do not generate a record, since `record_top_level_await` only touches a `ModuleInfo` when one is attached. The runtime transpiler cache stores these records on disk, so its format version is bumped (to 28; #40509 and #40677 took 26 and 27 for the wire format and string table changes); the only entries whose flag actually differs are the dead-await ones, but the cache policy is to bump on any change to the serialized output.

`dumpRecordInfo` now prints `hasTLA`, so debug builds refuse to start a binary (or load an `--isolate` module) whose record disagrees with JSC's analyzer in either direction. With only that line applied, the unfixed record fails both repro shapes above with `hasTLA: false` in the record vs `true` from JSC, and fails the dead-await shape the other way round (`true` vs `false`, both for a compiled binary and for a test file under `--isolate`); with the fix, everything listed below passes the cross-check.

## Verification

New tests, failing before this change with a release build (the observable output above) and passing after:

- `test/bundler/bundler_compile.test.ts`, ESM bytecode matrix (plain and minified): `AwaitInitOfAsyncWrappedDependency` (prints only `dep evaluated` before), `AwaitInitOfAsyncWrappedEntryPoint` (`unhandledRejection:` instead of `uncaughtException:` before).

New tests that pass on main's release build and exist for the debug cross-check and the new producer:

- `bundler_compile.test.ts` matrix: `DeadTopLevelAwait` (record must not claim the eliminated await; fails the cross-check with the keyword-derived flag), `AwaitOnlyInsideFunctions` (awaits inside arrow, function expression, declaration, object and class method bodies must not mark the record, pinning the depth counter).
- `test/bundler/bundler_compile_splitting.test.ts`: `TopLevelAwaitOnlyInSharedChunk` (+minify), the precision requirement above; `TopLevelAwaitForms` (+minify), where `for await`, `await using` and `for (await using ...)` each live in their own split chunk with their own record, so each printer site is pinned independently (without splitting those modules would be inlined as async `__esm` wrappers and only the entry's await expression would be exercised). With the non-expression recording sites deleted, both variants fail the debug cross-check.
- `test/cli/test/isolation.test.ts`: a real TLA test file plus a dead-await one under `--isolate`, covering the runtime producer in both directions.

With the debug build (cross-check active), on top of current main: all of `bundler_compile.test.ts` (except the pre-existing `compile/HelloWorldWithProcessVersionsBun`, which fails on every debug build independently of this change and is being fixed separately), `bundler_compile_splitting`, `bundler_barrel` `ESMBytecodeCompileSkipsDeferredImports`, `bun-build-compile`, `regression/issue/26298`, `typescript/type-export`, `bundler_edgecase`, `transpiler/transpiler.test.js`, and for the runtime records `cli/test/isolation`, `cli/run/transpiler-cache`, `regression/issue/30887` (TLA preloads under `--isolate` / `--parallel` and the cache round trip) and `regression/issue/29519` pass. With `src/` reset to main the four `AwaitInit*` tests fail with the output described above.

</details>




