### PR TITLE
node:zlib: schedule the async write through the handle's own pointer

### DIFF
--- a/src/jsc/JSCell.rs
+++ b/src/jsc/JSCell.rs
@@ -163,20 +163,6 @@ impl<T> JsCell<T> {
     pub const fn as_ptr(&self) -> *mut T {
         self.0.get()
     }
-
-    /// Raw pointer to the inner `T` of the cell `this` points at, keeping
-    /// `this`'s provenance (`UnsafeCell::raw_get`). `as_ptr` goes through a
-    /// `&JsCell<T>`, which is a reborrow of just the cell: a pointer that is
-    /// later `container_of`'d back to the enclosing object (intrusive task
-    /// fields) has to be projected from the enclosing object's pointer with
-    /// this instead, `JsCell::raw_get(&raw mut (*obj).field)`.
-    ///
-    /// Safe for the same reason `UnsafeCell::raw_get` is: nothing is read,
-    /// the result is only as valid as `this`.
-    #[inline(always)]
-    pub const fn raw_get(this: *const Self) -> *mut T {
-        core::cell::UnsafeCell::raw_get(this.cast::<core::cell::UnsafeCell<T>>())
-    }
 }
 
 impl<T: Default> Default for JsCell<T> {

--- a/src/jsc/JSCell.rs
+++ b/src/jsc/JSCell.rs
@@ -163,6 +163,20 @@ impl<T> JsCell<T> {
     pub const fn as_ptr(&self) -> *mut T {
         self.0.get()
     }
+
+    /// Raw pointer to the inner `T` of the cell `this` points at, keeping
+    /// `this`'s provenance (`UnsafeCell::raw_get`). `as_ptr` goes through a
+    /// `&JsCell<T>`, which is a reborrow of just the cell: a pointer that is
+    /// later `container_of`'d back to the enclosing object (intrusive task
+    /// fields) has to be projected from the enclosing object's pointer with
+    /// this instead, `JsCell::raw_get(&raw mut (*obj).field)`.
+    ///
+    /// Safe for the same reason `UnsafeCell::raw_get` is: nothing is read,
+    /// the result is only as valid as `this`.
+    #[inline(always)]
+    pub const fn raw_get(this: *const Self) -> *mut T {
+        core::cell::UnsafeCell::raw_get(this.cast::<core::cell::UnsafeCell<T>>())
+    }
 }
 
 impl<T: Default> Default for JsCell<T> {

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -243,18 +243,10 @@ pub(crate) trait CompressionStreamImpl:
     // Intrusive refcount.
     fn ref_(&self);
     /// Decrement the intrusive refcount and free `*this` (via `Self::deinit` /
-    /// `heap::take`) when it hits zero.
-    ///
-    /// Raw-pointer receiver so the destroy path keeps the
-    /// allocation's full write provenance (routing through `&self` and casting
-    /// back to `*mut` would be UB under Stacked Borrows when `Box::from_raw`
-    /// reclaims). Every call site that may hit zero (`run_from_js_thread`,
-    /// `release_unrun`, `finalize`) holds the original `m_ctx` pointer: the GC
-    /// hands it to `finalize`, and `write` posts it (taken from the wrapper via
-    /// `T::from_js`); the bracketed `ref_()`/`deref()` in `write_sync` can never
-    /// hit zero while the JS wrapper's +1 is still live, so its
-    /// `(&T as *const T).cast_mut()` provenance is sufficient (only the
-    /// `Cell<u32>` is touched).
+    /// `heap::take`) when it hits zero. A call that can hit zero must pass the
+    /// wrapper's own `m_ctx` pointer, never a cast `&self` (`finalize` gets it
+    /// from the GC, the write completion from `write`); `write_sync`'s
+    /// bracketed pair cannot hit zero while the wrapper's ref is live.
     ///
     /// SAFETY: `this` must point to a live `Self` allocated via `heap::alloc`
     /// in `constructor()`. After this returns, `*this` may have been freed.
@@ -419,12 +411,10 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         let _ = (in_off, in_len, out_off, out_len);
 
         Self::throw_unless_idle(this, global_this)?;
-        // The pool posts this pointer back and the completion may free through
-        // it (see `deref`), so it is the wrapper's `m_ctx`, not `this` cast. The
-        // thunk downcast `this_value` to produce `this`, so this cannot fail.
-        let this_ptr: *mut T =
+        // The completion may `deref` this to zero, so it is the wrapper's pointer, not `this` cast.
+        let m_ctx: *mut T =
             T::from_js(this_value).expect("write: this_value is not this handle's wrapper");
-        debug_assert!(core::ptr::eq(this_ptr.cast_const(), this));
+        debug_assert!(core::ptr::eq(m_ctx.cast_const(), this));
         // Pin both buffers before mutating any state: materializing a
         // FastTypedArray's backing store can fail on OOM, and failing here
         // leaves nothing to unwind.
@@ -474,8 +464,8 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         // The task is a field of this JS-owned stream: counted, so the VM waits
         // for it (see `VmHandle::embedded_work_scheduled`).
         this.loop_handle().embedded_work_scheduled();
-        // SAFETY: `this_ptr` is `this`, live for the whole call.
-        WorkPool::schedule(unsafe { T::field_of(this_ptr) });
+        // SAFETY: `m_ctx` is `this`, live for the whole call.
+        WorkPool::schedule(unsafe { T::field_of(m_ctx) });
 
         Ok(JSValue::UNDEFINED)
     }
@@ -483,9 +473,8 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
     // Safe fn: coerces to the `WorkPoolTask.callback` field type at the
     // struct-init site in `write` above.
     fn async_job_run_task(task: *mut WorkPoolTask) {
-        // SAFETY: the pool calls back with the pointer `write` scheduled,
-        // `T::field_of` of the `m_ctx` pointer, and the `ref_()` taken there
-        // keeps the stream alive.
+        // SAFETY: `task` is the `T::field_of(m_ctx)` that `write` scheduled;
+        // the `ref_()` taken there keeps the stream alive.
         let this: *mut T = unsafe { T::from_task_ptr(task) };
         Self::async_job_run(this);
     }
@@ -1031,8 +1020,7 @@ macro_rules! __impl_compression_stream {
             }
         }
 
-        // `task` is a `JsCell<WorkPoolTask>`; `JsCell` is `repr(transparent)`,
-        // so the task sits at `offset_of!(task)` like a bare field would.
+        // The field is a `repr(transparent)` `JsCell<WorkPoolTask>`, so its offset is the task's.
         ::bun_threading::intrusive_work_task!($native, task);
 
         /// `T.js.*` — cached-property accessors emitted by

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -14,7 +14,7 @@ use bun_jsc::{
     self as jsc, CallFrame, ErrorCode, JSGlobalObject, JSValue, JsCell, JsResult, StringJsc as _,
     StrongOptional, WorkPoolTask,
 };
-use bun_threading::work_pool::WorkPool;
+use bun_threading::{IntrusiveWorkTask, WorkPool};
 use bun_zlib;
 
 bun_output::declare_scope!(zlib, hidden);
@@ -195,7 +195,9 @@ pub(crate) trait CompressionContext {
 // R-2 (host-fn re-entrancy): every JS-exposed mixin method takes `&T`; per-field
 // interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). Accessors return the
 // cell wrapper so the mixin can `.get()`/`.set()`/`.with_mut()` as needed.
-pub(crate) trait CompressionStreamImpl: Sized + Taskable + jsc::JsClass + 'static {
+pub(crate) trait CompressionStreamImpl:
+    Sized + Taskable + jsc::JsClass + IntrusiveWorkTask + 'static
+{
     type Stream: CompressionContext;
 
     // Field accessors (interior-mutability cells; all `&self`).
@@ -238,24 +240,6 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + jsc::JsClass + 'stati
     fn pending_close(&self) -> &Cell<bool>;
     fn closed(&self) -> &Cell<bool>;
 
-    /// Project the embedded `WorkPoolTask` out of `this` without going through
-    /// a reference to the field; inverse of [`from_task`](Self::from_task).
-    /// This is what `write` hands the pool: the pointer keeps `this`'s
-    /// provenance, which `from_task` relies on (`task().as_ptr()` would only
-    /// cover the task field).
-    ///
-    /// # Safety
-    /// `this` must point to a live `Self`.
-    unsafe fn task_of(this: *mut Self) -> *mut WorkPoolTask;
-
-    /// Recover `*mut Self` from the embedded `WorkPoolTask`.
-    ///
-    /// # Safety
-    /// `task` must have been produced by [`task_of`](Self::task_of) on a
-    /// still-live `Self`; the result carries whatever provenance that `this`
-    /// had.
-    unsafe fn from_task(task: *mut WorkPoolTask) -> *mut Self;
-
     // Intrusive refcount.
     fn ref_(&self);
     /// Decrement the intrusive refcount and free `*this` (via `Self::deinit` /
@@ -265,10 +249,9 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + jsc::JsClass + 'stati
     /// allocation's full write provenance (routing through `&self` and casting
     /// back to `*mut` would be UB under Stacked Borrows when `Box::from_raw`
     /// reclaims). Every call site that may hit zero (`run_from_js_thread`,
-    /// `release_unrun`, `finalize`) holds the original `m_ctx` pointer:
-    /// `finalize` is handed it by the GC, the other two get back the pointer
-    /// `write` posted, which it takes from the wrapper (`T::from_js`) for this
-    /// reason; the bracketed `ref_()`/`deref()` in `write_sync` can never
+    /// `release_unrun`, `finalize`) holds the original `m_ctx` pointer: the GC
+    /// hands it to `finalize`, and `write` posts it (taken from the wrapper via
+    /// `T::from_js`); the bracketed `ref_()`/`deref()` in `write_sync` can never
     /// hit zero while the JS wrapper's +1 is still live, so its
     /// `(&T as *const T).cast_mut()` provenance is sufficient (only the
     /// `Cell<u32>` is touched).
@@ -436,11 +419,9 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         let _ = (in_off, in_len, out_off, out_len);
 
         Self::throw_unless_idle(this, global_this)?;
-        // The pool posts this pointer back to `run_from_js_thread` /
-        // `release_unrun`, whose trailing `T::deref` may free through it, so it
-        // has to be the wrapper's `m_ctx` itself (see `deref`), not a pointer
-        // derived from the `&T` receiver. The thunk downcast `this_value` to
-        // produce `this`, so this lookup yields the same object.
+        // The pool posts this pointer back and the completion may free through
+        // it (see `deref`), so it is the wrapper's `m_ctx`, not `this` cast. The
+        // thunk downcast `this_value` to produce `this`, so this cannot fail.
         let this_ptr: *mut T =
             T::from_js(this_value).expect("write: this_value is not this handle's wrapper");
         debug_assert!(core::ptr::eq(this_ptr.cast_const(), this));
@@ -494,7 +475,7 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         // for it (see `VmHandle::embedded_work_scheduled`).
         this.loop_handle().embedded_work_scheduled();
         // SAFETY: `this_ptr` is `this`, live for the whole call.
-        WorkPool::schedule(unsafe { T::task_of(this_ptr) });
+        WorkPool::schedule(unsafe { T::field_of(this_ptr) });
 
         Ok(JSValue::UNDEFINED)
     }
@@ -502,10 +483,10 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
     // Safe fn: coerces to the `WorkPoolTask.callback` field type at the
     // struct-init site in `write` above.
     fn async_job_run_task(task: *mut WorkPoolTask) {
-        // SAFETY: the pool only calls this with the pointer `write` scheduled:
-        // `T::task_of` of the stream's `m_ctx` pointer, which the `ref_()` in
-        // `write` keeps alive. `from_task` hands that `m_ctx` pointer back.
-        let this: *mut T = unsafe { T::from_task(task) };
+        // SAFETY: the pool calls back with the pointer `write` scheduled,
+        // `T::field_of` of the `m_ctx` pointer, and the `ref_()` taken there
+        // keeps the stream alive.
+        let this: *mut T = unsafe { T::from_task_ptr(task) };
         Self::async_job_run(this);
     }
 
@@ -1050,6 +1031,10 @@ macro_rules! __impl_compression_stream {
             }
         }
 
+        // `task` is a `JsCell<WorkPoolTask>`; `JsCell` is `repr(transparent)`,
+        // so the task sits at `offset_of!(task)` like a bare field would.
+        ::bun_threading::intrusive_work_task!($native, task);
+
         /// `T.js.*` — cached-property accessors emitted by
         /// `generate-classes.ts` for the `values:` list in `zlib.classes.ts`.
         #[allow(unused)]
@@ -1080,22 +1065,6 @@ macro_rules! __impl_compression_stream {
             #[inline] fn write_in_progress(&self) -> &::core::cell::Cell<bool> { &self.write_in_progress }
             #[inline] fn pending_close(&self) -> &::core::cell::Cell<bool> { &self.pending_close }
             #[inline] fn closed(&self) -> &::core::cell::Cell<bool> { &self.closed }
-
-            #[inline]
-            unsafe fn task_of(this: *mut Self) -> *mut ::bun_jsc::WorkPoolTask {
-                // SAFETY: `this` is live (fn contract); `&raw mut` projects the
-                // field without forming a reference to it.
-                ::bun_jsc::JsCell::raw_get(unsafe { &raw mut (*this).task })
-            }
-
-            #[inline]
-            unsafe fn from_task(task: *mut ::bun_jsc::WorkPoolTask) -> *mut Self {
-                // SAFETY: fn contract — `task` came out of `task_of`, so it
-                // points at the `task` field with the enclosing object's
-                // provenance. `JsCell` is `repr(transparent)`, so the value
-                // sits at `offset_of!(Self, task)`.
-                unsafe { ::bun_core::from_field_ptr!(Self, task, task) }
-            }
 
             // All three `Native*` structs `#[derive(bun_ptr::CellRefCounted)]`
             // with their own `#[ref_count(destroy = …)]` (or the default

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -242,11 +242,11 @@ pub(crate) trait CompressionStreamImpl:
 
     // Intrusive refcount.
     fn ref_(&self);
-    /// Decrement the intrusive refcount; frees `*this` at zero, so a call that
-    /// can reach zero passes the wrapper's `m_ctx` pointer, not a cast `&self`.
+    /// Decrement the intrusive refcount; frees `*this` when it hits zero.
     ///
-    /// SAFETY: `this` must point to a live `Self` allocated via `heap::alloc`
-    /// in `constructor()`. After this returns, `*this` may have been freed.
+    /// SAFETY: `this` must point to a live `Self` allocated in `constructor()`
+    /// and, unless the call cannot reach zero, be that allocation's own pointer
+    /// (the wrapper's `m_ctx`). After this returns, `*this` may have been freed.
     unsafe fn deref(this: *mut Self);
 
     // Per-class codegen (`T.js.*` cached-property accessors).

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -242,11 +242,8 @@ pub(crate) trait CompressionStreamImpl:
 
     // Intrusive refcount.
     fn ref_(&self);
-    /// Decrement the intrusive refcount and free `*this` (via `Self::deinit` /
-    /// `heap::take`) when it hits zero. A call that can hit zero must pass the
-    /// wrapper's own `m_ctx` pointer, never a cast `&self` (`finalize` gets it
-    /// from the GC, the write completion from `write`); `write_sync`'s
-    /// bracketed pair cannot hit zero while the wrapper's ref is live.
+    /// Decrement the intrusive refcount; frees `*this` at zero, so a call that
+    /// can reach zero passes the wrapper's `m_ctx` pointer, not a cast `&self`.
     ///
     /// SAFETY: `this` must point to a live `Self` allocated via `heap::alloc`
     /// in `constructor()`. After this returns, `*this` may have been freed.

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -195,7 +195,7 @@ pub(crate) trait CompressionContext {
 // R-2 (host-fn re-entrancy): every JS-exposed mixin method takes `&T`; per-field
 // interior mutability via `Cell` (Copy) / `JsCell` (non-Copy). Accessors return the
 // cell wrapper so the mixin can `.get()`/`.set()`/`.with_mut()` as needed.
-pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
+pub(crate) trait CompressionStreamImpl: Sized + Taskable + jsc::JsClass + 'static {
     type Stream: CompressionContext;
 
     // Field accessors (interior-mutability cells; all `&self`).
@@ -238,8 +238,22 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     fn pending_close(&self) -> &Cell<bool>;
     fn closed(&self) -> &Cell<bool>;
 
+    /// Project the embedded `WorkPoolTask` out of `this` without going through
+    /// a reference to the field; inverse of [`from_task`](Self::from_task).
+    /// This is what `write` hands the pool: the pointer keeps `this`'s
+    /// provenance, which `from_task` relies on (`task().as_ptr()` would only
+    /// cover the task field).
+    ///
+    /// # Safety
+    /// `this` must point to a live `Self`.
+    unsafe fn task_of(this: *mut Self) -> *mut WorkPoolTask;
+
     /// Recover `*mut Self` from the embedded `WorkPoolTask`.
-    /// SAFETY: caller guarantees `task` points at the `task` field of a live `Self`.
+    ///
+    /// # Safety
+    /// `task` must have been produced by [`task_of`](Self::task_of) on a
+    /// still-live `Self`; the result carries whatever provenance that `this`
+    /// had.
     unsafe fn from_task(task: *mut WorkPoolTask) -> *mut Self;
 
     // Intrusive refcount.
@@ -251,8 +265,10 @@ pub(crate) trait CompressionStreamImpl: Sized + Taskable + 'static {
     /// allocation's full write provenance (routing through `&self` and casting
     /// back to `*mut` would be UB under Stacked Borrows when `Box::from_raw`
     /// reclaims). Every call site that may hit zero (`run_from_js_thread`,
-    /// `finalize`) holds a `*mut T` derived from the original `m_ctx`
-    /// allocation; the bracketed `ref_()`/`deref()` in `write_sync` can never
+    /// `release_unrun`, `finalize`) holds the original `m_ctx` pointer:
+    /// `finalize` is handed it by the GC, the other two get back the pointer
+    /// `write` posted, which it takes from the wrapper (`T::from_js`) for this
+    /// reason; the bracketed `ref_()`/`deref()` in `write_sync` can never
     /// hit zero while the JS wrapper's +1 is still live, so its
     /// `(&T as *const T).cast_mut()` provenance is sufficient (only the
     /// `Cell<u32>` is touched).
@@ -420,6 +436,14 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         let _ = (in_off, in_len, out_off, out_len);
 
         Self::throw_unless_idle(this, global_this)?;
+        // The pool posts this pointer back to `run_from_js_thread` /
+        // `release_unrun`, whose trailing `T::deref` may free through it, so it
+        // has to be the wrapper's `m_ctx` itself (see `deref`), not a pointer
+        // derived from the `&T` receiver. The thunk downcast `this_value` to
+        // produce `this`, so this lookup yields the same object.
+        let this_ptr: *mut T =
+            T::from_js(this_value).expect("write: this_value is not this handle's wrapper");
+        debug_assert!(core::ptr::eq(this_ptr.cast_const(), this));
         // Pin both buffers before mutating any state: materializing a
         // FastTypedArray's backing store can fail on OOM, and failing here
         // leaves nothing to unwind.
@@ -469,7 +493,8 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
         // The task is a field of this JS-owned stream: counted, so the VM waits
         // for it (see `VmHandle::embedded_work_scheduled`).
         this.loop_handle().embedded_work_scheduled();
-        WorkPool::schedule(this.task().as_ptr());
+        // SAFETY: `this_ptr` is `this`, live for the whole call.
+        WorkPool::schedule(unsafe { T::task_of(this_ptr) });
 
         Ok(JSValue::UNDEFINED)
     }
@@ -477,12 +502,9 @@ impl<T: CompressionStreamImpl> CompressionStream<T> {
     // Safe fn: coerces to the `WorkPoolTask.callback` field type at the
     // struct-init site in `write` above.
     fn async_job_run_task(task: *mut WorkPoolTask) {
-        // SAFETY: `task` points to `T.task` — only ever invoked by the thread
-        // pool against a `T` scheduled in `write`, so provenance covers the
-        // full `T` allocation. Recover *mut T via container_of
-        // (`CompressionStreamImpl::from_task`). The task field is a
-        // `JsCell<WorkPoolTask>` — `#[repr(transparent)]` over the value, so
-        // `offset_of!(T, task)` is the value's offset.
+        // SAFETY: the pool only calls this with the pointer `write` scheduled:
+        // `T::task_of` of the stream's `m_ctx` pointer, which the `ref_()` in
+        // `write` keeps alive. `from_task` hands that `m_ctx` pointer back.
         let this: *mut T = unsafe { T::from_task(task) };
         Self::async_job_run(this);
     }
@@ -1060,10 +1082,18 @@ macro_rules! __impl_compression_stream {
             #[inline] fn closed(&self) -> &::core::cell::Cell<bool> { &self.closed }
 
             #[inline]
+            unsafe fn task_of(this: *mut Self) -> *mut ::bun_jsc::WorkPoolTask {
+                // SAFETY: `this` is live (fn contract); `&raw mut` projects the
+                // field without forming a reference to it.
+                ::bun_jsc::JsCell::raw_get(unsafe { &raw mut (*this).task })
+            }
+
+            #[inline]
             unsafe fn from_task(task: *mut ::bun_jsc::WorkPoolTask) -> *mut Self {
-                // SAFETY: `task` points at the `task` field of a live `Self`;
-                // `from_field_ptr!`
-                // computes the byte offset via `offset_of!(Self, task)`.
+                // SAFETY: fn contract — `task` came out of `task_of`, so it
+                // points at the `task` field with the enclosing object's
+                // provenance. `JsCell` is `repr(transparent)`, so the value
+                // sits at `offset_of!(Self, task)`.
                 unsafe { ::bun_core::from_field_ptr!(Self, task, task) }
             }
 

--- a/test/internal/source-lints/work-pool-schedule-field-ref.test.ts
+++ b/test/internal/source-lints/work-pool-schedule-field-ref.test.ts
@@ -1,0 +1,227 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// The `*mut Task` handed to `WorkPool::schedule` must be projected out of a
+// pointer to the object that embeds the task, never out of a reference to the
+// task field itself:
+//
+//   WorkPool::schedule(this.task().as_ptr());      // accessor returns &JsCell<Task>
+//   WorkPool::schedule(this.task());               // accessor returns &mut Task
+//   WorkPool::schedule(&mut self.task);            // coerces to *mut Task
+//
+// are banned; `&raw mut (*p).task`, `&raw mut self.task`, `T::field_of(p)`,
+// `T::task_of(p)` (an associated fn given the object's pointer) are the
+// shapes to use.
+//
+// The pool calls back with exactly the pointer it was given, and every
+// trampoline behind these sites `container_of`s it back to the embedding
+// object and then uses the rest of the object through the result (see
+// `bun_core::container_of`'s contract: "a `&mut field` reborrow does not
+// suffice"). A reference to a field carries provenance for that field only, so
+// a pointer taken through one (`&JsCell<Task>` -> `.as_ptr()`, `&mut Task`
+// coerced to `*mut Task`) stops at the field's bounds: the sibling fields the
+// callback reads and writes, and the allocation the completion may free, are
+// outside it. Stacked Borrows rejects every out-of-range access; Tree Borrows
+// (what `bun run rust:miri` uses) rejects the writes and the free. A raw
+// projection from the object's pointer (`&raw mut (*p).task`) keeps `p`'s
+// provenance; that is what `WorkPool::schedule_owned` does
+// (src/threading/work_pool.rs) and what `CompressionStream::write` in
+// src/runtime/node/node_zlib_binding.rs, the instance this was written for,
+// does now via `CompressionStreamImpl::task_of`.
+//
+// Scope: the argument expression at the `WorkPool::schedule(` call. A pointer
+// projected the wrong way somewhere else and passed in through a local is the
+// same bug and is not caught here. This lint is about the range of the pointer
+// the pool gets; `&raw mut self.task` has the whole object's range and passes
+// here, and the separate problem with it (the `&mut self` it is taken through
+// stays protected while the pool thread is already running) is the subject of
+// work-pool-schedule-projection.test.ts (#37768). Siblings:
+// self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
+// frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `WorkPool::schedule(`, however the path is qualified. `schedule_owned` /
+// `schedule_new` take the object itself and do the projection internally, so
+// they do not match.
+const SCHEDULE = /\bWorkPool::schedule\s*\(/g;
+
+// A method-call chain rooted at a receiver (`this.task()`, `self.task.as_ptr()`,
+// `(*this).task.as_ptr()`, `self.task_mut()`): an accessor auto-refs the field
+// or returns a reference to it, so the pointer that comes out covers the field
+// only. Associated-fn calls (`T::task_of(p)`, `JsCell::raw_get(..)`) are not
+// rooted at a receiver and do not match.
+const METHOD_CHAIN = /^(?:[\w:]+|\(\s*\*\s*[\w.]+\s*\))(?:\.\w+)*(?:\.\w+\s*\([^()]*\)\s*)+$/;
+// A reference formed anywhere in the argument: `&mut self.task` coercing to
+// `*mut Task`, `from_mut(&mut self.task)`, `JsCell::as_ptr(&self.task)`.
+// `&raw mut` / `&raw const` are the raw projections this lint asks for.
+const REFERENCE = /&(?!\s*raw\b)/;
+// The reference-to-pointer conversions, in case the reference itself is
+// spelled somewhere the regex above does not see (a macro, a cast chain).
+const FROM_REF = /\bfrom_(?:mut|ref)\b/;
+
+/** The argument text of the call whose opening paren is at `open`, or null if unbalanced. */
+function argumentAt(source: string, open: number): string | null {
+  for (let depth = 0, i = open; i < source.length; i++) {
+    const c = source[i];
+    if (c === "(" || c === "{" || c === "[") depth++;
+    else if (c === ")" || c === "}" || c === "]") {
+      if (--depth === 0) return source.slice(open + 1, i);
+    }
+  }
+  return null;
+}
+
+function normalize(argument: string): string {
+  let arg = argument.replace(/\s+/g, " ").trim().replace(/,$/, "").trim();
+  const unsafeBlock = /^unsafe\s*\{(.*)\}$/.exec(arg);
+  if (unsafeBlock) arg = unsafeBlock[1].trim();
+  return arg;
+}
+
+function isBanned(argument: string): boolean {
+  const arg = normalize(argument);
+  return METHOD_CHAIN.test(arg) || REFERENCE.test(arg) || FROM_REF.test(arg);
+}
+
+/** Byte offsets (into `stripped`) of every banned schedule call in one file. */
+function findBannedSchedules(stripped: string): number[] {
+  const hits: number[] = [];
+  for (const m of stripped.matchAll(SCHEDULE)) {
+    const argument = argumentAt(stripped, m.index + m[0].length - 1);
+    if (argument !== null && isBanned(argument)) hits.push(m.index);
+  }
+  return hits;
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape. Prefer converting over adding an entry here.
+const ALLOW: Record<string, number> = {
+  // `FileCloser::on_io_request_closed` schedules `this.task()`, the trait's
+  // `&mut Task` accessor. #37768 converts it together with the `&mut self`
+  // schedule sites; delete this entry when that lands.
+  "src/runtime/webcore/Blob.rs": 1,
+};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+let scheduleSites = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including the in-tree comments
+  // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
+  // newlines and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  scheduleSites += [...stripped.matchAll(SCHEDULE)].length;
+  for (const offset of findBannedSchedules(stripped)) {
+    counts[source] = (counts[source] ?? 0) + 1;
+    if (counts[source] > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${lineOf(stripped, offset)}`);
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources containing schedule calls", () => {
+  // Guards against the tracked/realpath filters (or the call pattern) failing
+  // to match anything, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+  expect(scheduleSites).toBeGreaterThan(0);
+});
+
+test("the classifier recognizes the spellings it claims to", () => {
+  const banned = [
+    // `CompressionStream::write` before `task_of`: `task()` returns
+    // `&JsCell<WorkPoolTask>`.
+    "this.task().as_ptr()",
+    // `FileCloser::on_io_request_closed`: `task()` returns `&mut WorkPoolTask`.
+    "this.task()",
+    "self.task.as_ptr()",
+    "(*this).task.as_ptr()",
+    "self.task_mut()",
+    "&mut self.task",
+    "&mut (*this).task",
+    "&self.task as *const _ as *mut _",
+    "ptr::from_mut(&mut self.task)",
+    "core::ptr::from_ref(&self.task).cast_mut()",
+    "JsCell::as_ptr(&self.task)",
+    // rustfmt-wrapped.
+    "\n            this.task().as_ptr(),\n        ",
+    "unsafe { this.task_cell().as_ptr() }",
+  ];
+  const allowed = [
+    // The shapes in the tree.
+    "&raw mut self.task",
+    "&raw mut this.task",
+    "&raw mut raw.task",
+    "&raw mut (*st).task",
+    "&raw mut (*subtask).work_task",
+    "unsafe { &raw mut (*job).task }",
+    "unsafe { T::task_of(this_ptr) }",
+    "unsafe { T::field_of(raw) }",
+    "unsafe { ::bun_jsc::JsCell::raw_get(&raw mut (*this).task) }",
+    "core::ptr::addr_of_mut!((*this).task)",
+    // A pointer projected elsewhere is out of scope.
+    "task",
+    "task_ptr",
+    // rustfmt-wrapped.
+    "unsafe {\n                &raw mut (*this).task\n            }",
+    "\n            &raw mut (*this).task,\n        ",
+  ];
+  expect(banned.filter(s => !isBanned(s))).toEqual([]);
+  expect(allowed.filter(s => isBanned(s))).toEqual([]);
+});
+
+test("the call matcher finds the call and takes its whole argument", () => {
+  const source = [
+    "fn a(this: &T) {",
+    "    WorkPool::schedule(this.task().as_ptr());",
+    "    bun_jsc::WorkPool::schedule(",
+    "        this.task(),",
+    "    );",
+    "    WorkPool::schedule(unsafe { &raw mut (*this).task });",
+    "    WorkPool::schedule_owned(task);",
+    "    WorkPool::get().schedule(batch);",
+    "}",
+  ].join("\n");
+  expect(findBannedSchedules(source).map(offset => lineOf(source, offset))).toEqual([2, 3]);
+});
+
+test("no schedule call projects the task out of a reference to the field", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: once an allowlisted instance is converted, delete its entry so
+  // a new one cannot take its place.
+  for (const [f, n] of Object.entries(ALLOW)) {
+    expect(counts[f] ?? 0).toBe(n);
+  }
+});

--- a/test/internal/source-lints/work-pool-schedule-field-ref.test.ts
+++ b/test/internal/source-lints/work-pool-schedule-field-ref.test.ts
@@ -12,9 +12,9 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //   WorkPool::schedule(this.task());               // accessor returns &mut Task
 //   WorkPool::schedule(&mut self.task);            // coerces to *mut Task
 //
-// are banned; `&raw mut (*p).task`, `&raw mut self.task`, `T::field_of(p)`,
-// `T::task_of(p)` (an associated fn given the object's pointer) are the
-// shapes to use.
+// are banned; `&raw mut (*p).task`, `&raw mut self.task` and `T::field_of(p)`
+// (`bun_core::IntrusiveField`, given the object's pointer) are the shapes to
+// use.
 //
 // The pool calls back with exactly the pointer it was given, and every
 // trampoline behind these sites `container_of`s it back to the embedding
@@ -26,21 +26,29 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // callback reads and writes, and the allocation the completion may free, are
 // outside it. Stacked Borrows rejects every out-of-range access; Tree Borrows
 // (what `bun run rust:miri` uses) rejects the writes and the free. A raw
-// projection from the object's pointer (`&raw mut (*p).task`) keeps `p`'s
-// provenance; that is what `WorkPool::schedule_owned` does
-// (src/threading/work_pool.rs) and what `CompressionStream::write` in
-// src/runtime/node/node_zlib_binding.rs, the instance this was written for,
-// does now via `CompressionStreamImpl::task_of`.
+// projection from the object's pointer (`&raw mut (*p).task`, which is what
+// `IntrusiveField::field_of` computes) keeps `p`'s provenance; that is what
+// `WorkPool::schedule_owned` does (src/threading/work_pool.rs) and what
+// `CompressionStream::write` in src/runtime/node/node_zlib_binding.rs, the
+// instance this was written for, does now.
 //
-// Scope: the argument expression at the `WorkPool::schedule(` call. A pointer
-// projected the wrong way somewhere else and passed in through a local is the
-// same bug and is not caught here. This lint is about the range of the pointer
-// the pool gets; `&raw mut self.task` has the whole object's range and passes
-// here, and the separate problem with it (the `&mut self` it is taken through
-// stays protected while the pool thread is already running) is the subject of
-// work-pool-schedule-projection.test.ts (#37768). Siblings:
-// self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
-// frozen-nonnull-reborrow.test.ts.
+// Scope: the argument expression at the `WorkPool::schedule(` call. Every
+// method call in that position goes through a reference (an accessor returns
+// one, a cell's `.as_ptr()` auto-refs the field), so any method call is
+// banned, whether it is the whole argument (`x.task()`), the tail of one
+// (`T::task(x).as_ptr()`) or an operand (`JsCell::as_ptr(x.task())`), and so
+// is a call nested in a call (`JsCell::as_ptr(T::task(x))`); the shapes that
+// pass are place projections and one associated fn applied to a raw pointer or
+// a local, and what that fn does inside is not checked (the tree's is
+// `field_of`, whose body is the trait's). Not covered: a pointer
+// projected the wrong way somewhere else and passed in through a local, and
+// tasks that go into a `Batch::from(..)` and are scheduled later. This lint is
+// about the range of the pointer the pool gets; `&raw mut self.task` has the
+// whole object's range and passes here, and the separate problem with it (the
+// `&mut self` it is taken through stays protected while the pool thread is
+// already running) is the subject of work-pool-schedule-projection.test.ts
+// (#37768). Siblings: self-receiver-reclaim.test.ts,
+// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
@@ -63,19 +71,20 @@ const tracked: Set<string> | null = (() => {
 // they do not match.
 const SCHEDULE = /\bWorkPool::schedule\s*\(/g;
 
-// A method-call chain rooted at a receiver (`this.task()`, `self.task.as_ptr()`,
-// `(*this).task.as_ptr()`, `self.task_mut()`): an accessor auto-refs the field
-// or returns a reference to it, so the pointer that comes out covers the field
-// only. Associated-fn calls (`T::task_of(p)`, `JsCell::raw_get(..)`) are not
-// rooted at a receiver and do not match.
-const METHOD_CHAIN = /^(?:[\w:]+|\(\s*\*\s*[\w.]+\s*\))(?:\.\w+)*(?:\.\w+\s*\([^()]*\)\s*)+$/;
+// A method call anywhere in the argument (`this.task()`, `self.task.as_ptr()`,
+// `(*this).task.as_ptr()`, `self.task_mut()`, `JsCell::as_ptr(this.task())`).
+// Field paths without a call (`&raw mut (*p).task`) and associated-fn calls
+// (`T::field_of(p)`) have no `.name(` and do not match.
+const METHOD_CALL = /\.\w+(?:::<[^>]*>)?\s*\(/;
+// A call whose argument is itself a call (`JsCell::as_ptr(T::task(this))`):
+// whatever the inner call returned is what gets projected, and an associated
+// fn is only in the clear when it is applied to a raw pointer or a local.
+// `addr_of_mut!((*p).task)` has `!(` in front of its parens and does not match.
+const NESTED_CALL = /\w\s*\([^()]*\w\s*\(/;
 // A reference formed anywhere in the argument: `&mut self.task` coercing to
 // `*mut Task`, `from_mut(&mut self.task)`, `JsCell::as_ptr(&self.task)`.
 // `&raw mut` / `&raw const` are the raw projections this lint asks for.
 const REFERENCE = /&(?!\s*raw\b)/;
-// The reference-to-pointer conversions, in case the reference itself is
-// spelled somewhere the regex above does not see (a macro, a cast chain).
-const FROM_REF = /\bfrom_(?:mut|ref)\b/;
 
 /** The argument text of the call whose opening paren is at `open`, or null if unbalanced. */
 function argumentAt(source: string, open: number): string | null {
@@ -98,7 +107,7 @@ function normalize(argument: string): string {
 
 function isBanned(argument: string): boolean {
   const arg = normalize(argument);
-  return METHOD_CHAIN.test(arg) || REFERENCE.test(arg) || FROM_REF.test(arg);
+  return METHOD_CALL.test(arg) || NESTED_CALL.test(arg) || REFERENCE.test(arg);
 }
 
 /** Byte offsets (into `stripped`) of every banned schedule call in one file. */
@@ -158,7 +167,7 @@ test("scans a non-empty set of tracked Rust sources containing schedule calls", 
 
 test("the classifier recognizes the spellings it claims to", () => {
   const banned = [
-    // `CompressionStream::write` before `task_of`: `task()` returns
+    // `CompressionStream::write` as it was: `task()` returns
     // `&JsCell<WorkPoolTask>`.
     "this.task().as_ptr()",
     // `FileCloser::on_io_request_closed`: `task()` returns `&mut WorkPoolTask`.
@@ -166,6 +175,12 @@ test("the classifier recognizes the spellings it claims to", () => {
     "self.task.as_ptr()",
     "(*this).task.as_ptr()",
     "self.task_mut()",
+    // The same accessors in other positions.
+    "JsCell::as_ptr(this.task())",
+    "JsCell::as_ptr(T::task(this))",
+    "T::task(this).as_ptr()",
+    "<T as CompressionStreamImpl>::task(this).as_ptr()",
+    "this.task().as_ptr().cast::<WorkPoolTask>()",
     "&mut self.task",
     "&mut (*this).task",
     "&self.task as *const _ as *mut _",
@@ -184,9 +199,8 @@ test("the classifier recognizes the spellings it claims to", () => {
     "&raw mut (*st).task",
     "&raw mut (*subtask).work_task",
     "unsafe { &raw mut (*job).task }",
-    "unsafe { T::task_of(this_ptr) }",
+    "unsafe { T::field_of(this_ptr) }",
     "unsafe { T::field_of(raw) }",
-    "unsafe { ::bun_jsc::JsCell::raw_get(&raw mut (*this).task) }",
     "core::ptr::addr_of_mut!((*this).task)",
     // A pointer projected elsewhere is out of scope.
     "task",


### PR DESCRIPTION
### Problem
- No user-visible failure and no known crash. An async `node:zlib` write (zlib, brotli and zstd streams alike) hands the thread pool a task pointer taken through a reference to the stream's `task` field, so the pointer's provenance covers that one field and nothing else.
- Everything downstream treats it as a pointer to the whole stream: the pool callback recovers the stream from it, reads and writes sibling fields through it, and the completion frees the stream through it when the JS wrapper was finalized while the write was in flight.
- The address is right, so this is an aliasing-model violation only. Miri rejects a reduction of the same shape under Tree Borrows ("deallocation through &lt;tag&gt; is forbidden ... conflicting tag has state Frozen") and Stacked Borrows; the runtime crate itself cannot run under Miri.
- Deriving the pointer from the `&self` receiver instead is rejected the same way: nothing derived from a shared reference may free the allocation. Only the wrapper's own pointer passes.

### Fix
- `write` takes the wrapper's own pointer to the stream (the one `finalize` already frees through) and projects the task out of that; the pool side recovers the stream with the shared intrusive-task projection the other schedule sites use, replacing the binding's own copy.
- Correct because the pointer the pool gets now carries the whole allocation's provenance and is the same pointer the free goes through. Its value is unchanged, so there is no behaviour change; the cost is one fromJS lookup per async write.
- Verification: a new source lint fails on main, reporting exactly the zlib site, and passes here; the Miri reduction is in the collapsed original. `test/js/node/zlib/` and the zlib rows of the worker-terminate funnel tests pass on the ASAN build (one leak test needed its hook timeout raised); clippy is clean.
- #37768 converts the `&mut self` sites plus the one other instance of this shape (Blob.rs); that one is allowlisted here with a ratchet, and whichever PR lands second removes the entry. The two PRs touch different files.

### Background
- Provenance: under Rust's aliasing models a raw pointer may only touch the range of whatever it was derived from. `&x.task` then `.as_ptr()` covers the task field; `&raw mut (*p).task` from a whole-object pointer keeps the whole object. Both have the same address, so only Miri (`bun run rust:miri`) sees the difference.
- Intrusive work tasks: `WorkPool::schedule` takes a `*mut WorkPoolTask` that lives as a field inside the owning object, calls back with that exact pointer, and the callback container-ofs it back to the owner. `IntrusiveWorkTask` (`field_of` / `from_task_ptr`, stamped by `intrusive_work_task!`) is the shared projection pair for this.
- `m_ctx`: each JS zlib handle wraps a heap-allocated Rust stream and stores its raw pointer; `T::from_js(value)` returns it. The stream is intrusively refcounted, the wrapper holds one count and each in-flight write another, and whichever `deref` reaches zero frees it.
- JS-exposed methods on these streams take `&self` with `Cell` / `JsCell` fields because JS can re-enter them, so `write` only ever holds a shared reference and cannot legitimately mint a pointer that may free the stream.
- Source lints: `test/internal/source-lints/` holds `bun test` files that scan the tree for banned code shapes, with a ratcheted allowlist. That is how a rule Miri cannot check on this crate gets enforced.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/work-pool-schedule-field-ref.test.ts
bun test v1.4.0 (58cb60353)

test/internal/source-lints/work-pool-schedule-field-ref.test.ts:
(pass) scans a non-empty set of tracked Rust sources containing schedule calls [2.74ms]
(pass) the classifier recognizes the spellings it claims to [16.84ms]
(pass) the call matcher finds the call and takes its whole argument [6.41ms]
227 |   ].join("\n");
228 |   expect(findBannedSchedules(source).map(offset => lineOf(source, offset))).toEqual([2, 3]);
229 | });
230 | 
231 | test("no schedule call projects the task out of a reference to the field", () => {
232 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/node/node_zlib_binding.rs:472",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/work-pool-schedule-field-ref.test.ts:232:21)
(fail) no schedule call projects the task out of a reference to the field [4.86ms]
(pass) allowlisted files still ca
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/internal/source-lints/work-pool-schedule-field-ref.test.ts:
(pass) scans a non-empty set of tracked Rust sources containing schedule calls [0.14ms]
(pass) the classifier recognizes the spellings it claims to [0.35ms]
(pass) the call matcher finds the call and takes its whole argument [0.18ms]
227 |   ].join("\n");
228 |   expect(findBannedSchedules(source).map(offset => lineOf(source, offset))).toEqual([2, 3]);
229 | });
230 | 
231 | test("no schedule call projects the task out of a reference to the field", () => {
232 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/runtime/node/node_zlib_binding.rs:472",
+ ]

- Expected  - 1
+ Received  + 3

      at <anonymous> (/workspace/bun/test/internal/source-lints/work-pool-schedule-field-ref.test.ts:232:21)
(fail) no schedule call projects the task out of a reference to the field [0.28ms]
(pass) allowlisted files still carry exactly their documented count [0.10ms]

 4 pass
 1 fail
 7 expect() calls
Ran 5 tests across 1 file. [739.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/work-pool-schedule-field-ref.test.ts
bun test v1.4.0 (58cb60353)

test/internal/source-lints/work-pool-schedule-field-ref.test.ts:
(pass) scans a non-empty set of tracked Rust sources containing schedule calls [5.39ms]
(pass) the classifier recognizes the spellings it claims to [25.98ms]
(pass) the call matcher finds the call and takes its whole argument [11.60ms]
(pass) no schedule call projects the task out of a reference to the field [2.57ms]
(pass) allowlisted files still carry exactly their documented count [3.67ms]

 5 pass
 0 fail
 7 expect() calls
Ran 5 tests across 1 file. [27.73s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     58cb603531
  features     baseline

22 deps, 107 codegen, 1176 objects in 864ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] gen .bind.ts → GeneratedBindings.cpp
[4/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1238] fetch tinycc
[tinycc] up to date
[7/1237] fetch picohttpparser
[picohttpparser] up to date
[8/1237] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [74.00ms]
[9/1237] fetch zlib
[zlib] up to date
[10/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuf
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/node/node_zlib_binding.rs              |  56 ++---
 .../work-pool-schedule-field-ref.test.ts           | 241 +++++++++++++++++++++
 2 files changed, 261 insertions(+), 36 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/runtime/node/node_zlib_binding.rs                        17     22      0
…ernal/source-lints/work-pool-schedule-field-ref.test.ts      3     10      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem

`CompressionStream::write` (src/runtime/node/node_zlib_binding.rs, shared by `NativeZlib` / `NativeBrotli` / `NativeZstd`) hands the pool its task like this:

```rust
WorkPool::schedule(this.task().as_ptr());   // task() is `&self.task`, a &JsCell<WorkPoolTask>
```

That pointer is taken through a reference to the `task` field, so its provenance covers the task field and nothing else. Everything downstream treats it as a pointer to the whole stream: `async_job_run_task` container-ofs it back with `from_task`, `async_job_run` reads `loop_handle` and writes `stream` (`do_work`) through the result and posts it to the JS thread, and `run_from_js_thread` / `release_unrun` end with `T::deref(this_ptr)` on it, which frees the stream when the JS wrapper was finalized while the write was in flight. The `SAFETY` comment in `async_job_run_task` claimed the provenance "covers the full `T` allocation"; `bun_core::container_of`'s contract says the opposite about a field reborrow, and `WorkPool::schedule_owned` (src/threading/work_pool.rs) projects the task out of the whole-object pointer for exactly this reason.

No crash is known; the pointer has the right address, this is an aliasing-model violation (the kind `bun run rust:miri` checks for; `bun_runtime` itself cannot run under Miri). The reduction below has the same shape as the binding: a boxed stream whose raw pointer the wrapper holds (`m_ctx`), a host fn that receives it as `&Stream`, a pool callback that container-ofs, reads a plain field, writes a `JsCell` field and `deref`s, with the wrapper finalized in between so that `deref` is the one that frees. Three ways for `write` to derive the pointer it schedules:

| pointer scheduled by `write` | Tree Borrows (`bun run rust:miri`'s model) | Stacked Borrows |
| --- | --- | --- |
| `this.task.as_ptr()` (main) | UB at the free: "deallocation through &lt;tag&gt; is forbidden ... conflicting tag has state Frozen", the conflicting tag being the `&Stream` receiver | UB at the first use in the callback: "trying to retag from &lt;tag&gt; for SharedReadWrite permission at alloc[0x0], but that tag does not exist in the borrow stack for this location" (the tag created by `as_ptr`) |
| `ptr::from_ref(this).cast_mut()`, then `&raw mut (*p).task` | UB at the free, same Frozen receiver tag | UB at the free: "that tag only grants SharedReadOnly permission for this location" |
| the wrapper's `m_ctx` pointer, then `&raw mut (*m_ctx).task` (this PR) | ok | ok |

The second row is why this does not just switch to the receiver's address: the pointer the pool gets is also the pointer the completion frees through, and nothing derived from a `&T` may do that (the `deref` docs in this file and `CellRefCounted::deref` in src/ptr/ref_count.rs both already say so; the `deref` docs claimed the posted pointer was `m_ctx`-derived, which it was not).

<details>
<summary>Reduction (cargo miri test, each test run on its own)</summary>

```rust
#[repr(transparent)]
pub struct JsCell<T>(UnsafeCell<T>);
impl<T> JsCell<T> {
    fn as_ptr(&self) -> *mut T { self.0.get() }
    fn with_mut<R>(&self, f: impl FnOnce(&mut T) -> R) -> R { f(unsafe { &mut *self.0.get() }) }
    const fn raw_get(this: *const Self) -> *mut T { UnsafeCell::raw_get(this.cast::<UnsafeCell<T>>()) }
}
pub struct Task { callback: fn(*mut Task) }
pub struct Stream { ref_count: Cell<u32>, loop_handle: u32, stream: JsCell<u64>, task: JsCell<Task> }

impl Stream {
    unsafe fn deref(this: *mut Stream) {
        let rc = unsafe { &*(&raw const (*this).ref_count) };
        let n = rc.get() - 1;
        rc.set(n);
        if n == 0 { drop(unsafe { Box::from_raw(this) }); }
    }
    unsafe fn from_task(task: *mut Task) -> *mut Stream {
        unsafe { task.byte_sub(offset_of!(Stream, task)).cast::<Stream>() }
    }
}

// async_job_run_task + async_job_run + run_from_js_thread, collapsed.
fn pool_callback(task: *mut Task) {
    let this = unsafe { Stream::from_task(task) };
    let this_ref = unsafe { &*this };
    std::hint::black_box(this_ref.loop_handle);
    this_ref.stream.with_mut(|s| *s += 1);
    unsafe { Stream::deref(this) };
}

fn write_through_field_ref(this: &Stream) {
    arm(this);                                   // ref_(); task.callback = pool_callback
    work_pool_schedule(this.task.as_ptr());
}
fn write_through_receiver(this: &Stream) {
    arm(this);
    let p: *mut Stream = std::ptr::from_ref(this).cast_mut();
    work_pool_schedule(JsCell::raw_get(unsafe { &raw mut (*p).task }));
}
fn write_through_m_ctx(this: &Stream, m_ctx: *mut Stream) {
    arm(this);
    work_pool_schedule(JsCell::raw_get(unsafe { &raw mut (*m_ctx).task }));
}

fn scenario(write: impl FnOnce(&Stream, *mut Stream)) {
    let m_ctx = Box::into_raw(Box::new(Stream { ref_count: Cell::new(1), .. }));
    write(unsafe { &*m_ctx }, m_ctx);           // host fn receives m_ctx as &Stream
    unsafe { Stream::deref(m_ctx) };             // finalize: the wrapper's +1 goes away
    work_pool_run();                             // pool callback + completion: reads, writes, frees
}
```

```
$ MIRIFLAGS=-Zmiri-tree-borrows cargo miri test -- --exact tests::through_field_ref
error: Undefined Behavior: deallocation through <133754> at alloc43913[0x14] is forbidden
  = help: the accessed tag <133754> is a child of the conflicting tag <133525>
  = help: the conflicting tag <133525> has state Frozen which forbids this deallocation (acting as a child write access)
help: the conflicting tag <133525> was created here, in the initial state Cell
  95 | fn write_through_field_ref(this: &Stream) {
$ MIRIFLAGS=-Zmiri-tree-borrows cargo miri test -- --exact tests::through_receiver
error: Undefined Behavior: deallocation through <133241> at alloc43730[0x14] is forbidden
$ MIRIFLAGS=-Zmiri-tree-borrows cargo miri test -- --exact tests::through_m_ctx
test result: ok. 1 passed

$ cargo miri test -- --exact tests::through_field_ref          # Stacked Borrows
error: Undefined Behavior: trying to retag from <135913> for SharedReadWrite permission at alloc43913[0x0], but that tag does not exist in the borrow stack for this location
  73 |     let this_ref: &Stream = unsafe { &*this };
  20 |         self.0.get()
$ cargo miri test -- --exact tests::through_receiver
error: Undefined Behavior: trying to retag from <135374> for Unique permission at alloc43730[0x14], but that tag only grants SharedReadOnly permission for this location
 104 |     let p: *mut Stream = std::ptr::from_ref(this).cast_mut();
$ cargo miri test -- --exact tests::through_m_ctx
test result: ok. 1 passed
```

</details>

In the reduction the third row projects the task with a local `raw_get` helper; in the binding the same pointer comes out of `IntrusiveField::field_of`, and the receiver being protected while the pool thread runs does not change the verdicts (variants with the callback running inline, on a second thread, and straddling `write`'s return all pass with the `m_ctx` pointer; the only shapes that fail are a `&mut self` receiver, which is #37768's class, and a pool side that writes a non-`Cell` field, which this one does not).


### Fix

`write` takes the pointer from the wrapper: `T::from_js(this_value)` returns the handle's `m_ctx`, the pointer `heap::into_raw` produced in the constructor and the one `finalize` already frees through. The generated C++ thunk reached `this` by downcasting the same `this_value`, so the lookup cannot fail and yields the same object (`debug_assert!`ed). The task is projected out of it with `T::field_of(m_ctx)` and recovered on the pool thread with `T::from_task_ptr`: `__impl_compression_stream!` now stamps `bun_threading::intrusive_work_task!` on the three natives (the field is a `repr(transparent)` `JsCell<WorkPoolTask>`, so its offset is the task's) and `CompressionStreamImpl` is bounded on `IntrusiveWorkTask`, which is the pair `WorkPool::schedule_owned` and the other eight intrusive task types use; the binding's own `from_task` (the last hand-rolled copy of that projection in the tree) goes away. `CompressionStreamImpl` also gains a `JsClass` supertrait bound for `from_js` (all three natives already derive it). The requirement that a `deref` which can reach zero gets the `m_ctx` pointer is now stated as `deref`'s safety contract; the previous paragraph there claimed the posted pointer already satisfied it.

The pointer value the pool receives is the same as before; there is no behaviour change. Cost is one `NativeZlib__fromJS` call per async write, next to a thread-pool round trip.

This is the `&self` + `JsCell` site that #37768 names as out of scope; #37768 converts the `&mut self` schedule sites and the `FileCloser` accessor, and its lint accepts the spelling used here (checked by running it against this branch: it reports its own eight sites and nothing in the zlib binding). The two PRs touch different files.

### Verification

`test/internal/source-lints/work-pool-schedule-field-ref.test.ts` bans handing `WorkPool::schedule` a task pointer projected through a reference to the field. The argument may not contain a method call (`x.task()`, `x.task().as_ptr()`, `x.task.as_ptr()`, and the same accessors as operands or tails, `JsCell::as_ptr(x.task())`, `T::task(x).as_ptr()`), a call nested in a call (`JsCell::as_ptr(T::task(x))`), or a non-raw reference (`&mut x.task`, `JsCell::as_ptr(&x.task)`); `&raw mut (*p).task`, `&raw mut self.task`, one associated fn applied to a raw pointer or local (`T::field_of(p)`) and a bare local pass. The header says how this relates to #37768's lint (this one is about the pointer's range, that one about the reference held during the hand-over) and that `Batch::from(..)` sites are out of scope (the one such instance of this shape, in the Windows install hardlink queue, has been reported separately). On main it reports exactly

```
src/runtime/node/node_zlib_binding.rs:472
```

and passes with this branch. `FileCloser::on_io_request_closed` in Blob.rs is the one other instance of the shape; #37768 converts it, so it is allowlisted at exactly one with a ratchet, and whichever of the two PRs lands second deletes that entry (the ratchet test says so).

Against the debug (ASAN) build: `test/js/node/zlib/` (449 pass; the one failure, `leak.test.ts`, is its `beforeAll` of 10,000 `deflateSync` calls exceeding the default 5 s hook timeout in this container, which is about 6x slower than the CI ASAN lane on this file; with `--timeout` raised all 8 leak tests pass, which is 20,000 async deflate and gzip writes plus the brotli and zstd ones through the changed path), `test/js/web/workers/worker-terminate-funnels.test.ts` `pool` and `counted` (the in-flight completion and the `release_unrun` teardown rows for zlib), and `test/internal/source-lints/` (87 pass), re-run after the switch to `IntrusiveWorkTask` (the zlib suites 450 pass, the 8 leak tests pass, the two funnels families pass). `cargo clippy -p bun_runtime` is clean.

</details>
