### PR TITLE
bake: run accept callbacks and dispose handlers once per hot update

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -616,7 +616,6 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   const toReload = new Set<HMRModule>();
   const toAccept: ToAccept[] = [];
   let failures: Set<Id> | null = null;
-  // A set like `toReload`: a boundary reached from several replaced modules is disposed of once.
   const toDispose = new Set<HMRModule>();
 
   // Discover all HMR boundaries
@@ -636,9 +635,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
 
     // Discover all HMR boundaries
     const visited = new Set<HMRModule>();
-    // Importers accepting `key` are reached again through every module walked
-    // past on the way up (they import `key` directly as well). Each callback
-    // runs once for `key`; the array form still runs once per updated module.
+    // An importer accepting `key` is reached again from every module walked past on the way up.
     const accepted = new Set<HotAccept>();
     const queue: HMRModule[] = [existing];
     visited.add(existing);

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -635,6 +635,10 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
 
     // Discover all HMR boundaries
     const visited = new Set<HMRModule>();
+    // Importers accepting `key` are reached again through every module walked
+    // past on the way up (they import `key` directly as well). Each callback
+    // runs once for `key`; the array form still runs once per updated module.
+    const accepted = new Set<HotAccept>();
     const queue: HMRModule[] = [existing];
     visited.add(existing);
     while (true) {
@@ -672,6 +676,8 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
       for (const importer of mod.importers) {
         const cb = importer.depAccepts?.[key];
         if (cb) {
+          if (accepted.has(cb)) continue;
+          accepted.add(cb);
           toAccept.push({ cb, key });
         } else if (hadSelfAccept) {
           if (visited.has(importer)) continue;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -616,7 +616,8 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   const toReload = new Set<HMRModule>();
   const toAccept: ToAccept[] = [];
   let failures: Set<Id> | null = null;
-  const toDispose: HMRModule[] = [];
+  // A set like `toReload`: a boundary reached from several replaced modules is disposed of once.
+  const toDispose = new Set<HMRModule>();
 
   // Discover all HMR boundaries
   outer: for (const key of Object.keys(modules)) {
@@ -652,7 +653,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         visited.add(mod);
         hadSelfAccept = false;
         if (mod.onDispose) {
-          toDispose.push(mod);
+          toDispose.add(mod);
         }
       }
       // Modules that mutate data are implied to handle updates via reusing their `data` property
@@ -662,7 +663,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         visited.add(mod);
         hadSelfAccept = false;
         if (mod.onDispose) {
-          toDispose.push(mod);
+          toDispose.add(mod);
         }
       }
 
@@ -739,7 +740,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   }
 
   // Dispose all modules
-  if (toDispose.length > 0) {
+  if (toDispose.size > 0) {
     const disposePromises: Promise<void>[] = [];
     for (const mod of toDispose) {
       mod.state = State.Stale;

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -313,6 +313,62 @@ devTest("import.meta.hot.accept multiple modules", {
     await c.expectMessageInAnyOrder("Counter updated: 3", "Name updated: Charlie");
   },
 });
+devTest("import.meta.hot.accept specifier callback runs once per update, however many paths lead to the module", {
+  // Updating `d` walks every importer of `d` and of the modules that do not
+  // accept it (`a`, `c`, `b`), reaching `index` and `other` once per path.
+  // Each accept callback must still run once.
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    //  index -> d
+    //  index -> a -> d
+    //  index -> b -> c -> d
+    //  index -> other -> d
+    //           other -> a
+    "index.ts": `
+      import { d } from "./d";
+      import { a } from "./a";
+      import { b } from "./b";
+      import "./other";
+      console.log("index " + d + " " + a + " " + b);
+      import.meta.hot.accept("./d", newModule => {
+        console.log("index accepted " + newModule.d);
+      });
+    `,
+    "other.ts": `
+      import "./d";
+      import "./a";
+      import.meta.hot.accept(["./d", "./a"], newModules => {
+        console.log("other accepted " + newModules[0]?.d + " " + newModules[1]?.a);
+      });
+    `,
+    "a.ts": `
+      import { d } from "./d";
+      export const a = "a(" + d + ")";
+    `,
+    "b.ts": `
+      import { c } from "./c";
+      export const b = "b(" + c + ")";
+    `,
+    "c.ts": `
+      import { d } from "./d";
+      export const c = "c(" + d + ")";
+    `,
+    "d.ts": `
+      export const d = "d1";
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("index d1 a(d1) b(c(d1))");
+    await dev.write("d.ts", `export const d = "d2";`);
+    await c.expectMessage("index accepted d2", "other accepted d2 undefined");
+    // The next update starts over: the callbacks run again, still once each.
+    await dev.write("d.ts", `export const d = "d3";`);
+    await c.expectMessage("index accepted d3", "other accepted d3 undefined");
+  },
+});
 devTest("import.meta.hot.data persistence", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -444,6 +444,42 @@ devTest("import.meta.hot.dispose cleanup", {
     await c.expectMessage("Cleaning up", "Third setup");
   },
 });
+devTest("import.meta.hot.dispose runs once when one update replaces two modules the boundary imports", {
+  // Both replaced modules propagate up to `index`, which must be disposed of
+  // and re-evaluated once. Disposing of it a second time used to throw
+  // (its dispose list is cleared after running), turning the update into a
+  // full reload.
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import "./d";
+      import "./e";
+      console.log("index evaluated");
+      import.meta.hot.dispose(() => {
+        console.log("index disposed");
+      });
+      import.meta.hot.accept();
+    `,
+    "d.ts": `
+      export const d = "d1";
+    `,
+    "e.ts": `
+      export const e = "e1";
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("index evaluated");
+    {
+      await using batch = await dev.batchChanges();
+      await dev.write("d.ts", `export const d = "d2";`);
+      await dev.write("e.ts", `export const e = "e2";`);
+    }
+    await c.expectMessage("index disposed", "index evaluated");
+  },
+});
 devTest("import.meta.hot invalid usage", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
### Problem
- An `import.meta.hot.accept("./dep", cb)` callback runs once per import path by which the update reaches the module: with `./dep` imported directly and again through another module, saving it fires `cb` twice on bun 1.4.0. The array form behaves the same way.
- A self-accepting module with an `import.meta.hot.dispose()` handler, reached from two modules replaced in one update, is disposed of twice. The second pass throws `TypeError: mod.onDispose is not iterable` and the client falls back to a full page reload.
- Cause: the update walk dedupes the modules it queues but not the accept callbacks it collects, and the dispose list is a plain array that every replaced module's walk appends to.
- Found while working on a neighbouring dev server bug; there is no issue for it.

### Fix
- Each replaced module's walk keeps a set of the accept callbacks it has already recorded, so a callback is queued once per replaced module. Per replaced module on purpose: an array-form accept whose modules are updated in one batch is still called once for each of them, as an existing test checks.
- The dispose list becomes a `Set`, like the reload list next to it, so a boundary reached from two replaced modules is disposed of once. Which importers get queued, and when a root is reached, is unchanged.
- Verification: two new dev server tests, one per bug, that fail on bun 1.4.0 and without the fix (five accept messages instead of two; the `TypeError` above) and pass with it.
- #37785 and #37795 change neighbouring lines of the same function; the original below says how they relate.

### Background
- bake is bun's dev server. `hmr-module.ts` is its hot module replacement runtime, shared by the client and server sides.
- On a file save, `replaceModules()` walks upwards from each replaced module through its importers looking for HMR boundaries: an importer that accepts the update stops the walk there, one that does not is queued and its own importers are walked in turn.
- `import.meta.hot.accept("./dep", cb)`, or an array of specifiers, declares that a module accepts updates to a dependency and wants `cb` called with the new module each time it updates. A bare `accept()` means the module accepts updates to itself and is re-evaluated.
- `import.meta.hot.dispose(cb)` registers cleanup to run before a self-accepting module is re-evaluated. The handler list is cleared once it has run, which is why disposing twice throws.
- `dev.batchChanges()` in the tests delivers several file writes as one hot update, which is how one boundary comes to be reached from two replaced modules.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

`replaceModules()` in `src/runtime/bake/hmr-module.ts` (the hot update walk shared by the client and server dev runtimes) collected two of its results once per time it came across them instead of once per update:

1. A module's `import.meta.hot.accept("./dep", cb)` callback was invoked once for every path by which the walk reached that module.

   ```ts
   // index.ts
   import { d } from "./d";
   import { a } from "./a"; // a.ts imports ./d too
   import.meta.hot.accept("./d", m => console.log("accepted " + m.d));
   ```

   Saving `d.ts` logs `accepted d2` twice on bun 1.4.0. With more modules between `d` and `index` it is logged once more per extra path (three times in the new test), and the array form `accept(["./d", ...], cb)` behaves the same way.

2. A self-accepting module with an `import.meta.hot.dispose()` handler that is reached from two modules replaced by the same update (two of its imports saved together) was listed for disposal twice. The second pass iterated its already cleared dispose list and threw `TypeError: mod.onDispose is not iterable`, which the client turns into a full page reload.

### Why

The walk goes upwards from each replaced module: importers that accept it get their callback pushed onto `toAccept`, importers that do not are queued and their own importers are looked at in turn. `visited` only dedupes the queued modules, so an accepting importer gets pushed again from every module the walk passes through on its way up (it imports the replaced module directly, so it is also an importer of each of those). `toDispose` was a plain array filled by the walks of all replaced modules, while `toReload` next to it is already a `Set`.

The accept callback is documented as being called when the dependency is updated (and this is how Vite behaves as well): one update, one call. Disposing of and reloading a boundary are one operation per update; the reload side already was.

### Fix

- A per replaced module `Set` of the accepts recorded during its walk; each is pushed once. It is per replaced module on purpose: an array-form accept whose modules are updated together in one batch is still called once for each of them, with the matching slot filled in, which `import.meta.hot.accept multiple modules` in `hot.test.ts` checks. Which importers are queued, and when a root is reached, is unchanged.
- `toDispose` becomes a `Set`, like `toReload`.

Not changed here: a replaced module's own dispose handlers only run when it self-accepts (#37785), and modules walked past between the replaced module and an accepting importer are not re-evaluated (#37795). Both are separate behaviours of the same function with their own PRs.

### Known limitation, and how this relates to #37785 and #37795

The reload phase still reloads `toReload` in insertion order and marks each module stale only right before loading it. For the dispose case above that order is `d, index, e`, so the boundary's single re-evaluation still sees the sibling that is reloaded after it at its old version (its import binding is patched afterwards). That is what already happens today for the same graph without a dispose handler; this PR only makes the dispose case stop failing the update, it does not make the re-evaluation see both new versions. #37795 marks everything stale before reloading anything, which fixes that for both cases, and that is where an assertion on the values the boundary sees belongs; the dispose test here deliberately only pins that the update applies and runs the handler once. #37785 replaces `toDispose` with disposing of `toReload` directly, which supersedes the `Set` change here. All three PRs touch the same lines of `replaceModules()`, so whichever lands later needs a trivial rebase; the accept dedupe is only in this one.

### Tests

`test/bake/dev/hot.test.ts`:

- `import.meta.hot.accept specifier callback runs once per update, however many paths lead to the module`: `index` reaches `d` directly, through `a`, and through `b -> c`; `other` reaches it directly and through `a`, with the array form. Updating `d` must produce exactly one message from each callback, and a second update must produce them again. Without the fix the first update produces five messages (`index` three times, `other` twice).
- `import.meta.hot.dispose runs once when one update replaces two modules the boundary imports`: `index` self-accepts with a dispose handler and imports `d` and `e`, which are saved in one batch. Expects one dispose message and one re-evaluation. Without the fix the client exits on `TypeError: mod.onDispose is not iterable` while applying the update.

Both fail on the released bun 1.4.0 and with `src/` stashed, and pass with the fix; the rest of `hot.test.ts` passes with it too.

Found while working on a neighbouring dev server bug; there is no issue for it.

</details>
