### PR TITLE
Give the debugger thread's VM its own env loader, filled from the process environment only

### DIFF
--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -432,10 +432,7 @@ impl Debugger {
         jsc::mark_binding();
 
         let vm_ptr = VirtualMachine::init(crate::virtual_machine::InitOptions {
-            // Without a loader of its own, `Transpiler::init` would hand this VM
-            // the process-wide `dot_env` instance, i.e. the parent VM's loader,
-            // which the parent thread is using concurrently (#22206). Never
-            // freed: this VM lives until the process exits (`start` never returns).
+            // `None` would share the parent thread's loader (#22206). Never freed, like this VM.
             env_loader: Some(bun_core::heap::alloc_nn(bun_dotenv::Loader::init())),
             is_main_thread: false,
             ..Default::default()
@@ -445,9 +442,7 @@ impl Debugger {
         // `init` installs the freshly-boxed VM as this thread's singleton.
         let vm = VirtualMachine::get().as_mut();
 
-        // The inspected program's .env files are not this VM's to read; all it
-        // needs from its environment is `BUN_INSPECT_NOTIFY`, which tooling puts
-        // in the process environment.
+        // Only `BUN_INSPECT_NOTIFY` is read from this env; it comes from the process environment.
         vm.transpiler.options.env.behavior = bun_dotenv::DotEnvBehavior::Disable;
         vm.transpiler
             .configure_defines()

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -427,14 +427,17 @@ impl Debugger {
     /// not have — UB. We hold a raw `*VirtualMachine` and
     /// never materialize a `&`/`&mut VirtualMachine` to the foreign-thread VM.
     pub(crate) fn start_js_debugger_thread(other_vm: *mut VirtualMachine) {
-        // The global allocator is mimalloc and `InitOptions` does not carry
-        // `allocator`/`env_loader` (those are wired by
-        // `RuntimeHooks::init_runtime_state`).
         bun_core::Output::Source::configure_named_thread(bun_core::zstr!("Debugger"));
         bun_core::scoped_log!(debugger, "startJSDebuggerThread");
         jsc::mark_binding();
 
         let vm_ptr = VirtualMachine::init(crate::virtual_machine::InitOptions {
+            // Without a loader of its own, `Transpiler::init` hands this VM the
+            // process-wide `dot_env` instance, i.e. the parent VM's loader, and
+            // `configure_defines()` below would load env files into a map the
+            // parent thread is concurrently using (#22206). Never freed: this VM
+            // lives until the process exits (`start` never returns).
+            env_loader: Some(bun_core::heap::alloc_nn(bun_dotenv::Loader::init())),
             is_main_thread: false,
             ..Default::default()
         })
@@ -443,6 +446,8 @@ impl Debugger {
         // `init` installs the freshly-boxed VM as this thread's singleton.
         let vm = VirtualMachine::get().as_mut();
 
+        // Whatever this loader finds was already reported by the parent VM's.
+        vm.transpiler.env_mut().quiet = true;
         vm.transpiler
             .configure_defines()
             .unwrap_or_else(|_| panic!("Failed to configure defines"));

--- a/src/jsc/Debugger.rs
+++ b/src/jsc/Debugger.rs
@@ -432,11 +432,10 @@ impl Debugger {
         jsc::mark_binding();
 
         let vm_ptr = VirtualMachine::init(crate::virtual_machine::InitOptions {
-            // Without a loader of its own, `Transpiler::init` hands this VM the
-            // process-wide `dot_env` instance, i.e. the parent VM's loader, and
-            // `configure_defines()` below would load env files into a map the
-            // parent thread is concurrently using (#22206). Never freed: this VM
-            // lives until the process exits (`start` never returns).
+            // Without a loader of its own, `Transpiler::init` would hand this VM
+            // the process-wide `dot_env` instance, i.e. the parent VM's loader,
+            // which the parent thread is using concurrently (#22206). Never
+            // freed: this VM lives until the process exits (`start` never returns).
             env_loader: Some(bun_core::heap::alloc_nn(bun_dotenv::Loader::init())),
             is_main_thread: false,
             ..Default::default()
@@ -446,8 +445,10 @@ impl Debugger {
         // `init` installs the freshly-boxed VM as this thread's singleton.
         let vm = VirtualMachine::get().as_mut();
 
-        // Whatever this loader finds was already reported by the parent VM's.
-        vm.transpiler.env_mut().quiet = true;
+        // The inspected program's .env files are not this VM's to read; all it
+        // needs from its environment is `BUN_INSPECT_NOTIFY`, which tooling puts
+        // in the process environment.
+        vm.transpiler.options.env.behavior = bun_dotenv::DotEnvBehavior::Disable;
         vm.transpiler
             .configure_defines()
             .unwrap_or_else(|_| panic!("Failed to configure defines"));

--- a/test/regression/issue/test_env_loader_threading.test.ts
+++ b/test/regression/issue/test_env_loader_threading.test.ts
@@ -1,58 +1,119 @@
-import { spawn } from "bun";
 import { expect, test } from "bun:test";
-import { bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
-test("env_loader should not have allocator threading issues with BUN_INSPECT_CONNECT_TO", async () => {
-  await using dir = tempDir("env-loader-threading", {
-    ".env": "TEST_ENV_VAR=hello_world",
-    "index.js": `console.log(process.env.TEST_ENV_VAR || 'undefined');`,
+// The inspector runs on a second VirtualMachine on its own thread (start_js_debugger_thread in
+// src/jsc/Debugger.rs). That VM needs a dotenv Loader of its own: without one, Transpiler::init
+// falls back to the process-wide instance, which is the main VM's loader, and the debugger VM's
+// configure_defines() then loads .env files into the map the main thread is using (#22206).
+//
+// The fixture runs with --env-file=custom.env next to a .env file, so the main VM must never see
+// MARKER. The debugger VM runs with default env options and does load .env; with a shared loader
+// that shows up on the main thread, both in process.env and in the environment of child processes
+// (which is built from the VM's env map, not from the process.env object).
+const MARKER = "DEBUGGER_THREAD_ENV_LOADER_MARKER";
+
+type Mode = "none" | "connect" | "inspector.open";
+
+const fixture = /* ts */ `
+  import { open } from "node:inspector";
+
+  const [mode, cleanDir] = process.argv.slice(2);
+  if (mode === "inspector.open") {
+    // Returns once the debugger thread reports its server as listening, which happens after
+    // that thread's VM has loaded its env files.
+    open(0);
+  } else if (mode === "connect") {
+    // The test closes our stdin once the debugger thread has connected to it.
+    await Bun.stdin.text();
+  }
+
+  const child = Bun.spawnSync({
+    cmd: [process.execPath, "-e", "console.log(JSON.stringify(process.env.${MARKER} ?? null))"],
+    cwd: cleanDir,
   });
+  console.log(
+    JSON.stringify({
+      processEnv: process.env.${MARKER} ?? null,
+      childEnv: JSON.parse(child.stdout.toString()),
+    }),
+  );
+`;
 
-  // This test verifies that when BUN_INSPECT_CONNECT_TO is set,
-  // the debugger thread creates its own env_loader with proper allocator isolation
-  // and doesn't cause threading violations when accessing environment files.
+async function runFixture(mode: Mode, args: string[]) {
+  using dir = tempDir("debugger-thread-env-loader", {
+    ".env": `${MARKER}=loaded-from-dotenv\n`,
+    "custom.env": "UNRELATED=1\n",
+    "fixture.ts": fixture,
+  });
+  // The grandchild runs here so that it cannot load the .env above on its own.
+  using cleanDir = tempDir("debugger-thread-env-loader-clean", {});
+  const env: Record<string, string | undefined> = { ...bunEnv, [MARKER]: undefined };
 
-  // First, test normal execution without inspector to establish baseline
-  const normalProc = spawn({
-    cmd: [bunExe(), "index.js"],
-    cwd: dir,
-    env: {
-      ...Bun.env,
-      TEST_ENV_VAR: undefined, // Remove from process env to test .env loading
+  const { promise: debuggerConnected, resolve: onDebuggerConnected } = Promise.withResolvers<void>();
+  using listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open: () => onDebuggerConnected(),
+      data() {},
     },
-    stdio: ["inherit", "pipe", "pipe"],
   });
+  if (mode === "connect") {
+    env.BUN_INSPECT_CONNECT_TO = `tcp://127.0.0.1:${listener.port}`;
+  }
 
-  const normalResult = await normalProc.exited;
-  const normalStdout = await normalProc.stdout.text();
-
-  expect(normalResult).toBe(0);
-  expect(normalStdout.trim()).toBe("hello_world");
-
-  // Now test with BUN_INSPECT_CONNECT_TO set to a non-existent socket
-  // This should trigger the debugger thread creation without actually connecting
-  const inspectorProc = spawn({
-    cmd: [bunExe(), "index.js"],
-    cwd: dir,
-    env: {
-      ...Bun.env,
-      BUN_INSPECT_CONNECT_TO: "/tmp/non-existent-debug-socket",
-      TEST_ENV_VAR: undefined, // Remove from process env to test .env loading
-    },
-    stdio: ["inherit", "pipe", "pipe"],
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), ...args, "fixture.ts", mode, String(cleanDir)],
+    cwd: String(dir),
+    env,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
   });
+  if (mode === "connect") {
+    await Promise.race([
+      debuggerConnected,
+      proc.exited.then(code => {
+        throw new Error(`fixture exited with code ${code} before its debugger thread connected`);
+      }),
+    ]);
+  }
+  proc.stdin.end();
 
-  const inspectorResult = await inspectorProc.exited;
-  const inspectorStdout = await inspectorProc.stdout.text();
-  const inspectorStderr = await inspectorProc.stderr.text();
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout: JSON.parse(stdout), stderr, exitCode };
+}
 
-  // The process should still work correctly and load .env file
-  expect(inspectorResult).toBe(0);
-  expect(inspectorStdout.trim()).toBe("hello_world");
+const loaded = { processEnv: "loaded-from-dotenv", childEnv: "loaded-from-dotenv" };
+const excluded = { processEnv: null, childEnv: null };
 
-  // Should not have any allocator-related errors or panics
-  expect(inspectorStderr).not.toContain("panic");
-  expect(inspectorStderr).not.toContain("allocator");
-  expect(inspectorStderr).not.toContain("thread");
-  expect(inspectorStderr).not.toContain("assertion failed");
-}, 10000); // 10 second timeout for potential debugger connection attempts
+test.concurrent("the .env fixture is loaded by default", async () => {
+  expect(await runFixture("none", [])).toEqual({ stdout: loaded, stderr: "", exitCode: 0 });
+});
+
+test.concurrent("--env-file excludes .env", async () => {
+  expect(await runFixture("none", ["--env-file=custom.env"])).toEqual({ stdout: excluded, stderr: "", exitCode: 0 });
+});
+
+test.concurrent("the main VM still loads .env while a debugger thread is running", async () => {
+  expect(await runFixture("connect", [])).toEqual({ stdout: loaded, stderr: "", exitCode: 0 });
+});
+
+test.concurrent(
+  "the debugger thread started by BUN_INSPECT_CONNECT_TO does not load .env into the main VM",
+  async () => {
+    expect(await runFixture("connect", ["--env-file=custom.env"])).toEqual({
+      stdout: excluded,
+      stderr: "",
+      exitCode: 0,
+    });
+  },
+);
+
+test.concurrent("the debugger thread started by inspector.open() does not load .env into the main VM", async () => {
+  expect(await runFixture("inspector.open", ["--env-file=custom.env"])).toEqual({
+    stdout: excluded,
+    stderr: expect.stringMatching(/^Debugger listening on ws:\/\/127\.0\.0\.1:\d+\/[0-9a-f-]+\n$/),
+    exitCode: 0,
+  });
+});

--- a/test/regression/issue/test_env_loader_threading.test.ts
+++ b/test/regression/issue/test_env_loader_threading.test.ts
@@ -1,18 +1,22 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { symlinkSync } from "node:fs";
+import { join } from "node:path";
 
 // The inspector runs on a second VirtualMachine on its own thread (start_js_debugger_thread in
-// src/jsc/Debugger.rs). That VM needs a dotenv Loader of its own: without one, Transpiler::init
-// falls back to the process-wide instance, which is the main VM's loader, and the debugger VM's
-// configure_defines() then loads .env files into the map the main thread is using (#22206).
+// src/jsc/Debugger.rs). That VM gets a dotenv Loader of its own, filled from the process
+// environment only. Without one, Transpiler::init falls back to the process-wide instance, which is
+// the main VM's loader, and the debugger VM's configure_defines() then loads the cwd's .env files
+// into the map the main thread is using (#22206).
 //
 // The fixture runs with --env-file=custom.env next to a .env file, so the main VM must never see
-// MARKER. The debugger VM runs with default env options and does load .env; with a shared loader
-// that shows up on the main thread, both in process.env and in the environment of child processes
-// (which is built from the VM's env map, not from the process.env object).
+// MARKER. With a shared loader it shows up on the main thread anyway, both in process.env and in the
+// environment of child processes (which is built from the VM's env map, not from the process.env
+// object). BUN_INSPECT_NOTIFY is read through the debugger VM's own process.env, so the "inspect"
+// mode also checks that the debugger VM does see the process environment.
 const MARKER = "DEBUGGER_THREAD_ENV_LOADER_MARKER";
 
-type Mode = "none" | "connect" | "inspector.open";
+type Mode = "none" | "connect" | "inspect" | "inspector.open";
 
 const fixture = /* ts */ `
   import { open } from "node:inspector";
@@ -20,10 +24,10 @@ const fixture = /* ts */ `
   const [mode, cleanDir] = process.argv.slice(2);
   if (mode === "inspector.open") {
     // Returns once the debugger thread reports its server as listening, which happens after
-    // that thread's VM has loaded its env files.
+    // that thread's VM has been set up.
     open(0);
-  } else if (mode === "connect") {
-    // The test closes our stdin once the debugger thread has connected to it.
+  } else if (mode === "connect" || mode === "inspect") {
+    // The test closes our stdin once the debugger thread has reached its listener.
     await Bun.stdin.text();
   }
 
@@ -39,27 +43,38 @@ const fixture = /* ts */ `
   );
 `;
 
-async function runFixture(mode: Mode, args: string[]) {
+async function runFixture(mode: Mode, args: string[], { brokenDotEnv = false } = {}) {
   using dir = tempDir("debugger-thread-env-loader", {
-    ".env": `${MARKER}=loaded-from-dotenv\n`,
+    ...(brokenDotEnv ? {} : { ".env": `${MARKER}=loaded-from-dotenv\n` }),
     "custom.env": "UNRELATED=1\n",
     "fixture.ts": fixture,
   });
+  if (brokenDotEnv) {
+    // Opening this fails with ELOOP, which the env loader does not tolerate.
+    symlinkSync(".env", join(String(dir), ".env"));
+  }
   // The grandchild runs here so that it cannot load the .env above on its own.
   using cleanDir = tempDir("debugger-thread-env-loader-clean", {});
   const env: Record<string, string | undefined> = { ...bunEnv, [MARKER]: undefined };
 
-  const { promise: debuggerConnected, resolve: onDebuggerConnected } = Promise.withResolvers<void>();
+  const { promise: connected, resolve: onConnected } = Promise.withResolvers<void>();
+  const { promise: notified, resolve: onNotified } = Promise.withResolvers<string>();
   using listener = Bun.listen({
     hostname: "127.0.0.1",
     port: 0,
     socket: {
-      open: () => onDebuggerConnected(),
-      data() {},
+      open: () => onConnected(),
+      data: (_socket, payload) => onNotified(payload.toString()),
     },
   });
+  let reached: Promise<unknown> | undefined;
   if (mode === "connect") {
     env.BUN_INSPECT_CONNECT_TO = `tcp://127.0.0.1:${listener.port}`;
+    reached = connected;
+  } else if (mode === "inspect") {
+    args = ["--inspect=127.0.0.1:0", ...args];
+    env.BUN_INSPECT_NOTIFY = `tcp://127.0.0.1:${listener.port}`;
+    reached = notified;
   }
 
   await using proc = Bun.spawn({
@@ -70,22 +85,35 @@ async function runFixture(mode: Mode, args: string[]) {
     stdout: "pipe",
     stderr: "pipe",
   });
-  if (mode === "connect") {
+  if (reached) {
     await Promise.race([
-      debuggerConnected,
+      reached,
       proc.exited.then(code => {
-        throw new Error(`fixture exited with code ${code} before its debugger thread connected`);
+        throw new Error(`fixture exited with code ${code} before its debugger thread reached the test's listener`);
       }),
     ]);
   }
   proc.stdin.end();
 
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  return { stdout: JSON.parse(stdout), stderr, exitCode };
+  return {
+    stdout: stdout === "" ? stdout : JSON.parse(stdout),
+    stderr: stderr.replaceAll(/127\.0\.0\.1:\d+\/[0-9a-z-]+/g, "127.0.0.1:PORT/ID"),
+    exitCode,
+    ...(mode === "inspect" ? { notification: await notified } : {}),
+  };
 }
 
 const loaded = { processEnv: "loaded-from-dotenv", childEnv: "loaded-from-dotenv" };
 const excluded = { processEnv: null, childEnv: null };
+const inspectorOpenStderr = "Debugger listening on ws://127.0.0.1:PORT/ID\n";
+const inspectBanner =
+  "--------------------- Bun Inspector ---------------------\n" +
+  "Listening:\n" +
+  "  ws://127.0.0.1:PORT/ID\n" +
+  "Inspect in browser:\n" +
+  "  https://debug.bun.sh/#127.0.0.1:PORT/ID\n" +
+  "--------------------- Bun Inspector ---------------------\n";
 
 test.concurrent("the .env fixture is loaded by default", async () => {
   expect(await runFixture("none", [])).toEqual({ stdout: loaded, stderr: "", exitCode: 0 });
@@ -113,7 +141,28 @@ test.concurrent(
 test.concurrent("the debugger thread started by inspector.open() does not load .env into the main VM", async () => {
   expect(await runFixture("inspector.open", ["--env-file=custom.env"])).toEqual({
     stdout: excluded,
-    stderr: expect.stringMatching(/^Debugger listening on ws:\/\/127\.0\.0\.1:\d+\/[0-9a-f-]+\n$/),
+    stderr: inspectorOpenStderr,
+    exitCode: 0,
+  });
+});
+
+test.concurrent(
+  "the debugger thread started by --inspect does not load .env into the main VM and still sees BUN_INSPECT_NOTIFY",
+  async () => {
+    expect(await runFixture("inspect", ["--env-file=custom.env"])).toEqual({
+      stdout: excluded,
+      stderr: inspectBanner,
+      exitCode: 0,
+      notification: "1",
+    });
+  },
+);
+
+// Creating the symlink needs a privilege on Windows.
+test.concurrent.skipIf(isWindows)("the debugger thread does not open a .env the main VM was told to skip", async () => {
+  expect(await runFixture("inspector.open", ["--env-file=custom.env"], { brokenDotEnv: true })).toEqual({
+    stdout: excluded,
+    stderr: inspectorOpenStderr,
     exitCode: 0,
   });
 });


### PR DESCRIPTION
### Problem

- With the inspector on (`--inspect`, `BUN_INSPECT_CONNECT_TO`, or `inspector.open()`), a program run with `--env-file=custom.env` still gets the cwd's `.env`: children it spawns inherit those variables, and with `--inspect` or `BUN_INSPECT_CONNECT_TO` its own `process.env` has them too. Without the inspector the `.env` is left out as it should be.
- If that `.env` cannot be opened (a symlink loop, for instance), a program that was told to skip it runs fine on its own but aborts with `panic: Failed to configure defines` as soon as the inspector is on.
- Cause: the debugger thread's VM has no env loader of its own, so it shares the main VM's, and from its own thread it loads the default `.env` files into that map while the main thread may be reading or writing it.
- #22206 fixed the same thing in the Zig version; the port fell back to the shared loader. #37766 removes a related log-level write and lists this as out of scope; the two are independent.

### Fix

- The debugger thread's VM gets a loader of its own, as worker VMs already do, so nothing that thread does touches the main VM's env map. It is never freed, like the debugger VM itself, which lives until the process exits.
- Before that loader is filled, `.env` file loading is switched off for it, so it holds the process environment only and the debugger thread never opens files in the cwd. With no files to open, filling it can only fail on allocation, which removes the abort.
- Why this is enough: the only variable the debugger VM reads from its environment is `BUN_INSPECT_NOTIFY`, and the tooling that uses it sets it in the process environment, like `BUN_INSPECT` and `BUN_INSPECT_CONNECT_TO`. The one thing dropped is `BUN_INSPECT_NOTIFY` taken from a `.env` file, which worked only by accident of the shared loader.
- Verification: the regression test from #22206 is rewritten to run a program with `--env-file` next to a `.env` under each way of starting the inspector and check `process.env`, a grandchild's environment, stderr and the exit code. On the unmodified release binary the three `--env-file` plus inspector cases load the `.env` and the symlink case exits 134 with the panic above; all seven cases pass with the change.

### Background

- Env loader: every VM owns a map of environment variables, filled from the process environment and then from `.env` files in the cwd. `process.env` and the environment handed to spawned children are both built from this map; `--env-file` replaces the default file list.
- Debugger thread: when the inspector is on, bun starts a second VM on its own thread to run the inspector's internal modules. A VM created without an explicit loader gets the process-wide instance, which is the main VM's loader.
- A VM fills its loader in its `configure_defines()` step, which reads the process environment, opens the configured `.env` files, and derives compile-time defines from the result. A file that fails to open fails the step, and the debugger thread panics on that.
- The `disable` env behavior tells a loader to take the process environment and open no files. `JSTranspiler` already runs in it, as does a compiled executable's main VM with `.env` loading turned off, so it is a normal configuration for a runtime VM.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/regression/issue/test_env_loader_threading.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

The inspector runs a second `VirtualMachine` on its own thread (`start_js_debugger_thread` in `src/jsc/Debugger.rs`). That VM was created with `InitOptions::default()`, i.e. `env_loader: None`, so `Transpiler::init` gave it the process-wide `dot_env` instance. That instance is the main VM's loader (the main VM's own `Transpiler::init` registered it), so right after that the debugger thread ran `configure_defines()` on the main VM's loader: `load_process()`, `Loader::load()` (which can `map.put`), `print_loaded()`, and `load_defines()` reading the whole map, while the main thread may be reading or writing the same map (`process.env` materialization, proxy var writes through `Bun__setEnvValue`, `Bun.spawn` building a child environment, and so on). The debugger VM's own `process.env` was built from the main VM's map from the debugger thread as well, and `Transpiler::init` wrote `quiet` on the main loader from the debugger VM's default log level.

This is what #22206 fixed in the Zig version (the debugger thread got a `DotEnv.Loader` of its own, passed to `VirtualMachine.init`); the port dropped that and fell back to the shared instance again. #37766 removes the `quiet` write from `Transpiler::init` and lists this as out of scope; the two changes are independent.

### Repro

Visible deterministically, without any race, because the debugger VM ran with default env options and therefore loaded the default `.env` files even when the main VM was told not to. In a directory with `.env` containing `MARKER=from-dotenv` and an unrelated `custom.env`:

```ts
// fixture.ts
import { open } from "node:inspector";
open(0); // returns once the debugger thread's VM is up
console.log(process.env.MARKER);
console.log(Bun.spawnSync({ cmd: [process.execPath, "-e", "console.log(process.env.MARKER)"], cwd: "/" }).stdout.toString());
```

```
$ bun --env-file=custom.env fixture.ts        # before
undefined        (process.env was already materialized by the time the debugger thread ran)
from-dotenv      (children are built from the VM's env map, which now has the .env contents)
```

Same with `--inspect` or `BUN_INSPECT_CONNECT_TO=tcp://...`; there `process.env.MARKER` itself is `from-dotenv` too. Without the inspector both print `undefined`. In a debug build the debugger thread additionally prints the main loader's file list to stderr (`[0.16ms] ".env", "custom.env"`), because it had flipped that loader to non-quiet.

A second consequence of reading the program's `.env` files from the debugger thread: if `.env` cannot be opened (a symlink loop, for instance) and the program itself was told to skip it with `--env-file`, the program runs fine without the inspector, but with `--inspect` / `BUN_INSPECT*` / `inspector.open()` the debugger thread aborts the whole process:

```
panic: Failed to configure defines
```

### Fix

`start_js_debugger_thread` creates a `bun_dotenv::Loader` for its VM and passes it as `InitOptions::env_loader`, the same thing `web_worker.rs` does for worker VMs and what #22206 did. The loader is never freed because the debugger VM itself lives until the process exits (`start` never returns).

Before `configure_defines()` it also sets `options.env.behavior` to `disable`, so that the loader is filled from the process environment only (`load_process()`), and the debugger thread never lists the cwd or opens `.env` files. The debugger VM only runs the internal inspector modules; the one thing read from its environment is `BUN_INSPECT_NOTIFY` in `internal/debugger.ts`, and the tooling that uses it (bun-vscode, bun-debug-adapter-protocol) sets it in the process environment, just like `BUN_INSPECT` and `BUN_INSPECT_CONNECT_TO`, which are only ever read from the process environment (`configure_debugger` in `jsc_hooks.rs`). `disable` is the mode `JSTranspiler` uses before `configure_defines()` and the mode a compiled executable's main VM runs in when `.env` loading is turned off, so it is a normal configuration for a runtime VM. It also means `configure_defines()` has nothing left to fail on apart from allocation, which removes the abort above, and there is no output from this loader to silence (an earlier revision of this PR set `quiet` on it instead, which only hid the file list the debugger thread was still producing). The one observable thing this drops is `BUN_INSPECT_NOTIFY` taken from a `.env` file rather than the environment, which worked only by accident of the shared loader and is not a configuration anything uses.

### Test

`test/regression/issue/test_env_loader_threading.test.ts` is the regression test #22206 added; its inspector assertions were `stderr` not containing `"panic"` / `"thread"`, which did not catch this. It is rewritten to run a fixture with `--env-file=custom.env` next to a `.env` and check `process.env`, the environment a grandchild inherits (the grandchild runs in a directory without a `.env`, so it can only get the marker from the parent's env map), `stderr` (exact, with port and id normalized), and the exit code, for:

* no inspector: the `.env` fixture loads by default, `--env-file` excludes it;
* `BUN_INSPECT_CONNECT_TO=tcp://...` pointing at a listener in the test, which closes the fixture's stdin once the debugger thread has connected (that happens after the debugger VM's `configure_defines()`), with and without `--env-file`;
* `inspector.open(0)`, which returns once the debugger thread's server is up;
* `--inspect=127.0.0.1:0` with `BUN_INSPECT_NOTIFY=tcp://...` pointing at the test's listener: the `.env` must stay out of the main VM, and the listener must receive the `"1"` notification, which only happens if the debugger VM's own `process.env` was filled from the process environment (this is the path that actually reads the debugger VM's loader);
* `--env-file` plus a `.env` that is a symlink to itself, with `inspector.open()`: must exit 0 (POSIX only, since creating the symlink needs a privilege on Windows).

On the unmodified release binary (`USE_SYSTEM_BUN=1`) the three `--env-file` + inspector cases fail with `loaded-from-dotenv` in both fields and the symlink case fails with exit code 134 and the panic above; an unmodified debug build additionally fails the `stderr: ""` assertions in the connect cases with the `".env", "custom.env"` line. With only the loader change (the `disable` line removed), debug builds fail the `stderr` assertions with `[0.16ms] ".env"` printed by the debugger thread's own loader and both build types fail the symlink case. With the whole change all seven pass under `bun bd test` (about 6s for the file, the cases run concurrently).

`test/cli/inspect`, `test/js/node/inspector`, `test/regression/issue/28159.test.ts` and `test/config/bunfig/preload.test.ts` were run as well; the `websocket` cases in `inspect.test.ts` fail identically with the unmodified release binary in this environment (`localhost` resolves to `::1` first here while the test's client connects to `127.0.0.1`), everything else passes.

</details>
