### PR TITLE
Make toStrictEqual and strict Bun.deepEquals distinguish null-prototype objects from object literals

### DIFF
--- a/docs/guides/util/deep-equals.mdx
+++ b/docs/guides/util/deep-equals.mdx
@@ -34,6 +34,9 @@ class Foo {
   a = 1;
 }
 Bun.deepEquals(new Foo(), { a: 1 }, true); // false
+
+// object literals vs objects with a null prototype
+Bun.deepEquals({ __proto__: null, a: 1 }, { a: 1 }, true); // false
 ```
 
 ---

--- a/docs/runtime/utils.mdx
+++ b/docs/runtime/utils.mdx
@@ -291,6 +291,9 @@ class Foo {
   a = 1;
 }
 Bun.deepEquals(new Foo(), { a: 1 }, true); // false
+
+// object literals vs objects with a null prototype
+Bun.deepEquals({ __proto__: null, a: 1 }, { a: 1 }, true); // false
 ```
 
 ## `Bun.escapeHTML()`

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -815,8 +815,8 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     ASSERT(c2);
 
     // Node's deepStrictEqual compares [[Prototype]]s with ===. Only the
-    // node:assert/node:util entry point does this; Bun.deepEquals and
-    // expect() keep their prototype-blind semantics.
+    // node:assert/node:util entry point does this; in strict mode Bun.deepEquals
+    // and expect() compare class names instead (see the isStrict check below).
     if constexpr (checkPrototypes && !skipPrototypeIdentity) {
         JSObject* protoCheck1 = v1.getObject();
         JSObject* protoCheck2 = v2.getObject();
@@ -955,6 +955,15 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
     if constexpr (isStrict && !skipPrototypeIdentity) {
         if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
+            return false;
+        }
+        // calculatedClassName is "Object" for `{}` and for a null-prototype object
+        // alike; jest's toStrictEqual tells them apart (the latter has no constructor).
+        JSValue proto1 = o1->getPrototype(globalObject);
+        RETURN_IF_EXCEPTION(scope, false);
+        JSValue proto2 = o2->getPrototype(globalObject);
+        RETURN_IF_EXCEPTION(scope, false);
+        if (proto1.isNull() != proto2.isNull()) {
             return false;
         }
     }
@@ -3096,7 +3105,7 @@ bool JSC__JSValue__jestStrictDeepEquals(JSC::EncodedJSValue JSValue0, JSC::Encod
 }
 
 // node:assert deepStrictEqual / node:util.isDeepStrictEqual: strict deepEquals
-// plus node's [[Prototype]] identity rule (Bun.deepEquals stays prototype-blind).
+// plus node's [[Prototype]] identity rule (Bun.deepEquals only compares class names).
 bool Bun__deepEqualsNodeStrict(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* globalObject)
 {
     return deepEqualsWrapperImpl<true, false, true>(JSValue0, JSValue1, globalObject);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -814,9 +814,8 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     ASSERT(c1);
     ASSERT(c2);
 
-    // Node's deepStrictEqual compares [[Prototype]]s with ===. Only the
-    // node:assert/node:util entry point does this; in strict mode Bun.deepEquals
-    // and expect() compare class names instead (see the isStrict check below).
+    // Node's deepStrictEqual compares [[Prototype]]s with ===; Bun.deepEquals and
+    // expect() only compare class names (the isStrict block below).
     if constexpr (checkPrototypes && !skipPrototypeIdentity) {
         JSObject* protoCheck1 = v1.getObject();
         JSObject* protoCheck2 = v2.getObject();
@@ -957,9 +956,8 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
             return false;
         }
-        // calculatedClassName is "Object" for `{}` and for a null-prototype object
-        // alike; jest's toStrictEqual tells them apart (the latter has no constructor).
-        // The node entry point already compared the prototypes by identity above.
+        // calculatedClassName() is "Object" for null-prototype objects too; node mode
+        // already compared the prototypes themselves above.
         if constexpr (!checkPrototypes) {
             JSValue proto1 = o1->getPrototype(globalObject);
             RETURN_IF_EXCEPTION(scope, false);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -959,12 +959,15 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         }
         // calculatedClassName is "Object" for `{}` and for a null-prototype object
         // alike; jest's toStrictEqual tells them apart (the latter has no constructor).
-        JSValue proto1 = o1->getPrototype(globalObject);
-        RETURN_IF_EXCEPTION(scope, false);
-        JSValue proto2 = o2->getPrototype(globalObject);
-        RETURN_IF_EXCEPTION(scope, false);
-        if (proto1.isNull() != proto2.isNull()) {
-            return false;
+        // The node entry point already compared the prototypes by identity above.
+        if constexpr (!checkPrototypes) {
+            JSValue proto1 = o1->getPrototype(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            JSValue proto2 = o2->getPrototype(globalObject);
+            RETURN_IF_EXCEPTION(scope, false);
+            if (proto1.isNull() != proto2.isNull()) {
+                return false;
+            }
         }
     }
 
@@ -3105,7 +3108,7 @@ bool JSC__JSValue__jestStrictDeepEquals(JSC::EncodedJSValue JSValue0, JSC::Encod
 }
 
 // node:assert deepStrictEqual / node:util.isDeepStrictEqual: strict deepEquals
-// plus node's [[Prototype]] identity rule (Bun.deepEquals only compares class names).
+// plus node's [[Prototype]] identity rule (Bun.deepEquals compares class names, not prototype identity).
 bool Bun__deepEqualsNodeStrict(JSC::EncodedJSValue JSValue0, JSC::EncodedJSValue JSValue1, JSC::JSGlobalObject* globalObject)
 {
     return deepEqualsWrapperImpl<true, false, true>(JSValue0, JSValue1, globalObject);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -814,8 +814,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
     ASSERT(c1);
     ASSERT(c2);
 
-    // Node's deepStrictEqual compares [[Prototype]]s with ===; Bun.deepEquals and
-    // expect() only compare class names (the isStrict block below).
+    // Node's deepStrictEqual compares [[Prototype]]s with ===; Bun.deepEquals and expect() only compare class names (below).
     if constexpr (checkPrototypes && !skipPrototypeIdentity) {
         JSObject* protoCheck1 = v1.getObject();
         JSObject* protoCheck2 = v2.getObject();
@@ -956,8 +955,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         if (!equal(JSObject::calculatedClassName(o1), JSObject::calculatedClassName(o2))) {
             return false;
         }
-        // calculatedClassName() is "Object" for null-prototype objects too; node mode
-        // already compared the prototypes themselves above.
+        // calculatedClassName() is "Object" for null-prototype objects too (node mode compared the prototypes above).
         if constexpr (!checkPrototypes) {
             JSValue proto1 = o1->getPrototype(globalObject);
             RETURN_IF_EXCEPTION(scope, false);

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -124,10 +124,44 @@ describe("Bun.deepEquals strict mode", () => {
     expect(Bun.deepEquals({ a: { b: 1 } }, { a: { b: 1, c: undefined } }, true)).toBe(false);
   });
 
-  // Matches Node's util.isDeepStrictEqual, which rejects a null prototype
-  // against Object.prototype.
-  it.failing("distinguishes a null-prototype object from an object literal", () => {
+  it("distinguishes a null-prototype object from an object literal", () => {
+    expect(Bun.deepEquals(Object.create(null), {})).toBe(true);
     expect(Bun.deepEquals(Object.create(null), {}, true)).toBe(false);
+    expect(Bun.deepEquals({}, Object.create(null), true)).toBe(false);
+
+    const nullProto = Object.assign(Object.create(null), { a: 1 });
+    expect(Bun.deepEquals(nullProto, { a: 1 })).toBe(true);
+    expect(Bun.deepEquals(nullProto, { a: 1 }, true)).toBe(false);
+    expect(Bun.deepEquals({ a: 1 }, nullProto, true)).toBe(false);
+    expect(Bun.deepEquals({ x: nullProto }, { x: { a: 1 } }, true)).toBe(false);
+    expect(Bun.deepEquals([nullProto], [{ a: 1 }], true)).toBe(false);
+  });
+
+  it("treats two null-prototype objects like any other objects", () => {
+    expect(Bun.deepEquals({ __proto__: null, a: 1 }, Object.assign(Object.create(null), { a: 1 }), true)).toBe(true);
+    expect(Bun.deepEquals({ __proto__: null, a: 1 }, { __proto__: null, a: 2 }, true)).toBe(false);
+    expect(Bun.deepEquals({ __proto__: null, a: 1 }, { __proto__: null, a: 1, b: undefined }, true)).toBe(false);
+    expect(Bun.deepEquals({ __proto__: null, a: 1 }, { __proto__: null, a: 1, b: undefined })).toBe(true);
+  });
+
+  it("compares the prototype a Proxy reports, not the Proxy itself", () => {
+    const nullProto = new Proxy(Object.create(null), {});
+    const plain = new Proxy({}, {});
+    expect(Bun.deepEquals(nullProto, new Proxy(Object.create(null), {}), true)).toBe(true);
+    expect(Bun.deepEquals(nullProto, plain, true)).toBe(false);
+    expect(Bun.deepEquals(plain, nullProto, true)).toBe(false);
+
+    const err = new Error("getPrototypeOf trap");
+    const throwing = new Proxy(
+      {},
+      {
+        getPrototypeOf() {
+          throw err;
+        },
+      },
+    );
+    expect(() => Bun.deepEquals(throwing, plain, true)).toThrow(err);
+    expect(() => Bun.deepEquals(plain, throwing, true)).toThrow(err);
   });
 });
 

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -1,4 +1,5 @@
 import { bunEnv, bunExe, isASAN, isWindows } from "harness";
+import util from "node:util";
 import vm from "node:vm";
 
 describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
@@ -144,24 +145,32 @@ describe("Bun.deepEquals strict mode", () => {
     expect(Bun.deepEquals({ __proto__: null, a: 1 }, { __proto__: null, a: 1, b: undefined })).toBe(true);
   });
 
-  it("compares the prototype a Proxy reports, not the Proxy itself", () => {
-    const nullProto = new Proxy(Object.create(null), {});
+  // node's skipPrototype mode shares this implementation, with every prototype check disabled.
+  it("does not apply the null-prototype rule in skipPrototype mode", () => {
+    const nullProto = Object.assign(Object.create(null), { a: 1 });
+    expect(util.isDeepStrictEqual(nullProto, { a: 1 })).toBe(false);
+    expect(util.isDeepStrictEqual(nullProto, { a: 1 }, true)).toBe(true);
+    expect(util.isDeepStrictEqual({ a: 1 }, nullProto, true)).toBe(true);
+  });
+
+  it("sees through a Proxy to a null-prototype target", () => {
     const plain = new Proxy({}, {});
+    const nullProto = new Proxy(Object.create(null), {});
     expect(Bun.deepEquals(nullProto, new Proxy(Object.create(null), {}), true)).toBe(true);
     expect(Bun.deepEquals(nullProto, plain, true)).toBe(false);
     expect(Bun.deepEquals(plain, nullProto, true)).toBe(false);
+  });
 
-    const err = new Error("getPrototypeOf trap");
-    const throwing = new Proxy(
-      {},
-      {
-        getPrototypeOf() {
-          throw err;
-        },
-      },
-    );
-    expect(() => Bun.deepEquals(throwing, plain, true)).toThrow(err);
-    expect(() => Bun.deepEquals(plain, throwing, true)).toThrow(err);
+  it("uses the prototype a Proxy's getPrototypeOf trap reports, not the target's", () => {
+    const plain = new Proxy({}, {});
+    const nullProto = new Proxy(Object.create(null), {});
+    // Both targets are extensible, so the traps may legally contradict them.
+    const reportsNull = new Proxy({}, { getPrototypeOf: () => null });
+    expect(Bun.deepEquals(reportsNull, plain, true)).toBe(false);
+    expect(Bun.deepEquals(reportsNull, nullProto, true)).toBe(true);
+    const reportsObject = new Proxy(Object.create(null), { getPrototypeOf: () => Object.prototype });
+    expect(Bun.deepEquals(reportsObject, plain, true)).toBe(true);
+    expect(Bun.deepEquals(reportsObject, nullProto, true)).toBe(false);
   });
 });
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -274,6 +274,38 @@ describe("expect()", () => {
     expect([, 1]).toEqual([undefined, 1]);
   });
 
+  test("toStrictEqual() distinguishes null-prototype objects from object literals", () => {
+    const nullProto = () => ANY(Object.assign(Object.create(null), { a: 1 }));
+
+    expect(nullProto()).toEqual({ a: 1 });
+    expect({ a: 1 }).toEqual(nullProto());
+    expect(nullProto()).not.toStrictEqual({ a: 1 });
+    expect({ a: 1 }).not.toStrictEqual(nullProto());
+    expect(ANY(Object.create(null))).not.toStrictEqual({});
+    expect({}).not.toStrictEqual(ANY(Object.create(null)));
+
+    // Nested in an object property and in an array element.
+    expect({ x: nullProto() }).toEqual({ x: { a: 1 } });
+    expect({ x: nullProto() }).not.toStrictEqual({ x: { a: 1 } });
+    expect({ x: { a: 1 } }).not.toStrictEqual({ x: nullProto() });
+    expect([nullProto()]).toEqual([{ a: 1 }]);
+    expect([nullProto()]).not.toStrictEqual([{ a: 1 }]);
+    expect([{ a: 1 }]).not.toStrictEqual([nullProto()]);
+
+    // Two null-prototype objects compare like any other pair of objects.
+    expect(nullProto()).toStrictEqual(nullProto());
+    expect({ x: nullProto() }).toStrictEqual({ x: nullProto() });
+    expect([nullProto()]).toStrictEqual([nullProto()]);
+    expect(nullProto()).not.toStrictEqual(ANY(Object.assign(Object.create(null), { a: 2 })));
+    expect(nullProto()).not.toStrictEqual(ANY(Object.assign(Object.create(null), { a: 1, b: undefined })));
+    expect(nullProto()).toEqual(ANY(Object.assign(Object.create(null), { a: 1, b: undefined })));
+
+    const grouped = Object.groupBy([1, 2, 3], n => (n % 2 ? "odd" : "even"));
+    expect(grouped).toEqual({ odd: [1, 3], even: [2] });
+    expect(grouped).not.toStrictEqual({ odd: [1, 3], even: [2] });
+    expect(grouped).toStrictEqual(Object.groupBy([1, 2, 3], n => (n % 2 ? "odd" : "even")));
+  });
+
   describe("toEqual() with DOM types", () => {
     test("URLSearchParams", () => {
       expect(new URLSearchParams("a=1")).not.toEqual(new URLSearchParams("b=1"));


### PR DESCRIPTION
### Problem
- On Bun 1.4.0, `expect(Object.assign(Object.create(null), { a: 1 })).toStrictEqual({ a: 1 })` passes; jest and vitest fail it. Same for an `Object.groupBy` result against a literal, and `Bun.deepEquals(Object.create(null), {}, true)` returns true.
- Strict mode's "same type" check compares class names, and a null-prototype object and an object literal both report `"Object"`, so strict mode cannot tell them apart. Class instances are already caught by that check.
- `node:assert.deepStrictEqual` and `util.isDeepStrictEqual` already fail these since #34660; this is the `bun:test` / `Bun.deepEquals` side of the same gap. `toEqual` passes them in every runner and keeps doing so.

### Fix
- In strict mode, after the class names match, read both prototypes and report unequal when exactly one of them is null.
- Only the strict type check gets tighter. Loose mode, `toMatchObject`, the skipPrototype variants, and the node entry point (which already compared prototypes by identity before this point) behave as before, and two null-prototype objects still compare equal.
- One divergence from jest is left alone: an object whose chain ends in a null-prototype object further up (`Object.create(Object.create(null))`) still equals `{}` here.
- Verification: the new `toStrictEqual` test and the three new strict `Bun.deepEquals` tests fail on Bun 1.4.0 and pass with this change; the `expect` test also passes under vitest 4.1.9. Docs gain the null-prototype example.

### Background
- `toStrictEqual` and `Bun.deepEquals(a, b, true)` share one C++ deep-equality routine, specialised by template flags. The same routine backs `node:assert.deepStrictEqual` (prototype identity checked) and node's skipPrototype mode (every prototype check off).
- Strict mode's type check uses JSC's `calculatedClassName()`, which names an object after its `constructor` and falls back to `"Object"` when there is none, so `{}` and `Object.create(null)` look identical to it.
- jest and vitest instead compare `a.constructor === b.constructor` in `toStrictEqual`; a null-prototype object has no `constructor`, so it never strictly equals a literal there. Arrays are exempt in both jest and this routine.
- For a Proxy, reading the prototype invokes its `getPrototypeOf` trap, so the trap's answer decides, not the target's prototype.
- Null-prototype objects are common return values: `Object.groupBy`, `querystring.parse`, `parseArgs().values`, and `{ __proto__: null }` literals.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/bun-object/deep-equals.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

```ts
import { expect, test } from "bun:test";

test("null-prototype object vs object literal", () => {
  expect(Object.assign(Object.create(null), { a: 1 })).toStrictEqual({ a: 1 }); // passes in bun, fails in jest and vitest
  expect({ a: 1 }).toStrictEqual({ __proto__: null, a: 1 }); // same
  expect(Object.groupBy([1, 2], n => (n % 2 ? "odd" : "even"))).toStrictEqual({ odd: [1], even: [2] }); // same
});

Bun.deepEquals(Object.create(null), {}, true); // true, documented strict mode says instances and literals differ
```

Verified on Bun 1.4.0. `toEqual` passes all of these in every runner, and keeps doing so.

### Cause

`toStrictEqual` and `Bun.deepEquals(a, b, true)` go through `Bun__deepEquals<isStrict = true>` in `src/jsc/bindings/bindings.cpp`. The strict "same type" check compares `JSObject::calculatedClassName()` of both operands. That returns `"Object"` both for an object inheriting from `Object.prototype` and for an object with no prototype at all (the `constructor` lookup finds nothing and it falls back to the class info name), so a null-prototype object and an object literal pass as the same type. Class instances were already caught by this check; null-prototype objects are the one shape it cannot see.

Jest and vitest fail these: `toStrictEqual` runs the `typeEquality` tester, which compares `a.constructor === b.constructor`, and a null-prototype object has no `constructor` (`undefined !== Object`). Checked against vitest 4.1.9's `equals()` with the `toStrictEqual` tester list:

```
Object.create(null){a:1} vs {a:1}             toStrictEqual=false  toEqual=true
{a:1} vs Object.create(null){a:1}             toStrictEqual=false  toEqual=true
nested: {x:nullproto} vs {x:{a:1}}            toStrictEqual=false  toEqual=true
array element: [nullproto] vs [{a:1}]         toStrictEqual=false  toEqual=true
Object.groupBy result vs literal              toStrictEqual=false  toEqual=true
both null-proto                               toStrictEqual=true   toEqual=true
```

`node:assert.deepStrictEqual` / `util.isDeepStrictEqual` already fail these since #34660 (they compare prototypes by identity on their own entry point); this is the `bun:test` / `Bun.deepEquals` side of the same gap. Bun's own `util.inspect` also already treats the two shapes as different types (`[Object: null prototype] {}` vs `{}`), and the repo's `parseArgs` tests write `{ __proto__: null }` on the expected side of `toStrictEqual` precisely because they expect this to be checked.

### Fix

In the `isStrict && !skipPrototypeIdentity` block, after the class names match, read both `[[Prototype]]`s and return false when exactly one of them is null. This is the fixing hunk:

```cpp
if constexpr (!checkPrototypes) {
    JSValue proto1 = o1->getPrototype(globalObject);
    RETURN_IF_EXCEPTION(scope, false);
    JSValue proto2 = o2->getPrototype(globalObject);
    RETURN_IF_EXCEPTION(scope, false);
    if (proto1.isNull() != proto2.isNull())
        return false;
}
```

Why this shape:

- It only tightens the strict type check, which is the step that lost the information. Loose mode (`toEqual`, `Bun.deepEquals(a, b)`), asymmetric matchers, `toMatchObject` and the `skipPrototype` variants (`Bun.deepEquals(a, b, true, true)`, `util.isDeepStrictEqual(a, b, true)`) are untouched. The node entry point (`checkPrototypes`) already compared the prototypes by identity before reaching this block, so the new lookups are compiled out there and it keeps invoking a Proxy's `getPrototypeOf` trap once per side, as before.
- It stays name based rather than switching to jest's constructor identity, so objects from another realm (`node:vm`) still compare the way they did. Null vs non-null is the one distinction `calculatedClassName` collapses that shows up in practice (`Object.create(null)`, `{ __proto__: null }`, `Object.groupBy`, `querystring.parse`, `parseArgs().values`, node style `fs.promises` results).
- `getPrototype(globalObject)` is the same call the node entry point uses a few lines up (and the same thing `util.inspect` consults when it prints `[Object: null prototype]`). For ordinary objects it is a type-info bit test plus a load. For a Proxy it is the `getPrototypeOf` trap result, which only matters Proxy vs Proxy, since a Proxy already fails the class name check against a non-Proxy. That coincides with jest unless a trap contradicts its target (jest reads `.constructor` through the `get` trap instead); the tests pin the trap-result behaviour so the choice is explicit. Both new calls have `RETURN_IF_EXCEPTION`; the file was also run under `BUN_JSC_validateExceptionChecks=1`.
- Arrays are not affected (they take the array branch above this check), matching jest, which exempts arrays from `typeEquality`.

The surrounding comments that described `Bun.deepEquals`/`expect()` as prototype-blind are updated, and the null-prototype case is added to the strict mode list in the `Bun.deepEquals` docs next to the class instance example.

One remaining divergence, left alone as it does not come up in practice: an object whose prototype chain ends in a null-prototype object without ever defining `constructor` (`Object.create(Object.create(null))`) still compares equal to `{}` here, while jest rejects it.

### Tests

- `test/js/bun/test/expect.test.js`: new `toStrictEqual()` test covering both operand orders, nesting in an object property and an array element, two null-prototype objects still being strictly equal (and still differing on values / `undefined` properties), `Object.groupBy`, and `toEqual` continuing to pass for all of it. This file also runs under jest and vitest; the new test passes under vitest 4.1.9.
- `test/js/bun/bun-object/deep-equals.test.ts`: the existing `it.failing` for `Bun.deepEquals(Object.create(null), {}, true)` now passes and is un-marked and extended; new tests for two null-prototype objects, for Proxies (a Proxy around a null-prototype target, and traps that report a different prototype than their target, which is what distinguishes reading the trap from unwrapping the target), and a guard that `util.isDeepStrictEqual(a, b, true)` (node's skipPrototype mode, which instantiates the same function with `skipPrototypeIdentity`) still treats a null-prototype object and a literal as equal, as node does.

On Bun 1.4.0 exactly the new `toStrictEqual` test and the three new `Bun.deepEquals` strict mode tests fail; with this change both files pass (416 and 49 tests). Also ran `test/js/node/assert/` (406 pass), `test/js/node/util/parse_args/` (all `toStrictEqual` uses there already spell out `__proto__: null`; the only failure is a pre-existing 1000x `Bun.gc()` stress test timing out on the debug build) and the other test files in the repo that use `toStrictEqual`; the only failures there were debug build timeouts and container networking limits, none involving equality, so nothing else relied on the old behaviour.

#32872 contains this same check as one of four unrelated fixes, but it predates #34660 and no longer applies to main (conflicts in `bindings.cpp` and two test files), so this is the null-prototype part on its own.

</details>
