### PR TITLE
build: run the ninja tree's bun helpers with a single GC marker

### DIFF
--- a/scripts/build/configure.ts
+++ b/scripts/build/configure.ts
@@ -217,6 +217,30 @@ function ccacheEnv(cfg: Config): Record<string, string> {
 }
 
 /**
+ * Environment for everything ninja spawns (ConfigureResult.env).
+ *
+ * The stream.ts wrappers, fetch-cli.ts and the src/codegen scripts are all
+ * bun processes. Each one starts numberOfGCMarkers - 1 HeapHelper threads
+ * (7 on an 8+ core host) at its first GC, so even a wrapper that only pipes
+ * a child's output holds ~14 threads, and a cold build starts about twenty
+ * of them at once next to cargo/rustc. In a container with a 512 task pids
+ * limit that was over the limit: pthread_create failed in the helpers and
+ * WTF::Thread::create aborted them ("abort() called" from fetch-cli.ts and
+ * cppbind.ts on the first `bun bd` in a fresh container, fine on the second).
+ * One marker removes those threads with no measurable change in the scripts'
+ * wall time. useConcurrentJIT=false would save one more thread per process
+ * but doubles cppbind.ts's run time. Whichever bun runs the helpers parses
+ * this and exits on an option name it doesn't know, so only long-standing
+ * JSC option names belong here.
+ */
+export function buildEnv(cfg: Config): Record<string, string> {
+  return {
+    ...ccacheEnv(cfg),
+    BUN_JSC_numberOfGCMarkers: "1",
+  };
+}
+
+/**
  * Configure: resolve config → emit build.ninja. Returns the resolved config
  * and emitted build info.
  *
@@ -361,5 +385,5 @@ export async function configure(input: ConfigureInput): Promise<ConfigureResult>
   const elapsed = Math.round(performance.now() - start);
   const exe = bunExeName(cfg) + (shouldStrip(cfg) ? " → bun (stripped)" : "");
 
-  return { cfg, output, ninjaFile, env: ccacheEnv(cfg), elapsed, changed, exe };
+  return { cfg, output, ninjaFile, env: buildEnv(cfg), elapsed, changed, exe };
 }

--- a/test/internal/build-ninja-env.test.ts
+++ b/test/internal/build-ninja-env.test.ts
@@ -1,0 +1,135 @@
+/**
+ * scripts/build.ts hands ninja the environment from configure.ts's
+ * buildEnv(). Every stream.ts wrapper, fetch-cli.ts and src/codegen script
+ * ninja runs is a bun process, and by default each of them starts
+ * numberOfGCMarkers - 1 (7 on an 8+ core host) HeapHelper threads at its first
+ * GC. A cold build starts about twenty of them at once, which pushed a
+ * container with a 512 task pids limit over the limit; pthread_create then
+ * failed inside the helpers and WTF::Thread::create aborted them ("abort()
+ * called" from fetch-cli.ts and cppbind.ts on the first `bun bd` in a fresh
+ * container). buildEnv() caps the helpers at one GC marker.
+ *
+ * The option is parsed by whichever bun runs the helpers, and bun exits on a
+ * BUN_JSC_ variable it does not recognize, so besides pinning the env this
+ * runs the bun under test with it: the option name must still exist and it
+ * must still remove the helper threads.
+ */
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { availableParallelism } from "node:os";
+import { resolve } from "node:path";
+
+import { resolveConfig, type Config, type Toolchain } from "../../scripts/build/config.ts";
+import { buildEnv } from "../../scripts/build/configure.ts";
+
+/** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
+function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: "/fake/llvm/bin/ld64.lld",
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: "/fake/llvm/bin/dsymutil",
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+    ...overrides,
+  };
+}
+
+/** A host-targeted config rooted in `dir` (build dir and cache dir), so nothing outside the temp dir is referenced. */
+function hostConfig(dir: string, toolchain: Toolchain = mockToolchain()): Config {
+  return resolveConfig({ buildDir: dir, cacheDir: dir }, toolchain);
+}
+
+/**
+ * Mirrors a build helper: a script file (not `-e`, which bun already runs
+ * with a single GC marker), a full GC, then the names of the process's
+ * threads. JSC names its parallel markers "HeapHelper" on Linux.
+ */
+const threadNamesFixture = `
+  import { readdirSync, readFileSync } from "node:fs";
+  Bun.gc(true);
+  const names = readdirSync("/proc/self/task").map(tid => readFileSync("/proc/self/task/" + tid + "/comm", "utf8").trim());
+  console.log(JSON.stringify(names));
+`;
+
+async function threadNames(extraEnv: Record<string, string>): Promise<string[]> {
+  using dir = tempDir("build-ninja-env", { "helper.ts": threadNamesFixture });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "helper.ts"],
+    cwd: String(dir),
+    env: { ...bunEnv, ...extraEnv },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(exitCode).toBe(0);
+  return JSON.parse(stdout);
+}
+
+describe("buildEnv", () => {
+  test("caps the build's bun helper processes at one GC marker", () => {
+    using dir = tempDir("build-ninja-env", {});
+    expect(buildEnv(hostConfig(String(dir)))).toEqual({ BUN_JSC_numberOfGCMarkers: "1" });
+  });
+
+  test("keeps the ccache variables alongside it", () => {
+    using dir = tempDir("build-ninja-env", {});
+    expect(buildEnv(hostConfig(String(dir), mockToolchain({ ccache: "/fake/bin/ccache" })))).toMatchObject({
+      CCACHE_DIR: resolve(String(dir), "ccache"),
+      BUN_JSC_numberOfGCMarkers: "1",
+    });
+  });
+
+  test.concurrent("the bun under test accepts the environment", async () => {
+    using dir = tempDir("build-ninja-env", { "helper.ts": `console.log("ok");` });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "helper.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, ...buildEnv(hostConfig(String(dir))) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("ok\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Thread names come from /proc. The control needs a host where JSC's
+  // default (min(cores, 8) markers) starts at least one helper.
+  test.concurrent.skipIf(!isLinux || availableParallelism() < 2)(
+    "without it a helper script starts parallel GC marker threads",
+    async () => {
+      expect(await threadNames({})).toContain("HeapHelper");
+    },
+  );
+
+  test.concurrent.skipIf(!isLinux)("with it a helper script starts none", async () => {
+    using dir = tempDir("build-ninja-env", {});
+    expect(await threadNames(buildEnv(hostConfig(String(dir))))).not.toContain("HeapHelper");
+  });
+});

--- a/test/internal/build-ninja-env.test.ts
+++ b/test/internal/build-ninja-env.test.ts
@@ -19,53 +19,34 @@ import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { availableParallelism } from "node:os";
 import { resolve } from "node:path";
 
-import { resolveConfig, type Config, type Toolchain } from "../../scripts/build/config.ts";
+import type { Config } from "../../scripts/build/config.ts";
 import { buildEnv } from "../../scripts/build/configure.ts";
 
-/** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
-function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
-  return {
-    cc: "/fake/llvm/bin/clang",
-    cxx: "/fake/llvm/bin/clang++",
-    hostCc: undefined,
-    hostCxx: undefined,
-    clangVersion: "21.1.8",
-    clangResourceDir: "/fake/llvm/lib/clang/21",
-    ar: "/fake/llvm/bin/llvm-ar",
-    ranlib: "/fake/llvm/bin/llvm-ranlib",
-    ld: "/fake/llvm/bin/ld.lld",
-    ld64Lld: "/fake/llvm/bin/ld64.lld",
-    rustLld: undefined,
-    rustLlvmVersion: "22.1.4",
-    rustSysroot: undefined,
-    rustHostTriple: undefined,
-    strip: "/fake/bin/strip",
-    llvmStrip: "/fake/llvm/bin/llvm-strip",
-    dsymutil: "/fake/llvm/bin/dsymutil",
-    bun: "/fake/bin/bun",
-    jsRuntime: "/fake/bin/bun",
-    esbuild: "/fake/bin/esbuild",
+/** The fields buildEnv() reads. */
+const cfg = (overrides: Partial<Config> = {}) =>
+  ({
     ccache: undefined,
-    cmake: "/fake/bin/cmake",
-    cargo: undefined,
-    cargoHome: undefined,
-    rustupHome: undefined,
-    msvcLinker: undefined,
-    rc: undefined,
-    mt: undefined,
-    nasm: undefined,
+    cacheDir: "/cache",
+    cwd: "/repo",
+    buildDir: "/repo/build/debug",
+    ci: false,
     ...overrides,
-  };
-}
-
-/** A host-targeted config rooted in `dir` (build dir and cache dir), so nothing outside the temp dir is referenced. */
-function hostConfig(dir: string, toolchain: Toolchain = mockToolchain()): Config {
-  return resolveConfig({ buildDir: dir, cacheDir: dir }, toolchain);
-}
+  }) as Config;
 
 /**
- * Mirrors a build helper: a script file (not `-e`, which bun already runs
- * with a single GC marker), a full GC, then the names of the process's
+ * The control below asserts on JSC's default, so neither the variable under
+ * test nor JSC's own spelling of it may leak in from the environment running
+ * this test file. Bun.spawn drops undefined entries.
+ */
+const defaultEnv: Record<string, string | undefined> = {
+  ...bunEnv,
+  BUN_JSC_numberOfGCMarkers: undefined,
+  JSC_numberOfGCMarkers: undefined,
+};
+
+/**
+ * Stands in for a build helper: a script file (not `-e`, which bun already
+ * runs with a single marker), a full GC, then the names of the process's
  * threads. JSC names its parallel markers "HeapHelper" on Linux.
  */
 const threadNamesFixture = `
@@ -75,12 +56,12 @@ const threadNamesFixture = `
   console.log(JSON.stringify(names));
 `;
 
-async function threadNames(extraEnv: Record<string, string>): Promise<string[]> {
+async function threadNames(env: Record<string, string | undefined>): Promise<string[]> {
   using dir = tempDir("build-ninja-env", { "helper.ts": threadNamesFixture });
   await using proc = Bun.spawn({
     cmd: [bunExe(), "helper.ts"],
     cwd: String(dir),
-    env: { ...bunEnv, ...extraEnv },
+    env,
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -92,14 +73,12 @@ async function threadNames(extraEnv: Record<string, string>): Promise<string[]> 
 
 describe("buildEnv", () => {
   test("caps the build's bun helper processes at one GC marker", () => {
-    using dir = tempDir("build-ninja-env", {});
-    expect(buildEnv(hostConfig(String(dir)))).toEqual({ BUN_JSC_numberOfGCMarkers: "1" });
+    expect(buildEnv(cfg())).toEqual({ BUN_JSC_numberOfGCMarkers: "1" });
   });
 
   test("keeps the ccache variables alongside it", () => {
-    using dir = tempDir("build-ninja-env", {});
-    expect(buildEnv(hostConfig(String(dir), mockToolchain({ ccache: "/fake/bin/ccache" })))).toMatchObject({
-      CCACHE_DIR: resolve(String(dir), "ccache"),
+    expect(buildEnv(cfg({ ccache: "/usr/bin/ccache" }))).toMatchObject({
+      CCACHE_DIR: resolve("/cache", "ccache"),
       BUN_JSC_numberOfGCMarkers: "1",
     });
   });
@@ -109,7 +88,7 @@ describe("buildEnv", () => {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "helper.ts"],
       cwd: String(dir),
-      env: { ...bunEnv, ...buildEnv(hostConfig(String(dir))) },
+      env: { ...defaultEnv, ...buildEnv(cfg()) },
       stdout: "pipe",
       stderr: "pipe",
     });
@@ -124,12 +103,11 @@ describe("buildEnv", () => {
   test.concurrent.skipIf(!isLinux || availableParallelism() < 2)(
     "without it a helper script starts parallel GC marker threads",
     async () => {
-      expect(await threadNames({})).toContain("HeapHelper");
+      expect(await threadNames(defaultEnv)).toContain("HeapHelper");
     },
   );
 
   test.concurrent.skipIf(!isLinux)("with it a helper script starts none", async () => {
-    using dir = tempDir("build-ninja-env", {});
-    expect(await threadNames(buildEnv(hostConfig(String(dir))))).not.toContain("HeapHelper");
+    expect(await threadNames({ ...defaultEnv, ...buildEnv(cfg()) })).not.toContain("HeapHelper");
   });
 });


### PR DESCRIPTION
### Problem
- The first `bun bd` in a fresh container with a 512 pids limit intermittently fails on two or three unrelated build edges (`fetch-cli.ts`, `cppbind.ts`): the bun running the script dies about 24ms in with `panic(main thread): abort() called`. The second `bun bd` passes.
- Both crash reports decode to `WTF::Thread::create` -> `RELEASE_ASSERT` on `pthread_create`, via `AutomaticThread::start`: the pids limit was full, `pthread_create` returned `EAGAIN`, and WebKit aborts on that. Bun's own thread pools already tolerate a failed spawn.
- The build fills the limit itself: every helper ninja runs is a bun process, and each starts 7 parallel GC marker threads at its first GC, so a wrapper that only pipes `sleep` holds 14 threads.
- A cold build starts all ~24 codegen edges, the fetch pool and cargo at once (310-347 tasks sampled here, over 512 where it was reported); on the second run most edges are up to date.

### Fix
- The environment configure hands to ninja now also carries `BUN_JSC_numberOfGCMarkers=1`, so every helper the build spawns runs with one GC marker, as `bun -e` already does. The binary `bun bd` execs afterwards does not inherit it.
- Safe because the helpers live for a few hundred milliseconds, so the parallel markers do no useful work: cppbind.ts wall time is unchanged while its peak threads drop from 19-21 to 11-14. `useConcurrentJIT=false` was measured and left out: it doubles cppbind.ts wall time for one more thread.
- Whichever bun invoked `bun bd` parses the variable and exits on an unknown `BUN_JSC_*` name; `numberOfGCMarkers` is accepted by 1.3.14 and by current canary. Other things can still fill the limit; #36985 makes the crash message name it.
- Verification: a new test runs the bun under test as a helper and lists its threads from `/proc`; the marker threads are present without the env, absent with it, and it fails with the `scripts/` change stashed. A fresh build checked by hand had helpers at 5-7 threads instead of 12-14. The crash itself is not exercised.

### Background
- `bun bd` builds the debug binary through `scripts/build.ts`: configure, then ninja. The codegen scripts, fetch edges and `stream.ts` wrappers in that tree are run by the bun that invoked `bun bd`, not the bun being built, so ninja's environment reaches all of them.
- JSC marks the heap in parallel on `numberOfGCMarkers` threads (default `min(cores, 8)`); the extras are the `HeapHelper` threads, started at a process's first GC. `BUN_JSC_<option>` env vars set JSC options by name.
- A cgroup pids limit counts threads as well as processes; once the container reaches it, `pthread_create` fails with `EAGAIN` in every process in the container, not only the one that spawned the most.
- WebKit's `WTF::Thread::create` release-asserts that the thread was created, so a failed `pthread_create` inside JSC aborts the process instead of returning an error; that is the panic above.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

The first `bun bd` in a fresh container (pids limit 512) intermittently fails on two or three unrelated script edges because the bun running the build scripts dies ~24ms in:

```
panic(main thread): abort() called
oh no: Bun has crashed. ...
```

The second `bun bd` passes. Seen on the `fetch-cli.ts dep lsqpack ...` edge (`vendor/lsqpack/.ref`) and on `src/codegen/cppbind.ts` (`codegen/cpp.rs`), 6+ resets in a row.

### Cause

Both crash reports decode (against a `bun-profile` of the same revision, da3851e57) to the same abort site, `WTF::Thread::create` -> `RELEASE_ASSERT(success)` on the result of `pthread_create` (`Threading.cpp:330`), reached from `AutomaticThread::start`:

- fetch-cli.ts: `LLInt::jitCompileAndSetHeuristics` -> `JITWorklist::enqueue` -> `JITWorklist::wakeThreads` -> `AutomaticThread::start` -> `WTF::Thread::create`
- cppbind.ts: `Heap::runBeginPhase` -> `ParallelHelperClient::setTask` -> `AutomaticThreadCondition::notifyAll` -> `AutomaticThread::start` -> `WTF::Thread::create`

So this is not a missing errno check in Bun (Bun's own thread pool, IO and HTTP threads handle a failed spawn); it is `pthread_create` returning `EAGAIN` because the container's cgroup pids limit (512, and it counts threads) was exhausted, and WebKit aborting on that. What exhausts it is the build itself. Every `stream.ts` wrapper, `fetch-cli.ts` invocation and `src/codegen` script ninja runs is a bun process, and each of them starts `numberOfGCMarkers - 1` (7 on an 8+ core host) `HeapHelper` threads at its first GC:

```
stream.ts wrapper around `sleep`:   14 threads  (7 HeapHelper, 3 JITWorker, main, mi-scavenger, 2 Bun Pool)
create-hash-table.ts:               12-13 threads
cppbind.ts / bundle-modules.ts:     ~21 threads
```

A cold build starts all ~24 codegen edges, the `dep` pool (two bun processes per fetch edge) and cargo at the same moment. Sampling the cgroup every 20ms while starting a build in a fresh build dir with the fetch edges dirty peaked at 310-347 tasks in this container (the cgroup's own `pids.peak` reached 391 during a real `bun bd`); in the busier environment that reported this it crossed 512. On the second run most of those edges are up to date, so it fits.

### Fix

`configure.ts` already returns the environment `build.ts` hands to ninja (the ccache variables). Add `BUN_JSC_numberOfGCMarkers=1` to it, so every helper the build spawns runs with a single GC marker, which is what `JSCInitialize` already does for `bun -e` / `bun --print`. The parallel markers are pure overhead for scripts that live for a few hundred milliseconds:

```
                                  default     numberOfGCMarkers=1
cppbind.ts wall time (3 runs)     433-540ms   457-476ms
cppbind.ts peak threads           19-21       11-14
stream.ts wrapper threads         14          5-7
cold-start burst, sampled peak    310-347     238 tasks
```

`useConcurrentJIT=false` (the other knob `bun -e` uses, and the thread in the first trace) was measured and deliberately not included: it removes one thread per process and doubles cppbind.ts's wall time (874-914ms), because DFG/FTL compiles move onto the script's thread.

The variable is parsed by whichever bun runs the helpers (the one that invoked `bun bd`, so potentially much older or newer than this checkout), and bun exits on an unknown `BUN_JSC_*` name, so the comment on `buildEnv()` restricts it to long-standing option names; `numberOfGCMarkers` is the option `ZigGlobalObject.cpp` itself sets by name, and it is accepted by the 1.3.14 release and by the current canary. The env goes through both the local and the CI ninja spawn in `build.ts`; the binary that `bun bd <args>` execs afterwards does not inherit it.

Thread creation can still fail if something else fills the limit (Bun's own IO and HTTP threads have to start too); this removes the build's largest avoidable contribution to it. #36985 is the complementary runtime-side change that makes the crash message say "thread limit" instead of "bug in Bun" when a limit is hit.

### Verification

`test/internal/build-ninja-env.test.ts` pins `buildEnv()` (with and without ccache) and, because the point of the variable is what it does to the helper processes, runs the bun under test as a helper would be run (a script file, not `-e`, which already gets one marker) and lists its threads after a full GC via `/proc`: with the default environment the `HeapHelper` threads are there, with `buildEnv()` they are not, and the process accepts the variable on every platform.

The fix is in `scripts/`, so the before/after check is:

```
git stash push -- scripts/ && bun bd test test/internal/build-ninja-env.test.ts   # fails
git stash pop            && bun bd test test/internal/build-ninja-env.test.ts   # 5 pass
```

(With the `BUN_JSC_numberOfGCMarkers` line removed from `buildEnv()` but the export kept, the two env assertions and the "starts none" test fail.) Also checked end to end: starting a build through `scripts/build.ts` in a fresh build dir, the live `stream.ts` / codegen processes under ninja have `BUN_JSC_numberOfGCMarkers=1` in `/proc/<pid>/environ` and 5-7 threads instead of 12-14.

</details>
