### PR TITLE
Hand pool-finished transpiler and patch jobs back through their pointer, not a &mut receiver

### DIFF
--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -141,24 +141,38 @@ impl PatchTask {
     /// # Safety
     /// Only invoked by `ThreadPool` via the `callback` fn-pointer registered in
     /// `new_calc_patch_hash` / `new_apply_patch_hash`. `task` must be live and
-    /// point at the `task` field of a heap-allocated `PatchTask`, with the pool
-    /// granting exclusive access for the duration of the call.
+    /// point at the `task` field of a heap-allocated `PatchTask`, which this
+    /// thread owns until it pushes the task back to the main thread.
     pub(crate) unsafe fn run_from_thread_pool(task: *mut ThreadPoolTask) {
         // SAFETY: thread-pool callback contract — `task` points to the `task`
         // field of a live `PatchTask` (set at construction); the pool runs
         // each task at most once with exclusive access for the call.
-        let patch_task = unsafe { &mut *PatchTask::from_task_ptr(task) };
-        patch_task.run_from_thread_pool_impl();
+        let this = unsafe { PatchTask::from_task_ptr(task) };
+        // SAFETY: as above. The main thread reclaims the task's `Box` as soon as
+        // the push below lands, so the `&mut` the autoref forms is scoped to
+        // its statement and the push goes through `this`, not a reference.
+        let mgr = unsafe {
+            (*this).run_from_thread_pool_impl();
+            (*this).manager.as_ptr()
+        };
+        // SAFETY: `this` is non-null (recovered from a live task). `mgr` is a
+        // long-lived BACKREF; the worker thread only touches the lock-free
+        // `patch_task_queue` and the event-loop wake atomics, neither of which
+        // alias data the main thread holds an exclusive borrow on.
+        unsafe {
+            (*mgr)
+                .patch_task_queue
+                .push(core::ptr::NonNull::new_unchecked(this));
+            PackageManager::wake_raw(mgr);
+        }
     }
 
-    pub(crate) fn run_from_thread_pool_impl(&mut self) {
+    fn run_from_thread_pool_impl(&mut self) {
         bun_output::scoped_log!(
             InstallPatch,
             "runFromThreadPoolImpl {}",
             <&'static str>::from(&self.callback)
         );
-        // There are no early returns in the body, so the ordering
-        // (body → push → wake) is inlined below.
         match &mut self.callback {
             Callback::CalcHash(_) => {
                 let result = self.calc_hash();
@@ -172,17 +186,6 @@ impl PatchTask {
                 // bun.handleOom(this.apply()) → panic on OOM.
                 self.apply().expect("OOM");
             }
-        }
-        let mgr = self.manager.as_ptr();
-        // SAFETY: `self.manager` is a long-lived BACKREF;
-        // the worker thread only touches the lock-free `patch_task_queue` and the
-        // event-loop wake atomics, neither of which alias data the main thread
-        // holds an exclusive borrow on.
-        unsafe {
-            (*mgr)
-                .patch_task_queue
-                .push(core::ptr::NonNull::from(&mut *self));
-            PackageManager::wake_raw(mgr);
         }
     }
 

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -148,17 +148,14 @@ impl PatchTask {
         // field of a live `PatchTask` (set at construction); the pool runs
         // each task at most once with exclusive access for the call.
         let this = unsafe { PatchTask::from_task_ptr(task) };
-        // SAFETY: as above. The main thread reclaims the task's `Box` as soon as
-        // the push below lands, so the `&mut` the autoref forms is scoped to
-        // its statement and the push goes through `this`, not a reference.
+        // SAFETY: as above; the `&mut` ends with its statement. The main thread
+        // frees the task as soon as the push below lands.
         let mgr = unsafe {
             (*this).run_from_thread_pool_impl();
             (*this).manager.as_ptr()
         };
-        // SAFETY: `this` is non-null (recovered from a live task). `mgr` is a
-        // long-lived BACKREF; the worker thread only touches the lock-free
-        // `patch_task_queue` and the event-loop wake atomics, neither of which
-        // alias data the main thread holds an exclusive borrow on.
+        // SAFETY: `this` is non-null (as above). `mgr` is a long-lived BACKREF;
+        // the lock-free queue and the wake atomics are all this thread touches.
         unsafe {
             (*mgr)
                 .patch_task_queue

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -403,9 +403,10 @@ pub struct TranspilerJob {
     // raw pointers/BackRefs are used (BACKREF — VM owns the
     // store and outlives every job).
     pub(crate) vm: *mut VirtualMachine,
-    /// The pool thread runs this job under `loop_handle.borrow()`: the job's
-    /// own slot, the transpiler it copies and the store queue it pushes to are
-    /// all VM-owned, and the VM's teardown waits for the borrow to end.
+    /// The pool thread transpiles under `loop_handle.borrow_if_running()` (the
+    /// transpiler it copies is VM-owned) and counts as embedded work from
+    /// `schedule` until it has pushed the slot back to the store queue, so the
+    /// VM's teardown waits for both.
     pub(crate) loop_handle: crate::LoopHandle,
     pub global_this: BackRef<JSGlobalObject>,
     pub(crate) fetcher: Fetcher,
@@ -514,18 +515,29 @@ impl TranspilerJob {
         // replacement a second time).
     }
 
-    fn dispatch_to_main_thread(&mut self) {
-        let vm = self.vm;
-        let loop_handle = self.loop_handle.clone();
+    /// Hands the job back to the JS thread, which completes it
+    /// (`run_from_js_thread`) or releases it (`release_queued_jobs_for_teardown`);
+    /// either way it writes the slot and `put()`s it (a `Box` free once the hive
+    /// is full) as soon as the push lands. Takes the pointer, not `&mut self`: a
+    /// reference argument stays protected until its call returns, so the JS
+    /// thread would be writing to, or freeing, protected memory. The caller must
+    /// not hold a reference into `*this` across the call either.
+    ///
+    /// # Safety
+    /// `this` is the live slot `transpile()` scheduled, still owned by the pool
+    /// thread; nothing on this thread touches `*this` afterwards.
+    unsafe fn dispatch_to_main_thread(this: *mut Self) {
+        // SAFETY: fn contract; both accesses end at the `;`, before the push.
+        let (vm, loop_handle) = unsafe { ((*this).vm, (*this).loop_handle.clone()) };
         // SAFETY: vm outlives the job (BACKREF — VM owns the store).
         let transpiler_store: *mut RuntimeTranspilerStore =
             unsafe { ptr::addr_of_mut!((*vm).transpiler_store) };
-        let job = NonNull::from(&mut *self);
-        // SAFETY: queue is concurrent-safe (UnboundedQueue uses atomics).
-        unsafe { (*transpiler_store).queue.push(job) };
-        // Another thread may free `self` at any time after .push, so we cannot use it any more
-        // (the handle was cloned out above for exactly this reason). The VM
-        // waits for embedded work before closing its handle, so this is queued.
+        // SAFETY: `this` is non-null per fn contract; the queue is
+        // concurrent-safe (UnboundedQueue uses atomics). The JS thread owns the
+        // job from here on.
+        unsafe { (*transpiler_store).queue.push(NonNull::new_unchecked(this)) };
+        // The VM waits for embedded work before closing its handle, so this is
+        // queued.
         let crate::vm_handle::Posted::Queued =
             loop_handle.post_task(ConcurrentTask::create_from(transpiler_store))
         else {
@@ -613,16 +625,18 @@ impl TranspilerJob {
         // SAFETY: as above.
         let handle = unsafe { (*this).loop_handle.clone() };
         if let Some(_vm) = handle.borrow_if_running() {
-            // SAFETY: live slot, exclusively ours until dispatched.
+            // SAFETY: live slot, exclusively ours until dispatched. The `&mut`
+            // this autoref forms ends with the statement, before the dispatch
+            // publishes the slot.
             unsafe { (*this).run() };
-        } else {
-            // SAFETY: as above.
-            unsafe { (*this).dispatch_to_main_thread() };
         }
-        // Last touch of the slot from this thread was the dispatch.
+        // SAFETY: as above; the dispatch is this thread's last touch of the slot.
+        unsafe { Self::dispatch_to_main_thread(this) };
         handle.embedded_work_finished();
     }
 
+    /// Fills in `resolved_source` or `parse_error`; the caller hands the job
+    /// back to the JS thread afterwards, on every return path.
     fn run(&mut self) {
         // Stack-local per call, bulk-freed on return. An earlier version hoisted
         // this to a per-worker-thread leaked `Box<MimallocArena>` (and a second
@@ -639,14 +653,6 @@ impl TranspilerJob {
         // start-of-call `reset()` but the worker holds **zero** retained pages
         // between calls.
         let arena = Arena::new();
-
-        // `defer this.dispatchToMainThread()` — fires on every return path.
-        let this_ptr: *mut TranspilerJob = self;
-        scopeguard::defer! {
-            // SAFETY: `self` outlives this guard (guard drops before fn return);
-            // no other &mut alias is live at drop time.
-            unsafe { (*this_ptr).dispatch_to_main_thread() };
-        }
 
         // SAFETY contract: `vm` outlives the job (BACKREF — VM owns the store).
         // Note: kept as a raw pointer — never form `&mut VirtualMachine`

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -404,10 +404,8 @@ pub struct TranspilerJob {
     // raw pointers/BackRefs are used (BACKREF — VM owns the
     // store and outlives every job).
     pub(crate) vm: *mut VirtualMachine,
-    /// The pool thread transpiles under `loop_handle.borrow_if_running()` (the
-    /// transpiler it copies is VM-owned) and counts as embedded work from
-    /// `schedule` until it has pushed the slot back to the store queue, so the
-    /// VM's teardown waits for both.
+    /// The pool thread transpiles under `borrow_if_running()` and is counted as
+    /// embedded work from `schedule` until it has pushed the slot back.
     pub(crate) loop_handle: crate::LoopHandle,
     pub global_this: BackRef<JSGlobalObject>,
     pub(crate) fetcher: Fetcher,
@@ -449,9 +447,8 @@ impl Fetcher {
     }
 }
 
-/// A finished job's result, moved out of its slot (`TranspilerJob::take_completion`)
-/// so the slot can be returned to the store before `AsyncModule::fulfill` runs.
-/// `specifier` and `referrer` carry the +1 that `fulfill` releases.
+/// A finished job's result, moved out of its slot so the slot can go back to
+/// the store before `AsyncModule::fulfill` runs.
 struct Completion {
     promise: JSValue,
     global_this: BackRef<JSGlobalObject>,
@@ -530,29 +527,21 @@ impl TranspilerJob {
         // replacement a second time).
     }
 
-    /// Hands the job back to the JS thread, which completes it
-    /// (`run_from_js_thread`) or releases it (`release_queued_jobs_for_teardown`);
-    /// either way it writes the slot and `put()`s it (a `Box` free once the hive
-    /// is full) as soon as the push lands. Takes the pointer, not `&mut self`: a
-    /// reference argument stays protected until its call returns, so the JS
-    /// thread would be writing to, or freeing, protected memory. The caller must
-    /// not hold a reference into `*this` across the call either.
+    /// Hands the job to the JS thread, which recycles or frees the slot as soon
+    /// as the push lands: no reference to it (a `&mut self` included, it stays
+    /// protected until the call returns) may be live across the push.
     ///
     /// # Safety
-    /// `this` is the live slot `transpile()` scheduled, still owned by the pool
-    /// thread; nothing on this thread touches `*this` afterwards.
+    /// `this` is the live slot this pool thread owns; it is not touched afterwards.
     unsafe fn dispatch_to_main_thread(this: *mut Self) {
-        // SAFETY: fn contract; both accesses end at the `;`, before the push.
+        // SAFETY: fn contract; both accesses end before the push.
         let (vm, loop_handle) = unsafe { ((*this).vm, (*this).loop_handle.clone()) };
         // SAFETY: vm outlives the job (BACKREF — VM owns the store).
         let transpiler_store: *mut RuntimeTranspilerStore =
             unsafe { ptr::addr_of_mut!((*vm).transpiler_store) };
-        // SAFETY: `this` is non-null per fn contract; the queue is
-        // concurrent-safe (UnboundedQueue uses atomics). The JS thread owns the
-        // job from here on.
+        // SAFETY: `this` is non-null (fn contract); the queue is concurrent-safe.
         unsafe { (*transpiler_store).queue.push(NonNull::new_unchecked(this)) };
-        // The VM waits for embedded work before closing its handle, so this is
-        // queued.
+        // The VM waits for embedded work before closing its handle, so this is queued.
         let crate::vm_handle::Posted::Queued =
             loop_handle.post_task(ConcurrentTask::create_from(transpiler_store))
         else {
@@ -560,19 +549,15 @@ impl TranspilerJob {
         };
     }
 
-    /// Completes the import. The slot goes back to the store first (a `Box`
-    /// free when it was heap-spilled; `fulfill` runs script, which may claim it
-    /// again), so this takes the pointer rather than a `&mut self` that would
-    /// still be protected while the slot is dropped or freed.
+    /// The slot is recycled or freed before `fulfill` runs script, so, as in
+    /// `dispatch_to_main_thread`, no reference to it may be live at that point.
     ///
     /// # Safety
-    /// `this` is a live job popped from the store queue; the caller does not
-    /// touch it afterwards.
+    /// `this` is a live job popped from the store queue; it is not touched afterwards.
     unsafe fn run_from_js_thread(this: *mut Self) -> JsResult<()> {
-        // SAFETY: fn contract; both accesses end at the `;`, before the put.
+        // SAFETY: fn contract; both accesses end before the put.
         let (vm, completion) = unsafe { ((*this).vm, (*this).take_completion()) };
-        // SAFETY: `vm` outlives the job; `this` is the slot `transpile()` claimed
-        // from this store and nothing uses it past this point.
+        // SAFETY: `vm` outlives the job; `this` came from this store's `get_init`.
         unsafe { (*vm).transpiler_store.store.put(this) };
 
         let Completion {
@@ -596,8 +581,7 @@ impl TranspilerJob {
         )
     }
 
-    /// Moves everything `AsyncModule::fulfill` needs out of the slot and
-    /// resets it, leaving only what `store.put()`'s drop glue releases.
+    /// Moves the result out of the slot and resets it for `store.put()`.
     fn take_completion(&mut self) -> Completion {
         let promise = self.promise.swap();
         let global_this = self.global_this;
@@ -607,9 +591,7 @@ impl TranspilerJob {
 
         let referrer = core::mem::take(&mut self.non_threadsafe_referrer).into_inner();
         let log = core::mem::replace(&mut self.log, bun_ast::Log::init());
-        // Take RAII ownership out of the job; `into_ffi()` in the caller
-        // transfers the +1 strings to `AsyncModule::fulfill` → C++
-        // `Zig::ResolvedSource`.
+        // The caller's `into_ffi()` transfers the +1 strings to `AsyncModule::fulfill`.
         let mut owned_resolved_source = core::mem::take(&mut self.resolved_source);
         let resolved_source = owned_resolved_source.as_mut();
         let specifier = 'brk: {
@@ -666,18 +648,16 @@ impl TranspilerJob {
         // SAFETY: as above.
         let handle = unsafe { (*this).loop_handle.clone() };
         if let Some(_vm) = handle.borrow_if_running() {
-            // SAFETY: live slot, exclusively ours until dispatched. The `&mut`
-            // this autoref forms ends with the statement, before the dispatch
-            // publishes the slot.
+            // SAFETY: live slot, exclusively ours until dispatched; the `&mut`
+            // ends with this statement.
             unsafe { (*this).run() };
         }
-        // SAFETY: as above; the dispatch is this thread's last touch of the slot.
+        // SAFETY: as above; this thread's last touch of the slot.
         unsafe { Self::dispatch_to_main_thread(this) };
         handle.embedded_work_finished();
     }
 
-    /// Fills in `resolved_source` or `parse_error`; the caller hands the job
-    /// back to the JS thread afterwards, on every return path.
+    /// Fills in `resolved_source` or `parse_error`; the caller dispatches.
     fn run(&mut self) {
         // Stack-local per call, bulk-freed on return. An earlier version hoisted
         // this to a per-worker-thread leaked `Box<MimallocArena>` (and a second

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -238,22 +238,33 @@ impl RuntimeTranspilerStore {
     /// VM teardown (JS thread, heap alive, script forbidden, embedded work
     /// waited for so no job is mid-flight): jobs whose completion will not run —
     /// queued after the last tick, or posted after `close()` began — release
-    /// their source, log and module promise here instead of running.
+    /// their source, log and module promise here instead of running. (A batch
+    /// that `run_from_js_thread` had already popped when script was terminated
+    /// is released there.)
     pub fn release_queued_jobs_for_teardown(&mut self) {
-        let batch = self.queue.pop_batch();
-        let mut iter = batch.iterator();
-        loop {
-            let job = iter.next();
-            if job.is_null() {
-                break;
-            }
-            // SAFETY: a live job popped from the intrusive queue; this thread
-            // owns it now (its worker-thread part finished before `close()`).
+        let mut iter = self.queue.pop_batch().iterator();
+        let first = iter.next();
+        self.release_unrun_jobs(first, &mut iter);
+    }
+
+    /// Releases `job` and whatever is left in `iter`: jobs whose completion
+    /// will not run drop their module promise here, on the JS thread, and go
+    /// back to the pool.
+    fn release_unrun_jobs(
+        &self,
+        mut job: *mut TranspilerJob,
+        iter: &mut unbounded_queue::BatchIterator<TranspilerJob>,
+    ) {
+        while !job.is_null() {
+            // SAFETY: a live job popped from the intrusive queue, owned by this
+            // thread since its pool-thread part pushed it; `iter` has already
+            // moved past it, and nothing else refers to it.
             unsafe {
                 (*job).promise.deinit();
                 (*job).reset_for_pool();
                 self.store.put(job);
             }
+            job = iter.next();
         }
     }
 
@@ -287,6 +298,9 @@ impl RuntimeTranspilerStore {
             if unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) }
                 .is_err()
             {
+                // Script was terminated. The rest of this batch is already off
+                // the queue, so the teardown would never see it: release it now.
+                self.release_unrun_jobs(job, &mut iter);
                 return;
             }
             // SAFETY: as for `first`.

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -238,27 +238,22 @@ impl RuntimeTranspilerStore {
     /// VM teardown (JS thread, heap alive, script forbidden, embedded work
     /// waited for so no job is mid-flight): jobs whose completion will not run —
     /// queued after the last tick, or posted after `close()` began — release
-    /// their source, log and module promise here instead of running. (A batch
-    /// that `run_from_js_thread` had already popped when script was terminated
-    /// is released there.)
+    /// their source, log and module promise here instead of running.
     pub fn release_queued_jobs_for_teardown(&mut self) {
         let mut iter = self.queue.pop_batch().iterator();
         let first = iter.next();
         self.release_unrun_jobs(first, &mut iter);
     }
 
-    /// Releases `job` and whatever is left in `iter`: jobs whose completion
-    /// will not run drop their module promise here, on the JS thread, and go
-    /// back to the pool.
+    /// Releases `job` and the rest of `iter` without running their completions.
     fn release_unrun_jobs(
         &self,
         mut job: *mut TranspilerJob,
         iter: &mut unbounded_queue::BatchIterator<TranspilerJob>,
     ) {
         while !job.is_null() {
-            // SAFETY: a live job popped from the intrusive queue, owned by this
-            // thread since its pool-thread part pushed it; `iter` has already
-            // moved past it, and nothing else refers to it.
+            // SAFETY: a live job popped from the queue, owned by this thread since
+            // the pool pushed it; `iter` has already moved past it.
             unsafe {
                 (*job).promise.deinit();
                 (*job).reset_for_pool();
@@ -298,8 +293,7 @@ impl RuntimeTranspilerStore {
             if unsafe { (*event_loop.as_ptr()).drain_microtasks_with_global(global, jsc_vm) }
                 .is_err()
             {
-                // Script was terminated. The rest of this batch is already off
-                // the queue, so the teardown would never see it: release it now.
+                // Terminated; the rest of the batch is off the queue, so only we can release it.
                 self.release_unrun_jobs(job, &mut iter);
                 return;
             }

--- a/src/jsc/RuntimeTranspilerStore.rs
+++ b/src/jsc/RuntimeTranspilerStore.rs
@@ -272,8 +272,9 @@ impl RuntimeTranspilerStore {
             return;
         }
         // we run just one job first to see if there are more
-        // SAFETY: `first` is a live job popped from the intrusive queue.
-        if let Err(err) = unsafe { (*first).run_from_js_thread() } {
+        // SAFETY: `first` is a live job popped from the intrusive queue; the
+        // batch iterator has already moved past it.
+        if let Err(err) = unsafe { TranspilerJob::run_from_js_thread(first) } {
             global.report_uncaught_exception_from_error(err);
         }
         loop {
@@ -288,8 +289,8 @@ impl RuntimeTranspilerStore {
             {
                 return;
             }
-            // SAFETY: `job` is a live job popped from the intrusive queue.
-            if let Err(err) = unsafe { (*job).run_from_js_thread() } {
+            // SAFETY: as for `first`.
+            if let Err(err) = unsafe { TranspilerJob::run_from_js_thread(job) } {
                 global.report_uncaught_exception_from_error(err);
             }
         }
@@ -448,6 +449,19 @@ impl Fetcher {
     }
 }
 
+/// A finished job's result, moved out of its slot (`TranspilerJob::take_completion`)
+/// so the slot can be returned to the store before `AsyncModule::fulfill` runs.
+/// `specifier` and `referrer` carry the +1 that `fulfill` releases.
+struct Completion {
+    promise: JSValue,
+    global_this: BackRef<JSGlobalObject>,
+    specifier: String,
+    referrer: String,
+    log: bun_ast::Log,
+    resolved_source: OwnedResolvedSource,
+    parse_error: Option<crate::CrateError>,
+}
+
 /// Per-worker output buffer. The printer is the **only** state
 /// retained across `run()` calls — its backing `Vec<u8>` is genuinely worth
 /// reusing (capped at 512 K / 2 M below). The parse arena and AST memory
@@ -485,8 +499,9 @@ fn tls_get_or_leak<T>(
 
 impl TranspilerJob {
     /// Kept as a private inherent fn (not `impl Drop`) because the
-    /// slot is recycled into the HiveArray via `store.put(this)`. Only caller is
-    /// `run_from_js_thread`.
+    /// slot is recycled into the HiveArray via `store.put(this)`. Called right
+    /// before that `put` by `take_completion` and
+    /// `release_queued_jobs_for_teardown`.
     ///
     /// Note: `HiveArrayFallback::put` runs `drop_in_place` on the slot (see
     /// hive_array.rs note), so the Drop-carrying fields — `OwnedString` ×2,
@@ -545,21 +560,56 @@ impl TranspilerJob {
         };
     }
 
-    fn run_from_js_thread(&mut self) -> JsResult<()> {
-        let vm = self.vm;
+    /// Completes the import. The slot goes back to the store first (a `Box`
+    /// free when it was heap-spilled; `fulfill` runs script, which may claim it
+    /// again), so this takes the pointer rather than a `&mut self` that would
+    /// still be protected while the slot is dropped or freed.
+    ///
+    /// # Safety
+    /// `this` is a live job popped from the store queue; the caller does not
+    /// touch it afterwards.
+    unsafe fn run_from_js_thread(this: *mut Self) -> JsResult<()> {
+        // SAFETY: fn contract; both accesses end at the `;`, before the put.
+        let (vm, completion) = unsafe { ((*this).vm, (*this).take_completion()) };
+        // SAFETY: `vm` outlives the job; `this` is the slot `transpile()` claimed
+        // from this store and nothing uses it past this point.
+        unsafe { (*vm).transpiler_store.store.put(this) };
+
+        let Completion {
+            promise,
+            global_this,
+            specifier,
+            referrer,
+            mut log,
+            resolved_source,
+            parse_error,
+        } = completion;
+        let mut resolved_source = resolved_source.into_ffi();
+        AsyncModule::fulfill(
+            &global_this,
+            promise,
+            &mut resolved_source,
+            parse_error,
+            specifier,
+            referrer,
+            &mut log,
+        )
+    }
+
+    /// Moves everything `AsyncModule::fulfill` needs out of the slot and
+    /// resets it, leaving only what `store.put()`'s drop glue releases.
+    fn take_completion(&mut self) -> Completion {
         let promise = self.promise.swap();
-        // Copy the BackRef out (it is `Copy`) so the borrow of `*self` ends
-        // before `reset_for_pool`/`put` need `&mut *self` below; deref at the
-        // `fulfill` call site instead.
         let global_this = self.global_this;
         // Note: the KeepAlive takes an `EventLoopCtx`
         // vtable; resolve it via the `get_vm_ctx` hook (registered by `bun_runtime::init`).
         self.poll_ref.unref(get_vm_ctx(AllocatorType::Js));
 
         let referrer = core::mem::take(&mut self.non_threadsafe_referrer).into_inner();
-        let mut log = core::mem::replace(&mut self.log, bun_ast::Log::init());
-        // Take RAII ownership out of the job; `into_ffi()` below transfers the
-        // +1 strings to `AsyncModule::fulfill` → C++ `Zig::ResolvedSource`.
+        let log = core::mem::replace(&mut self.log, bun_ast::Log::init());
+        // Take RAII ownership out of the job; `into_ffi()` in the caller
+        // transfers the +1 strings to `AsyncModule::fulfill` → C++
+        // `Zig::ResolvedSource`.
         let mut owned_resolved_source = core::mem::take(&mut self.resolved_source);
         let resolved_source = owned_resolved_source.as_mut();
         let specifier = 'brk: {
@@ -581,24 +631,15 @@ impl TranspilerJob {
         self.promise.deinit();
         self.reset_for_pool();
 
-        // SAFETY: vm outlives the job; transpiler_store.store.put recycles the slot.
-        unsafe {
-            (*vm)
-                .transpiler_store
-                .store
-                .put(std::ptr::from_mut::<TranspilerJob>(self))
-        };
-
-        let mut resolved_source = owned_resolved_source.into_ffi();
-        AsyncModule::fulfill(
-            &global_this,
+        Completion {
             promise,
-            &mut resolved_source,
-            parse_error,
+            global_this,
             specifier,
             referrer,
-            &mut log,
-        )
+            log,
+            resolved_source: owned_resolved_source,
+            parse_error,
+        }
     }
 
     fn schedule(&mut self) {

--- a/test/internal/source-lints/self-receiver-push-put.test.ts
+++ b/test/internal/source-lints/self-receiver-push-put.test.ts
@@ -4,61 +4,69 @@ import { realpathSync } from "fs";
 import path from "path";
 import { globAllSources } from "../../../scripts/glob-sources.ts";
 
-// A method must not push its own receiver onto a queue. Inside a `&mut self`
-// method, the receiver's address
+// A method must not push its own receiver onto a queue or put it back into its
+// pool. Inside a `&mut self` method, the receiver's address
 //
 //   queue.push(NonNull::from(&mut *self))
+//   store.put(ptr::from_mut(self))
 //   let job = NonNull::from(&mut *self); ... queue.push(job)
 //   let p: *mut Self = self;             ... queue.push(NonNull::new_unchecked(p))
 //
-// as the argument of a `.push(..)` is banned.
+// as the argument of a `.push(..)` or `.put(..)` is banned.
 //
-// The push is the hand-over: it is how a pool thread gives a finished job
-// back to the thread that owns it (`UnboundedQueue::push`, then a wakeup).
-// From the moment it lands the consumer writes to the object or frees it (the
-// runtime transpiler store `put()`s the slot back into its hive, a `Box` free
-// once the hive is full; the package manager reclaims the `Box` a patch task
-// lives in), and it does so while the `self` of the method that pushed is
-// still a live argument. A reference argument is protected for the duration
-// of its call, and writing to or deallocating protected memory is UB under
-// both aliasing models whether or not the method touches `self` again: Tree
-// Borrows (what `bun run rust:miri` uses) reports "deallocation through <tag>
-// is forbidden ... the strongly protected tag disallows deallocations" or a
-// data race on the protector's release, pointing at the receiver; Stacked
-// Borrows reports "deallocating while item [Unique] is strongly protected".
-// Codegen relies on the same guarantee: a `&mut self` argument is
-// `noalias dereferenceable` for the whole call, so the compiler is free to
-// re-read a field through it after the push instead of keeping the copy taken
-// before; a read after the push (spelled out in the source, there) is what
-// crashed the Zig version of the transpiler store (#29128).
+// Both calls give the receiver's storage away. A push is how a pool thread
+// hands a finished job back to the thread that owns it (`UnboundedQueue::push`,
+// then a wakeup); from the moment it lands the consumer writes to the object or
+// frees it (the package manager reclaims the `Box` a patch task lives in). A
+// `put` returns a slot to its hive (`HiveArrayFallback::put`), which drops it
+// in place, or frees it when it was a heap spill, before returning. Either way
+// the `self` of the method that made the call is still a live argument while
+// that happens. A reference argument is protected for the duration of its
+// call, and writing to or deallocating protected memory is UB under both
+// aliasing models whether or not the method touches `self` again: Tree Borrows
+// (what `bun run rust:miri` uses) reports "deallocation through <tag> is
+// forbidden ... the strongly protected tag disallows deallocations" or, for the
+// cross-thread writes, a data race on the protector's release, pointing at the
+// receiver; Stacked Borrows reports "deallocating while item [Unique] is
+// strongly protected". Codegen relies on the same guarantee: a `&mut self`
+// argument is `noalias dereferenceable` for the whole call, so the compiler is
+// free to re-read a field through it after the call instead of keeping the copy
+// taken before; a read after the push (spelled out in the source, there) is
+// what crashed the Zig version of the transpiler store (#29128).
 // `TranspilerJob::dispatch_to_main_thread(&mut self)` (reached from inside
-// `run(&mut self)` via a scope guard, so two protected frames deep) and
-// `PatchTask::run_from_thread_pool_impl(&mut self)` were the instances this
+// `run(&mut self)` via a scope guard, so two protected frames deep),
+// `TranspilerJob::run_from_js_thread(&mut self)` (the `put` of the same slot)
+// and `PatchTask::run_from_thread_pool_impl(&mut self)` were the instances this
 // was written for.
 //
 // The object was a raw pointer in the caller's hands before it became `self`
-// (the pool recovers it from the intrusive task field), so the fix is to keep
-// it one: run the body through a statement-scoped reborrow (`(*this).run();`),
-// read whatever the hand-over needs through `(*this).field` accesses that end
-// before the push, push `this`, and never touch it again. Templates:
-// `TranspilerJob::run_from_worker_thread` / `dispatch_to_main_thread` in
+// (the pool recovers it from the intrusive task field, the queue pops it), so
+// the fix is to keep it one: run the body through a statement-scoped reborrow
+// (`(*this).run();`, `(*this).take_completion()`), read whatever comes after
+// through `(*this).field` accesses that end before the call, push or put
+// `this`, and never touch it again. Templates: `TranspilerJob::
+// run_from_worker_thread` / `dispatch_to_main_thread` / `run_from_js_thread` in
 // src/jsc/RuntimeTranspilerStore.rs, `PatchTask::run_from_thread_pool` in
 // src/install/patch_install.rs, `NetworkTask::notify` in
 // src/install/NetworkTask.rs, `Task::callback` in src/install/PackageManagerTask.rs.
 //
 // Scope: the exclusive spellings below (`from_mut(self)`, `&mut *self`,
 // `&raw mut *self`, `self as *mut _`, ...), with `self` as the receiver and
-// `.push(` as the callee, inline or through a local of the same function.
-// Outside it: the shared spellings (`from_ref(self)`, `&*self`; what this tree
-// pushes from a `&self` method is a same-thread registry entry, quic's
-// `ENDPOINT_REGISTRY`, whose consumer neither writes nor frees), a pointer
-// produced by a helper (`self.as_ptr()`), something the receiver owns
-// (`NonNull::from(&mut self.task)`, `&raw mut self.task`), and reference
-// parameters other than `self` (`fn f(this: &mut Task)` pushing
+// `.push(` / `.put(` as the callee, inline or through a local of the same
+// function. Outside it: the shared spellings (`from_ref(self)`, `&*self`; what
+// this tree pushes from a `&self` method is a same-thread registry entry,
+// quic's `ENDPOINT_REGISTRY`, whose consumer neither writes nor frees), a bare
+// `self` argument (the `put(self, ..)` map inserts and `err.put(global, ..)`
+// property writes, where `self` is a key or a context, not storage being given
+// away), a pointer produced by a helper (`self.as_ptr()`), something the
+// receiver owns (`NonNull::from(&mut self.task)`, `&raw mut self.task`), and
+// reference parameters other than `self` (`fn f(this: &mut Task)` pushing
 // `NonNull::from(this)`; a local reference is not protected and the push moves
 // it, but a reference *parameter* pushed that way is the same bug, convert it
-// on sight). Siblings: self-receiver-reclaim.test.ts,
-// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+// on sight). Other helpers that free their argument (`Self::destroy(..)`) are
+// the population self-receiver-reclaim.test.ts names as outside its scope.
+// Siblings: self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
+// frozen-nonnull-reborrow.test.ts.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
@@ -76,10 +84,10 @@ const tracked: Set<string> | null = (() => {
   return new Set(r.stdout.toString().split("\0").filter(Boolean));
 })();
 
-// The publish. Anchored on the argument below, so the `Vec::push` calls all
-// over the tree only count when what is pushed is the receiver's address.
-// `\s*` after the paren so a rustfmt-wrapped argument still matches.
-const PUSH = String.raw`\.\s*push\s*\(\s*`;
+// The hand-over. Anchored on the argument below, so the `Vec::push` and map
+// `put` calls all over the tree only count when the argument is the receiver's
+// address. `\s*` after the paren so a rustfmt-wrapped argument still matches.
+const HAND_OVER = String.raw`\.\s*(?:push|put)\s*\(\s*`;
 
 // Optional path in front of an item (`core::ptr::NonNull`, `std::ptr::from_mut`).
 const PATH = String.raw`(?:[\w:]+::)?`;
@@ -113,11 +121,11 @@ const SAME_ADDRESS = String.raw`(?:\s*\.\s*(?:cast(?:_mut|_const)?${TURBOFISH}\(
 // this shape, and neither is `.push(p.field)` for a binding `p` below.
 const ARG_END = String.raw`\s*[,)]`;
 
-const DIRECT = new RegExp(`${PUSH}${SELF_AS_POINTER}${SAME_ADDRESS}${ARG_END}`, "g");
+const DIRECT = new RegExp(`${HAND_OVER}${SELF_AS_POINTER}${SAME_ADDRESS}${ARG_END}`, "g");
 
-// A local bound to the receiver's address, then pushed further down the same
-// function (which ends at the next `fn` item; a closure inside it is the same
-// function for this purpose). `let p: *mut Self = self;` is the coercion
+// A local bound to the receiver's address, then handed over further down the
+// same function (which ends at the next `fn` item; a closure inside it is the
+// same function for this purpose). `let p: *mut Self = self;` is the coercion
 // spelling; without the annotation `let p = self;` is just another reference.
 const BINDING_HEAD = String.raw`\blet\s+(?:mut\s+)?(\w+)\s*`;
 const SELF_POINTER_BINDINGS = [
@@ -126,14 +134,14 @@ const SELF_POINTER_BINDINGS = [
 ];
 const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s+\w+/m;
 
-// The binding pushed as is, or wrapped into a `NonNull` at the push.
-function pushOfBinding(name: string): RegExp {
+// The binding passed as is, or wrapped into a `NonNull` at the call.
+function handOverOfBinding(name: string): RegExp {
   const wrapped = String.raw`${PATH}NonNull::(?:new_unchecked|new|from)${TURBOFISH}\(\s*${name}${SAME_ADDRESS}\s*\)`;
-  return new RegExp(`${PUSH}(?:${wrapped}|\\b${name})${SAME_ADDRESS}${ARG_END}`);
+  return new RegExp(`${HAND_OVER}(?:${wrapped}|\\b${name})${SAME_ADDRESS}${ARG_END}`);
 }
 
-/** Byte offsets (into `stripped`) of every banned push in one file. */
-function findPushes(stripped: string): number[] {
+/** Byte offsets (into `stripped`) of every banned hand-over in one file. */
+function findHandOvers(stripped: string): number[] {
   const hits: number[] = [];
   for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
   for (const pattern of SELF_POINTER_BINDINGS) {
@@ -142,8 +150,8 @@ function findPushes(stripped: string): number[] {
       const rest = stripped.slice(start);
       const fnEnd = rest.search(FN_ITEM);
       const body = fnEnd === -1 ? rest : rest.slice(0, fnEnd);
-      const push = body.search(pushOfBinding(binding[1]));
-      if (push !== -1) hits.push(start + push);
+      const call = body.search(handOverOfBinding(binding[1]));
+      if (call !== -1) hits.push(start + call);
     }
   }
   return hits.sort((a, b) => a - b);
@@ -153,6 +161,20 @@ function lineOf(text: string, offset: number): number {
   return text.slice(0, offset).split("\n").length;
 }
 
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape. Lower an entry when you convert one; do not add entries.
+const ALLOW: Record<string, number> = {
+  // `FilePoll::deinit_possibly_defer(&mut self, ..)` puts its own slot back
+  // (`Store::put`, which recycles it at once, freeing it if it was a heap
+  // spill, when the poll was never registered; otherwise it is queued and
+  // freed after the event loop turn). Every `FilePoll::deinit*` entry point is
+  // `&mut self` and reached from many owners, so the conversion is a change of
+  // its own; tracked separately.
+  "src/io/posix_event_loop.rs": 1,
+  "src/io/windows_event_loop.rs": 1,
+};
+
+const counts: Record<string, number> = {};
 const offenders: string[] = [];
 let scanned = 0;
 for (const abs of rustSources) {
@@ -167,8 +189,11 @@ for (const abs of rustSources) {
   // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
   // newlines and would swallow blank lines, shifting the reported line numbers.
   const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
-  for (const offset of findPushes(stripped)) {
-    offenders.push(`${source}:${lineOf(stripped, offset)}`);
+  for (const offset of findHandOvers(stripped)) {
+    counts[source] = (counts[source] ?? 0) + 1;
+    if (counts[source] > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${lineOf(stripped, offset)}`);
+    }
   }
 }
 
@@ -184,6 +209,13 @@ test("the patterns match the banned spellings and nothing else", () => {
     "let job = NonNull::from(&mut *self);\nunsafe { (*transpiler_store).queue.push(job) };",
     // `PatchTask::run_from_thread_pool_impl(&mut self)` as it was.
     "unsafe {\n    (*mgr)\n        .patch_task_queue\n        .push(core::ptr::NonNull::from(&mut *self));\n    PackageManager::wake_raw(mgr);\n}",
+    // `TranspilerJob::run_from_js_thread(&mut self)` as it was.
+    "unsafe {\n    (*vm)\n        .transpiler_store\n        .store\n        .put(std::ptr::from_mut::<TranspilerJob>(self))\n};",
+    "pool.put(self as *mut Self);",
+    "let slot = ptr::from_mut(self);\nunsafe { (*store).put(slot) };",
+    // The allowlisted `FilePoll::deinit_possibly_defer`, posix and windows spellings.
+    "let this = ptr::NonNull::from(self);\nvm.file_polls_mut().put(this, vm, was_ever_registered);",
+    "let this: ptr::NonNull<FilePoll> = ptr::NonNull::from(&mut *self);\nvm.file_polls_mut().put(this, vm, was_ever_registered);",
     // Other spellings of the same thing.
     "queue.push(NonNull::from(self));",
     "queue.push(core::ptr::NonNull::from(&mut  *self));",
@@ -204,8 +236,14 @@ test("the patterns match the banned spellings and nothing else", () => {
     // The raw-pointer shape the fix produces.
     "unsafe { (*transpiler_store).queue.push(NonNull::new_unchecked(this)) };",
     "(*mgr)\n    .patch_task_queue\n    .push(core::ptr::NonNull::new_unchecked(this));",
+    "unsafe { (*vm).transpiler_store.store.put(this) };",
+    "self.store.put(job);",
     // A local reference parameter, moved into the push.
     "installer.task_queue.push(core::ptr::NonNull::from(this));",
+    // `self` as a key or a context, not as storage.
+    "bun_core::handle_oom(handles.put(self, ()));",
+    'err.put(self, b"name", name_value);',
+    "unsafe { self.owner.put(self.slot.as_ptr()) };",
     // Something the receiver owns.
     "queue.push(NonNull::from(&mut *self.inner));",
     "queue.push(NonNull::from(&mut self.task));",
@@ -227,10 +265,17 @@ test("the patterns match the banned spellings and nothing else", () => {
     // The binding's function ends before the push.
     "let this = std::ptr::from_mut(self);\n    }\n\n    fn other(&mut self, this: NonNull<Job>) {\n        self.queue.push(this);",
   ];
-  expect(banned.filter(s => findPushes(s).length === 0)).toEqual([]);
-  expect(allowed.filter(s => findPushes(s).length !== 0)).toEqual([]);
+  expect(banned.filter(s => findHandOvers(s).length === 0)).toEqual([]);
+  expect(allowed.filter(s => findHandOvers(s).length !== 0)).toEqual([]);
 });
 
-test("no method pushes its own receiver onto a queue", () => {
+test("no method pushes or puts its own receiver", () => {
   expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: once an allowlisted instance is converted, delete its entry so
+  // a new one cannot take its place.
+  const actual = Object.fromEntries(Object.keys(ALLOW).map(f => [f, counts[f] ?? 0]));
+  expect(actual).toEqual(ALLOW);
 });

--- a/test/internal/source-lints/self-receiver-push-put.test.ts
+++ b/test/internal/source-lints/self-receiver-push-put.test.ts
@@ -169,7 +169,7 @@ const ALLOW: Record<string, number> = {
   // spill, when the poll was never registered; otherwise it is queued and
   // freed after the event loop turn). Every `FilePoll::deinit*` entry point is
   // `&mut self` and reached from many owners, so the conversion is a change of
-  // its own; tracked separately.
+  // its own: #37803. Delete both entries when it lands.
   "src/io/posix_event_loop.rs": 1,
   "src/io/windows_event_loop.rs": 1,
 };

--- a/test/internal/source-lints/self-receiver-queue-push.test.ts
+++ b/test/internal/source-lints/self-receiver-queue-push.test.ts
@@ -1,0 +1,236 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A method must not push its own receiver onto a queue. Inside a `&mut self`
+// method, the receiver's address
+//
+//   queue.push(NonNull::from(&mut *self))
+//   let job = NonNull::from(&mut *self); ... queue.push(job)
+//   let p: *mut Self = self;             ... queue.push(NonNull::new_unchecked(p))
+//
+// as the argument of a `.push(..)` is banned.
+//
+// The push is the hand-over: it is how a pool thread gives a finished job
+// back to the thread that owns it (`UnboundedQueue::push`, then a wakeup).
+// From the moment it lands the consumer writes to the object or frees it (the
+// runtime transpiler store `put()`s the slot back into its hive, a `Box` free
+// once the hive is full; the package manager reclaims the `Box` a patch task
+// lives in), and it does so while the `self` of the method that pushed is
+// still a live argument. A reference argument is protected for the duration
+// of its call, and writing to or deallocating protected memory is UB under
+// both aliasing models whether or not the method touches `self` again: Tree
+// Borrows (what `bun run rust:miri` uses) reports "deallocation through <tag>
+// is forbidden ... the strongly protected tag disallows deallocations" or a
+// data race on the protector's release, pointing at the receiver; Stacked
+// Borrows reports "deallocating while item [Unique] is strongly protected".
+// Codegen relies on the same guarantee: a `&mut self` argument is
+// `noalias dereferenceable` for the whole call, so the compiler is free to
+// re-read a field through it after the push instead of keeping the copy taken
+// before; a read after the push (spelled out in the source, there) is what
+// crashed the Zig version of the transpiler store (#29128).
+// `TranspilerJob::dispatch_to_main_thread(&mut self)` (reached from inside
+// `run(&mut self)` via a scope guard, so two protected frames deep) and
+// `PatchTask::run_from_thread_pool_impl(&mut self)` were the instances this
+// was written for.
+//
+// The object was a raw pointer in the caller's hands before it became `self`
+// (the pool recovers it from the intrusive task field), so the fix is to keep
+// it one: run the body through a statement-scoped reborrow (`(*this).run();`),
+// read whatever the hand-over needs through `(*this).field` accesses that end
+// before the push, push `this`, and never touch it again. Templates:
+// `TranspilerJob::run_from_worker_thread` / `dispatch_to_main_thread` in
+// src/jsc/RuntimeTranspilerStore.rs, `PatchTask::run_from_thread_pool` in
+// src/install/patch_install.rs, `NetworkTask::notify` in
+// src/install/NetworkTask.rs, `Task::callback` in src/install/PackageManagerTask.rs.
+//
+// Scope: the exclusive spellings below (`from_mut(self)`, `&mut *self`,
+// `&raw mut *self`, `self as *mut _`, ...), with `self` as the receiver and
+// `.push(` as the callee, inline or through a local of the same function.
+// Outside it: the shared spellings (`from_ref(self)`, `&*self`; what this tree
+// pushes from a `&self` method is a same-thread registry entry, quic's
+// `ENDPOINT_REGISTRY`, whose consumer neither writes nor frees), a pointer
+// produced by a helper (`self.as_ptr()`), something the receiver owns
+// (`NonNull::from(&mut self.task)`, `&raw mut self.task`), and reference
+// parameters other than `self` (`fn f(this: &mut Task)` pushing
+// `NonNull::from(this)`; a local reference is not protected and the push moves
+// it, but a reference *parameter* pushed that way is the same bug, convert it
+// on sight). Siblings: self-receiver-reclaim.test.ts,
+// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// The publish. Anchored on the argument below, so the `Vec::push` calls all
+// over the tree only count when what is pushed is the receiver's address.
+// `\s*` after the paren so a rustfmt-wrapped argument still matches.
+const PUSH = String.raw`\.\s*push\s*\(\s*`;
+
+// Optional path in front of an item (`core::ptr::NonNull`, `std::ptr::from_mut`).
+const PATH = String.raw`(?:[\w:]+::)?`;
+const TURBOFISH = String.raw`(?:::<[^>]*>)?`;
+
+// `self` as a `*mut`. The `&raw` form needs the `(?!\s*\.)` so
+// `&raw mut *self.field` (something the receiver owns) stays out; `self as`
+// swallows the pointer type that follows.
+const SELF_AS_RAW = [
+  String.raw`${PATH}from_mut${TURBOFISH}\(\s*self\s*\)`,
+  String.raw`self\s+as\s+\*mut\b[^,;)]*`,
+  String.raw`&raw\s+mut\s+\*\s*self\b(?!\s*\.)`,
+  String.raw`${PATH}addr_of_mut!\s*\(\s*\*\s*self\s*\)`,
+].join("|");
+
+// `self` as a `NonNull`: from the reference itself (`NonNull::from(self)`,
+// `NonNull::from(&mut *self)`; the `\)` right after `self` keeps
+// `NonNull::from(&mut *self.field)` out) or wrapped around a raw spelling.
+const SELF_AS_NONNULL = [
+  String.raw`${PATH}NonNull::from\(\s*(?:&\s*mut\s+\*\s*)?self\s*\)`,
+  String.raw`${PATH}NonNull::(?:new_unchecked|new)${TURBOFISH}\(\s*(?:${SELF_AS_RAW})\s*\)`,
+].join("|");
+
+const SELF_AS_POINTER = `(?:${SELF_AS_RAW}|${SELF_AS_NONNULL})`;
+
+// Method calls that keep the address: how a `NonNull::new(..)` is unwrapped
+// and how a binding is adapted to the queue's element type.
+const SAME_ADDRESS = String.raw`(?:\s*\.\s*(?:cast(?:_mut|_const)?${TURBOFISH}\(\)|as_ptr\(\)|unwrap\(\)|expect\([^)]*\)))*`;
+
+// The argument has to end there: `.push(NonNull::from(self).foo)` is not
+// this shape, and neither is `.push(p.field)` for a binding `p` below.
+const ARG_END = String.raw`\s*[,)]`;
+
+const DIRECT = new RegExp(`${PUSH}${SELF_AS_POINTER}${SAME_ADDRESS}${ARG_END}`, "g");
+
+// A local bound to the receiver's address, then pushed further down the same
+// function (which ends at the next `fn` item; a closure inside it is the same
+// function for this purpose). `let p: *mut Self = self;` is the coercion
+// spelling; without the annotation `let p = self;` is just another reference.
+const BINDING_HEAD = String.raw`\blet\s+(?:mut\s+)?(\w+)\s*`;
+const SELF_POINTER_BINDINGS = [
+  new RegExp(`${BINDING_HEAD}(?::[^=;]*)?=\\s*${SELF_AS_POINTER}${SAME_ADDRESS}\\s*;`, "g"),
+  new RegExp(`${BINDING_HEAD}:\\s*\\*(?:mut|const)\\b[^=;]*=\\s*self\\s*;`, "g"),
+];
+const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s+\w+/m;
+
+// The binding pushed as is, or wrapped into a `NonNull` at the push.
+function pushOfBinding(name: string): RegExp {
+  const wrapped = String.raw`${PATH}NonNull::(?:new_unchecked|new|from)${TURBOFISH}\(\s*${name}${SAME_ADDRESS}\s*\)`;
+  return new RegExp(`${PUSH}(?:${wrapped}|\\b${name})${SAME_ADDRESS}${ARG_END}`);
+}
+
+/** Byte offsets (into `stripped`) of every banned push in one file. */
+function findPushes(stripped: string): number[] {
+  const hits: number[] = [];
+  for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
+  for (const pattern of SELF_POINTER_BINDINGS) {
+    for (const binding of stripped.matchAll(pattern)) {
+      const start = binding.index + binding[0].length;
+      const rest = stripped.slice(start);
+      const fnEnd = rest.search(FN_ITEM);
+      const body = fnEnd === -1 ? rest : rest.slice(0, fnEnd);
+      const push = body.search(pushOfBinding(binding[1]));
+      if (push !== -1) hits.push(start + push);
+    }
+  }
+  return hits.sort((a, b) => a - b);
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including the in-tree comments
+  // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
+  // newlines and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const offset of findPushes(stripped)) {
+    offenders.push(`${source}:${lineOf(stripped, offset)}`);
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the patterns match the banned spellings and nothing else", () => {
+  const banned = [
+    // `TranspilerJob::dispatch_to_main_thread(&mut self)` as it was.
+    "let job = NonNull::from(&mut *self);\nunsafe { (*transpiler_store).queue.push(job) };",
+    // `PatchTask::run_from_thread_pool_impl(&mut self)` as it was.
+    "unsafe {\n    (*mgr)\n        .patch_task_queue\n        .push(core::ptr::NonNull::from(&mut *self));\n    PackageManager::wake_raw(mgr);\n}",
+    // Other spellings of the same thing.
+    "queue.push(NonNull::from(self));",
+    "queue.push(core::ptr::NonNull::from(&mut  *self));",
+    "queue.push(NonNull::new_unchecked(std::ptr::from_mut::<Self>(self)));",
+    "queue.push(NonNull::new(self as *mut Self).unwrap());",
+    "queue.push(core::ptr::NonNull::new_unchecked(&raw mut *self));",
+    "queue.push(NonNull::new_unchecked(ptr::addr_of_mut!(*self)).cast());",
+    "pending.push(ptr::from_mut(self));",
+    "pending.push(self as *mut Self as *mut c_void);",
+    "pending.push(\n    NonNull::from(&mut *self),\n);",
+    // Through a local.
+    "let this = std::ptr::from_mut::<Self>(self);\nlet x = 1;\nqueue.push(NonNull::new_unchecked(this));",
+    "let this: *mut Self = self;\nif done {\n    return;\n}\nqueue.push(NonNull::new(this).unwrap());",
+    "let this = NonNull::from(self).cast::<Job>();\nqueue.push(this.cast());",
+    "let mut this = NonNull::from(&mut *self);\n(*vm).store.queue.push(this, );",
+  ];
+  const allowed = [
+    // The raw-pointer shape the fix produces.
+    "unsafe { (*transpiler_store).queue.push(NonNull::new_unchecked(this)) };",
+    "(*mgr)\n    .patch_task_queue\n    .push(core::ptr::NonNull::new_unchecked(this));",
+    // A local reference parameter, moved into the push.
+    "installer.task_queue.push(core::ptr::NonNull::from(this));",
+    // Something the receiver owns.
+    "queue.push(NonNull::from(&mut *self.inner));",
+    "queue.push(NonNull::from(&mut self.task));",
+    "batch.push(Batch::from(&raw mut self.task));",
+    "batch.push(Batch::from(core::ptr::addr_of_mut!(self.task)));",
+    "self.tasks.push(NonNull::new_unchecked(concurrent));",
+    "self.entries.push(item);",
+    "out.push(self.len);",
+    "let job = NonNull::from(&mut *self.job);\nqueue.push(job);",
+    // A helper-produced pointer and the shared spellings are out of scope.
+    "queue.push(self.as_non_null());",
+    "queue.push(NonNull::from(&*self));",
+    "let me = core::ptr::from_ref(self).cast_mut();\nENDPOINT_REGISTRY.with_borrow_mut(|v| {\n    if !v.contains(&me) {\n        v.push(me);\n    }\n});",
+    // A self pointer that is not pushed, or whose name is only a prefix of
+    // what is pushed.
+    "let this = std::ptr::from_mut(self);\nSelf::finalize(this);",
+    "let this = std::ptr::from_mut(self);\nqueue.push(this_task);",
+    "let this = std::ptr::from_mut(self);\nqueue.push(NonNull::from(&mut (*this).task));",
+    // The binding's function ends before the push.
+    "let this = std::ptr::from_mut(self);\n    }\n\n    fn other(&mut self, this: NonNull<Job>) {\n        self.queue.push(this);",
+  ];
+  expect(banned.filter(s => findPushes(s).length === 0)).toEqual([]);
+  expect(allowed.filter(s => findPushes(s).length !== 0)).toEqual([]);
+});
+
+test("no method pushes its own receiver onto a queue", () => {
+  expect(offenders).toEqual([]);
+});

--- a/test/js/bun/resolve/concurrent-dynamic-import.test.ts
+++ b/test/js/bun/resolve/concurrent-dynamic-import.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { bunEnv, bunExe, isDebug, tempDir } from "harness";
+import { join } from "path";
 
 // Two dynamic imports of the same specifier issued before the first async
 // transpile/fetch settles must both resolve. Under the new C++ module loader
@@ -32,13 +33,15 @@ test.concurrent("concurrent dynamic imports of the same module both resolve", as
 });
 
 // All of these import()s claim their transpiler-store job before the first one
-// is handed back, so they overflow the store's 64-slot hive
-// (TRANSPILER_JOB_HIVE_CAP in src/jsc/RuntimeTranspilerStore.rs): the spilled
-// jobs are freed, not recycled, when the JS thread takes them back. The ones
-// that fail to parse reach that hand-back through the transpiler's early
-// return. Every import must settle with its own module's result.
+// is handed back, so they overflow the store's inline hive: the spilled jobs
+// are freed, not recycled, when the JS thread takes them back. The ones that
+// fail to parse reach that hand-back through the transpiler's early return.
+// Every import must settle with its own module's result, and (debug builds log
+// each job the store takes on) every one of them must have gone through the
+// store rather than the on-thread fallback, or the test exercises nothing.
 test.concurrent("more concurrent dynamic imports than the transpiler store keeps inline all settle", async () => {
-  const count = 96;
+  const hiveCap = 64; // TRANSPILER_JOB_HIVE_CAP in src/jsc/RuntimeTranspilerStore.rs
+  const count = hiveCap + 32;
   const failsToParse = (i: number) => i % 8 === 7;
   const files: Record<string, string> = {
     "entry.mjs": `
@@ -60,11 +63,12 @@ test.concurrent("more concurrent dynamic imports than the transpiler store keeps
       : `export const value = ${i};`;
   }
   using dir = tempDir("many-concurrent-dyn-imports", files);
+  const debugLog = join(String(dir), "debug.log");
 
   await using proc = Bun.spawn({
     cmd: [bunExe(), "entry.mjs"],
     cwd: String(dir),
-    env: bunEnv,
+    env: { ...bunEnv, ...(isDebug ? { BUN_DEBUG: debugLog, BUN_DEBUG_RuntimeTranspilerStore: "1" } : {}) },
     stdio: ["ignore", "pipe", "pipe"],
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
@@ -73,4 +77,8 @@ test.concurrent("more concurrent dynamic imports than the transpiler store keeps
   );
   expect(stderr).toBe("");
   expect(exitCode).toBe(0);
+  if (isDebug) {
+    const log = await Bun.file(debugLog).text();
+    expect(log.split("transpile(").length - 1).toBe(count);
+  }
 });

--- a/test/js/bun/resolve/concurrent-dynamic-import.test.ts
+++ b/test/js/bun/resolve/concurrent-dynamic-import.test.ts
@@ -6,7 +6,7 @@ import { bunEnv, bunExe, tempDir } from "harness";
 // each call gets its own embedder fetch promise (the registry entry is created
 // only after the first fetch settles), so the loser of that race must still be
 // resolved by Bun__onFulfillAsyncModule rather than left pending forever.
-test("concurrent dynamic imports of the same module both resolve", async () => {
+test.concurrent("concurrent dynamic imports of the same module both resolve", async () => {
   using dir = tempDir("concurrent-dyn-import", {
     "shared.ts": `export const heavy = "H";`,
     "modules.ts": `import { heavy } from "./shared";\nexport const lazy = heavy + "-lazy";`,
@@ -28,5 +28,49 @@ test("concurrent dynamic imports of the same module both resolve", async () => {
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   expect(stdout.trim()).toBe("ok");
+  expect(exitCode).toBe(0);
+});
+
+// All of these import()s claim their transpiler-store job before the first one
+// is handed back, so they overflow the store's 64-slot hive
+// (TRANSPILER_JOB_HIVE_CAP in src/jsc/RuntimeTranspilerStore.rs): the spilled
+// jobs are freed, not recycled, when the JS thread takes them back. The ones
+// that fail to parse reach that hand-back through the transpiler's early
+// return. Every import must settle with its own module's result.
+test.concurrent("more concurrent dynamic imports than the transpiler store keeps inline all settle", async () => {
+  const count = 96;
+  const failsToParse = (i: number) => i % 8 === 7;
+  const files: Record<string, string> = {
+    "entry.mjs": `
+      const settled = await Promise.allSettled(
+        Array.from({ length: ${count} }, (_, i) => import("./mod" + i + ".ts")),
+      );
+      console.log(
+        JSON.stringify(
+          settled.map(r =>
+            r.status === "fulfilled" ? r.value.value : r.reason.name + ":" + r.reason.errors[0].constructor.name,
+          ),
+        ),
+      );
+    `,
+  };
+  for (let i = 0; i < count; i++) {
+    files[`mod${i}.ts`] = failsToParse(i)
+      ? `export const value: number = ${i}; export {`
+      : `export const value = ${i};`;
+  }
+  using dir = tempDir("many-concurrent-dyn-imports", files);
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "entry.mjs"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(JSON.parse(stdout)).toEqual(
+    Array.from({ length: count }, (_, i) => (failsToParse(i) ? "AggregateError:BuildMessage" : i)),
+  );
+  expect(stderr).toBe("");
   expect(exitCode).toBe(0);
 });

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -536,6 +536,38 @@ describe("web worker", () => {
       expect(stdout).toBe("PASS\n");
       expect(exitCode).toBe(0);
     });
+
+    // The worker's import()s are transpiled on the thread pool, in job slots
+    // that live inside the worker's VM. Terminating it while they are in flight
+    // makes the pool hand the remaining jobs back untranspiled and the teardown
+    // release them. Three workers per round share the pool, so part of each
+    // round's jobs is still queued when terminate() lands; the 0-3ms stagger
+    // varies how much.
+    test("terminate() while the worker's imports are still being transpiled", async () => {
+      const modules = 96;
+      const files: Record<string, string> = {
+        "worker.js": `for (let i = 0; i < ${modules}; i++) import("./mod" + i + ".js").catch(() => {});
+          postMessage("importing");`,
+      };
+      for (let i = 0; i < modules; i++) files[`mod${i}.js`] = `export const value = ${i};`;
+      using dir = tempDir("worker-transpile-churn", files);
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `for (let r = 0; r < 2; r++) await Promise.all(Array.from({ length: 3 }, (_, i) => new Promise(res => {
+             const w = new Worker(process.argv[1]); w.addEventListener("close", res);
+             w.onmessage = () => setTimeout(() => w.terminate(), (r + i) % 4) })));
+           console.log("PASS");`,
+          path.join(String(dir), "worker.js"),
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "PASS\n", stderr: "", exitCode: 0 });
+    });
   });
 });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { once } from "events";
-import { bunEnv, bunExe, tempDir } from "harness";
+import { readFileSync } from "fs";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, tempDir } from "harness";
 import path from "path";
 import wt from "worker_threads";
 
@@ -537,37 +538,71 @@ describe("web worker", () => {
       expect(exitCode).toBe(0);
     });
 
-    // The worker's import()s are transpiled on the thread pool, in job slots
-    // that live inside the worker's VM. Terminating it while they are in flight
-    // makes the pool hand the remaining jobs back untranspiled and the teardown
-    // release them. Three workers per round share the pool, so part of each
-    // round's jobs is still queued when terminate() lands; the 0-3ms stagger
-    // varies how much.
-    test("terminate() while the worker's imports are still being transpiled", async () => {
-      const modules = 96;
-      const files: Record<string, string> = {
-        "worker.js": `for (let i = 0; i < ${modules}; i++) import("./mod" + i + ".js").catch(() => {});
-          postMessage("importing");`,
-      };
-      for (let i = 0; i < modules; i++) files[`mod${i}.js`] = `export const value = ${i};`;
-      using dir = tempDir("worker-transpile-churn", files);
-      await using proc = Bun.spawn({
-        cmd: [
-          bunExe(),
-          "-e",
-          `for (let r = 0; r < 2; r++) await Promise.all(Array.from({ length: 3 }, (_, i) => new Promise(res => {
-             const w = new Worker(process.argv[1]); w.addEventListener("close", res);
-             w.onmessage = () => setTimeout(() => w.terminate(), (r + i) % 4) })));
-           console.log("PASS");`,
-          path.join(String(dir), "worker.js"),
-        ],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout, stderr, exitCode }).toEqual({ stdout: "PASS\n", stderr: "", exitCode: 0 });
-    });
+    // A worker's import()s are transpiled on the thread pool, in job slots that
+    // live inside the worker's VM, and come back to the JS thread in batches.
+    // Each worker keeps 64 imports in flight (every module that evaluates
+    // imports the next one; the query string makes each a fresh transpile) and
+    // asks to be terminated once the first one has evaluated, so the termination
+    // lands while the JS thread is part-way through a batch: the rest of that
+    // batch has to be released on the spot (the teardown never sees it), the
+    // jobs still queued or still out on the pool by the teardown. Under ASAN the
+    // host is leak-checked for all of them, minus the suppression covering
+    // everything allocated inside a transpile, which would hide the jobs' own
+    // storage; debug builds also log each job the store takes on, which rules
+    // out the imports having gone through the on-thread fallback instead.
+    const leakCheck = isASAN && isLinux;
+    test(
+      "terminate() while the worker's imports are still being transpiled",
+      async () => {
+        const files: Record<string, string> = {
+          "worker.js": `
+            let n = 0, posted = false;
+            function next() { const i = n++; import("./mod" + (i % 16) + ".js?v=" + i).then(done, done); }
+            function done() { if (!posted) { posted = true; postMessage("streaming"); } next(); }
+            for (let k = 0; k < 64; k++) next();
+          `,
+        };
+        for (let i = 0; i < 16; i++) files[`mod${i}.js`] = `export const value = ${i};`;
+        if (leakCheck) {
+          files["leaksan.supp"] = readFileSync(path.join(import.meta.dirname, "../../../leaksan.supp"), "utf8")
+            .split("\n")
+            .filter(line => line !== "leak:Bun__transpileFile")
+            .join("\n");
+        }
+        using dir = tempDir("worker-transpile-churn", files);
+        const debugLog = path.join(String(dir), "debug.log");
+        await using proc = Bun.spawn({
+          cmd: [
+            bunExe(),
+            "-e",
+            `await Promise.all(Array.from({ length: 3 }, () => new Promise(res => {
+               const w = new Worker(process.argv[1]); w.addEventListener("close", res);
+               w.onmessage = () => w.terminate() })));
+             console.log("PASS");`,
+            path.join(String(dir), "worker.js"),
+          ],
+          env: {
+            ...bunEnv,
+            ...(leakCheck
+              ? {
+                  BUN_DESTRUCT_VM_ON_EXIT: "1",
+                  ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+                  LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(String(dir), "leaksan.supp")}`,
+                }
+              : {}),
+            ...(isDebug ? { BUN_DEBUG: debugLog, BUN_DEBUG_RuntimeTranspilerStore: "1" } : {}),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect({ stdout, stderr, exitCode }).toEqual({ stdout: "PASS\n", stderr: "", exitCode: 0 });
+        if (isDebug) expect(readFileSync(debugLog, "utf8")).toContain("transpile(");
+      },
+      // A leak report's symbolization alone takes tens of seconds on the debug
+      // binary; the failure mode must get to print it.
+      leakCheck ? 90_000 : undefined,
+    );
   });
 });
 


### PR DESCRIPTION
### Problem
- Three jobs finished on the thread pool hand themselves back from inside a `&mut self` method: the transpiler job pushes itself onto the store queue and later `put`s itself back into its hive, and the patch task pushes itself onto the package manager's queue.
- Once the push or put lands the object belongs to the other side: the JS thread rewrites or frees the transpiler slot, the package manager drops the patch task, and `put` itself drops the slot in place (and frees it when more than 64 jobs are in flight). The calling method's `&mut self` is still live while that happens.
- A `&mut` argument is protected until its call returns, so the compiler may re-read through it after the push, and `bun run rust:miri` rejects the free outright ("the strongly protected tag disallows deallocations"). A read after the push is what crashed the Zig version of this code (#29128).
- No crash is known from any of the three sites today. Same contract bug as #37681, #37703, #37723 and #37768, in two spellings (`push`, `put`) that none of those lints cover.

### Fix
- The hand-over moves out to the caller, which already holds the job as a raw pointer: run the body through a statement-scoped reborrow, copy out what is still needed, push or put the pointer, and never touch it again. The shell, network and package manager task callbacks already have this shape.
- Correct because every `&mut` to the object ends with its own statement, so none exists at the moment the other side takes it.
- The transpiler's `defer!` dispatch becomes an unconditional dispatch by the worker after `run()`; the workspace is `panic = "abort"`, so the same early returns are covered, and the push stays under the embedded-work count teardown waits on. The finished result is moved out into a struct so the slot still goes back before script runs; a batch cut short by VM termination now releases the jobs it had already popped.
- Verification: a new source lint bans passing the receiver's address to `.push`/`.put`; it reports exactly these three sites on main and passes here (two `FilePoll` sites are allowlisted at an exact count until #37803). Behaviour is unchanged, so the rest is coverage under the ASAN debug build: a new 96-way concurrent `import()` test that overflows the hive and includes parse failures, a new worker `terminate()`-during-transpile test, and the existing patch tests.

### Background
- Transpiler store: `import()`s are transpiled on the thread pool in per-VM job slots (64 inline, heap boxes past that). The pool pushes a finished slot onto a queue; the JS thread pops it, fulfils the module promise and `put`s the slot back, which drops it in place or frees a heap spill.
- Patch task: `bun install` computes and applies package patches on the thread pool; the worker pushes the finished task onto the package manager's queue and the main thread takes it and drops it.
- Protectors: for the whole of a call, a `&mut` argument is `noalias` and `dereferenceable`. Writing to or freeing that memory before the call returns, from any thread, is undefined behaviour even if the method never reads it again; Miri's Tree Borrows mode reports it, and codegen relies on it.
- Embedded work: the VM's teardown waits on a counter that `schedule` bumps and the worker releases after dispatch, which is what makes pushing and posting outside the `borrow_if_running()` guard safe.
- Source lints: `test/internal/source-lints/` holds tests that scan the Rust tree for a banned shape and pin allowlisted leftovers to an exact count, so a converted site cannot be replaced by a new one.

<details>
<summary>Original description</summary>

### Problem

Three places give an object's storage away from inside a `&mut self` method on that object:

| site | shape |
| --- | --- |
| `TranspilerJob::dispatch_to_main_thread(&mut self)` (src/jsc/RuntimeTranspilerStore.rs) | `queue.push(NonNull::from(&mut *self))`, run from a `scopeguard::defer!` inside `run(&mut self)`, which `run_from_worker_thread` enters through `(*this).run()`; the not-running branch calls `(*this).dispatch_to_main_thread()` directly |
| `TranspilerJob::run_from_js_thread(&mut self)` (same file) | `store.put(ptr::from_mut(self))`, entered through `(*job).run_from_js_thread()` |
| `PatchTask::run_from_thread_pool_impl(&mut self)` (src/install/patch_install.rs) | `patch_task_queue.push(NonNull::from(&mut *self))`, entered through `&mut *PatchTask::from_task_ptr(task)` |

The push is the hand-over: as soon as it lands, the JS thread pops the transpiler job, writes its fields (`run_from_js_thread`, or `release_queued_jobs_for_teardown` during teardown) and `put()`s it, and the package manager's main thread `heap::take`s the patch task and drops it (src/install/PackageManager/runTasks.rs). The `put` is the hive return itself: `HiveArrayFallback::put` drops the slot in place, and when more than `TRANSPILER_JOB_HIVE_CAP` (64) jobs are in flight the slot is a heap `Box` that `put` frees. In all three cases this happens while the `&mut self` of the method that made the call (and, for the transpiler's push, of `run` one frame up) is still a live argument.

A reference argument is protected until its call returns: rustc emits it as `noalias` + `dereferenceable` for the whole call, so the compiler may re-read through it after the call instead of keeping the copies taken before it (a source-level read after the push is what crashed the Zig version of this code, #29128), and under the aliasing model `bun run rust:miri` checks (Tree Borrows) freeing the `Box` is rejected outright ("the strongly protected tag disallows deallocations") and the other thread's writes race with the protector's release. The comment in `dispatch_to_main_thread` described the hazard, but the receiver type contradicted it. No crash is known from any of the three today; this is the same contract bug as #37681, #37703, #37723 and #37768, in two spellings (`push`, `put`) none of those lints cover.

### Fix

All three go through the pointer the caller already holds, the shape `ShellTask::on_finish`, `NetworkTask::notify` and `PackageManagerTask::Task::callback` already use:

* `dispatch_to_main_thread` becomes `unsafe fn(this: *mut Self)`: it copies `vm` and clones `loop_handle` through accesses that end before the push, pushes `this`, and posts the store. `run_from_worker_thread` runs `run()` through a statement-scoped reborrow (only while the VM is running, as before) and then dispatches unconditionally, which replaces the `defer!` in `run`: that guard only existed to cover `run`'s early returns, and the workspace is `panic = "abort"`, so a call after the scoped `run()` covers the same paths. The dispatch now happens after the `borrow_if_running()` guard is released on the running path too; the push and post are covered by the embedded-work count (`schedule` increments it, `embedded_work_finished` follows the dispatch, and teardown waits for it before `close()`), which is what the not-running branch already relied on.
* `run_from_js_thread` becomes `unsafe fn(this: *mut Self)`. The body that moves the result out of the slot and resets it is now `take_completion(&mut self) -> Completion`, invoked as a statement-scoped `(*this).take_completion()`; the `put` then takes `this`, and `AsyncModule::fulfill` runs on the moved-out values, in the same order as before (slot back first, then script). The two callers in `RuntimeTranspilerStore::run_from_js_thread` pass the popped pointer.
* `PatchTask::run_from_thread_pool` keeps the raw pointer it recovers from the pool task, runs the body through `(*this).run_from_thread_pool_impl()`, and pushes `this`; the push and wake move out of the `&mut self` method.

Out of scope, on purpose: `TranspilerJob::schedule` in the same file is the `WorkPool::schedule` instance of this and is converted by #37768 (the hunks do not overlap). `FilePoll::deinit_possibly_defer` (src/io/posix_event_loop.rs and the Windows twin) puts its own slot back the same way; every `FilePoll::deinit*` entry point is `&mut self` with many owners, so it is allowlisted in the lint below with an exact count; #37803 converts those two sites and carries the same lint file with the allowlist turned around, so whichever of the two PRs lands second deletes the entries that remain (the ratchet test fails until it does). quic's `ENDPOINT_REGISTRY` pushes `from_ref(self).cast_mut()` from a `&self` method into a same-thread registry whose consumer neither writes nor frees; the lint leaves the shared spellings out rather than allowlisting it.

### Verification

`test/internal/source-lints/self-receiver-push-put.test.ts` bans passing the receiver's address (`NonNull::from(&mut *self)`, `from_mut(self)`, `&raw mut *self`, `self as *mut _`, wrapped in `NonNull::new*` or not, inline or through a local of the same function) to a `.push(..)` or `.put(..)`, with a self-test of the spellings it does and does not match and an exact-count ratchet for the two `FilePoll` entries. Against main it reports exactly the three sites above:

```
src/install/patch_install.rs:184
src/jsc/RuntimeTranspilerStore.rs:525
src/jsc/RuntimeTranspilerStore.rs:577
```

and passes with this branch.

Behaviour is unchanged, so the rest is coverage of the converted paths, run against the debug (ASAN) build:

* `test/js/bun/resolve/concurrent-dynamic-import.test.ts`: new test issues 96 `import()`s at once, 12 of which fail to parse, and checks every one settles with its own module's result. All 96 jobs are claimed before the first is handed back, so this covers the hive slots, the heap-spilled slots that `put()` frees, and both the success and the early-return paths of `run()` reaching the caller-side dispatch. An interleaved comparison of the per-import round trip between this branch and a main build of the same tree showed no difference (3.8 to 6.6 ms per import on a loaded debug box, both builds alike).
* `test/js/web/workers/worker.test.ts`: new test terminates workers while their imports are still on the pool. With `BUN_DEBUG_Worker=1` the teardown log shows between 1 and 57 jobs still out on the pool in most of the teardowns, so the not-running branch and `release_queued_jobs_for_teardown` are exercised; the test asserts a clean exit. About 1.2s locally under ASAN. Three older tests in the same block fail locally on this machine exactly the same way without this change (two time out at 5s, one expects a worker to have posted within 30ms; debug build speed), so they are not touched here.
* `test/cli/install/bun-install-patch.test.ts` (18 pass) and `test/cli/install/bun-patch.test.ts` (31 pass) for the patch task hand-over.

`cargo build` of the touched crates is warning-free; `rustfmt --check` is clean.

</details>
