### PR TITLE
bake: do not rewrite a recorded module failure when require() hits top-level await

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -127,8 +127,14 @@ export class HMRModule {
       const mod = loadModuleSync(id, true, this);
       return mod.esm ? (mod.cjs ??= toCommonJS(mod.exports)) : mod.cjs.exports;
     } catch (e: any) {
+      // The user-facing error is a new, plain Error so that the `require()`
+      // calls it propagates out of (and the `failure` a module records, which
+      // is rethrown on every later load) pass it along unchanged, like any
+      // other error thrown while evaluating a module.
       if (e instanceof AsyncImportError) {
-        e.message = `Cannot require "${id}" because "${e.asyncId}" uses top-level await, but 'require' is a synchronous operation.`;
+        throw new Error(
+          `Cannot require "${id}" because "${e.asyncId}" uses top-level await, but 'require' is a synchronous operation.`,
+        );
       }
       throw e;
     }

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -944,12 +944,6 @@ function isReactRefreshBoundary(esmExports): boolean {
 
 function implicitAcceptFunction() {}
 
-declare global {
-  interface Error {
-    asyncId?: string;
-  }
-}
-
 // bun:bake/server, bun:bake/client, and bun:wrap are
 // provided by this file instead of the bundler
 registerSynthetic("bun:wrap", {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -127,10 +127,7 @@ export class HMRModule {
       const mod = loadModuleSync(id, true, this);
       return mod.esm ? (mod.cjs ??= toCommonJS(mod.exports)) : mod.cjs.exports;
     } catch (e: any) {
-      // The user-facing error is a new, plain Error so that the `require()`
-      // calls it propagates out of (and the `failure` a module records, which
-      // is rethrown on every later load) pass it along unchanged, like any
-      // other error thrown while evaluating a module.
+      // A new Error rather than a rewrite of `e`: enclosing require() calls and recorded failures rethrow it as-is.
       if (e instanceof AsyncImportError) {
         throw new Error(
           `Cannot require "${id}" because "${e.asyncId}" uses top-level await, but 'require' is a synchronous operation.`,

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -126,7 +126,7 @@ export class HMRModule {
     try {
       const mod = loadModuleSync(id, true, this);
       return mod.esm ? (mod.cjs ??= toCommonJS(mod.exports)) : mod.cjs.exports;
-    } catch (e: any) {
+    } catch (e) {
       // A new Error rather than a rewrite of `e`: enclosing require() calls and recorded failures rethrow it as-is.
       if (e instanceof AsyncImportError) {
         throw new Error(

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -858,7 +858,6 @@ class AsyncImportError extends Error {
   constructor(asyncId: string) {
     super(`Cannot load async module "${asyncId}" synchronously because it uses top-level await.`);
     this.asyncId = asyncId;
-    Object.defineProperty(this, "name", { value: "Error" });
   }
 }
 

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -361,6 +361,82 @@ devTest("cannot require a module with top level await", {
     });
   },
 });
+devTest("the error for requiring a module with top level await names the require call that failed", {
+  // `require()` used to produce this message by rewriting, in place, the error
+  // the loader threw. Every enclosing `require()` the error then propagated
+  // through renamed it again, including the error a failed module records and
+  // rethrows on every later load of it.
+  framework: minimalFramework,
+  files: {
+    "tla.ts": `
+      await 1;
+      export const value = "tla";
+    `,
+    "imports-tla.ts": `
+      import "./tla";
+      export const value = "unreachable";
+    `,
+    "outer.ts": `
+      require("./inner");
+      export const value = "unreachable";
+    `,
+    "inner.ts": `
+      require("./tla");
+      export const value = "unreachable";
+    `,
+    "requires-tla.ts": `
+      require("./tla");
+      export const value = "unreachable";
+    `,
+    "imports-requires-tla.ts": `
+      import "./requires-tla";
+      export const value = "unreachable";
+    `,
+    "routes/index.ts": `
+      async function attempt(load) {
+        try {
+          await load();
+          return "loaded";
+        } catch (e) {
+          return e.message;
+        }
+      }
+      export default async function () {
+        return Response.json({
+          requireTla: await attempt(() => require("../tla")),
+          requireImportsTla: await attempt(() => require("../imports-tla")),
+          requireOuter: await attempt(() => require("../outer")),
+          importRequiresTla: await attempt(() => import("../requires-tla")),
+          requireRequiresTla: await attempt(() => require("../requires-tla")),
+          requireImportsRequiresTla: await attempt(() => require("../imports-requires-tla")),
+          importRequiresTlaAgain: await attempt(() => import("../requires-tla")),
+        });
+      }
+    `,
+  },
+  async test(dev) {
+    const cannotRequire = (id: string, asyncId: string) =>
+      `Cannot require "${id}" because "${asyncId}" uses top-level await, but 'require' is a synchronous operation.`;
+    expect(await dev.fetch("/").json()).toEqual({
+      // The required module, or one of its static imports, has top-level await.
+      requireTla: cannotRequire("tla.ts", "tla.ts"),
+      requireImportsTla: cannotRequire("imports-tla.ts", "tla.ts"),
+      // outer.ts and inner.ts can be required. The call that failed is the
+      // require("./tla") in inner.ts, and its error propagates out of the two
+      // enclosing require() calls unchanged, like any other error thrown while
+      // evaluating a required module. (This used to name outer.ts.)
+      requireOuter: cannotRequire("tla.ts", "tla.ts"),
+      // The import() records the error on requires-tla.ts. The two require()
+      // calls rethrow that recorded error (directly, then through a static
+      // importer); they used to rename it to requires-tla.ts and then to
+      // imports-requires-tla.ts, which is what the second import() reported.
+      importRequiresTla: cannotRequire("tla.ts", "tla.ts"),
+      requireRequiresTla: cannotRequire("tla.ts", "tla.ts"),
+      requireImportsRequiresTla: cannotRequire("tla.ts", "tla.ts"),
+      importRequiresTlaAgain: cannotRequire("tla.ts", "tla.ts"),
+    });
+  },
+});
 devTest("function that is assigned to should become a live binding", {
   files: {
     "index.html": emptyHtmlFile({


### PR DESCRIPTION
### Problem
- In the dev server, `require()` of a module that uses top-level await (itself or through a static import) throws `Cannot require "X" because "Y" uses top-level await, but 'require' is a synchronous operation.` In two cases the `X` is the wrong module.
- Nested: with `outer.ts` requiring `inner.ts`, which requires `tla.ts`, `require("./outer")` said `Cannot require "outer.ts"`, a module that can be required, while the stack pointed at the `require("./tla")` in `inner.ts`.
- Recorded failure: after an `import()` of a module has failed this way, an unrelated `require()` that hits the recorded failure renames it, and a later `import()` of the same module then names a module it never involved.
- Cause: `require()` produced the message by overwriting `message` on the loader's own error and rethrowing it. That one object is shared with every enclosing `require()` and with the module's recorded failure, so each `require()` it passed through renamed it.

### Fix
- `require()` now throws a new plain `Error` carrying the message and leaves the caught loader error alone.
- Why that is right: the internal error only ever leaves the loader through `require()`, so the conversion happens exactly once, at the `require()` that failed, and from there it propagates unchanged like any other evaluation error. `bun build` attaches its equivalent error at the same place.
- Message text and error `name` are unchanged, so the direct and static-import cases report exactly what they did before. Two leftovers that only existed because the internal error escaped (a global `Error.asyncId` type augmentation and a `name` override) are deleted.
- Verified by a new dev-server test that exercises the direct, static-import, nested and recorded-failure paths in one route. Against a bun without the fix it fails on the four renamed messages; with the fix it and the rest of the esm suite pass.

### Background
- The dev server (bake) ships its own module loader to the page. `require()`, `import()` and static imports of user modules all go through it, and this error message is produced there.
- A module with top-level await is asynchronous and cannot be loaded by the synchronous `require()`. The loader reports this with an internal error naming the offending module, which may be a static dependency of the module that was required rather than that module itself.
- When a module's body throws during evaluation, the loader records the error as that module's failure and rethrows the same object on every later load of it, so one error object can outlive the call that first threw it.
- A required module's body may itself call `require()`, so one failing call unwinds through several `require()` frames, and every one of them sees the same error object.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/esm.test.ts
bun test v1.4.0 (b9547997f)

test/bake/dev/esm.test.ts:
Dev server testing directory: /tmp/bun-dev-test-F8oKG1
^[[0;30mdev|^[[0m Started development server: http://localhost:35809
^[[0;30mdev|^[[0m ^[[32mBundled page in 279ms^[[0m^[[2m:^[[0m routes/index.ts ^[[2m+ 1 more^[[0m
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "routes/index.ts" is a root module that does not self-accept.
^[[0;30mdev|^[[0m ^[[32mReloaded in 117ms^[[0m^[[2m:^[[0m routes/index.ts
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "state.ts" is not accepted by routes/index.ts,
^[[0;30mdev|^[[0m ^[[36m[x2]^[[0m ^[[32mReloaded i
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/bake/dev/esm.test.ts:
Dev server testing directory: /tmp/bun-dev-test-bP4f4p
^[[0;30mdev|^[[0m Started development server: http://localhost:38707
^[[0;30mdev|^[[0m ^[[32mBundled page in 3ms^[[0m^[[2m:^[[0m routes/index.ts ^[[2m+ 1 more^[[0m
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "routes/index.ts" is a root module that does not self-accept.
^[[0;30mdev|^[[0m ^[[32mReloaded in 2ms^[[0m^[[2m:^[[0m routes/index.ts
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "state.ts" is not accepted by routes/index.ts,
^[[0;30mdev|^[[0m ^[[36m[x2]^[[0m ^[[32mReloaded in 1ms^[[0m^[[2m:^[[0m state.ts
(pass)  DEV:esm-1: live bindings with `var` [211.23ms]
^[[0;30mdev|^[[0m Started development server: http://localhost:36845
^[[0;
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/esm.test.ts
bun test v1.4.0 (b9547997f)

test/bake/dev/esm.test.ts:
Dev server testing directory: /tmp/bun-dev-test-Z7rv5y
^[[0;30mdev|^[[0m Started development server: http://localhost:34563
^[[0;30mdev|^[[0m ^[[32mBundled page in 148ms^[[0m^[[2m:^[[0m routes/index.ts ^[[2m+ 1 more^[[0m
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "routes/index.ts" is a root module that does not self-accept.
^[[0;30mdev|^[[0m ^[[32mReloaded in 79ms^[[0m^[[2m:^[[0m routes/index.ts
^[[0;30mdev|^[[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
^[[0;30mdev|^[[0m 
^[[0;30mdev|^[[0m Module "state.ts" is not accepted by routes/index.ts,
^[[0;30mdev|^[[0m ^[[36m[x2]^[[0m ^[[32mReloaded in
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     b9547997f3
  features     baseline

22 deps, 107 codegen, 1176 objects in 1021ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [30.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (da3851e57)

Checked 1 install across 2 packages (no changes) [3.00ms]
[4/1238] fetch tinycc
[tinycc] up to date
[5/1237] fetch zlib
[zlib] up to date
[6/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (da3851e57)

Checked 129 installs across 147 packages (no changes) [23.00ms]
[8/1237] subst deps/zlib/zlib.h
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] subst deps/zlib/zconf.h
[11/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/hmr-module.ts | 14 +++-----
 test/bake/dev/esm.test.ts      | 76 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 81 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                            reads  edits  tests
src/runtime/bake/hmr-module.ts      6      8      0
test/bake/dev/esm.test.ts           3      5      0
```

</details>

**root cause** · written by the author bot

HMRModule.require() handled an AsyncImportError by overwriting the caught object's message and rethrowing that same object, while the loader also stored that object by reference as the module's recorded failure and rethrew it on every later load, so each enclosing require() the shared object passed through renamed it after the module that was most recently required rather than the one that had actually failed. The fix has require() throw a fresh Error carrying the rewritten message instead of mutating the caught one, so a recorded failure keeps the message from the point where it was record…

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What does this PR do?

In the dev server's module loader (`src/runtime/bake/hmr-module.ts`), `HMRModule.require()` turns the loader's internal `AsyncImportError` (thrown when the required module, or one of its static imports, uses top-level await) into the user-facing message by assigning `e.message` on the error it caught and rethrowing that same object.

The object is shared. A module whose body fails on such a `require()` records the error as its `failure` and rethrows the same object on every later load, so every `require()` the recorded error later propagates through renames it again, and the message ends up naming whichever module was `require()`d most recently:

```ts
// tla.ts:                   await 1; export const value = "tla";
// requires-tla.ts:          require("./tla"); export const value = 1;
// imports-requires-tla.ts:  import "./requires-tla"; export const value = 1;

await import("../requires-tla");
// Cannot require "tla.ts" because "tla.ts" uses top-level await, but 'require' is a synchronous operation.
// (recorded as requires-tla.ts's failure)
require("../imports-requires-tla");
// Cannot require "imports-requires-tla.ts" because "tla.ts" ...   (rewrote the recorded error in place)
await import("../requires-tla");
// Cannot require "imports-requires-tla.ts" because "tla.ts" ...   (wrong: this import never involved that module)
```

The in-place rewrite also renames the error once per enclosing `require()` when the failing `require()` is inside a required module's body. With `outer.ts` requiring `inner.ts`, which requires `tla.ts`, `require("./outer")` reported `Cannot require "outer.ts" because "tla.ts" ...`, naming a module that can be required, while the error's stack pointed at the `require("./tla")` in `inner.ts`.

`require()` now throws a new, plain `Error` with the message instead of mutating the caught one. `AsyncImportError` is only thrown by `loadModuleSync`, and `require()` is the only way out of the loader for it (`import()` and static imports go through `loadModuleAsync`, which never throws it), so the conversion happens exactly once, at the `require()` call that failed. From there the error propagates through enclosing `require()` calls, and through a module's recorded failure, unchanged, the same way every other error thrown while evaluating a module does. It is also where `bun build` reports the equivalent build error (the diagnostic in `LinkerContext.rs` is attached to the `require()` call whose import graph contains the top-level await), and this runtime is documented as mirroring `bun build`. The message text and the error's `name` (`"Error"` in both cases: `AsyncImportError` inherited it) are unchanged, so the direct and static-import cases, including the existing "cannot require a module with top level await" test, report exactly what they did before; only the two cases above change. As a side effect the browser console now shows `Error: Cannot require ...` with a stack starting at the user's `require()` call instead of the minified class name, the loader's internal frames and an `asyncId` property.

Also deleted, since the `AsyncImportError` instance no longer leaves the loader and these two lines were only there on account of it escaping: the `declare global { interface Error { asyncId?: string } }` augmentation at the bottom of the file (the only `asyncId` read is on the `AsyncImportError` instance itself, which declares the field; nothing needed the augmentation for type-checking), and the own-property `name` override in `AsyncImportError`'s constructor (a subclass of `Error` already reports `name === "Error"` through the prototype, so the override changed nothing observable either). The `catch (e: any)` in `require()` is now a bare `catch (e)` like the other catch clauses in the file; `instanceof` narrows it.

Related: #37742 records failures on more loader paths and matches the module name loosely in its `requireWithDepThatFailedToRequire` case because of this. With this change a recorded failure is never an `AsyncImportError`, so that match can be exact and its `state !== State.Error` guard becomes redundant (it stays correct). The `Cannot require` expectations in #37759 and #37765 are direct requires and are unaffected.

### How did you verify your code works?

New test in `test/bake/dev/esm.test.ts`, "the error for requiring a module with top level await names the require call that failed". One route handler goes through every path out of `require()`'s catch: a direct `require()` of a top-level-await module and one through a static import chain (both messages unchanged), the nested `require()` chain, and a failure recorded by `import()` that is then rethrown by a direct `require()`, by a `require()` of a static importer, and by a second `import()`.

With `USE_SYSTEM_BUN=1` it fails on the four renamed messages (`outer.ts`, `requires-tla.ts`, and `imports-requires-tla.ts` twice). With `bun bd test` it passes, as does the rest of `test/bake/dev/esm.test.ts`.

</details>
