### PR TITLE
Bun.build: read env from a per-build copy instead of the VM's live loader

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -309,8 +309,9 @@ impl<'a> Transpiler<'a> {
     /// lifetime-carrying borrows in `BundleOptions<'_>` / `Resolver<'_>`
     /// (`framework`, `optimize_imports`, `standalone_module_graph`,
     /// `env_loader`) are widened from `from`'s lifetime to `'a` via a
-    /// layout-preserving transmute — sound because those reference
-    /// process-lifetime data in every caller, but unprovable to borrowck.
+    /// layout-preserving transmute — sound because what they point at
+    /// outlives `from` in every caller (process-lifetime singletons, or for
+    /// `env_loader` the build that owns `from`), but unprovable to borrowck.
     pub(crate) unsafe fn for_worker(
         from: &Transpiler<'_>,
         arena: &'a Arena,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -595,6 +595,26 @@ impl Loader {
         }
     }
 
+    /// Deep copy of the variables and of the "already loaded" bookkeeping, so
+    /// `load_process` / `load` on the copy skip exactly what they skip on
+    /// `self`. The lazily derived caches (S3 credentials, TLS
+    /// reject-unauthorized) start empty and are rebuilt from the copied map.
+    ///
+    /// A loader keeps being mutated on the thread that owns it
+    /// (`process.env.HTTPS_PROXY = ...` replaces map values in place), so work
+    /// that reads env on another thread takes one of these instead.
+    pub fn clone(&self) -> Result<Loader, AllocError> {
+        Ok(Loader {
+            map: self.map.clone_with_allocator()?,
+            default_files_loaded: self.default_files_loaded,
+            custom_files_loaded: self.custom_files_loaded.clone()?,
+            quiet: self.quiet,
+            did_load_process: self.did_load_process,
+            reject_unauthorized: Cell::new(None),
+            aws_credentials: None,
+        })
+    }
+
     pub fn load_process(&mut self) -> Result<(), AllocError> {
         if self.did_load_process {
             return Ok(());

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -595,14 +595,9 @@ impl Loader {
         }
     }
 
-    /// Deep copy of the variables and of the "already loaded" bookkeeping, so
-    /// `load_process` / `load` on the copy skip exactly what they skip on
-    /// `self`. The lazily derived caches (S3 credentials, TLS
-    /// reject-unauthorized) start empty and are rebuilt from the copied map.
-    ///
-    /// A loader keeps being mutated on the thread that owns it
-    /// (`process.env.HTTPS_PROXY = ...` replaces map values in place), so work
-    /// that reads env on another thread takes one of these instead.
+    /// Copies the variables and the loaded-files bookkeeping (so `load_process`
+    /// / `load` on the copy are the same no-ops as on `self`); the lazily
+    /// derived caches are rebuilt from the copied map on demand.
     pub fn clone(&self) -> Result<Loader, AllocError> {
         Ok(Loader {
             map: self.map.clone_with_allocator()?,

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -423,15 +423,25 @@ impl Macro {
             // `RuntimeHooks::init_runtime_state` builds the macro VM's
             // transpiler from a fresh `TransformOptions` value rather than
             // borrowing the caller's, so there is nothing to mutate-and-restore
-            // on `resolver.opts` here. `log`/`env_loader` *are* threaded so the
-            // CLI-path macro VM uses the caller's log sink and env loader.
+            // on `resolver.opts` here. `log` *is* threaded so the CLI-path
+            // macro VM uses the caller's log sink.
 
             // JSC needs to be initialized if building from CLI
             jsc::initialize(false);
 
+            // This VM stays on the thread and serves every later build's
+            // macros too, while `env` is the current build's (Bun.build frees
+            // its copy with the build), so the VM gets a copy that lives as
+            // long as it does: it is never destroyed.
+            let env_loader = NonNull::new(env).map(|env| {
+                // SAFETY: the caller's loader, live for this call and not
+                // written to while the build's files are being parsed.
+                let copy = bun_core::handle_oom(unsafe { env.as_ref() }.clone());
+                bun_core::heap::into_raw_nn(Box::new(copy))
+            });
             let _vm = VirtualMachine::init(VirtualMachineInitOptions {
                 log: Some(NonNull::from(&mut *log)),
-                env_loader: NonNull::new(env),
+                env_loader,
                 is_main_thread: false,
                 ..Default::default()
             })?;

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -441,6 +441,13 @@ impl Macro {
                 env_loader,
                 is_main_thread: false,
                 ..Default::default()
+            })
+            .inspect_err(|_| {
+                if let Some(copy) = env_loader {
+                    // SAFETY: a failed `init` never wrote the transpiler that
+                    // would have kept this pointer, so the copy is still ours.
+                    unsafe { bun_core::heap::destroy(copy.as_ptr()) };
+                }
             })?;
             (_vm, true)
         };

--- a/src/js_parser_jsc/Macro.rs
+++ b/src/js_parser_jsc/Macro.rs
@@ -429,13 +429,10 @@ impl Macro {
             // JSC needs to be initialized if building from CLI
             jsc::initialize(false);
 
-            // This VM stays on the thread and serves every later build's
-            // macros too, while `env` is the current build's (Bun.build frees
-            // its copy with the build), so the VM gets a copy that lives as
-            // long as it does: it is never destroyed.
+            // The VM outlives this build (later builds' macros reuse it; it is
+            // never destroyed) and `env` does not, so the VM gets its own copy.
             let env_loader = NonNull::new(env).map(|env| {
-                // SAFETY: the caller's loader, live for this call and not
-                // written to while the build's files are being parsed.
+                // SAFETY: the caller's loader, live and unwritten during this build.
                 let copy = bun_core::handle_oom(unsafe { env.as_ref() }.clone());
                 bun_core::heap::into_raw_nn(Box::new(copy))
             });

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1194,9 +1194,8 @@ impl CompletionStruct for JSBundleCompletionTask {
         };
 
         let log: *mut bun_ast::Log = &raw mut self.log;
-        // Freed with `self`, so only read until `complete_on_bundle_thread` hands
-        // `self` back; the per-thread macro VM, which outlives the build, takes
-        // its own copy (`Macro::init`).
+        // Freed with `self`: read only until `complete_on_bundle_thread`, except
+        // by the per-thread macro VM, which copies it (`Macro::init`).
         let env: *mut bun_dotenv::Loader = &raw mut *self.env;
         let t = Transpiler::init(bump, log, opts, Some(env))?;
         let transpiler: &'a mut Transpiler<'a> = bump.alloc(t);

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -59,7 +59,14 @@ pub struct JSBundleCompletionTask {
     pub global_this: BackRef<JSGlobalObject>,
     pub(crate) promise: jsc::JSPromiseStrong,
     pub poll_ref: KeepAlive,
-    pub(crate) env: *mut bun_dotenv::Loader,
+    /// The calling VM's env as of the `Bun.build()` call. The build reads env
+    /// (`configure_defines`, `env: "inline"` defines, the resolver's
+    /// `NODE_PATH`) on the bundle thread and its workers, while the VM's own
+    /// loader keeps being mutated on the JS thread (`Bun__setEnvValue` for
+    /// `process.env.HTTPS_PROXY = ...` frees the value it replaces), so the
+    /// build must not read that one. Boxed so the pointer `Transpiler::init`
+    /// keeps is to an allocation of its own, not into this struct.
+    pub(crate) env: Box<bun_dotenv::Loader>,
     pub(crate) log: bun_ast::Log,
     /// Set by the owner giving up on the result (HTMLBundle route torn down)
     /// or by the VM's stop phase; read by `on_complete` (skip delivery) and by
@@ -120,7 +127,7 @@ impl JSBundleCompletionTask {
             // last-ref drop is the only place that releases it.
             Plugin::destroy(plugin.as_ptr());
         }
-        // Owned fields (`config`, `log`, `result`, `promise`) drop with the Box.
+        // Owned fields (`config`, `env`, `log`, `result`, `promise`) drop with the Box.
     }
 }
 
@@ -141,7 +148,10 @@ pub(crate) fn create_and_schedule_completion_task(
     global_this: &JSGlobalObject,
 ) -> crate::Result<*mut JSBundleCompletionTask> {
     let vm = global_this.bun_vm_ptr();
-    let env = global_this.bun_vm().transpiler.env;
+    // Copied here on this VM's JS thread, the thread `Bun__setEnvValue` mutates
+    // the loader from, so unlike a Worker's clone (web_worker.rs) this one
+    // needs no `proxy_env_storage` lock.
+    let env = Box::new(global_this.bun_vm().env_loader().clone()?);
     let completion = bun_core::heap::into_raw(Box::new(JSBundleCompletionTask {
         ref_count: RefCount::init(),
         config,
@@ -173,8 +183,8 @@ pub(crate) fn create_and_schedule_completion_task(
     let _ = WorkPool::get();
 
     // Out on the bundle thread from here until it posts the completion: it
-    // reads this VM's env loader and the plugin cell, so the VM cancels it at
-    // teardown (registry) and waits for it (embedded work).
+    // reads this VM's plugin cell and posts into this VM's queue, so the VM
+    // cancels it at teardown (registry) and waits for it (embedded work).
     // SAFETY: `completion` is live (refcount==1), JS thread.
     unsafe { (*completion).loop_handle.embedded_work_scheduled() };
     crate::jsc_hooks::ActiveHandle::Bundle(NonNull::new(completion).expect("completion"))
@@ -426,10 +436,7 @@ impl JSBundleCompletionTask {
             root_dir.fd,
             module_prefix,
             outfile_for_executable,
-            // SAFETY: `self.env` is the per-VM `DotEnv.Loader` stashed at
-            // construction; valid for the lifetime of the VirtualMachine, and
-            // nothing inside `to_executable` reaches it otherwise.
-            unsafe { &mut *self.env },
+            &mut self.env,
             self.config.format,
             &WindowsOptions {
                 hide_console: compile_options.windows_hide_console,
@@ -909,9 +916,9 @@ impl CompletionStruct for JSBundleCompletionTask {
             core::hint::spin_loop();
         }
         // The VM released everything thread-affine (`stop_for_vm_teardown`);
-        // what is left — config, log, an empty promise slot, a `Done`
-        // keep-alive, the handle clone — is ours to drop here. The queue held
-        // the creation reference.
+        // what is left (config, the env copy, log, an empty promise slot, a
+        // `Done` keep-alive, the handle clone) is ours to drop here. The
+        // queue held the creation reference.
         // SAFETY: dequeued ⇒ sole owner; nothing JS-affine remains.
         drop(unsafe { bun_core::heap::take(this) });
     }
@@ -1105,8 +1112,9 @@ impl CompletionStruct for JSBundleCompletionTask {
                 .conditions
                 .append_slice(&[b"development"])?;
         }
-        // `transpiler.env` is the dotenv loader installed by
-        // `Transpiler::init`; non-null and valid for `'a`.
+        // `transpiler.env` is this build's env copy (`self.env`), installed by
+        // `create_and_configure_transpiler`; the resolver's workers read
+        // `NODE_PATH` through it.
         transpiler.resolver.env_loader = NonNull::new(transpiler.env);
         // `Resolver.opts` is the resolver-crate subset
         // — re-project from the now-mutated `transpiler.options`.
@@ -1191,7 +1199,11 @@ impl CompletionStruct for JSBundleCompletionTask {
         };
 
         let log: *mut bun_ast::Log = &raw mut self.log;
-        let t = Transpiler::init(bump, log, opts, Some(self.env))?;
+        // The build's own env copy (see the field doc). Same lifetime argument
+        // as `log`: every read through the transpiler happens before
+        // `complete_on_bundle_thread` hands this task back to the JS thread.
+        let env: *mut bun_dotenv::Loader = &raw mut *self.env;
+        let t = Transpiler::init(bump, log, opts, Some(env))?;
         let transpiler: &'a mut Transpiler<'a> = bump.alloc(t);
 
         // Post-init field wiring.

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -150,8 +150,12 @@ pub(crate) fn create_and_schedule_completion_task(
     let vm = global_this.bun_vm_ptr();
     // Copied here on this VM's JS thread, the thread `Bun__setEnvValue` mutates
     // the loader from, so unlike a Worker's clone (web_worker.rs) this one
-    // needs no `proxy_env_storage` lock.
-    let env = Box::new(global_this.bun_vm().env_loader().clone()?);
+    // needs no `proxy_env_storage` lock. OOM aborts like the `Box::new` below:
+    // returning an error would leak the `plugins` Bun.build hands us, which
+    // only the task's `deinit` releases.
+    let env = Box::new(bun_core::handle_oom(
+        global_this.bun_vm().env_loader().clone(),
+    ));
     let completion = bun_core::heap::into_raw(Box::new(JSBundleCompletionTask {
         ref_count: RefCount::init(),
         config,

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -1194,7 +1194,9 @@ impl CompletionStruct for JSBundleCompletionTask {
         };
 
         let log: *mut bun_ast::Log = &raw mut self.log;
-        // Like `log`: used only until `complete_on_bundle_thread` hands `self` back.
+        // Freed with `self`, so only read until `complete_on_bundle_thread` hands
+        // `self` back; the per-thread macro VM, which outlives the build, takes
+        // its own copy (`Macro::init`).
         let env: *mut bun_dotenv::Loader = &raw mut *self.env;
         let t = Transpiler::init(bump, log, opts, Some(env))?;
         let transpiler: &'a mut Transpiler<'a> = bump.alloc(t);

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -59,13 +59,9 @@ pub struct JSBundleCompletionTask {
     pub global_this: BackRef<JSGlobalObject>,
     pub(crate) promise: jsc::JSPromiseStrong,
     pub poll_ref: KeepAlive,
-    /// The calling VM's env as of the `Bun.build()` call. The build reads env
-    /// (`configure_defines`, `env: "inline"` defines, the resolver's
-    /// `NODE_PATH`) on the bundle thread and its workers, while the VM's own
-    /// loader keeps being mutated on the JS thread (`Bun__setEnvValue` for
-    /// `process.env.HTTPS_PROXY = ...` frees the value it replaces), so the
-    /// build must not read that one. Boxed so the pointer `Transpiler::init`
-    /// keeps is to an allocation of its own, not into this struct.
+    /// This build's copy of the calling VM's env, read on the bundle thread
+    /// while the VM's own loader keeps changing on the JS thread
+    /// (`Bun__setEnvValue`). Boxed: the build's transpiler holds a pointer to it.
     pub(crate) env: Box<bun_dotenv::Loader>,
     pub(crate) log: bun_ast::Log,
     /// Set by the owner giving up on the result (HTMLBundle route torn down)
@@ -148,11 +144,8 @@ pub(crate) fn create_and_schedule_completion_task(
     global_this: &JSGlobalObject,
 ) -> crate::Result<*mut JSBundleCompletionTask> {
     let vm = global_this.bun_vm_ptr();
-    // Copied here on this VM's JS thread, the thread `Bun__setEnvValue` mutates
-    // the loader from, so unlike a Worker's clone (web_worker.rs) this one
-    // needs no `proxy_env_storage` lock. OOM aborts like the `Box::new` below:
-    // returning an error would leak the `plugins` Bun.build hands us, which
-    // only the task's `deinit` releases.
+    // Same thread as `Bun__setEnvValue`, so no `proxy_env_storage` lock (unlike
+    // web_worker.rs). An error return here would leak `plugins`, so OOM aborts.
     let env = Box::new(bun_core::handle_oom(
         global_this.bun_vm().env_loader().clone(),
     ));
@@ -1116,9 +1109,7 @@ impl CompletionStruct for JSBundleCompletionTask {
                 .conditions
                 .append_slice(&[b"development"])?;
         }
-        // `transpiler.env` is this build's env copy (`self.env`), installed by
-        // `create_and_configure_transpiler`; the resolver's workers read
-        // `NODE_PATH` through it.
+        // `transpiler.env` is this build's copy (`self.env`), not the VM's loader.
         transpiler.resolver.env_loader = NonNull::new(transpiler.env);
         // `Resolver.opts` is the resolver-crate subset
         // — re-project from the now-mutated `transpiler.options`.
@@ -1203,9 +1194,7 @@ impl CompletionStruct for JSBundleCompletionTask {
         };
 
         let log: *mut bun_ast::Log = &raw mut self.log;
-        // The build's own env copy (see the field doc). Same lifetime argument
-        // as `log`: every read through the transpiler happens before
-        // `complete_on_bundle_thread` hands this task back to the JS thread.
+        // Like `log`: used only until `complete_on_bundle_thread` hands `self` back.
         let env: *mut bun_dotenv::Loader = &raw mut *self.env;
         let t = Transpiler::init(bump, log, opts, Some(env))?;
         let transpiler: &'a mut Transpiler<'a> = bump.alloc(t);

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -214,4 +214,49 @@ describe.concurrent("env is copied when the build is scheduled", () => {
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
   });
+
+  // Macros run in a VM that a bundler thread creates the first time a macro
+  // runs on it and then reuses for every later build, so it must not keep
+  // reading the env of the build that created it, which is freed with that
+  // build. Two bundler threads and four builds guarantee that later builds run
+  // their macro on a thread whose VM an earlier build created.
+  test("macros in later builds reuse a VM created during an earlier build", async () => {
+    const builds = 4;
+    const env: Record<string, string> = { ...bunEnv, UV_THREADPOOL_SIZE: "2" };
+    const files: Record<string, string> = {
+      "macro.ts": /* ts */ `export function envValue(name: string) { return process.env[name]; }`,
+      "build-fixture.ts": /* ts */ `
+        for (let i = 0; i < ${builds}; i++) {
+          const result = await Bun.build({ entrypoints: ["./entry" + i + ".ts"] });
+          if (!result.success) throw new AggregateError(result.logs, "build " + i + " failed");
+          process.stdout.write(await result.outputs[0].text());
+        }
+      `,
+    };
+    for (let i = 0; i < builds; i++) {
+      // Each build reads a key no earlier build has read, so the lookup goes
+      // to the VM's env instead of an already materialized process.env entry.
+      env[`MACRO_ENV_${i}`] = `value-of-build-${i}`;
+      files[`entry${i}.ts`] = /* ts */ `
+        import { envValue } from "./macro.ts" with { type: "macro" };
+        console.log(envValue("MACRO_ENV_${i}"));
+      `;
+    }
+    using dir = tempDir("bun-build-env-macro-vm", files);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build-fixture.ts"],
+      env,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout.match(/console\.log\("(value-of-build-\d)"\)/g)).toEqual(
+      Array.from({ length: builds }, (_, i) => `console.log("value-of-build-${i}")`),
+    );
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -1,4 +1,5 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { itBundled } from "./expectBundled";
 
 for (let backend of ["api", "cli"] as const) {
@@ -118,3 +119,99 @@ for (let backend of ["api", "cli"] as const) {
       });
   });
 }
+
+// A build inlines the env as of the call that started it. The bundler thread
+// reads env from its own copy: `process.env.HTTPS_PROXY = ...` (one of the
+// few assignments that write through to the native env map, replacing the
+// stored value in place) while a build is in flight must not change, or free
+// out from under, what the build inlines.
+describe.concurrent("env is copied when the build is scheduled", () => {
+  const atCall = "http://proxy-when-the-build-was-scheduled.example:1111/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+  const duringBuild = "http://proxy-assigned-while-bundling.example:2222/bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+  // The plugin's onLoad runs on the JS thread while the bundle is in flight,
+  // after the bundler has built its defines.
+  const pluginSource = (filter: string) => /* ts */ `
+    export default {
+      name: "assign-proxy-env-while-bundling",
+      setup(build) {
+        build.onLoad({ filter: ${filter} }, () => {
+          process.env.HTTPS_PROXY = ${JSON.stringify(duringBuild)};
+          return { loader: "ts", contents: "console.log(process.env.HTTPS_PROXY);" };
+        });
+      },
+    };
+  `;
+
+  test.each(["inline", "HTTPS_*"] as const)("Bun.build({ env: %j })", async env => {
+    using dir = tempDir("bun-build-env-copy", {
+      "entry.ts": "export {};",
+      "plugin.ts": pluginSource("/entry\\.ts$/"),
+      "build-fixture.ts": /* ts */ `
+        import plugin from "./plugin.ts";
+        process.env.HTTPS_PROXY = ${JSON.stringify(atCall)};
+        const result = await Bun.build({
+          entrypoints: ["./entry.ts"],
+          env: ${JSON.stringify(env)},
+          plugins: [plugin],
+        });
+        process.stdout.write(await result.outputs[0].text());
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build-fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain(`console.log(${JSON.stringify(atCall)})`);
+    expect(stdout).not.toContain(duringBuild);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  // Bun.serve's HTML routes (without HMR) are built through the same bundler
+  // thread, with env behavior and plugins coming from bunfig.
+  test('Bun.serve HTML route with [serve.static] env = "inline"', async () => {
+    using dir = tempDir("bun-serve-html-env-copy", {
+      "bunfig.toml": /* toml */ `
+        [serve.static]
+        env = "inline"
+        plugins = ["./plugin.ts"]
+      `,
+      "index.html": /* html */ `<!DOCTYPE html><html><body><script type="module" src="./app.ts"></script></body></html>`,
+      "app.ts": "export {};",
+      "plugin.ts": pluginSource("/app\\.ts$/"),
+      "serve-fixture.ts": /* ts */ `
+        import index from "./index.html";
+        process.env.HTTPS_PROXY = ${JSON.stringify(atCall)};
+        using server = Bun.serve({
+          port: 0,
+          development: false,
+          routes: { "/": index },
+        });
+        const html = await (await fetch(server.url)).text();
+        const script = html.match(/src="([^"]+\\.js)"/)![1];
+        process.stdout.write(await (await fetch(new URL(script, server.url))).text());
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "serve-fixture.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain(`console.log(${JSON.stringify(atCall)})`);
+    expect(stdout).not.toContain(duringBuild);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- `Bun.build({ env: "inline" })` (or an `env: "PREFIX_*"` pattern) whose plugin assigns `process.env.HTTPS_PROXY` while the build is in flight emits a freed buffer: release inlines `"0\x02\x00\x00roxy-at-build-call..."`, ASAN reports `heap-use-after-free` in `best_quote_char_for_string` on `Bun Pool 0`, freed by `Bun__setEnvValue` on the JS thread. `Bun.serve` HTML routes without HMR build through the same task.
- Cause: the build handed the bundle thread the calling VM's live env loader, and every inlined define borrowed the value bytes stored in that map for the rest of the build.
- The JS thread keeps writing that map during the build: assigning a proxy variable frees the old value in place, and a new key can grow the map while the build is iterating it. The Zig version had the same design, so this is not a port regression.

### Fix
- The build task now takes its own copy of the loader inside the `Bun.build()` call, the build's transpiler and resolver read that copy, and it is freed with the task. The build never reads the VM's loader and the VM can never reach the copy.
- The copy also carries the loaded-files and did-load-process flags, so `.env` files and `environ` are not re-read on the copy; derived caches start empty and are rebuilt on demand. Semantically a build's defines are a snapshot anyway, so the output now reflects the env at the moment `Bun.build()` was called instead of an unspecified later point.
- The macro VM a pool thread creates on first use is reused by every later build on that thread, so with a per-build env it read a freed copy (caught in review of the first revision). It now clones the loader it is given, the same arrangement Worker VMs have; macros observe the same values as before.
- Verification: three child-process tests (`env: "inline"`, `env: "HTTPS_*"`, a `Bun.serve` HTML route) fail on the released build and abort under ASAN without the fix, and pass with it. A fourth test (four builds using a macro with `UV_THREADPOOL_SIZE=2`) aborted under ASAN with the first revision and passes with the macro change. The copy costs well under a millisecond per build with a 30-variable environment.

### Background
- The env loader is bun's native map of environment variables (process environment plus `.env` files). Each VM materializes its `process.env` from it, and only a few assignments (the proxy variables, since #28614) write back through to the native map.
- The `env: "inline"` and `env: "PREFIX_*"` build options turn matching variables into defines, constants substituted into the output. A define points at the loader's stored bytes rather than holding a copy.
- `Bun.build()` returns a promise and bundles on a process-wide thread pool while JS, including plugin `onLoad` callbacks, keeps running on the calling thread, so anything the build reads from the VM must be copied or never written during the build.
- Macros are functions run at bundle time inside a VM that each pool thread creates the first time a macro runs there and never destroys; that VM keeps whatever env pointer it was created with.

<details>
<summary>Original description</summary>

### What

`Bun.build()` (and `Bun.serve` HTML routes without HMR, which go through the same `JSBundleCompletionTask`) handed the calling VM's live dotenv `Loader` to the bundle thread. The task stored `vm.transpiler.env` and `create_and_configure_transpiler` passed it to `Transpiler::init`, so on the bundle thread `configure_defines` ran `load_process()` / `load()` / `load_defines()` against it, the resolver (and its worker threads) read `NODE_PATH` through it, and with `env: "inline"` or an `env: "PREFIX_*"` pattern every define was an `E::String` borrowing the value bytes stored in that map for the rest of the build (`defines.rs`, `env_string_store_put`).

The JS thread keeps mutating that same loader while a build is in flight: `process.env.HTTPS_PROXY = ...` (and `HTTP_PROXY` / `NO_PROXY` and the lowercase variants, since #28614) goes through `Bun__setEnvValue`, whose `Map::put` assigns over the `HashTableValue` and frees the `Box<[u8]>` the build's define points at. A new key can also grow the map under a `load_defines` that is iterating it. The original Zig code had the same design, so this is not a port regression.

### Repro

No thread race is needed; a plugin is enough, because the defines are built before any `onLoad` runs:

```ts
process.env.HTTPS_PROXY = "http://proxy-at-build-call.example:1111/aaaaaaaaaaaaaaaaaaaaaaaaaaaa";
const result = await Bun.build({
  entrypoints: ["./entry.ts"],
  env: "inline",
  plugins: [{
    name: "p",
    setup(build) {
      build.onLoad({ filter: /entry\.ts$/ }, () => {
        process.env.HTTPS_PROXY = "http://proxy-set-during-build.example:2222/bbbbbbbbbbbbbbbbbbbbbbbbbbbb";
        return { loader: "ts", contents: "console.log(process.env.HTTPS_PROXY);" };
      });
    },
  }],
});
console.log(await result.outputs[0].text());
```

Release build (`bun 1.4.0-canary`): the inlined string is the freed buffer, with the allocator's free-list pointer in its first bytes:

```
console.log("0\x02\x00\x00roxy-at-build-call.example:1111/aaaa...");
```

Debug (ASAN) build:

```
ERROR: AddressSanitizer: heap-use-after-free ... thread T11 (Bun Pool 0)
    #0 bun_js_printer::best_quote_char_for_string src/js_printer/lib.rs:680
    ...
freed by thread T0 here:
    ... <bun_collections::array_hash_map::StringArrayHashMap<bun_dotenv::env_loader::HashTableValue>>::put
    <bun_dotenv::env_loader::Map>::put
    Bun__setEnvValue src/runtime/api/BunObject.rs
    Bun::jsSetterProxyEnvironmentVariable JSEnvironmentVariableMap.cpp
```

### Fix

`JSBundleCompletionTask.env` is now a `Box<bun_dotenv::Loader>` of its own, copied from the VM's loader in `create_and_schedule_completion_task` (JS thread, inside the `Bun.build()` call), and `create_and_configure_transpiler` / `configure_bundler` point the build's transpiler and resolver at that copy. Nothing the build runs reads the VM's loader anymore, and nothing the VM does can reach the build's copy; the copy is dropped with the task.

`Loader::clone` (new, `bun_dotenv`) copies the map together with `default_files_loaded` / `custom_files_loaded` / `did_load_process` / `quiet`, so `load_process()` and `load()` on the copy are the same no-ops (and print the same, or nothing) that they were on the VM's loader; a copy of just the map would have re-read `environ` over runtime-assigned values and re-read the `.env` files on every build. The derived caches (S3 credentials, `NODE_TLS_REJECT_UNAUTHORIZED`) start empty; they are computed from the map on first use and the build path does not use them.

Why a copy at call time is the right semantics, not just a safe one: a build's defines are a snapshot by nature (they are baked into the output), and the only thing the previous code "gained" from reading live was an unspecified point in time between `Bun.build()` returning its promise and the bundle thread getting around to `configure_defines`. Now the environment that a build inlines is the environment at the moment `Bun.build()` was called. The compile step's download settings (proxy / TLS for fetching a cross-compile target) come from the same copy, which is the same call-time semantics #37507 is moving that code to.

**The macro VM.** One consumer of the transpiler's env pointer outlives a build: `Macro::init` creates a VM on each bundler thread the first time a macro runs there, created with the env pointer of the build that happened to be running, and reuses that VM for every later build (it is never destroyed; the pool threads are process-wide). With a per-build env, the next build running a macro on that thread read the freed copy (`Bun__getEnvValue` -> `Loader::get` on a freed map, ASAN heap-use-after-free on `Bun Pool 0`, freed by the task drop on the JS thread; this was surfaced in review of the first revision). Before this PR the pointer happened to be the calling VM's loader, which outlives everything on the main thread (a `Bun.build()` inside a Worker had the same problem, since the worker's loader dies with the worker). `Macro::init` now gives the VM a clone of the loader it is handed, which lives as long as the VM does, the same arrangement Worker VMs have. Semantically the macro VM's env was already fixed at VM creation (`process.env` is materialized per VM), so macros observe what they did before; the per-thread macro VM's `configure_defines` also stops writing `.env` contents into a loader it shares with other threads (previously the calling VM's live loader, in the first revision the build's copy).

Copying the env is per build, roughly one small allocation per variable; under the ASAN debug build a 500-module `Bun.build()` takes ~320 ms and this adds well under a millisecond with a 30-variable environment.

Related, independent: #37766 removes the `quiet` write `Transpiler::init` did on a passed-in loader (with this change that write would only ever have hit the build's copy); #37775 gives the debugger thread's VM its own loader. The bake dev server inlines env through the same define path against the VM's loader for the server's lifetime; that is a separate fix (copying the bytes in `env_string_store_put`) and has been filed separately.

### Tests

`test/bundler/bundler_env.test.ts`, "env is copied when the build is scheduled": the scenario above run in a child process for `Bun.build({ env: "inline" })`, `Bun.build({ env: "HTTPS_*" })`, and a `Bun.serve({ development: false })` HTML route with `[serve.static] env = "inline"` and the plugin loaded from bunfig. Each asserts the bundle inlines the value that was set when the build was scheduled and not the one assigned mid-build. All three fail on the released build (the inlined string is the clobbered buffer shown above) and on the unfixed debug build (ASAN abort), and pass with this change.

A fourth test covers the macro VM: four sequential `Bun.build()` calls in one child process with `UV_THREADPOOL_SIZE=2`, each bundling a file whose macro returns a key of `process.env` no earlier build has read, so the lookup reaches the VM's loader. With two pool threads the third and fourth builds necessarily reuse a VM created by an earlier build. It passes on the released build (where the VM points at the process-lifetime loader), aborted under ASAN with the first revision of this PR (builds 0 and 1 print, build 2 dies in `Loader::get`), and passes with the `Macro::init` change.

Also ran locally with the debug build: the rest of `bundler_env.test.ts`, `bun-build-api.test.ts` (the 400-build stress test lands at ~167 s of its 180 s budget on this machine with or without the env copy being a factor), `bun-serve-html.test.ts` (its five `development: true` tests fail here with `EMFILE while initializing file watcher` on the released build as well; the `development: false` ones pass), and a `Bun.build({ compile })` of the host target.

</details>
