### PR TITLE
test: cover embedded sqlite, import attributes and shared chunks in the ESM bytecode module record

### DIFF
--- a/test/bundler/bundler_compile.test.ts
+++ b/test/bundler/bundler_compile.test.ts
@@ -174,9 +174,17 @@ describe("bundler", () => {
   // ESM bytecode test matrix: each scenario × {default, minified} = 2 tests per scenario.
   // With --compile, static imports are inlined into one chunk, but dynamic imports
   // create separate modules in the standalone graph — each with its own bytecode + ModuleInfo.
+  function serializedHelloDatabase() {
+    const db = new Database(":memory:");
+    db.exec("create table messages (message text)");
+    db.exec("insert into messages values ('Hello, world!')");
+    return db.serialize();
+  }
   const esmBytecodeScenarios: Array<{
     name: string;
-    files: Record<string, string>;
+    files: BundlerTestInput["files"];
+    /** Written next to the binary after bundling; the binary runs with that directory as cwd. */
+    runtimeFiles?: BundlerTestInput["runtimeFiles"];
     stdout: string;
   }> = [
     {
@@ -306,6 +314,48 @@ describe("bundler", () => {
       },
       stdout: "function",
     },
+    {
+      // An embedded database becomes a module whose body is synthesized by the
+      // bundler (`import.meta.require(...)`) rather than parsed, so the chunk's
+      // import.meta flag has to be derived from what is printed. Without it the
+      // binary used to segfault on startup.
+      name: "EmbeddedSqlite",
+      files: {
+        "/entry.ts": `
+          import db from "./db.sqlite" with { type: "sqlite", embed: "true" };
+          console.log(db.query("select message from messages limit 1").get().message);
+        `,
+        "/db.sqlite": serializedHelloDatabase(),
+      },
+      stdout: "Hello, world!",
+    },
+    {
+      // A database loaded at runtime stays an import statement with its attribute
+      // in the chunk. The module record has to carry the attribute as well (the
+      // extension alone does not select the sqlite loader); without it the binary
+      // tried to parse the database file as JavaScript. helper.ts is printed
+      // before the entry, so the entry's strings get different ids in the chunk's
+      // record than they had while printing the entry on its own.
+      name: "ImportAttributeOnRuntimeFile",
+      files: {
+        "/entry.ts": `
+          import { locate } from "./helper.ts";
+          import db from "./data.db" with { type: "sqlite" };
+          console.log(locate(), db.query("select message from messages limit 1").get().message);
+        `,
+        "/helper.ts": `
+          import { basename } from "node:path";
+          import { existsSync } from "node:fs";
+          export function locate() {
+            return basename("/some/where/data.db") + ":" + existsSync("data.db");
+          }
+        `,
+      },
+      runtimeFiles: {
+        "/data.db": serializedHelloDatabase(),
+      },
+      stdout: "data.db:true Hello, world!",
+    },
   ];
 
   for (const scenario of esmBytecodeScenarios) {
@@ -320,7 +370,8 @@ describe("bundler", () => {
           minifyWhitespace: true,
         }),
         files: scenario.files,
-        run: { stdout: scenario.stdout },
+        runtimeFiles: scenario.runtimeFiles,
+        run: { stdout: scenario.stdout, setCwd: scenario.runtimeFiles !== undefined },
       });
     }
   }

--- a/test/bundler/bundler_compile_splitting.test.ts
+++ b/test/bundler/bundler_compile_splitting.test.ts
@@ -149,5 +149,41 @@ describe("bundler", () => {
         },
       });
     }
+
+    // Same re-exports in a file that two chunks share. Its code is hoisted into
+    // a shared chunk, which hands the bindings on through the cross-chunk
+    // `export { readFileSync, fsns }` suffix instead of an entry point tail, so
+    // the record has to pair those exports with the imports printed in the
+    // chunk body. Without the imports the binary segfaulted on startup.
+    for (const minify of [false, true]) {
+      itBundled(`compile/splitting/ReExportExternalFromSharedChunk${minify ? "+minify" : ""}`, {
+        compile: true,
+        splitting: true,
+        bytecode: true,
+        format: "esm",
+        ...(minify ? { minifySyntax: true, minifyIdentifiers: true, minifyWhitespace: true } : {}),
+        files: {
+          "/entry.ts": /* js */ `
+            import { rfs, fsns } from "./shared.ts";
+            console.log("entry:", typeof rfs, typeof fsns.readFileSync);
+            const lazy = await import("./lazy.ts");
+            lazy.report();
+          `,
+          "/lazy.ts": /* js */ `
+            import { rfs, fsns } from "./shared.ts";
+            export function report() {
+              console.log("lazy:", typeof rfs, typeof fsns.readFileSync);
+            }
+          `,
+          "/shared.ts": /* js */ `
+            export { readFileSync as rfs } from "node:fs";
+            export * as fsns from "node:fs";
+          `,
+        },
+        run: {
+          stdout: "entry: function function\nlazy: function function",
+        },
+      });
+    }
   });
 });


### PR DESCRIPTION
### Problem
- Test-only follow-up to #37677, which builds each `--compile --bytecode --format=esm` chunk's module record from what the printer emits. Three shapes it repairs had no test.
- Embedded sqlite import on released 1.4.0: `panic(main thread): Segmentation fault at address 0x0`. The module body is synthesized, not parsed, so the record's `import.meta` flag was false.
- Sqlite import resolved at runtime: `error: Expected ";" but found "format"` at `data.db:1:8`. The attribute's string id was not remapped for the chunk, so the database was parsed as JavaScript.
- `node:fs` re-export shared by two chunks under `--splitting`: `panic(main thread): Segmentation fault at address 0x8`. The record had the chunk's exports but not the imports they came from.

### Fix
- Adds the three shapes as tests, plain and minified: two in the ESM bytecode matrix, one in the splitting suite.
- The matrix gains optional `runtimeFiles`, written next to the binary and used as its cwd, for a database that is not embedded.
- The shared-chunk test is the only one that builds a non-entry chunk's record. The existing no-bytecode embedded sqlite test passes either way, which pins the embed crash to the record.
- Verification: all six fail with `USE_SYSTEM_BUN=1` and on a debug build of `da3851e5` (ASAN SEGV, or `Imports different between parseFromSourceCode and fallbackParse`), and pass on current main.

### Background
- With `--compile --bytecode --format=esm` each chunk ships as JSC bytecode plus a module record (imports, exports, attributes, `import.meta` use). JSC links from the record, not the source, so a record that disagrees with the printed code fails at startup.
- An import attribute that survives bundling is a string slot in the record; slots are renumbered when a file's part is appended into a chunk.
- `embed: "true"` on a sqlite import copies the database into the binary and synthesizes the module body (`import.meta.require(...)`); without it the import stays a statement and the file is opened at runtime.
- Under `--splitting`, a file used by both the entry and an `import()`ed module is hoisted into a shared chunk, whose bindings leave through a cross-chunk `export { ... }` suffix rather than an entry point tail.
- Debug builds cross-check the record against a re-parse; the `import.meta` flag is not compared, so its absence shows only as the crash.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

Test-only follow-up to #37677, which made `--compile --bytecode --format=esm` build each chunk's module record from what the printer emits. Reviewing that change afterwards turned up three shapes it repairs that nothing tests. On the released 1.4.0 they fail like this:

```
# import db from "./db.sqlite" with { type: "sqlite", embed: "true" }
panic(main thread): Segmentation fault at address 0x0

# import db from "./data.db" with { type: "sqlite" }   (database present at runtime)
error: Expected ";" but found "format"
    at data.db:1:8

# export { readFileSync as rfs } from "node:fs" in a file shared by two chunks (--splitting)
panic(main thread): Segmentation fault at address 0x8
```

Why each one is a distinct path through the record:

- `EmbeddedSqlite` (ESM bytecode matrix, plain and minified): the embedded database is a module whose body the bundler synthesizes (`import.meta.require(...)`), so it never goes through the parser and the old per-source `has_import_meta` flag was false for it. The record now gets the flag from the printer when it prints `import.meta`; without it JSC runs the module without an `import.meta` binding and crashes in `llint_op_get_by_id`. The debug cross-check does not compare this flag, so the crash is the only signal.
- `ImportAttributeOnRuntimeFile` (matrix, plain and minified): an attribute on a file that stays an import statement is recorded as host-defined fetch parameters, i.e. a string id that `ModuleInfo::append` has to remap like any other slot. The entry imports a helper that itself imports `node:path` / `node:fs`, so the helper's part is appended first and the entry's ids differ between its own part and the chunk. `.db` was chosen because the extension does not imply the sqlite loader, so the recorded attribute is what selects it. The matrix gained optional `runtimeFiles` for this (the binary then runs with that directory as cwd, like `compile/sqlite-file`).
- `ReExportExternalFromSharedChunk` (`bundler_compile_splitting.test.ts`, plain and minified): `ReExportExternalFromSplitChunk` from #37677 reaches the re-exporting file only through `import()`, so it is an entry chunk and its exports go through the entry point tail. Here `entry.ts` and the lazy chunk both import it, so its code is hoisted into a shared chunk whose bindings leave through the cross-chunk `export { readFileSync, fsns }` suffix; the record has to pair that suffix with the `import` statements recorded from the chunk body (one named import, one namespace import). This is also the only test where a non-entry chunk's record is built.

## Verification

All six fail with `USE_SYSTEM_BUN=1` (the errors above) and on a debug build of `da3851e5` (the two sqlite-embed variants with the ASAN SEGV, the other four with `Imports different between parseFromSourceCode and fallbackParse`), and pass with `bun bd test` on current main. The existing `compile/EmbeddedSqlite` (no bytecode) passes on both, which is what pins the crash to the record.

</details>
