### PR TITLE
node:http2: keep flushing after a fatal send that was delivered on retry

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3382,35 +3382,38 @@ impl H2FrameParser {
         handler.close(bun_uws::CloseCode::Normal);
     }
 
+    /// The latched send was delivered by a later flush after all, and frames corked since
+    /// then are waiting on this same auto-flush registration (cork() does not add a second
+    /// one): clears the latch so on_auto_flush flushes them instead of releasing the
+    /// registration, which would leave them in the still-owned cork slot for good.
+    fn fatal_send_recovered_with_corked_frames(&self) -> bool {
+        if self.has_backpressure() || CORKED_H2.with(|c| c.get()) != Some(self.as_ctx_ptr()) {
+            return false;
+        }
+        self.transport_write_fatal.set(false);
+        true
+    }
+
     pub(crate) fn on_auto_flush(&self) -> bool {
         let _keepalive = self.keepalive();
-        if self.transport_write_fatal.get() {
+        if self.transport_write_fatal.get() && !self.fatal_send_recovered_with_corked_frames() {
+            // Returning `false` makes DeferredTaskQueue::run remove the entry
+            // itself, so only the registration's flag and ref are released here
+            // - never a re-entrant map mutation from inside run(). The flag is
+            // cleared before the close so the teardown paths the close re-enters
+            // (detach -> unregister_auto_flush) see an unregistered flusher and
+            // early-return instead of removing a map entry run() still owns.
+            self.auto_flusher.get().registered.set(false);
+            self.deref();
+            // An empty write buffer here means a later write in the same flush()
+            // cycle already drained the bytes the failing send left behind (racy
+            // one-off errnos, e.g. macOS EPROTOTYPE) - the transport recovered.
             if self.has_backpressure() {
-                // Returning `false` makes DeferredTaskQueue::run remove the entry
-                // itself, so only the registration's flag and ref are released here
-                // - never a re-entrant map mutation from inside run(). The flag is
-                // cleared before the close so the teardown paths the close re-enters
-                // (detach -> unregister_auto_flush) see an unregistered flusher and
-                // early-return instead of removing a map entry run() still owns.
-                self.auto_flusher.get().registered.set(false);
-                self.deref();
                 self.close_transport_after_fatal_write();
-                return false;
+            } else {
+                self.transport_write_fatal.set(false);
             }
-            // An empty write buffer here means a later write already drained the bytes the
-            // failing send left behind (racy one-off errnos, e.g. macOS EPROTOTYPE) - the
-            // transport recovered.
-            self.transport_write_fatal.set(false);
-            if CORKED_H2.with(|c| c.get()) != Some(self.as_ctx_ptr()) {
-                self.auto_flusher.get().registered.set(false);
-                self.deref();
-                return false;
-            }
-            // Frames corked since the failing send are waiting on this same registration
-            // (cork() found it registered and did not add another). Releasing it here would
-            // leave them in the cork slot for good: the slot stays owned, so every later
-            // cork() is a no-op and nothing written afterwards reaches the socket until
-            // something calls flush() explicitly. Flush them like any other corked batch.
+            return false;
         }
         if self.pending_header_compression_error.get() {
             // Keep the pending latch set across dispatch+flush: re-entrant detach() ->
@@ -3735,13 +3738,9 @@ impl Payload {
 
 /// Trait to abstract over TLSSocket / TCPSocket for `generic_flush`/`generic_write`.
 ///
-/// Returns -1 without touching the fd while the socket is still connecting: a client
-/// session attaches to its `net.Socket` handle before the connect has completed and
-/// writes the connection preface right away, and a send() on a connecting fd is
-/// platform-dependent (EAGAIN on Linux, ENOTCONN on macOS and Windows, which the socket
-/// layer reports as a fatal peer-gone write). -1 is the same "not writable yet" answer a
-/// detached handle gives, so the bytes wait in `write_buffer` for the connect callback's
-/// `setNativeSocket()` flush.
+/// A still-connecting socket (the client session attaches before its connect completes)
+/// answers -1 like a detached one: send() on a connecting fd is ENOTCONN on macOS and
+/// Windows, which the socket layer reports as a fatal peer-gone write.
 pub(crate) trait NativeSocketWrite {
     fn write_maybe_corked(&mut self, buf: &[u8]) -> i32;
 }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3382,10 +3382,8 @@ impl H2FrameParser {
         handler.close(bun_uws::CloseCode::Normal);
     }
 
-    /// The latched send was delivered by a later flush after all, and frames corked since
-    /// then are waiting on this same auto-flush registration (cork() does not add a second
-    /// one): clears the latch so on_auto_flush flushes them instead of releasing the
-    /// registration, which would leave them in the still-owned cork slot for good.
+    /// Frames corked after the failing send share its registration (cork() never adds a
+    /// second one), so releasing it would strand them in the cork slot.
     fn fatal_send_recovered_with_corked_frames(&self) -> bool {
         if self.has_backpressure() || CORKED_H2.with(|c| c.get()) != Some(self.as_ctx_ptr()) {
             return false;
@@ -3737,10 +3735,8 @@ impl Payload {
 }
 
 /// Trait to abstract over TLSSocket / TCPSocket for `generic_flush`/`generic_write`.
-///
-/// A still-connecting socket (the client session attaches before its connect completes)
-/// answers -1 like a detached one: send() on a connecting fd is ENOTCONN on macOS and
-/// Windows, which the socket layer reports as a fatal peer-gone write.
+/// A socket that is still connecting answers -1 like a detached one: send() on a
+/// connecting fd is ENOTCONN on macOS and Windows, which the socket layer reports as fatal.
 pub(crate) trait NativeSocketWrite {
     fn write_maybe_corked(&mut self, buf: &[u8]) -> i32;
 }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -3385,23 +3385,32 @@ impl H2FrameParser {
     pub(crate) fn on_auto_flush(&self) -> bool {
         let _keepalive = self.keepalive();
         if self.transport_write_fatal.get() {
-            // Returning `false` makes DeferredTaskQueue::run remove the entry
-            // itself, so only the registration's flag and ref are released here
-            // - never a re-entrant map mutation from inside run(). The flag is
-            // cleared before the close so the teardown paths the close re-enters
-            // (detach -> unregister_auto_flush) see an unregistered flusher and
-            // early-return instead of removing a map entry run() still owns.
-            self.auto_flusher.get().registered.set(false);
-            self.deref();
-            // An empty write buffer here means a later write in the same flush()
-            // cycle already drained the bytes the failing send left behind (racy
-            // one-off errnos, e.g. macOS EPROTOTYPE) - the transport recovered.
             if self.has_backpressure() {
+                // Returning `false` makes DeferredTaskQueue::run remove the entry
+                // itself, so only the registration's flag and ref are released here
+                // - never a re-entrant map mutation from inside run(). The flag is
+                // cleared before the close so the teardown paths the close re-enters
+                // (detach -> unregister_auto_flush) see an unregistered flusher and
+                // early-return instead of removing a map entry run() still owns.
+                self.auto_flusher.get().registered.set(false);
+                self.deref();
                 self.close_transport_after_fatal_write();
-            } else {
-                self.transport_write_fatal.set(false);
+                return false;
             }
-            return false;
+            // An empty write buffer here means a later write already drained the bytes the
+            // failing send left behind (racy one-off errnos, e.g. macOS EPROTOTYPE) - the
+            // transport recovered.
+            self.transport_write_fatal.set(false);
+            if CORKED_H2.with(|c| c.get()) != Some(self.as_ctx_ptr()) {
+                self.auto_flusher.get().registered.set(false);
+                self.deref();
+                return false;
+            }
+            // Frames corked since the failing send are waiting on this same registration
+            // (cork() found it registered and did not add another). Releasing it here would
+            // leave them in the cork slot for good: the slot stays owned, so every later
+            // cork() is a no-op and nothing written afterwards reaches the socket until
+            // something calls flush() explicitly. Flush them like any other corked batch.
         }
         if self.pending_header_compression_error.get() {
             // Keep the pending latch set across dispatch+flush: re-entrant detach() ->
@@ -3725,11 +3734,22 @@ impl Payload {
 }
 
 /// Trait to abstract over TLSSocket / TCPSocket for `generic_flush`/`generic_write`.
+///
+/// Returns -1 without touching the fd while the socket is still connecting: a client
+/// session attaches to its `net.Socket` handle before the connect has completed and
+/// writes the connection preface right away, and a send() on a connecting fd is
+/// platform-dependent (EAGAIN on Linux, ENOTCONN on macOS and Windows, which the socket
+/// layer reports as a fatal peer-gone write). -1 is the same "not writable yet" answer a
+/// detached handle gives, so the bytes wait in `write_buffer` for the connect callback's
+/// `setNativeSocket()` flush.
 pub(crate) trait NativeSocketWrite {
     fn write_maybe_corked(&mut self, buf: &[u8]) -> i32;
 }
 impl NativeSocketWrite for &TLSSocket {
     fn write_maybe_corked(&mut self, buf: &[u8]) -> i32 {
+        if !self.socket.get().is_established() {
+            return -1;
+        }
         // Forward to the inherent NewSocket<true>::write_maybe_corked (R-2: now
         // takes `&self`). UFCS to avoid resolving back to this trait impl.
         TLSSocket::write_maybe_corked(*self, buf)
@@ -3737,6 +3757,9 @@ impl NativeSocketWrite for &TLSSocket {
 }
 impl NativeSocketWrite for &TCPSocket {
     fn write_maybe_corked(&mut self, buf: &[u8]) -> i32 {
+        if !self.socket.get().is_established() {
+            return -1;
+        }
         TCPSocket::write_maybe_corked(*self, buf)
     }
 }

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tls as certs, isASAN, isWindows } from "harness";
 import { once } from "node:events";
 import http2 from "node:http2";
+import net from "node:net";
+import os from "node:os";
 import path from "node:path";
 
 const skip = !fault.available() || isWindows;
@@ -229,5 +231,118 @@ describe.skipIf(skip)("node:http2 seeded short-I/O fuzz", () => {
         client.close();
       }
     }
+  });
+});
+
+// A raw TCP peer that only records the HTTP/2 frames the client sends and never answers, so
+// the only thing that can put a frame on the wire is the client's own flushing.
+const FRAME_HEADERS = 0x1;
+const FRAME_RST_STREAM = 0x3;
+const FRAME_SETTINGS = 0x4;
+const PREFACE_LENGTH = "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n".length;
+type RawFrame = { type: number; flags: number; streamId: number; payload: Buffer };
+
+async function silentRawServer() {
+  const frames: RawFrame[] = [];
+  let waiter: { pred: (f: RawFrame) => boolean; resolve: (f: RawFrame) => void } | null = null;
+  let buf = Buffer.alloc(0);
+  let sawPreface = false;
+  let socket: net.Socket | null = null;
+  const server = net.createServer(s => {
+    socket = s;
+    s.on("error", () => {});
+    s.on("data", (chunk: Buffer) => {
+      buf = Buffer.concat([buf, chunk]);
+      if (!sawPreface) {
+        if (buf.length < PREFACE_LENGTH) return;
+        buf = buf.subarray(PREFACE_LENGTH);
+        sawPreface = true;
+      }
+      while (buf.length >= 9) {
+        const length = buf.readUIntBE(0, 3);
+        if (buf.length < 9 + length) break;
+        const frame: RawFrame = {
+          type: buf.readUInt8(3),
+          flags: buf.readUInt8(4),
+          streamId: buf.readUInt32BE(5) & 0x7fffffff,
+          payload: buf.subarray(9, 9 + length),
+        };
+        buf = buf.subarray(9 + length);
+        frames.push(frame);
+        if (waiter !== null && waiter.pred(frame)) {
+          const { resolve } = waiter;
+          waiter = null;
+          resolve(frame);
+        }
+      }
+    });
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  return {
+    url: `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`,
+    frames,
+    waitFor(pred: (f: RawFrame) => boolean): Promise<RawFrame> {
+      const existing = frames.find(pred);
+      if (existing) return Promise.resolve(existing);
+      return new Promise(resolve => (waiter = { pred, resolve }));
+    },
+    [Symbol.dispose]() {
+      socket?.destroy();
+      server.close();
+    },
+  };
+}
+
+// close() on a request made before the session connected: the stream is submitted from the
+// connect callback, and its RST_STREAM is written from a later setImmediate with nothing else
+// going on, so that frame only reaches the wire through the parser's deferred auto-flush. Against
+// a silent peer nothing else ever flushes it. (Without fault injection this is the case the
+// darwin CI lane hit: the preface send() on the still-connecting socket fails with ENOTCONN there.)
+async function closedPendingRequestGetsReset(raw: Awaited<ReturnType<typeof silentRawServer>>) {
+  const client = http2.connect(raw.url);
+  const sessionErrors: Error[] = [];
+  client.on("error", err => sessionErrors.push(err));
+  const sessionClosed = once(client, "close").then(() => {
+    throw new Error(`session closed before the RST_STREAM went out (${sessionErrors.map(e => e.message)})`);
+  });
+  try {
+    const req = client.request({ ":method": "POST", ":path": "/" });
+    req.on("error", () => {});
+    expect(req.pending).toBe(true);
+    req.end("hello");
+    req.close();
+
+    const rst = await Promise.race([raw.waitFor(f => f.streamId === 1 && f.type === FRAME_RST_STREAM), sessionClosed]);
+    expect(rst.payload.readUInt32BE(0)).toBe(http2.constants.NGHTTP2_NO_ERROR);
+    expect(raw.frames.map(f => [f.type, f.streamId])).toEqual([
+      [FRAME_SETTINGS, 0],
+      [FRAME_HEADERS, 1],
+      [0 /* DATA */, 1],
+      [FRAME_RST_STREAM, 1],
+    ]);
+    expect(sessionErrors).toEqual([]);
+  } finally {
+    client.removeAllListeners("close");
+    client.destroy();
+  }
+}
+
+test("client: a request close()d while the session was still connecting is reset once it is submitted", async () => {
+  using raw = await silentRawServer();
+  await closedPendingRequestGetsReset(raw);
+});
+
+describe.skipIf(skip)("node:http2 after a send() that fails with a peer-gone errno but is delivered on retry", () => {
+  // Models what macOS does for the preface write on a still-connecting loopback socket (ENOTCONN,
+  // which the socket layer reports as fatal), or a racy EPROTOTYPE: the send fails once, the bytes
+  // are delivered by the next flush. The parser must keep flushing the frames written after that,
+  // not treat the connection as dead or stop flushing it.
+  test("frames written after the failed send still reach the wire", async () => {
+    using raw = await silentRawServer();
+    // The first send() of the connection, no matter whether it happens before or after the
+    // connect completes; the raw peer never sends, so no other send() can consume the rule.
+    fault.set({ syscall: "send", action: "errno", errno: os.constants.errno.ENOTCONN, repeat: 1 });
+    await closedPendingRequestGetsReset(raw);
   });
 });

--- a/test/js/node/http2/node-http2-syscall-fault.test.ts
+++ b/test/js/node/http2/node-http2-syscall-fault.test.ts
@@ -9,7 +9,11 @@ import path from "node:path";
 
 const skip = !fault.available() || isWindows;
 
-afterEach(() => fault.clear());
+// fault.clear() throws on builds without the hooks compiled in, and the unfaulted scenario at the
+// bottom of this file runs on those builds too.
+afterEach(() => {
+  if (fault.available()) fault.clear();
+});
 
 // http2 sessions go through the same uSockets bsd_recv/bsd_send chokepoints.
 // Faults are process-global, so client and server (both in this process)


### PR DESCRIPTION
### Problem
- An h2c client requests before the session has connected, then `close()`s the request. On macOS the `RST_STREAM(NO_ERROR)` never reaches a peer that sends nothing back until `client.destroy()`; Linux delivers it. Seen deterministically on the darwin-14-aarch64 lane while #37722 carried this scenario as a test.
- The parser writes the preface before the connect completes. On macOS and Windows that `send()` fails with `ENOTCONN`, which the socket layer treats as peer gone, so the parser latches its fatal-write flag even though the next flush delivers the bytes.
- The latch and `cork()` share one deferred flush registration. When the deferred task saw the bytes delivered it released the registration without flushing, so frames corked behind it stayed in the cork slot and later `cork()` calls registered nothing. A `RST_STREAM` from `close()` against a silent peer has no other route to the wire.
- Reproduces on Linux by injecting `ENOTCONN` into the connection's first `send()`.

### Fix
- When the deferred task finds the latched send was transient (no backpressure left) and this parser still owns the cork slot, it clears the latch and runs the normal flush instead of returning. Property to check: a recovered send never releases the registration while frames are corked. The dead-transport branch is unchanged.
- The parser no longer calls `send()` on a still-connecting socket; it gets the -1 a detached handle gets, so the preface waits for the connect callback's flush on every platform. `node:net` never writes before connect, so only the parser's own writes change.
- The first change is the fix and also covers what the latch exists for (a one-off errno such as macOS `EPROTOTYPE`); the second stops every new h2c connection on macOS and Windows from setting it.
- Verification: a test injects `ENOTCONN` into the first `send()` against a silent raw TCP peer and checks all four frames arrive; it times out without the fix (ASAN builds, where the fault hooks exist). The unfaulted copy is what the darwin lane hits for real and passes on Linux either way. Existing http2 suites were run on a debug build.

### Background
- h2c is HTTP/2 over plain TCP. A client opens by writing a fixed preface string and a `SETTINGS` frame; `RST_STREAM(NO_ERROR)` cancels one stream without closing the session.
- A `request()` made before the socket connects is pending: queued in JS, submitted to the parser from the connect callback.
- Corking: frames written during one turn collect in a per-thread cork slot owned by one parser, and one deferred task flushes them. `cork()` registers that task only if the slot was free, so whoever holds the registration must flush or nothing behind it goes out.
- The fatal-write latch (#32488): a send error reported as peer gone is judged later by that same deferred task, since a retry may still deliver the bytes; if it did not, the task closes the socket.
- `send()` on a still-connecting fd returns `EAGAIN` on Linux but `ENOTCONN` on macOS and Windows.

<details>
<summary>Original description</summary>

### Repro

An h2c client against a peer that never sends anything back (a raw `net.Server` here). The request is made before the session has connected, so it is queued and submitted from the connect callback; `close()` on it sends `RST_STREAM(NO_ERROR)` from a later `setImmediate`:

```js
const client = http2.connect(`http://127.0.0.1:${port}`); // raw net server, sends nothing
const req = client.request({ ":method": "POST", ":path": "/" }); // req.pending === true
req.end("hello");
req.close();
// peer: wait for RST_STREAM on stream 1
```

Linux: the peer receives `SETTINGS`, `HEADERS`, `DATA`, `RST_STREAM(0)`.
macOS (observed deterministically on the darwin-14-aarch64 lane while #37722 carried this scenario as a test, build 92773): the `RST_STREAM` never arrives. It only goes out when `client.destroy()` finally flushes the session.

The same thing reproduces on Linux by making the first `send()` of the connection fail with `ENOTCONN` through the socket fault-injection hooks, which is the test added here:

```
(fail) frames written after the failed send still reach the wire  [5000.82ms] (timed out)
```

### Cause

The client session attaches the parser to `socket._handle` in its constructor and the parser writes the connection preface right away, before the connect has completed, straight to the fd. What that `send()` returns depends on the kernel: Linux answers `EAGAIN` (would block, re-armed), macOS and Windows answer `ENOTCONN`, and `us_socket_write_check_error` classifies `ENOTCONN` as a peer-gone errno, so the parser latches `transport_write_fatal` and registers its deferred task (`note_transport_write_fatal`, from #32488). The preface itself is fine: it is buffered and `setNativeSocket()` flushes it once the socket connects.

The latch is what loses the later frames. `on_auto_flush` is one registration shared by the latch and by `cork()`, and `cork()` does not register twice. When the deferred task ran and found the latch set but the bytes delivered, it released the registration and returned without flushing. Every frame corked in between (here the `HEADERS` submitted from the connect callback, and later the `RST_STREAM`) stayed in the cork slot, and because the slot stayed owned by this parser, every subsequent `cork()` was a no-op that registered nothing, so nothing written afterwards reached the socket until something called `flush()` explicitly. Paths that flush explicitly (`_final`, `setNativeSocket()`, inbound frame processing) hid it; a `RST_STREAM` written from `close()`'s `setImmediate` against a silent peer has none of those.

### Fix

`on_auto_flush`: when the latched write turned out to be transient (no backpressure left) and this parser owns the cork slot, clear the latch and go on to the regular flush instead of returning, so the corked frames go out and the registration is released by `uncork()` the way it always is. The dead-transport branch (bytes still undelivered, close the socket) and the "nothing corked" branch are unchanged.

`NativeSocketWrite`: the parser no longer issues a `send()` on a socket that is still connecting; it returns -1, the same "not writable yet" answer a detached handle already gets, so the bytes wait in `write_buffer` for the connect callback's flush on every platform instead of depending on which errno the kernel picks for a connecting fd. `node:net` itself never writes before connect (it queues in JS), so this only affects the h2 parser's direct writes.

The first change is the one that fixes the lost frame and also covers the case the latch was written for (a racy one-off errno such as macOS `EPROTOTYPE` on an established connection); the second removes the spurious way of setting the latch on every new h2c connection on macOS and Windows.

### Verification

`test/js/node/http2/node-http2-syscall-fault.test.ts`:
- `frames written after the failed send still reach the wire`: injects `ENOTCONN` on the first `send()` of the connection, then runs the scenario above against a silent raw peer and checks that `SETTINGS`, `HEADERS`, `DATA`, `RST_STREAM(NO_ERROR)` all arrive and the session did not error. Times out without the fix (ASAN builds, where the fault hooks are compiled in).
- `a request close()d while the session was still connecting is reset once it is submitted`: the same scenario without fault injection, which is what the darwin lane exercises for real. Passes on Linux either way.

Also run with the debug build: the rest of that file, `node-http2.test.js` (357 pass), `h2-conformance.test.ts`, the other bun-owned http2 suites, and the upstream `test-http2-*-before-connect.js`, `test-http2-connect*.js`, `test-http2-client-*destroy*.js`, `test-http2-destroy-after-write.js`, `test-http2-close-while-writing.js`, `test-http2-client-upload.js`, `test-http2-trailers.js`, `test-http2-no-wanttrailers-listener.js`, `test-http2-session-timeout.js`, `test-http2-ping-unsolicited-ack.js` and `test-http2-write-empty-string.js`, all passing.

</details>
