### PR TITLE
bun:test: print array holes as empty slots in diffs and snapshots

### DIFF
--- a/src/jsc/ConsoleObject.rs
+++ b/src/jsc/ConsoleObject.rs
@@ -4346,7 +4346,7 @@ pub mod formatter {
                 let _qs = defer_restore!(self.quote_strings, prev_quote_strings);
                 let mut empty_start: Option<u32> = None;
                 'first: {
-                    let element = value.get_direct_index(self.global_this, 0);
+                    let element = value.get_direct_index(self.global_this, 0)?;
 
                     let tag = Tag::get_advanced(element, self.global_this, tag_opts)?;
 
@@ -4386,7 +4386,7 @@ pub mod formatter {
                 let mut nonempty_count: u32 = 1;
 
                 while (i as u64) < len {
-                    let element = value.get_direct_index(self.global_this, i);
+                    let element = value.get_direct_index(self.global_this, i)?;
                     if element.is_empty() {
                         if empty_start.is_none() {
                             empty_start = Some(i);

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2524,10 +2524,10 @@ impl JSValue {
         }
         JSBuffer__isBuffer(global, self)
     }
-    /// `JSValue.getDirectIndex` — read the `i`th indexed
-    /// own-property slot directly (no prototype walk, no getters). Returns
-    /// the empty value for holes.
-    pub fn get_direct_index(self, global: &JSGlobalObject, i: u32) -> JSValue {
+    /// `JSValue.getDirectIndex` — read the `i`th indexed own property (no
+    /// prototype walk). Returns the empty value for holes. An own accessor at
+    /// that index is invoked, so this can throw. `self` must be an object.
+    pub fn get_direct_index(self, global: &JSGlobalObject, i: u32) -> JsResult<JSValue> {
         unsafe extern "C" {
             safe fn JSC__JSValue__getDirectIndex(
                 this: JSValue,
@@ -2535,7 +2535,11 @@ impl JSValue {
                 i: u32,
             ) -> JSValue;
         }
-        JSC__JSValue__getDirectIndex(self, global, i)
+        debug_assert!(self.is_object());
+        crate::top_scope!(scope, global);
+        let v = JSC__JSValue__getDirectIndex(self, global, i);
+        scope.return_if_exception()?;
+        Ok(v)
     }
     /// Smallest own present index of a `JSArray` that is `>= start`, or
     /// `None` when every index from `start` to the end of the array is a

--- a/src/jsc/JSValue.rs
+++ b/src/jsc/JSValue.rs
@@ -2524,9 +2524,7 @@ impl JSValue {
         }
         JSBuffer__isBuffer(global, self)
     }
-    /// `JSValue.getDirectIndex` — read the `i`th indexed own property (no
-    /// prototype walk). Returns the empty value for holes. An own accessor at
-    /// that index is invoked, so this can throw. `self` must be an object.
+    /// Own element `i` or empty for a hole; no prototype walk. May run an accessor and throw.
     pub fn get_direct_index(self, global: &JSGlobalObject, i: u32) -> JsResult<JSValue> {
         unsafe extern "C" {
             safe fn JSC__JSValue__getDirectIndex(

--- a/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
@@ -28,7 +28,7 @@ pub(crate) fn to_have_last_returned_with(
     let mut last_error_value: JSValue = JSValue::UNDEFINED;
 
     if calls_count > 0 {
-        let last_result = returns.get_direct_index(global_this, calls_count - 1);
+        let last_result = returns.get_direct_index(global_this, calls_count - 1)?;
 
         if last_result.is_object() {
             let result_type = last_result.get(global_this, "type")?.unwrap_or(JSValue::UNDEFINED);

--- a/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveNthReturnedWith.rs
@@ -43,7 +43,7 @@ pub(crate) fn to_have_nth_returned_with(
 
     if index < calls_count {
         nth_call_exists = true;
-        let nth_result = returns.get_direct_index(global, index);
+        let nth_result = returns.get_direct_index(global, index)?;
         if nth_result.is_object() {
             let result_type = nth_result.get(global, "type")?.unwrap_or(JSValue::UNDEFINED);
             if result_type.is_string() {

--- a/src/runtime/test_runner/expect/toHaveReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveReturnedWith.rs
@@ -31,7 +31,7 @@ pub(crate) fn to_have_returned_with(
 
     // Check for a pass and collect info for error messages
     for i in 0..calls_count {
-        let result = returns.get_direct_index(global, i);
+        let result = returns.get_direct_index(global, i)?;
 
         if result.is_object() {
             let result_type = result.get(global, "type")?.unwrap_or(JSValue::UNDEFINED);

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1401,9 +1401,7 @@ impl<'a> Formatter<'a> {
                         writer.write_all(b"[");
                         self.add_for_new_line(1);
 
-                        // `indent` and `quote_strings` must be restored even when
-                        // `get_direct_index` / `Tag::get` / `format` throw. Wrap the fallible
-                        // body in a closure and restore unconditionally afterward.
+                        // Closure so `indent`/`quote_strings` are restored if an element throws.
                         let inner: JsResult<()> = (|| {
                             for i in 0..len {
                                 if i > 0 {
@@ -1413,12 +1411,10 @@ impl<'a> Formatter<'a> {
                                 writer.write_all(b"\n");
                                 self.write_indent(writer.ctx).expect("unreachable");
 
-                                // pretty-format prints a hole as a bare comma, so a hole and
-                                // an explicit `undefined` stay distinguishable in diffs/snapshots.
-                                // Own indices only, like Bun__deepEquals: an index inherited
-                                // from the prototype is a hole here too.
+                                // Own indices only, the same view Bun__deepEquals compares.
                                 let element = value.get_direct_index(self.global_this, i)?;
                                 if element.is_empty() {
+                                    // A hole is just the comma, as in pretty-format.
                                     continue;
                                 }
                                 let tag = Tag::get(element, self.global_this)?;

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -402,21 +402,6 @@ pub enum Tag {
 }
 
 impl Tag {
-    pub(crate) fn is_primitive(self) -> bool {
-        matches!(
-            self,
-            Tag::String
-                | Tag::StringPossiblyFormatted
-                | Tag::Undefined
-                | Tag::Double
-                | Tag::Integer
-                | Tag::Null
-                | Tag::Boolean
-                | Tag::Symbol
-                | Tag::BigInt
-        )
-    }
-
     #[inline]
     pub(crate) const fn can_have_circular_references(self) -> bool {
         matches!(self, Tag::Array | Tag::Object | Tag::Map | Tag::Set)
@@ -1406,80 +1391,46 @@ impl<'a> Formatter<'a> {
                         writer.write_all(b"\n");
                     }
 
-                    let mut was_good_time = self.always_newline_scope;
                     {
                         self.indent += 1;
-
-                        self.add_for_new_line(2);
 
                         let prev_quote_strings = self.quote_strings;
                         self.quote_strings = true;
 
-                        // `indent` and `quote_strings` must be
-                        // restored even when `Tag::get` / `format` throw. Wrap the fallible body in
-                        // a closure and restore unconditionally afterward.
+                        self.reset_line();
+                        writer.write_all(b"[");
+                        self.add_for_new_line(1);
+
+                        // `indent` and `quote_strings` must be restored even when
+                        // `get_direct_index` / `Tag::get` / `format` throw. Wrap the fallible
+                        // body in a closure and restore unconditionally afterward.
                         let inner: JsResult<()> = (|| {
-                            {
-                                let element = value.get_index(self.global_this, 0)?;
-                                let tag = Tag::get(element, self.global_this)?;
-
-                                was_good_time = was_good_time
-                                    || !tag.tag.is_primitive()
-                                    || self.good_time_for_a_new_line();
-
-                                self.reset_line();
-                                writer.write_all(b"[");
-                                writer.write_all(b"\n");
-                                self.write_indent(writer.ctx).expect("unreachable");
-                                self.add_for_new_line(1);
-
-                                self.format::<W, ENABLE_ANSI_COLORS>(
-                                    tag, writer.ctx, element, self.global_this,
-                                )?;
-
-                                if tag.cell.is_string_like() {
-                                    if ENABLE_ANSI_COLORS {
-                                        writer.write_all(
-                                            pretty_fmt_const::<true>("<r>").as_bytes(),
-                                        );
-                                    }
-                                }
-
-                                if len == 1 {
+                            for i in 0..len {
+                                if i > 0 {
                                     self.print_comma::<W, ENABLE_ANSI_COLORS>(writer.ctx)
                                         .expect("unreachable");
                                 }
-                            }
-
-                            let mut i: u32 = 1;
-                            while i < len {
-                                self.print_comma::<W, ENABLE_ANSI_COLORS>(writer.ctx)
-                                    .expect("unreachable");
-
                                 writer.write_all(b"\n");
                                 self.write_indent(writer.ctx).expect("unreachable");
 
-                                let element = value.get_index(self.global_this, i)?;
+                                // pretty-format prints a hole as a bare comma, so a hole and
+                                // an explicit `undefined` stay distinguishable in diffs/snapshots.
+                                let element = value.get_direct_index(self.global_this, i)?;
+                                if element.is_empty() {
+                                    continue;
+                                }
                                 let tag = Tag::get(element, self.global_this)?;
 
                                 self.format::<W, ENABLE_ANSI_COLORS>(
                                     tag, writer.ctx, element, self.global_this,
                                 )?;
 
-                                if tag.cell.is_string_like() {
-                                    if ENABLE_ANSI_COLORS {
-                                        writer.write_all(
-                                            pretty_fmt_const::<true>("<r>").as_bytes(),
-                                        );
-                                    }
+                                if tag.cell.is_string_like() && ENABLE_ANSI_COLORS {
+                                    writer.write_all(pretty_fmt_const::<true>("<r>").as_bytes());
                                 }
-
-                                if i == len - 1 {
-                                    self.print_comma::<W, ENABLE_ANSI_COLORS>(writer.ctx)
-                                        .expect("unreachable");
-                                }
-                                i += 1;
                             }
+                            self.print_comma::<W, ENABLE_ANSI_COLORS>(writer.ctx)
+                                .expect("unreachable");
                             Ok(())
                         })();
 

--- a/src/runtime/test_runner/pretty_format.rs
+++ b/src/runtime/test_runner/pretty_format.rs
@@ -1415,6 +1415,8 @@ impl<'a> Formatter<'a> {
 
                                 // pretty-format prints a hole as a bare comma, so a hole and
                                 // an explicit `undefined` stay distinguishable in diffs/snapshots.
+                                // Own indices only, like Bun__deepEquals: an index inherited
+                                // from the prototype is a hole here too.
                                 let element = value.get_direct_index(self.global_this, i)?;
                                 if element.is_empty() {
                                     continue;

--- a/test/js/bun/test/snapshot-tests/__snapshots__/existing-snapshots.test.ts.snap
+++ b/test/js/bun/test/snapshot-tests/__snapshots__/existing-snapshots.test.ts.snap
@@ -69,3 +69,69 @@ exports[`it will work with an existing snapshot file made with bun 7`] = `
   "j": Any<RegExp>,
 }
 `;
+
+exports[`array holes match the snapshot entries jest writes 1`] = `
+[
+  1,
+  ,
+  3,
+]
+`;
+
+exports[`array holes match the snapshot entries jest writes 2`] = `
+[
+  ,
+  "b",
+]
+`;
+
+exports[`array holes match the snapshot entries jest writes 3`] = `
+[
+  1,
+  2,
+  ,
+]
+`;
+
+exports[`array holes match the snapshot entries jest writes 4`] = `
+[
+  ,
+  ,
+]
+`;
+
+exports[`array holes match the snapshot entries jest writes 5`] = `
+[
+  ,
+]
+`;
+
+exports[`array holes match the snapshot entries jest writes 6`] = `
+{
+  "a": [
+    ,
+    1,
+  ],
+}
+`;
+
+exports[`array holes match the snapshot entries jest writes 7`] = `
+[
+  [
+    ,
+    1,
+  ],
+  ,
+  [
+    2,
+  ],
+]
+`;
+
+exports[`array holes match the snapshot entries jest writes 8`] = `
+[
+  1,
+  undefined,
+  3,
+]
+`;

--- a/test/js/bun/test/snapshot-tests/existing-snapshots.test.ts
+++ b/test/js/bun/test/snapshot-tests/existing-snapshots.test.ts
@@ -13,3 +13,17 @@ test("it will work with an existing snapshot file made with bun", () => {
     b: expect.any(String),
   });
 });
+
+// The entries for this test in the .snap file are what jest's serializer
+// (pretty-format) writes: a hole is a line holding only the comma, and only an
+// element that is actually present prints as `undefined`. Do not regenerate them with -u.
+test("array holes match the snapshot entries jest writes", () => {
+  expect([1, , 3]).toMatchSnapshot();
+  expect([, "b"]).toMatchSnapshot();
+  expect([1, 2, ,]).toMatchSnapshot();
+  expect(new Array(2)).toMatchSnapshot();
+  expect([,]).toMatchSnapshot();
+  expect({ a: [, 1] }).toMatchSnapshot();
+  expect([[, 1], , [2]]).toMatchSnapshot();
+  expect([1, undefined, 3]).toMatchSnapshot();
+});

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -371,6 +371,80 @@ test("basic unchanging inline snapshot", () => {
   );
 });
 
+// Same format as jest's pretty-format: a hole prints as a line with only the
+// comma, so a sparse array and an array of explicit `undefined`s do not
+// serialize identically.
+test("array holes in inline snapshots", () => {
+  expect([1, , 3]).toMatchInlineSnapshot(`
+    [
+      1,
+      ,
+      3,
+    ]
+  `);
+  expect([1, undefined, 3]).toMatchInlineSnapshot(`
+    [
+      1,
+      undefined,
+      3,
+    ]
+  `);
+  expect([, "b"]).toMatchInlineSnapshot(`
+    [
+      ,
+      "b",
+    ]
+  `);
+  expect([1, 2, ,]).toMatchInlineSnapshot(`
+    [
+      1,
+      2,
+      ,
+    ]
+  `);
+  expect(new Array(2)).toMatchInlineSnapshot(`
+    [
+      ,
+      ,
+    ]
+  `);
+  expect({ a: [[, 1], , [2]] }).toMatchInlineSnapshot(`
+    {
+      "a": [
+        [
+          ,
+          1,
+        ],
+        ,
+        [
+          2,
+        ],
+      ],
+    }
+  `);
+
+  class List extends Array {}
+  const list = List.of(1, 2, 3);
+  delete list[1];
+  expect(list).toMatchInlineSnapshot(`
+    [
+      1,
+      ,
+      3,
+    ]
+  `);
+
+  // An index backed by an accessor is present, not a hole; the getter runs like in jest.
+  const accessor = [1, 2];
+  Object.defineProperty(accessor, 1, { get: () => "from getter", enumerable: true });
+  expect(accessor).toMatchInlineSnapshot(`
+    [
+      1,
+      "from getter",
+    ]
+  `);
+});
+
 class InlineSnapshotTester {
   tmpdir: string;
   tmpid: number;

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -434,7 +434,23 @@ test("array holes in inline snapshots", () => {
     ]
   `);
 
-  // An index backed by an accessor is present, not a hole; the getter runs like in jest.
+  // Only own indices count, which is also what toEqual/toStrictEqual compare: an index
+  // that is only reachable through the prototype is still a hole.
+  class Inherited extends Array {}
+  Inherited.prototype[1] = "proto";
+  const inherited = Inherited.of(1, 2, 3);
+  delete inherited[1];
+  expect(1 in inherited).toBe(true);
+  expect(inherited[1]).toBe("proto");
+  expect(inherited).toMatchInlineSnapshot(`
+    [
+      1,
+      ,
+      3,
+    ]
+  `);
+
+  // An index backed by an own accessor is present, not a hole; the getter runs like in jest.
   const accessor = [1, 2];
   Object.defineProperty(accessor, 1, { get: () => "from getter", enumerable: true });
   expect(accessor).toMatchInlineSnapshot(`

--- a/test/js/bun/test/spyMatchers.test.ts
+++ b/test/js/bun/test/spyMatchers.test.ts
@@ -1343,5 +1343,21 @@ describe.each(["toHaveLastReturnedWith", "toHaveNthReturnedWith", "toHaveReturne
         expect(() => jestExpect(fn)[returnedWith]("foo")).toThrow();
       }
     });
+
+    test("propagates an exception thrown by an accessor on mock.results", () => {
+      const fn = jest.fn(() => "foo");
+      fn();
+      Object.defineProperty(fn.mock.results, 0, {
+        get() {
+          throw new Error("results-getter");
+        },
+      });
+
+      if (isToHaveNth(returnedWith)) {
+        expect(() => jestExpect(fn)[returnedWith](1, "foo")).toThrow("results-getter");
+      } else {
+        expect(() => jestExpect(fn)[returnedWith]("foo")).toThrow("results-getter");
+      }
+    });
   },
 );

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -588,6 +588,56 @@ it("expect().toEqual() on objects with property indices doesn't print undefined"
   expect(err).not.toContain("undefined");
 });
 
+it("expect() diffs print an array hole as an empty slot, like jest", async () => {
+  using dir = tempDir("diff-array-holes", {
+    "holes.test.js": `
+      import { expect, test } from "bun:test";
+      test("hole vs undefined", () => {
+        expect([1, , 3]).toStrictEqual([1, undefined, 3]);
+      });
+      test("hole vs value", () => {
+        expect([1, , 3]).toEqual([1, 2, 3]);
+      });
+    `,
+  });
+  await using proc = spawn({
+    cmd: [bunExe(), "test", "holes.test.js"],
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: bunEnv,
+  });
+  const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  // Keep only the matcher output: from each `error:` line up to its stack trace.
+  const diffs = [...stderr.matchAll(/^error: expect\(received\)[^]*?(?=\n\s+at )/gm)].map(m => m[0]);
+  expect(diffs.join("\n")).toMatchInlineSnapshot(`
+    "error: expect(received).toStrictEqual(expected)
+
+      [
+        1,
+    -   undefined,
+    +   ,
+        3,
+      ]
+
+    - Expected  - 1
+    + Received  + 1
+    error: expect(received).toEqual(expected)
+
+      [
+        1,
+    -   2,
+    +   ,
+        3,
+      ]
+
+    - Expected  - 1
+    + Received  + 1"
+  `);
+  expect(exitCode).toBe(1);
+});
+
 it("test --preload supports global lifecycle hooks", () => {
   const preloadedPath = join(tmp, "test-fixture-preload-global-lifecycle-hook-preloaded.js");
   const path = join(tmp, "test-fixture-preload-global-lifecycle-hook-test.test.js");

--- a/test/js/bun/test/test-test.test.ts
+++ b/test/js/bun/test/test-test.test.ts
@@ -598,6 +598,10 @@ it("expect() diffs print an array hole as an empty slot, like jest", async () =>
       test("hole vs value", () => {
         expect([1, , 3]).toEqual([1, 2, 3]);
       });
+      test("hole vs the value inherited through the prototype", () => {
+        Array.prototype[1] = "proto";
+        expect([1, , 3]).toStrictEqual([1, "proto", 3]);
+      });
     `,
   });
   await using proc = spawn({
@@ -628,6 +632,17 @@ it("expect() diffs print an array hole as an empty slot, like jest", async () =>
       [
         1,
     -   2,
+    +   ,
+        3,
+      ]
+
+    - Expected  - 1
+    + Received  + 1
+    error: expect(received).toStrictEqual(expected)
+
+      [
+        1,
+    -   "proto",
     +   ,
         3,
       ]


### PR DESCRIPTION
### Problem
- `expect([1, , 3]).toStrictEqual([1, undefined, 3])` fails, but the printed diff is empty (`- Expected  - 0` / `+ Received  + 0`): both sides render as `undefined`.
- The same formatter writes snapshots, so bun wrote `undefined` for a hole, and a `.snap` written by jest for a sparse array (a line holding only a comma) did not match bun's output.
- Cause: the `bun:test` formatter read array elements through a lookup that returns `undefined` for a hole, so a hole and an explicit `undefined` element produced identical text.

### Fix
- Elements are now read as own indexed slots and a hole prints as just the comma, which is what jest's pretty-format does (checked against 29.7.0). Own slots are also what `toEqual`/`toStrictEqual` compare, so the diff shows exactly what failed; an index supplied only by the prototype still prints as a hole, as equality treats it.
- Reading an own slot can run an own accessor, so that read is now fallible. The three `toHave*ReturnedWith` matchers, which already used it, now throw a throwing accessor's error from `mock.results` instead of a message truncated at `Expected: `; for `console.log` this is not observable.
- Compatibility: a `.snap` or inline snapshot of a sparse array written by an older bun (holes as `undefined`) needs `bun test -u`; jest-written ones now match. JSX children arrays are unchanged.
- Verification: new tests for the diff, `.snap`, inline snapshot and matcher cases fail on the released bun and pass with the fix. Open #37764 has one snapshot hunk that whichever PR merges second must update.

### Background
- An array hole (`[1, , 3]`) has no property at index 1 at all; `[1, undefined, 3]` has one whose value is `undefined`. Indexing returns `undefined` for both; only `1 in arr` tells them apart.
- An ordinary indexed read walks the prototype chain, so `Array.prototype[1] = x` fills a hole from that reader's point of view. Reading only own slots ignores that, and JSC marks a hole with a special empty value that is not a JS value.
- pretty-format is jest's serializer; bun's `bun:test` formatter mirrors its output so `.snap` files and diffs are interchangeable with jest.
- JSC reports a JS exception thrown inside a native call by leaving it pending on the VM. Native code has to check after any call that can run user code (an accessor here); otherwise it keeps producing output with the exception still pending.
- `mock.results` is the array of per-call outcomes on a `jest.fn()`; the `toHave*ReturnedWith` matchers read it index by index, so a user-installed accessor on it runs during the matcher.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/test/test-test.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

```ts
import { test, expect } from "bun:test";
test("hole vs undefined", () => {
  expect([1, , 3]).toStrictEqual([1, undefined, 3]);
});
```

Before (the two sides render identically, so the diff is empty):

```
error: expect(received).toStrictEqual(expected)

  [
    1,
    undefined,
    3,
  ]

- Expected  - 0
+ Received  + 0
```

After:

```
  [
    1,
-   undefined,
+   ,
    3,
  ]

- Expected  - 1
+ Received  + 1
```

The same formatter serializes snapshots, so `expect([1, , 3]).toMatchSnapshot()` wrote `undefined` for the hole, and a `.snap` written by jest for a sparse array (`Array [\n  1,\n  ,\n  3,\n]` with the default `printBasicPrototype: false` becomes `[\n  1,\n  ,\n  3,\n]`) did not match bun's output.

### Cause

The `Tag::Array` branch of `src/runtime/test_runner/pretty_format.rs` read every element with `get_index`, which returns `undefined` for a hole, so a hole and an explicit `undefined` element were indistinguishable in the rendered text.

### Fix

Read elements with `get_direct_index` (own indexed property, empty value for a hole) and print nothing for a hole, keeping the comma. This is what `pretty-format`'s `printListItems` does (it only prints the value when `i in list`), verified against pretty-format 29.7.0. The `.snap` entries added in this PR are the text pretty-format produces for the same values.

Reading own indices also matches what `toEqual`/`toStrictEqual` compare (`Bun__deepEquals` reads own indices too), so the diff now shows exactly the thing that made the comparison fail. The one observable difference from `i in list` is an index satisfied only by the prototype chain (`Array.prototype[1] = x`), which still prints as a hole here; equality treats it as a hole as well.

`JSObject::getDirectIndex` invokes an own accessor at that index (same as `getIndex` did), so `JSValue::get_direct_index` now returns `JsResult` and checks the exception scope like `get_own` does; its existing callers (`console.log`'s array printer and the three `toHave*ReturnedWith` matchers) propagate the error with `?`. For `console.log` this is not observable (the pending exception was already picked up by the next call into JSC). For the three matchers it is: a throwing accessor installed on `mock.results` used to leave its exception pending while the matcher went on to build its own message, which came out truncated at `Expected: `; now the accessor's error is what the matcher throws. The first-element special case in the array branch only existed to feed `was_good_time`, which nothing read, so the branch is now a single loop and the now-unused `Tag::is_primitive` is deleted.

Not changed: JSX children arrays in the same file are printed by a separate loop whose output already differs from jest's ReactElement plugin (which drops `null`/`undefined` children entirely), so holes there are out of scope for this change.

### Compatibility note

Snapshot serialization of sparse arrays changes: an existing `.snap` or inline snapshot of a sparse array that was written by bun (containing `undefined` for holes) will need `bun test -u`. Snapshots written by jest for the same values now match.

#37764 (open) adds a `toStrictEqual` hole-vs-`undefined` case to `test/js/bun/test/printing/diffexample.fixture.ts` whose expected output becomes a real diff once this lands; whichever PR merges second needs that one snapshot hunk updated.

### Tests

- `test/js/bun/test/snapshot-tests/existing-snapshots.test.ts`: `toMatchSnapshot` against entries in the checked-in `.snap` in jest's format (middle, leading, trailing, all-holes, single hole, nested in an object, nested arrays, and a `[1, undefined, 3]` control that must still print `undefined`).
- `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts`: the same shapes through `toMatchInlineSnapshot`, plus an `Array` subclass with a deleted index, a subclass whose prototype supplies the deleted index (`1 in list` is true, it still prints as a hole; 1.4.0 printed the inherited value), and an index backed by an own getter (present, so its value prints).
- `test/js/bun/test/test-test.test.ts`: spawned `bun test` asserting the `toStrictEqual` (hole vs `undefined`), `toEqual` (hole vs value) and `toStrictEqual` (hole vs the value inherited through `Array.prototype`) diffs.
- `test/js/bun/test/spyMatchers.test.ts`: in the existing `describe.each` over `toHaveLastReturnedWith` / `toHaveNthReturnedWith` / `toHaveReturnedWith`, a throwing accessor on `mock.results` now surfaces as the matcher's error.

All four files fail with `USE_SYSTEM_BUN=1 bun test` (only the new tests; the hole renders as `undefined`, the matchers throw their truncated message) and pass with `bun bd test`. Also ran `test/js/bun/test/expect.test.js`, `printing/`, `snapshot-tests/`, `expect-toHaveReturnedWith.test.js`, `spyMatchers.test.ts`, `test/js/bun/util/inspect.test.js` and `test/js/web/console/` with the debug build; the only failures are two pre-existing debug-build ones unrelated to this change (`pretty-format-overflow.test.ts` stack depth, tracked by #34885, and the `[N.NNs]` run-time suffix in `diffexample.test.ts`, fixed in #37764).

</details>
