### PR TITLE
bundler: copy inlined env values into the define arena instead of aliasing the env map

### DIFF
--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -51,10 +51,9 @@ fn env_string_store_put(
     key: &[u8],
     value: &[u8],
 ) -> Result<(), crate::Error> {
-    // Both the `E.String` node and its bytes go in `bump`, which lives as long
-    // as the `Define` table: the thread-local `Expr.Data.Store` is reset when
-    // `configure_defines` returns, and `value` borrows an env-map entry that
-    // `Bun__setEnvValue` (`process.env.HTTPS_PROXY = ..`) frees on overwrite.
+    // Node and bytes both live in `bump` (the `Define` table's lifetime): the
+    // thread-local Expr store is reset when `configure_defines` returns, and
+    // `Bun__setEnvValue` frees the env-map entry `value` points into.
     let value: &[u8] = bump.alloc_slice_copy(value);
     let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(
         bump.alloc(bun_ast::E::EString::init(value)),

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -51,16 +51,10 @@ fn env_string_store_put(
     key: &[u8],
     value: &[u8],
 ) -> Result<(), crate::Error> {
-    // The `E.String` slab must NOT live in the thread-local
-    // `Expr.Data.Store` — `configureDefines` resets that store on return, so
-    // the env-define payloads must outlive it. Allocate from `bump` (the
-    // transpiler arena) so the slab is bulk-freed with the `Define` table
-    // instead of leaking a `Box` per env var.
-    //
-    // The bytes are copied into `bump` as well: `value` borrows a `Box<[u8]>`
-    // inside the env map, which `Bun__setEnvValue` replaces (freeing the old
-    // box) every time JS assigns one of the proxy vars, while this `Define`
-    // table lives as long as the transpiler (the whole DevServer in bake).
+    // Both the `E.String` node and its bytes go in `bump`, which lives as long
+    // as the `Define` table: the thread-local `Expr.Data.Store` is reset when
+    // `configure_defines` returns, and `value` borrows an env-map entry that
+    // `Bun__setEnvValue` (`process.env.HTTPS_PROXY = ..`) frees on overwrite.
     let value: &[u8] = bump.alloc_slice_copy(value);
     let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(
         bump.alloc(bun_ast::E::EString::init(value)),

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -55,8 +55,13 @@ fn env_string_store_put(
     // `Expr.Data.Store` — `configureDefines` resets that store on return, so
     // the env-define payloads must outlive it. Allocate from `bump` (the
     // transpiler arena) so the slab is bulk-freed with the `Define` table
-    // instead of leaking a `Box` per env var. Value bytes alias the long-lived
-    // env-map storage.
+    // instead of leaking a `Box` per env var.
+    //
+    // The bytes are copied into `bump` as well: `value` borrows a `Box<[u8]>`
+    // inside the env map, which `Bun__setEnvValue` replaces (freeing the old
+    // box) every time JS assigns one of the proxy vars, while this `Define`
+    // table lives as long as the transpiler (the whole DevServer in bake).
+    let value: &[u8] = bump.alloc_slice_copy(value);
     let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(
         bump.alloc(bun_ast::E::EString::init(value)),
     ));

--- a/src/bundler/defines.rs
+++ b/src/bundler/defines.rs
@@ -51,9 +51,7 @@ fn env_string_store_put(
     key: &[u8],
     value: &[u8],
 ) -> Result<(), crate::Error> {
-    // Node and bytes both live in `bump` (the `Define` table's lifetime): the
-    // thread-local Expr store is reset when `configure_defines` returns, and
-    // `Bun__setEnvValue` frees the env-map entry `value` points into.
+    // Copied because `Bun__setEnvValue` frees the env-map entry `value` points into.
     let value: &[u8] = bump.alloc_slice_copy(value);
     let value: ExprData = ExprData::EString(bun_ast::StoreRef::from_bump(
         bump.alloc(bun_ast::E::EString::init(value)),

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -336,6 +336,7 @@ impl Loader {
     /// Get proxy URL for HTTP/HTTPS requests, respecting NO_PROXY.
     /// `hostname` is the host without port (e.g., "localhost")
     /// `host` is the host with port if present (e.g., "localhost:3000")
+    /// The returned URL borrows the map entry, which `Map::put` frees.
     pub fn get_http_proxy(
         &self,
         is_http: bool,
@@ -1394,6 +1395,7 @@ impl Map {
         }
     }
 
+    /// Frees the old value; JS hits this via `Bun__setEnvValue`, so don't hold borrows across JS.
     #[inline]
     pub fn put(&mut self, key: &[u8], value: &[u8]) -> Result<(), AllocError> {
         #[cfg(all(windows, debug_assertions))]

--- a/src/jsc/rare_data.rs
+++ b/src/jsc/rare_data.rs
@@ -537,8 +537,7 @@ impl ProxyEnvSlots {
 // RefCountedEnvValue
 // ──────────────────────────────────────────────────────────────────────────
 
-/// A ref-counted heap-allocated byte slice. The env map stores borrowed
-/// `.bytes` slices; as long as any VM holds a ref, the bytes stay valid.
+/// Last JS-assigned proxy value, shared with later Workers; the env map keeps its own copy.
 ///
 /// Holders are `Arc<RefCountedEnvValue>` (per LIFETIMES.tsv): the refcount
 /// lives in the `Arc` header, so ref/deref are `Arc::clone`/`drop`.

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,6 +1,6 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
 import { expect } from "bun:test";
-import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
+import { Dev, devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 devTest("import identifier doesnt get renamed", {
   framework: minimalFramework,
@@ -863,5 +863,59 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
+  },
+});
+
+// With `[serve.static] env = "inline"`, DevServer builds its define table from
+// the VM's env map once at startup and keeps it for the life of the server.
+// Assigning a proxy variable on process.env replaces that variable's entry in
+// the env map, so the define must own a copy of the value instead of pointing
+// into the map; otherwise every rebuild of a module that reads the variable
+// inlines freed memory.
+const startupProxy = "http://proxy-at-startup.example:8080/" + Buffer.alloc(120, "a").toString();
+async function clientBundle(dev: Dev) {
+  const html = await dev.fetch("/").text();
+  const scripts = [...html.matchAll(/src="([^"]+\.js)"/g)];
+  expect(scripts).toHaveLength(1);
+  return dev.fetch(scripts[0][1]).text();
+}
+devTest("inlined env var survives a runtime process.env write to a proxy variable", {
+  files: {
+    "bunfig.toml": `
+      [serve.static]
+      env = "inline"
+    `,
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `console.log("v1", process.env.HTTPS_PROXY);`,
+    "bun.app.ts": `
+      import html from "./index.html";
+      export default {
+        static: { "/": html },
+        fetch(req) {
+          if (new URL(req.url).pathname === "/set-proxy") {
+            process.env.HTTPS_PROXY = "http://changed-at-runtime.example:1/";
+            return new Response("ok");
+          }
+          return new Response("Not Found", { status: 404 });
+        },
+      };
+    `,
+  },
+  htmlFiles: [],
+  env: { HTTPS_PROXY: startupProxy },
+  async test(dev) {
+    const before = await clientBundle(dev);
+    expect(before).toContain('"v1"');
+    expect(before).toContain(startupProxy);
+
+    await dev.fetch("/set-proxy").equals("ok");
+
+    // Rebuilding index.ts prints the define again, now that the env map entry
+    // it was created from is gone.
+    await dev.write("index.ts", `console.log("v2", process.env.HTTPS_PROXY);`);
+    const after = await clientBundle(dev);
+    expect(after).toContain('"v2"');
+    expect(after).toContain(startupProxy);
+    expect(after).not.toContain("changed-at-runtime");
   },
 });

--- a/test/bundler/bundler_env.test.ts
+++ b/test/bundler/bundler_env.test.ts
@@ -1,4 +1,5 @@
-import { describe } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { itBundled } from "./expectBundled";
 
 for (let backend of ["api", "cli"] as const) {
@@ -118,3 +119,78 @@ for (let backend of ["api", "cli"] as const) {
       });
   });
 }
+
+// The define table is built from the env map when the build is configured.
+// Assigning one of the proxy variables on process.env (the only process.env
+// writes that reach the native env map) replaces the map entry that define was
+// built from, so the define has to own its value: here that write happens
+// while the build is still running, from a macro and from a plugin.
+const proxyAtStart = "http://proxy-at-start.example:8080/" + Buffer.alloc(120, "a").toString();
+
+describe("bundler/cli", () => {
+  itBundled("env/inline survives macro proxy write", {
+    backend: "cli",
+    dotenv: "inline",
+    env: { HTTPS_PROXY: proxyAtStart },
+    files: {
+      "/a.ts": /* ts */ `
+        import { setProxy } from "./macro.ts" with { type: "macro" };
+        setProxy();
+        console.log(process.env.HTTPS_PROXY);
+      `,
+      "/macro.ts": /* ts */ `
+        export function setProxy() {
+          process.env.HTTPS_PROXY = "http://changed-by-macro.example:1/";
+          return 0;
+        }
+      `,
+    },
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain(proxyAtStart);
+      api.expectFile("/out.js").not.toContain("changed-by-macro");
+    },
+    run: {
+      env: { HTTPS_PROXY: "http://not-inlined.example:1/" },
+      stdout: proxyAtStart + "\n",
+    },
+  });
+});
+
+describe("bundler/api", () => {
+  test.concurrent("env: inline survives a plugin assigning a proxy variable during the build", async () => {
+    using dir = tempDir("bundler-env-inline-plugin-proxy", {
+      "entry.ts": `export const replaced = "by the plugin";`,
+      "build.ts": /* ts */ `
+        const result = await Bun.build({
+          entrypoints: ["./entry.ts"],
+          env: "inline",
+          plugins: [{
+            name: "assign-proxy",
+            setup(build) {
+              build.onLoad({ filter: /entry\\.ts$/ }, () => {
+                process.env.HTTPS_PROXY = "http://changed-by-plugin.example:1/";
+                return { loader: "ts", contents: "export const proxy = process.env.HTTPS_PROXY;" };
+              });
+            },
+          }],
+        });
+        if (!result.success) throw new AggregateError(result.logs, "build failed");
+        process.stdout.write(await result.outputs[0].text());
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, HTTPS_PROXY: proxyAtStart },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain(`var proxy = ${JSON.stringify(proxyAtStart)};`);
+    expect(stdout).not.toContain("changed-by-plugin");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -168,6 +168,44 @@ describe("web worker", () => {
     expect(exitCode).toBe(0);
   });
 
+  // A worker's transpiler builds its process.env defines from the worker's env
+  // map when the worker starts. Assigning a proxy variable replaces that map
+  // entry, so a module transpiled afterwards must not read the old entry's
+  // memory. Spawned so the launch value is set without touching this
+  // process's proxy settings.
+  test("worker-env: a module transpiled after the worker assigns HTTPS_PROXY sees a real value", async () => {
+    const launchValue = "http://proxy-at-launch.example:8080/" + Buffer.alloc(120, "a").toString();
+    const workerValue = "http://assigned-in-worker.example:1/" + Buffer.alloc(120, "b").toString();
+    using dir = tempDir("worker-env-proxy-define", {
+      "main.ts": `
+        const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+        worker.onerror = e => { console.error(e.message); process.exit(1); };
+        worker.onmessage = e => {
+          console.log(JSON.stringify(e.data));
+          worker.terminate();
+        };
+      `,
+      "worker.ts": `
+        process.env.HTTPS_PROXY = ${JSON.stringify(workerValue)};
+        const { proxy } = await import("./mod.ts");
+        postMessage(proxy);
+      `,
+      "mod.ts": `export const proxy = process.env.HTTPS_PROXY;`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, HTTPS_PROXY: launchValue },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    // Either value is a correct answer (it depends on whether worker
+    // transpiles inline process.env reads); bytes of a freed map entry are not.
+    expect(JSON.parse(stdout)).toBeOneOf([launchValue, workerValue]);
+    expect(exitCode).toBe(0);
+  });
+
   test("worker-env with a lot of properties", done => {
     const obj: any = {};
 


### PR DESCRIPTION
### Problem
- With env inlining on (`[serve.static] env = "inline"`, `bun build --env=inline`, `Bun.build({ env: "inline" })`, or a Worker), assigning `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` on `process.env` after the define table is built makes later output inline garbage such as `"@z..\x03\x00\x00roxy-at-startup.example:8080/..."` in place of the value.
- The ASAN build reports `heap-use-after-free` in `bun_js_printer::best_quote_char_for_string`, freed by `Map::put` via `Bun__setEnvValue`.
- Cause: each `process.env.X` define pointed at the bytes held by the env map instead of owning them, and a proxy-variable write replaces and frees that map entry while the table is still in use.
- The table outlives such writes in the dev server (built once per server), `bun build` (a macro can write mid-file), `Bun.build` (a plugin `onLoad` can write mid-build) and Workers (built at spawn).

### Fix
- Copy each value into the define table's own arena before building the string node, which is what `--define` values already do. (#37780 separately gives `Bun.build` its own copy of the whole map; the two overlap only in tests.)
- Correct because a define is a snapshot of the environment at table-build time, and bytes in the arena live exactly as long as the nodes pointing at them. Cost is one small copy per variable per table build; `bun run`, `bun test` and `Bun.Transpiler` never take this path.
- Known trade: a Worker's arena is never bulk freed, so repeated worker spawns now retain the environment's bytes per spawn on top of the nodes they already retained, until #34211 stops Workers inlining env.
- Verification: four new tests (dev server, `bun build` with a macro, `Bun.build` with a plugin, Worker) fail on the released binary with the clobbered strings above, abort under ASAN on the unfixed debug build, and pass with the fix.

### Background
- Env inlining: with `env = "inline"` the bundler replaces every `process.env.X` read with a string literal. It builds a define table (one constant per variable) from the env map up front and reuses it for every module it prints.
- The env map is bun's native copy of the environment (the dotenv `Loader`). Most `process.env` writes stay in JS; the proxy variables are the exception and are written through to the native map, where `Map::put` frees the previous entry.
- The define table's nodes come from a bump arena owned by whoever owns the table (the dev server, one `Bun.build`, the CLI) and freed with it, so anything copied into that arena has the same lifetime as the table.
- `RefCountedEnvValue` holds the last JS-assigned proxy value so later Workers inherit it; its comment said the env map borrowed those bytes, which stopped being true when `Map::put` began copying, so the comment is corrected here.

<details>
<summary>Original description</summary>

### What

When env inlining is on, `copy_env_for_define` builds one `process.env.X` define per variable. `env_string_store_put` (`src/bundler/defines.rs`) allocated the `E::String` node in the define arena but left its bytes pointing into the dotenv `Loader`'s map ("Value bytes alias the long-lived env-map storage"). That storage is not stable: assigning `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` (or the lowercase variants) on `process.env` goes through `Bun__setEnvValue` -> `Map::put`, which replaces the entry and frees the `Box<[u8]>` the define points at. Every define table built before that write then prints freed memory the next time a module that reads the variable is parsed or printed.

The define table outlives such writes in four places:

* bake DevServer (`[serve.static] env = "inline"`): `Framework::init_transpiler` runs `configure_defines` once when `Bun.serve()` starts and keeps the table for the life of the server. A runtime `process.env.HTTPS_PROXY = ...` followed by any rebuild of a module that reads `process.env.HTTPS_PROXY` serves the freed bytes.
* `bun build --env=inline`: the macro VM shares the CLI transpiler's loader, so a macro assigning a proxy variable frees the bytes before the rest of the file is printed.
* `Bun.build()` / non-HMR HTML routes: a plugin `onLoad` (JS thread) assigning the variable mid-build frees the bytes the bundle thread prints later.
* Worker VMs: `WebWorker::start_vm` calls `configure_defines` with the `Target::Bun` default of `load_all` (the main thread, `bun test`, the REPL and compiled executables switch to `load_all_without_inlining` first; workers do not, which is what #34211 changes), so a worker's table is built from its own env map at spawn. A worker that assigns the variable and then imports a module reading it gets the freed bytes.

### Repro

Dev server (`bunfig.toml` has `[serve.static]` / `env = "inline"`, `index.html` loads `index.ts` which does `console.log("v1", process.env.HTTPS_PROXY)`), run with `HTTPS_PROXY=http://proxy-at-startup.example:8080/aaaa...` set:

```ts
import html from "./index.html";
const server = Bun.serve({ port: 0, development: true, routes: { "/": html }, fetch: () => new Response("", { status: 404 }) });
await fetch(server.url); // first bundle is fine
process.env.HTTPS_PROXY = "http://changed-at-runtime.example:1/";
writeFileSync("index.ts", 'console.log("v2", process.env.HTTPS_PROXY);'); // triggers a rebuild
// the rebuilt chunk now contains:
//   console.log("v2", "@z..\x03\x00\x00roxy-at-startup.example:8080/aaaa...")
```

Release 1.4.0 inlines the freed buffer with the allocator's free-list word in its first bytes; the other three variants produce the same shape (`bun build --env=inline` with a macro: `"\x00\x00\x00\x00\x00\x00\x00\x00roxy-at-start.example:8080/..."`; a worker posts back `" \nA\x00\x02\x00\x00roxy-at-launch.example:8080/..."`). The ASAN debug build reports, for all of them:

```
ERROR: AddressSanitizer: heap-use-after-free
    #0 bun_js_printer::best_quote_char_for_string src/js_printer/lib.rs:680
    ...
freed by thread T0 here:
    <bun_collections::array_hash_map::StringArrayHashMap<bun_dotenv::env_loader::HashTableValue>>::put
    <bun_dotenv::env_loader::Map>::put
    Bun__setEnvValue src/runtime/api/BunObject.rs
    Bun::jsSetterProxyEnvironmentVariable src/jsc/bindings/JSEnvironmentVariableMap.cpp
```

### Fix

`env_string_store_put` copies the value into `bump` before building the `E::String`. `bump` is the arena the define table's nodes are already allocated from, so the bytes live exactly as long as the nodes that point at them: `UserOptions.arena` for the dev server (dropped with the DevServer), the per-build arena for `Bun.build` (dropped with the build), the CLI arena for `bun build`. This is also what `DefineData::parse` does for `--define` values a few lines down, and what `E::EString::init` documents as its contract (the data must be arena owned).

A define is a snapshot of the environment at the time the table is built (that is what gets baked into the output), so owning the bytes is the semantics the code already intended; the old comment just assumed the map entries were immutable. The cost is one small copy per variable each time a table is built with inlining on. The main VM, `bun test` and `Bun.Transpiler` never reach this function, so `bun run` startup is unaffected.

Workers do reach it, and there the arena is the per-VM `transpiler_arena`, which wraps the main mimalloc heap and is never bulk freed. The define nodes built at worker spawn already stayed allocated after the worker exited; with this change the value bytes do too, so a process that spawns workers repeatedly retains roughly the byte size of its environment per spawn on top of that (a few KB for a typical environment) until #34211 lands, which stops workers from inlining env at all and takes them off this path entirely. Leaving workers reading freed memory is the worse trade, and fixing the arena ownership or the inlining default is that PR's job rather than this one's.

Two doc lines record the invariant where the next reader will look for it: `Map::put` frees the previous value (and JS can trigger it through `Bun__setEnvValue`), and `get_http_proxy` returns a borrow of such an entry. The `RefCountedEnvValue` doc in `rare_data.rs` still said the env map borrows those bytes, which has not been true since `Map::put` started boxing its own copy, so it is corrected as well. The two S3 call sites in `blob/Store.rs` that hold a `get_http_proxy` borrow across JS-visible option reads are the same invariant in a different consumer and have been filed separately.

#37780 is the complementary change for `Bun.build`: it gives each build its own copy of the loader so the bundle thread stops reading the VM's live map at all (the map can also be mutated while the build is iterating it, which a byte copy does not address). This PR is what covers the dev server, `bun build` and workers, where the table is built and later read on the same thread and only the aliased bytes were the problem. Each is correct on its own; both append tests to `bundler_env.test.ts`, so whichever lands second needs a trivial rebase, and the `Bun.build` plus plugin test here can be dropped at that point since #37780 carries the same case.

### Tests

* `test/bake/dev/bundle.test.ts`: dev server with `[serve.static] env = "inline"`; checks the first bundle inlines the startup value, assigns `process.env.HTTPS_PROXY` through a route, rewrites `index.ts` to force a rebuild, and checks the rebuilt bundle still inlines the startup value.
* `test/bundler/bundler_env.test.ts`: `bun build --env=inline` where a macro assigns the variable (checks the output file and runs it), and `Bun.build({ env: "inline" })` where a plugin `onLoad` assigns it mid-build.
* `test/js/web/workers/worker.test.ts`: a worker assigns `HTTPS_PROXY`, then imports a module that reads it; the value it posts back must be either the launch value or the assigned one (so the test stays valid once #34211 makes workers read live), never the contents of the freed entry.

All four fail on the released binary (`USE_SYSTEM_BUN=1`, the clobbered strings above) and on the unfixed debug build (ASAN abort; the dev test reports "DevServer crashed while waiting for hot reload"), and pass with the fix. Also ran `test/bake/dev/bundle.test.ts` in full, the `worker-env` tests in `worker.test.ts`, `bundler_splitting.test.ts`, `cli/run/env.test.ts` and `transpiler/macro-test.test.ts` against the debug build (four unrelated terminate-race tests in `worker.test.ts` time out on this machine's ASAN build with or without the new test; they pass on the release build and that file passed on the ASAN lane in CI for the earlier revision of this branch). Self-review surfaced the worker path and the stale docs; both are addressed above.

</details>
