### PR TITLE
bake: run import.meta.hot.dispose callbacks of every module a hot update re-evaluates

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -725,11 +725,8 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     }
   }
 
-  // Dispose of every module that is about to be evaluated again: the replaced
-  // modules (also when an importer accepts them) and the boundaries they
-  // bubbled up to. Modules are only marked stale by the reload loop below:
-  // marking one stale here would let the reload of an importer that precedes
-  // it in `toReload` evaluate it, and its own reload evaluate it again.
+  // Every module that is about to be evaluated again is disposed of first.
+  // Only the reload loop below marks modules stale.
   const disposePromises: Promise<void>[] = [];
   for (const mod of toReload) {
     const { onDispose } = mod;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -725,8 +725,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     }
   }
 
-  // Every module that is about to be evaluated again is disposed of first.
-  // Only the reload loop below marks modules stale.
+  // Dispose all modules
   const disposePromises: Promise<void>[] = [];
   for (const mod of toReload) {
     const { onDispose } = mod;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -616,7 +616,6 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   const toReload = new Set<HMRModule>();
   const toAccept: ToAccept[] = [];
   let failures: Set<Id> | null = null;
-  const toDispose: HMRModule[] = [];
 
   // Discover all HMR boundaries
   outer: for (const key of Object.keys(modules)) {
@@ -647,9 +646,6 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         toReload.add(mod);
         visited.add(mod);
         hadSelfAccept = false;
-        if (mod.onDispose) {
-          toDispose.push(mod);
-        }
       }
       // Modules that mutate data are implied to handle updates via reusing their `data` property
       else if (Object.keys(mod.data).length > 0) {
@@ -657,9 +653,6 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         toReload.add(mod);
         visited.add(mod);
         hadSelfAccept = false;
-        if (mod.onDispose) {
-          toDispose.push(mod);
-        }
       }
 
       // All importers will be visited
@@ -732,22 +725,24 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     }
   }
 
-  // Dispose all modules
-  if (toDispose.length > 0) {
-    const disposePromises: Promise<void>[] = [];
-    for (const mod of toDispose) {
-      mod.state = State.Stale;
-      for (const fn of mod.onDispose!) {
-        const p = fn(mod.data);
-        if (p && p instanceof Promise) {
-          disposePromises.push(p);
-        }
+  // Dispose of every module that is about to be evaluated again: the replaced
+  // modules (also when an importer accepts them) and the boundaries they
+  // bubbled up to.
+  const disposePromises: Promise<void>[] = [];
+  for (const mod of toReload) {
+    const { onDispose } = mod;
+    if (!onDispose) continue;
+    mod.state = State.Stale;
+    for (const fn of onDispose) {
+      const p = fn(mod.data);
+      if (p && p instanceof Promise) {
+        disposePromises.push(p);
       }
-      mod.onDispose = null;
     }
-    if (disposePromises.length > 0) {
-      await Promise.all(disposePromises);
-    }
+    mod.onDispose = null;
+  }
+  if (disposePromises.length > 0) {
+    await Promise.all(disposePromises);
   }
 
   // Reload all modules

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -727,12 +727,13 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
 
   // Dispose of every module that is about to be evaluated again: the replaced
   // modules (also when an importer accepts them) and the boundaries they
-  // bubbled up to.
+  // bubbled up to. Modules are only marked stale by the reload loop below:
+  // marking one stale here would let the reload of an importer that precedes
+  // it in `toReload` evaluate it, and its own reload evaluate it again.
   const disposePromises: Promise<void>[] = [];
   for (const mod of toReload) {
     const { onDispose } = mod;
     if (!onDispose) continue;
-    mod.state = State.Stale;
     for (const fn of onDispose) {
       const p = fn(mod.data);
       if (p && p instanceof Promise) {

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -388,6 +388,181 @@ devTest("import.meta.hot.dispose cleanup", {
     await c.expectMessage("Cleaning up", "Third setup");
   },
 });
+devTest("import.meta.hot.dispose runs when the update is accepted by an importer", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { d } from "./d";
+      console.log("index " + d);
+      import.meta.hot.accept("./d", newModule => {
+        console.log("index accepted " + newModule.d);
+      });
+    `,
+    "d.ts": `
+      export const d = "d1";
+      console.log("evaluated " + d);
+      import.meta.hot.dispose(() => {
+        console.log("disposed " + d);
+      });
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("evaluated d1", "index d1");
+
+    // The copy being thrown away is disposed of before the next one is evaluated.
+    await dev.patch("d.ts", { find: "d1", replace: "d2" });
+    await c.expectMessage("disposed d1", "evaluated d2", "index accepted d2");
+
+    // The dispose callback registered by a copy that was itself hot-loaded
+    // runs too, and the first copy's callback does not run again.
+    await dev.patch("d.ts", { find: "d2", replace: "d3" });
+    await c.expectMessage("disposed d2", "evaluated d3", "index accepted d3");
+
+    // The next copy self-accepts. The copy being replaced still does not, so
+    // this update is still accepted by index.
+    await dev.write(
+      "d.ts",
+      `
+        export const d = "d4";
+        console.log("evaluated " + d);
+        import.meta.hot.dispose(() => {
+          console.log("disposed " + d);
+        });
+        import.meta.hot.accept();
+      `,
+    );
+    await c.expectMessage("disposed d3", "evaluated d4", "index accepted d4");
+
+    // Self-accepting update. Only the copy being replaced is disposed of; the
+    // callbacks of d1, d2 and d3 were consumed by the earlier updates instead
+    // of piling up until a self-accepting copy came along.
+    await dev.patch("d.ts", { find: "d4", replace: "d5" });
+    await c.expectMessage("disposed d4", "evaluated d5", "index accepted d5");
+  },
+});
+devTest("import.meta.hot.dispose runs when the update is accepted by a self-accepting importer", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // index (self-accepting) -> mid -> d
+    "index.ts": `
+      import { mid } from "./mid";
+      console.log("index " + mid());
+      import.meta.hot.dispose(() => {
+        console.log("index disposed");
+      });
+      import.meta.hot.accept();
+    `,
+    "mid.ts": `
+      import { d } from "./d";
+      console.log("mid evaluated");
+      export function mid() {
+        return "mid(" + d + ")";
+      }
+      import.meta.hot.dispose(() => {
+        console.log("mid disposed");
+      });
+    `,
+    "d.ts": `
+      export const d = "d1";
+      import.meta.hot.dispose(() => {
+        console.log("disposed " + d);
+      });
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("mid evaluated", "index mid(d1)");
+
+    // d (replaced) and index (the boundary) are both evaluated again, so both
+    // are disposed of first. mid keeps its instance and gets its import of d
+    // patched, so it is neither disposed of nor evaluated again.
+    await dev.patch("d.ts", { find: "d1", replace: "d2" });
+    await c.expectMessage("disposed d1", "index disposed", "index mid(d2)");
+
+    await dev.patch("d.ts", { find: "d2", replace: "d3" });
+    await c.expectMessage("disposed d2", "index disposed", "index mid(d3)");
+  },
+});
+devTest("import.meta.hot.dispose runs once per module when one update replaces several modules", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // Both replaced modules bubble up to the same boundary. It is evaluated
+    // again once, so it is disposed of once (disposing of it twice used to
+    // throw, since its dispose list is cleared by the first pass).
+    "index.ts": `
+      import "./d";
+      import "./e";
+      console.log("index evaluated");
+      import.meta.hot.dispose(() => {
+        console.log("index disposed");
+      });
+      import.meta.hot.accept();
+    `,
+    "d.ts": `
+      export const d = "d1";
+      import.meta.hot.dispose(() => {
+        console.log("disposed " + d);
+      });
+    `,
+    "e.ts": `
+      export const e = "e1";
+      import.meta.hot.dispose(() => {
+        console.log("disposed " + e);
+      });
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("index evaluated");
+    {
+      await using batch = await dev.batchChanges();
+      await dev.patch("d.ts", { find: "d1", replace: "d2" });
+      await dev.patch("e.ts", { find: "e1", replace: "e2" });
+    }
+    // The replaced modules are disposed of in the order they appear in the
+    // update, which is not specified.
+    await c.expectMessageInAnyOrder("disposed d1", "disposed e1", "index disposed", "index evaluated");
+  },
+});
+devTest("import.meta.hot.on listeners of a module accepted by its importer are removed when it is replaced", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { d } from "./d";
+      console.log("index " + d);
+      import.meta.hot.accept("./d", newModule => {
+        console.log("index accepted " + newModule.d);
+      });
+    `,
+    "d.ts": `
+      export const d = "d1";
+      import.meta.hot.on("bun:afterUpdate", () => {
+        console.log(d + " saw afterUpdate");
+      });
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("index d1");
+
+    // Only the listener registered by the current copy of d is still attached
+    // once the update is applied.
+    await dev.patch("d.ts", { find: "d1", replace: "d2" });
+    await c.expectMessage("index accepted d2", "d2 saw afterUpdate");
+
+    await dev.patch("d.ts", { find: "d2", replace: "d3" });
+    await c.expectMessage("index accepted d3", "d3 saw afterUpdate");
+  },
+});
 devTest("import.meta.hot invalid usage", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -393,9 +393,14 @@ devTest("import.meta.hot.dispose runs when the update is accepted by an importer
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
     }),
+    // index handles every update below with its accept callback and is never
+    // evaluated again, so its own dispose callback must never run.
     "index.ts": `
       import { d } from "./d";
       console.log("index " + d);
+      import.meta.hot.dispose(() => {
+        console.log("index disposed");
+      });
       import.meta.hot.accept("./d", newModule => {
         console.log("index accepted " + newModule.d);
       });
@@ -448,27 +453,21 @@ devTest("import.meta.hot.dispose runs when the update is accepted by a self-acce
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
     }),
-    // index (self-accepting) -> mid -> d
+    // Both d (replaced) and index (the boundary) are evaluated again. All
+    // dispose callbacks run, and the promise index's returns is settled,
+    // before either module is evaluated.
     "index.ts": `
-      import { mid } from "./mid";
-      console.log("index " + mid());
-      import.meta.hot.dispose(() => {
+      import { d } from "./d";
+      console.log("index " + d);
+      import.meta.hot.dispose(async () => {
+        await null;
         console.log("index disposed");
       });
       import.meta.hot.accept();
     `,
-    "mid.ts": `
-      import { d } from "./d";
-      console.log("mid evaluated");
-      export function mid() {
-        return "mid(" + d + ")";
-      }
-      import.meta.hot.dispose(() => {
-        console.log("mid disposed");
-      });
-    `,
     "d.ts": `
       export const d = "d1";
+      console.log("evaluated " + d);
       import.meta.hot.dispose(() => {
         console.log("disposed " + d);
       });
@@ -476,16 +475,13 @@ devTest("import.meta.hot.dispose runs when the update is accepted by a self-acce
   },
   async test(dev) {
     await using c = await dev.client("/");
-    await c.expectMessage("mid evaluated", "index mid(d1)");
+    await c.expectMessage("evaluated d1", "index d1");
 
-    // d (replaced) and index (the boundary) are both evaluated again, so both
-    // are disposed of first. mid keeps its instance and gets its import of d
-    // patched, so it is neither disposed of nor evaluated again.
     await dev.patch("d.ts", { find: "d1", replace: "d2" });
-    await c.expectMessage("disposed d1", "index disposed", "index mid(d2)");
+    await c.expectMessage("disposed d1", "index disposed", "evaluated d2", "index d2");
 
     await dev.patch("d.ts", { find: "d2", replace: "d3" });
-    await c.expectMessage("disposed d2", "index disposed", "index mid(d3)");
+    await c.expectMessage("disposed d2", "index disposed", "evaluated d3", "index d3");
   },
 });
 devTest("import.meta.hot.dispose runs once per module when one update replaces several modules", {
@@ -493,8 +489,8 @@ devTest("import.meta.hot.dispose runs once per module when one update replaces s
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
     }),
-    // The boundary is reached from both replaced modules, and is reloaded
-    // before the second of them, which it imports. Each module must be
+    // The boundary is reached from both replaced modules, imports both, and
+    // comes between them in the update's reload order. Each module must be
     // disposed of once and evaluated once per update; the second round catches
     // dispose callbacks registered by a duplicate evaluation.
     "index.ts": `
@@ -525,7 +521,7 @@ devTest("import.meta.hot.dispose runs once per module when one update replaces s
     await using c = await dev.client("/");
     await c.expectMessage("evaluated d1", "evaluated e1", "index evaluated");
     // The order the modules of one update are processed in is not specified;
-    // the dispose-before-evaluate ordering is covered by the tests above.
+    // the ordering between disposing and evaluating is pinned by the test above.
     {
       await using batch = await dev.batchChanges();
       await dev.patch("d.ts", { find: "d1", replace: "d2" });
@@ -552,6 +548,56 @@ devTest("import.meta.hot.dispose runs once per module when one update replaces s
       "evaluated e3",
       "index evaluated",
     );
+  },
+});
+devTest("import.meta.hot.dispose runs for a copy whose evaluation threw when the module is replaced", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // The failing module is reached through import() so that the page itself
+    // stays up. What it set up before throwing still has to be torn down when
+    // the fixed copy replaces it.
+    "index.ts": `
+      globalThis.loadDep = async () => {
+        try {
+          return (await import("./dep")).value;
+        } catch (e) {
+          return "failed: " + e.message;
+        }
+      };
+      console.log("index evaluated");
+      import.meta.hot.accept();
+    `,
+    "dep.ts": `
+      import.meta.hot.dispose(() => {
+        console.log("dep disposed");
+      });
+      export const value = "v1";
+      throw new Error("dep is broken");
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("index evaluated");
+    expect(await c.js`loadDep()`).toBe("failed: dep is broken");
+
+    await dev.write(
+      "dep.ts",
+      `
+        import.meta.hot.dispose(() => {
+          console.log("dep disposed");
+        });
+        export const value = "v2";
+      `,
+    );
+    // dep is replaced and index, which imported it, self-accepts.
+    await c.expectMessage("dep disposed", "index evaluated");
+    expect(await c.js`loadDep()`).toBe("v2");
+
+    await dev.patch("dep.ts", { find: "v2", replace: "v3" });
+    await c.expectMessage("dep disposed", "index evaluated");
+    expect(await c.js`loadDep()`).toBe("v3");
   },
 });
 devTest("import.meta.hot.on listeners of a module accepted by its importer are removed when it is replaced", {

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -493,16 +493,10 @@ devTest("import.meta.hot.dispose runs once per module when one update replaces s
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
     }),
-    // Both replaced modules bubble up to the same boundary. Every module is
-    // disposed of once and evaluated once per update:
-    // - the boundary is reached from both replaced modules (disposing of it
-    //   twice used to throw, since its dispose list is cleared by the first
-    //   pass)
-    // - the boundary is reloaded before whichever replaced module the update
-    //   listed second, and imports it. Marking that module stale before its
-    //   own reload would make the boundary's reload evaluate it, and its own
-    //   reload evaluate it again, which would also register its dispose
-    //   callback twice (hence the second round).
+    // The boundary is reached from both replaced modules, and is reloaded
+    // before the second of them, which it imports. Each module must be
+    // disposed of once and evaluated once per update; the second round catches
+    // dispose callbacks registered by a duplicate evaluation.
     "index.ts": `
       import "./d";
       import "./e";

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -493,9 +493,16 @@ devTest("import.meta.hot.dispose runs once per module when one update replaces s
     "index.html": emptyHtmlFile({
       scripts: ["index.ts"],
     }),
-    // Both replaced modules bubble up to the same boundary. It is evaluated
-    // again once, so it is disposed of once (disposing of it twice used to
-    // throw, since its dispose list is cleared by the first pass).
+    // Both replaced modules bubble up to the same boundary. Every module is
+    // disposed of once and evaluated once per update:
+    // - the boundary is reached from both replaced modules (disposing of it
+    //   twice used to throw, since its dispose list is cleared by the first
+    //   pass)
+    // - the boundary is reloaded before whichever replaced module the update
+    //   listed second, and imports it. Marking that module stale before its
+    //   own reload would make the boundary's reload evaluate it, and its own
+    //   reload evaluate it again, which would also register its dispose
+    //   callback twice (hence the second round).
     "index.ts": `
       import "./d";
       import "./e";
@@ -507,12 +514,14 @@ devTest("import.meta.hot.dispose runs once per module when one update replaces s
     `,
     "d.ts": `
       export const d = "d1";
+      console.log("evaluated " + d);
       import.meta.hot.dispose(() => {
         console.log("disposed " + d);
       });
     `,
     "e.ts": `
       export const e = "e1";
+      console.log("evaluated " + e);
       import.meta.hot.dispose(() => {
         console.log("disposed " + e);
       });
@@ -520,15 +529,35 @@ devTest("import.meta.hot.dispose runs once per module when one update replaces s
   },
   async test(dev) {
     await using c = await dev.client("/");
-    await c.expectMessage("index evaluated");
+    await c.expectMessage("evaluated d1", "evaluated e1", "index evaluated");
+    // The order the modules of one update are processed in is not specified;
+    // the dispose-before-evaluate ordering is covered by the tests above.
     {
       await using batch = await dev.batchChanges();
       await dev.patch("d.ts", { find: "d1", replace: "d2" });
       await dev.patch("e.ts", { find: "e1", replace: "e2" });
     }
-    // The replaced modules are disposed of in the order they appear in the
-    // update, which is not specified.
-    await c.expectMessageInAnyOrder("disposed d1", "disposed e1", "index disposed", "index evaluated");
+    await c.expectMessageInAnyOrder(
+      "disposed d1",
+      "disposed e1",
+      "index disposed",
+      "evaluated d2",
+      "evaluated e2",
+      "index evaluated",
+    );
+    {
+      await using batch = await dev.batchChanges();
+      await dev.patch("d.ts", { find: "d2", replace: "d3" });
+      await dev.patch("e.ts", { find: "e2", replace: "e3" });
+    }
+    await c.expectMessageInAnyOrder(
+      "disposed d2",
+      "disposed e2",
+      "index disposed",
+      "evaluated d3",
+      "evaluated e3",
+      "index evaluated",
+    );
   },
 });
 devTest("import.meta.hot.on listeners of a module accepted by its importer are removed when it is replaced", {


### PR DESCRIPTION
### Problem
- In the dev server, saving a module whose update is accepted by an importer (`accept("./d", cb)` or a self-accepting importer) evaluates the new copy without running the old copy's `import.meta.hot.dispose()` callbacks. On bun 1.4.0 the example in the original description leaks one interval per save.
- `import.meta.hot.on()` is built on `dispose()`, so listeners pile up too: a `bun:afterUpdate` listener in such a module fires one more time after each save. The skipped callbacks stay registered and all run at once the first time a copy of the module self-accepts.
- One update replacing two modules that share a boundary queued the boundary for disposal twice; the second pass threw `TypeError: mod.onDispose is not iterable` and the update became a full page reload.
- Cause: modules to dispose of were collected only while walking up to self-accepting boundaries, so the replaced module itself was disposed of only if it self-accepted, even though every update evaluates it again.

### Fix
- The dispose pass now runs over the set of modules the update is about to evaluate again; the separate dispose list is gone. `dispose()` is documented as running just before a module is replaced with another copy, and that set is exactly the modules being replaced. An importer handling the update with an `accept("./dep")` callback keeps its instance and is not in it.
- The dispose pass no longer marks modules stale; only the reload loop does, just before evaluating each one. Marking earlier let a boundary reloaded before one of its replaced imports evaluate that import itself, so it was evaluated twice per update. Promise-returning callbacks are still awaited before anything is reloaded.
- Side effects: the set is deduplicated, so the `TypeError` above goes away (overlaps with #37773 and #37795, textual conflicts only). A dispose callback that writes `import.meta.hot.data` now also runs for a module accepted from above, which then counts as self-accepting on the next update, as documented for `data`.
- Verification, per the original description: five new dev-server tests, each failing on released bun 1.4.0 and passing with this change; the batch test also fails against an earlier revision of this PR that still marked modules stale during dispose. No linked issue.

### Background
- Bake is bun's dev server. Its hot module replacement (HMR) runtime, shared by the client and server sides, applies a saved file by evaluating the changed module again and walking up its importers until every path reaches a module that accepts the update; if none does, the page reloads.
- `import.meta.hot.accept()` with no arguments makes a module self-accepting: it stops the walk (a "boundary") and is evaluated again whenever a dependency changes. `import.meta.hot.accept("./dep", cb)` also stops the walk, but the importer keeps its instance and only `cb` runs.
- `import.meta.hot.dispose(cb)` registers cleanup for the current copy of a module. It receives `import.meta.hot.data`, which is handed to the next copy, and a module with anything in `data` is treated as self-accepting.
- `import.meta.hot.on()` listeners are implemented on top of `dispose()`, so a listener is removed only when its module's dispose callbacks run.
- Within an update, a module marked stale is evaluated again by whatever imports it next, and the collected modules are reloaded one at a time in no particular order, so a boundary can be reloaded before a module it imports.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

In the dev server, `import.meta.hot.dispose()` callbacks of a hot-replaced module only ran when that module self-accepted. When the update was accepted by an importer instead, the module was evaluated again without being disposed of.

```ts
// index.ts
import { d } from "./d";
import.meta.hot.accept("./d", m => console.log("index accepted " + m.d));

// d.ts
export const d = "d1";
const timer = setInterval(tick, 1000);
import.meta.hot.dispose(() => { console.log("disposed " + d); clearInterval(timer); });
```

Saving `d.ts` on bun 1.4.0 evaluates the new `d.ts` and calls the accept callback, but never logs `disposed d1`: every save leaks another interval. The same happens when `index.ts` self-accepts (`import.meta.hot.accept()`) instead of accepting `./d`; only `index.ts`'s own dispose callbacks run. Since `import.meta.hot.on()` is implemented on top of `dispose()`, the event listeners of such a module pile up too: after one save of `d.ts`, a `bun:afterUpdate` listener registered in it fires twice, then three times, and so on. The stale dispose callbacks also stay in the module's list, so once a later copy of the module does self-accept, the callbacks of every copy evaluated so far run at once.

### Why

`replaceModules()` in `src/runtime/bake/hmr-module.ts` (shared by the client and server runtimes) adds the replaced module to `toReload` unconditionally and then walks up its importers, adding each self-accepting boundary to `toReload` and, if it has dispose callbacks, to `toDispose`. The replaced module itself only reached `toDispose` through the same branch, i.e. when it self-accepted. The reload loop then evaluates everything in `toReload`, so a module accepted from above was replaced with a new copy without its callbacks running, and without its `onDispose` list being cleared.

`dispose()` is documented (docs/bundler/hot-reloading.mdx, `devserver.d.ts`) as running "just before the module is replaced with another copy (before the next is loaded)". The set of modules a hot update replaces with another copy is exactly `toReload`, so that is what the dispose pass should be derived from. A module that handles the update with an `accept("./dep")` callback is not in it: it keeps its instance, so its callbacks correctly stay registered (the first test checks this). This also holds for a replaced copy whose evaluation threw: it is in `toReload` like any other replaced module, and whatever it registered before throwing (`dispose()`, or listeners via `on()`) is torn down when the fixed copy replaces it, as was already the case for a self-accepting copy (fourth test). Vite also runs the disposer of the module being re-imported in the `accept("./dep")` case.

### Fix

The dispose pass iterates `toReload` and disposes of every module in it that has callbacks; the separate `toDispose` list and the two places that filled it are gone. Promise-returning callbacks are still awaited before anything is reloaded, `data` is still passed, and when no callback returns a promise the function still reaches the reload loop synchronously, as before.

The dispose pass no longer marks the modules it disposes of as stale; only the reload loop does that, right before reloading each one. With the replaced modules now part of the dispose pass, marking them stale there would let a boundary that precedes one of them in `toReload` evaluate it during its own reload (its dependency load sees the stale state), after which the module's own turn in the reload loop evaluated it a second time and registered its new dispose callbacks twice. An update replacing `d` and `e`, both imported by a self-accepting `index`, reloads in the order `d, index, e` and evaluated the new `e` twice with the first revision of this PR. The old code had the same problem in a narrower shape (a self-accepting boundary imported by another boundary reloaded before it); it is gone too.

What this PR leaves as it is: in that same `d, index, e` update, `index` is evaluated before the new `e` and reads the previous `e` (its binding is patched afterwards). That is how the reload loop already behaved; the difference is that the previous `e` has now had its dispose callbacks run at that point, which is where the documented order puts them (all callbacks run, and their promises are awaited, before anything is reloaded). Evaluating `index` against the new `e` needs the reload loop to mark everything stale before loading anything so that the loader evaluates imports first, which #37795 (and #31944) do; with that loop and this dispose pass the update disposes of everything, then evaluates each module once in import order. The batch test here asserts exactly one evaluation per module per update, which holds for both loops and fails for a loop that marks modules stale both before and during reloading.

Because `toReload` is a `Set`, this also covers a boundary reached from two modules replaced in the same update. Such a boundary was pushed onto the `toDispose` array twice and the second pass threw `TypeError: mod.onDispose is not iterable`, turning the update into a full page reload. #37773 fixes that case by making `toDispose` a `Set`; with this change that part of it is no longer needed (its accept callback dedupe is independent), so whichever of the two lands second has a small conflict in this function and in `hot.test.ts`. #37795 adds the modules an update propagates through to `toReload`; combined with this change they get disposed of as well, which is right since it evaluates them again. None of the tests here involve such a module, so the two only conflict textually.

One consequence worth spelling out: a dispose callback that stores state into `import.meta.hot.data` now runs for modules accepted from above as well, and a module with data in `import.meta.hot.data` is treated as self-accepting on the following update. That is the documented behaviour of `data` and applies the same way it already did to self-accepting modules.

### Tests

Five tests added to `test/bake/dev/hot.test.ts`, next to the existing `import.meta.hot.dispose cleanup` (which only covered a self-accepting module):

- update accepted by an importer via `accept("./d", cb)`: each save disposes of exactly the copy being replaced, before the new copy is evaluated and before the accept callback runs; the callbacks of earlier copies do not run again once a later copy self-accepts; the accepting importer's own dispose callback never runs.
- update accepted by a self-accepting importer: the replaced module and the boundary are both disposed of, and the boundary's callback returns a promise. The strict message order pins that every callback has run and been awaited before either module is evaluated (a loop disposing of and reloading one module at a time, or not awaiting, produces a different order).
- one update replacing two modules that share a boundary, twice in a row: each of the three modules is disposed of once and evaluated once per update (the second round would see the doubled dispose callbacks of a module evaluated twice by the first).
- a replaced copy whose evaluation threw (reached through `import()` so the page stays up): its dispose callback runs when the fixed copy replaces it, and exactly once more on the following update.
- `import.meta.hot.on()` in a module accepted by its importer: only the current copy's listener fires after each save.

All five fail on the released bun 1.4.0 (the dispose message of the replaced module missing, the stale listener firing, or, for the batch test, the `TypeError` above) and pass with this change. The batch test also fails, with an extra `evaluated e2`, against the first revision of this PR that still marked modules stale in the dispose pass. The rest of `hot.test.ts`, and `esm.test.ts`, `bundle.test.ts` and `react-spa.test.ts` in `test/bake/dev/`, pass with it as well.

No issue for this; it came up while working on another dev server bug.

</details>
