### PR TITLE
Fix stale exception and null prototype dereference in Bun.inspect's property walk

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5605,10 +5605,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5680,7 +5681,12 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototype" trap.
+            CLEAR_IF_EXCEPTION(scope);
+            if (!prototype) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -579,6 +579,75 @@ it("Bun.inspect huge sparse array summarizes holes without iterating them", asyn
   });
 });
 
+// When resolving a property throws partway through the property walk (a Proxy trap, or a
+// lazily-initialized native property whose initializer threw), the exception used to be
+// left pending while the walk moved on to the next property and up the prototype chain.
+describe.concurrent("Bun.inspect when looking up a property throws", () => {
+  async function inspectInChild(code) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", code],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  it("skips the property whose Proxy get trap threw and prints the rest", async () => {
+    const result = await inspectInChild(`
+      const proto = new Proxy(
+        { a: 1, b: 2, c: 3 },
+        {
+          get(target, key) {
+            if (key === "a") throw new Error("boom");
+            return target[key];
+          },
+        },
+      );
+      console.log(JSON.stringify(Bun.inspect(Object.create(proto))));
+    `);
+    expect(result).toEqual({ stdout: JSON.stringify("{\n  b: 2,\n  c: 3,\n}") + "\n", stderr: "", exitCode: 0 });
+  });
+
+  it("stops walking the prototype chain when a Proxy getPrototypeOf trap throws", async () => {
+    const result = await inspectInChild(`
+      const proto = new Proxy(
+        { a: 1 },
+        {
+          getPrototypeOf() {
+            throw new Error("boom");
+          },
+        },
+      );
+      console.log(JSON.stringify(Bun.inspect(Object.create(proto))));
+    `);
+    expect(result).toEqual({ stdout: JSON.stringify("{\n  a: 1,\n}") + "\n", stderr: "", exitCode: 0 });
+  });
+
+  it("keeps printing the Bun object after a lazily-initialized property throws", async () => {
+    // Bun.$ is built lazily by JS that calls Object.setPrototypeOf, so removing it makes
+    // resolving that property throw. "$" is the first property in Bun's table, and the
+    // properties after it used to be dropped from the output.
+    const result = await inspectInChild(`
+      Object.setPrototypeOf = undefined;
+      let shellThrew = false;
+      try {
+        Bun.$;
+      } catch {
+        shellThrew = true;
+      }
+      const inspected = Bun.inspect(Bun);
+      console.log(JSON.stringify({ shellThrew, hasArchive: inspected.includes("Archive: ") }));
+    `);
+    expect(result).toEqual({
+      stdout: JSON.stringify({ shellThrew: true, hasArchive: true }) + "\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+});
+
 describe("console.logging function displays async and generator names", async () => {
   const cases = [
     function () {},


### PR DESCRIPTION
### What does this PR do?

`JSC__JSValue__forEachPropertyImpl` in `bindings.cpp` is the property walk behind `Bun.inspect` and `console.log`. In its slow path (objects with static property tables, Proxies in the chain, accessors, and so on) it only cleared a pending exception after `getPropertySlot` had *found* the property. When the lookup itself threw, the loop did `continue` with the exception still pending, and everything after that runs with a stale exception:

- Every later lookup on the same object bails out early, so those properties silently disappear from the output. On the current release, `Object.setPrototypeOf = undefined; Bun.inspect(Bun)` prints the object starting at `main:`; everything between `$` and `main` is gone.
- In debug builds the next lazy property callback on the object (`Bun.Archive` right after `Bun.$`) returns a value while an exception is pending, and the exception scope check aborts with `Unexpected exception observed ... releaseAssertNoException()`. This is the crash Fuzzilli reported. The fuzzer runs scripts back to back in one global, so an earlier script had removed `Object.setPrototypeOf`; the reported script then hit `ReadableStream.from(Bun)`, whose "must be iterable" error message formats the `Bun` object, and building `Bun.$` threw inside the walk.
- At the bottom of the loop `iterating->getPrototype(globalObject)` returns the empty value when an exception is pending (or when a Proxy `getPrototypeOf` trap throws on its own), and `.getObject()` on the empty value reads through a null cell. On the current release both of these segfault at address 0x5:

```js
const proto = new Proxy({ a: 1, b: 2, c: 3 }, { get(t, k) { if (k === "a") throw new Error("boom"); return t[k]; } });
console.log(Object.create(proto));
```

```js
console.log(Object.create(new Proxy({}, { getPrototypeOf() { throw new Error("boom"); } })));
```

The fix moves the `CLEAR_IF_EXCEPTION` ahead of the `continue`, which is how `JSC__JSValue__forEachPropertyOrdered` a few lines down already does it, and makes the prototype step clear the exception and stop the walk when `getPrototype()` throws, matching what the fast path does for the same trap. A property whose lookup throws is still skipped, as before; the other properties are printed now. With the change, the first snippet prints `{ b: 2, c: 3 }`, the second prints `{}`, `Bun.inspect(Bun)` with `Object.setPrototypeOf` removed prints everything except `$`, and the fuzzer script runs to completion on a debug build.

### How did you verify your code works?

Added three cases to `test/js/bun/util/inspect.test.js`, each running in a child process: the throwing `get` trap, the throwing `getPrototypeOf` trap, and the `Bun.$` case from the fuzzer (it also checks that `Bun.$` really does throw in that setup, so the test cannot pass vacuously if the shell builtin stops depending on the global `Object.setPrototypeOf`).

With `USE_SYSTEM_BUN=1` (release 1.4.0) the two Proxy tests fail with exit code 139 and the `Bun.$` test fails because `Archive` is missing from the output; the same `Bun.$` script aborts on the pre-fix debug build with the assertion from the report. All three pass with `bun bd test`, as does the rest of `inspect.test.js`, `test/js/node/util/bun-inspect.test.ts`, `custom-inspect.test.js`, and the `test/js/bun/console` tests.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->