### PR TITLE
io(kqueue): unregister before handing the owner off on close, and bit-test EV_ERROR

### DIFF
--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1117,8 +1117,7 @@ impl IoRequestLoop {
                     match (request.callback)(request) {
                         Action::Readable(readable) => {
                             Poll::apply_kqueue(
-                                ApplyAction::Readable,
-                                readable.tag,
+                                ApplyAction::Readable(readable.tag),
                                 readable.poll,
                                 readable.fd,
                                 add_one(&mut events_list),
@@ -1126,8 +1125,7 @@ impl IoRequestLoop {
                         }
                         Action::Writable(writable) => {
                             Poll::apply_kqueue(
-                                ApplyAction::Writable,
-                                writable.tag,
+                                ApplyAction::Writable(writable.tag),
                                 writable.poll,
                                 writable.fd,
                                 add_one(&mut events_list),
@@ -1139,12 +1137,15 @@ impl IoRequestLoop {
                             {
                                 Poll::apply_kqueue(
                                     ApplyAction::Cancel,
-                                    close.tag,
                                     close.poll,
                                     close.fd,
                                     add_one(&mut events_list),
                                 );
                             }
+                            // From here on another thread may finish and free
+                            // the owner, before the kevent() below has even
+                            // submitted the cancel; safe only because the cancel
+                            // addresses nobody (see `ApplyAction::Cancel`).
                             (close.on_done)(close.ctx);
                         }
                     }
@@ -1158,10 +1159,10 @@ impl IoRequestLoop {
                 self.pollfd().native(),
                 events_list.as_ptr(),
                 c_int::try_from(change_count).expect("int cast"),
-                // The same array may be used for the changelist and eventlist.
+                // The same array may be used for the changelist and eventlist;
+                // a rejected change comes back through it as an EV_ERROR entry
+                // (see `on_update_kqueue`) instead of failing the call.
                 events_list.as_mut_ptr(),
-                // we set 0 here so that if we get an error on
-                // registration, it becomes errno
                 c_int::try_from(capacity).expect("int cast"),
                 core::ptr::null(),
             );
@@ -1353,11 +1354,12 @@ pub struct FileAction<'a> {
     pub on_error: fn(*mut (), &sys::Error),
 }
 
+/// No [`PollableTag`], unlike [`FileAction`]: `on_done` hands the owner to
+/// another thread, so nothing a close submits may dispatch back into it.
 pub struct CloseAction<'a> {
     pub fd: Fd,
     pub poll: &'a mut Poll,
     pub ctx: *mut (),
-    pub tag: PollableTag,
     pub on_done: fn(*mut ()),
 }
 
@@ -1496,8 +1498,15 @@ pub type FlagsSet = enumset::EnumSet<Flags>;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 #[derive(PartialEq, Eq, Clone, Copy)]
 enum ApplyAction {
-    Readable,
-    Writable,
+    /// One-shot `EV_ADD`; its event, or the `EV_ERROR` entry if the add is
+    /// rejected, dispatches to the owner the tag names.
+    Readable(PollableTag),
+    Writable(PollableTag),
+    /// `EV_DELETE` of whatever the poll still has armed, submitted with
+    /// `udata = 0` so that `on_update_kqueue` drops its reply like the waker's.
+    /// The reply is the rule, not the exception (the one-shot knote is usually
+    /// gone already: ENOENT; or the owner closed the fd first: EBADF), and by
+    /// the time it arrives `tick_kqueue` has handed the owner to another thread.
     Cancel,
 }
 
@@ -1506,7 +1515,6 @@ impl Poll {
     #[inline]
     pub(crate) fn apply_kqueue(
         action: ApplyAction,
-        tag: PollableTag,
         poll: &mut Poll,
         fd: Fd,
         kqueue_event: &mut KEvent,
@@ -1514,23 +1522,31 @@ impl Poll {
         log!(
             "register({}, {})",
             match action {
-                ApplyAction::Readable => "readable",
-                ApplyAction::Writable => "writable",
+                ApplyAction::Readable(_) => "readable",
+                ApplyAction::Writable(_) => "writable",
                 ApplyAction::Cancel => "cancel",
             },
             fd
         );
 
         let one_shot_flag = libc::EV_ONESHOT;
-        let udata: usize = Pollable::init(tag, std::ptr::from_mut::<Poll>(poll)).ptr() as usize;
-        let (filter, flags_): (i16, u16) = match action {
-            ApplyAction::Readable => (libc::EVFILT_READ, libc::EV_ADD | one_shot_flag),
-            ApplyAction::Writable => (libc::EVFILT_WRITE, libc::EV_ADD | one_shot_flag),
+        let poll_ptr = std::ptr::from_mut::<Poll>(poll);
+        let (filter, flags_, udata): (i16, u16, usize) = match action {
+            ApplyAction::Readable(tag) => (
+                libc::EVFILT_READ,
+                libc::EV_ADD | one_shot_flag,
+                Pollable::init(tag, poll_ptr).ptr() as usize,
+            ),
+            ApplyAction::Writable(tag) => (
+                libc::EVFILT_WRITE,
+                libc::EV_ADD | one_shot_flag,
+                Pollable::init(tag, poll_ptr).ptr() as usize,
+            ),
             ApplyAction::Cancel => {
                 if poll.flags.contains(Flags::PollReadable) {
-                    (libc::EVFILT_READ, libc::EV_DELETE)
+                    (libc::EVFILT_READ, libc::EV_DELETE, 0)
                 } else if poll.flags.contains(Flags::PollWritable) {
-                    (libc::EVFILT_WRITE, libc::EV_DELETE)
+                    (libc::EVFILT_WRITE, libc::EV_DELETE, 0)
                 } else {
                     unreachable!()
                 }
@@ -1561,10 +1577,10 @@ impl Poll {
         }
 
         match action {
-            ApplyAction::Readable => {
+            ApplyAction::Readable(_) => {
                 poll.flags.insert(Flags::PollReadable);
             }
-            ApplyAction::Writable => {
+            ApplyAction::Writable(_) => {
                 poll.flags.insert(Flags::PollWritable);
             }
             ApplyAction::Cancel => {
@@ -1611,8 +1627,9 @@ impl Poll {
 
         let pollable = Pollable::from(event.udata as u64);
         let tag = pollable.tag();
-        // The waker is registered with udata=0 → tag=.empty. The wakeup exists
-        // only to unblock kevent() so the pending queue drains.
+        // udata=0 → tag=.empty is both the waker (registered only to unblock
+        // kevent() so the pending queue drains) and the EV_ERROR reply to an
+        // `ApplyAction::Cancel`, whose owner may already be gone.
         if tag == PollableTag::Empty {
             return;
         }
@@ -1620,7 +1637,11 @@ impl Poll {
         // CYCLEBREAK: owner (ReadFile/WriteFile) is T6; dispatch via link-time
         // `extern "Rust"` defined in `bun_runtime::dispatch`. The
         // container_of(io_poll) recovery happens there.
-        if event.flags == libc::EV_ERROR {
+        //
+        // A rejected change comes back with EV_ERROR set in `flags`; xnu ORs it
+        // into the bits we submitted (EV_ADD|EV_ONESHOT|EV_ERROR) while FreeBSD
+        // replaces them, so test the bit rather than the whole word.
+        if (event.flags & libc::EV_ERROR) != 0 {
             log!("error({}) = {}", event.ident, event.data);
             // SAFETY: poll is the `io_poll` field of a live owner; link-time
             // extern body matches on `tag`.

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1600,15 +1600,13 @@ impl Poll {
         self.flags.remove(Flags::Registered);
     }
 
-    /// Applied on the spot rather than with the next batch: the caller hands
-    /// the owner to another thread as soon as this returns.
+    /// Not batched into the next `kevent()`: the caller hands the owner off right after this.
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     pub(crate) fn unregister_kqueue(&mut self, watcher_fd: Fd, fd: Fd) {
         let mut change: KEvent = bun_core::ffi::zeroed();
         Poll::apply_kqueue(ApplyAction::Cancel, self, fd, &mut change);
-        // With nevents = 0 the call returns as soon as the change is applied.
-        // It fails with ENOENT once the one-shot registration has fired and
-        // with EBADF once the fd is closed; either way nothing is left to remove.
+        // nevents = 0: apply only. ENOENT (one-shot already fired) and EBADF
+        // (fd already closed) are the usual outcomes; nothing to do for either.
         let _ = kevent_call(
             watcher_fd.native(),
             &raw const change,

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1135,17 +1135,8 @@ impl IoRequestLoop {
                             if close.poll.flags.contains(Flags::PollReadable)
                                 || close.poll.flags.contains(Flags::PollWritable)
                             {
-                                Poll::apply_kqueue(
-                                    ApplyAction::Cancel,
-                                    close.poll,
-                                    close.fd,
-                                    add_one(&mut events_list),
-                                );
+                                close.poll.unregister_kqueue(self.pollfd(), close.fd);
                             }
-                            // From here on another thread may finish and free
-                            // the owner, before the kevent() below has even
-                            // submitted the cancel; safe only because the cancel
-                            // addresses nobody (see `ApplyAction::Cancel`).
                             (close.on_done)(close.ctx);
                         }
                     }
@@ -1159,9 +1150,7 @@ impl IoRequestLoop {
                 self.pollfd().native(),
                 events_list.as_ptr(),
                 c_int::try_from(change_count).expect("int cast"),
-                // The same array may be used for the changelist and eventlist;
-                // a rejected change comes back through it as an EV_ERROR entry
-                // (see `on_update_kqueue`) instead of failing the call.
+                // The same array may be used for the changelist and eventlist.
                 events_list.as_mut_ptr(),
                 c_int::try_from(capacity).expect("int cast"),
                 core::ptr::null(),
@@ -1354,8 +1343,6 @@ pub struct FileAction<'a> {
     pub on_error: fn(*mut (), &sys::Error),
 }
 
-/// No [`PollableTag`], unlike [`FileAction`]: `on_done` hands the owner to
-/// another thread, so nothing a close submits may dispatch back into it.
 pub struct CloseAction<'a> {
     pub fd: Fd,
     pub poll: &'a mut Poll,
@@ -1498,15 +1485,10 @@ pub type FlagsSet = enumset::EnumSet<Flags>;
 #[cfg(any(target_os = "macos", target_os = "freebsd"))]
 #[derive(PartialEq, Eq, Clone, Copy)]
 enum ApplyAction {
-    /// One-shot `EV_ADD`; its event, or the `EV_ERROR` entry if the add is
-    /// rejected, dispatches to the owner the tag names.
+    /// One-shot `EV_ADD` whose events dispatch to the owner the tag names.
     Readable(PollableTag),
     Writable(PollableTag),
-    /// `EV_DELETE` of whatever the poll still has armed, submitted with
-    /// `udata = 0` so that `on_update_kqueue` drops its reply like the waker's.
-    /// The reply is the rule, not the exception (the one-shot knote is usually
-    /// gone already: ENOENT; or the owner closed the fd first: EBADF), and by
-    /// the time it arrives `tick_kqueue` has handed the owner to another thread.
+    /// `EV_DELETE` of whatever the poll still has armed; dispatches to nobody.
     Cancel,
 }
 
@@ -1618,6 +1600,25 @@ impl Poll {
         self.flags.remove(Flags::Registered);
     }
 
+    /// Applied on the spot rather than with the next batch: the caller hands
+    /// the owner to another thread as soon as this returns.
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    pub(crate) fn unregister_kqueue(&mut self, watcher_fd: Fd, fd: Fd) {
+        let mut change: KEvent = bun_core::ffi::zeroed();
+        Poll::apply_kqueue(ApplyAction::Cancel, self, fd, &mut change);
+        // With nevents = 0 the call returns as soon as the change is applied.
+        // It fails with ENOENT once the one-shot registration has fired and
+        // with EBADF once the fd is closed; either way nothing is left to remove.
+        let _ = kevent_call(
+            watcher_fd.native(),
+            &raw const change,
+            1,
+            core::ptr::null_mut(),
+            0,
+            core::ptr::null(),
+        );
+    }
+
     #[cfg(any(target_os = "macos", target_os = "freebsd"))]
     pub(crate) fn on_update_kqueue(event: KEvent) {
         #[cfg(target_os = "macos")]
@@ -1627,9 +1628,8 @@ impl Poll {
 
         let pollable = Pollable::from(event.udata as u64);
         let tag = pollable.tag();
-        // udata=0 → tag=.empty is both the waker (registered only to unblock
-        // kevent() so the pending queue drains) and the EV_ERROR reply to an
-        // `ApplyAction::Cancel`, whose owner may already be gone.
+        // The waker is registered with udata=0 → tag=.empty. The wakeup exists
+        // only to unblock kevent() so the pending queue drains.
         if tag == PollableTag::Empty {
             return;
         }
@@ -1638,9 +1638,8 @@ impl Poll {
         // `extern "Rust"` defined in `bun_runtime::dispatch`. The
         // container_of(io_poll) recovery happens there.
         //
-        // A rejected change comes back with EV_ERROR set in `flags`; xnu ORs it
-        // into the bits we submitted (EV_ADD|EV_ONESHOT|EV_ERROR) while FreeBSD
-        // replaces them, so test the bit rather than the whole word.
+        // xnu ORs EV_ERROR into the flags of a rejected change (EV_ADD|EV_ONESHOT
+        // |EV_ERROR); FreeBSD replaces them. Only the bit is common to both.
         if (event.flags & libc::EV_ERROR) != 0 {
             log!("error({}) = {}", event.ident, event.data);
             // SAFETY: poll is the `io_poll` field of a live owner; link-time

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -7031,8 +7031,6 @@ pub trait FileOpener: Sized {
 
 // TODO: move to bun_sys?
 pub trait FileCloser: Sized {
-    const IO_TAG: bun_io::Tag;
-
     fn opened_fd(&self) -> Fd;
     fn set_opened_fd(&mut self, fd: Fd);
     fn close_after_io(&self) -> bool;
@@ -7109,15 +7107,13 @@ pub trait FileCloser: Sized {
 }
 
 /// Implements [`FileCloser`] for a task struct with the standard field set
-/// (`opened_fd`, `close_after_io`, `state`, `io_request`, `io_poll`, `task`),
-/// an inherent `update()`, and a [`bun_io::Tag`] variant named after the type.
-/// The type must also carry `bun_threading::intrusive_work_task!` and
-/// `bun_io::intrusive_io_request!`, which provide the parent-pointer recovery
-/// used by the two trampolines.
+/// (`opened_fd`, `close_after_io`, `state`, `io_request`, `io_poll`, `task`)
+/// and an inherent `update()`. The type must also carry
+/// `bun_threading::intrusive_work_task!` and `bun_io::intrusive_io_request!`,
+/// which provide the parent-pointer recovery used by the two trampolines.
 macro_rules! impl_file_closer {
     ($T:ident) => {
         impl crate::webcore::blob::FileCloser for $T {
-            const IO_TAG: ::bun_io::Tag = ::bun_io::Tag::$T;
             fn opened_fd(&self) -> ::bun_sys::Fd {
                 self.opened_fd
             }
@@ -7164,7 +7160,6 @@ macro_rules! impl_file_closer {
                     fd,
                     poll,
                     ctx: this.cast::<()>(),
-                    tag: <Self as crate::webcore::blob::FileCloser>::IO_TAG,
                     on_done,
                 })
             }

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -960,7 +960,6 @@ impl<'a> FileOpener for ReadFileUV<'a> {
 
 #[cfg(windows)]
 impl<'a> FileCloser for ReadFileUV<'a> {
-    const IO_TAG: bun_io::Tag = bun_io::Tag::ReadFile;
     fn opened_fd(&self) -> Fd {
         self.opened_fd
     }

--- a/test/internal/source-lints/kevent-ev-error-equality.test.ts
+++ b/test/internal/source-lints/kevent-ev-error-equality.test.ts
@@ -43,7 +43,9 @@ const tracked: Set<string> | null = (() => {
 // `bun_sys::darwin::EV::ERROR`, ...
 const CONSTANT = String.raw`(?:\w+::)*EV(?:_ERROR|::ERROR)\b`;
 // `x & EV_ERROR`: the bit test. `(?<!&)&(?!&)` keeps `&&` out of it.
-const BIT_TEST = new RegExp(String.raw`(?<!&)&(?!&)\s*${CONSTANT}`);
+const BIT_TEST = new RegExp(String.raw`(?<!&)&(?!&)\s*${CONSTANT}`, "g");
+// `(x & EV_ERROR) == EV_ERROR`: the same test spelled as a masked compare.
+const MASKED_COMPARE = new RegExp(String.raw`(?<!&)&(?!&)\s*${CONSTANT}\s*\)\s*(?:==|!=)\s*${CONSTANT}`, "g");
 // The constant as either operand of `==` / `!=`, optionally parenthesized.
 const COMPARED = new RegExp(String.raw`(?:==|!=)\s*\(?\s*${CONSTANT}|\b${CONSTANT}\s*\)?\s*(?:==|!=)`);
 
@@ -52,15 +54,21 @@ const COMPARED = new RegExp(String.raw`(?:==|!=)\s*\(?\s*${CONSTANT}|\b${CONSTAN
 // swallow everything up to some distant `*/`, silently blinding the lint to
 // whatever is in between. Rust has no `/* */` comments in the kqueue code and
 // a prose mention in one would fail loudly here, which is the better failure.
-function classify(line: string): "bit-test" | "compared" | null {
-  const code = line.replace(/\/\/.*$/, "");
-  // A line that masks with the constant is not comparing the whole word
-  // against it, whatever else it does: `(flags & EV_ERROR) == EV_ERROR` is a
-  // (verbose) bit test, and so is Rust's `flags & EV_ERROR == 0`, since `&`
-  // binds tighter than `==` there.
-  if (BIT_TEST.test(code)) return "bit-test";
-  if (COMPARED.test(code)) return "compared";
-  return null;
+function code(line: string): string {
+  return line.replace(/\/\/.*$/, "");
+}
+
+function hasBitTest(line: string): boolean {
+  BIT_TEST.lastIndex = 0;
+  return BIT_TEST.test(code(line));
+}
+
+// Erase the bit tests first (the masked-compare spelling as a whole, then the
+// bare `& EV_ERROR`, which also takes care of Rust's `flags & EV_ERROR == 0`
+// since `&` binds tighter than `==` there); whatever is still compared against
+// the constant after that is a whole flags word.
+function comparesWholeWord(line: string): boolean {
+  return COMPARED.test(code(line).replace(MASKED_COMPARE, "").replace(BIT_TEST, ""));
 }
 
 const offenders: string[] = [];
@@ -76,14 +84,8 @@ for (const abs of rustSources) {
   const content = await file(abs).text();
   if (!content.includes("EV_ERROR") && !content.includes("EV::ERROR")) continue;
   for (const [index, line] of content.split("\n").entries()) {
-    switch (classify(line)) {
-      case "bit-test":
-        filesWithBitTests.add(source);
-        break;
-      case "compared":
-        offenders.push(`${source}:${index + 1}: ${line.trim()}`);
-        break;
-    }
+    if (hasBitTest(line)) filesWithBitTests.add(source);
+    if (comparesWholeWord(line)) offenders.push(`${source}:${index + 1}: ${line.trim()}`);
   }
 }
 
@@ -96,9 +98,10 @@ test("scans a non-empty set of tracked Rust sources", () => {
 test("the scan still sees the bit tests that are known to be in the tree", () => {
   // Named files rather than a count: if the file set or the comment handling
   // ever stops seeing one of these, the ban below would be vacuous for it.
-  // FilePoll's register/unregister and the process reaper's kevent loop.
+  // The io request loop's event dispatch, FilePoll's register/unregister and
+  // the process reaper's kevent loop.
   expect([...filesWithBitTests].sort()).toEqual(
-    expect.arrayContaining(["src/io/posix_event_loop.rs", "src/spawn/process.rs"]),
+    expect.arrayContaining(["src/io/lib.rs", "src/io/posix_event_loop.rs", "src/spawn/process.rs"]),
   );
 });
 
@@ -110,21 +113,30 @@ test("the pattern recognizes the spellings it claims to", () => {
     "if libc::EV_ERROR == event.flags {",
     "let failed = event.flags == (EV::ERROR);",
     "if event.flags == EV_ERROR && event.data != 0 {",
+    // A bit test elsewhere on the line does not excuse a whole-word compare.
+    "if (event.flags & libc::EV_ERROR) != 0 && event.flags == libc::EV_ERROR {",
+    "let whole = flags == EV::ERROR || (flags & EV::ERROR) == EV::ERROR;",
   ];
-  const allowed = [
+  // Bit tests: allowed, and what the liveness check above counts.
+  const bitTests = [
     "if (event.flags & libc::EV_ERROR) != 0 {",
     "if (changelist[0].flags & EV::ERROR) != 0 && changelist[0].data != 0 {",
     "if (changelist[i].flags & EV::ERROR) == 0 || changelist[i].data == 0 {",
     "if (event.flags & EV_ERROR) == EV_ERROR {",
+    "if (event.flags & libc::EV_ERROR) != libc::EV_ERROR {",
     "if r.flags & libc::EV_ERROR == 0 || r.data == 0 {",
     "if event.data != 0 && event.flags & EV_ERROR != 0 {",
     "let is_error = event.flags & EV::ERROR != 0;",
-    "pub const ERROR: u16 = libc::EV_ERROR;",
-    "    // xnu ORs EV_ERROR in, so `flags == EV_ERROR` is the bug this comment is about",
     "let rejected = (kev.flags & EV::ERROR) != 0; // not kev.flags == EV::ERROR",
   ];
-  expect(banned.filter(s => classify(s) !== "compared")).toEqual([]);
-  expect(allowed.filter(s => classify(s) === "compared")).toEqual([]);
+  // Neither: mentions of the constant that are not tests of a flags word.
+  const neither = [
+    "pub const ERROR: u16 = libc::EV_ERROR;",
+    "    // xnu ORs EV_ERROR in, so `flags == EV_ERROR` is the bug this comment is about",
+  ];
+  expect(banned.filter(s => !comparesWholeWord(s))).toEqual([]);
+  expect(bitTests.filter(s => !hasBitTest(s) || comparesWholeWord(s))).toEqual([]);
+  expect(neither.filter(s => hasBitTest(s) || comparesWholeWord(s))).toEqual([]);
 });
 
 test("kevent EV_ERROR is tested as a bit, never compared against the whole flags word", () => {

--- a/test/internal/source-lints/kevent-ev-error-equality.test.ts
+++ b/test/internal/source-lints/kevent-ev-error-equality.test.ts
@@ -11,17 +11,18 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //   xnu      (bsd/kern/kern_event.c, kevent_register)   kev->flags |= EV_ERROR;
 //   FreeBSD  (sys/kern/kern_event.c, kqueue_kevent)      kevp->flags = EV_ERROR;
 //
-// so on macOS the reply to a failed `EV_ADD|EV_ONESHOT` reads 0x4011, not
-// 0x4000, and `flags == EV_ERROR` silently classifies it as a ready event.
-// For the io request loop that meant a rejected registration was dispatched
-// as "readable", which re-reads, gets EAGAIN, re-registers, and spins; for
-// FilePoll (posix_event_loop.rs) it meant change errors were swallowed. Both
-// kernels agree on the bit, so that is what gets tested:
+// so on macOS the reply to a rejected `EV_ADD|EV_ONESHOT` reads 0x4011, not
+// 0x4000, and `flags == EV_ERROR` is false for it: the io request loop
+// (src/io/lib.rs) dispatched such a reply as a ready event, and FilePoll
+// (src/io/posix_event_loop.rs) used to swallow its change errors the same way
+// (#31701). Both kernels agree on the bit, so that is what gets tested:
 //
-//   flags == EV_ERROR / flags != EV::ERROR   →   (flags & EV_ERROR) != 0
+//   flags == EV_ERROR / flags != EV::ERROR   ->   (flags & EV_ERROR) != 0
 //
-// The Zig original carried the equality in both kqueue users; the port fixed
-// FilePoll's and this lint keeps the other from coming back.
+// Both of the io layer's kqueue users inherited the equality from the Zig
+// original; this keeps it from coming back in either. Scope is the Rust tree
+// because that is what .github/workflows/source-lints.yml runs this for; the C
+// kqueue code in packages/bun-usockets is outside its triggers.
 
 const root = path.resolve(import.meta.dir, "..", "..", "..");
 const rustSources = globAllSources().rust.filter(abs => abs.endsWith(".rs"));
@@ -41,21 +42,30 @@ const tracked: Set<string> | null = (() => {
 // The constant in any of its spellings: `EV_ERROR`, `libc::EV_ERROR`,
 // `bun_sys::darwin::EV::ERROR`, ...
 const CONSTANT = String.raw`(?:\w+::)*EV(?:_ERROR|::ERROR)\b`;
-// `x & EV_ERROR` is the bit test this lint asks for. It is erased before
-// looking for comparisons so that `(flags & EV_ERROR) == 0`, and Rust's
-// `flags & EV_ERROR == 0` (`&` binds tighter than `==` in Rust), do not
-// register as comparing the whole word. `(?<!&)&(?!&)` keeps `&&` out of it.
-const BIT_TEST = new RegExp(String.raw`(?<!&)&(?!&)\s*${CONSTANT}`, "g");
+// `x & EV_ERROR`: the bit test. `(?<!&)&(?!&)` keeps `&&` out of it.
+const BIT_TEST = new RegExp(String.raw`(?<!&)&(?!&)\s*${CONSTANT}`);
 // The constant as either operand of `==` / `!=`, optionally parenthesized.
 const COMPARED = new RegExp(String.raw`(?:==|!=)\s*\(?\s*${CONSTANT}|\b${CONSTANT}\s*\)?\s*(?:==|!=)`);
 
-function comparesWholeWord(line: string): boolean {
-  return COMPARED.test(line.replace(BIT_TEST, ""));
+// Comments are cut per line at `//`, and only per line: stripping `/* */`
+// spans would let a `/*` inside a line comment or a glob string literal
+// swallow everything up to some distant `*/`, silently blinding the lint to
+// whatever is in between. Rust has no `/* */` comments in the kqueue code and
+// a prose mention in one would fail loudly here, which is the better failure.
+function classify(line: string): "bit-test" | "compared" | null {
+  const code = line.replace(/\/\/.*$/, "");
+  // A line that masks with the constant is not comparing the whole word
+  // against it, whatever else it does: `(flags & EV_ERROR) == EV_ERROR` is a
+  // (verbose) bit test, and so is Rust's `flags & EV_ERROR == 0`, since `&`
+  // binds tighter than `==` there.
+  if (BIT_TEST.test(code)) return "bit-test";
+  if (COMPARED.test(code)) return "compared";
+  return null;
 }
 
 const offenders: string[] = [];
+const filesWithBitTests = new Set<string>();
 let scanned = 0;
-let bitTests = 0;
 for (const abs of rustSources) {
   const source = path.relative(root, abs).replaceAll(path.sep, "/");
   // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
@@ -65,14 +75,15 @@ for (const abs of rustSources) {
   scanned++;
   const content = await file(abs).text();
   if (!content.includes("EV_ERROR") && !content.includes("EV::ERROR")) continue;
-  // Drop comments (the ones in posix_event_loop.rs and io/lib.rs describe this
-  // very hazard) without disturbing line numbers: block comments keep their
-  // newlines, line comments are cut at the `//`.
-  const stripped = content.replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n]/g, "")).replace(/\/\/.*$/gm, "");
-  for (const [index, line] of stripped.split("\n").entries()) {
-    BIT_TEST.lastIndex = 0;
-    if (BIT_TEST.test(line)) bitTests++;
-    if (comparesWholeWord(line)) offenders.push(`${source}:${index + 1}: ${line.trim()}`);
+  for (const [index, line] of content.split("\n").entries()) {
+    switch (classify(line)) {
+      case "bit-test":
+        filesWithBitTests.add(source);
+        break;
+      case "compared":
+        offenders.push(`${source}:${index + 1}: ${line.trim()}`);
+        break;
+    }
   }
 }
 
@@ -82,11 +93,13 @@ test("scans a non-empty set of tracked Rust sources", () => {
   expect(scanned).toBeGreaterThan(0);
 });
 
-test("the scan still sees the tree's EV_ERROR bit tests", () => {
-  // FilePoll's register/unregister (src/io/posix_event_loop.rs) and the
-  // process reaper (src/spawn/process.rs) test the bit; if none are seen, the
-  // file set or the comment stripping is broken and the ban below is vacuous.
-  expect(bitTests).toBeGreaterThan(0);
+test("the scan still sees the bit tests that are known to be in the tree", () => {
+  // Named files rather than a count: if the file set or the comment handling
+  // ever stops seeing one of these, the ban below would be vacuous for it.
+  // FilePoll's register/unregister and the process reaper's kevent loop.
+  expect([...filesWithBitTests].sort()).toEqual(
+    expect.arrayContaining(["src/io/posix_event_loop.rs", "src/spawn/process.rs"]),
+  );
 });
 
 test("the pattern recognizes the spellings it claims to", () => {
@@ -102,13 +115,16 @@ test("the pattern recognizes the spellings it claims to", () => {
     "if (event.flags & libc::EV_ERROR) != 0 {",
     "if (changelist[0].flags & EV::ERROR) != 0 && changelist[0].data != 0 {",
     "if (changelist[i].flags & EV::ERROR) == 0 || changelist[i].data == 0 {",
+    "if (event.flags & EV_ERROR) == EV_ERROR {",
     "if r.flags & libc::EV_ERROR == 0 || r.data == 0 {",
     "if event.data != 0 && event.flags & EV_ERROR != 0 {",
-    "pub const ERROR: u16 = libc::EV_ERROR;",
     "let is_error = event.flags & EV::ERROR != 0;",
+    "pub const ERROR: u16 = libc::EV_ERROR;",
+    "    // xnu ORs EV_ERROR in, so `flags == EV_ERROR` is the bug this comment is about",
+    "let rejected = (kev.flags & EV::ERROR) != 0; // not kev.flags == EV::ERROR",
   ];
-  expect(banned.filter(s => !comparesWholeWord(s))).toEqual([]);
-  expect(allowed.filter(comparesWholeWord)).toEqual([]);
+  expect(banned.filter(s => classify(s) !== "compared")).toEqual([]);
+  expect(allowed.filter(s => classify(s) === "compared")).toEqual([]);
 });
 
 test("kevent EV_ERROR is tested as a bit, never compared against the whole flags word", () => {

--- a/test/internal/source-lints/kevent-ev-error-equality.test.ts
+++ b/test/internal/source-lints/kevent-ev-error-equality.test.ts
@@ -1,0 +1,116 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A kevent changelist entry the kernel rejects is handed back in the eventlist
+// with EV_ERROR set in `flags` and the errno in `data`. How it is "set" differs
+// between the two kqueue kernels we build for:
+//
+//   xnu      (bsd/kern/kern_event.c, kevent_register)   kev->flags |= EV_ERROR;
+//   FreeBSD  (sys/kern/kern_event.c, kqueue_kevent)      kevp->flags = EV_ERROR;
+//
+// so on macOS the reply to a failed `EV_ADD|EV_ONESHOT` reads 0x4011, not
+// 0x4000, and `flags == EV_ERROR` silently classifies it as a ready event.
+// For the io request loop that meant a rejected registration was dispatched
+// as "readable", which re-reads, gets EAGAIN, re-registers, and spins; for
+// FilePoll (posix_event_loop.rs) it meant change errors were swallowed. Both
+// kernels agree on the bit, so that is what gets tested:
+//
+//   flags == EV_ERROR / flags != EV::ERROR   →   (flags & EV_ERROR) != 0
+//
+// The Zig original carried the equality in both kqueue users; the port fixed
+// FilePoll's and this lint keeps the other from coming back.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(abs => abs.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout).
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// The constant in any of its spellings: `EV_ERROR`, `libc::EV_ERROR`,
+// `bun_sys::darwin::EV::ERROR`, ...
+const CONSTANT = String.raw`(?:\w+::)*EV(?:_ERROR|::ERROR)\b`;
+// `x & EV_ERROR` is the bit test this lint asks for. It is erased before
+// looking for comparisons so that `(flags & EV_ERROR) == 0`, and Rust's
+// `flags & EV_ERROR == 0` (`&` binds tighter than `==` in Rust), do not
+// register as comparing the whole word. `(?<!&)&(?!&)` keeps `&&` out of it.
+const BIT_TEST = new RegExp(String.raw`(?<!&)&(?!&)\s*${CONSTANT}`, "g");
+// The constant as either operand of `==` / `!=`, optionally parenthesized.
+const COMPARED = new RegExp(String.raw`(?:==|!=)\s*\(?\s*${CONSTANT}|\b${CONSTANT}\s*\)?\s*(?:==|!=)`);
+
+function comparesWholeWord(line: string): boolean {
+  return COMPARED.test(line.replace(BIT_TEST, ""));
+}
+
+const offenders: string[] = [];
+let scanned = 0;
+let bitTests = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  if (!content.includes("EV_ERROR") && !content.includes("EV::ERROR")) continue;
+  // Drop comments (the ones in posix_event_loop.rs and io/lib.rs describe this
+  // very hazard) without disturbing line numbers: block comments keep their
+  // newlines, line comments are cut at the `//`.
+  const stripped = content.replace(/\/\*[\s\S]*?\*\//g, m => m.replace(/[^\n]/g, "")).replace(/\/\/.*$/gm, "");
+  for (const [index, line] of stripped.split("\n").entries()) {
+    BIT_TEST.lastIndex = 0;
+    if (BIT_TEST.test(line)) bitTests++;
+    if (comparesWholeWord(line)) offenders.push(`${source}:${index + 1}: ${line.trim()}`);
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the scan still sees the tree's EV_ERROR bit tests", () => {
+  // FilePoll's register/unregister (src/io/posix_event_loop.rs) and the
+  // process reaper (src/spawn/process.rs) test the bit; if none are seen, the
+  // file set or the comment stripping is broken and the ban below is vacuous.
+  expect(bitTests).toBeGreaterThan(0);
+});
+
+test("the pattern recognizes the spellings it claims to", () => {
+  const banned = [
+    "if event.flags == libc::EV_ERROR {",
+    "if changelist[0].flags == EV::ERROR {",
+    "if ev.flags != bun_sys::darwin::EV::ERROR {",
+    "if libc::EV_ERROR == event.flags {",
+    "let failed = event.flags == (EV::ERROR);",
+    "if event.flags == EV_ERROR && event.data != 0 {",
+  ];
+  const allowed = [
+    "if (event.flags & libc::EV_ERROR) != 0 {",
+    "if (changelist[0].flags & EV::ERROR) != 0 && changelist[0].data != 0 {",
+    "if (changelist[i].flags & EV::ERROR) == 0 || changelist[i].data == 0 {",
+    "if r.flags & libc::EV_ERROR == 0 || r.data == 0 {",
+    "if event.data != 0 && event.flags & EV_ERROR != 0 {",
+    "pub const ERROR: u16 = libc::EV_ERROR;",
+    "let is_error = event.flags & EV::ERROR != 0;",
+  ];
+  expect(banned.filter(s => !comparesWholeWord(s))).toEqual([]);
+  expect(allowed.filter(comparesWholeWord)).toEqual([]);
+});
+
+test("kevent EV_ERROR is tested as a bit, never compared against the whole flags word", () => {
+  expect(offenders).toEqual([]);
+});

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -11,6 +11,7 @@ import {
   tempDir,
   withoutAggressiveGC,
 } from "harness";
+import { mkfifo } from "mkfifo";
 import path, { join } from "path";
 
 let i = 0;
@@ -535,6 +536,46 @@ const IS_UV_FS_COPYFILE_DISABLED =
       resolved: String(size),
     });
     expect(exitCode).toBe(0);
+  });
+
+  // Bun.write(Bun.file(fd), bytes) and Bun.file(fd).text() on a pipe run on
+  // the thread pool and, whenever poll() says the pipe is not ready, park on
+  // the io thread (src/io/lib.rs IoRequestLoop: epoll on Linux, kqueue on
+  // macOS) until it is. The reader below starts on an empty FIFO and the
+  // writer has several times more than any platform's pipe buffer holds, so
+  // both of them take that detour, repeatedly, before this resolves.
+  it.skipIf(isWindows)("Bun.write and Bun.file(fd).text() on a non-blocking FIFO wait for each other", async () => {
+    using dir = tempDir("bun-write-fifo", {});
+    const fifo = join(String(dir), "data.fifo");
+    mkfifo(fifo);
+    // O_RDWR: opening a FIFO for both directions never blocks waiting for a
+    // peer, and keeps a writer attached so the reader cannot see EOF early.
+    // O_NONBLOCK: a full pipe reports EAGAIN to the writer instead of blocking
+    // a pool thread. Two separate fds because epoll registers an fd only once,
+    // and the reader and the writer each register their own.
+    const flags = fs.constants.O_RDWR | fs.constants.O_NONBLOCK;
+    const readFd = fs.openSync(fifo, flags);
+    const writeFd = fs.openSync(fifo, flags);
+    try {
+      // 256 KiB is also the size from which Bun.write() always goes to the
+      // thread pool instead of first trying a synchronous write.
+      const payload = Buffer.alloc(256 * 1024, "0123456789abcdef\n").toString();
+
+      const reading = Bun.file(readFd).slice(0, payload.length).text();
+
+      const destination = Bun.file(writeFd);
+      // Bun.write() only waits for an fd destination to become writable once
+      // the fd's type has been resolved; reading .size does that up front.
+      destination.size;
+      const writing = Bun.write(destination, payload);
+
+      const [text, written] = await Promise.all([reading, writing]);
+      expect({ written, length: text.length }).toEqual({ written: payload.length, length: payload.length });
+      expect(text).toBe(payload);
+    } finally {
+      fs.closeSync(writeFd);
+      fs.closeSync(readFd);
+    }
   });
 
   it("Bun.file(0) survives GC", async () => {


### PR DESCRIPTION
### Problem
- On the kqueue side of the io request loop (macOS and FreeBSD), closing a polled fd put its `EV_DELETE` into the next batched `kevent()` call but handed the owning `ReadFile`/`WriteFile` to the work pool first, so the owner could be finished and freed before the delete was submitted.
- Registrations are one-shot, so that delete normally fails (ENOENT, or EBADF once the pool closed the fd). The kernel returns the failure as an event whose `udata` still points into that owner, and the loop dispatched it (`on_io_error` on FreeBSD, `on_ready` on macOS) into an object another thread owned or had already freed.
- The error check was `event.flags == EV_ERROR`. FreeBSD replaces the flags word with `EV_ERROR`; xnu ORs it in, so on macOS a rejected registration would have been dispatched as ready rather than as an error.
- Found by reading the code; there is no crash report. On FreeBSD the close path is the normal completion of every polled read or write, but FreeBSD has no test lane; on macOS neither defect is known to be reachable today.

### Fix
- The close arm now applies the `EV_DELETE` on the spot with its own `kevent()` call (nevents = 0), ignores the expected ENOENT/EBADF, and only then hands the owner off, which is what the epoll arm already does. Property to check: once the owner belongs to another thread, kqueue holds nothing that could produce a reply for it.
- Because a close no longer dispatches anything, the close request drops its tag; the tag lives on the readable/writable registrations and a cancel is submitted with `udata = 0`.
- The error check becomes a bit test, `(flags & EV_ERROR) != 0`, the same change #31701 made to the sibling event loop. A rejected registration then reports its errno the way an `epoll_ctl` failure already does.
- Verification: the new source lint fails on the unfixed tree and passes with the fix. The new FIFO test drives the kqueue registration path but passes before and after. The close-arm defect has no failing test (unreachable on macOS, no FreeBSD lane); cargo check and clippy were run for the darwin, freebsd and windows targets.

### Background
- `IoRequestLoop` (`src/io/lib.rs`) is the io thread that `Bun.file(fd).text()` and `Bun.write()` park on when a pipe, FIFO or socket is not ready; epoll on Linux, kqueue on macOS and FreeBSD. The reads and writes themselves run on the work pool, so the loop must be done with an owner before handing it over.
- `kevent()` takes a changelist (adds and deletes) and returns an eventlist in one call. The loop batches a tick's changes into the same call it then blocks in; with nevents = 0 the kernel applies the changes and returns at once.
- A change the kernel rejects is not an errno. It comes back as an eventlist entry with `EV_ERROR` set in `flags`, the errno in `data`, and the caller's `udata`, so it flows through the same dispatch as a real readiness event.
- `udata` is a tagged pointer to the owner's `io_poll` field; the tag says whether the owner is a `ReadFile` or a `WriteFile`, and dispatch uses it to recover the owner and call into it. Whatever `udata` a change carries is where its error lands.
- `EV_ONESHOT` registrations are removed by the kernel when they fire, and the loop keeps its own readable/writable flags set afterwards, which is why a later delete of the same registration usually fails.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

Two defects in the kqueue side of `IoRequestLoop` (`src/io/lib.rs`), the request loop behind `Bun.file(...).text()` / `Bun.write()` on fds that have to be polled (pipes, FIFOs, sockets). Found by reading the code; there is no crash report. FreeBSD is in the Rust target matrix (CI builds it) but has no test lane, and on macOS neither path is known to be reachable today (see "Reachability").

**1. The Close arm hands the owner away while its `EV_DELETE` is still in flight.**
`tick_kqueue` batches all changes of one tick into the single `kevent()` call it then blocks in. Its `Action::Close` arm appended the owner's `EV_DELETE` to that batch (`udata` = the owner's `io_poll`) and immediately called `close.on_done`. `on_done` (`FileCloser::on_io_request_closed`) schedules the owner on the work pool; the pool runs `on_close_io_request -> update -> on_finish -> do_close`, closes the fd and calls `io_task.finish()`, after which the JS thread frees the `ReadFile`/`WriteFile`. All of that can happen before the io thread reaches the `kevent()` that submits the delete.

Both registrations are `EV_ONESHOT` and nothing clears `PollReadable`/`PollWritable` when the one-shot fires, so by the time a close arrives the knote is already gone and the delete fails: ENOENT, or EBADF if the pool thread closed the fd first. A failed change is returned in the eventlist with `EV_ERROR` and the `udata` we submitted, i.e. a pointer into the handed-off owner, and `on_update_kqueue` dispatched it: on FreeBSD as `on_io_error` (which overwrites and re-schedules the owner's `task` while the pool may be running it, or after it was freed), on xnu as `on_ready` (same thing via the other entry point). Either way it is a dispatch into an object another thread owns or has already freed. The epoll arm does not have this problem: it applies `EPOLL_CTL_DEL` synchronously and ignores the result before calling `on_done`.

**2. `on_update_kqueue` compared the whole flags word against `EV_ERROR`.**
The kernels differ in how they report a rejected change:

```c
// FreeBSD sys/kern/kern_event.c, kqueue_kevent()
kevp->flags = EV_ERROR;
kevp->data = error;
// xnu bsd/kern/kern_event.c, kevent_register()
kev->flags |= EV_ERROR;
kev->data = error;
```

So on macOS the reply to a rejected `EV_ADD|EV_ONESHOT` has `flags == 0x4011`, `event.flags == libc::EV_ERROR` is false, and a rejected registration would be dispatched as `on_ready` instead of `on_io_error`. `posix_event_loop.rs` already bit-tests for exactly this reason (#31701); this site was the remaining equality test, inherited from the Zig original (`io.zig`, `event.flags == std.c.EV.ERROR`).

### Fix

* The Close arm now does what the epoll arm does: `Poll::unregister_kqueue` applies the `EV_DELETE` on the spot with its own `kevent(..., nevents = 0)` call (both kernels return as soon as the changelist is processed when `nevents` is 0; FreeBSD `kqueue_scan` returns immediately for `maxevents == 0`, xnu skips the scan for `nevents == 0`), ignoring the expected ENOENT/EBADF, and only then calls `on_done`. Once the owner belongs to another thread nothing about the close is pending anywhere, so there is no reply that could be delivered into it, and the order of `on_done` relative to the next batch no longer matters. The first revision of this PR instead kept the delete in the batch and made it anonymous (`udata = 0`); that also works, but its safety rested on an argument about what the kernel can hand back, and review rightly asked for code that does not need the argument.
* Because a close no longer has anything to dispatch, `CloseAction` loses its `tag` field and the tag moves into `ApplyAction::Readable(tag)` / `Writable(tag)`; `Cancel` writes `udata = 0`. `FileCloser::IO_TAG` had no other consumer and goes with the field (trait, `impl_file_closer!`, and the Windows `ReadFileUV` impl).
* `on_update_kqueue`: `(event.flags & libc::EV_ERROR) != 0`. With that, a rejected registration takes the path the epoll arm already takes on `epoll_ctl` failure: `on_io_error` records the errno and the pool task finishes with it; on macOS `close_after_io` is cleared on the way there (`ReadFile::on_io_error`, `WriteFile::do_write_loop_task`), so the error reaches JS without going through the Close arm.

### Reachability

Defect 1: on FreeBSD the Close arm is the normal completion path of every `ReadFile`/`WriteFile` that waited on the io thread (`wait_for_readable`/`wait_for_writable` set `close_after_io`, and only `#[cfg(target_os = "macos")]` code in `ReadFile::on_ready`/`on_io_error` and `WriteFile::do_write_loop_task` clears it), e.g. `Bun.stdin.text()` from a pipe. On macOS those cfg blocks clear `close_after_io`, so the Close arm is not reached today.

Defect 2: not known to be reachable on macOS today either. Every registration is preceded by a `poll()` pre-check (`bun_core::is_readable`/`is_writable`, called from `read_file.rs` and `write_file.rs` before each `wait_for_*`), and xnu's `poll()` (`bsd/kern/sys_generic.c`) is implemented by registering the same kqueue filters, reporting an fd they reject as `POLLNVAL`, which those helpers count as ready. So the fds kqueue would reject never reach `apply_kqueue`; what is left is a registration failing after a successful pre-check (fd closed underneath us, resource exhaustion). On FreeBSD the exact comparison happened to be right. The bit test is the correct classification rather than a fix for an observed failure; it is the same change #31701 made to the sibling loop, and the lint below is what keeps it.

### Tests

* `test/internal/source-lints/kevent-ev-error-equality.test.ts` bans comparing a flags word against `EV_ERROR` (any spelling) in `src/**/*.rs`. Bit tests, including the `(flags & EV_ERROR) == EV_ERROR` spelling, are erased before looking for a comparison, so a whole-word compare is reported even on a line that also bit-tests; comments are cut per line only (stripping `/* */` spans let a `/*` inside a line comment blind an earlier revision of this file to the Darwin section of `src/sys/lib.rs`); the liveness check names the files that must contain bit tests (`src/io/lib.rs` among them) and the self-check covers the accepted and rejected spellings. On the unfixed tree it reports `src/io/lib.rs:1623: if event.flags == libc::EV_ERROR {` (and `src/io/lib.rs` missing from the bit-test files); it passes with this change. This is the test that fails before and passes after.
* `test/js/bun/io/bun-write.test.js`, "Bun.write and Bun.file(fd).text() on a non-blocking FIFO wait for each other": a `ReadFile` started on an empty FIFO and a `WriteFile` given 256 KiB (more than any platform's pipe buffer) on a second fd of the same FIFO, resolving against each other. With the io loop's debug logging on, one run of this body on Linux shows 8 readable and 11 writable registrations and 54 ready dispatches; on the macOS lanes the same body goes through `apply_kqueue(Readable(tag))` / `apply_kqueue(Writable(tag))` and `on_update_kqueue`'s ready branch, i.e. the code restructured here. Nothing else in the suite drove `wait_for_writable` (the existing `Bun.write(Bun.stdout, Bun.stdin)` test is a `CopyFile`). This test passes before and after the change on every platform; it is runtime coverage for the refactored registration path, not the discriminator. Two fds because epoll registers a given fd once; `destination.size` because `Bun.write()` only treats an fd destination as pollable once its type has been resolved (without it the writer currently spins on a stale EAGAIN instead of waiting; that pre-existing bug, which also affects `Bun.write(Bun.stdout, ...)` onto a non-blocking pipe and `Bun.write(fifoPath, ...)`, turned up while writing this test and is tracked separately).

The Close arm itself (defect 1) cannot be exercised by a test that fails before the fix anywhere CI runs: the code is compiled only for macOS and FreeBSD, it is unreachable on macOS, and there is no FreeBSD lane.

### Verification

* `cargo check -p bun_runtime` (pulls in `bun_io`) for `x86_64-apple-darwin`, `aarch64-apple-darwin` (`bun_io`), `x86_64-unknown-freebsd` and `x86_64-pc-windows-msvc`; `cargo clippy --no-deps` for `bun_io` + `bun_runtime` on the host and on darwin, and for `bun_io` on freebsd; `cargo fmt --check`.
* `bun bd` builds; `test/internal/source-lints/` passes both as the workflow runs it (released bun) and under `bun bd test`; the FIFO test passes repeatedly on the debug build (about 50 ms) and `bun-write.test.js` as a whole has no new failures.

</details>
