### PR TITLE
collections: join the pool tests' thread before asserting on the drop counter

### DIFF
--- a/src/collections/pool.rs
+++ b/src/collections/pool.rs
@@ -543,20 +543,14 @@ mod tests {
     static RESETS: AtomicUsize = AtomicUsize::new(0);
 
     /// `DROPS`/`RESETS` are process-wide but libtest runs `#[test]`s on parallel
-    /// threads, so every test asserting on them holds this for its duration
-    /// (pool teardown included: see [`in_pool_thread`]).
+    /// threads, so every test asserting on them holds this for its duration.
     static SERIAL: Mutex<()> = Mutex::new(());
 
     fn serial() -> MutexGuard<'static, ()> {
         SERIAL.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
-    /// Runs `body` on its own thread and joins it, so the pool's `thread_local!`
-    /// free list is torn down (dropping the nodes still cached in it) before
-    /// this returns, i.e. while the caller still holds `SERIAL`; on the `#[test]`
-    /// thread that teardown would run after the test has released it. Keep the
-    /// explicit `join()`: `thread::scope`'s implicit join does not wait for the
-    /// thread's TLS destructors.
+    /// Runs `body` on its own thread and joins it, which tears down that thread's pool.
     fn in_pool_thread(body: impl FnOnce() + Send + 'static) {
         let name = std::thread::current()
             .name()
@@ -566,6 +560,7 @@ mod tests {
             .name(name)
             .spawn(body)
             .expect("spawn pool test thread")
+            // Not `thread::scope`: its implicit join does not wait for TLS destructors.
             .join();
         if let Err(panic) = joined {
             std::panic::resume_unwind(panic);

--- a/src/collections/pool.rs
+++ b/src/collections/pool.rs
@@ -543,11 +543,38 @@ mod tests {
     static RESETS: AtomicUsize = AtomicUsize::new(0);
 
     /// `DROPS`/`RESETS` are process-wide but libtest runs `#[test]`s on parallel
-    /// threads, so every test asserting on them holds this for its duration.
+    /// threads, so every test asserting on them holds this for its duration,
+    /// and everything that touches a pool goes through [`in_pool_thread`] so
+    /// that the pool's teardown happens while it is still held.
     static SERIAL: Mutex<()> = Mutex::new(());
 
     fn serial() -> MutexGuard<'static, ()> {
         SERIAL.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Runs `body` on a fresh thread (an empty pool) and waits for that thread
+    /// to exit, which is when the pool's `thread_local!` free list drops the
+    /// nodes still cached in it. Their `DROPS` therefore land before this
+    /// returns, while the caller still holds `SERIAL`, and the caller asserts
+    /// them. Using the `#[test]` thread for the body instead is the race this
+    /// avoids: libtest reports a test as finished before its thread has exited,
+    /// so the cached nodes would be dropped after `SERIAL` was released, inside
+    /// whichever test holds it next. `thread::scope` would not do either: its
+    /// implicit join only waits for the closure to return, not for the thread's
+    /// TLS destructors; `JoinHandle::join` waits for the thread itself.
+    fn in_pool_thread(body: impl FnOnce() + Send + 'static) {
+        let name = std::thread::current()
+            .name()
+            .unwrap_or("pool test")
+            .to_owned();
+        let joined = std::thread::Builder::new()
+            .name(name)
+            .spawn(body)
+            .expect("spawn pool test thread")
+            .join();
+        if let Err(panic) = joined {
+            std::panic::resume_unwind(panic);
+        }
     }
 
     fn drops() -> usize {
@@ -646,23 +673,29 @@ mod tests {
             let before = drops();
             let resets_before = resets();
 
-            let first_ptr = {
+            in_pool_thread(move || {
+                let first_ptr = {
+                    let mut guard = Pool::get();
+                    *guard.0 = 11;
+                    ptr::from_ref::<Tracked>(&*guard)
+                }; // guard drop → node returns to the free list
+
+                // Reuse: same allocation, `reset()` ran, value cleared.
                 let mut guard = Pool::get();
-                *guard.0 = 11;
-                ptr::from_ref::<Tracked>(&*guard)
-            }; // guard drop → node returns to the free list
+                assert_eq!(ptr::from_ref::<Tracked>(&*guard), first_ptr);
+                assert_eq!(resets(), resets_before + 1);
+                assert_eq!(*guard.0, 0);
+                *guard.0 = 22;
+                assert_eq!(*guard.0, 22);
+                drop(guard);
 
-            // Reuse: same allocation, `reset()` ran, value cleared.
-            let mut guard = Pool::get();
-            assert_eq!(ptr::from_ref::<Tracked>(&*guard), first_ptr);
-            assert_eq!(resets(), resets_before + 1);
-            assert_eq!(*guard.0, 0);
-            *guard.0 = 22;
-            assert_eq!(*guard.0, 22);
-            drop(guard);
+                // Nothing was destroyed: the free list still owns the node.
+                assert_eq!(drops(), before);
+            });
 
-            // Nothing was destroyed: the free list still owns the node.
-            assert_eq!(drops(), before);
+            // The thread's free list went away with the thread, taking the one
+            // node it still owned.
+            assert_eq!(drops(), before + 1);
         }
     }
 
@@ -680,17 +713,22 @@ mod tests {
             let _serial = serial();
             let before = drops();
 
-            let a = Pool::get();
-            let b = Pool::get();
-            assert_ne!(ptr::from_ref::<Tracked>(&*a), ptr::from_ref::<Tracked>(&*b));
-            assert!(!Pool::full());
+            in_pool_thread(move || {
+                let a = Pool::get();
+                let b = Pool::get();
+                assert_ne!(ptr::from_ref::<Tracked>(&*a), ptr::from_ref::<Tracked>(&*b));
+                assert!(!Pool::full());
 
-            drop(a); // cached (count 0 → 1)
-            assert!(Pool::full());
-            assert_eq!(drops(), before);
+                drop(a); // cached (count 0 → 1)
+                assert!(Pool::full());
+                assert_eq!(drops(), before);
 
-            drop(b); // pool full → destroyed
-            assert_eq!(drops(), before + 1);
+                drop(b); // pool full → destroyed
+                assert_eq!(drops(), before + 1);
+            });
+
+            // `a` stayed cached until the thread's free list was dropped.
+            assert_eq!(drops(), before + 2);
         }
     }
 
@@ -707,21 +745,28 @@ mod tests {
         fn push_then_get_if_exists() {
             let _serial = serial();
             let before = drops();
-            // Nothing cached yet: `get_if_exists` must not allocate.
-            assert!(Pool::get_if_exists().is_none());
 
-            Pool::push(Tracked(Box::new(5)));
-            let node = Pool::get_if_exists().expect("pushed node");
-            // SAFETY: `node` was just popped; `push` initialized `data`, and
-            // `get_if_exists` already ran `reset()` on it.
-            assert_eq!(unsafe { *(*node).data.assume_init_ref().0 }, 0);
-            // The pool is empty again — the node is ours.
-            assert!(Pool::get_if_exists().is_none());
+            in_pool_thread(move || {
+                // Nothing cached yet: `get_if_exists` must not allocate.
+                assert!(Pool::get_if_exists().is_none());
 
-            // Hand it back.
-            // SAFETY: `node` came from this pool and `data` is initialized.
-            unsafe { Pool::release(node) };
-            assert_eq!(drops(), before);
+                Pool::push(Tracked(Box::new(5)));
+                let node = Pool::get_if_exists().expect("pushed node");
+                // SAFETY: `node` was just popped; `push` initialized `data`, and
+                // `get_if_exists` already ran `reset()` on it.
+                assert_eq!(unsafe { *(*node).data.assume_init_ref().0 }, 0);
+                // The pool is empty again — the node is ours.
+                assert!(Pool::get_if_exists().is_none());
+
+                // Hand it back.
+                // SAFETY: `node` came from this pool and `data` is initialized.
+                unsafe { Pool::release(node) };
+                assert_eq!(drops(), before);
+            });
+
+            // The released node stayed cached until the thread's free list was
+            // dropped.
+            assert_eq!(drops(), before + 1);
         }
     }
 }

--- a/src/collections/pool.rs
+++ b/src/collections/pool.rs
@@ -543,25 +543,20 @@ mod tests {
     static RESETS: AtomicUsize = AtomicUsize::new(0);
 
     /// `DROPS`/`RESETS` are process-wide but libtest runs `#[test]`s on parallel
-    /// threads, so every test asserting on them holds this for its duration,
-    /// and everything that touches a pool goes through [`in_pool_thread`] so
-    /// that the pool's teardown happens while it is still held.
+    /// threads, so every test asserting on them holds this for its duration
+    /// (pool teardown included: see [`in_pool_thread`]).
     static SERIAL: Mutex<()> = Mutex::new(());
 
     fn serial() -> MutexGuard<'static, ()> {
         SERIAL.lock().unwrap_or_else(PoisonError::into_inner)
     }
 
-    /// Runs `body` on a fresh thread (an empty pool) and waits for that thread
-    /// to exit, which is when the pool's `thread_local!` free list drops the
-    /// nodes still cached in it. Their `DROPS` therefore land before this
-    /// returns, while the caller still holds `SERIAL`, and the caller asserts
-    /// them. Using the `#[test]` thread for the body instead is the race this
-    /// avoids: libtest reports a test as finished before its thread has exited,
-    /// so the cached nodes would be dropped after `SERIAL` was released, inside
-    /// whichever test holds it next. `thread::scope` would not do either: its
-    /// implicit join only waits for the closure to return, not for the thread's
-    /// TLS destructors; `JoinHandle::join` waits for the thread itself.
+    /// Runs `body` on its own thread and joins it, so the pool's `thread_local!`
+    /// free list is torn down (dropping the nodes still cached in it) before
+    /// this returns, i.e. while the caller still holds `SERIAL`; on the `#[test]`
+    /// thread that teardown would run after the test has released it. Keep the
+    /// explicit `join()`: `thread::scope`'s implicit join does not wait for the
+    /// thread's TLS destructors.
     fn in_pool_thread(body: impl FnOnce() + Send + 'static) {
         let name = std::thread::current()
             .name()
@@ -693,8 +688,7 @@ mod tests {
                 assert_eq!(drops(), before);
             });
 
-            // The thread's free list went away with the thread, taking the one
-            // node it still owned.
+            // Thread exit dropped the free list and the node it still held.
             assert_eq!(drops(), before + 1);
         }
     }
@@ -764,8 +758,7 @@ mod tests {
                 assert_eq!(drops(), before);
             });
 
-            // The released node stayed cached until the thread's free list was
-            // dropped.
+            // Thread exit dropped the free list and the released node in it.
             assert_eq!(drops(), before + 1);
         }
     }

--- a/test/internal/rust-collections-cargo-test.test.ts
+++ b/test/internal/rust-collections-cargo-test.test.ts
@@ -49,20 +49,22 @@ const POOL_TESTS = [
   "pool::tests::recycle::pool_recycles_the_same_node",
 ];
 
+async function run(cmd: string[], env: Record<string, string | undefined> = process.env) {
+  await using proc = Bun.spawn({ cmd, cwd: repoRoot, env, stdout: "pipe", stderr: "pipe" });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { stdout, stderr, exitCode };
+}
+
 test.skipIf(isWindows || !cargo || !workspaceResolvable)(
   "bun_collections unit tests pass under libtest's thread-per-test concurrency",
-  () => {
-    const build = Bun.spawnSync({
-      cmd: [cargo!, "test", "--locked", "-p", "bun_collections", "--lib", "--no-run", "--message-format=json"],
-      cwd: repoRoot,
-      env: { ...process.env, CARGO_TERM_COLOR: "never" },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    expect({ stderr: build.stderr.toString(), exitCode: build.exitCode }).toMatchObject({ exitCode: 0 });
+  async () => {
+    const build = await run(
+      [cargo!, "test", "--locked", "-p", "bun_collections", "--lib", "--no-run", "--message-format=json"],
+      { ...process.env, CARGO_TERM_COLOR: "never" },
+    );
+    expect({ stderr: build.stderr, exitCode: build.exitCode }).toMatchObject({ exitCode: 0 });
 
     const executables = build.stdout
-      .toString()
       .split("\n")
       .filter(line => line.startsWith("{"))
       .map(line => JSON.parse(line))
@@ -77,33 +79,20 @@ test.skipIf(isWindows || !cargo || !workspaceResolvable)(
     expect(executables).toHaveLength(1);
     const [testBinary] = executables;
 
-    const whole = Bun.spawnSync({ cmd: [testBinary], cwd: repoRoot, stdout: "pipe", stderr: "pipe" });
-    const wholeStdout = whole.stdout.toString();
-    expect({ stdout: wholeStdout, stderr: whole.stderr.toString(), exitCode: whole.exitCode }).toMatchObject({
-      exitCode: 0,
-    });
+    const whole = await run([testBinary]);
+    expect(whole).toMatchObject({ exitCode: 0 });
     // The loop below filters on `pool::`; make sure that still names these tests.
     for (const name of POOL_TESTS) {
-      expect(wholeStdout).toContain(`test ${name} ... ok`);
+      expect(whole.stdout).toContain(`test ${name} ... ok`);
     }
 
-    for (let run = 1; run <= POOL_TEST_RUNS; run++) {
-      const pool = Bun.spawnSync({
-        cmd: [testBinary, "pool::", "--test-threads=4"],
-        cwd: repoRoot,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      expect({
-        run,
-        stdout: pool.stdout.toString(),
-        stderr: pool.stderr.toString(),
-        exitCode: pool.exitCode,
-      }).toMatchObject({ exitCode: 0 });
+    for (let attempt = 1; attempt <= POOL_TEST_RUNS; attempt++) {
+      const pool = await run([testBinary, "pool::", "--test-threads=4"]);
+      expect({ attempt, ...pool }).toMatchObject({ exitCode: 0 });
     }
   },
   // A fresh target dir compiles bun_core and its dependencies first (about 15s
   // on 12 cores); warm, the cargo step takes well under a second and the runs
-  // about a second.
+  // a few seconds under a debug build.
   120_000,
 );

--- a/test/internal/rust-collections-cargo-test.test.ts
+++ b/test/internal/rust-collections-cargo-test.test.ts
@@ -1,15 +1,15 @@
 // Runs bun_collections' own unit tests as the native libtest binary, i.e. with
-// libtest's default of one thread per test running concurrently. The only CI
-// lane that runs these tests today is `bun run rust:miri`, which runs them one
-// at a time, so it never sees the failure this guards against:
+// several tests alive at once. The only CI lane that runs these tests today is
+// `bun run rust:miri`, which runs them one at a time, so it never sees the
+// failure this guards against:
 //
 // The tests in src/collections/pool.rs count `Tracked` drops in a process-wide
 // counter and serialize on a mutex, while every `object_pool!(.., threadsafe, ..)`
 // free list is a `thread_local!` that drops whatever it still caches when the
-// thread running the test exits. libtest reports a test as finished before its
-// thread has exited, so a pool test that returned with a node still cached
-// bumped the counter after releasing the mutex, inside whichever test held it
-// next:
+// thread running the test exits. A test releases the mutex when its function
+// returns, and its thread's TLS destructors run after that, so a pool test that
+// returned with a node still cached bumped the counter inside whichever test was
+// already waiting on the mutex:
 //
 //   test pool::tests::push_get::push_then_get_if_exists ... FAILED
 //   assertion `left == right` failed
@@ -17,12 +17,14 @@
 //    right: 1
 //
 // The pool tests now run their bodies on a thread they join (which waits for
-// that thread's TLS destructors) before asserting. The race needs two CPUs the
-// test threads can actually run on and then hits a few percent of runs (4% to
-// 17% measured on 2 to 12 CPUs), so the pool tests are run a few hundred times.
-// `--test-threads` is passed explicitly because libtest otherwise sizes its
-// pool from available_parallelism, which a CPU quota can put at 1, and with a
-// single test thread libtest joins each test before starting the next.
+// that thread's TLS destructors) before releasing the mutex. The race needs
+// another test to be waiting, so `--test-threads` is passed explicitly: libtest
+// sizes it from available_parallelism, which a CPU quota can put at 1, and with
+// one test thread the next test is not started until the previous one has been
+// joined. It also needs two CPUs to run on and then hits a few percent of runs
+// (4% to 17% measured on 2 to 12 CPUs), so the pool tests are run a few hundred
+// times, each run checked to have actually run them: libtest exits 0 when a
+// filter matches nothing.
 //
 // Cargo resolves the whole workspace before applying -p, so like
 // rust-windows-sys-link.test.ts this needs the configured tree (vendor/lolhtml
@@ -43,6 +45,7 @@ const workspaceResolvable =
   existsSync(join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
 
 const POOL_TEST_RUNS = 300;
+const POOL_FILTER = "pool::";
 const POOL_TESTS = [
   "pool::tests::capped::pool_over_max_count_destroys_the_node",
   "pool::tests::push_get::push_then_get_if_exists",
@@ -56,10 +59,21 @@ async function run(cmd: string[], env: Record<string, string | undefined> = proc
 }
 
 test.skipIf(isWindows || !cargo || !workspaceResolvable)(
-  "bun_collections unit tests pass under libtest's thread-per-test concurrency",
+  "bun_collections unit tests pass with several tests running at once",
   async () => {
+    // json-render-diagnostics rather than json: compile errors still go to
+    // stderr as text, where the assertion below shows them.
     const build = await run(
-      [cargo!, "test", "--locked", "-p", "bun_collections", "--lib", "--no-run", "--message-format=json"],
+      [
+        cargo!,
+        "test",
+        "--locked",
+        "-p",
+        "bun_collections",
+        "--lib",
+        "--no-run",
+        "--message-format=json-render-diagnostics",
+      ],
       { ...process.env, CARGO_TERM_COLOR: "never" },
     );
     expect({ stderr: build.stderr, exitCode: build.exitCode }).toMatchObject({ exitCode: 0 });
@@ -79,16 +93,12 @@ test.skipIf(isWindows || !cargo || !workspaceResolvable)(
     expect(executables).toHaveLength(1);
     const [testBinary] = executables;
 
-    const whole = await run([testBinary]);
-    expect(whole).toMatchObject({ exitCode: 0 });
-    // The loop below filters on `pool::`; make sure that still names these tests.
-    for (const name of POOL_TESTS) {
-      expect(whole.stdout).toContain(`test ${name} ... ok`);
-    }
+    expect(await run([testBinary])).toMatchObject({ exitCode: 0 });
 
     for (let attempt = 1; attempt <= POOL_TEST_RUNS; attempt++) {
-      const pool = await run([testBinary, "pool::", "--test-threads=4"]);
-      expect({ attempt, ...pool }).toMatchObject({ exitCode: 0 });
+      const pool = await run([testBinary, POOL_FILTER, "--test-threads=4"]);
+      const notRun = POOL_TESTS.filter(name => !pool.stdout.includes(`test ${name} ... ok`));
+      expect({ attempt, notRun, ...pool }).toMatchObject({ exitCode: 0, notRun: [] });
     }
   },
   // A fresh target dir compiles bun_core and its dependencies first (about 15s

--- a/test/internal/rust-collections-cargo-test.test.ts
+++ b/test/internal/rust-collections-cargo-test.test.ts
@@ -1,0 +1,109 @@
+// Runs bun_collections' own unit tests as the native libtest binary, i.e. with
+// libtest's default of one thread per test running concurrently. The only CI
+// lane that runs these tests today is `bun run rust:miri`, which runs them one
+// at a time, so it never sees the failure this guards against:
+//
+// The tests in src/collections/pool.rs count `Tracked` drops in a process-wide
+// counter and serialize on a mutex, while every `object_pool!(.., threadsafe, ..)`
+// free list is a `thread_local!` that drops whatever it still caches when the
+// thread running the test exits. libtest reports a test as finished before its
+// thread has exited, so a pool test that returned with a node still cached
+// bumped the counter after releasing the mutex, inside whichever test held it
+// next:
+//
+//   test pool::tests::push_get::push_then_get_if_exists ... FAILED
+//   assertion `left == right` failed
+//     left: 2
+//    right: 1
+//
+// The pool tests now run their bodies on a thread they join (which waits for
+// that thread's TLS destructors) before asserting. The race needs two CPUs the
+// test threads can actually run on and then hits a few percent of runs (4% to
+// 17% measured on 2 to 12 CPUs), so the pool tests are run a few hundred times.
+// `--test-threads` is passed explicitly because libtest otherwise sizes its
+// pool from available_parallelism, which a CPU quota can put at 1, and with a
+// single test thread libtest joins each test before starting the next.
+//
+// Cargo resolves the whole workspace before applying -p, so like
+// rust-windows-sys-link.test.ts this needs the configured tree (vendor/lolhtml
+// and build_options.rs) and skips on the test-only CI lanes, which run a
+// prebuilt bun without one. On Windows hosts the test binary of any bun_core
+// dependent does not link yet (link.exe rejects the unresolved FFI references
+// that lld discards as dead; #37575), so it is skipped there too.
+import { which } from "bun";
+import { expect, test } from "bun:test";
+import { isWindows } from "harness";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const cargo = which("cargo");
+const repoRoot = join(import.meta.dir, "..", "..");
+const workspaceResolvable =
+  existsSync(join(repoRoot, "vendor", "lolhtml", "Cargo.toml")) &&
+  existsSync(join(repoRoot, "build", "debug", "codegen", "build_options.rs"));
+
+const POOL_TEST_RUNS = 300;
+const POOL_TESTS = [
+  "pool::tests::capped::pool_over_max_count_destroys_the_node",
+  "pool::tests::push_get::push_then_get_if_exists",
+  "pool::tests::recycle::pool_recycles_the_same_node",
+];
+
+test.skipIf(isWindows || !cargo || !workspaceResolvable)(
+  "bun_collections unit tests pass under libtest's thread-per-test concurrency",
+  () => {
+    const build = Bun.spawnSync({
+      cmd: [cargo!, "test", "--locked", "-p", "bun_collections", "--lib", "--no-run", "--message-format=json"],
+      cwd: repoRoot,
+      env: { ...process.env, CARGO_TERM_COLOR: "never" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    expect({ stderr: build.stderr.toString(), exitCode: build.exitCode }).toMatchObject({ exitCode: 0 });
+
+    const executables = build.stdout
+      .toString()
+      .split("\n")
+      .filter(line => line.startsWith("{"))
+      .map(line => JSON.parse(line))
+      .filter(
+        message =>
+          message.reason === "compiler-artifact" &&
+          message.target.name === "bun_collections" &&
+          message.profile.test &&
+          message.executable,
+      )
+      .map(message => message.executable as string);
+    expect(executables).toHaveLength(1);
+    const [testBinary] = executables;
+
+    const whole = Bun.spawnSync({ cmd: [testBinary], cwd: repoRoot, stdout: "pipe", stderr: "pipe" });
+    const wholeStdout = whole.stdout.toString();
+    expect({ stdout: wholeStdout, stderr: whole.stderr.toString(), exitCode: whole.exitCode }).toMatchObject({
+      exitCode: 0,
+    });
+    // The loop below filters on `pool::`; make sure that still names these tests.
+    for (const name of POOL_TESTS) {
+      expect(wholeStdout).toContain(`test ${name} ... ok`);
+    }
+
+    for (let run = 1; run <= POOL_TEST_RUNS; run++) {
+      const pool = Bun.spawnSync({
+        cmd: [testBinary, "pool::", "--test-threads=4"],
+        cwd: repoRoot,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect({
+        run,
+        stdout: pool.stdout.toString(),
+        stderr: pool.stderr.toString(),
+        exitCode: pool.exitCode,
+      }).toMatchObject({ exitCode: 0 });
+    }
+  },
+  // A fresh target dir compiles bun_core and its dependencies first (about 15s
+  // on 12 cores); warm, the cargo step takes well under a second and the runs
+  // about a second.
+  120_000,
+);


### PR DESCRIPTION
### Problem
- The `pool::` unit tests in `bun_collections` fail a few percent of the time as a normal cargo test binary (159 of 1000 runs on one machine) with ``assertion `left == right` failed`` (left: 2, right: 1). The failing test varies; it is always exactly one extra drop.
- The tests count destructors in a process-wide counter and hold a mutex for the test's duration, but three of them return with a node still cached in the thread-local free list. That node is dropped, and the counter bumped, after the mutex has been released.
- libtest keeps several tests alive on separate threads, so the next test has already taken the mutex and its "before" snapshot when the previous test's teardown lands.
- Miri, the only CI lane that runs these tests today, runs one test at a time and never sees it.

### Fix
- Test module only: the three pool tests run their bodies on a spawned thread and join it while still holding the mutex. Nothing outside `#[cfg(test)]` changes.
- Joining waits for the thread's thread-local destructors, so every counter change now happens under the mutex. Each test also asserts the drops the teardown produces, so the free list freeing cached nodes at thread exit is now covered.
- A new test under `test/internal/` builds the crate's test binary and runs the `pool::` tests 300 times with 4 test threads, checking each run actually ran all three. It skips without cargo, without a configured tree, and on Windows.
- Verification, from the original: 0 failures in 1000 runs with the change against the rate above without it; the new test fails every time on the old pool.rs (11 of 11 tries); Miri, fmt and clippy unchanged.

### Background
- `object_pool!(.., threadsafe, ..)` keeps a free list per thread in a `thread_local!`; releasing an object caches it there, and the list's `Drop` frees whatever is still cached when the thread exits.
- Thread-local destructors run after the test function has returned, so anything the function body held (here the serialising mutex guard) is already released when they run.
- `JoinHandle::join` returns only once the thread has fully exited, destructors included; `thread::scope` returns when the closure does, which is why it is not used here.
- libtest, the runner behind `cargo test`, sizes its thread count from `available_parallelism`, which a CPU quota can put at 1, hence the explicit `--test-threads`. It also exits 0 when a filter matches nothing, hence the per-run check that the tests ran.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/internal/rust-collections-cargo-test.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

On a configured checkout, the `pool::` tests of `bun_collections` fail a few percent of the time when run as a normal (non-Miri) test binary:

```
$ cargo test --locked -p bun_collections --lib pool::
test pool::tests::push_get::push_then_get_if_exists ... FAILED

thread 'pool::tests::push_get::push_then_get_if_exists' panicked at src/collections/pool.rs:724:13:
assertion `left == right` failed
  left: 2
 right: 1
```

The victim varies (`recycle::pool_recycles_the_same_node` at pool.rs:665, `singly_linked_list_drop_frees_nodes` at pool.rs:631), and it is always exactly one extra drop. Measured on the test binary built from main: 159 of 1000 runs failed on this machine (12 CPU quota; 12/300 pinned to 2 CPUs, 43/300 pinned to 4, 0/300 with `--test-threads=1`). `bun run rust:miri -p bun_collections`, the only lane that runs these tests today, runs them one at a time and never sees it.

### Cause

The tests count `Tracked` destructors in a process-wide `DROPS` and serialize on `SERIAL`, but every pool under test is `object_pool!(.., threadsafe, ..)`, whose free list is a `thread_local!`. `recycle`, `capped` (node `a`) and `push_get` each return with one node still cached. A test's `_serial` guard is dropped when the test function returns; the thread's TLS destructors, which drop that cached node and bump `DROPS`, run after that. libtest runs each test on its own thread and, by default, has several tests alive at once, so another `DROPS`-asserting test is already blocked on `SERIAL`, gets in the moment the guard drops, takes its `before` snapshot, and then sees the previous test's teardown land. (libtest does join every test thread before reporting it; that is not what orders things here, since the waiting test is already running.) With one test thread (Miri, `--test-threads=1`) the next test is not started until the previous one has been joined, which is why this only shows up natively.

### Fix

`src/collections/pool.rs` (test module only): the three pool tests run their bodies through `in_pool_thread`, which spawns a thread for the body and `join()`s it while the caller still holds `SERIAL`. `JoinHandle::join` waits for the thread itself, so the TLS teardown has happened by the time it returns and before the guard is released (`thread::scope`'s implicit join would not do: it only waits for the closure to return, before the TLS destructors run). Every `DROPS` change now happens under `SERIAL`, and each test additionally asserts the drops the teardown produces (`before + 1`, `before + 2`, `before + 1`), so the free list's `Drop` impl freeing cached nodes at thread exit, which the impl's comment gives as its reason to exist, is now covered too. Making the teardown part of the test is the reason for this shape rather than draining the pools by hand at the end of each test, which would need a test-only drain helper and would stop counting the teardown. Panics in the body are re-raised on the test thread, and the body thread takes the test's name, so failures read as before. Nothing outside `#[cfg(test)]` changes.

`test/internal/rust-collections-cargo-test.test.ts` builds the crate's test binary (`cargo test --no-run --message-format=json-render-diagnostics`, so a compile error is still printed to stderr, which the assertion shows), runs it once whole and then the `pool::` tests 300 times with `--test-threads=4`. The thread count is explicit because the race needs another test to be waiting, and libtest sizes its default from available_parallelism, which a CPU quota can put at 1. Each iteration asserts that the three pool tests were actually run and passed, not just the exit code, because libtest exits 0 for a filter that matches nothing. It needs cargo and a configured tree and skips on the test-only CI lanes like `rust-windows-sys-link.test.ts`; it also skips on Windows, where test binaries of bun_core dependents do not link until #37575. Warm it takes about a second with a release bun and about 3s under the debug build; a cold target dir adds the bun_core compile, hence the 120s ceiling `linear-fifo.test.ts` also uses.

#37599 leaves `bun_collections` out of the native `cargo test` step because of this; it can go back on that list once both have landed.

### Verification

* Test binary built with this change: 0 failures in 1000 runs of `pool::` (also 0/300 pinned to 2 CPUs and 0/300 whole crate); built from main, the same loop fails as above.
* Making `SinglyLinkedList::drop` leak instead of dropping fails all three pool tests at the new `before + n` assertions; an assertion failure inside a body is reported under the test's own name as before.
* `bun run rust:miri -p bun_collections`: 35 passed. `cargo fmt --check` clean; `cargo clippy -p bun_collections --tests` reports the same 14 pre-existing findings as main (the new helper uses `thread::Builder`, which is not on the disallowed list; `bun_threading` sits above this crate).
* `bun bd test test/internal/rust-collections-cargo-test.test.ts` passes; with main's `pool.rs` in place it fails every time (11 of 11 attempts so far, always within the first 34 iterations), printing the panic above. Changing the filter to one that matches nothing fails it on the first iteration with the three test names listed as not run.

</details>
