### PR TITLE
bake: keep the dev server running when a server module throws during a hot update

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4295,9 +4295,7 @@ pub(super) fn finalize_bundle(
                 ir.client_components_removed.as_slice(),
             )
         };
-        // `registerUpdate` is async. The runtime (hmr-runtime-server.ts) reports
-        // a module that throws while the update is applied, so the promise
-        // returned here is not observed.
+        // The returned promise is not observed: the runtime reports failed updates itself.
         if let Err(err) = dev.server_register_update_callback.get().unwrap().call(
             global,
             global.to_js_value(),

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4295,7 +4295,10 @@ pub(super) fn finalize_bundle(
                 ir.client_components_removed.as_slice(),
             )
         };
-        let errors = match dev.server_register_update_callback.get().unwrap().call(
+        // `registerUpdate` is async. The runtime (hmr-runtime-server.ts) reports
+        // a module that throws while the update is applied, so the promise
+        // returned here is not observed.
+        if let Err(err) = dev.server_register_update_callback.get().unwrap().call(
             global,
             global.to_js_value(),
             &[
@@ -4304,17 +4307,13 @@ pub(super) fn finalize_bundle(
                 dev.make_array_for_server_components_patch(global, removed)?,
             ],
         ) {
-            Ok(v) => v,
-            Err(err) => {
-                // SAFETY: vm is JSC_BORROW — valid for DevServer lifetime
-                dev.vm_mut()
-                    .print_error_like_object_to_console(global.take_exception(err));
-                panic!(
-                    "Error thrown in Hot-module-replacement code. This is always a bug in the HMR runtime."
-                );
-            }
-        };
-        let _ = errors; // TODO:
+            // SAFETY: vm is JSC_BORROW — valid for DevServer lifetime
+            dev.vm_mut()
+                .print_error_like_object_to_console(global.take_exception(err));
+            panic!(
+                "Error thrown in Hot-module-replacement code. This is always a bug in the HMR runtime."
+            );
+        }
     }
 
     let mut route_bits = DynamicBitSet::init_empty(dev.route_bundles.len())?;

--- a/src/runtime/bake/hmr-runtime-server.ts
+++ b/src/runtime/bake/hmr-runtime-server.ts
@@ -159,7 +159,15 @@ server_exports = {
     }
   },
   async registerUpdate(modules, componentManifestAdd, componentManifestDelete) {
-    replaceModules(modules);
+    try {
+      await replaceModules(modules);
+    } catch (err) {
+      // The dev server does not observe the promise this function returns, so
+      // a module (or one of its hot callbacks) throwing while the update is
+      // applied would otherwise be an unhandled rejection that ends the
+      // process. The module stays failed until it is saved again.
+      console.error(err);
+    }
 
     if (componentManifestAdd) {
       for (const uid of componentManifestAdd) {

--- a/src/runtime/bake/hmr-runtime-server.ts
+++ b/src/runtime/bake/hmr-runtime-server.ts
@@ -159,15 +159,15 @@ server_exports = {
     }
   },
   async registerUpdate(modules, componentManifestAdd, componentManifestDelete) {
-    try {
-      await replaceModules(modules);
-    } catch (err) {
-      // The dev server does not observe the promise this function returns, so
-      // a module (or one of its hot callbacks) throwing while the update is
-      // applied would otherwise be an unhandled rejection that ends the
-      // process. The module stays failed until it is saved again.
+    // The dev server does not observe the promise this function returns, so a
+    // module (or a hot callback) throwing while the update is applied has to be
+    // reported here; as an unhandled rejection it would end the process.
+    // Deliberately not awaited: requests deferred on this bundle are dispatched
+    // as soon as this function returns and read the manifest updated below, so
+    // that update should not wait for the reload to settle.
+    replaceModules(modules).catch(err => {
       console.error(err);
-    }
+    });
 
     if (componentManifestAdd) {
       for (const uid of componentManifestAdd) {

--- a/src/runtime/bake/hmr-runtime-server.ts
+++ b/src/runtime/bake/hmr-runtime-server.ts
@@ -159,12 +159,8 @@ server_exports = {
     }
   },
   async registerUpdate(modules, componentManifestAdd, componentManifestDelete) {
-    // The dev server does not observe the promise this function returns, so a
-    // module (or a hot callback) throwing while the update is applied has to be
-    // reported here; as an unhandled rejection it would end the process.
-    // Deliberately not awaited: requests deferred on this bundle are dispatched
-    // as soon as this function returns and read the manifest updated below, so
-    // that update should not wait for the reload to settle.
+    // Unhandled, a rejection here exits the process. Not awaited: requests deferred
+    // on this bundle run as soon as this returns and read the manifest updated below.
     replaceModules(modules).catch(err => {
       console.error(err);
     });

--- a/src/runtime/bake/hmr-runtime-server.ts
+++ b/src/runtime/bake/hmr-runtime-server.ts
@@ -159,8 +159,7 @@ server_exports = {
     }
   },
   async registerUpdate(modules, componentManifestAdd, componentManifestDelete) {
-    // Unhandled, a rejection here exits the process. Not awaited: requests deferred
-    // on this bundle run as soon as this returns and read the manifest updated below.
+    // Not awaited: requests deferred on this bundle run as soon as this returns and read the manifest below.
     replaceModules(modules).catch(err => {
       console.error(err);
     });

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -228,7 +228,30 @@ export class Dev extends EventEmitter {
     this.output.on("panic", () => {
       this.panicked = true;
     });
+    this.devProcess.exited.then(() => this.emit("exit"));
     this.nodeEnv = nodeEnv;
+  }
+
+  /**
+   * A dev server that dies while a change is applied never sends the watch
+   * synchronization messages `write()` and friends wait for. Rejecting those
+   * waits when the process exits fails the test at the call that killed the
+   * dev server instead of at the test timeout.
+   */
+  #rejectOnExit<T>(promise: Promise<T>, waitingFor: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const onExit = () => {
+        const { exitCode, signalCode } = this.devProcess;
+        const how = exitCode !== null ? `code ${exitCode}` : `signal ${signalCode}`;
+        reject(new Error(`Dev server exited with ${how} while waiting for ${waitingFor}`));
+      };
+      if (this.devProcess.exitCode !== null || this.devProcess.signalCode !== null) {
+        onExit();
+      } else {
+        this.once("exit", onExit);
+      }
+      promise.then(resolve, reject).finally(() => this.off("exit", onExit));
+    });
   }
 
   connectSocket() {
@@ -267,7 +290,7 @@ export class Dev extends EventEmitter {
   }
 
   #waitForSyncEvent(event: WatchSynchronization) {
-    return new Promise<void>((resolve, reject) => {
+    const received = new Promise<void>(resolve => {
       let dev = this;
       function handle(kind: WatchSynchronization) {
         if (kind === event) {
@@ -277,6 +300,7 @@ export class Dev extends EventEmitter {
       }
       dev.on("watch_synchronization", handle);
     });
+    return this.#rejectOnExit(received, "watch synchronization event " + WatchSynchronization[event]);
   }
 
   async batchChanges(options: { errors?: null | ErrorSpec[]; snapshot?: string } = {}) {
@@ -319,10 +343,8 @@ export class Dev extends EventEmitter {
     const b = {
       write: resetSeenFilesWithResolvers,
       [Symbol.asyncDispose]: async () => {
-        if (wantsHmrEvent && interactive) {
-          await seenFiles.promise;
-        } else if (wantsHmrEvent) {
-          await Promise.race([seenFiles.promise]);
+        if (wantsHmrEvent) {
+          await this.#rejectOnExit(seenFiles.promise, "the dev server to see the changed files");
         }
         // One Bun.write can surface as several watcher events (notably on
         // Windows); let them coalesce so releasing the batch bundles once.
@@ -331,7 +353,7 @@ export class Dev extends EventEmitter {
         dev.off("watch_synchronization", onSeenFiles);
 
         this.socket!.send("H");
-        await wait;
+        await this.#rejectOnExit(wait, "the hot reload");
 
         let errors = options.errors;
         if (errors !== null) {

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -206,6 +206,61 @@ devTest("export { default as y }", {
     await dev.fetch("/").equals("Value: 2");
   },
 });
+devTest("server module throwing while it is hot reloaded is reported and fixed by the next save", {
+  framework: minimalFramework,
+  files: {
+    "config.ts": `
+      export const value = "v1";
+    `,
+    "routes/index.ts": `
+      import { value } from '../config';
+      export default function(req, meta) {
+        return new Response(value);
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("v1");
+
+    // The new version of the module throws while the server runtime evaluates
+    // it during the update. Before the fix this was an unhandled rejection in
+    // the dev server process, which exited; every `dev.write` below then
+    // failed because nothing was listening any more.
+    await dev.write(
+      "config.ts",
+      `
+        throw new Error("config boom sync");
+        export const value = "v2";
+      `,
+    );
+    await dev.output.waitForLine(/config boom sync/);
+    // Still answering requests (served from the modules loaded before the failed update).
+    await dev.fetch("/");
+    await dev.write("config.ts", `export const value = "v3";`);
+    await dev.fetch("/").equals("v3");
+
+    // Same thing when the module fails asynchronously: the update is applied
+    // through a promise when the module uses top-level await.
+    await dev.write(
+      "config.ts",
+      `
+        await 1;
+        throw new Error("config boom async");
+        export const value = "v4";
+      `,
+    );
+    await dev.output.waitForLine(/config boom async/);
+    await dev.fetch("/");
+    await dev.write(
+      "config.ts",
+      `
+        await 1;
+        export const value = "v5";
+      `,
+    );
+    await dev.fetch("/").equals("v5");
+  },
+});
 devTest("export * as namespace", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bake/dev/esm.test.ts
+++ b/test/bake/dev/esm.test.ts
@@ -234,13 +234,15 @@ devTest("server module throwing while it is hot reloaded is reported and fixed b
       `,
     );
     await dev.output.waitForLine(/config boom sync/);
-    // Still answering requests (served from the modules loaded before the failed update).
-    await dev.fetch("/");
+    // The route keeps being served from the modules evaluated before the failed
+    // update (the importer is not re-evaluated), and saving the file again
+    // replaces the module whatever state the failed evaluation left it in.
+    await dev.fetch("/").equals("v1");
     await dev.write("config.ts", `export const value = "v3";`);
     await dev.fetch("/").equals("v3");
 
-    // Same thing when the module fails asynchronously: the update is applied
-    // through a promise when the module uses top-level await.
+    // Same thing when the module fails asynchronously: with top-level await the
+    // update is applied through a promise that rejects instead of a throw.
     await dev.write(
       "config.ts",
       `
@@ -250,7 +252,7 @@ devTest("server module throwing while it is hot reloaded is reported and fixed b
       `,
     );
     await dev.output.waitForLine(/config boom async/);
-    await dev.fetch("/");
+    await dev.fetch("/").equals("v3");
     await dev.write(
       "config.ts",
       `


### PR DESCRIPTION
### Problem
- In a Bake app in development, saving a server module whose new version throws at top level (or rejects through a top-level await) kills the dev server: `error: config boom` is printed as an unhandled rejection with `registerUpdate (bake://server-runtime.js)` on the stack, the process exits with code 1, and the next request gets `ConnectionRefused`.
- A `dispose` or `accept` callback or a `bun:beforeUpdate` handler that throws while an update is applied does the same.
- Cause: applying a server update re-evaluates the replaced modules behind a promise that neither the server runtime nor the native caller looked at, so a failing module became an unhandled rejection in the dev server's own process. Leftover from the 1.2.5 HMR rewrite (#17954), which moved error reporting to the callers and only gave the client runtime a handler.
- A bake test whose dev server died this way hung until the test timeout, because the harness kept waiting for messages the dead process would never send.

### Fix
- The server runtime attaches a handler to the update's promise and prints the error with `console.error`, as the client runtime and the pre-1.2.5 runtime do. The native side only drops an unused binding and its TODO.
- The update is still not awaited, on purpose: requests held for this bundle run as soon as the runtime returns and read the component manifest, so the manifest update has to keep starting where it does today. Only the report is new; the update's timing is unchanged.
- The next save recovers the module, because an update re-evaluates every module in it whatever state a failed evaluation left behind. Until then requests are served from the modules evaluated before the failure, and a throwing `dispose` or `bun:beforeUpdate` callback stays registered; that containment is left to #37773, #37785 and #37795.
- Verification: a new bake test saves a version that throws synchronously, then one whose top-level await rejects, and checks that the error is printed, the old value is still served and the next save takes effect; it fails on main and passes with the fix. The harness now fails a write as soon as the dev server exits (`Dev server exited with code 1 while waiting for ...`) instead of hanging.

### Background
- Bake is bun's full-stack dev server. In development it bundles the server modules (routes and what they import) and hot-reloads them inside its own process, so an error while evaluating one is an error in the dev server process.
- An unhandled promise rejection exits a bun process with code 1; the dev server gets no exemption.
- Applying a server update is asynchronous: a module that throws, or whose top-level await rejects, surfaces as a rejection of the update's promise, not as a throw at the call site. That is why the native caller's synchronous error check never fires.
- The client component manifest is a table the server runtime updates right after it starts replacing modules; requests held while the bundle built are released as soon as the native side gets control back, and they read that table.
- The bake test harness drives a real dev server subprocess and synchronizes each file write on "watch synchronization" messages the server sends once it has seen the files and finished reloading.

<details>
<summary>Original description</summary>

### What does this PR do?

In a Bake app in development, saving a server module whose new version throws at top level takes the whole dev server down instead of reporting the error:

```ts
// config.ts (imported by routes/index.ts)
export const value = "v1";
// saved as:
throw new Error("config boom");
export const value = "v2";
```

The terminal shows `Reloaded in 2ms: config.ts`, then the error is printed as an unhandled rejection:

```
error: config boom
      at <anonymous> (bake://server.patch.js:4:11)
      ...
      at registerUpdate (bake://server-runtime.js:5:3804)

Bun v1.4.0-canary.1+da3851e57 (Linux x64)
```

and the process exits with code 1; the next request gets `ConnectionRefused`. The same happens when the new version rejects asynchronously (top-level await), and when anything else throws while an update is applied (a `dispose` or `accept` callback, a `bun:beforeUpdate` handler).

#### Cause

`registerUpdate()` in `src/runtime/bake/hmr-runtime-server.ts` called `replaceModules(modules)` and did nothing with the promise it returns. `replaceModules()` is async and re-evaluates the replaced modules eagerly, so a throwing module body rejects that promise, and nothing handled the rejection. The native side (`finalize_bundle` in `DevServer.rs`) only handles a synchronous throw out of `registerUpdate` (which cannot happen for an async function) and does not look at the returned promise either, so the rejection was unhandled in the dev server's own process, which exits like any bun process with an unhandled rejection.

This is a leftover from the HMR runtime rewrite in 1.2.5 (#17954): before it, the shared `replaceModules()` caught module errors and `console.error`ed them; the rewrite moved that to the callers, and the client runtime got `replaceModules(...).catch(e => { console.error(e); fullReload(); })` while the server runtime got nothing.

#### Fix

`registerUpdate()` attaches a handler to the `replaceModules()` promise and reports the error with `console.error`, which is how the client runtime and the pre-1.2.5 runtime reported it and where server-side errors show up in development. The call is still not awaited, on purpose: `finalize_bundle` dispatches the requests that were waiting for this bundle as soon as `registerUpdate` returns, and the client component manifest that `registerUpdate` updates next is read by those requests, so the manifest update keeps starting from the same point as before (an earlier revision of this PR awaited the call, which pushed the manifest update one microtask later than it is today; the comment in the code is there so that this is not reintroduced). Apart from the report, nothing about the timing of the update changes.

What recovers the module is the next save of its file: `replaceModules()` marks every module in the update stale and evaluates it again whatever state the failed evaluation left it in (`State.Error` for a synchronous throw; today still `State.Pending` for a rejected top-level await, which #37742 changes, and which does not matter here). The test covers both shapes.

`DevServer.rs` only loses the unused `errors` binding and its `TODO`; a one-line comment says why the promise is not looked at there. Handling the rejection natively as well would duplicate the runtime's reporting, which is the contract the call site has always assumed.

Not changed by this PR, and behaving the same as before it except that the process now survives:

- the requests made after a failed update are still served from the modules evaluated before it (the importers of the failed module are not invalidated; #37742 and #37765 are in that area), which the test asserts as the current behavior;
- an update whose first module fails does not go on to evaluate the other modules of the same batch, which is also how the client behaves before it reloads the page;
- a `dispose` callback or a `bun:beforeUpdate` handler that throws is reported, but `replaceModules()` leaves the throwing callback registered, so later saves of that module (or, for a `bun:beforeUpdate` handler, of any module) fail the same way until the dev server is restarted. The client resets all of this with its full reload; the server has no equivalent, so the containment belongs in `replaceModules()` itself, which #37773, #37785 and #37795 are currently restructuring. Tracked separately rather than added here.

The bake test harness also changes: the waits inside `dev.write()`/`patch()`/`delete()` (the `Started` and `SeenFiles` watch synchronization messages and the hot reload itself) now reject as soon as the dev server process exits. A dev server that dies applying a change never sends those messages, so until now such a test hung until the test timeout (30 s times the debug/ASAN multiplier) instead of failing at the write that killed it with `Dev server exited with code 1 while waiting for ...`. The `Promise.race([seenFiles.promise])` it replaces was a leftover of a removed timeout and awaited the same promise in both branches.

### How did you verify your code works?

New test in `test/bake/dev/esm.test.ts`: `server module throwing while it is hot reloaded is reported and fixed by the next save`. It saves `config.ts` as a version that throws synchronously, waits for the error to be printed, checks that the route still answers with the previous value, saves a working version and expects it to be served; then repeats the sequence with a version whose top-level await rejects (the update then fails through the promise rather than a synchronous throw) and a working top-level-await version.

With `src/` at main it fails within a few seconds, either with `ConnectionRefused` on the request after the throwing save or with the new harness error on the next write, depending on how quickly the process goes away; with the fix it passes and the dev server exits cleanly at the end. `test/bake/dev/{esm,hot,bundle,css,html,server-sourcemap,incremental-graph-edge-deletion,stress}.test.ts`, `test/bake/dev-and-prod.test.ts` and `test/bake/deinitialization.test.ts` pass on the debug build with the harness change (no listener warnings from the added exit handling).

</details>
