### PR TITLE
bake: evaluate the modules between a hot-updated module and its boundary again

### DIFF
--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -613,8 +613,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     cb: HotAccept;
     key: Id;
   };
-  /** Every module this update replaces with a new copy (disposed of, then evaluated again): the replaced
-   * modules, the modules their updates propagate through, and the self-accepting modules they stop at. */
+  /** Every module this update replaces with a new copy: disposed of, then evaluated again. */
   const toReload = new Set<HMRModule>();
   const toAccept: ToAccept[] = [];
   let failures: Set<Id> | null = null;
@@ -659,8 +658,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
 
       if (propagates) {
         if (mod.importers.size === 0) {
-          // Keep walking: the server applies the update regardless, so the
-          // modules behind the other importers of `key` still have to be found.
+          // The server applies the update anyway, so the other importers of `key` are still walked.
           failures ??= new Set();
           failures.add(key);
         } else {
@@ -750,8 +748,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     await Promise.all(disposePromises);
   }
 
-  // Reload all modules. All of them are marked stale before any is loaded, so
-  // that one importing another has the loader evaluate the imported one first.
+  // Reload all modules. All are marked stale before any is loaded, so the loader evaluates a stale import first.
   const selfAccepts = new Map<HMRModule, HotAcceptFunction | null>();
   for (const mod of toReload) {
     mod.state = State.Stale;
@@ -777,8 +774,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
       if (mod.state === State.Loaded) {
         selfAccept(getEsmExports(mod));
       } else {
-        // Still loading (top-level await) on behalf of a module reloaded
-        // earlier in this loop that imports it; that module's promise waits for it.
+        // Still loading (top-level await) for an importer reloaded above, whose promise waits for it.
         acceptsAfterLoad.push([mod, selfAccept]);
       }
     }

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -613,13 +613,14 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     cb: HotAccept;
     key: Id;
   };
+  /** Replaced modules, the modules their updates propagate through, and the self-accepting modules they stop at. */
   const toReload = new Set<HMRModule>();
   const toAccept: ToAccept[] = [];
   let failures: Set<Id> | null = null;
   const toDispose: HMRModule[] = [];
 
   // Discover all HMR boundaries
-  outer: for (const key of Object.keys(modules)) {
+  for (const key of Object.keys(modules)) {
     // Unref old source maps, and track new ones
     if (side === "client") {
       DEBUG.ASSERT(sourceMapId);
@@ -642,11 +643,11 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
       if (!mod) break;
 
       // Stop propagation if the module is self-accepting
-      let hadSelfAccept = true;
+      let propagates = true;
       if (mod.selfAccept) {
         toReload.add(mod);
         visited.add(mod);
-        hadSelfAccept = false;
+        propagates = false;
         if (mod.onDispose) {
           toDispose.push(mod);
         }
@@ -656,24 +657,29 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         mod.selfAccept ??= implicitAcceptFunction;
         toReload.add(mod);
         visited.add(mod);
-        hadSelfAccept = false;
+        propagates = false;
         if (mod.onDispose) {
           toDispose.push(mod);
         }
       }
 
-      // All importers will be visited
-      if (hadSelfAccept && mod.importers.size === 0) {
-        failures ??= new Set();
-        failures.add(key);
-        continue outer;
+      if (propagates) {
+        if (mod.importers.size === 0) {
+          // Keep walking: the server applies the update regardless, so the
+          // modules behind the other importers of `key` still have to be found.
+          failures ??= new Set();
+          failures.add(key);
+        } else {
+          // Its body ran against the previous version of `key`.
+          toReload.add(mod);
+        }
       }
 
       for (const importer of mod.importers) {
         const cb = importer.depAccepts?.[key];
         if (cb) {
           toAccept.push({ cb, key });
-        } else if (hadSelfAccept) {
+        } else if (propagates) {
           if (visited.has(importer)) continue;
           visited.add(importer);
           queue.push(importer);
@@ -727,9 +733,10 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         }),
       );
       fullReload();
-    } else {
-      console.warn(message);
+      return;
     }
+    // The server has no page to reload; the update is applied as far as it goes.
+    console.warn(message);
   }
 
   // Dispose all modules
@@ -750,20 +757,20 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     }
   }
 
-  // Reload all modules
-  const promises: Promise<HMRModule>[] = [];
+  // Reload all modules. All of them are marked stale before any is loaded, so
+  // that one importing another has the loader evaluate the imported one first.
+  const selfAccepts = new Map<HMRModule, HotAcceptFunction | null>();
   for (const mod of toReload) {
     mod.state = State.Stale;
-    const selfAccept = mod.selfAccept;
+    selfAccepts.set(mod, mod.selfAccept);
     mod.selfAccept = null;
     mod.depAccepts = null;
-
+  }
+  const promises: Promise<HMRModule>[] = [];
+  const acceptsAfterLoad: [HMRModule, HotAcceptFunction][] = [];
+  for (const [mod, selfAccept] of selfAccepts) {
     const modOrPromise = loadModuleAsync(mod.id, false, null);
-    if (modOrPromise === mod) {
-      if (selfAccept) {
-        selfAccept(getEsmExports(mod));
-      }
-    } else {
+    if (modOrPromise !== mod) {
       DEBUG.ASSERT(modOrPromise instanceof Promise);
       promises.push(
         (modOrPromise as Promise<HMRModule>).then(mod => {
@@ -773,10 +780,24 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
           return mod;
         }),
       );
+    } else if (selfAccept) {
+      if (mod.state === State.Loaded) {
+        selfAccept(getEsmExports(mod));
+      } else {
+        // Still loading (top-level await) on behalf of a module reloaded
+        // earlier in this loop that imports it; that module's promise waits for it.
+        acceptsAfterLoad.push([mod, selfAccept]);
+      }
     }
   }
   if (promises.length > 0) {
     await Promise.all(promises);
+  }
+  for (const [mod, selfAccept] of acceptsAfterLoad) {
+    // Only still pending when it was reached through import(), which nothing above waits for.
+    if (mod.state === State.Loaded) {
+      selfAccept(getEsmExports(mod));
+    }
   }
   for (const mod of toReload) {
     const { selfAccept } = mod;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -613,11 +613,11 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     cb: HotAccept;
     key: Id;
   };
-  /** Replaced modules, the modules their updates propagate through, and the self-accepting modules they stop at. */
+  /** Every module this update replaces with a new copy (disposed of, then evaluated again): the replaced
+   * modules, the modules their updates propagate through, and the self-accepting modules they stop at. */
   const toReload = new Set<HMRModule>();
   const toAccept: ToAccept[] = [];
   let failures: Set<Id> | null = null;
-  const toDispose: HMRModule[] = [];
 
   // Discover all HMR boundaries
   for (const key of Object.keys(modules)) {
@@ -648,9 +648,6 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         toReload.add(mod);
         visited.add(mod);
         propagates = false;
-        if (mod.onDispose) {
-          toDispose.push(mod);
-        }
       }
       // Modules that mutate data are implied to handle updates via reusing their `data` property
       else if (Object.keys(mod.data).length > 0) {
@@ -658,9 +655,6 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
         toReload.add(mod);
         visited.add(mod);
         propagates = false;
-        if (mod.onDispose) {
-          toDispose.push(mod);
-        }
       }
 
       if (propagates) {
@@ -740,21 +734,20 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
   }
 
   // Dispose all modules
-  if (toDispose.length > 0) {
-    const disposePromises: Promise<void>[] = [];
-    for (const mod of toDispose) {
-      mod.state = State.Stale;
-      for (const fn of mod.onDispose!) {
-        const p = fn(mod.data);
-        if (p && p instanceof Promise) {
-          disposePromises.push(p);
-        }
+  const disposePromises: Promise<void>[] = [];
+  for (const mod of toReload) {
+    const { onDispose } = mod;
+    if (!onDispose) continue;
+    for (const fn of onDispose) {
+      const p = fn(mod.data);
+      if (p && p instanceof Promise) {
+        disposePromises.push(p);
       }
-      mod.onDispose = null;
     }
-    if (disposePromises.length > 0) {
-      await Promise.all(disposePromises);
-    }
+    mod.onDispose = null;
+  }
+  if (disposePromises.length > 0) {
+    await Promise.all(disposePromises);
   }
 
   // Reload all modules. All of them are marked stale before any is loaded, so

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -440,6 +440,109 @@ devTest("a self-accepting module imported by another one being reloaded is evalu
     await c.expectMessageInAnyOrder("y evaluated y(d2)", "index d2 y(d2)", "y accepted y(d2)");
   },
 });
+devTest("a module evaluated again because of an update below it is disposed of first", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // index (self-accepting) -> mid -> d
+    //
+    // `mid` is replaced along with `d`, so the copy being thrown away has its
+    // dispose callbacks run, which also removes its event listener (on() is
+    // implemented with dispose()); only the new copy's listener fires.
+    "index.ts": `
+      import { mid } from "./mid";
+      console.log("index " + mid);
+      import.meta.hot.accept();
+    `,
+    "mid.ts": `
+      import { d } from "./d";
+      export const mid = "mid(" + d + ")";
+      console.log("mid evaluated " + mid);
+      import.meta.hot.dispose(() => console.log("mid disposed " + mid));
+      import.meta.hot.on("bun:afterUpdate", () => console.log("afterUpdate seen by " + mid));
+    `,
+    "d.ts": `
+      export const d = "d1";
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("mid evaluated mid(d1)", "index mid(d1)");
+
+    await dev.write("d.ts", `export const d = "d2";`);
+    await c.expectMessage(
+      "mid disposed mid(d1)",
+      "mid evaluated mid(d2)",
+      "index mid(d2)",
+      "afterUpdate seen by mid(d2)",
+    );
+
+    await dev.write("d.ts", `export const d = "d3";`);
+    await c.expectMessage(
+      "mid disposed mid(d2)",
+      "mid evaluated mid(d3)",
+      "index mid(d3)",
+      "afterUpdate seen by mid(d3)",
+    );
+  },
+});
+devTest("an update that is not accepted only reloads the page", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // index -> b -> d    (b accepts d)
+    // index -> c -> d    (c self-accepts)
+    // index -> d         (index does not accept anything: the update fails)
+    //
+    // Everything logs through the console.log captured when the page was
+    // loaded. The test client silences the console object as soon as the page
+    // starts reloading, but a captured reference still reaches the test, so
+    // anything the runtime still did in the page being left (disposing of c,
+    // evaluating d and c again, b's callback) would show up as a message
+    // between "full reload" and the messages of the freshly loaded page.
+    "index.ts": `
+      import "./b";
+      import "./c";
+      import "./d";
+      import.meta.hot.on("bun:beforeFullReload", () => globalThis.log("full reload"));
+      globalThis.log("index evaluated");
+    `,
+    "b.ts": `
+      import { d } from "./d";
+      globalThis.log("b evaluated " + d);
+      import.meta.hot.accept("./d", newModule => globalThis.log("b accepted " + newModule.d));
+    `,
+    "c.ts": `
+      import { d } from "./d";
+      globalThis.log("c evaluated " + d);
+      import.meta.hot.dispose(() => globalThis.log("c disposed " + d));
+      import.meta.hot.accept();
+    `,
+    "d.ts": `
+      globalThis.log ??= console.log;
+      export const d = "d1";
+      globalThis.log("d evaluated " + d);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("d evaluated d1", "b evaluated d1", "c evaluated d1", "index evaluated");
+
+    await c.expectReload(async () => {
+      await dev.write(
+        "d.ts",
+        `
+          globalThis.log ??= console.log;
+          export const d = "d2";
+          globalThis.log("d evaluated " + d);
+        `,
+      );
+    });
+    await c.expectMessage("full reload", "d evaluated d2", "b evaluated d2", "c evaluated d2", "index evaluated");
+  },
+});
 devTest("server: modules between the updated module and the route are evaluated again", {
   framework: minimalFramework,
   files: {

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,7 +1,7 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
 import { expect } from "bun:test";
 import { renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { devTest, emptyHtmlFile } from "../bake-harness";
+import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 devTest("import.meta.hot.accept basic", {
   files: {
@@ -311,6 +311,160 @@ devTest("import.meta.hot.accept multiple modules", {
     }
 
     await c.expectMessageInAnyOrder("Counter updated: 3", "Name updated: Charlie");
+  },
+});
+devTest("modules between the updated module and the importer accepting it are evaluated again", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // index -> d
+    // index -> a -> d
+    //
+    // `index` accepts `d`, so it is not evaluated again itself, but `a`
+    // computed its export from `d` and has to be. The accept callback records
+    // what it saw instead of logging it, so that the test does not depend on
+    // how many times it runs per update (#37773).
+    "index.ts": `
+      import { d } from "./d";
+      import { a } from "./a";
+      console.log("index " + d + " " + a);
+      globalThis.snapshot = () => d + " " + a;
+      import.meta.hot.accept("./d", newModule => {
+        globalThis.accepted = newModule.d + " " + a;
+      });
+    `,
+    "a.ts": `
+      import { d } from "./d";
+      export const a = "a(" + d + ")";
+      console.log("a evaluated " + a);
+    `,
+    "d.ts": `
+      export const d = "d1";
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("a evaluated a(d1)", "index d1 a(d1)");
+
+    await dev.write("d.ts", `export const d = "d2";`);
+    await c.expectMessage("a evaluated a(d2)");
+    expect(await c.js<string>`snapshot()`).toBe("d2 a(d2)");
+    expect(await c.js<string>`globalThis.accepted`).toBe("d2 a(d2)");
+
+    // The re-evaluated `a` takes part in the next update like the original did.
+    await dev.write("d.ts", `export const d = "d3";`);
+    await c.expectMessage("a evaluated a(d3)");
+    expect(await c.js<string>`snapshot()`).toBe("d3 a(d3)");
+    expect(await c.js<string>`globalThis.accepted`).toBe("d3 a(d3)");
+  },
+});
+devTest("modules between the updated module and a self-accepting importer are evaluated again, in dependency order", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // index -> b -> d
+    //          b -> a -> d
+    //
+    // `b` loads `d` before `a` does, so `d` lists `b` as an importer before
+    // `a`, and walking up from `d` finds `b` first. `b` must still be evaluated
+    // after `a`, which it imports.
+    "index.ts": `
+      import { b } from "./b";
+      console.log("index " + b);
+      import.meta.hot.accept();
+    `,
+    "b.ts": `
+      import { d } from "./d";
+      import { a } from "./a";
+      export const b = "b(" + d + "," + a + ")";
+      console.log("b evaluated " + b);
+    `,
+    "a.ts": `
+      import { d } from "./d";
+      export const a = "a(" + d + ")";
+      console.log("a evaluated " + a);
+    `,
+    "d.ts": `
+      export const d = "d1";
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("a evaluated a(d1)", "b evaluated b(d1,a(d1))", "index b(d1,a(d1))");
+
+    await dev.write("d.ts", `export const d = "d2";`);
+    await c.expectMessage("a evaluated a(d2)", "b evaluated b(d2,a(d2))", "index b(d2,a(d2))");
+  },
+});
+devTest("a self-accepting module imported by another one being reloaded is evaluated first", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    // index -> d
+    // index -> y -> d
+    //
+    // Both accept updates to `d`. `d` lists `index` as an importer first, so
+    // `index` is reloaded first; it must still see the new `y`, and `y`'s own
+    // accept callback must only run once `y`, which has top-level await, has
+    // finished evaluating.
+    "index.ts": `
+      import { d } from "./d";
+      import { y } from "./y";
+      console.log("index " + d + " " + y);
+      import.meta.hot.accept();
+    `,
+    "y.ts": `
+      import { d } from "./d";
+      await 0;
+      export const y = "y(" + d + ")";
+      console.log("y evaluated " + y);
+      import.meta.hot.accept(newModule => {
+        console.log("y accepted " + newModule.y);
+      });
+    `,
+    "d.ts": `
+      export const d = "d1";
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("y evaluated y(d1)", "index d1 y(d1)");
+
+    await dev.write("d.ts", `export const d = "d2";`);
+    // A callback that ran too early would see the previous `y`. Whether it runs
+    // before or after `index` finishes depends on how the loader reports a load
+    // that is already in flight (#37759), so only the values are checked.
+    await c.expectMessageInAnyOrder("y evaluated y(d2)", "index d2 y(d2)", "y accepted y(d2)");
+  },
+});
+devTest("server: modules between the updated module and the route are evaluated again", {
+  framework: minimalFramework,
+  files: {
+    // Routes never accept updates; the server applies them anyway (and warns).
+    // The route imports `config` before `derived`, so walking up from `config`
+    // reaches the route before `derived`, which still has to be found.
+    "config.ts": `
+      export const value = "v1";
+    `,
+    "derived.ts": `
+      import { value } from "./config";
+      export const derived = "derived(" + value + ")";
+    `,
+    "routes/index.ts": `
+      import { value } from "../config";
+      import { derived } from "../derived";
+      export default function () {
+        return new Response(value + " " + derived);
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("v1 derived(v1)");
+    await dev.write("config.ts", `export const value = "v2";`);
+    await dev.fetch("/").equals("v2 derived(v2)");
   },
 });
 devTest("import.meta.hot.data persistence", {


### PR DESCRIPTION
### Problem
- In the dev server, saving a file re-evaluates that module and the boundary that accepts the update, but not the modules in between. Whatever they computed from the saved file stays stale for the rest of the session, with no reload and no warning. No issue for this; found while working on a neighbouring dev server bug.
- Example: `index.ts` accepts `./d` and imports `a.ts`, which derives a value from `d.ts`. Saving `d.ts` on bun 1.4.0 runs the callback with `d2 a(d1)` and `a.ts` is never evaluated again. Same when `index.ts` self-accepts instead, and on the server, where a route keeps serving `v2 derived(v1)` after `config.ts` is saved.
- Cause: the walk up from the saved module only uses a non-accepting module to reach its importers and never schedules it for reload; patching its import bindings afterwards does not redo its top-level work.
- On the server the walk also stopped at the first root that did not accept the update, so whether the other importers were handled depended on the order they had been loaded in.

### Fix
- Every module the update propagates through is reloaded too, and the walk no longer stops at a non-accepting root. This is what the docs promise for `import.meta.hot.accept()` (the update bubbles up) and what Vite does: a module whose import is invalidated is invalidated as well.
- Two things follow from reloading more modules: the dispose pass now covers everything being reloaded (same hunk as #37785), so a re-evaluated module does not accumulate dispose callbacks and `hot.on()` listeners across saves; and everything is marked stale before anything is loaded, so an import is evaluated before its importer whatever order the walk found them in.
- On the client an update nobody accepts now stops as soon as the page reload is scheduled instead of disposing and re-evaluating modules in the page being left, so `bun:afterUpdate` no longer fires for it. Known trade-off: a CommonJS module reloaded alongside a top-level-await module it `require()`s now gets the existing "uses top-level await" error instead of the previous instance.
- Verification: six dev-server tests (five client, one server), each failing without the runtime change and passing with it; intermediate builds were used to check that each test pins a different part of the change. The remaining bake dev suites pass on a debug build.

### Background
- Bake is bun's dev server. `hmr-module.ts` is the hot-reload runtime shared by the browser client and the server side, so this change affects both.
- A hot update walks up from the saved module through its importers looking for a boundary: a module that self-accepts (`import.meta.hot.accept()`), which is re-evaluated, or an importer that accepts that specific dependency (`accept("./dep", cb)`), which only has its callback run.
- If the walk reaches a root with no boundary, the update is not accepted: the client reloads the page; the server has no page, so it warns and applies the update anyway. Route modules never accept, so on the server this is the normal path.
- Modules walked past used to have their live import bindings patched in place, which updates what they import but does not re-run their top-level code.
- A module lists its importers in the order they loaded it, not in dependency order, so correct re-evaluation relies on the loader evaluating a stale import before its importer, which needs every module marked stale up front.

<details>
<summary>Original description</summary>

### What

In the dev server, a hot update re-evaluated the saved module and the self-accepting modules it bubbled up to, but not the modules in between. Anything those computed from the saved module stayed stale for the rest of the session, with no reload and no warning.

```ts
// index.ts
import { d } from "./d";
import { a } from "./a";
import.meta.hot.accept("./d", m => console.log(m.d, a));

// a.ts
import { d } from "./d";
export const a = "a(" + d + ")";

// d.ts
export const d = "d1";
```

Saving `d.ts` with `d2` on bun 1.4.0 runs the callback with `d2 a(d1)`; `a.ts` is never evaluated again. The same happens when `index.ts` self-accepts instead (it is re-evaluated and reads the stale `a`), and on the server runtime, where routes never accept updates: with `config.ts <- derived.ts <- routes/index.ts`, saving `config.ts` makes the route serve `v2 derived(v1)` from then on.

### Why

`replaceModules()` in `src/runtime/bake/hmr-module.ts` (shared by the client and the server runtime) walks up from the replaced module. A module that does not accept the update is only queued so that its importers get looked at; only the replaced module and the self-accepting modules found on the way are added to `toReload`. `patchImporters()` afterwards rewrites the live import bindings of the modules walked past, which does not redo their top-level work. On the server the walk also stopped at the first root that did not accept the update (`continue outer`), so what was behind the other importers depended on the order in which they had been loaded.

This is the behavior the docs describe for `import.meta.hot.accept()` ("whenever `foo.ts` or any of its dependencies are saved, the update bubbles up to `index.ts`") and what Vite does: a module whose imported module is invalidated is invalidated too and re-executes when the boundary re-imports it.

### Fix

- The walk adds every module the update propagates through to `toReload` (the `toReload.add(mod)` in the new `propagates` branch is the fix for the bug itself), and no longer stops at a root that does not accept the update; `failures` is a set of replaced modules, so the message and the reload decision are unchanged.
- The dispose pass runs for everything in `toReload` instead of a separate list filled only for self-accepting modules. The modules this PR starts evaluating again would otherwise keep the dispose callbacks and `import.meta.hot.on()` listeners of every copy evaluated so far (one more `bun:afterUpdate` listener firing per save). This hunk is identical to #37785, which fixes the same omission for the saved module itself; the stale marking the old pass did is left to the reload loop, which marks every module right before loading (marking during an awaited dispose callback would let a load in that window evaluate the module before its accept registrations are captured below).
- The reload loop marks everything in `toReload` stale before loading anything. The walk order is not a dependency order (a module `d` lists its importers in the order they loaded it, so an importer can come before a module it imports), and the loader already evaluates a stale import before its importer, exactly like on the initial load. A self-accepting module that is still loading when its turn comes (it has top-level await and an importer reloaded earlier in the loop started it) has its callback run after the loads have settled instead of immediately, since its namespace is not final yet.
- On the client, an update that is not accepted returns right after scheduling the page reload. Before, the runtime went on in the page being left: it disposed of the boundaries it had found, re-evaluated the saved module and those boundaries, and ran the `accept("./dep")` callbacks of the other importers; with `toReload` now also holding the modules in between (which includes the entry point, since the HTML file is the root) that would have re-run the application entry right before the reload. None of it is useful in a page that is being replaced, and the test client already expects full reloads to be acknowledged by the new page. `bun:beforeFullReload` still fires; `bun:afterUpdate` no longer does for such an update.

Kept as is: a module whose importer accepts it via `accept("./dep")` is not re-evaluated (its callback runs), importers' `accept("./dep")` callbacks still run when `dep` self-accepts, and on the server a root that does not accept the update (a route module) is still only patched, as before: that case is reported by the existing warning, whereas the modules in between were silently stale. Re-evaluating them eagerly rather than marking them stale for the next request is deliberate: on the client nothing would ever load them again when the boundary is an `accept("./dep")` importer, and keeping one model for both runtimes keeps dispose, accept registration and patching in one place. A module in between that throws when evaluated again fails the update the same way the saved module throwing already does today (on the server that rejection is currently not handled by `registerUpdate()`, which is a separate pre-existing problem being fixed on its own).

One trade-off of marking everything stale first: a CommonJS module reloaded by an update that `require()`s a top-level-await module reloaded by the same update now gets the existing "uses top-level await" error (the module cannot be re-evaluated synchronously) where before it was handed the previous instance. That `require()` only worked because something else had loaded the module first.

Open PRs in this function: #37785 (same dispose hunk, its five tests pass on this branch; whichever lands second merges cleanly and keeps its tests), #37773 (accept callback dedupe; the first test below records what the callback saw instead of counting calls, so it passes with or without it), #37765 (removes the same `continue outer`), #31944 (same stale-first reload loop; whichever lands second drops its copy), #37759 (once the loader hands out in-flight loads, the deferred-callback branch is only reached through a dynamic `import()`; the third test below is written so that it passes either way).

### Tests

Six tests in `test/bake/dev/hot.test.ts`. All six fail with the `src/` side of this PR removed (a debug build of main's runtime) and pass with it; I also built the intermediate variants to check that each test pins a different part of the change:

- `modules between the updated module and the importer accepting it are evaluated again`: the repro above, over two updates (the re-evaluated module has to take part in the next update as well). Unfixed: `a` is never evaluated again. This is the only one that passes with just `toReload.add(mod)` added to the walk.
- `... a self-accepting importer are evaluated again, in dependency order`: `b` imports `d` and `a`, `a` imports `d`, `index` self-accepts. `d` lists `b` before `a`, so without the stale-first reload loop `b` is evaluated against the old `a` (`b(d2,a(d1))`). Unfixed: only `index` is evaluated again, against the old `b`.
- `a self-accepting module imported by another one being reloaded is evaluated first`: two boundaries for the same update, one with top-level await and an accept callback. Without the stale-first loop `index` sees the old `y`; without deferring the callback it receives the previous `y` (`y accepted y(d1)`). The messages are checked without order because the order of the last two changes once #37759 lands; the values are what shows the callback ran after the evaluation.
- `a module evaluated again because of an update below it is disposed of first`: `index` (self-accepting) imports `mid`, which imports `d` and registers a dispose callback and a `bun:afterUpdate` listener. Each save of `d` must log one dispose, one evaluation and one listener call. Unfixed: `mid` is not evaluated at all; with the first commit of this PR alone it is evaluated again but not disposed of, and the listeners accumulate (`afterUpdate seen by mid(d1)` and `mid(d2)` after one save).
- `an update that is not accepted only reloads the page`: `b` accepts `d`, `c` self-accepts with a dispose callback, `index` imports `d` directly and accepts nothing. Every module logs through a `console.log` captured on the first load, which the test client does not silence when the page reloads, so whatever the runtime still does in the page being left shows up as messages. With main's runtime the update produces `c disposed d1`, `d evaluated d2`, `c evaluated d2` and `b accepted d2` between `full reload` and the new page's messages; with this PR only `full reload` and the new page's messages.
- `server: modules between the updated module and the route are evaluated again`: the server repro above, with the route importing `config` before `derived` so that the walk reaches the non-accepting root before `derived`. Fails both unfixed (`v2 derived(v1)`) and with `continue outer` kept.

The rest of `hot.test.ts`, and `esm`, `react-spa`, `bundle`, `html`, `css`, `sourcemap`, `server-sourcemap`, `react-response`, `incremental-graph-edge-deletion`, `plugins`, `stress`, `ssg-pages-router`, `vfile` in `test/bake/dev/` plus `test/bake/dev-and-prod.test.ts` pass on the debug build with this change.

Found while working on a neighbouring dev server bug; there is no issue for it.


</details>
