### PR TITLE
node:http2: send array values in raw-form header lists as one field per element

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3769,7 +3769,9 @@ class ServerHttp2Stream extends Http2Stream {
     const sensitiveNames = buildSensitiveNames(headers, sensitives);
     // Pre-validate single-value headers in JS so a throwing respond() leaves no partial state in
     // the shared HPACK table (same rule request() applies).
-    if (session[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
+    if (session[kStrictSingleValueFields] !== false) {
+      assertSingleValueHeaders(rawHeadersList !== null ? rawHeadersList : headers);
+    }
     // node keeps the never-index list visible on sentHeaders (symbol keys are not iterated by the
     // wire-encoding path, so re-attaching is safe).
     if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;
@@ -4007,20 +4009,35 @@ function stripInvalidWhitespaceFields(rawheaders: string[]): string[] {
 // node validates header constraints in JS before anything reaches the native encoder, so a
 // throwing request leaves no partial state in the shared HPACK table. Mirror the single-value
 // rule here: duplicated single-value fields (across case variants) and multi-element arrays for
-// them throw before encoding starts.
+// them throw before encoding starts. Takes either the object form or the raw [name, value, ...]
+// list; the list is judged slot by slot, like the encoder will, so a slot the encoder skips
+// (undefined value, empty array) is not an occurrence whichever position it is in.
 function assertSingleValueHeaders(headers) {
   let seen = null;
+  if ($isArray(headers)) {
+    for (let i = 0; i < headers.length; i += 2) {
+      const name = headers[i];
+      const value = headers[i + 1];
+      if (typeof name !== "string" || value === undefined || ($isArray(value) && value.length === 0)) continue;
+      seen = noteSingleValueField(seen, name, value);
+    }
+    return;
+  }
   const keys = Object.keys(headers);
   for (let i = 0; i < keys.length; i++) {
-    const lower = keys[i].toLowerCase();
-    if (!kSingleValueHeaders.has(lower)) continue;
-    const value = headers[keys[i]];
-    if (($isArray(value) && value.length > 1) || (seen !== null && seen.has(lower))) {
-      throw $ERR_HTTP2_HEADER_SINGLE_VALUE(`Header field "${lower}" must only have a single value`);
-    }
-    if (seen === null) seen = new SafeSet();
-    seen.add(lower);
+    seen = noteSingleValueField(seen, keys[i], headers[keys[i]]);
   }
+}
+
+function noteSingleValueField(seen, name, value) {
+  const lower = name.toLowerCase();
+  if (!kSingleValueHeaders.has(lower)) return seen;
+  if (($isArray(value) && value.length > 1) || (seen !== null && seen.has(lower))) {
+    throw $ERR_HTTP2_HEADER_SINGLE_VALUE(`Header field "${lower}" must only have a single value`);
+  }
+  if (seen === null) seen = new SafeSet();
+  seen.add(lower);
+  return seen;
 }
 
 // Renders a received value the way node's determineSpecificType does for error messages.
@@ -6236,7 +6253,9 @@ class ClientHttp2Session extends Http2Session {
       }
       // Validate single-value constraints before anything is encoded (a mid-encode throw would
       // desync the shared HPACK table from the peer).
-      if (this[kStrictSingleValueFields] !== false) assertSingleValueHeaders(headers);
+      if (this[kStrictSingleValueFields] !== false) {
+        assertSingleValueHeaders(rawHeadersList !== null ? rawHeadersList : headers);
+      }
       // node keeps the never-index list visible on the request's sentHeaders (symbol keys are
       // not iterated by the wire-encoding path, so re-attaching is safe).
       if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -3752,19 +3752,7 @@ class ServerHttp2Stream extends Http2Stream {
         headers.push(HTTP2_HEADER_DATE, utcDate());
       }
       rawHeadersList = headers;
-      const headersObject = { __proto__: null };
-      for (let i = 0; i < rawHeadersList.length; i += 2) {
-        const key = rawHeadersList[i];
-        const value = rawHeadersList[i + 1];
-        const existing = headersObject[key];
-        if (existing === undefined) headersObject[key] = value;
-        else if ($isArray(existing)) existing.push(value);
-        else headersObject[key] = [existing, value];
-      }
-      if (rawHeadersList[sensitiveHeaders] !== undefined) {
-        headersObject[sensitiveHeaders] = rawHeadersList[sensitiveHeaders];
-      }
-      headers = headersObject;
+      headers = rawHeadersToObject(rawHeadersList, rawHeadersList[sensitiveHeaders]);
     } else if (!$isObject(headers)) {
       throw $ERR_INVALID_ARG_TYPE("headers", "object", headers);
     } else {
@@ -4067,6 +4055,25 @@ function buildSensitiveNames(headers, sensitives) {
     }
   }
   return map;
+}
+
+// The object form (node's sentHeaders shape) of an outbound raw [name, value, ...] list: keys keep
+// their casing, a repeated name accumulates its values into an array. An array given as a value is
+// copied first: the list itself is what gets encoded, so accumulating a later duplicate into the
+// caller's array would also put that duplicate on the wire twice.
+function rawHeadersToObject(rawHeadersList, sensitives) {
+  const headersObject = { __proto__: null };
+  for (let i = 0; i < rawHeadersList.length; i += 2) {
+    const key = rawHeadersList[i];
+    let value = rawHeadersList[i + 1];
+    if ($isArray(value)) value = value.slice();
+    const existing = headersObject[key];
+    if (existing === undefined) headersObject[key] = value;
+    else if ($isArray(existing)) existing.push(value);
+    else headersObject[key] = [existing, value];
+  }
+  if (sensitives !== undefined) headersObject[sensitiveHeaders] = sensitives;
+  return headersObject;
 }
 
 function toHeaderObject(headers, sensitiveHeadersValue) {
@@ -6173,19 +6180,7 @@ class ClientHttp2Session extends Http2Session {
           if (path !== undefined) throw $ERR_HTTP2_CONNECT_PATH();
         }
         rawHeadersList = additionalPseudoHeaders.length ? additionalPseudoHeaders.concat(raw) : raw;
-        const headersObject = { __proto__: null };
-        for (let i = 0; i < rawHeadersList.length; i += 2) {
-          const key = rawHeadersList[i];
-          const value = rawHeadersList[i + 1];
-          const existing = headersObject[key];
-          if (existing === undefined) headersObject[key] = value;
-          else if ($isArray(existing)) existing.push(value);
-          else headersObject[key] = [existing, value];
-        }
-        if (raw[sensitiveHeaders] !== undefined) {
-          headersObject[sensitiveHeaders] = raw[sensitiveHeaders];
-        }
-        headers = headersObject;
+        headers = rawHeadersToObject(rawHeadersList, raw[sensitiveHeaders]);
       } else if (!$isObject(headers)) {
         throw $ERR_INVALID_ARG_TYPE("headers", "object", headers);
       } else {

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4057,15 +4057,13 @@ function buildSensitiveNames(headers, sensitives) {
   return map;
 }
 
-// The object form (node's sentHeaders shape) of an outbound raw [name, value, ...] list: keys keep
-// their casing, a repeated name accumulates its values into an array. An array given as a value is
-// copied first: the list itself is what gets encoded, so accumulating a later duplicate into the
-// caller's array would also put that duplicate on the wire twice.
+// Backs sentHeaders for the raw [name, value, ...] form.
 function rawHeadersToObject(rawHeadersList, sensitives) {
   const headersObject = { __proto__: null };
   for (let i = 0; i < rawHeadersList.length; i += 2) {
     const key = rawHeadersList[i];
     let value = rawHeadersList[i + 1];
+    // The list itself is what gets encoded: a later duplicate must not be pushed into the caller's array.
     if ($isArray(value)) value = value.slice();
     const existing = headersObject[key];
     if (existing === undefined) headersObject[key] = value;

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4009,15 +4009,14 @@ function stripInvalidWhitespaceFields(rawheaders: string[]): string[] {
 // node validates header constraints in JS before anything reaches the native encoder, so a
 // throwing request leaves no partial state in the shared HPACK table. Mirror the single-value
 // rule here: duplicated single-value fields (across case variants) and multi-element arrays for
-// them throw before encoding starts. Takes either the object form or the raw [name, value, ...]
-// list; the list is judged slot by slot, like the encoder will, so a slot the encoder skips
-// (undefined value, empty array) is not an occurrence whichever position it is in.
+// them throw before encoding starts. Accepts the object form or the raw [name, value, ...] list.
 function assertSingleValueHeaders(headers) {
   let seen = null;
   if ($isArray(headers)) {
     for (let i = 0; i < headers.length; i += 2) {
       const name = headers[i];
       const value = headers[i + 1];
+      // A slot the encoder skips is not an occurrence, wherever it is in the list.
       if (typeof name !== "string" || value === undefined || ($isArray(value) && value.length === 0)) continue;
       seen = noteSingleValueField(seen, name, value);
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6313,7 +6313,7 @@ class ClientHttp2Session extends Http2Session {
       }
 
       let rejectContentLengthOnNoPayload = false;
-      if (NoPayloadMethods.has(method.toUpperCase())) {
+      if (typeof method === "string" && NoPayloadMethods.has(method.toUpperCase())) {
         // Like Node, a payload-meaningless method only defaults endStream to
         // true when the caller expressed no preference; an explicit endStream
         // (validated above) is honored, so { endStream: false } stays open.

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8852,7 +8852,9 @@ impl H2FrameParser {
                     }
 
                     let name_str = name_js.to_js_string(global_object)?;
-                    let name_slice = name_str.to_slice(global_object);
+                    // Owned copy: the name is still used after the value's toString() has run,
+                    // which may drop the list's only reference to the name string.
+                    let name_slice = name_str.to_slice_clone(global_object)?;
                     let name = name_slice.slice();
                     if name.is_empty() {
                         continue;

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8896,6 +8896,30 @@ impl H2FrameParser {
                         continue;
                     }
 
+                    let elements = if value_js.js_type().is_array() {
+                        Some(value_js.array_iterator(global_object)?)
+                    } else {
+                        None
+                    };
+                    let field_count = elements.as_ref().map_or(1, |items| items.len);
+                    // node (buildNgHeaderString): [] sends nothing and is not an occurrence.
+                    if field_count == 0 {
+                        continue;
+                    }
+                    if let Some(idx) = this.single_value_index_checked(validated_name) {
+                        if field_count > 1 || single_value_headers[idx] {
+                            let exception = global_object.to_type_error(
+                                bun_jsc::ErrorCode::HTTP2_HEADER_SINGLE_VALUE,
+                                format_args!(
+                                    "Header field \"{}\" must only have a single value",
+                                    BStr::new(validated_name)
+                                ),
+                            );
+                            return Err(global_object.throw_value(exception));
+                        }
+                        single_value_headers[idx] = true;
+                    }
+
                     let never_index = if Self::is_index_like_name(validated_name) {
                         false
                     } else {
@@ -8953,57 +8977,29 @@ impl H2FrameParser {
                         Ok(None)
                     };
 
-                    if value_js.js_type().is_array() {
-                        let mut value_iter = value_js.array_iterator(global_object)?;
-                        // node (buildNgHeaderString): [] sends nothing and is not an occurrence.
-                        if value_iter.len == 0 {
-                            continue;
-                        }
-                        if let Some(idx) = this.single_value_index_checked(validated_name) {
-                            if value_iter.len > 1 || single_value_headers[idx] {
-                                let exception = global_object.to_type_error(
-                                    bun_jsc::ErrorCode::HTTP2_HEADER_SINGLE_VALUE,
-                                    format_args!(
-                                        "Header field \"{}\" must only have a single value",
-                                        BStr::new(validated_name)
-                                    ),
-                                );
-                                return Err(global_object.throw_value(exception));
+                    match elements {
+                        Some(mut items) => {
+                            while let Some(item) = items.next()? {
+                                if item.is_empty_or_undefined_or_null() {
+                                    return Err(global_object
+                                        .err(
+                                            JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
+                                            format_args!(
+                                                "Invalid value for header \"{}\"",
+                                                BStr::new(validated_name)
+                                            ),
+                                        )
+                                        .throw());
+                                }
+                                if let Some(ret) = encode_value(item)? {
+                                    return Ok(ret);
+                                }
                             }
-                            single_value_headers[idx] = true;
                         }
-                        while let Some(item) = value_iter.next()? {
-                            if item.is_empty_or_undefined_or_null() {
-                                return Err(global_object
-                                    .err(
-                                        JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                        format_args!(
-                                            "Invalid value for header \"{}\"",
-                                            BStr::new(validated_name)
-                                        ),
-                                    )
-                                    .throw());
-                            }
-                            if let Some(ret) = encode_value(item)? {
+                        None => {
+                            if let Some(ret) = encode_value(value_js)? {
                                 return Ok(ret);
                             }
-                        }
-                    } else {
-                        if let Some(idx) = this.single_value_index_checked(validated_name) {
-                            if single_value_headers[idx] {
-                                let exception = global_object.to_type_error(
-                                    bun_jsc::ErrorCode::HTTP2_HEADER_SINGLE_VALUE,
-                                    format_args!(
-                                        "Header field \"{}\" must only have a single value",
-                                        BStr::new(validated_name)
-                                    ),
-                                );
-                                return Err(global_object.throw_value(exception));
-                            }
-                            single_value_headers[idx] = true;
-                        }
-                        if let Some(ret) = encode_value(value_js)? {
-                            return Ok(ret);
                         }
                     }
                 }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8840,6 +8840,8 @@ impl H2FrameParser {
         // Raw (flat [name, value, ...] array) headers form: encode each pair in
         // its given order, pseudo-headers first (same two-pass split as the
         // object form below), preserving interleaved duplicates on the wire.
+        // A value slot holding an array sends one field per element, exactly
+        // like an array value in the object form.
         let headers_are_raw_pairs = headers_arg.js_type().is_array();
         if headers_are_raw_pairs {
             for ignore_pseudo_headers in 0..2usize {
@@ -8895,22 +8897,6 @@ impl H2FrameParser {
                         continue;
                     }
 
-                    if let Some(idx) = this.single_value_index_checked(validated_name) {
-                        if single_value_headers[idx] {
-                            let exception = global_object.to_type_error(
-                                bun_jsc::ErrorCode::HTTP2_HEADER_SINGLE_VALUE,
-                                format_args!(
-                                    "Header field \"{}\" must only have a single value",
-                                    BStr::new(validated_name)
-                                ),
-                            );
-                            return Err(global_object.throw_value(exception));
-                        }
-                        single_value_headers[idx] = true;
-                    }
-
-                    let value_str = value_js.to_js_string(global_object)?;
-
                     let never_index = if Self::is_index_like_name(validated_name) {
                         false
                     } else {
@@ -8920,48 +8906,107 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_str.to_slice(global_object);
-                    let value = value_slice.slice();
-                    if !is_valid_header_value(value) {
-                        return Err(global_object
-                            .err(
-                                JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
-                                format_args!(
-                                    "Invalid value for header \"{}\"",
-                                    BStr::new(validated_name)
-                                ),
-                            )
-                            .throw());
-                    }
-                    bun_output::scoped_log!(
-                        H2FrameParser,
-                        "encode header {} {}",
-                        BStr::new(validated_name),
-                        BStr::new(value)
-                    );
-
-                    if let Err(err) = this.encode_header_into_list(
-                        &mut encoded_headers,
-                        validated_name,
-                        value,
-                        never_index,
-                    ) {
-                        if matches!(err, crate::Error::Alloc(_)) {
+                    let mut encode_value = |item: JSValue| -> JsResult<Option<JSValue>> {
+                        let value_str = item.to_js_string(global_object)?;
+                        let value_slice = value_str.to_slice(global_object);
+                        let value = value_slice.slice();
+                        if !is_valid_header_value(value) {
                             return Err(global_object
-                                .throw(format_args!("Failed to allocate header buffer")));
+                                .err(
+                                    JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
+                                    format_args!(
+                                        "Invalid value for header \"{}\"",
+                                        BStr::new(validated_name)
+                                    ),
+                                )
+                                .throw());
                         }
-                        let Some(stream) = this.handle_received_stream_id(stream_id) else {
-                            return Ok(JSValue::js_number(-1.0));
-                        };
-                        // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-                        let stream = unsafe { &mut *stream };
-                        if !stream_ctx_arg.is_empty_or_undefined_or_null()
-                            && stream_ctx_arg.is_object()
-                        {
-                            stream.set_context(stream_ctx_arg, global_object);
+                        bun_output::scoped_log!(
+                            H2FrameParser,
+                            "encode header {} {}",
+                            BStr::new(validated_name),
+                            BStr::new(value)
+                        );
+
+                        if let Err(err) = this.encode_header_into_list(
+                            &mut encoded_headers,
+                            validated_name,
+                            value,
+                            never_index,
+                        ) {
+                            if matches!(err, crate::Error::Alloc(_)) {
+                                return Err(global_object
+                                    .throw(format_args!("Failed to allocate header buffer")));
+                            }
+                            let Some(stream) = this.handle_received_stream_id(stream_id) else {
+                                return Ok(Some(JSValue::js_number(-1.0)));
+                            };
+                            // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
+                            let stream = unsafe { &mut *stream };
+                            if !stream_ctx_arg.is_empty_or_undefined_or_null()
+                                && stream_ctx_arg.is_object()
+                            {
+                                stream.set_context(stream_ctx_arg, global_object);
+                            }
+                            this.schedule_header_compression_session_error();
+                            return Ok(Some(JSValue::js_number(stream_id as f64)));
                         }
-                        this.schedule_header_compression_session_error();
-                        return Ok(JSValue::js_number(stream_id as f64));
+                        Ok(None)
+                    };
+
+                    if value_js.js_type().is_array() {
+                        let mut value_iter = value_js.array_iterator(global_object)?;
+                        // node (buildNgHeaderString): an empty array sends nothing and does not
+                        // count as an occurrence of a single-value field.
+                        if value_iter.len == 0 {
+                            continue;
+                        }
+                        if let Some(idx) = this.single_value_index_checked(validated_name) {
+                            if value_iter.len > 1 || single_value_headers[idx] {
+                                let exception = global_object.to_type_error(
+                                    bun_jsc::ErrorCode::HTTP2_HEADER_SINGLE_VALUE,
+                                    format_args!(
+                                        "Header field \"{}\" must only have a single value",
+                                        BStr::new(validated_name)
+                                    ),
+                                );
+                                return Err(global_object.throw_value(exception));
+                            }
+                            single_value_headers[idx] = true;
+                        }
+                        while let Some(item) = value_iter.next()? {
+                            if item.is_empty_or_undefined_or_null() {
+                                return Err(global_object
+                                    .err(
+                                        JscErrorCode::HTTP2_INVALID_HEADER_VALUE,
+                                        format_args!(
+                                            "Invalid value for header \"{}\"",
+                                            BStr::new(validated_name)
+                                        ),
+                                    )
+                                    .throw());
+                            }
+                            if let Some(ret) = encode_value(item)? {
+                                return Ok(ret);
+                            }
+                        }
+                    } else {
+                        if let Some(idx) = this.single_value_index_checked(validated_name) {
+                            if single_value_headers[idx] {
+                                let exception = global_object.to_type_error(
+                                    bun_jsc::ErrorCode::HTTP2_HEADER_SINGLE_VALUE,
+                                    format_args!(
+                                        "Header field \"{}\" must only have a single value",
+                                        BStr::new(validated_name)
+                                    ),
+                                );
+                                return Err(global_object.throw_value(exception));
+                            }
+                            single_value_headers[idx] = true;
+                        }
+                        if let Some(ret) = encode_value(value_js)? {
+                            return Ok(ret);
+                        }
                     }
                 }
             }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8840,8 +8840,6 @@ impl H2FrameParser {
         // Raw (flat [name, value, ...] array) headers form: encode each pair in
         // its given order, pseudo-headers first (same two-pass split as the
         // object form below), preserving interleaved duplicates on the wire.
-        // A value slot holding an array sends one field per element, exactly
-        // like an array value in the object form.
         let headers_are_raw_pairs = headers_arg.js_type().is_array();
         if headers_are_raw_pairs {
             for ignore_pseudo_headers in 0..2usize {
@@ -8956,8 +8954,7 @@ impl H2FrameParser {
 
                     if value_js.js_type().is_array() {
                         let mut value_iter = value_js.array_iterator(global_object)?;
-                        // node (buildNgHeaderString): an empty array sends nothing and does not
-                        // count as an occurrence of a single-value field.
+                        // node (buildNgHeaderString): [] sends nothing and is not an occurrence.
                         if value_iter.len == 0 {
                             continue;
                         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8852,8 +8852,7 @@ impl H2FrameParser {
                     }
 
                     let name_str = name_js.to_js_string(global_object)?;
-                    // Owned copy: the name is still used after the value's toString() has run,
-                    // which may drop the list's only reference to the name string.
+                    // Owned: still used after the values' toString() may have dropped the list's reference to it.
                     let name_slice = name_str.to_slice_clone(global_object)?;
                     let name = name_slice.slice();
                     if name.is_empty() {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4075,7 +4075,7 @@ it("http2 stream.respond accepts raw-headers arrays; respondWithFD/respondWithFi
 // element, like an array value in the object form (node: buildNgHeaderString treats both forms the
 // same). Every assertion below is on the flat list the peer decoded from the wire, so it sees one
 // name/value pair per field; the expected values were checked against node v26.3.0.
-describe.concurrent("http2 raw-headers arrays with array values", () => {
+describe("http2 raw-headers arrays with array values", () => {
   function nonPseudoFields(rawHeaders) {
     const fields = [];
     for (let i = 0; i < rawHeaders.length; i += 2) {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4332,6 +4332,43 @@ describe("http2 raw-headers arrays with array values", () => {
     }
   });
 
+  // request() reads :method back to decide whether the stream ends with the HEADERS frame. An array
+  // in that slot (one element, or an empty one after the value) is sent as the method it holds, and
+  // like node the stream is then left open for the caller to end.
+  it("request() accepts an array in the :method slot", async () => {
+    let received;
+    const { client, close } = await peers((stream, _headers, _flags, rawHeaders) => {
+      received = [];
+      for (let i = 0; i < rawHeaders.length; i += 2) {
+        if (rawHeaders[i] === ":method") received.push(rawHeaders[i + 1]);
+      }
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    try {
+      const outcomes = [];
+      for (const headers of [
+        [":method", "GET", ":path", "/"],
+        [":method", ["GET"], ":path", "/"],
+        [":method", "GET", ":method", [], ":path", "/"],
+        { ":method": ["GET"], ":path": "/" },
+      ]) {
+        const req = client.request(headers);
+        const endedByRequest = req.writableEnded;
+        await exchange(req);
+        outcomes.push({ received, endedByRequest });
+      }
+      expect(outcomes).toEqual([
+        { received: ["GET"], endedByRequest: true },
+        { received: ["GET"], endedByRequest: false },
+        { received: ["GET"], endedByRequest: false },
+        { received: ["GET"], endedByRequest: false },
+      ]);
+    } finally {
+      close();
+    }
+  });
+
   it("sends each element of a single-value header when strictSingleValueFields is off", async () => {
     let received;
     const { client, close } = await peers(

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4070,6 +4070,298 @@ it("http2 stream.respond accepts raw-headers arrays; respondWithFD/respondWithFi
     server.close();
   }
 });
+
+// An array in a value slot of the raw [name, value, ...] headers form is sent as one field per
+// element, like an array value in the object form (node: buildNgHeaderString treats both forms the
+// same). Every assertion below is on the flat list the peer decoded from the wire, so it sees one
+// name/value pair per field; the expected values were checked against node v26.3.0.
+describe.concurrent("http2 raw-headers arrays with array values", () => {
+  function nonPseudoFields(rawHeaders) {
+    const fields = [];
+    for (let i = 0; i < rawHeaders.length; i += 2) {
+      if (!rawHeaders[i].startsWith(":")) fields.push(rawHeaders[i], rawHeaders[i + 1]);
+    }
+    return fields;
+  }
+
+  async function peers(onStream, { serverOptions, clientOptions, waitForConnect = true } = {}) {
+    const server = http2.createServer(serverOptions);
+    server.on("stream", onStream);
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const authority = `127.0.0.1:${server.address().port}`;
+    const client = http2.connect(`http://${authority}`, clientOptions);
+    if (waitForConnect) await new Promise(resolve => client.once("connect", resolve));
+    return {
+      client,
+      authority,
+      close() {
+        client.destroy();
+        server.close();
+      },
+    };
+  }
+
+  // Ends the request and resolves with the response head once the stream has closed.
+  function exchange(req) {
+    return new Promise((resolve, reject) => {
+      let response;
+      req.on("response", (headers, _flags, rawHeaders) => (response = { headers, rawHeaders }));
+      req.on("error", reject);
+      req.on("close", () => resolve(response));
+      req.resume();
+      req.end();
+    });
+  }
+
+  // The request is made on a connecting session in the second case, so it is queued and only
+  // encoded once the session connects.
+  for (const waitForConnect of [true, false]) {
+    it(`request() sends one field per element (${waitForConnect ? "connected" : "connecting"} session)`, async () => {
+      let received;
+      const { client, authority, close } = await peers(
+        (stream, headers, _flags, rawHeaders) => {
+          received = {
+            path: headers[":path"],
+            sensitive: headers[http2.sensitiveHeaders],
+            fields: nonPseudoFields(rawHeaders),
+          };
+          stream.respond({ ":status": 200 });
+          stream.end();
+        },
+        { waitForConnect },
+      );
+      try {
+        const arrayThenScalar = ["d1"];
+        const scalarThenArray = ["e2", "e3"];
+        const raw = [
+          ...[":path", ["/raw"]],
+          ...["x-multi", ["a", "b"]],
+          ...["x-number", [1, 2]],
+          ...["x-one", ["only"]],
+          ...["x-none", []],
+          ...["content-type", []],
+          ...["x-plain", "p"],
+          ...["x-dup", arrayThenScalar, "x-dup", "d2"],
+          ...["x-dup2", "e1", "x-dup2", scalarThenArray],
+          ...["x-secret", ["s1", "s2"]],
+        ];
+        raw[http2.sensitiveHeaders] = ["x-secret"];
+        const req = client.request(raw);
+        await exchange(req);
+
+        expect(received).toEqual({
+          path: "/raw",
+          // The receiver lists a name once per field that arrived never-indexed.
+          sensitive: ["x-secret", "x-secret"],
+          fields: [
+            ...["x-multi", "a", "x-multi", "b"],
+            ...["x-number", "1", "x-number", "2"],
+            ...["x-one", "only"],
+            ...["x-plain", "p"],
+            ...["x-dup", "d1", "x-dup", "d2"],
+            ...["x-dup2", "e1", "x-dup2", "e2", "x-dup2", "e3"],
+            ...["x-secret", "s1", "x-secret", "s2"],
+          ],
+        });
+        // Deriving sentHeaders (a later duplicate is appended to the name's array) must not append
+        // into the caller's arrays, which are what gets encoded.
+        expect({ arrayThenScalar, scalarThenArray }).toEqual({
+          arrayThenScalar: ["d1"],
+          scalarThenArray: ["e2", "e3"],
+        });
+        expect(req.sentHeaders).toEqual({
+          ":method": "GET",
+          ":authority": authority,
+          ":scheme": "http",
+          ":path": ["/raw"],
+          "x-multi": ["a", "b"],
+          "x-number": [1, 2],
+          "x-one": ["only"],
+          "x-none": [],
+          "content-type": [],
+          "x-plain": "p",
+          "x-dup": ["d1", "d2"],
+          "x-dup2": ["e1", ["e2", "e3"]],
+          "x-secret": ["s1", "s2"],
+          [http2.sensitiveHeaders]: ["x-secret"],
+        });
+      } finally {
+        close();
+      }
+    });
+  }
+
+  it("respond() sends one field per element", async () => {
+    let sent;
+    const arrayThenScalar = ["d1"];
+    const { client, close } = await peers(stream => {
+      stream.respond(
+        [
+          ...[":status", "200"],
+          ...["set-cookie", ["c1=1", "c2=2"]],
+          ...["x-multi", ["a", "b"]],
+          ...["x-none", []],
+          ...["x-dup", arrayThenScalar, "x-dup", "d2"],
+          ...["x-plain", "p"],
+        ],
+        { sendDate: false },
+      );
+      sent = stream.sentHeaders;
+      stream.end();
+    });
+    try {
+      const { headers, rawHeaders } = await exchange(client.request({ ":path": "/" }));
+      expect(rawHeaders).toEqual([
+        ...[":status", "200"],
+        ...["set-cookie", "c1=1", "set-cookie", "c2=2"],
+        ...["x-multi", "a", "x-multi", "b"],
+        ...["x-dup", "d1", "x-dup", "d2"],
+        ...["x-plain", "p"],
+      ]);
+      // What a receiver makes of those fields: set-cookie stays a list, other repeated fields are
+      // joined with ", ", and an empty array sends nothing at all.
+      expect(headers).toEqual({
+        ":status": 200,
+        "set-cookie": ["c1=1", "c2=2"],
+        "x-multi": "a, b",
+        "x-dup": "d1, d2",
+        "x-plain": "p",
+        [http2.sensitiveHeaders]: [],
+      });
+      expect(sent).toEqual({
+        ":status": "200",
+        "set-cookie": ["c1=1", "c2=2"],
+        "x-multi": ["a", "b"],
+        "x-none": [],
+        "x-dup": ["d1", "d2"],
+        "x-plain": "p",
+      });
+      expect(arrayThenScalar).toEqual(["d1"]);
+    } finally {
+      close();
+    }
+  });
+
+  it("request() applies the single-value rule to array values", async () => {
+    let received;
+    const { client, close } = await peers((stream, _headers, _flags, rawHeaders) => {
+      received = nonPseudoFields(rawHeaders);
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    try {
+      const attempts = [
+        [":path", "/", "content-type", ["text/plain", "text/html"]],
+        [":path", "/", "content-type", ["text/plain"], "content-type", "text/html"],
+        [":path", "/", "content-type", "text/plain", "content-type", ["text/html"]],
+        [":path", ["/a", "/b"]],
+      ];
+      const thrown = attempts.map(raw => {
+        try {
+          client.request(raw);
+          return null;
+        } catch (err) {
+          return { name: err.constructor.name, code: err.code, message: err.message };
+        }
+      });
+      const singleValue = name => ({
+        name: "TypeError",
+        code: "ERR_HTTP2_HEADER_SINGLE_VALUE",
+        message: `Header field "${name}" must only have a single value`,
+      });
+      expect(thrown).toEqual([
+        singleValue("content-type"),
+        singleValue("content-type"),
+        singleValue("content-type"),
+        singleValue(":path"),
+      ]);
+
+      // An empty array sends nothing, so it does not count as an occurrence of the field either.
+      await exchange(client.request([":path", "/", "content-type", [], "content-type", "text/html"]));
+      expect(received).toEqual(["content-type", "text/html"]);
+    } finally {
+      close();
+    }
+  });
+
+  it("sends each element of a single-value header when strictSingleValueFields is off", async () => {
+    let received;
+    const { client, close } = await peers(
+      (stream, _headers, _flags, rawHeaders) => {
+        received = nonPseudoFields(rawHeaders);
+        stream.respond([":status", "200", "content-type", ["text/plain", "text/html"]], { sendDate: false });
+        stream.end();
+      },
+      { serverOptions: { strictSingleValueFields: false }, clientOptions: { strictSingleValueFields: false } },
+    );
+    try {
+      const { rawHeaders } = await exchange(client.request([":path", "/", "content-type", ["a/b", "c/d"]]));
+      expect(received).toEqual(["content-type", "a/b", "content-type", "c/d"]);
+      expect(rawHeaders).toEqual([":status", "200", "content-type", "text/plain", "content-type", "text/html"]);
+    } finally {
+      close();
+    }
+  });
+
+  // Each element is validated like a single value: the same ERR_HTTP2_INVALID_HEADER_VALUE the
+  // object form raises for these elements.
+  for (const [label, element] of [
+    ["containing LF", "a\nb"],
+    ["that is null", null],
+  ]) {
+    it(`request() and respond() reject an array element ${label}`, async () => {
+      const describeError = err => ({ name: err.constructor.name, code: err.code, message: err.message });
+      const invalidValue = {
+        name: "TypeError",
+        code: "ERR_HTTP2_INVALID_HEADER_VALUE",
+        message: 'Invalid value for header "x-custom"',
+      };
+
+      // One session per call that throws: a block rejected part-way through encoding leaves that
+      // session's HPACK encoder ahead of the peer (pre-existing, not specific to arrays).
+      {
+        const { client, close } = await peers(() => {});
+        try {
+          let outcome = "returned";
+          try {
+            client.request([":path", "/", "x-custom", ["ok", element]]);
+          } catch (err) {
+            outcome = describeError(err);
+          }
+          expect(outcome).toEqual(invalidValue);
+        } finally {
+          close();
+        }
+      }
+
+      // respond() throws the same way; the stream is then closed so the client's request completes
+      // without ever having received a response head.
+      {
+        let outcome = "not called";
+        const { client, close } = await peers(stream => {
+          try {
+            stream.respond([":status", "200", "x-custom", ["ok", element]]);
+            outcome = "responded";
+          } catch (err) {
+            outcome = describeError(err);
+          }
+          stream.close(http2.constants.NGHTTP2_CANCEL);
+        });
+        try {
+          const req = client.request({ ":path": "/" });
+          req.on("error", () => {});
+          let response = null;
+          req.on("response", headers => (response = headers));
+          await new Promise(resolve => req.on("close", resolve));
+          expect({ outcome, response }).toEqual({ outcome: invalidValue, response: null });
+        } finally {
+          close();
+        }
+      }
+    });
+  }
+});
+
 it("http2 client.request() on a destroyed or closed session uses the right error codes", async () => {
   // Node: destroyed session -> ERR_HTTP2_INVALID_SESSION,
   // closed (GOAWAY-pending) session -> ERR_HTTP2_GOAWAY_SESSION.

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4303,8 +4303,9 @@ describe.concurrent("http2 raw-headers arrays with array values", () => {
     }
   });
 
-  // Each element is validated like a single value: the same ERR_HTTP2_INVALID_HEADER_VALUE the
-  // object form raises for these elements.
+  // Elements follow the rule the encoder already applies to array elements in the object form: a null
+  // element, or one containing CR/LF/NUL, throws ERR_HTTP2_INVALID_HEADER_VALUE from the call itself,
+  // for request() and respond() alike.
   for (const [label, element] of [
     ["containing LF", "a\nb"],
     ["that is null", null],

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4242,43 +4242,91 @@ describe("http2 raw-headers arrays with array values", () => {
     }
   });
 
-  it("request() applies the single-value rule to array values", async () => {
+  // The single-value rule counts what the encoder will send for the field: an array with several
+  // elements is several occurrences, an empty array (or an undefined value) is none, whichever slot
+  // of the list it is in; anything else is one. A violation throws from the call itself, before
+  // anything is encoded. Every row was checked against node v26.3.0.
+  const singleValue = {
+    name: "TypeError",
+    code: "ERR_HTTP2_HEADER_SINGLE_VALUE",
+    message: 'Header field "content-type" must only have a single value',
+  };
+  const singleValueRows = [
+    { pairs: ["content-type", ["text/plain", "text/html"]], outcome: singleValue },
+    { pairs: ["content-type", ["text/plain"], "content-type", "text/html"], outcome: singleValue },
+    { pairs: ["content-type", "text/plain", "content-type", ["text/html"]], outcome: singleValue },
+    { pairs: ["content-type", "text/plain", "content-type", null], outcome: singleValue },
+    { pairs: ["Content-Type", "text/plain", "content-type", "text/html"], outcome: singleValue },
+    { pairs: ["content-type", [], "content-type", "text/html"], outcome: ["text/html"] },
+    { pairs: ["content-type", "text/html", "content-type", []], outcome: ["text/html"] },
+    { pairs: ["content-type", ["text/html"], "content-type", []], outcome: ["text/html"] },
+    { pairs: ["content-type", [], "content-type", [], "content-type", "text/html"], outcome: ["text/html"] },
+    { pairs: ["content-type", undefined, "content-type", "text/html"], outcome: ["text/html"] },
+    { pairs: ["Content-Type", "text/html", "content-type", []], outcome: ["text/html"] },
+  ];
+  const describeError = err => ({ name: err.constructor.name, code: err.code, message: err.message });
+  const contentTypeValues = rawHeaders => {
+    const values = [];
+    for (let i = 0; i < rawHeaders.length; i += 2) {
+      if (rawHeaders[i] === "content-type") values.push(rawHeaders[i + 1]);
+    }
+    return values;
+  };
+
+  it("request() applies the single-value rule per slot of the list", async () => {
     let received;
     const { client, close } = await peers((stream, _headers, _flags, rawHeaders) => {
-      received = nonPseudoFields(rawHeaders);
+      received = contentTypeValues(rawHeaders);
       stream.respond({ ":status": 200 });
       stream.end();
     });
     try {
-      const attempts = [
-        [":path", "/", "content-type", ["text/plain", "text/html"]],
-        [":path", "/", "content-type", ["text/plain"], "content-type", "text/html"],
-        [":path", "/", "content-type", "text/plain", "content-type", ["text/html"]],
-        [":path", ["/a", "/b"]],
-      ];
-      const thrown = attempts.map(raw => {
+      const outcomes = [];
+      for (const { pairs } of singleValueRows) {
+        let req;
         try {
-          client.request(raw);
-          return null;
+          req = client.request([":path", "/", ...pairs]);
         } catch (err) {
-          return { name: err.constructor.name, code: err.code, message: err.message };
+          outcomes.push(describeError(err));
+          continue;
         }
-      });
-      const singleValue = name => ({
-        name: "TypeError",
-        code: "ERR_HTTP2_HEADER_SINGLE_VALUE",
-        message: `Header field "${name}" must only have a single value`,
-      });
-      expect(thrown).toEqual([
-        singleValue("content-type"),
-        singleValue("content-type"),
-        singleValue("content-type"),
-        singleValue(":path"),
-      ]);
+        await exchange(req);
+        outcomes.push(received);
+      }
+      expect(outcomes).toEqual(singleValueRows.map(row => row.outcome));
 
-      // An empty array sends nothing, so it does not count as an occurrence of the field either.
-      await exchange(client.request([":path", "/", "content-type", [], "content-type", "text/html"]));
-      expect(received).toEqual(["content-type", "text/html"]);
+      let pseudoOutcome = "returned";
+      try {
+        client.request([":path", ["/a", "/b"]]);
+      } catch (err) {
+        pseudoOutcome = describeError(err);
+      }
+      expect(pseudoOutcome).toEqual({ ...singleValue, message: 'Header field ":path" must only have a single value' });
+    } finally {
+      close();
+    }
+  });
+
+  it("respond() applies the single-value rule per slot of the list", async () => {
+    let row;
+    let respondError;
+    const { client, close } = await peers(stream => {
+      try {
+        stream.respond([":status", "200", ...row.pairs], { sendDate: false });
+      } catch (err) {
+        respondError = describeError(err);
+        stream.respond({ ":status": 200, "x-threw": "1" });
+      }
+      stream.end();
+    });
+    try {
+      const outcomes = [];
+      for (row of singleValueRows) {
+        respondError = undefined;
+        const { headers, rawHeaders } = await exchange(client.request({ ":path": "/" }));
+        outcomes.push(headers["x-threw"] ? respondError : contentTypeValues(rawHeaders));
+      }
+      expect(outcomes).toEqual(singleValueRows.map(r => r.outcome));
     } finally {
       close();
     }
@@ -4311,7 +4359,6 @@ describe("http2 raw-headers arrays with array values", () => {
     ["that is null", null],
   ]) {
     it(`request() and respond() reject an array element ${label}`, async () => {
-      const describeError = err => ({ name: err.constructor.name, code: err.code, message: err.message });
       const invalidValue = {
         name: "TypeError",
         code: "ERR_HTTP2_INVALID_HEADER_VALUE",


### PR DESCRIPTION
### Problem
- `session.request()` and `stream.respond()` accept headers as a flat `[name, value, name, value, ...]` list. An array in a value slot goes out as one field joined with `,`: `respond([":status", "200", "set-cookie", ["a=1", "b=2"]])` sends `set-cookie: a=1,b=2` and the client stores one broken cookie. Node sends one field per element, and bun's object form (`{ "set-cookie": [...] }`) already does too.
- Cause: the native encoder walks the object form and the flat form separately. The object walk has an array branch; the flat walk stringified the value slot as is, so an array went through `Array.prototype.toString`.
- Second defect: deriving `sentHeaders` from the flat list pushes a later duplicate of a name into the caller's array, and that array is what then gets encoded. With only the encoder fixed, `["x", ["a"], "x", "b"]` would send `a`, `b`, `b`.

### Fix
- The flat walk gets the array handling the object walk and `pushStream()` (#37579) already have: one field per element, each element validated on its own, never-index applied to each, an empty array sends nothing. For a single-value header, more than one element or a second occurrence of the name throws `ERR_HTTP2_HEADER_SINGLE_VALUE`; an empty array is not an occurrence, as in node.
- `sentHeaders` is built from a copy of each array value, so the caller's list is left alone; the resulting object has the same shape as before.
- The flat walk takes an owned copy of each name before coercing its values: a value's `toString()` can drop the list's reference to the name string, and the name is still used afterwards (the object walk gets its names from the property iterator as ref-holding strings, so it is not affected).
- The JS single-value pre-check (`assertSingleValueHeaders`) now judges the flat list slot by slot, skipping the slots the encoder skips (undefined value, empty array), instead of judging the object derived from it, where a later empty-array slot looked like a second value. `["content-type", "x", "content-type", []]` is accepted in either order, as in node; the object form goes through the same per-field code as before.
- `request()` no longer assumes `:method` holds a string: an array in that slot (`[":method", ["GET"]]`, or `[":method", "GET", ":method", []]`, in either header form) used to throw `TypeError: method.toUpperCase is not a function` before anything was encoded; it is now sent as the method it holds and, as in node, the stream is left open for the caller to end.
- Property to check: a value slot in the flat form now means what a property value means in the object form, because both are encoded by the same native rules. One deliberate difference from node: a `null` element, or one containing CR/LF/NUL, throws `ERR_HTTP2_INVALID_HEADER_VALUE` instead of being stringified, as bun's object form already does. Out of scope: HPACK state after a block is rejected part-way (pre-existing, #33470).
- Verification: nine tests run a real client and server and assert on the header list the peer decoded from the wire, including an eleven-row ordering matrix for the single-value rule run through both `request()` and `respond()`. Eight fail on the current release; all pass with this change. Every expected value was checked against node v26.3.0 (the matrix byte-for-byte), and the existing http2 suites still pass.

### Background
- node:http2 takes headers in two forms: an object, where an array value means the field is sent once per element, and a flat `[name, value, ...]` list, which sends fields in the order given and is the only form in which a name can legitimately appear twice. `request()` and `respond()` accept both.
- The JS layer validates and keeps bookkeeping; the header block itself is built natively (`H2FrameParser`), which walks the headers, applies the per-field rules and HPACK-encodes each field. HPACK is stateful per connection, so a block rejected half-way leaves the encoder out of step with the peer.
- Single-value fields: node refuses to send certain fields more than once (`content-type`, every pseudo-header such as `:path`); `strictSingleValueFields: false` disables the rule. Bun checks it in JS before encoding anything (so a violation cannot leave HPACK half-updated) and the native walk applies the same rule again while encoding; the two have to agree on what counts as an occurrence.
- Never-index: names listed under `http2.sensitiveHeaders` are encoded so the peer must not add them to its HPACK table. The receiver reports one entry per field that arrived this way, so a test can see the flag reached every element.
- `sentHeaders`: the object a stream exposes afterwards describing what it sent. For the flat form it is derived by collapsing the list into an object, with repeated names accumulated into an array.

<details>
<summary>Original description</summary>

## Repro

```js
const http2 = require("node:http2");
const server = http2.createServer();
server.on("stream", (stream, headers, flags, rawHeaders) => {
  console.log(JSON.stringify(rawHeaders.filter((_, i, a) => a[i - (i % 2)] === "x-v")));
  stream.respond({ ":status": 200 });
  stream.end();
});
server.listen(0, "127.0.0.1", () => {
  const client = http2.connect("http://127.0.0.1:" + server.address().port);
  const req = client.request([":path", "/", "x-v", ["ra", "rb"]]);
  req.on("close", () => { client.close(); server.close(); });
  req.resume(); req.end();
});
```

| | fields received for `x-v` |
| --- | --- |
| node v26.3.0 | `["x-v","ra","x-v","rb"]` |
| bun 1.4.0 / main | `["x-v","ra,rb"]` |
| this PR | `["x-v","ra","x-v","rb"]` |

`stream.respond()` with the same header list form has the same problem, which is where it matters most: `respond([":status", "200", "set-cookie", ["a=1", "b=2"]])` sends one `set-cookie` field containing `a=1,b=2`, so the client stores one broken cookie. The object form, `request({ "x-v": ["ra", "rb"] })`, already sends two fields on both runtimes; only the raw `[name, value, ...]` form is affected.

## Cause

`H2FrameParser::request()` in `h2_frame_parser.rs` is the encoder behind `session.request()` and `stream.respond()`. It has two walks over the header block. The object walk has an array branch that encodes one field per element; the raw-pairs walk called `to_js_string()` on the value slot directly, so an array went through `Array.prototype.toString` and was sent as one field joined with `","`. In node both forms go through the same `processHeader` in `buildNgHeaderString`, which emits one field per element either way.

There is a second, related defect in the JS layer. `request()` and `respond()` derive the object that backs `sentHeaders` from the raw list by storing each value and appending later duplicates of the name into it. When the first value slot for a name is itself an array, the duplicate is appended into the caller's array, and that array is also what the encoder reads afterwards. With the encoder fixed on its own, `["x", ["a"], "x", "b"]` would be sent as `a`, `b`, `b`. (On main it shows up as `a,b` followed by `b`.) Node's `sentHeaders` getter has the same accumulation, but node encodes the block synchronously inside the call and builds `sentHeaders` lazily afterwards, so nothing it does to the arrays can reach the wire.

## Fix

- `src/runtime/api/bun/h2_frame_parser.rs`: the raw-pairs walk gets the value handling the object walk and `push_promise()` (#37579) already have. An array value sends one field per element, each element is validated like a single value, the never-index flag applies to every element, and the single-value rule is applied to the array as a whole (more than one element, or a second occurrence of the field, is `ERR_HTTP2_HEADER_SINGLE_VALUE`). An empty array sends nothing and, as in node, does not count as an occurrence of the field, so `["content-type", [], "content-type", "x"]` sends one field instead of failing. That last rule only matters in this walk, because the raw form is the one place a name can legitimately repeat; in the object walk and `push_promise()` a repeated name never gets past the JS pre-check, so their array branches are left as they are. Scalar values take the same path as before.
- `src/js/node/http2.ts`: the `sentHeaders` derivation shared by `request()` and `respond()` is now `rawHeadersToObject()`, which copies an array value before accumulating into it. The resulting object has the same shape as before (and as node: `[":path", ["/x"]]` still shows up as `":path": ["/x"]`, `["x", "a", "x", ["b", "c"]]` as `["a", ["b", "c"]]`); the caller's arrays are simply left alone. `assertSingleValueHeaders()` accepts the raw list as well and judges it slot by slot (skipping the slots the encoder skips: undefined values and empty arrays), so `request()` and `respond()` check the list they are about to encode instead of the object derived from it, where a later empty-array slot showed up as a second element; the object form goes through the same per-field code as before.

Why this is the right shape: the raw form exists to put a caller-supplied list of fields on the wire in order, and in node a value slot accepts exactly what an object property accepts (both forms feed the same `processHeader`), so the two forms must not disagree about what a value means. Keeping that decision in the native encoder (rather than flattening the list in JS) keeps one definition of how a value is encoded for every entry point, which is how the object form and `pushStream()` already work.

Checked against node v26.3.0 with the same scenarios the tests use (`request()` on a connected and on a still-connecting session, `respond()`, `sentHeaders`, the never-index list the peer reports, the single-value cases, `strictSingleValueFields: false`); the fixed build produces the same results as node in every case except the one deliberate difference below.

Deliberate difference from node: a `null`/`undefined` element, or one containing CR/LF/NUL, throws `ERR_HTTP2_INVALID_HEADER_VALUE` from the call. Node stringifies such elements. This is the rule the encoder already applies to array elements in the object form (`request({ "x": ["ok", null] })` throws the same error today; `respond()`'s object form additionally drops CR/LF/NUL values in JS before encoding, a pre-existing filter that the raw form has never had for scalar values either), and what #37579 chose for `pushStream()`, so the raw form now matches the rest of bun.

Not changed here: a block that fails validation natively after some of its fields were encoded still leaves the session's HPACK encoder ahead of the peer. That is pre-existing for scalar values too and is what #33470 addresses; this change keeps the loop shape so that PR rebases mechanically. #37568 (coerce values in JS before taking a stream id) currently stringifies an array slot of the raw form in `toWireHeaders()`, which would reintroduce the join once both land; its raw branch needs the same element-wise copy its object branch does (noted on that PR).

## Verification

Nine tests added to `test/js/node/http2/node-http2.test.js` (`http2 raw-headers arrays with array values`), all asserting on the flat header list the peer decoded from the wire:

- `request()` on a connected session and on a connecting one (queued request): multi-element, numeric, single-element and empty arrays, an array in a pseudo-header slot, array-then-scalar and scalar-then-array duplicates, every element of a `[http2.sensitiveHeaders]` field arriving never-indexed, the caller's arrays unmodified, and the full `sentHeaders` object.
- `respond()`: `set-cookie` arriving as two fields, the received object form, `sentHeaders`, the caller's array unmodified.
- The single-value rule, as an eleven-row matrix run through both `request()` and `respond()`: five violating shapes (multi-element array, array-then-scalar, scalar-then-array, scalar-then-null, case-variant duplicate) throw `ERR_HTTP2_HEADER_SINGLE_VALUE` synchronously, and six accepted orderings (`[]` before or after the value, `[x]` then `[]`, `[]`, `[]` then `x`, `undefined` then `x`, case-variant name then `[]`) each send exactly one field; plus a pseudo-header array throwing from `request()`. Every row produces the same result as node v26.3.0, compared byte for byte.
- An array in the `:method` slot (one element; value followed by `[]`; and the object form) sends that method and leaves the stream open, next to a plain-string control row that is auto-ended.
- `strictSingleValueFields: false` sends each element in both directions.
- An element containing LF, and a `null` element, are rejected by both `request()` and `respond()` with `ERR_HTTP2_INVALID_HEADER_VALUE` and nothing reaches the peer.

Eight of the nine fail on the current release (`USE_SYSTEM_BUN=1`; the LF case already threw because the joined string contained the LF) and all pass with this change. The rest of `node-http2.test.js` (366 tests), `h2-conformance.test.ts`, and the ported `test-http2-raw-headers.js`, `test-http2-raw-headers-defaults.js`, `test-http2-sent-headers.js`, `test-http2-sensitive-headers.js`, `test-http2-multiheaders.js`, `test-http2-single-headers-validation-disabled.js`, `test-http2-cookies.js` and the header validation tests pass with the debug build.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 10 failed, 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (07414d2a7)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [1158.62ms]
(pass) node none > Client Basics > should be able to send a POST request [808.37ms]
(pass) node none > Client Basics > constants [31.19ms]
(pass) node none > Client Basics > getDefaultSettings [11.54ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [30.14ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [7.81ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [4.63ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [6.34ms]
(pass) node none > Client Basics > should be able to send data using end [867.73ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [854.94ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receivin
... (truncated)

release without fix: 18 failed, 6 skipped
bun test v1.4.0-canary.1 (da3851e57)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > constants [0.92ms]
(pass) node none > Client Basics > getDefaultSettings [0.16ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [0.55ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [0.11ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [0.04ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [0.07ms]
(pass) node none > Client Basics > is possible to abort request [2.82ms]
(pass) node none > Client Basics > aborted event should work with abortController [1.07ms]
(pass) node none > Client Basics > aborted event should work with aborted signal [1.05ms]
(pass) node none > Client Basics > signal validation matches node: non-signal objects throw, duck-typed { aborted } is accepted [1.73ms]
(pass) node none > Client Basics > headers cannot be bigger than 65536 bytes [56.31ms]
(skip) node none > Client Basics > should not leak memory
(pass) node none > Client Basics > should fail to con
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 6 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/node-http2.test.js"
bun test v1.4.0 (07414d2a7)

test/js/node/http2/node-http2.test.js:
(pass) node none > Client Basics > should be able to send a GET request [981.72ms]
(pass) node none > Client Basics > should be able to send a POST request [656.02ms]
(pass) node none > Client Basics > constants [19.17ms]
(pass) node none > Client Basics > getDefaultSettings [7.33ms]
(pass) node none > Client Basics > getPackedSettings/getUnpackedSettings [22.53ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is too small [5.23ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a multiple of 6 bytes [3.16ms]
(pass) node none > Client Basics > getUnpackedSettings should throw if buffer is not a buffer [4.98ms]
(pass) node none > Client Basics > should be able to send data using end [681.12ms]
(pass) node none > Client Basics > should be able to mutiplex GET requests [672.82ms]
(pass) node none > Client Basics > http2 should receive remoteSettings when receiving 
... (truncated)

release with fix: 6 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 840ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/103] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/103] gen cpp.rs (cppbind)
[3/103] gen JS modules (bundle-modules)
Preprocess modules (9470ms)
Bundle modules (67ms)
Postprocesss modules (218ms)
Bundle Functions (804ms)
Generate Code (39ms)

[10.62s] Bundled "src/js" for production
  2625 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[3/98] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

^[[1m^[[92m   Compiling^[[0m bun_simdutf_sys v0.0.0 (/workspace/bun/src/simdutf_sys)
^[[1m^[[92m   Compiling^[[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
^[[1m^[[92m   Compiling^[[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
^[[1m^[[92m   Compiling^[[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
^[[1m^[[92m   Compiling^[[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/http2.ts                   |  85 +++++----
 src/runtime/api/bun/h2_frame_parser.rs | 125 +++++++-----
 test/js/node/http2/node-http2.test.js  | 340 +++++++++++++++++++++++++++++++++
 3 files changed, 470 insertions(+), 80 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                                    reads  edits  tests
src/js/node/http2.ts                       11     11      0
src/runtime/api/bun/h2_frame_parser.rs      5      6      0
test/js/node/http2/node-http2.test.js       7      9      0
```

</details>

**root cause** · written by the author bot

The raw flat array header path in the native request encoder, which also serves respond(), converted each value slot straight to a string, so an array value was stringified into a single comma-joined field instead of one field per element as the object form and node already produce. The fix makes that walk compute the number of fields a slot will emit once (none for an empty array, the array length, or one for a scalar), skip empty arrays, apply the single-value header check against that count, and convert, validate and HPACK-encode each element as its own field. The JavaScript side now als…

<!-- robobun:evidence:end -->
