### PR TITLE
Read array index accessors in deepEquals instead of treating them as holes

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -647,7 +647,7 @@ static bool canPerformFastPropertyEnumerationForIterationBun(Structure* s)
 }
 
 // The empty JSValue means a hole. jest only sees enumerable indexes; node's
-// deepStrictEqual reads every own index with a[i].
+// deepStrictEqual reads indexes with a[i], enumerable or not.
 template<bool includeNonEnumerable>
 static JSValue getOwnIndexForDeepEquals(JSGlobalObject* globalObject, ThrowScope& scope, JSObject* obj, uint64_t i)
 {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -646,20 +646,29 @@ static bool canPerformFastPropertyEnumerationForIterationBun(Structure* s)
     return true;
 }
 
-JSValue getIndexWithoutAccessors(JSGlobalObject* globalObject, JSObject* obj, uint64_t i)
+// Reads one array index for the deep-equality walk; the empty JSValue means a hole.
+// Getters run, as they do for named properties. jest only sees own enumerable
+// indexes (for..in), node's deepStrictEqual sees every own index (hasOwnProperty +
+// a[i]), so a non-enumerable index is a hole unless the node entry point is asking.
+template<bool includeNonEnumerable>
+static JSValue getOwnIndexForDeepEquals(JSGlobalObject* globalObject, ThrowScope& scope, JSObject* obj, uint64_t i)
 {
     if (obj->canGetIndexQuickly(i)) {
         return obj->tryGetIndexQuickly(i);
     }
 
     PropertySlot slot(obj, PropertySlot::InternalMethodType::Get);
-    if (obj->methodTable()->getOwnPropertySlotByIndex(obj, globalObject, i, slot)) {
-        if (!slot.isAccessor()) {
-            return slot.getValue(globalObject, i);
+    bool hasIndex = obj->methodTable()->getOwnPropertySlotByIndex(obj, globalObject, i, slot);
+    RETURN_IF_EXCEPTION(scope, {});
+    if (!hasIndex) {
+        return {};
+    }
+    if constexpr (!includeNonEnumerable) {
+        if (slot.attributes() & PropertyAttribute::DontEnum) {
+            return {};
         }
     }
-
-    return JSValue();
+    return slot.getValue(globalObject, i);
 }
 
 template<bool isStrict, bool enableAsymmetricMatchers, bool checkPrototypes, bool skipPrototypeIdentity = false>
@@ -862,9 +871,9 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
 
         uint64_t i = 0;
         for (; i < array1Length; i++) {
-            JSValue left = getIndexWithoutAccessors(globalObject, o1, i);
+            JSValue left = getOwnIndexForDeepEquals<checkPrototypes>(globalObject, scope, o1, i);
             RETURN_IF_EXCEPTION(scope, false);
-            JSValue right = getIndexWithoutAccessors(globalObject, o2, i);
+            JSValue right = getOwnIndexForDeepEquals<checkPrototypes>(globalObject, scope, o2, i);
             RETURN_IF_EXCEPTION(scope, false);
 
             if constexpr (isStrict) {
@@ -888,7 +897,7 @@ bool Bun__deepEquals(JSC::JSGlobalObject* globalObject, JSValue v1, JSValue v2, 
         }
 
         for (; i < array2Length; i++) {
-            JSValue right = getIndexWithoutAccessors(globalObject, o2, i);
+            JSValue right = getOwnIndexForDeepEquals<checkPrototypes>(globalObject, scope, o2, i);
             RETURN_IF_EXCEPTION(scope, false);
 
             if (((right.isEmpty() || right.isUndefined()))) {

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -646,10 +646,8 @@ static bool canPerformFastPropertyEnumerationForIterationBun(Structure* s)
     return true;
 }
 
-// Reads one array index for the deep-equality walk; the empty JSValue means a hole.
-// Getters run, as they do for named properties. jest only sees own enumerable
-// indexes (for..in), node's deepStrictEqual sees every own index (hasOwnProperty +
-// a[i]), so a non-enumerable index is a hole unless the node entry point is asking.
+// The empty JSValue means a hole. jest only sees enumerable indexes; node's
+// deepStrictEqual reads every own index with a[i].
 template<bool includeNonEnumerable>
 static JSValue getOwnIndexForDeepEquals(JSGlobalObject* globalObject, ThrowScope& scope, JSObject* obj, uint64_t i)
 {

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -131,6 +131,62 @@ describe("Bun.deepEquals strict mode", () => {
   });
 });
 
+describe.each([true, false])("Bun.deepEquals(a, b, strict: %p) and array index accessors", strict => {
+  const deepEquals = (a: unknown, b: unknown) => Bun.deepEquals(a, b, strict);
+
+  function withIndexGetter(get: () => unknown, enumerable = true) {
+    const array: unknown[] = [1, 2];
+    Object.defineProperty(array, 1, { get, enumerable, configurable: true });
+    return array;
+  }
+
+  it("compares an enumerable index getter by the value it returns", () => {
+    const got = withIndexGetter(() => "got");
+    const gotToo = withIndexGetter(() => "got");
+    const other = withIndexGetter(() => "other");
+    expect(deepEquals(got, [1, "got"])).toBe(true);
+    expect(deepEquals([1, "got"], got)).toBe(true);
+    expect(deepEquals(got, gotToo)).toBe(true);
+    expect(deepEquals(got, [1, 2])).toBe(false);
+    expect(deepEquals(got, other)).toBe(false);
+    expect(deepEquals(got, [1, ,])).toBe(false);
+  });
+
+  it("runs each side's getter once", () => {
+    const calls = { left: 0, right: 0 };
+    const left = withIndexGetter(() => (calls.left++, "got"));
+    const right = withIndexGetter(() => (calls.right++, "got"));
+    expect(deepEquals(left, right)).toBe(true);
+    expect(calls).toEqual({ left: 1, right: 1 });
+  });
+
+  it("propagates a throwing getter", () => {
+    const throwing = withIndexGetter(() => {
+      throw new Error("index getter threw");
+    });
+    expect(() => deepEquals(throwing, [1, 2])).toThrow("index getter threw");
+    expect(() => deepEquals([1, 2], throwing)).toThrow("index getter threw");
+  });
+
+  it("ignores non-enumerable indexes, accessor or data", () => {
+    const hiddenGetter = withIndexGetter(() => 2, false);
+    expect(deepEquals(hiddenGetter, [1, 2])).toBe(false);
+    expect(deepEquals(hiddenGetter, [1, ,])).toBe(true);
+
+    const hiddenData: unknown[] = [1, 2];
+    Object.defineProperty(hiddenData, 1, { enumerable: false });
+    expect(deepEquals(hiddenData, [1, 2])).toBe(false);
+    expect(deepEquals([1, 2], hiddenData)).toBe(false);
+    expect(deepEquals(hiddenData, [1, ,])).toBe(true);
+    expect(deepEquals([1, ,], hiddenData)).toBe(true);
+  });
+
+  it("still reads the elements of a frozen array", () => {
+    expect(deepEquals(Object.freeze([1, { a: 2 }]), [1, { a: 2 }])).toBe(true);
+    expect(deepEquals(Object.freeze([1, 2]), [1, 3])).toBe(false);
+  });
+});
+
 // The object fast path used to recurse into nested values while walking the
 // structure's PropertyTable; a getter on a nested object that added or removed
 // properties on the parent rehashed that table and freed the vector being

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -168,6 +168,29 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p) and array index a
     expect(() => deepEquals([1, 2], throwing)).toThrow("index getter threw");
   });
 
+  // Strict mode rejects on length first. Loose mode walks the longer array's extra indexes
+  // and tolerates undefined there, as it does for ["asdf"] vs ["asdf", undefined] above.
+  it("reads a getter past the end of the shorter array", () => {
+    let calls = 0;
+    const longer = withIndexGetter(() => (calls++, "got"));
+    expect(deepEquals([1], longer)).toBe(false);
+    expect(calls).toBe(strict ? 0 : 1);
+
+    const returnsUndefined = withIndexGetter(() => undefined);
+    const hidden = withIndexGetter(() => 2, false);
+    expect(deepEquals([1], returnsUndefined)).toBe(!strict);
+    expect(deepEquals([1], hidden)).toBe(!strict);
+
+    const throwing = withIndexGetter(() => {
+      throw new Error("index getter threw");
+    });
+    if (strict) {
+      expect(deepEquals([1], throwing)).toBe(false);
+    } else {
+      expect(() => deepEquals([1], throwing)).toThrow("index getter threw");
+    }
+  });
+
   it("ignores non-enumerable indexes, accessor or data", () => {
     const hiddenGetter = withIndexGetter(() => 2, false);
     expect(deepEquals(hiddenGetter, [1, 2])).toBe(false);

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -542,6 +542,82 @@ describe("expect()", () => {
     }
   });
 
+  describe("deepEquals reads enumerable index accessors on arrays", () => {
+    /** `[1, <getter>]` where the getter at index 1 returns `value`. */
+    const withIndexGetter = (/** @type {unknown} */ value, { enumerable = true } = {}) => {
+      /** @type {any[]} */
+      const array = [1, 2];
+      Object.defineProperty(array, 1, { get: () => value, enumerable, configurable: true });
+      return array;
+    };
+
+    test("the getter's value is compared, on either side", () => {
+      expect(withIndexGetter("got")).toEqual([1, "got"]);
+      expect(withIndexGetter("got")).toStrictEqual([1, "got"]);
+      expect([1, "got"]).toEqual(withIndexGetter("got"));
+      expect([1, "got"]).toStrictEqual(withIndexGetter("got"));
+      expect(withIndexGetter({ a: 1 })).toEqual([1, { a: 1 }]);
+      expect(withIndexGetter({ a: 1 })).toStrictEqual([1, { a: 1 }]);
+      expect(withIndexGetter("got")).toEqual(withIndexGetter("got"));
+      expect(withIndexGetter("got")).toStrictEqual(withIndexGetter("got"));
+
+      expect(withIndexGetter("got")).not.toEqual([1, 2]);
+      expect(withIndexGetter("got")).not.toStrictEqual([1, 2]);
+      expect([1, 2]).not.toEqual(withIndexGetter("got"));
+      expect([1, 2]).not.toStrictEqual(withIndexGetter("got"));
+      expect(withIndexGetter("got")).not.toEqual(withIndexGetter("other"));
+      expect(withIndexGetter("got")).not.toStrictEqual(withIndexGetter("other"));
+      expect(withIndexGetter("got")).not.toEqual([1, ,]);
+      expect(withIndexGetter("got")).not.toStrictEqual([1, ,]);
+    });
+
+    test("an accessor is not a hole even when the getter returns undefined", () => {
+      expect(withIndexGetter(undefined)).toEqual([1, undefined]);
+      expect(withIndexGetter(undefined)).toStrictEqual([1, undefined]);
+      expect(withIndexGetter(undefined)).toEqual([1, ,]);
+      expect(withIndexGetter(undefined)).not.toStrictEqual([1, ,]);
+    });
+
+    test("a throwing getter propagates instead of the index passing as a hole", () => {
+      /** @type {any[]} */
+      const throwing = [1, 2];
+      Object.defineProperty(throwing, 1, {
+        get() {
+          throw new Error("index getter threw");
+        },
+        enumerable: true,
+      });
+      expect(() => expect(throwing).toEqual([1, ,])).toThrow("index getter threw");
+      expect(() => expect([1, ,]).toEqual(throwing)).toThrow("index getter threw");
+    });
+
+    test("non-enumerable indexes are skipped like non-enumerable named properties", () => {
+      expect(withIndexGetter("got", { enumerable: false })).not.toEqual([1, "got"]);
+      expect(withIndexGetter("got", { enumerable: false })).not.toStrictEqual([1, "got"]);
+      expect(withIndexGetter("got", { enumerable: false })).toEqual([1, ,]);
+      expect(withIndexGetter("got", { enumerable: false })).toStrictEqual([1, ,]);
+
+      /** @type {any[]} */
+      const hiddenData = [1, 2];
+      Object.defineProperty(hiddenData, 1, { enumerable: false });
+      expect(hiddenData).not.toEqual([1, 2]);
+      expect(hiddenData).not.toStrictEqual([1, 2]);
+      expect([1, 2]).not.toEqual(hiddenData);
+      expect([1, 2]).not.toStrictEqual(hiddenData);
+      expect(hiddenData).toEqual([1, ,]);
+      expect(hiddenData).toStrictEqual([1, ,]);
+      expect(hiddenData).toEqual([1, undefined]);
+      expect(hiddenData).not.toStrictEqual([1, undefined]);
+    });
+
+    test("frozen arrays still compare by value", () => {
+      expect(Object.freeze([1, { a: 2 }])).toEqual([1, { a: 2 }]);
+      expect(Object.freeze([1, { a: 2 }])).toStrictEqual([1, { a: 2 }]);
+      expect(Object.freeze([1, 2])).not.toEqual([1, 3]);
+      expect(Object.freeze([1, 2])).not.toStrictEqual([1, 3]);
+    });
+  });
+
   test("deepEquals bugfix #11370", () => {
     // Two objects with equal number of properties, but left object has
     // undefined keys and right object has keys that don't exist

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -569,6 +569,9 @@ describe("expect()", () => {
       expect(withIndexGetter("got")).not.toStrictEqual(withIndexGetter("other"));
       expect(withIndexGetter("got")).not.toEqual([1, ,]);
       expect(withIndexGetter("got")).not.toStrictEqual([1, ,]);
+      // The getter sits past the end of the shorter array.
+      expect([1]).not.toEqual(withIndexGetter("got"));
+      expect([1]).not.toStrictEqual(withIndexGetter("got"));
     });
 
     test("an accessor is not a hole even when the getter returns undefined", () => {

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -59,6 +59,13 @@ function withExtraProperty<T extends object>(value: T): T {
   return Object.assign(value, { extra: 1 });
 }
 
+/** `[1, <getter>]`: index 1 is an accessor property backed by `get`. */
+function withIndexGetter(get: () => unknown, enumerable = true) {
+  const array: unknown[] = [1, 2];
+  Object.defineProperty(array, 1, { get, enumerable, configurable: true });
+  return array;
+}
+
 function selfReferencingObject() {
   const object: Record<string, unknown> = {};
   object.self = object;
@@ -593,6 +600,35 @@ const cases: Case[] = [
   },
   { name: "arrays of different length", a: () => [1, 2], b: () => [1], strict: false, loose: false },
   { name: "'a' and ['a']", a: () => "a", b: () => ["a"], strict: false, loose: false },
+  // Index accessors are read through their getter, like named ones.
+  {
+    name: "an array with an index getter and a plain array",
+    a: () => withIndexGetter(() => 2),
+    b: () => [1, 2],
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "a plain array and an array with an index getter",
+    a: () => [1, 2],
+    b: () => withIndexGetter(() => 2),
+    strict: true,
+    loose: true,
+  },
+  {
+    name: "arrays whose index getters return different values",
+    a: () => withIndexGetter(() => 2),
+    b: () => withIndexGetter(() => 3),
+    strict: false,
+    loose: false,
+  },
+  {
+    name: "an array with an index getter and a sparse array",
+    a: () => withIndexGetter(() => 2),
+    b: () => [1, ,],
+    strict: false,
+    loose: false,
+  },
 
   // Cycles.
   {
@@ -706,6 +742,35 @@ describe("util.isDeepStrictEqual", () => {
     };
     expect(util.isDeepStrictEqual(make(), make())).toBe(true);
     expect(calls).toBe(2);
+  });
+
+  test("reads an array's index getter once per side", () => {
+    const calls = { a: 0, b: 0 };
+    const a = withIndexGetter(() => (calls.a++, 2));
+    const b = withIndexGetter(() => (calls.b++, 2));
+    expect(util.isDeepStrictEqual(a, b)).toBe(true);
+    expect(calls).toEqual({ a: 1, b: 1 });
+  });
+
+  // node reads the dense part of an array with a[i], which does not care about
+  // enumerability; jest-style comparisons (expect, Bun.deepEquals) skip these.
+  test("reads a non-enumerable index getter too, like node's a[i]", () => {
+    const hiddenTwo = withIndexGetter(() => 2, false);
+    const hiddenThree = withIndexGetter(() => 3, false);
+    expect(util.isDeepStrictEqual(hiddenTwo, [1, 2])).toBe(true);
+    expect(util.isDeepStrictEqual(hiddenThree, [1, 2])).toBe(false);
+    expect(util.isDeepStrictEqual(hiddenTwo, [1, ,])).toBe(false);
+    expect(() => assert.deepStrictEqual(hiddenTwo, [1, 2])).not.toThrow();
+  });
+
+  test("propagates an index getter that throws", () => {
+    const throwing = withIndexGetter(() => {
+      throw new Error("index getter threw");
+    });
+    expect(() => util.isDeepStrictEqual(throwing, [1, 2])).toThrow("index getter threw");
+    expect(() => util.isDeepStrictEqual([1, 2], throwing)).toThrow("index getter threw");
+    expect(() => assert.deepStrictEqual(throwing, [1, 2])).toThrow("index getter threw");
+    expect(() => assert.deepEqual(throwing, [1, 2])).toThrow("index getter threw");
   });
 
   // The third argument was added in Node v26.

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -636,9 +636,16 @@ const cases: Case[] = [
     strict: false,
     loose: false,
   },
-  // node reads indexes with a[i], so enumerability does not matter to it. Strict mode has
-  // its own entry point and does the same; assert.deepEqual is Bun.deepEquals, which like
-  // jest only sees enumerable indexes.
+  {
+    name: "a shorter array and an array whose extra index is a getter",
+    a: () => [1],
+    b: () => withIndexGetter(() => 2),
+    strict: false,
+    loose: false,
+  },
+  // node reads dense indexes with a[i], enumerable or not. Strict mode has its own entry
+  // point and does the same; assert.deepEqual is Bun.deepEquals, which like jest only sees
+  // enumerable indexes.
   {
     name: "an array with a non-enumerable index getter and a plain array",
     a: () => withIndexGetter(() => 2, false),
@@ -770,6 +777,7 @@ describe("util.isDeepStrictEqual", () => {
     expect(calls).toBe(2);
   });
 
+  // Like the symbol test above, the count is Bun's own guarantee; node reads a[i] more than once.
   test("reads an array's index getter once per side", () => {
     const calls = { a: 0, b: 0 };
     const a = withIndexGetter(() => (calls.a++, 2));
@@ -783,7 +791,7 @@ describe("util.isDeepStrictEqual", () => {
     const hiddenThree = withIndexGetter(() => 3, false);
     expect(util.isDeepStrictEqual(hiddenTwo, [1, 2])).toBe(true);
     expect(util.isDeepStrictEqual(hiddenThree, [1, 2])).toBe(false);
-    expect(util.isDeepStrictEqual(hiddenTwo, [1, ,])).toBe(false);
+    expect(util.isDeepStrictEqual([1, ,], hiddenTwo)).toBe(false);
   });
 
   test("propagates an index getter that throws", () => {

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -66,6 +66,13 @@ function withIndexGetter(get: () => unknown, enumerable = true) {
   return array;
 }
 
+/** `[1, 2]` whose index 1 is a non-enumerable data property. */
+function withNonEnumerableIndex() {
+  const array = [1, 2];
+  Object.defineProperty(array, 1, { enumerable: false });
+  return array;
+}
+
 function selfReferencingObject() {
   const object: Record<string, unknown> = {};
   object.self = object;
@@ -629,6 +636,25 @@ const cases: Case[] = [
     strict: false,
     loose: false,
   },
+  // node reads indexes with a[i], so enumerability does not matter to it. Strict mode has
+  // its own entry point and does the same; assert.deepEqual is Bun.deepEquals, which like
+  // jest only sees enumerable indexes.
+  {
+    name: "an array with a non-enumerable index getter and a plain array",
+    a: () => withIndexGetter(() => 2, false),
+    b: () => [1, 2],
+    strict: true,
+    loose: true,
+    looseBug: "reports not equal",
+  },
+  {
+    name: "an array with a non-enumerable index and a plain array",
+    a: withNonEnumerableIndex,
+    b: () => [1, 2],
+    strict: true,
+    loose: true,
+    looseBug: "reports not equal",
+  },
 
   // Cycles.
   {
@@ -752,15 +778,12 @@ describe("util.isDeepStrictEqual", () => {
     expect(calls).toEqual({ a: 1, b: 1 });
   });
 
-  // node reads the dense part of an array with a[i], which does not care about
-  // enumerability; jest-style comparisons (expect, Bun.deepEquals) skip these.
-  test("reads a non-enumerable index getter too, like node's a[i]", () => {
+  test("compares a non-enumerable index getter by its value, like node's a[i]", () => {
     const hiddenTwo = withIndexGetter(() => 2, false);
     const hiddenThree = withIndexGetter(() => 3, false);
     expect(util.isDeepStrictEqual(hiddenTwo, [1, 2])).toBe(true);
     expect(util.isDeepStrictEqual(hiddenThree, [1, 2])).toBe(false);
     expect(util.isDeepStrictEqual(hiddenTwo, [1, ,])).toBe(false);
-    expect(() => assert.deepStrictEqual(hiddenTwo, [1, 2])).not.toThrow();
   });
 
   test("propagates an index getter that throws", () => {


### PR DESCRIPTION
### Problem
- `expect(a).toEqual(...)`, `toStrictEqual`, `Bun.deepEquals` and `assert.deepStrictEqual` reject an array whose element is an enumerable getter, even when the getter returns the expected value. Jest and node accept it, and the same getter on a plain object already works in Bun.
- The other direction is worse: the getter index counted as a hole, so `[1, getter]` equalled `[1, ,]`, two arrays whose getters return different values compared equal, and a throwing getter was never called.
- The failure message showed two identical arrays, because the formatter does run the getter.
- Cause: the array comparison reported any index backed by an accessor as a hole. That came from the frozen-array fix (#2557), whose tests only used non-enumerable accessors, so skipping all of them went unnoticed.

### Fix
- The array element read now runs the getter, and decides what is a hole by enumerability instead of by accessor-ness. A getter that throws propagates through the existing exception checks at the call sites.
- Property to check: an index is now treated the same as a named property on the same entry point. `expect` and `Bun.deepEquals` see own enumerable indexes, as jest does; the `node:assert` / `node:util` strict entry point reads every own index, as node's `a[i]` does. Holes and frozen arrays behave as before.
- Two node differences remain and are pinned in the tests: loose `assert.deepEqual` runs through `Bun.deepEquals`, so it now skips a non-enumerable index data property that node compares; a non-enumerable index getter against a sparse array still differs from node in one operand order.
- Verification: new tests in the expect, `Bun.deepEquals` and `node:assert` suites; 4, 9 and 19 of them fail on the released bun and all pass with the fix. Node expectations were checked against node v26.3.0.

### Background
- An array index can be an accessor property (`Object.defineProperty(a, 1, { get })`) rather than a stored value; reading `a[1]` runs the getter. Like any property it can also be non-enumerable, which `for..in`, and therefore jest, skips.
- A hole is an index with no own property at all (`[1, ,]`). Bun's comparison represents it as the empty `JSValue`; loose mode treats a hole and `undefined` as equal, strict mode does not.
- One deep-equals routine backs `expect`, `Bun.deepEquals` and `node:assert`. Its `checkPrototypes` template flag is set only on the node strict entry point, and this PR reuses that flag to choose which indexes to read.
- `canGetIndexQuickly` is JSC's fast path for dense arrays of plain values. Accessors, sparse arrays and frozen arrays miss it and go through `getOwnPropertySlotByIndex`, which is the path this change alters.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/bun-object/deep-equals.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

```ts
const a = [1, 2];
Object.defineProperty(a, 1, { get: () => "got", enumerable: true, configurable: true });

expect(a).toEqual([1, "got"]);           // fails
expect(a).toStrictEqual([1, "got"]);     // fails
Bun.deepEquals(a, [1, "got"]);           // false
assert.deepStrictEqual(a, [1, "got"]);   // throws

// the same accessor on a plain object already works
const o = { x: 1 };
Object.defineProperty(o, "y", { get: () => "got", enumerable: true });
expect(o).toEqual({ x: 1, y: "got" });   // passes
```

Jest passes all of the `expect` lines above and node's `assert.deepStrictEqual` / `util.isDeepStrictEqual` accept the array, because both read the element with `a[i]`, which runs the getter. The failure message Bun printed was also confusing: the formatter does run the getter, so the diff showed two identical arrays.

The other direction is worse: because the accessor was treated as a hole, `expect(a).toEqual([1, ,])` passed, two arrays whose getters return different values compared equal, and a getter that throws was never called.

### Cause

The `JSArray` branch of `Bun__deepEquals` in `src/jsc/bindings/bindings.cpp` read elements with `getIndexWithoutAccessors()`, which returned the empty `JSValue` (the hole marker) for any index whose own property is an accessor. Named properties go through `get()` / `getOwnPropertySlot()` + `getValue()`, so objects and arrays disagreed.

The helper came from #2557 (#2417, immer-frozen arrays). That fix needed the `getOwnPropertySlotByIndex` fallback for arrays in sparse/dictionary indexing mode; its tests only used accessors created with `Object.defineProperty` defaults, i.e. non-enumerable ones, which jest ignores. Skipping every accessor happened to satisfy those tests but also dropped enumerable ones.

### Fix

`getIndexWithoutAccessors` is replaced by `getOwnIndexForDeepEquals<includeNonEnumerable>`, which reads the slot with `PropertySlot::getValue()` (running the getter, exception propagated by the existing `RETURN_IF_EXCEPTION` at the call sites) and uses enumerability, not accessor-ness, to decide what is a hole:

- `expect` matchers and `Bun.deepEquals` (`checkPrototypes == false`) see own enumerable indexes only. That is what jest's `equals()` sees (it collects keys with `for..in`), and it is how these entry points already treat named properties (`non-enumerable members should be skipped during equal` in `expect.test.js`). The existing `deepEquals works with accessors` test, whose accessors are non-enumerable, keeps passing for the right reason.
- The `node:assert` / `node:util` entry point (`checkPrototypes == true`) reads every own index, which is what node's `a[i]` loop does, including for non-enumerable getters. This path already compared non-enumerable index data properties, so it now treats data and accessor indexes alike.

One caller is intentionally on the first side of that line: `assert.deepEqual` (loose) is implemented as `Bun.deepEquals(a, b, false)`, so it now ignores a non-enumerable index data property that it used to compare (node compares it). Giving loose `assert.deepEqual` its own node-flavoured entry point is a separate change (the matrix in `deep-equal.test.ts` already documents a number of loose-mode differences from the same cause), so this PR documents the input as two `looseBug` rows instead.

One input where the node path still differs from node: a non-enumerable index getter compared against a sparse array. Node answers true in that order and false with the operands swapped (once the right side has a hole it falls back to comparing `Object.keys`), Bun answers false both ways, as it did for non-enumerable data indexes before this PR. The tests only pin the order node agrees with.

Holes (`canGetIndexQuickly` false and no own property) still come back as the empty `JSValue`, so all of the existing hole semantics are unchanged, and frozen arrays (#2417) still read their values since freezing does not clear enumerable.

### Verification

New tests in `test/js/bun/test/expect.test.js` (`toEqual` / `toStrictEqual`; the file also runs under vitest, where the new block passes unmodified), `test/js/bun/bun-object/deep-equals.test.ts` (both strict modes), and `test/js/node/assert/deep-equal.test.ts` (matrix rows for `deepStrictEqual` / `deepEqual` / `isDeepStrictEqual`, plus the non-enumerable index rows and test, once-per-side getter calls, a throwing getter, and a getter past the end of the shorter array, which is the loose-mode loop this change also touches). The expectations in the node file were checked against node v26.3.0.

```
USE_SYSTEM_BUN=1 bun test test/js/bun/test/expect.test.js              4 fail (the new tests), 416 pass
USE_SYSTEM_BUN=1 bun test test/js/bun/bun-object/deep-equals.test.ts    9 fail,               47 pass
USE_SYSTEM_BUN=1 bun test test/js/node/assert/deep-equal.test.ts       19 fail,              310 pass

bun bd test test/js/bun/test/expect.test.js                            420 pass, 0 fail
bun bd test test/js/bun/bun-object/deep-equals.test.ts                  56 pass, 0 fail
bun bd test test/js/node/assert/deep-equal.test.ts                     330 pass, 0 fail
```

Also green with the fix: `jest-extended.test.js`, `expect-extend.test.js`, `test-test.test.ts`, `spyMatchers.test.ts`, `mock-fn.test.js`, `test/js/node/assert/`, `test/js/node/util/util.test.js`, node's upstream `test-util-isDeepStrictEqual.js` and `test-assert-deep-with-error.js`, and the new tests under `BUN_JSC_validateExceptionChecks=1`.

</details>
