### PR TITLE
threading: take &self in Thread::pop, the worker Thread other threads steal from

### DIFF
--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1033,11 +1033,7 @@ enum WaitError {
 // the compiler is free to reorder fields (the 4-byte `Event` invites it),
 // which profiled ~43% hotter on the steal traversal.
 //
-// From `register` until the worker exits, other threads steal from this struct
-// and push into `idle_queue` through the published pointer, so nothing (the
-// owning worker included) may hold a `&mut Thread`: every method takes `&self`
-// and owner-private state is a `Cell`
-// (test/internal/source-lints/thread-pool-shared-receivers.test.ts).
+// Stolen from by other workers once registered, so every method takes `&self`.
 #[repr(C)]
 pub struct Thread {
     next: *mut Thread,

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1032,12 +1032,11 @@ enum WaitError {
 // `run_queue` header it reads immediately after. With the default `repr(Rust)`
 // the compiler is free to reorder fields (the 4-byte `Event` invites it),
 // which profiled ~43% hotter on the steal traversal.
-//
-// Stolen from by other workers once registered, so every method takes `&self`.
 #[repr(C)]
 pub struct Thread {
     next: *mut Thread,
-    /// Work-stealing cursor into the pool's `threads` stack; owner-private.
+    /// Steal cursor into the pool's `threads` stack. A `Cell` because other
+    /// workers are stealing from this struct while `pop` runs, so `pop` takes `&self`.
     target: Cell<*mut Thread>,
     join_event: Event,
     run_queue: node::Queue,
@@ -1195,7 +1194,7 @@ impl Thread {
         // SAFETY: self_ptr is our stack-local Thread.
         let _registration = unsafe { ThreadRegistration::new(pool, self_ptr) };
 
-        // Published now, so our own view is shared too (see the note on `Thread`).
+        // Published now: from here on this thread, like the stealers, only borrows it shared.
         let this: &Thread = &self_;
         let stats = stats_enabled();
         let mut is_waking = false;

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1035,8 +1035,6 @@ enum WaitError {
 #[repr(C)]
 pub struct Thread {
     next: *mut Thread,
-    /// Steal cursor into the pool's `threads` stack. A `Cell` because other
-    /// workers are stealing from this struct while `pop` runs, so `pop` takes `&self`.
     target: Cell<*mut Thread>,
     join_event: Event,
     run_queue: node::Queue,

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1033,18 +1033,15 @@ enum WaitError {
 // the compiler is free to reorder fields (the 4-byte `Event` invites it),
 // which profiled ~43% hotter on the steal traversal.
 //
-// Once `register` has published a worker's `Thread`, it is reached from other
-// threads through that pointer for as long as the worker runs: stealers read
-// `next` and drain `run_queue`/`run_buffer`, `push_idle_task` pushes into
-// `idle_queue`, and the join chain fires `join_event`. So nothing, the owning
-// worker included, may form a `&mut Thread` after that point; every method
-// takes `&self` and the worker's own state lives in a `Cell`
+// From `register` until the worker exits, other threads steal from this struct
+// and push into `idle_queue` through the published pointer, so nothing (the
+// owning worker included) may hold a `&mut Thread`: every method takes `&self`
+// and owner-private state is a `Cell`
 // (test/internal/source-lints/thread-pool-shared-receivers.test.ts).
 #[repr(C)]
 pub struct Thread {
     next: *mut Thread,
-    /// Work-stealing cursor into the pool's `threads` stack. Only read and
-    /// written by the owning worker, in `pop`.
+    /// Work-stealing cursor into the pool's `threads` stack; owner-private.
     target: Cell<*mut Thread>,
     join_event: Event,
     run_queue: node::Queue,
@@ -1202,11 +1199,8 @@ impl Thread {
         // SAFETY: self_ptr is our stack-local Thread.
         let _registration = unsafe { ThreadRegistration::new(pool, self_ptr) };
 
-        // SAFETY: `self_` is live for the rest of this fn, and from
-        // registration on it is only ever accessed shared, by this thread as
-        // much as by the stealers (see the note on `Thread`), so one `&Thread`
-        // serves the whole loop.
-        let this: &Thread = unsafe { &*self_ptr };
+        // Published now, so our own view is shared too (see the note on `Thread`).
+        let this: &Thread = &self_;
         let stats = stats_enabled();
         let mut is_waking = false;
         loop {
@@ -1277,10 +1271,6 @@ impl Thread {
     /// already proved liveness once (`join()` waits on every registered
     /// worker), so the per-access raw-pointer derefs that the `*const`
     /// signature forced are gone.
-    ///
-    /// Owner-only (it refills `run_buffer` and advances `target`), but `&self`
-    /// all the same: other workers are stealing from this `Thread` while it
-    /// runs (see the note on `Thread`).
     pub(crate) fn pop(&self, thread_pool: &ThreadPool) -> Option<node::Stole> {
         // Check our local buffer first
         if let Some(node) = self.run_buffer.pop() {

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1032,10 +1032,20 @@ enum WaitError {
 // `run_queue` header it reads immediately after. With the default `repr(Rust)`
 // the compiler is free to reorder fields (the 4-byte `Event` invites it),
 // which profiled ~43% hotter on the steal traversal.
+//
+// Once `register` has published a worker's `Thread`, it is reached from other
+// threads through that pointer for as long as the worker runs: stealers read
+// `next` and drain `run_queue`/`run_buffer`, `push_idle_task` pushes into
+// `idle_queue`, and the join chain fires `join_event`. So nothing, the owning
+// worker included, may form a `&mut Thread` after that point; every method
+// takes `&self` and the worker's own state lives in a `Cell`
+// (test/internal/source-lints/thread-pool-shared-receivers.test.ts).
 #[repr(C)]
 pub struct Thread {
     next: *mut Thread,
-    target: *mut Thread,
+    /// Work-stealing cursor into the pool's `threads` stack. Only read and
+    /// written by the owning worker, in `pop`.
+    target: Cell<*mut Thread>,
     join_event: Event,
     run_queue: node::Queue,
     idle_queue: node::Queue,
@@ -1178,7 +1188,7 @@ impl Thread {
 
         let mut self_ = Thread {
             next: ptr::null_mut(),
-            target: ptr::null_mut(),
+            target: Cell::new(ptr::null_mut()),
             join_event: Event::default(),
             run_queue: node::Queue::default(),
             idle_queue: node::Queue::default(),
@@ -1192,6 +1202,11 @@ impl Thread {
         // SAFETY: self_ptr is our stack-local Thread.
         let _registration = unsafe { ThreadRegistration::new(pool, self_ptr) };
 
+        // SAFETY: `self_` is live for the rest of this fn, and from
+        // registration on it is only ever accessed shared, by this thread as
+        // much as by the stealers (see the note on `Thread`), so one `&Thread`
+        // serves the whole loop.
+        let this: &Thread = unsafe { &*self_ptr };
         let stats = stats_enabled();
         let mut is_waking = false;
         loop {
@@ -1207,8 +1222,7 @@ impl Thread {
                     // worker thread tears down its own `Worker`/`WorkerData`
                     // (whose `ThreadLocalArena` is mimalloc thread-local and
                     // must be freed here, not from the bundler thread).
-                    // SAFETY: self_ptr is our own stack-local Thread.
-                    unsafe { (*self_ptr).drain_idle_events() };
+                    this.drain_idle_events();
                     return;
                 }
             };
@@ -1218,8 +1232,7 @@ impl Thread {
                     .fetch_add(now_ns().wrapping_sub(wait_start), Ordering::Relaxed);
             }
 
-            // SAFETY: self_ptr is our own stack-local Thread.
-            while let Some(result) = unsafe { (*self_ptr).pop(pool) } {
+            while let Some(result) = this.pop(pool) {
                 if result.pushed || is_waking {
                     pool.notify(is_waking);
                 }
@@ -1240,8 +1253,7 @@ impl Thread {
             }
 
             Output::flush();
-            // SAFETY: self_ptr is our own stack-local Thread.
-            unsafe { (*self_ptr).drain_idle_events() };
+            this.drain_idle_events();
         }
     }
 
@@ -1265,7 +1277,11 @@ impl Thread {
     /// already proved liveness once (`join()` waits on every registered
     /// worker), so the per-access raw-pointer derefs that the `*const`
     /// signature forced are gone.
-    pub(crate) fn pop(&mut self, thread_pool: &ThreadPool) -> Option<node::Stole> {
+    ///
+    /// Owner-only (it refills `run_buffer` and advances `target`), but `&self`
+    /// all the same: other workers are stealing from this `Thread` while it
+    /// runs (see the note on `Thread`).
+    pub(crate) fn pop(&self, thread_pool: &ThreadPool) -> Option<node::Stole> {
         // Check our local buffer first
         if let Some(node) = self.run_buffer.pop() {
             return Some(node::Stole {
@@ -1288,8 +1304,9 @@ impl Thread {
         let mut num_threads = thread_pool.sync.load(Ordering::Relaxed).spawned();
         while num_threads > 0 {
             // Traverse the stack of registered threads on the thread pool
-            let target = if !self.target.is_null() {
-                self.target
+            let cursor = self.target.get();
+            let target = if !cursor.is_null() {
+                cursor
             } else {
                 let t = thread_pool.threads.load(Ordering::Acquire);
                 if t.is_null() {
@@ -1298,7 +1315,7 @@ impl Thread {
                 t
             };
             // SAFETY: target is a registered Thread in the lock-free stack.
-            self.target = unsafe { (*target).next };
+            self.target.set(unsafe { (*target).next });
 
             // Try to steal from their queue first to avoid contention (the target steal's from queue last).
             // SAFETY: target is a registered Thread in the lock-free stack, alive until join().
@@ -1308,7 +1325,7 @@ impl Thread {
 
             // Skip stealing from the buffer if we're the target.
             // We still steal from our own queue above given it may have just been locked the first time we tried.
-            if target == std::ptr::from_mut::<Thread>(self) {
+            if ptr::eq(target, self) {
                 num_threads -= 1;
                 continue;
             }

--- a/test/internal/source-lints/thread-pool-shared-receivers.test.ts
+++ b/test/internal/source-lints/thread-pool-shared-receivers.test.ts
@@ -2,29 +2,24 @@ import { expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
-// The work-stealing pool in src/threading/ThreadPool.rs keeps each worker's
-// `Thread` on that worker's stack and publishes a raw pointer to it
-// (`ThreadPool::register`, the `CURRENT` thread-local, the bundler's
-// `Worker.thread`). For as long as the worker runs, other threads go through
-// that pointer: stealers read `next` and drain `run_queue` / `run_buffer`,
-// `push_idle_task` pushes into `idle_queue`, and the join chain fires
-// `join_event`. The queues are atomics, so there is no data race, but a
-// `&mut self` method on any of these types forms a `&mut` over the whole
-// struct, protected for the duration of the call, and a stealer's CAS landing
-// anywhere in it while the call is in progress is UB under Tree Borrows (under
-// Stacked Borrows even its loads are), whether or not the method itself touches
-// that field. `Thread::pop` had exactly that shape: it wanted `&mut` for its
-// private steal cursor while the other workers were stealing from the same
-// `Thread`; the cursor is a `Cell` now.
+// A worker's `Thread` in src/threading/ThreadPool.rs is published to the other
+// workers (and to the bundler, via `Worker.thread`) the moment it registers,
+// and they steal from it and push into it through that pointer for as long as
+// it runs; see the note on `struct Thread`. A `&mut self` method on it, or on
+// anything it leads to (`Event`, `node::Queue`, `node::Buffer`), is a protected
+// `&mut` over the whole struct for the duration of the call, which a stealer's
+// CAS landing anywhere in it makes UB under Tree Borrows (under Stacked Borrows
+// even its loads do), whether or not the method touches that field.
+// `Thread::pop` had that shape, wanting `&mut` for its private steal cursor;
+// the cursor is a `Cell` now, and this pins every receiver on those types to
+// `&self`.
 //
-// So the types a published `Thread` pointer leads to (`Thread` itself, its
-// `Event`, and `node::Queue` / `node::Buffer`) take `&self` everywhere;
-// owner-private state goes in a `Cell`. Only inherent impls are checked: the
-// one trait receiver that is `&mut self` by language rule (`Drop`) runs after
-// the join chain, when nothing else can reach the value. `ThreadPool` is
-// reached the same way and is all `&self` too, but is not pinned here: a
+// Scope: inherent impls only. The one trait receiver that is `&mut self` by
+// language rule (`Drop`) runs after the join chain, when nothing else reaches
+// the value. `ThreadPool` is reached the same way and is all `&self` too, but a
 // `&mut self` setter that runs before the first worker exists would be
-// legitimate for it.
+// legitimate for it, so it is not pinned. The scan fails closed: an impl block
+// or fn header it cannot parse fails the lint instead of exempting the method.
 //
 // Sibling guards: fn-long-mut-reborrow.test.ts (the same aliasing, formed on
 // the owning thread by re-entrant callbacks), self-receiver-reclaim.test.ts.
@@ -32,17 +27,24 @@ import path from "node:path";
 const SOURCE = "src/threading/ThreadPool.rs";
 const SHARED_TYPES = ["Thread", "Event", "Queue", "Buffer"] as const;
 
-// `impl Thread {` at any indentation (`Queue` / `Buffer` live in `pub mod
-// node`). `\s*\{` right after the name keeps trait impls (`impl Default for
-// Event`, `unsafe impl Sync for Queue`) out; none of these impls is generic.
-const INHERENT_IMPL = new RegExp(String.raw`^[ \t]*impl\s+(${SHARED_TYPES.join("|")})\s*\{`, "gm");
+// Header of an inherent impl of one of SHARED_TYPES, capturing its indentation
+// (`Queue` / `Buffer` sit inside `pub mod node`). The type name has to follow
+// `impl` directly (modulo generics and a module path), which is where a trait
+// impl has its trait instead (`impl Default for Event`, `unsafe impl Sync for
+// Queue`); `\b` keeps `impl ThreadPool` out. `[^{;]*` admits a `where` clause;
+// rustfmt leaves the `{` last on its line.
+const INHERENT_IMPL = new RegExp(
+  String.raw`^([ \t]*)impl(?:<[^>]*>)?\s+(?:\w+::)*(${SHARED_TYPES.join("|")})\b[^{;]*\{[ \t]*$`,
+  "gm",
+);
 
-// `fn name(` followed by the first parameter, which for a method is the
-// receiver. `[^,)]*` stops at the end of that parameter but lets it span the
-// line break rustfmt inserts in a wrapped signature. Generic parameter lists
-// may nest one level (`<T: Into<Batch>>`). Fn-pointer types
-// (`unsafe fn(*mut Task)`) have no name and do not match.
-const FN_FIRST_PARAM = /\bfn\s+(\w+)\s*(?:<(?:[^<>]|<[^<>]*>)*>)?\s*\(\s*([^,)]*)/g;
+// Every fn item in a block, and the anchored parse of its header up to the
+// first parameter (the receiver, for a method). Generic lists may nest one
+// level and contain `->` (`<F: FnMut(*mut Task) -> bool>`); anything the
+// second pattern does not accept is reported, not skipped. Fn-pointer types
+// (`unsafe fn(*mut Task)`) have no name and are not items.
+const FN_ITEM = /\bfn\s+(?:r#)?\w+/g;
+const FN_HEADER = /fn\s+((?:r#)?\w+)\s*(?:<(?:->|[^<>]|<(?:->|[^<>])*>)*>)?\s*\(\s*([^,)]*)/y;
 const RECEIVER = /^(?:&\s*(?:'\w+\s+)?(?:mut\s+)?self\b|(?:mut\s+)?self\b)/;
 // `&mut self`, `&'a mut self`, `self: &mut Self`, `self: Pin<&mut Self>`, ...
 const EXCLUSIVE_RECEIVER = /^(?:&\s*(?:'\w+\s+)?mut\s+self\b|(?:mut\s+)?self\s*:[^&]*&\s*(?:'\w+\s+)?mut\b)/;
@@ -51,17 +53,6 @@ function stripComments(source: string): string {
   // Full-line comments (including `///` docs) may talk about `&mut self`;
   // `[ \t]*` rather than `\s*` so blank lines survive and line numbers hold.
   return source.replace(/^[ \t]*\/\/.*$/gm, "");
-}
-
-/** Index just past the `}` matching the `{` at `open`. */
-function blockEnd(text: string, open: number): number {
-  let depth = 0;
-  for (let i = open; i < text.length; i++) {
-    const c = text[i];
-    if (c === "{") depth++;
-    else if (c === "}" && --depth === 0) return i + 1;
-  }
-  throw new Error(`unbalanced braces after offset ${open}`);
 }
 
 function lineOf(text: string, index: number): number {
@@ -75,12 +66,26 @@ function receiverMethods(source: string): Method[] {
   const text = stripComments(source);
   const methods: Method[] = [];
   for (const impl of text.matchAll(INHERENT_IMPL)) {
-    const open = impl.index + impl[0].length - 1;
-    const body = text.slice(open, blockEnd(text, open));
-    for (const fn of body.matchAll(FN_FIRST_PARAM)) {
-      const receiver = fn[2].trim().replace(/\s+/g, " ");
+    const [header, indent, type] = impl;
+    const label = `impl ${type} at ${SOURCE}:${lineOf(text, impl.index)}`;
+    const start = impl.index + header.length;
+    // rustfmt puts an impl's closing brace alone on a line at the header's
+    // indentation, and nothing inside the block at that indentation, so the
+    // block ends at the first such line. Immune to braces in string literals.
+    const end = text.indexOf(`\n${indent}}`, start);
+    if (end === -1) throw new Error(`${label}: no closing brace at its indentation`);
+    const body = text.slice(start, end);
+    for (const item of body.matchAll(FN_ITEM)) {
+      FN_HEADER.lastIndex = item.index;
+      const parsed = FN_HEADER.exec(body);
+      if (parsed === null) {
+        const line = body.slice(item.index).split("\n", 1)[0].trim();
+        throw new Error(`${label}: cannot parse the receiver of \`${line}\`; extend FN_HEADER`);
+      }
+      const [, name, firstParam] = parsed;
+      const receiver = firstParam.trim().replace(/\s+/g, " ");
       if (!RECEIVER.test(receiver)) continue;
-      methods.push({ type: impl[1], name: fn[1], receiver, line: lineOf(text, open + fn.index) });
+      methods.push({ type, name, receiver, line: lineOf(text, start + item.index) });
     }
   }
   return methods;
@@ -95,43 +100,69 @@ function exclusiveReceivers(source: string): string[] {
 const source = readFileSync(path.resolve(import.meta.dir, "..", "..", "..", SOURCE), "utf8");
 
 test("the patterns classify receivers the way they claim to", () => {
-  const flagged = (body: string) => exclusiveReceivers(`impl Thread {\n${body}\n}\n`).length;
-  expect(flagged("fn pop(&mut self, thread_pool: &ThreadPool) -> Option<node::Stole> {}")).toBe(1);
-  expect(flagged("fn pop<'a>(&'a mut self) {}")).toBe(1);
-  expect(flagged("fn push_all<T: Into<Batch>>(&mut self, batch: T) {}")).toBe(1);
-  expect(flagged("fn pop(self: &mut Self) {}")).toBe(1);
-  expect(flagged("fn pop(mut self: &mut Thread) {}")).toBe(1);
-  expect(flagged("fn pop(self: Pin<&mut Self>) {}")).toBe(1);
-  expect(flagged("fn pop(\n    &mut self,\n    thread_pool: &ThreadPool,\n) {}")).toBe(1);
-  // Comments are stripped; a nested `unsafe extern` fn, a fn-pointer field
-  // type and non-self `&mut` parameters are not receivers.
+  const flagged = (...items: string[]) => exclusiveReceivers(`impl Thread {\n    ${items.join("\n    ")}\n}\n`);
+  for (const item of [
+    "pub(crate) fn pop(&mut self, thread_pool: &ThreadPool) -> Option<node::Stole> {}",
+    "fn pop<'a>(&'a mut self) {}",
+    "fn push_all<T: Into<Batch>>(&mut self, batch: T) {}",
+    "fn retain<F: FnMut(*mut Task) -> bool>(&mut self, keep: F) {}",
+    "fn r#ref(&mut self) {}",
+    "fn pop(self: &mut Self) {}",
+    "fn pop(mut self: &mut Thread) {}",
+    "fn pop(self: Pin<&mut Self>) {}",
+    "fn pop(\n        &mut self,\n        thread_pool: &ThreadPool,\n    ) {}",
+  ]) {
+    expect(flagged(item)).toHaveLength(1);
+  }
+  // Comments are stripped; a nested `unsafe extern` fn, a fn-pointer type and
+  // non-`self` `&mut` parameters are not receivers.
   expect(
     flagged(
-      [
-        "/// Once took `fn pop(&mut self)`.",
-        "// fn old(&mut self) {}",
-        "pub fn push_idle_task(&self, task: *mut Task) {}",
-        "pub(super) fn push(&self, list: &mut List) -> Result<(), BufferPushError> {}",
-        "fn with<'a>(&'a self) {}",
-        "fn by_ref(self: &Self) {}",
-        "fn by_value(self) {}",
-        "fn current() -> *mut Thread {}",
-        'fn run(thread_pool: bun_ptr::BackRef<ThreadPool>) { unsafe extern "C" { safe fn mi_thread_set_in_threadpool(); } }',
-        "fn link(list: &mut List) {}",
-        "const CB: unsafe fn(*mut Task) = cb;",
-      ].join("\n"),
-    ),
-  ).toBe(0);
-  // Trait impls are out of scope, and the impl-block scan must not leak past
-  // the closing brace into a following item.
-  expect(
-    exclusiveReceivers(
-      "impl Drop for Thread {\n    fn drop(&mut self) {}\n}\nimpl Event {\n    fn wait(&self) {}\n}\nimpl Consumer<'_> {\n    fn pop(&mut self) {}\n}\n",
+      "/// Once took `fn pop(&mut self)`.",
+      "// fn old(&mut self) {}",
+      "pub fn push_idle_task(&self, task: *mut Task) {}",
+      "pub(super) fn push(&self, list: &mut List) -> Result<(), BufferPushError> {}",
+      "fn with<'a>(&'a self) {}",
+      "fn by_ref(self: &Self) {}",
+      "fn by_value(self) {}",
+      "fn current() -> *mut Thread {}",
+      'fn run(thread_pool: bun_ptr::BackRef<ThreadPool>) { unsafe extern "C" { safe fn mi_thread_set_in_threadpool(); } }',
+      "fn link(list: &mut List) {}",
+      "const CB: unsafe fn(*mut Task) = cb;",
     ),
   ).toEqual([]);
-  expect(exclusiveReceivers("    impl Queue {\n        fn push(&mut self) {}\n    }\n")).toEqual([
-    `${SOURCE}:2: impl Queue: fn push(&mut self)`,
+  // Headers the parser does not understand fail the lint rather than exempting
+  // the method.
+  expect(() => flagged("fn pop<T: Into<Option<Batch>>>(&mut self) {}")).toThrow(
+    /impl Thread at .*: cannot parse .*fn pop</,
+  );
+  expect(() => exclusiveReceivers("impl Event {\n    fn wait(&mut self) {}\n")).toThrow(
+    /impl Event at .*: no closing brace/,
+  );
+});
+
+test("the impl scan covers inherent impls of the shared types and nothing else", () => {
+  const block = (header: string, indent = "") => `${header}\n${indent}    fn f(&mut self) {}\n${indent}}\n`;
+  expect(exclusiveReceivers(block("impl Thread {"))).toEqual([`${SOURCE}:2: impl Thread: fn f(&mut self)`]);
+  expect(exclusiveReceivers(block("    impl Queue {", "    "))).toEqual([`${SOURCE}:2: impl Queue: fn f(&mut self)`]);
+  expect(exclusiveReceivers(block("impl node::Buffer {"))).toEqual([`${SOURCE}:2: impl Buffer: fn f(&mut self)`]);
+  expect(exclusiveReceivers(block("impl Event\nwhere\n    Self: Sized,\n{"))).toEqual([
+    `${SOURCE}:5: impl Event: fn f(&mut self)`,
   ]);
+  // Trait impls, other types (including `ThreadPool`, which starts with a
+  // pinned name) and the item after a block's closing brace are out of scope.
+  expect(
+    exclusiveReceivers(
+      [
+        block("impl Drop for Thread {"),
+        block("unsafe impl Sync for Queue {"),
+        block("impl ThreadPool {"),
+        block("impl Consumer<'_> {"),
+        "impl Event {\n    fn wait(&self) {}\n}\n",
+        block("impl Batch {"),
+      ].join(""),
+    ),
+  ).toEqual([]);
 });
 
 test(`${SOURCE} still defines the shared types this lint pins`, () => {

--- a/test/internal/source-lints/thread-pool-shared-receivers.test.ts
+++ b/test/internal/source-lints/thread-pool-shared-receivers.test.ts
@@ -5,8 +5,8 @@ import path from "node:path";
 // A worker's `Thread` in src/threading/ThreadPool.rs is published to the other
 // workers (and to the bundler, via `Worker.thread`) the moment it registers,
 // and they steal from it and push into it through that pointer for as long as
-// it runs; see the note on `struct Thread`. A `&mut self` method on it, or on
-// anything it leads to (`Event`, `node::Queue`, `node::Buffer`), is a protected
+// it runs. A `&mut self` method on it, or on anything it leads to (`Event`,
+// `node::Queue`, `node::Buffer`), is a protected
 // `&mut` over the whole struct for the duration of the call, which a stealer's
 // CAS landing anywhere in it makes UB under Tree Borrows (under Stacked Borrows
 // even its loads do), whether or not the method touches that field.

--- a/test/internal/source-lints/thread-pool-shared-receivers.test.ts
+++ b/test/internal/source-lints/thread-pool-shared-receivers.test.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+// The work-stealing pool in src/threading/ThreadPool.rs keeps each worker's
+// `Thread` on that worker's stack and publishes a raw pointer to it
+// (`ThreadPool::register`, the `CURRENT` thread-local, the bundler's
+// `Worker.thread`). For as long as the worker runs, other threads go through
+// that pointer: stealers read `next` and drain `run_queue` / `run_buffer`,
+// `push_idle_task` pushes into `idle_queue`, and the join chain fires
+// `join_event`. The queues are atomics, so there is no data race, but a
+// `&mut self` method on any of these types forms a `&mut` over the whole
+// struct, protected for the duration of the call, and a stealer's CAS landing
+// anywhere in it while the call is in progress is UB under Tree Borrows (under
+// Stacked Borrows even its loads are), whether or not the method itself touches
+// that field. `Thread::pop` had exactly that shape: it wanted `&mut` for its
+// private steal cursor while the other workers were stealing from the same
+// `Thread`; the cursor is a `Cell` now.
+//
+// So the types a published `Thread` pointer leads to (`Thread` itself, its
+// `Event`, and `node::Queue` / `node::Buffer`) take `&self` everywhere;
+// owner-private state goes in a `Cell`. Only inherent impls are checked: the
+// one trait receiver that is `&mut self` by language rule (`Drop`) runs after
+// the join chain, when nothing else can reach the value. `ThreadPool` is
+// reached the same way and is all `&self` too, but is not pinned here: a
+// `&mut self` setter that runs before the first worker exists would be
+// legitimate for it.
+//
+// Sibling guards: fn-long-mut-reborrow.test.ts (the same aliasing, formed on
+// the owning thread by re-entrant callbacks), self-receiver-reclaim.test.ts.
+
+const SOURCE = "src/threading/ThreadPool.rs";
+const SHARED_TYPES = ["Thread", "Event", "Queue", "Buffer"] as const;
+
+// `impl Thread {` at any indentation (`Queue` / `Buffer` live in `pub mod
+// node`). `\s*\{` right after the name keeps trait impls (`impl Default for
+// Event`, `unsafe impl Sync for Queue`) out; none of these impls is generic.
+const INHERENT_IMPL = new RegExp(String.raw`^[ \t]*impl\s+(${SHARED_TYPES.join("|")})\s*\{`, "gm");
+
+// `fn name(` followed by the first parameter, which for a method is the
+// receiver. `[^,)]*` stops at the end of that parameter but lets it span the
+// line break rustfmt inserts in a wrapped signature. Generic parameter lists
+// may nest one level (`<T: Into<Batch>>`). Fn-pointer types
+// (`unsafe fn(*mut Task)`) have no name and do not match.
+const FN_FIRST_PARAM = /\bfn\s+(\w+)\s*(?:<(?:[^<>]|<[^<>]*>)*>)?\s*\(\s*([^,)]*)/g;
+const RECEIVER = /^(?:&\s*(?:'\w+\s+)?(?:mut\s+)?self\b|(?:mut\s+)?self\b)/;
+// `&mut self`, `&'a mut self`, `self: &mut Self`, `self: Pin<&mut Self>`, ...
+const EXCLUSIVE_RECEIVER = /^(?:&\s*(?:'\w+\s+)?mut\s+self\b|(?:mut\s+)?self\s*:[^&]*&\s*(?:'\w+\s+)?mut\b)/;
+
+function stripComments(source: string): string {
+  // Full-line comments (including `///` docs) may talk about `&mut self`;
+  // `[ \t]*` rather than `\s*` so blank lines survive and line numbers hold.
+  return source.replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+/** Index just past the `}` matching the `{` at `open`. */
+function blockEnd(text: string, open: number): number {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if (c === "{") depth++;
+    else if (c === "}" && --depth === 0) return i + 1;
+  }
+  throw new Error(`unbalanced braces after offset ${open}`);
+}
+
+function lineOf(text: string, index: number): number {
+  return text.slice(0, index).split("\n").length;
+}
+
+type Method = { type: string; name: string; receiver: string; line: number };
+
+/** Every receiver-taking method in the inherent impls of SHARED_TYPES. */
+function receiverMethods(source: string): Method[] {
+  const text = stripComments(source);
+  const methods: Method[] = [];
+  for (const impl of text.matchAll(INHERENT_IMPL)) {
+    const open = impl.index + impl[0].length - 1;
+    const body = text.slice(open, blockEnd(text, open));
+    for (const fn of body.matchAll(FN_FIRST_PARAM)) {
+      const receiver = fn[2].trim().replace(/\s+/g, " ");
+      if (!RECEIVER.test(receiver)) continue;
+      methods.push({ type: impl[1], name: fn[1], receiver, line: lineOf(text, open + fn.index) });
+    }
+  }
+  return methods;
+}
+
+function exclusiveReceivers(source: string): string[] {
+  return receiverMethods(source)
+    .filter(m => EXCLUSIVE_RECEIVER.test(m.receiver))
+    .map(m => `${SOURCE}:${m.line}: impl ${m.type}: fn ${m.name}(${m.receiver})`);
+}
+
+const source = readFileSync(path.resolve(import.meta.dir, "..", "..", "..", SOURCE), "utf8");
+
+test("the patterns classify receivers the way they claim to", () => {
+  const flagged = (body: string) => exclusiveReceivers(`impl Thread {\n${body}\n}\n`).length;
+  expect(flagged("fn pop(&mut self, thread_pool: &ThreadPool) -> Option<node::Stole> {}")).toBe(1);
+  expect(flagged("fn pop<'a>(&'a mut self) {}")).toBe(1);
+  expect(flagged("fn push_all<T: Into<Batch>>(&mut self, batch: T) {}")).toBe(1);
+  expect(flagged("fn pop(self: &mut Self) {}")).toBe(1);
+  expect(flagged("fn pop(mut self: &mut Thread) {}")).toBe(1);
+  expect(flagged("fn pop(self: Pin<&mut Self>) {}")).toBe(1);
+  expect(flagged("fn pop(\n    &mut self,\n    thread_pool: &ThreadPool,\n) {}")).toBe(1);
+  // Comments are stripped; a nested `unsafe extern` fn, a fn-pointer field
+  // type and non-self `&mut` parameters are not receivers.
+  expect(
+    flagged(
+      [
+        "/// Once took `fn pop(&mut self)`.",
+        "// fn old(&mut self) {}",
+        "pub fn push_idle_task(&self, task: *mut Task) {}",
+        "pub(super) fn push(&self, list: &mut List) -> Result<(), BufferPushError> {}",
+        "fn with<'a>(&'a self) {}",
+        "fn by_ref(self: &Self) {}",
+        "fn by_value(self) {}",
+        "fn current() -> *mut Thread {}",
+        'fn run(thread_pool: bun_ptr::BackRef<ThreadPool>) { unsafe extern "C" { safe fn mi_thread_set_in_threadpool(); } }',
+        "fn link(list: &mut List) {}",
+        "const CB: unsafe fn(*mut Task) = cb;",
+      ].join("\n"),
+    ),
+  ).toBe(0);
+  // Trait impls are out of scope, and the impl-block scan must not leak past
+  // the closing brace into a following item.
+  expect(
+    exclusiveReceivers(
+      "impl Drop for Thread {\n    fn drop(&mut self) {}\n}\nimpl Event {\n    fn wait(&self) {}\n}\nimpl Consumer<'_> {\n    fn pop(&mut self) {}\n}\n",
+    ),
+  ).toEqual([]);
+  expect(exclusiveReceivers("    impl Queue {\n        fn push(&mut self) {}\n    }\n")).toEqual([
+    `${SOURCE}:2: impl Queue: fn push(&mut self)`,
+  ]);
+});
+
+test(`${SOURCE} still defines the shared types this lint pins`, () => {
+  // If one of these disappears the type was renamed or its impl restructured;
+  // update SHARED_TYPES / INHERENT_IMPL rather than letting the ban below pass
+  // on an empty set. `Thread::pop` is the method the ban exists for.
+  const methods = receiverMethods(source);
+  expect([...new Set(methods.map(m => m.type))].sort()).toEqual([...SHARED_TYPES].sort());
+  expect(methods.filter(m => m.type === "Thread").map(m => m.name)).toContain("pop");
+});
+
+test("types reached through a published worker Thread pointer take &self", () => {
+  expect(exclusiveReceivers(source)).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- Nothing breaks for users and no crash is known; every field other threads touch is atomic. This is an aliasing bug that `bun run rust:miri` reports, the same shape as #37626 and #37691, one layer down.
- A worker's stack-local `Thread` is published to the pool the moment the worker starts. Other workers steal from its queues, and the bundler pushes idle tasks into it, for as long as it runs.
- `Thread::pop` took `&mut self`, so every pop held an exclusive borrow of the whole `Thread` while those other threads were writing into it.
- A write from another thread into memory covered by a live `&mut` argument is UB under both Stacked Borrows and Tree Borrows, whether or not `pop` reads that field. The standalone reduction in the original description fails under both.

### Fix
- `pop` takes `&self`. The one field it wrote, its steal cursor, becomes a `Cell` of the same size and alignment, so the `repr(C)` layout is unchanged. The body of `pop` is otherwise the same, so there is no behaviour change.
- The worker loop borrows its own `Thread` once as `&Thread` instead of reborrowing through the raw pointer on each call.
- Why it is right: every other method reachable through a published `Thread` pointer already takes `&self`; `pop` was the only exclusive receiver. A shared borrow of memory other threads write through atomics is fine under both models, and the reduction passes in this shape.
- Verification: there is no runtime behaviour to observe, so the test is a source lint pinning the receivers of `Thread`, `Event`, `node::Queue` and `node::Buffer` to `&self`. It fails on main, naming only `Thread::pop`, and passes here. The bundler and install pool tests pass on a debug build.

### Background
- Work stealing: each pool worker owns a run queue and a run buffer. A worker with nothing local walks the pool's list of registered `Thread`s and takes tasks out of theirs, so a worker's `Thread` is read and written by other threads for its whole life.
- The steal cursor (`target`) is where a worker resumes that walk on its next pop. Only the owning worker reads or writes it, which is why a `Cell` is enough.
- `&mut self` promises exclusive access to the whole struct for the length of the call, not only to the fields the method uses. Miri's aliasing models (Stacked Borrows, Tree Borrows) treat an outside write during that window as UB even when atomics make the program race-free.
- `Cell<T>` permits mutation through `&self` for a word that only one thread touches; the queue in this file already keeps its consumer-private cache in one.
- Source lints (test/internal/source-lints/) are tests that read bun's source text and fail when a banned pattern appears; they are used where the property has nothing observable at runtime.

<details>
<summary>Original description</summary>

### What

`Thread::pop` in src/threading/ThreadPool.rs took `&mut self`, and the worker loop in `Thread::run` called it as `unsafe { (*self_ptr).pop(pool) }`, so every pop formed a `&mut` over the worker's whole stack-local `Thread` for the duration of the call. That `Thread` is published the moment the worker starts (`ThreadPool::register` pushes it on the pool's lock-free `threads` stack, `ThreadRegistration` stores it in the `CURRENT` thread-local, and the bundler keeps it as `Worker.thread`), and other threads use it while `pop` is running:

- other workers' `pop` reads `(*target).next` and runs `consume` / `steal` against our `run_queue` and `run_buffer` (CAS on the queue word and the buffer head);
- `Worker::deinit_soon` on the bundler thread calls `thread.push_idle_task(..)`, which pushes into our `idle_queue`.

Everything those threads touch is atomic, so there is no data race and no crash is known from this. It is an aliasing issue: a `&mut self` argument is protected for the duration of the call, and a write from another thread into memory it covers is UB under both Stacked Borrows and Tree Borrows (the model `bun run rust:miri` uses), whether or not `pop` itself touches that field. This is the same shape as #37626 and #37691, one layer down.

### Fix

`pop` only needed `&mut` for its steal cursor, `self.target`. The cursor is now a `Cell<*mut Thread>` (same size and alignment, so the `repr(C)` layout note above the struct still holds), `pop` takes `&self`, and `run()` borrows its own `Thread` once, as a plain `&self_`, in place of the three per-call `unsafe { (*self_ptr).. }` reborrows (the raw pointer is still what gets registered; a shared borrow of a local that other threads write to through atomics is fine under both models, and the reduction below was also run in this exact shape). Everything `pop` calls already took `&self` (`Buffer::pop/consume/steal`, `Queue::push`), as does every other method on `Thread`, `Event`, `node::Queue` and `node::Buffer`; `pop` was the one exclusive receiver among the types a published `Thread` pointer leads to. The body of `pop` is otherwise unchanged, so there is no behaviour change.

### Why this is the right shape

The worker is the only thread that drives `pop` (it refills `run_buffer` and advances `target`), but being the only caller is not the same as having exclusive access to the struct, and `&self` plus a `Cell` states exactly what is true: one owner-private word, everything else shared with the stealers. It is also how the rest of the file is already written. `Buffer::push` is single-producer and takes `&self` for the same reason, `Queue` keeps its consumer-private `cache` in a `Cell`, and the three other places that reach a `Thread` from another thread (`ThreadPool::wait`, `unregister`, `join`) go through a shared `BackRef`; `ParentRef`, which the bundler holds, documents that parents are mutated through interior mutability and never through `&mut`.

<details><summary>Standalone reduction under Miri (a stack-local struct published to a stealer thread, which does one <code>fetch_add</code> on its queue while the owner is inside <code>pop</code>)</summary>

With `fn pop(&mut self)`, Stacked Borrows:

```
error: Undefined Behavior: not granting access to tag <3313> because that would remove [Unique for <2234>] which is strongly protected
41 |             (*p.0).run_queue.stack.fetch_add(1, Ordering::AcqRel);
help: <2234> is this argument
20 |     fn pop(&mut self) -> usize {
```

Tree Borrows (`-Zmiri-tree-borrows`):

```
error: Undefined Behavior: write access through <3148> at alloc159[0x8] is forbidden
   = help: the accessed tag <3148> is foreign to the protected tag <2122> (i.e., it is not a child)
   = help: this foreign write access would cause the protected tag <2122> (currently Reserved (conflicted)) to become Disabled
   = help: protected tags must never be Disabled
help: the protected tag <2122> was created here, in the initial state Reserved
20 |     fn pop(&mut self) -> usize {
```

The same program with `target` in a `Cell`, `fn pop(&self)`, and the owner holding a `&Thread` across the stealer's access (the shape in this PR) runs to completion under both models.

</details>

### Test

There is no runtime behaviour to observe, so the test is a source lint, test/internal/source-lints/thread-pool-shared-receivers.test.ts: the inherent impls of `Thread`, `Event`, `node::Queue` and `node::Buffer` in src/threading/ThreadPool.rs must have only shared receivers. It attributes methods to impl blocks (a file-wide count would not do: `pop` is also the name of the legitimately `&mut self` `Batch::pop` and `node::Consumer::pop` in the same file, so the lint has to know which `pop` it is looking at) and fails closed: a fn header or impl block it cannot parse fails the lint instead of exempting the method. It checks its classification against positive and negative spellings (`&'a mut self`, `self: &mut Self`, `self: Pin<&mut Self>`, `r#ref`, `->` inside generic bounds, rustfmt-wrapped signatures, trait impls, `impl ThreadPool`, non-`self` `&mut` parameters, an unparseable header, a block without its closing brace), verifies it still finds all four types and `Thread::pop`, and against the previous src/ it reports exactly:

```
src/threading/ThreadPool.rs:1268: impl Thread: fn pop(&mut self)
```

`ThreadPool` itself is all `&self` too but is deliberately not pinned, since a `&mut self` setter that runs before the first worker exists would be legitimate for it. Its `Drop` (which shuts down and joins the workers while they still reach the pool through `&ThreadPool`) is the same class of issue one level up and is #37810.

### Verification

- `cargo check`, `cargo clippy` and `cargo fmt --check` on `bun_threading`; full debug (ASAN) build.
- Debug build: test/bundler/bun-build-api.test.ts (52 pass) and test/bundler/bundler_plugin.test.ts (53 pass), which exercise stealing across workers and the `push_idle_task` teardown on every build; test/cli/install/bun-install-streaming-extract.test.ts (10 pass) and the waiter-thread half of bun-install-lifecycle-scripts.test.ts (52 pass) for the install pool; plus an ad hoc run of 4 rounds of 3 concurrent `Bun.build` calls over a 600-module graph with 24 entrypoints, all successful.
- `bun test test/internal/source-lints/` (19 files, 86 tests) passes; the new lint fails as shown above with src/threading/ThreadPool.rs at its main version.

No overlap with #37738 apart from touching the same file; the hunks are disjoint. #37810 (the pool-level `Drop`) touches the neighbouring lines of `Thread::run` but is independent; whichever lands second has a trivial rebase.

</details>
