### PR TITLE
shell: finish the command when its buffered stdin is the last stdio to close

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -68,12 +68,7 @@ impl Cmd {
 pub struct SubprocExec {
     pub(crate) child: *mut ShellSubprocess,
     pub(crate) buffered_closed: BufferedIoClosed,
-    /// NodeId-arena backrefs so the legacy `&mut self` subprocess callbacks
-    /// (`buffered_input_close` / `buffered_output_close` / `on_exit`) can hand
-    /// a [`Yield`] back to the trampoline. The `Cmd` lives inside
-    /// `interp.nodes`, so we stash the indices and return
-    /// `Yield::Next(this_id)` for the caller (`PipeReader::run_yield` /
-    /// `ShellSubprocess::on_static_pipe_writer_done`) to drive.
+    /// Null until the spawn has returned; gates the `Yield` built by `finish_if_done`.
     pub(crate) interp: *mut Interpreter,
     pub(crate) this_id: NodeId,
 }
@@ -554,11 +549,11 @@ impl Cmd {
         // `did_exit_immediately` handling have returned: a synchronous
         // `Cmd::on_exit` (process exit handler) or `Cmd::buffered_output_close`
         // (an eager `read_all` on a pipe erroring inside the spawn) would
-        // otherwise hand its caller a `Yield::Next` to run while this frame
-        // still holds `&Interpreter`, tearing the Cmd down (and freeing
+        // otherwise drive the trampoline (`Yield::run(&*interp)`) while this
+        // frame still holds `&Interpreter`, tearing the Cmd down (and freeing
         // `child`) underneath the live `subproc` borrow. With `interp` null,
-        // `finish_if_done` records `exit_code`/`state = Done` and yields
-        // suspended; we resume via the Yield we hand back below.
+        // both record `exit_code`/`state = Done` and return; we resume via
+        // the Yield we hand back below.
         let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
         let buffered_closed = BufferedIoClosed::from_stdio(&spawn_args.stdio);
         interp.as_cmd_mut(this).exec = Exec::Subproc(Box::new(SubprocExec {
@@ -883,8 +878,8 @@ impl Cmd {
             core::mem::take(&mut me.exec)
         };
         // `me`'s borrow ended above: the teardown below re-enters this Cmd
-        // via stdin `on_stdin_writer_close` → `buffered_input_close` (a no-op
-        // once `exec` is taken).
+        // via stdin `on_stdin_writer_close` → `buffered_input_close` (a no-op once
+        // `exec` is taken).
         match exec {
             Exec::None => {}
             Exec::Builtin(b) => drop(b),
@@ -919,12 +914,7 @@ impl Cmd {
     }
 
     // ── Subprocess callbacks (legacy `*Cmd` backref shape) ────────────────
-    // `ShellSubprocess` / `PipeReader` resolve their `CmdHandle` backref and
-    // call these via `&mut self`. Each returns the resulting `Yield` instead of
-    // running it: the trampoline reaches `Cmd::deinit` (recycling this arena
-    // slot and freeing the subprocess), so it must run only after the `&mut
-    // Cmd` is gone, from a caller holding no reference to either. The NodeId
-    // backrefs stashed on `SubprocExec` make that Yield buildable here.
+    // Each returns its Yield: running it can free this Cmd and its subprocess.
 
     /// True once the command has both an exit code and (for subprocesses)
     /// all buffered stdio closed.
@@ -940,11 +930,7 @@ impl Cmd {
         }
     }
 
-    /// Mark the subprocess's buffered stdin as closed. The stdin writer can be
-    /// the last of the three to close (the child exits without draining its
-    /// stdin, so the write only fails once the exit and the stdout/stderr EOFs
-    /// have been processed), in which case this close is what finishes the
-    /// command. A no-op once `deinit` has taken `exec`.
+    /// Mark the subprocess's buffered stdin as closed; this may be the close that finishes it.
     pub(crate) fn buffered_input_close(&mut self) -> Yield {
         let Exec::Subproc(sub) = &mut self.exec else {
             return Yield::suspended();
@@ -968,20 +954,14 @@ impl Cmd {
         self.finish_if_done()
     }
 
-    /// Called by `ShellSubprocess::on_process_exit`, which drives the returned
-    /// Yield.
+    /// Called by `ShellSubprocess::on_process_exit`.
     pub(crate) fn on_exit(&mut self, exit_code: ExitCode) -> Yield {
         log!("cmd exit code={}", exit_code);
         self.exit_code = Some(exit_code);
         self.finish_if_done()
     }
 
-    /// Shared tail of the exit / stdio close callbacks: once the exit code and
-    /// every piped stdio are in, set `state = Done` and hand a Yield back to
-    /// the caller (`PipeReader::finish_after_state_set`,
-    /// `ShellSubprocess::on_stdin_writer_close` / `on_process_exit`), which
-    /// drives the trampoline, landing in `Cmd::next` → `CmdState::Done` →
-    /// `interp.child_done(...)`.
+    /// `Done` once the exit code and every piped stdio are in; the caller runs the Yield.
     fn finish_if_done(&mut self) -> Yield {
         if !self.has_finished() {
             return Yield::suspended();
@@ -989,14 +969,10 @@ impl Cmd {
         self.state = CmdState::Done;
         let (interp, this_id) = match &self.exec {
             Exec::Subproc(sub) => (sub.interp, sub.this_id),
-            // Only the subprocess path calls this; builtin output goes
-            // through `Builtin::done` → `on_exec_done`.
+            // Builtins finish through `Builtin::done` → `on_exec_done` instead.
             _ => return Yield::suspended(),
         };
-        // `exec.interp` stays null until the spawn has returned: a Yield run
-        // from a callback firing inside the spawn would reach `Cmd::deinit` and
-        // free the `ShellSubprocess` still on the spawn frame. With it null,
-        // `state = Done` is recorded here and `transition_to_exec` resumes.
+        // Still inside the spawn (see `transition_to_exec`, which resumes from `state`).
         if interp.is_null() {
             return Yield::suspended();
         }

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -69,11 +69,11 @@ pub struct SubprocExec {
     pub(crate) child: *mut ShellSubprocess,
     pub(crate) buffered_closed: BufferedIoClosed,
     /// NodeId-arena backrefs so the legacy `&mut self` subprocess callbacks
-    /// (`buffered_output_close` / `on_exit`) can hand a [`Yield`] back to the
-    /// trampoline. The `Cmd` lives inside `interp.nodes`, so we stash the
-    /// indices and
-    /// return `Yield::Next(this_id)` for the caller (`PipeReader::run_yield`)
-    /// to drive.
+    /// (`buffered_input_close` / `buffered_output_close` / `on_exit`) can hand
+    /// a [`Yield`] back to the trampoline. The `Cmd` lives inside
+    /// `interp.nodes`, so we stash the indices and return
+    /// `Yield::Next(this_id)` for the caller (`PipeReader::run_yield` /
+    /// `ShellSubprocess::on_static_pipe_writer_done`) to drive.
     pub(crate) interp: *mut Interpreter,
     pub(crate) this_id: NodeId,
 }
@@ -939,11 +939,17 @@ impl Cmd {
         }
     }
 
-    /// Mark the subprocess's buffered stdin as closed.
-    pub(crate) fn buffered_input_close(&mut self) {
-        if let Exec::Subproc(sub) = &mut self.exec {
-            sub.buffered_closed.close_stdin();
-        }
+    /// Mark the subprocess's buffered stdin as closed. The stdin writer can be
+    /// the last of the three to close (the child exits without draining its
+    /// stdin, so the write only fails once the exit and the stdout/stderr EOFs
+    /// have been processed), in which case this close is what finishes the
+    /// command. A no-op once `deinit` has taken `exec`.
+    pub(crate) fn buffered_input_close(&mut self) -> Yield {
+        let Exec::Subproc(sub) = &mut self.exec else {
+            return Yield::suspended();
+        };
+        sub.buffered_closed.close_stdin();
+        self.finish_if_done()
     }
 
     /// Mark the subprocess's buffered stdout/stderr as closed (flushing the
@@ -958,27 +964,33 @@ impl Cmd {
             OutKind::Stdout => self.buffered_output_close_stdout(err),
             OutKind::Stderr => self.buffered_output_close_stderr(err),
         }
-        if self.has_finished() {
-            // Set `state = Done` and hand the Yield back to the caller
-            // (`PipeReader::run_yield`), which drives the trampoline with the
-            // `*mut Interpreter` it already holds, landing in `Cmd::next` →
-            // `CmdState::Done` → `interp.child_done(...)`.
-            self.state = CmdState::Done;
-            let (interp, this_id) = match &self.exec {
-                Exec::Subproc(sub) => (sub.interp, sub.this_id),
-                // Only the subprocess path calls this; builtin output goes
-                // through `Builtin::done` → `on_exec_done`.
-                _ => return Yield::suspended(),
-            };
-            // Same gate as `on_exit`: `exec.interp` stays null until the spawn
-            // returns, so a Yield run here would reach `Cmd::deinit` and free the
-            // `ShellSubprocess` still on the spawn frame. `transition_to_exec` resumes.
-            if interp.is_null() {
-                return Yield::suspended();
-            }
-            return Yield::Next(this_id);
+        self.finish_if_done()
+    }
+
+    /// Shared tail of the stdio close callbacks: once the exit code and every
+    /// piped stdio are in, set `state = Done` and hand a Yield back to the
+    /// caller (`PipeReader::finish_after_state_set` /
+    /// `ShellSubprocess::on_static_pipe_writer_done`), which drives the
+    /// trampoline, landing in `Cmd::next` → `CmdState::Done` →
+    /// `interp.child_done(...)`.
+    fn finish_if_done(&mut self) -> Yield {
+        if !self.has_finished() {
+            return Yield::suspended();
         }
-        Yield::suspended()
+        self.state = CmdState::Done;
+        let (interp, this_id) = match &self.exec {
+            Exec::Subproc(sub) => (sub.interp, sub.this_id),
+            // Only the subprocess path calls this; builtin output goes
+            // through `Builtin::done` → `on_exec_done`.
+            _ => return Yield::suspended(),
+        };
+        // Same gate as `on_exit`: `exec.interp` stays null until the spawn
+        // returns, so a Yield run here would reach `Cmd::deinit` and free the
+        // `ShellSubprocess` still on the spawn frame. `transition_to_exec` resumes.
+        if interp.is_null() {
+            return Yield::suspended();
+        }
+        Yield::Next(this_id)
     }
 
     fn buffered_output_close_stdout(&mut self, err: Option<bun_sys::SystemError>) {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -554,11 +554,11 @@ impl Cmd {
         // `did_exit_immediately` handling have returned: a synchronous
         // `Cmd::on_exit` (process exit handler) or `Cmd::buffered_output_close`
         // (an eager `read_all` on a pipe erroring inside the spawn) would
-        // otherwise drive the trampoline (`Yield::run(&*interp)`) while this
-        // frame still holds `&Interpreter`, tearing the Cmd down (and freeing
+        // otherwise hand its caller a `Yield::Next` to run while this frame
+        // still holds `&Interpreter`, tearing the Cmd down (and freeing
         // `child`) underneath the live `subproc` borrow. With `interp` null,
-        // both record `exit_code`/`state = Done` and return; we resume via
-        // the Yield we hand back below.
+        // `finish_if_done` records `exit_code`/`state = Done` and yields
+        // suspended; we resume via the Yield we hand back below.
         let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();
         let buffered_closed = BufferedIoClosed::from_stdio(&spawn_args.stdio);
         interp.as_cmd_mut(this).exec = Exec::Subproc(Box::new(SubprocExec {
@@ -883,8 +883,8 @@ impl Cmd {
             core::mem::take(&mut me.exec)
         };
         // `me`'s borrow ended above: the teardown below re-enters this Cmd
-        // via stdin `on_close_io` → `buffered_input_close` (a no-op once
-        // `exec` is taken).
+        // via stdin `on_stdin_writer_close` → `buffered_input_close` (a no-op
+        // once `exec` is taken).
         match exec {
             Exec::None => {}
             Exec::Builtin(b) => drop(b),
@@ -919,11 +919,12 @@ impl Cmd {
     }
 
     // ── Subprocess callbacks (legacy `*Cmd` backref shape) ────────────────
-    // `ShellSubprocess` / `PipeReader` hold a `*mut Cmd` backref and call
-    // these via `&mut self`. The NodeId-arena port stashes `(interp, this_id)`
-    // on `SubprocExec` so the resulting `Yield` can be driven by the caller's
-    // `PipeReader::run_yield` without aliasing `&Interpreter` against
-    // `&mut self`.
+    // `ShellSubprocess` / `PipeReader` resolve their `CmdHandle` backref and
+    // call these via `&mut self`. Each returns the resulting `Yield` instead of
+    // running it: the trampoline reaches `Cmd::deinit` (recycling this arena
+    // slot and freeing the subprocess), so it must run only after the `&mut
+    // Cmd` is gone, from a caller holding no reference to either. The NodeId
+    // backrefs stashed on `SubprocExec` make that Yield buildable here.
 
     /// True once the command has both an exit code and (for subprocesses)
     /// all buffered stdio closed.
@@ -967,11 +968,19 @@ impl Cmd {
         self.finish_if_done()
     }
 
-    /// Shared tail of the stdio close callbacks: once the exit code and every
-    /// piped stdio are in, set `state = Done` and hand a Yield back to the
-    /// caller (`PipeReader::finish_after_state_set` /
-    /// `ShellSubprocess::on_static_pipe_writer_done`), which drives the
-    /// trampoline, landing in `Cmd::next` → `CmdState::Done` →
+    /// Called by `ShellSubprocess::on_process_exit`, which drives the returned
+    /// Yield.
+    pub(crate) fn on_exit(&mut self, exit_code: ExitCode) -> Yield {
+        log!("cmd exit code={}", exit_code);
+        self.exit_code = Some(exit_code);
+        self.finish_if_done()
+    }
+
+    /// Shared tail of the exit / stdio close callbacks: once the exit code and
+    /// every piped stdio are in, set `state = Done` and hand a Yield back to
+    /// the caller (`PipeReader::finish_after_state_set`,
+    /// `ShellSubprocess::on_stdin_writer_close` / `on_process_exit`), which
+    /// drives the trampoline, landing in `Cmd::next` → `CmdState::Done` →
     /// `interp.child_done(...)`.
     fn finish_if_done(&mut self) -> Yield {
         if !self.has_finished() {
@@ -984,9 +993,10 @@ impl Cmd {
             // through `Builtin::done` → `on_exec_done`.
             _ => return Yield::suspended(),
         };
-        // Same gate as `on_exit`: `exec.interp` stays null until the spawn
-        // returns, so a Yield run here would reach `Cmd::deinit` and free the
-        // `ShellSubprocess` still on the spawn frame. `transition_to_exec` resumes.
+        // `exec.interp` stays null until the spawn has returned: a Yield run
+        // from a callback firing inside the spawn would reach `Cmd::deinit` and
+        // free the `ShellSubprocess` still on the spawn frame. With it null,
+        // `state = Done` is recorded here and `transition_to_exec` resumes.
         if interp.is_null() {
             return Yield::suspended();
         }
@@ -1061,31 +1071,6 @@ impl Cmd {
             self.base.shell_mut().buffered_stderr(),
         );
         child.close_io(StdioKind::Stderr);
-    }
-
-    /// Called by `ShellSubprocess::on_process_exit`.
-    pub(crate) fn on_exit(&mut self, exit_code: ExitCode) {
-        self.exit_code = Some(exit_code);
-        let has_finished = self.has_finished();
-        log!("cmd exit code={} has_finished={}", exit_code, has_finished);
-        if has_finished {
-            self.state = CmdState::Done;
-            // `self` lives inside `interp.nodes`, so resume via the stashed
-            // backrefs.
-            let (interp, this_id) = match &self.exec {
-                Exec::Subproc(sub) => (sub.interp, sub.this_id),
-                _ => return,
-            };
-            if interp.is_null() {
-                return;
-            }
-            // SAFETY: `interp` outlives every spawned subprocess (it owns the
-            // arena slot containing `self`). `&mut self` is dead by NLL after
-            // this point so the `&Interpreter` borrow does not alias it.
-            // The caller (`ShellSubprocess::on_process_exit`) does not touch
-            // its `*mut Cmd` again after this returns.
-            Yield::Next(this_id).run(unsafe { &*interp });
-        }
     }
 }
 

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -299,15 +299,27 @@ impl ShellSubprocess {
         unsafe { &mut *self.process }
     }
 
+    /// Signal the owning `Cmd` that buffered stdin has closed and drive the
+    /// resulting `Yield`: when the exit and the stdout/stderr closes were
+    /// processed first, this is what finishes the command (mirrors
+    /// `PipeReader::finish_after_state_set` for the outputs). The trampoline
+    /// may reach `Cmd::deinit`, which frees `self`, so the caller must not
+    /// touch `self` afterwards and nothing here does either.
     pub(crate) fn on_static_pipe_writer_done(&mut self) {
         log!(
             "Subproc(0x{:x}) onStaticPipeWriterDone(cmd={})",
             std::ptr::from_mut(self) as usize,
             self.cmd_parent.id
         );
-        // SAFETY: cmd_parent backref resolves to the owning Cmd which outlives
-        // the subprocess (freed only in `Cmd::deinit` after all stdio closes).
-        unsafe { self.cmd_parent.cmd_mut() }.buffered_input_close();
+        let handle = self.cmd_parent;
+        // SAFETY: cmd_parent backref resolves to the owning Cmd, which outlives
+        // the subprocess (the subprocess is freed by that Cmd's `deinit`). The
+        // `&mut Cmd` ends before the trampoline below re-enters the arena.
+        let y = unsafe { handle.cmd_mut() }.buffered_input_close();
+        // `ParentRef: Deref<Target = Interpreter>`; the interpreter owns the
+        // Cmd that owns `self`, so it outlives this callback. `&mut self` is
+        // dead by NLL here — `run` may free `self` via `Cmd::deinit`.
+        y.run(&handle.interp);
     }
 
     pub(crate) fn has_exited(&self) -> bool {
@@ -403,9 +415,10 @@ impl ShellSubprocess {
                     self.stdin = Writable::Ignore;
                 }
                 Writable::Buffer(_) => {
-                    self.on_static_pipe_writer_done();
                     // RefPtr has no Drop — move it out before reassigning so the
-                    // create ref is actually released.
+                    // create ref is actually released. This does not free the
+                    // writer we are being called from: `start()`'s ref is only
+                    // released after this callback returns.
                     if let Writable::Buffer(buffer) =
                         core::mem::replace(&mut self.stdin, Writable::Ignore)
                     {
@@ -413,6 +426,8 @@ impl ShellSubprocess {
                         unsafe { buffer_mut(&buffer) }.source.detach();
                         buffer.deref();
                     }
+                    // Last: this may finish the Cmd, whose `deinit` frees `self`.
+                    self.on_static_pipe_writer_done();
                 }
                 _ => {}
             },

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -3,9 +3,7 @@ use std::sync::Arc;
 
 #[cfg(unix)]
 use crate::api::bun::process::SpawnResultExt as _;
-use crate::api::bun::process::{
-    self as bun_process, Process, Rusage, SignalCodeExt, SpawnOptions, Status,
-};
+use crate::api::bun::process::{self as bun_process, Process, SignalCodeExt, SpawnOptions, Status};
 #[cfg(windows)]
 use crate::api::bun::process::{WindowsOptions, WindowsStdioResult};
 use crate::api::bun::subprocess as JscSubprocess;
@@ -276,15 +274,20 @@ impl JscSubprocess::static_pipe_writer::StaticPipeWriterProcess for ShellSubproc
     const POLL_OWNER_TAG: bun_io::PollTag =
         bun_io::posix_event_loop::poll_tag::SHELL_STATIC_PIPE_WRITER;
     unsafe fn on_close_io(this: *mut Self, kind: StdioKind) {
-        // SAFETY: caller (StaticPipeWriter) guarantees `this` is live.
-        unsafe { (*this).on_close_io(kind) }
+        // `Writable::init` only ever creates the writer for stdin.
+        debug_assert!(matches!(kind, StdioKind::Stdin));
+        // SAFETY: caller (`StaticPipeWriter::on_close`) guarantees `this` is
+        // live and does not touch it afterwards. Forwarded raw, not autoref'd:
+        // the callee may free `*this`.
+        unsafe { Self::on_stdin_writer_close(this) }
     }
 }
 
 bun_spawn::link_impl_ProcessExit! {
     Shell for ShellSubprocess => |this| {
-        on_process_exit(process, status, rusage) =>
-            (*this).on_process_exit(&*process, &status, rusage),
+        // Forwarded raw, not autoref'd: the callee may free `*this`.
+        on_process_exit(_process, status, _rusage) =>
+            ShellSubprocess::on_process_exit(this, &status),
     }
 }
 
@@ -299,26 +302,53 @@ impl ShellSubprocess {
         unsafe { &mut *self.process }
     }
 
-    /// Signal the owning `Cmd` that buffered stdin has closed and drive the
-    /// resulting `Yield`: when the exit and the stdout/stderr closes were
-    /// processed first, this is what finishes the command (mirrors
-    /// `PipeReader::finish_after_state_set` for the outputs). The trampoline
-    /// may reach `Cmd::deinit`, which frees `self`, so the caller must not
-    /// touch `self` afterwards and nothing here does either.
-    pub(crate) fn on_static_pipe_writer_done(&mut self) {
+    /// The `< ${buffer}` stdin writer finished, failed, or was closed by
+    /// `deinit_in_flight_io`: release it, then tell the owning `Cmd` and drive
+    /// the resulting `Yield`, the way `PipeReader::finish_after_state_set`
+    /// does for stdout/stderr. When the exit and the output closes were
+    /// processed first, this is what finishes the command, and the trampoline
+    /// then reaches `Cmd::deinit`, which frees `*this`.
+    ///
+    /// Raw `this` rather than `&mut self` (same as [`Self::on_process_exit`])
+    /// so that no `&mut ShellSubprocess` is live while `*this` is freed.
+    ///
+    /// # Safety
+    /// `this` must be the live subprocess owning the writer, with no borrow of
+    /// it live; the caller must not touch it after this returns.
+    unsafe fn on_stdin_writer_close(this: *mut Self) {
+        {
+            // SAFETY: caller contract; this borrow of the slot ends with the
+            // block, before the trampoline below can free `*this`.
+            let slot = unsafe { &mut (*this).stdin };
+            match core::mem::replace(slot, Writable::Ignore) {
+                Writable::Buffer(buffer) => {
+                    // Releases `create()`'s ref (RefPtr has no Drop). This
+                    // cannot free the writer this callback is running inside
+                    // of: `start()`'s ref is only released after it returns.
+                    // SAFETY: single-threaded; sole borrow of the payload.
+                    unsafe { buffer_mut(&buffer) }.source.detach();
+                    buffer.deref();
+                }
+                // The writer only exists while the slot holds it.
+                other => {
+                    *slot = other;
+                    return;
+                }
+            }
+        }
+        // SAFETY: caller contract; copies the backref out, no borrow is kept.
+        let handle = unsafe { (*this).cmd_parent };
         log!(
-            "Subproc(0x{:x}) onStaticPipeWriterDone(cmd={})",
-            std::ptr::from_mut(self) as usize,
-            self.cmd_parent.id
+            "Subproc(0x{:x}) onStdinWriterClose(cmd={})",
+            this as usize,
+            handle.id
         );
-        let handle = self.cmd_parent;
-        // SAFETY: cmd_parent backref resolves to the owning Cmd, which outlives
-        // the subprocess (the subprocess is freed by that Cmd's `deinit`). The
-        // `&mut Cmd` ends before the trampoline below re-enters the arena.
+        // SAFETY: the owning Cmd outlives its subprocess (it is what frees it,
+        // in `deinit`). The `&mut Cmd` ends before the trampoline re-enters
+        // the arena.
         let y = unsafe { handle.cmd_mut() }.buffered_input_close();
         // `ParentRef: Deref<Target = Interpreter>`; the interpreter owns the
-        // Cmd that owns `self`, so it outlives this callback. `&mut self` is
-        // dead by NLL here — `run` may free `self` via `Cmd::deinit`.
+        // Cmd and outlives this callback. May free `*this`; nothing follows.
         y.run(&handle.interp);
     }
 
@@ -404,65 +434,40 @@ impl ShellSubprocess {
         self.close_io(StdioKind::Stderr);
     }
 
+    /// A stdout/stderr `PipeReader` has signalled the `Cmd`
+    /// (`PipeReader::finish_after_state_set`): swap it out of its slot for its
+    /// buffered bytes. Stdin is not handled here: the writer's close goes
+    /// through [`Self::on_stdin_writer_close`], which can free `self`.
     pub(crate) fn on_close_io(&mut self, kind: StdioKind) {
-        match kind {
-            StdioKind::Stdin => match &mut self.stdin {
-                Writable::Pipe(pipe) => {
-                    // DerefMut on the owning `&mut FileSinkPtr` encapsulates
-                    // the access.
-                    pipe.source.with_mut(|s| s.clear());
-                    // FileSinkPtr::drop derefs.
-                    self.stdin = Writable::Ignore;
+        let out: &mut Readable = match kind {
+            StdioKind::Stdout => &mut self.stdout,
+            StdioKind::Stderr => &mut self.stderr,
+            StdioKind::Stdin => unreachable!("stdin closes through on_stdin_writer_close"),
+        };
+        if let Readable::Pipe(pipe) = core::mem::replace(out, Readable::Ignore) {
+            // The only callers reach here from inside
+            // `PipeReader::on_reader_done`/`on_reader_error`, which still
+            // hold a raw `*mut PipeReader` to this same allocation.
+            // Route every read/write through `Arc::as_ptr` (no `Deref`)
+            // so we never materialise a `&PipeReader` that would alias
+            // those callers' access; see `PipeReader::take_done_buffer`.
+            let pp = Arc::as_ptr(&pipe).cast_mut();
+            // SAFETY: `pp` projects from the Arc allocation's NonNull;
+            // raw place read of the discriminant + raw-ptr write
+            // through `take_done_buffer` (see its doc).
+            let buf = unsafe {
+                if matches!(&(*pp).state, PipeReaderState::Done(_)) {
+                    Some(PipeReader::take_done_buffer(pp))
+                } else {
+                    None
                 }
-                Writable::Buffer(_) => {
-                    // RefPtr has no Drop — move it out before reassigning so the
-                    // create ref is actually released. This does not free the
-                    // writer we are being called from: `start()`'s ref is only
-                    // released after this callback returns.
-                    if let Writable::Buffer(buffer) =
-                        core::mem::replace(&mut self.stdin, Writable::Ignore)
-                    {
-                        // SAFETY: single-threaded; sole borrow of the payload.
-                        unsafe { buffer_mut(&buffer) }.source.detach();
-                        buffer.deref();
-                    }
-                    // Last: this may finish the Cmd, whose `deinit` frees `self`.
-                    self.on_static_pipe_writer_done();
-                }
-                _ => {}
-            },
-            StdioKind::Stdout | StdioKind::Stderr => {
-                let out: &mut Readable = match kind {
-                    StdioKind::Stdout => &mut self.stdout,
-                    StdioKind::Stderr => &mut self.stderr,
-                    StdioKind::Stdin => unreachable!(),
-                };
-                if let Readable::Pipe(pipe) = core::mem::replace(out, Readable::Ignore) {
-                    // The only callers reach here from inside
-                    // `PipeReader::on_reader_done`/`on_reader_error`, which still
-                    // hold a raw `*mut PipeReader` to this same allocation.
-                    // Route every read/write through `Arc::as_ptr` (no `Deref`)
-                    // so we never materialise a `&PipeReader` that would alias
-                    // those callers' access; see `PipeReader::take_done_buffer`.
-                    let pp = Arc::as_ptr(&pipe).cast_mut();
-                    // SAFETY: `pp` projects from the Arc allocation's NonNull;
-                    // raw place read of the discriminant + raw-ptr write
-                    // through `take_done_buffer` (see its doc).
-                    let buf = unsafe {
-                        if matches!(&(*pp).state, PipeReaderState::Done(_)) {
-                            Some(PipeReader::take_done_buffer(pp))
-                        } else {
-                            None
-                        }
-                    };
-                    if let Some(buf) = buf {
-                        *out = Readable::Buffer(buf);
-                    } else {
-                        *out = Readable::Ignore;
-                    }
-                    drop(pipe); // deref
-                }
+            };
+            if let Some(buf) = buf {
+                *out = Readable::Buffer(buf);
+            } else {
+                *out = Readable::Ignore;
             }
+            drop(pipe); // deref
         }
     }
 
@@ -518,13 +523,14 @@ impl ShellSubprocess {
     /// # Safety
     /// `this` must be the live `heap::alloc`'d subprocess with no outstanding
     /// borrows; single-threaded shell. Raw (not `&mut self`) because the
-    /// stdin close re-enters `on_close_io(&mut Self)` through the writer's
+    /// stdin close re-enters `on_stdin_writer_close` through the writer's
     /// process backref.
     #[cfg(not(windows))]
     pub(crate) unsafe fn deinit_in_flight_io(this: *mut Self) {
-        // Claim `start()`'s +1, `close()` (fires `on_close` → `on_close_io`:
-        // slot → `Ignore`, `create()`'s ref released), release the claimed
-        // ref — the JS `Subprocess::close_io` stdin shape.
+        // Claim `start()`'s +1, `close()` (fires `on_close` →
+        // `on_stdin_writer_close`: slot → `Ignore`, `create()`'s ref released;
+        // the Cmd signal is a no-op since `deinit` already took `exec`),
+        // release the claimed ref — the JS `Subprocess::close_io` stdin shape.
         // SAFETY: caller contract; the `stdin` borrow ends before `close()`.
         let pending_start: *mut StaticPipeWriter = match unsafe { &(*this).stdin } {
             Writable::Buffer(buffer) => {
@@ -973,8 +979,16 @@ impl ShellSubprocess {
         Ok(())
     }
 
-    pub(crate) fn on_process_exit(&mut self, _: &Process, status: &Status, _: &Rusage) {
-        log!("onProcessExit({:x})", std::ptr::from_mut(self) as usize);
+    /// Exit handler (`link_impl_ProcessExit!` above). Raw `this` for the same
+    /// reason as [`Self::on_stdin_writer_close`]: when the exit is the last of
+    /// the completion events, the `Yield` run here reaches `Cmd::deinit`,
+    /// which frees `*this`.
+    ///
+    /// # Safety
+    /// `this` must be the live subprocess registered as the exit handler, with
+    /// no borrow of it live; `Process::on_exit` does not touch it afterwards.
+    unsafe fn on_process_exit(this: *mut Self, status: &Status) {
+        log!("onProcessExit({:x})", this as usize);
         let exit_code: Option<u8> = 'brk: {
             if let Status::Exited(exited) = &status {
                 break 'brk Some(exited.code);
@@ -993,16 +1007,21 @@ impl ShellSubprocess {
             break 'brk None;
         };
 
-        if let Some(code) = exit_code {
-            let handle = self.cmd_parent;
-            // SAFETY: cmd_parent backref outlives subprocess; resolved
-            // through the node arena so it survives `Vec<Node>` reallocation.
-            // `&mut self` is dead by NLL before `on_exit` re-enters interp.
-            let cmd = unsafe { handle.cmd_mut() };
-            if cmd.exit_code.is_none() {
-                cmd.on_exit(code.into());
-            }
+        let Some(code) = exit_code else { return };
+        // SAFETY: caller contract; copies the backref out, no borrow is kept.
+        let handle = unsafe { (*this).cmd_parent };
+        // SAFETY: the owning Cmd outlives its subprocess; resolved through the
+        // node arena so it survives `Vec<Node>` reallocation. The `&mut Cmd`
+        // ends before the trampoline re-enters the arena.
+        let cmd = unsafe { handle.cmd_mut() };
+        // An exit code recorded earlier (a stdout/stderr read error) wins;
+        // the remaining stdio closes finish the command.
+        if cmd.exit_code.is_some() {
+            return;
         }
+        let y = cmd.on_exit(code.into());
+        // May free `*this`; nothing follows.
+        y.run(&handle.interp);
     }
 }
 

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -276,9 +276,8 @@ impl JscSubprocess::static_pipe_writer::StaticPipeWriterProcess for ShellSubproc
     unsafe fn on_close_io(this: *mut Self, kind: StdioKind) {
         // `Writable::init` only ever creates the writer for stdin.
         debug_assert!(matches!(kind, StdioKind::Stdin));
-        // SAFETY: caller (`StaticPipeWriter::on_close`) guarantees `this` is
-        // live and does not touch it afterwards. Forwarded raw, not autoref'd:
-        // the callee may free `*this`.
+        // SAFETY: `StaticPipeWriter::on_close` passes its live process backref and does not
+        // touch it afterwards. Forwarded raw (not autoref'd): the callee may free `*this`.
         unsafe { Self::on_stdin_writer_close(this) }
     }
 }
@@ -302,29 +301,19 @@ impl ShellSubprocess {
         unsafe { &mut *self.process }
     }
 
-    /// The `< ${buffer}` stdin writer finished, failed, or was closed by
-    /// `deinit_in_flight_io`: release it, then tell the owning `Cmd` and drive
-    /// the resulting `Yield`, the way `PipeReader::finish_after_state_set`
-    /// does for stdout/stderr. When the exit and the output closes were
-    /// processed first, this is what finishes the command, and the trampoline
-    /// then reaches `Cmd::deinit`, which frees `*this`.
-    ///
-    /// Raw `this` rather than `&mut self` (same as [`Self::on_process_exit`])
-    /// so that no `&mut ShellSubprocess` is live while `*this` is freed.
+    /// The `< ${buffer}` stdin writer closed: release it and let the `Cmd` finish.
     ///
     /// # Safety
-    /// `this` must be the live subprocess owning the writer, with no borrow of
-    /// it live; the caller must not touch it after this returns.
+    /// `this` must be live and unborrowed. It may be freed (by `Cmd::deinit`, reached
+    /// through the Yield run here) by the time this returns, which is why it is raw.
     unsafe fn on_stdin_writer_close(this: *mut Self) {
         {
-            // SAFETY: caller contract; this borrow of the slot ends with the
-            // block, before the trampoline below can free `*this`.
+            // SAFETY: caller contract; the borrow ends with this block, before the Yield runs.
             let slot = unsafe { &mut (*this).stdin };
             match core::mem::replace(slot, Writable::Ignore) {
                 Writable::Buffer(buffer) => {
-                    // Releases `create()`'s ref (RefPtr has no Drop). This
-                    // cannot free the writer this callback is running inside
-                    // of: `start()`'s ref is only released after it returns.
+                    // Releases `create()`'s ref; `start()`'s keeps the writer alive until
+                    // this callback returns.
                     // SAFETY: single-threaded; sole borrow of the payload.
                     unsafe { buffer_mut(&buffer) }.source.detach();
                     buffer.deref();
@@ -336,19 +325,17 @@ impl ShellSubprocess {
                 }
             }
         }
-        // SAFETY: caller contract; copies the backref out, no borrow is kept.
+        // SAFETY: caller contract; `CmdHandle` is `Copy`, no borrow is kept.
         let handle = unsafe { (*this).cmd_parent };
         log!(
             "Subproc(0x{:x}) onStdinWriterClose(cmd={})",
             this as usize,
             handle.id
         );
-        // SAFETY: the owning Cmd outlives its subprocess (it is what frees it,
-        // in `deinit`). The `&mut Cmd` ends before the trampoline re-enters
-        // the arena.
+        // SAFETY: the owning Cmd outlives its subprocess (its `deinit` is what frees it);
+        // the `&mut Cmd` ends before the Yield runs.
         let y = unsafe { handle.cmd_mut() }.buffered_input_close();
-        // `ParentRef: Deref<Target = Interpreter>`; the interpreter owns the
-        // Cmd and outlives this callback. May free `*this`; nothing follows.
+        // May free `*this`.
         y.run(&handle.interp);
     }
 
@@ -434,10 +421,7 @@ impl ShellSubprocess {
         self.close_io(StdioKind::Stderr);
     }
 
-    /// A stdout/stderr `PipeReader` has signalled the `Cmd`
-    /// (`PipeReader::finish_after_state_set`): swap it out of its slot for its
-    /// buffered bytes. Stdin is not handled here: the writer's close goes
-    /// through [`Self::on_stdin_writer_close`], which can free `self`.
+    /// A stdout/stderr `PipeReader` finished: swap it out of its slot for its buffered bytes.
     pub(crate) fn on_close_io(&mut self, kind: StdioKind) {
         let out: &mut Readable = match kind {
             StdioKind::Stdout => &mut self.stdout,
@@ -527,10 +511,9 @@ impl ShellSubprocess {
     /// process backref.
     #[cfg(not(windows))]
     pub(crate) unsafe fn deinit_in_flight_io(this: *mut Self) {
-        // Claim `start()`'s +1, `close()` (fires `on_close` →
-        // `on_stdin_writer_close`: slot → `Ignore`, `create()`'s ref released;
-        // the Cmd signal is a no-op since `deinit` already took `exec`),
-        // release the claimed ref — the JS `Subprocess::close_io` stdin shape.
+        // Claim `start()`'s +1, `close()` (fires `on_close` → `on_stdin_writer_close`:
+        // slot → `Ignore`, `create()`'s ref released), release the claimed
+        // ref — the JS `Subprocess::close_io` stdin shape.
         // SAFETY: caller contract; the `stdin` borrow ends before `close()`.
         let pending_start: *mut StaticPipeWriter = match unsafe { &(*this).stdin } {
             Writable::Buffer(buffer) => {
@@ -979,14 +962,11 @@ impl ShellSubprocess {
         Ok(())
     }
 
-    /// Exit handler (`link_impl_ProcessExit!` above). Raw `this` for the same
-    /// reason as [`Self::on_stdin_writer_close`]: when the exit is the last of
-    /// the completion events, the `Yield` run here reaches `Cmd::deinit`,
-    /// which frees `*this`.
+    /// Exit handler (`link_impl_ProcessExit!` above).
     ///
     /// # Safety
-    /// `this` must be the live subprocess registered as the exit handler, with
-    /// no borrow of it live; `Process::on_exit` does not touch it afterwards.
+    /// Same contract as [`Self::on_stdin_writer_close`]: `this` must be live and unborrowed,
+    /// and may be freed by the time this returns.
     unsafe fn on_process_exit(this: *mut Self, status: &Status) {
         log!("onProcessExit({:x})", this as usize);
         let exit_code: Option<u8> = 'brk: {
@@ -1008,19 +988,16 @@ impl ShellSubprocess {
         };
 
         let Some(code) = exit_code else { return };
-        // SAFETY: caller contract; copies the backref out, no borrow is kept.
+        // SAFETY: caller contract; `CmdHandle` is `Copy`, no borrow is kept.
         let handle = unsafe { (*this).cmd_parent };
-        // SAFETY: the owning Cmd outlives its subprocess; resolved through the
-        // node arena so it survives `Vec<Node>` reallocation. The `&mut Cmd`
-        // ends before the trampoline re-enters the arena.
+        // SAFETY: the owning Cmd outlives its subprocess (its `deinit` is what frees it);
+        // the `&mut Cmd` ends before the Yield runs.
         let cmd = unsafe { handle.cmd_mut() };
-        // An exit code recorded earlier (a stdout/stderr read error) wins;
-        // the remaining stdio closes finish the command.
         if cmd.exit_code.is_some() {
             return;
         }
         let y = cmd.on_exit(code.into());
-        // May free `*this`; nothing follows.
+        // May free `*this`.
         y.run(&handle.interp);
     }
 }

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -22,11 +22,8 @@ bun_output::declare_scope!(StaticPipeWriter, hidden);
 /// the process — materializing `&mut P` while `&mut writer` is live would alias.
 pub trait StaticPipeWriterProcess {
     const POLL_OWNER_TAG: bun_io::PollTag;
-    /// Called once, from the writer's close; the writer does not touch the process
-    /// afterwards, so the impl may free `*this` (and run arbitrary code doing so).
-    ///
     /// # Safety
-    /// `this` must point to a live `Self`.
+    /// `this` must be a live `Self`. Called once, from the writer's close; the impl may free it.
     unsafe fn on_close_io(this: *mut Self, kind: StdioKind);
 }
 

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -22,13 +22,15 @@ bun_output::declare_scope!(StaticPipeWriter, hidden);
 /// the process — materializing `&mut P` while `&mut writer` is live would alias.
 pub trait StaticPipeWriterProcess {
     const POLL_OWNER_TAG: bun_io::PollTag;
+    /// Called once, from the writer's close; the writer does not touch the process
+    /// afterwards, so the impl may free `*this` (and run arbitrary code doing so).
+    ///
     /// # Safety
     /// `this` must point to a live `Self`.
     unsafe fn on_close_io(this: *mut Self, kind: StdioKind);
 }
 
 /// Generic over the owning process type (e.g. `Subprocess`, `ShellSubprocess`).
-/// `P` must expose `fn on_close_io(&mut self, kind: StdioKind)`.
 // Cleanup lives in `impl Drop` below; the final Box free is
 // the derive's default destructor (`drop(heap::take(this))`).
 #[derive(bun_ptr::RefCounted)]
@@ -38,7 +40,7 @@ pub struct StaticPipeWriter<P: StaticPipeWriterProcess> {
     pub(crate) writer: IOWriter<P>,
     pub(crate) stdio_result: StdioResult,
     pub source: Source,
-    /// BACKREF: parent process is notified on close; never owned/destroyed here.
+    /// BACKREF: parent process, notified (and nulled) on close; never owned/destroyed here.
     pub(crate) process: *mut P,
     pub(crate) event_loop: EventLoopHandle,
     /// True while `start()`'s `+1` ref is outstanding.
@@ -270,9 +272,11 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         // frees that storage so no dangling slice survives the close.
         self.buffer = RawSlice::EMPTY;
         self.source.detach();
-        // SAFETY: `process` is a backref to the owning process, guaranteed alive
-        // for the lifetime of this writer (the process owns/outlives its stdio writers).
-        unsafe { P::on_close_io(self.process, StdioKind::Stdin) };
+        let process = core::mem::replace(&mut self.process, core::ptr::null_mut());
+        // SAFETY: the owning process keeps this backref alive until it has been told
+        // the writer closed, which is this (single) call; it may be freed by it, and
+        // the field is already nulled so nothing here can use it afterwards.
+        unsafe { P::on_close_io(process, StdioKind::Stdin) };
         #[cfg(windows)]
         if release_start_ref {
             // SAFETY: `started` was the token for start()'s outstanding +1;

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3117,20 +3117,23 @@ describe("stdin redirect still held open by a helper after the command's process
   // closes: that close is what has to complete the command. The helper either
   // just exits (the pending write fails) or drains the redirect, which it must
   // receive in full: the shell keeps pumping for whoever still holds the pipe.
-  const SIZE = 1 << 20; // bigger than any pipe buffer, so the write is still pending when the child exits
-  const helper = (afterRelease: string) => `
+  const SIZE = 4 << 20; // far more than a pipe or socketpair buffers, so the write is still pending when the child exits
+  // Each helper records what it did in RESULT_FILE once released, so a helper
+  // that died early (which would also fail the pending write) cannot pass as one
+  // that exited on cue.
+  const helper = (resultExpression: string) => `
     const deadline = Date.now() + 60_000;
     while (!(await Bun.file(process.env.RELEASE_FILE).exists()) && Date.now() < deadline) await Bun.sleep(5);
-    ${afterRelease}
+    await Bun.write(process.env.RESULT_FILE, ${resultExpression});
   `;
-  const exitingHelper = helper("");
-  const drainingHelper = helper(`await Bun.write(process.env.COUNT_FILE, String((await Bun.stdin.bytes()).length));`);
+  const exitingHelper = helper(`"released"`);
+  const drainingHelper = helper(`"read " + (await Bun.stdin.bytes()).length + " bytes"`);
   const childCode = `
     Bun.spawn({
       cmd: [process.execPath, "-e", process.env.HELPER_CODE],
       stdin: "inherit",
       stdout: "ignore",
-      stderr: "ignore",
+      stderr: Bun.file(process.env.HELPER_STDERR),
       detached: true,
     }).unref();
     await Bun.write(process.env.PID_FILE, String(process.pid));
@@ -3139,12 +3142,12 @@ describe("stdin redirect still held open by a helper after the command's process
     process.exitCode = 3;
   `;
 
-  async function until<T>(poll: () => T | Promise<T>): Promise<T> {
+  async function until<T>(what: string, poll: () => T | Promise<T>): Promise<T> {
     const deadline = Date.now() + 30_000;
     while (true) {
       const value = await poll();
       if (value) return value;
-      if (Date.now() > deadline) throw new Error("condition not met within 30s");
+      if (Date.now() > deadline) throw new Error(`${what} did not happen within 30s`);
       await Bun.sleep(5);
     }
   }
@@ -3162,25 +3165,30 @@ describe("stdin redirect still held open by a helper after the command's process
 
   async function run(helperCode: string, command: (env: Record<string, string | undefined>) => $.ShellPromise) {
     using dir = tempDir("shell-stdin-held-open", {});
-    const env = {
+    const env: Record<string, string | undefined> = {
       ...bunEnv,
       HELPER_CODE: helperCode,
+      HELPER_STDERR: join(String(dir), "helper.stderr"),
       PID_FILE: join(String(dir), "pid"),
       RELEASE_FILE: join(String(dir), "release"),
-      COUNT_FILE: join(String(dir), "count"),
+      RESULT_FILE: join(String(dir), "result"),
     };
+    // The ASAN CI lanes run with this set, which makes the child SIGKILL the helper when it exits.
+    delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
     const running = command(env).then(r => r); // `$` is lazy; start it now.
-    const pid = Number(await until(() => fileContents(env.PID_FILE)));
-    await until(() => hasExited(pid));
-    await Bun.write(env.RELEASE_FILE, "");
+    const pid = Number(await until("child pid file", () => fileContents(env.PID_FILE!)));
+    await until("child exit", () => hasExited(pid));
+    await Bun.write(env.RELEASE_FILE!, "");
     const result = await running;
-    const out: Record<string, unknown> = {
+    const helperResult = await until("helper result", () => fileContents(env.RESULT_FILE!)).catch(async error => {
+      throw new Error(`${error.message}; helper stderr: ${JSON.stringify(await fileContents(env.HELPER_STDERR!))}`);
+    });
+    return {
       stdout: result.stdout.toString(),
       stderr: result.stderr.toString(),
       exitCode: result.exitCode,
+      helper: helperResult,
     };
-    if (helperCode === drainingHelper) out.bytesRead = Number(await until(() => fileContents(env.COUNT_FILE)));
-    return out;
   }
 
   const redirects: Array<[string, () => Buffer | Blob]> = [
@@ -3190,12 +3198,17 @@ describe("stdin redirect still held open by a helper after the command's process
 
   test.concurrent.each(redirects)("helper exits without reading: %s", async (_name, input) => {
     const out = await run(exitingHelper, env => $`${BUN} -e ${childCode} < ${input()}`.env(env).quiet().nothrow());
-    expect(out).toEqual({ stdout: "child stdout\n", stderr: "child stderr\n", exitCode: 3 });
+    expect(out).toEqual({ stdout: "child stdout\n", stderr: "child stderr\n", exitCode: 3, helper: "released" });
   });
 
   test.concurrent.each(redirects)("helper drains the redirect: %s", async (_name, input) => {
     const out = await run(drainingHelper, env => $`${BUN} -e ${childCode} < ${input()}`.env(env).quiet().nothrow());
-    expect(out).toEqual({ stdout: "child stdout\n", stderr: "child stderr\n", exitCode: 3, bytesRead: SIZE });
+    expect(out).toEqual({
+      stdout: "child stdout\n",
+      stderr: "child stderr\n",
+      exitCode: 3,
+      helper: `read ${SIZE} bytes`,
+    });
   });
 
   test.concurrent("inside a pipeline", async () => {
@@ -3203,14 +3216,19 @@ describe("stdin redirect still held open by a helper after the command's process
     const out = await run(exitingHelper, env =>
       $`${BUN} -e ${childCode} < ${Buffer.alloc(SIZE, "a")} | ${BUN} -e ${upper}`.env(env).quiet().nothrow(),
     );
-    expect(out).toEqual({ stdout: "CHILD STDOUT\n", stderr: "child stderr\n", exitCode: 0 });
+    expect(out).toEqual({ stdout: "CHILD STDOUT\n", stderr: "child stderr\n", exitCode: 0, helper: "released" });
   });
 
   test.concurrent("as the left side of ||", async () => {
     const out = await run(exitingHelper, env =>
       $`${BUN} -e ${childCode} < ${Buffer.alloc(SIZE, "a")} || echo failed`.env(env).quiet().nothrow(),
     );
-    expect(out).toEqual({ stdout: "child stdout\nfailed\n", stderr: "child stderr\n", exitCode: 0 });
+    expect(out).toEqual({
+      stdout: "child stdout\nfailed\n",
+      stderr: "child stderr\n",
+      exitCode: 0,
+      helper: "released",
+    });
   });
 });
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3109,59 +3109,108 @@ describe("stdin redirect from a zero-length buffer delivers EOF to the spawned c
   });
 });
 
-describe("stdin redirect whose pipe is closed after the command has exited", () => {
-  // `< ${buf}` streams the bytes into the child over a pipe. A child that
-  // exits without reading its stdin leaves that write pending, and it only
-  // fails (and the stdin side of the command only closes) once the pipe's
-  // read end is gone. The child below hands its stdin to a helper process
-  // that outlives it without reading from it, so the exit code and the
-  // stdout/stderr EOFs are always processed first and the stdin close is
-  // what has to complete the command.
-  const SIZE = 1 << 20; // bigger than any pipe buffer: the write never drains
+describe("stdin redirect still held open by a helper after the command's process has exited", () => {
+  // `< ${buf}` is pumped into the child over a pipe. The child hands its stdin
+  // to a detached helper and exits without reading any of it, and the helper
+  // only acts once the test has seen the child disappear, so the exit code and
+  // the stdout/stderr EOFs have been processed by the time the stdin side
+  // closes: that close is what has to complete the command. The helper either
+  // just exits (the pending write fails) or drains the redirect, which it must
+  // receive in full: the shell keeps pumping for whoever still holds the pipe.
+  const SIZE = 1 << 20; // bigger than any pipe buffer, so the write is still pending when the child exits
+  const helper = (afterRelease: string) => `
+    const deadline = Date.now() + 60_000;
+    while (!(await Bun.file(process.env.RELEASE_FILE).exists()) && Date.now() < deadline) await Bun.sleep(5);
+    ${afterRelease}
+  `;
+  const exitingHelper = helper("");
+  const drainingHelper = helper(`await Bun.write(process.env.COUNT_FILE, String((await Bun.stdin.bytes()).length));`);
   const childCode = `
-    const holder = Bun.spawn({
-      cmd: [process.execPath, "-e", "setTimeout(() => {}, 500)"],
+    Bun.spawn({
+      cmd: [process.execPath, "-e", process.env.HELPER_CODE],
       stdin: "inherit",
       stdout: "ignore",
       stderr: "ignore",
       detached: true,
-    });
-    holder.unref();
+    }).unref();
+    await Bun.write(process.env.PID_FILE, String(process.pid));
     console.log("child stdout");
     console.error("child stderr");
     process.exitCode = 3;
   `;
-  const cases: Array<[string, () => Buffer | Blob]> = [
+
+  async function until<T>(poll: () => T | Promise<T>): Promise<T> {
+    const deadline = Date.now() + 30_000;
+    while (true) {
+      const value = await poll();
+      if (value) return value;
+      if (Date.now() > deadline) throw new Error("condition not met within 30s");
+      await Bun.sleep(5);
+    }
+  }
+  async function fileContents(path: string) {
+    return (await Bun.file(path).exists()) ? Bun.file(path).text() : "";
+  }
+  function hasExited(pid: number) {
+    try {
+      process.kill(pid, 0);
+      return false;
+    } catch {
+      return true;
+    }
+  }
+
+  async function run(helperCode: string, command: (env: Record<string, string | undefined>) => $.ShellPromise) {
+    using dir = tempDir("shell-stdin-held-open", {});
+    const env = {
+      ...bunEnv,
+      HELPER_CODE: helperCode,
+      PID_FILE: join(String(dir), "pid"),
+      RELEASE_FILE: join(String(dir), "release"),
+      COUNT_FILE: join(String(dir), "count"),
+    };
+    const running = command(env).then(r => r); // `$` is lazy; start it now.
+    const pid = Number(await until(() => fileContents(env.PID_FILE)));
+    await until(() => hasExited(pid));
+    await Bun.write(env.RELEASE_FILE, "");
+    const result = await running;
+    const out: Record<string, unknown> = {
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+      exitCode: result.exitCode,
+    };
+    if (helperCode === drainingHelper) out.bytesRead = Number(await until(() => fileContents(env.COUNT_FILE)));
+    return out;
+  }
+
+  const redirects: Array<[string, () => Buffer | Blob]> = [
     ["Buffer", () => Buffer.alloc(SIZE, "a")],
     ["Blob", () => new Blob([Buffer.alloc(SIZE, "a")])],
   ];
 
-  test.concurrent.each(cases)("%s", async (_name, input) => {
-    const result = await $`${BUN} -e ${childCode} < ${input()}`.quiet();
-    expect({
-      stdout: result.stdout.toString(),
-      stderr: result.stderr.toString(),
-      exitCode: result.exitCode,
-    }).toEqual({ stdout: "child stdout\n", stderr: "child stderr\n", exitCode: 3 });
+  test.concurrent.each(redirects)("helper exits without reading: %s", async (_name, input) => {
+    const out = await run(exitingHelper, env => $`${BUN} -e ${childCode} < ${input()}`.env(env).quiet().nothrow());
+    expect(out).toEqual({ stdout: "child stdout\n", stderr: "child stderr\n", exitCode: 3 });
+  });
+
+  test.concurrent.each(redirects)("helper drains the redirect: %s", async (_name, input) => {
+    const out = await run(drainingHelper, env => $`${BUN} -e ${childCode} < ${input()}`.env(env).quiet().nothrow());
+    expect(out).toEqual({ stdout: "child stdout\n", stderr: "child stderr\n", exitCode: 3, bytesRead: SIZE });
   });
 
   test.concurrent("inside a pipeline", async () => {
     const upper = "process.stdout.write((await Bun.stdin.text()).toUpperCase())";
-    const result = await $`${BUN} -e ${childCode} < ${Buffer.alloc(SIZE, "a")} | ${BUN} -e ${upper}`.quiet();
-    expect({
-      stdout: result.stdout.toString(),
-      stderr: result.stderr.toString(),
-      exitCode: result.exitCode,
-    }).toEqual({ stdout: "CHILD STDOUT\n", stderr: "child stderr\n", exitCode: 0 });
+    const out = await run(exitingHelper, env =>
+      $`${BUN} -e ${childCode} < ${Buffer.alloc(SIZE, "a")} | ${BUN} -e ${upper}`.env(env).quiet().nothrow(),
+    );
+    expect(out).toEqual({ stdout: "CHILD STDOUT\n", stderr: "child stderr\n", exitCode: 0 });
   });
 
   test.concurrent("as the left side of ||", async () => {
-    const result = await $`${BUN} -e ${childCode} < ${Buffer.alloc(SIZE, "a")} || echo failed`.quiet();
-    expect({
-      stdout: result.stdout.toString(),
-      stderr: result.stderr.toString(),
-      exitCode: result.exitCode,
-    }).toEqual({ stdout: "child stdout\nfailed\n", stderr: "child stderr\n", exitCode: 0 });
+    const out = await run(exitingHelper, env =>
+      $`${BUN} -e ${childCode} < ${Buffer.alloc(SIZE, "a")} || echo failed`.env(env).quiet().nothrow(),
+    );
+    expect(out).toEqual({ stdout: "child stdout\nfailed\n", stderr: "child stderr\n", exitCode: 0 });
   });
 });
 

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3109,6 +3109,62 @@ describe("stdin redirect from a zero-length buffer delivers EOF to the spawned c
   });
 });
 
+describe("stdin redirect whose pipe is closed after the command has exited", () => {
+  // `< ${buf}` streams the bytes into the child over a pipe. A child that
+  // exits without reading its stdin leaves that write pending, and it only
+  // fails (and the stdin side of the command only closes) once the pipe's
+  // read end is gone. The child below hands its stdin to a helper process
+  // that outlives it without reading from it, so the exit code and the
+  // stdout/stderr EOFs are always processed first and the stdin close is
+  // what has to complete the command.
+  const SIZE = 1 << 20; // bigger than any pipe buffer: the write never drains
+  const childCode = `
+    const holder = Bun.spawn({
+      cmd: [process.execPath, "-e", "setTimeout(() => {}, 500)"],
+      stdin: "inherit",
+      stdout: "ignore",
+      stderr: "ignore",
+      detached: true,
+    });
+    holder.unref();
+    console.log("child stdout");
+    console.error("child stderr");
+    process.exitCode = 3;
+  `;
+  const cases: Array<[string, () => Buffer | Blob]> = [
+    ["Buffer", () => Buffer.alloc(SIZE, "a")],
+    ["Blob", () => new Blob([Buffer.alloc(SIZE, "a")])],
+  ];
+
+  test.concurrent.each(cases)("%s", async (_name, input) => {
+    const result = await $`${BUN} -e ${childCode} < ${input()}`.quiet();
+    expect({
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+      exitCode: result.exitCode,
+    }).toEqual({ stdout: "child stdout\n", stderr: "child stderr\n", exitCode: 3 });
+  });
+
+  test.concurrent("inside a pipeline", async () => {
+    const upper = "process.stdout.write((await Bun.stdin.text()).toUpperCase())";
+    const result = await $`${BUN} -e ${childCode} < ${Buffer.alloc(SIZE, "a")} | ${BUN} -e ${upper}`.quiet();
+    expect({
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+      exitCode: result.exitCode,
+    }).toEqual({ stdout: "CHILD STDOUT\n", stderr: "child stderr\n", exitCode: 0 });
+  });
+
+  test.concurrent("as the left side of ||", async () => {
+    const result = await $`${BUN} -e ${childCode} < ${Buffer.alloc(SIZE, "a")} || echo failed`.quiet();
+    expect({
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+      exitCode: result.exitCode,
+    }).toEqual({ stdout: "child stdout\nfailed\n", stderr: "child stderr\n", exitCode: 0 });
+  });
+});
+
 test("output redirect buffer for an external command stays attached until the command finishes", async () => {
   // `> ${buf}` for an external (non-builtin) command stores the buffer and
   // copies the child's stdout into it as chunks arrive across event-loop

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -3176,9 +3176,17 @@ describe("stdin redirect still held open by a helper after the command's process
     // The ASAN CI lanes run with this set, which makes the child SIGKILL the helper when it exits.
     delete env.BUN_FEATURE_FLAG_NO_ORPHANS;
     const running = command(env).then(r => r); // `$` is lazy; start it now.
-    const pid = Number(await until("child pid file", () => fileContents(env.PID_FILE!)));
-    await until("child exit", () => hasExited(pid));
-    await Bun.write(env.RELEASE_FILE!, "");
+    let pid = 0;
+    try {
+      pid = Number(await until("child pid file", () => fileContents(env.PID_FILE!)));
+      await until("child exit", () => hasExited(pid));
+    } finally {
+      // Also on the failure path, so the helper and the command wind down now rather
+      // than lingering for the rest of the file.
+      await Bun.write(env.RELEASE_FILE!, "");
+      if (pid !== 0 && !hasExited(pid)) process.kill(pid, "SIGKILL");
+      await running;
+    }
     const result = await running;
     const helperResult = await until("helper result", () => fileContents(env.RESULT_FILE!)).catch(async error => {
       throw new Error(`${error.message}; helper stderr: ${JSON.stringify(await fileContents(env.HELPER_STDERR!))}`);


### PR DESCRIPTION
### Problem
- ``await $`cmd < ${buffer}` ``, where the child exits without reading a redirect bigger than the pipe, sometimes never resolves (2 of 8 runs on bun 1.4.0), and the process does not exit either, since the interpreter still counts as pending activity. It hangs every time if something holds the child's stdin open for a moment after the child exits.
- A command running a subprocess is complete once it has an exit code and stdin, stdout and stderr have all closed. Those four events arrive as separate event-loop callbacks in no fixed order.
- Three of the four moved the command to Done when they completed it. The stdin close only recorded itself, so whenever it landed last, the command was complete and nothing finished it.
- It lands last often: the pending stdin write only fails with `EPIPE` once the read end of the pipe is gone, which is at the same time as, or after, the exit and the stdout/stderr EOFs.

### Fix
- The stdin close now does what the stdout/stderr closes and the exit already did: all three end in one shared tail that marks the command Done when it is complete and returns the resumption for the caller to run.
- Correct because completion is a conjunction of four independently delivered events, so each must be able to finish the command; exactly one does, since the transition tears the subprocess down synchronously and the other events have already been delivered by then.
- Running that transition can free the subprocess, so the stdin-close and exit callbacks take a raw pointer instead of `&mut self` (the shape the stdout/stderr readers already had; the exit path had the same latent problem), and the shared pipe writer nulls its process backref before its single close notification.
- Verification: six new tests (Buffer and Blob redirects, a helper that exits or drains, the command inside a pipeline and on the left of `||`) force the stdin close to be the last event. All six time out without the `src/` changes and pass with them on bun 1.4.0 and a debug ASAN build; the existing shell, spawn and install-scanner tests still pass.

### Background
- A `< ${buffer}` (or Blob or `Response`) redirect in the Bun shell is pumped into the child's stdin over a pipe by a `StaticPipeWriter`, a writer `Bun.spawn` and the install security scanner also use. It reports its close to its owning process through a raw backref.
- A shell `Cmd` that spawned a subprocess tracks the exit code plus a closed flag per piped stdio and is finished only when all are in, whoever holds the pipes: a helper that inherited the child's stdin keeps the stdin side open after the child is gone, and the shell keeps pumping to it.
- Shell callbacks do not advance the interpreter directly. They return a `Yield` (resume this node, or nothing) that the caller runs; running it can complete the parent node and free the `Cmd` and its subprocess, so nothing may still borrow either at that point.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/bunshell.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

```ts
import { $ } from "bun";
// The child exits without reading its stdin; the buffer is bigger than the pipe,
// so the shell's stdin write is still pending when it does.
await $`sh -c 'exit 0' < ${Buffer.alloc(1 << 20, "a")}`.quiet();
```

This never resolves on some runs (2 of 8 with bun 1.4.0 here, about 2 of 3 on a debug build). Whether it hangs depends on the order in which the event loop happens to deliver four events that all become ready when the child exits. This variant forces the problematic order and hangs every time: a helper keeps the child's stdin open (without reading it) for a moment after the child itself has exited.

```ts
await $`sh -c 'exec 3<&0; sleep 0.5 <&3 >/dev/null 2>&1 & exit 0' < ${Buffer.alloc(1 << 20, "a")}`.quiet();
```

### Cause

A `Cmd` running a subprocess is complete once it has an exit code and every piped stdio has closed (`Cmd::has_finished`). For a Buffer/Blob/`Response` redirect, stdin is piped: the bytes are pumped into the child by a `StaticPipeWriter`, and `BufferedIoClosed::stdin` has to be marked closed too. Three of the four events that can complete the command checked `has_finished()` and moved the `Cmd` to `Done` (`Cmd::on_exit`, and `Cmd::buffered_output_close` for stdout and stderr). The fourth, `Cmd::buffered_input_close` (reached from the writer's close through `ShellSubprocess::on_close_io` and `on_static_pipe_writer_done`), only set the flag.

When the child exits without draining its stdin, the pending write fails with EPIPE only once the pipe's read end is gone, so the stdin close is processed at the same time as, or after, the exit and the stdout/stderr EOFs. Whenever it lands last, the command is complete and nothing transitions it. The promise never settles, and since the interpreter still counts as pending activity the process does not exit either (the script above has to be killed), even though the child and all of its pipes are gone by then.

<details>
<summary>Debug trace of a hanging run (`BUN_DEBUG_SHELL=1 BUN_DEBUG_SHELL_SUBPROC=1 BUN_DEBUG_StaticPipeWriter=1`)</summary>

```
[shell_subproc] onProcessExit(...)
[shell] cmd exit code=0 has_finished=false
[shell] cmd close buffered stderr
[shell] BufferedIOClosed all_closed=false stdin=false stdout=false stderr=true
[shell] cmd close buffered stdout
[shell] BufferedIOClosed all_closed=false stdin=false stdout=true stderr=true
[staticpipewriter] StaticPipeWriter(...) onError(err=EPIPE: Broken pipe (send()))
[staticpipewriter] StaticPipeWriter(...) onClose()
[shell_subproc] Subproc(...) onStaticPipeWriterDone(cmd=Node#2)
(nothing further)
```

</details>

### Fix

* `Cmd::buffered_input_close`, `buffered_output_close` and `on_exit` all end in the same `finish_if_done` tail (`has_finished()` -> `state = Done` -> `Yield::Next(this)`, including the existing "spawn has not returned yet" gate that `transition_to_exec` resumes from) and return the `Yield` to their caller. Previously only the output closes and the exit did this, and `on_exit` ran the Yield itself. `buffered_input_close` stays a no-op once `deinit` has taken `exec`, which is the only way it is reached during teardown (`deinit_in_flight_io`).
* The two `ShellSubprocess` callbacks that run those Yields, `on_stdin_writer_close` (replaces `on_static_pipe_writer_done` plus the stdin arm of `on_close_io`) and `on_process_exit`, take `this: *mut Self` and are forwarded raw by the `StaticPipeWriterProcess` shim and the `link_impl_ProcessExit!` thunk. Running the Yield can reach `Cmd::deinit`, which frees the subprocess and recycles the Cmd's arena slot, so no `&mut` to either may be on the stack at that point; this is the shape `PipeReader::on_reader_done` / `finish_after_state_set` already use for stdout/stderr, and it also removes the pre-existing instance of the problem in the exit path. `on_stdin_writer_close` empties the `Writable::Buffer` slot before signalling (the subprocess may be gone afterwards); dropping `create()`'s ref there cannot free the writer the callback is running inside of, because every path into `StaticPipeWriter::on_close` holds `start()`'s ref (or the one `deinit_in_flight_io` claims) until after the callback returns.
* `on_close_io` is left with the stdout/stderr reader path, its only remaining caller. Its old `Writable::Pipe` arm was unreachable: the shell never creates a FileSink stdin, and a FileSink reports its close through `Writable::on_close`, not this function.
* `StaticPipeWriter` (`src/spawn/static_pipe_writer.rs`, shared with `Bun.spawn` and the install security scanner) so far documented its process backref as outliving the writer. The shell's callback can now free the process from inside `on_close_io` and run the rest of the script while doing so; nothing in the writer used the backref after that call before either, but the trait doc now states the contract, and `on_close` nulls the field before the (single) dispatch so a future use after it faults in every impl instead of dangling only for the shell. The other two impls are unaffected (they get the same pointer they got before).

Why this shape: the completion condition is a conjunction of four independently delivered events, so each of them has to be able to perform the transition, and making the stdin close do what the other three already do is the whole fix. Exactly one transition happens per command in any interleaving: the transition tears the subprocess down synchronously, and the other events have by then already been delivered (they are what made `has_finished()` true). The alternative would be to close the stdin writer when the child exits, as `Bun.spawn`'s `Subprocess` does for its buffer stdin; that would also end the hang, but it changes what `<` means: a process that inherited the child's stdin and outlives it would get a truncated redirect. Waiting for the writer keeps stdin consistent with how the shell already treats stdout/stderr capture (the command finishes when the pipes close, whoever holds them), and it is what `BufferedIoClosed` tracking stdin was evidently written for; the new tests pin that choice.

#37774 fixes a separate leak of the writer's `start()` ref on the same EPIPE path; it also edits `StaticPipeWriter::on_close`, so one of the two needs a trivial rebase, and they compose (it releases the ref after the dispatch). #37652 refactors the `SubprocExec` fields `finish_if_done` reads. #36895 adds ReadableStream stdin and calls the old `on_static_pipe_writer_done` from the exit handler; on top of this PR that call would need to move to the `Cmd` side, since the replacement runs the Yield. None of them covers this hang.

### Tests

`test/js/bun/shell/bunshell.test.ts`, "stdin redirect still held open by a helper after the command's process has exited". The child (`bun -e`) spawns a detached helper that inherits its stdin, writes its own pid to a file, prints to stdout and stderr and exits 3 without reading anything. The test waits until that pid is gone (the exit and both EOFs are then processed, or queued ahead of anything the helper can still cause) and only then releases the helper through a file, so the stdin close is always the last event, on every platform and without a fixed delay. Every helper records what it did once released, so a helper that died early (which also fails the pending write) cannot pass as one that exited on cue; the redirect is 4 MiB so the write is still pending when the child exits whatever the socket buffer size. The command's environment drops `BUN_FEATURE_FLAG_NO_ORPHANS`, which the ASAN CI lanes set and under which the child kills the helper as it exits (that is what the first CI run of the draining cases showed). Cases, for a Buffer and a Blob redirect each:

* the helper exits without reading (the pending write fails): exit code, captured output and the helper's "released" record must come back;
* the helper drains the redirect after the child is gone: the command must still wait for it, and the helper must receive all 4 MiB (a close-at-exit implementation would pass the first group and fail this one; this also exercises the drained close rather than the error close);
* plus the exiting helper with the command inside a pipeline and as the left operand of `||`, so the completion reaches a `Pipeline` and a `Binary` parent, not only a `Stmt`.

All six time out without the `src/` changes and pass with them, both with and without `BUN_FEATURE_FLAG_NO_ORPHANS=1` in the test process's environment (bun 1.4.0 and a debug ASAN build). Also passing on the debug ASAN build: the rest of `bunshell.test.ts` (422 tests), `shell-worker-terminate-leak` (covers `deinit_in_flight_io` closing the writer mid-flight), `shell-hang`, `epipe`, `lazy`, `yield`, `pipeline_stack`, `bunshell-file`, `shelloutput`, `exec`; for the other users of the writer, `spawn.test.ts` plus the stdin spawn tests both with memfd and with `BUN_FEATURE_FLAG_DISABLE_MEMFD=1` (which forces `Bun.spawn` onto the pipe writer), and `bun-install-security-provider.test.ts`.

</details>
