### PR TITLE
Route native-to-JS callback calls through a MicrotaskCallCache

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "7b763944f0ecd0e18cb9ac89a04ef994e3ccb4ae";
+export const WEBKIT_VERSION = "autobuild-preview-pr-415-83df6114";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/js/internal-for-testing.ts
+++ b/src/js/internal-for-testing.ts
@@ -694,6 +694,15 @@ export const isMemoryPressureWatcherInstalled: () => boolean = $newCppFunction(
 export const getEventLoopStats: () => { activeTasks: number; concurrentRef: number; numPolls: number } =
   $newRustFunction("event_loop.rs", "getActiveTasks", 0);
 
+/**
+ * Process-wide counters of the cache behind native-to-JS callback calls
+ * (`Bun::hostCall`, src/jsc/bindings/HostCall.h). `undefined` in builds
+ * without assertions, which do not keep them.
+ */
+export const hostCallCacheStats: () =>
+  | { hits: number; misses: number; replacements: number; fallbacks: number }
+  | undefined = $newCppFunction("InternalForTesting.cpp", "jsFunction_hostCallCacheStats", 0);
+
 export const hostedGitInfo = {
   parseUrl: $newRustFunction("hosted_git_info.rs", "TestingAPIs.jsParseUrl", 1),
   fromUrl: $newRustFunction("hosted_git_info.rs", "TestingAPIs.jsFromUrl", 1),

--- a/src/jsc/bindings/AsyncContextFrame.cpp
+++ b/src/jsc/bindings/AsyncContextFrame.cpp
@@ -1,6 +1,7 @@
 #include "root.h"
 #include "ZigGlobalObject.h"
 #include "AsyncContextFrame.h"
+#include "HostCall.h"
 #include <JavaScriptCore/InternalFieldTuple.h>
 
 #if ASSERT_ENABLED
@@ -108,7 +109,7 @@ extern "C" JSC::EncodedJSValue AsyncContextFrame__withAsyncContextIfNeeded(JSGlo
         restoreAsyncContext = asyncContextData->getInternalField(0);                \
         asyncContextData->putInternalField(vm, 0, wrapper->context.get());          \
     }                                                                               \
-    auto result = JSC::profiledCall(__VA_ARGS__);                                   \
+    auto result = Bun::hostCall(__VA_ARGS__);                                       \
     if (asyncContextData) {                                                         \
         asyncContextData->putInternalField(vm, 0, restoreAsyncContext);             \
     }                                                                               \
@@ -121,10 +122,10 @@ JSValue AsyncContextFrame::call(JSGlobalObject* global, JSValue functionObject, 
 #endif
 
     if (!global->isAsyncContextTrackingEnabled()) [[likely]] {
-        return JSC::profiledCall(global, ProfilingReason::API, functionObject, JSC::getCallData(functionObject), thisValue, args);
+        return Bun::hostCall(global, functionObject, JSC::getCallData(functionObject), thisValue, args);
     }
 
-    ASYNCCONTEXTFRAME_CALL_IMPL(global, ProfilingReason::API, functionObject, JSC::getCallData(functionObject), thisValue, args);
+    ASYNCCONTEXTFRAME_CALL_IMPL(global, functionObject, JSC::getCallData(functionObject), thisValue, args);
 }
 JSValue AsyncContextFrame::profiledCall(JSGlobalObject* global, JSValue functionObject, JSValue thisValue, const ArgList& args)
 {

--- a/src/jsc/bindings/AsyncContextFrame.h
+++ b/src/jsc/bindings/AsyncContextFrame.h
@@ -17,7 +17,7 @@ public:
     // When given a JSFunction that you want to call later, wrap it with this function
     static JSC::JSValue withAsyncContextIfNeeded(JSC::JSGlobalObject* globalObject, JSC::JSValue callback);
 
-    // The following is JSC::call but
+    // The following is Bun::hostCall (see HostCall.h) but
     // - it unwraps AsyncContextFrame
     // - does not take a CallData, because JSC::getCallData(AsyncContextFrame) -> not callable
     static JSC::JSValue call(JSC::JSGlobalObject*, JSC::JSValue functionObject, JSC::JSValue thisValue, const JSC::ArgList&);

--- a/src/jsc/bindings/HostCall.cpp
+++ b/src/jsc/bindings/HostCall.cpp
@@ -1,0 +1,147 @@
+#include "root.h"
+#include "HostCall.h"
+
+#include <JavaScriptCore/JSFunction.h>
+#include <JavaScriptCore/MicrotaskCallInlines.h>
+#include <JavaScriptCore/ScriptProfilingScope.h>
+#include <JavaScriptCore/VMEntryScopeInlines.h>
+#include <JavaScriptCore/VMInlines.h>
+
+#if ASSERT_ENABLED
+#include <cstdlib>
+#include <cstring>
+#include <wtf/DataLog.h>
+extern "C" void Bun__atexit(void (*)(void));
+#endif
+
+namespace Bun {
+using namespace JSC;
+
+#if ASSERT_ENABLED
+
+static HostCallCacheStats hostCallCacheStatsStorage;
+
+const HostCallCacheStats& hostCallCacheStats()
+{
+    return hostCallCacheStatsStorage;
+}
+
+static void printHostCallCacheStats()
+{
+    const auto& stats = hostCallCacheStatsStorage;
+    dataLogLn("[host_call_cache] hits=", stats.hits.load(std::memory_order_relaxed), " misses=", stats.misses.load(std::memory_order_relaxed), " replacements=", stats.replacements.load(std::memory_order_relaxed), " fallbacks=", stats.fallbacks.load(std::memory_order_relaxed));
+}
+
+// BUN_DEBUG_HOST_CALL_CACHE=1 prints the counters when the process exits.
+static ALWAYS_INLINE void installHostCallCacheStatsPrinter()
+{
+    [[maybe_unused]] static const bool installed = [] {
+        const char* value = getenv("BUN_DEBUG_HOST_CALL_CACHE");
+        if (value && *value && strcmp(value, "0"))
+            Bun__atexit(printHostCallCacheStats);
+        return true;
+    }();
+}
+
+static ALWAYS_INLINE void countHit()
+{
+    installHostCallCacheStatsPrinter();
+    hostCallCacheStatsStorage.hits.fetch_add(1, std::memory_order_relaxed);
+}
+
+static ALWAYS_INLINE void countMiss(MicrotaskCall& entryBeingReplaced)
+{
+    installHostCallCacheStatsPrinter();
+    hostCallCacheStatsStorage.misses.fetch_add(1, std::memory_order_relaxed);
+    if (entryBeingReplaced.functionExecutable())
+        hostCallCacheStatsStorage.replacements.fetch_add(1, std::memory_order_relaxed);
+}
+
+static ALWAYS_INLINE void countFallback()
+{
+    installHostCallCacheStatsPrinter();
+    hostCallCacheStatsStorage.fallbacks.fetch_add(1, std::memory_order_relaxed);
+}
+
+#else
+
+static ALWAYS_INLINE void countHit() {}
+static ALWAYS_INLINE void countMiss(MicrotaskCall&) {}
+static ALWAYS_INLINE void countFallback() {}
+
+#endif
+
+static ALWAYS_INLINE JSValue tryCachedHostCall(VM& vm, MicrotaskCall& entry, JSFunction* function, JSValue thisValue, const ArgList& args)
+{
+    // The context cell is the async stack trace origin recorded in the VMEntryRecord; a call from native
+    // code has none, which is also what JSC::call passes.
+    static_assert(MicrotaskCall::maxCallArguments == 6, "the switch below covers exactly the arities the thunks exist for");
+    switch (args.size()) {
+    case 0:
+        return entry.tryCallWithArguments(vm, function, thisValue, nullptr);
+    case 1:
+        return entry.tryCallWithArguments(vm, function, thisValue, nullptr, args.at(0));
+    case 2:
+        return entry.tryCallWithArguments(vm, function, thisValue, nullptr, args.at(0), args.at(1));
+    case 3:
+        return entry.tryCallWithArguments(vm, function, thisValue, nullptr, args.at(0), args.at(1), args.at(2));
+    case 4:
+        return entry.tryCallWithArguments(vm, function, thisValue, nullptr, args.at(0), args.at(1), args.at(2), args.at(3));
+    case 5:
+        return entry.tryCallWithArguments(vm, function, thisValue, nullptr, args.at(0), args.at(1), args.at(2), args.at(3), args.at(4));
+    case 6:
+        return entry.tryCallWithArguments(vm, function, thisValue, nullptr, args.at(0), args.at(1), args.at(2), args.at(3), args.at(4), args.at(5));
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+JSValue hostCall(JSGlobalObject* globalObject, JSValue functionObject, const CallData& callData, JSValue thisValue, const ArgList& args)
+{
+    auto& vm = JSC::getVM(globalObject);
+    ASSERT(callData.type != CallData::Type::None);
+
+    // CallData::Type::JS means a JSFunction with a FunctionExecutable, which is the only thing a
+    // MicrotaskCall can link. The last two conditions are the ones executeCallImpl turns into a stack
+    // overflow error / checkVMEntryPermission(); letting it do that keeps those paths identical.
+    if (callData.type != CallData::Type::JS || args.size() > MicrotaskCall::maxCallArguments || vm.disallowVMEntryCount || !vm.isSafeToRecurseSoft()) [[unlikely]] {
+        countFallback();
+        return JSC::profiledCall(globalObject, ProfilingReason::API, functionObject, callData, thisValue, args);
+    }
+
+    // Same order as profiledCall(): the profiling scope is opened before the VMEntryScope, so an outer
+    // entry scope (if any) is what gets reported.
+    ScriptProfilingScope profilingScope(vm.deprecatedVMEntryGlobalObject(globalObject), ProfilingReason::API);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    scope.assertNoException();
+
+    auto* function = uncheckedDowncast<JSFunction>(functionObject.asCell());
+    // tryCallWithArguments expects the caller to have entered the VM; executeCallImpl enters the
+    // callee's realm, not the global object the caller happens to hold.
+    VMEntryScope entryScope(vm, callData.js.scope->realm());
+
+    auto& cache = vm.hostCallCache();
+    auto* entry = cache.find(functionObject);
+    if (entry) [[likely]] {
+        countHit();
+    } else {
+        entry = cache.nextEntryToReplace();
+        countMiss(*entry);
+        entry->initialize(vm, function);
+        RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, {});
+    }
+
+    JSValue result = tryCachedHostCall(vm, *entry, function, thisValue, args);
+    if (result) [[likely]]
+        RELEASE_AND_RETURN(scope, result);
+
+    // An empty result is either an exception (thrown by the callee, or while relinking a CodeBlock that
+    // was jettisoned since the last call) or an entry that cannot take this call because the callee
+    // declares more parameters than it is being passed (the linked entry point skips the arity check).
+    // Only the latter may fall through to the generic call.
+    RETURN_IF_EXCEPTION_WITH_TRAPS_DEFERRED(scope, {});
+    countFallback();
+    RELEASE_AND_RETURN(scope, JSC::call(globalObject, functionObject, callData, thisValue, args));
+}
+
+} // namespace Bun

--- a/src/jsc/bindings/HostCall.h
+++ b/src/jsc/bindings/HostCall.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "root.h"
+#include <JavaScriptCore/ArgList.h>
+#include <JavaScriptCore/CallData.h>
+
+#if ASSERT_ENABLED
+#include <atomic>
+#endif
+
+namespace Bun {
+
+// JSC::profiledCall(globalObject, ProfilingReason::API, ...) for the callbacks the event loop invokes
+// from native code (timers, request and socket handlers, fs callbacks, ...). Those are a handful of
+// functions called over and over, so a plain JS function taking at most MicrotaskCall::maxCallArguments
+// arguments goes through VM::hostCallCache(): the first call links its CodeBlock into a cache entry and
+// later calls enter it directly through vmEntryToJavaScriptWith{N}Arguments, skipping getCallData,
+// prepareForExecution and the ProtoCallFrame / argument copy of Interpreter::executeCallImpl. Anything
+// else (bound functions, proxies, InternalFunctions, host functions, more arguments than that, a callee
+// declaring more parameters than it is passed) takes the regular JSC::call path. Either way the call
+// runs under a VMEntryScope for the callee's realm, exactly like executeCallImpl.
+//
+// `callData` is getCallData(functionObject); callers handle CallData::Type::None themselves.
+JSC::JSValue hostCall(JSC::JSGlobalObject*, JSC::JSValue functionObject, const JSC::CallData&, JSC::JSValue thisValue, const JSC::ArgList&);
+
+#if ASSERT_ENABLED
+// Process-wide counters (all VMs). Exposed to tests through bun:internal-for-testing and printed at exit
+// when BUN_DEBUG_HOST_CALL_CACHE=1 is set.
+struct HostCallCacheStats {
+    // Calls that found their function in the cache.
+    std::atomic<uint64_t> hits { 0 };
+    // Calls that did not and linked their function into an entry.
+    std::atomic<uint64_t> misses { 0 };
+    // The misses that evicted an entry still holding a live function. The cache is thrashing when this
+    // tracks misses.
+    std::atomic<uint64_t> replacements { 0 };
+    // Calls that ended up in JSC::call: not a plain JS function, too many arguments, or the callee
+    // declares more parameters than it was passed (those last ones are also counted as hits or misses).
+    std::atomic<uint64_t> fallbacks { 0 };
+};
+const HostCallCacheStats& hostCallCacheStats();
+#endif
+
+} // namespace Bun

--- a/src/jsc/bindings/InternalForTesting.cpp
+++ b/src/jsc/bindings/InternalForTesting.cpp
@@ -5,7 +5,9 @@
 #include "JavaScriptCore/JSCast.h"
 #include "JavaScriptCore/JSArrayBufferView.h"
 #include "headers-handwritten.h"
+#include "HostCall.h"
 #include "webcore/HTTPHeaderMap.h"
+#include <JavaScriptCore/ObjectConstructor.h>
 #include <wtf/text/StringImpl.h>
 #include <wtf/text/WTFString.h>
 
@@ -122,6 +124,25 @@ JSC_DEFINE_HOST_FUNCTION(jsFunction_emitMemoryPressure, (JSC::JSGlobalObject * g
 JSC_DEFINE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     return JSValue::encode(jsBoolean(Bun__MemoryPressure__isInstalled(defaultGlobalObject(globalObject))));
+}
+
+// Snapshot of the Bun::hostCall cache counters (see HostCall.h), so tests can
+// check that a callback actually went through the cached path. Builds without
+// assertions do not keep the counters and return undefined.
+JSC_DEFINE_HOST_FUNCTION(jsFunction_hostCallCacheStats, (JSC::JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+#if ASSERT_ENABLED
+    auto& vm = globalObject->vm();
+    const auto& stats = hostCallCacheStats();
+    auto* object = constructEmptyObject(globalObject);
+    object->putDirect(vm, Identifier::fromString(vm, "hits"_s), jsNumber(stats.hits.load(std::memory_order_relaxed)));
+    object->putDirect(vm, Identifier::fromString(vm, "misses"_s), jsNumber(stats.misses.load(std::memory_order_relaxed)));
+    object->putDirect(vm, Identifier::fromString(vm, "replacements"_s), jsNumber(stats.replacements.load(std::memory_order_relaxed)));
+    object->putDirect(vm, Identifier::fromString(vm, "fallbacks"_s), jsNumber(stats.fallbacks.load(std::memory_order_relaxed)));
+    return JSValue::encode(object);
+#else
+    return encodedJSUndefined();
+#endif
 }
 
 }

--- a/src/jsc/bindings/InternalForTesting.h
+++ b/src/jsc/bindings/InternalForTesting.h
@@ -13,5 +13,6 @@ JSC_DECLARE_HOST_FUNCTION(jsFunction_BunString_toThreadSafeRefCountDelta);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_lowercaseHeaderNameSIMD);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_emitMemoryPressure);
 JSC_DECLARE_HOST_FUNCTION(jsFunction_isMemoryPressureWatcherInstalled);
+JSC_DECLARE_HOST_FUNCTION(jsFunction_hostCallCacheStats);
 
 }

--- a/src/jsc/bindings/NodeTimerObject.cpp
+++ b/src/jsc/bindings/NodeTimerObject.cpp
@@ -13,6 +13,7 @@
 #include <JavaScriptCore/ObjectConstructor.h>
 #include "JavaScriptCore/JSCJSValue.h"
 #include "AsyncContextFrame.h"
+#include "HostCall.h"
 namespace Bun {
 using namespace JSC;
 
@@ -54,7 +55,7 @@ static bool call(JSGlobalObject* globalObject, JSValue timerObject, JSValue call
             args.append(argumentsValue);
         }
 
-        JSC::profiledCall(globalObject, ProfilingReason::API, callbackValue, callData, timerObject, args);
+        hostCall(globalObject, callbackValue, callData, timerObject, args);
     }
 
     bool hadException = false;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -157,6 +157,7 @@
 #include "JSURLSearchParams.h"
 
 #include "AsyncContextFrame.h"
+#include "HostCall.h"
 #include "JavaScriptCore/InternalFieldTuple.h"
 #include "JavaScriptCore/JSAsyncFunctionGenerator.h"
 #include "JavaScriptCore/JSGenerator.h"
@@ -3191,7 +3192,7 @@ extern "C" JSC::EncodedJSValue Bun__JSValue__call(JSC::JSGlobalObject* globalObj
         return {};
     }
 
-    auto result = JSC::profiledCall(globalObject, ProfilingReason::API, jsObject, callData, jsThisObject, argList);
+    auto result = Bun::hostCall(globalObject, jsObject, callData, jsThisObject, argList);
 
     if (asyncContextData) {
         asyncContextData->putInternalField(vm, 0, restoreAsyncContext);

--- a/test/js/bun/jsc/host-call-cache.test.ts
+++ b/test/js/bun/jsc/host-call-cache.test.ts
@@ -1,0 +1,524 @@
+// Native -> JS callback calls (timers, Bun.serve handlers, HTMLRewriter handlers, ...) go through
+// Bun::hostCall (src/jsc/bindings/HostCall.cpp), which links plain JS callees into the VM's
+// MicrotaskCallCache and enters them directly on later calls. These tests drive each wired call
+// site and, in builds that keep the counters, check which path every call took.
+//
+// The counters are process-wide, so the tests in this file have to stay sequential: a concurrent
+// test would add its own calls to another test's before/after window.
+import { hostCallCacheStats } from "bun:internal-for-testing";
+import { numberOfDFGCompiles, optimizeNextInvocation } from "bun:jsc";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// MicrotaskCallCache::cacheSize (WebKit, interpreter/MicrotaskCall.h).
+const CACHE_SIZE = 8;
+
+type Stats = NonNullable<ReturnType<typeof hostCallCacheStats>>;
+
+// Builds without assertions do not keep the counters and return undefined. The behaviour
+// assertions below run everywhere; the counter assertions only where there are counters.
+const hasStats = hostCallCacheStats() !== undefined;
+
+function snapshot(): Stats {
+  return hostCallCacheStats() ?? { hits: 0, misses: 0, replacements: 0, fallbacks: 0 };
+}
+
+function delta(before: Stats, after: Stats = snapshot()): Stats {
+  return {
+    hits: after.hits - before.hits,
+    misses: after.misses - before.misses,
+    replacements: after.replacements - before.replacements,
+    fallbacks: after.fallbacks - before.fallbacks,
+  };
+}
+
+/**
+ * Has the timer code path (Bun__JSTimeout__call) call `callback` itself with `args`, and resolves
+ * once it ran. Counter-wise this is one hit or miss for `callback`, plus one fallback for `resolve`,
+ * which is a host function.
+ */
+function callFromTimer(callback: (...args: any[]) => unknown, ...args: unknown[]): Promise<void> {
+  const { promise, resolve } = Promise.withResolvers<void>();
+  setImmediate(callback, ...args);
+  setImmediate(resolve);
+  return promise;
+}
+
+/** Has the HTMLRewriter (Bun__JSValue__call, synchronous for string input) call `handler` once per <p>. */
+function rewrite(handler: (element: HTMLRewriterTypes.Element) => void, html = "<p></p>"): string {
+  return new HTMLRewriter().on("p", { element: handler }).transform(html);
+}
+
+describe("timers", () => {
+  test("this and the arguments arrive on the linking call and on cached calls alike", async () => {
+    const seen: unknown[] = [];
+    function callback(this: object, a: unknown, b: unknown) {
+      seen.push([this.constructor.name, a, b]);
+    }
+
+    const before = snapshot();
+    for (let i = 0; i < 3; i++) await callFromTimer(callback, i, `arg-${i}`);
+
+    expect(seen).toEqual([
+      ["Immediate", 0, "arg-0"],
+      ["Immediate", 1, "arg-1"],
+      ["Immediate", 2, "arg-2"],
+    ]);
+    if (hasStats) {
+      expect(delta(before)).toEqual({ hits: 2, misses: 1, replacements: expect.any(Number), fallbacks: 3 });
+    }
+  });
+
+  test("one entry serves every argument count the register-passing entry points exist for", async () => {
+    let received: unknown[][] = [];
+    // `arguments` instead of parameters, so the arity check never applies.
+    const callee = function () {
+      received.push(Array.from(arguments));
+    };
+
+    for (let count = 0; count <= 6; count++) {
+      const args = Array.from({ length: count }, (_, i) => i * 10);
+      received = [];
+
+      const before = snapshot();
+      for (let i = 0; i < 3; i++) await callFromTimer(callee, ...args);
+
+      expect(received).toEqual([args, args, args]);
+      if (hasStats) {
+        // Entries are keyed by FunctionExecutable, so the callee is linked once (by the first call
+        // with zero arguments) and every later argument count hits that same entry.
+        const { hits, misses, fallbacks } = delta(before);
+        expect({ count, hits, misses, fallbacks }).toEqual(
+          count === 0 ? { count, hits: 2, misses: 1, fallbacks: 3 } : { count, hits: 3, misses: 0, fallbacks: 3 },
+        );
+      }
+    }
+  });
+
+  test("closures of the same function literal share an entry", async () => {
+    const seen: string[] = [];
+    const makeCallee = (tag: string) => () => {
+      seen.push(tag);
+    };
+
+    const before = snapshot();
+    for (const tag of ["a", "b", "c"]) await callFromTimer(makeCallee(tag));
+
+    expect(seen).toEqual(["a", "b", "c"]);
+    if (hasStats) {
+      // Three JSFunctions, one FunctionExecutable: linked once, and each call uses its own closure's
+      // scope (the tags differ), since the callee object is passed to the linked code on every call.
+      expect(delta(before)).toEqual({ hits: 2, misses: 1, replacements: expect.any(Number), fallbacks: 3 });
+    }
+  });
+
+  test("seven arguments take the generic path and all arrive", async () => {
+    const received: unknown[][] = [];
+    const callee = function () {
+      received.push(Array.from(arguments));
+    };
+
+    const before = snapshot();
+    for (let i = 0; i < 3; i++) await callFromTimer(callee, 1, 2, 3, 4, 5, 6, 7);
+
+    expect(received).toEqual([
+      [1, 2, 3, 4, 5, 6, 7],
+      [1, 2, 3, 4, 5, 6, 7],
+      [1, 2, 3, 4, 5, 6, 7],
+    ]);
+    if (hasStats) {
+      expect(delta(before)).toEqual({ hits: 0, misses: 0, replacements: 0, fallbacks: 6 });
+    }
+  });
+
+  test("a callee declaring more parameters than it is passed takes the generic path and sees undefined for the rest", async () => {
+    const received: unknown[][] = [];
+    const callee = (a: unknown, b: unknown, c: unknown) => {
+      received.push([a, b, c]);
+    };
+
+    const before = snapshot();
+    for (let i = 0; i < 3; i++) await callFromTimer(callee, "only");
+
+    expect(received).toEqual([
+      ["only", undefined, undefined],
+      ["only", undefined, undefined],
+      ["only", undefined, undefined],
+    ]);
+    if (hasStats) {
+      // The callee is still looked up and linked, but the linked entry point skips the arity fixup,
+      // so each of the three calls additionally goes through the generic path (3 + 3 for resolve).
+      expect(delta(before)).toEqual({ hits: 2, misses: 1, replacements: expect.any(Number), fallbacks: 6 });
+    }
+  });
+
+  test("a callee declaring fewer parameters than it is passed takes the cached path", async () => {
+    const received: unknown[] = [];
+    const callee = (a: unknown) => {
+      received.push(a);
+    };
+
+    const before = snapshot();
+    for (let i = 0; i < 3; i++) await callFromTimer(callee, "first", "ignored", "ignored too");
+
+    expect(received).toEqual(["first", "first", "first"]);
+    if (hasStats) {
+      expect(delta(before)).toEqual({ hits: 2, misses: 1, replacements: expect.any(Number), fallbacks: 3 });
+    }
+  });
+
+  test("a bound function takes the generic path", async () => {
+    const received: unknown[][] = [];
+    const bound = function (this: { tag: string }, a: unknown) {
+      received.push([this.tag, a]);
+    }.bind({ tag: "bound this" });
+
+    const before = snapshot();
+    for (let i = 0; i < 3; i++) await callFromTimer(bound, i);
+
+    expect(received).toEqual([
+      ["bound this", 0],
+      ["bound this", 1],
+      ["bound this", 2],
+    ]);
+    if (hasStats) {
+      // A bound function's executable is native, so the lookup never matches and nothing is linked.
+      expect(delta(before)).toEqual({ hits: 0, misses: 0, replacements: 0, fallbacks: 6 });
+    }
+  });
+
+  test("an async callee is a plain JSFunction and takes the cached path", async () => {
+    const results: string[] = [];
+    let resolveAll!: () => void;
+    const all = new Promise<void>(resolve => (resolveAll = resolve));
+    const callee = async function (value: string) {
+      await null;
+      results.push(value);
+      if (results.length === 3) resolveAll();
+    };
+
+    const before = snapshot();
+    setImmediate(callee, "v0");
+    setImmediate(callee, "v1");
+    setImmediate(callee, "v2");
+    await all;
+
+    expect(results).toEqual(["v0", "v1", "v2"]);
+    if (hasStats) {
+      expect(delta(before)).toEqual({ hits: 2, misses: 1, replacements: expect.any(Number), fallbacks: 0 });
+    }
+  });
+
+  test("the entry follows the callee while it tiers up", async () => {
+    let sum = 0;
+    let calls = 0;
+    function hot(iterations: number, resolve: () => void) {
+      let local = 0;
+      for (let i = 0; i < iterations; i++) local += i;
+      sum += local;
+      calls++;
+      resolve();
+    }
+    const call = () => {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      setImmediate(hot, 50, resolve);
+      return promise;
+    };
+
+    const before = snapshot();
+    for (let i = 0; i < 20; i++) await call();
+    // numberOfDFGCompiles() becomes 1 once an optimized CodeBlock is installed for `hot` (or right
+    // away when the JIT is disabled). Every call that gets it there is made through the entry that
+    // was linked to the interpreter CodeBlock; optimizeNextInvocation() only takes effect once the
+    // baseline JIT has kicked in, and the compile itself runs concurrently, hence the polling.
+    for (let rounds = 0; numberOfDFGCompiles(hot) < 1 && rounds < 500; rounds++) {
+      optimizeNextInvocation(hot);
+      for (let i = 0; i < 10; i++) await call();
+    }
+    expect(numberOfDFGCompiles(hot)).toBeGreaterThanOrEqual(1);
+
+    const optimized = snapshot();
+    for (let i = 0; i < 50; i++) await call();
+
+    expect(sum).toBe(calls * ((50 * 49) / 2));
+    expect(calls).toBeGreaterThanOrEqual(70);
+    if (hasStats) {
+      const total = delta(before);
+      expect(total.fallbacks).toBe(0);
+      expect(total.hits + total.misses).toBe(calls);
+      // Each tier-up upgrades the entry in place. A collection between two calls can additionally
+      // jettison a CodeBlock that is not on the stack (JSC ages them), which costs one relink, so
+      // the total is bounded rather than exact; the window after the optimized code was installed is.
+      expect(total.misses).toBeLessThanOrEqual(3);
+      expect(delta(optimized)).toEqual({ hits: 50, misses: 0, replacements: 0, fallbacks: 0 });
+    }
+  });
+});
+
+describe("garbage collection", () => {
+  test("a live callee stays linked across a full collection", () => {
+    const handler = (element: HTMLRewriterTypes.Element) => element.setAttribute("seen", "");
+    expect(rewrite(handler)).toBe('<p seen=""></p>');
+
+    const before = snapshot();
+    Bun.gc(true);
+    expect(rewrite(handler)).toBe('<p seen=""></p>');
+    if (hasStats) {
+      expect(delta(before)).toEqual({ hits: 1, misses: 0, replacements: 0, fallbacks: 0 });
+    }
+  });
+
+  // Each callee is created with `new Function` so that it owns its FunctionExecutable; a function
+  // literal in this file would share its executable's lifetime with this module's code.
+  function callFreshCallees(count: number) {
+    const callees = Array.from(
+      { length: count },
+      (_, i) =>
+        new Function("element", `element.setAttribute("n", "${i}")`) as (element: HTMLRewriterTypes.Element) => void,
+    );
+    const results = callees.map(callee => rewrite(callee));
+    expect(results).toEqual(Array.from({ length: count }, (_, i) => `<p n="${i}"></p>`));
+    return callees;
+  }
+
+  test.skipIf(!hasStats)("entries whose callee was collected are released rather than evicted", () => {
+    // Fill every slot, then keep those callees alive while another batch goes in: each of them has
+    // to evict a live callee.
+    const firstBatch = callFreshCallees(CACHE_SIZE);
+    const filled = snapshot();
+    let secondBatch: unknown[] | null = callFreshCallees(CACHE_SIZE);
+    expect(delta(filled)).toEqual({ hits: 0, misses: CACHE_SIZE, replacements: CACHE_SIZE, fallbacks: 0 });
+    expect(firstBatch).toHaveLength(CACHE_SIZE);
+
+    // Now every slot holds a second-batch callee; drop them. The HTMLRewriter objects protect their
+    // handlers until they are finalized, so it takes one collection to finalize the rewriters and a
+    // second one to collect the callees, at which point VM::finalizeUnconditionally() clears the
+    // entries. The conservative stack scan may still see a pointer to one of them.
+    secondBatch = null;
+    Bun.gc(true);
+    Bun.gc(true);
+
+    const collected = snapshot();
+    callFreshCallees(CACHE_SIZE);
+    const d = delta(collected);
+    expect({ hits: d.hits, misses: d.misses, fallbacks: d.fallbacks }).toEqual({
+      hits: 0,
+      misses: CACHE_SIZE,
+      fallbacks: 0,
+    });
+    expect(d.replacements).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("exceptions", () => {
+  // Plain JS, unlike expect().toThrow(), which calls its argument from native code and would show
+  // up in the counters itself.
+  function messageThrownBy(fn: () => unknown): string | undefined {
+    try {
+      fn();
+    } catch (error) {
+      return (error as Error).message;
+    }
+  }
+
+  test("a throwing callee propagates from the linking call and from a cached call, then keeps working", () => {
+    let calls = 0;
+    const handler = () => {
+      calls++;
+      if (calls <= 2) throw new Error(`thrown on call ${calls}`);
+    };
+
+    const before = snapshot();
+    const outcomes = [
+      messageThrownBy(() => rewrite(handler)),
+      messageThrownBy(() => rewrite(handler)),
+      rewrite(handler),
+    ];
+
+    expect(outcomes).toEqual(["thrown on call 1", "thrown on call 2", "<p></p>"]);
+    expect(calls).toBe(3);
+    if (hasStats) {
+      expect(delta(before)).toEqual({ hits: 2, misses: 1, replacements: expect.any(Number), fallbacks: 0 });
+    }
+  });
+
+  test("a class constructor is a JS callee whose call CodeBlock throws, on the linking call and on cached calls", () => {
+    class Handler {
+      constructor() {
+        throw new Error("constructed");
+      }
+    }
+
+    const before = snapshot();
+    const messages = [
+      messageThrownBy(() => rewrite(Handler as unknown as (element: HTMLRewriterTypes.Element) => void)),
+      messageThrownBy(() => rewrite(Handler as unknown as (element: HTMLRewriterTypes.Element) => void)),
+    ];
+
+    expect(messages).toEqual([
+      "Cannot call a class constructor Handler without |new|",
+      "Cannot call a class constructor Handler without |new|",
+    ]);
+    if (hasStats) {
+      expect(delta(before)).toEqual({ hits: 1, misses: 1, replacements: expect.any(Number), fallbacks: 0 });
+    }
+  });
+
+  test("a callee invoked near stack exhaustion throws a RangeError, and the cache works afterwards", () => {
+    let handlerCalls = 0;
+    const handler = () => {
+      handlerCalls++;
+    };
+    let depth = 0;
+    // Spreading 4096 arguments into every level makes each frame ~32 KiB, so the stack runs out
+    // after a couple of hundred levels instead of tens of thousands (each level is a full rewrite,
+    // which is slow in debug builds).
+    const padding = new Array<number>(4096).fill(0);
+    function recurse(...pad: number[]): number {
+      depth++;
+      // Every level makes one native -> JS call, so one of them happens right at the limit.
+      rewrite(handler);
+      // Not `return recurse(...)`: this is strict mode code, where JSC would make that a proper
+      // tail call and the stack would never grow.
+      return recurse(...pad) + 1;
+    }
+
+    let caught: unknown;
+    try {
+      recurse(...padding);
+    } catch (error) {
+      caught = error;
+    }
+    expect(caught).toBeInstanceOf(RangeError);
+    expect((caught as RangeError).message).toBe("Maximum call stack size exceeded.");
+    expect(depth).toBeGreaterThan(20);
+    // Either the deepest level's native -> JS call was refused (handler not run for that level) or
+    // the recursion itself overflowed right after it ran.
+    expect(handlerCalls).toBeOneOf([depth, depth - 1]);
+
+    const before = snapshot();
+    expect(rewrite(handler)).toBe("<p></p>");
+    expect(rewrite(element => element.setAttribute("fresh", ""))).toBe('<p fresh=""></p>');
+    expect(handlerCalls).toBeOneOf([depth + 1, depth]);
+    if (hasStats) {
+      // The refused call left the handler's entry alone, so it is still a hit; the new arrow links.
+      expect(delta(before)).toEqual({ hits: 1, misses: 1, replacements: expect.any(Number), fallbacks: 0 });
+    }
+  });
+});
+
+describe("Bun.serve", () => {
+  test("fetch handler (Bun__JSValue__call) and route handler (AsyncContextFrame::call)", async () => {
+    const calls: string[] = [];
+    using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/route/:name": (request, serverArgument) => {
+          calls.push(`route ${request.params.name} ${serverArgument === server}`);
+          return new Response(`route ${request.params.name}`);
+        },
+      },
+      fetch(request, serverArgument) {
+        const { pathname } = new URL(request.url);
+        calls.push(`fetch ${pathname} ${serverArgument === server}`);
+        return new Response(`fetch ${pathname}`);
+      },
+    });
+
+    const before = snapshot();
+    const bodies: string[] = [];
+    for (const path of ["/a", "/b", "/route/x", "/route/y", "/c"]) {
+      const response = await fetch(new URL(path, server.url));
+      bodies.push(await response.text());
+    }
+
+    expect(bodies).toEqual(["fetch /a", "fetch /b", "route x", "route y", "fetch /c"]);
+    expect(calls).toEqual(["fetch /a true", "fetch /b true", "route x true", "route y true", "fetch /c true"]);
+    if (hasStats) {
+      // Two callees, each linked by its first request. fetch() on the client side settles through
+      // promises, not through a native -> JS call, so nothing else lands in the window.
+      expect(delta(before)).toEqual({ hits: 3, misses: 2, replacements: expect.any(Number), fallbacks: 0 });
+    }
+  });
+
+  test("a fetch handler that throws is reported per request and later requests still work", async () => {
+    let calls = 0;
+    using server = Bun.serve({
+      port: 0,
+      fetch() {
+        calls++;
+        if (calls <= 2) throw new Error(`request ${calls} failed`);
+        return new Response(`request ${calls} ok`);
+      },
+      error(error) {
+        return new Response(`caught: ${error.message}`, { status: 500 });
+      },
+    });
+
+    const before = snapshot();
+    const results: [number, string][] = [];
+    for (let i = 0; i < 3; i++) {
+      const response = await fetch(server.url);
+      results.push([response.status, await response.text()]);
+    }
+
+    expect(results).toEqual([
+      [500, "caught: request 1 failed"],
+      [500, "caught: request 2 failed"],
+      [200, "request 3 ok"],
+    ]);
+    if (hasStats) {
+      // fetch: linked once, hit twice (the linking call is the one that throws first). error: linked
+      // once, hit once.
+      expect(delta(before)).toEqual({ hits: 3, misses: 2, replacements: expect.any(Number), fallbacks: 0 });
+    }
+  });
+
+  test("handlers registered inside AsyncLocalStorage.run() see their store on every call", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+        const { AsyncLocalStorage } = require("node:async_hooks");
+        const als = new AsyncLocalStorage();
+        (async () => {
+          const server = als.run("store", () =>
+            Bun.serve({
+              port: 0,
+              routes: { "/route": () => new Response(String(als.getStore())) },
+              fetch() { return new Response(String(als.getStore())); },
+            }),
+          );
+          const seen = [];
+          for (const path of ["/route", "/route", "/fetch", "/fetch"]) {
+            seen.push(await (await fetch(new URL(path, server.url))).text(), String(als.getStore()));
+          }
+          server.stop(true);
+          console.log(JSON.stringify(seen));
+        })();
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    // Bun.serve() wraps both handlers in an AsyncContextFrame when it is called inside run(). The
+    // route goes through AsyncContextFrame::call, fetch through Bun__JSValue__call; both restore the
+    // store around the linking call and around the cached one, and the caller's context comes back.
+    expect(JSON.parse(stdout)).toEqual([
+      "store",
+      "undefined",
+      "store",
+      "undefined",
+      "store",
+      "undefined",
+      "store",
+      "undefined",
+    ]);
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem
- Every callback native code invokes (timers, `Bun.serve` and socket handlers, `node:http`, napi, plugins) went through `JSC::profiledCall`, which redoes `getCallData`, `prepareForExecution`, `ProtoCallFrame` setup and the generic argument copy on each call.
- Those callbacks are a handful of functions called over and over, so that setup is repeated per call although its result does not change between calls.
- JSC already avoids this for promise reactions with `MicrotaskCallCache`: once a function is linked, a call is a cache lookup plus a direct entry thunk.

### Fix
- Adds `Bun::hostCall` and routes the three native-to-JS call sites through it: a plain JS function passed at most 6 arguments is linked into a VM-owned cache on its first call and entered directly afterwards. The cache itself is oven-sh/WebKit#415; `WEBKIT_VERSION` points at that PR's preview build until it merges.
- Everything else (bound functions, proxies, host functions, 7 or more arguments, a callee declaring more parameters than it is passed, VM entry disallowed, stack nearly exhausted) still takes the old `profiledCall` / `JSC::call` path, so behaviour outside the cached case is unchanged.
- The cached path opens the same profiling scope and the same `VMEntryScope` (the callee's realm) as before, and checks for an exception before falling through, so a throwing callee is never run twice.
- Verification: a new test drives all three call sites and, on assertion builds, checks which path each call took (tier-up, GC, throwing callees, stack overflow included); it cannot pass without this PR because the counters do not exist there. Benchmarks on a loaded box show about 10 ns saved per call, inside the noise at event loop granularity.

### Background
- `JSC::profiledCall` / `JSC::call` is the generic way native code invokes any callable. Each call goes through `Interpreter::executeCallImpl`, which classifies the callee, makes sure it is compiled, and builds a call frame before entering JS.
- `CallData` is what `getCallData(value)` returns. `Type::JS` means an ordinary JS function backed by a `FunctionExecutable`, as opposed to a bound function, proxy or native function; the callers here already compute it to reject non-functions.
- `MicrotaskCall` / `MicrotaskCallCache` is JSC's 8-entry round-robin cache used when draining promise reactions. An entry holds one executable's linked entry point, follows it through tier-up, is unlinked on jettison or GC, and can only enter callees with up to 6 register-passed arguments.
- `VMEntryScope` marks a native-to-JS transition for a realm. `executeCallImpl` sets one up itself; the cached entry thunks do not, so `hostCall` has to.
- Only builds with `ASSERT_ENABLED` (debug, and the release-asan CI lane) compile in the hit/miss counters, so `hostCallCacheStats()` from `bun:internal-for-testing` is `undefined` on a normal release binary.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 0 · 11 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsc/host-call-cache.test.ts
bun test v1.4.0 (8431da9ad)

test/js/bun/jsc/host-call-cache.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'hostCallCacheStats' not found in module 'bun:internal-for-testing'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [2.46s]
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: BUILD FAILED (no junit output)
bun test v1.4.0-canary.1 (1adeb974d)

test/js/bun/jsc/host-call-cache.test.ts:

# Unhandled error between tests
-------------------------------
SyntaxError: Export named 'hostCallCacheStats' not found in module 'bun:internal-for-testing'.
-------------------------------


 0 pass
 1 fail
 1 error
Ran 1 test across 1 file. [175.00ms]
__F:-1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/jsc/host-call-cache.test.ts
bun test v1.4.0 (8431da9ad)

test/js/bun/jsc/host-call-cache.test.ts:
(pass) timers > this and the arguments arrive on the linking call and on cached calls alike [17.19ms]
(pass) timers > one entry serves every argument count the register-passing entry points exist for [30.20ms]
(pass) timers > closures of the same function literal share an entry [12.79ms]
(pass) timers > seven arguments take the generic path and all arrive [9.68ms]
(pass) timers > a callee declaring more parameters than it is passed takes the generic path and sees undefined for the rest [9.28ms]
(pass) timers > a callee declaring fewer parameters than it is passed takes the cached path [15.60ms]
(pass) timers > a bound function takes the generic path [10.44ms]
(pass) timers > an async callee is a plain JSFunction and takes the cached path [16.02ms]
(pass) timers > the entry follows the callee while it tiers up [56.58ms]
(pass) garbage collection > a live callee stays linked across a full collection [57.84ms]
(pass) garbage colle
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1002ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/142] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[2/142] gen cpp.rs (cppbind)
[3/142] gen ZigGeneratedClasses.{cpp,h,rs}
Found 2 classes from /workspace/bun/src/jsc/resolve_message.classes.ts
  - ResolveMessage (15 fields)
  - BuildMessage (10 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Archive.classes.ts
  - Archive (4 fields, 1 class fields)
Found 2 classes from /workspace/bun/src/runtime/api/BunObject.classes.ts
  - ResourceUsage (8 fields)
  - Subprocess (20 fields)
Found 1 classes from /workspace/bun/src/runtime/api/cron.classes.ts
  - CronJob (5 fields)
Found 3 classes from /workspace/bun/src/runtime/api/filesystem_router.classes.ts
  - FileSystemRouter (5 fields)
  - FrameworkFileSystemRouter (2 fields)
  - MatchedRoute (8 fields)
Found 1 classes from /workspace/bun/src/runtime/api/Glob.classes.ts
  - Glob (5 fields)
Found 1 classes from /workspace/bun/src/runtime/api/h2.classes.ts
  - H2Fr
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts            |   2 +-
 src/js/internal-for-testing.ts          |   9 +
 src/jsc/bindings/AsyncContextFrame.cpp  |   7 +-
 src/jsc/bindings/AsyncContextFrame.h    |   2 +-
 src/jsc/bindings/HostCall.cpp           | 147 +++++++++
 src/jsc/bindings/HostCall.h             |  44 +++
 src/jsc/bindings/InternalForTesting.cpp |  21 ++
 src/jsc/bindings/InternalForTesting.h   |   1 +
 src/jsc/bindings/NodeTimerObject.cpp    |   3 +-
 src/jsc/bindings/bindings.cpp           |   3 +-
 test/js/bun/jsc/host-call-cache.test.ts | 524 ++++++++++++++++++++++++++++++++
 11 files changed, 756 insertions(+), 7 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
scripts/build/deps/webkit.ts                 1      1      0
src/js/internal-for-testing.ts               1      1      0
src/jsc/bindings/AsyncContextFrame.cpp       1      2      0
src/jsc/bindings/AsyncContextFrame.h         1      2      0
src/jsc/bindings/HostCall.cpp                1      4      0
src/jsc/bindings/HostCall.h                  0      2      0
src/jsc/bindings/InternalForTesting.cpp      1      2      0
src/jsc/bindings/InternalForTesting.h        1      2      0
src/jsc/bindings/NodeTimerObject.cpp         1      2      0
src/jsc/bindings/bindings.cpp                3      2      0
test/js/bun/jsc/host-call-cache.test.ts      2     10      0
```

</details>

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

Every callback the event loop invokes from native code (`Bun__JSValue__call`, which is what the Rust side's `JSValue::call` uses for `Bun.serve` handlers, socket handlers and everything else; `AsyncContextFrame::call`, used by route handlers, `node:http`, napi and plugins; and the timer callback in `NodeTimerObject.cpp`) went through `JSC::profiledCall` -> `Interpreter::executeCallImpl`: `getCallData`, `prepareForExecution`, `ProtoCallFrame::init` and the generic `vmEntryToJavaScript` header/argument copy on every call. The functions on the other end are a handful of callbacks called over and over, which is the situation JSC's `MicrotaskCall` / `MicrotaskCallCache` already handles for promise reactions: once a `FunctionExecutable` is linked, a call is a cache lookup plus `vmEntryToJavaScriptWith{0..6}Arguments`.

Engine half: oven-sh/WebKit#415 adds `VM::hostCallCache()`, a second VM-owned `MicrotaskCallCache` next to `m_syncResumeCallCache`, visited from `VM::finalizeUnconditionally()` like that one. `WEBKIT_VERSION` currently points at that PR's preview build (`autobuild-preview-pr-415-83df6114`); once it merges I will repoint it at the merge commit before this is merged.

### Change

`Bun::hostCall(globalObject, fn, callData, thisValue, args)` (`src/jsc/bindings/HostCall.{h,cpp}`) replaces `profiledCall` at the three call sites above. It takes the `CallData` the callers already compute, since they handle "not a function" themselves, and `CallData::Type::JS` is exactly "a `JSFunction` with a `FunctionExecutable`", which is the only thing a `MicrotaskCall` can link.

- Cached path, taken when `callData.type == JS` and `args.size() <= MicrotaskCall::maxCallArguments` (6): `ScriptProfilingScope` (opened before the entry scope, in the same order as `profiledCall`), `VMEntryScope` for the callee's realm (`callData.js.scope->realm()`, which is what `executeCallImpl` enters; `tryCallWithArguments` does not set one up itself), `find()`, on a miss `nextEntryToReplace()->initialize()`, then `tryCallWithArguments` for the argument count. An empty result is either an exception (from the callee, or from relinking a CodeBlock that was jettisoned since the last call) or an entry that cannot take the call because the callee declares more parameters than it is passed (the linked entry point skips the arity fixup), so the exception check comes first and only the second case falls through to `JSC::call`.
- `vm.disallowVMEntryCount` and `!vm.isSafeToRecurseSoft()` route to `profiledCall` instead of being handled here, so `checkVMEntryPermission()` and the stack overflow `RangeError` come from the same place as before.
- Everything else (bound functions, proxies, `InternalFunction`s, host functions, 7+ arguments) goes straight to `profiledCall`.
- Closures of the same function literal share an entry; the callee object is passed to the linked code on every call, so each call runs with its own scope. Tier-ups upgrade the entry in place (`installCode` -> `unlinkOrUpgradeIncomingCalls`), jettisons clear `m_addressForCall` and the next call relinks, and `visitWeak` drops entries whose executable or CodeBlock died.

Builds with assertions (debug, and the release-asan CI lane) count hits, misses, replacements (misses that evicted an entry still holding a live function) and fallbacks. `BUN_DEBUG_HOST_CALL_CACHE=1` prints them at exit, and `bun:internal-for-testing` exposes them as `hostCallCacheStats()` (undefined in builds without assertions). Release builds compile none of that in (`hostCallCacheStats()` returns undefined on a release build of this branch).

### Tests

`test/js/bun/jsc/host-call-cache.test.ts` drives the three call sites (timers; `HTMLRewriter` string transforms, which call the handler synchronously through `Bun__JSValue__call`; `Bun.serve` `fetch` and `routes`, the latter through `AsyncContextFrame::call`, plus a subprocess with both registered inside `AsyncLocalStorage.run()`) and, where counters exist, asserts exactly which path every call took:

- `this` and arguments arrive on the linking call and on cached calls; one entry serves argument counts 0 through 6; 7 arguments, bound functions and a callee declaring more parameters than it is passed fall back (the last one is also linked, as described above); a callee declaring fewer parameters and an `async` callee take the cached path; closures of one literal share an entry.
- Tier-up while cached: the callee is driven through the cache until `numberOfDFGCompiles()` reports an optimized CodeBlock installed, then 50 more calls are exactly 50 hits and 0 misses.
- GC: a live callee is still a hit after `Bun.gc(true)`; filling all 8 slots with `new Function` callees and refilling while they are alive is exactly 8 replacements, refilling after they were collected is 0 (the test allows 1 for the conservative scan; it takes two collections because `HTMLRewriter` protects its handlers until it is finalized, and the counters show 8 after one collection and 0 after two, i.e. the `finalizeUnconditionally` hook in WebKit#415 is what clears them).
- A callee that throws on the linking call and on a cached call, a class constructor (a JS callee whose call CodeBlock throws), and a callee invoked at every level of a recursion until the stack runs out: `RangeError: Maximum call stack size exceeded.`, and the entry is still a hit afterwards.
- `Bun.serve`: `fetch` + route handlers are 2 misses and 3 hits over 5 requests; a throwing `fetch` handler plus `error` handler is 2 misses and 3 hits over 3 requests.

The file passes 11 runs in a row on the debug (ASAN) build, including `BUN_GARBAGE_COLLECTOR_LEVEL=1` and `2`. Also run locally on the debug build: `test/js/web/timers/`, `html-rewriter*.test`, `plugins.test.ts` (its require recursion goes native -> JS -> native through this path), `AsyncLocalStorage*.test.ts`, `node-http.test.ts`, `serve.test.ts`, `napi.test.ts`: about 1200 tests, with the only failures being ones that fail identically with the unmodified release binary in this container (no IPv6, running as root, proxy env) and the leak fixtures that detect ASAN by binary name, which is already tracked.

### Hit rates (`BUN_DEBUG_HOST_CALL_CACHE=1`, debug build)

| workload | counters |
|---|---|
| `setImmediate` chain, 200 callbacks | hits=199 misses=1 replacements=0 fallbacks=0 |
| TCP echo, 64 connections, 80k round trips | hits=160250 misses=6 replacements=0 fallbacks=0 |
| `Bun.serve` + oha, 8907 requests | hits=8922 misses=2 replacements=0 fallbacks=0 |
| `HTMLRewriter`, 200 elements | hits=199 misses=1 replacements=0 fallbacks=0 |
| `fs.read` callback loop | no host calls at all: `fs` callbacks are invoked from JS, so this path is not involved |

No workload came anywhere near evicting, so `cacheSize` stays at 8. (Like the microtask cache it is round-robin, so a strict rotation of more than 8 distinct callees would thrash; the `replacements` counter is there to see that if it ever happens.)

### Benchmarks

Two release builds from this branch on the same WebKit tarball, differing only in the Bun side (baseline has the `src/` changes reverted), alternated run by run. The box was heavily loaded (load average around 50 on a 12 CPU quota), so the in-process numbers are minimums over many short windows, and two-binary layout differences alone move a workload with no host calls in it by 1 to 3% in either direction (checked with a `Bun.inspect`/`TextEncoder`/`Buffer` loop), which is the resolution of everything below except the first row.

| benchmark (ns per callback unless noted) | baseline | branch |
|---|---|---|
| `HTMLRewriter` element handler, synchronous call per element, min over 5000-element windows, 5 runs each | 338 to 343 | 329 to 334 |
| `setImmediate` chain, median per callback, 5 runs each | 1203 to 1260 | 1179 to 1222 |
| TCP echo `socket.data`, 64 connections, min per callback, 6 runs each | 3513 to 3555 | 3544 to 3582 |
| `Bun.serve` + `oha -c 64 -z 5s`, req/s, 6 runs each (median / best) | 126.4k / 129.0k | 124.2k / 130.8k |
| `setTimeout(fn, 0)` chain and `setInterval(fn, 0)` | 1.07 to 1.09 ms per callback either way: clamped to 1 ms, so they measure the clamp | |

So the call itself gets about 10 ns cheaper (the rewriter row is the only one where the call is a visible fraction of the work, about 3% of a handler call there), and at event loop granularity (1.2 us per immediate, 3.5 us per socket callback, 8 us per request on this box) the difference is inside the layout/noise band in both directions. What is still on the cached path per call, for reference: the `MarkedArgumentBuffer` copy and `AsyncContextFrame` downcast in `Bun__JSValue__call`, the profiling scope, and the `VMEntryScope` set-up/tear-down, which is outermost for every event loop callback and which `executeCallImpl` was paying as well.

Windows x64 is covered by the same mechanism the microtask drain already uses there (`vmEntryToJavaScriptWith*` are `SYSV_ABI`); CI is the check for that.

</details>
