### PR TITLE
ipc: deliver a received net.Server before its backlog is accepted

### DIFF
--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -55,9 +55,11 @@ export function parseHandle(target, serialized, fd) {
   switch (serialized.type) {
     case "net.Server": {
       const server = new net.Server();
-      server.listen({ fd, exclusive: true }, () => {
-        emit(target, serialized.msg, server);
-      });
+      server.listen({ fd, exclusive: true });
+      // Not from the 'listening' callback: net.Server emits that from a timer, and the
+      // first poll of the adopted fd accepts its whole backlog, so 'connection' events
+      // emitted before the receiver holds the server would go to nobody.
+      emit(target, serialized.msg, server);
       return;
     }
     case "net.Socket": {

--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -56,9 +56,7 @@ export function parseHandle(target, serialized, fd) {
     case "net.Server": {
       const server = new net.Server();
       server.listen({ fd, exclusive: true });
-      // Not from the 'listening' callback: net.Server emits that from a timer, and the
-      // first poll of the adopted fd accepts its whole backlog, so 'connection' events
-      // emitted before the receiver holds the server would go to nobody.
+      // Not from the 'listening' callback (a timer): the first poll accepts the whole backlog before it fires.
       emit(target, serialized.msg, server);
       return;
     }

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -691,7 +691,8 @@ let childReport = '';
 child.stderr.on('data', d => { childReport += d; });
 child.on('message', (m, h) => { got.push(h ? 'handle:' + m : m); if (h) h.close(); });
 child.on('disconnect', () => got.push('disconnect'));
-child.on('exit', code => console.log(JSON.stringify({ got, code, child: JSON.parse(childReport) })));
+// 'close' waits for 'exit', 'disconnect' and the end of the stderr pipe; 'exit' can beat the other two.
+child.on('close', code => console.log(JSON.stringify({ got, code, child: JSON.parse(childReport) })));
 `,
       "child.js": `
 const net = require('node:net');

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -384,6 +384,77 @@ process.on('message', (m, socket) => {
     });
   });
 
+  // The receiver's first poll of the adopted fd accepts everything already queued in its
+  // backlog, so the server has to reach the 'message' listener before that poll happens.
+  test.concurrent(
+    "connections queued before a net.Server handoff reach the receiver's 'connection' listener",
+    async () => {
+      using dir = tempDir("ipc-handle-busy-server", {
+        "parent.js": `
+const { fork } = require('node:child_process');
+const net = require('node:net');
+const N = 20;
+const child = fork('child.js');
+const server = net.createServer();
+let served = 0;
+let report;
+
+function finish(extra) {
+  console.log(JSON.stringify({ served, ...report, ...extra }));
+  child.kill();
+  process.exit(0);
+}
+
+child.on('exit', code => finish({ childExit: code }));
+child.on('message', m => {
+  report = m;
+  // Connections accepted before the child held the server can never be served.
+  if (m.acceptedBeforeDelivery !== 0 || served === N) finish();
+});
+
+server.listen(0, '127.0.0.1', () => {
+  const { port } = server.address();
+  child.send('srv', server);
+  // send() duplicated the descriptor, so the socket keeps listening after the parent drops
+  // its own copy: the connects below queue up in the backlog with only the child able to
+  // accept them.
+  server.close();
+  for (let i = 0; i < N; i++) {
+    const client = net.connect(port, '127.0.0.1');
+    client.setEncoding('utf8');
+    let data = '';
+    client.on('data', c => (data += c));
+    client.on('end', () => {
+      if (data === 'C') served++;
+      if (served === N && report) finish();
+    });
+    client.on('error', e => finish({ clientError: e.message }));
+  }
+});
+`,
+        "child.js": `
+process.on('message', (m, server) => {
+  server.on('connection', s => s.end('C'));
+  process.send({ acceptedBeforeDelivery: server._connections });
+});
+`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "parent.js"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+        out: { served: 20, acceptedBeforeDelivery: 0 },
+        stderr: "",
+      });
+      expect(exitCode).toBe(0);
+    },
+  );
+
   test.concurrent("received net.Socket has connecting=false and remoteAddress synchronously", async () => {
     using dir = tempDir("ipc-handle-connecting", {
       "parent.js": `
@@ -608,10 +679,9 @@ process.on('disconnect', () => process.exit(sawQueued ? 0 : 3));
   );
 
   // The child sends a server and disconnects at once. node: process.connected drops immediately, a
-  // second disconnect() errors, and the parent still receives the server (its adoption completes a
-  // loop turn later, which must not lose it) as well as the message queued behind it. Order is not
-  // pinned: bun currently emits the late-adopted handle after 'disconnect', node before it.
-  test.concurrent("a handle sent right before the child's disconnect() is still delivered", async () => {
+  // second disconnect() errors, and the parent receives the server, then the message queued behind
+  // it (it is only sent once the handle is acked), then 'disconnect'.
+  test.concurrent("a handle sent right before the child's disconnect() is delivered, in order", async () => {
     using dir = tempDir("ipc-handle-then-disconnect", {
       "parent.js": `
 const { fork } = require('node:child_process');
@@ -621,7 +691,7 @@ let childReport = '';
 child.stderr.on('data', d => { childReport += d; });
 child.on('message', (m, h) => { got.push(h ? 'handle:' + m : m); if (h) h.close(); });
 child.on('disconnect', () => got.push('disconnect'));
-child.on('exit', code => console.log(JSON.stringify({ got: got.sort(), code, child: JSON.parse(childReport) })));
+child.on('exit', code => console.log(JSON.stringify({ got, code, child: JSON.parse(childReport) })));
 `,
       "child.js": `
 const net = require('node:net');
@@ -647,7 +717,7 @@ const server = net.createServer().listen(0, '127.0.0.1', () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
       out: {
-        got: ["after-handle", "disconnect", "handle:srv"],
+        got: ["handle:srv", "after-handle", "disconnect"],
         code: 0,
         child: { connectedAfterDisconnect: false, secondDisconnect: "ERR_IPC_DISCONNECTED" },
       },


### PR DESCRIPTION
### Problem
- Follow-up to #31829. Sending a listening `net.Server` to a child while connections were already queued in its accept backlog stranded them: the clients hung with no data, FIN or RST, and the accepted sockets stayed open in the child. node v26.3.0 serves all of them.
- Cause: the child got the server from the `'listening'` callback, a loop turn after adopting the fd, and the first poll of the fd accepts the whole backlog. Those connections were emitted on a server no user code held yet.
- node's `'listening'` runs before I/O, so the same shape works there.

### Fix
- Emit `'message'` as soon as `listen()` returns instead of from the `'listening'` callback, as the `net.Socket` arm already does.
- Correct because adopting the fd is synchronous: the receiver's listeners are attached before the loop can poll the fd, so nothing is accepted before user code holds the server.
- Side effect: the handle now arrives before messages queued behind it, which is node's order; the test that recorded the old order now pins node's. `dgram.Socket` is unaffected.
- Not changed: the received server still fires its own `'listening'` about 1ms later (node never does); that touches every net/tls server and is left for a separate change.
- Verification: the new test fails on main (`acceptedBeforeDelivery: 20, served: 0`) and passes with the fix, 20/20 reruns; the reordered disconnect test also fails on main. The vendored node handle-passing tests pass on a debug build.

### Background
- Handle passing: `child.send(msg, server)` duplicates the server's fd into the child, which wraps it in a new `net.Server` and delivers it as the second argument of `'message'`. Both processes then hold the same listening socket.
- Accept backlog: connections to a listening socket wait in the kernel until some holder accepts them; once the parent closes its copy, only the child can.
- In bun, `net.Server` emits `'listening'` from a 1ms timer, but adopting an fd completes before `listen()` returns.
- bun's accept loop takes every queued connection the first time the fd polls readable, so the whole backlog arrives in one turn.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process_ipc_handle.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

Follow-up to #31829. Passing a listening `net.Server` that already has connections waiting in its accept backlog (`child.send('srv', server)` under load) stranded those connections in the receiver.

### Repro

Parent listens, sends the server, closes its own copy (the descriptor was dup'd for the message, so the socket keeps listening) and then opens 20 connections, which can only be accepted by the child:

```js
// child
process.on('message', (m, server) => {
  server.on('connection', s => s.end('C'));
  process.send({ acceptedBeforeDelivery: server._connections });
});
```

Before, on every run: `{"served":0,"acceptedBeforeDelivery":20}`. The child's `server._connections` was already 20 when the `'message'` event fired, its handler saw none of them, the 20 accepted sockets were never closed (fds stay open in the child) and the clients hung with no data, FIN or RST. node v26.3.0 prints `{"served":20,"acceptedBeforeDelivery":0}`.

### Cause

`parseHandle()` in `src/js/builtins/Ipc.ts` emitted the message from the `listen()` callback. `net.Server` emits `'listening'` from a 1ms `setTimeout`, i.e. after at least one turn of the event loop, and uSockets' accept loop drains the whole backlog on the first readiness of the adopted fd. So every queued connection was emitted as `'connection'` on a server no user code had a reference to yet. node gets away with the same shape because its `'listening'` is a `nextTick`, which runs before I/O.

### Fix

`Bun.listen({ fd })` adopts the descriptor synchronously (`_handle` is set when `listen()` returns), so emit right after `listen()` returns, as the `net.Socket` arm already does. The receiver attaches its listeners inside the `'message'` handler, before the loop polls the fd. A side effect is that the handle is now delivered before any message queued behind it, which is node's order; the test that documented the old order as a known divergence now pins node's order. The `dgram.Socket` arm is unaffected: `Bun.udpSocket()` resolves synchronously and its `'listening'` fires in the microtask drain of the same read, so datagrams queued before a handoff were already delivered (verified with the same kind of repro).

Not changed here: the 1ms deferral of `'listening'` itself in `net.ts`, which is long-standing and not specific to handle passing. One consequence of emitting before it: the received server still fires its `'listening'` about 1ms after delivery, so a listener attached to it inside the `'message'` handler runs, where node never fires it (the server is already listening at delivery in both). Converging on that means emitting `'listening'` from `nextTick` in `net.ts` like node, which affects every net/tls server and is left for a separate change.

### Verification

`test/js/node/child_process/child_process_ipc_handle.test.ts`: new "connections queued before a net.Server handoff" test fails on main with `acceptedBeforeDelivery: 20, served: 0` and passes with the fix (20/20 reruns); the "handle sent right before disconnect()" test now asserts the delivery order and also fails on main (it reports from `'close'`, since `'exit'` can fire before the parent's `'disconnect'`, which one CI run on alpine aarch64 hit). The rest of that file, `spawn.ipc*.test.ts`, and the vendored `test-child-process-fork-net-server`, `fork-net-socket`, `send-keep-open`, `cluster-net-send` and `cluster-send-handle-large-payload` tests pass with the debug build.

</details>
