### PR TITLE
io: return a FilePoll to its store through the owner's pointer, not a &mut receiver

### DIFF
--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -369,15 +369,11 @@ impl EventLoopCtx {
     /// Single backref-deref accessor for the per-thread `Store`. Same contract
     /// as [`loop_mut`]: `pub(crate)`, `&self → &mut`, must NOT be called while
     /// another `&mut Store` (or a `&mut FilePoll` that lives inside the inline
-    /// hive buffer) is live. Every in-crate caller is a leaf op that itself
-    /// holds no `&mut FilePoll` at the call: the `FilePoll::deinit*` path works
-    /// on the raw slot pointer and has dropped its statement-scoped reborrow by
-    /// then, and `init_with_owner` / `alloc_file_poll` never form one. So no
-    /// two `&mut Store` ever coexist. The one `&mut FilePoll` that can still be
-    /// live is the receiver of `on_update` when an owner deinits its poll from
-    /// inside the poll's own callback (the dispatch chain in
-    /// `posix_event_loop` is still `&mut self` based); that put only queues
-    /// the slot.
+    /// hive buffer) is live. Every in-crate caller is a leaf op holding none
+    /// itself (`FilePoll::deinit*` works on the raw slot pointer; `init_with_owner`
+    /// / `alloc_file_poll` never form one), so no two `&mut Store` coexist; the
+    /// `&mut self` of `on_update` further up the stack during an in-callback
+    /// deinit is the remaining exception, and that put only queues the slot.
     #[inline]
     fn file_polls_mut(&self) -> &'static mut Store {
         // SAFETY: per-thread set-once pointer (`BackRef`-shaped); the event
@@ -1827,9 +1823,8 @@ impl FilePollRef {
     #[inline]
     pub(crate) fn deinit_force_unregister(self) {
         // SAFETY: type invariant — `self.0` is the live slot `init` claimed, and
-        // every copy of this handle is dead once the owner calls this. Not
-        // routed through `inner()`: the store may free the slot inside the
-        // call, so it gets the pointer rather than a `&mut` (see `FilePoll::deinit`).
+        // every copy of this handle is dead once the owner calls this. Passed as
+        // the pointer, not via `inner()`: the store may free the slot in there.
         unsafe { FilePoll::deinit_force_unregister(self.0.as_ptr()) };
     }
     /// Single nonnull-asref accessor for the process-global uWS loop pointer.

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -369,10 +369,11 @@ impl EventLoopCtx {
     /// Single backref-deref accessor for the per-thread `Store`. Same contract
     /// as [`loop_mut`]: `pub(crate)`, `&self → &mut`, must NOT be called while
     /// another `&mut Store` (or a `&mut FilePoll` that lives inside the inline
-    /// hive buffer) is live. Every in-crate caller is a leaf op that decays
-    /// any conflicting `&mut FilePoll` to a raw slot pointer first
-    /// (`deinit_possibly_defer`) or holds none (`init_with_owner`,
-    /// `alloc_file_poll`), so no two `&mut Store` ever coexist.
+    /// hive buffer) is live. Every in-crate caller is a leaf op that holds no
+    /// `&mut FilePoll` at the call: the `FilePoll::deinit*` path works on the
+    /// raw slot pointer and has dropped its statement-scoped reborrow by then,
+    /// and `init_with_owner` / `alloc_file_poll` never form one. So no two
+    /// `&mut Store` ever coexist.
     #[inline]
     fn file_polls_mut(&self) -> &'static mut Store {
         // SAFETY: per-thread set-once pointer (`BackRef`-shaped); the event
@@ -1821,7 +1822,11 @@ impl FilePollRef {
     }
     #[inline]
     pub(crate) fn deinit_force_unregister(self) {
-        self.inner().deinit_force_unregister();
+        // SAFETY: type invariant — `self.0` is the live slot `init` claimed, and
+        // every copy of this handle is dead once the owner calls this. Not
+        // routed through `inner()`: the store may free the slot inside the
+        // call, so it gets the pointer rather than a `&mut` (see `FilePoll::deinit`).
+        unsafe { FilePoll::deinit_force_unregister(self.0.as_ptr()) };
     }
     /// Single nonnull-asref accessor for the process-global uWS loop pointer.
     ///

--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -369,11 +369,15 @@ impl EventLoopCtx {
     /// Single backref-deref accessor for the per-thread `Store`. Same contract
     /// as [`loop_mut`]: `pub(crate)`, `&self → &mut`, must NOT be called while
     /// another `&mut Store` (or a `&mut FilePoll` that lives inside the inline
-    /// hive buffer) is live. Every in-crate caller is a leaf op that holds no
-    /// `&mut FilePoll` at the call: the `FilePoll::deinit*` path works on the
-    /// raw slot pointer and has dropped its statement-scoped reborrow by then,
-    /// and `init_with_owner` / `alloc_file_poll` never form one. So no two
-    /// `&mut Store` ever coexist.
+    /// hive buffer) is live. Every in-crate caller is a leaf op that itself
+    /// holds no `&mut FilePoll` at the call: the `FilePoll::deinit*` path works
+    /// on the raw slot pointer and has dropped its statement-scoped reborrow by
+    /// then, and `init_with_owner` / `alloc_file_poll` never form one. So no
+    /// two `&mut Store` ever coexist. The one `&mut FilePoll` that can still be
+    /// live is the receiver of `on_update` when an owner deinits its poll from
+    /// inside the poll's own callback (the dispatch chain in
+    /// `posix_event_loop` is still `&mut self` based); that put only queues
+    /// the slot.
     #[inline]
     fn file_polls_mut(&self) -> &'static mut Store {
         // SAFETY: per-thread set-once pointer (`BackRef`-shaped); the event

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -386,17 +386,66 @@ impl FilePoll {
 
     // Note: not `impl Drop` — FilePoll is pool-allocated (HiveArray) and explicitly
     // put back via `Store::put`; Drop would be wrong here.
-    pub fn deinit(&mut self) {
-        let ctx = get_vm_ctx(self.allocator_type);
-        self.deinit_possibly_defer(ctx, false);
+    //
+    // The `deinit*` entry points take the slot pointer the owner holds, not
+    // `&mut self`: for a poll that was never registered `Store::put` recycles
+    // the slot before returning (a `Box` free once the hive has spilled to the
+    // heap), and a reference argument is protected, so must stay allocated,
+    // until the call it was passed to returns.
+
+    /// Returns the slot to the event loop's `Store`.
+    ///
+    /// # Safety
+    /// `this` is a live slot returned by [`FilePoll::init`] on this thread;
+    /// the caller must not use it afterwards.
+    pub unsafe fn deinit(this: *mut FilePoll) {
+        // SAFETY: fn contract; the field read ends at the `;`.
+        let ctx = get_vm_ctx(unsafe { (*this).allocator_type });
+        // SAFETY: fn contract.
+        unsafe { Self::deinit_possibly_defer(this, ctx, false) }
     }
 
-    pub(crate) fn deinit_force_unregister(&mut self) {
-        let ctx = get_vm_ctx(self.allocator_type);
-        self.deinit_possibly_defer(ctx, true);
+    /// [`FilePoll::deinit`], but also removes the kernel registration of a
+    /// fired one-shot poll, which `unregister` otherwise skips.
+    ///
+    /// # Safety
+    /// As for [`FilePoll::deinit`].
+    pub(crate) unsafe fn deinit_force_unregister(this: *mut FilePoll) {
+        // SAFETY: fn contract; the field read ends at the `;`.
+        let ctx = get_vm_ctx(unsafe { (*this).allocator_type });
+        // SAFETY: fn contract.
+        unsafe { Self::deinit_possibly_defer(this, ctx, true) }
     }
 
-    fn deinit_possibly_defer(&mut self, vm: EventLoopCtx, force_unregister: bool) {
+    /// [`FilePoll::deinit`] for callers that already hold the poll's context.
+    ///
+    /// # Safety
+    /// As for [`FilePoll::deinit`]; `vm` is the context the poll was created on.
+    pub unsafe fn deinit_with_vm(this: *mut FilePoll, vm: EventLoopCtx) {
+        // SAFETY: fn contract.
+        unsafe { Self::deinit_possibly_defer(this, vm, false) }
+    }
+
+    /// # Safety
+    /// As for [`FilePoll::deinit_with_vm`].
+    unsafe fn deinit_possibly_defer(this: *mut FilePoll, vm: EventLoopCtx, force_unregister: bool) {
+        // SAFETY: fn contract. The `&mut` the autoref forms ends with the
+        // statement, so no reference into the slot is live when the store
+        // takes it back.
+        let was_ever_registered = unsafe { (*this).clear_for_put(vm, force_unregister) };
+        // SAFETY: `this` is non-null per fn contract.
+        let slot = unsafe { ptr::NonNull::new_unchecked(this) };
+        // `file_polls_mut()` is the per-thread set-once `Store` back-pointer
+        // (`BackRef`-shaped); the `&mut Store` it produces is the only
+        // reference into the hive at this point. `Store::put` touches `slot`
+        // only via raw-pointer ops (see its doc).
+        vm.file_polls_mut().put(slot, vm, was_ever_registered);
+    }
+
+    /// Unregisters and clears the poll; returns whether it was ever
+    /// registered, which is what decides whether `Store::put` recycles the
+    /// slot now or after the current event loop turn.
+    fn clear_for_put(&mut self, vm: EventLoopCtx, force_unregister: bool) -> bool {
         // `loop_mut()` is the crate-private nonnull-asref accessor (single
         // deref in `EventLoopCtx`); the `&mut Loop` is consumed by `unregister`
         // and dropped before any `&mut Store` is materialised.
@@ -406,21 +455,7 @@ impl FilePoll {
         let was_ever_registered = self.flags.contains(Flags::WasEverRegistered);
         self.flags = FlagsSet::empty();
         self.fd = INVALID_FD;
-        // `self` may live inside the `Store.hive` inline array, so a
-        // `&mut Store` taken while `&mut self` is live would assert unique
-        // access over the slot and invalidate `self`'s tag (Stacked Borrows).
-        // Decay `self` to a raw slot pointer first, *then* materialise the
-        // `&mut Store` via the crate-private backref-deref accessor.
-        let this = ptr::NonNull::from(self);
-        // `file_polls_mut()` is the per-thread set-once `Store` back-pointer
-        // (`BackRef`-shaped); `&mut self` has been retired to `this` above so
-        // the `&mut Store` it produces is the sole unique borrow into the hive.
-        // `Store::put` touches `this` only via raw-pointer ops (see its doc).
-        vm.file_polls_mut().put(this, vm, was_ever_registered);
-    }
-
-    pub fn deinit_with_vm(&mut self, vm: EventLoopCtx) {
-        self.deinit_possibly_defer(vm, false);
+        was_ever_registered
     }
 
     pub fn is_registered(&self) -> bool {

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -388,10 +388,13 @@ impl FilePoll {
     // put back via `Store::put`; Drop would be wrong here.
     //
     // The `deinit*` entry points take the slot pointer the owner holds, not
-    // `&mut self`: for a poll that was never registered `Store::put` recycles
-    // the slot before returning (a `Box` free once the hive has spilled to the
-    // heap), and a reference argument is protected, so must stay allocated,
-    // until the call it was passed to returns.
+    // `&mut self`: `Store::put` may recycle the slot before it returns (a
+    // `Box` free once the hive has spilled to the heap) when the poll never
+    // went through `register*`, and a reference argument is protected, so must
+    // stay allocated, until the call it was passed to returns. (In-tree owners
+    // all register right after `init`, and `register*` marks the poll
+    // `WasEverRegistered` even when the syscall fails, so that branch is
+    // currently the store's contract rather than a path anything takes.)
 
     /// Returns the slot to the event loop's `Store`.
     ///
@@ -430,15 +433,17 @@ impl FilePoll {
     /// As for [`FilePoll::deinit_with_vm`].
     unsafe fn deinit_possibly_defer(this: *mut FilePoll, vm: EventLoopCtx, force_unregister: bool) {
         // SAFETY: fn contract. The `&mut` the autoref forms ends with the
-        // statement, so no reference into the slot is live when the store
-        // takes it back.
+        // statement, so this path holds no reference into the slot when the
+        // store takes it back. (A poll deinit'd from inside its own callback
+        // still has `on_update`'s `&mut self` live up the stack; a dispatched
+        // poll was registered, so that put is the deferred one and frees
+        // nothing under it.)
         let was_ever_registered = unsafe { (*this).clear_for_put(vm, force_unregister) };
         // SAFETY: `this` is non-null per fn contract.
         let slot = unsafe { ptr::NonNull::new_unchecked(this) };
         // `file_polls_mut()` is the per-thread set-once `Store` back-pointer
-        // (`BackRef`-shaped); the `&mut Store` it produces is the only
-        // reference into the hive at this point. `Store::put` touches `slot`
-        // only via raw-pointer ops (see its doc).
+        // (`BackRef`-shaped); `Store::put` touches `slot` only via raw-pointer
+        // ops (see its doc).
         vm.file_polls_mut().put(slot, vm, was_ever_registered);
     }
 

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -385,22 +385,15 @@ impl FilePoll {
     }
 
     // Note: not `impl Drop` — FilePoll is pool-allocated (HiveArray) and explicitly
-    // put back via `Store::put`; Drop would be wrong here.
-    //
-    // The `deinit*` entry points take the slot pointer the owner holds, not
-    // `&mut self`: `Store::put` may recycle the slot before it returns (a
-    // `Box` free once the hive has spilled to the heap) when the poll never
-    // went through `register*`, and a reference argument is protected, so must
-    // stay allocated, until the call it was passed to returns. (In-tree owners
-    // all register right after `init`, and `register*` marks the poll
-    // `WasEverRegistered` even when the syscall fails, so that branch is
-    // currently the store's contract rather than a path anything takes.)
+    // put back via `Store::put`; Drop would be wrong here. The `deinit*` entry
+    // points take the slot pointer rather than `&mut self` because `Store::put`
+    // may free the slot before it returns, which a reference argument (protected
+    // until its call returns) does not allow.
 
     /// Returns the slot to the event loop's `Store`.
     ///
     /// # Safety
-    /// `this` is a live slot returned by [`FilePoll::init`] on this thread;
-    /// the caller must not use it afterwards.
+    /// `this` is a live slot from [`FilePoll::init`] on this thread and is not used afterwards.
     pub unsafe fn deinit(this: *mut FilePoll) {
         // SAFETY: fn contract; the field read ends at the `;`.
         let ctx = get_vm_ctx(unsafe { (*this).allocator_type });
@@ -408,11 +401,7 @@ impl FilePoll {
         unsafe { Self::deinit_possibly_defer(this, ctx, false) }
     }
 
-    /// [`FilePoll::deinit`], but also removes the kernel registration of a
-    /// fired one-shot poll, which `unregister` otherwise skips.
-    ///
-    /// # Safety
-    /// As for [`FilePoll::deinit`].
+    /// [`FilePoll::deinit`] that also unregisters a fired one-shot poll. Safety: as for `deinit`.
     pub(crate) unsafe fn deinit_force_unregister(this: *mut FilePoll) {
         // SAFETY: fn contract; the field read ends at the `;`.
         let ctx = get_vm_ctx(unsafe { (*this).allocator_type });
@@ -420,36 +409,23 @@ impl FilePoll {
         unsafe { Self::deinit_possibly_defer(this, ctx, true) }
     }
 
-    /// [`FilePoll::deinit`] for callers that already hold the poll's context.
-    ///
-    /// # Safety
-    /// As for [`FilePoll::deinit`]; `vm` is the context the poll was created on.
+    /// [`FilePoll::deinit`] with the context the poll was created on. Safety: as for `deinit`.
     pub unsafe fn deinit_with_vm(this: *mut FilePoll, vm: EventLoopCtx) {
         // SAFETY: fn contract.
         unsafe { Self::deinit_possibly_defer(this, vm, false) }
     }
 
-    /// # Safety
-    /// As for [`FilePoll::deinit_with_vm`].
     unsafe fn deinit_possibly_defer(this: *mut FilePoll, vm: EventLoopCtx, force_unregister: bool) {
-        // SAFETY: fn contract. The `&mut` the autoref forms ends with the
-        // statement, so this path holds no reference into the slot when the
-        // store takes it back. (A poll deinit'd from inside its own callback
-        // still has `on_update`'s `&mut self` live up the stack; a dispatched
-        // poll was registered, so that put is the deferred one and frees
-        // nothing under it.)
+        // SAFETY: as for `deinit_with_vm`. The `&mut` the autoref forms ends
+        // with this statement, so this path holds no reference into the slot
+        // when the store takes it back.
         let was_ever_registered = unsafe { (*this).clear_for_put(vm, force_unregister) };
-        // SAFETY: `this` is non-null per fn contract.
+        // SAFETY: `this` is non-null per the contract above.
         let slot = unsafe { ptr::NonNull::new_unchecked(this) };
-        // `file_polls_mut()` is the per-thread set-once `Store` back-pointer
-        // (`BackRef`-shaped); `Store::put` touches `slot` only via raw-pointer
-        // ops (see its doc).
         vm.file_polls_mut().put(slot, vm, was_ever_registered);
     }
 
-    /// Unregisters and clears the poll; returns whether it was ever
-    /// registered, which is what decides whether `Store::put` recycles the
-    /// slot now or after the current event loop turn.
+    /// Returns whether the poll was ever registered, which `Store::put` needs.
     fn clear_for_put(&mut self, vm: EventLoopCtx, force_unregister: bool) -> bool {
         // `loop_mut()` is the crate-private nonnull-asref accessor (single
         // deref in `EventLoopCtx`); the `&mut Loop` is consumed by `unregister`

--- a/src/io/windows_event_loop.rs
+++ b/src/io/windows_event_loop.rs
@@ -86,27 +86,20 @@ impl FilePoll {
     }
 
     // Note: not `impl Drop` — FilePoll lives in a HiveArray pool slot, not a Box;
-    // teardown returns the slot to the pool via `Store::put`.
-    //
-    // Like the POSIX `FilePoll`, the `deinit*` entry points take the slot
-    // pointer, not `&mut self`: for a poll that was never registered (on
-    // Windows, every poll; see `unregister`) `Store::put` recycles the slot
-    // before returning (a `Box` free once the hive has spilled to the heap),
-    // and a reference argument is protected, so must stay allocated, until the
-    // call it was passed to returns.
+    // teardown returns the slot to the pool via `Store::put`. As on POSIX, the
+    // `deinit*` entry points take the slot pointer rather than `&mut self`
+    // because `Store::put` frees the slot before it returns.
 
     /// Returns the slot to the event loop's `Store`.
     ///
     /// # Safety
-    /// `this` is a live slot returned by [`FilePoll::init`] on this thread;
-    /// the caller must not use it afterwards.
+    /// `this` is a live slot from [`FilePoll::init`] on this thread and is not used afterwards.
     pub unsafe fn deinit(this: *mut FilePoll) {
         // SAFETY: fn contract.
         unsafe { Self::deinit_with_vm(this, js_vm_ctx()) }
     }
 
-    /// # Safety
-    /// As for [`FilePoll::deinit`].
+    /// Safety: as for [`FilePoll::deinit`].
     pub(crate) unsafe fn deinit_force_unregister(this: *mut FilePoll) {
         // SAFETY: fn contract.
         unsafe { Self::deinit(this) }
@@ -131,9 +124,7 @@ impl FilePoll {
         true
     }
 
-    /// Unregisters and clears the poll; returns whether it was ever
-    /// registered, which is what decides whether `Store::put` recycles the
-    /// slot now or after the current event loop turn.
+    /// Returns whether the poll was ever registered, which `Store::put` needs.
     fn clear_for_put(&mut self, loop_: &mut WindowsLoop) -> bool {
         if self.is_registered() {
             let _ = self.unregister(loop_);
@@ -145,23 +136,15 @@ impl FilePoll {
         was_ever_registered
     }
 
-    /// # Safety
-    /// As for [`FilePoll::deinit`]; `vm` is the context the poll was created on.
+    /// Safety: as for [`FilePoll::deinit`]; `vm` is the context the poll was created on.
     pub(crate) unsafe fn deinit_with_vm(this: *mut FilePoll, vm: EventLoopCtx) {
-        // `loop_mut()` — crate-private nonnull-asref accessor (single deref in
-        // `EventLoopCtx`); the uws loop is a disjoint allocation from the slot,
-        // and the borrow is consumed by `clear_for_put`.
         let loop_ = vm.loop_mut();
-        // SAFETY: fn contract. The `&mut` the autoref forms ends with the
-        // statement, so no reference into the slot is live when the store
-        // takes it back.
+        // SAFETY: fn contract. The `&mut` the autoref forms ends with this
+        // statement, so this path holds no reference into the slot when the
+        // store takes it back.
         let was_ever_registered = unsafe { (*this).clear_for_put(loop_) };
         // SAFETY: `this` is non-null per fn contract.
         let slot = unsafe { ptr::NonNull::new_unchecked(this) };
-        // `file_polls_mut()` is the per-thread set-once `Store` back-pointer
-        // (`BackRef`-shaped); the `&mut Store` it produces is the only
-        // reference into the hive at this point. `Store::put` touches `slot`
-        // only via raw-pointer ops (see its doc).
         vm.file_polls_mut().put(slot, vm, was_ever_registered);
     }
 

--- a/src/io/windows_event_loop.rs
+++ b/src/io/windows_event_loop.rs
@@ -87,12 +87,29 @@ impl FilePoll {
 
     // Note: not `impl Drop` — FilePoll lives in a HiveArray pool slot, not a Box;
     // teardown returns the slot to the pool via `Store::put`.
-    pub fn deinit(&mut self) {
-        self.deinit_with_vm(js_vm_ctx());
+    //
+    // Like the POSIX `FilePoll`, the `deinit*` entry points take the slot
+    // pointer, not `&mut self`: for a poll that was never registered (on
+    // Windows, every poll; see `unregister`) `Store::put` recycles the slot
+    // before returning (a `Box` free once the hive has spilled to the heap),
+    // and a reference argument is protected, so must stay allocated, until the
+    // call it was passed to returns.
+
+    /// Returns the slot to the event loop's `Store`.
+    ///
+    /// # Safety
+    /// `this` is a live slot returned by [`FilePoll::init`] on this thread;
+    /// the caller must not use it afterwards.
+    pub unsafe fn deinit(this: *mut FilePoll) {
+        // SAFETY: fn contract.
+        unsafe { Self::deinit_with_vm(this, js_vm_ctx()) }
     }
 
-    pub(crate) fn deinit_force_unregister(&mut self) {
-        self.deinit()
+    /// # Safety
+    /// As for [`FilePoll::deinit`].
+    pub(crate) unsafe fn deinit_force_unregister(this: *mut FilePoll) {
+        // SAFETY: fn contract.
+        unsafe { Self::deinit(this) }
     }
 
     pub(crate) fn unregister(&mut self, _loop: &mut WindowsLoop) -> bool {
@@ -104,7 +121,7 @@ impl FilePoll {
         // ever sets the `Poll*` registration flags after construction (this
         // module defines no `register`), and every in-tree constructor passes
         // empty/default flags, so `is_registered()` stays false and
-        // `deinit_possibly_defer` — the only path here — never takes the
+        // `clear_for_put` — the only path here — never takes the
         // `unregister` branch. If a Windows registration path is ever added,
         // this cast must be replaced with a real `uv_handle_t` pointer first
         // (see TODO above); `uv_unref` dereferences its argument.
@@ -114,7 +131,10 @@ impl FilePoll {
         true
     }
 
-    fn deinit_possibly_defer(&mut self, vm: EventLoopCtx, loop_: &mut WindowsLoop) {
+    /// Unregisters and clears the poll; returns whether it was ever
+    /// registered, which is what decides whether `Store::put` recycles the
+    /// slot now or after the current event loop turn.
+    fn clear_for_put(&mut self, loop_: &mut WindowsLoop) -> bool {
         if self.is_registered() {
             let _ = self.unregister(loop_);
         }
@@ -122,26 +142,27 @@ impl FilePoll {
         let was_ever_registered = self.flags.contains(Flags::WasEverRegistered);
         self.flags = FlagsSet::default();
         self.fd = Fd::INVALID;
-        // All `self` field writes are done. Decay `self` to a raw slot pointer
-        // *before* materializing `&mut Store` so the `&mut Store` borrow (which
-        // covers the inline hive buffer) is the only live unique reference into
-        // that allocation when `Store::put` runs. `self` is never touched after
-        // this line — `Store::put` itself accesses `this` only via raw-pointer ops.
-        let this: ptr::NonNull<FilePoll> = ptr::NonNull::from(&mut *self);
-        // `file_polls_mut()` is the per-thread set-once `Store` back-pointer
-        // (`BackRef`-shaped); `&mut self` has been retired to `this` above so
-        // the `&mut Store` it produces is the sole unique borrow into the hive.
-        vm.file_polls_mut().put(this, vm, was_ever_registered);
+        was_ever_registered
     }
 
-    pub(crate) fn deinit_with_vm(&mut self, vm: EventLoopCtx) {
+    /// # Safety
+    /// As for [`FilePoll::deinit`]; `vm` is the context the poll was created on.
+    pub(crate) unsafe fn deinit_with_vm(this: *mut FilePoll, vm: EventLoopCtx) {
         // `loop_mut()` — crate-private nonnull-asref accessor (single deref in
-        // `EventLoopCtx`); the uws loop is a disjoint allocation from `self`.
-        // Stacked-Borrows: `self` may live inside `Store.hive`'s inline buffer,
-        // so `&mut Store` is materialised only *after* `&mut self` is retired
-        // inside `deinit_possibly_defer` (via `file_polls_mut()`).
+        // `EventLoopCtx`); the uws loop is a disjoint allocation from the slot,
+        // and the borrow is consumed by `clear_for_put`.
         let loop_ = vm.loop_mut();
-        self.deinit_possibly_defer(vm, loop_);
+        // SAFETY: fn contract. The `&mut` the autoref forms ends with the
+        // statement, so no reference into the slot is live when the store
+        // takes it back.
+        let was_ever_registered = unsafe { (*this).clear_for_put(loop_) };
+        // SAFETY: `this` is non-null per fn contract.
+        let slot = unsafe { ptr::NonNull::new_unchecked(this) };
+        // `file_polls_mut()` is the per-thread set-once `Store` back-pointer
+        // (`BackRef`-shaped); the `&mut Store` it produces is the only
+        // reference into the hive at this point. `Store::put` touches `slot`
+        // only via raw-pointer ops (see its doc).
+        vm.file_polls_mut().put(slot, vm, was_ever_registered);
     }
 
     pub(crate) fn enable_keeping_process_alive(&mut self, vm: EventLoopCtx) {

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -656,10 +656,10 @@ pub(crate) fn tick_queue_with_count(
 #[cfg(not(windows))]
 #[unsafe(no_mangle)]
 pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
-    // SAFETY: contract above.
-    let poll_ref = unsafe { &mut *poll };
-    let owner = poll_ref.owner;
-    let hup = poll_ref.flags.contains(PollFlag::Hup);
+    // SAFETY: contract above; both reads end at the `;`. No reference into the
+    // slot is kept: the arms below may return it to the store (directly in the
+    // memory-pressure and DNS arms, through the owner's close path elsewhere).
+    let (owner, hup) = unsafe { ((*poll).owner, (*poll).flags.contains(PollFlag::Hup)) };
 
     debug_assert!(!owner.is_null());
 
@@ -706,8 +706,9 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
             unsafe { Process::on_wait_pid_from_event_loop_task(proc) };
         }
         poll_tag::MEMORY_PRESSURE => {
-            // SAFETY: `poll` is live per `__bun_run_file_poll`'s contract.
-            crate::node::memory_pressure::on_poll(unsafe { &mut *poll }, size_or_offset);
+            // SAFETY: `poll` is live per `__bun_run_file_poll`'s contract. Passed
+            // raw: `on_poll` may return the slot to the store.
+            unsafe { crate::node::memory_pressure::on_poll(poll, size_or_offset) };
         }
         poll_tag::PARENT_DEATH_WATCHDOG => {
             let wd = owner_as!(bun_io::parent_death_watchdog::ParentDeathWatchdog);
@@ -740,8 +741,10 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
             // `Channel::process` re-enters the resolver via c-ares callbacks.
             // SAFETY: tag set with this pointee type at `FilePoll::init`.
             let resolver = unsafe { &*owner.ptr.cast_const().cast::<DNSResolver>() };
-            // SAFETY: `poll` outlives this call (caller contract).
-            resolver.on_dns_poll(unsafe { &mut *poll });
+            // SAFETY: `poll` is live per `__bun_run_file_poll`'s contract and is
+            // the resolver's registered poll for its fd (it set this owner on
+            // it). Passed raw: `on_dns_poll` may return the slot to the store.
+            unsafe { resolver.on_dns_poll(poll) };
         }
         poll_tag::GET_ADDR_INFO_REQUEST => {
             #[cfg(target_os = "macos")]

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -656,9 +656,9 @@ pub(crate) fn tick_queue_with_count(
 #[cfg(not(windows))]
 #[unsafe(no_mangle)]
 pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
-    // SAFETY: contract above; both reads end at the `;`. No reference into the
-    // slot is kept: the arms below may return it to the store (directly in the
-    // memory-pressure and DNS arms, through the owner's close path elsewhere).
+    // SAFETY: contract above; both reads end at the `;`. The arms below get
+    // `poll` itself where they need it (the memory-pressure and DNS arms may
+    // return it to the store), so this frame keeps no reference into the slot.
     let (owner, hup) = unsafe { ((*poll).owner, (*poll).flags.contains(PollFlag::Hup)) };
 
     debug_assert!(!owner.is_null());

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4783,11 +4783,13 @@ impl Resolver {
     /// the structural fix for the previously ASM-verified PROVEN_CACHED
     /// miscompile that needed `black_box` laundering under `&mut self`.
     ///
-    /// `poll` is raw rather than `&mut`: this either returns the slot to the
-    /// store itself (no channel) or runs `Channel::process`, whose socket-state
-    /// callback (`on_dns_socket_state`) returns it when c-ares closes the
-    /// socket. Neither may happen while a reference argument to the slot is
-    /// still live, so the poll is read before and never touched after.
+    /// `poll` is raw, the shape `FilePoll::deinit` takes: this either returns
+    /// the slot to the store itself (no channel) or runs `Channel::process`,
+    /// whose socket-state callback (`on_dns_socket_state`) returns it when
+    /// c-ares closes the socket, so the poll is read up front and not touched
+    /// afterwards. (A fired poll was registered, so either put only queues the
+    /// slot, and `on_update`'s `&mut self` is still live up the stack; this
+    /// just keeps this frame's parameter out of it.)
     ///
     /// # Safety
     /// `poll` is the live poll that fired, registered in `self.polls` for its fd

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4783,17 +4783,9 @@ impl Resolver {
     /// the structural fix for the previously ASM-verified PROVEN_CACHED
     /// miscompile that needed `black_box` laundering under `&mut self`.
     ///
-    /// `poll` is raw, the shape `FilePoll::deinit` takes: this either returns
-    /// the slot to the store itself (no channel) or runs `Channel::process`,
-    /// whose socket-state callback (`on_dns_socket_state`) returns it when
-    /// c-ares closes the socket, so the poll is read up front and not touched
-    /// afterwards. (A fired poll was registered, so either put only queues the
-    /// slot, and `on_update`'s `&mut self` is still live up the stack; this
-    /// just keeps this frame's parameter out of it.)
-    ///
-    /// # Safety
-    /// `poll` is the live poll that fired, registered in `self.polls` for its fd
-    /// (`__bun_run_file_poll`'s contract).
+    /// Safety: `poll` is the live poll that fired (`__bun_run_file_poll`'s contract). It is
+    /// raw, as `FilePoll::deinit` takes it, since both the no-channel branch and (through
+    /// `on_dns_socket_state`) `Channel::process` may return it to the store.
     #[cfg(not(windows))]
     pub(crate) unsafe fn on_dns_poll(&self, poll: *mut FilePoll) {
         let vm = self.vm();

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4782,26 +4782,46 @@ impl Resolver {
     /// UnsafeCell-backed, LLVM cannot cache `ref_count` across the FFI call —
     /// the structural fix for the previously ASM-verified PROVEN_CACHED
     /// miscompile that needed `black_box` laundering under `&mut self`.
+    ///
+    /// `poll` is raw rather than `&mut`: this either returns the slot to the
+    /// store itself (no channel) or runs `Channel::process`, whose socket-state
+    /// callback (`on_dns_socket_state`) returns it when c-ares closes the
+    /// socket. Neither may happen while a reference argument to the slot is
+    /// still live, so the poll is read before and never touched after.
+    ///
+    /// # Safety
+    /// `poll` is the live poll that fired, registered in `self.polls` for its fd
+    /// (`__bun_run_file_poll`'s contract).
     #[cfg(not(windows))]
-    pub(crate) fn on_dns_poll(&self, poll: &mut FilePoll) {
+    pub(crate) unsafe fn on_dns_poll(&self, poll: *mut FilePoll) {
         let vm = self.vm();
         let _exit = vm.enter_event_loop_scope();
+        // SAFETY: fn contract; the read ends at the `;`.
+        let fd = unsafe { (*poll).fd.native() };
         let Some(channel) = self.channel.get() else {
             self.polls.with_mut(|p| {
-                let _ = p.remove(&poll.fd.native());
+                let _ = p.remove(&fd);
             });
-            poll.deinit();
+            // SAFETY: fn contract; the map entry that held the slot is gone, so
+            // this is its last use.
+            unsafe { FilePoll::deinit(poll) };
             return;
         };
 
         // SAFETY: `self` is the heap allocation from `init`; ref_scope keeps count > 0 across re-entrant callbacks.
         let _deref = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
+        // SAFETY: fn contract; each `&mut` the autoref forms ends with its
+        // statement, before `process` can reach the slot through the map.
+        let readable = unsafe { (*poll).is_readable() };
+        // SAFETY: as above.
+        let writable = unsafe { (*poll).is_writable() };
+
         // SAFETY: `channel` is the live c-ares channel owned by `self`; no `&mut`
         // to `*self` is held across this re-entrant call (all fields are
         // UnsafeCell-backed).
         unsafe {
-            (*channel).process(poll.fd.native(), poll.is_readable(), poll.is_writable());
+            (*channel).process(fd, readable, writable);
         }
 
         // c-ares detaches a query only *after* its callback returns, so
@@ -4891,8 +4911,10 @@ impl Resolver {
                 // the socket is now closed. We must free the data associated with
                 // socket.
                 if let Some(value) = self.polls.with_mut(|p| p.remove(&fd)) {
-                    // SAFETY: `value` is the heap-allocated FilePoll for this fd.
-                    unsafe { (*value).deinit_with_vm(ctx) };
+                    // SAFETY: `value` is the live slot `FilePoll::init` returned
+                    // for this fd below; removing it from the map was the only
+                    // other reference to it.
+                    unsafe { FilePoll::deinit_with_vm(value, ctx) };
                 }
                 return;
             }

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -385,8 +385,7 @@ impl SharedConnection {
             )
         };
         if rc.is_err() {
-            // SAFETY: as above. Never registered, so the store recycles the slot
-            // inside this call; nothing uses it afterwards.
+            // SAFETY: as above; nothing uses the slot after this.
             unsafe { FilePoll::deinit(poll_ptr) };
             // SAFETY: FFI; `main_ref` is the live connection ref.
             unsafe { DNSServiceRefDeallocate(main_ref) };

--- a/src/runtime/dns_jsc/dns_sd.rs
+++ b/src/runtime/dns_jsc/dns_sd.rs
@@ -372,18 +372,22 @@ impl SharedConnection {
                 (&raw mut *this).cast(),
             ),
         );
-        // SAFETY: `FilePoll::init` returned a live pool slot; exclusive here.
-        let poll = unsafe { &mut *poll_ptr };
         // SAFETY: the event loop outlives every lookup made on it.
         let loop_ = unsafe { ctx.platform_event_loop() };
-        let rc = poll.register_with_fd(
-            loop_,
-            Async::PollKind::Readable,
-            Async::posix_event_loop::OneShotFlag::None,
-            fd,
-        );
+        // SAFETY: `FilePoll::init` returned a live pool slot that nothing else
+        // refers to yet; the `&mut` the autoref forms ends with the statement.
+        let rc = unsafe {
+            (*poll_ptr).register_with_fd(
+                loop_,
+                Async::PollKind::Readable,
+                Async::posix_event_loop::OneShotFlag::None,
+                fd,
+            )
+        };
         if rc.is_err() {
-            poll.deinit();
+            // SAFETY: as above. Never registered, so the store recycles the slot
+            // inside this call; nothing uses it afterwards.
+            unsafe { FilePoll::deinit(poll_ptr) };
             // SAFETY: FFI; `main_ref` is the live connection ref.
             unsafe { DNSServiceRefDeallocate(main_ref) };
             return None;
@@ -598,8 +602,9 @@ impl SharedConnection {
                     .remove(conn.early_out_timer.as_ptr())
             };
         }
-        // SAFETY: `file_poll` is the live hive slot; `deinit` returns it.
-        unsafe { (*conn.file_poll.as_ptr()).deinit() };
+        // SAFETY: `file_poll` is the live hive slot this connection owns, and
+        // `conn` (its only holder) is dropped below; `deinit` returns it.
+        unsafe { FilePoll::deinit(conn.file_poll.as_ptr()) };
         // SAFETY: FFI; releases the primary ref (and any remaining subordinates).
         unsafe { DNSServiceRefDeallocate(conn.main_ref) };
         drop(conn);

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -105,11 +105,7 @@ mod posix {
         Some(unsafe { bun_core::heap::take(raw.as_ptr().cast::<MemoryPressureWatcher>()) })
     }
 
-    /// Returns the slot to the store and (Linux) closes the PSI fd it watched.
-    ///
-    /// # Safety
-    /// `poll` is the live slot `register_os_watch` created, and this is its
-    /// last use.
+    /// Safety: `poll` is the live slot `register_os_watch` created, and this is its last use.
     unsafe fn deinit_poll(poll: *mut FilePoll) {
         // SAFETY: fn contract; the read ends at the `;`.
         #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -227,22 +223,16 @@ mod posix {
             return;
         };
         if let Some(poll) = watcher.poll {
-            // SAFETY: the watcher (just taken out of the slot, so the last
-            // reference to the poll) owned this live slot. `on_poll` enqueues a
-            // task instead of running user JS, so this is never reached from
-            // inside the poll's own dispatch.
+            // SAFETY: the watcher just taken out of the VM slot held the only
+            // reference to this live poll. `on_poll` enqueues a task instead of
+            // running user JS, so this is never reached from inside the dispatch.
             unsafe { deinit_poll(poll.as_ptr()) };
         }
     }
 
     /// `__bun_run_file_poll` dispatch target. `fflags` is the kqueue `fflags`
-    /// on macOS (carrying the pressure level) and 0 on Linux. `poll` is raw
-    /// because the Linux teardown branch hands it to `deinit_poll`, which
-    /// takes the pointer like `FilePoll::deinit` does.
-    ///
-    /// # Safety
-    /// `poll` is the live watcher poll that fired (`__bun_run_file_poll`'s
-    /// contract).
+    /// on macOS (carrying the pressure level) and 0 on Linux.
+    /// Safety: `poll` is the live watcher poll that fired; the Linux teardown branch deinits it.
     pub(crate) unsafe fn on_poll(poll: *mut FilePoll, fflags: i64) {
         let vm = VirtualMachine::get_mut();
 

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -236,11 +236,13 @@ mod posix {
     }
 
     /// `__bun_run_file_poll` dispatch target. `fflags` is the kqueue `fflags`
-    /// on macOS (carrying the pressure level) and 0 on Linux.
+    /// on macOS (carrying the pressure level) and 0 on Linux. `poll` is raw
+    /// because the Linux teardown branch hands it to `deinit_poll`, which
+    /// takes the pointer like `FilePoll::deinit` does.
     ///
     /// # Safety
     /// `poll` is the live watcher poll that fired (`__bun_run_file_poll`'s
-    /// contract); the Linux teardown branch returns it to the store.
+    /// contract).
     pub(crate) unsafe fn on_poll(poll: *mut FilePoll, fflags: i64) {
         let vm = VirtualMachine::get_mut();
 

--- a/src/runtime/node/memory_pressure.rs
+++ b/src/runtime/node/memory_pressure.rs
@@ -105,10 +105,17 @@ mod posix {
         Some(unsafe { bun_core::heap::take(raw.as_ptr().cast::<MemoryPressureWatcher>()) })
     }
 
-    fn deinit_poll(poll: &mut FilePoll) {
+    /// Returns the slot to the store and (Linux) closes the PSI fd it watched.
+    ///
+    /// # Safety
+    /// `poll` is the live slot `register_os_watch` created, and this is its
+    /// last use.
+    unsafe fn deinit_poll(poll: *mut FilePoll) {
+        // SAFETY: fn contract; the read ends at the `;`.
         #[cfg(any(target_os = "linux", target_os = "android"))]
-        let fd = poll.fd;
-        poll.deinit();
+        let fd = unsafe { (*poll).fd };
+        // SAFETY: fn contract.
+        unsafe { FilePoll::deinit(poll) };
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
             let _ = bun_sys::close(fd);
@@ -196,8 +203,8 @@ mod posix {
                 (*poll).register(ctx.platform_event_loop(), Flags::MemoryPressure, false)
             };
             if result.is_err() {
-                // SAFETY: fresh hive slot never handed out.
-                deinit_poll(unsafe { &mut *poll });
+                // SAFETY: fresh hive slot that nothing else refers to.
+                unsafe { deinit_poll(poll) };
                 return None;
             }
             NonNull::new(poll)
@@ -219,27 +226,39 @@ mod posix {
         let Some(watcher) = take_watcher(global.bun_vm().as_mut()) else {
             return;
         };
-        if let Some(mut poll) = watcher.poll {
-            // SAFETY: `on_poll` enqueues a task instead of running user JS,
-            // so this is never reached from inside the dispatch and no other
-            // `&mut FilePoll` is live.
-            deinit_poll(unsafe { poll.as_mut() });
+        if let Some(poll) = watcher.poll {
+            // SAFETY: the watcher (just taken out of the slot, so the last
+            // reference to the poll) owned this live slot. `on_poll` enqueues a
+            // task instead of running user JS, so this is never reached from
+            // inside the poll's own dispatch.
+            unsafe { deinit_poll(poll.as_ptr()) };
         }
     }
 
     /// `__bun_run_file_poll` dispatch target. `fflags` is the kqueue `fflags`
     /// on macOS (carrying the pressure level) and 0 on Linux.
-    pub(crate) fn on_poll(poll: &mut FilePoll, fflags: i64) {
+    ///
+    /// # Safety
+    /// `poll` is the live watcher poll that fired (`__bun_run_file_poll`'s
+    /// contract); the Linux teardown branch returns it to the store.
+    pub(crate) unsafe fn on_poll(poll: *mut FilePoll, fflags: i64) {
         let vm = VirtualMachine::get_mut();
 
         // `EPOLLERR`/`EPOLLHUP` on a PSI fd means the trigger is dead (e.g.
         // the cgroup was removed). kernfs reports that permanently, so tear
         // the watch down instead of emitting to avoid a level-triggered spin.
         #[cfg(any(target_os = "linux", target_os = "android"))]
-        if poll.flags.contains(Flags::Eof) || poll.flags.contains(Flags::Hup) {
-            drop(take_watcher(vm));
-            deinit_poll(poll);
-            return;
+        {
+            // SAFETY: fn contract; the reads end at the `;`.
+            let dead =
+                unsafe { (*poll).flags.contains(Flags::Eof) || (*poll).flags.contains(Flags::Hup) };
+            if dead {
+                drop(take_watcher(vm));
+                // SAFETY: fn contract; the watcher that held the slot is gone,
+                // so this is its last use.
+                unsafe { deinit_poll(poll) };
+                return;
+            }
         }
 
         #[cfg(not(any(target_os = "linux", target_os = "android")))]

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -818,16 +818,15 @@ pub enum PollerPosix {
 #[cfg(unix)]
 impl PollerPosix {
     /// NOT `impl Drop`: this enum is reassigned freely (`self.poller =
-    /// Poller::Detached`, `Poller::WaiterThread(..)`, etc.), and `close()`
-    /// reassigns it to `Detached` right after calling this. A `Drop` impl
-    /// would double-free the hive slot on those reassignments. Called from
-    /// `Process::close` and `Process` drop (a no-op on `Detached`).
+    /// Poller::Detached`, `Poller::WaiterThread(..)`, etc.) and `close()`
+    /// calls this explicitly before reassigning. A `Drop` impl would
+    /// double-free the hive slot on those reassignments. Also called from
+    /// `Process` drop.
     pub(crate) fn deinit(&mut self) {
         match self {
             // SAFETY: `Fd` holds the only handle to a live hive slot, and the
-            // variant is overwritten (`close`) or dropped with the `Process`
-            // right after this, so nothing uses the slot once the store has it
-            // back.
+            // variant is overwritten (`close`) or dropped with the `Process` right
+            // after this, so nothing uses the slot once the store has it back.
             PollerPosix::Fd(poll) => unsafe { FilePoll::deinit(poll.as_ptr()) },
             PollerPosix::WaiterThread(w) => w.disable(),
             PollerPosix::Detached => {}

--- a/src/spawn/process.rs
+++ b/src/spawn/process.rs
@@ -564,15 +564,11 @@ impl Process {
     pub fn close(&mut self) {
         #[cfg(unix)]
         {
-            let mut stranded_watch_ref = false;
-            // Route the `Fd` arm through the centralized `fd_poll_mut()`
-            // accessor instead of open-coding `(*poll.as_ptr()).deinit()`.
-            if let Some(poll) = self.poller.fd_poll_mut() {
-                stranded_watch_ref = poll.is_registered();
-                poll.deinit();
-            } else if let Poller::WaiterThread(waiter) = &mut self.poller {
-                waiter.disable();
-            }
+            let stranded_watch_ref = self
+                .poller
+                .fd_poll_mut()
+                .is_some_and(|poll| poll.is_registered());
+            self.poller.deinit();
             self.poller = Poller::Detached;
             if stranded_watch_ref && !self.has_exited() {
                 // SAFETY: callers hold their own +1, so this never drops to zero.
@@ -822,17 +818,19 @@ pub enum PollerPosix {
 #[cfg(unix)]
 impl PollerPosix {
     /// NOT `impl Drop`: this enum is reassigned freely (`self.poller =
-    /// Poller::Detached`, `Poller::WaiterThread(..)`, etc.) and `close()`
-    /// already performs the same teardown explicitly before reassigning. A
-    /// `Drop` impl would double-free the hive slot on those reassignments.
-    /// Called only from `Process` drop.
+    /// Poller::Detached`, `Poller::WaiterThread(..)`, etc.), and `close()`
+    /// reassigns it to `Detached` right after calling this. A `Drop` impl
+    /// would double-free the hive slot on those reassignments. Called from
+    /// `Process::close` and `Process` drop (a no-op on `Detached`).
     pub(crate) fn deinit(&mut self) {
-        // Route the `Fd` arm through the centralized `fd_poll_mut()` accessor
-        // instead of open-coding the `NonNull` deref here.
-        if let Some(poll) = self.fd_poll_mut() {
-            poll.deinit();
-        } else if let PollerPosix::WaiterThread(w) = self {
-            w.disable();
+        match self {
+            // SAFETY: `Fd` holds the only handle to a live hive slot, and the
+            // variant is overwritten (`close`) or dropped with the `Process`
+            // right after this, so nothing uses the slot once the store has it
+            // back.
+            PollerPosix::Fd(poll) => unsafe { FilePoll::deinit(poll.as_ptr()) },
+            PollerPosix::WaiterThread(w) => w.disable(),
+            PollerPosix::Detached => {}
         }
     }
 

--- a/test/internal/source-lints/self-receiver-push-put.test.ts
+++ b/test/internal/source-lints/self-receiver-push-put.test.ts
@@ -1,0 +1,286 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A method must not push its own receiver onto a queue or put it back into its
+// pool. Inside a `&mut self` method, the receiver's address
+//
+//   queue.push(NonNull::from(&mut *self))
+//   store.put(ptr::from_mut(self))
+//   let job = NonNull::from(&mut *self); ... queue.push(job)
+//   let p: *mut Self = self;             ... queue.push(NonNull::new_unchecked(p))
+//
+// as the argument of a `.push(..)` or `.put(..)` is banned.
+//
+// Both calls give the receiver's storage away. A push is how a pool thread
+// hands a finished job back to the thread that owns it (`UnboundedQueue::push`,
+// then a wakeup); from the moment it lands the consumer writes to the object or
+// frees it (the package manager reclaims the `Box` a patch task lives in). A
+// `put` returns a slot to its pool: `HiveArrayFallback::put` drops it in place,
+// or frees it when it was a heap spill, before returning (`FilePoll`'s
+// `Store::put` does that at once for a poll that was never registered, and
+// queues the slot for the end of the event loop turn otherwise). Either way
+// the `self` of the method that made the call is still a live argument while
+// that happens. A reference argument is protected for the duration of its
+// call, and writing to or deallocating protected memory is UB under both
+// aliasing models whether or not the method touches `self` again: Tree Borrows
+// (what `bun run rust:miri` uses) reports "deallocation through <tag> is
+// forbidden ... the strongly protected tag disallows deallocations" or, for the
+// cross-thread writes, a data race on the protector's release, pointing at the
+// receiver; Stacked Borrows reports "deallocating while item [Unique] is
+// strongly protected". Codegen relies on the same guarantee: a `&mut self`
+// argument is `noalias dereferenceable` for the whole call, so the compiler is
+// free to re-read a field through it after the call instead of keeping the copy
+// taken before; a read after the push (spelled out in the source, there) is
+// what crashed the Zig version of the transpiler store (#29128).
+// `TranspilerJob::dispatch_to_main_thread(&mut self)` (reached from inside
+// `run(&mut self)` via a scope guard, so two protected frames deep),
+// `TranspilerJob::run_from_js_thread(&mut self)` (the `put` of the same slot),
+// `PatchTask::run_from_thread_pool_impl(&mut self)` and
+// `FilePoll::deinit_possibly_defer(&mut self, ..)` (reached through the
+// `&mut self` `deinit` / `deinit_with_vm` / `deinit_force_unregister` entry
+// points, so again two protected frames deep) were the instances this was
+// written for.
+//
+// The object was a raw pointer in the caller's hands before it became `self`
+// (the pool recovers it from the intrusive task field, the queue pops it, a
+// poll's owner stores the slot pointer `FilePoll::init` returned), so the fix
+// is to keep it one: run the body through a statement-scoped reborrow
+// (`let was_registered = (*this).clear_for_put(..);`), read whatever else comes
+// after through `(*this).field` accesses that end before the call, push or put
+// `this`, and never touch it again. Templates: `FilePoll::deinit` /
+// `deinit_possibly_defer` in src/io/posix_event_loop.rs (and the Windows twin in
+// src/io/windows_event_loop.rs), `NetworkTask::notify` in
+// src/install/NetworkTask.rs, `Task::callback` in src/install/PackageManagerTask.rs.
+//
+// Scope: the exclusive spellings below (`from_mut(self)`, `&mut *self`,
+// `&raw mut *self`, `self as *mut _`, ...), with `self` as the receiver and
+// `.push(` / `.put(` as the callee, inline or through a local of the same
+// function. Outside it: the shared spellings (`from_ref(self)`, `&*self`; what
+// this tree pushes from a `&self` method is a same-thread registry entry,
+// quic's `ENDPOINT_REGISTRY`, whose consumer neither writes nor frees), a bare
+// `self` argument (the `put(self, ..)` map inserts and `err.put(global, ..)`
+// property writes, where `self` is a key or a context, not storage being given
+// away), a pointer produced by a helper (`self.as_ptr()`), something the
+// receiver owns (`NonNull::from(&mut self.task)`, `&raw mut self.task`), and
+// reference parameters other than `self` (`fn f(this: &mut Task)` pushing
+// `NonNull::from(this)`; a local reference is not protected and the push moves
+// it, but a reference *parameter* pushed that way is the same bug, convert it
+// on sight). Other helpers that free their argument (`Self::destroy(..)`) are
+// the population self-receiver-reclaim.test.ts names as outside its scope.
+// Siblings: self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
+// frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// The hand-over. Anchored on the argument below, so the `Vec::push` and map
+// `put` calls all over the tree only count when the argument is the receiver's
+// address. `\s*` after the paren so a rustfmt-wrapped argument still matches.
+const HAND_OVER = String.raw`\.\s*(?:push|put)\s*\(\s*`;
+
+// Optional path in front of an item (`core::ptr::NonNull`, `std::ptr::from_mut`).
+const PATH = String.raw`(?:[\w:]+::)?`;
+const TURBOFISH = String.raw`(?:::<[^>]*>)?`;
+
+// `self` as a `*mut`. The `&raw` form needs the `(?!\s*\.)` so
+// `&raw mut *self.field` (something the receiver owns) stays out; `self as`
+// swallows the pointer type that follows.
+const SELF_AS_RAW = [
+  String.raw`${PATH}from_mut${TURBOFISH}\(\s*self\s*\)`,
+  String.raw`self\s+as\s+\*mut\b[^,;)]*`,
+  String.raw`&raw\s+mut\s+\*\s*self\b(?!\s*\.)`,
+  String.raw`${PATH}addr_of_mut!\s*\(\s*\*\s*self\s*\)`,
+].join("|");
+
+// `self` as a `NonNull`: from the reference itself (`NonNull::from(self)`,
+// `NonNull::from(&mut *self)`; the `\)` right after `self` keeps
+// `NonNull::from(&mut *self.field)` out) or wrapped around a raw spelling.
+const SELF_AS_NONNULL = [
+  String.raw`${PATH}NonNull::from\(\s*(?:&\s*mut\s+\*\s*)?self\s*\)`,
+  String.raw`${PATH}NonNull::(?:new_unchecked|new)${TURBOFISH}\(\s*(?:${SELF_AS_RAW})\s*\)`,
+].join("|");
+
+const SELF_AS_POINTER = `(?:${SELF_AS_RAW}|${SELF_AS_NONNULL})`;
+
+// Method calls that keep the address: how a `NonNull::new(..)` is unwrapped
+// and how a binding is adapted to the queue's element type.
+const SAME_ADDRESS = String.raw`(?:\s*\.\s*(?:cast(?:_mut|_const)?${TURBOFISH}\(\)|as_ptr\(\)|unwrap\(\)|expect\([^)]*\)))*`;
+
+// The argument has to end there: `.push(NonNull::from(self).foo)` is not
+// this shape, and neither is `.push(p.field)` for a binding `p` below.
+const ARG_END = String.raw`\s*[,)]`;
+
+const DIRECT = new RegExp(`${HAND_OVER}${SELF_AS_POINTER}${SAME_ADDRESS}${ARG_END}`, "g");
+
+// A local bound to the receiver's address, then handed over further down the
+// same function (which ends at the next `fn` item; a closure inside it is the
+// same function for this purpose). `let p: *mut Self = self;` is the coercion
+// spelling; without the annotation `let p = self;` is just another reference.
+const BINDING_HEAD = String.raw`\blet\s+(?:mut\s+)?(\w+)\s*`;
+const SELF_POINTER_BINDINGS = [
+  new RegExp(`${BINDING_HEAD}(?::[^=;]*)?=\\s*${SELF_AS_POINTER}${SAME_ADDRESS}\\s*;`, "g"),
+  new RegExp(`${BINDING_HEAD}:\\s*\\*(?:mut|const)\\b[^=;]*=\\s*self\\s*;`, "g"),
+];
+const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s+\w+/m;
+
+// The binding passed as is, or wrapped into a `NonNull` at the call.
+function handOverOfBinding(name: string): RegExp {
+  const wrapped = String.raw`${PATH}NonNull::(?:new_unchecked|new|from)${TURBOFISH}\(\s*${name}${SAME_ADDRESS}\s*\)`;
+  return new RegExp(`${HAND_OVER}(?:${wrapped}|\\b${name})${SAME_ADDRESS}${ARG_END}`);
+}
+
+/** Byte offsets (into `stripped`) of every banned hand-over in one file. */
+function findHandOvers(stripped: string): number[] {
+  const hits: number[] = [];
+  for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
+  for (const pattern of SELF_POINTER_BINDINGS) {
+    for (const binding of stripped.matchAll(pattern)) {
+      const start = binding.index + binding[0].length;
+      const rest = stripped.slice(start);
+      const fnEnd = rest.search(FN_ITEM);
+      const body = fnEnd === -1 ? rest : rest.slice(0, fnEnd);
+      const call = body.search(handOverOfBinding(binding[1]));
+      if (call !== -1) hits.push(start + call);
+    }
+  }
+  return hits.sort((a, b) => a - b);
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape. Lower an entry when you convert one; do not add entries.
+const ALLOW: Record<string, number> = {
+  // `TranspilerJob::dispatch_to_main_thread(&mut self)` pushes its own slot to
+  // the JS thread and `TranspilerJob::run_from_js_thread(&mut self)` puts it
+  // back into the store; `PatchTask::run_from_thread_pool_impl(&mut self)`
+  // pushes the task it lives in back to the main thread. They are being
+  // converted separately (#37778); delete these entries when that lands.
+  "src/jsc/RuntimeTranspilerStore.rs": 2,
+  "src/install/patch_install.rs": 1,
+};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including the in-tree comments
+  // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
+  // newlines and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const offset of findHandOvers(stripped)) {
+    counts[source] = (counts[source] ?? 0) + 1;
+    if (counts[source] > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${lineOf(stripped, offset)}`);
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the patterns match the banned spellings and nothing else", () => {
+  const banned = [
+    // `TranspilerJob::dispatch_to_main_thread(&mut self)` as it was.
+    "let job = NonNull::from(&mut *self);\nunsafe { (*transpiler_store).queue.push(job) };",
+    // `PatchTask::run_from_thread_pool_impl(&mut self)` as it was.
+    "unsafe {\n    (*mgr)\n        .patch_task_queue\n        .push(core::ptr::NonNull::from(&mut *self));\n    PackageManager::wake_raw(mgr);\n}",
+    // `TranspilerJob::run_from_js_thread(&mut self)` as it was.
+    "unsafe {\n    (*vm)\n        .transpiler_store\n        .store\n        .put(std::ptr::from_mut::<TranspilerJob>(self))\n};",
+    "pool.put(self as *mut Self);",
+    "let slot = ptr::from_mut(self);\nunsafe { (*store).put(slot) };",
+    // `FilePoll::deinit_possibly_defer(&mut self, ..)` as it was, posix and
+    // windows spellings.
+    "let this = ptr::NonNull::from(self);\nvm.file_polls_mut().put(this, vm, was_ever_registered);",
+    "let this: ptr::NonNull<FilePoll> = ptr::NonNull::from(&mut *self);\nvm.file_polls_mut().put(this, vm, was_ever_registered);",
+    // Other spellings of the same thing.
+    "queue.push(NonNull::from(self));",
+    "queue.push(core::ptr::NonNull::from(&mut  *self));",
+    "queue.push(NonNull::new_unchecked(std::ptr::from_mut::<Self>(self)));",
+    "queue.push(NonNull::new(self as *mut Self).unwrap());",
+    "queue.push(core::ptr::NonNull::new_unchecked(&raw mut *self));",
+    "queue.push(NonNull::new_unchecked(ptr::addr_of_mut!(*self)).cast());",
+    "pending.push(ptr::from_mut(self));",
+    "pending.push(self as *mut Self as *mut c_void);",
+    "pending.push(\n    NonNull::from(&mut *self),\n);",
+    // Through a local.
+    "let this = std::ptr::from_mut::<Self>(self);\nlet x = 1;\nqueue.push(NonNull::new_unchecked(this));",
+    "let this: *mut Self = self;\nif done {\n    return;\n}\nqueue.push(NonNull::new(this).unwrap());",
+    "let this = NonNull::from(self).cast::<Job>();\nqueue.push(this.cast());",
+    "let mut this = NonNull::from(&mut *self);\n(*vm).store.queue.push(this, );",
+  ];
+  const allowed = [
+    // The raw-pointer shape the fix produces.
+    "unsafe { (*transpiler_store).queue.push(NonNull::new_unchecked(this)) };",
+    "(*mgr)\n    .patch_task_queue\n    .push(core::ptr::NonNull::new_unchecked(this));",
+    "unsafe { (*vm).transpiler_store.store.put(this) };",
+    "self.store.put(job);",
+    // A local reference parameter, moved into the push.
+    "installer.task_queue.push(core::ptr::NonNull::from(this));",
+    // `self` as a key or a context, not as storage.
+    "bun_core::handle_oom(handles.put(self, ()));",
+    'err.put(self, b"name", name_value);',
+    "unsafe { self.owner.put(self.slot.as_ptr()) };",
+    // Something the receiver owns.
+    "queue.push(NonNull::from(&mut *self.inner));",
+    "queue.push(NonNull::from(&mut self.task));",
+    "batch.push(Batch::from(&raw mut self.task));",
+    "batch.push(Batch::from(core::ptr::addr_of_mut!(self.task)));",
+    "self.tasks.push(NonNull::new_unchecked(concurrent));",
+    "self.entries.push(item);",
+    "out.push(self.len);",
+    "let job = NonNull::from(&mut *self.job);\nqueue.push(job);",
+    // A helper-produced pointer and the shared spellings are out of scope.
+    "queue.push(self.as_non_null());",
+    "queue.push(NonNull::from(&*self));",
+    "let me = core::ptr::from_ref(self).cast_mut();\nENDPOINT_REGISTRY.with_borrow_mut(|v| {\n    if !v.contains(&me) {\n        v.push(me);\n    }\n});",
+    // A self pointer that is not pushed, or whose name is only a prefix of
+    // what is pushed.
+    "let this = std::ptr::from_mut(self);\nSelf::finalize(this);",
+    "let this = std::ptr::from_mut(self);\nqueue.push(this_task);",
+    "let this = std::ptr::from_mut(self);\nqueue.push(NonNull::from(&mut (*this).task));",
+    // The binding's function ends before the push.
+    "let this = std::ptr::from_mut(self);\n    }\n\n    fn other(&mut self, this: NonNull<Job>) {\n        self.queue.push(this);",
+  ];
+  expect(banned.filter(s => findHandOvers(s).length === 0)).toEqual([]);
+  expect(allowed.filter(s => findHandOvers(s).length !== 0)).toEqual([]);
+});
+
+test("no method pushes or puts its own receiver", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: once an allowlisted instance is converted, delete its entry so
+  // a new one cannot take its place.
+  const actual = Object.fromEntries(Object.keys(ALLOW).map(f => [f, counts[f] ?? 0]));
+  expect(actual).toEqual(ALLOW);
+});

--- a/test/internal/source-lints/self-receiver-push-put.test.ts
+++ b/test/internal/source-lints/self-receiver-push-put.test.ts
@@ -9,6 +9,8 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //
 //   queue.push(NonNull::from(&mut *self))
 //   store.put(ptr::from_mut(self))
+//   list.push(self)                          (`&mut Self` coercing to `*mut Self`)
+//   queue.push(NonNull::new_unchecked(self)) (the same coercion, one call in)
 //   let job = NonNull::from(&mut *self); ... queue.push(job)
 //   let p: *mut Self = self;             ... queue.push(NonNull::new_unchecked(p))
 //
@@ -55,21 +57,29 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // src/io/windows_event_loop.rs), `NetworkTask::notify` in
 // src/install/NetworkTask.rs, `Task::callback` in src/install/PackageManagerTask.rs.
 //
-// Scope: the exclusive spellings below (`from_mut(self)`, `&mut *self`,
-// `&raw mut *self`, `self as *mut _`, ...), with `self` as the receiver and
-// `.push(` / `.put(` as the callee, inline or through a local of the same
-// function. Outside it: the shared spellings (`from_ref(self)`, `&*self`; what
-// this tree pushes from a `&self` method is a same-thread registry entry,
-// quic's `ENDPOINT_REGISTRY`, whose consumer neither writes nor frees), a bare
-// `self` argument (the `put(self, ..)` map inserts and `err.put(global, ..)`
-// property writes, where `self` is a key or a context, not storage being given
-// away), a pointer produced by a helper (`self.as_ptr()`), something the
-// receiver owns (`NonNull::from(&mut self.task)`, `&raw mut self.task`), and
-// reference parameters other than `self` (`fn f(this: &mut Task)` pushing
+// Scope: the exclusive spellings below (`from_mut(self)`, `NonNull::from(self)`,
+// `NonNull::new_unchecked(self)`, `self.into()`, `&raw mut *self`, ...), plus
+// `self` on its own as the only argument (the implicit `&mut Self` to
+// `*mut Self` coercion, which is the shortest spelling of all of these and the
+// one clippy does not catch: `ref_as_ptr` / `borrow_as_ptr` already deny the
+// `self as *mut _` and `&mut *self as *mut _` forms workspace-wide), with
+// `self` as the receiver and `.push(` / `.put(` as the callee, inline or through
+// a local of the same function. Outside it: the shared spellings
+// (`from_ref(self)`, `&*self`; what this tree pushes from a `&self` method is a
+// same-thread registry entry, quic's `ENDPOINT_REGISTRY`, whose consumer
+// neither writes nor frees), `self` as one of several arguments (the
+// `put(self, ..)` map inserts and `err.put(global, ..)` property writes, where
+// `self` is a key or a context, not storage being given away), a pointer
+// produced by a helper (`self.as_ptr()`), something the receiver owns
+// (`NonNull::from(&mut self.task)`, `&raw mut self.task`), and reference
+// parameters other than `self` (`fn f(this: &mut Task)` pushing
 // `NonNull::from(this)`; a local reference is not protected and the push moves
 // it, but a reference *parameter* pushed that way is the same bug, convert it
-// on sight). Other helpers that free their argument (`Self::destroy(..)`) are
-// the population self-receiver-reclaim.test.ts names as outside its scope.
+// on sight). A by-value `self` moved into a `Vec` would also spell
+// `v.push(self)`; nothing in the tree does that today, and such a method can
+// bind the value first (`let me = self;`) to say so. Other helpers that free
+// their argument (`Self::destroy(..)`) are the population
+// self-receiver-reclaim.test.ts names as outside its scope.
 // Siblings: self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
 // frozen-nonnull-reborrow.test.ts.
 
@@ -108,12 +118,18 @@ const SELF_AS_RAW = [
   String.raw`${PATH}addr_of_mut!\s*\(\s*\*\s*self\s*\)`,
 ].join("|");
 
-// `self` as a `NonNull`: from the reference itself (`NonNull::from(self)`,
-// `NonNull::from(&mut *self)`; the `\)` right after `self` keeps
-// `NonNull::from(&mut *self.field)` out) or wrapped around a raw spelling.
+// The receiver reference itself: `self` or its reborrow `&mut *self`. Every
+// use below is followed by `\s*\)` or `\s*,?\s*\)`, which keeps `self.field` /
+// `&mut *self.field` (something the receiver owns) out.
+const SELF_REF = String.raw`(?:&\s*mut\s+\*\s*)?self`;
+
+// `self` as a `NonNull`: converted from the reference itself (`NonNull::from(self)`,
+// `self.into()`), coerced to `*mut` inside a constructor
+// (`NonNull::new_unchecked(self)`), or wrapped around a raw spelling.
 const SELF_AS_NONNULL = [
-  String.raw`${PATH}NonNull::from\(\s*(?:&\s*mut\s+\*\s*)?self\s*\)`,
-  String.raw`${PATH}NonNull::(?:new_unchecked|new)${TURBOFISH}\(\s*(?:${SELF_AS_RAW})\s*\)`,
+  String.raw`${PATH}NonNull::from\(\s*${SELF_REF}\s*\)`,
+  String.raw`${PATH}NonNull::(?:new_unchecked|new)${TURBOFISH}\(\s*(?:${SELF_REF}|${SELF_AS_RAW})\s*\)`,
+  String.raw`${SELF_REF}\s*\.\s*into\(\)`,
 ].join("|");
 
 const SELF_AS_POINTER = `(?:${SELF_AS_RAW}|${SELF_AS_NONNULL})`;
@@ -127,6 +143,12 @@ const SAME_ADDRESS = String.raw`(?:\s*\.\s*(?:cast(?:_mut|_const)?${TURBOFISH}\(
 const ARG_END = String.raw`\s*[,)]`;
 
 const DIRECT = new RegExp(`${HAND_OVER}${SELF_AS_POINTER}${SAME_ADDRESS}${ARG_END}`, "g");
+
+// The reference itself as the whole argument list, coerced to `*mut Self` by
+// the callee's signature (`list.push(self)`, `store.put(&mut *self)`). Only as
+// the sole argument: with more arguments `self` is a key or a context (see the
+// header), not the storage being handed over.
+const COERCED = new RegExp(`${HAND_OVER}${SELF_REF}\\s*,?\\s*\\)`, "g");
 
 // A local bound to the receiver's address, then handed over further down the
 // same function (which ends at the next `fn` item; a closure inside it is the
@@ -149,6 +171,7 @@ function handOverOfBinding(name: string): RegExp {
 function findHandOvers(stripped: string): number[] {
   const hits: number[] = [];
   for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
+  for (const m of stripped.matchAll(COERCED)) hits.push(m.index);
   for (const pattern of SELF_POINTER_BINDINGS) {
     for (const binding of stripped.matchAll(pattern)) {
       const start = binding.index + binding[0].length;
@@ -176,6 +199,11 @@ const ALLOW: Record<string, number> = {
   // converted separately (#37778); delete these entries when that lands.
   "src/jsc/RuntimeTranspilerStore.rs": 2,
   "src/install/patch_install.rs": 1,
+  // `Resolve::dispatch(&mut self)` and `Load::dispatch(&mut self)` link their
+  // receiver into the bundle's outstanding lists (`outstanding_*.push(self)`,
+  // the coercion spelling) before posting it to the JS thread. Being converted
+  // separately (#37732); delete this entry when that lands.
+  "src/bundler/bundle_v2.rs": 2,
 };
 
 const counts: Record<string, number> = {};
@@ -221,6 +249,19 @@ test("the patterns match the banned spellings and nothing else", () => {
     // windows spellings.
     "let this = ptr::NonNull::from(self);\nvm.file_polls_mut().put(this, vm, was_ever_registered);",
     "let this: ptr::NonNull<FilePoll> = ptr::NonNull::from(&mut *self);\nvm.file_polls_mut().put(this, vm, was_ever_registered);",
+    // `Resolve::dispatch(&mut self)` in src/bundler/bundle_v2.rs (allowlisted
+    // above): the bare coercion.
+    "bv2.graph.outstanding_resolves.push(self);",
+    // The coercion spellings of the three instances above.
+    "unsafe { (*vm).transpiler_store.store.put(self) };",
+    "(*self.pool).put(&mut *self);",
+    "queue.push(NonNull::new_unchecked(self));",
+    "queue.push(NonNull::new(self).unwrap());",
+    "queue.push(NonNull::new_unchecked(&mut *self));",
+    "queue.push(self.into());",
+    "pending.push(\n    self,\n);",
+    "let this = NonNull::new_unchecked(self);\nqueue.push(this);",
+    "let this: NonNull<Self> = self.into();\nqueue.push(this);",
     // Other spellings of the same thing.
     "queue.push(NonNull::from(self));",
     "queue.push(core::ptr::NonNull::from(&mut  *self));",
@@ -255,8 +296,12 @@ test("the patterns match the banned spellings and nothing else", () => {
     "batch.push(Batch::from(&raw mut self.task));",
     "batch.push(Batch::from(core::ptr::addr_of_mut!(self.task)));",
     "self.tasks.push(NonNull::new_unchecked(concurrent));",
+    "self.tasks.push(NonNull::new_unchecked(self.task));",
     "self.entries.push(item);",
     "out.push(self.len);",
+    "out.push(self.node.into());",
+    "out.push(&mut *self.node);",
+    "out.push(selfie);",
     "let job = NonNull::from(&mut *self.job);\nqueue.push(job);",
     // A helper-produced pointer and the shared spellings are out of scope.
     "queue.push(self.as_non_null());",


### PR DESCRIPTION
### Problem
- The three `FilePoll` deinit entry points (POSIX, and the Windows twin) are `&mut self` methods that end by handing their own receiver to `Store::put`.
- For a poll that was never registered, `put` frees the slot on the spot, while the `&mut self` of the deinit frames still belongs to calls that have not returned. Both Miri models reject that (Tree Borrows: "the strongly protected tag disallows deallocations"; Stacked Borrows: "deallocating while item is strongly protected").
- Casting `self` to a raw pointer before the `put`, as the old comments did, does not lift the protection; only returning does.
- Nothing reaches that branch today: every POSIX owner registers right after `init`, registration flags the poll before checking the syscall result, and no Windows code creates a poll. The old code relied on that unstated invariant. No behaviour changes. Same shape as #37681 and #37778.

### Fix
- The deinit entry points take `*mut FilePoll`. Unregistering and field clearing move into a `&mut self` helper whose borrow ends at its statement, and the raw pointer is what goes to the store, so nothing references the slot when `put` may free it.
- Every owner already holds the poll as a pointer, so callers pass that. The two event loop callbacks that deinit the poll they are handed take a pointer too; those polls were registered, so their `put` is deferred, and the `&mut self` further up the event loop stack is unchanged and tracked separately.
- A new source lint bans handing a method's receiver to `.push(..)` / `.put(..)`. On main it reports exactly the two sites above; here the tree is clean. Two bundler sites are allowlisted pending #37732; the file is shared with #37778, and whichever lands second deletes the leftover entries.
- Verification: the lint fails on main and passes here. There is no behavioural fail-before test, since nothing reaches the freeing branch. `cargo check` for Linux, macOS and Windows targets, clippy, fmt, and the spawn, child_process, dns, memory-pressure and shell suites were run on a debug build; the three child_process failures also fail on released bun or are timeouts.

### Background
- A `FilePoll` is bun's registration of one fd with the platform event loop (epoll / kqueue). Pipes, child processes, the DNS resolver, dns_sd and the memory-pressure watcher each own one and hold it as a raw pointer.
- Polls are not boxed. They live in a per-thread `Store` whose hive has 128 inline slots and spills the rest to the heap, and a poll is released with `Store::put` rather than `Drop`.
- `Store::put` has two branches: a poll that was ever registered is queued and freed after the current event loop turn; one that never was is freed or recycled immediately.
- In Rust a `&mut T` argument is protected until its call returns (rustc emits `noalias dereferenceable`), so freeing it inside the call is undefined behaviour even via a raw pointer. `bun run rust:miri` checks this with Tree Borrows.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 9 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-push-put.test.ts
bun test v1.4.0 (68ad6349a)

test/internal/source-lints/self-receiver-push-put.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.39ms]
(pass) the patterns match the banned spellings and nothing else [41.67ms]
318 |   expect(banned.filter(s => findHandOvers(s).length === 0)).toEqual([]);
319 |   expect(allowed.filter(s => findHandOvers(s).length !== 0)).toEqual([]);
320 | });
321 | 
322 | test("no method pushes or puts its own receiver", () => {
323 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/io/posix_event_loop.rs:419",
+   "src/io/windows_event_loop.rs:134",
+ ]

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/internal/source-lints/self-receiver-push-put.test.ts:323:21)
(fail) no method pushes or puts its own receiver [5.33ms]
(pass) allowlisted files still carry exactly their documented count [6.86ms]

 3 pass
 1 fail
 5 expect() calls
Ran 4 tests across 1 
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/internal/source-lints/self-receiver-push-put.test.ts:
(pass) scans a non-empty set of tracked Rust sources [0.12ms]
(pass) the patterns match the banned spellings and nothing else [0.62ms]
318 |   expect(banned.filter(s => findHandOvers(s).length === 0)).toEqual([]);
319 |   expect(allowed.filter(s => findHandOvers(s).length !== 0)).toEqual([]);
320 | });
321 | 
322 | test("no method pushes or puts its own receiver", () => {
323 |   expect(offenders).toEqual([]);
                          ^
error: expect(received).toEqual(expected)

- []
+ [
+   "src/io/posix_event_loop.rs:419",
+   "src/io/windows_event_loop.rs:134",
+ ]

- Expected  - 1
+ Received  + 4

      at <anonymous> (/workspace/bun/test/internal/source-lints/self-receiver-push-put.test.ts:323:21)
(fail) no method pushes or puts its own receiver [0.23ms]
(pass) allowlisted files still carry exactly their documented count [0.16ms]

 3 pass
 1 fail
 5 expect() calls
Ran 4 tests across 1 file. [828.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/self-receiver-push-put.test.ts
bun test v1.4.0 (68ad6349a)

test/internal/source-lints/self-receiver-push-put.test.ts:
(pass) scans a non-empty set of tracked Rust sources [2.54ms]
(pass) the patterns match the banned spellings and nothing else [43.42ms]
(pass) no method pushes or puts its own receiver [1.54ms]
(pass) allowlisted files still carry exactly their documented count [6.83ms]

 4 pass
 0 fail
 5 expect() calls
Ran 4 tests across 1 file. [24.62s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 981ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/5] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[1/5] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_io v0.0.0 (/workspace/bun/src/io)
[1m[92m   Compiling[0m bun_zlib v0.0.0 (/workspace/bun/src/zlib)
[1m[92m   Compiling[0m bun_event_loop v0.0.0 (/workspace/bun/src/event_loop)
[1m[92m   Compiling[0m bun_sourcemap v0.0.0 (/workspace/bun/src/sourcemap)
[1m[92m   Compiling[0m bun_css v0.0.0 (/workspace/bun/src/css)
[1m[92m   Compiling[0m bun_options_types v0.0.0 (/workspace/bun/src/options_types)
[1m[92m   Compiling[0m bun_http v0.0.0 (/workspace/bun/src/http)
[1m[92m   Compiling[0m bun_crash_handler v0.0.0 (/workspace/bun/src/crash_handler)
[1m[92m   Compiling[0m bun_resolve_builtins v0.0.0 (/workspace/bun/src/resolve_builtins)
[1m[92m   Co
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/io/lib.rs                                      |  14 +-
 src/io/posix_event_loop.rs                         |  62 ++--
 src/io/windows_event_loop.rs                       |  56 ++--
 src/runtime/dispatch.rs                            |  19 +-
 src/runtime/dns_jsc/dns.rs                         |  28 +-
 src/runtime/dns_jsc/dns_sd.rs                      |  26 +-
 src/runtime/node/memory_pressure.rs                |  41 ++-
 src/spawn/process.rs                               |  33 +-
 .../source-lints/self-receiver-push-put.test.ts    | 331 +++++++++++++++++++++
 9 files changed, 498 insertions(+), 112 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
src/io/lib.rs                                                 5      7      0
src/io/posix_event_loop.rs                                    7     10      0
src/io/windows_event_loop.rs                                  4      8      0
src/runtime/dispatch.rs                                       2      4      0
src/runtime/dns_jsc/dns.rs                                    6      5      0
src/runtime/dns_jsc/dns_sd.rs                                 3      4      0
src/runtime/node/memory_pressure.rs                           5      9      0
src/spawn/process.rs                                          2      5      0
…st/internal/source-lints/self-receiver-push-put.test.ts      5     12      0
```

</details>

**root cause** · written by the author bot

FilePoll::deinit_possibly_defer (and its Windows twin) handed its own hive slot to Store::put while still executing under a &mut self receiver, so on the never-registered path the slot could be dropped and freed while that protected reference argument was still live, which is undefined behaviour under both Stacked Borrows and Tree Borrows even though no crash was known. The fix converts deinit, deinit_with_vm and deinit_force_unregister on POSIX and Windows into unsafe functions that take the slot pointer the owner already holds, perform the field work through a statement-scoped clear_for_p…

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

`FilePoll::deinit`, `deinit_with_vm` and `deinit_force_unregister` (src/io/posix_event_loop.rs, and the twin in src/io/windows_event_loop.rs) were `&mut self` methods that ended by putting their own receiver back into the event loop's `Store`:

```rust
fn deinit_possibly_defer(&mut self, vm: EventLoopCtx, force_unregister: bool) {
    ...
    let this = ptr::NonNull::from(self);
    vm.file_polls_mut().put(this, vm, was_ever_registered);   // posix_event_loop.rs:419
}
```

(`windows_event_loop.rs:134` is the same line spelled `NonNull::from(&mut *self)`.)

Same shape as #37681 (blob read handler) and #37778 (transpiler / patch jobs), in the FilePoll store.

### Why

`Store::put` has two branches. For a poll that went through `register*` it queues the slot and frees it after the event loop turn. Otherwise it calls `hive.put(slot)` right there: `drop_in_place` + recycle for one of the 128 inline slots, `heap::destroy` (a `Box` free) for a slot that spilled to the heap because more than 128 polls were live. In that branch the slot is freed while the `&mut self` of `deinit_possibly_defer`, and of the entry point one frame up, are still arguments of calls that have not returned. A reference argument has to stay valid until its call returns: rustc marks it `noalias dereferenceable` for the whole call, and both aliasing models reject freeing it (Tree Borrows, which `bun run rust:miri` uses: "the strongly protected tag disallows deallocations"; Stacked Borrows: "deallocating while item is strongly protected"). Converting `self` to a raw pointer before the `put`, which is what the old comments did, does not end the protection; only returning does.

How reachable that branch is today, checked while writing this: not at all. `register_with_fd_impl` sets `WasEverRegistered` right after the syscall, before it looks at the result (epoll, macOS and FreeBSD kqueue alike), and every owner in the tree registers immediately after `FilePoll::init` (pipe reader and writers, `Process::watch`, the resolver's socket-state callback, dns_sd, the memory-pressure watcher), so every POSIX deinit, including the ones on registration-failure paths, takes the deferred branch. The Windows twin would take the immediate branch for every poll, but no Windows code creates one (the POSIX reader/writer types that do are compiled there and unused). So this is not a fix for a path something takes; it is the store's contract (`put` may free) being satisfiable by the API's shape instead of by an invariant that nothing states or checks (a new owner that deinits before registering, or a change to how a failed registration is flagged, would make the old `&mut self` `put` free its own receiver), and it is what lets the push/put lint below hold tree-wide with no standing exception for this store. No behaviour changes.

### Fix

Every owner already holds the slot as a pointer (`FilePollRef(NonNull)`, `PollerPosix::Fd(NonNull)`, the resolver's `PollsMap` of `*mut FilePoll`, dns_sd's `file_poll`, the memory-pressure watcher's `Option<NonNull>`), so the entry points now take it:

```rust
pub unsafe fn deinit(this: *mut FilePoll)
pub unsafe fn deinit_with_vm(this: *mut FilePoll, vm: EventLoopCtx)
pub(crate) unsafe fn deinit_force_unregister(this: *mut FilePoll)
```

The unregister + field clearing moved into a `&mut self` helper (`clear_for_put`) invoked as a statement-scoped reborrow, and the pointer itself goes to the store. Callers pass the pointer they hold (`FilePollRef::deinit_force_unregister`, `PollerPosix::deinit`, which `Process::close` now also goes through, `Resolver::on_dns_socket_state`, `SharedConnection::{init,destroy}`, `memory_pressure::{deinit_poll,uninstall,register_os_watch}`).

The two dispatch targets that deinit the poll they are handed, `Resolver::on_dns_poll` and `memory_pressure::on_poll`, take `*mut FilePoll` as well, and `__bun_run_file_poll` reads `owner`/`hup` through scoped accesses. To be clear about what that is: those are the same shape as `deinit`, not a change in what the aliasing models see. A dispatched poll was registered, so its put is the deferred one, and the `&mut self` of `on_kqueue_event` / `on_epoll_event` / `on_update` in src/io/posix_event_loop.rs is still live up the stack while an owner deinits its poll from inside the callback, before and after this PR. That chain is reported separately and left alone here.

### Test

`test/internal/source-lints/self-receiver-push-put.test.ts` bans handing the receiver to `.push(..)` / `.put(..)` inside a method. Against main it reports exactly the two sites above; with this change the tree is clean. Compared with the version #37778 adds, this one also catches the spellings that need no conversion function at all, `list.push(self)` / `store.put(&mut *self)` (the `&mut Self` to `*mut Self` coercion at the call, which clippy's `ref_as_ptr` / `borrow_as_ptr` do not see), `NonNull::new_unchecked(self)` and `self.into()`, so the ratchet cannot be satisfied by deleting a `from_mut`. The extra arm finds the two `outstanding_*.push(self)` sites in src/bundler/bundle_v2.rs, allowlisted with a pointer to #37732, which converts them.

The file is shared with #37778: that PR allowlists these two FilePoll sites, this one allowlists the three transpiler/patch sites it converts (plus the two bundler sites). Whichever lands second deletes the entries that remain; the ratchet test in the file fails until it does.

There is no behavioural fail-before test: as described above, nothing reaches the branch whose shape this fixes, and the old code never touched the slot after the `put`.

### Verification

- `cargo check --workspace` for `x86_64-unknown-linux-gnu`, `aarch64-apple-darwin` (dns_sd and the macOS memory-pressure arm) and `x86_64-pc-windows-msvc` (the Windows twin); `cargo clippy` on `bun_io` / `bun_spawn` / `bun_runtime`; `cargo fmt --check`; the full `test/internal/source-lints/` directory.
- Against the debug build: `test/js/bun/spawn/spawn.test.ts` (140 pass), `spawn-many-teardown.test.ts` (350 children, so the hive spills to the heap), `spawn-pipe-stale-fd-unregister.test.ts`, `spawn-noread-leak.test.ts`, `spawn-stdin-destroy.test.ts`, `exit-code.test.ts`, `test/js/node/child_process/child_process.test.ts` (62 pass; the 3 failures are the `$SHELL`-is-unset test, which fails the same way with the released bun, and two tests that hit their 5 s timeout on a loaded machine while spawning 20 debug children; the GC fixture from the latter prints `OK` when run directly), `child-process-stdio.test.js`, `test/js/node/dns/dns-tcp-bidirectional-poll.test.ts` and `dns-resolver-concurrent-timeout.test.ts` (the `on_dns_poll` / socket-state path), `test/js/node/process/process-memory-pressure.test.ts`, and the shell suites `bunshell.test.ts` (418 pass), `pipeline_stack`, `epipe`, `shell-pipe-read-fault`.

</details>
