### PR TITLE
net: fail the writes still queued on a socket handed off over IPC with ECANCELED

### DIFF
--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -22,16 +22,9 @@ export function serialize(message, handle, options) {
   if (handle instanceof net.Socket) {
     // Only plain TCP sockets cross processes; a TLS session cannot (node: ERR_INVALID_HANDLE_TYPE).
     if (typeof handle[Symbol.for("::buntls::")] === "function") throw $ERR_INVALID_HANDLE_TYPE();
-    const native = handle._handle;
+    const { kDetachHandle } = require("internal/net/symbols");
+    const native = options?.keepOpen ? handle._handle : handle[kDetachHandle]();
     if (!native) return null;
-    if (!options?.keepOpen) {
-      // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/child_process.js#L120-L148
-      const { server } = handle;
-      if (server) server._connections--;
-      handle.setTimeout(0);
-      native.data = undefined;
-      handle._handle = null;
-    }
     return [native, { cmd: "NODE_HANDLE", msg: message, type: "net.Socket" }];
   }
   if (handle instanceof require("node:dgram").Socket) {

--- a/src/js/internal/net/symbols.ts
+++ b/src/js/internal/net/symbols.ts
@@ -4,4 +4,7 @@ export default {
   // 'secureConnect' (node parity), so internal deferrals park on this instead.
   kSecureConnectDone: Symbol("kSecureConnectDone"),
   kVerifyError: Symbol("kVerifyError"),
+  // Socket.prototype[kDetachHandle](): the socket gives up its native handle so
+  // the descriptor can be passed to another process (child.send(message, socket)).
+  kDetachHandle: Symbol("kDetachHandle"),
 };

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -42,7 +42,7 @@ import type { TLSSocket } from "node:tls";
 const { kTimeout, getTimerDuration } = require("internal/timers");
 const { validateFunction, validateNumber, validateAbortSignal, validatePort, validateBoolean, validateInt32, validateString } = require("internal/validators"); // prettier-ignore
 const { isIPv4, isIPv6, isIP } = require("internal/net/isIP");
-const { kArmHandshakeTimeout, kSecureConnectDone, kVerifyError } = require("internal/net/symbols");
+const { kArmHandshakeTimeout, kSecureConnectDone, kVerifyError, kDetachHandle } = require("internal/net/symbols");
 
 const ArrayPrototypeIncludes = Array.prototype.includes;
 const ArrayPrototypeJoin = Array.prototype.join;
@@ -1869,6 +1869,41 @@ Socket.prototype[kCloseRawConnection] = function () {
   connection.unref();
   connection.destroy();
 };
+
+// child.send(message, socket) without keepOpen: the receiving process takes the
+// connection over, so this socket lets go of its handle like node's
+// handleConversion["net.Socket"].send. Returns the native handle for the IPC
+// layer, or null when there is nothing to send.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/child_process.js#L120-L148
+//
+// The handle's drain/close events no longer reach this socket, so a write still
+// waiting on the native drain could never complete. Node's close of the sent
+// handle fails that write with ECANCELED, which in turn fails the chunks queued
+// behind it and destroys the socket; do the same rather than leave the
+// callbacks (and writableLength) pending forever.
+Socket.prototype[kDetachHandle] = function detachHandle() {
+  const handle = this._handle;
+  if (!handle) return null;
+  const server = this.server;
+  if (server) {
+    // The connection leaves the server's books now; _destroy() must not take
+    // it off a second time.
+    this._server = undefined;
+    server._connections--;
+    if (server._emitCloseIfDrained) server._emitCloseIfDrained();
+  }
+  this.setTimeout(0);
+  handle.data = undefined;
+  this._handle = null;
+  const pendingWrite = this[kwriteCallback];
+  if (pendingWrite) process.nextTick(cancelDetachedWriteNT, this, pendingWrite);
+  return handle;
+};
+
+function cancelDetachedWriteNT(self, callback) {
+  if (self[kwriteCallback] !== callback) return;
+  failWrite(self, UV_ECANCELED, callback);
+}
 
 Socket.prototype.connect = function connect(...args) {
   $debug("Socket.prototype.connect");

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -607,6 +607,134 @@ process.on('disconnect', () => process.exit(sawQueued ? 0 : 3));
     },
   );
 
+  // node: the handle close that follows the handoff cancels the write request still queued on it
+  // (write ECANCELED), that error fails the chunks queued behind it inside the stream, and the
+  // socket errors and closes. The sender used to drop all of it on the floor: the callbacks never
+  // ran and writableLength stayed put for the life of the socket.
+  test.concurrent("a net.Socket handed off with writes still queued fails them with ECANCELED", async () => {
+    using dir = tempDir("ipc-handle-queued-writes", {
+      "parent.js": `
+const { fork } = require('node:child_process');
+const net = require('node:net');
+const child = fork('child.js');
+const result = { events: [] };
+const server = net.createServer(socket => {
+  socket.on('error', e => result.events.push(['error', e.code, e.syscall, e.message]));
+  socket.on('close', () => result.events.push(['close']));
+  const chunk = Buffer.alloc(1 << 20, 'w');
+  const outcomes = new Map();
+  let id = 0;
+  const write = () => { const n = id++; return socket.write(chunk, err => outcomes.set(n, err ? err.code : null)); };
+  // The client never reads: write until a chunk is left waiting on the kernel buffer, then queue
+  // one more behind it inside the stream.
+  while (write()) {}
+  write();
+  const queued = [id - 2, id - 1];
+  result.writableLengthBeforeSend = socket.writableLength;
+  child.send('socket', socket);
+  child.on('message', m => {
+    // The reply takes whole event-loop turns to arrive; whatever the sender does about the queued
+    // writes happens in the ticks right after send().
+    result.child = m;
+    result.completedWrites = [...outcomes].filter(([n]) => !queued.includes(n)).map(([, code]) => code);
+    result.queuedWrites = queued.map(n => (outcomes.has(n) ? outcomes.get(n) : 'callback never ran'));
+    result.writableLength = socket.writableLength;
+    result.destroyed = socket.destroyed;
+    server.getConnections((err, count) => {
+      result.connections = err ? err.message : count;
+      console.log(JSON.stringify(result));
+      child.kill();
+      process.exit(0);
+    });
+  });
+});
+server.listen(0, '127.0.0.1', () => {
+  const client = net.connect(server.address().port, '127.0.0.1');
+  client.pause();
+  client.on('error', () => {});
+});
+`,
+      "child.js": `
+const net = require('node:net');
+process.on('message', (m, socket) => {
+  const received = socket instanceof net.Socket;
+  if (received) socket.destroy();
+  process.send({ message: m, received });
+});
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const out = JSON.parse(stdout.trim());
+    expect({ ...out, completedWrites: out.completedWrites.every(code => code === null), stderr }).toEqual({
+      writableLengthBeforeSend: 2 * (1 << 20),
+      child: { message: "socket", received: true },
+      completedWrites: true,
+      queuedWrites: ["ECANCELED", "ECANCELED"],
+      events: [["error", "ECANCELED", "write", "write ECANCELED"], ["close"]],
+      writableLength: 0,
+      destroyed: true,
+      connections: 0,
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // The handoff takes the connection off the server's books, so a server that was already closing
+  // has nothing left to wait for. (node leaves such a server waiting forever and, once the sender's
+  // socket object is destroyed, counts the handed-off connection off a second time.)
+  test.concurrent("handing off the last connection of a closing server lets it emit 'close'", async () => {
+    using dir = tempDir("ipc-handle-closing-server", {
+      "parent.js": `
+const { fork } = require('node:child_process');
+const net = require('node:net');
+const child = fork('child.js');
+const events = [];
+const server = net.createServer(socket => {
+  server.close(() => events.push('server close'));
+  child.send('socket', socket);
+  events.push('sent');
+  child.on('message', m => {
+    events.push('child replied');
+    console.log(JSON.stringify({ events, received: m.received }));
+    child.kill();
+    process.exit(0);
+  });
+});
+server.listen(0, '127.0.0.1', () => {
+  net.connect(server.address().port, '127.0.0.1').on('error', () => {});
+});
+`,
+      "child.js": `
+const net = require('node:net');
+process.on('message', (m, socket) => {
+  const received = socket instanceof net.Socket;
+  if (received) socket.destroy();
+  process.send({ received });
+});
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+      out: { events: ["sent", "server close", "child replied"], received: true },
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   // The child sends a server and disconnects at once. node: process.connected drops immediately, a
   // second disconnect() errors, and the parent still receives the server (its adoption completes a
   // loop turn later, which must not lose it) as well as the message queued behind it. Order is not


### PR DESCRIPTION
### Problem
- `child.send(msg, socket)` on a `net.Socket` with writes still queued silently drops them: the callbacks never run, `writableLength` never drops, no `'error'` or `'close'`. Node fails the callbacks with `write ECANCELED`, then errors and closes the socket.
- Cause: the handoff detached the native handle, which also cut off the drain/close events that would have completed the one write parked on it. Nothing else ever settles that write, so the chunks queued behind it never fail either.
- Also on this path: destroying the sender's socket after a handoff took the connection off the server's count twice, and a closing server never emitted `'close'` after its last connection was handed off.

### Fix
- The detach moves from the IPC serializer into a socket method, which fails the parked write with `ECANCELED` on the next tick. The stream then fails the queued chunks with the same error and destroys the socket, as node does.
- Property to check: after a handoff without `keepOpen` no write callback can stay pending, since the only write that can be waiting on the handle is the one the detach fails.
- The detach also drops the socket's server reference before decrementing the connection count, so a later destroy cannot decrement again, and runs the server's close-if-drained check.
- `keepOpen: true` and sockets with nothing queued behave as before.
- Verification, per the original: two added tests fail on main with the symptoms above and pass with the fix; existing handle passing tests still pass. The evidence footer below records no local run of that file and defers to CI.

### Background
- Handle passing: `child.send(message, socket)` sends the descriptor to the child over IPC. Without `keepOpen: true` the sender gives up the connection and its socket object is detached from the native handle.
- The native handle's `data` slot points back at the JS socket; clearing it is what keeps the handle's later drain/close events away from the sender.
- bun's `net.Socket` keeps one write in flight against the handle, parked as a callback until the handle drains; further chunks wait inside the Writable stream behind it. Failing that one write is what lets the stream fail the rest.
- `failWrite` is net's existing helper for completing a pending write with a libuv error code; `ECANCELED` is what node reports when closing a handle cancels a queued write.
- A `net.Server` counts live connections and `server.close()` only emits `'close'` once the count reaches zero; `_emitCloseIfDrained()` is that check.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process_ipc_handle.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What does this PR do?

`child.send(msg, socket)` on a `net.Socket` that still has writes queued (new handle passing from #31829) silently dropped them: the write callbacks never ran, `writableLength` stayed put for the life of the socket, and no `'error'` or `'close'` was emitted. Node reports the same data loss: the callbacks get `write ECANCELED`, and the socket errors and closes.

```js
const net = require("net"), cp = require("child_process");
if (process.argv[2] === "child") {
  process.on("message", (m, s) => s.destroy());
} else {
  net.createServer(s => {
    const child = cp.fork(__filename, ["child"]);
    const r = { cbs: [], events: [] };
    s.on("error", e => r.events.push("error:" + e.code)).on("close", () => r.events.push("close"));
    const big = Buffer.alloc(4 << 20, "w"); // the client below never reads
    s.write(big, e => r.cbs.push(e ? e.code : "ok"));
    s.write(big, e => r.cbs.push(e ? e.code : "ok"));
    child.send("go", s);
    child.on("message", () => { r.writableLength = s.writableLength; console.log(JSON.stringify(r)); process.exit(); });
  }).listen(0, "127.0.0.1", function () { net.connect(this.address().port, "127.0.0.1").pause(); });
}
```

| | `cbs` | `events` | `writableLength` |
|---|---|---|---|
| main (`626034fda`) | `[]` | `[]` | `8388608`, forever |
| node v26.3.0 | `["ECANCELED","ECANCELED"]` | `["error:ECANCELED","close"]` | `0` |
| this PR | `["ECANCELED","ECANCELED"]` | `["error:ECANCELED","close"]` | `0` |

#### Cause

`Ipc.ts` `serialize()` detached the socket by clearing the native handle's `data` slot and nulling `_handle`. That is what keeps the handle's later events away from the sender, but it also cuts off the `drain`/`close` events that would have completed the `_write` parked on `kwriteCallback`. Nothing else ever settles that callback, so the stream never gets to fail the chunks queued behind it either. Node's equivalent works because closing the sent handle cancels its queued `uv_write_t`, and the `ECANCELED` flows through the normal write error path.

#### Fix

The detach moves from `Ipc.ts` into `Socket.prototype[kDetachHandle]` in `net.ts`, where it can fail the parked write through the existing `failWrite(self, UV_ECANCELED, cb)` helper (on the next tick, so nothing runs inside `send()`). The stream then fails the queued chunks with the same error and destroys the socket, which is exactly node's sequence. The write is reported as cancelled when the socket is handed off rather than when the handle is eventually closed after the ack; the outcome is the same, the sender has no way to track those bytes any more either way.

Two bookkeeping details that the new destroy exposes, both in the same method: `_server` is cleared after the connection is taken off the server's count, so the destroy that now follows (or a user `destroy()`, which already hit this on main) does not count it off a second time (`getConnections()` stays at 0; node reports -1 here), and `_emitCloseIfDrained()` runs so a server that was already closing emits `'close'` once its last connection has been handed off instead of waiting forever.

`keepOpen: true` is unchanged. Sockets with nothing queued are unchanged as well: still no `'end'`/`'close'` on the sender (the existing detach test covers that).

### How did you verify your code works?

Two tests added to `test/js/node/child_process/child_process_ipc_handle.test.ts`; both fail on main with the symptoms above (`callback never ran` x2, `events: []`, `writableLength: 2097152`; server `'close'` never emitted) and pass with the fix. The rest of that file, `cluster.test.ts`, and the vendored handle passing tests (`test-child-process-fork-net-socket`, `test-child-process-send-keep-open`, `test-cluster-net-send`, `test-cluster-send-deadlock`, `test-cluster-send-socket-to-worker-http-server`, `test-cluster-send-handle-large-payload`) still pass.

</details>
