### PR TITLE
Bun.serve: release the [serve.static] plugin cell when the server is freed

### DIFF
--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -440,8 +440,6 @@ pub mod js_bundler {
     }
 
     impl Config {
-        /// On error the caller still holds whatever was stored in `plugins`;
-        /// dropping it releases the plugin cell.
         pub fn from_js(
             global_this: &JSGlobalObject,
             config: JSValue,
@@ -1791,11 +1789,9 @@ pub mod js_bundler {
         }
     }
 
-    /// Owner of a `JSBundlerPlugin` from [`PluginJscExt::create`]. The handle
-    /// is a `protect()`ed JSCell, not a heap allocation: a `Box<Plugin>` around
-    /// it frees nothing (`Plugin` is a ZST opaque), so the only thing that
-    /// releases the cell is this type's `Drop` calling [`PluginJscExt::destroy`].
-    /// JS thread only.
+    /// Owns a cell from [`PluginJscExt::create`]; `Drop` is its one
+    /// [`PluginJscExt::destroy`]. The cell is a protected JSCell, not a heap
+    /// allocation, so nothing else (a `Box<Plugin>` included) releases it. JS thread only.
     pub struct OwnedPlugin(core::ptr::NonNull<Plugin>);
 
     impl OwnedPlugin {
@@ -1806,9 +1802,7 @@ pub mod js_bundler {
             )
         }
 
-        /// The handle itself, for holders that only borrow the plugin (the
-        /// bundle thread, routes and the dev server sharing a server's plugins).
-        /// Valid until `self` drops.
+        /// For holders that only borrow the cell; valid until `self` drops.
         #[inline]
         pub fn as_non_null(&self) -> core::ptr::NonNull<Plugin> {
             self.0

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1789,9 +1789,7 @@ pub mod js_bundler {
         }
     }
 
-    /// Owns a cell from [`PluginJscExt::create`]; `Drop` is its one
-    /// [`PluginJscExt::destroy`]. The cell is a protected JSCell, not a heap
-    /// allocation, so nothing else (a `Box<Plugin>` included) releases it. JS thread only.
+    /// A [`PluginJscExt::create`] cell; dropping it is its [`PluginJscExt::destroy`]. JS thread only.
     pub struct OwnedPlugin(core::ptr::NonNull<Plugin>);
 
     impl OwnedPlugin {

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -440,10 +440,12 @@ pub mod js_bundler {
     }
 
     impl Config {
+        /// On error the caller still holds whatever was stored in `plugins`;
+        /// dropping it releases the plugin cell.
         pub fn from_js(
             global_this: &JSGlobalObject,
             config: JSValue,
-            plugins: &mut Option<*mut Plugin>,
+            plugins: &mut Option<OwnedPlugin>,
         ) -> JsResult<Config> {
             // Config implements Drop, so functional-record-update from Default::default()
             // is rejected by rustc (E0509). Construct default then mutate instead.
@@ -451,12 +453,6 @@ pub mod js_bundler {
             // `define` defaults to `StringMap::init(false)`; only the flag differs.
             this.define.dupe_keys = true;
             // errdefer this.deinit(allocator) — handled by `impl Drop for Config` on `?` paths.
-            // errdefer if (plugins.*) |plugin| plugin.deinit() — scopeguard below.
-            let mut plugins = scopeguard::guard(plugins, |p| {
-                if let Some(pl) = p.take() {
-                    Plugin::destroy(pl);
-                }
-            });
 
             let mut did_set_target = false;
             if let Some(slice) = config.get_optional_slice(global_this, b"target")? {
@@ -516,33 +512,25 @@ pub mod js_bundler {
                         )));
                     };
 
-                    let bun_plugins: *mut Plugin = match **plugins {
-                        Some(p) => p,
-                        None => {
-                            let p = Plugin::create(
-                                global_this,
-                                match this.target {
-                                    Target::Bun | Target::BunMacro => jsc::BunPluginTarget::Bun,
-                                    Target::Node => jsc::BunPluginTarget::Node,
-                                    _ => jsc::BunPluginTarget::Browser,
-                                },
-                            );
-                            **plugins = Some(p);
-                            p
-                        }
-                    };
+                    let bun_plugins: &mut OwnedPlugin = plugins.get_or_insert_with(|| {
+                        OwnedPlugin::create(
+                            global_this,
+                            match this.target {
+                                Target::Bun | Target::BunMacro => jsc::BunPluginTarget::Bun,
+                                Target::Node => jsc::BunPluginTarget::Node,
+                                _ => jsc::BunPluginTarget::Browser,
+                            },
+                        )
+                    });
 
                     let is_last = i == (length as usize).saturating_sub(1);
-                    // SAFETY: bun_plugins is a valid pointer created/stored above
-                    let mut plugin_result = unsafe {
-                        (*bun_plugins).add_plugin(
-                            function,
-                            config,
-                            onstart_promise_array,
-                            is_last,
-                            false,
-                        )?
-                    };
+                    let mut plugin_result = bun_plugins.add_plugin(
+                        function,
+                        config,
+                        onstart_promise_array,
+                        is_last,
+                        false,
+                    )?;
 
                     if !plugin_result.is_empty_or_undefined_or_null() {
                         if let Some(promise) = plugin_result.as_any_promise() {
@@ -1305,7 +1293,6 @@ pub mod js_bundler {
                 }
             }
 
-            scopeguard::ScopeGuard::into_inner(plugins);
             Ok(this)
         }
     }
@@ -1363,7 +1350,7 @@ pub mod js_bundler {
                  const result = Bun.spawnSync([\"bun\", \"build\", entrypoint, \"--format=esm\"]);")));
         }
 
-        let mut plugins: Option<*mut Plugin> = None;
+        let mut plugins: Option<OwnedPlugin> = None;
         let config = Config::from_js(global_this, arguments[0], &mut plugins)?;
 
         // `BundleV2.generateFromJavaScript` — the completion-task struct lives in
@@ -1373,7 +1360,7 @@ pub mod js_bundler {
         let completion =
             crate::api::js_bundle_completion_task::create_and_schedule_completion_task(
                 config,
-                plugins.and_then(core::ptr::NonNull::new),
+                plugins.map(crate::api::js_bundle_completion_task::BuildPlugins::Owned),
                 global_this,
             )
             .map_err(|_| JsError::OutOfMemory)?;
@@ -1804,6 +1791,51 @@ pub mod js_bundler {
         }
     }
 
+    /// Owner of a `JSBundlerPlugin` from [`PluginJscExt::create`]. The handle
+    /// is a `protect()`ed JSCell, not a heap allocation: a `Box<Plugin>` around
+    /// it frees nothing (`Plugin` is a ZST opaque), so the only thing that
+    /// releases the cell is this type's `Drop` calling [`PluginJscExt::destroy`].
+    /// JS thread only.
+    pub struct OwnedPlugin(core::ptr::NonNull<Plugin>);
+
+    impl OwnedPlugin {
+        pub fn create(global: &JSGlobalObject, target: jsc::BunPluginTarget) -> Self {
+            Self(
+                core::ptr::NonNull::new(Plugin::create(global, target))
+                    .expect("JSBundlerPlugin__create returns a non-null cell"),
+            )
+        }
+
+        /// The handle itself, for holders that only borrow the plugin (the
+        /// bundle thread, routes and the dev server sharing a server's plugins).
+        /// Valid until `self` drops.
+        #[inline]
+        pub fn as_non_null(&self) -> core::ptr::NonNull<Plugin> {
+            self.0
+        }
+    }
+
+    impl core::ops::Deref for OwnedPlugin {
+        type Target = Plugin;
+        #[inline]
+        fn deref(&self) -> &Plugin {
+            Plugin::opaque_ref(self.0.as_ptr())
+        }
+    }
+
+    impl core::ops::DerefMut for OwnedPlugin {
+        #[inline]
+        fn deref_mut(&mut self) -> &mut Plugin {
+            Plugin::opaque_mut(self.0.as_ptr())
+        }
+    }
+
+    impl Drop for OwnedPlugin {
+        fn drop(&mut self) {
+            Plugin::destroy(self.0.as_ptr());
+        }
+    }
+
     /// Convert a JS exception value into a `logger.Msg`. If the conversion itself
     /// throws (e.g. `Symbol.toPrimitive` on the thrown object throws), clear that
     /// secondary exception and return a generic fallback message so
@@ -1880,6 +1912,7 @@ pub mod js_bundler {
 
 pub use js_bundler as JSBundler;
 pub use js_bundler::Config;
+pub(crate) use js_bundler::OwnedPlugin;
 /// `jsc.API.JSBundler.Plugin` — re-exported for `crate::bake` (`SplitBundlerOptions.plugin`).
 pub use js_bundler::Plugin;
 pub(crate) use js_bundler::PluginJscExt;

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -92,8 +92,7 @@ pub struct JSBundleCompletionTask {
 pub(crate) enum BuildPlugins {
     /// `Bun.build({ plugins })`: created for this one build.
     Owned(OwnedPlugin),
-    /// HTML route build: owned by the server's `ServePlugins`, which outlives
-    /// the build like the route's own server back-reference does.
+    /// HTML route build: owned by the server's `ServePlugins`.
     Borrowed(NonNull<Plugin>),
 }
 

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -39,7 +39,9 @@ use bun_sys::Dir;
 #[cfg(not(windows))]
 use bun_sys::OpenDirOptions;
 
-use crate::api::js_bundler::js_bundler::{Config as JSBundlerConfig, Plugin, PluginJscExt};
+use crate::api::js_bundler::js_bundler::{
+    Config as JSBundlerConfig, OwnedPlugin, Plugin, PluginJscExt,
+};
 use crate::api::output_file_jsc::OutputFileJsc as _;
 use crate::node::fs::{self as node_fs, NodeFS, args as fs_args};
 use crate::node::types::{FileSystemFlags, PathLike, PathOrFileDescriptor, StringOrBuffer};
@@ -82,8 +84,40 @@ pub struct JSBundleCompletionTask {
     pub(crate) next: bun_threading::Link<JSBundleCompletionTask>,
     /// arena-owned by BundleThread heap
     pub(crate) transpiler: *mut BundleV2<'static>,
-    pub(crate) plugins: Option<NonNull<Plugin>>,
+    pub(crate) plugins: Option<BuildPlugins>,
     pub(crate) started_at_ns: u64,
+}
+
+/// The plugin cell a build runs against, and whether this task releases it.
+/// The task drops it wherever it gives up its JS-side state (`deinit`, the
+/// queued branch of `stop_for_vm_teardown`); only `Owned` releases the cell.
+pub(crate) enum BuildPlugins {
+    /// `Bun.build({ plugins })`: created for this one build.
+    Owned(OwnedPlugin),
+    /// HTML route build: the cell belongs to the server's `ServePlugins`,
+    /// which shares it across every build that server runs (same lifetime
+    /// the route's own server back-reference relies on).
+    Borrowed(NonNull<Plugin>),
+}
+
+impl BuildPlugins {
+    #[inline]
+    fn as_non_null(&self) -> NonNull<Plugin> {
+        match self {
+            BuildPlugins::Owned(plugin) => plugin.as_non_null(),
+            BuildPlugins::Borrowed(plugin) => *plugin,
+        }
+    }
+
+    #[inline]
+    fn plugin(&self) -> &Plugin {
+        Plugin::opaque_ref(self.as_non_null().as_ptr())
+    }
+
+    #[inline]
+    fn plugin_mut(&mut self) -> &mut Plugin {
+        Plugin::opaque_mut(self.as_non_null().as_ptr())
+    }
 }
 
 #[repr(u8)]
@@ -115,12 +149,8 @@ impl JSBundleCompletionTask {
         if boxed.poll_ref.is_active() {
             boxed.poll_ref.disable();
         }
-        if let Some(plugin) = boxed.plugins.take() {
-            // `plugin` is the live FFI handle stashed at construction;
-            // last-ref drop is the only place that releases it.
-            Plugin::destroy(plugin.as_ptr());
-        }
-        // Owned fields (`config`, `log`, `result`, `promise`) drop with the Box.
+        // Owned fields (`config`, `log`, `result`, `promise`, `plugins`) drop
+        // with the Box; `BuildPlugins::Owned` releases the plugin cell here.
     }
 }
 
@@ -137,7 +167,7 @@ unsafe impl Send for JSBundleCompletionTask {}
 /// ref, and hand the task to the bundle-thread singleton.
 pub(crate) fn create_and_schedule_completion_task(
     config: JSBundlerConfig,
-    plugins: Option<NonNull<Plugin>>,
+    plugins: Option<BuildPlugins>,
     global_this: &JSGlobalObject,
 ) -> crate::Result<*mut JSBundleCompletionTask> {
     let vm = global_this.bun_vm_ptr();
@@ -163,8 +193,8 @@ pub(crate) fn create_and_schedule_completion_task(
     }));
     // SAFETY: freshly-boxed allocation with ref_count == 1; sole handle.
     unsafe {
-        if let Some(plugin) = (*completion).plugins {
-            (*plugin.as_ptr()).set_config(completion.cast());
+        if let Some(plugin) = &mut (*completion).plugins {
+            plugin.plugin_mut().set_config(completion.cast());
         }
     }
 
@@ -215,20 +245,11 @@ impl JSBundleCompletionTask {
         Ok(value != JSValue::UNDEFINED)
     }
 
-    /// Mutable borrow of the attached `Plugin`, if any.
-    ///
-    /// Centralises the `Option<NonNull> → Option<&mut T>` deref so callers
-    /// (`to_js_error` / `on_complete_anytask`) stay safe. The plugin is a C++
-    /// `JSBundlerPlugin` opaque created by [`PluginJscExt::create`] and
-    /// `protect()`-ed for the task's lifetime; it is freed only via
-    /// `Plugin::destroy` in `deinit` *after* `take()` clears `self.plugins`.
-    /// While the field is `Some` the pointee is therefore live, pinned, and
-    /// disjoint from `*self` (separate C++-heap allocation).
+    /// Mutable borrow of the attached `Plugin`, if any (see [`BuildPlugins`]
+    /// for why the cell is live while the field is `Some`).
     #[inline]
     fn plugins_mut(&mut self) -> Option<&mut Plugin> {
-        // SAFETY: see fn doc — C++-heap opaque, live while `self.plugins` is
-        // `Some`, disjoint from `*self`. Single JS-mutator thread.
-        self.plugins.map(|p| unsafe { &mut *p.as_ptr() })
+        self.plugins.as_mut().map(BuildPlugins::plugin_mut)
     }
 
     fn to_js_error(
@@ -586,9 +607,9 @@ impl JSBundleCompletionTask {
     /// `this` is live (registered ⇒ its completion has not run); JS thread.
     pub(crate) unsafe fn stop_for_vm_teardown(this: *mut Self) {
         use core::sync::atomic::Ordering;
-        // SAFETY: fn contract; the plugin cell is protected by this task; the
-        // loop pointer is a thread's uws loop, valid for that thread's
-        // lifetime, and wakeup is thread-safe.
+        // SAFETY: fn contract; the plugin cell is live while `plugins` is
+        // `Some` (see `BuildPlugins`); the loop pointer is a thread's uws
+        // loop, valid for that thread's lifetime, and wakeup is thread-safe.
         unsafe {
             if (*this)
                 .stage
@@ -601,9 +622,9 @@ impl JSBundleCompletionTask {
                 .is_ok()
             {
                 (*this).poll_ref.disable();
-                if let Some(plugin) = (*this).plugins.take() {
-                    Plugin::destroy(plugin.as_ptr());
-                }
+                // Must happen on this (JS) thread: the bundle thread drops the
+                // rest of `*this` in `free_released_unstarted`.
+                (*this).plugins = None;
                 (*this).promise = jsc::JSPromiseStrong::default();
                 let handle = (*this).loop_handle.clone();
                 // Publish only now: from here the bundle thread may free `this`.
@@ -613,8 +634,8 @@ impl JSBundleCompletionTask {
                 handle.embedded_work_finished();
                 return;
             }
-            if let Some(plugins) = (*this).plugins {
-                crate::api::JSBundler::PluginJscExt::tombstone(plugins.as_ref());
+            if let Some(plugins) = &(*this).plugins {
+                plugins.plugin().tombstone();
             }
             (*this).cancelled.store(true, Ordering::Release);
             let l = (*this).bundle_loop.load(Ordering::Acquire);
@@ -635,7 +656,6 @@ impl JSBundleCompletionTask {
         }
 
         if let Some(html_build_task) = this.html_build_task {
-            this.plugins = None;
             // SAFETY: `html_build_task` is a backref set by `HTMLBundle::Route` which
             // bumped its own refcount before scheduling and stays alive until this returns.
             // R-2: deref as shared — `on_complete` takes `&self`.
@@ -1138,7 +1158,7 @@ impl CompletionStruct for JSBundleCompletionTask {
     }
     fn plugins(&self) -> Option<NonNull<JSBundlerPlugin>> {
         // `Plugin` and `JSBundlerPlugin` are the same `bun_bundler` opaque.
-        self.plugins
+        self.plugins.as_ref().map(BuildPlugins::as_non_null)
     }
     fn file_map(&mut self) -> Option<NonNull<Bv2FileMap>> {
         // `FileMap` and `Bv2FileMap` are the same `bun_bundler` type.

--- a/src/runtime/api/js_bundle_completion_task.rs
+++ b/src/runtime/api/js_bundle_completion_task.rs
@@ -88,15 +88,12 @@ pub struct JSBundleCompletionTask {
     pub(crate) started_at_ns: u64,
 }
 
-/// The plugin cell a build runs against, and whether this task releases it.
-/// The task drops it wherever it gives up its JS-side state (`deinit`, the
-/// queued branch of `stop_for_vm_teardown`); only `Owned` releases the cell.
+/// The plugin cell a build runs against; only `Owned` releases it (on drop).
 pub(crate) enum BuildPlugins {
     /// `Bun.build({ plugins })`: created for this one build.
     Owned(OwnedPlugin),
-    /// HTML route build: the cell belongs to the server's `ServePlugins`,
-    /// which shares it across every build that server runs (same lifetime
-    /// the route's own server back-reference relies on).
+    /// HTML route build: owned by the server's `ServePlugins`, which outlives
+    /// the build like the route's own server back-reference does.
     Borrowed(NonNull<Plugin>),
 }
 
@@ -149,8 +146,7 @@ impl JSBundleCompletionTask {
         if boxed.poll_ref.is_active() {
             boxed.poll_ref.disable();
         }
-        // Owned fields (`config`, `log`, `result`, `promise`, `plugins`) drop
-        // with the Box; `BuildPlugins::Owned` releases the plugin cell here.
+        // Owned fields (`config`, `log`, `result`, `promise`, `plugins`) drop with the Box.
     }
 }
 
@@ -245,8 +241,7 @@ impl JSBundleCompletionTask {
         Ok(value != JSValue::UNDEFINED)
     }
 
-    /// Mutable borrow of the attached `Plugin`, if any (see [`BuildPlugins`]
-    /// for why the cell is live while the field is `Some`).
+    /// Mutable borrow of the attached `Plugin`, if any.
     #[inline]
     fn plugins_mut(&mut self) -> Option<&mut Plugin> {
         self.plugins.as_mut().map(BuildPlugins::plugin_mut)
@@ -622,8 +617,7 @@ impl JSBundleCompletionTask {
                 .is_ok()
             {
                 (*this).poll_ref.disable();
-                // Must happen on this (JS) thread: the bundle thread drops the
-                // rest of `*this` in `free_released_unstarted`.
+                // Released here on the JS thread; the bundle thread drops the rest.
                 (*this).plugins = None;
                 (*this).promise = jsc::JSPromiseStrong::default();
                 let handle = (*this).loop_handle.clone();

--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -18,7 +18,7 @@ use bun_ptr::{AsCtxPtr, IntrusiveRc, RefCount};
 use bun_uws::{AnyRequest, AnyResponse};
 
 use crate::api::js_bundle_completion_task::{
-    JSBundleCompletionTask, create_and_schedule_completion_task,
+    BuildPlugins, JSBundleCompletionTask, create_and_schedule_completion_task,
 };
 use crate::api::js_bundler::js_bundler::{self as JSBundler, Config as JSBundlerConfig};
 use crate::api::output_file_jsc::OutputFileJsc as _;
@@ -499,7 +499,11 @@ impl Route {
         }
         config.source_map = bundler_options::SourceMapOption::Linked;
 
-        let completion_task = create_and_schedule_completion_task(config, plugins, global)?;
+        let completion_task = create_and_schedule_completion_task(
+            config,
+            plugins.map(BuildPlugins::Borrowed),
+            global,
+        )?;
         // SAFETY: `completion_task` is the freshly-boxed allocation (refcount==1); sole owner.
         unsafe {
             (*completion_task).started_at_ns =

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -899,8 +899,8 @@ pub struct ServePlugins {
 pub enum ServePluginsState {
     Unqueued(Box<[Box<[u8]>]>),
     Pending {
+        plugin: JSBundler::OwnedPlugin,
         /// Promise may be empty if the plugin load finishes synchronously.
-        plugin: Box<JSBundler::Plugin>,
         promise: jsc::JSPromiseStrong,
         html_bundle_routes: Vec<*mut html_bundle::Route>,
         // LIFETIMES.tsv classifies this BORROW_PARAM (`Option<&'a DevServer>`),
@@ -911,7 +911,9 @@ pub enum ServePluginsState {
         // comments at the deref sites in `on_plugins_resolved`/`_rejected`).
         dev_server: Option<NonNull<DevServer>>,
     },
-    Loaded(Box<JSBundler::Plugin>),
+    /// Shared by every build this server runs (`HTMLBundle::Route`, DevServer);
+    /// released when the last `ServePlugins` ref drops.
+    Loaded(JSBundler::OwnedPlugin),
     /// Error information is not stored as it is already reported.
     Err,
 }
@@ -1023,8 +1025,8 @@ impl ServePlugins {
         }
         // NOTE: split out of the loop so the `Loaded` arm's borrow of
         // `self.state` doesn't conflict with the `Unqueued` arm's `&mut self`.
-        match &mut self.state {
-            ServePluginsState::Loaded(plugins) => Ok(GetOrStartLoadResult::Ready(Some(plugins))),
+        match &self.state {
+            ServePluginsState::Loaded(plugin) => Ok(GetOrStartLoadResult::Ready(Some(&**plugin))),
             _ => unreachable!(),
         }
     }
@@ -1047,9 +1049,7 @@ impl ServePlugins {
         // here would give it a tag that is invalidated by the writes to `self.state`
         // below (Stacked Borrows), making the eventual `heap::take` in `deref_` UB.
 
-        let plugin = JSBundler::Plugin::create(global, bun_jsc::BunPluginTarget::Browser);
-        // SAFETY: `Plugin::create` returns a freshly-boxed `*mut Plugin` (single owner).
-        let plugin: Box<JSBundler::Plugin> = unsafe { bun_core::heap::take(plugin) };
+        let plugin = JSBundler::OwnedPlugin::create(global, bun_jsc::BunPluginTarget::Browser);
         let mut bunstring_array: Vec<BunString> = Vec::with_capacity(plugin_list.len());
         for raw_plugin in &plugin_list {
             bunstring_array.push(BunString::init(&***raw_plugin));
@@ -1067,7 +1067,7 @@ impl ServePlugins {
         global.bun_vm().event_loop_mut().enter();
         let result = jsc::host_fn::from_js_host_call(global, || {
             match &self.state {
-                ServePluginsState::Pending { plugin, .. } => plugin.as_ref(),
+                ServePluginsState::Pending { plugin, .. } => &**plugin,
                 _ => unreachable!(),
             }
             .load_and_resolve_plugins_for_serve(plugin_js_array, bunfig_folder_bunstr)
@@ -1137,19 +1137,18 @@ impl ServePlugins {
         };
         drop(promise); // Drop on JscStrong releases the slot.
 
+        // Routes and the DevServer hold this pointer without a ref of their own:
+        // the server that owns them holds a counted ref on `self`, and `self`
+        // owns the cell until it drops.
+        let plugin_ptr = plugin.as_non_null();
         self.state = ServePluginsState::Loaded(plugin);
-        let plugin_ref = match &self.state {
-            ServePluginsState::Loaded(p) => &**p,
-            _ => unreachable!(),
-        };
 
         for route in html_bundle_routes {
             // BACKREF: route was ref'd when stored (intrusive +1 keeps it alive
             // for this call). R-2: `on_plugins_resolved` takes `&self`.
             let route_nn = NonNull::new(route).expect("html_bundle::Route ref'd when stored");
             bun_core::handle_oom(
-                bun_ptr::BackRef::from(route_nn)
-                    .on_plugins_resolved(Some(NonNull::from(plugin_ref))),
+                bun_ptr::BackRef::from(route_nn).on_plugins_resolved(Some(plugin_ptr)),
             );
             // SAFETY: paired with the `ref_` taken when the route was pushed.
             unsafe { bun_ptr::RefCount::<html_bundle::Route>::deref(route) };
@@ -1158,9 +1157,9 @@ impl ServePlugins {
             // SAFETY: dev_server outlives plugin load (stored as a back-reference
             // by `get_or_start_load`; the owning Box<DevServer> is held by the
             // server instance, which itself holds a counted ref on `self`).
-            bun_core::handle_oom(unsafe { server.as_mut() }.on_plugins_resolved(Some(
-                std::ptr::from_ref::<JSBundler::Plugin>(plugin_ref).cast_mut(),
-            )));
+            bun_core::handle_oom(
+                unsafe { server.as_mut() }.on_plugins_resolved(Some(plugin_ptr.as_ptr())),
+            );
         }
     }
 
@@ -1175,7 +1174,7 @@ impl ServePlugins {
         else {
             unreachable!()
         };
-        drop(plugin); // pending.plugin.deinit()
+        drop(plugin); // Drop on OwnedPlugin tombstones and unprotects the cell.
         drop(promise); // Drop on JscStrong releases the slot.
 
         for route in html_bundle_routes {
@@ -1230,7 +1229,7 @@ impl Drop for ServePlugins {
         match &self.state {
             ServePluginsState::Unqueued(_) => {}
             ServePluginsState::Pending { .. } => debug_assert!(false), // should have one ref while pending!
-            ServePluginsState::Loaded(_) => {}                         // Box<Plugin> drops
+            ServePluginsState::Loaded(_) => {}                         // OwnedPlugin drops
             ServePluginsState::Err => {}
         }
     }

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -911,8 +911,7 @@ pub enum ServePluginsState {
         // comments at the deref sites in `on_plugins_resolved`/`_rejected`).
         dev_server: Option<NonNull<DevServer>>,
     },
-    /// Shared by every build this server runs (`HTMLBundle::Route`, DevServer);
-    /// released when the last `ServePlugins` ref drops.
+    /// Shared by every build this server runs; released with the last `ServePlugins` ref.
     Loaded(JSBundler::OwnedPlugin),
     /// Error information is not stored as it is already reported.
     Err,
@@ -1137,9 +1136,7 @@ impl ServePlugins {
         };
         drop(promise); // Drop on JscStrong releases the slot.
 
-        // Routes and the DevServer hold this pointer without a ref of their own:
-        // the server that owns them holds a counted ref on `self`, and `self`
-        // owns the cell until it drops.
+        // Handed out raw: the server owning the routes/DevServer also holds a ref on `self`.
         let plugin_ptr = plugin.as_non_null();
         self.state = ServePluginsState::Loaded(plugin);
 

--- a/test/js/bun/http/serve-plugins-leak-fixture/app.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/app.ts
@@ -1,0 +1,5 @@
+// plugin.ts replaces this import's contents, which is how the fixture tells
+// that a build actually ran with the plugin.
+import message from "./message.txt";
+
+console.log(message);

--- a/test/js/bun/http/serve-plugins-leak-fixture/bunfig.toml
+++ b/test/js/bun/http/serve-plugins-leak-fixture/bunfig.toml
@@ -1,0 +1,2 @@
+[serve.static]
+plugins = ["./plugin.ts"]

--- a/test/js/bun/http/serve-plugins-leak-fixture/cells.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/cells.ts
@@ -1,0 +1,75 @@
+// Shared by the fixtures in this directory. "Cells" are the native
+// BundlerPlugin objects the `[serve.static]` plugins (or a Bun.build()'s
+// plugins) are loaded into; their owner protects them from GC while in use.
+import type { HTMLBundle, Server } from "bun";
+import { heapStats } from "bun:jsc";
+
+export const MARKER = "text-from-plugin";
+
+export const liveCells = () => heapStats().objectTypeCounts.BundlerPlugin ?? 0;
+export const protectedCells = () => heapStats().protectedObjectTypeCounts.BundlerPlugin ?? 0;
+const liveServerObjects = () => {
+  const counts = heapStats().objectTypeCounts;
+  return (counts.HTTPServer ?? 0) + (counts.DebugHTTPServer ?? 0);
+};
+
+// A turn of the event loop: a freed server releases its cell from a deferred
+// task. The two scheduling paths alternate so that convergence does not hinge
+// on what one of them happens to keep reachable for a few turns.
+const turn = (i: number) => new Promise<void>(resolve => (i % 2 ? setImmediate(resolve) : setTimeout(resolve, 0)));
+
+// A released cell is only unprotected; it still has to be collected, so
+// alternate turns with collections. This converges within a few rounds when
+// the cells are released and never when they are not, so the bound only
+// decides how long the failing case takes. On failure the per-round survivors
+// go to stderr (run-length encoded), which tells whether the Server object
+// itself or only its cell is still alive.
+export async function collectCells(phase: string) {
+  const survivors: { what: string; rounds: number }[] = [];
+  for (let i = 0; i < 100 && liveCells() > 0; i++) {
+    await turn(i);
+    Bun.gc(true);
+    await turn(i + 1);
+    // The Server object count includes the shared prototype: 1 means no instances are left.
+    const what = `${liveCells()} BundlerPlugin cells, ${liveServerObjects()} Server objects`;
+    const last = survivors.at(-1);
+    if (last?.what === what) last.rounds++;
+    else survivors.push({ what, rounds: 1 });
+  }
+  const remaining = liveCells();
+  if (remaining > 0) {
+    const trace = survivors.map(({ what, rounds }) => `${what} x${rounds}`).join("\n");
+    console.error(`${phase}: still alive after each collection round:\n${trace}`);
+  }
+  return remaining;
+}
+
+export function serveHtml(html: HTMLBundle, development: boolean) {
+  return Bun.serve({
+    port: 0,
+    development,
+    routes: { "/": html },
+    fetch: () => new Response("not found", { status: 404 }),
+  });
+}
+
+// Starts `count` servers, requests the route of each (which loads the plugins
+// and bundles the route), checks the plugin took part in the bundle, counts
+// the cells while every server is still alive, then stops them all. Lives in
+// its own function so the servers are unreachable once it returns.
+export async function serveAndStop(html: HTMLBundle, development: boolean, count: number) {
+  const servers: Server[] = [];
+  let usedPlugin = 0;
+  for (let i = 0; i < count; i++) {
+    const server = serveHtml(html, development);
+    servers.push(server);
+    const page = await fetch(server.url);
+    if (page.status !== 200) throw new Error("HTML route responded with " + page.status);
+    const script = (await page.text()).match(/src="([^"]+\.js)"/)![1];
+    const chunk = await fetch(new URL(script, server.url));
+    if ((await chunk.text()).includes(MARKER)) usedPlugin++;
+  }
+  const cellsWhileServing = liveCells();
+  await Promise.all(servers.map(server => server.stop(true)));
+  return { usedPlugin, cellsWhileServing };
+}

--- a/test/js/bun/http/serve-plugins-leak-fixture/index.html
+++ b/test/js/bun/http/serve-plugins-leak-fixture/index.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script type="module" src="./app.ts"></script>
+  </head>
+  <body></body>
+</html>

--- a/test/js/bun/http/serve-plugins-leak-fixture/message.txt
+++ b/test/js/bun/http/serve-plugins-leak-fixture/message.txt
@@ -1,0 +1,1 @@
+text-from-disk

--- a/test/js/bun/http/serve-plugins-leak-fixture/plugin.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/plugin.ts
@@ -2,6 +2,8 @@ import type { BunPlugin } from "bun";
 
 declare global {
   var setups: number;
+  /** When set by a fixture, every build parks inside onLoad until the returned promise settles. */
+  var holdBuild: (() => Promise<void>) | undefined;
 }
 
 // Loaded both through `[serve.static] plugins` (bunfig.toml, once per server)
@@ -13,10 +15,10 @@ const plugin: BunPlugin = {
   name: "plugin-cell-probe",
   setup(build) {
     globalThis.setups++;
-    build.onLoad({ filter: /\.txt$/ }, () => ({
-      loader: "text",
-      contents: "text-from-plugin",
-    }));
+    build.onLoad({ filter: /\.txt$/ }, async () => {
+      await globalThis.holdBuild?.();
+      return { loader: "text", contents: "text-from-plugin" };
+    });
   },
 };
 

--- a/test/js/bun/http/serve-plugins-leak-fixture/plugin.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/plugin.ts
@@ -15,6 +15,8 @@ const plugin: BunPlugin = {
   name: "plugin-cell-probe",
   setup(build) {
     globalThis.setups++;
+    // serve-plugins-reject-fixture.ts: makes the whole plugin load reject.
+    if (process.env.SERVE_PLUGIN_SETUP_THROWS) throw new Error("setup() failed on purpose");
     build.onLoad({ filter: /\.txt$/ }, async () => {
       await globalThis.holdBuild?.();
       return { loader: "text", contents: "text-from-plugin" };

--- a/test/js/bun/http/serve-plugins-leak-fixture/plugin.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/plugin.ts
@@ -1,0 +1,23 @@
+import type { BunPlugin } from "bun";
+
+declare global {
+  var setups: number;
+}
+
+// Loaded both through `[serve.static] plugins` (bunfig.toml, once per server)
+// and passed directly to Bun.build() by the fixture. Same module instance
+// either way, so this counts every setup() call in the process.
+globalThis.setups = 0;
+
+const plugin: BunPlugin = {
+  name: "plugin-cell-probe",
+  setup(build) {
+    globalThis.setups++;
+    build.onLoad({ filter: /\.txt$/ }, () => ({
+      loader: "text",
+      contents: "text-from-plugin",
+    }));
+  },
+};
+
+export default plugin;

--- a/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-dev-server-fixture.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-dev-server-fixture.ts
@@ -1,0 +1,9 @@
+// Same as the serve part of serve-plugins-leak-fixture.ts, but with the
+// DevServer (`development: true`), the other consumer of a server's plugins.
+import { collectCells, serveAndStop } from "./cells.ts";
+import html from "./index.html";
+
+const { usedPlugin, cellsWhileServing } = await serveAndStop(html, true, 2);
+const cellsAfter = await collectCells("after the dev servers were stopped");
+
+console.log(JSON.stringify({ setups: globalThis.setups, usedPlugin, cellsWhileServing, cellsAfter }));

--- a/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-exit-mid-build-fixture.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-exit-mid-build-fixture.ts
@@ -1,0 +1,23 @@
+// Exits while an HTML route is still being bundled with the server's shared
+// plugin cell. VM teardown then cancels that build, which must not release the
+// cell it only borrows from the server (nor crash under ASAN while giving it up).
+import html from "./index.html";
+
+const parked = Promise.withResolvers<void>();
+globalThis.holdBuild = () => {
+  parked.resolve();
+  return new Promise(() => {});
+};
+
+const server = Bun.serve({
+  port: 0,
+  development: false,
+  routes: { "/": html },
+  fetch: () => new Response("not found", { status: 404 }),
+});
+// Never answered: the process exits while this request's build is parked in the plugin.
+fetch(server.url).catch(() => {});
+await parked.promise;
+
+console.log("build parked in the plugin, exiting");
+process.exit(0);

--- a/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-leak-fixture.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-leak-fixture.ts
@@ -13,18 +13,39 @@ const SERVERS = 2;
 const MARKER = "text-from-plugin";
 
 const liveCells = () => heapStats().objectTypeCounts.BundlerPlugin ?? 0;
-const turn = () => new Promise(resolve => setTimeout(resolve, 0));
+const liveServerWrappers = () => {
+  const counts = heapStats().objectTypeCounts;
+  return (counts.HTTPServer ?? 0) + (counts.DebugHTTPServer ?? 0);
+};
+// A turn of the event loop: a freed server releases its cell from a deferred
+// task. The two scheduling paths alternate so that convergence does not hinge
+// on what one of them happens to keep reachable for a few turns.
+const turn = (i: number) => new Promise<void>(resolve => (i % 2 ? setImmediate(resolve) : setTimeout(resolve, 0)));
 
-// A released cell is only unprotected; it still has to be collected, and a
-// freed server releases its cell from a deferred task, so alternate turns of
-// the event loop with collections.
-async function collectCells() {
-  for (let i = 0; i < 20 && liveCells() > 0; i++) {
-    await turn();
+// A released cell is only unprotected; it still has to be collected, so
+// alternate turns with collections. This converges within a few rounds when
+// the cells are released and never when they are not, so the bound only
+// decides how long the failing case takes. On failure the per-round survivors
+// go to stderr (run-length encoded), which tells whether the Server object
+// itself or only its cell is still alive.
+async function collectCells(phase: string) {
+  const survivors: { what: string; rounds: number }[] = [];
+  for (let i = 0; i < 100 && liveCells() > 0; i++) {
+    await turn(i);
     Bun.gc(true);
-    await turn();
+    await turn(i + 1);
+    // The Server object count includes the shared prototype: 1 means no instances are left.
+    const what = `${liveCells()} BundlerPlugin cells, ${liveServerWrappers()} Server objects`;
+    const last = survivors.at(-1);
+    if (last?.what === what) last.rounds++;
+    else survivors.push({ what, rounds: 1 });
   }
-  return liveCells();
+  const remaining = liveCells();
+  if (remaining > 0) {
+    const trace = survivors.map(({ what, rounds }) => `${what} x${rounds}`).join("\n");
+    console.error(`${phase}: still alive after each collection round:\n${trace}`);
+  }
+  return remaining;
 }
 
 async function build() {
@@ -36,7 +57,7 @@ async function build() {
   return result.success && (await result.outputs[0].text()).includes(MARKER);
 }
 
-// Separate function so the servers are unreachable by the time collectCells() runs.
+// Separate functions so the servers are unreachable by the time collectCells() runs.
 async function serve() {
   const servers: Server[] = [];
   let usedPlugin = 0;
@@ -61,10 +82,44 @@ async function serve() {
   return { usedPlugin, cellsWhileServing };
 }
 
+// The server is stopped while its route is still being bundled with the
+// shared plugin; the build then finishes against the stopped server, which
+// still has to give the cell up once it is gone.
+async function stopMidBuild() {
+  const parked = Promise.withResolvers<void>();
+  const released = Promise.withResolvers<void>();
+  globalThis.holdBuild = () => {
+    parked.resolve();
+    return released.promise;
+  };
+  try {
+    const server = Bun.serve({
+      port: 0,
+      development: false,
+      routes: { "/": html },
+      fetch: () => new Response("not found", { status: 404 }),
+    });
+    const page = fetch(server.url);
+    await parked.promise;
+    // Graceful: stops listening but lets the parked request finish.
+    const stopped = server.stop();
+    released.resolve();
+    const response = await page;
+    await response.text();
+    await server.stop(true);
+    await stopped;
+    return response.status;
+  } finally {
+    globalThis.holdBuild = undefined;
+  }
+}
+
 const buildUsedPlugin = await build();
-const buildCellsAfter = await collectCells();
+const buildCellsAfter = await collectCells("after Bun.build()");
 const { usedPlugin: serveUsedPlugin, cellsWhileServing } = await serve();
-const serveCellsAfter = await collectCells();
+const serveCellsAfter = await collectCells("after the servers were stopped");
+const stopMidBuildStatus = await stopMidBuild();
+const stopMidBuildCellsAfter = await collectCells("after the server stopped mid-build");
 
 console.log(
   JSON.stringify({
@@ -74,5 +129,7 @@ console.log(
     serveUsedPlugin,
     cellsWhileServing,
     serveCellsAfter,
+    stopMidBuildStatus,
+    stopMidBuildCellsAfter,
   }),
 );

--- a/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-leak-fixture.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-leak-fixture.ts
@@ -1,0 +1,78 @@
+// Every Bun.serve() that loads the `[serve.static]` plugins from the bunfig.toml
+// next to this file creates one native BundlerPlugin cell and protects it from
+// GC; so does a Bun.build() with plugins. The cell (and everything the plugin
+// callbacks capture) has to become collectable once the server is gone, or
+// once the build is done. Prints one JSON line; serve-plugins-leak.test.ts asserts it.
+import type { Server } from "bun";
+import { heapStats } from "bun:jsc";
+import { join } from "node:path";
+import html from "./index.html";
+import plugin from "./plugin.ts";
+
+const SERVERS = 2;
+const MARKER = "text-from-plugin";
+
+const liveCells = () => heapStats().objectTypeCounts.BundlerPlugin ?? 0;
+const turn = () => new Promise(resolve => setTimeout(resolve, 0));
+
+// A released cell is only unprotected; it still has to be collected, and a
+// freed server releases its cell from a deferred task, so alternate turns of
+// the event loop with collections.
+async function collectCells() {
+  for (let i = 0; i < 20 && liveCells() > 0; i++) {
+    await turn();
+    Bun.gc(true);
+    await turn();
+  }
+  return liveCells();
+}
+
+async function build() {
+  const result = await Bun.build({
+    entrypoints: [join(import.meta.dir, "app.ts")],
+    target: "browser",
+    plugins: [plugin],
+  });
+  return result.success && (await result.outputs[0].text()).includes(MARKER);
+}
+
+// Separate function so the servers are unreachable by the time collectCells() runs.
+async function serve() {
+  const servers: Server[] = [];
+  let usedPlugin = 0;
+  for (let i = 0; i < SERVERS; i++) {
+    const server = Bun.serve({
+      port: 0,
+      development: false,
+      routes: { "/": html },
+      fetch: () => new Response("not found", { status: 404 }),
+    });
+    servers.push(server);
+    // The first request loads the plugins and bundles the route.
+    const page = await fetch(server.url);
+    if (page.status !== 200) throw new Error("HTML route responded with " + page.status);
+    const script = (await page.text()).match(/src="([^"]+\.js)"/)![1];
+    const chunk = await fetch(new URL(script, server.url));
+    if ((await chunk.text()).includes(MARKER)) usedPlugin++;
+  }
+  // Every server is still alive here, so every one of their cells must be too.
+  const cellsWhileServing = liveCells();
+  await Promise.all(servers.map(server => server.stop(true)));
+  return { usedPlugin, cellsWhileServing };
+}
+
+const buildUsedPlugin = await build();
+const buildCellsAfter = await collectCells();
+const { usedPlugin: serveUsedPlugin, cellsWhileServing } = await serve();
+const serveCellsAfter = await collectCells();
+
+console.log(
+  JSON.stringify({
+    setups: globalThis.setups,
+    buildUsedPlugin,
+    buildCellsAfter,
+    serveUsedPlugin,
+    cellsWhileServing,
+    serveCellsAfter,
+  }),
+);

--- a/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-leak-fixture.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-leak-fixture.ts
@@ -1,52 +1,12 @@
 // Every Bun.serve() that loads the `[serve.static]` plugins from the bunfig.toml
-// next to this file creates one native BundlerPlugin cell and protects it from
-// GC; so does a Bun.build() with plugins. The cell (and everything the plugin
+// next to this file creates one BundlerPlugin cell and protects it from GC; so
+// does a Bun.build() with plugins. The cell (and everything the plugin
 // callbacks capture) has to become collectable once the server is gone, or
 // once the build is done. Prints one JSON line; serve-plugins-leak.test.ts asserts it.
-import type { Server } from "bun";
-import { heapStats } from "bun:jsc";
 import { join } from "node:path";
+import { MARKER, collectCells, serveAndStop, serveHtml } from "./cells.ts";
 import html from "./index.html";
 import plugin from "./plugin.ts";
-
-const SERVERS = 2;
-const MARKER = "text-from-plugin";
-
-const liveCells = () => heapStats().objectTypeCounts.BundlerPlugin ?? 0;
-const liveServerWrappers = () => {
-  const counts = heapStats().objectTypeCounts;
-  return (counts.HTTPServer ?? 0) + (counts.DebugHTTPServer ?? 0);
-};
-// A turn of the event loop: a freed server releases its cell from a deferred
-// task. The two scheduling paths alternate so that convergence does not hinge
-// on what one of them happens to keep reachable for a few turns.
-const turn = (i: number) => new Promise<void>(resolve => (i % 2 ? setImmediate(resolve) : setTimeout(resolve, 0)));
-
-// A released cell is only unprotected; it still has to be collected, so
-// alternate turns with collections. This converges within a few rounds when
-// the cells are released and never when they are not, so the bound only
-// decides how long the failing case takes. On failure the per-round survivors
-// go to stderr (run-length encoded), which tells whether the Server object
-// itself or only its cell is still alive.
-async function collectCells(phase: string) {
-  const survivors: { what: string; rounds: number }[] = [];
-  for (let i = 0; i < 100 && liveCells() > 0; i++) {
-    await turn(i);
-    Bun.gc(true);
-    await turn(i + 1);
-    // The Server object count includes the shared prototype: 1 means no instances are left.
-    const what = `${liveCells()} BundlerPlugin cells, ${liveServerWrappers()} Server objects`;
-    const last = survivors.at(-1);
-    if (last?.what === what) last.rounds++;
-    else survivors.push({ what, rounds: 1 });
-  }
-  const remaining = liveCells();
-  if (remaining > 0) {
-    const trace = survivors.map(({ what, rounds }) => `${what} x${rounds}`).join("\n");
-    console.error(`${phase}: still alive after each collection round:\n${trace}`);
-  }
-  return remaining;
-}
 
 async function build() {
   const result = await Bun.build({
@@ -55,31 +15,6 @@ async function build() {
     plugins: [plugin],
   });
   return result.success && (await result.outputs[0].text()).includes(MARKER);
-}
-
-// Separate functions so the servers are unreachable by the time collectCells() runs.
-async function serve() {
-  const servers: Server[] = [];
-  let usedPlugin = 0;
-  for (let i = 0; i < SERVERS; i++) {
-    const server = Bun.serve({
-      port: 0,
-      development: false,
-      routes: { "/": html },
-      fetch: () => new Response("not found", { status: 404 }),
-    });
-    servers.push(server);
-    // The first request loads the plugins and bundles the route.
-    const page = await fetch(server.url);
-    if (page.status !== 200) throw new Error("HTML route responded with " + page.status);
-    const script = (await page.text()).match(/src="([^"]+\.js)"/)![1];
-    const chunk = await fetch(new URL(script, server.url));
-    if ((await chunk.text()).includes(MARKER)) usedPlugin++;
-  }
-  // Every server is still alive here, so every one of their cells must be too.
-  const cellsWhileServing = liveCells();
-  await Promise.all(servers.map(server => server.stop(true)));
-  return { usedPlugin, cellsWhileServing };
 }
 
 // The server is stopped while its route is still being bundled with the
@@ -93,12 +28,7 @@ async function stopMidBuild() {
     return released.promise;
   };
   try {
-    const server = Bun.serve({
-      port: 0,
-      development: false,
-      routes: { "/": html },
-      fetch: () => new Response("not found", { status: 404 }),
-    });
+    const server = serveHtml(html, false);
     const page = fetch(server.url);
     await parked.promise;
     // Graceful: stops listening but lets the parked request finish.
@@ -116,7 +46,7 @@ async function stopMidBuild() {
 
 const buildUsedPlugin = await build();
 const buildCellsAfter = await collectCells("after Bun.build()");
-const { usedPlugin: serveUsedPlugin, cellsWhileServing } = await serve();
+const { usedPlugin: serveUsedPlugin, cellsWhileServing } = await serveAndStop(html, false, 2);
 const serveCellsAfter = await collectCells("after the servers were stopped");
 const stopMidBuildStatus = await stopMidBuild();
 const stopMidBuildCellsAfter = await collectCells("after the server stopped mid-build");

--- a/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-reject-fixture.ts
+++ b/test/js/bun/http/serve-plugins-leak-fixture/serve-plugins-reject-fixture.ts
@@ -1,0 +1,20 @@
+// Spawned with SERVE_PLUGIN_SETUP_THROWS set, so loading the plugins rejects.
+// The server reports that on stderr and answers the route with an error; the
+// cell it had created for the load must be unprotected by then (it used to stay
+// protected for good). One server only: a second load in the same process
+// would hit the module cache and reject synchronously, a separate code path.
+import { protectedCells } from "./cells.ts";
+import html from "./index.html";
+
+const server = Bun.serve({
+  port: 0,
+  development: false,
+  routes: { "/": html },
+  fetch: () => new Response("not found", { status: 404 }),
+});
+const response = await fetch(server.url);
+await response.text();
+const protectedCellsAfterReject = protectedCells();
+await server.stop(true);
+
+console.log(JSON.stringify({ setups: globalThis.setups, status: response.status, protectedCellsAfterReject }));

--- a/test/js/bun/http/serve-plugins-leak.test.ts
+++ b/test/js/bun/http/serve-plugins-leak.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { bunRun } from "harness";
+import { bunEnv, bunRun, isWindows } from "harness";
 import { join } from "node:path";
 
 // Each Bun.serve() that loads `[serve.static]` plugins creates one native
@@ -9,17 +9,40 @@ import { join } from "node:path";
 // callbacks captured, rooted for the rest of the process. The fixture also
 // covers Bun.build(), whose per-build cell must be released once the build is
 // done, since both now share the same owning handle.
-test("[serve.static] plugins and Bun.build() plugins release their BundlerPlugin cell", async () => {
-  // bunRun() runs the fixture with its own directory as cwd, which is where its bunfig.toml lives.
-  const result = await bunRun(join(import.meta.dir, "serve-plugins-leak-fixture", "serve-plugins-leak-fixture.ts"));
+//
+// The fixtures run with their own directory as cwd (bunRun), which is where
+// the bunfig.toml that configures the plugin lives.
+const fixtures = join(import.meta.dir, "serve-plugins-leak-fixture");
+
+test.concurrent("[serve.static] plugins and Bun.build() plugins release their BundlerPlugin cell", async () => {
+  const result = await bunRun(join(fixtures, "serve-plugins-leak-fixture.ts"));
   expect(result).toSpawn();
   expect(JSON.parse(result.stdout)).toEqual({
-    // One setup() for the build, one per server.
-    setups: 3,
+    // One setup() for the build, one per server (two served to completion, one stopped mid-build).
+    setups: 4,
     buildUsedPlugin: true,
     buildCellsAfter: 0,
     serveUsedPlugin: 2,
     cellsWhileServing: 2,
     serveCellsAfter: 0,
+    stopMidBuildStatus: 200,
+    stopMidBuildCellsAfter: 0,
   });
+});
+
+// VM teardown cancels a route build that is still parked in the plugin. That
+// build only borrows the server's cell, so giving the task up must not release
+// or touch anything the server still owns. BUN_DESTRUCT_VM_ON_EXIT makes
+// process.exit() actually tear the VM down; Malloc=1 puts JSC cells under the
+// system allocator so the debug/ASAN build would see a use of a released cell
+// (and, as in the other tests that set it, leak detection is turned off because
+// it then reports JSC's process-lifetime allocations).
+test.concurrent("exiting while an HTML route build is parked in the server's plugins tears down cleanly", async () => {
+  const result = await bunRun(join(fixtures, "serve-plugins-exit-mid-build-fixture.ts"), {
+    BUN_DESTRUCT_VM_ON_EXIT: "1",
+    ...(isWindows
+      ? {}
+      : { Malloc: "1", ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=0"].filter(Boolean).join(":") }),
+  });
+  expect(result).toSpawn("build parked in the plugin, exiting");
 });

--- a/test/js/bun/http/serve-plugins-leak.test.ts
+++ b/test/js/bun/http/serve-plugins-leak.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test";
+import { bunRun } from "harness";
+import { join } from "node:path";
+
+// Each Bun.serve() that loads `[serve.static]` plugins creates one native
+// BundlerPlugin cell (a protected JSCell) for them. ServePlugins used to drop
+// its handle to that cell without ever unprotecting it, so every server that
+// had served an HTML route left its plugin cell, and everything the plugin
+// callbacks captured, rooted for the rest of the process. The fixture also
+// covers Bun.build(), whose per-build cell must be released once the build is
+// done, since both now share the same owning handle.
+test("[serve.static] plugins and Bun.build() plugins release their BundlerPlugin cell", async () => {
+  // bunRun() runs the fixture with its own directory as cwd, which is where its bunfig.toml lives.
+  const result = await bunRun(join(import.meta.dir, "serve-plugins-leak-fixture", "serve-plugins-leak-fixture.ts"));
+  expect(result).toSpawn();
+  expect(JSON.parse(result.stdout)).toEqual({
+    // One setup() for the build, one per server.
+    setups: 3,
+    buildUsedPlugin: true,
+    buildCellsAfter: 0,
+    serveUsedPlugin: 2,
+    cellsWhileServing: 2,
+    serveCellsAfter: 0,
+  });
+});

--- a/test/js/bun/http/serve-plugins-leak.test.ts
+++ b/test/js/bun/http/serve-plugins-leak.test.ts
@@ -5,17 +5,17 @@ import { join } from "node:path";
 // Each Bun.serve() that loads `[serve.static]` plugins creates one native
 // BundlerPlugin cell (a protected JSCell) for them. ServePlugins used to drop
 // its handle to that cell without ever unprotecting it, so every server that
-// had served an HTML route left its plugin cell, and everything the plugin
-// callbacks captured, rooted for the rest of the process. The fixture also
-// covers Bun.build(), whose per-build cell must be released once the build is
-// done, since both now share the same owning handle.
+// had loaded its plugins (whether the load succeeded or not) left the cell, and
+// everything the plugin callbacks captured, rooted for the rest of the process.
+// The fixtures also cover Bun.build(), whose per-build cell must be released
+// once the build is done, since both now share the same owning handle.
 //
 // The fixtures run with their own directory as cwd (bunRun), which is where
 // the bunfig.toml that configures the plugin lives.
-const fixtures = join(import.meta.dir, "serve-plugins-leak-fixture");
+const fixture = (name: string) => join(import.meta.dir, "serve-plugins-leak-fixture", name);
 
 test.concurrent("[serve.static] plugins and Bun.build() plugins release their BundlerPlugin cell", async () => {
-  const result = await bunRun(join(fixtures, "serve-plugins-leak-fixture.ts"));
+  const result = await bunRun(fixture("serve-plugins-leak-fixture.ts"));
   expect(result).toSpawn();
   expect(JSON.parse(result.stdout)).toEqual({
     // One setup() for the build, one per server (two served to completion, one stopped mid-build).
@@ -30,6 +30,34 @@ test.concurrent("[serve.static] plugins and Bun.build() plugins release their Bu
   });
 });
 
+test.concurrent("the dev server's [serve.static] plugins release their BundlerPlugin cell too", async () => {
+  const result = await bunRun(fixture("serve-plugins-dev-server-fixture.ts"));
+  expect({
+    ...result,
+    stdout: JSON.parse(result.stdout),
+    // The dev server reports every bundle on stderr.
+    stderr: result.stderr.replaceAll(/\d+ms/g, "<n>ms"),
+  }).toEqual({
+    stdout: { setups: 2, usedPlugin: 2, cellsWhileServing: 2, cellsAfter: 0 },
+    stderr: "Bundled page in <n>ms: index.html\nBundled page in <n>ms: index.html",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+test.concurrent("a [serve.static] plugin load that rejects releases its BundlerPlugin cell", async () => {
+  const { stderr, ...result } = await bunRun(fixture("serve-plugins-reject-fixture.ts"), {
+    SERVE_PLUGIN_SETUP_THROWS: "1",
+  });
+  expect({ ...result, stdout: JSON.parse(result.stdout) }).toEqual({
+    stdout: { setups: 1, status: 500, protectedCellsAfterReject: 0 },
+    exitCode: 0,
+    signalCode: null,
+  });
+  expect(stderr).toContain("Failed to load plugins for Bun.serve:");
+  expect(stderr).toContain("setup() failed on purpose");
+});
+
 // VM teardown cancels a route build that is still parked in the plugin. That
 // build only borrows the server's cell, so giving the task up must not release
 // or touch anything the server still owns. BUN_DESTRUCT_VM_ON_EXIT makes
@@ -38,7 +66,7 @@ test.concurrent("[serve.static] plugins and Bun.build() plugins release their Bu
 // (and, as in the other tests that set it, leak detection is turned off because
 // it then reports JSC's process-lifetime allocations).
 test.concurrent("exiting while an HTML route build is parked in the server's plugins tears down cleanly", async () => {
-  const result = await bunRun(join(fixtures, "serve-plugins-exit-mid-build-fixture.ts"), {
+  const result = await bunRun(fixture("serve-plugins-exit-mid-build-fixture.ts"), {
     BUN_DESTRUCT_VM_ON_EXIT: "1",
     ...(isWindows
       ? {}


### PR DESCRIPTION
### Problem
- Every `Bun.serve()` that loads `[serve.static] plugins` (HTML routes, with or without the dev server) leaks the native plugin object the plugins were loaded into, one per server. After 3 servers are started and stopped, `heapStats().objectTypeCounts.BundlerPlugin` stays at 3 for good; a `Bun.build()` with plugins goes back to 0.
- The leaked object keeps every `onLoad` / `onResolve` callback registered on it, and whatever they close over, rooted for the rest of the process.
- Cause: creating the object protects it from GC and only an explicit destroy unprotects it. The serve side dropped its handle without ever destroying, both after a successful load and when the load was rejected.

### Fix
- The plugin object is now held through a handle whose drop is the destroy. The server's plugin state holds that handle, so the object is released when the server is freed or the load is rejected; `Bun.build()` uses the same handle.
- A build task now records whether it owns its plugin object (`Bun.build()`) or borrows the server's (HTML route builds), and only the owning kind releases it. Before, a route build cancelled at VM teardown destroyed the server's shared object; once the server releases it too, that would be a double release.
- Property to check: create protects exactly once, so exactly one holder destroys, and it is the one that outlives every use: the server's plugin state for serve, the build task for `Bun.build()`.
- Caveat, not changed here: a route build does not keep its server alive today (a use-after-free on main, fixed by #37813). Until that lands, this change turns that scenario from a crash into a build that never finishes; landing #37813 first avoids the window.
- Verification: a new test with four fixtures. Three fail on the unfixed build with the exact leaked count (HTML routes, dev server, rejected load); the fourth only exercises the teardown path with a borrowed object, where nothing was observable before either. Run on Linux debug/ASAN, two of the four also on Windows.

### Background
- `[serve.static] plugins` in bunfig.toml lists bundler plugins that `Bun.serve()` applies when it bundles an HTML route. The production route path and the dev server (`development: true`) both load them through one per-server holder.
- Loading them creates one native `BundlerPlugin` JS cell per server (or per `Bun.build()` call); the plugins' `setup()` callbacks are registered on that cell.
- The cell is `protect()`ed when created, which makes it a GC root until a matching destroy (tombstone plus `unprotect()`). JSC never collects a protected cell on its own.
- On the Rust side the cell type is an opaque zero-sized FFI type, so dropping a `Box` of it runs nothing; the release has to be an explicit call, which is what the new RAII handle makes automatic.
- `heapStats()` from `bun:jsc` reports live and protected cells by type, which is how the tests count leaks.

<details>
<summary>Original description</summary>

### What

Every `Bun.serve()` that loads `[serve.static] plugins` (HTML routes without HMR, and the dev server) leaked the native plugin object those plugins were loaded into, once per server instance.

Repro (`heapStats().objectTypeCounts.BundlerPlugin` counts the cells; `test/js/bun/http/serve-plugins-leak-fixture/` is the same thing as a test):

```ts
// bunfig.toml: [serve.static] plugins = ["./plugin.ts"]
import html from "./index.html";
for (let i = 0; i < 3; i++) {
  const server = Bun.serve({ port: 0, development: false, routes: { "/": html }, fetch: () => new Response("") });
  await fetch(server.url); // loads the plugins, bundles the route
  await server.stop(true);
}
// gc + event loop turns ...
console.log(heapStats().objectTypeCounts.BundlerPlugin); // 3 before, 0 after
```

Before this change the count stays at 3 forever (also with `development: true`, verified manually; the dev server goes through the same `ServePlugins`). A `Bun.build()` with plugins correctly goes back to 0, which the fixture also checks.

### Cause

`ServePlugins::load_and_resolve_plugins` (`src/runtime/server/server_body.rs`) did

```rust
let plugin = JSBundler::Plugin::create(global, Browser);
let plugin: Box<JSBundler::Plugin> = unsafe { bun_core::heap::take(plugin) };
```

`Plugin` is an `opaque_ffi!` zero-sized type and `Plugin::create` returns the JSC cell after `protect()`ing it, so that `Box` owns nothing: dropping it (in `impl Drop for ServePlugins` for `Loaded`, and `drop(plugin)` on the reject path) runs no code. The only thing that balances the `protect()` is `Plugin::destroy` (tombstone + `unprotect()`), and nothing called it for serve plugins. The cell, and therefore every `onLoad`/`onResolve` callback registered on it and whatever they close over, stayed a GC root after the server was gone. (`bake`'s `UserOptions` pairs the same `create` with `destroy` in its `Drop`; this is the serve-side equivalent.)

### Fix

* `OwnedPlugin` (`src/runtime/api/JSBundler.rs`): RAII handle around the cell whose `Drop` calls `Plugin::destroy`. `ServePluginsState::Pending` / `Loaded` hold it, so the cell is released when the last `ServePlugins` ref drops (the server's ref is released in `Drop for NewServer`) or when the load is rejected. This is the fix; the state enum's field types in `server_body.rs` are the load-bearing lines. Routes and the dev server keep getting a plain pointer as before; the server that owns them holds the counted ref on `ServePlugins`. `Bun.build`'s `Config::from_js` uses the same handle, which replaces the scopeguard that destroyed the plugin on error paths.
* `JSBundleCompletionTask.plugins` is now `Option<BuildPlugins>`, `Owned(OwnedPlugin)` for `Bun.build()` and `Borrowed(NonNull<Plugin>)` for HTML route builds. The task used to clear the field in the normal `on_complete` path for HTML builds but still destroyed the server's shared cell from `deinit` when the build had been cancelled, and from the queued branch of `stop_for_vm_teardown`. (Route builds are only ever cancelled by VM teardown: `HTMLBundle`'s `State::deinit` has a cancelling arm, but a route holds a ref on itself while building, so that arm is not reachable.) That was wrong before too and would become a double release now that `ServePlugins` releases its own handle, so the variant decides who releases it; the `on_complete` clearing is gone because the type encodes it. Observable behaviour of `Bun.build()` is unchanged: the owned cell is still released in `deinit` / `stop_for_vm_teardown`, and the started branch still tombstones either kind.

Why this is correct: `create` takes exactly one `protect()`, so there has to be exactly one `destroy`, by the one owner that knows when nothing can use the cell any more. For serve plugins that owner is `ServePlugins`: builds that use the cell are started through the server, which holds the counted ref, and the ref is only dropped when the server itself is freed. For `Bun.build()` it is the completion task. Having the handle type carry that makes the reject path, the error paths in `Config::from_js`, and the cancelled-build paths fall out of `Drop` instead of each site remembering.

`Borrowed` therefore relies on the server outliving every build it started. Today that is not enforced: a route build keeps nothing alive but itself, so a server whose last client disconnected can be stopped, collected and freed while its build is still running. That scenario already reads the freed server when the build lands (use-after-free on main; #37813 fixes it by counting the build as a pending request, which also makes the server, and with it `ServePlugins` and the cell, outlive the build). Until #37813 lands, this change alters what that broken scenario does: the cell is tombstoned when the server is freed, so a plugin callback answering afterwards is dropped and the build never finishes, instead of the build finishing and crashing. Landing #37813 first, or together with this, avoids that window; nothing here conflicts with it (it only touches `HTMLBundle.rs` around `schedule_bundle` / `on_complete`).

Intentionally not changed here (tracked separately): the framework plugin a bake `app` config creates is moved into the `DevServer` and is also never destroyed, but that slot doubles as the place the dev server stores the borrowed serve plugin, so it needs its own owned/borrowed split. Also found while writing the tests and filed separately: an HTML route stuck in its error state answers later requests with 200 and an empty body in production mode, and a plugin load that rejects synchronously (second server in a process) is reported twice and exits the process with 1; the rejection fixture below uses one server per process because of the latter. #37740 refactors the same `create_and_schedule_completion_task` call sites (adds a `Deliver` argument); whichever lands second has a small mechanical rebase.

### Verification

`test/js/bun/http/serve-plugins-leak.test.ts` with the fixtures in `serve-plugins-leak-fixture/` (they run with that directory as cwd, where the bunfig.toml lives). On the unfixed build the first three fail, each on exactly the count named; on this branch all four pass (Linux debug/ASAN; the first and fourth also on a Windows box, release build of this branch 40/40 and debug 13/13, after the first CI run had left one of two cells behind there once at 20 collection rounds, which is why the loop is now 100 rounds of alternating `setTimeout` / `setImmediate` turns and prints the per-round survivors on failure; it converges in 1 to 2 rounds everywhere I ran it).

* HTML routes without the dev server: `Bun.build()` with plugins (cell used, then released), two servers served to completion (`serveCellsAfter`, 2 on the unfixed build), and a server stopped while its route build is parked in the plugin, the build then finishing against the stopped server (`stopMidBuildCellsAfter`, 3 unfixed). Every build is checked to have actually run the plugin, so a wrong `Owned` / `Borrowed` pointer handed to the bundle thread fails it as well.
* The same two servers through the dev server (`development: true`), the other consumer of `ServePlugins` (`cellsAfter`, 2 unfixed).
* A plugin whose `setup()` throws, so the load rejects: the route answers 500, the failure is reported, and `heapStats().protectedObjectTypeCounts.BundlerPlugin` is 0 right after (1 unfixed), which is the `handle_on_reject` release site and needs no collection at all.
* Exiting with `BUN_DESTRUCT_VM_ON_EXIT=1` (plus `Malloc=1` off Windows) while a route build is parked in the plugin, the only way to reach `stop_for_vm_teardown` and the cancelled `on_complete` with a borrowed cell. Coverage for those paths rather than a fail-before test: nothing frees the server at teardown today, so the old code did nothing observable there either. Without that variable `process.exit()` does not tear the VM down at all; with it (and once with LeakSanitizer on) the ASAN build also exited cleanly by hand with a second route build queued behind the parked one, i.e. the queued branch too.

Also passing on this branch's debug (ASAN) build: `test/bundler/bundler_plugin.test.ts`, `bundler_plugin_chain.test.ts`, `plugin-error-nested-throw.test.ts`, `plugin-sync-exception-fallback.test.ts`, `bun-build-api.test.ts`, `test/js/bun/http/bun-serve-html.test.ts` and `bun-serve-html-405.test.ts`, `test/bake/serve-plugins-dev-server.test.ts` (the dev server's resolve and reject notifications, i.e. `handle_on_reject` with a dev server attached) and `test/bake/deinitialization.test.ts` (dev servers with `[serve.static]` plugins stopped from inside `onLoad`), and the two `worker_threads` tests that terminate a worker mid-`Bun.build` (owned cell through both `stop_for_vm_teardown` branches).

</details>
