### PR TITLE
test(fetch): factor the body-stream matrix so it registers 800 tests instead of 9086

### DIFF
--- a/test/js/web/fetch/body-stream.test.ts
+++ b/test/js/web/fetch/body-stream.test.ts
@@ -1,625 +1,525 @@
-// @ts-nocheck
-import { ServeOptions } from "bun";
-import { afterAll, describe, expect, it, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { tls } from "harness";
 
-const port = 0;
-const globalFetch = fetch;
+// Round-trips request bodies through Bun.serve and back out through fetch(),
+// over HTTP/1.1 and over HTTP/3. One server per transport serves every test:
+// a request carries its server-side configuration in the `x-config` header and
+// the handler reports what it saw in the `x-server` response header, so each
+// test is a single `toEqual` over the client's and the server's view of the
+// round trip, and the tests are independent enough to run concurrently.
+//
+// The matrix is factored by what a dimension can influence:
+//   - the body *types* (Uint8Array, DataView, Int16Array.subarray(1), Blob, ...)
+//     only change how fetch() serializes the request; the server sees bytes
+//     either way. They run once per source size against a plain reader.
+//   - the server/client *modes* (clone, touchBody, defer, lateReader, direct vs
+//     default response stream, every Request body mixin) run at every body size
+//     with one body type.
+//   - the string / ArrayBuffer / Buffer fixtures and fetch(url) vs
+//     fetch(new Request()) only change the client; they run against one mixin.
 
-// Run the entire suite once over plain HTTP/1.1 and once over HTTP/3 so the
-// streaming-body matrix exercises both transports end-to-end. The http/3 row
-// uses `http1: false` so a regression that silently falls back to TCP fails
-// outright.
+const port = 0;
+
+const MIXINS = ["arrayBuffer", "bytes", "blob", "text", "json"] as const;
+type Mixin = (typeof MIXINS)[number];
+const MIXIN_RESULT_TYPE: Record<Mixin, string> = {
+  arrayBuffer: "ArrayBuffer",
+  bytes: "Uint8Array",
+  blob: "Blob",
+  text: "string",
+  // the handler JSON.stringify()s what json() parsed before summarizing it
+  json: "string",
+};
+
+// Flags a test combines, and which side acts on them:
+//   clone       server: request.clone(), consume both; client: response.clone(), consume both
+//   touchBody   read `.body` before consuming, so the buffered native body is turned into a
+//               ReadableStream first and consuming it takes the ReadableStream -> X conversion
+//               (which clone() then tees). Server side for the mixins, client side everywhere.
+//   defer       server: wait a microtask before touching the request body (and, when pumping it
+//               into the response, before the first write), i.e. act only after the handler's
+//               promise has been handed back to the server
+//   lateReader  server: take the request body reader a microtask into the handler instead of
+//               synchronously
+interface Mode {
+  name: string;
+  clone: boolean;
+  touchBody: boolean;
+  defer?: boolean;
+  lateReader?: boolean;
+}
+
+type ServerConfig = Mode &
+  ({ op: "mixin"; mixin: Mixin } | { op: "reader" } | { op: "stream"; kind: "direct" | "default" });
+
+/** Every on/off combination of `flags`; `name` lists the ones that are on. */
+function combos(flags: string[]): Mode[] {
+  let rows: Array<Record<string, boolean>> = [{}];
+  for (const flag of flags) {
+    rows = rows.flatMap(row => [
+      { ...row, [flag]: false },
+      { ...row, [flag]: true },
+    ]);
+  }
+  return rows.map(row => ({ ...row, name: flags.filter(flag => row[flag]).join(" + ") || "plain" })) as Mode[];
+}
+
+const plain: Mode = { name: "plain", clone: false, touchBody: false };
+const mixinModes = combos(["clone", "touchBody"]);
+const readerModes = combos(["clone", "touchBody", "defer"]);
+const streamModes = combos(["clone", "touchBody", "defer", "lateReader"]);
+
+function digest(bytes: Uint8Array | ArrayBuffer) {
+  return { size: bytes.byteLength, sha1: Bun.SHA1.hash(bytes, "base64") };
+}
+
+// Non-repeating contents, so a chunk that is dropped, duplicated or delivered
+// out of order anywhere in the body changes the digest.
+function makeBody(size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  const words = new Uint32Array(bytes.buffer, 0, size >>> 2);
+  let x = 0x9e3779b9;
+  for (let i = 0; i < words.length; i++) {
+    x ^= x << 13;
+    x ^= x >>> 17;
+    x ^= x << 5;
+    words[i] = x;
+  }
+  for (let i = words.length * 4; i < size; i++) bytes[i] = 255 - i;
+  return bytes;
+}
+
+function bodyFixture(size: number) {
+  const body = makeBody(size);
+  return { size, body, sha1: digest(body).sha1 };
+}
+
+/**
+ * The same source bytes handed to fetch() as every kind of BodyInit, each with
+ * the digest of the bytes that must reach the server. Small sources are widened
+ * element-per-byte (a 95 byte source becomes a 760 byte Float64Array); the
+ * largest source is viewed in place so its bodies stay at the source size.
+ */
+function bodyVariants(source: Uint8Array, viewInPlace: boolean) {
+  const widen = (Ctor: any) => (viewInPlace ? new Ctor(source.buffer) : new Ctor(source));
+  const int16 = (): Int16Array => widen(Int16Array);
+  const int32 = (): Int32Array => widen(Int32Array);
+  const variants: Array<[label: string, body: Blob | ArrayBuffer | ArrayBufferView]> = [
+    ["Uint8Array", source],
+    ["ArrayBuffer", source.buffer],
+    ["DataView", new DataView(source.buffer)],
+    ["Blob", new Blob([source])],
+    ["Int8Array", widen(Int8Array)],
+    ["Uint16Array", widen(Uint16Array)],
+    ["Uint32Array", widen(Uint32Array)],
+    ["Int16Array", int16()],
+    ["Int32Array", int32()],
+    ["Float64Array", widen(Float64Array)],
+    // views that do not span their buffer: byteOffset and byteLength have to be
+    // honoured instead of sending the backing ArrayBuffer
+    ["Int16Array.subarray(1)", int16().subarray(1)],
+    ["Int32Array.subarray(1)", int32().subarray(1)],
+    ["Int16Array.subarray(0, -1)", int16().subarray(0, -1)],
+    ["Int32Array.subarray(0, -1)", int32().subarray(0, -1)],
+    ["Int16Array.subarray(1, -1)", int16().subarray(1, -1)],
+    ["Int16Array.subarray(0, 1)", int16().subarray(0, 1)],
+    ["Int32Array.subarray(0, 1)", int32().subarray(0, 1)],
+    ["Float32Array.subarray(0, 1)", (widen(Float32Array) as Float32Array).subarray(0, 1)],
+  ];
+  return variants
+    .map(([label, body]) => {
+      const wire =
+        body instanceof Blob
+          ? source
+          : body instanceof ArrayBuffer
+            ? new Uint8Array(body)
+            : new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+      return { label, body, ...digest(wire) };
+    })
+    .filter(variant => variant.size > 0);
+}
+
+const SHORT = JSON.stringify("Hello World");
+const LONG_LATIN1 = JSON.stringify("EXTREMELY LONG VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100));
+const LONG_UTF16 = JSON.stringify(
+  "EXTREMELY LONG 🔥 UTF16 🔥 VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100),
+);
+
+function textFixture(label: string, text: string, body: BodyInit = Buffer.from(text)) {
+  return { label, text, body, ...digest(Buffer.from(text)) };
+}
+
+// What the server has to decode varies with the length and with whether the
+// text is pure latin1; how the client serialized it never reaches the server.
+const serverInputs = [
+  textFixture("short", SHORT),
+  textFixture("long latin1", LONG_LATIN1),
+  textFixture("long utf-16", LONG_UTF16),
+];
+
+const clientInputs = [
+  textFixture("string", SHORT, SHORT),
+  textFixture("ArrayBuffer", SHORT, new Uint8Array(Buffer.from(SHORT)).buffer),
+  textFixture("Buffer", SHORT),
+  textFixture("long latin1 Buffer", LONG_LATIN1),
+  textFixture("long utf-16 Buffer", LONG_UTF16),
+  // sent as a string: encoded to UTF-8 on the way out and sized in UTF-8 bytes,
+  // not in UTF-16 code units
+  textFixture("long utf-16 string", LONG_UTF16, LONG_UTF16),
+];
+
+const clientCalls = [
+  { label: "fetch(url, init)", useRequestObject: false },
+  { label: "fetch(new Request({ url, ...init }))", useRequestObject: true },
+];
+
+const CLIENT_HEADERS = { "content-type": "text/plain", "x-custom": "hello" };
+// what the handler sees: the headers above plus the user-agent fetch() adds by itself
+const REQUEST_HEADERS_SEEN = { ...CLIENT_HEADERS, "user-agent": navigator.userAgent };
+
+function headersSeen(request: Request) {
+  return Object.fromEntries(Object.keys(REQUEST_HEADERS_SEEN).map(name => [name, request.headers.get(name)]));
+}
+
+async function summarize(result: unknown) {
+  if (typeof result === "string") return { type: "string", ...digest(Buffer.from(result)) };
+  if (result instanceof Blob) {
+    return { type: "Blob", size: result.size, sha1: Bun.SHA1.hash(await result.bytes(), "base64") };
+  }
+  const buffer = result as ArrayBuffer | Uint8Array;
+  return { type: buffer.constructor.name, ...digest(buffer) };
+}
+
+async function readAll(body: ReadableStream<Uint8Array>) {
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) return chunks;
+    chunks.push(value);
+  }
+}
+
+async function handle(request: Request): Promise<Response> {
+  const config: ServerConfig = JSON.parse(request.headers.get("x-config")!);
+  const branches: unknown[] = [];
+  const respond = (body: BodyInit) => {
+    const headers = new Headers({ "content-type": "text/plain", "x-server": JSON.stringify(branches) });
+    const counter = request.headers.get("x-counter");
+    if (counter !== null) headers.set("x-counter", counter);
+    return new Response(body, { headers });
+  };
+
+  try {
+    switch (config.op) {
+      case "mixin": {
+        if (config.touchBody) request.body;
+        let result: any;
+        for (const req of config.clone ? [request.clone(), request] : [request]) {
+          result = await req[config.mixin]();
+          // json() returns the parsed value; serializing it again yields the
+          // exact text it was parsed from, which is what the fixtures digest
+          if (config.mixin === "json") result = JSON.stringify(result);
+          branches.push({ headers: headersSeen(req), ...(await summarize(result)) });
+        }
+        return respond(result);
+      }
+
+      case "reader": {
+        if (config.defer) await 1;
+        let blob!: Blob;
+        for (const req of config.clone ? [request.clone(), request] : [request]) {
+          blob = new Blob(await readAll(req.body!));
+          branches.push({
+            headers: headersSeen(req),
+            size: blob.size,
+            sha1: Bun.SHA1.hash(await blob.arrayBuffer(), "base64"),
+          });
+        }
+        return respond(blob);
+      }
+
+      case "stream": {
+        if (config.defer) await 1;
+        let reader!: ReadableStreamDefaultReader<Uint8Array>;
+        for (const req of config.clone ? [request.clone(), request] : [request]) {
+          if (config.lateReader) await 1;
+          // With clone, the clone's reader is taken and then abandoned: only the
+          // last reader (the original request's) is pumped below, so the tee has
+          // to let one branch drain while the other stays locked and unread.
+          reader = req.body!.getReader();
+          branches.push({ headers: headersSeen(req) });
+        }
+        const pump = async (write: (chunk: Uint8Array) => unknown, close: () => unknown) => {
+          for (;;) {
+            const { done, value } = await reader.read();
+            if (done) {
+              close();
+              return;
+            }
+            write(value);
+          }
+        };
+        const stream =
+          config.kind === "direct"
+            ? new ReadableStream({
+                type: "direct",
+                async pull(controller) {
+                  if (config.defer) await 1;
+                  await pump(
+                    chunk => controller.write(chunk),
+                    () => controller.end(),
+                  );
+                },
+              })
+            : new ReadableStream({
+                async start() {
+                  if (config.defer) await 1;
+                },
+                pull: controller =>
+                  pump(
+                    chunk => controller.enqueue(chunk),
+                    () => controller.close(),
+                  ),
+              });
+        return respond(stream);
+      }
+    }
+  } catch (error) {
+    return new Response(Bun.inspect(error), { status: 500 });
+  }
+}
+
 describe.each([
   { name: "http/1.1", http3: false },
   { name: "http/3", http3: true },
 ])("body-stream over $name", ({ http3 }) => {
-  const fetch: typeof globalFetch = http3
-    ? (input, init) => globalFetch(input, { ...init, protocol: "http3", tls: { rejectUnauthorized: false } } as any)
-    : globalFetch;
+  // `http1: false` so an http/3 request that silently fell back to TCP fails
+  // instead of passing against a TCP listener on the same port.
+  const serveOptions = http3 ? { port, tls, http3: true, http1: false } : { port };
+  const transportInit = http3 ? ({ protocol: "http3", tls: { rejectUnauthorized: false } } as RequestInit) : undefined;
 
-  test("Should receive the response body when direct stream is properly flushed", async () => {
-    var called = false;
-    await runInServer(
-      {
-        async fetch() {
-          var stream = new ReadableStream({
-            type: "direct",
-            async pull(controller) {
-              controller.write("hey");
-              await Bun.sleep(1);
-              await controller.end();
-            },
-          });
+  // The MB rows are what makes request bodies arrive in many reads and response
+  // writes hit backpressure over TCP. Over QUIC in a debug+ASAN build their
+  // per-packet cost blows the timeout, and 64 KB already spans many packets
+  // and flow-control windows, so http/3 stops there.
+  const largest = http3 ? 64 * 1024 : 1024 * 1024;
+  const sizes = [1, 2, 12, 95, 1024, largest, ...(http3 ? [] : [2 * largest])];
+  const bodies = sizes.map(bodyFixture);
 
-          return new Response(stream);
-        },
-      },
-      async url => {
-        called = true;
-        expect(await fetch(url).then(res => res.text())).toBe("hey");
-      },
-    );
-
-    expect(called).toBe(true);
+  let sharedServer: ReturnType<typeof Bun.serve>;
+  beforeAll(() => {
+    sharedServer = Bun.serve({ ...serveOptions, fetch: handle });
   });
+  afterAll(() => sharedServer.stop(true));
 
-  for (let doClone of [true, false]) {
-    const BodyMixin = [
-      Request.prototype.arrayBuffer,
-      Request.prototype.bytes,
-      Request.prototype.blob,
-      Request.prototype.text,
-      Request.prototype.json,
-    ];
-    const useRequestObjectValues = [true, false];
-
-    test("Should not crash when not returning a promise when stream is in progress", async () => {
-      var called = false;
-      let controller;
-      const pulled = Promise.withResolvers();
-      await runInServer(
-        {
-          async fetch() {
-            var stream = new ReadableStream({
-              type: "direct",
-              pull(c) {
-                c.write("hey");
-                controller = c;
-                pulled.resolve();
-              },
-            });
-
-            return new Response(stream);
-          },
-        },
-        async url => {
-          called = true;
-          const responsePromise = fetch(url);
-          await pulled.promise;
-          controller.end();
-          // the response stays open until controller.end() is called
-          expect(await responsePromise.then(res => res.text())).toBe("hey");
-        },
-      );
-
-      expect(called).toBe(true);
-    });
-
-    for (let RequestPrototypeMixin of BodyMixin) {
-      for (let useRequestObject of useRequestObjectValues) {
-        // When you do req.body
-        // We go through Bun.readableStreamTo${Method}(stream)
-        for (let forceReadableStreamConversionFastPath of [true, false]) {
-          describe(`Request.prototoype.${RequestPrototypeMixin.name}() ${
-            useRequestObject
-              ? "fetch(req)"
-              : "fetch(url)" +
-                (forceReadableStreamConversionFastPath ? " (force fast ReadableStream conversion)" : "") +
-                (doClone ? " (clone)" : "")
-          }`, () => {
-            const inputFixture = [
-              [JSON.stringify("Hello World"), JSON.stringify("Hello World")],
-              [JSON.stringify("Hello World 123"), Buffer.from(JSON.stringify("Hello World 123")).buffer],
-              [JSON.stringify("Hello World 456"), Buffer.from(JSON.stringify("Hello World 456"))],
-              [
-                JSON.stringify("EXTREMELY LONG VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100)),
-                Buffer.from(
-                  JSON.stringify("EXTREMELY LONG VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100)),
-                ),
-              ],
-              [
-                JSON.stringify(
-                  "EXTREMELY LONG 🔥 UTF16 🔥 VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100),
-                ),
-                Buffer.from(
-                  JSON.stringify(
-                    "EXTREMELY LONG 🔥 UTF16 🔥 VERY LONG STRING WOW SO LONG YOU WONT BELIEVE IT! ".repeat(100),
-                  ),
-                ),
-              ],
-            ];
-
-            for (const [name, input] of inputFixture) {
-              test(`${name.slice(0, Math.min(name.length ?? name.byteLength, 64))}`, async () => {
-                await runInServer(
-                  {
-                    async fetch(req) {
-                      if (forceReadableStreamConversionFastPath) {
-                        req.body;
-                      }
-
-                      var result;
-                      for (const request of doClone ? [req.clone(), req] : [req]) {
-                        result = await RequestPrototypeMixin.call(request);
-                        if (RequestPrototypeMixin === Request.prototype.json) {
-                          result = JSON.stringify(result);
-                        }
-                        if (typeof result === "string") {
-                          expect(result.length).toBe(name.length);
-                          expect(result).toBe(name);
-                        } else if (result && result instanceof Blob) {
-                          expect(result.size).toBe(new TextEncoder().encode(name).byteLength);
-                          expect(await result.text()).toBe(name);
-                        } else {
-                          expect(result.byteLength).toBe(Buffer.from(input).byteLength);
-                          expect(Bun.SHA1.hash(result, "base64")).toBe(Bun.SHA1.hash(input, "base64"));
-                        }
-                      }
-                      return new Response(result, {
-                        headers: req.headers,
-                      });
-                    },
-                  },
-                  async url => {
-                    var response;
-
-                    // once, then batch of 5
-
-                    if (useRequestObject) {
-                      response = await fetch(
-                        new Request({
-                          body: input,
-                          method: "POST",
-                          url: url,
-                          headers: {
-                            "content-type": "text/plain",
-                          },
-                        }),
-                      );
-                    } else {
-                      response = await fetch(url, {
-                        body: input,
-                        method: "POST",
-                        headers: {
-                          "content-type": "text/plain",
-                        },
-                      });
-                    }
-
-                    if (forceReadableStreamConversionFastPath) {
-                      response.body;
-                    }
-
-                    const originalResponse = response;
-
-                    if (doClone) {
-                      response = response.clone();
-                    }
-
-                    expect(response.status).toBe(200);
-                    expect(response.headers.get("content-length")).toBe(String(Buffer.from(input).byteLength));
-                    expect(response.headers.get("content-type")).toBe("text/plain");
-                    const initialResponseText = await response.text();
-                    expect(initialResponseText).toBe(name);
-
-                    if (doClone) {
-                      expect(await originalResponse.text()).toBe(name);
-                    }
-
-                    let promises = Array.from({ length: 5 }).map((_, i) => {
-                      if (useRequestObject) {
-                        return fetch(
-                          new Request({
-                            body: input,
-                            method: "POST",
-                            url: url,
-                            headers: {
-                              "content-type": "text/plain",
-                              "x-counter": i,
-                            },
-                          }),
-                        );
-                      } else {
-                        return fetch(url, {
-                          body: input,
-                          method: "POST",
-                          headers: {
-                            "content-type": "text/plain",
-                            "x-counter": i,
-                          },
-                        });
-                      }
-                    });
-
-                    promises = await Promise.all(promises);
-
-                    await Promise.all(
-                      promises.map(async (originalResponse, i) => {
-                        if (forceReadableStreamConversionFastPath) {
-                          originalResponse.body;
-                        }
-
-                        for (let response of doClone
-                          ? [originalResponse.clone(), originalResponse]
-                          : [originalResponse]) {
-                          expect(response.status).toBe(200);
-                          expect(response.headers.get("content-length")).toBe(String(Buffer.from(input).byteLength));
-                          expect(response.headers.get("content-type")).toBe("text/plain");
-                          expect(response.headers.get("x-counter")).toBe(String(i));
-                          const responseText = await response.text();
-                          expect(responseText).toBe(name);
-                        }
-                      }),
-                    );
-                  },
-                );
-              });
-            }
-          });
-        }
-      }
-    }
-  }
-
-  var existingServer;
-  async function runInServer(opts: ServeOptions, cb: (url: string) => void | Promise<void>) {
-    var server;
-    const handler = {
-      ...opts,
-      port: 0,
-      ...(http3 ? { tls, http3: true, http1: false } : {}),
-      fetch(req) {
-        try {
-          return opts.fetch(req);
-        } catch (e) {
-          console.error(e.message);
-          console.log(e.stack);
-          throw e;
-        }
-      },
-      error(err) {
-        console.log(err.message);
-        console.log(err.stack);
-        throw err;
+  async function post<T>(
+    config: ServerConfig,
+    body: BodyInit,
+    consume: (response: Response) => Promise<T>,
+    responseHeaders: string[],
+    { counter, useRequestObject = false }: { counter?: number; useRequestObject?: boolean } = {},
+  ) {
+    const init: RequestInit = {
+      method: "POST",
+      body,
+      headers: {
+        ...CLIENT_HEADERS,
+        ...(counter !== undefined && { "x-counter": String(counter) }),
+        "x-config": JSON.stringify(config),
       },
     };
+    const response = useRequestObject
+      ? await fetch(new Request({ url: sharedServer.url.href, ...init } as any), transportInit)
+      : await fetch(sharedServer.url, { ...init, ...transportInit });
+    if (response.status !== 200) throw new Error(`server responded ${response.status}: ${await response.text()}`);
 
-    if (!existingServer) {
-      existingServer = server = Bun.serve(handler);
-    } else {
-      server = existingServer;
-      server.reload(handler);
-    }
+    if (config.touchBody) response.body;
+    const bodies: T[] = [];
+    for (const branch of config.clone ? [response.clone(), response] : [response]) bodies.push(await consume(branch));
 
-    const scheme = http3 ? "https" : "http";
-    try {
-      await cb(`${scheme}://${server.hostname}:${server.port}`);
-    } catch (e) {
-      throw e;
-    } finally {
-    }
+    return {
+      status: response.status,
+      headers: Object.fromEntries(responseHeaders.map(name => [name, response.headers.get(name)])),
+      server: JSON.parse(response.headers.get("x-server")!),
+      bodies,
+    };
   }
 
-  afterAll(() => {
-    existingServer && existingServer.stop();
-    existingServer = null;
-  });
-
-  function fillRepeating(dstBuffer, start, end) {
-    let len = dstBuffer.length,
-      sLen = end - start,
-      p = sLen;
-    while (p < len) {
-      if (p + sLen > len) sLen = len - p;
-      dstBuffer.copyWithin(p, start, sLen);
-      p += sLen;
-      sLen <<= 1;
-    }
+  function perBranch<T>(mode: Mode, value: T) {
+    return mode.clone ? [value, value] : [value];
   }
 
-  function gc() {
-    Bun.gc(true);
+  async function expectMixinEcho(
+    config: ServerConfig & { op: "mixin" },
+    input: (typeof serverInputs)[number],
+    useRequestObject = false,
+  ) {
+    const run = (counter: number) =>
+      post(config, input.body, response => response.text(), ["content-type", "content-length", "x-counter"], {
+        counter,
+        useRequestObject,
+      });
+    // One request on its own, then a concurrent batch: the batch reuses the
+    // first request's keep-alive connection and opens fresh ones next to it
+    // (over http/3, parallel streams on the one connection). The echoed counter
+    // pairs each response with its request.
+    const results = [await run(0), ...(await Promise.all([1, 2, 3].map(run)))];
+
+    const branch = {
+      headers: REQUEST_HEADERS_SEEN,
+      type: MIXIN_RESULT_TYPE[config.mixin],
+      size: input.size,
+      sha1: input.sha1,
+    };
+    expect(results).toEqual(
+      [0, 1, 2, 3].map(counter => ({
+        status: 200,
+        headers: { "content-type": "text/plain", "content-length": String(input.size), "x-counter": String(counter) },
+        server: perBranch(config, branch),
+        bodies: perBranch(config, input.text),
+      })),
+    );
   }
 
-  for (let doClone of [true, false]) {
-    describe("reader" + (doClone ? " (clone)" : ""), function () {
-      for (let forceReadableStreamConversionFastPath of [true, false]) {
-        for (let withDelay of [false, true]) {
-          try {
-            // - 1 byte
-            // - less than the InlineBlob limit
-            // - multiple chunks
-            // - backpressure
-
-            // The 1 MB / 2 MB rows fan out to 8–16 MB typed arrays; over QUIC
-            // in a debug+ASAN build the per-packet cost pushes those past the
-            // default timeout without exercising any path the smaller sizes
-            // don't already cover.
-            const inputLengths = http3
-              ? [1, 2, 12, 95, 1024, 64 * 1024]
-              : [1, 2, 12, 95, 1024, 1024 * 1024, 1024 * 1024 * 2];
-            for (let inputLength of inputLengths) {
-              var bytes = new Uint8Array(inputLength);
-              {
-                const chunk = Math.min(bytes.length, 256);
-                for (var i = 0; i < chunk; i++) {
-                  bytes[i] = 255 - i;
-                }
-              }
-
-              if (bytes.length > 255) fillRepeating(bytes, 0, bytes.length);
-
-              // On the 1 MB / 2 MB rows, element-per-byte construction balloons
-              // the multi-byte-element bodies to 4-16 MB. View `bytes.buffer`
-              // instead (same element types, byteLength == inputLength).
-              const isLargeRow = inputLength >= 1024 * 1024;
-              const Float64 = isLargeRow ? new Float64Array(bytes.buffer) : new Float64Array(bytes);
-              const Uint16 = isLargeRow ? new Uint16Array(bytes.buffer) : new Uint16Array(bytes);
-              const Uint32 = isLargeRow ? new Uint32Array(bytes.buffer) : new Uint32Array(bytes);
-              const Int16 = () => (isLargeRow ? new Int16Array(bytes.buffer) : new Int16Array(bytes));
-              const Int32 = () => (isLargeRow ? new Int32Array(bytes.buffer) : new Int32Array(bytes));
-              const Float32 = () => (isLargeRow ? new Float32Array(bytes.buffer) : new Float32Array(bytes));
-
-              for (const huge_ of [
-                bytes,
-                bytes.buffer,
-                new DataView(bytes.buffer),
-                new Int8Array(bytes),
-                new Blob([bytes]),
-                Float64,
-
-                Uint16,
-                Uint32,
-                Int16(),
-                Int32(),
-
-                // make sure we handle subarray() as expected when reading
-                // typed arrays from native code
-                Int16().subarray(1),
-                Int16().subarray(0, Int16().byteLength - 1),
-                Int32().subarray(1),
-                Int32().subarray(0, Int32().byteLength - 1),
-                Int16().subarray(0, 1),
-                Int32().subarray(0, 1),
-                Float32().subarray(0, 1),
-              ]) {
-                const thisArray = huge_;
-                if (Number(thisArray.byteLength ?? thisArray.size) === 0) continue;
-
-                it(
-                  `works with ${thisArray.constructor.name}(${
-                    thisArray.byteLength ?? thisArray.size
-                  }:${inputLength}) via req.body.getReader() in chunks` +
-                    (withDelay ? " with delay" : "") +
-                    (forceReadableStreamConversionFastPath ? " (force ReadableStream conversion)" : ""),
-                  async () => {
-                    var huge = thisArray;
-                    var called = false;
-
-                    const expectedHash =
-                      huge instanceof Blob
-                        ? Bun.SHA1.hash(await huge.bytes(), "base64")
-                        : Bun.SHA1.hash(huge, "base64");
-                    const expectedSize = huge instanceof Blob ? huge.size : huge.byteLength;
-
-                    const out = await runInServer(
-                      {
-                        async fetch(request) {
-                          try {
-                            if (withDelay) await 1;
-
-                            const run = async function (req) {
-                              expect(req.headers.get("x-custom")).toBe("hello");
-                              expect(req.headers.get("content-type")).toBe("text/plain");
-                              expect(req.headers.get("user-agent")).toBe(navigator.userAgent);
-
-                              expect(req.headers.get("x-custom")).toBe("hello");
-                              expect(req.headers.get("content-type")).toBe("text/plain");
-                              expect(req.headers.get("user-agent")).toBe(navigator.userAgent);
-
-                              let reader = req.body.getReader();
-                              called = true;
-                              let buffers = [];
-                              while (true) {
-                                let { done, value } = await reader.read();
-                                if (done) break;
-                                buffers.push(value);
-                              }
-                              let out = new Blob(buffers);
-                              expect(out.size).toBe(expectedSize);
-                              expect(Bun.SHA1.hash(await out.arrayBuffer(), "base64")).toBe(expectedHash);
-                              expect(req.headers.get("x-custom")).toBe("hello");
-                              expect(req.headers.get("content-type")).toBe("text/plain");
-                              expect(req.headers.get("user-agent")).toBe(navigator.userAgent);
-                              return out;
-                            };
-
-                            let out;
-                            for (let req of doClone ? [request.clone(), request] : [request]) {
-                              out = await run(req);
-                            }
-
-                            return new Response(out, {
-                              headers: request.headers,
-                            });
-                          } catch (e) {
-                            console.error(e);
-                            throw e;
-                          }
-                        },
-                      },
-                      async url => {
-                        if (withDelay) await 1;
-                        const pendingResponse = await fetch(url, {
-                          body: huge,
-                          method: "POST",
-                          headers: {
-                            "content-type": "text/plain",
-                            "x-custom": "hello",
-                            "x-typed-array": thisArray.constructor.name,
-                          },
-                        });
-                        if (withDelay) {
-                          await 1;
-                        }
-                        let response = await pendingResponse;
-                        if (forceReadableStreamConversionFastPath) {
-                          response.body;
-                        }
-                        let originalResponse = response;
-                        if (doClone) {
-                          response = response.clone();
-                        }
-                        huge = undefined;
-                        expect(response.status).toBe(200);
-                        for (let body of doClone ? [response, originalResponse] : [response]) {
-                          const response_body = await body.bytes();
-                          expect(response_body.byteLength).toBe(expectedSize);
-                          expect(Bun.SHA1.hash(response_body, "base64")).toBe(expectedHash);
-                        }
-
-                        expect(response.headers.get("content-type")).toBe("text/plain");
-                      },
-                    );
-                    expect(called).toBe(true);
-
-                    return out;
-                  },
-                );
-
-                for (let isDirectStream of [true, false]) {
-                  const positions = ["begin", "end"];
-                  const inner = thisArray => {
-                    for (let position of positions) {
-                      it(
-                        `streaming back ${thisArray.constructor.name}(${
-                          thisArray.byteLength ?? thisArray.size
-                        }:${inputLength}) starting request.body.getReader() at ${position}` +
-                          (forceReadableStreamConversionFastPath ? " (force ReadableStream conversion)" : ""),
-                        async () => {
-                          var huge = thisArray;
-                          var called = false;
-
-                          const expectedHash =
-                            huge instanceof Blob
-                              ? Bun.SHA1.hash(await huge.bytes(), "base64")
-                              : Bun.SHA1.hash(huge, "base64");
-                          const expectedSize = huge instanceof Blob ? huge.size : huge.byteLength;
-
-                          const out = await runInServer(
-                            {
-                              async fetch(request) {
-                                try {
-                                  var reader;
-
-                                  if (withDelay) await 1;
-
-                                  for (let req of doClone ? [request.clone(), request] : [request]) {
-                                    if (position === "begin") {
-                                      reader = req.body.getReader();
-                                    }
-
-                                    if (position === "end") {
-                                      await 1;
-                                      reader = req.body.getReader();
-                                    }
-
-                                    expect(req.headers.get("x-custom")).toBe("hello");
-                                    expect(req.headers.get("content-type")).toBe("text/plain");
-                                    expect(req.headers.get("user-agent")).toBe(navigator.userAgent);
-                                  }
-
-                                  const direct = {
-                                    type: "direct",
-                                    async pull(controller) {
-                                      if (withDelay) await 1;
-
-                                      while (true) {
-                                        const { done, value } = await reader.read();
-                                        if (done) {
-                                          called = true;
-                                          controller.end();
-
-                                          return;
-                                        }
-                                        controller.write(value);
-                                      }
-                                    },
-                                  };
-
-                                  const web = {
-                                    async start() {
-                                      if (withDelay) await 1;
-                                    },
-                                    async pull(controller) {
-                                      while (true) {
-                                        const { done, value } = await reader.read();
-                                        if (done) {
-                                          called = true;
-                                          controller.close();
-                                          return;
-                                        }
-                                        controller.enqueue(value);
-                                      }
-                                    },
-                                  };
-
-                                  return new Response(new ReadableStream(isDirectStream ? direct : web), {
-                                    headers: request.headers,
-                                  });
-                                } catch (e) {
-                                  console.error(e);
-                                  throw e;
-                                }
-                              },
-                            },
-                            async url => {
-                              let response = await fetch(url, {
-                                body: huge,
-                                method: "POST",
-                                headers: {
-                                  "content-type": "text/plain",
-                                  "x-custom": "hello",
-                                  "x-typed-array": thisArray.constructor.name,
-                                },
-                              });
-                              huge = undefined;
-                              expect(response.status).toBe(200);
-                              if (forceReadableStreamConversionFastPath) {
-                                response.body;
-                              }
-
-                              const originalResponse = response;
-                              if (doClone) {
-                                response = response.clone();
-                              }
-
-                              for (let body of doClone ? [response, originalResponse] : [response]) {
-                                const response_body = await body.bytes();
-                                expect(response_body.byteLength).toBe(expectedSize);
-                                expect(Bun.SHA1.hash(response_body, "base64")).toBe(expectedHash);
-                              }
-
-                              if (!response.headers.has("content-type")) {
-                                console.error(Object.fromEntries(response.headers.entries()));
-                              }
-
-                              expect(response.headers.get("content-type")).toBe("text/plain");
-                            },
-                          );
-                          expect(called).toBe(true);
-
-                          return out;
-                        },
-                      );
-                    }
-                  };
-
-                  if (isDirectStream) {
-                    describe(" direct stream", () => inner(thisArray));
-                  } else {
-                    describe("default stream", () => inner(thisArray));
-                  }
-                }
-              }
-            }
-          } catch (e) {
-            console.error(e);
-            throw e;
-          }
-        }
-      }
+  async function expectReaderEcho(mode: Mode, body: BodyInit, { size, sha1 }: { size: number; sha1: string }) {
+    const result = await post({ op: "reader", ...mode }, body, async response => digest(await response.bytes()), [
+      "content-type",
+      "content-length",
+    ]);
+    expect(result).toEqual({
+      status: 200,
+      headers: { "content-type": "text/plain", "content-length": String(size) },
+      server: perBranch(mode, { headers: REQUEST_HEADERS_SEEN, size, sha1 }),
+      bodies: perBranch(mode, { size, sha1 }),
     });
   }
+
+  async function expectStreamEcho(
+    mode: Mode,
+    kind: "direct" | "default",
+    { body, size, sha1 }: ReturnType<typeof bodyFixture>,
+  ) {
+    // Whether a pumped response goes out with a content-length (everything was
+    // written before the headers were flushed) or chunked depends on the body
+    // size and on when the request body arrived, so the framing is not
+    // asserted, only the bytes.
+    const result = await post({ op: "stream", kind, ...mode }, body, async response => digest(await response.bytes()), [
+      "content-type",
+    ]);
+    expect(result).toEqual({
+      status: 200,
+      headers: { "content-type": "text/plain" },
+      server: perBranch(mode, { headers: REQUEST_HEADERS_SEEN }),
+      bodies: perBranch(mode, { size, sha1 }),
+    });
+  }
+
+  describe.concurrent("direct stream responses", () => {
+    // https://github.com/oven-sh/bun/pull/18707: a chunk written by pull() is
+    // flushed to the client on its own; the end() that follows has to close the
+    // response without dropping or repeating it.
+    test("a chunk written before end() arrives on its own, and end() then closes the response", async () => {
+      const chunkReceived = Promise.withResolvers<void>();
+      using server = Bun.serve({
+        ...serveOptions,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              async pull(controller) {
+                controller.write("hey");
+                await chunkReceived.promise;
+                await controller.end();
+              },
+            }),
+          );
+        },
+      });
+
+      const response = await fetch(server.url, transportInit);
+      const reader = response.body!.getReader();
+      const decoder = new TextDecoder();
+      let text = "";
+      while (text.length < "hey".length) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value, { stream: true });
+      }
+      const beforeEnd = text;
+      chunkReceived.resolve();
+      for (;;) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        text += decoder.decode(value, { stream: true });
+      }
+      expect({ status: response.status, beforeEnd, text }).toEqual({ status: 200, beforeEnd: "hey", text: "hey" });
+    });
+
+    // https://github.com/oven-sh/bun/issues/32137: a pull() that returns without
+    // a promise keeps the response open until the captured controller ends it.
+    test("sync pull() keeps the response open until the controller is ended later", async () => {
+      const pulled = Promise.withResolvers<ReadableStreamDirectController>();
+      using server = Bun.serve({
+        ...serveOptions,
+        fetch() {
+          return new Response(
+            new ReadableStream({
+              type: "direct",
+              pull(controller) {
+                controller.write("hey");
+                pulled.resolve(controller);
+              },
+            }),
+          );
+        },
+      });
+
+      const pending = fetch(server.url, transportInit);
+      // a failing fetch() rejects here instead of leaving the test waiting for pull()
+      const controller = await Promise.race([pulled.promise, pending.then(() => pulled.promise)]);
+      controller.end();
+      const response = await pending;
+      expect({ status: response.status, text: await response.text() }).toEqual({ status: 200, text: "hey" });
+    });
+  });
+
+  describe.concurrent("Request body mixins", () => {
+    describe.each(mixinModes)("$name", mode => {
+      describe.each([...MIXINS])("request.%s()", mixin => {
+        test.each(serverInputs)("$label", input => expectMixinEcho({ op: "mixin", mixin, ...mode }, input));
+      });
+    });
+  });
+
+  describe.concurrent("request body serialization", () => {
+    describe.each(clientCalls)("$label", ({ useRequestObject }) => {
+      test.each(clientInputs)("$label", input =>
+        expectMixinEcho({ op: "mixin", mixin: "text", ...plain }, input, useRequestObject),
+      );
+    });
+
+    // 1: one element per view, so the offset views are empty and skipped.
+    // 2: the smallest source where every offset view has an element.
+    // 95: odd length, many elements. largest: viewed in place, many chunks.
+    describe.each([1, 2, 95, largest])("source of %d bytes", source => {
+      test.each(bodyVariants(makeBody(source), source === largest))("$label -> $size bytes", ({ body, size, sha1 }) =>
+        expectReaderEcho(plain, body, { size, sha1 }),
+      );
+    });
+  });
+
+  describe.concurrent("request.body.getReader() read to the end, echoed as a Blob", () => {
+    describe.each(readerModes)("$name", mode => {
+      test.each(bodies)("$size-byte body", fixture => expectReaderEcho(mode, fixture.body, fixture));
+    });
+  });
+
+  describe.concurrent("request.body pumped into the response stream", () => {
+    describe.each(["direct", "default"])("%s stream", kind => {
+      describe.each(streamModes)("$name", mode => {
+        test.each(bodies)("$size-byte body", fixture => expectStreamEcho(mode, kind, fixture));
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Problem
- `test/js/web/fetch/body-stream.test.ts` is one of the slowest non-integration files in the repo: 82s on the debian 13 x64-asan lane in build 92779. Test-only change, no `src/` changes.
- It registered 9086 tests. On a debug+ASAN build a 1 byte round trip and a 1 MB round trip cost about the same (~13ms vs ~23ms), mostly fixed per-test overhead including a `server.reload()` per test, so the test count is the cost, not the bytes.
- ~17 request body types were crossed with every clone / fastPath / delay / size / consumption combination. fetch() turns each of those types into bytes before anything reaches the server, so the body type cannot interact with any other dimension and that multiplier was repetition.
- Some assertions were weaker than they looked: the body filler was a no-op past byte 256 (a reordered or duplicated chunk hashed the same), and the two `subarray(0, byteLength - 1)` variants clamped to the full view, duplicating it.

### Fix
- The matrix is factored by what each dimension can affect: the 18 body types run once per source size against a plain reader, and every server/client mode combination that existed before still runs at every body size, with one body type. 9086 tests become 800; nothing is skipped or `.todo`.
- One `Bun.serve` per transport handles every test. The request carries its server-side configuration in an `x-config` header, the handler reports what it saw in an `x-server` header, and each test is one `toEqual` over status, headers, server report and client bodies. A handler failure comes back as a 500 that fails the test. With no per-test `server.reload()`, no `expect()` inside the handler and no shared variables, the blocks run under `describe.concurrent`.
- Assertions tighten where they were loose: bodies are non-repeating, the shortened subarray variants now shorten the view, each mixin's result type is asserted, and the direct-stream flush test waits for the chunk to arrive instead of `Bun.sleep(1)`. `content-length` is still not asserted on pumped stream responses, since chunked vs content-length there depends on timing.
- Verification: same machine and debug+ASAN build, main runs the file in 186s and this branch in 22 to 26s; the first CI run reports 2.92s on the asan lane that took 82s. The committed file passed 4 of 4 local runs. Two mutations confirm the assertions are live: dropping the last byte of each pumped chunk fails exactly the 416 pumped-stream tests, and hashing the whole backing buffer instead of the view fails exactly the partial-view variants.

### Background
- BodyInit: `fetch()` takes a string, `ArrayBuffer`, any typed array or `DataView`, or a `Blob` as a request body. Bun copies a view's bytes (honouring `byteOffset` and `byteLength`) into an internal blob when the request is built, so `subarray()` bodies are the case where the type matters, and only on the client side.
- Request body mixins: `arrayBuffer()`, `bytes()`, `blob()`, `text()` and `json()` consume a body. Reading `.body` first converts the buffered native body into a `ReadableStream`, so a later mixin call takes the stream conversion path instead of the buffered one. That is the `touchBody` flag (formerly `fastPath`).
- Direct streams: `new ReadableStream({ type: "direct" })` is a Bun extension where `pull()` writes straight out with `controller.write()` and `controller.end()`, as opposed to a default stream's `enqueue()` and `close()`. Both are used here as response bodies pumped from the request body.
- `clone()` on a Request or Response tees the body into two branches. The tests consume both, and the pump block takes the clone's reader and abandons it, so one branch draining while the other stays locked is exercised.
- `describe.concurrent` interleaves a block's tests on the same JS thread that runs the server, which is why each request has to carry its own configuration, and why it is only a small part of the speedup.

<details>
<summary>Original description</summary>

`test/js/web/fetch/body-stream.test.ts` is one of the slowest non-integration files in the repo: 82s on debian 13 x64-asan in build 92779. Test-only change; no `src/` changes.

### Why it was slow

The file registered **9086 tests**. The reader block alone was 8680 of them: `doClone x fastPath x withDelay` (8) x 7 sizes x ~17 body types x 5 consumption kinds, per transport. Measured on main with the local debug+ASAN build, a 1 byte round trip and a 1 MB round trip cost about the same (~13ms vs ~23ms per test, most of it fixed per-test overhead including a `server.reload()` per test), so the test count is the cost, not the bytes. The 17 body types are the multiplier, and they are independent of everything else in the matrix. The chain to check: `fetch(url, { body })` goes through `HTTPRequestBody::from_js` (`src/runtime/webcore/fetch/FetchTasklet.rs:213`) into `Body::Value::from_js` (`src/runtime/webcore/Body.rs:936`), which for every typed array, `DataView` and `ArrayBuffer` calls `as_array_buffer` and copies `byte_slice()` into an `InternalBlob`. The per-type handling is the single switch in `JSC__JSValue__asArrayBuffer` (`src/jsc/bindings/bindings.cpp:3406`): one arm for all views (`vector()` + `byteLength()`, which is where byteOffset/length are applied and what the subarray variants exercise) and one for `ArrayBuffer`. A `Blob` body takes the separate `Value::Blob` arm, and it stays in the body-types block as its own variant. `fetch(new Request(...))` reuses the body the Request constructor already converted the same way (`src/runtime/webcore/fetch.rs:1280`); that call form is covered by the serialization block. Past that point the body is bytes, so nothing on the server side can tell the types apart, which is why the types now run once per source size and the modes run with one type.

### What the file does now

One `Bun.serve` per transport handles every test. The request carries its server-side configuration in an `x-config` header, the handler reports what it saw (headers, and for the buffered kinds the type/size/sha1 of every branch it consumed) in an `x-server` header, and each test is one `toEqual` over `{ status, response headers, server report per branch, client body per branch }`. That removes the per-test `server.reload()`, the `expect()` calls inside the server handler, and the shared `called` / `controller` variables, which is what makes the blocks safe to run under `describe.concurrent`.

Coverage mapping, per transport (same for http/1.1 and http/3):

| before | after |
|---|---|
| direct stream flush test (`Bun.sleep(1)` between `write` and `end`) | same scenario, but `pull()` waits until the client has actually received the chunk, and the test asserts the chunk arrived before `end()` (stronger than the sleep, which passed even if nothing was flushed early) |
| "not returning a promise" test, registered twice (the `doClone` loop did not use `doClone`) | registered once, also asserts the status |
| mixins: `clone x fastPath x useRequestObject x 5 mixins x 5 inputs` = 200 | `clone x touchBody x 5 mixins x {short, long latin1, long utf-8}` = 60. Every mixin still runs in every clone/touchBody combination, still as one request followed by a concurrent batch (batch of 3 instead of 5: one reused keep-alive connection plus fresh ones is what the batch exercises). The ArrayBuffer and Buffer inputs were dropped from this block because they put the same bytes on the wire as the string input. |
| (the client-side half of the above) | `fetch(url, init)` / `fetch(new Request({ url, ... }))` x 6 inputs = 12: the old string / ArrayBuffer / Buffer / long Buffer inputs through both call forms, plus a new long UTF-16 *string* body (the old long inputs were all sent as Buffers, so string bodies were only ever 13 bytes of latin1). |
| reader kind: `clone x fastPath x withDelay` x sizes x ~17 types | `clone x touchBody x defer` x all sizes with one body = 56 (h3: 48) |
| streaming back: `clone x fastPath x withDelay x direct/default x begin/end` x sizes x ~17 types | `direct/default x clone x touchBody x defer x lateReader` x all sizes with one body = 224 (h3: 192). The full mode cross product is kept at every size; only the body-type multiplier is gone. With `clone`, the clone's reader is still taken and abandoned while the original is pumped, as before. |
| body types x everything | 18 BodyInit variants x 4 source sizes against a plain reader = 66. Sizes are 1 (single-element views; offset views are empty and skipped, as before), 2 (smallest source where every offset view is non-empty), 95, and the largest row viewed in place (the old 1 MB shape, now also exercised over http/3 at 64 KB). |

Flag names: `fastPath` became `touchBody` (it reads `.body` before consuming so the consume goes through the ReadableStream conversion), `withDelay` became `defer` (it was always a microtask, never a timer), `position: end` became `lateReader`. Each flag does exactly what it did before, on the same side; the comment above `Mode` spells it out.

Registered tests: 9086 before, 800 after. Nothing is skipped or `.todo`.

### Assertion changes

- Every round trip is compared as one structure: status, the response headers that are deterministic for that kind, the server's per-branch report (headers it received including the user-agent fetch() adds, result type, size, sha1), and the per-branch client body (exact text for the mixin block, size + sha1 for the binary blocks). With `clone`, the two branches are separate entries in the compared arrays on both sides.
- The mixin block now asserts what each mixin returned (`ArrayBuffer` / `Uint8Array` / `Blob` / `string`); before, the type was only implied by which `instanceof` branch happened to run.
- `content-length` is asserted on every buffered response (mixins and the Blob echo). It is deliberately not asserted for the pumped stream responses: whether those go out with a content-length or chunked depends on the size and on whether the request body had already arrived when the headers were flushed (a 1 byte body gets a content-length, 1024 bytes gets chunked), so asserting it would be timing dependent. It was not asserted there before either.
- Server-side failures now come back as a 500 carrying the error, which the client turns into the test failure, instead of an `expect()` throwing inside the handler.
- Bodies are non-repeating. The old `fillRepeating(bytes, 0, bytes.length)` call was a no-op (`p` starts at `len`), so every body past byte 256 was zeros and a reordered or duplicated chunk in the MB rows would not have changed the hash.
- The two `subarray(0, X.byteLength - 1)` variants clamped to the full view (byteLength is twice or four times the element count), so they duplicated the full-view variants; they now shorten the view, and a `subarray(1, -1)` variant (offset and shortened) is added.
- No `Bun.sleep` left in the file.

### Verification

Same machine, same debug+ASAN build (`bun bd test test/js/web/fetch/body-stream.test.ts`), runs back to back:

| | tests | bun-reported | wall |
|---|---|---|---|
| main (9a543cc18f) | 9086 | 186.5s (earlier run: 194.3s) | 3m08s |
| this branch | 800 | 22.4s / 25.7s / 24.6s | 24s to 27s |

On CI, the debian 13 x64-asan lane of build 93100 (this PR's first run) reports `Ran 800 tests across 1 file. [2.92s]` for the file, against the 82s in build 92779 that prompted this.

Of the ~23s locally, about 4.3s is `bun test` startup plus collection (a one-test file importing `harness` takes 3.4s on this build). `describe.concurrent` is only a small win here because the server and the client share the JS thread: two serial runs of the new file came in at 23.3s and 24.2s against 20.9s and 22.6s concurrent, so it is kept but it is not where the speedup comes from.

The committed file passed 4 of 4 local runs; the functionally identical iterations before it passed another 7 (3 of those with `describe.concurrent` swapped for `describe`). Two mutations were run to check the assertions are live: dropping the last byte of each chunk in the server's pump fails exactly the 416 pumped-stream tests, and computing the expected digest over the whole backing buffer instead of the view fails exactly the partial-view variants.

<details>
<summary>Per-block timing of the new file (serial run, so the per-test numbers are real)</summary>

```
http/1.1 > request.body pumped into the response stream    n=224  4.6s  avg 20.7ms
http/3   > Request body mixins                             n= 60  3.5s  avg 59.1ms  (4 round trips each)
http/3   > request.body pumped into the response stream    n=192  3.4s  avg 17.5ms
http/1.1 > Request body mixins                             n= 60  2.9s  avg 48.2ms
http/3   > request body serialization                      n= 78  1.5s  avg 19.6ms
http/1.1 > request body serialization                      n= 78  1.5s  avg 18.8ms
http/1.1 > getReader() read to the end, echoed as a Blob   n= 56  1.1s  avg 20.1ms
http/3   > getReader() read to the end, echoed as a Blob   n= 48  0.9s  avg 17.9ms
direct stream responses (2 per transport)                  n=  4  0.3s
```
</details>




</details>
