### PR TITLE
sql: accept the documented `socket` option and `?socket=` as aliases of `path`

### DIFF
--- a/docs/runtime/sql.mdx
+++ b/docs/runtime/sql.mdx
@@ -121,8 +121,8 @@ new SQL("mysql2://user:pass@localhost:3306/database");
 // With query parameters
 new SQL("mysql://user:pass@localhost/db?ssl=true");
 
-// Unix socket connection
-new SQL("mysql://user:pass@/database?socket=/var/run/mysqld/mysqld.sock");
+// Unix socket connection (the host is ignored when a socket is given)
+new SQL("mysql://user:pass@localhost/database?socket=/var/run/mysqld/mysqld.sock");
 ```
 
 </Accordion>
@@ -613,7 +613,7 @@ const sql = new SQL({
   username: "dbuser",
   password: "secretpass",
 
-  // Unix socket connection (alternative to hostname/port)
+  // Unix socket connection (alternative to hostname/port; `path` is accepted as an alias)
   // socket: "/var/run/mysqld/mysqld.sock",
 
   // Connection pool settings

--- a/packages/bun-types/sql.d.ts
+++ b/packages/bun-types/sql.d.ts
@@ -336,10 +336,24 @@ declare module "bun" {
       ssl?: Bun.BunFile | TLSOptions | boolean | undefined;
 
       /**
-       * Unix domain socket path for connection
+       * Unix domain socket to connect through instead of TCP. When it is set,
+       * {@link hostname} and {@link port} are not used to connect. For
+       * PostgreSQL it may also be the directory containing the server's
+       * `.s.PGSQL.<port>` socket. If the path does not exist when the client is
+       * created, it is ignored and a TCP connection is made instead. Can also be
+       * given as the `?path=` query parameter of the connection URL.
        * @default undefined
        */
       path?: string | undefined;
+
+      /**
+       * Unix domain socket to connect through instead of TCP (alias for
+       * {@link path}, matching the `socket` option of the MySQL client tools).
+       * Can also be given as the `?socket=` query parameter of the connection
+       * URL.
+       * @default undefined
+       */
+      socket?: string | undefined;
 
       /**
        * Called when a connection attempt completes.

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1779,9 +1779,8 @@ function parseOptions(
   let path: string;
   let prepare: boolean = true;
 
-  // In postgres.js configs `socket` is a function that creates a custom socket;
-  // only a string is the unix socket path alias.
-  const socketOption = typeof options.socket === "string" ? options.socket : undefined;
+  // postgres.js configs use `socket` for a socket factory function, which is not a path.
+  const socketPath = typeof options.socket === "string" ? options.socket : undefined;
 
   if (url !== null) {
     url = url instanceof URL ? url : new URL(url);
@@ -1821,7 +1820,7 @@ function parseOptions(
     }
     query = query.trim();
 
-    path ||= pathParam || socketParam || options.path || socketOption || (url.hostname ? "" : url.pathname);
+    path ||= pathParam || socketParam || options.path || socketPath || (url.hostname ? "" : url.pathname);
   }
 
   switch (adapter) {
@@ -1854,7 +1853,7 @@ function parseOptions(
     }
   }
 
-  path ||= options.path || socketOption || "";
+  path ||= options.path || socketPath || "";
 
   if (adapter === "postgres") {
     // add /.s.PGSQL.${port} if the unix domain socket is listening on that path

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1791,15 +1791,18 @@ function parseOptions(
     username ||= options.user || options.username || decodeIfValid(url.username);
     password ||= options.pass || options.password || decodeIfValid(url.password);
 
-    path ||= options.path || options.socket || (url.hostname ? "" : url.pathname);
+    let pathParam: string | undefined;
+    let socketParam: string | undefined;
 
     const queryObject = url.searchParams.toJSON();
     for (const key in queryObject) {
       const lowerKey = key.toLowerCase();
       if (lowerKey === "sslmode") {
         sslMode = normalizeSSLMode(queryObject[key]);
-      } else if (lowerKey === "path" || lowerKey === "socket") {
-        path = queryObject[key];
+      } else if (lowerKey === "path") {
+        pathParam = queryObject[key];
+      } else if (lowerKey === "socket") {
+        socketParam = queryObject[key];
       } else {
         // this is valid for postgres for other databases it might not be valid
         // check adapter then implement for other databases
@@ -1813,6 +1816,8 @@ function parseOptions(
       }
     }
     query = query.trim();
+
+    path ||= pathParam || socketParam || options.path || options.socket || (url.hostname ? "" : url.pathname);
   }
 
   switch (adapter) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1779,6 +1779,10 @@ function parseOptions(
   let path: string;
   let prepare: boolean = true;
 
+  // In postgres.js configs `socket` is a function that creates a custom socket;
+  // only a string is the unix socket path alias.
+  const socketOption = typeof options.socket === "string" ? options.socket : undefined;
+
   if (url !== null) {
     url = url instanceof URL ? url : new URL(url);
   }
@@ -1817,7 +1821,7 @@ function parseOptions(
     }
     query = query.trim();
 
-    path ||= pathParam || socketParam || options.path || options.socket || (url.hostname ? "" : url.pathname);
+    path ||= pathParam || socketParam || options.path || socketOption || (url.hostname ? "" : url.pathname);
   }
 
   switch (adapter) {
@@ -1850,7 +1854,7 @@ function parseOptions(
     }
   }
 
-  path ||= options.path || options.socket || "";
+  path ||= options.path || socketOption || "";
 
   if (adapter === "postgres") {
     // add /.s.PGSQL.${port} if the unix domain socket is listening on that path

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1791,13 +1791,14 @@ function parseOptions(
     username ||= options.user || options.username || decodeIfValid(url.username);
     password ||= options.pass || options.password || decodeIfValid(url.password);
 
-    path ||= options.path || (url.hostname ? "" : url.pathname);
+    path ||= options.path || options.socket || (url.hostname ? "" : url.pathname);
 
     const queryObject = url.searchParams.toJSON();
     for (const key in queryObject) {
-      if (key.toLowerCase() === "sslmode") {
+      const lowerKey = key.toLowerCase();
+      if (lowerKey === "sslmode") {
         sslMode = normalizeSSLMode(queryObject[key]);
-      } else if (key.toLowerCase() === "path") {
+      } else if (lowerKey === "path" || lowerKey === "socket") {
         path = queryObject[key];
       } else {
         // this is valid for postgres for other databases it might not be valid
@@ -1844,7 +1845,7 @@ function parseOptions(
     }
   }
 
-  path ||= options.path || "";
+  path ||= options.path || options.socket || "";
 
   if (adapter === "postgres") {
     // add /.s.PGSQL.${port} if the unix domain socket is listening on that path

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -2,11 +2,13 @@ import { SQL } from "bun";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { isWindows, tempDir } from "harness";
 import { unlinkSync } from "js/node/fs/export-star-from";
+import { join } from "node:path";
 
 declare module "bun" {
   namespace SQL {
     export interface PostgresOrMySQLOptions {
       sslMode?: number;
+      query?: string;
     }
   }
 }
@@ -424,6 +426,64 @@ describe("SQL adapter environment variable precedence", () => {
       expect(options.options.path).toBe("/tmp/thisisacoolmysql.sock");
 
       unlinkSync(sock.unix);
+    });
+
+    // parseOptions only keeps a socket path that exists on disk, so these point
+    // at a file in a temp dir; for option parsing a regular file is enough.
+    describe("unix socket option", () => {
+      const adapters: Array<"postgres" | "mysql" | "mariadb"> = ["postgres", "mysql", "mariadb"];
+
+      test.each(adapters)("%s: `socket` selects the unix socket", adapter => {
+        using dir = tempDir("sql-socket-option", { "db.sock": "" });
+        const sock = join(String(dir), "db.sock");
+
+        const options = new SQL({ adapter, socket: sock });
+        expect(options.options.path).toBe(sock);
+      });
+
+      test.each(adapters)("%s: `socket` option combines with a connection string", adapter => {
+        using dir = tempDir("sql-socket-option-url", { "db.sock": "" });
+        const sock = join(String(dir), "db.sock");
+
+        const options = new SQL(`${adapter}://user:pass@dbhost/appdb`, { socket: sock });
+        expect({
+          adapter: options.options.adapter,
+          hostname: options.options.hostname,
+          username: options.options.username,
+          path: options.options.path,
+        }).toEqual({ adapter, hostname: "dbhost", username: "user", path: sock });
+      });
+
+      test.each([
+        ["postgres", "path"],
+        ["postgres", "socket"],
+        ["mysql", "path"],
+        ["mysql", "socket"],
+        ["mariadb", "path"],
+        ["mariadb", "socket"],
+      ] as const)("%s: ?%s= in the connection string selects the unix socket", (adapter, key) => {
+        using dir = tempDir("sql-socket-query", { "db.sock": "" });
+        const sock = join(String(dir), "db.sock");
+
+        const options = new SQL(`${adapter}://user:pass@localhost/appdb?${key}=${sock}`);
+        expect({
+          adapter: options.options.adapter,
+          path: options.options.path,
+          // Unknown query keys are forwarded to the server (postgres startup
+          // parameters / mysql connection attributes); the socket key must not be.
+          query: options.options.query,
+        }).toEqual({ adapter, path: sock, query: "" });
+      });
+
+      test("`path` wins when both `path` and `socket` are given", () => {
+        using dir = tempDir("sql-socket-both", { "a.sock": "", "b.sock": "" });
+        const options = new SQL({
+          adapter: "mysql",
+          path: join(String(dir), "a.sock"),
+          socket: join(String(dir), "b.sock"),
+        });
+        expect(options.options.path).toBe(join(String(dir), "a.sock"));
+      });
     });
 
     test.skipIf(isWindows)("postgres URL with a host uses the pathname as the database name, not a socket path", () => {

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -485,6 +485,17 @@ describe("SQL adapter environment variable precedence", () => {
         expect(options.options.path).toBe(join(String(dir), "a.sock"));
       });
 
+      // postgres.js uses `socket` for a custom socket factory; configs carrying
+      // one must keep connecting over TCP instead of being read as a path.
+      test.each(adapters)("%s: a non-string `socket` is ignored", adapter => {
+        // @ts-expect-error deliberately not a string
+        const options = new SQL({ adapter, hostname: "dbhost", socket: () => null });
+        expect({ hostname: options.options.hostname, path: options.options.path }).toEqual({
+          hostname: "dbhost",
+          path: undefined,
+        });
+      });
+
       test.each([
         ["?path=A&socket=B", (a: string, b: string) => `?path=${a}&socket=${b}`],
         ["?socket=B&path=A", (a: string, b: string) => `?socket=${b}&path=${a}`],

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -484,6 +484,17 @@ describe("SQL adapter environment variable precedence", () => {
         });
         expect(options.options.path).toBe(join(String(dir), "a.sock"));
       });
+
+      test.each([
+        ["?path=A&socket=B", (a: string, b: string) => `?path=${a}&socket=${b}`],
+        ["?socket=B&path=A", (a: string, b: string) => `?socket=${b}&path=${a}`],
+      ])("?path= wins over ?socket= regardless of order (%s)", (_, search) => {
+        using dir = tempDir("sql-socket-both-query", { "a.sock": "", "b.sock": "" });
+        const a = join(String(dir), "a.sock");
+        const b = join(String(dir), "b.sock");
+        const options = new SQL(`mysql://user:pass@localhost/appdb${search(a, b)}`);
+        expect(options.options.path).toBe(a);
+      });
     });
 
     test.skipIf(isWindows)("postgres URL with a host uses the pathname as the database name, not a socket path", () => {

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -1,13 +1,25 @@
 import { SQL, randomUUIDv7 } from "bun";
 import { beforeAll, describe, expect, mock, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, describeWithContainer, isDockerEnabled, tempDirWithFiles } from "harness";
+import {
+  bunEnv,
+  bunExe,
+  bunRun,
+  describeWithContainer,
+  isDockerEnabled,
+  isWindows,
+  tempDir,
+  tempDirWithFiles,
+} from "harness";
+import net from "node:net";
 import path from "path";
 import {
+  closedPort,
   listeningServer,
   mysqlColumnDefinition,
   mysqlHandshakeV10,
   mysqlLenencInt,
   mysqlOkPacket,
+  mysqlParseHandshakeResponse41,
   mysqlRawPacket,
   mysqlReadPackets,
   mysqlStmtPrepareOk,
@@ -1275,4 +1287,52 @@ test("MySQL: binary TIME with a very large days field formats without integer wr
   } finally {
     await new Promise<void>(r => server.close(() => r()));
   }
+});
+
+// The containers only expose TCP, so a scripted server listening on a unix
+// socket stands in for mysqld; it only has to answer the handshake. Skipped on
+// Windows: net.Server.listen(path) is a named pipe there, so no socket file
+// exists on disk, and parseOptions only honors a socket path that exists.
+describe.skipIf(isWindows)("MySQL: unix socket", () => {
+  test.concurrent.each([
+    [
+      "the `socket` option",
+      (sock: string, port: number) =>
+        new SQL({ adapter: "mysql", socket: sock, hostname: "127.0.0.1", port, username: "socket_user", max: 1 }),
+    ],
+    [
+      "?socket= in the connection string",
+      (sock: string, port: number) => new SQL(`mysql://socket_user@127.0.0.1:${port}/db?socket=${sock}`, { max: 1 }),
+    ],
+  ])("connects over the unix socket given as %s", async (_, connect) => {
+    using dir = tempDir("sql-mysql-unix-socket", {});
+    const sock = path.join(String(dir), "mysqld.sock");
+    const handshakeUsernames: string[] = [];
+    const server = net.createServer(socket => {
+      let buffered: Buffer = Buffer.alloc(0);
+      socket.write(mysqlHandshakeV10());
+      socket.on("data", (chunk: Buffer) => {
+        buffered = mysqlReadPackets(Buffer.concat([buffered, chunk]), (seq, payload) => {
+          if (handshakeUsernames.length === 0) {
+            handshakeUsernames.push(mysqlParseHandshakeResponse41(payload).username);
+            socket.write(mysqlOkPacket(seq + 1));
+          } else {
+            socket.end();
+          }
+        });
+      });
+      socket.on("error", () => {});
+    });
+    await new Promise<void>(resolve => server.listen(sock, resolve));
+
+    try {
+      // hostname/port name a TCP port nothing listens on: with a socket
+      // configured they must not be used, so connecting there is the failure.
+      await using sql = connect(sock, await closedPort());
+      await sql.connect();
+      expect(handshakeUsernames).toEqual(["socket_user"]);
+    } finally {
+      await new Promise<void>(resolve => server.close(() => resolve()));
+    }
+  });
 });

--- a/test/js/sql/sql-mysql.test.ts
+++ b/test/js/sql/sql-mysql.test.ts
@@ -10,6 +10,7 @@ import {
   tempDir,
   tempDirWithFiles,
 } from "harness";
+import { once } from "node:events";
 import net from "node:net";
 import path from "path";
 import {
@@ -1323,7 +1324,8 @@ describe.skipIf(isWindows)("MySQL: unix socket", () => {
       });
       socket.on("error", () => {});
     });
-    await new Promise<void>(resolve => server.listen(sock, resolve));
+    server.listen(sock);
+    await once(server, "listening");
 
     try {
       // hostname/port name a TCP port nothing listens on: with a socket


### PR DESCRIPTION
### Problem
- The `Bun.SQL` docs show two ways to reach MySQL over a unix socket, the `socket:` option and a `?socket=` URL key. Neither works on main; only `path` and `?path=` are read.
- `socket:` is silently ignored and the client connects over TCP to `hostname:port` instead. With a server on 3306 this shows up as a misleading `Access denied`, which is what the reporter of #26195 hit.
- `?socket=` is treated like any other unknown query key and forwarded to the server as a connection parameter.
- The documented URL form `mysql://user:pass@/database?...` throws `ERR_INVALID_URL` before any option parsing: the URL parser rejects credentials followed by an empty host.

### Fix
- Option parsing accepts `socket` and `?socket=` as aliases of `path` and `?path=`, for postgres, mysql and mariadb alike, since `path` already applies to all three. A non-string `socket` (a postgres.js socket factory) stays ignored as before.
- Precedence is `?path=`, `?socket=`, `path`, `socket`, then the pathname of a host-less URL, so `path` beats `socket` in both the options object and the URL whatever order the query keys come in. `unix://` URLs and the fall back to TCP when the path does not exist on disk are unchanged.
- The types now declare `socket` and describe what `path` does, and the docs URL example gains a host so it parses (the host is ignored once a socket is set), so docs, types and runtime agree.
- Verification: option-parsing tests per adapter, plus two end-to-end MySQL tests against a scripted server on a unix socket while `hostname:port` name a closed TCP port. Without the parser change 9 parsing tests fail and both end-to-end tests fail with `ERR_MYSQL_CONNECTION_REFUSED`.

### Background
- `Bun.SQL` takes an optional connection URL plus one options object shared by the postgres, mysql and mariadb adapters; a single parser merges URL parts, query keys, options and env vars into what `sql.options` reports.
- `path` is the existing way to connect over a unix domain socket instead of TCP. It can also come from `?path=` or from the pathname of a URL with no host, and since #22048 a path that does not exist on disk is dropped in favour of TCP.
- Query keys the parser does not recognise are not errors: they are passed through to the server as postgres startup parameters or MySQL connection attributes.
- Bun.SQL mirrors postgres.js option names, and in postgres.js `socket` is a custom socket factory function, not a path.

<details>
<summary>Original description</summary>

### What does this PR do?

`docs/runtime/sql.mdx` documents two ways to reach MySQL over a unix socket:

```ts
new SQL({ adapter: "mysql", socket: "/var/run/mysqld/mysqld.sock", username, password, database });
new SQL("mysql://user:pass@/database?socket=/var/run/mysqld/mysqld.sock");
```

Neither works on main. `parseOptions` in `src/js/internal/sql/shared.ts` only reads `path` (the option) and `?path=` (the URL query key), so:

- `socket:` is silently ignored and the client connects over TCP to `hostname:port` instead. With a server on 3306 this surfaces as a confusing `Access denied` from the TCP listener; this is what the reporter of #26195 was running into alongside the auth bug fixed there (their repro uses `socket:` from the docs).
- `?socket=` is not recognized either, and like every other unknown query key it is forwarded to the server (MySQL connection attribute `socket=/...`, or an unknown PostgreSQL startup parameter).
- The documented URL form `mysql://user:pass@/database?...` cannot work at all: the WHATWG URL parser rejects credentials followed by an empty host, so it throws `ERR_INVALID_URL` before any option parsing happens.

`packages/bun-types/sql.d.ts` only declares `path`, so docs, types and implementation all disagreed.

### Fix

`parseOptions` now reads `options.socket` and the `?socket=` query key as aliases of `path` / `?path=`. With a connection string the socket path is resolved in one chain, `?path=`, then `?socket=`, then `options.path`, then `options.socket`, then the pathname of a host-less (`unix://`) URL, so `path` wins over `socket` in both the options object and the URL, independent of the order of the query keys; without a connection string it is `options.path || options.socket` as before. The alias applies to postgres, mysql and mariadb alike because `path` already does and the three adapters share one options object; there is no adapter for which a socket path is meaningless. The existing behavior is otherwise unchanged: `?path=` still wins over the options object as before, `unix://` URLs still work, and a socket path that does not exist on disk still falls back to TCP (the pre-existing rule from #22048).

Only a string `socket` is taken as a path. postgres.js, whose option names Bun.SQL mirrors, uses `socket` for a custom socket factory function; Bun has always ignored that key in such configs, and it keeps ignoring it (previously the alias would have fed the function into the postgres `.s.PGSQL` suffix check and thrown at construction).

The `socket` name itself is the one the docs have advertised (and the one MySQL's own tooling uses), so the fix is to make the documented spelling work rather than to rename it in the docs; `path` stays the canonical field (it is what `sql.options.path` reports and what postgres.js users expect). Two names for one setting follows the existing `hostname`/`host`, `username`/`user`, `tls`/`ssl` pattern in the same function.

Also in this PR, so that docs, types and runtime agree:

- `bun-types`: declare `socket?: string` and describe what `path` actually does (hostname/port unused, postgres directory form, `?path=` / `?socket=` query keys, fallback to TCP when the path does not exist).
- docs: the URL example now uses a host (`mysql://user:pass@localhost/database?socket=...`), which parses; the host is ignored once a socket is configured.

### Tests

`test/js/sql/adapter-env-var-precedence.test.ts` (option parsing, all platforms): `socket:` for each adapter, `socket:` combined with a connection string, `?path=` and `?socket=` for each adapter (also asserting the key is no longer forwarded in `query`), `path` winning over `socket` in the options object, `?path=` winning over `?socket=` in either order, and a function-valued `socket` (postgres.js style) being ignored for each adapter.

`test/js/sql/sql-mysql.test.ts` (end to end, posix): a scripted server listening on a unix socket answers the handshake; the client is created with `socket:` (and, in a second case, `?socket=`) plus a hostname/port that point at a TCP port nothing listens on, and the test asserts the HandshakeResponse for the configured user arrived on the unix socket.

Without the `shared.ts` change, 9 of the parsing tests fail (`path` is `undefined`) and both end-to-end tests fail with `ERR_MYSQL_CONNECTION_REFUSED` from the TCP attempt; with it, both files pass (77 tests). The `bun-types` integration test passes with the `.d.ts` change.

While here I noticed (and left alone, tracked separately) that `PGDATABASE` / `MYSQL_DATABASE` take precedence over the database named in an explicit connection URL, unlike host, port, user and password.

</details>
