### PR TITLE
shell: report the spawned command's exit code when argv comes from a sole $(...)

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -26,7 +26,14 @@ pub struct Cmd {
     pub(crate) redirection_file: Vec<u8>,
     pub(crate) redirection_fd: Option<*mut CowFd>,
     pub(crate) exec: Exec,
+    /// `Some` once the exec has reported (or a read error / expansion failure
+    /// ended the command early). `has_finished` and
+    /// `ShellSubprocess::on_process_exit` key off it, so it must stay `None`
+    /// until the exec starts.
     pub(crate) exit_code: Option<ExitCode>,
+    /// Status of a sole `$(...)` argv atom: the command's status when it
+    /// expands to no words (POSIX 2.9.1), ignored once something runs.
+    cmd_subst_exit_code: ExitCode,
 }
 
 #[derive(Default, strum::IntoStaticStr)]
@@ -216,6 +223,7 @@ impl Cmd {
             redirection_fd: None,
             exec: Exec::None,
             exit_code: None,
+            cmd_subst_exit_code: 0,
         }))
     }
 
@@ -342,31 +350,14 @@ impl Cmd {
             match interp.as_cmd_mut(this).state {
                 CmdState::ExpandingArgs { ref mut idx } => {
                     *idx += 1;
-                    let new_idx = *idx;
-                    // When the sole
-                    // `name_and_args` atom is a `.simple == .cmd_subst`, stash
-                    // `e.out_exit_code` so an empty-argv command consisting
-                    // only of `$(cmd)` propagates `cmd`'s exit code via the
-                    // empty-argv0 branch in `transition_to_exec` (POSIX: "if
-                    // there is no command name, but the command contained a
-                    // command substitution, the command shall complete with
-                    // the exit status of the last command substitution
-                    // performed").
+                    let me = interp.as_cmd_mut(this);
+                    if let [ast::Atom::Simple(ast::SimpleAtom::CmdSubst(_))] =
+                        me.ast_node().name_and_args
                     {
-                        let n = interp.as_cmd(this).ast_node();
-                        if new_idx == 1
-                            && n.name_and_args.len() == 1
-                            && matches!(
-                                n.name_and_args[0],
-                                ast::Atom::Simple(ast::SimpleAtom::CmdSubst(_))
-                            )
-                        {
-                            interp.as_cmd_mut(this).exit_code = Some(out.out_exit_code);
-                        }
+                        me.cmd_subst_exit_code = out.out_exit_code;
                     }
                     // `out.bounds` splits the expansion into multiple argv
                     // words (glob/IFS).
-                    let me = interp.as_cmd_mut(this);
                     if out.bounds.is_empty() {
                         // An empty
                         // expansion that did *not* see a `""` literal pushes
@@ -416,9 +407,8 @@ impl Cmd {
             }
         }
 
-        // Empty/null argv[0] → exit
-        // with the exit code from a sole command-substitution (stashed by
-        // `child_done` from `Expansion::out_exit_code`), else 0.
+        // Empty/null argv[0] → nothing to run; the command's status is that
+        // of its sole command substitution, if any (else 0).
         let first_arg: Vec<u8> = {
             let me = interp.as_cmd(this);
             match me.args.first() {
@@ -427,7 +417,7 @@ impl Cmd {
                     a[..a.len() - 1].to_vec()
                 }
                 _ => {
-                    let exit = me.exit_code.unwrap_or(0);
+                    let exit = me.cmd_subst_exit_code;
                     let parent = me.base.parent;
                     return interp.child_done(parent, this, exit);
                 }

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -26,13 +26,9 @@ pub struct Cmd {
     pub(crate) redirection_file: Vec<u8>,
     pub(crate) redirection_fd: Option<*mut CowFd>,
     pub(crate) exec: Exec,
-    /// `Some` once the exec has reported (or a read error / expansion failure
-    /// ended the command early). `has_finished` and
-    /// `ShellSubprocess::on_process_exit` key off it, so it must stay `None`
-    /// until the exec starts.
+    /// `Some` means the exec has reported (`has_finished`, `on_process_exit`).
     pub(crate) exit_code: Option<ExitCode>,
-    /// Status of a sole `$(...)` argv atom: the command's status when it
-    /// expands to no words (POSIX 2.9.1), ignored once something runs.
+    /// Status of a sole `$(...)` argv atom; used only if it expands to no words.
     cmd_subst_exit_code: ExitCode,
 }
 
@@ -407,8 +403,7 @@ impl Cmd {
             }
         }
 
-        // Empty/null argv[0] → nothing to run; the command's status is that
-        // of its sole command substitution, if any (else 0).
+        // Empty/null argv[0] → nothing to run.
         let first_arg: Vec<u8> = {
             let me = interp.as_cmd(this);
             match me.args.first() {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -556,6 +556,11 @@ describe("bunshell", () => {
       .exitCode(0)
       .runAsTest("failing substitution does not override the command's exit code");
 
+    TestBuilder.command`$(echo ${BUN} exit7.js) || echo fallback`
+      .file("exit7.js", exit7)
+      .stdout("ran\nfallback\n")
+      .runAsTest("external command's exit code drives ||");
+
     TestBuilder.command`$(echo false)`.exitCode(1).runAsTest("builtin");
 
     TestBuilder.command`$(echo; exit 3)`

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -524,6 +524,45 @@ describe("bunshell", () => {
     TestBuilder.command`FOO="" $FOO`.runAsTest("empty var");
   });
 
+  // When `$(...)` is the only word of a command and expands to a command
+  // line, the exit code is that of the command it expanded to, not the
+  // substitution's (bash: `$(echo ./exit7.sh); echo $?` prints 7).
+  describe("cmd subst expanding to the whole command", () => {
+    const exit7 = "console.log('ran'); process.exit(7);";
+
+    TestBuilder.command`$(echo ${BUN} exit7.js)`
+      .file("exit7.js", exit7)
+      .stdout("ran\n")
+      .exitCode(7)
+      .runAsTest("external command");
+
+    TestBuilder.command`$(echo ${BUN} exit7.js) > out.txt`
+      .file("exit7.js", exit7)
+      .fileEquals("out.txt", "ran\n")
+      .exitCode(7)
+      .runAsTest("external command with stdout redirected");
+
+    // With both streams redirected nothing is piped back to the shell, so the
+    // command can only finish through the process exit notification.
+    TestBuilder.command`$(echo ${BUN} exit7.js) &> out.txt`
+      .file("exit7.js", exit7)
+      .fileEquals("out.txt", "ran\n")
+      .exitCode(7)
+      .runAsTest("external command with stdout and stderr redirected");
+
+    TestBuilder.command`$(echo ${BUN} ok.js; exit 5)`
+      .file("ok.js", "console.log('ran');")
+      .stdout("ran\n")
+      .exitCode(0)
+      .runAsTest("failing substitution does not override the command's exit code");
+
+    TestBuilder.command`$(echo false)`.exitCode(1).runAsTest("builtin");
+
+    TestBuilder.command`$(echo; exit 3)`
+      .exitCode(3)
+      .runAsTest("substitution expanding to nothing keeps its own exit code");
+  });
+
   describe("tilde_expansion", () => {
     describe("with paths", async () => {
       TestBuilder.command`echo ~/Documents`.stdout(`${process.env.HOME}/Documents\n`).runAsTest("normal");


### PR DESCRIPTION
### Problem
- In Bun Shell, `$(echo ./exit7.sh)` reports exit code 0 when the script exits 7, and `$(echo /bin/true; exit 5)` reports 5 instead of 0. bash reports 7 and 0.
- `$(echo ./exit7.sh) &> out.txt` never resolves.
- Only a command that is a single `$(...)` word expanding to an external command is affected. Builtins overwrite the exit code and are fine.
- Cause: the substitution's status was stored in the field that also means "the process has already reported", so the real status was ignored, and with nothing piped back to the shell nothing ever finished the command.

### Fix
- The substitution's status gets its own field, read only when the expansion produced no command name (POSIX 2.9.1). `$(exit 3)` still reports 3.
- Property to check: the exit-code field stays unset until a builtin or the subprocess reports, which is what the finish and process-exit paths assume.
- Verification: new shell tests. Without the fix the external-command cases report 0, the `&>` case times out, and the failing-substitution case reports 5. The builtin and empty-expansion cases already passed.

### Background
- Command substitution: `$(cmd)` runs `cmd` and splices its stdout into the command line as words, so `$(echo ./x.sh)` becomes the command `./x.sh`.
- Each simple command in Bun Shell's Rust interpreter is a `Cmd` state: it expands its words one at a time, then runs a builtin or spawns a subprocess.
- A spawned command is finished once its exit code is recorded and its pipes back to the shell are closed. A file redirect removes the pipe, so only the process exit notification can finish it.
- The exit-code field doubles as an "already reported" flag: the process-exit handler leaves it alone when set, so a stdout/stderr read error wins over the process status.

<details>
<summary>Original description</summary>

### Repro

```ts
import { $ } from "bun";
// exit7.sh: #!/bin/sh
//           exit 7
console.log((await $`$(echo ./exit7.sh)`.nothrow()).exitCode);         // 0, expected 7
console.log((await $`$(echo ./exit7.sh) x`.nothrow()).exitCode);       // 7 (two words, works)
console.log((await $`$(echo /bin/true; exit 5)`.nothrow()).exitCode);  // 5, expected 0
await $`$(echo ./exit7.sh) &> out.txt`.nothrow();                      // never resolves
```

bash reports 7, 7, 0 for the first three (`$(echo ./exit7.sh); echo $?` prints 7): once a substitution expands to a command name, the status of the simple command is the status of the command that ran. The substitution's own status only counts when there is no command name at all (POSIX 2.9.1), which is `$(exit 3)` reporting 3 today.

Only the combination "the whole command is one `$(...)` word" and "it expands to an external command" is affected. Builtins are fine because `Builtin::done` overwrites the exit code unconditionally.

### Cause

`Cmd::child_done` (`src/runtime/shell/states/Cmd.rs`) stashed the substitution's status in `Cmd::exit_code` when the sole argv atom is a `$(...)`, so that the empty-argv branch of `transition_to_exec` could return it. When argv turned out to be non-empty the stash was left in place, and `exit_code.is_some()` is what the subprocess path uses to mean "the exec has already reported":

- `ShellSubprocess::on_process_exit` skips `Cmd::on_exit` when `exit_code` is already set (so that a stdout/stderr read error wins over the process status), so the real status was never recorded and the stale value was reported.
- `Cmd::has_finished` only checks `exit_code.is_some()` plus the piped stdio being closed, so with stdout/stderr captured the command "finished" as soon as the pipes closed, and with nothing piped (`&> file`, or a file redirect on both streams) nothing ever finished it, so the promise hung.

### Fix

Keep the substitution's status in its own `Cmd` field and read it only in the empty-argv branch. `exit_code` now stays `None` until the builtin or subprocess actually reports, which is the invariant `has_finished` and `on_process_exit` rely on. The empty-argv behavior (`$(exit 3)` reports 3) is unchanged.

### Tests

New cases in the `cmd subst expanding to the whole command` block of `test/js/bun/shell/bunshell.test.ts`. Against the current release the first two report 0 instead of 7, the third times out, and the fourth reports 5 instead of 0; the last two already pass and pin the builtin and empty-argv paths.

- `$(echo bun exit7.js)` with stdout/stderr captured: 7
- the same with `> out.txt` (stderr still piped): 7
- the same with `&> out.txt` (nothing piped): 7, and the command completes
- `$(echo bun ok.js; exit 5)`: 0
- `$(echo false)`: 1
- `$(echo; exit 3)`: 3

</details>
