### PR TITLE
sql: let the database named in a connection URL win over PGDATABASE and friends

### DIFF
--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1766,7 +1766,7 @@ function parseOptions(
   let port: number | string | undefined;
   let username: string | null | undefined;
   let password: string | (() => Bun.MaybePromise<string>) | undefined | null;
-  let database: string | undefined;
+  let database: string | null | undefined;
   let tls: Bun.TLSOptions | boolean | undefined;
   let query: string = "";
   let idleTimeout: number | null | undefined;
@@ -1790,6 +1790,12 @@ function parseOptions(
     port ||= options.port || url.port;
     username ||= options.user || options.username || decodeIfValid(url.username);
     password ||= options.pass || options.password || decodeIfValid(url.password);
+    // postgres://host/<database>: the pathname names the database and, like the
+    // fields above, outranks PGDATABASE and friends. Without a host the pathname
+    // is a socket path (below); the per-adapter switch still falls back to it last.
+    if (url.hostname) {
+      database ||= options.database || options.db || decodeIfValid(url.pathname.slice(1));
+    }
 
     path ||= options.path || (url.hostname ? "" : url.pathname);
 

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1813,11 +1813,7 @@ function parseOptions(
     }
     query = query.trim();
 
-    // The pathname names the database (postgres://host/db) and, like the fields
-    // above, outranks PGDATABASE and friends. The exception is a host-less URL
-    // whose pathname was taken as the socket path above and not replaced by
-    // options.path or ?path=; the per-adapter switch below still uses that as
-    // the last-resort database name it has always been.
+    // postgres://host/db names a database; a host-less pathname is the socket path taken above.
     const pathnameIsSocketPath = !url.hostname && path === url.pathname;
     if (!pathnameIsSocketPath) {
       database ||= options.database || options.db || decodeIfValid(url.pathname.slice(1));

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1791,7 +1791,14 @@ function parseOptions(
     username ||= options.user || options.username || decodeIfValid(url.username);
     password ||= options.pass || options.password || decodeIfValid(url.password);
 
-    path ||= options.path || (url.hostname ? "" : url.pathname);
+    let pathnameIsSocketPath = false;
+    if (options.path) {
+      path = options.path;
+    } else if (!url.hostname) {
+      // postgres:///run/postgresql: a host-less pathname is the socket path, not a database name.
+      path = url.pathname;
+      pathnameIsSocketPath = true;
+    }
 
     const queryObject = url.searchParams.toJSON();
     for (const key in queryObject) {
@@ -1799,6 +1806,7 @@ function parseOptions(
         sslMode = normalizeSSLMode(queryObject[key]);
       } else if (key.toLowerCase() === "path") {
         path = queryObject[key];
+        pathnameIsSocketPath = false;
       } else {
         // this is valid for postgres for other databases it might not be valid
         // check adapter then implement for other databases
@@ -1813,8 +1821,6 @@ function parseOptions(
     }
     query = query.trim();
 
-    // postgres://host/db names a database; a host-less pathname is the socket path taken above.
-    const pathnameIsSocketPath = !url.hostname && path === url.pathname;
     if (!pathnameIsSocketPath) {
       database ||= options.database || options.db || decodeIfValid(url.pathname.slice(1));
     }

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1790,12 +1790,6 @@ function parseOptions(
     port ||= options.port || url.port;
     username ||= options.user || options.username || decodeIfValid(url.username);
     password ||= options.pass || options.password || decodeIfValid(url.password);
-    // postgres://host/<database>: the pathname names the database and, like the
-    // fields above, outranks PGDATABASE and friends. Without a host the pathname
-    // is a socket path (below); the per-adapter switch still falls back to it last.
-    if (url.hostname) {
-      database ||= options.database || options.db || decodeIfValid(url.pathname.slice(1));
-    }
 
     path ||= options.path || (url.hostname ? "" : url.pathname);
 
@@ -1818,6 +1812,16 @@ function parseOptions(
       }
     }
     query = query.trim();
+
+    // The pathname names the database (postgres://host/db) and, like the fields
+    // above, outranks PGDATABASE and friends. The exception is a host-less URL
+    // whose pathname was taken as the socket path above and not replaced by
+    // options.path or ?path=; the per-adapter switch below still uses that as
+    // the last-resort database name it has always been.
+    const pathnameIsSocketPath = !url.hostname && path === url.pathname;
+    if (!pathnameIsSocketPath) {
+      database ||= options.database || options.db || decodeIfValid(url.pathname.slice(1));
+    }
   }
 
   switch (adapter) {

--- a/src/js/internal/sql/shared.ts
+++ b/src/js/internal/sql/shared.ts
@@ -1791,9 +1791,10 @@ function parseOptions(
     username ||= options.user || options.username || decodeIfValid(url.username);
     password ||= options.pass || options.password || decodeIfValid(url.password);
 
+    const optionsPath = options.path;
     let pathnameIsSocketPath = false;
-    if (options.path) {
-      path = options.path;
+    if (optionsPath) {
+      path = optionsPath;
     } else if (!url.hostname) {
       // postgres:///run/postgresql: a host-less pathname is the socket path, not a database name.
       path = url.pathname;

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -2,6 +2,7 @@ import { SQL } from "bun";
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import { isWindows, tempDir } from "harness";
 import { unlinkSync } from "js/node/fs/export-star-from";
+import { join } from "node:path";
 
 declare module "bun" {
   namespace SQL {
@@ -381,9 +382,9 @@ describe("SQL adapter environment variable precedence", () => {
       },
     );
 
-    // A host-less URL's pathname is taken as the unix socket path. None of these
-    // sockets need to exist: parseOptions drops a missing socket path but resolves
-    // the database name the same way either way.
+    // A host-less URL's pathname is taken as the unix socket path. The database
+    // name resolves the same way whether or not the socket exists (parseOptions
+    // only drops a missing socket path), so most of these use one that does not.
     describe("host-less URLs", () => {
       const socket = "/tmp/bun-sql-database-precedence.sock";
 
@@ -417,9 +418,23 @@ describe("SQL adapter environment variable precedence", () => {
         (_adapter, envVar, url) => {
           process.env[envVar] = "envdb";
 
-          expect(new SQL(`${url}?path=${socket}`).options.database).toBe("urldb");
-          expect(new SQL(url, { path: socket }).options.database).toBe("urldb");
-          expect(new SQL({ url, path: socket }).options.database).toBe("urldb");
+          // "/urldb" is an explicit socket path that happens to spell the same as the pathname.
+          for (const path of [socket, "/urldb"]) {
+            expect(new SQL(`${url}?path=${path}`).options.database).toBe("urldb");
+            expect(new SQL(url, { path }).options.database).toBe("urldb");
+            expect(new SQL({ url, path }).options.database).toBe("urldb");
+          }
+        },
+      );
+
+      test.each(hostlessUrls)(
+        "%s: an explicit socket path does not change which socket is used",
+        (_adapter, _envVar, url) => {
+          using dir = tempDir("sql-hostless-socket", { "db.sock": "" });
+          const path = join(String(dir), "db.sock");
+
+          expect(new SQL(`${url}?path=${path}`).options).toMatchObject({ database: "urldb", path });
+          expect(new SQL(url, { path }).options).toMatchObject({ database: "urldb", path });
         },
       );
     });

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -26,8 +26,12 @@ describe("SQL adapter environment variable precedence", () => {
     'TLS_MARIADB_DATABASE_URL',
     'SQLITE_URL', 'SQLITEURL',
     'PGHOST', 'PGUSER', 'PGPASSWORD', 'PGDATABASE', 'PGPORT',
+    'PG_HOST', 'PG_USER', 'PG_PASSWORD', 'PG_DATABASE', 'PG_PORT',
     'PGSSLMODE', 'PG_SSLMODE',
-    'MYSQL_HOST', 'MYSQL_USER', 'MYSQL_PASSWORD', 'MYSQL_DATABASE', 'MYSQL_PORT'
+    'MYSQL_HOST', 'MYSQL_USER', 'MYSQL_PASSWORD', 'MYSQL_DATABASE', 'MYSQL_PORT',
+    'MYSQLHOST', 'MYSQLUSER', 'MYSQLPASSWORD', 'MYSQLDATABASE', 'MYSQLPORT',
+    'MARIADB_HOST', 'MARIADB_USER', 'MARIADB_PASSWORD', 'MARIADB_DATABASE', 'MARIADB_PORT',
+    'MARIADBHOST', 'MARIADBUSER', 'MARIADBPASSWORD', 'MARIADBDATABASE', 'MARIADBPORT',
   ];
 
   beforeEach(() => {
@@ -291,6 +295,104 @@ describe("SQL adapter environment variable precedence", () => {
     expect(options.options.hostname).toBe("host");
     expect(options.options.port).toBe(3306);
     expect(options.options.sslMode).toBe(2); // SSLMode.require
+  });
+
+  describe("database name precedence", () => {
+    // prettier-ignore
+    const databaseEnvVars = [
+      ["postgres", "PGDATABASE",       "postgres://urluser:urlpass@urlhost:5432"],
+      ["postgres", "PG_DATABASE",      "postgres://urluser:urlpass@urlhost:5432"],
+      ["mysql",    "MYSQL_DATABASE",   "mysql://urluser:urlpass@urlhost:3306"],
+      ["mysql",    "MYSQLDATABASE",    "mysql://urluser:urlpass@urlhost:3306"],
+      ["mariadb",  "MARIADB_DATABASE", "mariadb://urluser:urlpass@urlhost:3306"],
+      ["mariadb",  "MARIADBDATABASE",  "mariadb://urluser:urlpass@urlhost:3306"],
+    ] as const;
+
+    test.each(databaseEnvVars)("%s: the database named in the URL wins over $%s", (adapter, envVar, base) => {
+      process.env[envVar] = "envdb";
+
+      const expected = { adapter, hostname: "urlhost", username: "urluser", password: "urlpass", database: "urldb" };
+      expect(new SQL(`${base}/urldb`).options).toMatchObject(expected);
+      expect(new SQL(`${base}/urldb`, { adapter }).options).toMatchObject(expected);
+      expect(new SQL({ url: `${base}/urldb` }).options).toMatchObject(expected);
+      expect(new SQL({ adapter, url: `${base}/urldb` }).options).toMatchObject(expected);
+    });
+
+    test.each(databaseEnvVars)(
+      "%s: the database in the URL is percent-decoded before $%s is consulted",
+      (_, envVar, base) => {
+        process.env[envVar] = "envdb";
+
+        expect(new SQL(`${base}/url%20db`).options.database).toBe("url db");
+      },
+    );
+
+    test.each(databaseEnvVars)("%s: an explicit database option wins over both the URL and $%s", (_, envVar, base) => {
+      process.env[envVar] = "envdb";
+
+      expect(new SQL(`${base}/urldb`, { database: "optiondb" }).options.database).toBe("optiondb");
+      expect(new SQL(`${base}/urldb`, { db: "optiondb" }).options.database).toBe("optiondb");
+      expect(new SQL({ url: `${base}/urldb`, database: "optiondb" }).options.database).toBe("optiondb");
+    });
+
+    test.each(databaseEnvVars)(
+      "%s: $%s fills in the database when the URL does not name one",
+      (adapter, envVar, base) => {
+        process.env[envVar] = "envdb";
+
+        expect(new SQL(base).options).toMatchObject({ adapter, hostname: "urlhost", database: "envdb" });
+        expect(new SQL(`${base}/`).options).toMatchObject({ adapter, hostname: "urlhost", database: "envdb" });
+        expect(new SQL({ url: base }).options).toMatchObject({ adapter, hostname: "urlhost", database: "envdb" });
+      },
+    );
+
+    test.each([
+      ["postgres://urluser@urlhost:5432", "urluser"],
+      ["mysql://urluser@urlhost:3306", "mysql"],
+      ["mariadb://urluser@urlhost:3306", "mariadb"],
+    ])(
+      "%s falls back to the adapter default database when neither the URL nor the environment names one",
+      (url, database) => {
+        expect(new SQL(url).options.database).toBe(database);
+        expect(new SQL(`${url}/`).options.database).toBe(database);
+      },
+    );
+
+    // prettier-ignore
+    const urlEnvVars = [
+      ["postgres", "DATABASE_URL", "postgres://urluser@urlhost:5432/urldb", "PG"],       // $PGHOST, $PGUSER, $PGDATABASE
+      ["postgres", "POSTGRES_URL", "postgres://urluser@urlhost:5432/urldb", "PG"],
+      ["mysql",    "DATABASE_URL", "mysql://urluser@urlhost:3306/urldb",    "MYSQL_"],   // $MYSQL_HOST, ...
+      ["mysql",    "MYSQL_URL",    "mysql://urluser@urlhost:3306/urldb",    "MYSQL_"],
+      ["mariadb",  "MARIADB_URL",  "mariadb://urluser@urlhost:3306/urldb",  "MARIADB_"], // $MARIADB_HOST, ...
+    ] as const;
+
+    test.each(urlEnvVars)(
+      "%s: every field of a connection URL taken from $%s wins over the per-field variables, the database included",
+      (adapter, urlVar, url, prefix) => {
+        process.env[urlVar] = url;
+        process.env[`${prefix}HOST`] = "envhost";
+        process.env[`${prefix}USER`] = "envuser";
+        process.env[`${prefix}DATABASE`] = "envdb";
+
+        const expected = { adapter, hostname: "urlhost", username: "urluser", database: "urldb" };
+        expect(new SQL().options).toMatchObject(expected);
+        expect(new SQL({ adapter }).options).toMatchObject(expected);
+      },
+    );
+
+    test.each([
+      ["postgres", "PGDATABASE"],
+      ["mysql", "MYSQL_DATABASE"],
+      ["mariadb", "MARIADB_DATABASE"],
+    ] as const)(
+      "%s: the pathname of a host-less URL is a socket path, so $%s still names the database",
+      (adapter, envVar) => {
+        process.env[envVar] = "envdb";
+
+        expect(new SQL("unix:///tmp/bun-sql-database-precedence.sock", { adapter }).options.database).toBe("envdb");
+      },
+    );
   });
 
   describe("PGSSLMODE", () => {

--- a/test/js/sql/adapter-env-var-precedence.test.ts
+++ b/test/js/sql/adapter-env-var-precedence.test.ts
@@ -381,18 +381,48 @@ describe("SQL adapter environment variable precedence", () => {
       },
     );
 
-    test.each([
-      ["postgres", "PGDATABASE"],
-      ["mysql", "MYSQL_DATABASE"],
-      ["mariadb", "MARIADB_DATABASE"],
-    ] as const)(
-      "%s: the pathname of a host-less URL is a socket path, so $%s still names the database",
-      (adapter, envVar) => {
-        process.env[envVar] = "envdb";
+    // A host-less URL's pathname is taken as the unix socket path. None of these
+    // sockets need to exist: parseOptions drops a missing socket path but resolves
+    // the database name the same way either way.
+    describe("host-less URLs", () => {
+      const socket = "/tmp/bun-sql-database-precedence.sock";
 
-        expect(new SQL("unix:///tmp/bun-sql-database-precedence.sock", { adapter }).options.database).toBe("envdb");
-      },
-    );
+      // prettier-ignore
+      const hostlessUrls = [
+        ["postgres", "PGDATABASE",       "postgres:///urldb"],
+        ["mysql",    "MYSQL_DATABASE",   "mysql:///urldb"],
+        ["mariadb",  "MARIADB_DATABASE", "mariadb:///urldb"],
+      ] as const;
+
+      test.each(hostlessUrls)(
+        "%s: $%s still names the database when the pathname is taken as the socket path",
+        (adapter, envVar, url) => {
+          process.env[envVar] = "envdb";
+
+          expect(new SQL(url).options.database).toBe("envdb");
+          expect(new SQL(`unix://${socket}`, { adapter }).options.database).toBe("envdb");
+        },
+      );
+
+      test.each(hostlessUrls)(
+        "%s: without $%s the pathname is still the last-resort database name",
+        (_adapter, _envVar, url) => {
+          expect(new SQL(url).options.database).toBe("urldb");
+          expect(new SQL(url.replace("urldb", "url%20db")).options.database).toBe("url db");
+        },
+      );
+
+      test.each(hostlessUrls)(
+        "%s: when the socket comes from ?path= or options.path, the pathname names the database and wins over $%s",
+        (_adapter, envVar, url) => {
+          process.env[envVar] = "envdb";
+
+          expect(new SQL(`${url}?path=${socket}`).options.database).toBe("urldb");
+          expect(new SQL(url, { path: socket }).options.database).toBe("urldb");
+          expect(new SQL({ url, path: socket }).options.database).toBe("urldb");
+        },
+      );
+    });
   });
 
   describe("PGSSLMODE", () => {


### PR DESCRIPTION
### Problem
- With `PGDATABASE` set (likewise `MYSQL_DATABASE`, `MARIADB_DATABASE`, and the `PG_DATABASE` / `MYSQLDATABASE` spellings), `new SQL("postgres://u:p@h:5432/urldb")` connects to the environment's database instead of `urldb`. Same for `new SQL({ url })` and for a URL read from `DATABASE_URL` and friends.
- Host, port, user and password already come from the URL before the environment is consulted; the database alone was resolved with the environment variable ranked above the URL path.
- Regression from #22260 (bun 1.2.22). Before it, and in postgres.js and libpq, the URL's database beat the variable, and the docs describe the per-field variables as what applies when no URL is given.

### Fix
- The database is resolved with the other URL fields, so every field now follows one order: explicit option, then the connection URL, then the per-field variable, then the adapter default. Same for postgres, mysql and mariadb.
- Exception: a host-less URL (`postgres:///x`, `unix:///x`) uses its path as the unix socket, so that path is not promoted to a database name and the variable still wins there, as today. Once the socket is named explicitly (`?path=` or `options.path`) the path is a database name again and beats the variable.
- Whether the path was used as the socket is recorded where the socket is chosen, not inferred afterwards, so an explicit socket spelled the same as the path still counts as explicit.
- Verification: 20 of the new test cases fail on the released bun and pass with this change. Also checked against local postgres and mariadb servers: with the variable set, `select current_database()` / `select database()` return the URL's database, including over the postgres unix socket with `?path=`.

### Background
- `SQL` options come from three layers: the options object, a connection URL (a string, `{ url }`, or read from `DATABASE_URL` / `POSTGRES_URL` / `MYSQL_URL` / `MARIADB_URL`), and per-field variables such as `PGDATABASE` or `MYSQL_DATABASE`, each also accepted without the underscore.
- A URL names its database in the path: the leading `/` is dropped and the rest percent-decoded, so `postgres://h/url%20db` names `url db`. An empty or bare `/` path names nothing.
- Since #36165 a URL with no host uses its path as the unix socket path (`postgres:///run/postgresql`) unless `?path=` or `options.path` names the socket, so such a URL has no separate place to name a database.
- When nothing names a database each adapter has a default: postgres uses the username, mysql uses `mysql`, mariadb uses `mariadb`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/sql/adapter-env-var-precedence.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

```sh
PGDATABASE=envdb MYSQL_DATABASE=envdb bun -e '
  const { SQL } = require("bun");
  console.log(new SQL("postgres://u:p@h:5432/urldb").options.database); // "envdb", expected "urldb"
  console.log(new SQL("mysql://u:p@h:3306/urldb").options.database);    // "envdb", expected "urldb"
  console.log(new SQL("postgres://u:p@h:5432/urldb").options.hostname); // "h" (the URL wins, as for every other field)
'
```

Same result for `new SQL({ url })`, for `MARIADB_DATABASE` / `MARIADBDATABASE` / `PG_DATABASE` / `MYSQLDATABASE`, for a URL that itself comes from `DATABASE_URL` / `POSTGRES_URL` / `MYSQL_URL` / `MARIADB_URL`, and for a host-less URL whose socket is given separately (`postgres:///urldb?path=/run/pg`, `new SQL("mysql:///urldb", { path })`). Against a real server the client connects to the environment's database while the connection string names a different one.

### Cause

In `parseOptions` (`src/js/internal/sql/shared.ts`) hostname, port, username and password are taken from the URL before any per-field environment variable is consulted, but the database was resolved per adapter as `options.database || options.db || env.PGDATABASE || url.pathname || default` (same shape for MySQL and MariaDB), so an environment fallback outranked the connection string.

This is a regression from #22260 (bun 1.2.22). Before that the chain was `options.database || options.db || url.pathname.slice(1) || env.PGDATABASE || username`, which is also what postgres.js does, and libpq likewise lets a `dbname` in the URI beat `PGDATABASE`. The docs (`docs/runtime/sql.mdx`, "Database Environment Variables") describe the per-field variables as what is consulted when no connection URL is provided.

### Fix

The database is now resolved in the same block as the other URL-derived fields: the URL pathname names the database and ranks right after the explicit `database` / `db` options, ahead of the environment. The per-adapter `switch` is untouched, so `PGDATABASE` and friends still fill in the database for a URL that does not name one, and the adapter defaults still apply after that.

The one exception is a host-less URL whose pathname is being used as the unix socket path. Since #36165, `postgres:///x` and `unix:///x` mean "socket at /x" (unless `options.path` or `?path=` names the socket), so promoting that pathname to the database name would let `unix:///var/run/mysqld/mysqld.sock` override `MYSQL_DATABASE`, a configuration that works today. For that shape nothing changes: the environment variable is used, and the pathname stays the last-resort fallback it was before (`postgres:///mydb` with no variable set still gives `mydb`; with `PGDATABASE` set the variable still wins, which is where Bun's reading of a host-less URL deliberately differs from libpq's). As soon as the socket is named explicitly (`?path=` or `options.path`), the pathname is a database name and wins over the environment like any other URL. The "pathname was taken as the socket" state is tracked where `path` is assigned, rather than inferred afterwards, so an explicit socket path that happens to spell the same as the pathname is still treated as explicit.

Resulting order, per field, for all three adapters: explicit option > connection URL (explicit or from `*_URL`) > per-field environment variable > default.

### Verification

`test/js/sql/adapter-env-var-precedence.test.ts` gets a "database name precedence" block covering, for postgres / mysql / mariadb and both spellings of each variable: URL string, `{ url }`, and explicit-adapter forms beating the variable; percent-decoding of the URL database; explicit `database` / `db` beating both; the variable still filling in for a URL with no path or a bare `/`; adapter defaults when nothing names a database; a URL from `DATABASE_URL` / `POSTGRES_URL` / `MYSQL_URL` / `MARIADB_URL` beating the per-field variables; and the host-less shapes: `scheme:///db` and `unix:///sock` still taking the database from the variable, `scheme:///db` with no variable still falling back to the pathname (including percent-decoding; deleting the fallback terms from the `switch` fails exactly these), `?path=` / `options.path` / `{ url, path }` making the pathname win over the variable (with a socket path distinct from the pathname and one spelled identically to it), and an explicit socket path still being the one kept in `options.path`. The `SQL_ENV_VARS` list the file clears before each test also gains the `PG_*`, `MYSQL*` and `MARIADB*` spellings it was missing.

20 of the new cases fail on the released bun (`USE_SYSTEM_BUN=1`), all 100 in the file pass with this change; `adapter-override`, `sqlite-url-parsing`, `postgres-pgsslmode-env` and `sql-connect-error-reporting` still pass. Also checked end to end against local postgres and mariadb servers: with `PGDATABASE` / `MYSQL_DATABASE` set, `select current_database()` / `select database()` now return the database from the connection string, and the environment's database when the URL has no path; over the postgres unix socket, `postgres:///bun_sql_test?path=/var/run/postgresql` now connects to `bun_sql_test` with `PGDATABASE=postgres` set (the release connects to `postgres`), while `postgres:///var/run/postgresql` still connects to `postgres` as before.

</details>
