### PR TITLE
test: run the type-export fixtures through one compile and assert their output

### DIFF
--- a/test/js/bun/typescript/type-export.test.ts
+++ b/test/js/bun/typescript/type-export.test.ts
@@ -20,8 +20,8 @@ function errorLine(stderr: string, dir: string) {
 
 // Fixtures whose entry point prints one JSON line when type-only exports are handled correctly. Each one is run
 // three ways (see the describe block below) by a generated runner that imports every fixture in turn and reports
-// all of the results keyed by fixture name, so one process (and, for `compile`, one standalone executable)
-// covers all of them while a failure still names the fixture that produced it.
+// each result under the fixture's name as it goes, so one process (and, for `compile`, one standalone executable)
+// covers all of them while a failure, or a crash part way through, still names the fixture responsible.
 type Fixture = { files: Record<string, string>; entry: string; expected: unknown };
 const fixtures: Record<string, Fixture> = {};
 
@@ -127,6 +127,7 @@ fixtures["import-only-used-in-decorator"] = {
       class OtherClass {
         other?: TestInterface;
       }
+      delete Reflect.metadata;
 
       export { TestInterface };
 
@@ -168,33 +169,39 @@ function runnerSource(entries: Record<string, string>) {
     ([name, specifier]) => `[${JSON.stringify(name)}, () => import(${JSON.stringify(specifier)})],`,
   );
   return `
-    const results = {};
     const log = console.log;
     for (const [name, load] of [
       ${imports.join("\n")}
     ]) {
       const lines = [];
       console.log = (...args) => lines.push(args.join(" "));
+      let result;
       try {
         await load();
-        results[name] = lines.length === 1 ? JSON.parse(lines[0]) : { lines };
+        result = lines.length === 1 ? JSON.parse(lines[0]) : { lines };
       } catch (error) {
-        results[name] = { error: String(error), lines };
+        result = { error: String(error), lines };
       } finally {
         console.log = log;
       }
+      console.log(JSON.stringify([name, result]));
     }
-    console.log(JSON.stringify(results));
   `;
 }
 
+/** The runner's output as `{ [fixture]: result }`; a fixture that took the process down is simply missing. */
 async function runFixtures(cmd: string[], cwd: string) {
   const { stdout, stderr, exitCode } = await run(cmd, cwd);
   let results: unknown = stdout;
   try {
-    results = JSON.parse(stdout);
+    results = Object.fromEntries(
+      stdout
+        .trim()
+        .split("\n")
+        .map(line => JSON.parse(line)),
+    );
   } catch {
-    // The process died before the runner printed; the raw output is the best report there is.
+    // Whatever was printed instead is the best report there is.
   }
   return { results, stderr, exitCode };
 }

--- a/test/js/bun/typescript/type-export.test.ts
+++ b/test/js/bun/typescript/type-export.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isCI, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
 
 async function run(cmd: string[], cwd: string) {
   await using proc = Bun.spawn({
@@ -226,10 +226,7 @@ describe.concurrent("type-only exports through re-exports", () => {
     expect(await runFixtures([bunExe(), "runner.ts"], dir)).toEqual(allFixturesPass);
   });
 
-  // --compile copies the whole executable (about 1 GB for a debug build), which takes a few seconds on its own and
-  // longer than the default timeout on a busy machine. Outside CI (which sets its own --timeout) give it the same
-  // ceiling itBundled gives compile tests.
-  test("compile", { timeout: isCI ? undefined : 30_000 }, async () => {
+  test("compile", async () => {
     await using dir = tempDir("type-export-compile", { ...fixtureFiles, "runner.ts": runnerSource(sourceEntries) });
     const outfile = `${dir}/runner${isWindows ? ".exe" : ""}`;
 

--- a/test/js/bun/typescript/type-export.test.ts
+++ b/test/js/bun/typescript/type-export.test.ts
@@ -351,19 +351,16 @@ describe("through export merge", () => {
             ["c." + fmt]: "export const value = 'c';",
           });
 
-          for (const file of ["main." + fmt, "a." + fmt]) {
+          for (const [file, expected_stderr] of [
+            // jsc's syntax error, from linking a while running main
+            ["main." + fmt, "SyntaxError: Cannot export a duplicate name 'value'.\n"],
+            // bun's syntax error, which points at the duplicate
+            ["a." + fmt, `error: Multiple exports with the same name "value"\n    at <dir>/a.${fmt}:1:`],
+          ]) {
             test.concurrent(file, async () => {
               const result = await run([bunExe(), file], dir);
 
-              expect(result.stderr.trim()).toInclude(
-                file === "a." + fmt
-                  ? 'error: Multiple exports with the same name "value"\n' // bun's syntax error
-                  : "SyntaxError: Cannot export a duplicate name 'value'.\n", // jsc's syntax error
-              );
-
-              if (file === "a." + fmt) {
-                expect(normalizeBunSnapshot(result.stderr, dir)).toContain(`\n    at <dir>/a.${fmt}:1:`);
-              }
+              expect(normalizeBunSnapshot(result.stderr, dir)).toContain(expected_stderr);
               expect({ stdout: result.stdout, exitCode: result.exitCode }).toEqual({ stdout: "", exitCode: 1 });
             });
           }

--- a/test/js/bun/typescript/type-export.test.ts
+++ b/test/js/bun/typescript/type-export.test.ts
@@ -179,7 +179,7 @@ function runnerSource(entries: Record<string, string>) {
         await load();
         results[name] = lines.length === 1 ? JSON.parse(lines[0]) : { lines };
       } catch (error) {
-        results[name] = { error: String(error) };
+        results[name] = { error: String(error), lines };
       } finally {
         console.log = log;
       }

--- a/test/js/bun/typescript/type-export.test.ts
+++ b/test/js/bun/typescript/type-export.test.ts
@@ -1,53 +1,29 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
-
-const ext = isWindows ? ".exe" : "";
+import { bunEnv, bunExe, isCI, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
 
 async function run(cmd: string[], cwd: string) {
   await using proc = Bun.spawn({
     cmd,
     env: bunEnv,
     cwd,
-    stdio: ["inherit", "pipe", "pipe"],
+    stdio: ["ignore", "pipe", "pipe"],
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { stdout, stderr, exitCode };
 }
 
-// Cap in-flight `--compile` builds: each one reads + rewrites a full standalone
-// executable, and running all of them at once exhausts CI memory/IO
-// (see the note at the top of test/bundler/bundler_compile.test.ts).
-const maxConcurrentCompiles = 4;
-let activeCompiles = 0;
-const compileWaiters: (() => void)[] = [];
-async function withCompileSlot<T>(fn: () => Promise<T>): Promise<T> {
-  while (activeCompiles >= maxConcurrentCompiles) {
-    const { promise, resolve } = Promise.withResolvers<void>();
-    compileWaiters.push(resolve);
-    await promise;
-  }
-  activeCompiles++;
-  try {
-    return await fn();
-  } finally {
-    activeCompiles--;
-    compileWaiters.shift()?.();
-  }
+/** The `error:` / `SomeError:` line of a failed run, with the fixture directory replaced by `<dir>`. */
+function errorLine(stderr: string, dir: string) {
+  const normalized = normalizeBunSnapshot(stderr, dir);
+  return normalized.split("\n").find(line => /^(?:\w*Error|error):/.test(line)) ?? normalized;
 }
 
-async function compileAndRun(dir: string, entrypoint: string) {
-  const outfile = dir + `/compiled${ext}`;
-  return await withCompileSlot(async () => {
-    const buildResult = await run(
-      [bunExe(), "build", "--compile", "--bytecode", "--format=esm", entrypoint, "--outfile", outfile],
-      dir,
-    );
-    expect(buildResult.stderr).toBe("");
-    expect(buildResult.exitCode).toBe(0);
-
-    return run([outfile], dir);
-  });
-}
+// Fixtures whose entry point prints one JSON line when type-only exports are handled correctly. Each one is run
+// three ways (see the describe block below) by a generated runner that imports every fixture in turn and reports
+// all of the results keyed by fixture name, so one process (and, for `compile`, one standalone executable)
+// covers all of them while a failure still names the fixture that produced it.
+type Fixture = { files: Record<string, string>; entry: string; expected: unknown };
+const fixtures: Record<string, Fixture> = {};
 
 const a_file = `
   export type my_string = "1";
@@ -69,118 +45,274 @@ const a_with_value = `
   export const my_value = "2";
 `;
 
-const b_files = [
-  {
-    name: "export from",
-    value: `export { my_string, my_value, my_only } from "./a.ts";`,
-  },
-  {
-    name: "import then export",
-    value: `
-      import { my_string, my_value, my_only } from "./a.ts";
-      export { my_string, my_value, my_only };
-    `,
-  },
-  {
-    name: "export star",
-    value: `export * from "./a.ts";`,
-  },
-  {
-    name: "export merge",
-    value: `export * from "./a_no_value.ts"; export * from "./a_with_value.ts"`,
-  },
-];
+// How `b` re-exports `a`.
+const b_files = {
+  "export-from": `export { my_string, my_value, my_only } from "./a.ts";`,
+  "import-then-export": `
+    import { my_string, my_value, my_only } from "./a.ts";
+    export { my_string, my_value, my_only };
+  `,
+  "export-star": `export * from "./a.ts";`,
+  "export-merge": `export * from "./a_no_value.ts"; export * from "./a_with_value.ts"`,
+};
 
-const c_files = [
-  { name: "require", value: `console.log(JSON.stringify(require("./b")));` },
-  { name: "import star", value: `import * as b from "./b"; console.log(JSON.stringify(b));` },
-  { name: "await import", value: `console.log(JSON.stringify(await import("./b")));` },
-  {
-    name: "import individual",
-    value: `
-      import { my_string, my_value, my_only } from "./b";
-      console.log(JSON.stringify({ my_only, my_value }));
-    `,
-  },
-];
+// How `c` imports `b`.
+const c_files = {
+  "require": `console.log(JSON.stringify(require("./b")));`,
+  "import-star": `import * as b from "./b"; console.log(JSON.stringify(b));`,
+  "await-import": `console.log(JSON.stringify(await import("./b")));`,
+  "import-individual": `
+    import { my_string, my_value, my_only } from "./b";
+    console.log(JSON.stringify({ my_only, my_value }));
+  `,
+};
 
-for (const b_file of b_files) {
-  describe(`re-export with ${b_file.name}`, () => {
-    for (const c_file of c_files) {
-      describe(`import with ${c_file.name}`, () => {
-        const dir = tempDirWithFiles("type-export", {
-          "a.ts": a_file,
-          "b.ts": b_file.value,
-          "c.ts": c_file.value,
-          "a_no_value.ts": a_no_value,
-          "a_with_value.ts": a_with_value,
-        });
-
-        describe.each(["run", "compile", "build"])("%s", mode => {
-          // TODO: "run" is skipped until ESM module_info is enabled in the runtime transpiler.
-          // Currently module_info is only generated for standalone ESM bytecode (--compile).
-          // Once enabled, flip this to include "run".
-          const testFn = mode === "run" ? test.skip : test.concurrent;
-          testFn("works", async () => {
-            let result: { stdout: string; stderr: string; exitCode: number };
-            if (mode === "compile") {
-              result = await compileAndRun(dir, dir + "/c.ts");
-            } else if (mode === "build") {
-              const build_result = await Bun.build({
-                entrypoints: [dir + "/c.ts"],
-                outdir: dir + "/dist",
-              });
-              expect(build_result.success).toBe(true);
-              result = await run([bunExe(), "run", dir + "/dist/c.js"], dir);
-            } else {
-              result = await run([bunExe(), "run", "c.ts"], dir);
-            }
-
-            const parsedOutput = JSON.parse(result.stdout.trim());
-            expect(parsedOutput).toEqual({ my_value: "2", my_only: "3" });
-            expect(result.exitCode).toBe(0);
-          });
-        });
-      });
-    }
-  });
+for (const [b_name, b_file] of Object.entries(b_files)) {
+  for (const [c_name, c_file] of Object.entries(c_files)) {
+    fixtures[`${b_name}/${c_name}`] = {
+      files: {
+        "a.ts": a_file,
+        "a_no_value.ts": a_no_value,
+        "a_with_value.ts": a_with_value,
+        "b.ts": b_file,
+        "c.ts": c_file,
+      },
+      entry: "c.ts",
+      expected: { my_value: "2", my_only: "3" },
+    };
+  }
 }
 
-describe("import not found", () => {
-  for (const [ccase, target_value, name] of [
-    [``, /SyntaxError: Export named 'not_found' not found in module '[^']+?'\./, "none"],
-    [
-      `export default function not_found() {};`,
-      /SyntaxError: Export named 'not_found' not found in module '[^']+?'\. Did you mean to import default\?/,
-      "default with same name",
-    ],
-    [
-      `export type not_found = "not_found";`,
-      /SyntaxError: Export named 'not_found' not found in module '[^']+?'\./,
-      "type",
-    ],
-  ] as const)
-    test.concurrent(`${name}`, async () => {
-      await using dir = tempDir("type-export", {
-        "a.ts": ccase,
-        "b.ts": /*js*/ `
-          import { not_found } from "./a";
-          console.log(not_found);
-        `,
-        "nf.ts": "",
-      });
+fixtures["ownkeys-of-star-import"] = {
+  files: {
+    "main.ts": `
+      import * as ns from './a';
+      console.log(JSON.stringify({
+        keys: Object.keys(ns).sort(),
+        ns,
+        has_sometype: Object.hasOwn(ns, 'sometype'),
+      }));
+    `,
+    "a.ts": "export * from './b'; export {sometype} from './b';",
+    "b.ts": "export const value = 'b'; export const anotherValue = 'another'; export type sometype = 'sometype';",
+  },
+  entry: "main.ts",
+  expected: {
+    keys: ["anotherValue", "value"],
+    ns: { anotherValue: "another", value: "b" },
+    has_sometype: false,
+  },
+};
 
-      const result = await run([bunExe(), "run", "b.ts"], dir);
+// https://github.com/oven-sh/bun/issues/8439: an interface imported without `import type`, used only in
+// emitDecoratorMetadata output and re-exported. tsc emits `design:type` metadata of `Object` for it.
+fixtures["import-only-used-in-decorator"] = {
+  files: {
+    "index.ts": `
+      import { TestInterface } from "./interface.ts";
 
-      expect(result.stderr.trim()).toMatch(target_value);
-      expect({
-        exitCode: result.exitCode,
-        stdout: result.stdout.trim(),
-      }).toEqual({
-        exitCode: 1,
-        stdout: "",
-      });
+      const metadata = {};
+      Reflect.metadata = (key, value) => () => {
+        metadata[key] = value;
+      };
+
+      function Decorator(): PropertyDecorator {
+        return () => {};
+      }
+
+      class TestClass {
+        @Decorator()
+        test?: TestInterface;
+      }
+      class OtherClass {
+        other?: TestInterface;
+      }
+
+      export { TestInterface };
+
+      console.log(JSON.stringify({ design_type: metadata["design:type"] === Object ? "Object" : metadata }));
+    `,
+    "interface.ts": "export interface TestInterface {};",
+    "tsconfig.json": JSON.stringify({
+      compilerOptions: {
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
+      },
+    }),
+  },
+  entry: "index.ts",
+  expected: { design_type: "Object" },
+};
+
+const fixtureFiles = Object.fromEntries(
+  Object.entries(fixtures).flatMap(([name, { files }]) =>
+    Object.entries(files).map(([file, contents]) => [`fixtures/${name}/${file}`, contents]),
+  ),
+);
+const sourceEntries = Object.fromEntries(
+  Object.entries(fixtures).map(([name, { entry }]) => [name, `./fixtures/${name}/${entry}`]),
+);
+const builtEntries = Object.fromEntries(
+  Object.entries(fixtures).map(([name, { entry }]) => [name, `./dist/${name}/${entry.replace(/\.ts$/, ".js")}`]),
+);
+const allFixturesPass = {
+  results: Object.fromEntries(Object.entries(fixtures).map(([name, { expected }]) => [name, expected])),
+  stderr: "",
+  exitCode: 0,
+};
+
+// One `import()` with a literal specifier per fixture, so that `bun build --compile --splitting` gives every
+// fixture its own chunk, bytecode and module record.
+function runnerSource(entries: Record<string, string>) {
+  const imports = Object.entries(entries).map(
+    ([name, specifier]) => `[${JSON.stringify(name)}, () => import(${JSON.stringify(specifier)})],`,
+  );
+  return `
+    const results = {};
+    const log = console.log;
+    for (const [name, load] of [
+      ${imports.join("\n")}
+    ]) {
+      const lines = [];
+      console.log = (...args) => lines.push(args.join(" "));
+      try {
+        await load();
+        results[name] = lines.length === 1 ? JSON.parse(lines[0]) : { lines };
+      } catch (error) {
+        results[name] = { error: String(error) };
+      } finally {
+        console.log = log;
+      }
+    }
+    console.log(JSON.stringify(results));
+  `;
+}
+
+async function runFixtures(cmd: string[], cwd: string) {
+  const { stdout, stderr, exitCode } = await run(cmd, cwd);
+  let results: unknown = stdout;
+  try {
+    results = JSON.parse(stdout);
+  } catch {
+    // The process died before the runner printed; the raw output is the best report there is.
+  }
+  return { results, stderr, exitCode };
+}
+
+// describe.concurrent rather than test.concurrent: a non-concurrent test (a skipped one included) ends the batch
+// of tests that run together, which is what used to serialize every compile in this file.
+describe.concurrent("type-only exports through re-exports", () => {
+  // The runtime transpiler does not hand JSC a module record for the modules it transpiles yet (only the bundler
+  // does, for --compile ESM bytecode), so JSC's own linker still rejects the re-exported types (#7384).
+  test.skip("run", async () => {
+    await using dir = tempDir("type-export-run", { ...fixtureFiles, "runner.ts": runnerSource(sourceEntries) });
+
+    expect(await runFixtures([bunExe(), "runner.ts"], dir)).toEqual(allFixturesPass);
+  });
+
+  test("build", async () => {
+    await using dir = tempDir("type-export-build", { ...fixtureFiles, "runner.ts": runnerSource(builtEntries) });
+
+    // One build of every entry point. Without splitting each of them still gets its own self-contained bundle,
+    // written to dist/<fixture>/<entry>.js, which is where the runner imports it from.
+    const { logs } = await Bun.build({
+      entrypoints: Object.entries(fixtures).map(([name, { entry }]) => `${dir}/fixtures/${name}/${entry}`),
+      root: `${dir}/fixtures`,
+      outdir: `${dir}/dist`,
+      throw: false,
     });
+    expect(logs.map(String)).toEqual([]);
+
+    expect(await runFixtures([bunExe(), "runner.ts"], dir)).toEqual(allFixturesPass);
+  });
+
+  // --compile copies the whole executable (about 1 GB for a debug build), which takes a few seconds on its own and
+  // longer than the default timeout on a busy machine. Outside CI (which sets its own --timeout) give it the same
+  // ceiling itBundled gives compile tests.
+  test("compile", { timeout: isCI ? undefined : 30_000 }, async () => {
+    await using dir = tempDir("type-export-compile", { ...fixtureFiles, "runner.ts": runnerSource(sourceEntries) });
+    const outfile = `${dir}/runner${isWindows ? ".exe" : ""}`;
+
+    const build = await run(
+      [bunExe(), "build", "--compile", "--bytecode", "--format=esm", "--splitting", "runner.ts", "--outfile", outfile],
+      dir,
+    );
+    expect({ stderr: build.stderr, exitCode: build.exitCode }).toEqual({ stderr: "", exitCode: 0 });
+
+    expect(await runFixtures([outfile], dir)).toEqual(allFixturesPass);
+  });
+});
+
+describe.concurrent("importing a name that is not exported as a value", () => {
+  const import_not_found = `
+    import { not_found } from "./a";
+    console.log(not_found);
+  `;
+  const type_only = "export type type_only = 'type_only';";
+  const type_only_and_default = "export type type_only = 'type_only'; export default function type_only() {};";
+
+  const cases: Record<string, { files: Record<string, string>; entry: string; error: string }> = {
+    "import not found": {
+      files: { "a.ts": "", "b.ts": import_not_found },
+      entry: "b.ts",
+      error: "SyntaxError: Export named 'not_found' not found in module '<dir>/a.ts'.",
+    },
+    "import not found, default export with the same name": {
+      files: { "a.ts": "export default function not_found() {};", "b.ts": import_not_found },
+      entry: "b.ts",
+      error: "SyntaxError: Export named 'not_found' not found in module '<dir>/a.ts'. Did you mean to import default?",
+    },
+    "import not found, type with the same name": {
+      files: { "a.ts": `export type not_found = "not_found";`, "b.ts": import_not_found },
+      entry: "b.ts",
+      error: "SyntaxError: Export named 'not_found' not found in module '<dir>/a.ts'.",
+    },
+    "js file type import": {
+      files: { "b.js": "import {type_only} from './ts.ts';", "ts.ts": type_only },
+      entry: "b.js",
+      error: "SyntaxError: Export named 'type_only' not found in module '<dir>/ts.ts'.",
+    },
+    "js file type import with default export": {
+      files: { "b.js": "import {type_only} from './ts.ts';", "ts.ts": type_only_and_default },
+      entry: "b.js",
+      error: "SyntaxError: Export named 'type_only' not found in module '<dir>/ts.ts'. Did you mean to import default?",
+    },
+    "js file with through export": {
+      files: { "b.js": "export {type_only} from './ts.ts';", "ts.ts": type_only_and_default },
+      entry: "b.js",
+      error: "SyntaxError: export 'type_only' not found in './ts.ts'",
+    },
+    "js file with through export 2": {
+      files: { "b.js": "import {type_only} from './ts.ts'; export {type_only};", "ts.ts": type_only_and_default },
+      entry: "b.js",
+      error: "SyntaxError: export 'type_only' not found in './ts.ts'",
+    },
+    "ambiguous export star merge": {
+      files: {
+        "main.ts": "import {value} from './a'; console.log(value);",
+        "a.ts": "export * from './b'; export * from './c';",
+        "b.ts": "export const value = 'b';",
+        "c.ts": "export const value = 'c';",
+      },
+      entry: "main.ts",
+      error:
+        "SyntaxError: Export named 'value' cannot be resolved due to ambiguous multiple bindings in module '<dir>/a.ts'.",
+    },
+  };
+
+  for (const [name, { files, entry, error }] of Object.entries(cases)) {
+    test(name, async () => {
+      await using dir = tempDir("type-export", files);
+
+      const result = await run([bunExe(), entry], dir);
+
+      expect({
+        error: errorLine(result.stderr, dir),
+        stdout: result.stdout,
+        exitCode: result.exitCode,
+      }).toEqual({ error, stdout: "", exitCode: 1 });
+    });
+  }
 });
 
 test.concurrent("js file type export", async () => {
@@ -190,58 +322,15 @@ test.concurrent("js file type export", async () => {
 
   const result = await run([bunExe(), "a.js"], dir);
 
-  expect(result.stderr.trim()).toInclude('error: "not_found" is not declared in this file');
-  expect(result.exitCode).toBe(1);
-});
+  expect(normalizeBunSnapshot(result.stderr, dir)).toMatchInlineSnapshot(`
+    "1 | export {not_found};
+                ^
+    error: "not_found" is not declared in this file
+        at <dir>/a.js:1:9
 
-test.concurrent("js file type import", async () => {
-  await using dir = tempDir("type-import", {
-    "b.js": "import {type_only} from './ts.ts';",
-    "ts.ts": "export type type_only = 'type_only';",
-  });
-
-  const result = await run([bunExe(), "b.js"], dir);
-
-  expect(result.stderr.trim()).toInclude("Export named 'type_only' not found in module '");
-  expect(result.stderr.trim()).not.toInclude("Did you mean to import default?");
-  expect(result.exitCode).toBe(1);
-});
-
-test.concurrent("js file type import with default export", async () => {
-  await using dir = tempDir("type-import", {
-    "b.js": "import {type_only} from './ts.ts';",
-    "ts.ts": "export type type_only = 'type_only'; export default function type_only() {};",
-  });
-
-  const result = await run([bunExe(), "b.js"], dir);
-
-  expect(result.stderr.trim()).toInclude("Export named 'type_only' not found in module '");
-  expect(result.stderr.trim()).toInclude("Did you mean to import default?");
-  expect(result.exitCode).toBe(1);
-});
-
-test.concurrent("js file with through export", async () => {
-  await using dir = tempDir("type-import", {
-    "b.js": "export {type_only} from './ts.ts';",
-    "ts.ts": "export type type_only = 'type_only'; export default function type_only() {};",
-  });
-
-  const result = await run([bunExe(), "b.js"], dir);
-
-  expect(result.stderr.trim()).toInclude("SyntaxError: export 'type_only' not found in './ts.ts'");
-  expect(result.exitCode).toBe(1);
-});
-
-test.concurrent("js file with through export 2", async () => {
-  await using dir = tempDir("type-import", {
-    "b.js": "import {type_only} from './ts.ts'; export {type_only};",
-    "ts.ts": "export type type_only = 'type_only'; export default function type_only() {};",
-  });
-
-  const result = await run([bunExe(), "b.js"], dir);
-
-  expect(result.stderr.trim()).toInclude("SyntaxError: export 'type_only' not found in './ts.ts'");
-  expect(result.exitCode).toBe(1);
+    Bun v<bun-version>"
+  `);
+  expect({ stdout: result.stdout, exitCode: result.exitCode }).toEqual({ stdout: "", exitCode: 1 });
 });
 
 describe("through export merge", () => {
@@ -272,7 +361,10 @@ describe("through export merge", () => {
                   : "SyntaxError: Cannot export a duplicate name 'value'.\n", // jsc's syntax error
               );
 
-              expect(result.exitCode).toBe(1);
+              if (file === "a." + fmt) {
+                expect(normalizeBunSnapshot(result.stderr, dir)).toContain(`\n    at <dir>/a.${fmt}:1:`);
+              }
+              expect({ stdout: result.stdout, exitCode: result.exitCode }).toEqual({ stdout: "", exitCode: 1 });
             });
           }
         });
@@ -281,163 +373,64 @@ describe("through export merge", () => {
   }
 });
 
-describe("check ownkeys from a star import", () => {
-  const dir = tempDirWithFiles("ownkeys-star-import", {
-    ["main.ts"]: `
-      import * as ns from './a';
-      console.log(JSON.stringify({
-        keys: Object.keys(ns).sort(),
-        ns,
-        has_sometype: Object.hasOwn(ns, 'sometype'),
-      }));
-    `,
-    ["a.ts"]: "export * from './b'; export {sometype} from './b';",
-    ["b.ts"]: "export const value = 'b'; export const anotherValue = 'another'; export type sometype = 'sometype';",
-  });
-
-  const expected = {
-    keys: ["anotherValue", "value"],
-    ns: {
-      anotherValue: "another",
-      value: "b",
-    },
-    has_sometype: false,
-  };
-
-  describe.each(["run", "compile"] as const)("%s", mode => {
-    const testFn = mode === "run" ? test.skip : test.concurrent;
-
-    testFn("works", async () => {
-      const result =
-        mode === "compile" ? await compileAndRun(dir, dir + "/main.ts") : await run([bunExe(), "main.ts"], dir);
-
-      expect(result.stderr.trim()).toBe("");
-      expect(JSON.parse(result.stdout.trim())).toEqual(expected);
-      expect(result.exitCode).toBe(0);
-    });
-  });
-});
-
 test.concurrent("check commonjs", async () => {
   await using dir = tempDir("commonjs", {
     ["main.ts"]: "const {my_value, my_type} = require('./a'); console.log(my_value, my_type);",
     ["a.ts"]: "module.exports = require('./b');",
     ["b.ts"]: "export const my_value = 'my_value'; export type my_type = 'my_type';",
   });
-  const result = await run([bunExe(), "main.ts"], dir);
-  expect(result.stderr.trim()).toBe("");
-  expect(result.stdout.trim()).toBe("my_value undefined");
-  expect(result.exitCode).toBe(0);
+
+  expect(await run([bunExe(), "main.ts"], dir)).toEqual({ stdout: "my_value undefined\n", stderr: "", exitCode: 0 });
 });
 
-test.concurrent("check merge", async () => {
-  await using dir = tempDir("merge", {
-    ["main.ts"]: "import {value} from './a'; console.log(value);",
-    ["a.ts"]: "export * from './b'; export * from './c';",
-    ["b.ts"]: "export const value = 'b';",
-    ["c.ts"]: "export const value = 'c';",
-  });
-  const result = await run([bunExe(), "main.ts"], dir);
-  expect(result.stderr.trim()).toInclude(
-    "SyntaxError: Export named 'value' cannot be resolved due to ambiguous multiple bindings in module",
-  );
-  expect(result.exitCode).toBe(1);
-});
+// Each re-export form is run both through an importer (`main`, which prints what it imported) and as the entry
+// point itself (`a`, which prints nothing).
+describe.concurrent("re-export forms", () => {
+  const forms = [
+    {
+      name: "export * from './module'",
+      fmts: ["js", "ts"],
+      main: "import {value} from './a'; console.log(value);",
+      a: "export * from './b';",
+      b: "export const value = 'b';",
+      stdout: "b\n",
+    },
+    {
+      name: "export * as ns from './module'",
+      fmts: ["js", "ts"],
+      main: "import {ns} from './a'; console.log(ns.value);",
+      a: "export * as ns from './b';",
+      b: "export const value = 'b';",
+      stdout: "b\n",
+    },
+    {
+      name: "export type {Type} from './module'",
+      fmts: ["ts"],
+      main: "import {Type} from './a'; const x: Type = 'test'; console.log(x);",
+      a: "export type {Type} from './b';",
+      b: "export type Type = string;",
+      stdout: "test\n",
+    },
+  ];
 
-describe("export * from './module'", () => {
-  for (const fmt of ["js", "ts"]) {
-    describe(fmt, () => {
-      const dir = tempDirWithFiles("export-star", {
-        ["main." + fmt]: "import {value} from './a'; console.log(value);",
-        ["a." + fmt]: "export * from './b';",
-        ["b." + fmt]: "export const value = 'b';",
-      });
-      for (const file of ["main." + fmt, "a." + fmt]) {
-        test.concurrent(file, async () => {
-          const result = await run([bunExe(), file], dir);
-          expect(result.stderr.trim()).toBe("");
-          expect(result.exitCode).toBe(0);
-        });
+  for (const form of forms) {
+    describe(form.name, () => {
+      for (const fmt of form.fmts) {
+        for (const [file, stdout] of [
+          [`main.${fmt}`, form.stdout],
+          [`a.${fmt}`, ""],
+        ]) {
+          test(file, async () => {
+            await using dir = tempDir("re-export", {
+              [`main.${fmt}`]: form.main,
+              [`a.${fmt}`]: form.a,
+              [`b.${fmt}`]: form.b,
+            });
+
+            expect(await run([bunExe(), file], dir)).toEqual({ stdout, stderr: "", exitCode: 0 });
+          });
+        }
       }
     });
   }
-});
-
-describe("export * as ns from './module'", () => {
-  for (const fmt of ["js", "ts"]) {
-    describe(fmt, () => {
-      const dir = tempDirWithFiles("export-star-as", {
-        ["main." + fmt]: "import {ns} from './a'; console.log(ns.value);",
-        ["a." + fmt]: "export * as ns from './b';",
-        ["b." + fmt]: "export const value = 'b';",
-      });
-      for (const file of ["main." + fmt, "a." + fmt]) {
-        test.concurrent(file, async () => {
-          const result = await run([bunExe(), file], dir);
-          expect(result.stderr.trim()).toBe("");
-          expect(result.exitCode).toBe(0);
-        });
-      }
-    });
-  }
-});
-
-describe("export type {Type} from './module'", () => {
-  for (const fmt of ["ts"]) {
-    describe(fmt, () => {
-      const dir = tempDirWithFiles("export-type", {
-        ["main." + fmt]: "import {Type} from './a'; const x: Type = 'test'; console.log(x);",
-        ["a." + fmt]: "export type {Type} from './b';",
-        ["b." + fmt]: "export type Type = string;",
-      });
-      for (const file of ["main." + fmt, "a." + fmt]) {
-        test.concurrent(file, async () => {
-          const result = await run([bunExe(), file], dir);
-          expect(result.stderr.trim()).toBe("");
-          expect(result.exitCode).toBe(0);
-        });
-      }
-    });
-  }
-});
-
-describe("import only used in decorator (#8439)", () => {
-  const dir = tempDirWithFiles("import-only-used-in-decorator", {
-    ["index.ts"]: /*js*/ `
-      import { TestInterface } from "./interface.ts";
-
-      function Decorator(): PropertyDecorator {
-        return () => {};
-      }
-
-      class TestClass {
-        @Decorator()
-        test?: TestInterface;
-      }
-      class OtherClass {
-        other?: TestInterface;
-      }
-
-      export {TestInterface};
-    `,
-    ["interface.ts"]: "export interface TestInterface {};",
-    "tsconfig.json": JSON.stringify({
-      compilerOptions: {
-        experimentalDecorators: true,
-        emitDecoratorMetadata: true,
-      },
-    }),
-  });
-
-  describe.each(["run", "compile"] as const)("%s", mode => {
-    const testFn = mode === "run" ? test.skip : test.concurrent;
-
-    testFn("works", async () => {
-      const result =
-        mode === "compile" ? await compileAndRun(dir, dir + "/index.ts") : await run([bunExe(), "index.ts"], dir);
-
-      expect(result.stderr.trim()).toBe("");
-      expect(result.exitCode).toBe(0);
-    });
-  });
 });

--- a/test/no-validate-leaksan.txt
+++ b/test/no-validate-leaksan.txt
@@ -393,6 +393,3 @@ test/js/node/tls/node-tls-connect.test.ts
 # ("TODO: think about the finalizer here"), so the meta is never freed. All 18
 # tests pass; only the exit check fails. Remove once that TODO is resolved.
 test/bundler/native-plugin.test.ts
-
-# Slow
-test/js/bun/typescript/type-export.test.ts


### PR DESCRIPTION
### Problem
- `test/js/bun/typescript/type-export.test.ts` is one of the slowest non-integration test files: 53s on the slowest lane of build 92779, 50s to 61s per local debug run.
- Each of its 18 fixtures compiled its own standalone executable, a full copy of the bun binary (about 100 MB release, 800 MB debug), about 3s each, and left all 18 in the temp dir (about 14 GB per debug run).
- The compiles ran one after another despite `test.concurrent`: every fixture also had a skipped `run` test, and a non-concurrent entry closes the batch of concurrent tests that run together.
- Because one debug compile could pass the per-test timeout on a loaded host, the file was listed as slow in `test/no-validate-leaksan.txt`, so ASAN lanes did not leak-check it.

### Fix
- All 18 fixtures go into one temp tree and a generated runner imports them in turn, printing one result line each. Each mode is one test over the whole set: `build` is one `Bun.build` plus one process (was 16 of each), `compile` is one `--compile --splitting` executable plus one run (was 18), `run` stays skipped for #7384.
- Coverage holds because with `--splitting` each fixture, and each `b` it loads with `import()`, gets its own chunk, bytecode and module record; before, everything was inlined into one chunk and the record held nothing type-related.
- A failure still names its fixture: the assertion is one `toEqual` keyed by fixture name, and a crash appears as the first missing key with the crash in stderr. Assertions also tighten: empty stderr, the decorator fixture prints the `design:type` it received (`Object`, per #8439), and error cases compare the whole error line including the module it names.
- The compile semaphore and the leaksan entry go away, and the executable is deleted after the test.
- Verification is local timing and passing runs, no test that fails without the change: debug goes from 50s to 61s down to 5.6s to 5.8s (3 runs each), release from 2.85s to under 0.7s, five runs at load average 60 to 120 passed in 8.3s to 11.0s, and the LeakSanitizer environment passes in about 9s. Un-skipping `run` today fails on the 10 fixtures #35605 is expected to fix.

### Background
- A type-only export (`export type`, or an interface re-exported by name) has no runtime binding, so a re-export chain that names one must drop it at link time or the linker reports `export 'my_string' not found`. This file checks that across `require`, `import *`, `import()` and named imports.
- The module record is the export list bun hands JSC for a module. Today bun only emits it for `--compile --bytecode --format=esm` output, not from the runtime transpiler (#7384), which is why `run` is skipped and only `build` and `compile` are asserted.
- `bun build --compile` makes a standalone executable by copying the whole bun binary and appending the bundle, so a compile costs the copy, not the bundling. `--splitting` puts each `import()` target in its own chunk instead of inlining it.
- In `bun:test`, `test.concurrent` tests only run together within a batch, and any non-concurrent test in between (a skipped one included) ends the batch; `describe.concurrent` keeps a group in one batch.
- `test/no-validate-leaksan.txt` lists test files the ASAN lanes run without LeakSanitizer's exit check; removing a file turns that check back on for it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

`test/js/bun/typescript/type-export.test.ts` is one of the slowest non-integration test files (53s on the slowest lane of build 92779, a release x64 lane). Test-only change (the test file plus its line in `test/no-validate-leaksan.txt`); no `src/` changes.

## Why it was slow

Every one of the 16 `b` x `c` fixtures, plus the ownkeys and decorator fixtures, ran `bun build --compile --bytecode --format=esm` on its own: 18 executables, each one a full copy of the bun binary (about 100 MB release, about 800 MB debug). The file already used `test.concurrent`, but each fixture's skipped `run` test sits in a plain `describe`, so it is a non-concurrent entry, and a non-concurrent entry closes the batch of concurrent tests that run together (`append_or_extend_concurrent_group` in `src/runtime/test_runner/Order.rs`). The compiles therefore ran one after another: 18 x about 3s.

## What changed

* All 18 fixtures are written into one temp tree (`fixtures/<name>/...`) and a generated `runner.ts` imports them one after another, capturing what each prints and printing one JSON object keyed by fixture name. The three modes become three tests in one `describe.concurrent`:
  * `run`: `bun runner.ts`, still skipped (#7384). If it is un-skipped today it fails with the 10 affected fixtures (the 8 `export-from` / `import-then-export` combinations, ownkeys, decorator) each reporting `SyntaxError: export 'my_string' not found in './a.ts'` etc. under their own key, so it is ready for #35605 to flip.
  * `build`: one `Bun.build` of all the entry points (without splitting each entry still gets its own self-contained bundle; the per-fixture module code is byte-identical to a build of that fixture alone, only the shared helper preamble differs), then one `bun runner.ts` over the outputs. Was 16 builds + 16 processes.
  * `compile`: one `bun build --compile --bytecode --format=esm --splitting runner.ts`, then one run of the executable. With `--splitting` every fixture is its own chunk with its own bytecode and module record, and in the `await import("./b")` fixtures `b` becomes a chunk of its own, so its module record's export list (`my_value`, `my_only`, and not the type-only `my_string`) is now exercised by the compiled build; previously everything was inlined into one chunk per executable and the record had nothing type-related in it. Was 18 executables.
* A failing fixture is still attributable: the runner prints one `[name, result]` line per fixture and the assertion is a single `toEqual` against `{ results: { "<fixture>": ... }, stderr: "", exitCode: 0 }`, so the diff names the fixture and shows its parsed output, or `{ error, lines }` with whatever it managed to print before failing. A fixture that takes the process down shows up as the first missing key, with the crash in `stderr`.
* The 4-slot compile semaphore is gone since there is one compile. That one test costs what each of the old compile tests did (about 3s on a debug build: the time is the executable copy, `--splitting` and the extra chunks add about 0.1s), so the file's exposure to the default per-test timeout goes from 18 tests to 1.
* `test/no-validate-leaksan.txt` listed this file under `# Slow`. With one compile that reason is gone, so the entry is removed and ASAN lanes validate leaks for it again; locally, `bun bd test` with the CI runner's LeakSanitizer setup (`BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1`, `test/leaksan.supp`, its `--timeout`) passes at this head in 10.7s on a loaded machine (load average about 75) with no leak reports and nothing left in the temp dir.
* Fixture dirs are created inside the tests with `await using`, so the executable is deleted afterwards. Before, the 18 executables were left in the temp dir (about 14 GB per debug run).

Every shape the file covered is still covered:

| before | now |
| --- | --- |
| `re-export with <4 b> > import with <4 c> > run / compile / build` | the 16 `<b>/<c>` fixtures, in the `run` / `build` / `compile` tests |
| `check ownkeys from a star import > run / compile` | `ownkeys-of-star-import` fixture (now also covered by `build`) |
| `import only used in decorator (#8439) > run / compile` | `import-only-used-in-decorator` fixture (now also covered by `build`) |
| `import not found > none / default with same name / type`, `js file type import`, `... with default export`, `js file with through export`, `... 2`, `check merge` | the `importing a name that is not exported as a value` table, same names |
| `js file type export` | unchanged test, full stderr inline snapshot |
| `through export merge` (js/ts x 4 x main/a) | unchanged structure |
| `check commonjs` | unchanged test |
| `export * from`, `export * as ns from` (js/ts x main/a), `export type {Type} from` (ts x main/a) | the `re-export forms` table |

## Assertions

* The 18 fixtures: stdout is parsed and compared as a whole, stderr must be empty, build logs must be empty (previously the matrix ignored stderr, and the decorator test only checked that nothing was printed to stderr).
* The decorator fixture installs a `Reflect.metadata` recorder for the duration of its class definitions and prints the `design:type` it received, so it asserts the `Object` that tsc emits for an interface (the expected behaviour in #8439) instead of just exiting 0.
* `export *` / `export * as ns` / `export type {}`: exact stdout per file (`b`, `test`, or nothing for the re-exporting file itself) plus empty stderr, instead of a bare exit code.
* Error cases: the exact error line including the module it names (`'<dir>/a.ts'`, `'<dir>/ts.ts'`, `'./ts.ts'`), plus empty stdout and exit code 1, instead of `toInclude` on a fragment. `js file type export` snapshots the whole normalized stderr, including the `at <dir>/a.js:1:9` location. `through export merge` keeps JSC's message for the `main` entry and, for the `a` entry, expects bun's message immediately followed by its `at <dir>/a.<ext>:1:` location (the `main` expectation is the line #33899 will change).
* Only the error line is compared for the JSC link errors, so #36635 (which adds the importing file's location under it) stays green.

## Timing

Same machine, same debug build, `bun bd test test/js/bun/typescript/type-export.test.ts`:

| | before | after |
| --- | --- | --- |
| debug build, reported by the runner | 50.2s, 51.1s, 60.7s (3 runs) | 5.6s, 5.7s, 5.8s (3 runs) |
| release build (`USE_SYSTEM_BUN=1 bun test`) | 2.85s | 0.4s to 0.7s |

Five further `bun bd test` runs while the host was heavily loaded (load average 60 to 120) took 8.3s to 11.0s and passed every time; the same load is what pushed a single debug compile past 5s and motivated the ceiling. Test count goes from 70 pass + 18 skip to 38 pass + 1 skip, per the table above; `expect()` calls from 196 to 57, with the 18 fixtures compared in two `toEqual`s per mode and the 16 `through export merge` runs in two each.

</details>

