### PR TITLE
Bun.serve: keep the server alive while an HTML route is building

### DIFF
--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -169,6 +169,8 @@ pub struct Route {
 
 pub enum State {
     Pending,
+    /// `None` while the server's plugins are still loading. In either form the
+    /// route holds a pending request on `Route::server` (`schedule_bundle`).
     Building(Option<*mut JSBundleCompletionTask>),
     Err(Log),
     /// Intrusive-refcounted; freed via `StaticRoute::deref_` in `State::deinit`.
@@ -387,20 +389,41 @@ impl Route {
     }
 
     /// Schedule a bundle to be built.
-    /// If success, bumps the ref count and returns true;
-    fn schedule_bundle(&self, server: AnyServer) -> Result<(), crate::Error> {
+    ///
+    /// Entering `State::Building` counts as a pending request on the server:
+    /// the plugin load and the build finish on later event-loop turns and call
+    /// back into it (`on_plugins_resolved`, `on_complete`), so its
+    /// `deinit_if_we_can` must not free it before then. Nothing else holds it
+    /// on the route's behalf; the clients waiting in `pending_responses` only
+    /// count as connections and can disconnect at any time. `finish_building`
+    /// releases the pending request when the route leaves `State::Building`.
+    fn schedule_bundle(&self, mut server: AnyServer) -> Result<(), crate::Error> {
         match server.get_or_load_plugins(ServePluginsCallback::HtmlBundleRoute(self.as_ctx_ptr())) {
             GetOrStartLoadResult::Err => {
                 self.state.set(State::Err(Log::init()));
             }
             GetOrStartLoadResult::Ready(plugins) => {
-                self.on_plugins_resolved(plugins.map(NonNull::from))?;
+                let plugins = plugins.map(NonNull::from);
+                server.on_pending_request();
+                self.on_plugins_resolved(plugins)?;
             }
             GetOrStartLoadResult::Pending => {
+                server.on_pending_request();
                 self.state.set(State::Building(None));
             }
         }
         Ok(())
+    }
+
+    /// Leaves `State::Building`: answers the requests that arrived while the
+    /// route was building, then releases the pending request `schedule_bundle`
+    /// took on the server. The release comes last because it runs the server's
+    /// idle pass (`deinit_if_we_can`), which schedules the server's deinit when
+    /// this build was the only thing still keeping a stopped server alive.
+    fn finish_building(&self) {
+        debug_assert!(matches!(self.state.get(), State::Err(_) | State::Html(_)));
+        self.resume_pending_responses();
+        self.server.get().expect("server set").on_request_complete();
     }
 
     pub(crate) fn on_plugins_resolved(
@@ -530,7 +553,7 @@ impl Route {
             std::ptr::from_ref(self) as usize
         );
         self.state.set(State::Err(Log::init()));
-        self.resume_pending_responses();
+        self.finish_building();
         Ok(())
     }
 
@@ -538,6 +561,10 @@ impl Route {
         // For the build task — matches the ref() taken in on_plugins_resolved.
         // SAFETY: self is IntrusiveRc-managed; `adopt` consumes the prior +1 on Drop.
         let _drop_build_ref = unsafe { bun_ptr::ScopedRef::<Route>::adopt(self.as_ctx_ptr()) };
+        // Still allocated, even if it has been stopped and its JS wrapper
+        // collected since: the route holds a pending request on it until
+        // `finish_building` (see `schedule_bundle`).
+        let server = self.server.get().expect("server set");
 
         match &mut completion_task.result {
             BundleV2Result::Err(err) => {
@@ -546,16 +573,14 @@ impl Route {
                 }
                 let mut log = Log::init();
                 completion_task.log.clone_to_with_recycled(&mut log, true);
-                if let Some(server) = self.server.get() {
-                    if server.config().is_development() {
-                        // `Output.errorWriterBuffered()` → process-global writer;
-                        // `Log::print` accepts it via the `*mut io::Writer`
-                        // `IntoLogWrite` adapter and dispatches on
-                        // `enable_ansi_colors_stderr` internally.
-                        let writer: *mut bun_core::io::Writer = bun_output::error_writer_buffered();
-                        let _ = log.print(writer);
-                        bun_output::flush();
-                    }
+                if server.config().is_development() {
+                    // `Output.errorWriterBuffered()` → process-global writer;
+                    // `Log::print` accepts it via the `*mut io::Writer`
+                    // `IntoLogWrite` adapter and dispatches on
+                    // `enable_ansi_colors_stderr` internally.
+                    let writer: *mut bun_core::io::Writer = bun_output::error_writer_buffered();
+                    let _ = log.print(writer);
+                    bun_output::flush();
                 }
                 self.state.set(State::Err(log));
             }
@@ -564,9 +589,6 @@ impl Route {
                     bun_output::scoped_log!(debug, "onComplete: success");
                 }
                 // Find the HTML entry point and create static routes
-                let Some(server) = self.server.get() else {
-                    return;
-                };
                 // S008: `JSGlobalObject` is an `opaque_ffi!` ZST — safe `*const → &` deref.
                 let global_this = bun_opaque::opaque_deref(server.global_this());
                 let output_files = &mut bundle.output_files;
@@ -711,11 +733,10 @@ impl Route {
             BundleV2Result::Pending => unreachable!(),
         }
 
-        // Handle pending responses
-        self.resume_pending_responses();
+        self.finish_building();
     }
 
-    pub(crate) fn resume_pending_responses(&self) {
+    fn resume_pending_responses(&self) {
         // R-2: `JsCell::replace` moves the Vec out so the per-response loop
         // (which writes responses and may run uws callbacks) holds no borrow
         // into `self.pending_responses`.

--- a/test/js/bun/http/bun-serve-html-build-holds-server.test.ts
+++ b/test/js/bun/http/bun-serve-html-build-holds-server.test.ts
@@ -1,0 +1,137 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
+
+// An HTML route served without the DevServer bundles on its first request. The
+// plugin load and the build finish on later event-loop turns and call back into
+// the server through the route's raw back-pointer, while the clients waiting on
+// the build only count as connections. Once they disconnected, nothing kept the
+// server alive: stop(true) settled, the wrapper became collectable, the server
+// was freed, and the build's completion then used it (heap-use-after-free in
+// Route::on_complete or Route::on_plugins_resolved under ASAN). A building route
+// now holds a pending request on the server, so stop() cannot settle before the
+// build has finished and the server is still there when it does.
+//
+// The fixture parks the route inside the plugin (argv[2] picks where), drops
+// the only client, calls stop(true), drops the server, and reports whether
+// stop() settled while the route was still parked.
+const fixture = {
+  "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+  "index.html": `<!DOCTYPE html><html><head></head><body><script type="module" src="./entry.ts"></script></body></html>`,
+  "entry.ts": `console.log("entry");`,
+  "plugin.ts": /* ts */ `
+    const { __mode: mode, __parked: parked, __release: release } = globalThis as any;
+    export default {
+      name: "park-the-route",
+      async setup(build: any) {
+        if (mode.startsWith("plugin setup")) {
+          parked();
+          await release;
+          if (mode === "plugin setup rejection") throw new Error("plugin setup rejected on purpose");
+        }
+        build.onLoad({ filter: /entry\\.ts$/ }, async () => {
+          if (mode === "build") {
+            parked();
+            await release;
+          }
+          return { loader: "ts", contents: "console.log('built')" };
+        });
+      },
+    };
+  `,
+  "run.ts": /* ts */ `
+    import html from "./index.html";
+
+    // Read by plugin.ts, which Bun.serve loads into this same global on the
+    // first request.
+    const parked = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    Object.assign(globalThis, { __mode: process.argv[2], __parked: parked.resolve, __release: release.promise });
+
+    let collected = false;
+    const registry = new FinalizationRegistry(() => void (collected = true));
+    const turn = () => new Promise<void>(r => setTimeout(r, 0));
+    async function collectServer() {
+      for (let i = 0; i < 50 && !collected; i++) {
+        Bun.gc(true);
+        await turn();
+      }
+      return collected;
+    }
+
+    // Its own frame, so that nothing on the stack still refers to the server
+    // once it returns.
+    async function stopWhileParked() {
+      const server = Bun.serve({
+        port: 0,
+        development: false,
+        routes: { "/": html },
+        fetch: () => new Response("fallback"),
+      });
+      registry.register(server, "server");
+      const controller = new AbortController();
+      const request = fetch(server.url, { signal: controller.signal }).then(
+        response => "status " + response.status,
+        error => error.name,
+      );
+      await parked.promise;
+      const pendingRequestsWhileParked = server.pendingRequests;
+      controller.abort();
+      return { fetch: await request, pendingRequestsWhileParked, stopped: server.stop(true) };
+    }
+
+    const { fetch: fetchResult, pendingRequestsWhileParked, stopped } = await stopWhileParked();
+    let settled = false;
+    stopped.then(() => void (settled = true));
+    for (let i = 0; i < 10; i++) await turn();
+    const stopBeforeRelease = settled ? "settled" : "pending";
+    if (settled) {
+      // Nothing holds the server for the parked route: let it be freed before
+      // the route resumes, which is the use-after-free.
+      await collectServer();
+      await turn();
+    }
+
+    release.resolve();
+    await stopped;
+    console.log(
+      JSON.stringify({
+        fetch: fetchResult,
+        pendingRequestsWhileParked,
+        stopBeforeRelease,
+        collectedAfterwards: await collectServer(),
+      }),
+    );
+  `,
+};
+
+test.concurrent.each(["build", "plugin setup", "plugin setup rejection"])(
+  "a server whose HTML route is parked in its %s outlives stop(true) until the route is done",
+  async mode => {
+    using dir = tempDir("serve-html-build-holds-server", fixture);
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run.ts", mode],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // A crash (the ASAN report) replaces the fixture's report in the assertion.
+    expect(stdout.trim() === "" ? stderr : JSON.parse(stdout)).toEqual({
+      fetch: "AbortError",
+      pendingRequestsWhileParked: 1,
+      stopBeforeRelease: "pending",
+      collectedAfterwards: true,
+    });
+    if (mode === "plugin setup rejection") {
+      expect(stderr).toContain("plugin setup rejected on purpose");
+    } else {
+      expect(stderr).toBe("");
+    }
+    expect(exitCode).toBe(0);
+  },
+  // Passes in about a second; the ceiling is for the failure path, where ASAN
+  // symbolizes the report against the debug binary before the child exits.
+  30_000,
+);


### PR DESCRIPTION
### Problem
- An HTML route served without the DevServer (`development: false` or `{ hmr: false }`) bundles on its first request. If the only client disconnects and `server.stop(true)` is called while a `[serve.static]` plugin still has that build parked, `stop()` settles, the next GC frees the server, and the build then finishes against the freed server.
- Debug build: `AddressSanitizer: heap-use-after-free` in `html_bundle::Route::on_complete` (parked in `onLoad`) or `Route::on_plugins_resolved` (parked in the plugin's `setup()`). A release build reads the freed `NewServer` with no report.
- Cause: while a route is building, nothing counts as keeping the server alive. The clients waiting on the build only count as connections, so once they drop the server's idle check sees no pending work.
- The other route kinds already count their asynchronous work in the server's pending-request counter; the HTML build was the one piece of in-flight work that did not.

### Fix
- Entering the building state now takes one pending request on the server; both ways out of it (build finished, plugin load rejected) answer the waiting clients and then release it.
- This holds the server for exactly the window in which the route will call back into it. The release runs the server's idle pass, so a server stopped mid-build is freed right after the build lands.
- Visible change: `server.pendingRequests` is 1 while an HTML route bundles and `await server.stop()` waits for the bundle, as it already does for a `fetch` handler still running. A build cancelled by VM teardown is not covered; at exit it leaves the same state an in-flight `fetch` handler does.
- Verification: a new test parks the route in the build, in the plugin load, and in a plugin load that rejects. Unfixed debug build: all three report 0 pending requests and an early-settled `stop()`, and the first two die with the ASAN reports above. Fixed: all three pass, as do the existing HTML-serve tests that do not need the DevServer.

### Background
- HTML routes: `Bun.serve({ routes: { "/": html } })` with an imported `.html` file. Without the DevServer the route bundles the page once, on the first request, registers the outputs as static routes, and holds requests that arrive during the build.
- `[serve.static]` plugins: a bunfig entry naming bundler plugins for these routes, loaded on the first request. Both the plugin load and the bundle finish on later event-loop turns and complete by calling back into the server through a raw pointer stored on the route.
- Pending requests: the server's count of in-flight work, exposed as `server.pendingRequests`. `stop()` settles and the server can be torn down only when the count is zero; static and file routes already raise it when a response goes asynchronous.
- Server lifetime: stopping a server does not free it. Once nothing is pending, the JS wrapper becomes collectable and the native server is freed on a later GC, so a stale pointer to it only fails after a GC.

<details>
<summary>Original description</summary>

### Repro

HTML route served without the DevServer (`development: false` or `{ hmr: false }`), with a `[serve.static]` plugin whose `onLoad` parks on a promise. Request the route, drop the client, `server.stop(true)`, drop the server, `Bun.gc(true)` plus a couple of event-loop turns, then let `onLoad` resolve. Debug (ASAN) build:

```
==1165==ERROR: AddressSanitizer: heap-use-after-free on address 0x73defa800738 ...
READ of size 8 at 0x73defa800738 thread T0
    #0 in <bun_runtime::server::NewServer<false, false>>::global_this src/runtime/server/mod.rs:451
    #1 in <bun_runtime::server::AnyServer>::global_this src/runtime/server/mod.rs:3847
    #2 in <bun_runtime::server::html_bundle::Route>::on_complete src/runtime/server/HTMLBundle.rs
    #3 in JSBundleCompletionTask::on_complete src/runtime/api/js_bundle_completion_task.rs:642
freed by thread T0 here:
    ...
    #11 in <bun_runtime::server::NewServer<false, false>>::deinit src/runtime/server/mod.rs:2122
    #12 in NewServer::schedule_deinit::{closure#1} src/runtime/server/mod.rs:1957
```

Parking in the plugin's `setup()` instead (so the route is still waiting for the plugin load when the server goes away) gives the same report one step earlier:

```
READ of size 1 ... in <bun_runtime::server::html_bundle::Route>::on_plugins_resolved src/runtime/server/HTMLBundle.rs
    #1 in <bun_runtime::server::server_body::ServePlugins>::handle_on_resolve src/runtime/server/server_body.rs:1150
    #2 in bun_runtime::server::server_body::on_resolve_impl
```

On a release build the same sequence reads a freed `NewServer` (its config, then `append_static_route` / `reload_static_routes` on it) without a report.

### Cause

`html_bundle::Route` keeps a raw `server` back-pointer and bundles on its first request. Both the plugin load and the build finish on later event-loop turns and call back into the server through that pointer (`on_plugins_resolved` reads the config, `on_complete` registers the output files as static routes and reloads the route table). While the route is in `State::Building`, nothing holds the server on its behalf: `on_plugins_resolved` only refs the route itself, and the clients waiting in `pending_responses` only count as connections, which they can drop at any time. So once the last client disconnects and the server is stopped, `deinit_if_we_can` sees no pending requests, settles `stop()`, downgrades the wrapper, and the next GC frees the `NewServer` with the build still in flight.

`StaticRoute` / `FileRoute` / `DirectoryRoute` already handle their asynchronous work with the server's `pending_requests` counter (`on_pending_request` when a response goes async, `on_static_request_complete` when it finishes); the route's build is the same kind of in-flight work and was the one thing not counted.

### Fix

`schedule_bundle` calls `server.on_pending_request()` whenever the route enters `State::Building` (plugins ready, or plugins still loading), and the two ways out of that state (`on_complete`, `on_plugins_rejected`) go through a new `finish_building`, which answers the pending responses and then calls `on_request_complete()`. That keeps the server allocated for exactly the window in which the route will call back into it, and `on_request_complete` runs the idle pass, so a server that was stopped while building is downgraded and freed right after the build lands (the `stop()` promise now settles then as well, matching what happens for a `fetch` handler that is still running when `stop()` is called). With that invariant, `on_complete` no longer needs its `Option` handling of the back-pointer; it takes the server once at the top, the same way `on_plugins_resolved` already did.

A visible consequence: `server.pendingRequests` is 1 while an HTML route is bundling, and `await server.stop()` waits for the bundle. A build whose plugin never settles therefore keeps the server allocated, as an unsettled `fetch` handler already does. Not covered: a build cancelled by VM teardown never reaches `Route::on_complete` (the completion task returns early on `cancelled`), so at exit the route keeps its ref and, now, its pending request; that is the same state an in-flight `fetch` handler leaves a server in at exit and nothing observes it. The DevServer's own plugin wait uses a different back-pointer and is not changed here.

### Verification

`test/js/bun/http/bun-serve-html-build-holds-server.test.ts` (separate small file; `bun-serve-html.test.ts` is too slow under the debug ASAN build for a lifetime test, as `bun-serve-html-hot-reload-drop.test.ts` notes). One fixture, parked in turn in the build (`onLoad`), in the plugin load (`setup()`), and in a plugin load that then rejects (the `on_plugins_rejected` exit has to release the request too). Each child reports `server.pendingRequests` while parked, whether `stop(true)` settled across ten event-loop turns before the route was released, and whether the wrapper became collectable afterwards; the test expects `{ pendingRequestsWhileParked: 1, stopBeforeRelease: "pending", collectedAfterwards: true }` plus a clean exit. If `stop()` did settle early, the fixture lets the server get collected before releasing the route, which is the sequence above.

Unfixed debug build: all three report `pendingRequestsWhileParked: 0, stopBeforeRelease: "settled"`, and the first two children die with the ASAN reports above (the rejection case has no use-after-free to hit; it fails on the report). Fixed: the three pass in under a second each. Also run on the fixed debug build: `bun-serve-html-405.test.ts`, `bun-serve-html-hot-reload-drop.test.ts`, `test/bake/serve-plugins-dev-server.test.ts` (all pass), and `bun-serve-html.test.ts`, where everything that does not need the DevServer passes, including `serve plugins > concurrent requests to multiple routes during plugin load`; its `development: true` cases fail in this container with `EMFILE while initializing file watcher for development server` (inotify instance limit) before reaching any of this code.


</details>
