### PR TITLE
cluster: fix two ways a Windows worker stops reacting (shared accept() race, early handle ack); fixes test-cluster-shared-leak timeouts

### DIFF
--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -216,6 +216,21 @@ function exitedAfterDisconnect(worker, message) {
   send(worker, { ack: message.seq });
 }
 
+// RoundRobinHandle: the primary accepts and hands each connection to a worker. SharedHandle: every
+// worker accepts on its own copy of one socket. UDP has no connections to hand out, and a TLS
+// server accepts natively, so both always share.
+//
+// On Windows a TCP listener is served by the primary even under SCHED_NONE. accept() on a
+// duplicated listener blocks the worker's event loop when another worker takes the connection first
+// (mswsock checks for a pending connection, then waits for one), and libuv's exclusive AFD polls on
+// one socket from two processes cancel each other in a loop. Node shares listeners there through
+// AcceptEx, which Bun's listen sockets do not use.
+function usesRoundRobinHandle(message) {
+  if (message.sharedOnly === true || message.addressType === "udp4" || message.addressType === "udp6") return false;
+  if (schedulingPolicy === SCHED_RR) return true;
+  return process.platform === "win32" && (message.addressType === 4 || message.addressType === 6);
+}
+
 function queryServer(worker, message) {
   // Stop processing if worker already disconnecting
   if (worker.exitedAfterDisconnect) return;
@@ -237,15 +252,7 @@ function queryServer(worker, message) {
     send(worker, { errno: UV_EINVAL, key, ack: message.seq, data: handle.data, bunHint: kSharedOnlyHint }, null);
     return;
   }
-  if (
-    schedulingPolicy === SCHED_RR &&
-    handle !== undefined &&
-    message.sharedOnly !== true &&
-    handle instanceof SharedHandle &&
-    handle.sharedOnly &&
-    message.addressType !== "udp4" &&
-    message.addressType !== "udp6"
-  ) {
+  if (handle instanceof SharedHandle && handle.sharedOnly && usesRoundRobinHandle(message)) {
     send(worker, { errno: UV_EINVAL, key, ack: message.seq, data: handle.data, bunHint: kSharedOnlyHint }, null);
     return;
   }
@@ -260,9 +267,6 @@ function queryServer(worker, message) {
       if (message.address.length < address.length) address = message.address;
     }
 
-    // UDP is exempt from round-robin connection balancing for what should
-    // be obvious reasons: it's connectionless. There is nothing to send to
-    // the workers except raw datagrams and that's pointless.
     if (process.platform === "win32" && (message.addressType === "udp4" || message.addressType === "udp6")) {
       const error = new Error(`write ENOTSUP - cannot share a dgram socket with a worker on Windows`);
       error.code = "ENOTSUP";
@@ -270,15 +274,10 @@ function queryServer(worker, message) {
       worker.emit("error", error);
       return;
     }
-    if (
-      schedulingPolicy !== SCHED_RR ||
-      message.sharedOnly === true ||
-      message.addressType === "udp4" ||
-      message.addressType === "udp6"
-    ) {
-      handle = new SharedHandle(key, address, message);
-    } else {
+    if (usesRoundRobinHandle(message)) {
       handle = new RoundRobinHandle(key, address, message);
+    } else {
+      handle = new SharedHandle(key, address, message);
     }
 
     if (!cachedHandle) handles.set(key, handle);

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -246,8 +246,8 @@ function queryServer(worker, message) {
   if (cachedHandle && !cachedHandle.has(worker)) handle = cachedHandle;
 
   const kSharedOnlyHint =
-    "TLS and non-TLS cluster workers cannot share the same address:port under SCHED_RR " +
-    "(Bun's TLS accept is native and cannot adopt round-robin connection fds)";
+    "TLS and non-TLS cluster workers cannot share the same address:port while the primary distributes its connections " +
+    "(Bun's TLS accept is native and cannot adopt handed-off connections); listen on different ports";
   if (handle !== undefined && message.sharedOnly === true && handle instanceof RoundRobinHandle) {
     send(worker, { errno: UV_EINVAL, key, ack: message.seq, data: handle.data, bunHint: kSharedOnlyHint }, null);
     return;

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -216,15 +216,10 @@ function exitedAfterDisconnect(worker, message) {
   send(worker, { ack: message.seq });
 }
 
-// RoundRobinHandle: the primary accepts and hands each connection to a worker. SharedHandle: every
-// worker accepts on its own copy of one socket. UDP has no connections to hand out, and a TLS
-// server accepts natively, so both always share.
-//
-// On Windows a TCP listener is served by the primary even under SCHED_NONE. When two workers poll
-// copies of one listening socket, the worker that loses the race for a connection blocks inside
-// accept() (the copy is non-blocking, Winsock waits anyway) and its event loop stops, and libuv's
-// exclusive AFD polls on the same socket from two processes cancel each other in a loop. Node shares
-// listeners there through AcceptEx, which Bun's listen sockets do not use.
+// Windows cannot accept from copies of one listening socket in two processes: the worker losing the
+// race for a connection blocks inside accept() despite its copy being non-blocking, and libuv's
+// exclusive AFD polls from two processes cancel each other in a loop (node uses AcceptEx there).
+// So on Windows the primary distributes TCP connections under every policy; UDP and TLS always share.
 function usesRoundRobinHandle(message) {
   if (message.sharedOnly === true || message.addressType === "udp4" || message.addressType === "udp6") return false;
   if (schedulingPolicy === SCHED_RR) return true;

--- a/src/js/internal/cluster/primary.ts
+++ b/src/js/internal/cluster/primary.ts
@@ -220,11 +220,11 @@ function exitedAfterDisconnect(worker, message) {
 // worker accepts on its own copy of one socket. UDP has no connections to hand out, and a TLS
 // server accepts natively, so both always share.
 //
-// On Windows a TCP listener is served by the primary even under SCHED_NONE. accept() on a
-// duplicated listener blocks the worker's event loop when another worker takes the connection first
-// (mswsock checks for a pending connection, then waits for one), and libuv's exclusive AFD polls on
-// one socket from two processes cancel each other in a loop. Node shares listeners there through
-// AcceptEx, which Bun's listen sockets do not use.
+// On Windows a TCP listener is served by the primary even under SCHED_NONE. When two workers poll
+// copies of one listening socket, the worker that loses the race for a connection blocks inside
+// accept() (the copy is non-blocking, Winsock waits anyway) and its event loop stops, and libuv's
+// exclusive AFD polls on the same socket from two processes cancel each other in a loop. Node shares
+// listeners there through AcceptEx, which Bun's listen sockets do not use.
 function usesRoundRobinHandle(message) {
   if (message.sharedOnly === true || message.addressType === "udp4" || message.addressType === "udp6") return false;
   if (schedulingPolicy === SCHED_RR) return true;

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -922,6 +922,10 @@ pub struct SendQueue {
     root: Cell<Option<core::ptr::NonNull<SendQueue>>>,
     pub(crate) queue: JsCell<Vec<SendHandle>>,
     pub(crate) waiting_for_ack: JsCell<Option<SendHandle>>,
+    /// The peer's reply to a handle message whose write has not completed yet (`on_write_complete`
+    /// is what moves the message into `waiting_for_ack`). Only asynchronous writes (libuv, i.e.
+    /// Windows) can observe the reply first; `on_write_complete` applies it.
+    early_ack_nack: Cell<Option<AckNack>>,
 
     pub(crate) retry_count: Cell<u32>,
     pub(crate) keep_alive: JsCell<KeepAlive>,
@@ -1046,6 +1050,7 @@ impl SendQueue {
             root: Cell::new(None),
             queue: JsCell::new(Vec::new()),
             waiting_for_ack: JsCell::new(None),
+            early_ack_nack: Cell::new(None),
             retry_count: Cell::new(0),
             keep_alive: JsCell::new(KeepAlive::default()),
             #[cfg(debug_assertions)]
@@ -1355,7 +1360,18 @@ impl SendQueue {
             Some(item) => Some(item.handle.is_some()),
         });
         let Some(has_handle) = waiting else {
-            log!("onAckNack: ack received but not waiting for ack");
+            let handle_write_in_progress = self.write_in_progress.get()
+                && self
+                    .queue
+                    .get()
+                    .first()
+                    .is_some_and(|first| first.handle.is_some());
+            if handle_write_in_progress {
+                log!("onAckNack: ack/nack arrived before the handle message's write completed");
+                self.early_ack_nack.set(Some(ack_nack));
+            } else {
+                log!("onAckNack: ack received but not waiting for ack");
+            }
             return;
         };
         if !has_handle {
@@ -1547,6 +1563,7 @@ impl SendQueue {
             return;
         }
         self.write_in_progress.set(false);
+        let early_ack_nack = self.early_ack_nack.take();
         let global_this = self.get_global_this();
 
         enum Done {
@@ -1590,9 +1607,12 @@ impl SendQueue {
             }
         });
         match done {
-            Done::AwaitAck => {
-                self.continue_send(&global_this, ContinueSendReason::OnWritable);
-            }
+            Done::AwaitAck => match early_ack_nack {
+                // The peer already replied while the write was in flight; settle the message now,
+                // otherwise it would wait in waiting_for_ack forever and block everything behind it.
+                Some(ack_nack) => self.on_ack_nack(&global_this, ack_nack),
+                None => self.continue_send(&global_this, ContinueSendReason::OnWritable),
+            },
             Done::Completed(item) => {
                 item.complete(&global_this); // call the callback & deinit
                 self.continue_send(&global_this, ContinueSendReason::OnWritable);

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -922,9 +922,8 @@ pub struct SendQueue {
     root: Cell<Option<core::ptr::NonNull<SendQueue>>>,
     pub(crate) queue: JsCell<Vec<SendHandle>>,
     pub(crate) waiting_for_ack: JsCell<Option<SendHandle>>,
-    /// The peer's reply to a handle message whose write has not completed yet (`on_write_complete`
-    /// is what moves the message into `waiting_for_ack`). Only asynchronous writes (libuv, i.e.
-    /// Windows) can observe the reply first; `on_write_complete` applies it.
+    /// Reply to a handle message read before libuv reported that message's own write complete;
+    /// `on_write_complete` (which moves the message into `waiting_for_ack`) applies it.
     early_ack_nack: Cell<Option<AckNack>>,
 
     pub(crate) retry_count: Cell<u32>,
@@ -1608,8 +1607,6 @@ impl SendQueue {
         });
         match done {
             Done::AwaitAck => match early_ack_nack {
-                // The peer already replied while the write was in flight; settle the message now,
-                // otherwise it would wait in waiting_for_ack forever and block everything behind it.
                 Some(ack_nack) => self.on_ack_nack(&global_this, ack_nack),
                 None => self.continue_send(&global_this, ContinueSendReason::OnWritable),
             },

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -204,7 +204,7 @@ if (cluster.isPrimary) {
   const { stdout } = await bunRun(joinP(dir, "main.ts"), bunEnv);
   expect(stdout).toContain("tls listen error code: EINVAL");
   expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
-});
+}, 30_000);
 
 test("cluster pipe listen error carries no port suffix", async () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -451,18 +451,26 @@ if (cluster.isPrimary) {
   expect(stdout).toContain("listening workers: 2 distinct ports: 1");
 });
 
-// Two workers accepting on copies of one Windows listening socket race each other for every
-// connection, and the loser blocks inside accept(): its event loop never runs again, so it stops
-// answering IPC and never exits. Each connection below is one such race; the primary pings both
-// workers after every one. TCP listens under SCHED_NONE are served by the primary on Windows instead.
-test.skipIf(!isWindows)(
-  "SCHED_NONE: two workers sharing one port keep answering IPC while connections arrive, then exit",
-  async () => {
-    using dir = tempDir("cluster-shared-accept-race", {
-      "main.ts": `
+// Every connection below is one chance for a worker to stop answering IPC; the primary pings both
+// workers after each one and the workers must still disconnect cleanly at the end.
+//
+// SCHED_NONE: two workers accepting on copies of one Windows listening socket race each other for
+// every connection, and the loser blocked inside accept(), so its event loop never ran again. TCP
+// listens under SCHED_NONE are served by the primary on Windows now.
+//
+// SCHED_RR: the primary sends each connection as a handle message. On Windows the worker's ack for
+// it could be read before libuv reported the write itself complete; the primary then dropped the ack
+// and waited for it forever, and every later message to that worker (pings, disconnect) sat behind
+// it. This ordering needs a busy machine, so before the fix this variant only failed under load.
+for (const policy of ["SCHED_NONE", "SCHED_RR"]) {
+  test.skipIf(!isWindows)(
+    `${policy}: two workers on one port keep answering IPC while connections arrive, then exit`,
+    async () => {
+      using dir = tempDir("cluster-worker-responsiveness", {
+        "main.ts": `
 const cluster = require("node:cluster");
 const net = require("node:net");
-cluster.schedulingPolicy = cluster.SCHED_NONE;
+cluster.schedulingPolicy = cluster.${policy};
 
 if (cluster.isPrimary) {
   const CONNECTIONS = 100;
@@ -529,23 +537,24 @@ if (cluster.isPrimary) {
   });
 }
 `,
-    });
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.ts"],
-      env: bunEnv,
-      cwd: String(dir),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "served: 100 ports: 1\nexits: 0,0\n",
-      stderr: expect.any(String),
-      exitCode: 0,
-    });
-  },
-  30_000,
-);
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "main.ts"],
+        env: bunEnv,
+        cwd: String(dir),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode }).toEqual({
+        stdout: "served: 100 ports: 1\nexits: 0,0\n",
+        stderr: expect.any(String),
+        exitCode: 0,
+      });
+    },
+    30_000,
+  );
+}
 
 test("SCHED_NONE: close() releases the shared handle so the worker can re-listen on the same port", async () => {
   using dir = tempDir("cluster-shared-relisten", {
@@ -958,7 +967,9 @@ test.skipIf(!isWindows)(
     const dir = tempDirWithFiles("bun-test", netWorkerAfterTlsWorkerFixture);
     const { stdout } = await bunRun(joinP(dir, "main.ts"), { NODE_CLUSTER_SCHED_POLICY: "none" });
     expect(stdout).toContain("net listen error code: EINVAL");
-    expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
+    expect(stdout).toContain(
+      "TLS and non-TLS cluster workers cannot share the same address:port while the primary distributes its connections",
+    );
   },
   30_000,
 );

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -451,6 +451,104 @@ if (cluster.isPrimary) {
   expect(stdout).toContain("listening workers: 2 distinct ports: 1");
 });
 
+// Windows cannot let two workers accept() on copies of one listening socket: the worker that loses
+// the race for a connection blocks inside accept() and its event loop never runs again, so it stops
+// answering IPC and never exits. TCP listens under SCHED_NONE go through the primary there instead.
+test.skipIf(!isWindows)(
+  "SCHED_NONE: two workers on one port stay responsive and exit after bursts of connections",
+  async () => {
+    using dir = tempDir("cluster-shared-accept-race", {
+      "main.ts": `
+const cluster = require("node:cluster");
+const net = require("node:net");
+cluster.schedulingPolicy = cluster.SCHED_NONE;
+
+if (cluster.isPrimary) {
+  const BURSTS = 8;
+  const PER_BURST = 16;
+  const workers = [cluster.fork(), cluster.fork()];
+  const ports = new Set();
+  const exits = [];
+  let listening = 0;
+
+  cluster.on("listening", (worker, address) => {
+    ports.add(address.port);
+    if (++listening !== workers.length) return;
+    run(address.port).catch(err => {
+      console.log("error:", err.message);
+      process.exit(1);
+    });
+  });
+
+  cluster.on("exit", (worker, code, signal) => {
+    exits.push(code ?? signal);
+    if (exits.length === workers.length) console.log("exits:", exits.join(","));
+  });
+
+  function connectOnce(port) {
+    return new Promise((resolve, reject) => {
+      const c = net.connect(port, "127.0.0.1");
+      let data = "";
+      c.setEncoding("utf8");
+      c.on("data", chunk => (data += chunk));
+      c.on("error", reject);
+      c.on("close", () => (data === "hi" ? resolve() : reject(new Error("got " + JSON.stringify(data)))));
+    });
+  }
+
+  function pingWorkers(burst) {
+    return Promise.all(
+      workers.map(worker => {
+        return new Promise(resolve => {
+          const stuck = setTimeout(() => {
+            console.log("worker " + worker.id + " stopped answering after burst " + burst);
+            process.exit(1);
+          }, 10_000);
+          worker.once("message", () => {
+            clearTimeout(stuck);
+            resolve();
+          });
+          worker.send("ping");
+        });
+      }),
+    );
+  }
+
+  async function run(port) {
+    for (let burst = 1; burst <= BURSTS; burst++) {
+      const connections = [];
+      for (let i = 0; i < PER_BURST; i++) connections.push(connectOnce(port));
+      await Promise.all(connections);
+      await pingWorkers(burst);
+    }
+    console.log("served:", BURSTS * PER_BURST, "ports:", ports.size);
+    for (const worker of workers) worker.disconnect();
+  }
+} else {
+  net.createServer(socket => socket.end("hi")).listen(0, "127.0.0.1");
+  process.on("message", message => {
+    if (message === "ping") process.send("pong");
+  });
+}
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "served: 128 ports: 1\nexits: 0,0\n",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  },
+  30_000,
+);
+
 test("SCHED_NONE: close() releases the shared handle so the worker can re-listen on the same port", async () => {
   using dir = tempDir("cluster-shared-relisten", {
     "main.ts": `
@@ -807,11 +905,10 @@ if (cluster.isPrimary) {
   expect(stdout).toContain("reply: echo:hi");
 }, 30_000);
 
-test("plain worker listening on a key already owned by a TLS shared-only handle fails with EINVAL", async () => {
-  const dir = tempDirWithFiles("bun-test", {
-    "cert.pem": tlsCerts.cert,
-    "key.pem": tlsCerts.key,
-    "main.ts": `
+const netWorkerAfterTlsWorkerFixture = {
+  "cert.pem": tlsCerts.cert,
+  "key.pem": tlsCerts.key,
+  "main.ts": `
 const cluster = require("node:cluster");
 const net = require("node:net");
 const tls = require("node:tls");
@@ -824,11 +921,18 @@ if (cluster.isPrimary) {
   const tlsWorker = cluster.fork({ ROLE: "tls" });
   cluster.once("listening", () => {
     const netWorker = cluster.fork({ ROLE: "net" });
-    netWorker.on("message", msg => {
-      console.log("net listen error code:", msg.code, msg.msg);
+    const done = code => {
       tlsWorker.kill();
       netWorker.kill();
-      process.exit(0);
+      process.exit(code);
+    };
+    netWorker.on("message", msg => {
+      console.log("net listen error code:", msg.code, msg.msg);
+      done(0);
+    });
+    netWorker.on("listening", () => {
+      console.log("net worker is listening on the TLS worker's socket");
+      done(1);
     });
   });
 } else if (process.env.ROLE === "tls") {
@@ -839,11 +943,27 @@ if (cluster.isPrimary) {
   server.listen(0);
 }
 `,
-  });
+};
+
+test("plain worker listening on a key already owned by a TLS shared-only handle fails with EINVAL", async () => {
+  const dir = tempDirWithFiles("bun-test", netWorkerAfterTlsWorkerFixture);
   const { stdout } = await bunRun(joinP(dir, "main.ts"), bunEnv);
   expect(stdout).toContain("net listen error code: EINVAL");
   expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
 }, 30_000);
+
+// On Windows the primary serves TCP listens under SCHED_NONE too (two workers accepting on copies of
+// one socket is what hangs a worker there), so the plain worker is refused under either policy.
+test.skipIf(!isWindows)(
+  "SCHED_NONE on Windows: plain worker listening on a key owned by a TLS shared-only handle fails with EINVAL",
+  async () => {
+    const dir = tempDirWithFiles("bun-test", netWorkerAfterTlsWorkerFixture);
+    const { stdout } = await bunRun(joinP(dir, "main.ts"), { NODE_CLUSTER_SCHED_POLICY: "none" });
+    expect(stdout).toContain("net listen error code: EINVAL");
+    expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
+  },
+  30_000,
+);
 
 test.skipIf(isWindows)(
   "SCHED_NONE listen({fd:2}) fails EINVAL like node and does not close the primary's stderr",

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -412,6 +412,8 @@ if (cluster.isPrimary) {
   expect(stdout).toContain("ipv6 connect ok");
 });
 
+// A SharedHandle binds its socket natively; only a RoundRobinHandle makes the primary itself
+// listen() with a net.Server. Windows serves SCHED_NONE TCP listens round-robin, see primary.ts.
 test("SCHED_NONE: a second worker listens on the same shared handle", async () => {
   const dir = tempDirWithFiles("bun-test", {
     "main.ts": `
@@ -421,6 +423,12 @@ const net = require("node:net");
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
 if (cluster.isPrimary) {
+  let primaryListenCalls = 0;
+  const listen = net.Server.prototype.listen;
+  net.Server.prototype.listen = function () {
+    primaryListenCalls++;
+    return listen.apply(this, arguments);
+  };
   const workers = [cluster.fork(), cluster.fork()];
   let listening = 0;
   const ports = new Set();
@@ -429,6 +437,7 @@ if (cluster.isPrimary) {
     ports.add(address.port);
     if (++listening !== 2) return;
     console.log("listening workers:", listening, "distinct ports:", ports.size);
+    console.log("primary listen() calls:", primaryListenCalls);
     for (const w of workers) w.kill();
     process.exit(0);
   });
@@ -449,6 +458,7 @@ if (cluster.isPrimary) {
   const { stdout } = await bunRun(joinP(dir, "main.ts"), bunEnv);
   expect(stdout).toContain("policy is SCHED_NONE: true");
   expect(stdout).toContain("listening workers: 2 distinct ports: 1");
+  expect(stdout).toContain(`primary listen() calls: ${isWindows ? 1 : 0}`);
 });
 
 // Every connection below is one chance for a worker to stop answering IPC; the primary pings both
@@ -928,18 +938,18 @@ if (cluster.isPrimary) {
   const tlsWorker = cluster.fork({ ROLE: "tls" });
   cluster.once("listening", () => {
     const netWorker = cluster.fork({ ROLE: "net" });
-    const done = code => {
+    const done = () => {
       tlsWorker.kill();
       netWorker.kill();
-      process.exit(code);
+      process.exit(0);
     };
     netWorker.on("message", msg => {
       console.log("net listen error code:", msg.code, msg.msg);
-      done(0);
+      done();
     });
     netWorker.on("listening", () => {
       console.log("net worker is listening on the TLS worker's socket");
-      done(1);
+      done();
     });
   });
 } else if (process.env.ROLE === "tls") {
@@ -959,20 +969,21 @@ test("plain worker listening on a key already owned by a TLS shared-only handle 
   expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
 }, 30_000);
 
-// On Windows the primary serves TCP listens under SCHED_NONE too (two workers accepting on copies of
-// one socket is what hangs a worker there), so the plain worker is refused under either policy.
-test.skipIf(!isWindows)(
-  "SCHED_NONE on Windows: plain worker listening on a key owned by a TLS shared-only handle fails with EINVAL",
-  async () => {
-    const dir = tempDirWithFiles("bun-test", netWorkerAfterTlsWorkerFixture);
-    const { stdout } = await bunRun(joinP(dir, "main.ts"), { NODE_CLUSTER_SCHED_POLICY: "none" });
+// Under SCHED_NONE the plain worker shares the TLS worker's socket, as in node. On Windows the primary
+// serves TCP listens under SCHED_NONE too (two workers accepting on copies of one socket is what hangs
+// a worker there), so it is refused there under either policy.
+test("SCHED_NONE: plain worker listening on a key owned by a TLS shared-only handle", async () => {
+  const dir = tempDirWithFiles("bun-test", netWorkerAfterTlsWorkerFixture);
+  const { stdout } = await bunRun(joinP(dir, "main.ts"), { NODE_CLUSTER_SCHED_POLICY: "none" });
+  if (isWindows) {
     expect(stdout).toContain("net listen error code: EINVAL");
     expect(stdout).toContain(
       "TLS and non-TLS cluster workers cannot share the same address:port while the primary distributes its connections",
     );
-  },
-  30_000,
-);
+  } else {
+    expect(stdout).toBe("net worker is listening on the TLS worker's socket");
+  }
+}, 30_000);
 
 test.skipIf(isWindows)(
   "SCHED_NONE listen({fd:2}) fails EINVAL like node and does not close the primary's stderr",

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -451,11 +451,12 @@ if (cluster.isPrimary) {
   expect(stdout).toContain("listening workers: 2 distinct ports: 1");
 });
 
-// Windows cannot let two workers accept() on copies of one listening socket: the worker that loses
-// the race for a connection blocks inside accept() and its event loop never runs again, so it stops
-// answering IPC and never exits. TCP listens under SCHED_NONE go through the primary there instead.
+// Two workers accepting on copies of one Windows listening socket race each other for every
+// connection, and the loser blocks inside accept(): its event loop never runs again, so it stops
+// answering IPC and never exits. Each connection below is one such race; the primary pings both
+// workers after every one. TCP listens under SCHED_NONE are served by the primary on Windows instead.
 test.skipIf(!isWindows)(
-  "SCHED_NONE: two workers on one port stay responsive and exit after bursts of connections",
+  "SCHED_NONE: two workers sharing one port keep answering IPC while connections arrive, then exit",
   async () => {
     using dir = tempDir("cluster-shared-accept-race", {
       "main.ts": `
@@ -464,20 +465,22 @@ const net = require("node:net");
 cluster.schedulingPolicy = cluster.SCHED_NONE;
 
 if (cluster.isPrimary) {
-  const BURSTS = 8;
-  const PER_BURST = 16;
+  const CONNECTIONS = 100;
   const workers = [cluster.fork(), cluster.fork()];
   const ports = new Set();
   const exits = [];
   let listening = 0;
 
+  function fail(message) {
+    console.log(message);
+    for (const worker of workers) worker.process.kill();
+    process.exit(1);
+  }
+
   cluster.on("listening", (worker, address) => {
     ports.add(address.port);
     if (++listening !== workers.length) return;
-    run(address.port).catch(err => {
-      console.log("error:", err.message);
-      process.exit(1);
-    });
+    run(address.port).catch(err => fail("error: " + err.message));
   });
 
   cluster.on("exit", (worker, code, signal) => {
@@ -496,14 +499,11 @@ if (cluster.isPrimary) {
     });
   }
 
-  function pingWorkers(burst) {
+  function pingWorkers(connection) {
     return Promise.all(
       workers.map(worker => {
         return new Promise(resolve => {
-          const stuck = setTimeout(() => {
-            console.log("worker " + worker.id + " stopped answering after burst " + burst);
-            process.exit(1);
-          }, 10_000);
+          const stuck = setTimeout(() => fail("worker " + worker.id + " stopped answering after connection " + connection), 10_000);
           worker.once("message", () => {
             clearTimeout(stuck);
             resolve();
@@ -515,13 +515,11 @@ if (cluster.isPrimary) {
   }
 
   async function run(port) {
-    for (let burst = 1; burst <= BURSTS; burst++) {
-      const connections = [];
-      for (let i = 0; i < PER_BURST; i++) connections.push(connectOnce(port));
-      await Promise.all(connections);
-      await pingWorkers(burst);
+    for (let connection = 1; connection <= CONNECTIONS; connection++) {
+      await connectOnce(port);
+      await pingWorkers(connection);
     }
-    console.log("served:", BURSTS * PER_BURST, "ports:", ports.size);
+    console.log("served:", CONNECTIONS, "ports:", ports.size);
     for (const worker of workers) worker.disconnect();
   }
 } else {
@@ -541,7 +539,7 @@ if (cluster.isPrimary) {
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr, exitCode }).toEqual({
-      stdout: "served: 128 ports: 1\nexits: 0,0\n",
+      stdout: "served: 100 ports: 1\nexits: 0,0\n",
       stderr: expect.any(String),
       exitCode: 0,
     });


### PR DESCRIPTION
### Problem
- `test/js/node/test/parallel/test-cluster-shared-leak.js` times out on the Windows lanes on most builds since #31829 (626034fda0), and `test-cluster-disconnect.js` occasionally; Linux and macOS are unaffected.
- In both, a cluster worker stops reacting to IPC, so it never acts on `disconnect()` and the primary waits for it forever. Two separate Windows-only causes.
- Cause 1, shared listening (`SCHED_NONE`): every worker holds a copy of one listening socket and Windows wakes all of them per connection. The loser blocks inside `accept()` although its copy is non-blocking (`WSAAccept` <- `bsd_accept_socket` <- `uv_run`) and its loop never runs again. Two idle workers also burn about 1.0 to 1.6s CPU per 3s, their exclusive AFD polls completing each other.
- Cause 2, round-robin handoff: on Windows the worker's ack for a handed-off connection can be read before the write callback for that message runs. The primary dropped the ack, then parked the message as waiting for one, and every later message to that worker (pings, `act: 'disconnect'`) queued behind it forever. Needs a busy machine; unreachable on POSIX, where the write is synchronous.

### Fix
- On Windows the primary now hands connections out itself (a round-robin handle) for every TCP listen, whatever `cluster.schedulingPolicy` says, so exactly one process accepts on any listener. On POSIX the decision reduces to the old `SCHED_RR` check. UDP and TLS handles still share, so two TLS workers on one Windows port stay exposed to cause 1 (pre-existing, tracked separately).
- The refusal that stops a plain worker joining a TLS worker's shared socket uses the same decision, so it now also applies under `SCHED_NONE` on Windows; its hint no longer names `SCHED_RR`.
- An ack or nack read while the head of the send queue is a handle message still being written is kept and applied once that write completes (a kept nack takes the normal retransmit path). It can only apply to the message it was read for, because the queue head cannot change while a write is in progress.
- Verification: a new Windows-only test pushes 100 connections through two workers on one port under each policy, pinging both after each. The `SCHED_NONE` variant fails 10/10 unfixed; the `SCHED_RR` variant only failed unfixed under load (it is what caught cause 2, in this PR's first CI run). On a Windows debug build `test-cluster-shared-leak.js` passes 40/40 (3/40 hung unfixed) and all 85 vendored `test-cluster-*` files pass, on Linux too.

### Background
- `node:cluster` has two ways to put workers on one port. `SCHED_NONE` (a shared handle) gives every worker the listening socket and each accepts for itself; `SCHED_RR` (a round-robin handle) has the primary listen and pass each accepted connection to a worker over IPC. Bun already defaults to round-robin on Windows; this PR changes what an explicit `SCHED_NONE` gets there.
- Shared listening on Windows, added in #31829, duplicates the socket into each worker (`WSADuplicateSocketW`) and drives it with `uv_poll` plus a plain `accept()`. libuv and node drive a shared listening socket with `AcceptEx`, which Bun's listen sockets do not use, so node has neither cause 1 problem.
- A handle message is an IPC message carrying a socket. The sender holds it as waiting for an ack until the receiver confirms it and sends nothing else on that channel until then, so a lost ack blocks the channel. The message only becomes "waiting" in the write-completion callback.
- On Windows `uv_write` completes asynchronously, so the peer's reply can be read before the write callback runs; on POSIX the pipe write is synchronous and the callback always runs first. That is why cause 2 exists on one platform only.
- A TLS listen is a `sharedOnly` handle: Bun's TLS accept is native and cannot adopt a connection handed over by the primary, so mixing TLS and plain workers on one port is refused with EINVAL whenever the plain side would be round-robin.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/cluster.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

Fixes `test/js/node/test/parallel/test-cluster-shared-leak.js` timing out on the Windows lanes since #31829 landed (626034fda0). It shows up on most builds since then, e.g. https://buildkite.com/bun/bun/builds/93004 (4/4 attempts on Windows 2019 x64, with a one-file diff) and https://buildkite.com/bun/bun/builds/93005 (Windows 11 aarch64); nothing on Linux or macOS. Culprit: #31829, which added the TCP `SharedHandle` this test exercises and the round-robin handle passing it now falls back to. Two separate Windows problems, both of which leave a worker that never reacts to `disconnect()` again, so the primary waits for it forever.

### 1. Shared listening sockets: the losing worker blocks inside `accept()`

On a Windows box with the 626034fda0 canary, the test hangs 3/40 runs in a loop (7-15% in other batches), with the primary and both workers still alive. An instrumented copy shows that the worker which did **not** get the test's one connection stops processing anything from that moment on. Native stacks of its main thread:

```
ntdll.dll!NtWaitForSingleObject
mswsock.dll!...
WS2_32.dll!WSAAccept
WS2_32.dll!accept
bun.exe  (bsd_accept_socket <- us_internal_dispatch_ready_poll <- poll_cb)
bun.exe!uv__fast_poll_process_poll_req
bun.exe!uv_run
```

#31829 implements `SCHED_NONE` on Windows by `WSADuplicateSocketW`-ing one listening socket into every worker, where `us_socket_group_listen_fd` puts it under a `uv_poll` and the normal accept loop calls `accept()`. With more than one process on the socket:

- AFD reports an incoming connection to every process polling the socket, so both workers call `accept()`. One gets it; the other blocks inside `accept()` although its descriptor is non-blocking (checked with a small `bun:ffi` program: the blocking mode of a duplicated socket is per descriptor, and each worker does set its own copy non-blocking in `uv_poll_init_socket`; `accept()` blocked anyway). Nothing else connects in this test, so that event loop is gone for good; in a real server it would sit there until the next connection arrives and then take it.
- `uv_poll` submits AFD polls with `Exclusive = TRUE`, which completes any other outstanding exclusive poll on the same socket, including one from another process, and libuv resubmits on an empty completion. Two idle `SCHED_NONE` workers sharing a port burn about 1.0s and 1.6s of CPU per worker per 3s of idling (`process.cpuUsage()`); a single worker uses 0.

Node has neither problem because libuv's shared listening sockets (`UV_HANDLE_SHARED_TCP_SOCKET`) are driven with `AcceptEx`, which Bun's listen sockets do not use.

**Fix:** `queryServer` (`internal/cluster/primary.ts`) creates a `RoundRobinHandle` for TCP listens on Windows regardless of `cluster.schedulingPolicy`, so exactly one process accepts on a listener, the same path Bun already defaults to on Windows (and the PR already takes Windows-specific routes for UDP and pipes). The choice is factored into `usesRoundRobinHandle(message)`; the existing "a plain worker may not join a TLS worker's shared-only handle" check uses the same predicate, so it also applies under `SCHED_NONE` on Windows (otherwise the plain worker would accept on the TLS worker's socket, which is exactly the situation above). The hint attached to that error no longer names `SCHED_RR`, since the condition is no longer tied to it. On POSIX the predicate reduces to the previous `schedulingPolicy === SCHED_RR` with the same sharedOnly/UDP exclusions, so nothing changes there; `cluster.schedulingPolicy` itself is not touched.

`sharedOnly` (TLS) handles still share on Windows, since TLS servers cannot adopt handed-off connections; two or more TLS workers on one port there remain exposed to both problems until listen sockets can accept with `AcceptEx`. That is pre-existing from #31829 and tracked separately.

### 2. Round-robin handoff: a handle ack read before the write callback was dropped

The first CI run of this PR failed its own new test on Windows 2019 x64 with the primary distributing connections: `worker 2 stopped answering after connection 52`, passing on retry. Reproducible on the canary too by running the round-robin variant of the fixture in 10-12 parallel copies (4/10 release, 5/12 debug); it never reproduces on an idle machine. In the stalled state the worker is idle in `uv_run`, the primary's `worker.send()` returns `false`, and a probe in `SendQueue::on_ack_nack` reports, in every stalled instance:

```
early ack: write_in_progress=true queue_len=1 head_has_handle=true head_cursor=0
```

i.e. the worker's `NODE_HANDLE` ack for the `newconn` message arrived (and was processed) before libuv had invoked the write callback for that message. Writes are asynchronous on Windows (`uv_write`), and it is `on_write_complete` that moves a handle message into `waiting_for_ack`; `on_ack_nack` therefore found nothing waiting and dropped the ack, the write callback then parked the message in `waiting_for_ack`, and every later message to that worker (pings, `act: 'disconnect'`) queued up behind it forever. On POSIX the write is synchronous and `on_write_complete` runs before any read can be processed, so this is unreachable there. This also explains the occasional `test-cluster-disconnect.js` timeout on Windows (build 93008), and it would have kept `test-cluster-shared-leak.js` rarely hanging on the round-robin path after fix 1.

**Fix:** `on_ack_nack` keeps a reply that arrives while the head of the queue is a handle message being written (`early_ack_nack`), and `on_write_complete` applies it once the message has moved into `waiting_for_ack`; a NACK stored this way goes through the normal retransmit path. The stash is taken on every write completion, and the queue head cannot change while a write is in progress (`insert_message` inserts behind it), so it can only ever apply to the message it was read for.

### Tests (`test/js/node/cluster.test.ts`)

- `SCHED_NONE: a second worker listens on the same shared handle` (existing, all platforms) now also counts the primary's own `net.Server` `listen()` calls, which only a `RoundRobinHandle` makes, and expects 1 on Windows and 0 elsewhere. This pins which handle a `SCHED_NONE` TCP listen gets on each platform; the rest of the `SCHED_NONE` suite passes identically either way (which is how the Windows runs below can pass at all). On the canary it fails on Windows with `primary listen() calls: 0`.
- `SCHED_NONE: plain worker listening on a key owned by a TLS shared-only handle` (all platforms): the existing TLS-then-plain fixture run with `NODE_CLUSTER_SCHED_POLICY=none`. On POSIX the plain worker shares the TLS worker's socket (node's behaviour, unchanged); on Windows it gets EINVAL with the reworded hint. On the canary the Windows run reports the worker listening on the TLS socket instead.
- `SCHED_NONE` / `SCHED_RR: two workers on one port keep answering IPC while connections arrive, then exit` (Windows-only, since both hangs are): 100 sequential connections to two workers on one port, pinging both workers over IPC after each one, then `disconnect()` and both exit 0. The `SCHED_NONE` variant fails 10/10 runs on the canary (`worker N stopped answering after connection K`, the blocked `accept()`); the `SCHED_RR` variant exercises the handoff ack path and, as described above, only failed on the unfixed build under load (it is what caught fix 2 in CI). Both take about 2.0s on a debug build, 1.3s of which is starting three debug processes.
- The existing TLS-vs-round-robin EINVAL test gets the same 30s budget as its two siblings; it takes 4.9-5.0s on a Linux debug build (three debug process startups plus loading `node:tls`) and was failing on the default 5s timeout for me while the machine was busy. Unrelated to the fix otherwise.

### Verification

Windows x64, debug build of this branch, vendored tests invoked the way the CI runner invokes them:

- Round-robin fixture in 12 parallel copies x 100 connections: 0 stalls in 36 instances (unfixed debug build: 5 of 12 instances stalled, twice); same with the `SCHED_NONE` fixture, 0 in 24.
- `test-cluster-shared-leak.js`: 40/40 pass (canary through the same loop: 3/40 time out).
- All 85 `test-cluster-*.js` files plus the `test-child-process-fork*`/`send*`/`pass-fd` handle tests: 111/111 pass.
- `cluster.test.ts`: 26 pass, 9 skipped (the pre-existing Windows skips); `spawn.ipc*.test.ts`, `child_process_ipc_handle.test.ts`, `child_process.test.ts`: 64 pass, 0 fail.
- Two idle `SCHED_NONE` workers on one port: 0ms user / 0ms system each.

Linux x64, debug build: `cluster.test.ts` 32 pass / 3 skip (the Windows-only tests), the IPC test files above pass, and all 85 vendored `test-cluster-*` files pass.

</details>
