### PR TITLE
test: share one mock Toolchain between the build-script tests

### DIFF
--- a/test/_util/mock-toolchain.ts
+++ b/test/_util/mock-toolchain.ts
@@ -1,0 +1,79 @@
+/**
+ * Fake `Toolchain`s for driving scripts/build's `resolveConfig()` from tests.
+ * None of the paths exist: resolveConfig() records them without running
+ * anything, so the build-script tests run on hosts with no LLVM installed.
+ *
+ * Every `Toolchain` field is populated, so adding a field to the interface is
+ * a type error here and nowhere else; test/internal/source-lints/
+ * mock-toolchain.test.ts checks the same thing at runtime, since the test
+ * tree is not type-checked in CI.
+ */
+import type { Toolchain } from "../../scripts/build/config.ts";
+
+/**
+ * What `resolveLlvmToolchain()` (scripts/build/tools.ts) finds on a Linux host
+ * with a complete LLVM install, as used for native linux targets and for
+ * darwin cross-compiles: GNU `strip` is the default strip, and the optional
+ * Mach-O tools (ld64.lld, llvm-strip, dsymutil) are all present. Tools that
+ * are only resolved for windows targets are absent.
+ */
+export function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
+  const toolchain: Toolchain = {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    // The LLVM_VERSION pin in scripts/build/tools.ts. rustc's LLVM is kept a
+    // major ahead of it: the tests that set `rustLld` rely on that skew to
+    // make resolveConfig() swap rust-lld in as `ld`.
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: "/fake/llvm/bin/ld64.lld",
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: "/fake/llvm/bin/dsymutil",
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+  };
+  return { ...toolchain, ...overrides };
+}
+
+/**
+ * The same host resolving a windows target: `resolveLlvmToolchain()` switches
+ * to the MSVC-flavored tool family (clang-cl, llvm-lib, lld-link, llvm-rc,
+ * llvm-mt, nasm), keeps plain clang/clang++ as the host compilers, and skips
+ * the resource-dir probe. Everything host-side is inherited from
+ * `mockToolchain()`.
+ */
+export function mockWindowsCrossToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
+  return mockToolchain({
+    cc: "/fake/llvm/bin/clang-cl",
+    cxx: "/fake/llvm/bin/clang-cl",
+    hostCc: "/fake/llvm/bin/clang",
+    hostCxx: "/fake/llvm/bin/clang++",
+    clangResourceDir: undefined,
+    ar: "/fake/llvm/bin/llvm-lib",
+    ld: "/fake/llvm/bin/lld-link",
+    rc: "/fake/llvm/bin/llvm-rc",
+    mt: "/fake/llvm/bin/llvm-mt",
+    nasm: "/fake/bin/nasm",
+    ...overrides,
+  });
+}

--- a/test/internal/build-debug-info-flags.test.ts
+++ b/test/internal/build-debug-info-flags.test.ts
@@ -15,43 +15,9 @@
 import { describe, expect, test } from "bun:test";
 import { isMacOS, tempDir } from "harness";
 
-import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
+import { mockToolchain } from "_util/mock-toolchain.ts";
+import { resolveConfig, type Config, type PartialConfig } from "../../scripts/build/config.ts";
 import { computeDepFlags, computeFlags } from "../../scripts/build/flags.ts";
-
-/** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
-function mockToolchain(): Toolchain {
-  return {
-    cc: "/fake/llvm/bin/clang",
-    cxx: "/fake/llvm/bin/clang++",
-    hostCc: undefined,
-    hostCxx: undefined,
-    clangVersion: "21.1.8",
-    clangResourceDir: "/fake/llvm/lib/clang/21",
-    ar: "/fake/llvm/bin/llvm-ar",
-    ranlib: "/fake/llvm/bin/llvm-ranlib",
-    ld: "/fake/llvm/bin/ld.lld",
-    ld64Lld: "/fake/llvm/bin/ld64.lld",
-    rustLld: undefined,
-    rustLlvmVersion: "22.1.4",
-    rustSysroot: undefined,
-    rustHostTriple: undefined,
-    strip: "/fake/bin/strip",
-    llvmStrip: "/fake/llvm/bin/llvm-strip",
-    dsymutil: "/fake/llvm/bin/dsymutil",
-    bun: "/fake/bin/bun",
-    jsRuntime: "/fake/bin/bun",
-    esbuild: "/fake/bin/esbuild",
-    ccache: undefined,
-    cmake: "/fake/bin/cmake",
-    cargo: undefined,
-    cargoHome: undefined,
-    rustupHome: undefined,
-    msvcLinker: undefined,
-    rc: undefined,
-    mt: undefined,
-    nasm: undefined,
-  };
-}
 
 /**
  * A linux-x64 target resolves on every host once it is told where its sysroot

--- a/test/internal/build-post-link-ordering.test.ts
+++ b/test/internal/build-post-link-ordering.test.ts
@@ -15,45 +15,10 @@ import { describe, expect, test } from "bun:test";
 import { isMacOS, tempDir } from "harness";
 import { join, resolve } from "node:path";
 
+import { mockToolchain } from "_util/mock-toolchain.ts";
 import { emitPostLink } from "../../scripts/build/bun.ts";
-import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
+import { resolveConfig, type Config, type PartialConfig } from "../../scripts/build/config.ts";
 import { Ninja } from "../../scripts/build/ninja.ts";
-
-/** A fully-populated fake toolchain; resolveConfig never spawns any of these. */
-function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
-  return {
-    cc: "/fake/llvm/bin/clang",
-    cxx: "/fake/llvm/bin/clang++",
-    hostCc: undefined,
-    hostCxx: undefined,
-    clangVersion: "21.1.8",
-    clangResourceDir: "/fake/llvm/lib/clang/21",
-    ar: "/fake/llvm/bin/llvm-ar",
-    ranlib: "/fake/llvm/bin/llvm-ranlib",
-    ld: "/fake/llvm/bin/ld.lld",
-    ld64Lld: "/fake/llvm/bin/ld64.lld",
-    rustLld: undefined,
-    rustLlvmVersion: "22.1.4",
-    rustSysroot: undefined,
-    rustHostTriple: undefined,
-    strip: "/fake/bin/strip",
-    llvmStrip: "/fake/llvm/bin/llvm-strip",
-    dsymutil: "/fake/llvm/bin/dsymutil",
-    bun: "/fake/bin/bun",
-    jsRuntime: "/fake/bin/bun",
-    esbuild: "/fake/bin/esbuild",
-    ccache: undefined,
-    cmake: "/fake/bin/cmake",
-    cargo: undefined,
-    cargoHome: undefined,
-    rustupHome: undefined,
-    msvcLinker: undefined,
-    rc: undefined,
-    mt: undefined,
-    nasm: undefined,
-    ...overrides,
-  };
-}
 
 /**
  * Resolve a host-targeted config: no os/arch override, so `canRunOnHost` is

--- a/test/internal/macos-cross-config.test.ts
+++ b/test/internal/macos-cross-config.test.ts
@@ -12,7 +12,8 @@ import { bunEnv, bunExe, isMacOS, tempDir } from "harness";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
-import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../scripts/build/config.ts";
+import { mockToolchain } from "_util/mock-toolchain.ts";
+import { resolveConfig, type Config, type PartialConfig } from "../../scripts/build/config.ts";
 import { webkit } from "../../scripts/build/deps/webkit.ts";
 import { parsePackedFeaturesList } from "../../scripts/build/features-json.ts";
 import { computeFlags, DARWIN_STACK_SIZE } from "../../scripts/build/flags.ts";
@@ -23,40 +24,6 @@ import {
   machoEntitlementsPlist,
   machoPostlinkCommand,
 } from "../../scripts/build/shims.ts";
-
-/** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
-function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
-  return {
-    cc: "/fake/llvm/bin/clang",
-    cxx: "/fake/llvm/bin/clang++",
-    clangVersion: "21.1.8",
-    clangResourceDir: "/fake/llvm/lib/clang/21",
-    ar: "/fake/llvm/bin/llvm-ar",
-    ranlib: "/fake/llvm/bin/llvm-ranlib",
-    ld: "/fake/llvm/bin/ld.lld",
-    ld64Lld: "/fake/llvm/bin/ld64.lld",
-    rustLld: undefined,
-    rustLlvmVersion: "22.1.4",
-    rustSysroot: undefined,
-    rustHostTriple: undefined,
-    strip: "/fake/bin/strip",
-    llvmStrip: "/fake/llvm/bin/llvm-strip",
-    dsymutil: "/fake/llvm/bin/dsymutil",
-    bun: "/fake/bin/bun",
-    jsRuntime: "/fake/bin/bun",
-    esbuild: "/fake/bin/esbuild",
-    ccache: undefined,
-    cmake: "/fake/bin/cmake",
-    cargo: undefined,
-    cargoHome: undefined,
-    rustupHome: undefined,
-    msvcLinker: undefined,
-    rc: undefined,
-    mt: undefined,
-    nasm: undefined,
-    ...overrides,
-  };
-}
 
 /** Shorthand: resolve a config for a darwin target (cross on non-darwin hosts). */
 function resolveDarwin(partial: PartialConfig = {}, toolchain = mockToolchain()): Config {

--- a/test/internal/source-lints/README.md
+++ b/test/internal/source-lints/README.md
@@ -13,7 +13,7 @@ the bun binary stay in `test/internal/` so the Buildkite lanes run them against
 the build under test.
 
 The workflow runs on a bare checkout (no `bun install`), so tests here may
-only import built-ins, relative paths, and `harness` (resolved via
+only import built-ins, relative paths, and `harness` / `_util/*` (resolved via
 `test/tsconfig.json` paths).
 
 To run locally: `bun test test/internal/source-lints/`.

--- a/test/internal/source-lints/mock-toolchain.test.ts
+++ b/test/internal/source-lints/mock-toolchain.test.ts
@@ -1,0 +1,27 @@
+/**
+ * test/_util/mock-toolchain.ts stands in for a resolved `Toolchain` in the
+ * build-script tests. It is typed as a `Toolchain`, so a field added to the
+ * interface and not to the mock is a type error, but nothing type-checks the
+ * test tree in CI (the per-file copies this helper replaced had been missing
+ * `hostCc`/`hostCxx` since those fields were added). Pin the mock's keys to
+ * the interface's declared properties at runtime instead.
+ */
+import { mockToolchain, mockWindowsCrossToolchain } from "_util/mock-toolchain.ts";
+import { expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/** The property names declared by `export interface Toolchain` in scripts/build/config.ts. */
+function declaredToolchainFields(): string[] {
+  const configTs = join(import.meta.dir, "..", "..", "..", "scripts", "build", "config.ts");
+  const body = readFileSync(configTs, "utf8").match(/^export interface Toolchain \{\n([\s\S]*?)^\}/m)?.[1];
+  if (body === undefined) throw new Error("export interface Toolchain not found in scripts/build/config.ts");
+  const withoutComments = body.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*/g, "");
+  return [...withoutComments.matchAll(/^\s+(\w+)\??:/gm)].map(m => m[1]).sort();
+}
+
+test("the mock toolchains define exactly the fields Toolchain declares", () => {
+  const declared = declaredToolchainFields();
+  expect(Object.keys(mockToolchain()).sort()).toEqual(declared);
+  expect(Object.keys(mockWindowsCrossToolchain()).sort()).toEqual(declared);
+});

--- a/test/internal/source-lints/webkit-prebuilt-url.test.ts
+++ b/test/internal/source-lints/webkit-prebuilt-url.test.ts
@@ -3,43 +3,9 @@
  * hit the plain `autobuild-<sha>` tag. Configure-time only. */
 import { describe, expect, test } from "bun:test";
 
-import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../../scripts/build/config.ts";
+import { mockToolchain } from "_util/mock-toolchain.ts";
+import { resolveConfig, type Config, type PartialConfig } from "../../../scripts/build/config.ts";
 import { webkit, WEBKIT_VERSION } from "../../../scripts/build/deps/webkit.ts";
-
-/** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
-function mockToolchain(): Toolchain {
-  return {
-    cc: "/fake/llvm/bin/clang",
-    cxx: "/fake/llvm/bin/clang++",
-    hostCc: undefined,
-    hostCxx: undefined,
-    clangVersion: "21.1.8",
-    clangResourceDir: "/fake/llvm/lib/clang/21",
-    ar: "/fake/llvm/bin/llvm-ar",
-    ranlib: "/fake/llvm/bin/llvm-ranlib",
-    ld: "/fake/llvm/bin/ld.lld",
-    ld64Lld: "/fake/llvm/bin/ld64.lld",
-    rustLld: undefined,
-    rustLlvmVersion: "22.1.4",
-    rustSysroot: undefined,
-    rustHostTriple: undefined,
-    strip: "/fake/bin/strip",
-    llvmStrip: "/fake/llvm/bin/llvm-strip",
-    dsymutil: "/fake/llvm/bin/dsymutil",
-    bun: "/fake/bin/bun",
-    jsRuntime: "/fake/bin/bun",
-    esbuild: "/fake/bin/esbuild",
-    ccache: undefined,
-    cmake: "/fake/bin/cmake",
-    cargo: undefined,
-    cargoHome: undefined,
-    rustupHome: undefined,
-    msvcLinker: undefined,
-    rc: undefined,
-    mt: undefined,
-    nasm: undefined,
-  };
-}
 
 /** Shorthand: a Linux glibc x64 release target. linuxSysroot stubbed so the
  * cross-arch block in resolveConfig never throws on a non-x64-glibc host. */

--- a/test/internal/source-lints/windows-cross-config.test.ts
+++ b/test/internal/source-lints/windows-cross-config.test.ts
@@ -14,44 +14,11 @@ import { describe, expect, test } from "bun:test";
 import { isWindows, tempDir } from "harness";
 import { join } from "node:path";
 
-import { resolveConfig, type Config, type PartialConfig, type Toolchain } from "../../../scripts/build/config.ts";
+import { mockToolchain, mockWindowsCrossToolchain } from "_util/mock-toolchain.ts";
+import { resolveConfig, type Config, type PartialConfig } from "../../../scripts/build/config.ts";
 import { webkit } from "../../../scripts/build/deps/webkit.ts";
 import { computeFlags } from "../../../scripts/build/flags.ts";
 import { rustTarget } from "../../../scripts/build/rust.ts";
-
-/** A fully-populated fake toolchain — resolveConfig never spawns any of these. */
-function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
-  return {
-    cc: "/fake/llvm/bin/clang-cl",
-    cxx: "/fake/llvm/bin/clang-cl",
-    clangVersion: "21.1.8",
-    clangResourceDir: "/fake/llvm/lib/clang/21",
-    ar: "/fake/llvm/bin/llvm-lib",
-    ranlib: undefined,
-    ld: "/fake/llvm/bin/lld-link",
-    ld64Lld: undefined,
-    rustLld: undefined,
-    rustLlvmVersion: "22.1.4",
-    rustSysroot: undefined,
-    rustHostTriple: undefined,
-    strip: "/fake/llvm/bin/llvm-strip",
-    llvmStrip: "/fake/llvm/bin/llvm-strip",
-    dsymutil: undefined,
-    bun: "/fake/bin/bun",
-    jsRuntime: "/fake/bin/bun",
-    esbuild: "/fake/bin/esbuild",
-    ccache: undefined,
-    cmake: "/fake/bin/cmake",
-    cargo: undefined,
-    cargoHome: undefined,
-    rustupHome: undefined,
-    msvcLinker: undefined,
-    rc: "/fake/llvm/bin/llvm-rc",
-    mt: undefined,
-    nasm: "/fake/bin/nasm",
-    ...overrides,
-  };
-}
 
 /**
  * Shorthand: resolve a config for a Windows target the way the CI cross lane
@@ -59,7 +26,7 @@ function mockToolchain(overrides: Partial<Toolchain> = {}): Toolchain {
  * the LTO default applies, with an explicit fake sysroot so the local-build
  * "create one with xwin" error never triggers.
  */
-function resolveWindowsCross(partial: PartialConfig = {}, toolchain = mockToolchain()): Config {
+function resolveWindowsCross(partial: PartialConfig = {}, toolchain = mockWindowsCrossToolchain()): Config {
   return resolveConfig(
     {
       os: "windows",
@@ -140,7 +107,7 @@ describe.skipIf(isWindows)("Windows cross-compile LTO config (non-windows host)"
     const rustLld = join(String(dir), "gcc-ld", "ld.lld");
     const cfg = resolveWindowsCross(
       { lto: true, baseline: false },
-      mockToolchain({ rustLld, rustLlvmVersion: "22.1.4" }),
+      mockWindowsCrossToolchain({ rustLld, rustLlvmVersion: "22.1.4" }),
     );
     expect(cfg.ld).toBe(join(String(dir), "gcc-ld", "lld-link"));
     // Cargo-driven links (bun_shim_impl.exe) must NOT follow the swap: rustc
@@ -150,7 +117,10 @@ describe.skipIf(isWindows)("Windows cross-compile LTO config (non-windows host)"
 
     // Without LTO there's no bitcode skew to work around — keep the host
     // LLVM's lld-link.
-    const plain = resolveWindowsCross({ lto: false }, mockToolchain({ rustLld, rustLlvmVersion: "22.1.4" }));
+    const plain = resolveWindowsCross(
+      { lto: false },
+      mockWindowsCrossToolchain({ rustLld, rustLlvmVersion: "22.1.4" }),
+    );
     expect(plain.ld).toBe("/fake/llvm/bin/lld-link");
 
     // If rustc's gcc-ld/ ever stops shipping lld-link, fall back to the host
@@ -159,7 +129,7 @@ describe.skipIf(isWindows)("Windows cross-compile LTO config (non-windows host)"
     using bare = tempDir("win-cross-rust-lld-bare", { "gcc-ld/ld.lld": "" });
     const bareCfg = resolveWindowsCross(
       { lto: true, baseline: false },
-      mockToolchain({ rustLld: join(String(bare), "gcc-ld", "ld.lld"), rustLlvmVersion: "22.1.4" }),
+      mockWindowsCrossToolchain({ rustLld: join(String(bare), "gcc-ld", "ld.lld"), rustLlvmVersion: "22.1.4" }),
     );
     expect(bareCfg.ld).toBe("/fake/llvm/bin/lld-link");
   });
@@ -193,7 +163,7 @@ describe.skipIf(isWindows)("Windows cross-compile LTO config (non-windows host)"
   test("linux LTO config uses ThinLTO with WPD and no-split-lto-unit", () => {
     const linux = resolveConfig(
       { os: "linux", arch: "x64", abi: "gnu", buildType: "Release", ci: true, buildkite: false, linuxSysroot: "/fake" },
-      mockToolchain({ cc: "/fake/llvm/bin/clang", cxx: "/fake/llvm/bin/clang++", ld: "/fake/llvm/bin/ld.lld" }),
+      mockToolchain(),
     );
     expect(linux.lto).toBe(true);
     const linuxFlags = computeFlags(linux);


### PR DESCRIPTION
### Problem
- Five build-script tests under `test/internal/` each carry their own copy of a fake `Toolchain` for `resolveConfig()`, and the copies have drifted.
- Two of them never got `hostCc` / `hostCxx` (added in #31300), so they fail to type-check: `error TS2322 ... Property 'hostCc' is optional ... but required in type 'Toolchain'`. The test tree is not type-checked in CI, so nobody noticed.
- Every new `Toolchain` field has to land once per copy; #34299 touches three of the five and #37575 would add a sixth.

### Fix
- One shared helper in `test/_util/`: a unix fixture, plus a windows-cross variant that overrides it, so a new field has exactly one place to go. The five local copies are deleted.
- A new source-lints test checks that both fixtures have exactly the properties `interface Toolchain` declares. It runs on every PR touching `scripts/build/**` or `test/_util/**`, so the next added field fails CI until the mock follows; dropping `hostCc` / `hostCxx` from the helper makes it fail.
- Deriving the windows fixture from the unix one moves a few pass-through values (`hostCc` / `hostCxx`, `clangResourceDir`, `ranlib` / `dsymutil` / `mt`); every field `resolveConfig()` derives from them comes out identical, and no assertion reads the moved ones.
- Verification is unit tests only: the six files pass under released bun and `bun bd test`, and a narrowed `tsc` run over the touched files is clean.

### Background
- `Toolchain` (`scripts/build/config.ts`) is the record of resolved tool paths (clang, lld, ar, cmake, ...) that `resolveConfig()` turns, together with os / arch / build type, into the full build `Config`. It only records the paths, so tests pass fakes and run without LLVM.
- For a windows target the resolver switches to the MSVC-flavoured tools (`clang-cl`, `llvm-lib`, `lld-link`, ...) but keeps plain clang / clang++ as host compilers, hence the second fixture.
- `test/internal/source-lints/` holds tests a GitHub workflow runs with released bun on a bare checkout when certain paths change; they may only import built-ins, relative paths, `harness` and `_util/*`.
- Nothing type-checks the test tree in CI, so a typed literal missing a field is only caught at runtime.

<details>
<summary>Original description</summary>

### What

The build-script tests under `test/internal/` each carried a private copy of a fake `Toolchain` for `resolveConfig()`: `build-debug-info-flags`, `build-post-link-ordering`, `macos-cross-config`, `source-lints/windows-cross-config` and `source-lints/webkit-prebuilt-url` (#36139 added the fourth copy and left the dedupe as a follow-up). This replaces them with one helper, `test/_util/mock-toolchain.ts`, and adds a source-lints test that keeps it in sync with the interface.

### Why

The copies had already drifted. `Toolchain.hostCc` / `hostCxx` were added in #31300; the `macos-cross-config` and `windows-cross-config` copies never got them, so those two files fail to type-check against `Toolchain`:

```
internal/macos-cross-config.test.ts(29,3): error TS2322: Type '{ cc: string; ... }' is not assignable to type 'Toolchain'.
  Property 'hostCc' is optional in type '{ ... }' but required in type 'Toolchain'.
internal/source-lints/windows-cross-config.test.ts(24,3): error TS2322: ... Property 'hostCc' is optional ... but required in type 'Toolchain'.
```

(`tsc --noEmit` with a config extending `test/tsconfig.json` and including just these files.) Nobody noticed because the test tree is not type-checked in CI. The same fan-out shows up in open PRs: #34299 (LLVM 22) bumps `clangVersion` in three of the five copies, and #37575 adds what would be a sixth copy; both can use the shared helper after a rebase.

### Change

* `test/_util/mock-toolchain.ts`: `mockToolchain(overrides?)` is the unix fixture (identical values to the three copies that were up to date). `mockWindowsCrossToolchain(overrides?)` layers the MSVC-flavored family (`clang-cl`, `llvm-lib`, `lld-link`, `llvm-rc`, `llvm-mt`, `nasm`) on top of it instead of being a second full literal, so a new `Toolchain` field has exactly one place to go. `test/_util/` is already a trigger path of the source-lints workflow, and `_util/*` already resolves there through `test/harness.ts`.
* The five test files import the helper; the local bodies are deleted (-185 lines). `windows-cross-config`'s linux case uses `mockToolchain()` directly instead of patching `cc`/`cxx`/`ld` onto the windows copy.
* `test/internal/source-lints/mock-toolchain.test.ts`: asserts `Object.keys()` of both fixtures equals the property list parsed out of `export interface Toolchain` in `scripts/build/config.ts`. This is the runtime stand-in for the type check CI does not run; the source-lints workflow runs it on every PR touching `scripts/build/**` or `test/_util/**`, so the next added field fails there in seconds unless the mock is updated. With `hostCc`/`hostCxx` removed from the helper (the drift above) it fails with `Expected - 2` naming the two fields.

Deriving the windows fixture from the unix one changes a few of its values compared with the old windows copy. Resolving the windows x64/arm64, lto/non-lto, ci/local shapes the tests use with both versions and diffing the resulting `Config`s, the fields that move are `hostCc`/`hostCxx` (`clang-cl` -> `clang`/`clang++`, which is what `resolveLlvmToolchain()` actually returns for a windows target on a unix host), `clangResourceDir` (now undefined, as tools.ts skips the probe for msvc targets), and `ranlib`/`dsymutil`/`mt` (now defined, as they are on a linux host). All of them are pass-through fields; `computeFlags`, `webkit.source`, `rustTarget`, `ld`, `strip` and `msvcLinker` come out identical, and no assertion in the file reads the moved fields.

### Verification

* `bun test` (released bun, as the source-lints workflow runs it) and `bun bd test` on the six files: 43 pass.
* `bun test test/internal/source-lints/`: 83 pass across 19 files.
* The narrowed `tsc` run above reports no errors in any of the touched files after the change.

</details>
