### PR TITLE
test: run http-server-chunking in-process and concurrently on every lane

### DIFF
--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -3,16 +3,17 @@ import { describe, expect, test } from "bun:test";
 import { isPosix } from "harness";
 
 /**
- * A way to wait until something written to a loopback connection has not only
- * been delivered but also read by its in-process receiver, without guessing at
- * a delay. Loopback delivers in order, so by the time a byte sent through this
- * extra connection shows up in JS, everything written before it has reached
- * its socket too and was readable in the same poll; the immediate then lets the
- * loop finish dispatching that poll's batch, which includes the receiver's read.
+ * Lets a test wait until bytes it wrote to one loopback connection have been
+ * read by their in-process receiver, without guessing at a delay. Two orderings
+ * make it work: loopback delivers in the order things were written, so once a
+ * byte pushed through this spare connection has shown up in JS, anything
+ * written before it had reached its socket too and was readable in the same
+ * poll; and an immediate queued while that poll's batch is being dispatched
+ * runs only once the whole batch, the receiver's read included, is done.
  *
- * setImmediate alone would not do: an immediate queued from ordinary JS runs
- * before the loop polls again, and an already-due timer fires in the tick that
- * armed it, so either one lets a second write coalesce with the first.
+ * Neither half works alone. An immediate queued from ordinary JS runs before
+ * the loop polls again, and an already-due timer fires in the tick that armed
+ * it, so a second write paced by either one lands in the same read as the first.
  */
 async function loopbackClock() {
   let arrived = () => {};
@@ -54,6 +55,7 @@ interface SeenRequest {
   error?: string;
 }
 
+/** What a pending `req.text()` rejects with once the parser has closed the connection. */
 const BODY_REJECTED = "AbortError: The connection was closed.";
 
 /**
@@ -157,13 +159,13 @@ describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
       socket: { data() {} },
     });
 
-    for (const segment of ["5\r", "\n", "Hello\r\n"]) {
+    for (const segment of ["first", "second", "third"]) {
       socket.write(segment);
       socket.flush();
       await clock.tick();
     }
 
-    expect(reads).toEqual(["5\r", "\n", "Hello\r\n"]);
+    expect(reads).toEqual(["first", "second", "third"]);
   });
 
   test.concurrent.each([
@@ -289,18 +291,17 @@ describe.if(isPosix)("HTTP server handles fragmented requests", () => {
   test.concurrent("parses pipelined requests trickling in through a tiny send buffer", async () => {
     // The parser used to answer 400 when a read ended right after the request
     // line, with the header block still on its way. A 1-byte send buffer gets
-    // the requests across in pieces of a few bytes; as the request length is
-    // not a multiple of the piece size, every byte offset of the request is a
-    // read boundary on some request of the connection.
+    // the requests across in pieces of a few bytes, so over 20 pipelined
+    // requests the read boundaries fall at offsets all over the request.
     const connections = 10;
     const requestsPerConnection = 20;
-    const seen: { connection: string; method: string; headers: Record<string, string> }[] = [];
+    // Keyed by request path, which names the connection the request came in on.
+    const seen: Record<string, { method: string; headers: Record<string, string> }[]> = {};
     await using server = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
       fetch(req) {
-        seen.push({
-          connection: new URL(req.url).pathname,
+        (seen[new URL(req.url).pathname] ??= []).push({
           method: req.method,
           headers: Object.fromEntries(req.headers),
         });
@@ -361,19 +362,15 @@ describe.if(isPosix)("HTTP server handles fragmented requests", () => {
 
     const statuses = await Promise.all(Array.from({ length: connections }, (_, connection) => drive(connection)));
 
-    const expectedSeen = Object.fromEntries(
-      Array.from({ length: connections }, (_, connection) => [
-        `/connection-${connection}`,
-        Array.from({ length: requestsPerConnection }, (_, index) => ({
-          connection: `/connection-${connection}`,
-          method: "GET",
-          headers: index === requestsPerConnection - 1 ? { ...headers, connection: "close" } : headers,
-        })),
-      ]),
-    );
-    expect({ statuses, seen: Object.groupBy(seen, ({ connection }) => connection) }).toEqual({
+    const expectedRequests = Array.from({ length: requestsPerConnection }, (_, index) => ({
+      method: "GET",
+      headers: index === requestsPerConnection - 1 ? { ...headers, connection: "close" } : headers,
+    }));
+    expect({ statuses, seen }).toEqual({
       statuses: Array.from({ length: connections }, () => Array(requestsPerConnection).fill("HTTP/1.1 200 OK")),
-      seen: expectedSeen,
+      seen: Object.fromEntries(
+        Array.from({ length: connections }, (_, connection) => [`/connection-${connection}`, expectedRequests]),
+      ),
     });
   });
 });

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -3,17 +3,47 @@ import { describe, expect, test } from "bun:test";
 import { isPosix } from "harness";
 
 /**
- * Resolves after the event loop has polled for I/O at least `count` more times.
+ * A way to wait until something written to a loopback connection has not only
+ * been delivered but also read by its in-process receiver, without guessing at
+ * a delay. Loopback delivers in order, so by the time a byte sent through this
+ * extra connection shows up in JS, everything written before it has reached
+ * its socket too and was readable in the same poll; the immediate then lets the
+ * loop finish dispatching that poll's batch, which includes the receiver's read.
  *
- * An immediate queued from ordinary JS runs before the loop's next poll, and
- * one queued from inside an immediate runs after that poll, so every extra
- * link in the chain is one more poll. Timers are no substitute: one that is
- * already due fires at the end of the tick that armed it, before the next poll.
+ * setImmediate alone would not do: an immediate queued from ordinary JS runs
+ * before the loop polls again, and an already-due timer fires in the tick that
+ * armed it, so either one lets a second write coalesce with the first.
  */
-async function afterIOPolls(count: number) {
-  for (let i = 0; i <= count; i++) {
-    await new Promise<void>(resolve => setImmediate(resolve));
-  }
+async function loopbackClock() {
+  let arrived = () => {};
+  const listener = Bun.listen({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      data() {
+        arrived();
+      },
+    },
+  });
+  const socket = await Bun.connect({
+    hostname: listener.hostname,
+    port: listener.port,
+    socket: { data() {} },
+  });
+  return {
+    async tick() {
+      const { promise, resolve } = Promise.withResolvers<void>();
+      arrived = resolve;
+      socket.write(".");
+      socket.flush();
+      await promise;
+      await new Promise<void>(resolve => setImmediate(resolve));
+    },
+    [Symbol.dispose]() {
+      socket.end();
+      listener.stop();
+    },
+  };
 }
 
 interface SeenRequest {
@@ -33,9 +63,9 @@ const BODY_REJECTED = "AbortError: The connection was closed.";
  * too).
  *
  * Each segment reaches the server in its own read: the next one is written only
- * after the server has had a poll in which to read the previous one, plus a
- * poll for its reaction to reach us. Once the server has answered or hung up,
- * the remaining segments stay unsent. They are still worth listing for the
+ * once the server has read the previous one and whatever it wrote back in
+ * reaction has reached `received`. Once the server has answered or hung up, the
+ * remaining segments stay unsent. They are still worth listing for the
  * rejection cases: a server that wrongly kept the request going gets them and
  * is caught answering 200, while one that rightly rejected it is left alone.
  */
@@ -68,6 +98,7 @@ async function exchange(segments: string[], options: { maxRequestBodySize?: numb
   let received = "";
   let closed = false;
   const { promise: closedPromise, resolve: onClose } = Promise.withResolvers<void>();
+  using clock = await loopbackClock();
   using socket = await Bun.connect({
     hostname: server.hostname,
     port: server.port,
@@ -87,7 +118,10 @@ async function exchange(segments: string[], options: { maxRequestBodySize?: numb
     if (received !== "" || closed) break;
     socket.write(segment);
     socket.flush();
-    await afterIOPolls(2);
+    // First tick: the server has read the segment (and written any reaction).
+    // Second tick: that reaction has been read into `received` on this side.
+    await clock.tick();
+    await clock.tick();
   }
 
   await closedPromise;
@@ -103,7 +137,7 @@ function chunkedRequest(path = "/") {
 }
 
 describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
-  test.concurrent("writes spaced by afterIOPolls() reach the server as separate reads", async () => {
+  test.concurrent("writes separated by a loopbackClock() tick arrive as separate reads", async () => {
     // Guards the premise of every split-segment case below. If the writes
     // coalesced, those cases would still pass, just against unsplit input.
     const reads: string[] = [];
@@ -116,6 +150,7 @@ describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
         },
       },
     });
+    using clock = await loopbackClock();
     using socket = await Bun.connect({
       hostname: listener.hostname,
       port: listener.port,
@@ -125,7 +160,7 @@ describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
     for (const segment of ["5\r", "\n", "Hello\r\n"]) {
       socket.write(segment);
       socket.flush();
-      await afterIOPolls(2);
+      await clock.tick();
     }
 
     expect(reads).toEqual(["5\r", "\n", "Hello\r\n"]);

--- a/test/js/bun/http/http-server-chunking.test.ts
+++ b/test/js/bun/http/http-server-chunking.test.ts
@@ -1,648 +1,344 @@
-import type { Socket } from "bun";
 import { setSocketOptions } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isPosix } from "harness";
+import { isPosix } from "harness";
+
+/**
+ * Resolves after the event loop has polled for I/O at least `count` more times.
+ *
+ * An immediate queued from ordinary JS runs before the loop's next poll, and
+ * one queued from inside an immediate runs after that poll, so every extra
+ * link in the chain is one more poll. Timers are no substitute: one that is
+ * already due fires at the end of the tick that armed it, before the next poll.
+ */
+async function afterIOPolls(count: number) {
+  for (let i = 0; i <= count; i++) {
+    await new Promise<void>(resolve => setImmediate(resolve));
+  }
+}
+
+interface SeenRequest {
+  path: string;
+  /** What `req.text()` resolved to. */
+  body?: string;
+  /** What `req.text()` rejected with, when the parser gave up on the body instead. */
+  error?: string;
+}
+
+const BODY_REJECTED = "AbortError: The connection was closed.";
+
+/**
+ * Sends `segments` over one connection to a Bun.serve whose handler echoes the
+ * request body, and resolves once the server has closed the connection (every
+ * request asks for `Connection: close`, so a successful exchange ends that way
+ * too).
+ *
+ * Each segment reaches the server in its own read: the next one is written only
+ * after the server has had a poll in which to read the previous one, plus a
+ * poll for its reaction to reach us. Once the server has answered or hung up,
+ * the remaining segments stay unsent. They are still worth listing for the
+ * rejection cases: a server that wrongly kept the request going gets them and
+ * is caught answering 200, while one that rightly rejected it is left alone.
+ */
+async function exchange(segments: string[], options: { maxRequestBodySize?: number } = {}) {
+  const seen: SeenRequest[] = [];
+  const handled: Promise<Response>[] = [];
+  await using server = Bun.serve({
+    ...options,
+    port: 0,
+    fetch(req) {
+      const request: SeenRequest = { path: new URL(req.url).pathname };
+      seen.push(request);
+      const response = req.text().then(
+        body => {
+          request.body = body;
+          return new Response("Got: " + body);
+        },
+        (error: Error) => {
+          request.error = `${error.name}: ${error.message}`;
+          // By now the parser has answered and closed the connection itself;
+          // a 500 showing up in `status` means it did not.
+          return new Response(null, { status: 500 });
+        },
+      );
+      handled.push(response);
+      return response;
+    },
+  });
+
+  let received = "";
+  let closed = false;
+  const { promise: closedPromise, resolve: onClose } = Promise.withResolvers<void>();
+  using socket = await Bun.connect({
+    hostname: server.hostname,
+    port: server.port,
+    socket: {
+      data(_socket, chunk) {
+        received += chunk.toString();
+      },
+      close() {
+        closed = true;
+        onClose();
+      },
+      error() {},
+    },
+  });
+
+  for (const segment of segments) {
+    if (received !== "" || closed) break;
+    socket.write(segment);
+    socket.flush();
+    await afterIOPolls(2);
+  }
+
+  await closedPromise;
+  await Promise.all(handled);
+
+  const [status] = received.split("\r\n");
+  const headersEnd = received.indexOf("\r\n\r\n");
+  return { status, body: headersEnd === -1 ? "" : received.slice(headersEnd + 4), seen };
+}
+
+function chunkedRequest(path = "/") {
+  return `POST ${path} HTTP/1.1\r\nHost: x\r\nConnection: close\r\nTransfer-Encoding: chunked\r\n\r\n`;
+}
 
 describe.if(isPosix)("HTTP server handles chunked transfer encoding", () => {
-  test.concurrentIf(!isASAN)("handles fragmented chunk terminators", async () => {
-    const script = `
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const body = await req.text();
-          return new Response("Got: " + body);
+  test.concurrent("writes spaced by afterIOPolls() reach the server as separate reads", async () => {
+    // Guards the premise of every split-segment case below. If the writes
+    // coalesced, those cases would still pass, just against unsplit input.
+    const reads: string[] = [];
+    using listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        data(_socket, chunk) {
+          reads.push(chunk.toString());
         },
-      });
-      const { promise, resolve } = Promise.withResolvers();
-      const socket = await Bun.connect({
-        hostname: "localhost",
-        port: server.port,
-        socket: {
-          data(socket, data) {
-            console.log(data.toString());
-            socket.end();
-          },
-          open(socket) {
-            socket.write("POST / HTTP/1.1\\r\\nHost: localhost\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n4\\r\\nWiki\\r");
-            socket.flush();
-            setTimeout(() => {
-              socket.write("\\n0\\r\\n\\r\\n");
-              socket.flush();
-            }, 50);
-          },
-          error() {},
-          close() { resolve(); },
-        },
-      });
-      await promise;
-      server.stop();
-    `;
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+      },
+    });
+    using socket = await Bun.connect({
+      hostname: listener.hostname,
+      port: listener.port,
+      socket: { data() {} },
     });
 
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
+    for (const segment of ["5\r", "\n", "Hello\r\n"]) {
+      socket.write(segment);
+      socket.flush();
+      await afterIOPolls(2);
+    }
 
-    expect(stdout).toContain("200 OK");
-    expect(stdout).toContain("Got: Wiki");
-    expect(exitCode).toBe(0);
+    expect(reads).toEqual(["5\r", "\n", "Hello\r\n"]);
   });
 
-  test.concurrentIf(!isASAN)("rejects invalid terminator in fragmented reads", async () => {
-    const script = `
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const body = await req.text();
-          return new Response("Got: " + body);
-        },
-      });
-      const { promise, resolve } = Promise.withResolvers();
-      const socket = await Bun.connect({
-        hostname: "localhost",
-        port: server.port,
-        socket: {
-          data(socket, data) {
-            console.log(data.toString());
-            socket.end();
-          },
-          open(socket) {
-            socket.write("POST / HTTP/1.1\\r\\nHost: localhost\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n4\\r\\nTestX");
-            socket.flush();
-            setTimeout(() => {
-              socket.write("\\n0\\r\\n\\r\\n");
-              socket.flush();
-            }, 50);
-          },
-          error() {},
-          close() { resolve(); },
-        },
-      });
-      await promise;
-      server.stop();
-    `;
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
-
-    expect(stdout).toContain("400");
-    expect(exitCode).toBe(0);
-  });
-});
-
-describe.if(isPosix)("HTTP server handles split chunk-size CRLF", () => {
-  test.concurrentIf(!isASAN)("handles lone CR at end of chunk-size line across TCP segments", async () => {
-    // Regression test: when a TCP segment boundary falls between the \r and \n
-    // of a chunk-size line (e.g. "5\r" in one segment, "\n..." in the next),
-    // the server must buffer and resume correctly instead of spinning.
-    const script = `
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const body = await req.text();
-          return new Response("Got: " + body);
-        },
-      });
-      const { promise, resolve } = Promise.withResolvers();
-      const socket = await Bun.connect({
-        hostname: "localhost",
-        port: server.port,
-        socket: {
-          data(socket, data) {
-            console.log(data.toString());
-            socket.end();
-          },
-          open(socket) {
-            // Send headers
-            socket.write("PUT / HTTP/1.1\\r\\nHost: localhost\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n");
-            socket.flush();
-            // After a delay, send chunk size with lone \\r (no \\n yet)
-            setTimeout(() => {
-              socket.write("5\\r");
-              socket.flush();
-              // After another delay, send the rest: \\n, chunk data, and final chunk
-              setTimeout(() => {
-                socket.write("\\nHello\\r\\n0\\r\\n\\r\\n");
-                socket.flush();
-              }, 50);
-            }, 50);
-          },
-          error() {},
-          close() { resolve(); },
-        },
-      });
-      await promise;
-      server.stop();
-    `;
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
-
-    expect(stdout).toContain("200 OK");
-    expect(stdout).toContain("Got: Hello");
-    expect(exitCode).toBe(0);
-  });
-
-  test.concurrentIf(!isASAN)("handles lone CR in chunk-size with extensions", async () => {
-    // Same split but with a chunk extension before the CRLF
-    const script = `
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          const body = await req.text();
-          return new Response("Got: " + body);
-        },
-      });
-      const { promise, resolve } = Promise.withResolvers();
-      const socket = await Bun.connect({
-        hostname: "localhost",
-        port: server.port,
-        socket: {
-          data(socket, data) {
-            console.log(data.toString());
-            socket.end();
-          },
-          open(socket) {
-            socket.write("PUT / HTTP/1.1\\r\\nHost: localhost\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n");
-            socket.flush();
-            setTimeout(() => {
-              // chunk size with extension, CR split from LF
-              socket.write("5;ext=val\\r");
-              socket.flush();
-              setTimeout(() => {
-                socket.write("\\nHello\\r\\n0\\r\\n\\r\\n");
-                socket.flush();
-              }, 50);
-            }, 50);
-          },
-          error() {},
-          close() { resolve(); },
-        },
-      });
-      await promise;
-      server.stop();
-    `;
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-
-    const [stdout, stderr, exitCode] = await Promise.all([
-      new Response(proc.stdout).text(),
-      new Response(proc.stderr).text(),
-      proc.exited,
-    ]);
-
-    expect(stdout).toContain("200 OK");
-    expect(stdout).toContain("Got: Hello");
-    expect(exitCode).toBe(0);
-  });
-
-  test.concurrentIf(!isASAN)("rejects chunk extensions that exceed the 16 KiB per-chunk cap", async () => {
-    // A hostile client can hold a connection and unmetered inbound bandwidth by
-    // streaming arbitrarily large chunk-extension bytes, which maxRequestBodySize
-    // never sees. llhttp (Node) caps this at 16 KiB per chunk; Bun.serve must too.
-    const script = `
-      const server = Bun.serve({
-        port: 0,
-        maxRequestBodySize: 1024 * 1024,
-        async fetch(req) {
-          const n = (await req.arrayBuffer()).byteLength;
-          return new Response("n=" + n);
-        },
-      });
-      const { promise, resolve } = Promise.withResolvers();
-      let received = "";
-      const socket = await Bun.connect({
-        hostname: "localhost",
-        port: server.port,
-        socket: {
-          data(s, d) { received += d.toString(); },
-          open(s) {
-            // 20 KiB of extension bytes on one chunk-size line (cap is 16 KiB).
-            // Body is 2 bytes, well under maxRequestBodySize.
-            const ext = Buffer.alloc(20 * 1024, "e").toString();
-            s.write("POST / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n2;" + ext + "\\r\\nhi\\r\\n0\\r\\n\\r\\n");
-            s.flush();
-          },
-          error() {},
-          close() { console.log(JSON.stringify({ received })); resolve(); },
-        },
-      });
-      await promise;
-      server.stop();
-    `;
-
-    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).toBe("");
-    const { received } = JSON.parse(stdout);
-    // Server must reject (413) and close the connection; it must not hand the
-    // request to fetch() (which would answer 200 "n=2").
-    expect(received).not.toContain("200");
-    expect(received).not.toContain("n=2");
-    expect(received).toContain("413");
-    expect(exitCode).toBe(0);
-  });
-
-  test.concurrentIf(!isASAN)(
-    "accepts small chunk extensions on every chunk (cap is per chunk, not per message)",
-    async () => {
-      // 10 chunks x 8 KiB extension each = 80 KiB total extension bytes, but each
-      // chunk-size line is under the 16 KiB cap so the request must succeed.
-      const script = `
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) { return new Response("Got: " + (await req.text())); },
-      });
-      const { promise, resolve } = Promise.withResolvers();
-      let received = "";
-      const socket = await Bun.connect({
-        hostname: "localhost",
-        port: server.port,
-        socket: {
-          data(s, d) { received += d.toString(); },
-          open(s) {
-            const ext = Buffer.alloc(8 * 1024, "e").toString();
-            let wire = "POST / HTTP/1.1\\r\\nHost: x\\r\\nConnection: close\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n";
-            for (let i = 0; i < 10; i++) wire += "1;" + ext + "\\r\\nA\\r\\n";
-            wire += "0\\r\\n\\r\\n";
-            s.write(wire);
-            s.flush();
-          },
-          error() {},
-          close() { console.log(received); resolve(); },
-        },
-      });
-      await promise;
-      server.stop();
-    `;
-
-      await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr).toBe("");
-      expect(stdout).toContain("200 OK");
-      expect(stdout).toContain("Got: AAAAAAAAAA");
-      expect(exitCode).toBe(0);
+  test.concurrent.each([
+    {
+      name: "a chunk-data CRLF split after the CR",
+      segments: [chunkedRequest() + "4\r\nWiki\r", "\n0\r\n\r\n"],
+      body: "Wiki",
     },
-  );
-
-  test.concurrentIf(!isASAN)("rejects bare LF in chunk-size position (invalid byte not stranded)", async () => {
-    // A byte <=32 that isn't \r in chunk-size position must error immediately.
-    // Previously this could strand the byte in HttpParser's fallback buffer,
-    // corrupting header parsing on the next request.
-    const script = `
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) {
-          try {
-            await req.text();
-            return new Response("OK");
-          } catch {
-            return new Response("Body error", { status: 400 });
-          }
-        },
-      });
-      const { promise, resolve } = Promise.withResolvers();
-      let received = "";
-      const socket = await Bun.connect({
-        hostname: "localhost",
-        port: server.port,
-        socket: {
-          data(socket, data) {
-            received += data.toString();
-          },
-          open(socket) {
-            // Bare LF (0x0A) where chunk-size hex is expected
-            socket.write("PUT / HTTP/1.1\\r\\nHost: localhost\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n\\n");
-            socket.flush();
-          },
-          error() {},
-          close() {
-            console.log(received);
-            resolve();
-          },
-        },
-      });
-      await promise;
-      server.stop();
-    `;
-
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "-e", script],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
+    {
+      // The parser used to spin when a read ended between the \r and \n of a
+      // chunk-size line instead of remembering the \r and resuming.
+      name: "a chunk-size CRLF split after the CR",
+      segments: [chunkedRequest(), "5\r", "\nHello\r\n0\r\n\r\n"],
+      body: "Hello",
+    },
+    {
+      // Same split, resuming out of the chunk-extension state this time.
+      name: "a chunk-size CRLF split after the CR of a line with an extension",
+      segments: [chunkedRequest(), "5;ext=val\r", "\nHello\r\n0\r\n\r\n"],
+      body: "Hello",
+    },
+    {
+      // 80 KiB of extension bytes per message, but the 16 KiB cap is per chunk
+      // (llhttp resets its counter on every chunk header), so this goes
+      // through. The over-the-cap counterpart is the 413 case further down.
+      name: "an 8 KiB chunk extension on each of 10 chunks",
+      segments: [
+        chunkedRequest() +
+          Array(10)
+            .fill(`1;${Buffer.alloc(8 * 1024, "e").toString()}\r\nA\r\n`)
+            .join("") +
+          "0\r\n\r\n",
+      ],
+      body: "AAAAAAAAAA",
+    },
+  ])("accepts $name", async ({ segments, body }) => {
+    expect(await exchange(segments)).toEqual({
+      status: "HTTP/1.1 200 OK",
+      body: "Got: " + body,
+      seen: [{ path: "/", body }],
     });
-
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    // Server should reject with 400, not hang or accept
-    expect(stderr).toBe("");
-    expect(stdout).toContain("400");
-    expect(exitCode).toBe(0);
   });
 
-  test.concurrentIf(!isASAN)("rejects Content-Length values that would alias chunked-encoding state bits", async () => {
-    // remainingStreamingBytes is shared between CL and chunked state. CL >= 2^59 would
-    // set STATE_HAS_HEXDIG and route a fixed-length body into the chunked decoder.
-    const script = `
-      let urls = [];
-      const server = Bun.serve({
-        port: 0,
-        async fetch(req) { urls.push(new URL(req.url).pathname); return new Response("OK"); },
-      });
-      const { promise, resolve } = Promise.withResolvers();
-      let received = "";
-      const socket = await Bun.connect({
-        hostname: "localhost",
-        port: server.port,
-        socket: {
-          data(s, d) { received += d.toString(); },
-          async open(s) {
-            s.write("GET /first HTTP/1.1\\r\\nHost: x\\r\\nContent-Length: 576460752303423488\\r\\n\\r\\n");
-            s.flush();
-            await Bun.sleep(20);
-            s.write("\\r\\n\\r\\nGET /smuggled HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
-            s.flush();
-          },
-          error() {},
-          close() { console.log(JSON.stringify({ received, urls })); resolve(); },
-        },
-      });
-      await promise;
-      server.stop();
-    `;
-
-    await using proc = Bun.spawn({ cmd: [bunExe(), "-e", script], env: bunEnv, stdout: "pipe", stderr: "pipe" });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-    expect(stderr).toBe("");
-    const { received, urls } = JSON.parse(stdout);
-    expect(received).toContain("400");
-    expect(urls).not.toContain("/smuggled");
-    expect(exitCode).toBe(0);
+  test.concurrent.each([
+    {
+      // "TestX" arrives with one byte of the chunk terminator still to come, so
+      // the X has to be caught by the partial-read path. Had it been let
+      // through, the second segment would complete a 200 for "Test".
+      name: "a chunk-data terminator whose CR is some other byte",
+      segments: [chunkedRequest() + "4\r\nTestX", "\n0\r\n\r\n"],
+      seen: [{ path: "/", error: BODY_REJECTED }],
+    },
+    {
+      // A byte <= 0x20 other than \r in chunk-size position must fail on the
+      // spot. It used to be left behind in the parser's fallback buffer, where
+      // it corrupted the next request on the connection.
+      name: "a bare LF in chunk-size position",
+      segments: [chunkedRequest() + "\n"],
+      seen: [{ path: "/", error: BODY_REJECTED }],
+    },
+    {
+      // RFC 7230 4.1: chunk-size = 1*HEXDIG. An empty chunk-size line used to
+      // parse as the last chunk, so whatever followed the bogus terminator was
+      // read as a second request. It must never reach the handler.
+      name: "a chunk-size line with no hex digits, followed by a smuggled request",
+      segments: [chunkedRequest("/first") + "\r\n\r\nGET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"],
+      seen: [{ path: "/first", error: BODY_REJECTED }],
+    },
+    {
+      name: "a chunk-size line with only an extension, followed by a smuggled request",
+      segments: [chunkedRequest("/first") + ";a=b\r\n\r\nGET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n"],
+      seen: [{ path: "/first", error: BODY_REJECTED }],
+    },
+    {
+      // The same verdict when the line arrives on its own, with the parser
+      // suspended before and after it. A server that took the line for the
+      // last chunk would go on to answer the final CRLF with a 200.
+      name: "a chunk-size line with no hex digits, arriving in its own segment",
+      segments: [chunkedRequest(), "\r\n", "\r\n"],
+      seen: [{ path: "/", error: BODY_REJECTED }],
+    },
+    {
+      name: "a chunk-size line with only an extension, arriving in its own segment",
+      segments: [chunkedRequest(), ";a=b\r\n", "\r\n"],
+      seen: [{ path: "/", error: BODY_REJECTED }],
+    },
+    {
+      // The remaining-body counter doubles as the chunked decoder's state word.
+      // A Content-Length of 2^59 would set the decoder's "has hex digit" bit
+      // and route a fixed-length body through the chunked decoder, which would
+      // then take the bytes after the CRLFs for a second request. It has to be
+      // refused at header time, before fetch() runs at all.
+      name: "a Content-Length that aliases the chunked decoder's state bits",
+      segments: [
+        "GET /first HTTP/1.1\r\nHost: x\r\nContent-Length: 576460752303423488\r\n\r\n",
+        "\r\n\r\nGET /smuggled HTTP/1.1\r\nHost: x\r\n\r\n",
+      ],
+      seen: [],
+    },
+  ])("answers 400 to $name", async ({ segments, seen }) => {
+    expect(await exchange(segments)).toEqual({
+      status: "HTTP/1.1 400 Bad Request",
+      body: "",
+      seen,
+    });
   });
 
-  describe.each([
-    ["bare CRLF", "\\r\\n"],
-    ["extension only", ";a=b\\r\\n"],
-  ])("rejects chunk-size with zero hex digits (%s)", (_, chunkSizeLine) => {
-    // RFC 7230 4.1: chunk-size = 1*HEXDIG. A chunk-size line with no hex digit
-    // must be rejected. Previously this parsed as size 0 (last-chunk), allowing a
-    // pipelined request after the bogus terminator to be smuggled.
-    test.concurrentIf(!isASAN)("rejects and does not process trailing pipelined request", async () => {
-      const script = `
-        let requests = 0;
-        const server = Bun.serve({
-          port: 0,
-          async fetch(req) {
-            requests++;
-            try {
-              await req.text();
-              return new Response("OK " + req.url);
-            } catch {
-              return new Response("Body error", { status: 400 });
-            }
-          },
-        });
-        const { promise, resolve } = Promise.withResolvers();
-        let received = "";
-        const socket = await Bun.connect({
-          hostname: "localhost",
-          port: server.port,
-          socket: {
-            data(socket, data) { received += data.toString(); },
-            open(socket) {
-              socket.write(
-                "PUT /first HTTP/1.1\\r\\nHost: x\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n" +
-                "${chunkSizeLine}\\r\\n" +
-                "GET /smuggled HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n"
-              );
-              socket.flush();
-            },
-            error() {},
-            close() { console.log(JSON.stringify({ received, requests })); resolve(); },
-          },
-        });
-        await promise;
-        server.stop();
-      `;
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", script],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr).toBe("");
-      const { received, requests } = JSON.parse(stdout);
-      expect(received).toContain("400");
-      expect(received).not.toContain("/smuggled");
-      // The smuggled request must never reach the handler.
-      expect(requests).toBeLessThanOrEqual(1);
-      expect(exitCode).toBe(0);
-    });
-
-    test.concurrentIf(!isASAN)("rejects when chunk-size line is split across packets", async () => {
-      const script = `
-        const server = Bun.serve({
-          port: 0,
-          async fetch(req) {
-            try { await req.text(); return new Response("OK"); }
-            catch { return new Response("Body error", { status: 400 }); }
-          },
-        });
-        const { promise, resolve } = Promise.withResolvers();
-        let received = "";
-        const socket = await Bun.connect({
-          hostname: "localhost",
-          port: server.port,
-          socket: {
-            data(socket, data) { received += data.toString(); },
-            async open(socket) {
-              socket.write("PUT / HTTP/1.1\\r\\nHost: x\\r\\nTransfer-Encoding: chunked\\r\\n\\r\\n");
-              socket.flush();
-              await Bun.sleep(20);
-              socket.write("${chunkSizeLine}");
-              socket.flush();
-              await Bun.sleep(20);
-              socket.write("\\r\\n");
-              socket.flush();
-            },
-            error() {},
-            close() { console.log(received); resolve(); },
-          },
-        });
-        await promise;
-        server.stop();
-      `;
-
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", script],
-        env: bunEnv,
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-
-      expect(stderr).toBe("");
-      expect(stdout).toContain("400");
-      expect(exitCode).toBe(0);
+  test.concurrent("answers 413 to a chunk extension over the 16 KiB per-chunk cap", async () => {
+    // Extension bytes do not count toward maxRequestBodySize, so without a cap
+    // of their own a client could stream them indefinitely on one connection.
+    // llhttp caps them at 16 KiB per chunk. The body is 2 bytes against a 1 MiB
+    // limit, so this 413 can only be the extension cap.
+    const segments = [chunkedRequest() + `2;${Buffer.alloc(20 * 1024, "e").toString()}\r\nhi\r\n0\r\n\r\n`];
+    expect(await exchange(segments, { maxRequestBodySize: 1024 * 1024 })).toEqual({
+      status: "HTTP/1.1 413 Payload Too Large",
+      body: "",
+      seen: [{ path: "/", error: BODY_REJECTED }],
     });
   });
 });
 
 describe.if(isPosix)("HTTP server handles fragmented requests", () => {
-  test.concurrentIf(!isASAN)("handles requests with tiny send buffer (regression test)", async () => {
-    using server = Bun.serve({
+  test.concurrent("parses pipelined requests trickling in through a tiny send buffer", async () => {
+    // The parser used to answer 400 when a read ended right after the request
+    // line, with the header block still on its way. A 1-byte send buffer gets
+    // the requests across in pieces of a few bytes; as the request length is
+    // not a multiple of the piece size, every byte offset of the request is a
+    // read boundary on some request of the connection.
+    const connections = 10;
+    const requestsPerConnection = 20;
+    const seen: { connection: string; method: string; headers: Record<string, string> }[] = [];
+    await using server = Bun.serve({
       hostname: "127.0.0.1",
-
       port: 0,
-      async fetch(req) {
-        const body = await req.text();
-        const headers: Record<string, string> = {};
-        req.headers.forEach((value, key) => {
-          headers[key] = value;
+      fetch(req) {
+        seen.push({
+          connection: new URL(req.url).pathname,
+          method: req.method,
+          headers: Object.fromEntries(req.headers),
         });
-        return new Response(
-          JSON.stringify({
-            method: req.method,
-            url: req.url,
-            headers,
-            body,
-          }),
-          {
-            headers: { "Content-Type": "application/json" },
-          },
-        );
+        return new Response("ok");
       },
     });
 
-    const { port } = server;
-    // 10 == batchSize is deliberate: one full-width batch preserves the concurrent-accept
-    // pressure. The old value of 100 repeated the same per-connection path 10x over.
-    let remaining = 10;
-    const batchSize = 10;
-
-    for (let i = 0; i < remaining; i += batchSize) {
-      const promises: Promise<void>[] = [];
-      for (let j = 0; j < batchSize; j++) {
-        promises.push(
-          (async i => {
-            const { resolve: resolveClose, reject: rejectClose, promise: closePromise } = Promise.withResolvers();
-
-            let buffer: Buffer;
-            let offset = 0;
-
-            function actuallyWrite(socket) {
-              while (offset < buffer.length) {
-                const written = socket.write(buffer, offset, 1);
-
-                if (written == 0) break;
-
-                if (written > 1) {
-                  throw new Error(`Written ${written} bytes, expected 1`);
-                }
-                socket.flush();
-                offset += written;
-              }
-            }
-
-            let remainingRequests = 20;
-
-            const socket = await Bun.connect({
-              hostname: server.hostname,
-              port: server.port!,
-              socket: {
-                open(socket: Socket) {
-                  // Set a very small send buffer to force fragmentation
-                  // This simulates the condition that triggered the bug
-                  setSocketOptions(socket, 1, 1); // 1 = send buffer, 1 = size
-
-                  const input = `GET /test-${i} HTTP/1.1\r\nHost: ${server.hostname}:${port}\r\nUser-Agent: Bun-Test\r\nAccept: */*\r\n\r\n`;
-                  const repeated = Buffer.alloc(input.length * remainingRequests, input);
-
-                  buffer = repeated;
-                  actuallyWrite(socket);
-                },
-                data(socket: Socket, data: Buffer) {
-                  // Mini HTTP parser to count complete responses
-                  const dataStr = data.toString();
-                  const responses = dataStr.split("\r\n\r\n");
-
-                  // Count complete responses (those that have both headers and body)
-                  for (let k = 0; k < responses.length - 1; k++) {
-                    if (responses[k].includes("HTTP/1.1 200 OK")) {
-                      remainingRequests--;
-                    }
-                  }
-                  if (remainingRequests == 0) {
-                    socket.end();
-                  }
-                },
-                close() {
-                  if (remainingRequests > 0) {
-                    throw new Error(`Expected 20 responses, got ${20 - remainingRequests}`);
-                  }
-
-                  resolveClose();
-                },
-                drain(socket: Socket) {
-                  actuallyWrite(socket);
-                },
-                error(_socket: Socket, error: Error) {
-                  rejectClose(error);
-                },
-              },
-            });
-
-            // Wait for the socket to close
-            await closePromise;
-          })(i),
-        );
-      }
-
-      await Promise.all(promises);
+    const headers = { host: `127.0.0.1:${server.port}`, "user-agent": "Bun-Test", accept: "*/*" };
+    function request(connection: number, index: number) {
+      return (
+        `GET /connection-${connection} HTTP/1.1\r\n` +
+        `Host: ${headers.host}\r\nUser-Agent: ${headers["user-agent"]}\r\nAccept: ${headers.accept}\r\n` +
+        // The server closes the connection after the last response, which is
+        // how the client below knows it has everything.
+        (index === requestsPerConnection - 1 ? "Connection: close\r\n" : "") +
+        "\r\n"
+      );
     }
 
-    server.stop();
+    async function drive(connection: number): Promise<string[]> {
+      const wire = Buffer.from(
+        Array.from({ length: requestsPerConnection }, (_, index) => request(connection, index)).join(""),
+      );
+      let offset = 0;
+      function writeUntilFull(socket: Bun.Socket) {
+        while (offset < wire.length) {
+          const written = socket.write(wire, offset, 1);
+          if (written === 0) break; // drain() picks up from here
+          offset += written;
+          socket.flush();
+        }
+      }
+
+      let received = "";
+      const { promise, resolve, reject } = Promise.withResolvers<string>();
+      await Bun.connect({
+        hostname: server.hostname,
+        port: server.port,
+        socket: {
+          open(socket) {
+            setSocketOptions(socket, 1 /* SO_SNDBUF */, 1);
+            writeUntilFull(socket);
+          },
+          drain: writeUntilFull,
+          data(_socket, chunk) {
+            received += chunk.toString();
+          },
+          close() {
+            resolve(received);
+          },
+          error(_socket, error) {
+            reject(error);
+          },
+        },
+      });
+      return (await promise).match(/HTTP\/1\.1 [^\r]*/g) ?? [];
+    }
+
+    const statuses = await Promise.all(Array.from({ length: connections }, (_, connection) => drive(connection)));
+
+    const expectedSeen = Object.fromEntries(
+      Array.from({ length: connections }, (_, connection) => [
+        `/connection-${connection}`,
+        Array.from({ length: requestsPerConnection }, (_, index) => ({
+          connection: `/connection-${connection}`,
+          method: "GET",
+          headers: index === requestsPerConnection - 1 ? { ...headers, connection: "close" } : headers,
+        })),
+      ]),
+    );
+    expect({ statuses, seen: Object.groupBy(seen, ({ connection }) => connection) }).toEqual({
+      statuses: Array.from({ length: connections }, () => Array(requestsPerConnection).fill("HTTP/1.1 200 OK")),
+      seen: expectedSeen,
+    });
   });
 });


### PR DESCRIPTION
### Problem
- `test/js/bun/http/http-server-chunking.test.ts` took 67s on the debian 13 x64-asan lane (build 92779), one of the slowest non-integration files there. Nothing in it was failing; this PR only changes how the tests are built.
- 12 of the 13 tests spawned a separate `bun` to host the server, and under ASAN they were gated to run one at a time. That lane sets `detect_leaks=1`, so every child paid a LeakSanitizer scan on exit (about 5s each), and the file's time was those scans added up.
- The serial-under-ASAN gate came from #29569 with no reason recorded; the tests never shared any state.
- The split-segment cases paced their writes with 50ms timers, and the old assertions were substring checks on the whole stream (`toContain("400")`) that mostly did not look at what the handler received.

### Fix
- Every scenario runs against an in-process `Bun.serve` through one `exchange()` helper and is `test.concurrent` on every lane. This is safe because no assertion was about exit codes or crash isolation; all of them were about the bytes the server wrote back, and every scenario still sends the same bytes.
- Segment pacing is a loopback clock instead of a delay: after each write, one byte is pushed through a spare loopback connection and awaited, then one immediate. Loopback delivers in order, so the server has read a segment before the next one is written. A new test asserts that premise directly (three paced writes arrive as three reads); swapping the clock for `setImmediate` makes only that test fail.
- Each scenario is now one `toEqual` on the exact status line, the exact body after the headers, and the exact list of requests the handler saw, so smuggled requests and mid-body rejections are checked directly. The tiny-send-buffer workload is unchanged but now asserts exactly 20 responses and 20 parsed requests per connection instead of counting substrings.
- Verification: on the same lane, build 93136 reports `Ran 14 tests across 1 file. [312.00ms]` against 66.68s for main; `--rerun-each` runs went 280/280 and 210/210 on debug+ASAN and 420/420 on release.

### Background
- Chunked transfer encoding sends an HTTP/1.1 body as `<hex size>\r\n<data>\r\n` pieces ending in `0\r\n\r\n`. These tests end a read at awkward positions (between `\r` and `\n`, mid chunk-size line) and check the parser resumes, or answers 400 instead of treating the leftover bytes as a second, smuggled request.
- The ASAN lane runs with `detect_leaks=1`, so every bun subprocess pays a LeakSanitizer scan at exit. A test file that spawns one child per case pays it once per case, and more if the cases are serialized.
- Two writes to a socket in the same event-loop tick normally reach the peer as one read, so a "split" test only tests a split if the first segment is known to have been read before the second is written. `setImmediate` and `Bun.sleep(0)` both run before the loop polls again, so they do not split writes; the loopback clock waits for an actual read.
- `test.concurrent` and `test.concurrent.each` let bun:test overlap the tests within a file; `test.concurrentIf(cond)` is the conditional form the old file used. llhttp caps chunk extensions at 16 KiB per chunk independently of `maxRequestBodySize`, which is what the 413 case exercises.

<details>
<summary>Original description</summary>

`test/js/bun/http/http-server-chunking.test.ts` was one of the slowest non-integration test files on the ASAN lane (67s on debian 13 x64-asan in build 92779). Nothing in it was failing; this only changes how the tests are built, not what they cover.

## Why it was slow

- 12 of the 13 tests spawned a separate `bun` to host the server, and every test was declared `test.concurrentIf(!isASAN)`, so on the ASAN lane the 12 children ran one after another. The ASAN lane's log for build 92779 shows where the time went: the file reported `Ran 13 tests across 1 file. [66.68s]`, with the per-test progress dots landing about 5.1s apart, one per child. The CI runner sets `ASAN_OPTIONS=...detect_leaks=1...` on that lane and the children inherit it, so each child pays a LeakSanitizer scan of a process that has run a server on exit. Locally the same child script exits in 0.46s with bun's default `detect_leaks=0` and takes 5.4s with `detect_leaks=1`, which matches the CI spacing. The same applies to any test that spawns one bun child per test on that lane; serializing them, as this file did, just adds the scans up.
- The `!isASAN` gate was added in #29569 (`test: run http-server-chunking serially under ASAN`, no reason recorded). The tests never shared state; the only thing they shared was the cost of a dozen ASAN children exiting at once, so with no children left there is nothing to serialize.
- The split-segment scenarios paced their writes with `setTimeout(..., 50)` / `Bun.sleep(20)`, 50 to 100ms of sleeping per test.

## What changed

- Every scenario now runs against an in-process `Bun.serve` through one `exchange(segments, options)` helper, and everything is `test.concurrent` on every lane. The assertions never needed a subprocess: none of them was about exit codes or crash isolation, they were about the bytes the server wrote back.
- The 12 scenarios are two `test.concurrent.each` tables (accepted input with the expected echoed body; rejected input with what the handler saw) plus the 413 case, which needs `maxRequestBodySize`. Every scenario from main is still here with the same bytes on the wire; the rationale comments moved onto the table rows.
- Segment pacing is now a `loopbackClock()` instead of a delay. After writing a segment, `exchange()` pushes a byte through a spare loopback connection to an in-process listener and waits for it to arrive, then for one immediate. Loopback delivers in order, so when that byte shows up the segment had reached the server's socket and was readable in the same poll, and the immediate lets that poll's batch (the server's read included) finish. It does this twice per segment: once so the server has read the segment, once more so whatever the server wrote back in reaction has been read on the client side. Once the server has answered or closed, the remaining segments are not written, so a rejecting server is never written to after it hung up (no RST race with the response bytes), while a server that wrongly kept a request going still receives the rest and gets caught answering 200.
  - `setImmediate` does not work for this, which is worth knowing because it looks like it should: an immediate queued from ordinary JS runs before the loop's next poll, and `Bun.sleep(0)` fires at the end of the tick that armed it, also before the next poll. Measured with a raw `Bun.listen` receiver, 200 of 200 write pairs paced by one `setImmediate` or one `Bun.sleep(0)` coalesced into a single read; paced by the clock, 960 of 960 four-segment writes (32 connections at a time, debug+ASAN build) arrived as four reads. Timers with a nonzero delay do split, but only while the delay outlasts the tick, which is what the old 50ms was buying.
  - A new test asserts the premise directly: three writes paced by the clock arrive at a `Bun.listen` as three reads. Without it the split cases would keep passing on coalesced input if the event loop ever changed shape; replacing the clock tick with a single `setImmediate` makes exactly this test fail and all 13 others still pass.
- No explicit test timeouts are left (the six on main were there for the subprocesses).

## Assertions

Each scenario is now one `toEqual` on `{ status, body, seen }`:

- `status` is the exact status line (`HTTP/1.1 400 Bad Request`, `HTTP/1.1 413 Payload Too Large`, `HTTP/1.1 200 OK`) instead of `toContain("400")` / `toContain("413")` / `not.toContain("200")` on the whole stream.
- `body` is exactly what followed the response headers: the echoed body on success, and `""` on rejection, which also proves no second response was ever written (main checked `not.toContain("/smuggled")`).
- `seen` is the exact list of requests the handler got, with each one's `req.text()` outcome: the body on success, and `AbortError: The connection was closed.` on rejection, so a request that was rejected mid-body is shown both to have been rejected and to have had its pending body read settled rather than left hanging. The smuggling cases assert `seen` is exactly the first request (main allowed `<= 1` requests) and the Content-Length case asserts it is `[]`, i.e. refused before `fetch()` ran. Main's rejection cases mostly did not look at the handler at all.
- The tiny-send-buffer test keeps its workload (10 connections x 20 pipelined requests, 1-byte send buffer) but now asserts, per connection, exactly 20 `HTTP/1.1 200 OK` status lines and that the handler saw exactly 20 requests with the right method and header set (main only counted `200 OK` substrings per `data` event and never looked at what was parsed; on a shortfall it threw inside the `close` callback, which hung the test instead of failing it). The last request on each connection carries `Connection: close` so the client reads until the server closes instead of counting inside `data`.
- The subprocess-only assertions (`exitCode === 0`, `stderr === ""`) went away with the subprocesses. Nothing asserted the absence of "panic" or similar.

This test's workload is unchanged and is now most of the file's remaining cost (about 1.75s of the post-startup time locally); #33622 deliberately kept it at this size, so I left it alone.

## Timing

On the lane this was filed for (debian 13 x64-asan), as reported by `bun test` in the job logs: build 92779 (main) `Ran 13 tests across 1 file. [66.68s]`; build 93136 (this PR) `Ran 14 tests across 1 file. [312.00ms]`.

Locally, same machine, same `bun bd` (debug+ASAN, `detect_leaks=0`) binary, `bun test` on the file; "before" is the file as of main (9a543cc18f) run from the same checkout. The debug build makes the unchanged tiny-send-buffer test itself the dominant cost, which is why the local ratio is much smaller than CI's:

| | before | after |
|---|---|---|
| quiet host, `Ran ... [..]` (4 and 5 runs) | 9.55s, 9.94s, 10.29s, 10.66s | 4.39s, 4.41s, 4.42s, 4.52s, 4.59s |
| loaded host (load avg ~60), interleaved, 3 rounds | 10.88s, 11.44s, 12.23s | 5.08s, 5.71s, 6.53s |
| loaded host, wall clock of the whole process, 3 rounds | 13.9s, 15.3s, 15.4s | 7.5s, 7.8s, 7.8s |

A trivial test file takes about 2.35s on this build (runner startup plus harness import), and the unchanged tiny-send-buffer test about 1.75s, so the 12 chunked scenarios went from roughly 5.2s of serial subprocess time to about 0.2s of concurrent in-process time. In CI the subprocess spawns are a much larger share of the 67s than they are here, so the saving there should be larger in proportion.

## Flakiness

- `bun bd test <file> --rerun-each=20`: 280/280; a later revision `--rerun-each=15`: 210/210 (debug+ASAN, all reruns of a file's concurrent tests interleaved).
- `USE_SYSTEM_BUN=1 bun test <file> --rerun-each=30`: 420/420 (release).
- Well over a dozen further plain runs of the file on the debug build across its revisions, all green, including on the loaded host above.
- With the process pinned to one core shared with two busy loops (about a third of one core for the ASAN build), the 13 chunked tests including the premise test still pass; the only failure is the unchanged tiny-send-buffer workload hitting the local 5s default timeout, which the version on main does identically under the same conditions (verified: 2 of 2 runs) (CI's per-test timeout is 90s, or 270s on ASAN).

The file stays `describe.if(isPosix)` as on main. #32887 adds tests to the end of this file; they will need a small rebase onto the new structure, and its `setImmediate` pacing has the coalescing problem described above, so `exchange()` would suit them as well.

</details>
