### PR TITLE
shell: report the last command substitution's status when argv expands to nothing

### DIFF
--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -31,8 +31,7 @@ pub struct Cmd {
     /// `ShellSubprocess::on_process_exit` key off it, so it must stay `None`
     /// until the exec starts.
     pub(crate) exit_code: Option<ExitCode>,
-    /// Status of a sole `$(...)` argv atom: the command's status when it
-    /// expands to no words (POSIX 2.9.1), ignored once something runs.
+    /// Status of the last `$(...)` in argv; reported when argv expands to nothing (POSIX 2.9.1).
     cmd_subst_exit_code: ExitCode,
 }
 
@@ -351,10 +350,8 @@ impl Cmd {
                 CmdState::ExpandingArgs { ref mut idx } => {
                     *idx += 1;
                     let me = interp.as_cmd_mut(this);
-                    if let [ast::Atom::Simple(ast::SimpleAtom::CmdSubst(_))] =
-                        me.ast_node().name_and_args
-                    {
-                        me.cmd_subst_exit_code = out.out_exit_code;
+                    if let Some(code) = out.cmd_subst_exit_code {
+                        me.cmd_subst_exit_code = code;
                     }
                     // `out.bounds` splits the expansion into multiple argv
                     // words (glob/IFS).
@@ -407,8 +404,7 @@ impl Cmd {
             }
         }
 
-        // Empty/null argv[0] → nothing to run; the command's status is that
-        // of its sole command substitution, if any (else 0).
+        // Empty/null argv[0] → nothing to run; report `cmd_subst_exit_code`.
         let first_arg: Vec<u8> = {
             let me = interp.as_cmd(this);
             match me.args.first() {

--- a/src/runtime/shell/states/Expansion.rs
+++ b/src/runtime/shell/states/Expansion.rs
@@ -46,9 +46,6 @@ pub struct Expansion {
     /// [`ExpansionOut`] (both → `buf=[], bounds=[]`) and Cmd would push an
     /// empty arg for unset vars — diverging from POSIX field-splitting.
     pub(crate) has_quoted_empty: bool,
-    /// Exit code of a sole-command-substitution arg — propagated to `Cmd`
-    /// so `$(false)` as argv0 fails.
-    pub(crate) out_exit_code: ExitCode,
 }
 
 #[derive(Default, strum::IntoStaticStr)]
@@ -70,11 +67,8 @@ pub struct ExpansionOut {
     pub(crate) buf: Vec<u8>,
     /// Word boundaries within `buf` (for IFS splitting / glob results).
     pub(crate) bounds: Vec<u32>,
-    /// Set when the atom is a sole `$(…)`
-    /// that exited non-zero, so [`Cmd::child_done`] can propagate it as the
-    /// command's exit code when that substitution was argv0 and argv is
-    /// otherwise empty.
-    pub(crate) out_exit_code: ExitCode,
+    /// Status of the last `$(…)` in this word, if it had any; feeds `Cmd::cmd_subst_exit_code`.
+    pub(crate) cmd_subst_exit_code: Option<ExitCode>,
     /// When `buf`/`bounds` are both
     /// empty, this distinguishes `""` (push one empty arg) from `$unset`
     /// (push no arg). See [`Expansion::has_quoted_empty`].
@@ -104,7 +98,6 @@ impl Expansion {
             child_script: None,
             cmd_subst_quoted: false,
             has_quoted_empty: false,
-            out_exit_code: 0,
         }))
     }
 
@@ -606,19 +599,10 @@ impl Expansion {
         }
         .clone();
 
-        // Propagate the exit code if the *whole* atom was a single `$(...)`
-        // (so `$(false)` as argv0 fails the command).
-        let sole_cmd_subst = matches!(
-            interp.as_expansion(this).node.get(),
-            ast::Atom::Simple(ast::SimpleAtom::CmdSubst(_))
-        );
-
         let quoted = interp.as_expansion(this).cmd_subst_quoted;
         {
             let me = interp.as_expansion_mut(this);
-            if exit_code != 0 && sole_cmd_subst {
-                me.out_exit_code = exit_code;
-            }
+            me.out.cmd_subst_exit_code = Some(exit_code);
             if quoted {
                 let mut hi = stdout.len();
                 while hi > 0 && matches!(stdout[hi - 1], b' ' | b'\n' | b'\r' | b'\t') {
@@ -732,7 +716,6 @@ impl Expansion {
     pub(crate) fn take_out(interp: &Interpreter, this: NodeId) -> ExpansionOut {
         let me = interp.as_expansion_mut(this);
         let mut out = core::mem::take(&mut me.out);
-        out.out_exit_code = me.out_exit_code;
         out.has_quoted_empty = me.has_quoted_empty;
         out
     }

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -524,6 +524,37 @@ describe("bunshell", () => {
     TestBuilder.command`FOO="" $FOO`.runAsTest("empty var");
   });
 
+  // A command with no command name completes with the status of the last
+  // command substitution it performed (POSIX 2.9.1), wherever in the command
+  // line that substitution was (bash: `$(exit 3) $(exit 4); echo $?` prints 4).
+  describe("no command name, status of the last cmd subst", () => {
+    TestBuilder.command`$(exit 3) $(exit 4)`.exitCode(4).runAsTest("two substitutions");
+    TestBuilder.command`$(exit 4) $(exit 0)`.exitCode(0).runAsTest("last substitution succeeded");
+    TestBuilder.command`$(exit 3) $UNSET`.exitCode(3).runAsTest("substitution before an empty word");
+    TestBuilder.command`$UNSET $(exit 3)`.exitCode(3).runAsTest("substitution after an empty word");
+    TestBuilder.command`$(exit 3)$(exit 4)`.exitCode(4).runAsTest("two substitutions in one word");
+    TestBuilder.command`$(exit 4)$(exit 0)`.exitCode(0).runAsTest("last substitution in a word succeeded");
+    TestBuilder.command`$(exit 3)$UNSET`.exitCode(3).runAsTest("substitution joined to an empty expansion");
+    TestBuilder.command`$(exit 3)$(exit 4) $(exit 5)`.exitCode(5).runAsTest("last word wins over a compound word");
+    TestBuilder.command`$(exit 5) $(exit 3)$(exit 4)`.exitCode(4).runAsTest("last substitution of the last word wins");
+    TestBuilder.command`FOO=1 $(exit 3) $(exit 4)`.exitCode(4).runAsTest("with a prefix assignment");
+    TestBuilder.command`echo a | $(exit 3) $(exit 4)`.exitCode(4).runAsTest("as the last command of a pipeline");
+    TestBuilder.command`$(exit 3) $(exit 4) && echo hi`.exitCode(4).runAsTest("fails an && chain");
+    TestBuilder.command`$(exit 3) $(exit 4) || echo hi`.stdout("hi\n").runAsTest("takes the || branch");
+    TestBuilder.command`$(exit 3) $(exit 4) false`
+      .exitCode(1)
+      .runAsTest("ignored once a command name is left after expansion: builtin");
+
+    // Builtins overwrite the command's exit code unconditionally, so only a
+    // subprocess can show a substitution's status leaking into it; with `&>`
+    // nothing is piped back, so a leak would also stop the command from finishing.
+    TestBuilder.command`$(exit 3) $(exit 4) ${BUN} exit7.js &> out.txt`
+      .file("exit7.js", "console.log('ran'); process.exit(7);")
+      .fileEquals("out.txt", "ran\n")
+      .exitCode(7)
+      .runAsTest("ignored once a command name is left after expansion: external command");
+  });
+
   // When `$(...)` is the only word of a command and expands to a command
   // line, the exit code is that of the command it expanded to, not the
   // substitution's (bash: `$(echo ./exit7.sh); echo $?` prints 7).


### PR DESCRIPTION
### Problem
- In the bun shell, `$(exit 3) $(exit 4)`, `$(exit 3) $UNSET` and `$(exit 3)$(exit 4)` all report exit code 0; bash and dash report 4, 3 and 4. An `&&` or `||` after such a command takes the wrong branch.
- POSIX 2.9.1: a command whose words expand to no command name completes with the status of the last command substitution it performed. Bun only did this when the whole command line was one bare `$(...)` word.
- Cause: a substitution's status was recorded only when its word was a bare `$(...)`, and copied into the command only when argv had exactly one word. Every other shape reported 0.

### Fix
- Each expanded word now reports the status of the last `$(...)` it contained, if any, and the command keeps the last such status it sees across its words. The empty-argv path reports that value, as before. The two sole-word checks are removed.
- This is the "last performed" rule: a word with no substitution leaves the value alone, and a later substitution overwrites it even when it exits 0. Once argv is non-empty the value is never read, so commands that run are unaffected.
- Not covered, on purpose: substitutions inside assignments (`FOO=$(exit 3)` still reports 0) and inside redirect targets.
- Verification: 15 new shell test cases. 11 fail on the current release (exit code 0, or the wrong `&&` / `||` branch); the other 4 pass before and after and pin the behaviour around the fix. Existing related tests still pass.

### Background
- The bun shell interpreter (`src/runtime/shell/states`) runs each syntax node as a small state machine; when a child node finishes, the parent's `child_done` runs with the child's output.
- `Expansion` turns one word of a command line into zero or more argv strings, running any `$(...)` in it as a child script, and hands the result up as an `ExpansionOut`.
- `Cmd` is a simple command. It expands its words one at a time, then execs argv[0]; if expansion leaves argv empty there is nothing to run and it reports a status itself.
- `Cmd::exit_code` cannot carry this status: once set, the finish and process-exit paths treat it as "the exec already reported". The separate field this PR writes comes from #37808, so this PR is stacked on that branch and the diff here is only this change.

<details>
<summary>Original description</summary>

Stacked on #37808: this PR is based on that PR's branch, so the diff here is only this change (GitHub retargets it to `main` when #37808 merges). The dependency is load-bearing, not just convenient: `main` stashes the substitution status in `Cmd::exit_code`, which `has_finished` and `ShellSubprocess::on_process_exit` treat as "the exec already reported", so recording a status for every argv word is only possible with the dedicated `cmd_subst_exit_code` field that #37808 introduces.

### Repro

```ts
import { $ } from "bun";
console.log((await $`$(exit 3) $(exit 4)`.nothrow()).exitCode);  // 0, expected 4
console.log((await $`$(exit 3) $UNSET`.nothrow()).exitCode);      // 0, expected 3
console.log((await $`$(exit 3)$(exit 4)`.nothrow()).exitCode);    // 0, expected 4
console.log((await $`$(exit 3)`.nothrow()).exitCode);             // 3 (already correct)
```

bash and dash report 4, 3, 4, 3. POSIX 2.9.1: a simple command with no command name that contained a command substitution completes with the status of the last command substitution performed. The bun shell only implemented this when the whole command line was a single `$(...)` word, so `$(a) $(b)`, `$(a) $unset`, `$(a)$(b)` and `$(a) $(b) || fallback` all reported 0 (and took the wrong branch of `&&` / `||`).

### Cause

The status was plumbed through two places, each with its own "sole word" restriction:

- `Expansion::child_done` (`src/runtime/shell/states/Expansion.rs`) only stored the substitution's status when the whole atom was a bare `$(...)`, so compound words like `$(exit 3)$(exit 4)` never reported one.
- `Cmd::child_done` (`src/runtime/shell/states/Cmd.rs`) only copied it when `name_and_args` had exactly one atom, so with two or more words nothing was recorded and the empty-argv branch of `transition_to_exec` reported 0.

### Fix

`ExpansionOut` now carries `cmd_subst_exit_code: Option<ExitCode>`, the status of the last `$(...)` in that word (`None` when the word had none). `Expansion::child_done` sets it for every substitution, and `Cmd::child_done` keeps the last `Some` it sees across argv words; the empty-argv branch reports that, as before. The `sole_cmd_subst` check in Expansion, the `name_and_args` pattern match in Cmd and the separate `Expansion::out_exit_code` field become dead and are removed. A word with no substitution leaves the recorded status alone, and a later substitution that exits 0 overwrites it, which is the "last performed" rule.

Once argv is non-empty the value is never read, so commands that actually run are unaffected. Not covered here, on purpose: substitutions inside assignments (`FOO=$(exit 3)` reports 0; that is the `Assigns` state, tracked separately) and inside redirect targets (bun expands the redirect before argv, the opposite of POSIX order, so "last performed" would not match bash there either way).

### Tests

New `no command name, status of the last cmd subst` block in `test/js/bun/shell/bunshell.test.ts`, 15 cases: several words, compound words, empty words on either side, prefix assignment, last command of a pipeline, `&&` and `||` chains, plus pins. 11 of them fail on the current release (exit code 0 instead of 3/4/5, and the `&&` / `||` cases take the wrong branch). The other 4 pass before and after and pin the contracts around the fix:

- `$(exit 4) $(exit 0)` and `$(exit 4)$(exit 0)` are 0 (a later successful substitution overwrites, across words and within a word);
- `$(exit 3) $(exit 4) false` is 1 (ignored once something runs, builtin);
- `$(exit 3) $(exit 4) bun exit7.js &> out.txt` is 7 (same, external command). Builtins overwrite `exit_code` unconditionally, so this is the only shape that can see a substitution status leaking back into `Cmd::exit_code`; with `&>` nothing is piped back, so a leak makes the command never finish. Verified by temporarily re-adding the leak: this case times out while the builtin one still passes.

The existing `empty_expansion` and `cmd subst expanding to the whole command` blocks still pass.

</details>
