### PR TITLE
Bun.file(fifo).bytes(): wait for a named pipe's EOF with select(2) on macOS

### DIFF
--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -470,8 +470,7 @@ impl ReadFile {
         }
     }
 
-    /// `wait_for_readable` for named pipes: waits on this (pool) thread.
-    /// Returns `false` if the wait failed, with the error recorded for `then()`.
+    /// `wait_for_readable` for named pipes, on this thread; `false` if the wait itself failed.
     #[cfg(target_os = "macos")]
     fn block_until_readable(&mut self) -> bool {
         bloblog!("ReadFile.blockUntilReadable");

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -484,6 +484,23 @@ impl ReadFile {
         }
     }
 
+    /// A named pipe's whole read, as its own pool task: `JobContext::run` holds a
+    /// VM borrow and VM teardown waits for borrows, so waiting for a writer must
+    /// not happen inside it. Waiting before the first read also keeps a FIFO
+    /// with no writer yet from reading as empty.
+    #[cfg(target_os = "macos")]
+    fn read_named_pipe_task(task: *mut WorkPoolTask) {
+        // SAFETY: only reached via `WorkPoolTask::callback` with `task` =
+        // `&mut self.task` (intrusive) scheduled by `run_async_with_fd`;
+        // recover parent.
+        let this = unsafe { &mut *ReadFile::from_task_ptr(task) };
+        if this.block_until_readable() {
+            this.do_read_loop();
+        } else {
+            this.on_finish();
+        }
+    }
+
     /// Pick the read target: `buffer`'s spare capacity if it is at least as
     /// large as `stack_buffer`, otherwise `stack_buffer`; capped by
     /// `max_length - read_off`. Returns `(use_stack, target)` so the caller
@@ -780,12 +797,11 @@ impl ReadFile {
         if self.could_block {
             #[cfg(target_os = "macos")]
             if self.is_named_pipe {
-                // Before the first read too: with no writer yet, read() says EOF.
-                if self.block_until_readable() {
-                    self.do_read_loop();
-                } else {
-                    self.on_finish();
-                }
+                self.task = WorkPoolTask {
+                    node: Default::default(),
+                    callback: Self::read_named_pipe_task,
+                };
+                WorkPool::schedule(&raw mut self.task);
                 return;
             }
 

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -285,6 +285,11 @@ pub struct ReadFile {
     pub(crate) io_request: io::Request,
     #[cfg(not(windows))]
     pub(crate) could_block: bool,
+    /// A FIFO vnode as opposed to a `pipe(2)` pipe. kqueue never reports EOF
+    /// for these, so their waits happen in `block_until_readable` instead of
+    /// going through the io thread; see `bun_sys::block_until_readable`.
+    #[cfg(target_os = "macos")]
+    pub(crate) is_named_pipe: bool,
     pub(crate) close_after_io: bool,
     pub(crate) state: AtomicU8, // ClosingState
 }
@@ -380,6 +385,8 @@ impl ReadFile {
                 scheduled: false,
             },
             could_block: false,
+            #[cfg(target_os = "macos")]
+            is_named_pipe: false,
             close_after_io: false,
             state: AtomicU8::new(ClosingState::Running as u8),
         };
@@ -462,6 +469,22 @@ impl ReadFile {
             .store_callback_seq_cst(Self::on_request_readable);
         if !self.io_request.scheduled {
             io::IoRequestLoop::schedule(&mut self.io_request);
+        }
+    }
+
+    /// The named-pipe counterpart of `wait_for_readable`: waits right here on
+    /// the pool thread, like `fs.readFile` does for every FIFO. Returns `false`
+    /// when the wait itself failed, with the error recorded for `then()`.
+    #[cfg(target_os = "macos")]
+    fn block_until_readable(&mut self) -> bool {
+        bloblog!("ReadFile.blockUntilReadable");
+        match bun_sys::block_until_readable(self.opened_fd) {
+            Ok(()) => true,
+            Err(err) => {
+                self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
+                self.system_error = Some(err.to_system_error().into());
+                false
+            }
         }
     }
 
@@ -682,6 +705,13 @@ impl ReadFile {
         }
 
         self.could_block = !bun_sys::is_regular_file(stat.st_mode as _);
+        #[cfg(target_os = "macos")]
+        {
+            // `pipe(2)` pipes are S_IFIFO too; XNU's pipe_stat leaves their
+            // st_dev 0, whereas a FIFO on a filesystem carries its volume's
+            // device number.
+            self.is_named_pipe = bun_sys::S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0;
+        }
         self.total_size =
             SizeType::try_from((stat.st_size as i64).max(0).min(MAX_SIZE as i64)).unwrap();
 
@@ -754,6 +784,18 @@ impl ReadFile {
         // If we immediately call read(), it will block until stdin is
         // readable.
         if self.could_block {
+            #[cfg(target_os = "macos")]
+            if self.is_named_pipe {
+                // Waiting before the first read is also what keeps a FIFO
+                // whose writer has not connected yet from reading as empty.
+                if self.block_until_readable() {
+                    self.do_read_loop();
+                } else {
+                    self.on_finish();
+                }
+                return;
+            }
+
             if bun_core::is_readable(fd) == bun_core::Pollable::NotReady {
                 self.wait_for_readable();
                 return;
@@ -864,6 +906,13 @@ impl ReadFile {
                                 bun_core::Pollable::NotReady => {}
                                 bun_core::Pollable::Ready | bun_core::Pollable::Hup => continue,
                             }
+                        }
+                        #[cfg(target_os = "macos")]
+                        if self.is_named_pipe {
+                            if self.block_until_readable() {
+                                continue;
+                            }
+                            break;
                         }
                         self.read_eof = false;
                         self.buffer = buffer;

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -285,9 +285,7 @@ pub struct ReadFile {
     pub(crate) io_request: io::Request,
     #[cfg(not(windows))]
     pub(crate) could_block: bool,
-    /// A FIFO vnode as opposed to a `pipe(2)` pipe. kqueue never reports EOF
-    /// for these, so their waits happen in `block_until_readable` instead of
-    /// going through the io thread; see `bun_sys::block_until_readable`.
+    /// FIFO vnode (not a `pipe(2)` pipe); see `bun_sys::block_until_readable`.
     #[cfg(target_os = "macos")]
     pub(crate) is_named_pipe: bool,
     pub(crate) close_after_io: bool,
@@ -472,9 +470,8 @@ impl ReadFile {
         }
     }
 
-    /// The named-pipe counterpart of `wait_for_readable`: waits right here on
-    /// the pool thread, like `fs.readFile` does for every FIFO. Returns `false`
-    /// when the wait itself failed, with the error recorded for `then()`.
+    /// `wait_for_readable` for named pipes: waits on this (pool) thread.
+    /// Returns `false` if the wait failed, with the error recorded for `then()`.
     #[cfg(target_os = "macos")]
     fn block_until_readable(&mut self) -> bool {
         bloblog!("ReadFile.blockUntilReadable");
@@ -707,9 +704,7 @@ impl ReadFile {
         self.could_block = !bun_sys::is_regular_file(stat.st_mode as _);
         #[cfg(target_os = "macos")]
         {
-            // `pipe(2)` pipes are S_IFIFO too; XNU's pipe_stat leaves their
-            // st_dev 0, whereas a FIFO on a filesystem carries its volume's
-            // device number.
+            // pipe(2) pipes are S_IFIFO with st_dev == 0 (XNU pipe_stat).
             self.is_named_pipe = bun_sys::S::ISFIFO(stat.st_mode as _) && stat.st_dev != 0;
         }
         self.total_size =
@@ -786,8 +781,7 @@ impl ReadFile {
         if self.could_block {
             #[cfg(target_os = "macos")]
             if self.is_named_pipe {
-                // Waiting before the first read is also what keeps a FIFO
-                // whose writer has not connected yet from reading as empty.
+                // Before the first read too: with no writer yet, read() says EOF.
                 if self.block_until_readable() {
                     self.do_read_loop();
                 } else {

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -897,6 +897,13 @@ impl ReadFile {
                         // call. We already know it's done.
                         && !self.read_eof)
                     {
+                        #[cfg(target_os = "macos")]
+                        if self.is_named_pipe {
+                            if self.block_until_readable() {
+                                continue;
+                            }
+                            break;
+                        }
                         if self.could_block
                         // If we received EOF, we can skip the poll() system
                         // call. We already know it's done.
@@ -906,13 +913,6 @@ impl ReadFile {
                                 bun_core::Pollable::NotReady => {}
                                 bun_core::Pollable::Ready | bun_core::Pollable::Hup => continue,
                             }
-                        }
-                        #[cfg(target_os = "macos")]
-                        if self.is_named_pipe {
-                            if self.block_until_readable() {
-                                continue;
-                            }
-                            break;
                         }
                         self.read_eof = false;
                         self.buffer = buffer;

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1711,11 +1711,8 @@ mod nocancel {
         ) -> isize;
         #[link_name = "poll$NOCANCEL"]
         pub(crate) fn poll(fds: *mut libc::pollfd, nfds: libc::nfds_t, timeout: c_int) -> c_int;
-        // The `_DARWIN_UNLIMITED_SELECT` variant of select(2) (same
-        // `$DARWIN_EXTSN` scheme as `realpath` in `posix_impl`). libsyscall
-        // maps it straight onto the syscall, so there is no FD_SETSIZE check
-        // and each set is a bitmap of ceil(nfds / 32) 32-bit words rather
-        // than a `libc::fd_set`; hence the word pointers.
+        // `_DARWIN_UNLIMITED_SELECT` select(2): the bare syscall, so no
+        // FD_SETSIZE check, and a set is just ceil(nfds / 32) 32-bit words.
         #[link_name = "select$DARWIN_EXTSN$NOCANCEL"]
         pub(crate) fn select(
             nfds: c_int,
@@ -7623,21 +7620,15 @@ pub fn kevent(
     }
 }
 
-/// Blocks the calling thread in `select(2)` until `fd` is readable, where
-/// readable includes EOF. Retries on EINTR.
+/// Blocks in `select(2)` until `fd` is readable or at EOF; retries on EINTR.
 ///
-/// This is how a named pipe (a FIFO opened by path, or one inherited as
-/// stdin) has to be waited on under macOS. XNU attaches kqueue `EVFILT_READ`
-/// filters for a FIFO to its vnode, and that filter only fires while bytes are
-/// buffered (`vnode_readable_data_count`); the last writer closing posts
-/// nothing to the vnode, so a kqueue registration never wakes a reader up for
-/// EOF, and neither does `poll(2)`, which XNU implements on top of kqueue.
-/// `select(2)` instead goes through `fifo_select` to the FIFO's underlying
-/// socket, whose readability includes the `SS_CANTRCVMORE` state that the last
-/// writer's close sets (and that a writer which has not connected yet leaves
-/// clear, so a FIFO that is still waiting for its first writer blocks here
-/// rather than reading as empty). `pipe(2)` pipes are not affected: their own
-/// kqueue filter reports `EV_EOF`.
+/// For named pipes. XNU hooks a FIFO's `EVFILT_READ` (and `poll(2)`, which it
+/// implements with kqueue) to the vnode, where it only fires while bytes are
+/// buffered, and `fifo_close` posts nothing, so neither ever reports the last
+/// writer closing. `select(2)` goes through `fifo_select` to the FIFO's socket,
+/// whose readability includes `SS_CANTRCVMORE`: set by that close, clear while
+/// no writer has connected yet. `pipe(2)` pipes have their own filter with
+/// `EV_EOF` and do not need this.
 #[cfg(target_os = "macos")]
 pub fn block_until_readable(fd: Fd) -> Maybe<()> {
     debug_assert!(fd.is_valid());

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1411,6 +1411,8 @@ impl Tag {
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
     pub const clone3: Tag = Tag(107);
+    #[cfg(target_os = "macos")]
+    pub(crate) const select: Tag = Tag(108);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1418,7 +1420,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 108] = [
+        const NAMES: [&str; 109] = [
             "TODO",
             "dup",
             "access",
@@ -1528,6 +1530,7 @@ impl Tag {
             "getrlimit",
             "setrlimit",
             "clone3",
+            "select",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }
@@ -1708,6 +1711,19 @@ mod nocancel {
         ) -> isize;
         #[link_name = "poll$NOCANCEL"]
         pub(crate) fn poll(fds: *mut libc::pollfd, nfds: libc::nfds_t, timeout: c_int) -> c_int;
+        // The `_DARWIN_UNLIMITED_SELECT` variant of select(2) (same
+        // `$DARWIN_EXTSN` scheme as `realpath` in `posix_impl`). libsyscall
+        // maps it straight onto the syscall, so there is no FD_SETSIZE check
+        // and each set is a bitmap of ceil(nfds / 32) 32-bit words rather
+        // than a `libc::fd_set`; hence the word pointers.
+        #[link_name = "select$DARWIN_EXTSN$NOCANCEL"]
+        pub(crate) fn select(
+            nfds: c_int,
+            readfds: *mut u32,
+            writefds: *mut u32,
+            errorfds: *mut u32,
+            timeout: *mut libc::timeval,
+        ) -> c_int;
         // Remaining `$NOCANCEL` variants Bun links against.
         // safe: by-value `c_int` fd; bad fd → -1/EBADF, no UB.
         #[link_name = "close$NOCANCEL"]
@@ -7603,6 +7619,50 @@ pub fn kevent(
             E::SUCCESS => return Ok(rc as usize),
             E::EINTR => continue,
             e => return Err(Error::from_code(e, Tag::kevent).with_fd(fd)),
+        }
+    }
+}
+
+/// Blocks the calling thread in `select(2)` until `fd` is readable, where
+/// readable includes EOF. Retries on EINTR.
+///
+/// This is how a named pipe (a FIFO opened by path, or one inherited as
+/// stdin) has to be waited on under macOS. XNU attaches kqueue `EVFILT_READ`
+/// filters for a FIFO to its vnode, and that filter only fires while bytes are
+/// buffered (`vnode_readable_data_count`); the last writer closing posts
+/// nothing to the vnode, so a kqueue registration never wakes a reader up for
+/// EOF, and neither does `poll(2)`, which XNU implements on top of kqueue.
+/// `select(2)` instead goes through `fifo_select` to the FIFO's underlying
+/// socket, whose readability includes the `SS_CANTRCVMORE` state that the last
+/// writer's close sets (and that a writer which has not connected yet leaves
+/// clear, so a FIFO that is still waiting for its first writer blocks here
+/// rather than reading as empty). `pipe(2)` pipes are not affected: their own
+/// kqueue filter reports `EV_EOF`.
+#[cfg(target_os = "macos")]
+pub fn block_until_readable(fd: Fd) -> Maybe<()> {
+    debug_assert!(fd.is_valid());
+    let index = fd.native() as usize;
+    let word = index / 32;
+    let mut read_set = vec![0u32; word + 1];
+    loop {
+        read_set.fill(0);
+        read_set[word] = 1 << (index % 32);
+        // SAFETY: `read_set` holds the ceil(nfds / 32) words the kernel reads
+        // and writes back for `nfds = fd + 1`; the write and error sets and the
+        // timeout (wait indefinitely) may be null.
+        let rc = unsafe {
+            nocancel::select(
+                fd.native() + 1,
+                read_set.as_mut_ptr(),
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+                core::ptr::null_mut(),
+            )
+        };
+        match get_errno(rc) {
+            E::SUCCESS => return Ok(()),
+            E::EINTR => continue,
+            e => return Err(Error::from_code(e, Tag::select).with_fd(fd)),
         }
     }
 }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1711,8 +1711,7 @@ mod nocancel {
         ) -> isize;
         #[link_name = "poll$NOCANCEL"]
         pub(crate) fn poll(fds: *mut libc::pollfd, nfds: libc::nfds_t, timeout: c_int) -> c_int;
-        // `_DARWIN_UNLIMITED_SELECT` select(2): the bare syscall, so no
-        // FD_SETSIZE check, and a set is just ceil(nfds / 32) 32-bit words.
+        // `_DARWIN_UNLIMITED_SELECT` select(2): no FD_SETSIZE limit; a set is ceil(nfds/32) words.
         #[link_name = "select$DARWIN_EXTSN$NOCANCEL"]
         pub(crate) fn select(
             nfds: c_int,
@@ -7622,13 +7621,10 @@ pub fn kevent(
 
 /// Blocks in `select(2)` until `fd` is readable or at EOF; retries on EINTR.
 ///
-/// For named pipes. XNU hooks a FIFO's `EVFILT_READ` (and `poll(2)`, which it
-/// implements with kqueue) to the vnode, where it only fires while bytes are
-/// buffered, and `fifo_close` posts nothing, so neither ever reports the last
-/// writer closing. `select(2)` goes through `fifo_select` to the FIFO's socket,
-/// whose readability includes `SS_CANTRCVMORE`: set by that close, clear while
-/// no writer has connected yet. `pipe(2)` pipes have their own filter with
-/// `EV_EOF` and do not need this.
+/// For named pipes: XNU's kqueue filter for a FIFO (`filt_vnode_common`, which
+/// `poll(2)` uses too) fires only while bytes are buffered, never for the last
+/// writer closing; `fifo_select` consults the FIFO's socket, which reports that
+/// close (and not a writer that has yet to connect). `pipe(2)` pipes report `EV_EOF`.
 #[cfg(target_os = "macos")]
 pub fn block_until_readable(fd: Fd) -> Maybe<()> {
     debug_assert!(fd.is_valid());

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -96,14 +96,18 @@ describe.skipIf(isWindows)("reading a named pipe to EOF", () => {
   // The child must already have the FIFO open for reading before a writer can
   // connect to it: a non-blocking open for writing fails with ENXIO until then.
   async function openWriterOnceChildIsReading(fifo: string, child: Bun.Subprocess) {
+    const deadline = performance.now() + 10_000;
     while (true) {
       try {
         return openFd(fifo, constants.O_WRONLY | constants.O_NONBLOCK);
       } catch (err: any) {
         if (err.code !== "ENXIO") throw err;
       }
-      if (child.exitCode !== null || child.signalCode !== null) {
-        throw new Error(`child exited (${child.exitCode ?? child.signalCode}) without opening the FIFO`);
+      const exited = child.exitCode ?? child.signalCode;
+      if (exited !== null || performance.now() > deadline) {
+        throw new Error(
+          `nothing opened ${fifo} for reading; child ${exited === null ? "is still running" : `exited (${exited})`}`,
+        );
       }
       await Bun.sleep(5);
     }

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -58,13 +58,13 @@ describe("Bun.file read-loop target selection", () => {
   });
 });
 
-// Whole-file reads of a named pipe. Every one of these ends with the reader
+// Whole-file reads of a named pipe. All but the last end with the reader
 // having drained the pipe and then learning that the last writer closed; on
 // macOS that EOF is invisible to kqueue and poll(2) (they only see buffered
 // bytes on a FIFO), so the reader has to wait for it differently than it does
 // for a pipe(2) pipe, and each of these used to leave the child blocked
 // forever there.
-describe.skipIf(isWindows)("reading a named pipe to EOF", () => {
+describe.skipIf(isWindows)("reading a named pipe", () => {
   function readFifoInChild(script: string, fifo: string, stdin: number | "ignore" = "ignore") {
     return Bun.spawn({
       cmd: [bunExe(), "-e", script],
@@ -202,6 +202,76 @@ describe.skipIf(isWindows)("reading a named pipe to EOF", () => {
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr }).toEqual({ stdout: JSON.stringify("stdin is a named pipe\n"), stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  // The macOS wait is a select(2); this is the case where a plain fd_set
+  // would not hold the descriptor (FD_SETSIZE is 1024 there).
+  it.concurrent("Bun.file(fd) reads a FIFO whose descriptor number is above FD_SETSIZE", async () => {
+    using dir = tempDir("bun-file-read-fifo-high-fd", {});
+    const fifo = path.join(String(dir), "high.fifo");
+    mkfifo(fifo);
+
+    await using proc = readFifoInChild(
+      `import { constants, openSync } from "node:fs";
+       while (openSync("/dev/null", "r") < 1024) {}
+       const fd = openSync(process.env.FIFO, constants.O_RDONLY | constants.O_NONBLOCK);
+       const text = await Bun.file(fd).text();
+       process.stdout.write(JSON.stringify({ fd, text }));`,
+      fifo,
+    );
+    using writer = await openWriterOnceChildIsReading(fifo, proc);
+    writeSync(writer.fd, "read through a high fd\n");
+    writer.close();
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    const { fd, text } = JSON.parse(stdout);
+    expect(fd).toBeGreaterThanOrEqual(1024);
+    expect(text).toBe("read through a high fd\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // A read that is waiting for a writer which never shows up must not keep
+  // its VM from shutting down: the wait has to happen outside the job's VM
+  // borrow, which terminate() waits for.
+  it.concurrent("terminate() completes while a worker's read is waiting on an idle writer", async () => {
+    using dir = tempDir("bun-file-read-fifo-worker", {
+      "main.ts": `
+        const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+        const closed = new Promise(resolve => worker.addEventListener("close", resolve));
+        worker.addEventListener("message", ({ data }) => console.log(data));
+        // Our stdin is closed once the test has connected a writer to the FIFO.
+        await Bun.stdin.text();
+        worker.terminate();
+        await closed;
+        console.log("terminated");
+      `,
+      "worker.ts": `
+        const read = Bun.file(process.env.FIFO!).text();
+        postMessage("reading");
+        await read;
+        postMessage("the read finished, which it should not have");
+      `,
+    });
+    const fifo = path.join(String(dir), "idle.fifo");
+    mkfifo(fifo);
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      cwd: String(dir),
+      env: { ...bunEnv, FIFO: fifo },
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    // Connecting a writer proves the worker's read has the FIFO open; never
+    // writing to it keeps that read waiting for the rest of the test.
+    using _idleWriter = await openWriterOnceChildIsReading(fifo, proc);
+    proc.stdin.end();
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "reading\nterminated\n", stderr: "" });
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -75,12 +75,30 @@ describe.skipIf(isWindows)("reading a named pipe to EOF", () => {
     });
   }
 
+  // When a FIFO end gets closed is what these tests are about, so each one is
+  // closed explicitly at the right moment; `using` only covers the failure paths.
+  function openFd(file: string, flags: number | string) {
+    let fd = openSync(file, flags);
+    return {
+      get fd() {
+        return fd;
+      },
+      close() {
+        if (fd !== -1) closeSync(fd);
+        fd = -1;
+      },
+      [Symbol.dispose]() {
+        this.close();
+      },
+    };
+  }
+
   // The child must already have the FIFO open for reading before a writer can
   // connect to it: a non-blocking open for writing fails with ENXIO until then.
-  async function openWriterOnceChildIsReading(fifo: string, child: Bun.Subprocess): Promise<number> {
+  async function openWriterOnceChildIsReading(fifo: string, child: Bun.Subprocess) {
     while (true) {
       try {
-        return openSync(fifo, constants.O_WRONLY | constants.O_NONBLOCK);
+        return openFd(fifo, constants.O_WRONLY | constants.O_NONBLOCK);
       } catch (err: any) {
         if (err.code !== "ENXIO") throw err;
       }
@@ -99,42 +117,32 @@ describe.skipIf(isWindows)("reading a named pipe to EOF", () => {
     // The write end can only be opened, and written to without EPIPE, while
     // some reader has the FIFO open; `holder` is that reader until the child
     // has opened its own. It never reads, so every byte goes to the child.
-    let holder = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
-    const closeHolder = () => {
-      if (holder !== -1) closeSync(holder);
-      holder = -1;
-    };
-    let writer = openSync(fifo, "w");
-    try {
-      await using proc = readFifoInChild(
-        `const bytes = await Bun.file(process.env.FIFO).bytes(); process.stdout.write(bytes.length + " " + Bun.hash(bytes));`,
-        fifo,
-      );
-      const stderr = proc.stderr.text();
-      // The write end is blocking, so this write only completes as the child
-      // drains the pipe, and closing it afterwards is what ends the child's
-      // read. The child cannot exit before that unless it failed; dropping
-      // `holder` then leaves the pipe without readers, so the blocked write
-      // fails with EPIPE instead of waiting forever.
-      const childDied = proc.exited.then(async exitCode => {
-        closeHolder();
-        throw new Error(`child exited with ${exitCode} before the payload was written: ${await stderr}`);
-      });
-      const written = await Promise.race([Bun.write(Bun.file(writer), payload), childDied]);
-      closeSync(writer);
-      writer = -1;
-      const [stdout, stderrText, exitCode] = await Promise.all([proc.stdout.text(), stderr, proc.exited]);
+    using holder = openFd(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+    using writer = openFd(fifo, "w");
+    await using proc = readFifoInChild(
+      `const bytes = await Bun.file(process.env.FIFO).bytes(); process.stdout.write(bytes.length + " " + Bun.hash(bytes));`,
+      fifo,
+    );
+    const stderr = proc.stderr.text();
+    // The write end is blocking, so this write only completes as the child
+    // drains the pipe, and closing it afterwards is what ends the child's
+    // read. The child cannot exit before that unless it failed; dropping
+    // `holder` then leaves the pipe without readers, so the blocked write
+    // fails with EPIPE instead of waiting forever.
+    const childDied = proc.exited.then(async exitCode => {
+      holder.close();
+      throw new Error(`child exited with ${exitCode} before the payload was written: ${await stderr}`);
+    });
+    const written = await Promise.race([Bun.write(Bun.file(writer.fd), payload), childDied]);
+    writer.close();
+    const [stdout, stderrText, exitCode] = await Promise.all([proc.stdout.text(), stderr, proc.exited]);
 
-      expect({ written, stdout, stderr: stderrText }).toEqual({
-        written: payload.length,
-        stdout: `${payload.length} ${Bun.hash(payload)}`,
-        stderr: "",
-      });
-      expect(exitCode).toBe(0);
-    } finally {
-      if (writer !== -1) closeSync(writer);
-      closeHolder();
-    }
+    expect({ written, stdout, stderr: stderrText }).toEqual({
+      written: payload.length,
+      stdout: `${payload.length} ${Bun.hash(payload)}`,
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
   });
 
   it.concurrent("text() waits for a writer that connects after the read started", async () => {
@@ -143,9 +151,9 @@ describe.skipIf(isWindows)("reading a named pipe to EOF", () => {
     mkfifo(fifo);
 
     await using proc = readFifoInChild(`process.stdout.write(await Bun.file(process.env.FIFO).text());`, fifo);
-    const writer = await openWriterOnceChildIsReading(fifo, proc);
-    writeSync(writer, "written after the reader opened\n");
-    closeSync(writer);
+    using writer = await openWriterOnceChildIsReading(fifo, proc);
+    writeSync(writer.fd, "written after the reader opened\n");
+    writer.close();
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr }).toEqual({ stdout: "written after the reader opened\n", stderr: "" });
@@ -161,7 +169,8 @@ describe.skipIf(isWindows)("reading a named pipe to EOF", () => {
       `const text = await Bun.file(process.env.FIFO).text(); process.stdout.write(JSON.stringify(text));`,
       fifo,
     );
-    closeSync(await openWriterOnceChildIsReading(fifo, proc));
+    using writer = await openWriterOnceChildIsReading(fifo, proc);
+    writer.close();
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr }).toEqual({ stdout: '""', stderr: "" });
@@ -175,13 +184,17 @@ describe.skipIf(isWindows)("reading a named pipe to EOF", () => {
 
     // Same dance as above: a reader has to exist before the write end can be
     // opened; here that reader becomes the child's stdin.
-    const readEnd = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
-    const writer = openSync(fifo, "w");
-    await using proc = readFifoInChild(`process.stdout.write(JSON.stringify(await Bun.stdin.text()));`, fifo, readEnd);
+    using readEnd = openFd(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+    using writer = openFd(fifo, "w");
+    await using proc = readFifoInChild(
+      `process.stdout.write(JSON.stringify(await Bun.stdin.text()));`,
+      fifo,
+      readEnd.fd,
+    );
     // The child has its own descriptor for the read end now.
-    closeSync(readEnd);
-    writeSync(writer, "stdin is a named pipe\n");
-    closeSync(writer);
+    readEnd.close();
+    writeSync(writer.fd, "stdin is a named pipe\n");
+    writer.close();
 
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout, stderr }).toEqual({ stdout: JSON.stringify("stdin is a named pipe\n"), stderr: "" });

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -237,8 +237,8 @@ describe.skipIf(isWindows)("reading a named pipe", () => {
   // borrow, which terminate() waits for.
   it.concurrent("terminate() completes while a worker's read is waiting on an idle writer", async () => {
     using dir = tempDir("bun-file-read-fifo-worker", {
-      "main.ts": `
-        const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+      "main.fixture.ts": `
+        const worker = new Worker(new URL("./worker.fixture.ts", import.meta.url).href);
         const closed = new Promise(resolve => worker.addEventListener("close", resolve));
         worker.addEventListener("message", ({ data }) => console.log(data));
         // Our stdin is closed once the test has connected a writer to the FIFO.
@@ -247,7 +247,7 @@ describe.skipIf(isWindows)("reading a named pipe", () => {
         await closed;
         console.log("terminated");
       `,
-      "worker.ts": `
+      "worker.fixture.ts": `
         const read = Bun.file(process.env.FIFO!).text();
         postMessage("reading");
         await read;
@@ -258,7 +258,7 @@ describe.skipIf(isWindows)("reading a named pipe", () => {
     mkfifo(fifo);
 
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "main.ts"],
+      cmd: [bunExe(), "main.fixture.ts"],
       cwd: String(dir),
       env: { ...bunEnv, FIFO: fifo },
       stdin: "pipe",

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+import { mkfifo } from "mkfifo";
+import { randomBytes } from "node:crypto";
+import { closeSync, constants, openSync, writeSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -52,5 +55,136 @@ describe("Bun.file read-loop target selection", () => {
     const buf = new Uint8Array(await Bun.file(p).slice(start, end).arrayBuffer());
     expect(buf.length).toBe(end - start);
     expect(Bun.hash(buf)).toBe(Bun.hash(bytes.subarray(start, end)));
+  });
+});
+
+// Whole-file reads of a named pipe. Every one of these ends with the reader
+// having drained the pipe and then learning that the last writer closed; on
+// macOS that EOF is invisible to kqueue and poll(2) (they only see buffered
+// bytes on a FIFO), so the reader has to wait for it differently than it does
+// for a pipe(2) pipe, and each of these used to leave the child blocked
+// forever there.
+describe.skipIf(isWindows)("reading a named pipe to EOF", () => {
+  function readFifoInChild(script: string, fifo: string, stdin: number | "ignore" = "ignore") {
+    return Bun.spawn({
+      cmd: [bunExe(), "-e", script],
+      env: { ...bunEnv, FIFO: fifo },
+      stdin,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+  }
+
+  // The child must already have the FIFO open for reading before a writer can
+  // connect to it: a non-blocking open for writing fails with ENXIO until then.
+  async function openWriterOnceChildIsReading(fifo: string, child: Bun.Subprocess): Promise<number> {
+    while (true) {
+      try {
+        return openSync(fifo, constants.O_WRONLY | constants.O_NONBLOCK);
+      } catch (err: any) {
+        if (err.code !== "ENXIO") throw err;
+      }
+      if (child.exitCode !== null || child.signalCode !== null) {
+        throw new Error(`child exited (${child.exitCode ?? child.signalCode}) without opening the FIFO`);
+      }
+      await Bun.sleep(5);
+    }
+  }
+
+  it.concurrent("bytes() collects a payload that arrives in pieces and ends when the writer closes", async () => {
+    const payload = randomBytes(256 * 1024);
+    using dir = tempDir("bun-file-read-fifo", {});
+    const fifo = path.join(String(dir), "in.fifo");
+    mkfifo(fifo);
+    // The write end can only be opened, and written to without EPIPE, while
+    // some reader has the FIFO open; `holder` is that reader until the child
+    // has opened its own. It never reads, so every byte goes to the child.
+    let holder = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+    const closeHolder = () => {
+      if (holder !== -1) closeSync(holder);
+      holder = -1;
+    };
+    let writer = openSync(fifo, "w");
+    try {
+      await using proc = readFifoInChild(
+        `const bytes = await Bun.file(process.env.FIFO).bytes(); process.stdout.write(bytes.length + " " + Bun.hash(bytes));`,
+        fifo,
+      );
+      const stderr = proc.stderr.text();
+      // The write end is blocking, so this write only completes as the child
+      // drains the pipe, and closing it afterwards is what ends the child's
+      // read. The child cannot exit before that unless it failed; dropping
+      // `holder` then leaves the pipe without readers, so the blocked write
+      // fails with EPIPE instead of waiting forever.
+      const childDied = proc.exited.then(async exitCode => {
+        closeHolder();
+        throw new Error(`child exited with ${exitCode} before the payload was written: ${await stderr}`);
+      });
+      const written = await Promise.race([Bun.write(Bun.file(writer), payload), childDied]);
+      closeSync(writer);
+      writer = -1;
+      const [stdout, stderrText, exitCode] = await Promise.all([proc.stdout.text(), stderr, proc.exited]);
+
+      expect({ written, stdout, stderr: stderrText }).toEqual({
+        written: payload.length,
+        stdout: `${payload.length} ${Bun.hash(payload)}`,
+        stderr: "",
+      });
+      expect(exitCode).toBe(0);
+    } finally {
+      if (writer !== -1) closeSync(writer);
+      closeHolder();
+    }
+  });
+
+  it.concurrent("text() waits for a writer that connects after the read started", async () => {
+    using dir = tempDir("bun-file-read-fifo-late-writer", {});
+    const fifo = path.join(String(dir), "late.fifo");
+    mkfifo(fifo);
+
+    await using proc = readFifoInChild(`process.stdout.write(await Bun.file(process.env.FIFO).text());`, fifo);
+    const writer = await openWriterOnceChildIsReading(fifo, proc);
+    writeSync(writer, "written after the reader opened\n");
+    closeSync(writer);
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: "written after the reader opened\n", stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("text() resolves empty when the writer connects and closes without writing", async () => {
+    using dir = tempDir("bun-file-read-fifo-empty", {});
+    const fifo = path.join(String(dir), "empty.fifo");
+    mkfifo(fifo);
+
+    await using proc = readFifoInChild(
+      `const text = await Bun.file(process.env.FIFO).text(); process.stdout.write(JSON.stringify(text));`,
+      fifo,
+    );
+    closeSync(await openWriterOnceChildIsReading(fifo, proc));
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: '""', stderr: "" });
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("Bun.stdin.text() reads a FIFO inherited as stdin to EOF", async () => {
+    using dir = tempDir("bun-file-read-fifo-stdin", {});
+    const fifo = path.join(String(dir), "stdin.fifo");
+    mkfifo(fifo);
+
+    // Same dance as above: a reader has to exist before the write end can be
+    // opened; here that reader becomes the child's stdin.
+    const readEnd = openSync(fifo, constants.O_RDONLY | constants.O_NONBLOCK);
+    const writer = openSync(fifo, "w");
+    await using proc = readFifoInChild(`process.stdout.write(JSON.stringify(await Bun.stdin.text()));`, fifo, readEnd);
+    // The child has its own descriptor for the read end now.
+    closeSync(readEnd);
+    writeSync(writer, "stdin is a named pipe\n");
+    closeSync(writer);
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr }).toEqual({ stdout: JSON.stringify("stdin is a named pipe\n"), stderr: "" });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- On macOS, `Bun.file(fifo).bytes()` / `.text()` / `.arrayBuffer()` / `.json()` on a named pipe, and `Bun.stdin.text()` when stdin is a named pipe, never resolve. Every byte the writer sends arrives, then the read sits forever after the writer closes; Linux resolves at the close.
- This is why the FIFO test in #37787 ran to its 90 s timeout on the darwin lanes and is skipped there. main behaves the same, so #37787 did not cause it.
- Cause: both ways the reader waits on a pipe (a `poll(2)` pre-check, then a kqueue `EVFILT_READ` wait on the io thread) wake for a FIFO only while bytes are buffered, and XNU reports the last writer closing through neither. Once a read drains the pipe the EOF wake-up never comes; only reads whose writer was gone before the first `read()` finish today.
- `pipe(2)` pipes are unaffected: XNU gives them their own filter that reports `EV_EOF`, which is why stdin from an ordinary pipe already works on macOS.

### Fix
- macOS only: a whole-file read of a named pipe (fstat says `S_IFIFO` with a non-zero `st_dev`; `pipe(2)` pipes report `st_dev == 0`) no longer polls or parks on the io thread. It runs as its own pool task that blocks in `select(2)` before the first read and again each time a read drains the pipe, then continues the existing read loop; everything else, on every platform, takes the old path unchanged.
- This is correct because XNU's `select` on a FIFO consults the FIFO's socket, which does flag the last writer's close, and `read()` then returns 0. Waiting before the first read also makes a FIFO with no writer yet wait for one, as Linux does today, instead of reading as empty.
- The wait is a separate pool task rather than inline in the job because the job runs under a borrow of the VM that worker teardown waits for; inline, a worker with a FIFO read pending against an idle writer could not be `terminate()`d.
- Verification: six new tests (payload delivered in pieces, writer connecting late, writer closing without writing, FIFO as stdin, fd above 1024, worker terminate during the wait). They pass on Linux with and without the change; on macOS the first five hang on main, so this PR's darwin CI lanes are the fail-to-pass evidence. The author had no macOS machine and did not run them there before CI.

### Background
- A named pipe (FIFO) is a filesystem entry made with `mkfifo`; a reader's `read()` returns 0 only once nothing is buffered and every writer has closed. A `pipe(2)` pipe is the anonymous kind behind `cmd | bun` and subprocess stdio. Both fstat as `S_IFIFO`; on XNU only the named one has a non-zero `st_dev`.
- On macOS, `poll(2)` is implemented on top of kqueue, so poll and kqueue see the same events for an fd, and for a FIFO that event is only "bytes are buffered". `select(2)` goes through the FIFO's underlying socket, which also reports "no more writers". Linux reports FIFO EOF through epoll, so it never had this bug. Go hit the same kernel behaviour (golang/go#24164).
- `ReadFile` is the off-thread half of a whole-file read such as `Bun.file(x).bytes()`. For anything that is not a regular file it polls, and when not ready registers the fd with the io thread's kqueue and finishes when woken; this diff adds a third path beside those two.
- A pool task is a job on bun's blocking work pool, where `fs.readFile` already does its blocking reads on every platform. Unlike `JobContext::run`, a pool task holds no VM borrow, so a thread sleeping in one does not block a worker's teardown.
- `select$DARWIN_EXTSN` is the `_DARWIN_UNLIMITED_SELECT` flavour of select: the read set is a bitmap of `fd / 32 + 1` words with no `FD_SETSIZE` (1024) cap. The plain `select` rejects `nfds > FD_SETSIZE` with EINVAL, which is what the fd-above-1024 test pins.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/bun-file-read.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What

On macOS, `Bun.file(fifo).bytes()` / `.text()` / `.arrayBuffer()` / `.json()` on a named pipe, and `Bun.stdin.text()` when stdin is a named pipe, never resolve once the reader has to wait for anything after receiving data. The read delivers every byte the writer sends and then sits forever after the writer closes.

```ts
// mkfifo /tmp/p; then, in another process: cat some-file > /tmp/p
const bytes = await Bun.file("/tmp/p").bytes(); // macOS: never resolves; Linux: resolves at the writer's close
```

This is how the FIFO test added in #37787 behaved on its darwin lanes (build 93007: the child stayed alive until the 90 s timeout, while every Linux lane passed), which is why that PR skips it on macOS. Nothing in #37787 caused it; the same thing happens on main.

### Cause

Both ways `ReadFile` (src/runtime/webcore/blob/read_file.rs) finds out whether a pipe is readable are blind to a named pipe's EOF on macOS:

* The wait itself is a kqueue `EVFILT_READ` registration on the io thread. XNU attaches that filter for a FIFO to the vnode (`vn_kqfilter`), and `filt_vnode_common` activates it only when `fifo_charcount()` is non-zero, i.e. while bytes are buffered; `fifo_close_internal` only calls `socantrcvmore()` on the FIFO's socket and posts nothing to the vnode. So a reader parked in kqueue is never woken up by the last writer closing.
* The `bun_core::is_readable` pre-check is `poll(2)`, which XNU implements by registering the same kqueue filter (`poll_nocancel` in sys_generic.c), so it reports not-ready for a drained FIFO whether or not the writers are gone.

Together they make the hang deterministic rather than a race: after any successful read the loop polls (not ready), hands off to kqueue, and the EOF event never comes. The only reads that complete today are the ones where `read()` itself returns 0 because the writer was already gone before the first read. `pipe(2)` pipes are not affected: they have their own filter (`filt_piperead_common` sets `EV_EOF`), which is why the Bun.stdin-from-a-pipe tests pass on macOS. Go ran into the same kernel behaviour and stopped using kqueue for FIFOs on darwin (golang/go#24164).

What does work is `select(2)`: `fifo_select` goes to `soo_select` on the FIFO's read socket, and `soreadable()` includes `SS_CANTRCVMORE`, which is exactly what the last writer's close sets (and `socantrcvmore` does the select wakeup). `fifo_read` then returns 0 when there are no writers and nothing buffered.

<details>
<summary>XNU references (apple-oss-distributions/xnu, current main)</summary>

* bsd/vfs/vfs_vnops.c: `vn_kqfilter` (FIFO knotes attach to `v_knotes`), `vnode_readable_data_count` (`fifo_charcount`), `filt_vnode_common` (`activate = (data != 0)` for `EVFILT_READ`; `EV_EOF` only on `NOTE_REVOKE`), `vn_select` -> `VNOP_SELECT`.
* bsd/miscfs/fifofs/fifo_vnops.c: `fifo_write`/`fifo_read` post to the vnode (`lock_vnode_and_post`), `fifo_close_internal` does not; `fifo_select` -> `soo_select`; `fifo_read` returns 0 with `fi_writers < 1` and an empty buffer.
* bsd/kern/sys_socket.c `soo_select`, bsd/kern/uipc_socket2.c `soreadable` / `socantrcvmore`.
* bsd/kern/sys_generic.c `poll_nocancel`: poll is `kevent_register(EVFILT_READ | EV_POLL)` per fd.
* bsd/kern/sys_pipe.c: `pipeclose` sets `PIPE_EOF` and KNOTEs the peer; `pipe_stat` leaves `st_dev` 0 ("Left as 0: st_dev, ...").
* libsyscall/wrappers/select-base.c and libsyscall/Platforms/MacOSX/{arm64,x86_64}/syscall.map: `select$DARWIN_EXTSN$NOCANCEL` exists on both architectures and maps straight to `__select_nocancel`; the non-`EXTSN` variants reject `nfds > FD_SETSIZE` with `EINVAL`.

</details>

### Fix

* `bun_sys::block_until_readable(fd)` (macOS only): blocks in `select(2)` on one fd, EINTR-retried. It links `select$DARWIN_EXTSN$NOCANCEL` next to the other `$NOCANCEL` imports, so there is no `FD_SETSIZE` limit (the read set is a bitmap of `fd / 32 + 1` words; both darwin build lanes link it), and gets a `Tag::select` appended to the syscall tag table.
* `ReadFile` records `is_named_pipe` from the fstat it already does: `S_IFIFO` with a non-zero `st_dev`. `pipe(2)` pipes report `st_dev == 0` (see `pipe_stat` above) and keep the existing io-thread path, so `cmd | bun` stdin and subprocess pipes are untouched.
* For a named pipe, `run_async_with_fd` does not poll or hand the request to the io thread; it schedules `read_named_pipe_task` on the pool and returns. That task waits in `select`, runs the existing read loop, and whenever a read drains the pipe waits in `select` again and carries on (the `poll(2)` pre-check is skipped there, since it answers nothing `select` does not); a failed `select` is reported through the usual `errno` / `system_error` path, and `on_finish` closes the fd and posts the completion exactly as after an io-thread wake-up today. Scheduling a task rather than waiting inline matters because `JobContext::run` executes under a VM borrow (`VmHandle::borrow`: "jobs that could block indefinitely on an external party must own their memory instead") and a worker's teardown waits for outstanding borrows, so a wait inside `run` would have made a worker with a `Bun.file(fifo).text()` pending against an idle or absent writer impossible to `terminate()`. The rescheduled task holds no borrow, and `ReadFile` is the job's owned off-thread part, so a read that finishes after its VM is gone is released the same way a late io-thread wake-up is.
* Waiting before the first read as well is what makes a FIFO whose writer has not connected yet wait for that writer instead of reading as empty, which is what Linux does today (poll on a never-written FIFO is not ready there, and `read()` would return 0 on both systems).

Why this shape: kqueue cannot be made to deliver this event, so some thread has to sit in a call that the kernel does wake up for. Waiting on the pool thread is what `fs.readFile(fifo)` already does on every platform (a blocking `read()` on the pool), it is confined to FIFO vnodes on macOS, and every read it slows down is one that never completed before. Anonymous pipes, sockets, character devices and every other platform still go through the io thread exactly as before. If pinning a pool thread per in-flight FIFO read ever matters, the next step would be a select-based wait on the io thread; that is a much larger change to src/io for a path that is currently non-functional.

Composition with #37787 (open; restructures the same two functions and adds a macOS-skipped copy of the first test below): the two conflict textually and whichever lands second rebases. If that is this PR, the named-pipe branch goes into its `prepare_read` / `read_until_blocked` exits and its skipped FIFO test is replaced by this describe block; if #37787 lands second, its FIFO test should be dropped in favour of the one here, which is the same scenario without the macOS skip. Noted on #37787 as well.

Out of scope, same kernel behaviour, reported separately: `WriteFile`'s `EVFILT_WRITE` wait on a FIFO cannot see the reader going away either (a parked `Bun.write` to a FIFO hangs instead of getting EPIPE; #37852), and the streaming readers (`Bun.file(fifo).stream()`, FIFO responses in `Bun.serve`, the area #37090 is working in) register the same vnode filter on the main loop's kqueue, so their EOF on macOS depends on the writer having closed before the drain loop's last `read()`.

### Tests

`test/js/bun/util/bun-file-read.test.ts`, "reading a named pipe", six concurrent cases:

* a 256 KiB payload pushed through a blocking writer, so the child drains and re-waits several times (the #37787 scenario; traced on Linux with the `WriteFile` debug scope, 300 KB is five `waitForReadable` round trips there);
* a writer that connects only after the child opened the FIFO;
* a writer that connects and closes without writing (must resolve to `""`);
* a FIFO passed to the child as stdin, read through `Bun.stdin.text()` (the fd-based classification);
* a FIFO opened in the child after 1024 other descriptors and read through `Bun.file(fd)`, so the `select` set needs a second word and `nfds > FD_SETSIZE`; this is what pins the `$DARWIN_EXTSN` variant (the plain one returns EINVAL here, which would surface as a rejected read);
* a worker whose `Bun.file(fifo).text()` is waiting on a connected but idle writer must still be `terminate()`-able (stdout `reading` / `terminated`, natural exit). This one pins the pool-task shape: it hangs if the wait happens inside `JobContext::run`, and passes on main, where the read parks on the io thread.

All of them pass on Linux with and without this change, since Linux reports FIFO EOF through epoll; macOS is where the first five distinguish the two trees, so the darwin lanes of this PR are the fail-to-pass evidence, with build 93007 of #37787 as the failing-before data point for the first case. The other four hang on main for the same reason (data or a close is delivered, then the poll pre-check is blind and the kqueue wait never fires). I have no macOS machine in this environment, so I could not run them there myself before CI.

### Verification

Debug build on Linux: the file above (11 pass), `test/regression/issue/07500`, `bun-stdin-slice`, `bun-file-fd-read`, and `test/internal/source-lints` (82 pass). `cargo clippy -p bun_sys -p bun_runtime` is clean natively and for `aarch64-apple-darwin` (the only kind of target where the new code is compiled); `cargo check` of the same for `x86_64-apple-darwin`, and of `bun_sys` for `x86_64-unknown-freebsd` and `x86_64-pc-windows-msvc` (the tag table is shared); `cargo fmt` and prettier are clean. Both darwin build lanes pass on every revision, which covers the new symbol's linkage, and the `:darwin: 14 aarch64` test lane of build 93455 ran the file above against fc757cd: `11 pass, 0 fail, Ran 11 tests across 1 file. [657.00ms]` (the four-case revision 8bf43ec had passed the same way in build 93193).

</details>

