### PR TITLE
test: keep the async-context fixtures off the network and assert on their output

### DIFF
--- a/test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts
@@ -1,40 +1,56 @@
 import { Glob } from "bun";
-import { describe, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isBroken, isLinux, nodeExe } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, nodeExe, tempDir } from "harness";
 import { basename, join } from "path";
 
+// Every fixture in async-context/ calls one API inside asyncLocalStorage.run() and
+// exits 0 without printing anything if all of its callbacks still see the store.
+// Otherwise it prints "FAIL: ..." (context lost) or "ERROR: ..." (the API itself
+// failed) to stderr and exits 1. Fixtures only talk to servers they start
+// themselves, so none of this depends on the network.
+//
+// Each fixture also runs under node, which proves the fixture itself is valid.
+const node = nodeExe();
+if (!node) throw new Error("node is required to validate the async-context fixtures");
+
+const fixturesDir = join(import.meta.dir, "async-context");
+const fixtures = [...new Glob("async-context-*.js").scanSync(fixturesDir)].sort();
+
+// Fixtures bun still fails. `bun test --todo` runs them and reports any that
+// have started passing.
+const todos = ["async-context-worker_threads-message.js"];
+
+async function run(exe: string, fixture: string, cwd: string) {
+  await using proc = Bun.spawn({
+    cmd: [exe, join(fixturesDir, fixture)],
+    cwd,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  return { exe: basename(exe), fixture, stdout, stderr, exitCode, signalCode: proc.signalCode };
+}
+
+function passed(exe: string, fixture: string) {
+  return { exe: basename(exe), fixture, stdout: "", stderr: "", exitCode: 0, signalCode: null };
+}
+
 describe.concurrent("AsyncLocalStorage passes context to callbacks", () => {
-  let files = [...new Glob(join(import.meta.dir, "async-context", "async-context-*.js")).scanSync()];
+  test("every todo entry names an existing fixture", () => {
+    expect(fixtures).toEqual(expect.arrayContaining(todos));
+  });
 
-  let todos = ["async-context-worker_threads-message.js"];
-  if (isASAN && isBroken && isLinux) {
-    todos.push("async-context-dns-resolveTxt.js");
-  }
+  for (const fixture of fixtures) {
+    const name = fixture.replace(/^async-context-/, "").replace(/\.js$/, "");
 
-  files = files.filter(file => !todos.includes(basename(file)));
+    test.todoIf(todos.includes(fixture))(name, async () => {
+      // Some fixtures create scratch files relative to the cwd.
+      using cwd = tempDir("async-context", {});
 
-  for (const filepath of files) {
-    const file = basename(filepath).replaceAll("async-context-", "").replaceAll(".js", "");
-    test(file, async () => {
-      async function run(exe) {
-        const { exited } = Bun.spawn({
-          cmd: [exe, filepath],
-          stdout: "inherit",
-          stderr: "inherit",
-          env: bunEnv,
-        });
+      const results = await Promise.all([run(bunExe(), fixture, String(cwd)), run(node, fixture, String(cwd))]);
 
-        if (await exited) {
-          throw new Error(`${basename(exe)} failed in ${filepath}`);
-        }
-      }
-
-      await Promise.all([run(bunExe()), run(nodeExe())]);
+      expect(results).toEqual([passed(bunExe(), fixture), passed(node, fixture)]);
     });
-  }
-
-  for (const filepath of todos) {
-    const file = basename(filepath).replaceAll("async-context-", "").replaceAll(".js", "");
-    test.todo(file);
   }
 });

--- a/test/js/node/async_hooks/async-context/async-context-child_process-spawn-events.js
+++ b/test/js/node/async_hooks/async-context/async-context-child_process-spawn-events.js
@@ -4,9 +4,12 @@ const { spawn } = require("child_process");
 
 const asyncLocalStorage = new AsyncLocalStorage();
 let failed = false;
+let sawStdout = false;
 
 asyncLocalStorage.run({ test: "child_process.spawn" }, () => {
-  const child = spawn("bun", ["-e", "Bun.sleepSync(100)"]);
+  // process.execPath is whichever of node or bun is running this fixture; both
+  // accept -e. The child prints something so that the stdout data event fires.
+  const child = spawn(process.execPath, ["-e", "console.log('child')"]);
 
   child.on("spawn", () => {
     if (asyncLocalStorage.getStore()?.test !== "child_process.spawn") {
@@ -15,7 +18,8 @@ asyncLocalStorage.run({ test: "child_process.spawn" }, () => {
     }
   });
 
-  child.stdout.on("data", data => {
+  child.stdout.on("data", () => {
+    sawStdout = true;
     if (asyncLocalStorage.getStore()?.test !== "child_process.spawn") {
       console.error("FAIL: spawn stdout data event lost context");
       failed = true;
@@ -27,10 +31,15 @@ asyncLocalStorage.run({ test: "child_process.spawn" }, () => {
       console.error("FAIL: spawn close event lost context");
       failed = true;
     }
+    if (code !== 0 || !sawStdout) {
+      console.error(`ERROR: child exited with code ${code}, stdout data event fired: ${sawStdout}`);
+      failed = true;
+    }
     process.exit(failed ? 1 : 0);
   });
 
-  child.on("error", () => {
+  child.on("error", err => {
+    console.error("ERROR:", err);
     process.exit(1);
   });
 });

--- a/test/js/node/async_hooks/async-context/async-context-dgram-send.js
+++ b/test/js/node/async_hooks/async-context/async-context-dgram-send.js
@@ -8,19 +8,31 @@ asyncLocalStorage.run({ test: "dgram.send" }, () => {
   const server = dgram.createSocket("udp4");
   const client = dgram.createSocket("udp4");
 
-  server.on("message", () => {
-    server.close();
-    client.close();
-  });
+  // Exit once the send callback has run and the datagram has arrived, in
+  // whichever order that happens.
+  let pending = 2;
+  function done() {
+    if (--pending === 0) {
+      server.close();
+      client.close();
+      process.exit(0);
+    }
+  }
+
+  server.on("message", done);
 
   server.bind(0, () => {
     const port = server.address().port;
     client.send("test", port, "localhost", err => {
+      if (err) {
+        console.error("ERROR:", err);
+        process.exit(1);
+      }
       if (asyncLocalStorage.getStore()?.test !== "dgram.send") {
         console.error("FAIL: dgram.send callback lost context");
         process.exit(1);
       }
-      setTimeout(() => process.exit(0), 100);
+      done();
     });
   });
 });

--- a/test/js/node/async_hooks/async-context/async-context-dns-resolveCname.js
+++ b/test/js/node/async_hooks/async-context/async-context-dns-resolveCname.js
@@ -1,15 +1,25 @@
 process.exitCode = 1;
 const { AsyncLocalStorage } = require("async_hooks");
 const dns = require("dns");
+const { startLocalDnsServer } = require("./local-dns-server");
 
 const asyncLocalStorage = new AsyncLocalStorage();
 
-asyncLocalStorage.run({ test: "dns.resolveCname" }, () => {
-  dns.resolveCname("www.example.com", (err, addresses) => {
-    if (asyncLocalStorage.getStore()?.test !== "dns.resolveCname") {
-      console.error("FAIL: dns.resolveCname callback lost context");
-      process.exit(1);
-    }
-    process.exit(0);
+startLocalDnsServer((server, address) => {
+  dns.setServers([address]);
+
+  asyncLocalStorage.run({ test: "dns.resolveCname" }, () => {
+    dns.resolveCname("context.test", err => {
+      server.close();
+      if (err) {
+        console.error("ERROR:", err);
+        process.exit(1);
+      }
+      if (asyncLocalStorage.getStore()?.test !== "dns.resolveCname") {
+        console.error("FAIL: dns.resolveCname callback lost context");
+        process.exit(1);
+      }
+      process.exit(0);
+    });
   });
 });

--- a/test/js/node/async_hooks/async-context/async-context-dns-resolveMx.js
+++ b/test/js/node/async_hooks/async-context/async-context-dns-resolveMx.js
@@ -1,15 +1,25 @@
 process.exitCode = 1;
 const { AsyncLocalStorage } = require("async_hooks");
 const dns = require("dns");
+const { startLocalDnsServer } = require("./local-dns-server");
 
 const asyncLocalStorage = new AsyncLocalStorage();
 
-asyncLocalStorage.run({ test: "dns.resolveMx" }, () => {
-  dns.resolveMx("example.com", (err, addresses) => {
-    if (asyncLocalStorage.getStore()?.test !== "dns.resolveMx") {
-      console.error("FAIL: dns.resolveMx callback lost context");
-      process.exit(1);
-    }
-    process.exit(0);
+startLocalDnsServer((server, address) => {
+  dns.setServers([address]);
+
+  asyncLocalStorage.run({ test: "dns.resolveMx" }, () => {
+    dns.resolveMx("context.test", err => {
+      server.close();
+      if (err) {
+        console.error("ERROR:", err);
+        process.exit(1);
+      }
+      if (asyncLocalStorage.getStore()?.test !== "dns.resolveMx") {
+        console.error("FAIL: dns.resolveMx callback lost context");
+        process.exit(1);
+      }
+      process.exit(0);
+    });
   });
 });

--- a/test/js/node/async_hooks/async-context/async-context-dns-resolveTxt.js
+++ b/test/js/node/async_hooks/async-context/async-context-dns-resolveTxt.js
@@ -1,15 +1,25 @@
 process.exitCode = 1;
 const { AsyncLocalStorage } = require("async_hooks");
 const dns = require("dns");
+const { startLocalDnsServer } = require("./local-dns-server");
 
 const asyncLocalStorage = new AsyncLocalStorage();
 
-asyncLocalStorage.run({ test: "dns.resolveTxt" }, () => {
-  dns.resolveTxt("google.com", (err, records) => {
-    if (asyncLocalStorage.getStore()?.test !== "dns.resolveTxt") {
-      console.error("FAIL: dns.resolveTxt callback lost context");
-      process.exit(1);
-    }
-    process.exit(0);
+startLocalDnsServer((server, address) => {
+  dns.setServers([address]);
+
+  asyncLocalStorage.run({ test: "dns.resolveTxt" }, () => {
+    dns.resolveTxt("context.test", err => {
+      server.close();
+      if (err) {
+        console.error("ERROR:", err);
+        process.exit(1);
+      }
+      if (asyncLocalStorage.getStore()?.test !== "dns.resolveTxt") {
+        console.error("FAIL: dns.resolveTxt callback lost context");
+        process.exit(1);
+      }
+      process.exit(0);
+    });
   });
 });

--- a/test/js/node/async_hooks/async-context/async-context-dns-reverse.js
+++ b/test/js/node/async_hooks/async-context/async-context-dns-reverse.js
@@ -1,15 +1,27 @@
 process.exitCode = 1;
 const { AsyncLocalStorage } = require("async_hooks");
 const dns = require("dns");
+const { startLocalDnsServer } = require("./local-dns-server");
 
 const asyncLocalStorage = new AsyncLocalStorage();
 
-asyncLocalStorage.run({ test: "dns.reverse" }, () => {
-  dns.reverse("8.8.8.8", (err, hostnames) => {
-    if (asyncLocalStorage.getStore()?.test !== "dns.reverse") {
-      console.error("FAIL: dns.reverse callback lost context");
-      process.exit(1);
-    }
-    process.exit(0);
+startLocalDnsServer((server, address) => {
+  dns.setServers([address]);
+
+  asyncLocalStorage.run({ test: "dns.reverse" }, () => {
+    // 192.0.2.1 (TEST-NET-1) is never in /etc/hosts, so the PTR query reaches
+    // the local server instead of being answered from the hosts file.
+    dns.reverse("192.0.2.1", err => {
+      server.close();
+      if (err) {
+        console.error("ERROR:", err);
+        process.exit(1);
+      }
+      if (asyncLocalStorage.getStore()?.test !== "dns.reverse") {
+        console.error("FAIL: dns.reverse callback lost context");
+        process.exit(1);
+      }
+      process.exit(0);
+    });
   });
 });

--- a/test/js/node/async_hooks/async-context/async-context-events-emitter.js
+++ b/test/js/node/async_hooks/async-context/async-context-events-emitter.js
@@ -31,14 +31,12 @@ asyncLocalStorage.run({ test: "EventEmitter" }, () => {
       console.error("FAIL: EventEmitter async listener lost context");
       failed = true;
     }
+    // The emits below are synchronous, so the other two listeners have already run.
+    process.exit(failed ? 1 : 0);
   });
 
   // Emit events
   emitter.emit("test");
   emitter.emit("once-test");
   emitter.emit("async-test");
-
-  setTimeout(() => {
-    process.exit(failed ? 1 : 0);
-  }, 100);
 });

--- a/test/js/node/async_hooks/async-context/async-context-fs-watch.js
+++ b/test/js/node/async_hooks/async-context/async-context-fs-watch.js
@@ -26,17 +26,9 @@ asyncLocalStorage.run({ test: "fs.watch" }, () => {
     process.exit(0);
   });
 
-  // Trigger the watch event
-  setTimeout(() => {
-    fs.writeFileSync(testFile, "modified");
-  }, 100);
-
-  // Timeout safety
-  setTimeout(() => {
-    watcher.close();
-    try {
-      fs.unlinkSync(testFile);
-    } catch {}
-    process.exit(0);
-  }, 5000);
+  // Some backends (FSEvents) start delivering events a little after watch()
+  // returns, so a single write could be missed. Keep modifying the file until
+  // the listener fires (it exits the process).
+  let content = "initial";
+  setInterval(() => fs.writeFileSync(testFile, (content += "+")), 20);
 });

--- a/test/js/node/async_hooks/async-context/async-context-fs-watchFile.js
+++ b/test/js/node/async_hooks/async-context/async-context-fs-watchFile.js
@@ -25,17 +25,9 @@ asyncLocalStorage.run({ test: "fs.watchFile" }, () => {
     process.exit(0);
   });
 
-  // Trigger the watch event
-  setTimeout(() => {
-    fs.writeFileSync(testFile, "modified");
-  }, 100);
-
-  // Timeout safety
-  setTimeout(() => {
-    fs.unwatchFile(testFile);
-    try {
-      fs.unlinkSync(testFile);
-    } catch {}
-    process.exit(0);
-  }, 5000);
+  // The watcher takes its baseline stat asynchronously, so a single write could
+  // land before it and never be reported. Keep growing the file until the
+  // listener fires (it exits the process).
+  let content = "initial";
+  setInterval(() => fs.writeFileSync(testFile, (content += "+")), 20);
 });

--- a/test/js/node/async_hooks/async-context/async-context-https-request.js
+++ b/test/js/node/async_hooks/async-context/async-context-https-request.js
@@ -1,26 +1,53 @@
 process.exitCode = 1;
 const { AsyncLocalStorage } = require("async_hooks");
+const fs = require("fs");
 const https = require("https");
+const path = require("path");
 
 const asyncLocalStorage = new AsyncLocalStorage();
+let failed = false;
 
-asyncLocalStorage.run({ test: "https.request" }, () => {
-  const req = https.request("https://httpbin.org/get", res => {
-    if (asyncLocalStorage.getStore()?.test !== "https.request") {
-      console.error("FAIL: https.request response callback lost context");
-      process.exit(1);
-    }
+const fixtures = path.join(__dirname, "..", "..", "http", "fixtures");
+const cert = fs.readFileSync(path.join(fixtures, "cert.pem"));
+const key = fs.readFileSync(path.join(fixtures, "cert.key"));
 
-    res.on("data", () => {});
-    res.on("end", () => {
-      process.exit(0);
+const server = https.createServer({ key, cert }, (req, res) => {
+  res.end("ok");
+});
+
+server.listen(0, "127.0.0.1", () => {
+  const port = server.address().port;
+
+  asyncLocalStorage.run({ test: "https.request" }, () => {
+    const req = https.request({ host: "127.0.0.1", port, ca: cert }, res => {
+      if (asyncLocalStorage.getStore()?.test !== "https.request") {
+        console.error("FAIL: https.request response callback lost context");
+        failed = true;
+      }
+
+      res.on("data", () => {
+        if (asyncLocalStorage.getStore()?.test !== "https.request") {
+          console.error("FAIL: https response data event lost context");
+          failed = true;
+        }
+      });
+
+      res.on("end", () => {
+        if (asyncLocalStorage.getStore()?.test !== "https.request") {
+          console.error("FAIL: https response end event lost context");
+          failed = true;
+        }
+        server.close();
+        process.exit(failed ? 1 : 0);
+      });
     });
-  });
 
-  req.on("error", () => {
-    // Skip test if network is unavailable
-    process.exit(0);
-  });
+    req.on("error", err => {
+      console.error("ERROR:", err);
+      server.close();
+      process.exit(1);
+    });
 
-  req.end();
+    req.end();
+  });
 });

--- a/test/js/node/async_hooks/async-context/async-context-net-server.js
+++ b/test/js/node/async_hooks/async-context/async-context-net-server.js
@@ -4,11 +4,13 @@ const net = require("net");
 
 const asyncLocalStorage = new AsyncLocalStorage();
 let failed = false;
+let sawConnection = false;
 
 asyncLocalStorage.run({ test: "net.Server" }, () => {
   const server = net.createServer();
 
   server.on("connection", socket => {
+    sawConnection = true;
     if (asyncLocalStorage.getStore()?.test !== "net.Server") {
       console.error("FAIL: net.Server connection event lost context");
       failed = true;
@@ -24,13 +26,20 @@ asyncLocalStorage.run({ test: "net.Server" }, () => {
 
     // Connect to trigger connection event
     const client = net.connect(server.address().port);
+    client.on("error", err => {
+      console.error("ERROR:", err);
+      process.exit(1);
+    });
     client.on("close", () => {
-      // Give time for server connection event to fire
-      setTimeout(() => {
-        server.close(() => {
-          process.exit(failed ? 1 : 0);
-        });
-      }, 50);
+      // The client only closes because the connection handler ended the
+      // server side, so that handler has already run.
+      if (!sawConnection) {
+        console.error("ERROR: net.Server never emitted a connection event");
+        failed = true;
+      }
+      server.close(() => {
+        process.exit(failed ? 1 : 0);
+      });
     });
   });
 

--- a/test/js/node/async_hooks/async-context/async-context-tls-connect.js
+++ b/test/js/node/async_hooks/async-context/async-context-tls-connect.js
@@ -1,29 +1,34 @@
 process.exitCode = 1;
 const { AsyncLocalStorage } = require("async_hooks");
+const fs = require("fs");
+const path = require("path");
 const tls = require("tls");
 
 const asyncLocalStorage = new AsyncLocalStorage();
 
-asyncLocalStorage.run({ test: "tls.connect" }, () => {
-  const socket = tls.connect(
-    443,
-    "example.com",
-    {
-      rejectUnauthorized: true,
-    },
-    () => {
+const fixtures = path.join(__dirname, "..", "..", "http", "fixtures");
+const cert = fs.readFileSync(path.join(fixtures, "cert.pem"));
+const key = fs.readFileSync(path.join(fixtures, "cert.key"));
+
+const server = tls.createServer({ key, cert });
+
+server.listen(0, "127.0.0.1", () => {
+  const port = server.address().port;
+
+  asyncLocalStorage.run({ test: "tls.connect" }, () => {
+    const socket = tls.connect({ host: "127.0.0.1", port, ca: cert }, () => {
+      socket.destroy();
+      server.close();
       if (asyncLocalStorage.getStore()?.test !== "tls.connect") {
         console.error("FAIL: tls.connect callback lost context");
-        socket.destroy();
         process.exit(1);
       }
-      socket.destroy();
       process.exit(0);
-    },
-  );
+    });
 
-  socket.on("error", () => {
-    // Skip test if network is unavailable
-    process.exit(0);
+    socket.on("error", err => {
+      console.error("ERROR:", err);
+      process.exit(1);
+    });
   });
 });

--- a/test/js/node/async_hooks/async-context/local-dns-server.js
+++ b/test/js/node/async_hooks/async-context/local-dns-server.js
@@ -1,0 +1,67 @@
+// Shared by the dns.resolve*/dns.reverse fixtures. Not a fixture itself: the
+// test file only runs async-context-*.js.
+//
+// A UDP DNS server on 127.0.0.1 that answers every question with one record of
+// the type asked for, so the fixtures never depend on a real resolver or on the
+// network. Runs under both node and bun.
+const dgram = require("dgram");
+
+function encodeName(name) {
+  const parts = [];
+  for (const label of name.split(".")) {
+    parts.push(Buffer.from([label.length]), Buffer.from(label));
+  }
+  parts.push(Buffer.from([0]));
+  return Buffer.concat(parts);
+}
+
+function encodeText(text) {
+  return Buffer.concat([Buffer.from([text.length]), Buffer.from(text)]);
+}
+
+const rdataByType = {
+  5: encodeName("canonical.example"), // CNAME
+  12: encodeName("host.example"), // PTR
+  15: Buffer.concat([Buffer.from([0, 10]), encodeName("mail.example")]), // MX: preference, exchange
+  16: encodeText("async-context"), // TXT
+};
+
+function buildResponse(query) {
+  // 12-byte header, then the question: QNAME (length-prefixed labels ending in
+  // a 0 byte), QTYPE, QCLASS.
+  let offset = 12;
+  while (offset < query.length && query[offset] !== 0) offset += query[offset] + 1;
+  if (offset + 5 > query.length) return null;
+  const question = query.subarray(12, offset + 5);
+  const qtype = query.readUInt16BE(offset + 1);
+  const rdata = rdataByType[qtype];
+
+  const header = Buffer.alloc(12);
+  query.copy(header, 0, 0, 2); // ID
+  header.writeUInt16BE(rdata ? 0x8180 : 0x8183, 2); // QR | RD | RA, rcode NOERROR or NXDOMAIN
+  header.writeUInt16BE(1, 4); // QDCOUNT
+  header.writeUInt16BE(rdata ? 1 : 0, 6); // ANCOUNT
+  if (!rdata) return Buffer.concat([header, question]);
+
+  const answer = Buffer.alloc(12);
+  answer.writeUInt16BE(0xc00c, 0); // NAME: pointer to the question name
+  answer.writeUInt16BE(qtype, 2);
+  answer.writeUInt16BE(1, 4); // CLASS IN
+  answer.writeUInt32BE(60, 6); // TTL
+  answer.writeUInt16BE(rdata.length, 10);
+  return Buffer.concat([header, question, answer, rdata]);
+}
+
+// Calls back with the bound server and its "ip:port" for dns.setServers().
+function startLocalDnsServer(callback) {
+  const server = dgram.createSocket("udp4");
+  server.on("message", (query, rinfo) => {
+    const response = buildResponse(query);
+    if (response) server.send(response, rinfo.port, rinfo.address);
+  });
+  server.bind(0, "127.0.0.1", () => {
+    callback(server, `127.0.0.1:${server.address().port}`);
+  });
+}
+
+module.exports = { startLocalDnsServer };


### PR DESCRIPTION
### Problem
- `AsyncLocalStorage-tracking.test.ts` regularly takes 35-60s in CI (46-60s on 6 of 10 platforms on main), although 74 of its 75 fixtures finish within about a second. One fixture stalls each run.
- Six fixtures (`dns.resolveTxt`/`Mx`/`Cname`, `dns.reverse`, `https.request`, `tls.connect`) query the public internet, and their error paths exit 0. With a resolver that never answers, each sits 10-30s in retries and then passes without exercising anything. This is also why `dns-resolveTxt` was a todo on the ASAN Linux lane.
- Other fixtures end on fixed timers, and `fs-watch`/`fs-watchFile` had 5s safety timers that exited 0 even if the watcher never fired, so a broken watcher passed after 5s.
- The test file only checked exit codes: a fixture's stderr went to the shared console instead of into the failing assertion, and each run left about 35 empty scratch directories in the repo root.

### Fix
- The four dns fixtures point `dns.setServers()` at a UDP server started on `127.0.0.1` that answers any question with one record; `https-request` and `tls-connect` connect to a local server using the http test cert, with `ca` set so certificate verification stays on.
- Fixed timers and the exit-0 safety timers are gone: each fixture exits when the event it waits for arrives, and an API error or missing event fails it. The test file now compares stdout, stderr, exit code and signal against an all-clean result for both the bun and node run. The ASAN todo is removed; no fixture is removed or skipped, and there are no `src/` changes.
- Property to check: a fixture can now only exit 0 if the API under test ran and every callback fired, and it exits as soon as that happens.
- Verification: with a resolver that never answers, the six network fixtures fall from 10-30s to 50-200ms under both bun and node; the changed fixtures ran 30x under node and release bun and 10x under a debug build with no failures; removing `ca` makes both runtimes fail the https fixture. Local wall time barely moves because debug startup dominates, so this PR's CI timing is the real before/after. On a heavily loaded host the https fixture hit the local 5s default timeout under a debug build; CI allows 90s.

### Background
- Each `async-context-*.js` fixture calls one node API inside `AsyncLocalStorage.run()` and checks that every callback still sees the store: exit 0 with no output on success, `FAIL:` or `ERROR:` on stderr and exit 1 otherwise. The test file runs every fixture under both bun and node, so node passing shows the fixture itself is valid.
- `dns.resolve*` and `dns.reverse` speak DNS over UDP to a configured resolver rather than going through the OS lookup, so `dns.setServers()` can point them at any local socket that returns a well-formed answer. Node's own dns tests use the same trick.
- `192.0.2.1` (TEST-NET-1) is never in `/etc/hosts`, so the reverse lookup has to reach the local server instead of being answered from the hosts file.
- `test.todoIf(cond)(name, body)` keeps the test body, so `bun test --todo` runs it and reports when it starts passing; a bare `test.todo(name)` never runs anything.

<details>
<summary>Original description</summary>

### Problem

`test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts` is a 40 line file that regularly takes 35-60s in CI. On main (`9a543cc18f`, build 93041) it took 46-60s on 6 of the 10 platforms; build 92779 had it at 40.8s on darwin 26; `test/expected-durations.json` has the musl median at 35.8s. In every slow run the Buildkite timestamps show 74 of the 75 dots within the first ~1s and the last dot 40-60s later, so a single fixture is stalling each time.

Six of the fixtures talk to the public internet and treat failure as success:

| fixture | did |
|---|---|
| `dns-resolveTxt` | `dns.resolveTxt("google.com")` |
| `dns-resolveMx` | `dns.resolveMx("example.com")` |
| `dns-resolveCname` | `dns.resolveCname("www.example.com")` |
| `dns-reverse` | `dns.reverse("8.8.8.8")` |
| `https-request` | `https.request("https://httpbin.org/get")`, `exit(0)` on error |
| `tls-connect` | `tls.connect(443, "example.com")`, `exit(0)` on error |

With a resolver that does not answer (reproduced locally by pointing `resolv.conf` at a UDP socket that never replies), each of them sits in resolver retries and then passes without exercising anything:

| fixture | old, bun | old, node | new, bun | new, node |
|---|---|---|---|---|
| dns-resolveTxt | 29.1s | 30.1s | 67ms | 90ms |
| dns-resolveMx | 27.1s | 25.1s | 84ms | 50ms |
| dns-resolveCname | 25.1s | 23.3s | 99ms | 94ms |
| dns-reverse | 25.1s | 23.2s | 100ms | 84ms |
| https-request | 10.1s (no request made) | 10.2s | 189ms | 196ms |
| tls-connect | 10.1s (no connection made) | 10.3s | 131ms | 129ms |

This is also the reason `dns-resolveTxt` was `.todo` on the ASAN Linux lane.

### Changes

Fixtures (all still run under both bun and node, so they only use APIs both have):

- The four `dns.*` fixtures start a tiny UDP DNS server on `127.0.0.1:0` (`async-context/local-dns-server.js`, answers every question with one record of the requested type) and call `dns.setServers()` before the API under test. Same approach as node's own `test-dns.js`. `dns.reverse` looks up `192.0.2.1` so the query is not answered from `/etc/hosts`. An error from the API now fails the fixture.
- `https-request` and `tls-connect` start a local `https`/`tls` server with `test/js/node/http/fixtures/cert.pem` (the same cert as harness `tls`) and connect with `ca` set, so certificate verification is still on. The "skip if network is unavailable" `exit(0)` paths are gone; errors fail the fixture. `https-request` also checks the `data` and `end` events like `http-request` does.
- `dgram-send`: exits once the send callback has run and the datagram arrived, instead of a 100ms timer.
- `events-emitter`: exits when the async listener finishes, instead of a 100ms timer.
- `net-server`: closes as soon as the client closes (which can only happen after the connection handler ran) instead of after 50ms; also fails if no `connection` event was seen or the client errors.
- `fs-watch`, `fs-watchFile`: the single delayed write is replaced by writing to the file every 20ms until the watcher fires, and the 5s "safety" timers that exited 0 if the watcher never fired are removed. A watcher that never fires now fails instead of silently passing after 5s.
- `child_process-spawn-events`: spawns `process.execPath -e "console.log('child')"` (node or the bun under test, not whatever `bun` is on `PATH`) instead of `bun -e Bun.sleepSync(100)`. The child now prints, so the `stdout` `data` listener actually runs; the fixture fails if it did not or if the child exited non-zero.

Test file:

- stdout/stderr are piped and each run is compared with `toEqual` against `{ exe, fixture, stdout: "", stderr: "", exitCode: 0, signalCode: null }`. The same expectation is used for the bun run and the node run, and a failure shows the fixture, the executable and the captured output, e.g. for the known worker_threads todo under `--todo`:

  ```
    {
      "exe": "bun-debug",
  -   "exitCode": 0,
  +   "exitCode": 1,
      "fixture": "async-context-worker_threads-message.js",
  -   "stderr": "",
  +   "stderr": "FAIL: worker message event lost context\n",
  ```
- Each fixture runs in a `tempDir` cwd. Previously every run left the fixtures' `mkdtemp` directories (`fstest*`, `test-*`, `watch-test*`, ...) in the repo root: about 35 empty directories per run.
- The ASAN todo for `dns-resolveTxt` is removed (it passes on the debug/ASAN build here). `worker_threads-message` stays a todo via `test.todoIf`, but now has a body, so `bun test --todo` runs it and reports when it starts passing. A small test checks that every todo entry names an existing fixture.
- No fixture was removed, skipped or todo'd. No `src/` changes.

### Verification

- `bun bd test test/js/node/async_hooks/AsyncLocalStorage-tracking.test.ts`, interleaved before/after on the same machine and debug build: before 35.1s and 34.6s, after 35.0s and 25.1s (74 pass, 1 todo). Locally both versions are bound by debug-build startup (`require("http")` alone takes ~2s in a debug build, and ASAN builds default `describe.concurrent` to 5 tests at a time), and DNS in this container fails instantly, so the local wall time does not show the network cost. The per-fixture table above and the CI timing of this PR are the meaningful before/after.
- Two further local runs, taken while the shared host had a load average around 70, had `https-request` hit bun test's local 5s default per-test timeout (it now does a real TLS round trip, ~3.5-4.5s standalone in the debug build on that host, 76ms in release; the untouched `http-request` was at 4.5s in the same runs). CI runs this file with a 90s per-test timeout (270s on ASAN), so this only concerns debug builds on a heavily loaded machine, but it is worth knowing.
- The 12 changed fixtures run 30x each under node and under a release bun, and 10x each under the debug build: no failures (the only failures seen were `EMFILE` from the shared host's inotify instance limit, hitting node and bun alike, and unrelated to this change).
- A deliberately failing fixture and `--todo` were used to check the failure output above.
- Verified that removing `ca` from the https fixture makes both node and bun fail it, i.e. verification is real.
- Release bun and node run every changed fixture in 20-200ms.

Note: #32805 also touches the todo list in this test file; whichever lands second has a one-line conflict.

</details>
