### PR TITLE
node:http: do not count upgrades against maxRequestsPerSocket

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1005,6 +1005,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         let rejectMissingHost = false;
         let reachedRequestsLimit = false;
         if (!is_upgrade) {
+          const maxRequestsPerSocket = server.maxRequestsPerSocket;
           if (
             server.requireHostHeader &&
             (dispatchBits & DISPATCH_HAS_HOST) === 0 &&
@@ -1016,18 +1017,18 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             // a request that fell through to normal dispatch instead must still
             // honor requireHostHeader, like Node.js.
             rejectMissingHost = true;
-          } else if (typeof server.maxRequestsPerSocket === "number" && server.maxRequestsPerSocket > 0) {
+          } else if (typeof maxRequestsPerSocket === "number" && maxRequestsPerSocket > 0) {
             const requestCount = (socket._requestCount || 0) + 1;
             socket._requestCount = requestCount;
-            http_res._maxRequestsPerSocket = server.maxRequestsPerSocket;
+            http_res._maxRequestsPerSocket = maxRequestsPerSocket;
             // At (or beyond) the limit the response advertises Connection:
             // close, like Node.js - including the over-limit 503 dropRequest
             // answer, which would otherwise claim keep-alive right before the
             // socket is destroyed. Closing the socket here instead would race
             // already-pipelined requests, which still need to be dispatched so
             // they can be answered with 503 via dropRequest.
-            http_res.maxRequestsOnConnectionReached = server.maxRequestsPerSocket <= requestCount;
-            reachedRequestsLimit = server.maxRequestsPerSocket < requestCount;
+            http_res.maxRequestsOnConnectionReached = maxRequestsPerSocket <= requestCount;
+            reachedRequestsLimit = maxRequestsPerSocket < requestCount;
           }
         }
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -998,10 +998,8 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           http_req._dumpAndCloseReadable();
         }
 
-        // An accepted upgrade is handed off and a missing Host is rejected
-        // before the request is counted against maxRequestsPerSocket, so
-        // neither is ever counted or answered with the 503 dropRequest:
-        // https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js (parserOnIncoming)
+        // Like Node's parserOnIncoming (https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js):
+        // an accepted upgrade or a missing-Host rejection never counts against maxRequestsPerSocket.
         let rejectMissingHost = false;
         let reachedRequestsLimit = false;
         if (!is_upgrade) {
@@ -1012,21 +1010,14 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             http_req.httpVersionMajor === 1 &&
             http_req.httpVersionMinor >= 1
           ) {
-            // The native parser exempts Upgrade/CONNECT requests from its Host
-            // check so they can dispatch through the 'upgrade'/'connect' events;
-            // a request that fell through to normal dispatch instead must still
-            // honor requireHostHeader, like Node.js.
+            // The native parser lets Upgrade requests past its Host check so they can reach
+            // 'upgrade'; one that dispatches as a normal request still needs the header.
             rejectMissingHost = true;
           } else if (typeof maxRequestsPerSocket === "number" && maxRequestsPerSocket > 0) {
             const requestCount = (socket._requestCount || 0) + 1;
             socket._requestCount = requestCount;
             http_res._maxRequestsPerSocket = maxRequestsPerSocket;
-            // At (or beyond) the limit the response advertises Connection:
-            // close, like Node.js - including the over-limit 503 dropRequest
-            // answer, which would otherwise claim keep-alive right before the
-            // socket is destroyed. Closing the socket here instead would race
-            // already-pipelined requests, which still need to be dispatched so
-            // they can be answered with 503 via dropRequest.
+            // <= like Node: the response that uses up the limit, and every 503 after it, advertises Connection: close.
             http_res.maxRequestsOnConnectionReached = maxRequestsPerSocket <= requestCount;
             reachedRequestsLimit = maxRequestsPerSocket < requestCount;
           }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -998,8 +998,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           http_req._dumpAndCloseReadable();
         }
 
-        // Like Node's parserOnIncoming (https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js):
-        // an accepted upgrade or a missing-Host rejection never counts against maxRequestsPerSocket.
+        // Node's parserOnIncoming never counts an accepted upgrade or a missing-Host 400 against maxRequestsPerSocket.
         let rejectMissingHost = false;
         let reachedRequestsLimit = false;
         if (!is_upgrade) {
@@ -1010,8 +1009,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
             http_req.httpVersionMajor === 1 &&
             http_req.httpVersionMinor >= 1
           ) {
-            // The native parser lets Upgrade requests past its Host check so they can reach
-            // 'upgrade'; one that dispatches as a normal request still needs the header.
+            // The native parser skips its Host check for Upgrade requests; one dispatched normally still needs it.
             rejectMissingHost = true;
           } else if (typeof maxRequestsPerSocket === "number" && maxRequestsPerSocket > 0) {
             const requestCount = (socket._requestCount || 0) + 1;

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -908,25 +908,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
         let resolveFunction;
         let didFinish = false;
 
-        const isRequestsLimitSet = typeof server.maxRequestsPerSocket === "number" && server.maxRequestsPerSocket > 0;
-        let reachedRequestsLimit = false;
-        if (isRequestsLimitSet) {
-          const requestCount = (socket._requestCount || 0) + 1;
-          socket._requestCount = requestCount;
-          http_res._maxRequestsPerSocket = server.maxRequestsPerSocket;
-          // At (or beyond) the limit the response advertises Connection:
-          // close, like Node.js - including the over-limit 503 dropRequest
-          // answer, which would otherwise claim keep-alive right before the
-          // socket is destroyed. Closing the socket here instead would race
-          // already-pipelined requests, which still need to be dispatched so
-          // they can be answered with 503 via dropRequest.
-          http_res.maxRequestsOnConnectionReached = server.maxRequestsPerSocket <= requestCount;
-          if (server.maxRequestsPerSocket < requestCount) {
-            reachedRequestsLimit = true;
-          }
-        }
-
-        if (isSocketNew && !reachedRequestsLimit) {
+        if (isSocketNew) {
           server.emit("connection", socket);
         }
 
@@ -1016,6 +998,39 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           http_req._dumpAndCloseReadable();
         }
 
+        // An accepted upgrade is handed off and a missing Host is rejected
+        // before the request is counted against maxRequestsPerSocket, so
+        // neither is ever counted or answered with the 503 dropRequest:
+        // https://github.com/nodejs/node/blob/v26.3.0/lib/_http_server.js (parserOnIncoming)
+        let rejectMissingHost = false;
+        let reachedRequestsLimit = false;
+        if (!is_upgrade) {
+          if (
+            server.requireHostHeader &&
+            (dispatchBits & DISPATCH_HAS_HOST) === 0 &&
+            http_req.httpVersionMajor === 1 &&
+            http_req.httpVersionMinor >= 1
+          ) {
+            // The native parser exempts Upgrade/CONNECT requests from its Host
+            // check so they can dispatch through the 'upgrade'/'connect' events;
+            // a request that fell through to normal dispatch instead must still
+            // honor requireHostHeader, like Node.js.
+            rejectMissingHost = true;
+          } else if (typeof server.maxRequestsPerSocket === "number" && server.maxRequestsPerSocket > 0) {
+            const requestCount = (socket._requestCount || 0) + 1;
+            socket._requestCount = requestCount;
+            http_res._maxRequestsPerSocket = server.maxRequestsPerSocket;
+            // At (or beyond) the limit the response advertises Connection:
+            // close, like Node.js - including the over-limit 503 dropRequest
+            // answer, which would otherwise claim keep-alive right before the
+            // socket is destroyed. Closing the socket here instead would race
+            // already-pipelined requests, which still need to be dispatched so
+            // they can be answered with 503 via dropRequest.
+            http_res.maxRequestsOnConnectionReached = server.maxRequestsPerSocket <= requestCount;
+            reachedRequestsLimit = server.maxRequestsPerSocket < requestCount;
+          }
+        }
+
         if (reachedRequestsLimit) {
           server.emit("dropRequest", http_req, socket);
           http_res.writeHead(503);
@@ -1068,16 +1083,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
           const { promise: upgradePromise, resolve: resolveUpgrade } = $newPromiseCapability(Promise);
           socket.once("close", resolveUpgrade);
           return upgradePromise;
-        } else if (
-          server.requireHostHeader &&
-          (dispatchBits & DISPATCH_HAS_HOST) === 0 &&
-          http_req.httpVersionMajor === 1 &&
-          http_req.httpVersionMinor >= 1
-        ) {
-          // The native parser exempts Upgrade/CONNECT requests from its Host
-          // check so they can dispatch through the 'upgrade'/'connect' events;
-          // a request that fell through to normal dispatch instead must still
-          // honor requireHostHeader, like Node.js.
+        } else if (rejectMissingHost) {
           http_res.writeHead(400, { Connection: "close" });
           http_res.end();
         } else {

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,15 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  // 127.0.0.1 rather than "localhost": where the resolver prefers IPv6 the
+  // server binds ::1 while the client dials 127.0.0.1 and the connect is
+  // refused. exampleSite() already binds 127.0.0.1.
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: "127.0.0.1",
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3825,6 +3825,119 @@ it("the over-limit 503 advertises Connection: close, not keep-alive", async () =
   }
 });
 
+// A server with maxRequestsPerSocket = 1 that records which event each request
+// reached, so the request sent after the limit is used up shows where it went.
+function createServerWithOneRequestPerSocket(events: string[]): Server {
+  const server = createServer((req, res) => {
+    events.push(`request ${req.url}`);
+    res.end("served");
+  });
+  server.maxRequestsPerSocket = 1;
+  server.on("dropRequest", req => events.push(`dropRequest ${req.url}`));
+  return server;
+}
+
+// Uses up the limit with a plain request, then sends `second` on the same
+// connection once the first response has fully arrived. Resolves with the two
+// status codes as soon as both are in: whether the connection is closed
+// afterwards differs per case (and Node keeps it open after a 503).
+function statusesOfFirstThen(port: number, second: string): Promise<string[]> {
+  const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+  const socket = connect(port, "127.0.0.1", () => socket.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n"));
+  let data = "";
+  let sentSecond = false;
+  socket.setEncoding("utf8");
+  socket.on("data", chunk => {
+    data += chunk;
+    if (!sentSecond) {
+      if (data.endsWith("served")) {
+        sentSecond = true;
+        socket.write(second);
+      }
+      return;
+    }
+    // Responses are back to back ("...servedHTTP/1.1 503 ..."), so no anchors.
+    const statuses = [...data.matchAll(/HTTP\/1\.1 (\d{3})/g)].map(m => m[1]);
+    if (statuses.length === 2) {
+      socket.destroy();
+      resolve(statuses);
+    }
+  });
+  socket.on("error", reject);
+  socket.on("close", () => reject(new Error(`connection closed after receiving: ${JSON.stringify(data)}`)));
+  return promise;
+}
+
+it.concurrent("an upgrade past maxRequestsPerSocket reaches 'upgrade' instead of being dropped", async () => {
+  // Node's parserOnIncoming hands an accepted upgrade off before it counts the
+  // request or checks the limit (Node v26.3.0 answers 200 then 101 here), so
+  // 'dropRequest' and the 503 never apply to it.
+  const events: string[] = [];
+  const server = createServerWithOneRequestPerSocket(events);
+  server.on("upgrade", (req, socket) => {
+    events.push(`upgrade ${req.url}`);
+    socket.end("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n");
+  });
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const statuses = await statusesOfFirstThen(
+      port,
+      "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n",
+    );
+
+    expect({ statuses, events }).toEqual({ statuses: ["200", "101"], events: ["request /first", "upgrade /ws"] });
+  } finally {
+    server.close();
+  }
+});
+
+it.concurrent("an Upgrade request nobody accepts still counts against maxRequestsPerSocket", async () => {
+  // With no 'upgrade' listener the request falls through to normal dispatch,
+  // which Node counts and drops like any other request (200 then 503).
+  const events: string[] = [];
+  const server = createServerWithOneRequestPerSocket(events);
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const statuses = await statusesOfFirstThen(
+      port,
+      "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n",
+    );
+
+    expect({ statuses, events }).toEqual({ statuses: ["200", "503"], events: ["request /first", "dropRequest /ws"] });
+  } finally {
+    server.close();
+  }
+});
+
+it.concurrent("a declined upgrade without Host past maxRequestsPerSocket gets the 400, not the 503", async () => {
+  // Node rejects a missing Host before counting the request, so the limit is
+  // never consulted and 'dropRequest' is not emitted (200 then 400). Only
+  // Upgrade-carrying requests can reach this point without a Host header: the
+  // native parser answers every other Host-less request itself.
+  const events: string[] = [];
+  const server = createServerWithOneRequestPerSocket(events);
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
+
+    const statuses = await statusesOfFirstThen(
+      port,
+      "GET /nohost HTTP/1.1\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n",
+    );
+
+    expect({ statuses, events }).toEqual({ statuses: ["200", "400"], events: ["request /first"] });
+  } finally {
+    server.close();
+  }
+});
+
 it("a non-200 CONNECT through a proxy that holds the connection open is destroyed client-side", async () => {
   // cleanupAndPropagate deliberately defers destroy to req.onSocket for
   // status-code tunnel failures; oncreate must forward the socket so

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -3825,94 +3825,94 @@ it("the over-limit 503 advertises Connection: close, not keep-alive", async () =
   }
 });
 
-// A server with maxRequestsPerSocket = 1 that records which event each request
-// reached, so the request sent after the limit is used up shows where it went.
-function createServerWithOneRequestPerSocket(events: string[]): Server {
-  const server = createServer((req, res) => {
+const upgradeRequest = "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n";
+
+// Uses up a limit of one request with a plain request, then sends `second` on
+// the same connection once that response has fully arrived. Returns the two
+// status codes the client saw and the server events each request reached.
+// Resolves as soon as both responses are in: whether the connection is closed
+// afterwards differs per case (and Node keeps it open after a 503).
+async function pastTheLimit(
+  second: string,
+  options: { shouldUpgradeCallback?: (req: IncomingMessage) => boolean; onUpgrade?: boolean } = {},
+): Promise<{ statuses: string[]; events: string[] }> {
+  const events: string[] = [];
+  const server = createServer({ shouldUpgradeCallback: options.shouldUpgradeCallback }, (req, res) => {
     events.push(`request ${req.url}`);
     res.end("served");
   });
   server.maxRequestsPerSocket = 1;
   server.on("dropRequest", req => events.push(`dropRequest ${req.url}`));
-  return server;
-}
+  if (options.onUpgrade) {
+    server.on("upgrade", (req, socket) => {
+      events.push(`upgrade ${req.url}`);
+      socket.end("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n");
+    });
+  }
+  try {
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as AddressInfo;
 
-// Uses up the limit with a plain request, then sends `second` on the same
-// connection once the first response has fully arrived. Resolves with the two
-// status codes as soon as both are in: whether the connection is closed
-// afterwards differs per case (and Node keeps it open after a 503).
-function statusesOfFirstThen(port: number, second: string): Promise<string[]> {
-  const { promise, resolve, reject } = Promise.withResolvers<string[]>();
-  const socket = connect(port, "127.0.0.1", () => socket.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n"));
-  let data = "";
-  let sentSecond = false;
-  socket.setEncoding("utf8");
-  socket.on("data", chunk => {
-    data += chunk;
-    if (!sentSecond) {
-      if (data.endsWith("served")) {
-        sentSecond = true;
-        socket.write(second);
+    const { promise, resolve, reject } = Promise.withResolvers<string[]>();
+    const socket = connect(port, "127.0.0.1", () => socket.write("GET /first HTTP/1.1\r\nHost: x\r\n\r\n"));
+    let data = "";
+    let sentSecond = false;
+    socket.setEncoding("utf8");
+    socket.on("data", chunk => {
+      data += chunk;
+      if (!sentSecond) {
+        if (data.endsWith("served")) {
+          sentSecond = true;
+          socket.write(second);
+        }
+        return;
       }
-      return;
-    }
-    // Responses are back to back ("...servedHTTP/1.1 503 ..."), so no anchors.
-    const statuses = [...data.matchAll(/HTTP\/1\.1 (\d{3})/g)].map(m => m[1]);
-    if (statuses.length === 2) {
-      socket.destroy();
-      resolve(statuses);
-    }
-  });
-  socket.on("error", reject);
-  socket.on("close", () => reject(new Error(`connection closed after receiving: ${JSON.stringify(data)}`)));
-  return promise;
+      // Responses are back to back ("...servedHTTP/1.1 503 ..."), so no anchors.
+      const statuses = [...data.matchAll(/HTTP\/1\.1 (\d{3})/g)].map(m => m[1]);
+      if (statuses.length === 2) {
+        socket.destroy();
+        resolve(statuses);
+      }
+    });
+    socket.on("error", reject);
+    socket.on("close", () => reject(new Error(`connection closed after receiving: ${JSON.stringify(data)}`)));
+    return { statuses: await promise, events };
+  } finally {
+    server.close();
+  }
 }
 
 it.concurrent("an upgrade past maxRequestsPerSocket reaches 'upgrade' instead of being dropped", async () => {
   // Node's parserOnIncoming hands an accepted upgrade off before it counts the
   // request or checks the limit (Node v26.3.0 answers 200 then 101 here), so
   // 'dropRequest' and the 503 never apply to it.
-  const events: string[] = [];
-  const server = createServerWithOneRequestPerSocket(events);
-  server.on("upgrade", (req, socket) => {
-    events.push(`upgrade ${req.url}`);
-    socket.end("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n");
+  expect(await pastTheLimit(upgradeRequest, { onUpgrade: true })).toEqual({
+    statuses: ["200", "101"],
+    events: ["request /first", "upgrade /ws"],
   });
-  try {
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const { port } = server.address() as AddressInfo;
-
-    const statuses = await statusesOfFirstThen(
-      port,
-      "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n",
-    );
-
-    expect({ statuses, events }).toEqual({ statuses: ["200", "101"], events: ["request /first", "upgrade /ws"] });
-  } finally {
-    server.close();
-  }
 });
 
 it.concurrent("an Upgrade request nobody accepts still counts against maxRequestsPerSocket", async () => {
   // With no 'upgrade' listener the request falls through to normal dispatch,
   // which Node counts and drops like any other request (200 then 503).
-  const events: string[] = [];
-  const server = createServerWithOneRequestPerSocket(events);
-  try {
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const { port } = server.address() as AddressInfo;
+  expect(await pastTheLimit(upgradeRequest)).toEqual({
+    statuses: ["200", "503"],
+    events: ["request /first", "dropRequest /ws"],
+  });
+});
 
-    const statuses = await statusesOfFirstThen(
-      port,
-      "GET /ws HTTP/1.1\r\nHost: x\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n",
-    );
-
-    expect({ statuses, events }).toEqual({ statuses: ["200", "503"], events: ["request /first", "dropRequest /ws"] });
-  } finally {
-    server.close();
-  }
+it.concurrent("shouldUpgradeCallback decides whether the request past maxRequestsPerSocket is counted", async () => {
+  // The exemption follows the callback's verdict, not the headers or the
+  // presence of an 'upgrade' listener (Node v26.3.0: 101 and 503 respectively).
+  const [accepted, declined] = await Promise.all([
+    pastTheLimit(upgradeRequest, { shouldUpgradeCallback: () => true, onUpgrade: true }),
+    pastTheLimit(upgradeRequest, { shouldUpgradeCallback: () => false, onUpgrade: true }),
+  ]);
+  expect({ accepted, declined }).toEqual({
+    accepted: { statuses: ["200", "101"], events: ["request /first", "upgrade /ws"] },
+    declined: { statuses: ["200", "503"], events: ["request /first", "dropRequest /ws"] },
+  });
 });
 
 it.concurrent("a declined upgrade without Host past maxRequestsPerSocket gets the 400, not the 503", async () => {
@@ -3920,22 +3920,10 @@ it.concurrent("a declined upgrade without Host past maxRequestsPerSocket gets th
   // never consulted and 'dropRequest' is not emitted (200 then 400). Only
   // Upgrade-carrying requests can reach this point without a Host header: the
   // native parser answers every other Host-less request itself.
-  const events: string[] = [];
-  const server = createServerWithOneRequestPerSocket(events);
-  try {
-    server.listen(0, "127.0.0.1");
-    await once(server, "listening");
-    const { port } = server.address() as AddressInfo;
-
-    const statuses = await statusesOfFirstThen(
-      port,
-      "GET /nohost HTTP/1.1\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n",
-    );
-
-    expect({ statuses, events }).toEqual({ statuses: ["200", "400"], events: ["request /first"] });
-  } finally {
-    server.close();
-  }
+  expect(await pastTheLimit("GET /nohost HTTP/1.1\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n")).toEqual({
+    statuses: ["200", "400"],
+    events: ["request /first"],
+  });
 });
 
 it("a non-200 CONNECT through a proxy that holds the connection open is destroyed client-side", async () => {


### PR DESCRIPTION
### Problem
- With `server.maxRequestsPerSocket` set, an Upgrade request that arrives after the connection has used up its limit is answered with `'dropRequest'` and a 503, even when the server accepts upgrades. Node hands it to the `'upgrade'` listener; the limit never applies to upgrades there.
- Smaller case of the same bug: an Upgrade-carrying request with no Host header that is not accepted as an upgrade also got the 503 past the limit. Node answers it with 400 and does not count it.
- Cause: the request was counted against the limit, and the over-limit verdict fixed, before Bun had decided whether the request was an accepted upgrade or a missing-Host rejection.

### Fix
- A request is now counted only once it is known to be neither an accepted upgrade nor a missing-Host rejection. The order in which the responses are chosen (503, upgrade, 400, normal) is unchanged.
- Property to check: a request Bun will answer with 101 or 400 never increments the per-socket count, so it can never be reported as over the limit; a declined upgrade is still counted and dropped like any other request.
- A clause that skipped the `'connection'` event when the limit was already exceeded is removed. A brand-new socket has a count of 1 and the limit is at least 1, so it could never fire.
- Verification: four new tests use up a limit of 1 and send a second request on the same connection; three of them fail on main with `200, 503` and `dropRequest`, and the same scenarios run under Node v26.3.0 print the values the tests expect. The proxy test change is separate: it is pinned to 127.0.0.1 because it fails under Node too where `localhost` resolves to `::1`.

### Background
- `maxRequestsPerSocket` (node:http) caps how many requests one keep-alive connection may carry. A request past the cap gets a 503 and the server emits `'dropRequest'` instead of `'request'`.
- An Upgrade request (`Upgrade:` plus `Connection: Upgrade` headers) is handed to the server's `'upgrade'` listener, which takes over the socket and writes the 101 itself. `shouldUpgradeCallback`, a `createServer` option, decides whether it is accepted; with no listener, or a false verdict, it is dispatched as an ordinary request.
- Bun's native parser calls one JS function per request, and that function picks between the over-limit 503, the upgrade hand-off, the missing-Host 400, and normal dispatch. The whole change is inside that function.
- `requireHostHeader` makes an HTTP/1.1 request without a Host header a 400. Bun's native parser answers those itself, except for Upgrade requests, which it lets through so they can reach `'upgrade'`; those are the only Host-less requests the JS function ever sees.

<details>
<summary>Original description</summary>

### What

With `server.maxRequestsPerSocket` set, an Upgrade request that arrives after the limit has been used up is answered with `'dropRequest'` + 503 even when the server accepts upgrades (an `'upgrade'` listener is installed / `shouldUpgradeCallback` returns true). Node hands it to the `'upgrade'` listener; the limit never applies to upgrades.

### Repro

```js
const http = require("http"), net = require("net");
const events = [];
const server = http.createServer((req, res) => { events.push("request " + req.url); res.end("served"); });
server.maxRequestsPerSocket = 1;
server.on("dropRequest", req => events.push("dropRequest " + req.url));
server.on("upgrade", (req, socket) => {
  events.push("upgrade " + req.url);
  socket.end("HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: test\r\n\r\n");
});
server.listen(0, "127.0.0.1", () => {
  const c = net.connect(server.address().port, "127.0.0.1", () => c.write("GET /1 HTTP/1.1\r\nHost: a\r\n\r\n"));
  let out = "", sent = false;
  c.on("data", d => {
    out += d;
    if (!sent && out.includes("served")) { sent = true; c.write("GET /ws HTTP/1.1\r\nHost: a\r\nUpgrade: test\r\nConnection: Upgrade\r\n\r\n"); }
  });
  c.on("close", () => { console.log([...out.matchAll(/HTTP\/1\.1 (\d+)/g)].map(m => m[1]), events); server.close(); });
});
```

```
node v26.3.0:  [ '200', '101' ] [ 'request /1', 'upgrade /ws' ]
bun 1.4.0:     [ "200", "503" ] [ "request /1", "dropRequest /ws" ]
```

### Cause

In the native dispatcher (`src/js/node/_http_server.ts`, `onNodeHTTPRequest`) the request was counted against `maxRequestsPerSocket` and `reachedRequestsLimit` computed before `shouldUpgradeCallback` was even consulted, and the dispatch chain tested the limit before the upgrade branch.

Node's `parserOnIncoming` (v26.3.0) returns for an accepted upgrade, and answers a missing Host with 400, before `state.requestsCount++` and the limit check, so neither kind of request is counted or dropped. CONNECT already takes its own early return in Bun; plain Upgrade was the divergent case. A second, smaller consequence of the same ordering: an Upgrade-carrying request without a Host header that falls through to normal dispatch (the only Host-less requests that reach this code, the native parser answers the rest itself) got the 503 past the limit where Node answers 400 and does not count it.

### Fix

The accounting block moves to just before the dispatch chain and only runs for requests that are neither an accepted upgrade nor a missing-Host rejection (the fixing lines are the `if (!is_upgrade)` / `rejectMissingHost` guard around the existing counting code). The Host condition is computed once there and reused by the 400 branch, which is otherwise unchanged. The chain itself keeps its order; `reachedRequestsLimit` can no longer be true for the requests ahead of it.

The `'connection'` emit used to be skipped when `reachedRequestsLimit` was set. That clause was dead: `isSocketNew` means the socket object was created for this dispatch, so its count is 1 and the limit is at least 1. It is dropped rather than carried past the move.

`test/js/node/http/node-http-proxy.js` is pinned to 127.0.0.1 (the same two lines as in #33472, so the two merge cleanly in either order): where `localhost` resolves to `::1` that test fails under Node as well, and it was the only failure in the full-file run used to verify this change.

Related open PRs touch neighbouring code but not this: #33472 changes how the connection is closed after the over-limit 503 (the 503 branch body is untouched here), and #37749 adds the limit to the HTTP/1 fallback path, where the upgrade hand-off already returns before counting.

### Verification

Four tests in `test/js/node/http/node-http.test.ts`, next to the existing over-limit 503 test. Each uses up a limit of 1 with a plain request and then sends a second request on the same connection:

- accepted upgrade (an `'upgrade'` listener is installed) past the limit: statuses `200, 101`, events `request, upgrade` (fails on main with `200, 503` / `dropRequest`)
- Upgrade request with no `'upgrade'` listener past the limit: still `200, 503` / `dropRequest` (the declined case must stay counted; passes before and after)
- explicit `shouldUpgradeCallback`: `() => true` reaches `'upgrade'` (fails on main), `() => false` with a listener installed is still counted and dropped, so the exemption follows the callback's verdict rather than listener presence or headers
- declined upgrade without Host past the limit: `200, 400`, no `dropRequest` (fails on main with `200, 503` / `dropRequest`)

The same scenarios run under Node v26.3.0 print exactly the expected values:

```
upgrade listener:            {"statuses":["200","101"],"events":["request /first","upgrade /ws"]}
no listener:                 {"statuses":["200","503"],"events":["request /first","dropRequest /ws"]}
callback true + listener:    {"statuses":["200","101"],"events":["request /first","upgrade /ws"]}
callback false + listener:   {"statuses":["200","503"],"events":["request /first","dropRequest /ws"]}
declined, no Host:           {"statuses":["200","400"],"events":["request /first"]}
```

`node-http.test.ts` passes in full with the fix (148 pass, 1 skip); with `src/` stashed exactly the three tests marked above fail. The upstream `test-http{,s}-keep-alive-drop-requests.js`, `test-http-keep-alive-{max,pipeline-max}-requests.js`, `test-http-server-keep-alive-max-requests-null.js`, the `test-http-upgrade-*` files, and the Host header tests in `test/js/node/test/parallel` pass with the debug build.

</details>
