### PR TITLE
threading: remove ThreadPool::needs_stack_bounds and the unreachable no-JS worker setup

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -401,35 +401,6 @@ impl Source {
         Self::configure_thread();
     }
 
-    /// Like [`configure_thread`] but **skips** the JSC `StackCheck` FFI call
-    /// (`Bun__StackCheck__initialize` → `WTF::StackBounds::currentThreadStackBoundsInternal`).
-    ///
-    /// Use on pure-Rust worker threads (ThreadPool workers, HTTP client,
-    /// watchers) that never execute JavaScript. On the `bun install` cold path
-    /// the WTF/JSC `.text` pages backing those C++ symbols sit ~6 pages across
-    /// three otherwise-untouched 64 KB blocks; faulting them in from every
-    /// worker is pure overhead when no JS will ever run on that thread.
-    ///
-    /// Threads that *may* run JS (web workers, debugger, the main VM thread)
-    /// must keep using [`configure_thread`] / [`configure_named_thread`].
-    pub(crate) fn configure_thread_no_js() {
-        if SOURCE_SET.get() {
-            return;
-        }
-        debug_assert!(STDOUT_STREAM_SET.load(Ordering::Relaxed));
-        // SAFETY: STDOUT_STREAM/STDERR_STREAM are write-once before any thread calls this.
-        SOURCE.with_borrow_mut(|s| unsafe {
-            Source::init(s, STDOUT_STREAM.read(), STDERR_STREAM.read())
-        });
-        // Intentionally NOT calling `crate::StackCheck::configure_thread()`.
-    }
-
-    /// Named variant of [`configure_thread_no_js`].
-    pub fn configure_named_thread_no_js(name: &crate::ZStr) {
-        Global::set_thread_name(name);
-        Self::configure_thread_no_js();
-    }
-
     pub(crate) fn is_no_color() -> bool {
         // Parsed bool, default false. NO_COLOR=0 → false.
         env_var::NO_COLOR.get().unwrap_or(false)

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1150,12 +1150,9 @@ impl Thread {
                     bun_core::ZStr::from_raw(c"Bun Pool".as_ptr().cast(), 8)
                 }
             };
-            // This also initializes the worker's `StackCheck` bounds. Every
-            // pool runs recursive parsers that depend on them (the bundler's
-            // JS parser, the runtime transpiler on `WorkPool`, npm manifest
-            // JSON on the install pool); with the bounds left unset,
-            // `is_safe_to_recurse()` is always true and deep input overflows
-            // the worker stack instead of reporting an error.
+            // Also initializes this thread's `StackCheck` bounds. Skipping that
+            // saves nothing (`main()` already ran the same code, so it is
+            // resident) and would leave any parser a task runs here unguarded.
             Output::Source::configure_named_thread(named);
         }
 

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -180,18 +180,6 @@ impl AtomicSync {
 }
 
 pub struct ThreadPool {
-    /// When `true` (default), each worker calls
-    /// [`Output::Source::configure_named_thread`] on startup, which initializes
-    /// the WTF `StackBounds` thread-local via `Bun__StackCheck__initialize`.
-    /// Pools whose tasks never recurse through `StackCheck` (e.g. the package
-    /// manager's network/extract pool, the HTTP client) should clear this so
-    /// their workers use the `_no_js` variant and avoid faulting in the
-    /// otherwise-cold WTF/JSC `.text` pages on paths like `bun install`.
-    ///
-    /// Left as a public field (not in [`Config`]) so existing
-    /// `Config { max_threads, stack_size }` literals keep compiling; callers
-    /// flip it after [`ThreadPool::init`].
-    pub(crate) needs_stack_bounds: bool,
     pub(crate) stack_size: u32,
     pub(crate) max_threads: u32,
     sync: AtomicSync,
@@ -226,7 +214,6 @@ impl ThreadPool {
     /// Statically initialize the thread pool using the configuration.
     pub fn init(config: Config) -> ThreadPool {
         ThreadPool {
-            needs_stack_bounds: true,
             stack_size: 1.max(config.stack_size),
             max_threads: 1.max(config.max_threads),
             sync: AtomicSync::new(Sync::zero()),
@@ -1163,17 +1150,13 @@ impl Thread {
                     bun_core::ZStr::from_raw(c"Bun Pool".as_ptr().cast(), 8)
                 }
             };
-            // Pools whose tasks never consult `StackCheck` (install, HTTP) opt
-            // out via `needs_stack_bounds = false` so we don't pull in
-            // `Bun__StackCheck__initialize` → `WTF::StackBounds` and fault the
-            // JSC `.text` pages on the `bun install` cold path. Bundler/parser
-            // pools leave it `true` (the parser's recursion guard reads the
-            // WTF stack-end this initializes).
-            if thread_pool.get().needs_stack_bounds {
-                Output::Source::configure_named_thread(named);
-            } else {
-                Output::Source::configure_named_thread_no_js(named);
-            }
+            // This also initializes the worker's `StackCheck` bounds. Every
+            // pool runs recursive parsers that depend on them (the bundler's
+            // JS parser, the runtime transpiler on `WorkPool`, npm manifest
+            // JSON on the install pool); with the bounds left unset,
+            // `is_safe_to_recurse()` is always true and deep input overflows
+            // the worker stack instead of reporting an error.
+            Output::Source::configure_named_thread(named);
         }
 
         let mut self_ = Thread {

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -1150,9 +1150,7 @@ impl Thread {
                     bun_core::ZStr::from_raw(c"Bun Pool".as_ptr().cast(), 8)
                 }
             };
-            // Also initializes this thread's `StackCheck` bounds. Skipping that
-            // saves nothing (`main()` already ran the same code, so it is
-            // resident) and would leave any parser a task runs here unguarded.
+            // Also initializes `StackCheck` for this thread; parsers run by tasks rely on it.
             Output::Source::configure_named_thread(named);
         }
 

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -394,6 +394,49 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  it("should report a manifest that is nested too deeply instead of overflowing the worker stack", async () => {
+    await withContext(defaultOpts, async ctx => {
+      // Manifests are parsed on the package manager's thread pool. The parser's
+      // recursion guard reads the stack bounds that every pool worker sets up on
+      // startup; without them this document would overflow the worker's stack
+      // instead of being rejected. Deep enough to trip the guard on the largest
+      // worker stack bun uses (18 MB on Windows).
+      const depth = 400_000;
+      const nested = Buffer.alloc(depth, "[").toString() + Buffer.alloc(depth, "]").toString();
+      const urls: string[] = [];
+      setContextHandler(ctx, async request => {
+        urls.push(request.url);
+        return new Response(
+          `{"name":"bar","dist-tags":{"latest":"0.0.2"},"versions":{"0.0.2":{"name":"bar","version":"0.0.2","dist":{"tarball":"${ctx.registry_url}bar-0.0.2.tgz"},"x":${nested}}}}`,
+        );
+      });
+      await writeFile(
+        join(ctx.package_dir, "package.json"),
+        JSON.stringify({
+          name: "foo",
+          version: "0.0.1",
+          dependencies: {
+            bar: "0.0.2",
+          },
+        }),
+      );
+      const { stdout, stderr, exited } = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: ctx.package_dir,
+        stdout: "pipe",
+        stdin: "pipe",
+        stderr: "pipe",
+        env,
+      });
+      const err = await stderr.text();
+      expect(err).toContain("JSON document is too deeply nested");
+      expect(err).toContain("parsing package manifest for bar");
+      expect(await stdout.text()).toEqual(expect.stringContaining("bun install v1."));
+      expect(await exited).toBe(1);
+      expect(urls).toEqual([`${ctx.registry_url}bar`]);
+    });
+  });
+
   it("should support --registry CLI flag", async () => {
     await withContext(defaultOpts, async ctx => {
       const connected = jest.fn();

--- a/test/internal/source-lints/dead-symbols-pub-exports-sweep.test.ts
+++ b/test/internal/source-lints/dead-symbols-pub-exports-sweep.test.ts
@@ -83,11 +83,19 @@ test("dead FFI declarations (sys crates) do not reappear", () => {
   expect(resurrected).toEqual([]);
 });
 
-test("dead Rust symbols (bun_core, jsc, test_runner) do not reappear", () => {
+test("dead Rust symbols (bun_core, threading, jsc, test_runner) do not reappear", () => {
   const checks: Array<[string, RegExp]> = [
     // BuildTarget::Wasi was never constructed (BUILD_TARGET is Native or Wasm).
     ["src/bun_core/env.rs", /\bWasi\b/],
     ["src/bun_core/env.rs", /\bIS_WASI\b/],
+    // ThreadPool::needs_stack_bounds was never cleared, so the StackCheck-less
+    // worker setup it selected was unreachable. It must stay gone: every pool
+    // runs recursive parsers (bundler JS parser, runtime transpiler, npm
+    // manifest JSON on the install pool) whose recursion guards read the
+    // bounds that configure_named_thread initializes.
+    ["src/threading/ThreadPool.rs", /\bneeds_stack_bounds\b/],
+    ["src/bun_core/output.rs", /\bfn configure_thread_no_js\b/],
+    ["src/bun_core/output.rs", /\bfn configure_named_thread_no_js\b/],
     // Rust-side imports of HTTPServerAgent notify hooks that no Rust code calls.
     ["src/jsc/HTTPServerAgent.rs", /\bBun__HTTPServerAgent__notifyRequestWillBeSent\b/],
     // throw2 + its carrier trait duplicated JSGlobalObject::throw_error.

--- a/test/internal/source-lints/dead-symbols-pub-exports-sweep.test.ts
+++ b/test/internal/source-lints/dead-symbols-pub-exports-sweep.test.ts
@@ -83,19 +83,11 @@ test("dead FFI declarations (sys crates) do not reappear", () => {
   expect(resurrected).toEqual([]);
 });
 
-test("dead Rust symbols (bun_core, threading, jsc, test_runner) do not reappear", () => {
+test("dead Rust symbols (bun_core, jsc, test_runner) do not reappear", () => {
   const checks: Array<[string, RegExp]> = [
     // BuildTarget::Wasi was never constructed (BUILD_TARGET is Native or Wasm).
     ["src/bun_core/env.rs", /\bWasi\b/],
     ["src/bun_core/env.rs", /\bIS_WASI\b/],
-    // ThreadPool::needs_stack_bounds was never cleared, so the StackCheck-less
-    // worker setup it selected was unreachable. It must stay gone: every pool
-    // runs recursive parsers (bundler JS parser, runtime transpiler, npm
-    // manifest JSON on the install pool) whose recursion guards read the
-    // bounds that configure_named_thread initializes.
-    ["src/threading/ThreadPool.rs", /\bneeds_stack_bounds\b/],
-    ["src/bun_core/output.rs", /\bfn configure_thread_no_js\b/],
-    ["src/bun_core/output.rs", /\bfn configure_named_thread_no_js\b/],
     // Rust-side imports of HTTPServerAgent notify hooks that no Rust code calls.
     ["src/jsc/HTTPServerAgent.rs", /\bBun__HTTPServerAgent__notifyRequestWillBeSent\b/],
     // throw2 + its carrier trait duplicated JSGlobalObject::throw_error.


### PR DESCRIPTION
### Problem
- `ThreadPool::needs_stack_bounds` (`src/threading/ThreadPool.rs`) is set to `true` in `ThreadPool::init` and never written again; its only read is the branch in `Thread::run`. The `else` arm calling `Output::Source::configure_named_thread_no_js` is unreachable, and that helper plus `configure_thread_no_js` (`src/bun_core/output.rs`) have no other callers. It has been this way since the field was added.
- rustc cannot flag any of it: the field is read, and the helper has a statically live call site.
- The doc comments on the field and the helpers describe an opt-out that no pool uses and that would be wrong to start using (below).

### Fix
- Remove the field, the branch, and the two helpers. Workers call `configure_named_thread` unconditionally, which is the path every worker already took; there is no runtime behavior change.
- Removing rather than wiring it up, because the opt-out the comments describe buys nothing and is a trap:
  - Nothing to save: `main()` (`src/bun_bin/lib.rs`) calls `StackCheck::configure_thread()` before dispatching any command, `bun install` included, so the code the comment wanted to keep cold is already resident when the first worker starts. `Bun__StackCheck__initialize` (`src/jsc/bindings/wtf-bindings.cpp`) is a single `thread_local` store, so the per-worker cost is one stack bounds query.
  - Wrong for the pool the comment names: install pool workers parse registry manifests (`PackageManagerTask::callback` -> `npm::Registry::get_package_metadata` -> `ParsedJson::parse_npm_manifest`), and the stage 2 JSON parser's `parse_array` / `parse_object` consult `StackCheck`. On a thread that skipped the init, `StackCheck::init()` reads a null bound and the guard never fires, so a deeply nested manifest would overflow the 4 MB worker stack instead of failing with "JSON document is too deeply nested".
  - Not repairable downstream: `configure_thread_no_js` set `SOURCE_SET`, which makes the `Output::Source::configure_thread()` call at the top of `PackageManagerTask::callback` return early. Once a thread opted out, nothing later could opt it back in.
  - Of the four pools (`bundler` worker pool, bundler IO pool, install pool, `WorkPool`), only the bundler IO pool never reaches `StackCheck` (it reads the file and re-schedules the parse onto the worker pool). The opt-out would have been harmless there and still pointless, per the first point.
- Test: `test/cli/install/bun-install.test.ts`, "should report a manifest that is nested too deeply instead of overflowing the worker stack". It pins the behavior that rules the opt-out out for the install pool (the second bullet above). Since this PR removes an unreachable branch, the test also passes on `main` (and with `USE_SYSTEM_BUN=1`): it is coverage for the existing invariant, not a regression test for the removal. Per `REVIEW.md` there is no lint pinning the deleted names. What it catches: with the `StackCheck` init removed from worker setup (a local experiment, not part of the diff), `bun install` against the same registry dies with `ASSERTION FAILED: m_bound` in `WTF::StackBounds::end()` (exit 134) on the debug build, and would overflow the worker stack on a release build, so both assertions in the test fail.
- Also checked: `git grep` finds no remaining references to the three names (none existed outside the removed code, including under platform `cfg`s); `bun bd` builds; `bun bd test test/bundler/bun-build-api.test.ts -t "too deeply nested"` (the bundler pool's guard) passes; in a full local `bun-install.test.ts` run the new test passes; the 14 failures in that run are 13 tests that fetch from bitbucket/gitlab/https hosts (no network here) plus "should support --registry CLI flag", which fails the same way with `main`'s copy of the file in this environment.

### Background
- `StackCheck` (`src/bun_core/util.rs`) is the recursion guard used by the JS/JSON/TOML/YAML parsers and the printer: `StackCheck::init()` caches the current thread's stack end and `is_safe_to_recurse()` compares it with the stack pointer. The cached value comes from a per-thread `WTF::StackBounds` that `Bun__StackCheck__initialize` fills in; `Output::Source::configure_thread` calls it as part of per-thread setup, which is why every thread entry point in bun goes through `configure_thread` / `configure_named_thread`.
- `SOURCE_SET` is the thread-local flag that makes `configure_thread` idempotent: the first call on a thread sets up the stdout/stderr writers and `StackCheck`, later calls return immediately.

<details>
<summary>Deep manifest install (current behavior, unchanged by this PR)</summary>

Local registry serving a manifest whose `versions["1.0.0"].x` is 200,000 nested arrays, `cache = false`:

```
Resolving dependencies
1 | [[[[[[[[...
error: JSON document is too deeply nested
    at deep:1:22999
error: PackageFailedToParse parsing package manifest for deep
error: deep@1.0.0 failed to resolve
```

The error is the install worker's guard firing at about 23k levels on the release build (about 850 on the debug ASAN build). Output is identical before and after this change.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->