### PR TITLE
test(bake): run bundle.test.ts against fewer dev servers and assert served output

### DIFF
--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,13 +1,80 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
+//
+// Cases whose fixtures do not interact share one dev server, with one route
+// per case. Writes that are immediately followed by a reload, console message
+// or HMR chunk assertion pass `errors: null`: the dev server only sends those
+// when the rebuild had no errors, so the harness's post-write error overlay
+// poll (5 x 200ms per connected client) would only add time there.
 import { expect } from "bun:test";
-import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
+import { Dev, devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
-devTest("import identifier doesnt get renamed", {
+const buildFailedTitle = "<title>Bun - Build Failed</title>";
+
+async function expectBuildFailedPage(dev: Dev, route: string) {
+  const res = await dev.fetch(route);
+  expect(res.status).toBe(500);
+  expect(await res.text()).toContain(buildFailedTitle);
+}
+
+/** Fetches an HTML route and returns the client bundle its page links to. */
+async function servedClientBundle(dev: Dev, route: string): Promise<string> {
+  const page = await dev.fetch(route);
+  expect(page.status).toBe(200);
+  const scripts = [...(await page.text()).matchAll(/<script[^>]*\ssrc="([^"]+)"/g)].map(m => m[1]);
+  expect(scripts).toHaveLength(1);
+  const bundle = await dev.fetch(scripts[0]);
+  expect(bundle.status).toBe(200);
+  return bundle.text();
+}
+
+// A client bundle ends in a module table keyed by project-relative path. ES
+// modules are printed as `"file": [imports, exports, stars, (hmr) => {...}, flag],`
+// and CommonJS modules as the method `"file"(hmr) {...},`.
+const moduleTableEntry = /^ {2}"((?:[^"\\]|\\.)*)"(?:: \[|\()/gm;
+
+/** Project-relative paths of the modules in a client bundle, in bundle order. */
+function servedModules(bundle: string): string[] {
+  return [...bundle.matchAll(moduleTableEntry)].map(m => m[1].replaceAll("\\\\", "/"));
+}
+
+/** The module table entry printed for one file of a client bundle. */
+function servedModule(bundle: string, file: string): string {
+  const entries = [...bundle.matchAll(moduleTableEntry)];
+  const index = entries.findIndex(m => m[1].replaceAll("\\\\", "/") === file);
+  expect(index, `${file} is not in the served bundle`).not.toBe(-1);
+  const start = entries[index].index!;
+  const end = index + 1 < entries.length ? entries[index + 1].index! : bundle.indexOf("\n}, {", start);
+  expect(end).toBeGreaterThan(start);
+  return bundle.slice(start, end).replace(/^ {2}/gm, "").trimEnd();
+}
+
+/** The files of the node_modules package `pkg` among `modules`, sorted. */
+function packageFiles(modules: string[], pkg: string): string[] {
+  const prefix = `node_modules/${pkg}/`;
+  return modules
+    .filter(file => file.startsWith(prefix))
+    .map(file => file.slice(prefix.length))
+    .sort();
+}
+
+/** The files of the node_modules package `pkg` that are in the bundle currently served for `route`. */
+async function bundledPackageFiles(dev: Dev, route: string, pkg: string): Promise<string[]> {
+  return packageFiles(servedModules(await servedClientBundle(dev, route)), pkg);
+}
+
+/** Writes a file back unchanged, like `dev.writeNoChanges`, without the post-write overlay poll. */
+function touch(dev: Dev, file: string) {
+  return dev.write(file, dev.read(file), { dedent: false, errors: null });
+}
+
+devTest("server routes: import identifier is not renamed, import_<name> collision, development condition", {
   framework: minimalFramework,
   files: {
-    "db.ts": `export const abc = "123";`,
-    "routes/index.ts": `
-      import { abc } from '../db';
+    // Each route gets its own copy of `db.ts` so both routes generate the
+    // same `import_db` binding that the original single-route cases did.
+    "identifier/db.ts": `export const abc = "123";`,
+    "routes/identifier.ts": `
+      import { abc } from '../identifier/db';
       export default function (req, meta) {
         let v1 = "";
         const v2 = v1
@@ -16,25 +83,10 @@ devTest("import identifier doesnt get renamed", {
         return new Response('Hello, ' + v2 + '!');
       }
     `,
-  },
-  async test(dev) {
-    await dev.fetch("/").equals("Hello, 123!");
-    await dev.write("db.ts", `export const abc = "456";`);
-    await dev.fetch("/").equals("Hello, 456!");
-    await dev.patch("routes/index.ts", {
-      find: "Hello",
-      replace: "Bun",
-    });
-    await dev.fetch("/").equals("Bun, 456!");
-  },
-});
-devTest("symbol collision with import identifier", {
-  framework: minimalFramework,
-  files: {
-    "db.ts": `export const abc = "123";`,
-    "routes/index.ts": `
+    "collision/db.ts": `export const abc = "123";`,
+    "routes/collision.ts": `
       let import_db = 987;
-      import { abc } from '../db';
+      import { abc } from '../collision/db';
       export default function (req, meta) {
         let v1 = "";
         const v2 = v1
@@ -43,16 +95,6 @@ devTest("symbol collision with import identifier", {
         return new Response('Hello, ' + v2 + ', ' + import_db + '!');
       }
     `,
-  },
-  async test(dev) {
-    await dev.fetch("/").equals("Hello, 123, 987!");
-    await dev.write("db.ts", `export const abc = "456";`);
-    await dev.fetch("/").equals("Hello, 456, 987!");
-  },
-});
-devTest('uses "development" condition', {
-  framework: minimalFramework,
-  files: {
     "node_modules/example/package.json": JSON.stringify({
       name: "example",
       version: "1.0.0",
@@ -65,7 +107,7 @@ devTest('uses "development" condition', {
     }),
     "node_modules/example/development.js": `export default "development";`,
     "node_modules/example/production.js": `export default "production";`,
-    "routes/index.ts": `
+    "routes/condition.ts": `
       import environment from 'example';
       export default function (req, meta) {
         return new Response('Environment: ' + environment);
@@ -73,44 +115,119 @@ devTest('uses "development" condition', {
     `,
   },
   async test(dev) {
-    await dev.fetch("/").equals("Environment: development");
+    // --- import identifier doesnt get renamed ---
+    await dev.fetch("/identifier").equals("Hello, 123!");
+    await dev.write("identifier/db.ts", `export const abc = "456";`);
+    await dev.fetch("/identifier").equals("Hello, 456!");
+    await dev.patch("routes/identifier.ts", { find: "Hello", replace: "Bun" });
+    await dev.fetch("/identifier").equals("Bun, 456!");
+
+    // --- symbol collision with import identifier ---
+    await dev.fetch("/collision").equals("Hello, 123, 987!");
+    await dev.write("collision/db.ts", `export const abc = "456";`);
+    await dev.fetch("/collision").equals("Hello, 456, 987!");
+
+    // --- uses "development" condition ---
+    await dev.fetch("/condition").equals("Environment: development");
+
+    await dev.fetch("/").expect404();
   },
 });
-devTest("importing a file before it is created", {
+
+devTest("client import rules: missing file, html import, bun builtin, html import with text loader", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
+    "before-created.html": emptyHtmlFile({ scripts: ["before-created.ts"] }),
+    "before-created.ts": `
       import { abc } from './second';
       console.log('value: ' + abc);
     `,
+    "import-html.html": emptyHtmlFile({ scripts: ["import-html.ts"] }),
+    "import-html.ts": `
+      import html from "./import-html.html";
+      console.log(html);
+    `,
+    "import-bun.html": emptyHtmlFile({ scripts: ["import-bun.ts"] }),
+    "import-bun.ts": `
+      import bun from "bun";
+      console.log(bun);
+    `,
+    "text-loader.html": emptyHtmlFile({ scripts: ["text-loader.ts"] }),
+    "text-loader.ts": `
+      import html from "./app.html" with { type: "text" };
+      console.log(html);
+    `,
+    "app.html": "<div>hello world</div>",
   },
+  htmlFiles: ["before-created.html", "import-html.html", "import-bun.html", "text-loader.html"],
   async test(dev) {
-    await using c = await dev.client("/", {
-      errors: [`index.ts:1:21: error: Could not resolve: "./second"`],
-    });
+    // Each failing case ends by fixing the file. Fixing it proves the error
+    // page reloads into the working page, and leaves the shared server without
+    // bundling errors for the next case (the dev server suppresses reloads and
+    // reports every outstanding error while any remain).
 
-    await c.expectReload(async () => {
-      await dev.write("second.ts", `export const abc = "456";`);
-    });
+    // --- importing a file before it is created ---
+    await expectBuildFailedPage(dev, "/before-created");
+    {
+      await using c = await dev.client("/before-created", {
+        errors: [`before-created.ts:1:21: error: Could not resolve: "./second"`],
+      });
+      await c.expectReload(async () => {
+        await dev.write("second.ts", `export const abc = "456";`, { errors: null });
+      });
+      await c.expectMessage("value: 456");
+    }
 
-    await c.expectMessage("value: 456");
+    // --- importing html file ---
+    await expectBuildFailedPage(dev, "/import-html");
+    {
+      await using c = await dev.client("/import-html", {
+        errors: ["import-html.ts:1:18: error: Browser builds cannot import HTML files."],
+      });
+      await c.expectReload(async () => {
+        await dev.write("import-html.ts", `console.log("html import removed");`, { errors: null });
+      });
+      await c.expectMessage("html import removed");
+    }
+
+    // --- importing bun on the client ---
+    await expectBuildFailedPage(dev, "/import-bun");
+    {
+      await using c = await dev.client("/import-bun", {
+        errors: ['import-bun.ts:1:17: error: Browser build cannot import Bun builtin: "bun"'],
+      });
+      await c.expectReload(async () => {
+        await dev.write("import-bun.ts", `console.log("bun import removed");`, { errors: null });
+      });
+      await c.expectMessage("bun import removed");
+    }
+
+    // --- importing html file with text loader (#18154) ---
+    // Unlike the plain html import above, an html import with an explicit
+    // non-html loader bundles, as a text module.
+    const bundle = await servedClientBundle(dev, "/text-loader");
+    expect(servedModules(bundle)).toEqual(["text-loader.html", "text-loader.ts", "app.html"]);
+    expect(servedModule(bundle, "app.html")).toMatchInlineSnapshot(`
+      ""app.html"(hmr) {
+        hmr.cjs.exports = "<div>hello world</div>"; // bun .s_lazy_export
+      },"
+    `);
   },
 });
-devTest("default export same-scope handling", {
+
+devTest("client module forms: import.meta.main, default export scoping, commonjs forms", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
+    "import-meta-main.html": emptyHtmlFile({ scripts: ["import-meta-main.ts"] }),
+    "import-meta-main.ts": `
+      console.log(import.meta.main);
+    `,
+
+    "default-export.html": emptyHtmlFile({ scripts: ["default-export.ts"] }),
+    "default-export.ts": `
       import.meta.hot.accept();
-      await import("./fixture1.ts"); 
-      console.log((new ((await import("./fixture2.ts")).default)).a); 
-      await import("./fixture3.ts"); 
-      console.log((new ((await import("./fixture4.ts")).default)).result); 
+      await import("./fixture1.ts");
+      console.log((new ((await import("./fixture2.ts")).default)).a);
+      await import("./fixture3.ts");
+      console.log((new ((await import("./fixture4.ts")).default)).result);
       console.log((await import("./fixture5.ts")).default);
       console.log((await import("./fixture6.ts")).default);
       console.log((await import("./fixture7.ts")).default());
@@ -165,42 +282,87 @@ devTest("default export same-scope handling", {
       export default function named(flag = true) { return flag ? "TEN" : "ELEVEN" };
       console.log(named());
     `,
+
+    "commonjs.html": emptyHtmlFile({ scripts: ["commonjs.ts"] }),
+    "commonjs.ts": `
+      import cjs from "./cjs.js";
+      console.log(cjs);
+    `,
+    "cjs.js": `
+      module.exports.field = {};
+    `,
   },
   async test(dev) {
-    await using c = await dev.client("/", { storeHotChunks: true });
-    c.expectMessage(
-      //
-      "ONE",
-      "TWO",
-      "THREE",
-      "FOUR",
-      "FIVE",
-      "SIX",
-      "SEVEN",
-      "EIGHT",
-      "NINE",
-      "TEN",
-      "ELEVEN",
+    // --- import.meta.main ---
+    // There is no single entry point in the dev server, so `import.meta.main`
+    // is inlined as `false`. A file that mentions `require` is bundled as
+    // CommonJS, which must not change that.
+    const esm = await servedClientBundle(dev, "/import-meta-main");
+    expect(servedModule(esm, "import-meta-main.ts")).toMatchInlineSnapshot(`
+      ""import-meta-main.ts": [ [], [], [], (hmr) => {
+        console.log(false);
+      }, false],"
+    `);
+    await dev.write(
+      "import-meta-main.ts",
+      `
+        require;
+        console.log(import.meta.main);
+      `,
     );
+    const cjs = await servedClientBundle(dev, "/import-meta-main");
+    expect(servedModule(cjs, "import-meta-main.ts")).toMatchInlineSnapshot(`
+      ""import-meta-main.ts"(hmr) {
+        hmr.require;
+        console.log(false);
+      },"
+    `);
 
-    const filesExpectingMove = Object.entries(dev.options.files)
-      .filter(([, content]) => content.includes("MOVE"))
-      .map(([path]) => path);
-    for (const file of filesExpectingMove) {
-      await dev.writeNoChanges(file);
-      const chunk = await c.getMostRecentHmrChunk();
-      expect(chunk).toMatch(/default:\s*(function|class)\s*MOVE/);
+    // --- default export same-scope handling ---
+    {
+      await using c = await dev.client("/default-export", { storeHotChunks: true });
+      await c.expectMessage("ONE", "TWO", "THREE", "FOUR", "FIVE", "SIX", "SEVEN", "EIGHT", "NINE", "TEN", "ELEVEN");
+
+      // A named default export stays a binding of the module scope, so the
+      // HMR chunk exports the declaration itself instead of a copy of it.
+      await touch(dev, "fixture4.ts");
+      expect(await c.getMostRecentHmrChunk()).toMatch(/default:\s*class\s+MOVE\b/);
+      await touch(dev, "fixture8.ts");
+      expect(await c.getMostRecentHmrChunk()).toMatch(/default:\s*function\s+MOVE\b/);
+
+      await touch(dev, "fixture7.ts");
+      expect(await c.getMostRecentHmrChunk()).toMatch(/default:\s*function\b/);
+      // fixture7.ts does not accept updates, so the update bubbles to
+      // default-export.ts, which re-runs its own console.log calls. The
+      // fixtures' own top-level logs (ONE, THREE, SIX, TEN) are not re-run.
+      await c.expectMessage("TWO", "FOUR", "FIVE", "SEVEN", "EIGHT", "NINE", "ELEVEN");
     }
 
-    await dev.writeNoChanges("fixture7.ts");
-    const chunk = await c.getMostRecentHmrChunk();
-    expect(chunk).toMatch(/default:\s*function/);
-
-    // Since fixture7.ts is not marked as accepting, it will bubble the update
-    // to `index.ts`, re-evaluate it and some of the dependencies.
-    c.expectMessage("TWO", "FOUR", "FIVE", "SEVEN", "EIGHT", "NINE", "ELEVEN");
+    // --- commonjs forms ---
+    // Neither cjs.js nor its importer accepts updates, so every rewrite of
+    // cjs.js reloads the page, which then logs the freshly evaluated exports.
+    {
+      await using c = await dev.client("/commonjs");
+      await c.expectMessage({ field: {} });
+      const forms: [source: string, field: string][] = [
+        [`exports.field = "1";`, "1"],
+        [`let theExports = exports; theExports.field = "2";`, "2"],
+        [`let theModule = module; theModule.exports.field = "3";`, "3"],
+        [`let { exports } = module; exports.field = "4";`, "4"],
+        [`var { exports } = module; exports.field = "4.5";`, "4.5"],
+        [`let theExports = module.exports; theExports.field = "5";`, "5"],
+        [`require; eval("module.exports.field = '6'");`, "6"],
+      ];
+      for (const [source, field] of forms) {
+        await c.expectReload(async () => {
+          await dev.write("cjs.js", source, { errors: null });
+        });
+        await c.expectMessage({ field });
+      }
+    }
   },
 });
+
 devTest("directory cache bust case #17576", {
   files: {
     "web/index.html": emptyHtmlFile({
@@ -216,24 +378,25 @@ devTest("directory cache bust case #17576", {
   async test(dev) {
     await using c = await dev.client("/");
     await c.expectMessage(123);
+    // Creating a file nothing imports yet must not rebuild anything; the
+    // client exits if any websocket message arrives while this runs.
     await c.expectNoWebSocketActivity(async () => {
-      await dev.write(
-        "web/Test.ts",
-        `
-          export const abc = 456;
-        `,
-      );
+      await dev.write("web/Test.ts", `export const abc = 456;`, { errors: null });
     });
+    // The import only resolves if the directory cache entry for web/ was
+    // invalidated by the file creation above.
     await dev.write(
       "web/index.ts",
       `
         import { abc } from "./Test.ts";
         console.log(abc);
       `,
+      { errors: null },
     );
     await c.expectMessage(456);
   },
 });
+
 devTest("deleting imported file shows error then recovers", {
   skip: [
     "win32", // unlinkSync is having weird behavior
@@ -261,17 +424,20 @@ devTest("deleting imported file shows error then recovers", {
       errors: ['index.ts:1:23: error: Could not resolve: "./other"'],
     });
     await c.expectReload(async () => {
-      await dev.write(
-        "other.ts",
-        `
-          export const value = 456;
-        `,
-      );
+      await dev.write("other.ts", `export const value = 456;`, { errors: null });
     });
     await c.expectMessage(456);
+    // Deleting a file that is not part of the graph is not a rebuild; the
+    // client exits if any websocket message arrives while this runs.
     await c.expectNoWebSocketActivity(async () => {
-      await dev.delete("unrelated.ts");
+      await dev.delete("unrelated.ts", { errors: null });
     });
+    // A reload is only sent while the server has no bundling errors, so this
+    // also proves the deletion above did not register one.
+    await c.expectReload(async () => {
+      await dev.write("other.ts", `export const value = 789;`, { errors: null });
+    });
+    await c.expectMessage(789);
   },
 });
 // Regression test: DirectoryWatchStore.Dep.source_file_path borrows the key
@@ -299,13 +465,20 @@ devTest("removing 'use client' from a component with a pending resolution failur
         return new Response('page: ' + (typeof Comp.marker));
       }
     `,
+    // Only requested at the very end, to show the server is still serving.
+    "routes/alive.ts": `
+      export default function (req, meta) {
+        return new Response('alive');
+      }
+    `,
     "components/Comp.ts": `
       "use client";
       export const marker = "initial";
     `,
     // Sibling.ts keeps a second, stable client-graph Dep on the
     // components/ directory watch so the watch survives after the
-    // Comp.ts-owned Dep is cleaned up.
+    // Comp.ts-owned Dep is cleaned up. Its import is never created, so the
+    // index route fails to build for the whole test.
     "components/Sibling.ts": `
       "use client";
       import './sibling-missing';
@@ -318,7 +491,7 @@ devTest("removing 'use client' from a component with a pending resolution failur
     // and the client graph owns the key string for Comp.ts. Sibling.ts
     // fails to resolve './sibling-missing' under the browser target,
     // leaving a client-graph Dep on the components/ directory watch.
-    await dev.fetch("/");
+    await expectBuildFailedPage(dev, "/");
 
     // Re-bundle Comp.ts with a failing import while it is still a CCB.
     // With separateSSRGraph the re-parse runs under the browser target,
@@ -353,9 +526,10 @@ devTest("removing 'use client' from a component with a pending resolution failur
     // a heap-use-after-free here and the dev server aborts.
     await dev.write("components/missing.ts", `export const value = "ok";`, { errors: null });
 
-    // The server must still be alive and responding.
-    const res = await dev.fetch("/");
-    expect(res).toBeInstanceOf(Response);
+    // The server must still be alive and responding: the index route still
+    // fails because of Sibling.ts, and an untouched route still renders.
+    expect((await dev.fetch("/")).status).toBe(500);
+    await dev.fetch("/alive").equals("alive");
   },
 });
 devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
@@ -373,7 +547,7 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
   },
   async test(dev) {
     // Initial bundle: both imports fail and attach deps to the sub/ watch.
-    await dev.fetch("/");
+    await expectBuildFailedPage(dev, "/");
 
     {
       await using _ = await dev.batchChanges({ errors: null });
@@ -388,9 +562,8 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
       await dev.write("sub/a.ts", `export {};`);
     }
 
-    // The server should still respond.
-    const res = await dev.fetch("/");
-    expect(res).toBeInstanceOf(Response);
+    // The rebuilt, import-free page is served normally.
+    expect(servedModules(await servedClientBundle(dev, "/"))).toEqual(["index.html", "index.ts"]);
 
     // Test teardown sends graceful-exit, which calls DevServer.deinit.
     // Before the fix, deinit iterated every dependencies.items slot and
@@ -398,470 +571,332 @@ devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
     // AllocationScope's invalid-free panic.
   },
 });
-devTest("importing html file", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import html from "./index.html";
-      console.log(html);
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ["index.ts:1:18: error: Browser builds cannot import HTML files."],
-    });
-  },
-});
-devTest("importing html file with text loader (#18154)", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import html from "./app.html" with { type: "text" };
-      console.log(html);
-    `,
-    "app.html": "<div>hello world</div>",
-  },
-  htmlFiles: ["index.html"],
-  async test(dev) {
-    await using c = await dev.client("/", {});
-    await c.expectMessage("<div>hello world</div>");
-  },
-});
-devTest("importing bun on the client", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import bun from "bun";
-      console.log(bun);
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ['index.ts:1:17: error: Browser build cannot import Bun builtin: "bun"'],
-    });
-  },
-});
-devTest("import.meta.main", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      console.log(import.meta.main);
-      import.meta.hot.accept();
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage(false); // import.meta.main is always false because there is no single entry point
-
-    await dev.write(
-      "index.ts",
-      `
-        require;
-        console.log(import.meta.main);
-      `,
-    );
-    await c.expectMessage(false);
-  },
-});
-devTest("commonjs forms", {
-  timeoutMultiplier: 2,
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: [],
-      scripts: ["index.ts"],
-    }),
-    "index.ts": `
-      import cjs from "./cjs.js";
-      console.log(cjs);
-    `,
-    "cjs.js": `
-      module.exports.field = {};
-    `,
-  },
-  async test(dev) {
-    console.log("Initial");
-    await using c = await dev.client("/");
-    console.log("  expecting message");
-    await c.expectMessage({ field: {} });
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `exports.field = "1";`);
-      console.log("  now reloading");
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "1" });
-    console.log("Second");
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `let theExports = exports; theExports.field = "2";`);
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "2" });
-    console.log("Third");
-    console.log("  expecting reload");
-    await c.expectReload(async () => {
-      console.log("  writing");
-      await dev.write("cjs.js", `let theModule = module; theModule.exports.field = "3";`);
-    });
-    console.log("  expecting message");
-    await c.expectMessage({ field: "3" });
-    console.log("Fourth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `let { exports } = module; exports.field = "4";`);
-    });
-    await c.expectMessage({ field: "4" });
-    console.log("Fifth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `var { exports } = module; exports.field = "4.5";`);
-    });
-    await c.expectMessage({ field: "4.5" });
-    console.log("Sixth");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `let theExports = module.exports; theExports.field = "5";`);
-    });
-    await c.expectMessage({ field: "5" });
-    console.log("Seventh");
-    await c.expectReload(async () => {
-      await dev.write("cjs.js", `require; eval("module.exports.field = '6'");`);
-    });
-    await c.expectMessage({ field: "6" });
-  },
-});
 
 // --- Barrel optimization tests ---
 
-devTest("barrel optimization skips unused submodules", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { Alpha } from 'barrel-lib';
-      console.log('got: ' + Alpha);
-    `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
+/** A `sideEffects: false` package whose `main` is a re-export barrel. */
+function barrelPackage(name: string, files: Record<string, string>) {
+  const out: Record<string, string> = {
+    [`node_modules/${name}/package.json`]: JSON.stringify({
+      name,
       version: "1.0.0",
       main: "./index.js",
       sideEffects: false,
     }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
-    `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = <<<SYNTAX_ERROR>>>;`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = <<<SYNTAX_ERROR>>>;`,
-  },
-  async test(dev) {
-    // Beta.js and Gamma.js have syntax errors.
-    // If barrel optimization works, they are never parsed, so no error.
-    await using c = await dev.client("/");
-    await c.expectMessage("got: ALPHA");
-  },
-});
+  };
+  for (const [file, contents] of Object.entries(files)) {
+    out[`node_modules/${name}/${file}`] = contents;
+  }
+  return out;
+}
 
-devTest("barrel optimization: adding a new import triggers reload", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { Alpha } from 'barrel-lib';
-      console.log('result: ' + Alpha);
+interface StaticBarrelCase {
+  name: string;
+  /** The module importing from the package(s) under test; logs exactly one line. */
+  consumer: string;
+  log: string;
+  files: Record<string, string>;
+  /** Per package, exactly which of its files end up in the bundle; the rest were deferred. */
+  bundled: Record<string, string[]>;
+}
+
+// Cases that only need a page to load once. They are bundled and evaluated
+// together: one page imports every consumer, in this order.
+const staticBarrelCases: StaticBarrelCase[] = [
+  {
+    name: "barrel optimization skips unused submodules",
+    consumer: `
+      import { Alpha } from 'barrel-skip';
+      console.log('skip: ' + Alpha);
     `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
+    log: "skip: ALPHA",
+    // beta.js and gamma.js are syntax errors; the page only builds if the
+    // barrel optimization never parses them.
+    files: barrelPackage("barrel-skip", {
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = "ALPHA";`,
+      "beta.js": `export const Beta = <<<SYNTAX_ERROR>>>;`,
+      "gamma.js": `export const Gamma = <<<SYNTAX_ERROR>>>;`,
     }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
-    `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = "BETA";`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = "GAMMA";`,
+    bundled: { "barrel-skip": ["alpha.js", "index.js"] },
   },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: ALPHA");
-
-    // Add a second import from the barrel — Beta was previously deferred,
-    // now needs to be loaded. The barrel file should be re-bundled with
-    // Beta un-deferred.
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.ts",
-        `
-        import { Alpha, Beta } from 'barrel-lib';
-        console.log('result: ' + Alpha + ' ' + Beta);
-      `,
-      );
-    });
-    await c.expectMessage("result: ALPHA BETA");
-
-    // Add a third import
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.ts",
-        `
-        import { Alpha, Beta, Gamma } from 'barrel-lib';
-        console.log('result: ' + Alpha + ' ' + Beta + ' ' + Gamma);
-      `,
-      );
-    });
-    await c.expectMessage("result: ALPHA BETA GAMMA");
-  },
-});
-
-devTest("barrel optimization: multi-file imports preserved across rebuilds", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { Alpha } from 'barrel-lib';
-      import { value } from './other';
-      console.log('result: ' + Alpha + ' ' + value);
-    `,
-    "other.ts": `
-      import { Beta } from 'barrel-lib';
-      export const value = Beta;
-    `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
-    `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = "BETA";`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = "GAMMA";`,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: ALPHA BETA");
-
-    // Edit only other.ts to also import Gamma. Alpha (from index.ts) must
-    // still be available even though index.ts is not re-parsed.
-    await c.expectReload(async () => {
-      await dev.write(
-        "other.ts",
-        `
-        import { Beta, Gamma } from 'barrel-lib';
-        export const value = Beta + ' ' + Gamma;
-      `,
-      );
-    });
-    await c.expectMessage("result: ALPHA BETA GAMMA");
-  },
-});
-
-devTest("barrel optimization: export star target not deferred (#27521)", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    // The user imports from consumer-lib, which is a non-barrel package
-    // that imports QueryClient from outer-lib.
-    "index.ts": `
+  {
+    name: "barrel optimization: export star target not deferred (#27521)",
+    // consumer-lib is NOT a barrel: it has real code that uses QueryClient
+    // from outer-lib. outer-lib re-exports inner-lib via `export *`, and
+    // inner-lib is the barrel that owns queryClient.js. This mirrors
+    // @refinedev/core -> @tanstack/react-query -> @tanstack/query-core.
+    // Without the fix, the barrel optimizer deferred queryClient.js because
+    // it did not know inner-lib is an export-star target (source_index is
+    // not set in dev server mode), so QueryClient became undefined.
+    consumer: `
       import { useQuery } from 'consumer-lib';
-      console.log('result: ' + useQuery());
+      console.log('export star: ' + useQuery());
     `,
-    // consumer-lib is NOT a barrel — it has real code that uses
-    // QueryClient from outer-lib. This mirrors @refinedev/core
-    // importing QueryClient from @tanstack/react-query.
-    "node_modules/consumer-lib/package.json": JSON.stringify({
-      name: "consumer-lib",
-      version: "1.0.0",
-      main: "./index.js",
-    }),
-    "node_modules/consumer-lib/index.js": `
-      import { QueryClient } from 'outer-lib';
-      export function useQuery() {
-        const client = new QueryClient();
-        return client instanceof QueryClient ? 'PASS' : 'FAIL';
-      }
-    `,
-    // outer-lib is a barrel with sideEffects:false that re-exports
-    // everything from inner-lib via export *. Mirrors @tanstack/react-query.
-    "node_modules/outer-lib/package.json": JSON.stringify({
-      name: "outer-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/outer-lib/index.js": `
-      export * from 'inner-lib';
-      export { Unrelated } from './unrelated.js';
-    `,
-    "node_modules/outer-lib/unrelated.js": `export const Unrelated = "X";`,
-    // inner-lib is a barrel with sideEffects:false that re-exports
-    // from submodules. Mirrors @tanstack/query-core. Without the fix,
-    // the barrel optimizer defers queryClient.js because it doesn't
-    // know inner-lib is an export-star target (source_index is not
-    // set in dev-server mode), so QueryClient becomes undefined.
-    "node_modules/inner-lib/package.json": JSON.stringify({
-      name: "inner-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
-    }),
-    "node_modules/inner-lib/index.js": `
-      export { QueryClient } from './queryClient.js';
-      export { Other } from './other.js';
-    `,
-    "node_modules/inner-lib/queryClient.js": `
-      export class QueryClient { constructor() { this.ready = true; } }
-    `,
-    "node_modules/inner-lib/other.js": `export const Other = "OTHER";`,
+    log: "export star: PASS",
+    files: {
+      "node_modules/consumer-lib/package.json": JSON.stringify({
+        name: "consumer-lib",
+        version: "1.0.0",
+        main: "./index.js",
+      }),
+      "node_modules/consumer-lib/index.js": `
+        import { QueryClient } from 'outer-lib';
+        export function useQuery() {
+          const client = new QueryClient();
+          return client instanceof QueryClient ? 'PASS' : 'FAIL';
+        }
+      `,
+      ...barrelPackage("outer-lib", {
+        "index.js": `
+          export * from 'inner-lib';
+          export { Unrelated } from './unrelated.js';
+        `,
+        "unrelated.js": `export const Unrelated = "X";`,
+      }),
+      ...barrelPackage("inner-lib", {
+        "index.js": `
+          export { QueryClient } from './queryClient.js';
+          export { Other } from './other.js';
+        `,
+        "queryClient.js": `
+          export class QueryClient { constructor() { this.ready = true; } }
+        `,
+        "other.js": `export const Other = "OTHER";`,
+      }),
+    },
+    // outer-lib's own unused re-export (unrelated.js) is still deferred; the
+    // export-star target is bundled whole, since what is needed from it
+    // cannot be known from outer-lib's import records.
+    bundled: {
+      "consumer-lib": ["index.js"],
+      "outer-lib": ["index.js"],
+      "inner-lib": ["index.js", "other.js", "queryClient.js"],
+    },
   },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: PASS");
-  },
-});
+  {
+    name: "barrel optimization: two export-from blocks pointing to the same source",
+    consumer: `
+      import { invariant } from 'barrel-split';
+      console.log('split export-from: ' + typeof invariant);
+    `,
+    log: "split export-from: function",
+    files: barrelPackage("barrel-split", {
+      "index.js": `
+        export {
+          createDataProperty,
+          defineProperty,
+        } from './utils.js';
 
-devTest("barrel optimization: two export-from blocks pointing to the same source", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { invariant } from 'barrel-lib';
-      console.log('got: ' + typeof invariant);
-    `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
+        export { unrelated } from './other.js';
+
+        export {
+          invariant,
+        } from './utils.js';
+      `,
+      "utils.js": `
+        export function createDataProperty() {}
+        export function defineProperty() {}
+        export function invariant(cond, msg) {
+          if (!cond) throw new Error(msg);
+        }
+      `,
+      "other.js": `export const unrelated = "OTHER";`,
     }),
-    "node_modules/barrel-lib/index.js": `
-      export {
-        createDataProperty,
-        defineProperty,
-      } from './utils.js';
-
-      export { unrelated } from './other.js';
-
-      export {
-        invariant,
-      } from './utils.js';
-    `,
-    "node_modules/barrel-lib/utils.js": `
-      export function createDataProperty() {}
-      export function defineProperty() {}
-      export function invariant(cond, msg) {
-        if (!cond) throw new Error(msg);
-      }
-    `,
-    "node_modules/barrel-lib/other.js": `export const unrelated = "OTHER";`,
+    bundled: { "barrel-split": ["index.js", "utils.js"] },
   },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("got: function");
-  },
-});
-
-// Regression: #28886
-// Consumer has TWO separate `import { X } from 'barrel'` statements for the
-// same barrel. HMR deduplicates the second into the first; the second's
-// import record is marked is_unused=true and never gets its path resolved.
-// Barrel optimization then fails to see the named import from the dedup'd
-// record and marks its target submodule as unused → submodule stays `{}` →
-// the export is `undefined` at runtime.
-devTest("barrel optimization: two import statements from the same barrel (#28886)", {
-  // Flakes on darwin in CI (timing); fix is platform-agnostic, coverage via linux/windows/alpine.
-  skip: ["darwin"],
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
-      import { Alpha } from 'barrel-lib';
-      import { Beta } from 'barrel-lib';
-      console.log('got: ' + Alpha() + ' ' + Beta());
+  {
+    // The consumer has TWO `import { X } from 'barrel'` statements for the
+    // same barrel. HMR deduplicates the second into the first; the second's
+    // import record is marked is_unused=true and never gets its path resolved.
+    // Barrel optimization then failed to see the named import from the
+    // dedup'd record and deferred its target submodule, so the export was
+    // `undefined` at runtime.
+    name: "barrel optimization: two import statements from the same barrel (#28886)",
+    consumer: `
+      import { Alpha } from 'barrel-twice';
+      import { Beta } from 'barrel-twice';
+      console.log('two imports: ' + Alpha() + ' ' + Beta());
     `,
-    "node_modules/barrel-lib/package.json": JSON.stringify({
-      name: "barrel-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
+    log: "two imports: ALPHA BETA",
+    files: barrelPackage("barrel-twice", {
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = () => "ALPHA";`,
+      "beta.js": `export const Beta = () => "BETA";`,
+      "gamma.js": `export const Gamma = () => "GAMMA";`,
     }),
-    "node_modules/barrel-lib/index.js": `
-      export { Alpha } from './alpha.js';
-      export { Beta } from './beta.js';
-      export { Gamma } from './gamma.js';
-    `,
-    "node_modules/barrel-lib/alpha.js": `export const Alpha = () => "ALPHA";`,
-    "node_modules/barrel-lib/beta.js": `export const Beta = () => "BETA";`,
-    "node_modules/barrel-lib/gamma.js": `export const Gamma = () => "GAMMA";`,
+    bundled: { "barrel-twice": ["alpha.js", "beta.js", "index.js"] },
   },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("got: ALPHA BETA");
-  },
-});
-
-devTest("barrel optimization: namespace re-export cycle through a star-exported module", {
-  files: {
-    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
-    "index.ts": `
+  {
+    name: "barrel optimization: namespace re-export cycle through a star-exported module",
+    consumer: `
       import { x, y, deepValue } from 'loop-lib';
       import { keep } from 'loop-lib/w.js';
       import { other } from 'loop-lib/g.js';
-      console.log('result: ' + typeof x + ' ' + y + ' ' + keep + ' ' + deepValue + ' ' + other);
+      console.log('cycle: ' + typeof x + ' ' + y + ' ' + keep + ' ' + deepValue + ' ' + other);
     `,
-    "node_modules/loop-lib/package.json": JSON.stringify({
-      name: "loop-lib",
-      version: "1.0.0",
-      main: "./index.js",
-      sideEffects: false,
+    log: "cycle: object Y KEEP DEEP OTHER",
+    files: barrelPackage("loop-lib", {
+      "index.js": `
+        export * from './t.js';
+      `,
+      "t.js": `
+        export { x } from './w.js';
+        export * from './r.js';
+        export * from './g.js';
+      `,
+      "w.js": `
+        import * as ns from './t.js';
+        export { ns as x };
+        export { keep } from './keep.js';
+      `,
+      "keep.js": `
+        export const keep = "KEEP";
+      `,
+      "r.js": `
+        export const y = "Y";
+      `,
+      "g.js": `
+        export { deepValue } from './deep.js';
+        export { other } from './other.js';
+      `,
+      "deep.js": `
+        export const deepValue = "DEEP";
+      `,
+      "other.js": `
+        export const other = "OTHER";
+      `,
     }),
-    "node_modules/loop-lib/index.js": `
-      export * from './t.js';
+    bundled: { "loop-lib": ["deep.js", "g.js", "index.js", "keep.js", "other.js", "r.js", "t.js", "w.js"] },
+  },
+];
+
+devTest("barrel optimization", {
+  files: {
+    "static.html": emptyHtmlFile({ scripts: ["static.ts"] }),
+    "static.ts": staticBarrelCases.map((_, i) => `import "./static-case-${i}.ts";`).join("\n"),
+    ...Object.fromEntries(staticBarrelCases.map((c, i) => [`static-case-${i}.ts`, c.consumer])),
+    ...Object.assign({}, ...staticBarrelCases.map(c => c.files)),
+
+    // --- barrel optimization: adding a new import triggers reload ---
+    "add.html": emptyHtmlFile({ scripts: ["add.ts"] }),
+    "add.ts": `
+      import { Alpha } from 'barrel-add';
+      console.log('result: ' + Alpha);
     `,
-    "node_modules/loop-lib/t.js": `
-      export { x } from './w.js';
-      export * from './r.js';
-      export * from './g.js';
+    ...barrelPackage("barrel-add", {
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = "ALPHA";`,
+      "beta.js": `export const Beta = "BETA";`,
+      "gamma.js": `export const Gamma = "GAMMA";`,
+    }),
+
+    // --- barrel optimization: multi-file imports preserved across rebuilds ---
+    "multi.html": emptyHtmlFile({ scripts: ["multi.ts"] }),
+    "multi.ts": `
+      import { Alpha } from 'barrel-multi';
+      import { value } from './multi-other';
+      console.log('result: ' + Alpha + ' ' + value);
     `,
-    "node_modules/loop-lib/w.js": `
-      import * as ns from './t.js';
-      export { ns as x };
-      export { keep } from './keep.js';
+    "multi-other.ts": `
+      import { Beta } from 'barrel-multi';
+      export const value = Beta;
     `,
-    "node_modules/loop-lib/keep.js": `
-      export const keep = "KEEP";
-    `,
-    "node_modules/loop-lib/r.js": `
-      export const y = "Y";
-    `,
-    "node_modules/loop-lib/g.js": `
-      export { deepValue } from './deep.js';
-      export { other } from './other.js';
-    `,
-    "node_modules/loop-lib/deep.js": `
-      export const deepValue = "DEEP";
-    `,
-    "node_modules/loop-lib/other.js": `
-      export const other = "OTHER";
-    `,
+    ...barrelPackage("barrel-multi", {
+      "index.js": `
+        export { Alpha } from './alpha.js';
+        export { Beta } from './beta.js';
+        export { Gamma } from './gamma.js';
+      `,
+      "alpha.js": `export const Alpha = "ALPHA";`,
+      "beta.js": `export const Beta = "BETA";`,
+      "gamma.js": `export const Gamma = "GAMMA";`,
+    }),
   },
   async test(dev) {
-    await using c = await dev.client("/");
-    await c.expectMessage("result: object Y KEEP DEEP OTHER");
+    // --- the single-load cases in `staticBarrelCases` ---
+    {
+      await using c = await dev.client("/static");
+      await c.expectMessage(...staticBarrelCases.map(staticCase => staticCase.log));
+    }
+    const modules = servedModules(await servedClientBundle(dev, "/static"));
+    for (const { name, bundled } of staticBarrelCases) {
+      for (const [pkg, files] of Object.entries(bundled)) {
+        expect(packageFiles(modules, pkg), `${name}: files of ${pkg} in the bundle`).toEqual(files);
+      }
+    }
+
+    // --- barrel optimization: adding a new import triggers reload ---
+    {
+      await using c = await dev.client("/add");
+      await c.expectMessage("result: ALPHA");
+      expect(await bundledPackageFiles(dev, "/add", "barrel-add")).toEqual(["alpha.js", "index.js"]);
+
+      // Importing a name that was deferred so far re-bundles the barrel with
+      // that submodule un-deferred; this is a reload because nothing accepts.
+      const importNames = (names: string[]) =>
+        c.expectReload(async () => {
+          await dev.write(
+            "add.ts",
+            `
+              import { ${names.join(", ")} } from 'barrel-add';
+              console.log('result: ' + ${names.join(" + ' ' + ")});
+            `,
+            { errors: null },
+          );
+        });
+
+      await importNames(["Alpha", "Beta"]);
+      await c.expectMessage("result: ALPHA BETA");
+      expect(await bundledPackageFiles(dev, "/add", "barrel-add")).toEqual(["alpha.js", "beta.js", "index.js"]);
+
+      await importNames(["Alpha", "Beta", "Gamma"]);
+      await c.expectMessage("result: ALPHA BETA GAMMA");
+      expect(await bundledPackageFiles(dev, "/add", "barrel-add")).toEqual([
+        "alpha.js",
+        "beta.js",
+        "gamma.js",
+        "index.js",
+      ]);
+    }
+
+    // --- barrel optimization: multi-file imports preserved across rebuilds ---
+    {
+      await using c = await dev.client("/multi");
+      await c.expectMessage("result: ALPHA BETA");
+      expect(await bundledPackageFiles(dev, "/multi", "barrel-multi")).toEqual(["alpha.js", "beta.js", "index.js"]);
+
+      // Only multi-other.ts is edited. Alpha, requested by multi.ts, must
+      // survive the re-bundle even though multi.ts is not re-parsed.
+      await c.expectReload(async () => {
+        await dev.write(
+          "multi-other.ts",
+          `
+            import { Beta, Gamma } from 'barrel-multi';
+            export const value = Beta + ' ' + Gamma;
+          `,
+          { errors: null },
+        );
+      });
+      await c.expectMessage("result: ALPHA BETA GAMMA");
+      expect(await bundledPackageFiles(dev, "/multi", "barrel-multi")).toEqual([
+        "alpha.js",
+        "beta.js",
+        "gamma.js",
+        "index.js",
+      ]);
+    }
   },
 });

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -32,9 +32,9 @@ async function servedClientBundle(dev: Dev, route: string): Promise<string> {
 // and CommonJS modules as the method `"file"(hmr) {...},`.
 const moduleTableEntry = /^ {2}"((?:[^"\\]|\\.)*)"(?:: \[|\()/gm;
 
-/** Project-relative paths of the modules in a client bundle, in bundle order. */
+/** Project-relative paths of the modules in a client bundle, sorted. */
 function servedModules(bundle: string): string[] {
-  return [...bundle.matchAll(moduleTableEntry)].map(m => m[1].replaceAll("\\\\", "/"));
+  return [...bundle.matchAll(moduleTableEntry)].map(m => m[1].replaceAll("\\\\", "/")).sort();
 }
 
 /** The module table entry printed for one file of a client bundle. */
@@ -205,7 +205,7 @@ devTest("client import rules: missing file, html import, bun builtin, html impor
     // Unlike the plain html import above, an html import with an explicit
     // non-html loader bundles, as a text module.
     const bundle = await servedClientBundle(dev, "/text-loader");
-    expect(servedModules(bundle)).toEqual(["text-loader.html", "text-loader.ts", "app.html"]);
+    expect(servedModules(bundle)).toEqual(["app.html", "text-loader.html", "text-loader.ts"]);
     expect(servedModule(bundle, "app.html")).toMatchInlineSnapshot(`
       ""app.html"(hmr) {
         hmr.cjs.exports = "<div>hello world</div>"; // bun .s_lazy_export


### PR DESCRIPTION
### Problem
- `test/bake/dev/bundle.test.ts` takes 41 to 47s on every CI lane and is one of the ten slowest non-integration test files. Release, ASAN, musl and Windows all take the same time, so the time is fixed sleeps, not bundling.
- The harness polls for an error overlay (5 x 200ms) on every client connect and on every write made while a client is connected. The old file triggered that poll 32 times, about 32s of a 42s release run.
- Under debug/ASAN each dev server boot and exit costs another ~2.3s, and the file booted 21 of them (106s in total).
- The "commonjs forms" case carried a `timeoutMultiplier: 2` that only papered over these sleeps.

### Fix
- Only the test file changes. Cases whose fixtures do not interact now share one dev server, one route per case; the four cases that change global state keep their own. 21 servers become 8, 16 browser clients become 10, and no case is deleted, skipped or made todo.
- Writes that are immediately followed by a reload, console message or HMR chunk assertion pass `errors: null`, which skips the overlay poll. This is sound because the dev server only sends a reload or a hot chunk when the rebuild had no errors, so the assertion that follows already proves what the poll was checking.
- Cases that do not need a browser assert on what the server serves: the page, the bundle it links to and the exact set of bundled modules. Failing routes are asserted as the 500 "Build Failed" page, and every failing case ends by fixing its file, so the shared server never carries a failure into the next case. `expect()` calls go from 44 to 104.
- Verification: same machine and build, before vs after. Linux release 42s to ~15.5s, debug plus ASAN 106s to ~45s, Windows release 40s to 14s, every run passing. `test/expected-durations.json` is left alone because a scheduled job regenerates it from CI.

### Background
- Bake is bun's dev server. It bundles each HTML route (or `minimalFramework` server route) on demand, watches the fixture files and rebuilds on change; this file covers bundling bugs that only show up in that incremental mode.
- `devTest` (in `test/bake/bake-harness.ts`) boots one dev server per case over a set of fixture files. `dev.client()` opens a happy-dom page connected to the server's HMR socket, and `dev.write`/`dev.delete` change a fixture and wait for the rebuild. Both poll for an error overlay unless the call says which errors to expect, or passes `errors: null`.
- After a rebuild the dev server either tells connected clients to reload the affected routes or sends a hot update chunk for the rebuilt module. It only sends either when the rebuild had no errors; while any bundling failure is outstanding, reloads are suppressed and the outstanding failures are reported instead.
- A route whose bundle has errors is served as a 500 page titled "Bun - Build Failed". A working HTML route serves 200 and links one client bundle script, and that bundle ends in a module table keyed by project-relative path, which is what the new helpers parse to list exactly what was bundled.
- Barrel optimization: when a package index only re-exports other files, the dev server bundles the submodules a consumer actually uses and defers the rest, so the observable for those cases is which package files appear in the served bundle.

<details>
<summary>Original description</summary>

### What

`test/bake/dev/bundle.test.ts` was one of the ten slowest non-integration test files (47s on the alpine aarch64 lane, 41-47s on every other lane per `test/expected-durations.json`). The near-identical numbers across release, ASAN, musl and Windows lanes already say the time is fixed sleeps, not bundling. Profiling a local release run (42s for 21 tests) confirms it:

- `Client.expectErrorOverlay([])` in the harness polls 5 x 200ms whenever no overlay is visible, and the harness calls it on every `dev.client()` connect and again on every `dev.write`/`delete` while a client is connected. The file made 32 such calls (13 connects, 19 writes), about 32s of the 42s. A connect-only case takes ~1450ms, each write with a client attached adds ~1070ms, and "commonjs forms" (1 client, 7 writes) took 8.9s, which is what its `timeoutMultiplier: 2` was papering over.
- Under the debug/ASAN build each dev server boot plus graceful exit costs another ~2.3s, and the file booted 21 of them (106s total).

This PR only touches the test file. It does not change `bake-harness.ts`; the overlay poll is the remaining lever for this file and for `css.test.ts`/`hot.test.ts`, which are built on the same primitives, and is worth its own harness PR. After this change the 7 clients that connect without expecting errors still pay the connect poll (~7s of the remaining ~15s), and the last write of the `use client` case still pays the harness's 500ms "nothing was bundled" grace sleep, since that write intentionally bundles nothing and there is no client to wrap it in `expectNoWebSocketActivity`.

### Changes

- Cases whose fixtures do not interact share a dev server, one route per case: the three `minimalFramework` cases, the four client import-rule cases, the three client module-form cases, and the seven barrel cases. The five barrel cases that only load a page once are a table (`staticBarrelCases`) bundled onto one page that imports each consumer in order; one client asserts all five console lines at once. The four cases that change global state keep their own server: `mainDir` (#17576), the win32-skipped deletion case, the `separateSSRGraph` use-after-free regression (its operation sequence is unchanged), and the deinit regression. 21 servers become 8, 16 happy-dom clients become 10 (7 of them paying the connect poll, down from 13).
- Writes that are immediately followed by an `expectReload`, `expectMessage` or `getMostRecentHmrChunk` assertion pass `errors: null`. This is sound because of how the dev server behaves, not just faster: `finalize_bundle` only emits the route reload list when `bundling_failures` is empty, a hot-update chunk for a file only exists if that file rebuilt cleanly, the console messages waited for cannot be produced by a failed rebuild, and a module that throws while evaluating exits the client fixture through `console.error`. The one write where the post-write poll used to be the only assertion (deleting `unrelated.ts`) is replaced by an event-based check, see case 7 below. The header comment in the file states the convention.
- Cases that do not need a browser assert on what the dev server serves: `servedClientBundle` fetches the page and the one bundle it links to (asserting 200 on both), `servedModules` lists the module table keys, `servedModule` slices one file's entry for an inline snapshot. Failing routes are asserted as the 500 "Build Failed" page.
- The shared error server works because every failing case ends by fixing its file: that asserts the error page reloads into the working page (new coverage), and leaves no outstanding failures, which matters because the dev server suppresses reloads and reports all outstanding failures while any exist.
- `timeoutMultiplier: 2` and the `console.log` tracing in "commonjs forms" are removed (added together in #20745 when the case was slow); with `errors: null` the same 7 rewrites take ~2.3s in release. The 7 forms are now a table.
- Two `expectMessage` calls in "default export same-scope handling" were not awaited; they are now, and still pass.

### Where each original case's assertions live

| # | Original case | Now | Assertions kept | Added / changed |
|---|---|---|---|---|
| 1 | import identifier doesnt get renamed | "server routes", `/identifier` | same 3 exact bodies across the write and the patch | |
| 2 | symbol collision with import identifier | "server routes", `/collision` | same 2 exact bodies; the dependency keeps the basename `db.ts` so the route still generates `import_db` | |
| 3 | uses "development" condition | "server routes", `/condition` | same exact body | unmatched path is a 404 |
| 4 | importing a file before it is created | "client import rules", `/before-created` | same overlay error text (file renamed), reload when `second.ts` appears, `value: 456` | route is the 500 Build Failed page first |
| 5 | default export same-scope handling | "client module forms", `/default-export` | same 11 initial logs, chunk checks for both MOVE fixtures and fixture7, same 7 re-evaluation logs | the two message assertions are awaited; fixture4 must keep `class MOVE` and fixture8 `function MOVE` (was: either) |
| 6 | directory cache bust case #17576 | unchanged standalone (`mainDir`) | `123`, no websocket activity while `Test.ts` is created, `456` | writes pass `errors: null` |
| 7 | deleting imported file shows error then recovers | unchanged standalone (win32 skip kept) | `123`, overlay error on delete, reload on recreate, `456`, no websocket activity for the unrelated delete | a further edit after the unrelated delete must still reload and log `789`; reloads are only sent while no failures exist, so this proves the deletion registered none (replaces the 1s poll) |
| 8 | removing 'use client' ... pending resolution failure | unchanged standalone, same operations | the operation sequence before and including the directory-watch trigger is unchanged | `toBeInstanceOf(Response)` becomes: first request is the 500 Build Failed page, final index request is still a 500, and a new untouched `/alive` route renders `alive` |
| 9 | deinit with a free-list slot | unchanged standalone | same batch | `toBeInstanceOf(Response)` becomes: 500 Build Failed first; afterwards the page and its bundle are 200 and the bundle contains exactly `index.html`, `index.ts` |
| 10 | importing html file | "client import rules", `/import-html` | same overlay error text | 500 Build Failed via fetch; removing the import reloads into a working page |
| 11 | importing html file with text loader (#18154) | "client import rules", `/text-loader` | the import bundles (was: client logged the string) | page and bundle are 200, module list is exactly `text-loader.html, text-loader.ts, app.html`, and `app.html`'s entry is an inline snapshot of the lazy text export |
| 12 | importing bun on the client | "client import rules", `/import-bun` | same overlay error text | 500 Build Failed via fetch; removing the import reloads into a working page |
| 13 | import.meta.main | "client module forms", `/import-meta-main` | `false` before and after the `require;` edit (was: client logged it) | inline snapshots of the served module entry: an ESM entry printing `console.log(false)`, then a CommonJS entry (`hmr.require;`) still printing `console.log(false)`, which is the ESM to CJS switch the `require;` edit exists to exercise |
| 14 | commonjs forms | "client module forms", `/commonjs` | same initial `{ field: {} }`, same 7 rewrites in the same order, each must reload and log its exports | table; `timeoutMultiplier` and tracing removed |
| 15 | barrel optimization skips unused submodules | `staticBarrelCases[0]` | `ALPHA` logged (beta/gamma are syntax errors) | bundle contains exactly `alpha.js, index.js` of the package |
| 16 | barrel: adding a new import triggers reload | "barrel optimization", `/add` | same 3 logs, both edits must reload | exact package files in the served bundle after each step |
| 17 | barrel: multi-file imports preserved across rebuilds | "barrel optimization", `/multi` | same 2 logs, edit must reload | exact package files before and after |
| 18 | barrel: export star target not deferred (#27521) | `staticBarrelCases[1]` | `PASS` logged | outer-lib's own unused re-export is still deferred while the export-star target inner-lib is bundled whole (`index.js, other.js, queryClient.js`) |
| 19 | barrel: two export-from blocks, same source | `staticBarrelCases[2]` | `typeof invariant` is `function` | exactly `index.js, utils.js` bundled |
| 20 | barrel: two import statements from the same barrel (#28886) | `staticBarrelCases[3]` | `ALPHA BETA` logged | exactly `alpha.js, beta.js, index.js` bundled (gamma deferred). Its `skip: ["darwin"]` is gone: it was added together with the test in #28888 for unspecified timing flakiness, and the three identically shaped neighbours have run on darwin since, so it now runs everywhere as part of the shared page |
| 21 | barrel: namespace re-export cycle | `staticBarrelCases[4]` | same log | all 8 loop-lib files are bundled (the namespace import of `t.js` needs all of them) |

No case is deleted, skipped or made todo. The trade-off of the shared barrel page is that a regression in one static case fails the group; the failure output still names the case (the bundler error names the file, a runtime throw is printed by the client fixture, and the file-set assertion messages carry the original case names).

While strengthening case 8 I noticed that after a hot update, a route whose `"use client"` import still fails is served by running its handler (runtime 500 "Failed to load bundled module 'components/Sibling.ts'") instead of the Build Failed page; that is a dev server bug to fix separately, so the test asserts the status, which both the current and the intended behavior agree on, plus liveness through `/alive`.

### Timing (same machine, same build, before vs after)

| build | before (21 tests) | after (8 tests) |
|---|---|---|
| linux release (`USE_SYSTEM_BUN=1 bun test`) | 42.2s, 43.1s | 15.3s, 15.7s, 15.8s |
| linux debug + ASAN (`bun bd test`) | 106.4s | 44.6s, 46.8s |
| windows release (`USE_SYSTEM_BUN=1`, 1 todo on both) | 40.2s | 14.0s |

Dev server boots 21 -> 8, happy-dom clients 16 -> 10, `expect()` calls 44 -> 104 (3 of them inline snapshots). Every listed run passed; the only local failures seen were runs where dev servers failed to start at all with `EMFILE while initializing file watcher` because of the sandbox's shared inotify instance limit, which affects the old file the same way and never got as far as a test body. `test/expected-durations.json` is left alone since the scheduled job regenerates it from CI.


</details>
