### PR TITLE
test(node:fs): speed up the slow tests in fs.test.ts

### DIFF
--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5,7 +5,6 @@ import {
   gc,
   getMaxFD,
   isBroken,
-  isDebug,
   isGlibc,
   isIntelMacOS,
   isLinux,
@@ -1815,20 +1814,25 @@ describe("readSync", () => {
   const firstFourBytes = new Uint32Array(new TextEncoder().encode("File").buffer)[0];
 
   it("works on large files", () => {
-    const dest = join(tmpdir(), "readSync-large-file.txt");
-    rmSync(dest, { force: true });
+    // A position that does not fit in 32 bits. The file is a hole below it
+    // everywhere except on NTFS, which zero-fills up to the write position
+    // (4.9 GB of disk writes, ~25s in CI) unless the file is marked sparse first.
+    const position = 4_900_000_000;
+    using dir = tempDir("readSync-large-file", { "large.txt": "" });
+    const dest = join(String(dir), "large.txt");
+    if (isWindows) {
+      const { exitCode, stdout, stderr } = spawnSync({ cmd: ["fsutil", "sparse", "setflag", dest], stderr: "pipe" });
+      expect(exitCode, String(stdout) + String(stderr)).toBe(0);
+    }
 
-    const writefd = openSync(dest, "w");
-    writeSync(writefd, Buffer.from([0x10]), 0, 1, 4_900_000_000);
-    closeSync(writefd);
-
-    const fd = openSync(dest, "r");
+    const fd = openSync(dest, "r+");
+    const written = writeSync(fd, Buffer.from([0x10]), 0, 1, position);
+    const { size } = fstatSync(fd);
     const out = Buffer.alloc(1);
-    const bytes = readSync(fd, out, 0, 1, 4_900_000_000);
-    expect(bytes).toBe(1);
-    expect(out[0]).toBe(0x10);
+    const read = readSync(fd, out, 0, 1, position);
     closeSync(fd);
-    rmSync(dest, { force: true });
+
+    expect({ written, size, read, byte: out[0] }).toEqual({ written: 1, size: position + 1, read: 1, byte: 0x10 });
   });
 
   it("works with bigint on read", () => {
@@ -4166,43 +4170,56 @@ describe("fs/promises", () => {
     100000,
   );
 
+  // Order-insensitive view of a recursive listing (a Set of the relative names,
+  // or parentPath -> Set of names for Dirents), so that the listings below can
+  // be compared with a readdirSync() of the same tree without sorting each one.
+  // Sorting thousands of entries per listing is what made these tests slow.
+  function listingShape(entries: string[] | Dirent[], withFileTypes: boolean) {
+    if (!withFileTypes) return new Set(entries as string[]);
+    const byDirectory = new Map<string, Set<string>>();
+    for (const { parentPath, name } of entries as Dirent[]) {
+      let names = byDirectory.get(parentPath);
+      if (names === undefined) byDirectory.set(parentPath, (names = new Set()));
+      names.add(name);
+    }
+    return byDirectory;
+  }
+
+  // readdirSync() listing of `dir` (test/js/node: thousands of entries in a few
+  // hundred directories) that the listings below are compared against. It has to
+  // include this file, so a wrong or empty tree cannot make them pass vacuously.
+  function expectedListing(dir: string, withFileTypes: boolean) {
+    const reference = readdirSync(dir, { recursive: true, withFileTypes });
+    if (withFileTypes) {
+      expect(reference).toContainEqual(
+        expect.objectContaining({ parentPath: import.meta.dir, name: path.basename(import.meta.path) }),
+      );
+    } else {
+      expect(reference).toContain(relative(dir, import.meta.path));
+    }
+    return { length: reference.length, shape: listingShape(reference, withFileTypes) };
+  }
+
+  // Enough listings that leaking one descriptor per listing exceeds the tolerance
+  // of the fd check below. Each listing of this tree takes a few hundred ms in a
+  // debug build, so more of them mostly adds time.
+  const iterCount = 8;
+
   for (let withFileTypes of [false, true] as const) {
-    const iterCount = isDebug ? 16 : 200;
     const full = resolve(import.meta.dir, "../");
 
     const doIt = async () => {
+      const expected = expectedListing(full, withFileTypes);
+
       const maxFD = getMaxFD();
 
-      await Promise.all(
-        Array.from({ length: iterCount }, () => promises.readdir(full, { withFileTypes, recursive: true })),
+      const results = await Promise.all(
+        Array.from({ length: iterCount }, () => promises.readdir(full, { recursive: true, withFileTypes })),
       );
 
-      const pending = new Array(iterCount);
-      for (let i = 0; i < iterCount; i++) {
-        pending[i] = promises.readdir(full, { recursive: true, withFileTypes });
-      }
-
-      const results = await Promise.all(pending);
-      // Sort the results for determinism.
-      if (withFileTypes) {
-        for (let i = 0; i < iterCount; i++) {
-          results[i].sort((a, b) => a.path.localeCompare(b.path));
-        }
-      } else {
-        for (let i = 0; i < iterCount; i++) {
-          results[i].sort();
-        }
-      }
-
-      expect(results[0].length).toBeGreaterThan(0);
-      for (let i = 1; i < iterCount; i++) {
-        expect(results[i]).toEqual(results[0]);
-      }
-
-      if (!withFileTypes) {
-        expect(results[0]).toContain(relative(full, import.meta.path));
-      } else {
-        expect(results[0][0].path).toEqual(full);
+      for (const entries of results) {
+        expect(entries).toHaveLength(expected.length);
+        expect(listingShape(entries, withFileTypes)).toEqual(expected.shape);
       }
 
       const newMaxFD = getMaxFD();
@@ -4236,44 +4253,28 @@ describe("fs/promises", () => {
 
     if (withFileTypes) {
       describe("withFileTypes", () => {
-        it("readdir(path, {recursive: true} should work x 100", doIt, 10_000);
-        it("readdir(path, {recursive: true} should fail x 100", fail, 10_000);
+        it(`readdir(path, {recursive: true}) should work x ${iterCount}`, doIt, 10_000);
+        it(`readdir(path, {recursive: true}) should fail x ${iterCount}`, fail, 10_000);
       });
     } else {
-      it("readdir(path, {recursive: true} should work x 100", doIt, 10_000);
-      it("readdir(path, {recursive: true} should fail x 100", fail, 10_000);
+      it(`readdir(path, {recursive: true}) should work x ${iterCount}`, doIt, 10_000);
+      it(`readdir(path, {recursive: true}) should fail x ${iterCount}`, fail, 10_000);
     }
   }
 
   for (let withFileTypes of [false, true] as const) {
-    const warmup = 1;
-    const iterCount = isDebug ? 4 : 200;
     const full = resolve(import.meta.dir, "../");
 
-    const doIt = async () => {
-      for (let i = 0; i < warmup; i++) {
-        readdirSync(full, { withFileTypes });
-      }
+    const doIt = () => {
+      // Taken before the fd baseline so that it also serves as the warm-up.
+      const expected = expectedListing(full, withFileTypes);
 
       const maxFD = getMaxFD();
 
-      const results = new Array(iterCount);
       for (let i = 0; i < iterCount; i++) {
-        results[i] = readdirSync(full, { recursive: true, withFileTypes });
-      }
-
-      for (let i = 0; i < iterCount; i++) {
-        results[i].sort();
-      }
-      expect(results[0].length).toBeGreaterThan(0);
-      for (let i = 1; i < iterCount; i++) {
-        expect(results[i]).toEqual(results[0]);
-      }
-
-      if (!withFileTypes) {
-        expect(results[0]).toContain(relative(full, import.meta.path));
-      } else {
-        expect(results[0][0].path).toEqual(full);
+        const entries = readdirSync(full, { recursive: true, withFileTypes });
+        expect(entries).toHaveLength(expected.length);
+        expect(listingShape(entries, withFileTypes)).toEqual(expected.shape);
       }
 
       const newMaxFD = getMaxFD();
@@ -4281,9 +4282,9 @@ describe("fs/promises", () => {
     };
 
     if (withFileTypes) {
-      it("readdirSync(path, {recursive: true, withFileTypes: true} should work x 100", doIt, 10_000);
+      it(`readdirSync(path, {recursive: true, withFileTypes: true}) should work x ${iterCount}`, doIt, 10_000);
     } else {
-      it("readdirSync(path, {recursive: true} should work x 100", doIt, 10_000);
+      it(`readdirSync(path, {recursive: true}) should work x ${iterCount}`, doIt, 10_000);
     }
   }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -4174,7 +4174,7 @@ describe("fs/promises", () => {
   // or parentPath -> Set of names for Dirents), so that the listings below can
   // be compared with a readdirSync() of the same tree without sorting each one.
   // Sorting thousands of entries per listing is what made these tests slow.
-  function listingShape(entries: string[] | Dirent[], withFileTypes: boolean) {
+  function listingShape(entries: unknown[], withFileTypes: boolean) {
     if (!withFileTypes) return new Set(entries as string[]);
     const byDirectory = new Map<string, Set<string>>();
     for (const { parentPath, name } of entries as Dirent[]) {


### PR DESCRIPTION
### Problem
- `test/js/node/fs/fs.test.ts` takes 42.8s on the Windows x64 lane, 32.8s on ASAN and 8 to 11s on Linux and macOS (build 92779). Five tests account for nearly all of it; none of them fails in CI.
- `readSync > works on large files` writes one byte at offset 4.9 GB. NTFS zero-fills a non-sparse file up to the write offset, so on Windows the test writes 4.9 GB to disk: about 25s in CI, and past the default 5s timeout on a normal Windows machine (CI allows 90s per test).
- The four recursive readdir tests listed `test/js/node` (6,657 entries) 200 times each in release builds and sorted every listing; the async variant did it twice and discarded the first round. In a debug build one sort alone is about 1.8s, so under `bun bd test` the async test took 30s+ and the sync one timed out.
- The old assertions were weak: the large-file test passed if write and read truncated the position the same way, and the Dirent readdir variants only inspected the first entry's `path`.

### Fix
- On Windows the large file is marked sparse (`fsutil sparse setflag`, needs only write access) before the write, so the gap below the byte is a hole on every platform. The test now also asserts the file size is `position + 1`, which a truncation applied to both write and read cannot satisfy.
- The readdir tests take one `readdirSync` listing as the reference (asserted to contain this test file, so a wrong or empty tree cannot pass) and compare 8 listings against it by length plus an order-insensitive set of names (per parent directory for Dirents). Nothing is sorted, and every entry of every listing, async included, is checked against the sync result.
- 8 iterations still catch a leak: one leaked descriptor per listing exceeds the async fd check's `< 5` tolerance, and the sync check is exact. The discarded async warm-up round is gone; test names now carry the real count.
- Verification, same binary before and after: Windows (bun 1.4.0) whole file 30.4s to 2 to 4s, large-file test 12s to 0.006s; `bun bd` 157.5s with one timeout to 90.6s. Touched tests passed 10 runs each on Windows and Linux release, and the shape comparison rejects hand-made bad listings. Test-only, no `src/` change.

### Background
- Sparse files: on POSIX filesystems a write past the end of a file leaves a hole that occupies no disk. NTFS only does this for files carrying the sparse attribute; a normal file gets zeros physically written up to the offset.
- The large-file test guards against read/write positions being truncated to 32 bits. A truncated read lands in the hole and returns 0 instead of 0x10; a truncated write shows up as a file far smaller than `position + 1`.
- `readdir(dir, { recursive: true })` returns every entry under a tree; with `withFileTypes: true` it returns `Dirent` objects carrying `parentPath` and `name` instead of relative path strings. The order of a recursive listing is not guaranteed, which is why the old tests sorted each copy.
- These readdir tests double as fd-leak checks: the highest open descriptor is sampled before and after the listings and the difference is bounded, so the iteration count only has to make a one-descriptor-per-listing leak visible.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

`test/js/node/fs/fs.test.ts` is one of the slowest test files in the repo: 42.8s on the Windows 2019 x64 lane (Buildkite build 92779), 32.0s on Windows aarch64, 32.8s on the x64 ASAN lane, 11.5s on macOS and 8.4-8.7s on Linux. Nothing in it fails; this only makes the expensive tests cheaper and tightens what they assert. No `src/` changes, no test removed or skipped.

### Where the time went

Per-test durations (`--reporter=junit`) on main, plus the gaps between progress dots in the build 92779 job logs, rank the same five tests on every lane. Everything else in the file adds up to roughly 1.4s on Windows and well under a second on Linux.

| test | Windows x64 CI (build 92779) | Windows x64, local release build | Linux, `bun bd` (debug) |
|---|---|---|---|
| `readSync > works on large files` | ~24.8s | 11.97s / 9.04s (fails: post-hoc 5s timeout) | 0.06s (file is sparse on Linux) |
| `readdir(path, {recursive: true} should work x 100` | ~4.6s | 5.68s | 33.3s |
| `withFileTypes > readdir(path, {recursive: true} should work x 100` | ~3.9s | 5.31s | 7.3s |
| `readdirSync(path, {recursive: true} should work x 100` | ~3.4s | 2.57s | 11.96s (fails: 10s timeout) |
| `readdirSync(path, {recursive: true, withFileTypes: true} should work x 100` | ~3.2s | 2.68s | 6.2s |
| whole file | 42.8s | 30.4s / 26.7s | 157.5s |

On the ASAN lane the four readdir tests take 4.8s, 6.3s, 5.6s and 5.6s (22s of its 32.8s); on macOS they are 10.3s of 11.5s; on Linux x64 7.1s of 8.65s. CI passes the 24.8s synchronous test only because the CI runner uses a 90s per-test timeout; with the default 5s it fails on a normal Windows machine, as in the local column.

### Causes

* `works on large files` writes one byte at offset 4,900,000,000 to check that read/write positions are not truncated to 32 bits. On POSIX filesystems the gap is a hole. NTFS only creates holes in files that carry the sparse attribute; for a normal file it zero-fills everything below the write offset, so the test writes 4.9 GB to disk.
* The recursive readdir tests listed `test/js/node` (6,657 entries in 401 directories) 200 times per test in release builds (the `isDebug` counts were 16 and 4), and called `.sort()` on every listing. The async variant did this twice, once for a warm-up round whose results were discarded. In a debug build each default-comparator sort of a 6,657-string array alone takes ~1.8s, which is why the async variant took 30s+ under `bun bd test` and the sync one timed out.

### Changes

`works on large files`
* On Windows the file is marked sparse with `fsutil sparse setflag` before the write. `fsutil sparse setflag` only needs write access to the file: verified with a token that has the Administrators group set to deny-only (`runas /trustlevel:0x20000`), where `fsutil dirty query` is refused with "Access is denied" and `setflag` succeeds. The file lives in a `tempDir` and the same `"r+"` fd is used on every platform, because opening with `"w"` would supersede the file and drop the attribute.
* The assertion now also checks `fstatSync(fd).size === position + 1`. The old test passed if both `writeSync` and `readSync` truncated the position the same way (the byte would be written and read back at the same wrong offset); the size check catches that, and `byte: 0x10` still catches a read-side truncation, since a truncated read lands in the hole.

Recursive readdir tests
* One `readdirSync` listing of the tree is the reference; it is asserted to contain this test file so the comparisons cannot pass vacuously on an empty or wrong tree (previously only `results[0][0].path === full` was checked for the Dirent variants).
* `iterCount` is 8 for all six tests (previously 200 in release; 16 and 4 in debug). Leaking one descriptor per listing still exceeds the `< 5` tolerance of the async fd check, and the sync fd check is exact. The async warm-up round is gone: the fd baseline was already taken before it (#13538), so it only doubled the work.
* Every listing is compared with the reference through an order-insensitive shape (`Set` of relative names, or `parentPath -> Set` of names for Dirents) plus a length check, instead of sorting each copy and comparing copies with each other. The async tests therefore now check the async implementation against the sync one instead of against itself, and every listing is checked for being complete and duplicate-free (length plus set equality). The Dirent variants compare `parentPath` and `name` for every entry; before, `.sort()` on Dirent objects was a no-op order and only `results[0][0].path` was inspected.
* Test names now carry the real count (`x 8`; the old `x 100` ran 200 iterations). The reference listing in the sync tests also replaces the non-recursive warm-up call that preceded the fd baseline.

The three `produces the same result as Node.js` recursive tests are now the largest remaining cost (about 0.2s each, concurrent; ~1.5s on the Windows lane). That time is spawning `node` and walking the tree for the oracle, so they are left alone.

### Results

Same binary for each before/after pair. Windows: released `bun` 1.4.0 on the same Windows Server 2019 VM. Linux: the same `bun bd` build, runs back to back (the container's host was heavily loaded, so the absolute debug numbers are inflated; the ratio is what matters).

| test | Windows before | Windows after | `bun bd` before | `bun bd` after |
|---|---|---|---|---|
| `works on large files` | 11.97s / 9.04s | 0.006s | 0.06s | 0.01s |
| `readdir ... should work` (async) | 5.68s | 0.12s | 33.26s | 2.47s |
| `withFileTypes > readdir ... should work` (async) | 5.31s | 0.12s | 7.31s | 2.98s |
| `readdirSync ... should work` | 2.57s | 0.09s | 11.96s (timed out) | 2.57s |
| `readdirSync ... withFileTypes ... should work` | 2.68s | 0.11s | 6.17s | 2.91s |
| whole file | 30.4s / 26.7s (1 fail) | 2.0s / 2.1s / 3.8s | 157.5s (1 fail) | 90.6s |

With the released Linux binary the whole file goes from 13.7s to 2.5-3.4s (same pass/fail set on both sides; the failures there are tests for fixes newer than 1.4.0). What remains of the debug time is mostly the three Node comparison tests, whose own `.sort()` calls cost ~22s in a debug build.

Flakiness: the seven touched tests were run 10 times on Windows, 10 times with the Linux release binary and 6 times under `bun bd test`, and the whole file 3 times on Windows, 3 times with the Linux release binary and once under `bun bd test`; every run passed. Nothing new is marked concurrent; the only shared state is the read-only tree these tests already listed before. The shape comparison was also checked against hand-made bad listings (missing entry, extra entry, duplicate replacing another entry, wrong or relative `parentPath`), all of which it rejects.

</details>
