### PR TITLE
ipc: close the descriptor of a received net.Server handle when listen() refuses it

### DIFF
--- a/src/js/builtins/Ipc.ts
+++ b/src/js/builtins/Ipc.ts
@@ -43,9 +43,12 @@ export function serialize(message, handle, options) {
   throw $ERR_INVALID_HANDLE_TYPE();
 }
 /**
+ * Adopts the descriptor that arrived with a NODE_HANDLE message into the handle type the sender
+ * named. Owns `fd`: when nothing adopted it, it is closed here; when this throws, ipc.rs closes it.
+ *
+ * @param {unknown} target
  * @param {Serialized} serialized
- * @param {unknown} handle
- * @param {(handle: Handle) => void} emit
+ * @param {number} fd
  * @returns {void}
  */
 export function parseHandle(target, serialized, fd) {
@@ -58,6 +61,12 @@ export function parseHandle(target, serialized, fd) {
       server.listen({ fd, exclusive: true }, () => {
         emit(target, serialized.msg, server);
       });
+      if (!server._handle) {
+        // listen({ fd }) adopts synchronously; when it refused the descriptor (the error is emitted
+        // on a later tick) the descriptor is still open and nothing refers to it anymore.
+        const closeRawHandle = $newRustFunction("node_cluster_binding.rs", "clusterCloseHandle", 1);
+        closeRawHandle(fd);
+      }
       return;
     }
     case "net.Socket": {
@@ -73,8 +82,7 @@ export function parseHandle(target, serialized, fd) {
       const wrap = new UDP();
       const err = wrap.open(fd);
       if (err) {
-        // The wrap only owns the descriptor on success; don't leak it.
-        require("node:fs").closeSync(fd);
+        // The wrap only owns the descriptor on success; throwing hands it back to ipc.rs, which closes it.
         throw new Error(`failed to open received dgram handle: ${err}`);
       }
       emit(target, serialized.msg, wrap);

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -508,6 +508,87 @@ server.listen(0, '127.0.0.1', () => {
     },
   );
 
+  // A NODE_HANDLE frame tagged net.Server whose descriptor cannot listen (here: a connected TCP
+  // socket, which only a corrupted or foreign peer would send). node closes the descriptor and the
+  // listen error is uncaught; the message is never delivered.
+  test.concurrent("a net.Server handle whose descriptor is refused by listen() is closed", async () => {
+    // One frame to settle the child, then N whose descriptors are counted.
+    const N = 4;
+    using dir = tempDir("ipc-handle-server-refused", {
+      "parent.js": `
+const { fork } = require('node:child_process');
+const net = require('node:net');
+const N = ${N};
+const child = fork('child.js');
+const clients = [];
+const server = net.createServer();
+
+function finish(out) {
+  console.log(JSON.stringify(out));
+  for (const c of clients) c.destroy();
+  server.close();
+  if (child.connected) child.disconnect();
+}
+child.on('exit', code => { if (code !== 0) finish({ childExit: code }); });
+
+// serialize() tags the frame after the object's class, but the descriptor it sends is taken
+// from _handle: this produces a net.Server frame carrying a connected socket.
+function sendAsServer(i) {
+  const notAServer = Object.create(net.Server.prototype);
+  notAServer._handle = clients[i]._handle;
+  child.send({ i }, notAServer, { keepOpen: true });
+}
+
+child.on('message', m => {
+  if (m !== 'settled') return finish(m);
+  for (let i = 1; i <= N; i++) sendAsServer(i);
+});
+
+server.listen(0, '127.0.0.1', () => {
+  let connecting = N + 1;
+  for (let i = 0; i <= N; i++) {
+    const client = net.connect(server.address().port, '127.0.0.1', () => {
+      if (--connecting === 0) sendAsServer(0);
+    });
+    client.on('error', () => {});
+    clients.push(client);
+  }
+});
+`,
+      "child.js": `
+const fs = require('node:fs');
+const N = ${N};
+const openFds = () => fs.readdirSync('/dev/fd').length;
+const codes = [];
+let delivered = 0;
+let fdsAfterFirst;
+process.on('message', () => delivered++);
+process.on('uncaughtException', err => {
+  codes.push(err.code);
+  if (codes.length === 1) {
+    fdsAfterFirst = openFds();
+    process.send('settled');
+  } else if (codes.length === N + 1) {
+    process.send({ codes, delivered, leakedFds: openFds() - fdsAfterFirst });
+  }
+});
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+      out: { codes: Array(N + 1).fill("EINVAL"), delivered: 0, leakedFds: 0 },
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
   test.concurrent("a received handle that lands on fd 0 is adopted", async () => {
     using dir = tempDir("ipc-handle-fd0", {
       "parent.js": `


### PR DESCRIPTION
### Problem
- A child that receives an IPC handle tagged `net.Server` whose descriptor cannot be listened on gets an uncaught `listen EINVAL`, the message is not delivered, and one descriptor per frame stays open until exit (`leakedFds: 4` after five frames on main). Follow-up to #31829.
- Only a corrupted or foreign peer sends such a frame, though a bun parent can build one. node fails the same way but closes the descriptor.
- Cause: the receiver owns the descriptor, and nothing on the `net.Server` path closes it. A refused `listen({ fd })` leaves it open and reports the error on a later tick, and the native side only closes it when the receiver throws synchronously, which this failure never does.

### Fix
- When `listen({ fd })` returns without a handle, close the descriptor with the native close the cluster child already uses. Sound because exclusive `listen({ fd })` adopts synchronously: no handle on return means the descriptor is open and nothing refers to it. The error and the dropped message are unchanged, matching node.
- The dgram arm closed the descriptor and then threw, and the native side closes it again on a throw; the extra close is removed.
- Verification: a new test fails on main with `leakedFds: 4` and passes with the fix (debug build); the existing IPC handle and cluster tests still pass.
- Overlaps #37802 on the same lines; the changes are independent, whichever lands second needs a trivial rebase.

### Background
- `child.send(msg, handle)` sends the handle's descriptor over the IPC channel with a tag naming its type; the receiver wraps the descriptor in an object of that type before delivering the message.
- The tag comes from the object's class and the descriptor from its `_handle`, so a `net.Server` tag does not guarantee a listening socket.
- On receipt the JS side owns the descriptor: the native IPC layer closes it only if the JS side throws synchronously, otherwise the JS side must adopt or close it.
- `listen({ fd })` adopts an existing descriptor. When it cannot, it leaves the descriptor open (it may be the caller's stdio) and emits `'error'` on a later tick.
- `clusterCloseHandle` is the native close cluster children use for received descriptors; unlike `fs.closeSync` it knows the Windows encoding of these values.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process_ipc_handle.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

Follow-up to #31829. The receiver of a `NODE_HANDLE` frame tagged `net.Server` leaked the descriptor that came with it whenever `listen({ fd })` refused it: one descriptor per frame, held until exit.

### Repro

Only a corrupted or foreign IPC peer produces such a frame (bun and node tag a `net.Server` frame with a listening socket), but a bun parent can build one because `serialize()` picks the tag from the object's class and the descriptor from `_handle`:

```js
// parent: connected TCP socket sent under the net.Server tag
const notAServer = Object.create(net.Server.prototype);
notAServer._handle = client._handle;
child.send({ i }, notAServer, { keepOpen: true });

// child
process.on('uncaughtException', e => console.log(e.code, fs.readdirSync('/dev/fd').length));
```

In the child every frame is acked, `new net.Server().listen({ fd })` fails with an uncaught `listen EINVAL`, the message is not delivered, and the open descriptor count grows by one per frame. With five frames on current main (debug build of 9a543cc18): `leakedFds: 4` measured from after the first one. node v26.3.0 behaves the same except that it closes the descriptor (`setupListenHandle` closes the handle before emitting the error).

### Cause

`parseHandle()` in `src/js/builtins/Ipc.ts` owns the received descriptor. `Bun.listen({ fd })` deliberately leaves a descriptor it cannot listen on with the caller (`us_socket_group_listen_fd`: it may be the caller's stdio), and `net.Server#listen` reports the failure through an `'error'` event on a later tick, so the `net.Server` arm had no path that closed the descriptor. ipc.rs only closes it when `parseHandle()` throws synchronously, which this failure never does.

### Fix

The exclusive `listen({ fd })` adopts synchronously (`server._handle` is set when it returns), so when it is not set afterwards the descriptor is still open and unreferenced: close it with the same `clusterCloseHandle` the cluster child uses for the raw descriptors it receives (it knows the Windows encoding of these values, unlike `fs.closeSync`). The error event and the undelivered message are unchanged, matching node.

The `dgram.Native` arm closed the descriptor itself and then threw, and ipc.rs closes it again on a throw; the extra close is removed and the ownership rule is documented on `parseHandle()`.

Looked at but not changed: the `dgram.Socket` arm throws synchronously on anything `guessHandleType` does not report as UDP (so ipc.rs closes it), and the `net.Socket` arm hands the descriptor to the native adoption in `Bun.connect({ fd })`, which is a separate path.

### Verification

`test/js/node/child_process/child_process_ipc_handle.test.ts`, "a net.Server handle whose descriptor is refused by listen() is closed": fails on main with `leakedFds: 4` (expected 0) and passes with the fix. The rest of that file, `spawn.ipc.test.ts`, and the vendored `test-child-process-fork-net-server`, `fork-net-socket`, `send-keep-open`, `test-cluster-net-send`, `test-cluster-dgram-{1,2,bind-fd,reuse}`, `test-cluster-shared-handle-bind-error`, `test-cluster-send-socket-to-worker-http-server`, `test-cluster-send-deadlock`, `test-cluster-rr-handle-close` and `test-cluster-shared-leak` pass with the debug build.

Touches the same lines of the `net.Server` arm as #37802; whichever lands second needs a trivial rebase, the two changes are independent.

</details>
