### PR TITLE
test(http2): measure the HPACK overhead instead of sweeping it in the DATA header cork straddle test

### DIFF
--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3442,36 +3442,39 @@ describe.concurrent(
 
     // HEADERS sized so the cork sits within 8 bytes of full: the 9-byte DATA frame header is
     // what straddles, so the Duplex runs before the payload itself is written at all. The
-    // header value uses a character HPACK will not huffman-encode, so the block length tracks
-    // N byte for byte; the sweep keeps the case on target if the fixed overhead ever shifts.
+    // header value uses a character HPACK will not huffman-encode, so the HEADERS frame corks
+    // the pad length plus a fixed overhead: a probe request measures that overhead and the second
+    // request pads to leave exactly 4 bytes of cork, whatever the overhead is. (Each request is a
+    // fresh session plus a full GC, which adds up quickly on a debug build, hence two requests
+    // rather than a sweep of pad lengths.)
     it("DATA frame header straddling the cork flush", async () => {
       const result = await run(/* js */ `
-      const results = [];
-      for (let n = 16344; n <= 16352; n++) {
+      async function post(padLength) {
         const holder = { src: payload(8000, false) };
         const snap = Buffer.from(holder.src);
         let armed = false, fired = 0;
         const duplex = wireDuplex(() => { if (armed && !fired++) yank(holder, "transfer"); });
         const session = await connect(duplex);
         const req = session.request(
-          { ":method": "POST", ":path": "/", "x-pad": Buffer.alloc(n, "\\\\").toString() },
+          { ":method": "POST", ":path": "/", "x-pad": Buffer.alloc(padLength, "\\\\").toString() },
           { endStream: false },
         );
         req.on("error", die("stream error"));
         armed = true;
         req.write(holder.src);
         await duplex.dataSeen(8000);
-        const corkOffset = 9 + duplex.headersLen();
-        results.push({ inWindow: corkOffset >= 16376 && corkOffset <= 16383, fired: fired > 0, foreign: foreign(duplex.data(), snap) });
+        return { corked: 9 + duplex.headersLen(), fired: fired > 0, foreign: foreign(duplex.data(), snap) };
       }
+      const probe = await post(15000);
+      const straddle = await post(15000 + (16380 - probe.corked));
       console.log(JSON.stringify({
-        hitWindow: results.some(r => r.inWindow),
-        allFired: results.every(r => r.fired),
-        foreign: results.reduce((a, r) => a + r.foreign, 0),
+        corked: straddle.corked,
+        fired: [probe.fired, straddle.fired],
+        foreign: [probe.foreign, straddle.foreign],
       }));
       process.exit(0);
     `);
-      expect(result).toEqual({ hitWindow: true, allFired: true, foreign: 0 });
+      expect(result).toEqual({ corked: 16380, fired: [true, true], foreign: [0, 0] });
     });
 
     // A write larger than the peer's window: the in-window part is batched and flushed (running


### PR DESCRIPTION
### Problem
- "DATA frame header straddling the cork flush" in `test/js/node/http2/node-http2.test.js` takes 3.7 to 5 s on a debug build and intermittently fails with `this test timed out after 5000ms`. Only local `bun bd test` sees it; CI passes a larger `--timeout`.
- The case needs a HEADERS frame that leaves 1..8 bytes of cork so the 9-byte DATA frame header straddles the flush. To land there it swept nine pad lengths, each a fresh session plus a full `Bun.gc(true)`.
- About 2.2 s of the case is debug-build startup, which every case in the block pays. The sweep added about 1.2 s on top, which is what made this case the slowest.

### Fix
- A probe request measures the HEADERS overhead, then a second request is padded to leave exactly 4 bytes of cork. The test asserts the exact landing (`corked: 16380`) plus the existing oracles.
- This holds because the pad character is one HPACK does not huffman-encode, so corked bytes are always pad length plus a constant. Measuring it survives any shift of the overhead; the sweep only tolerated 8 bytes.
- What is exercised is unchanged: same payload, same yank from the transport's `_write`, and a HEADERS frame leaving fewer than 9 bytes of cork (one landing instead of eight).
- Verification is timing, since only a test changes: standalone debug runs went from 3689 / 3661 / 3712 ms to 2684 / 2795 / 3694 ms. The file passes on debug, the case on release, and with the overhead artificially shifted by -1000 to +500 bytes it still lands on 16380.

### Background
- Cork: the http2 session batches outgoing bytes into a buffer (16384 bytes here) and flushes it when full. "Corked" is how many bytes HEADERS left in it; a frame that crosses the flush "straddles" it.
- Why the DATA frame header: every DATA frame starts with a 9-byte header. When that header itself crosses the flush, the transport's `_write` runs before any payload byte is written, which needs HEADERS to leave the buffer within 8 bytes of full.
- HPACK: HTTP/2 header compression. It may huffman-encode a value, which would break the byte-for-byte link between pad length and wire bytes, so the pad uses a character HPACK sends literally.
- Oracles: `fired` records that the transport JS ran during the write; `foreign` counts wire bytes not from the payload snapshot. Both are unchanged.

<details>
<summary>Original description</summary>

### What

`test/js/node/http2/node-http2.test.js`, "DATA frame header straddling the cork flush" (added in #36910) takes 3.7-5 s under a debug build and intermittently fails with `this test timed out after 5000ms` when its `describe.concurrent` block runs:

```console
$ bun bd test test/js/node/http2/node-http2.test.js -t "http2 DATA payload survives"
(pass) ... > single DATA frame straddling the cork flush (resize0) [3066.95ms]
(pass) ... > another session's transport JS running on cork handover [3230.29ms]
(pass) ... > flow-control-limited tail queued after a flush [3913.13ms]
(fail) ... > DATA frame header straddling the cork flush [5000.21ms]
  ^ this test timed out after 5000ms.
(pass) ... > TLSSocket over a JS Duplex against a real server (tail) [4099.89ms]
```

Run on its own it measured 3.66-3.71 s (once 4.8 s) here, and 4.35-5.0 s on the machine it was reported from. It only matters for the default per-test timeout, i.e. local `bun bd test` runs; CI passes a much larger `--timeout`.

### Cause

The case wants the HEADERS frame to leave 1..8 bytes of cork so that the 9-byte DATA frame header is what straddles the flush. To stay on target if the fixed HPACK overhead ever shifted, it swept nine pad lengths (16344..16352), opening a fresh session and doing a full `Bun.gc(true)` plus heap spray for each. Timing the subprocess under the debug build: about 2.2 s is starting bun and `require("node:http2")` (the same floor every case in the block pays), and the sweep adds about 1.2 s on top, which is what set this case apart from its siblings.

### Fix

The pad is a character HPACK does not huffman-encode, so the HEADERS frame corks the pad length plus a constant (31 bytes today). The test now makes one probe request to measure that constant and a second request padded to leave exactly 4 bytes of cork, and asserts the exact landing (`corked: 16380`) along with the existing oracles (the transport JS ran during both writes, no foreign bytes on the wire) instead of "some iteration landed in the window". Two sessions instead of nine, and it stays on target for any shift of the overhead rather than one of up to 8 bytes; running the child with the overhead artificially shifted by -1000, -20, +20 and +500 bytes still lands on 16380.

What the case exercises is unchanged: the same payload, the same yank from the transport's `_write`, and a HEADERS frame that leaves fewer than 9 bytes of cork (previously eight of the nine iterations did, at 16376..16383 corked bytes; now one does, at 16380). The probe request itself is the same shape as the "single DATA frame straddling" case above it.

### Verification

Debug build, this machine (16 vCPU container, 12 CPU quota), interleaved runs of the case on its own: before 3689 / 3661 / 3712 ms, after 2684 / 2795 / 3694 ms (the untouched siblings show the same run-to-run spread). In the concurrent block it now runs in 2.6 s, in line with the cheapest cases, where before it was the slowest. The whole file passes with the debug build (357 pass, 6 skip), and the case still passes with a release build (41 ms).

The remaining cases in the block are at their floor (one scenario each on top of the ~2.2 s debug startup; the TLS ones measure ~3.2 s standalone and 3.3-4.4 s in the block here, and in one of two full-file debug runs the TLS "straddle" case hit the 5 s timeout as well), so this leaves them alone rather than raising their timeouts; there is no workload to shrink in them.

</details>
