### PR TITLE
bake: process the first hot-reload event of a batch once

### DIFF
--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -662,11 +662,6 @@ impl HotReloadEvent {
 
         let mut entry_points = EntryPointList::default();
 
-        // SAFETY: `first` is live; `&mut *dev` re-borrowed for the call only.
-        // `process_file_list` mutates graph/watcher/transpiler fields of `dev`,
-        // all disjoint from `dev.watcher_atomics.events[_]` (where `first` lives).
-        unsafe { (*first).process_file_list(&mut *dev, &mut entry_points) };
-
         // SAFETY: `first` is live; `timer` was set by
         // `WatcherAtomics::watcher_acquire_event` before submission.
         let timer = unsafe { (*first).timer };
@@ -677,8 +672,10 @@ impl HotReloadEvent {
         let mut current: *mut HotReloadEvent = first;
         loop {
             // SAFETY: `current` always points at a live event owned by
-            // `dev.watcher_atomics`; `&mut *dev` re-borrowed for the call only,
-            // disjoint per the note above.
+            // `dev.watcher_atomics`; `&mut *dev` re-borrowed for the call only.
+            // `process_file_list` mutates graph/watcher/transpiler fields of
+            // `dev`, all disjoint from `dev.watcher_atomics.events[_]` (where
+            // `current` lives).
             unsafe { (*current).process_file_list(&mut *dev, &mut entry_points) };
             // SAFETY: `dev` is valid; recycle traffics in raw `*mut HotReloadEvent`.
             match unsafe {

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -279,6 +279,49 @@ export class Dev extends EventEmitter {
     });
   }
 
+  /**
+   * Runs `change` and returns the watch synchronization messages the dev
+   * server published while handling it, by name and in order. `change` must
+   * make the watcher report something (the project directory is watched once
+   * a route has been bundled), and the dev server publishes one `SeenFiles`
+   * per hot-reload event it processes that invalidates nothing.
+   *
+   * Once the first message arrives, batch mode is toggled on: the dev server
+   * acknowledges that on the same topic, and the acknowledgement is ordered
+   * after everything it published while processing `change`, so when it
+   * arrives the list is complete. Batch mode is toggled off again before
+   * returning.
+   */
+  async watchSynchronizationMessagesFor(change: () => void | Promise<void>): Promise<string[]> {
+    assert(this.batchingChanges === null, "watchSynchronizationMessagesFor cannot be used inside batchChanges");
+    const messages: WatchSynchronization[] = [];
+    const firstMessage = Promise.withResolvers<void>();
+    const batchStarted = Promise.withResolvers<void>();
+    function onEvent(kind: WatchSynchronization) {
+      if (kind === WatchSynchronization.Started) {
+        batchStarted.resolve();
+        return;
+      }
+      messages.push(kind);
+      firstMessage.resolve();
+    }
+    this.on("watch_synchronization", onEvent);
+    try {
+      await change();
+      await firstMessage.promise;
+      this.socket!.send("H");
+      await batchStarted.promise;
+    } finally {
+      this.off("watch_synchronization", onEvent);
+    }
+    // Leaving batch mode is answered with ResultDidNotBundle (nothing was
+    // batched) or, if `change` did invalidate something, with a build.
+    const batchEnded = this.waitForHotReload(false);
+    this.socket!.send("H");
+    await batchEnded;
+    return messages.map(kind => WatchSynchronization[kind]);
+  }
+
   async batchChanges(options: { errors?: null | ErrorSpec[]; snapshot?: string } = {}) {
     if (this.batchingChanges) {
       this.batchingChanges.write?.();

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,6 +1,6 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
 import { expect } from "bun:test";
-import { renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { mkdirSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { devTest, emptyHtmlFile } from "../bake-harness";
 
 devTest("import.meta.hot.accept basic", {
@@ -525,6 +525,31 @@ devTest("hmr forwards every merged inotify sub-path from a directory batch", {
       }
       await c.expectMessage(`atomic ${round}`);
     }
+  },
+});
+devTest("a hot-reload event that invalidates nothing is processed once", {
+  files: {
+    "index.html": emptyHtmlFile({
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      console.log("hello");
+    `,
+  },
+  async test(dev) {
+    // Bundling the route puts the project directory on the watch list. Wait
+    // for the build's own synchronization message so it is not recorded below.
+    const built = dev.waitForHotReload(false);
+    await dev.fetch("/");
+    await built;
+
+    // mkdir is a single notification from every platform's watcher, so the
+    // dev server receives exactly one hot-reload event for it. Nothing imports
+    // the directory, so the event invalidates nothing and is reported with one
+    // SeenFiles. The first event of a batch used to be processed (and
+    // reported) twice.
+    const messages = await dev.watchSynchronizationMessagesFor(() => mkdirSync(dev.join("unrelated")));
+    expect(messages).toEqual(["SeenFiles"]);
   },
 });
 devTest("hot update frames are not delivered to application websocket topics", {


### PR DESCRIPTION
### Problem
- Each watcher wake-up ran the dev server's first hot-reload event twice: once before the loop over the batch, then again as the loop's first iteration.
- Bundles were unaffected, since invalidation is idempotent. But a change that invalidates nothing was reported to the HMR socket as two `SeenFiles` frames instead of one, and debug builds logged `debug warn: nothing to bundle` twice.
- The extra call dates from #21328, which introduced the loop at two call sites but only removed the pre-loop call at one. The other site (bundle already in flight) has only the loop.

### Fix
- Delete the call before the loop. The loop starts at the first event, so every event in a batch is processed exactly once, matching the in-flight path.
- Verification: a new test bundles a route, creates an unrelated directory, and asserts exactly one `SeenFiles`. Fails 15/15 runs without the Rust change, passes 10/10 with it (debug and ASAN).

### Background
- Bake is bun's dev server for HTML routes. Once a route is bundled it watches the project directory and pushes hot reloads over a websocket.
- A hot-reload event is one watcher wake-up's worth of changed paths. Events arriving while one is handled are chained behind it and drained by a loop.
- Handling an event marks its paths stale in the bundle graphs. If nothing became stale, the dev server publishes a `SeenFiles` watch-synchronization frame instead of a bundle; tests use it to see that an event was handled.
- `mkdir` is a single notification on inotify, kqueue and Windows, so it produces exactly one event; a file write can produce several.

<details>
<summary>Original description</summary>

### What

`HotReloadEvent::run` (`src/runtime/bake/dev_server/mod.rs`) processed the first event of every watcher wake-up twice: once before the loop, and again as the loop's first iteration, which starts at `current = first` and only resets the event in `recycle_event_from_dev_server` afterwards. Each wake-up therefore ran the directory handling (resolver dir cache bust, `DirectoryWatchStore` re-resolution), re-added `extra_files`, and called `server_graph.invalidate` / `client_graph.invalidate` a second time for the same paths. The graph side of that is idempotent (`stale_files` is a bitset, `EntryPointList::append` deduplicates), so bundles were unaffected, but the "nothing to bundle" branch of `process_file_list` publishes a `TestingWatchSynchronization` `SeenFiles` frame, so a change that invalidates nothing was reported to the HMR socket twice per event (and logged twice in debug builds).

The duplicate comes from #21328, which replaced the first/second event handling with a loop in both `startNextBundleIfPresent` and `HotReloadEvent.run` but only removed the pre-loop `processFileList` call in the former; the Rust port kept the Zig shape. `DevServer::start_next_bundle_if_present` (the path taken when a bundle is already in flight) has only the loop, so this makes `run` match it.

### Repro

Against the released binary, the new test receives two frames for a single `mkdirSync` in the project directory:

```
expect(received).toEqual(expected)

  [
    "SeenFiles",
+   "SeenFiles",
  ]
```

A debug build also logs `debug warn: nothing to bundle` twice per wake-up before this change and once after.

### Fix

Drop the call before the loop; the loop already processes `first` and every event chained behind it exactly once.

### Test

`test/bake/dev/hot.test.ts`: bundle a route (which puts the project directory on the watch list), `mkdir` an unrelated directory, and assert the dev server reports exactly one `SeenFiles`. `mkdir` is used because it is a single notification from inotify, kqueue and ReadDirectoryChangesW, so the dev server receives exactly one hot-reload event for it; a file write can surface as several. The recording is delimited by toggling the harness's batch mode, whose acknowledgement is published on the same topic after anything the event published, so a second `SeenFiles` cannot arrive after the list is taken. That lives in a new `Dev.watchSynchronizationMessagesFor` helper in `test/bake/bake-harness.ts`.

Fails 15/15 runs with the released binary and with a debug build without the `src/` change, passes 10/10 runs with the fix (debug + ASAN). The rest of `test/bake` passes locally with the fix except for failures that also occur without it (host-wide inotify instance exhaustion in this container, and two `production.test.ts` cases that exceed the 5s default timeout under a debug build).

</details>
