### PR TITLE
test: keep the URL and Headers heap-snapshot tests under the default timeout on debug builds

### DIFF
--- a/test/js/bun/util/heap-snapshot.test.ts
+++ b/test/js/bun/util/heap-snapshot.test.ts
@@ -68,14 +68,17 @@ describe("Native types report their size correctly", () => {
   });
 
   it("URL (heap size reporting bug)", () => {
-    for (let i = 0; i < 500; i++) {
-      // need to use String.repeat(4096) here to ensure lots of tiny strings get allocated and joined.
-      // need to assign it to a global to ensure JSC and Bun do not eliminate it.
-      globalThis.url = new URL("Hello, 世界! 🌍".repeat(4096), "https://developer.mozilla.org");
-    }
+    // DOMURL stores the href's GC cost in a uint16_t. It used to be a signed short (#23887), so an href
+    // whose length has bit 15 set reported a negative cost, and once the GC visited the URL
+    // heapStats().extraMemorySize saturated to ~2**64 (18446744073706270000).
+    const url = new URL(Buffer.alloc(40000, "a").toString(), "https://developer.mozilla.org");
+    expect(url.href.length).toBeGreaterThan(0x7fff);
+    expect(url.href.length).toBeLessThan(0x10000);
 
-    // Expected: < 9007199254740991
-    // Received: 18446744073706270000
+    // Keep the URL reachable so the full collection below visits it and reports its cost.
+    globalThis.url = url;
+    Bun.gc(true);
+
     expect(heapStats().extraMemorySize).toBeLessThan(Number.MAX_SAFE_INTEGER);
 
     delete globalThis.url;
@@ -127,8 +130,14 @@ describe("Native types report their size correctly", () => {
   it("Headers", () => {
     const headers = new Headers();
     const original = estimateShallowMemoryUsageOf(headers);
+    // The expected size is summed from the inputs instead of read back through keys()/values():
+    // iterating a Headers object is quadratic in its size, which takes seconds for 1000 headers on a debug build.
+    let stringLength = 0;
     for (let i = 0; i < 1000; i++) {
-      headers.set(`a${i}`, `b${i}`);
+      const name = `a${i}`;
+      const value = `b${i}`;
+      headers.set(name, value);
+      stringLength += name.length + value.length;
     }
     const after = estimateShallowMemoryUsageOf(headers);
     expect(after).toBeGreaterThan(original + 1000 * 2);
@@ -141,7 +150,7 @@ describe("Native types report their size correctly", () => {
     const summariesMap = new Map(summariesList.map(summary => [summary.name, summary]));
 
     // Test that Headers includes the size of the strings
-    expect(summariesMap.get("Headers")?.size).toBeGreaterThan([...headers.keys(), ...headers.values()].join("").length);
+    expect(summariesMap.get("Headers")?.size).toBeGreaterThan(stringLength);
 
     delete globalThis.headers;
   });


### PR DESCRIPTION
### Problem
- `bun bd test test/js/bun/util/heap-snapshot.test.ts` on an unmodified debug+ASAN build of main fails two tests on time alone: `URL (heap size reporting bug)` at ~19.7s and `Headers` at ~13.1s, both "timed out after 5000ms". The rest of the file takes 1 to 3s per test.
- CI does not see it: it passes a 90s per-test timeout and runs release binaries, where the whole file takes ~1s. It only bites people running the file against `bun bd`.
- The URL test parses a 176,158 byte href 500 times (~40ms each on debug). The bug it guards (#23887) needs only one href of the right length plus a GC visiting it; the loop was there to make a GC happen by accident.
- The Headers test spends ~14s iterating `keys()` and `values()` just to compute an expected length. Iterating Headers is quadratic in the header count (tracked separately); the snapshot itself takes ~0.5s.

### Fix
- Test-only. The URL test builds one URL with a 40,030 byte href, asserts the length is in the range the old code truncated to negative (`0x7fff < length < 0x10000`), keeps it reachable and calls `Bun.gc(true)` before reading `extraMemorySize`.
- One URL is enough because the extra-memory total only changes when a GC visits the object, and the explicit full collection guarantees that visit.
- The Headers test sums name and value lengths as it inserts the same 1000 headers. The sum equals what the join produced (7780 either way), so the assertion is unchanged.
- Verification: with the #23887 bug reintroduced locally, the new URL test still fails (JSC aborts with `ASSERTION FAILED: m_maxHeapSize > m_sizeAfterLastCollect` right after `Bun.gc(true)`). On the restored debug+ASAN build the file passed 9/9 in six runs, URL under 0.8s and Headers about 2s; release also 9/9.

### Background
- `heapStats().extraMemorySize` is JSC's total of memory that native objects report as held outside the JS heap. It is only accumulated when a GC visits the object, so a mis-reported cost is invisible until a collection runs; `Bun.gc(true)` forces a full one.
- #23887: `DOMURL` kept the href's GC cost in a signed 16-bit field, so a length with bit 15 set (32768 to 65535) reported a negative cost that saturated the total to about 2**64. The field is unsigned now; the test pins the length inside that range so the old bug still trips.
- `bun bd` runs tests against the local debug build under the default 5s per-test timeout; CI uses 90s (x3 on ASAN) and release binaries, so a test can be far over 5s on debug and green in CI.
- Iterating a `Headers` object does a linear lookup per key, so `keys()`/`values()` over 1000 headers takes seconds on a debug build.

<details>
<summary>Original description</summary>

### What

`bun bd test test/js/bun/util/heap-snapshot.test.ts` fails two tests on an unmodified debug+ASAN build of main (9a543cc18f), purely on time:

```
(fail) Native types report their size correctly > URL (heap size reporting bug) [19705.64ms]
  ^ this test timed out after 5000ms.
(fail) Native types report their size correctly > Headers [13136.62ms]
  ^ this test timed out after 5000ms.
```

The other snapshot tests in the file take 1 to 3s on the same build. CI does not see this because the runner passes a 90s per-test timeout (x3 on the ASAN lane) and runs release binaries, where the whole file takes ~1s; it only affects running the file against `bun bd`, which is what anyone adding a test to this file does.

### Why

Timing the two tests piece by piece on the debug build:

- `URL (heap size reporting bug)` does `new URL("Hello, 世界! 🌍".repeat(4096), base)` 500 times. The `.repeat` is not the problem (500 of them take 53ms in total); parsing the 176,158 byte href is, at ~40ms per URL, so ~20s for the loop. The bug this test guards is #23887: `DOMURL` keeps the href's GC cost in what used to be a `short`, so any href whose length has bit 15 set (`static_cast<short>` of it is negative) made `memoryCostForGC()` sign-extend to ~2**64, and once the GC visited such a URL the heap's extra memory total saturated and `heapStats().extraMemorySize` came back as 18446744073706270000. That depends only on the length of one href, plus a GC visiting the URL. The 500 iterations were only there to make a GC happen incidentally.
- `Headers` spends ~14s of its 13 to 16s in `[...headers.keys(), ...headers.values()]`, which it only uses to compute the expected string length. Iterating a `Headers` object is quadratic in the number of headers (`FetchHeaders::Iterator::next()` does a linear `HTTPHeaderMap::get()` per key): on the release build 1000 headers iterate in ~4ms, 2000 in ~14ms, 4000 in ~54ms; on the debug build `keys()` alone takes ~6.7s for 1000 headers. That runtime issue is tracked separately; this test is about heap snapshot sizes and does not need to go through the iterator. The snapshot itself is not the slow part (generate + parse + summarize is ~0.5s here, in line with the URL and URLSearchParams tests that run between the two).

### Change

Test-only.

- `URL (heap size reporting bug)` builds a single URL with a 40,030 byte href, asserts the length is in the range that the old code truncated to a negative value (`0x7fff < length < 0x10000`), keeps it reachable from `globalThis` and calls `Bun.gc(true)` before checking `heapStats().extraMemorySize`. The explicit full collection is what makes one URL enough: `m_extraMemorySize` is only accumulated when the GC visits the object, so before the collection the value is unchanged whether or not the bug is present.
- `Headers` sums the name and value lengths while inserting the same 1000 headers and compares the snapshot size against that. The number is identical to what the `join("")` produced (7780 for both, checked), so the assertion is unchanged; only the way the expected value is computed is.

### Verification

- Reintroduced the #23887 bug locally (`short m_initialURLCostForGC` and the original `std::min(static_cast<short>(...))` initializer in `DOMURL.h` / `DOMURL.cpp`), rebuilt, and ran the new test: `new URL(...)` succeeds with `href.length === 40030`, `extraMemorySize` is unchanged until `Bun.gc(true)`, and the first allocation after the collection aborts the process on JSC's `ASSERTION FAILED: m_maxHeapSize > m_sizeAfterLastCollect` in `Heap::collectIfNecessaryOrDefer`, which is the same saturated extra-memory total the `expect` reports as ~2**64 on a build without assertions. So the single URL still fails on the bug, and deterministically rather than depending on an incidental GC. The src files were restored before committing (the diff is test-only).
- `bun bd test test/js/bun/util/heap-snapshot.test.ts` on the restored debug+ASAN build: 9/9 in six runs on a heavily loaded host (load average 70 to 170). `URL (heap size reporting bug)` went from 19.7s to 0.24 to 0.77s, `Headers` from 13.1s to 1.2 to 2.1s; the untouched tests stayed at 1 to 3.3s.
- `USE_SYSTEM_BUN=1 bun test test/js/bun/util/heap-snapshot.test.ts` (release): 9/9, the URL test went from 659ms to 8ms, the file from 1.4s to ~0.7s.

</details>
