### PR TITLE
Bun.deepEquals: drop the unused fourth skipPrototype argument

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -699,18 +699,11 @@ JSC_DEFINE_HOST_FUNCTION(functionBunDeepEquals, (JSGlobalObject * globalObject, 
     JSC::JSValue arg1 = callFrame->uncheckedArgument(0);
     JSC::JSValue arg2 = callFrame->uncheckedArgument(1);
     JSC::JSValue strict = callFrame->argument(2);
-    JSC::JSValue skipPrototype = callFrame->argument(3);
 
     Vector<std::pair<JSValue, JSValue>, 16> stack;
     MarkedArgumentBuffer gcBuffer;
 
     if (strict.isBoolean() && strict.asBoolean()) {
-        if (skipPrototype.isBoolean() && skipPrototype.asBoolean()) {
-            bool isEqual = Bun__deepEquals<true, false, false, true>(globalObject, arg1, arg2, gcBuffer, stack, scope, true);
-            RETURN_IF_EXCEPTION(scope, {});
-            return JSValue::encode(jsBoolean(isEqual));
-        }
-
         bool isEqual = Bun__deepEquals<true, false, false>(globalObject, arg1, arg2, gcBuffer, stack, scope, true);
         RETURN_IF_EXCEPTION(scope, {});
         return JSValue::encode(jsBoolean(isEqual));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1925,10 +1925,6 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
     return std::nullopt;
 }
 
-// The other combinations are instantiated by their uses in this file. This one is
-// only reached from `Bun.deepEquals(a, b, true, true)` in BunObject.cpp.
-template bool Bun__deepEquals<true, false, false, true>(JSC::JSGlobalObject*, JSValue, JSValue, MarkedArgumentBuffer&, Vector<std::pair<JSC::JSValue, JSC::JSValue>, 16>&, ThrowScope&, bool);
-
 /**
  * @brief `Bun.deepMatch(a, b)`
  *

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -112,6 +112,28 @@ describe("Bun.deepEquals strict mode", () => {
     expect(Bun.deepEquals(new Foo(), { a: 1 }, true)).toBe(false);
   });
 
+  // The switch that drops the constructor check (node's skipPrototype) is only
+  // reachable through util.isDeepStrictEqual; Bun.deepEquals has no fourth
+  // argument, so anything after `strict` is ignored.
+  it("ignores arguments after strict", () => {
+    const deepEquals = Bun.deepEquals as (a: unknown, b: unknown, ...rest: unknown[]) => boolean;
+    class Foo {
+      a = 1;
+    }
+    class Str extends String {}
+    for (const extra of [true, 1, "skipPrototype", {}]) {
+      expect(deepEquals(new Foo(), { a: 1 }, true, extra)).toBe(false);
+      expect(deepEquals({ a: 1 }, new Foo(), true, extra)).toBe(false);
+      expect(deepEquals({ x: new Foo() }, { x: { a: 1 } }, true, extra)).toBe(false);
+      expect(deepEquals(new String("a"), new Str("a"), true, extra)).toBe(false);
+      expect(deepEquals(new Str("a"), new String("a"), true, extra)).toBe(false);
+
+      expect(deepEquals(new Foo(), new Foo(), true, extra)).toBe(true);
+      expect(deepEquals({ a: 1 }, { a: 1, b: undefined }, true, extra)).toBe(false);
+      expect(deepEquals(new Foo(), { a: 1 }, false, extra)).toBe(true);
+    }
+  });
+
   it("is symmetric", () => {
     const a = { entries: [1, 2] };
     const b = { entries: [1, 2], extra: undefined };

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -113,8 +113,8 @@ describe("Bun.deepEquals strict mode", () => {
   });
 
   // The switch that drops the constructor check (node's skipPrototype) is only
-  // reachable through util.isDeepStrictEqual; Bun.deepEquals has no fourth
-  // argument, so anything after `strict` is ignored.
+  // reachable through util.isDeepStrictEqual and the node:assert Assert class;
+  // Bun.deepEquals has no fourth argument, so anything after `strict` is ignored.
   it("ignores arguments after strict", () => {
     const deepEquals = Bun.deepEquals as (a: unknown, b: unknown, ...rest: unknown[]) => boolean;
     class Foo {


### PR DESCRIPTION
### Problem
- `Bun.deepEquals(new Foo(), { a: 1 }, true)` returns false, as documented, but `Bun.deepEquals(new Foo(), { a: 1 }, true, true)` returns true on current main.
- `Bun.deepEquals` is typed and documented with three parameters, yet the runtime reads a fourth that turns strict mode into node's skipPrototype mode. It does not type check, is undocumented and untested, and nothing in tree passes it.
- #34434 added it as internal plumbing for `util.isDeepStrictEqual`; #34660 gave that its own native entry point, so it has had no consumer since. It has not shipped in a stable release.

### Fix
- Remove the fourth argument branch and the explicit template instantiation that existed only for it. Anything after `strict` is now ignored, as in every stable release.
- skipPrototype stays reachable where node exposes it, `util.isDeepStrictEqual(a, b, true)` and `new Assert({ skipPrototype: true })`; their entry point is untouched.
- Verification: a new test passes extra values after `strict` and expects them to be ignored; five of its assertions fail on main and pass with this change. The node assert, node util and expect suites were also run on a debug build.
- Merge note: #37788 adds a sibling instantiation next to the removed one, so whichever lands second has a one line conflict.

### Background
- `Bun.deepEquals(a, b, strict)` is Bun's public deep equality. Strict mode also compares constructors, so a class instance never equals an object literal, and counts a property set to `undefined` as present.
- skipPrototype is node's option on `util.isDeepStrictEqual` and the `Assert` class: strict comparison minus the constructor check. Bun implements it as a flag on the shared native comparer, reached by those node APIs through their own binding.
- The native comparer is a C++ template, one instantiation per flag combination. A combination used only from another file needs an explicit instantiation line; the one removed here served only the dropped branch.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/bun-object/deep-equals.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

```ts
class Foo { a = 1 }
Bun.deepEquals(new Foo(), { a: 1 }, true);       // false (documented strict mode)
Bun.deepEquals(new Foo(), { a: 1 }, true, true); // true on current main
```

`Bun.deepEquals` is declared as `(a, b, strict?)` in `packages/bun-types/bun.d.ts` and documented with three parameters, but the runtime reads a fourth one. The four argument call above does not type check, is mentioned nowhere in the docs, and has no test; the only in-tree caller of `Bun.deepEquals` is the three argument loose call in `src/js/node/assert.ts`.

### Cause

#34434 added `callFrame->argument(3)` to `functionBunDeepEquals` in `src/jsc/bindings/BunObject.cpp` so that the JS implementation of `util.isDeepStrictEqual(a, b, skipPrototype)` could reach the skip-prototype instantiation of `Bun__deepEquals` without a separate binding. The review thread on that PR states the intent: the argument is internal plumbing and the public contract of `Bun.deepEquals` stays at three arguments (https://github.com/oven-sh/bun/pull/34434#discussion_r3606577282).

#34660 then gave `util.isDeepStrictEqual` and the `Assert` class their own native entry point (`Bun__deepEqualsNodeStrictSkipProto`, called from `jsFunctionIsDeepStrictEqual` in `NodeUtilTypesModule.cpp`). That left the fourth argument of `Bun.deepEquals`, and the `Bun__deepEquals<true, false, false, true>` explicit instantiation in `bindings.cpp` that existed only for it, with no consumer.

### Fix

Remove the `argument(3)` branch from `functionBunDeepEquals` and the explicit instantiation it was the only user of. `Bun.deepEquals(a, b, true, <anything>)` is now the same as `Bun.deepEquals(a, b, true)`, which is what every release so far has done: the argument landed after 1.3.14 and has not shipped in a stable release, so no user code can depend on it.

Removing rather than documenting it because that is the intent recorded when it was added, and because the mode it selected (strict, minus the constructor/class name check) is node's `skipPrototype` option, which Bun exposes where node does: `util.isDeepStrictEqual(a, b, true)` and `new Assert({ skipPrototype: true })`. Those still use the `skipPrototypeIdentity` template parameter through `Bun__deepEqualsNodeStrictSkipProto`; that parameter and entry point are untouched.

This came up in #37776, which adds another strict-mode check gated on the same template parameter and skipped testing the four argument form because of the type mismatch. Note for merging: #37788 adds a sibling explicit instantiation next to the one removed here, so whichever of the two lands second has a one-line conflict in `bindings.cpp`.

### Tests

`test/js/bun/bun-object/deep-equals.test.ts` gets "ignores arguments after strict": a class instance vs a literal (both orders and nested), a boxed `String` vs a `String` subclass instance (both orders), with `true` and a few non-boolean values as the extra argument, plus checks that strict mode otherwise still applies and loose mode is unaffected. On main the five `toBe(false)` assertions with `true` as the extra argument all receive `true`; with this change the file passes.

Also ran `test/js/node/assert/deep-equal.test.ts` (covers `util.isDeepStrictEqual`'s `skipPrototype` argument, 305 pass), `test/js/node/util/util.test.js` (208 pass) and `test/js/bun/test/expect.test.js` (415 pass) on the debug build.

</details>
