### PR TITLE
bake: release the app plugins cell when the dev server is torn down

### DIFF
--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1804,6 +1804,51 @@ pub mod js_bundler {
         }
     }
 
+    /// Owner of a `JSBundlerPlugin` from [`PluginJscExt::create`]. The handle
+    /// is a `protect()`ed JSCell, not a heap allocation: a `Box<Plugin>` around
+    /// it frees nothing (`Plugin` is a ZST opaque), so the only thing that
+    /// releases the cell is this type's `Drop` calling [`PluginJscExt::destroy`].
+    /// JS thread only.
+    pub struct OwnedPlugin(core::ptr::NonNull<Plugin>);
+
+    impl OwnedPlugin {
+        pub fn create(global: &JSGlobalObject, target: jsc::BunPluginTarget) -> Self {
+            Self(
+                core::ptr::NonNull::new(Plugin::create(global, target))
+                    .expect("JSBundlerPlugin__create returns a non-null cell"),
+            )
+        }
+
+        /// The handle itself, for holders that only borrow the plugin (the
+        /// bundle thread, routes and the dev server sharing a server's plugins).
+        /// Valid until `self` drops.
+        #[inline]
+        pub fn as_non_null(&self) -> core::ptr::NonNull<Plugin> {
+            self.0
+        }
+    }
+
+    impl core::ops::Deref for OwnedPlugin {
+        type Target = Plugin;
+        #[inline]
+        fn deref(&self) -> &Plugin {
+            Plugin::opaque_ref(self.0.as_ptr())
+        }
+    }
+
+    impl core::ops::DerefMut for OwnedPlugin {
+        #[inline]
+        fn deref_mut(&mut self) -> &mut Plugin {
+            Plugin::opaque_mut(self.0.as_ptr())
+        }
+    }
+
+    impl Drop for OwnedPlugin {
+        fn drop(&mut self) {
+            Plugin::destroy(self.0.as_ptr());
+        }
+    }
+
     /// Convert a JS exception value into a `logger.Msg`. If the conversion itself
     /// throws (e.g. `Symbol.toPrimitive` on the thrown object throws), clear that
     /// secondary exception and return a generic fallback message so
@@ -1880,6 +1925,7 @@ pub mod js_bundler {
 
 pub use js_bundler as JSBundler;
 pub use js_bundler::Config;
+pub(crate) use js_bundler::OwnedPlugin;
 /// `jsc.API.JSBundler.Plugin` — re-exported for `crate::bake` (`SplitBundlerOptions.plugin`).
 pub use js_bundler::Plugin;
 pub(crate) use js_bundler::PluginJscExt;

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -198,8 +198,8 @@ pub enum Magic {
 
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum PluginState {
-    /// Should ask server for plugins. Once plugins are loaded, the plugin
-    /// pointer is written into `server_transpiler.options.plugin`
+    /// Should ask server for plugins (unless the app brought its own). Once
+    /// plugins are loaded, the cell is stored in `bundler_options.plugin`.
     Unknown,
     // These two states mean that `server.getOrLoadPlugins()` was called.
     Pending,
@@ -528,7 +528,6 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         w!(generation, 0);
         w!(graph_safety_lock, ThreadLock::init_unlocked());
         w!(framework, options.framework);
-        w!(bundler_options, options.bundler_options);
         w!(emit_incremental_visualizer_events, 0);
         w!(emit_memory_visualizer_events, 0);
         w!(
@@ -650,8 +649,11 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     //
     // SAFETY: `init_transpiler` writes the slot via `MaybeUninit::write` (see
     // `bake_body.rs`), so the previous (uninitialized) bytes are never dropped.
-    // `framework`/`log`/`bundler_options` were written above; reborrowing each
-    // individually via `addr_of_mut!` is sound because no `&mut DevServer` exists.
+    // `framework`/`log` were written above; reborrowing each individually via
+    // `addr_of_mut!` is sound because no `&mut DevServer` exists.
+    // `bundler_options` stays in `options` until the transpilers exist: it owns
+    // the app's plugin cell, and an `Err` before `assume_init()` drops nothing
+    // that was already written into the box.
     // Note: `Transpiler<'static>` erases the arena lifetime — `options.arena`
     // is the `UserOptions.arena` which is moved into / outlives the `DevServer`
     // box. Widen `'a → 'static` here once.
@@ -666,7 +668,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
     unsafe {
         let framework = &mut *addr_of_mut!((*p).framework);
         let log = &mut *addr_of_mut!((*p).log);
-        let bundler_options = &mut *addr_of_mut!((*p).bundler_options);
+        let bundler_options = &options.bundler_options;
 
         match framework.init_transpiler(
             arena,
@@ -719,6 +721,7 @@ pub(crate) fn init(options: Options) -> JsResult<Box<DevServer>> {
         }
 
         w!(bundler_framework_views, bundler_framework_views);
+        w!(bundler_options, options.bundler_options);
     }
 
     // ── every field is now written ───────────────────────────────────────────
@@ -2010,8 +2013,11 @@ fn ensure_route_is_bundled<Ctx: EnsureRouteCtx>(
                                     }
                                     crate::server::GetOrStartLoadResult::Ready(ready) => {
                                         dev.plugin_state = PluginState::Loaded;
-                                        dev.bundler_options.plugin =
-                                            ready.map(::core::ptr::NonNull::from);
+                                        dev.bundler_options.plugin = ready.map(|plugin| {
+                                            bake::DevServerPlugin::Borrowed(
+                                                ::core::ptr::NonNull::from(plugin),
+                                            )
+                                        });
                                     }
                                 }
                             }
@@ -3217,7 +3223,11 @@ impl DevServer {
                 ssr_transpiler: unsafe {
                     ::core::ptr::NonNull::from((*self_ptr).ssr_transpiler.assume_init_mut())
                 },
-                plugins: self.bundler_options.plugin,
+                plugins: self
+                    .bundler_options
+                    .plugin
+                    .as_ref()
+                    .map(bake::DevServerPlugin::as_non_null),
             }),
             // SAFETY: see `heap_ptr` note above.
             unsafe { &*heap_ptr },
@@ -6128,7 +6138,13 @@ impl DevServer {
         &mut self,
         plugins: Option<*mut crate::api::js_bundler::Plugin>,
     ) -> crate::Result<()> {
-        self.bundler_options.plugin = plugins.and_then(::core::ptr::NonNull::new);
+        // Only reached when the app declared no plugins of its own
+        // (`ensure_route_is_bundled` asks the server for plugins just then),
+        // so this never replaces an `Owned` cell.
+        debug_assert!(self.bundler_options.plugin.is_none());
+        self.bundler_options.plugin = plugins
+            .and_then(::core::ptr::NonNull::new)
+            .map(bake::DevServerPlugin::Borrowed);
         self.plugin_state = PluginState::Loaded;
         self.start_next_bundle_if_present();
         Ok(())

--- a/src/runtime/bake/bake_body.rs
+++ b/src/runtime/bake/bake_body.rs
@@ -5,7 +5,6 @@
 #![allow(unexpected_cfgs)] // `bun_codegen_embed` is set via RUSTFLAGS (scripts/build/rust.ts) for release/CI builds.
 
 use bun_alloc::ArenaVecExt as _;
-use core::ptr::NonNull;
 
 use bun_alloc::Arena; // = bumpalo::Bump
 use bun_collections::ArrayHashMap;
@@ -15,10 +14,7 @@ use bun_jsc::{JSGlobalObject, JSValue, JsError, JsResult, ZigStringSlice};
 use bun_options_types::schema as bun_schema;
 use bun_paths::{self as paths, PathBuffer};
 
-// `jsc.API.JSBundler.Plugin` — opaque FFI handle for the C++ JSBundlerPlugin.
-// Re-exported from `crate::api::js_bundler` so `SplitBundlerOptions.plugin`
-// shares the same type the bundler pipeline uses.
-pub(crate) use crate::api::js_bundler::Plugin;
+use crate::api::js_bundler::OwnedPlugin;
 use crate::api::js_bundler::js_bundler::PluginJscExt as _;
 
 // Note: parent `mod.rs` already declares `dev_server` / `framework_router`
@@ -143,20 +139,6 @@ pub struct UserOptions {
     pub(crate) root: &'static ZStr, // TODO(lifetime): arena-owned, self-referential with .arena
     pub(crate) framework: Framework,
     pub(crate) bundler_options: SplitBundlerOptions,
-}
-
-impl Drop for UserOptions {
-    fn drop(&mut self) {
-        // arena: dropped by Bump's Drop
-        // allocations: dropped by StringRefList's Drop
-        if let Some(p) = self.bundler_options.plugin {
-            // `p` is the FFI handle returned by `Plugin::create` in
-            // `parse_plugin_array`; `PluginJscExt::destroy` is its paired
-            // (safe) destructor — it null-checks via `opaque_ref` and
-            // unprotect()s the JSCell / tombstones the C++ object.
-            Plugin::destroy(p.as_ptr());
-        }
-    }
 }
 
 impl UserOptions {
@@ -296,7 +278,11 @@ impl StringRefList {
 
 #[derive(Default)]
 pub struct SplitBundlerOptions {
-    pub plugin: Option<NonNull<Plugin>>,
+    /// One cell holding both `framework.plugins` and `app.plugins`. Released
+    /// when this drops (`bun build --app`, or `Bun.serve` rejecting its
+    /// options) unless `NewServer::init` moves it into the `DevServer`, which
+    /// then owns it (`bake::DevServerPlugin::Owned`).
+    pub plugin: Option<OwnedPlugin>,
     pub client: BuildConfigSubset,
     pub server: BuildConfigSubset,
     pub ssr: BuildConfigSubset,
@@ -312,18 +298,11 @@ impl SplitBundlerOptions {
         plugin_array: JSValue,
         global: &JSGlobalObject,
     ) -> JsResult<()> {
-        // Create the Plugin and assign it to `opts.plugin` BEFORE iterating,
+        // Create the Plugin and assign it to `self.plugin` BEFORE iterating,
         // so `plugins: []` still leaves `self.plugin = Some(_)`.
-        let plugin: NonNull<Plugin> = match self.plugin {
-            Some(p) => p,
-            None => {
-                let p = Plugin::create(global, bun_jsc::BunPluginTarget::Bun);
-                let p = NonNull::new(p)
-                    .expect("JSBundlerPlugin__create returns a non-null protected JSCell");
-                self.plugin = Some(p);
-                p
-            }
-        };
+        let plugin: &mut OwnedPlugin = self
+            .plugin
+            .get_or_insert_with(|| OwnedPlugin::create(global, bun_jsc::BunPluginTarget::Bun));
         let empty_object = JSValue::create_empty_object(global, 0);
 
         let mut iter = plugin_array.array_iterator(global)?;
@@ -356,15 +335,8 @@ impl SplitBundlerOptions {
                 }
             };
 
-            // `Plugin` is an `opaque_ffi!` ZST — `opaque_mut` is the safe
-            // deref. Handle held live in `self.plugin` (protected JSCell).
-            let plugin_result = Plugin::opaque_mut(plugin.as_ptr()).add_plugin(
-                function,
-                empty_object,
-                JSValue::NULL,
-                false,
-                true,
-            )?;
+            let plugin_result =
+                plugin.add_plugin(function, empty_object, JSValue::NULL, false, true)?;
 
             if let Some(promise) = plugin_result.as_any_promise() {
                 promise.set_handled(global.vm());

--- a/src/runtime/bake/mod.rs
+++ b/src/runtime/bake/mod.rs
@@ -11,6 +11,8 @@
 use core::ptr::NonNull;
 use std::borrow::Cow;
 
+use crate::api::js_bundler::OwnedPlugin;
+
 // ─── Submodule bodies ────────────────────────────────────────────────────────
 // `bake_body.rs` carries the Framework/UserOptions/BuildConfigSubset `from_js`
 // impls plus the `init_server_runtime`/`get_hmr_runtime` host fns.
@@ -463,12 +465,32 @@ impl Framework {
     }
 }
 
+/// The plugin cell every bundle of a `DevServer` runs against, and whether
+/// the dev server is the one releasing it.
+pub(crate) enum DevServerPlugin {
+    /// `framework.plugins` / `app.plugins`: created for this dev server by
+    /// `UserOptions::from_js` and released when the dev server drops.
+    Owned(OwnedPlugin),
+    /// The server's `[serve.static]` plugins, used when the app declares
+    /// none. The cell belongs to the server's `ServePlugins`, released by the
+    /// same server that owns this dev server; `DevServer::on_plugins_resolved`
+    /// only stores the pointer.
+    Borrowed(NonNull<jsc::Plugin>),
+}
+
+impl DevServerPlugin {
+    pub(crate) fn as_non_null(&self) -> NonNull<jsc::Plugin> {
+        match self {
+            DevServerPlugin::Owned(plugin) => plugin.as_non_null(),
+            DevServerPlugin::Borrowed(plugin) => *plugin,
+        }
+    }
+}
+
 /// `bake.SplitBundlerOptions` — per-graph bundler config + shared plugin.
 #[derive(Default)]
 pub struct SplitBundlerOptions {
-    /// FFI: `jsc.API.JSBundler.Plugin` (`JSBundlerPlugin__create`); deinit
-    /// goes through the C++ side. See LIFETIMES.tsv.
-    pub(crate) plugin: Option<NonNull<jsc::Plugin>>,
+    pub(crate) plugin: Option<DevServerPlugin>,
     pub(crate) client: BuildConfigSubset,
     pub(crate) server: BuildConfigSubset,
     pub(crate) ssr: BuildConfigSubset,
@@ -561,9 +583,7 @@ impl From<bake_body::BuildConfigSubset> for BuildConfigSubset {
 impl From<bake_body::SplitBundlerOptions> for SplitBundlerOptions {
     fn from(src: bake_body::SplitBundlerOptions) -> Self {
         Self {
-            // `bake_body::Plugin` and keystone `jsc::Plugin` both alias
-            // `crate::api::js_bundler::Plugin` — same nominal type, no cast.
-            plugin: src.plugin,
+            plugin: src.plugin.map(DevServerPlugin::Owned),
             client: src.client.into(),
             server: src.server.into(),
             ssr: src.ssr.into(),

--- a/src/runtime/bake/production.rs
+++ b/src/runtime/bake/production.rs
@@ -630,7 +630,11 @@ fn build_with_vm(ctx: Context, cwd: &[u8], pt: &mut PerThread) -> crate::Result<
                 framework: bundler_framework,
                 client_transpiler: NonNull::new(client_ptr).expect("stack-owned transpiler"),
                 ssr_transpiler: NonNull::new(ssr_ptr).expect("stack-owned transpiler"),
-                plugins: options.bundler_options.plugin,
+                plugins: options
+                    .bundler_options
+                    .plugin
+                    .as_ref()
+                    .map(|plugin| plugin.as_non_null()),
             },
             &options.arena,
             Some(NonNull::from(&mut any_loop)),

--- a/test/bake/app-plugins-release.test.ts
+++ b/test/bake/app-plugins-release.test.ts
@@ -1,0 +1,57 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+import path from "node:path";
+
+// `app.plugins` / `framework.plugins` are held by one native BundlerPlugin cell
+// that the dev server takes over from the parsed serve options. The dev server
+// used to drop its handle to that cell without releasing it, so every dev
+// server created with plugins kept its cell, and every closure the plugins had
+// registered, rooted for the rest of the process; options rejected after the
+// cell had been created leaked it the same way. The fixture runs one of these
+// paths per process and reports how many cells survive a full GC afterwards.
+//
+// The cases run one at a time: each dev server needs a file watcher instance,
+// which Linux hands out per user, and a process only gives it back on exit.
+// The fixture waits for one when the machine is out of them (hence the
+// timeouts), and the debug build's startup plus full collections are slow.
+async function runCase(name: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "app-plugins-release.ts", name],
+    cwd: path.join(import.meta.dir, "fixtures/app-plugins-release"),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // stderr is not asserted: "init-fails" makes Bun print the framework file it
+  // could not resolve there.
+  expect(stdout, stderr).toStartWith("{");
+  return { ...JSON.parse(stdout), exitCode };
+}
+
+test("a stopped dev server releases the cell holding its app plugins", async () => {
+  expect(await runCase("stopped-server")).toEqual({
+    cellsWhileServing: 1,
+    devServersDeinitialized: 1,
+    leakedCells: 0,
+    exitCode: 0,
+  });
+}, 60_000);
+
+test("serve options rejected by a plugin's setup() release the cell", async () => {
+  expect(await runCase("setup-throws")).toEqual({
+    error: "setup failed on purpose",
+    devServersDeinitialized: 0,
+    leakedCells: 0,
+    exitCode: 0,
+  });
+}, 60_000);
+
+test("a dev server that fails to initialize releases the cell", async () => {
+  expect(await runCase("init-fails")).toEqual({
+    error: "Framework is missing required files!",
+    devServersDeinitialized: 1,
+    leakedCells: 0,
+    exitCode: 0,
+  });
+}, 60_000);

--- a/test/bake/fixtures/app-plugins-release/app-plugins-release.ts
+++ b/test/bake/fixtures/app-plugins-release/app-plugins-release.ts
@@ -1,0 +1,114 @@
+// Spawned by test/bake/app-plugins-release.test.ts, once per case, with this
+// directory as cwd.
+//
+// `Bun.serve({ app: { plugins } })` creates one native BundlerPlugin cell (the
+// JSC class name of JSBundlerPlugin) holding every setup()/onLoad/onResolve
+// closure, and protects it from GC until whoever owns it releases it. Each case
+// below makes the cell's owner go away in a different way and prints, as one
+// JSON line, how many cells are still alive after a full GC: the number of
+// cells that path leaked. Every case runs in its own process because a dev
+// server's file watcher instance is only given back when the process exits.
+import { getDevServerDeinitCount } from "bun:internal-for-testing";
+import { heapStats } from "bun:jsc";
+
+function liveCells(): number {
+  return heapStats().objectTypeCounts.BundlerPlugin ?? 0;
+}
+
+// A released cell is only unprotected: it still has to be collected, and a
+// stale pointer to it on the native stack can keep it alive for a collection,
+// so alternate collections with turns of the event loop. A released cell is
+// normally gone after the first collection; a protected one survives all of
+// them, which is what a leak looks like.
+async function liveCellsAfterGC(expected: number): Promise<number> {
+  for (let attempt = 0; attempt < 10 && liveCells() !== expected; attempt++) {
+    Bun.gc(true);
+    await new Promise(resolve => setTimeout(resolve, 0));
+  }
+  return liveCells();
+}
+
+function serveOptions(setup: (build: Bun.PluginBuilder) => void, serverEntryPoint = "./server.ts") {
+  return {
+    port: 0,
+    development: true,
+    fetch: () => new Response("unused"),
+    app: {
+      framework: {
+        fileSystemRouterTypes: [{ root: "routes", style: "nextjs-pages", serverEntryPoint }],
+      },
+      plugins: [{ name: "probe", setup }],
+    },
+  } as Bun.Serve.Options<undefined>;
+}
+
+function registerOnLoad(build: Bun.PluginBuilder) {
+  build.onLoad({ filter: /\.probe$/ }, () => ({ contents: "", loader: "js" }));
+}
+
+// Every dev server needs a file watcher instance (inotify on Linux), which is
+// a per-user limit shared with every other process on the machine. When the
+// machine is out of them, wait for one instead of failing on the spot. (Each
+// attempt that fails this way parses the options, so it creates and rejects a
+// cell of its own.)
+async function serve(options: Bun.Serve.Options<undefined>): Promise<Bun.Server<undefined>> {
+  const deadline = Date.now() + 30_000;
+  while (true) {
+    try {
+      return Bun.serve(options);
+    } catch (error) {
+      if (!(error as Error).message.startsWith("EMFILE") || Date.now() > deadline) throw error;
+      await Bun.sleep(100);
+    }
+  }
+}
+
+async function serveError(options: Bun.Serve.Options<undefined>): Promise<string> {
+  try {
+    (await serve(options)).stop(true);
+    return "did not throw";
+  } catch (error) {
+    return (error as Error).message;
+  }
+}
+
+let report: Record<string, unknown>;
+switch (process.argv[2]) {
+  // The dev server takes the cell over from the parsed options and has to
+  // release it when the stopped server tears the dev server down.
+  case "stopped-server": {
+    const server = await serve(serveOptions(registerOnLoad));
+    // The running dev server's cell is the one that must survive a collection.
+    const cellsWhileServing = await liveCellsAfterGC(1);
+    server.stop(true);
+    report = { cellsWhileServing };
+    break;
+  }
+  // The cell already exists when a plugin's setup() makes Bun.serve() throw,
+  // so the rejected options have to release it. No dev server is involved.
+  case "setup-throws": {
+    const error = await serveError(
+      serveOptions(() => {
+        throw new Error("setup failed on purpose");
+      }),
+    );
+    report = { error };
+    break;
+  }
+  // The dev server has already taken the cell over when it fails to resolve
+  // the framework's files, so the dev server that never finished initializing
+  // has to release it as it is torn down.
+  case "init-fails": {
+    const error = await serveError(serveOptions(registerOnLoad, "./does-not-exist.ts"));
+    report = { error };
+    break;
+  }
+  default:
+    throw new Error(`unknown case ${JSON.stringify(process.argv[2])}`);
+}
+
+report.leakedCells = await liveCellsAfterGC(0);
+// Read after the collections above gave a stopped server its turns of the
+// event loop to tear the dev server down.
+report.devServersDeinitialized = getDevServerDeinitCount();
+console.log(JSON.stringify(report));

--- a/test/bake/fixtures/app-plugins-release/server.ts
+++ b/test/bake/fixtures/app-plugins-release/server.ts
@@ -1,0 +1,5 @@
+// Framework server entry point for app-plugins-release.ts. Never bundled: the
+// probe starts and stops dev servers without ever requesting a route.
+export function render() {
+  return new Response("unused");
+}


### PR DESCRIPTION
### Problem
- Every dev server created by `Bun.serve({ app: { framework, plugins } })` leaks its native plugin cell (`BundlerPlugin` in `heapStats()`) after teardown, and with it every `setup()` / `onLoad` / `onResolve` closure registered on it. Stopping four such servers leaves four cells on 1.4.0-canary.
- The same cell leaks when `Bun.serve()` throws after creating it: a plugin's `setup()` throwing, or dev server init failing (for example `EMFILE while initializing file watcher`).
- Cause: the cell is GC-protected and held as a raw pointer. The only release was in the parsed options' destructor, but the server moves the options into the dev server first, and the dev server never released what it took over.

### Fix
- The cell is held in an RAII wrapper whose `Drop` releases it, so whichever struct holds it when it goes away (the parsed options or the dev server) releases it exactly once.
- The dev server's slot becomes an enum: `Owned` for the app's own cell, `Borrowed` for the server's `[serve.static]` plugins, which the server releases. The borrowed arm is only filled when the app declared no plugins, so it never displaces an owned cell.
- Dev server init moves the options into the server struct only after the fallible steps, so an early error drops them, and the cell, on the caller's side.
- Releasing on dev server drop is safe because the cell is only read when a bundle starts, and the server drops the dev server after it has stopped and drained. The wrapper is the same type #37805 adds, so either merge order is clean.
- Verification: a new test runs each of the three paths in its own process and counts cells surviving a full GC. Each path leaks 1 cell on 1.4.0-canary and 0 with this PR; the other reported fields are unchanged.

### Background
- `app.plugins` and `framework.plugins` are collected into one native `JSBundlerPlugin` object (the "cell") that every bundle of the dev server consults. Bun `protect()`s it from JSC's GC, so it and everything it references live until something calls `destroy`, which tombstones and unprotects it.
- Serve options are parsed into a Rust `UserOptions` struct. Creating a dev server moves the bundler options out of it, so cleanup left in `UserOptions` no longer sees them.
- An app that declares no plugins makes the dev server borrow the server's `[serve.static]` plugins, a cell the server owns and releases, so the slot has to tell an owned cell from a borrowed one.
- `DevServer::init` fills a `MaybeUninit` box field by field. On an error before the box is marked initialized, fields already written are not dropped, so anything that must be released on failure has to stay outside the box until the fallible steps are done.
- Each dev server takes a file watcher (inotify) instance, a per-user limit returned only on process exit, which is why the test runs each case in a separate process.

<details>
<summary>Original description</summary>

### What

The POSIX ready-poll dispatch chain held the poll being dispatched as a reference for the whole time its owner ran (line numbers on main):

```rust
// src/io/posix_event_loop.rs
let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };          // Bun__internal_dispatch_ready_poll, :1497
pub(crate) fn on_kqueue_event(&mut self, kqueue_event: &KQueueEvent)            // :351
pub(crate) fn on_epoll_event(&mut self, epoll_event: &epoll_event)              // :370
pub(crate) fn on_update(&mut self, size_or_offset: i64) {                       // :434
    unsafe { __bun_run_file_poll(self, size_or_offset) };
}

// src/runtime/dispatch.rs, __bun_run_file_poll
let poll_ref = unsafe { &mut *poll };                                            // :660
resolver.on_dns_poll(unsafe { &mut *poll });                                     // :744
// src/runtime/dns_jsc/dns.rs
pub(crate) fn on_dns_poll(&self, poll: &mut FilePoll)                           // :4786
```

Same receiver-shape class as #37681, #37778 and #37803. No crash is known from it.

### Why it is wrong

The `&mut self` of `on_kqueue_event` / `on_epoll_event` and of `on_update`, and the `&mut FilePoll` argument of `on_dns_poll`, are reference arguments: protected until those calls return, and the owner runs inside them. The owner does not use those references. It reaches the same slot through the pointer it keeps itself (`FilePollRef`, `PollerPosix::Fd`, the resolver's poll map), on the normal path, not only on teardown:

- Every reader poll is registered one-shot (`FilePollRef::register_with_fd` passes `OneShotFlag::Dispatch`), so `on_update` sets `NeedsRearm` and the owner's re-arm during the dispatch reads and clears it again (`register_with_fd_impl`, `unregister_with_fd_impl`) through its own pointer. The flag exists to be passed from this frame to the owner's call underneath it.
- An owner that is finished deinits the slot from inside the dispatch: pipe EOF (`PollOrFd::close_impl` -> `FilePollRef::deinit_force_unregister`), process exit (`Process::on_exit` -> `close` -> `PollerPosix`), and c-ares closing a socket, which happens inside the `Channel::process` call that `on_dns_poll` makes while its `&mut FilePoll` argument is live (`on_dns_socket_state` also re-registers the same poll through the map on every read/write transition).

Those are reads and writes through a pointer foreign to the protected references further up the stack, which both aliasing models reject (the protector rule the sibling PRs quote; rustc also marks the arguments `noalias`). `FilePollRef::inner` and `PollerPosix::fd_poll_mut` both document the `&mut FilePoll` they hand out as the only live reference to the slot; during a dispatch that was not true. It is latent today because nothing on the chain reads the slot after the owner returns, so there is nothing observable to assert on.

### Fix

The chain carries the pointer `Pollable` decodes all the way down, the shape `__bun_run_file_poll(poll: *mut FilePoll)` and `PosixBufferedReader::on_poll(this: *mut Self)` already have:

```rust
pub(crate) unsafe fn on_kqueue_event(this: *mut FilePoll, kqueue_event: &KQueueEvent)
pub(crate) unsafe fn on_epoll_event(this: *mut FilePoll, epoll_event: &epoll_event)
pub(crate) unsafe fn on_update(this: *mut FilePoll, size_or_offset: i64)
pub(crate) unsafe fn on_dns_poll(&self, poll: *mut FilePoll)
```

The entry point reads `IgnoreUpdates` through a statement-scoped access and passes the pointer on; `update_flags`, the `NeedsRearm` update, the kqueue `syslog!` and generation-number `debug_assert!`, and `__bun_run_file_poll`'s `owner`/`hup` reads become statement-scoped accesses; the DNS arm passes `poll` itself, and `on_dns_poll` reads `fd` / `is_readable()` / `is_writable()` into locals before `process` and does not touch the poll afterwards. Same operations in the same order, so no behaviour change.

The contract the chain relies on is only that the slot is live when each frame is entered: nothing on the chain reads it after the owner returns, so the comments say that rather than anything about the slot staying allocated for the duration of the call (deferred frees run from the after-tick callback, which a nested tick inside an owner's JS would also run).

Overlap with #37803: that PR converts the owner's side of the same contract (`FilePoll::deinit*` and its callers) and, to get there, also converts `on_dns_poll` and the `__bun_run_file_poll` reads; it leaves the four frames in posix_event_loop.rs to this PR. The two PRs therefore both touch `__bun_run_file_poll` and `on_dns_poll`, and a test merge conflicts in exactly those two functions (posix_event_loop.rs auto-merges). That is deliberate: whichever lands second rebases and takes either side of each conflict, and the lint below passes with both (checked with #37803's versions of dispatch.rs and dns.rs dropped onto this branch). An earlier revision of this PR instead allowlisted those two frames in the lint; since #37803 does not touch the lint file, that would have gone red on main after the second merge with nothing forcing anyone to notice, so the overlap is now textual.

The five src/io/PipeReader.rs comments about a protector "pre-existing on the parent chain" describe the reader's own `&mut self` entry points (`close`, `finish`, `start`, `watch`, and the Windows `on_read`), which parents call directly; converting this chain does not change them.

### Test

`test/internal/source-lints/file-poll-dispatch-raw.test.ts` locates every frame of the chain by name (`Bun__internal_dispatch_ready_poll`, `on_kqueue_event`, `on_epoll_event`, `on_update`, `__bun_run_file_poll` including its `extern "Rust"` declaration, `on_dns_poll`) and checks:

- signature: the poll arrives as `*mut FilePoll` (a `self` receiver on the FilePoll methods counts as by-reference unless it is a raw receiver), and no parameter takes it as `&FilePoll` / `&mut FilePoll`;
- hand-off: each frame calls the next frame(s) of the chain itself, with its pointer as the first argument (the entry point's pointer is its `let x: *mut FilePoll` binding). This is what keeps the chain closed: a helper interposed on any edge, whether it takes `&mut FilePoll` or is a `&mut self` method called as `(*this).helper()`, and a `&mut *this` argument (which coerces and would compile) are all reported;
- body: no `let` binding is a `&[mut] FilePoll` or a fn-long `&mut *..` / `unsafe { ..as_mut().. }` reborrow.

Fixtures cover the main spellings of all six frames (19 findings), the converted spellings (none), and six mutations of the converted chain (interposed `&mut FilePoll` helper, interposed `&mut self` helper, `&mut *this` argument on the epoll edge, `as_mut()` binding, untyped entry binding, `NonNull` parameter), with the expected line numbers written out by hand. On main it reports 13 lines across the three files (the six frames above); on this branch it is clean, and it also fails on the intermediate state where only posix_event_loop.rs is converted. The kqueue function is `#[cfg]`'d to macOS/FreeBSD, so the lint is also what pins that path from the Linux lanes.

A behavioural fail-before test is not possible for the reason given above (the old code never touched the references after the owner ran).

### Verification

- `cargo check` and `cargo clippy` for `bun_io` on x86_64-unknown-linux-gnu and aarch64-apple-darwin (the kqueue function, including the `syslog!` / `debug_assert!` spellings), `cargo check` on x86_64-unknown-freebsd; `cargo clippy -p bun_runtime`; `cargo fmt --check`; `test/internal/source-lints/` as a directory (88 pass).
- Against the debug build of this diff: `test/js/bun/spawn/spawn.test.ts`, `spawn-many-teardown.test.ts`, `spawn-pipe-stale-fd-unregister.test.ts` (pipe EOF and process exit deinit the poll from inside the dispatch), `test/js/node/dns/dns-tcp-bidirectional-poll.test.ts`, `dns-lookup-keepalive.test.ts`, `dns-resolver-concurrent-timeout.test.ts` (re-registration and deinit of the c-ares poll from inside `Channel::process`, i.e. the `on_dns_poll` path), `test/js/node/process/process-memory-pressure.test.ts`; earlier revision of the same code also ran `spawn-streaming-stdin.test.ts`, `spawn-stdin-destroy.test.ts` and the shell suites `pipeline_stack`, `epipe`, `shell-blocking-pipe`, `shell-pipe-read-fault`, `shell-write-fault`. `test/js/node/child_process/` passes except for the `$SHELL` test (the env `bun bd` runs tests with has no `SHELL`) and the 20-debug-child GC test hitting its 5 s budget on this machine (its fixture prints `OK` when run directly); `spawn-pipe-leak.test.ts` (750 debug children per test) hits its 30 s budget here the same way. #37803 reports the same local failures.

</details>
