### PR TITLE
bake: keep the dev server alive while its plugin load is pending; unlink deferred requests in Drop

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1113,17 +1113,16 @@ impl Drop for DevServer {
         }
 
         {
-            let mut r = self.next_bundle.requests.first;
-            while !r.is_null() {
-                // SAFETY: `r` is a live intrusive-list node linked by `defer_request`;
-                // read the link before `deref_` may reclaim the node.
-                let next = unsafe { (*r).next };
-                // SAFETY: `data` was initialized by `defer_request` before being
-                // linked; this exclusive borrow ends at `deref_` below.
+            // Unlink each node before `deref_` returns it to
+            // `deferred_request_pool`: the list's own `Drop` (which runs with the
+            // other fields after this body) frees whatever is still linked as if
+            // it were a heap node, and these are hive slots inside `*self`.
+            while let Some(r) = self.next_bundle.requests.pop_first() {
+                // SAFETY: `pop_first` returns a live node linked by `defer_request`;
+                // `data` was initialized there. The borrow ends at `deref_`.
                 let data = unsafe { (*r).data.assume_init_mut() };
                 debug_assert!(!matches!(data.handler, Handler::ServerHandler(_)));
                 data.deref_();
-                r = next;
             }
             self.next_bundle.promise.deinit_idempotently();
         }
@@ -1999,6 +1998,15 @@ fn ensure_route_is_bundled<Ctx: EnsureRouteCtx>(
                                     );
                                 match load_result {
                                     crate::server::GetOrStartLoadResult::Pending => {
+                                        // `ServePlugins` now points at this DevServer
+                                        // and will call `on_plugins_resolved` /
+                                        // `on_plugins_rejected` on it. As with a bundle
+                                        // in flight (`start_async_bundle`), hold a
+                                        // pending request until then so `stop()` cannot
+                                        // free the DevServer first.
+                                        if let Some(server) = dev.server.as_mut() {
+                                            server.on_pending_request();
+                                        }
                                         dev.plugin_state = PluginState::Pending;
                                         plugin = PluginState::Pending;
                                         continue 'plugin;
@@ -6128,13 +6136,16 @@ impl DevServer {
         &mut self,
         plugins: Option<*mut crate::api::js_bundler::Plugin>,
     ) -> crate::Result<()> {
+        debug_assert!(matches!(self.plugin_state, PluginState::Pending));
         self.bundler_options.plugin = plugins.and_then(::core::ptr::NonNull::new);
         self.plugin_state = PluginState::Loaded;
         self.start_next_bundle_if_present();
+        self.on_plugin_load_settled();
         Ok(())
     }
 
     pub(crate) fn on_plugins_rejected(&mut self) -> crate::Result<()> {
+        debug_assert!(matches!(self.plugin_state, PluginState::Pending));
         self.plugin_state = PluginState::Err;
         while let Some(item) = self.next_bundle.requests.pop_first() {
             // SAFETY: `pop_first` returns a valid `*mut Node<DeferredRequest>`;
@@ -6147,7 +6158,18 @@ impl DevServer {
         }
         self.next_bundle.route_queue.clear_retaining_capacity();
         // TODO: allow recovery from this state
+        self.on_plugin_load_settled();
         Ok(())
+    }
+
+    /// Releases the pending request taken when `plugin_state` became
+    /// `Pending` (see `ensure_route_is_bundled`). If the server was stopped
+    /// in the meantime this runs its idle pass, which drops `*self`, so it has
+    /// to be the caller's last use of `self`.
+    fn on_plugin_load_settled(&mut self) {
+        if let Some(mut server) = self.server {
+            server.on_static_request_complete();
+        }
     }
 }
 

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -907,8 +907,12 @@ pub enum ServePluginsState {
         // but `ServePlugins` is a refcounted heap object handed across FFI as
         // a raw promise-context pointer with dynamic lifetime, so a borrowed
         // `&'a DevServer` cannot be expressed here. Back-reference invariant:
-        // the DevServer outlives the pending plugin load (see the SAFETY
-        // comments at the deref sites in `on_plugins_resolved`/`_rejected`).
+        // a DevServer that registers itself here counts the load as one of
+        // its server's pending requests (`ensure_route_is_bundled`) until
+        // `on_plugins_resolved` / `on_plugins_rejected` is delivered, and
+        // every path that frees a `DevServer` goes through `deinit_if_we_can`,
+        // which requires that count to be zero. So the pointer is live until
+        // exactly that call, which must therefore be the last use of it.
         dev_server: Option<NonNull<DevServer>>,
     },
     Loaded(Box<JSBundler::Plugin>),
@@ -1155,9 +1159,9 @@ impl ServePlugins {
             unsafe { bun_ptr::RefCount::<html_bundle::Route>::deref(route) };
         }
         if let Some(mut server) = dev_server {
-            // SAFETY: dev_server outlives plugin load (stored as a back-reference
-            // by `get_or_start_load`; the owning Box<DevServer> is held by the
-            // server instance, which itself holds a counted ref on `self`).
+            // SAFETY: see `ServePluginsState::Pending::dev_server`: the
+            // DevServer holds a pending request on its server until this call,
+            // which may free it, so nothing touches `server` afterwards.
             bun_core::handle_oom(unsafe { server.as_mut() }.on_plugins_resolved(Some(
                 std::ptr::from_ref::<JSBundler::Plugin>(plugin_ref).cast_mut(),
             )));
@@ -1187,7 +1191,9 @@ impl ServePlugins {
             unsafe { bun_ptr::RefCount::<html_bundle::Route>::deref(route) };
         }
         if let Some(mut server) = dev_server {
-            // SAFETY: dev_server outlives plugin load
+            // SAFETY: see `ServePluginsState::Pending::dev_server`: the
+            // DevServer holds a pending request on its server until this call,
+            // which may free it, so nothing touches `server` afterwards.
             bun_core::handle_oom(unsafe { server.as_mut() }.on_plugins_rejected());
         }
 

--- a/test/bake/serve-plugins-dev-server.test.ts
+++ b/test/bake/serve-plugins-dev-server.test.ts
@@ -137,3 +137,124 @@ test.concurrent("DevServer is notified when [serve.static] plugin setup resolves
   expect(out).toEqual({ status: 200, fromPlugin: true });
   expect(exitCode).toBe(0);
 });
+
+// The cases below call server.stop(true) while the first request is still parked in
+// the DevServer waiting for the `[serve.static]` plugin's setup() to finish. The
+// request is aborted first (by the client, or by stop(true) itself closing the
+// connection), so nothing else keeps the server busy when stop() runs its idle pass.
+//
+// The DevServer must survive until the plugin load settles (ServePlugins still points
+// at it and calls on_plugins_resolved / on_plugins_rejected on it later), which is why
+// the load shows up in server.pendingRequests after stop(). Once it settles, on either
+// path, that pending request has to be released again: the stop() promise settles
+// and the same idle pass frees the DevServer.
+//
+// Without the fix the child dies inside stop(true): DevServer::drop returned the
+// aborted DeferredRequest to its pool without unlinking it from next_bundle.requests,
+// and the list's own Drop then walked the released slot (ASAN use-after-poison in
+// SinglyLinkedList<DeferredRequest>::drop). With only that part fixed, the plugin
+// settling would call into the freed DevServer instead.
+const pluginParkedInSetup = (afterRelease: string) => `
+  export default {
+    name: "parked-plugin",
+    async setup() {
+      globalThis.__parked();
+      await globalThis.__release;
+      ${afterRelease}
+    },
+  };
+`;
+
+const stopDuringPluginLoadServer = /* ts */ `
+  import html from "./index.html";
+
+  const parked = Promise.withResolvers();
+  const release = Promise.withResolvers();
+  globalThis.__parked = parked.resolve;
+  globalThis.__release = release.promise;
+
+  const server = Bun.serve({
+    port: 0,
+    development: true,
+    routes: { "/": html },
+    fetch() { return new Response("fallback"); },
+  });
+
+  const controller = new AbortController();
+  const request = fetch(server.url, { signal: controller.signal }).then(
+    res => String(res.status),
+    err => (typeof err.code === "string" ? err.code : err.name),
+  );
+  // setup() has been entered: the request is now deferred inside the DevServer until
+  // the plugin load settles.
+  await parked.promise;
+
+  if (process.argv[2] === "client-abort") {
+    controller.abort();
+    await request;
+    // A round trip through the plain fetch handler lets the server process the aborted
+    // connection before stop() runs (stop(true) would otherwise close it itself).
+    await fetch(new URL("/probe", server.url)).then(res => res.text());
+  }
+
+  const stopped = server.stop(true);
+  const pendingAfterStop = server.pendingRequests;
+
+  release.resolve();
+  let timer;
+  const stop = await Promise.race([
+    stopped.then(() => "closed"),
+    new Promise(resolve => { timer = setTimeout(() => resolve("timeout"), 10_000); }),
+  ]);
+  clearTimeout(timer);
+
+  console.log(JSON.stringify({ request: await request, pendingAfterStop, stop }));
+`;
+
+async function stopDuringPluginLoad(name: string, plugin: string, abortedBy: "client-abort" | "stop") {
+  using dir = tempDir(`serve-plugins-devserver-${name}`, {
+    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+    "plugin.ts": plugin,
+    "index.html": indexHtml,
+    "entry.ts": `console.log("entry");`,
+    "server.ts": stopDuringPluginLoadServer,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "server.ts", abortedBy],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const line = stdout.split("\n").find(l => l.startsWith("{"));
+  return { out: line === undefined ? undefined : JSON.parse(line), stderr, exitCode };
+}
+
+test.concurrent("stop(true) after the client aborted a request parked on plugin setup; setup resolves", async () => {
+  const { out, stderr, exitCode } = await stopDuringPluginLoad(
+    "abort-stop-resolve",
+    pluginParkedInSetup(""),
+    "client-abort",
+  );
+  expect(out, stderr).toEqual({ request: "AbortError", pendingAfterStop: 1, stop: "closed" });
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("stop(true) after the client aborted a request parked on plugin setup; setup rejects", async () => {
+  const { out, stderr, exitCode } = await stopDuringPluginLoad(
+    "abort-stop-reject",
+    pluginParkedInSetup(`throw new Error("plugin setup failed after stop");`),
+    "client-abort",
+  );
+  expect(out, stderr).toEqual({ request: "AbortError", pendingAfterStop: 1, stop: "closed" });
+  expect(stderr).toContain("plugin setup failed after stop");
+  expect(exitCode).toBe(0);
+});
+
+test.concurrent("stop(true) itself aborts the request parked on plugin setup", async () => {
+  const { out, stderr, exitCode } = await stopDuringPluginLoad("stop-aborts", pluginParkedInSetup(""), "stop");
+  expect(out, stderr).toEqual({ request: "ECONNRESET", pendingAfterStop: 1, stop: "closed" });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- `Bun.serve({ development: true })` with a `[serve.static]` plugin whose `setup()` is still pending: request the HTML route, let it abort, then `server.stop(true)`. A debug build dies with `AddressSanitizer: use-after-poison` in `Node<DeferredRequest>::next_of`, under `SinglyLinkedList<DeferredRequest> as Drop`, while `stop` drops the `Box<DevServer>`. A release build frees pointers into the DevServer's own allocation with no report.
- Cause 1: the DevServer's Drop returns each parked request to its pool but leaves it linked, so the list's own Drop then frees the released slots as if they were heap nodes. The list is only non-empty at drop time when the DevServer dies before its plugin load settles.
- Cause 2: with that fixed, the pending plugin load still holds a pointer to a DevServer that `stop()` has freed, because nothing counted the load as outstanding work; when `setup()` settles it calls into freed memory. A bundle in flight already counts itself; the plugin load before the first bundle did not.

### Fix
- The DevServer's Drop pops each parked request off the list before returning it to the pool, so the list is empty when its own Drop runs. Every other drain site already did this.
- When the plugin load comes back pending, the DevServer takes one pending request on its server and releases it as the last step of the resolve and reject callbacks. Every path that frees a DevServer requires that count to be zero, so the DevServer is live until exactly the call that releases it.
- Observable change: `stop()` during plugin setup now settles once the load (and the bundle it starts) finishes, the same as `stop()` during a bundle or a running `fetch` handler.
- Verification: three new tests park a request in `setup()`, call `stop(true)`, then resolve or reject setup, and check `server.pendingRequests` counts the load, the stop promise settles, and exit code 0. Without the fix all three die with the report above.

### Background
- DevServer is the object behind `development: true` HTML routes. The server owns it as a `Box` and frees it in an idle pass that runs once there is no listener, no connections and a pending-request count of zero.
- A request for a route that is not bundled yet is parked in an intrusive singly linked list on the DevServer until the next bundle (or the plugin load before the first one) settles. Its nodes are slots in a pool stored inline in the DevServer, not heap boxes.
- The list type's Drop frees whatever is still linked as a heap box, because its other user (the object pool free list) only links heap nodes. So this list must be empty when the DevServer is dropped.
- `[serve.static]` plugins may have an async `setup()`; the DevServer cannot bundle until it settles. While pending, the plugin loader keeps a raw back-pointer to the DevServer and calls it on resolve or reject.
- The server's pending-request count is the existing keep-alive for async work: holding one blocks `stop()` from tearing down until it is released.

<details>
<summary>Original description</summary>

### Repro

`Bun.serve({ development: true, routes: { "/": html } })` with a `[serve.static]` plugin whose `setup()` parks on a promise. Request the route (the DevServer defers it until the plugin load settles), abort the request from the client (or let `stop(true)` close it), then `server.stop(true)`. Debug (ASAN) build:

```
ERROR: AddressSanitizer: use-after-poison ... READ of size 8
    #0 <bun_collections::pool::Node<DeferredRequest>>::next_of src/collections/pool.rs:38
    #1 <bun_collections::pool::SinglyLinkedList<DeferredRequest> as Drop>::drop src/collections/pool.rs:75
    ... drop_glue::<NextBundle> / drop_glue::<Box<DevServer>>
    #7 <NewServer<false, true>>::deinit_if_we_can src/runtime/server/mod.rs:1902
    #8 NewServer::stop src/runtime/server/mod.rs:1791
    #9 NewServer::stop_from_js src/runtime/server/server_body.rs
SUMMARY: AddressSanitizer: use-after-poison src/collections/pool.rs:38:18 in Node<DeferredRequest>::next_of
```

The poisoned address is inside the `Box<DevServer>` allocation itself (the inline `deferred_request_pool` hive). A release build runs the same code without a report: `heap::take` on a pointer into the middle of the DevServer allocation.

### Cause

Two problems in the same window (DevServer freed while its plugin load is still pending):

1. `Drop for DevServer` walks `next_bundle.requests`, calling `deref_()` on each node, which returns the node to `deferred_request_pool`, but it never unlinks them, so `requests.first` still points at the released slots. `SinglyLinkedList` got a `Drop` in #30875 for its real owner, the `ObjectPool` free list, where every node is a heap `Box`; it runs as field drop glue right after this body and walks the released hive slots, `assume_init_drop`s them and frees them as boxes. `next_bundle.requests` is only non-empty at drop time when the DevServer goes away before a pending plugin load settles (aborted deferred requests stay linked by design until the list is drained), which is exactly this scenario. Every other drain site (`on_plugins_rejected`, `drain_current_bundle_requests`, `finalize_bundle`) uses `pop_first()`.

2. Once that no longer crashes, the same scenario leaves `ServePluginsState::Pending.dev_server` pointing at the freed DevServer. `deinit_if_we_can` drops the DevServer as soon as the server has no listener, connections or pending requests, and nothing counted the pending plugin load, so `handle_on_resolve` / `handle_on_reject` would later call `on_plugins_resolved` / `on_plugins_rejected` on freed memory (the SAFETY comments there assumed the server keeping `ServePlugins` alive also kept the DevServer alive, which is the wrong direction). A bundle in flight already handles this by calling `server.on_pending_request()` in `start_async_bundle` and releasing it in `finalize_bundle_cleanup`; the plugin load that precedes the first bundle was the one piece of asynchronous DevServer work that did not. (#37813 fixes the equivalent gap for the non-DevServer `html_bundle::Route`.)

### Fix

- `Drop for DevServer` drains `next_bundle.requests` with `pop_first()`, so the list is empty by the time its own `Drop` runs.
- When `get_or_load_plugins` returns `Pending`, the DevServer calls `server.on_pending_request()`; `on_plugins_resolved` and `on_plugins_rejected` release it as their last step (`on_plugin_load_settled`), since that release may run the idle pass that frees the DevServer. While the load is pending the DevServer can therefore not be freed (all DevServer teardown goes through `deinit_if_we_can`, which requires `pending_requests == 0`), which is what the back-reference in `ServePluginsState::Pending` needs; the comments there now state the actual invariant. On resolve, `start_next_bundle_if_present` takes the bundle's own pending request before this one is released, so the existing stop-during-bundle path takes over from there.

Observable effect: `server.stop()` called while the first request is waiting on plugin setup now settles once the load has landed (and the bundle it kicks off has finished), the same as `stop()` during a bundle or during a running `fetch` handler, instead of settling immediately and leaving a dangling pointer behind. `test/bake/deinitialization.test.ts` (which loads a `[serve.static]` plugin asynchronously on every case) still sees the DevServer deinit, so the reference is released on the normal path too.

This is independent of #36811 / #36812, which are about the `RequestContext` refs of framework-route (`ServerHandler`) entries; the keep-alive here also covers the `on_plugins_rejected` drain that #36812 brackets locally.

### Tests

`test/bake/serve-plugins-dev-server.test.ts` gains three cases that park a request on plugin `setup()`, call `stop(true)` (after a client abort, or letting `stop(true)` abort the request itself), then let setup resolve or reject. Each asserts the request outcome, that the load is still counted in `server.pendingRequests` right after `stop()`, that the `stop()` promise settles once the plugin settles (i.e. the reference is released on both paths), and exit code 0. Without the fix all three children die in `stop(true)` with the report above.

Also ran `test/bake/deinitialization.test.ts`, `test/bake/dev/plugins.test.ts`, `test/js/bun/http/bun-serve-html-405.test.ts` and `bun-serve-html-hot-reload-drop.test.ts` on the debug build.


</details>
