### PR TITLE
shell: report the command substitution status of an assignment-only command

### DIFF
--- a/src/runtime/shell/states/Assigns.rs
+++ b/src/runtime/shell/states/Assigns.rs
@@ -21,6 +21,10 @@ pub struct Assigns {
     pub node: bun_ptr::RawSlice<ast::Assign>,
     pub(crate) state: AssignsState,
     pub ctx: AssignCtx,
+    /// Status of the last `$(...)` performed while expanding the values, 0 if
+    /// none. An assignment list with no command name completes with it
+    /// (POSIX 2.9.1), so `FOO=$(false)` fails the way `false` does.
+    cmd_subst_exit_code: ExitCode,
 }
 
 #[derive(Default)]
@@ -47,6 +51,7 @@ impl Assigns {
             node: bun_ptr::RawSlice::new(node),
             state: AssignsState::Idle,
             ctx,
+            cmd_subst_exit_code: 0,
         }))
     }
 
@@ -76,8 +81,18 @@ impl Assigns {
                     return Expansion::start(interp, child);
                 }
                 AssignsState::Done => {
-                    let parent = interp.as_assigns(this).base.parent;
-                    return interp.child_done(parent, this, 0);
+                    let (parent, exit_code) = {
+                        let me = interp.as_assigns(this);
+                        let exit_code = match me.ctx {
+                            AssignCtx::Shell => me.cmd_subst_exit_code,
+                            // `Cmd` treats a nonzero status from this node as
+                            // an expansion failure; the command being prefixed
+                            // supplies the status (`FOO=$(false) echo hi` is 0).
+                            AssignCtx::Cmd => 0,
+                        };
+                        (me.base.parent, exit_code)
+                    };
+                    return interp.child_done(parent, this, exit_code);
                 }
             }
         }
@@ -108,8 +123,19 @@ impl Assigns {
             unreachable!("Assigns child_done outside Expanding")
         };
         // `idx` was bounds-checked in `next` before spawning the child.
-        let label = node.slice()[*idx as usize].label;
+        let assign = &node.slice()[*idx as usize];
         *idx += 1;
+
+        // Expansion reports `out_exit_code` only for a value that is a bare
+        // `$(...)` (0 when it succeeded). A value without a substitution leaves
+        // the status of an earlier one alone: `FOO=$(exit 3) BAR=x` is 3, while
+        // `FOO=$(exit 3) BAR=$(true)` is 0.
+        if matches!(
+            assign.value,
+            ast::Atom::Simple(ast::SimpleAtom::CmdSubst(_))
+        ) {
+            interp.as_assigns_mut(this).cmd_subst_exit_code = out.out_exit_code;
+        }
 
         // Join multi-word expansions with a single space. `ExpansionOut` stores all words contiguously in `buf`
         // with `bounds` marking inter-word offsets, so the merged value is
@@ -130,7 +156,7 @@ impl Assigns {
 
         let value_ref = EnvStr::init_ref_counted(value.into_boxed_slice());
         interp.as_assigns_mut(this).base.shell_mut().assign_var(
-            EnvStr::init_slice(label),
+            EnvStr::init_slice(assign.label),
             value_ref,
             ctx,
         );

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -518,6 +518,35 @@ describe("bunshell", () => {
     expect(stdout.toString()).toEqual(`noice\n`);
   });
 
+  // A command made only of assignments completes with the status of the last
+  // command substitution its values performed, or 0 if there was none
+  // (POSIX 2.9.1; bash and dash: `FOO=$(exit 3); echo $?` prints 3).
+  describe("assignment-only command, status of the last cmd subst", () => {
+    TestBuilder.command`FOO=$(exit 3)`.exitCode(3).runAsTest("failing substitution");
+    TestBuilder.command`FOO="$(exit 3)"`.exitCode(3).runAsTest("failing quoted substitution");
+    TestBuilder.command`FOO=$(exit 0)`.exitCode(0).runAsTest("successful substitution");
+    TestBuilder.command`false; FOO=bar`.exitCode(0).runAsTest("no substitution is 0 even after a failing command");
+    TestBuilder.command`FOO=$(echo v; exit 3); echo $FOO`
+      .stdout("v\n")
+      .runAsTest("value is still assigned and the next statement still runs");
+    TestBuilder.command`FOO=$(exit 3) BAR=$(exit 4)`.exitCode(4).runAsTest("last substitution wins");
+    TestBuilder.command`FOO=$(exit 3) BAR=$(exit 0)`.exitCode(0).runAsTest("later successful substitution wins");
+    TestBuilder.command`FOO=$(exit 3) BAR=bar`.exitCode(3).runAsTest("later literal value keeps the status");
+    TestBuilder.command`FOO=$(exit 3) BAR=*.nomatch`
+      .exitCode(3)
+      .runAsTest("later unmatched glob value keeps the status");
+    TestBuilder.command`FOO=$(false) || echo no`.stdout("no\n").runAsTest("takes the || branch");
+    TestBuilder.command`FOO=$(exit 3) && echo hi`.exitCode(3).runAsTest("fails an && chain");
+    TestBuilder.command`if FOO=$(false); then echo yes; else echo no; fi`
+      .stdout("no\n")
+      .runAsTest("as an if condition");
+    TestBuilder.command`(FOO=$(exit 3))`.exitCode(3).runAsTest("as the last command of a subshell");
+    TestBuilder.command`FOO=$(exit 3) echo hi`
+      .stdout("hi\n")
+      .exitCode(0)
+      .runAsTest("prefix assignment leaves the status to the command");
+  });
+
   describe("empty_expansion", () => {
     TestBuilder.command`$(exit 0) && echo hi`.stdout("hi\n").runAsTest("empty command subst");
     TestBuilder.command`$(exit 1) && echo hi`.exitCode(1).runAsTest("empty command subst 2");

--- a/test/js/bun/shell/exec.test.ts
+++ b/test/js/bun/shell/exec.test.ts
@@ -27,6 +27,11 @@ describe("bun exec", () => {
     .stdout('hi "there bud"\n')
     .runAsTest("it works2");
 
+  TestBuilder.command`${BUN} exec ${"FOO=$(exit 3)"}`
+    .env(bunEnv)
+    .exitCode(3)
+    .runAsTest("exits with the status of an assignment's command substitution");
+
   TestBuilder.command`${BUN} exec ${"cat filename"}`
     .file(
       "filename",


### PR DESCRIPTION
### Problem
- In the bun shell `FOO=$(exit 3)` exits 0, `FOO=$(false) || echo no` prints nothing, and `if x=$(false); then ...` takes the then branch. bash and dash give 3, `no`, and the else branch. `bun exec 'FOO=$(exit 3)'` exits 0 too.
- POSIX 2.9.1: a command with no command name exits with the status of the last command substitution it performed, or 0 if none. The bun shell already does this for a bare `$(exit 3)`.
- A command made only of assignments always reported 0, so a failing substitution inside one was invisible to `||`, `&&` and `if`.

### Fix
- An assignment-only command now finishes with the status of the last value that was a bare `$(...)`; values without one leave it alone, so as in bash `FOO=$(exit 3) BAR=x` is 3 and `FOO=$(exit 3) BAR=$(true)` is 0. A `$` script ending in one now rejects with `ShellError` unless `.nothrow()` is used, like the failing command run directly; earlier in a script the value is still assigned and the script continues, as before.
- Assignments in front of a command (`FOO=$(false) echo hi`) still report 0: the command they prefix supplies the status, and a nonzero status from the prefix would abort that command instead of running it.
- Out of scope, still 0: a substitution inside a longer value (`FOO=x$(exit 3)`, needs #37822) and a prefix whose command expands to nothing (`FOO=$(exit 3) $UNSET`, needs #37808).
- Verification: new shell tests, 10 of which fail on the current release and pass with the fix, plus 5 that pass both ways and pin what must not change; the existing assignment suites still pass on a debug build.

### Background
- The bun shell (`Bun.$`, `bun exec`) is bun's own POSIX-style shell, in Rust. Each syntax node runs as a small state machine and reports one exit status to its parent node when it finishes.
- A line made only of `NAME=value` words is a command of its own. The same words in front of a command name (`FOO=x cmd`) are prefix assignments scoped to that command; the node that performs assignments knows which of the two it is running as.
- Command substitution, `$(...)`, runs a command and splices its output into the word, and has an exit status of its own.
- Expanding a value already hands back that status next to the text, but only when the whole value is one bare `$(...)`; a substitution inside a longer word reports nothing yet, hence the first out-of-scope case.

<details>
<summary>Original description</summary>

### Repro

```ts
import { $ } from "bun";
console.log((await $`FOO=$(exit 3)`.nothrow()).exitCode);                     // 0, expected 3
console.log((await $`FOO=$(false) || echo no`.nothrow()).stdout.toString());  // "", expected "no\n"
console.log((await $`FOO=$(true) BAR=$(exit 3)`.nothrow()).exitCode);         // 0, expected 3
await $`if out=$(false); then echo yes; else echo no; fi`;                    // prints yes, expected no
```

`bun exec 'FOO=$(exit 3)'` exits 0 as well. bash and dash give 3, `no`, 3, `no`: a simple command with no command name completes with the status of the last command substitution it performed, or 0 if there was none (POSIX 2.9.1), and `X=$(cmd)` on its own is the everyday shape of that rule. The bun shell already applies it to `$(exit 3)` with no assignment, but an assignment-only command always reported 0, so the status of the substitution was unobservable: `$` resolved, `||` never took its branch, `if x=$(cmd)` always took the then branch.

### Cause

A standalone `FOO=...` statement runs as the `Assigns` state (`src/runtime/shell/states/Assigns.rs`). `Assigns::child_done` receives each value's `ExpansionOut`, which already carries the substitution's status in `out_exit_code` for a value that is a bare `$(...)` (the same field `Cmd` uses for the no-command-name case), but only used it for the value text. `Assigns::next` then reported a hardcoded 0 to its parent from the `Done` arm.

### Fix

`Assigns` keeps `cmd_subst_exit_code`: for every value that is a bare `$(...)` it takes that value's status (0 when it succeeded), so the last substitution performed wins and a value without one leaves the status alone (`FOO=$(exit 3) BAR=x` is 3, `FOO=$(exit 3) BAR=$(true)` is 0, both as in bash). The `Done` arm reports it when the assignments are a command of their own (`AssignCtx::Shell`). Prefix assignments (`AssignCtx::Cmd`) still report 0: `Cmd::child_done` reads a nonzero status from an `Assigns` child as an expansion failure and aborts the command, and `FOO=$(false) echo hi` has to run `echo` and exit 0.

Because the status is now reported, a script whose last command is an assignment with a failing substitution (say `v=$(git describe)` as the whole script) rejects with a `ShellError` unless `.nothrow()` is used, the same as running `git describe` directly does; a failing substitution earlier in the script still assigns the value and continues (`FOO=$(echo v; exit 3); echo $FOO` prints `v` and exits 0, as before).

Left out on purpose, both are handled by in-flight PRs touching the nodes they belong to:

- `FOO=x$(exit 3)` (substitution inside a compound value) still reports 0: `Expansion` only reports a status for a bare `$(...)` word today. #37822 changes `ExpansionOut` to report the last substitution of every word as an `Option`; once both are in, the AST check added here becomes `if let Some(code) = out.cmd_subst_exit_code` and that shape is covered too.
- `FOO=$(exit 3) $UNSET` (prefix assignment whose argv expands to nothing, bash: 3) still reports 0. That needs `Cmd` to read the status out of its `Assigns` child and use it in the empty-argv branch, which depends on the separate status field #37808 introduces in `Cmd`.

Assignments inside a pipeline are skipped entirely by design (`test/js/bun/shell/assignments-in-pipeline.test.ts`), so they are unaffected.

### Tests

New `assignment-only command, status of the last cmd subst` block in `test/js/bun/shell/bunshell.test.ts` and a `bun exec` case in `test/js/bun/shell/exec.test.ts`. Against the current release 10 of the 15 fail (exit code 0 instead of 3 or 4, or the wrong `||` / `if` branch): unquoted and quoted `$(...)`, last of two substitutions wins, a later literal or unmatched-glob value keeps the status, `||`, `&&`, `if` condition, inside a subshell, and `bun exec`. The other 5 pass before and after and pin the contracts the fix has to keep: a successful substitution is 0, an assignment without one is 0 (also right after `false`), the value is still assigned and the script continues after a failing substitution, a later successful substitution resets the status to 0 (which is what separates "last performed" from "last nonzero"), and a prefix assignment leaves the status to its command (which is what the `AssignCtx::Cmd` arm is for). The existing shell suites that use assignments (`bunshell.test.ts`, `assignments-in-pipeline.test.ts`, `exec.test.ts`, the glob-in-assignment tests) still pass with the debug build.


</details>
