### PR TITLE
io: dispatch a ready FilePoll through its pointer, not a &mut receiver

### DIFF
--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -349,12 +349,13 @@ impl FilePoll {
     // through the pointer the owner keeps (`FilePollRef`, `PollerPosix::Fd`,
     // the resolver's poll map): a one-shot re-arm reads and clears the
     // `NeedsRearm` that `on_update` set, and an owner that is finished deinits
-    // the slot (`Store::put` marks it `IgnoreUpdates`; the free itself is
-    // deferred past this turn). A `&mut self` receiver on any frame of the
-    // chain would be a protected reference spanning those foreign accesses,
-    // and a protected `&mut Loop` would alias the fresh `&mut Loop` the
-    // handler conjures via `EventLoopCtx::platform_event_loop()`. Nothing on
-    // the chain touches the slot after the handler returns.
+    // the slot. A `&mut self` receiver on any frame of the chain would be a
+    // protected reference spanning those foreign accesses, and a protected
+    // `&mut Loop` would alias the fresh `&mut Loop` the handler conjures via
+    // `EventLoopCtx::platform_event_loop()`. Each frame only needs the slot to
+    // be live when it is entered: nothing on the chain touches it after the
+    // handler returns, so what the handler did to it (up to returning it to
+    // the store) does not matter here.
 
     /// # Safety
     /// `this` is a live hive slot (the dispatch entry has checked `IgnoreUpdates`).
@@ -475,8 +476,8 @@ impl FilePoll {
         // Hot-path hoisted-match: the per-tag `switch` lives in
         // `bun_runtime::dispatch::__bun_run_file_poll` (link-time extern) so
         // this T3 crate names no variant types.
-        // SAFETY: caller contract; the slot stays allocated for the whole call
-        // even if the owner deinits it (`Store::put` defers the free).
+        // SAFETY: caller contract (`this` is live on entry). The owner may
+        // deinit the slot in there; nothing reads it afterwards, here or above.
         unsafe { __bun_run_file_poll(this, size_or_offset) };
     }
 
@@ -1531,9 +1532,10 @@ unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
     // `FilePoll::on_kqueue_event`.
     let file_poll: *mut FilePoll = tag.as_file_poll();
     // SAFETY: tag matched FilePoll; the pointer was set via `Pollable::init` in
-    // `register_with_fd`. A slot deinited earlier in this turn is still
-    // allocated (`Store::put` defers the free) and carries `IgnoreUpdates`.
-    // The borrow ends with the statement.
+    // `register_with_fd`, and `Store::put` keeps a slot whose owner has since
+    // deinited it readable for this check (it flags it `IgnoreUpdates` and
+    // defers the free to the tick's after-callback). The borrow ends with the
+    // statement.
     if unsafe { (*file_poll).flags.contains(Flags::IgnoreUpdates) } {
         return;
     }

--- a/src/io/posix_event_loop.rs
+++ b/src/io/posix_event_loop.rs
@@ -342,34 +342,57 @@ impl FilePoll {
         FileType::Pipe
     }
 
-    // Note: these handlers take no loop parameter: holding a
-    // protected `&mut Loop` across `on_update` would alias the fresh `&mut Loop`
-    // that downstream `__bun_run_file_poll` handlers conjure via
-    // `EventLoopCtx::platform_event_loop()` when they re-enter the loop
-    // (`register_with_fd`/`unregister`/`deinit`).
-    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-    pub(crate) fn on_kqueue_event(&mut self, kqueue_event: &KQueueEvent) {
-        self.update_flags(Flags::from_kqueue_event(kqueue_event));
-        syslog!("onKQueueEvent: {}", self);
+    // The ready-poll dispatch chain (`Bun__internal_dispatch_ready_poll` ->
+    // `on_kqueue_event`/`on_epoll_event` -> `on_update` ->
+    // `__bun_run_file_poll`) carries the poll as `*mut FilePoll` and takes no
+    // loop parameter. The owner handler at the bottom reaches this same slot
+    // through the pointer the owner keeps (`FilePollRef`, `PollerPosix::Fd`,
+    // the resolver's poll map): a one-shot re-arm reads and clears the
+    // `NeedsRearm` that `on_update` set, and an owner that is finished deinits
+    // the slot (`Store::put` marks it `IgnoreUpdates`; the free itself is
+    // deferred past this turn). A `&mut self` receiver on any frame of the
+    // chain would be a protected reference spanning those foreign accesses,
+    // and a protected `&mut Loop` would alias the fresh `&mut Loop` the
+    // handler conjures via `EventLoopCtx::platform_event_loop()`. Nothing on
+    // the chain touches the slot after the handler returns.
 
+    /// # Safety
+    /// `this` is a live hive slot (the dispatch entry has checked `IgnoreUpdates`).
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    pub(crate) unsafe fn on_kqueue_event(this: *mut FilePoll, kqueue_event: &KQueueEvent) {
+        // SAFETY: caller contract; the borrow ends with the statement.
+        unsafe { (*this).update_flags(Flags::from_kqueue_event(kqueue_event)) };
+        // SAFETY: caller contract; the borrow ends with the statement.
+        syslog!("onKQueueEvent: {}", unsafe { &*this });
+
+        // SAFETY: caller contract.
         #[cfg(all(target_os = "macos", debug_assertions))]
-        debug_assert!(self.generation_number == kqueue_event.ext[0] as usize);
+        debug_assert!(unsafe { (*this).generation_number } == kqueue_event.ext[0] as usize);
 
         // EVFILT_MEMORYSTATUS reports the pressure level in `fflags`, not `data`;
         // thread it through `size_or_offset` so the dispatch arm can read it.
         #[cfg(target_os = "macos")]
         if kqueue_event.filter == bun_sys::darwin::EVFILT::MEMORYSTATUS {
-            self.on_update(kqueue_event.fflags as i64);
+            // SAFETY: caller contract.
+            unsafe { Self::on_update(this, kqueue_event.fflags as i64) };
             return;
         }
 
-        self.on_update(kqueue_event.data as i64);
+        // SAFETY: caller contract.
+        unsafe { Self::on_update(this, kqueue_event.data as i64) };
     }
 
+    /// # Safety
+    /// `this` is a live hive slot (the dispatch entry has checked `IgnoreUpdates`).
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    pub(crate) fn on_epoll_event(&mut self, epoll_event: &bun_sys::linux::epoll_event) {
-        self.update_flags(Flags::from_epoll_event(epoll_event));
-        self.on_update(0);
+    pub(crate) unsafe fn on_epoll_event(
+        this: *mut FilePoll,
+        epoll_event: &bun_sys::linux::epoll_event,
+    ) {
+        // SAFETY: caller contract; the borrow ends with the statement.
+        unsafe { (*this).update_flags(Flags::from_epoll_event(epoll_event)) };
+        // SAFETY: caller contract.
+        unsafe { Self::on_update(this, 0) };
     }
 
     pub fn is_readable(&mut self) -> bool {
@@ -431,19 +454,30 @@ impl FilePoll {
             || self.flags.contains(Flags::PollMemoryPressure)
     }
 
-    pub(crate) fn on_update(&mut self, size_or_offset: i64) {
-        if self.flags.contains(Flags::OneShot) && !self.flags.contains(Flags::NeedsRearm) {
-            self.flags.insert(Flags::NeedsRearm);
-        }
+    /// Hands the ready poll to its owner; raw for the reasons given above
+    /// `on_kqueue_event` (the owner's re-arm reads the `NeedsRearm` set here
+    /// through its own pointer while this frame is still on the stack).
+    ///
+    /// # Safety
+    /// `this` is a live hive slot.
+    pub(crate) unsafe fn on_update(this: *mut FilePoll, size_or_offset: i64) {
+        // SAFETY: caller contract; every borrow in the block ends with its
+        // statement, before the owner runs.
+        unsafe {
+            if (*this).flags.contains(Flags::OneShot) && !(*this).flags.contains(Flags::NeedsRearm)
+            {
+                (*this).flags.insert(Flags::NeedsRearm);
+            }
 
-        debug_assert!(!self.owner.is_null());
+            debug_assert!(!(*this).owner.is_null());
+        }
 
         // Hot-path hoisted-match: the per-tag `switch` lives in
         // `bun_runtime::dispatch::__bun_run_file_poll` (link-time extern) so
         // this T3 crate names no variant types.
-        // SAFETY: `self` is a live FilePoll for the duration of the call
-        // (guaranteed by the uws loop callback contract).
-        unsafe { __bun_run_file_poll(self, size_or_offset) };
+        // SAFETY: caller contract; the slot stays allocated for the whole call
+        // even if the owner deinits it (`Store::put` defers the free).
+        unsafe { __bun_run_file_poll(this, size_or_offset) };
     }
 
     #[inline]
@@ -1493,9 +1527,14 @@ unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
         return;
     }
 
-    // SAFETY: tag matched FilePoll; pointer was set via Pollable::init in register_with_fd.
-    let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };
-    if file_poll.flags.contains(Flags::IgnoreUpdates) {
+    // Kept raw for the whole dispatch; see the note above
+    // `FilePoll::on_kqueue_event`.
+    let file_poll: *mut FilePoll = tag.as_file_poll();
+    // SAFETY: tag matched FilePoll; the pointer was set via `Pollable::init` in
+    // `register_with_fd`. A slot deinited earlier in this turn is still
+    // allocated (`Store::put` defers the free) and carries `IgnoreUpdates`.
+    // The borrow ends with the statement.
+    if unsafe { (*file_poll).flags.contains(Flags::IgnoreUpdates) } {
         return;
     }
 
@@ -1508,10 +1547,14 @@ unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
     // handler is free to form its own `&mut Loop`.
     let ev = unsafe { &*loop_ }.current_ready_event();
 
-    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-    file_poll.on_kqueue_event(&ev);
-    #[cfg(any(target_os = "linux", target_os = "android"))]
-    file_poll.on_epoll_event(&ev);
+    // SAFETY: `file_poll` is live (checked above) and is not touched again here
+    // once the owner has run.
+    unsafe {
+        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        FilePoll::on_kqueue_event(file_poll, &ev);
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        FilePoll::on_epoll_event(file_poll, &ev);
+    }
 }
 
 #[cfg(target_os = "macos")]

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -650,16 +650,22 @@ pub(crate) fn tick_queue_with_count(
 /// calls this directly (link-time resolved) so it never names `Subprocess` /
 /// `FileSink` / `DNSResolver` / etc.
 ///
+/// Every frame above this (`Bun__internal_dispatch_ready_poll` ->
+/// `on_kqueue_event`/`on_epoll_event` -> `on_update`) holds the poll only as
+/// this raw pointer, and so does this one: the handlers re-arm or deinit the
+/// slot through the pointer their owner keeps, so no frame on the chain may
+/// hold a reference into it while they run. An arm that hands the poll to such
+/// a handler passes `poll` itself, not a `&mut` reborrow.
+///
 /// # Safety
-/// `poll` must point at a live [`FilePoll`] for the duration of the call
-/// (guaranteed by `FilePoll::on_update`, the only caller).
+/// `poll` must point at a live [`FilePoll`] on entry (guaranteed by
+/// `FilePoll::on_update`, the only caller). The handler may deinit it; nothing
+/// reads `*poll` after the handler returns, here or in the callers.
 #[cfg(not(windows))]
 #[unsafe(no_mangle)]
 pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
-    // SAFETY: contract above.
-    let poll_ref = unsafe { &mut *poll };
-    let owner = poll_ref.owner;
-    let hup = poll_ref.flags.contains(PollFlag::Hup);
+    // SAFETY: contract above; both reads end with the statement.
+    let (owner, hup) = unsafe { ((*poll).owner, (*poll).flags.contains(PollFlag::Hup)) };
 
     debug_assert!(!owner.is_null());
 
@@ -740,8 +746,10 @@ pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i6
             // `Channel::process` re-enters the resolver via c-ares callbacks.
             // SAFETY: tag set with this pointee type at `FilePoll::init`.
             let resolver = unsafe { &*owner.ptr.cast_const().cast::<DNSResolver>() };
-            // SAFETY: `poll` outlives this call (caller contract).
-            resolver.on_dns_poll(unsafe { &mut *poll });
+            // Passed raw: those same callbacks re-register or deinit this poll
+            // through the resolver's poll map (`on_dns_socket_state`).
+            // SAFETY: `poll` is live per the contract above.
+            unsafe { resolver.on_dns_poll(poll) };
         }
         poll_tag::GET_ADDR_INFO_REQUEST => {
             #[cfg(target_os = "macos")]

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4782,27 +4782,43 @@ impl Resolver {
     /// UnsafeCell-backed, LLVM cannot cache `ref_count` across the FFI call —
     /// the structural fix for the previously ASM-verified PROVEN_CACHED
     /// miscompile that needed `black_box` laundering under `&mut self`.
+    ///
+    /// `poll` is raw for the same reason: `Channel::process` also fires the
+    /// socket-state callback, and `on_dns_socket_state` re-registers or deinits
+    /// this very poll through the pointer in `self.polls`. A `&mut FilePoll`
+    /// parameter would be a protected reference spanning those accesses, so
+    /// the poll is read into locals before `process` and not touched after.
+    ///
+    /// # Safety
+    /// `poll` is the live `FilePoll` this resolver registered for one of its
+    /// c-ares sockets (`__bun_run_file_poll`'s contract).
     #[cfg(not(windows))]
-    pub(crate) fn on_dns_poll(&self, poll: &mut FilePoll) {
+    pub(crate) unsafe fn on_dns_poll(&self, poll: *mut FilePoll) {
         let vm = self.vm();
         let _exit = vm.enter_event_loop_scope();
+        // SAFETY: fn contract; the read ends with the statement.
+        let fd = unsafe { (*poll).fd.native() };
         let Some(channel) = self.channel.get() else {
             self.polls.with_mut(|p| {
-                let _ = p.remove(&poll.fd.native());
+                let _ = p.remove(&fd);
             });
-            poll.deinit();
+            // SAFETY: fn contract; the map entry removed above was the only
+            // other handle to the slot, so this is its last use.
+            unsafe { (*poll).deinit() };
             return;
         };
 
         // SAFETY: `self` is the heap allocation from `init`; ref_scope keeps count > 0 across re-entrant callbacks.
         let _deref = unsafe { Self::ref_scope(self.as_ctx_ptr()) };
 
+        // SAFETY: fn contract; both autoref'd `&mut`s end with the statement,
+        // before `process` can reach the slot through the map.
+        let (readable, writable) = unsafe { ((*poll).is_readable(), (*poll).is_writable()) };
+
         // SAFETY: `channel` is the live c-ares channel owned by `self`; no `&mut`
-        // to `*self` is held across this re-entrant call (all fields are
-        // UnsafeCell-backed).
-        unsafe {
-            (*channel).process(poll.fd.native(), poll.is_readable(), poll.is_writable());
-        }
+        // to `*self` (all fields are UnsafeCell-backed) or to `*poll` is held
+        // across this re-entrant call.
+        unsafe { (*channel).process(fd, readable, writable) };
 
         // c-ares detaches a query only *after* its callback returns, so
         // `request_completed` may have seen it still counted; re-check now.

--- a/test/internal/source-lints/file-poll-dispatch-raw.test.ts
+++ b/test/internal/source-lints/file-poll-dispatch-raw.test.ts
@@ -17,38 +17,44 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // the pointer it keeps itself (`FilePollRef`, `PollerPosix::Fd`, the resolver's
 // poll map, and for the DNS frame c-ares' socket-state callback from inside
 // `Channel::process`): a one-shot re-arm reads and clears the `NeedsRearm` that
-// `on_update` just set, a reader at EOF / an exited process / a closed c-ares
-// socket deinits the slot, and `Store::put` marks it `IgnoreUpdates`. Those are
-// accesses through a pointer foreign to any `&mut self` / `&mut FilePoll`
-// argument still live up the stack, and a reference argument is protected for
-// the whole call under both aliasing models (the same protector rule
-// self-receiver-reclaim.test.ts describes for frees; rustc also emits
-// `noalias` for such arguments). The chain therefore carries the raw pointer
-// all the way down, reads the slot only through statement-scoped `(*p).field`
-// accesses, and never touches it after the owner returns. `FilePollRef::inner`
-// and `PollerPosix::fd_poll_mut` document their `&mut FilePoll` as the only live
-// reference to the slot; that is only true while this holds.
+// `on_update` just set, and a reader at EOF / an exited process / a closed
+// c-ares socket deinits the slot. Those are accesses through a pointer foreign
+// to any `&mut self` / `&mut FilePoll` argument still live up the stack, and a
+// reference argument is protected for the whole call under both aliasing models
+// (the same protector rule self-receiver-reclaim.test.ts describes for frees;
+// rustc also emits `noalias` for such arguments). The chain therefore carries
+// the raw pointer all the way down, reads the slot only through
+// statement-scoped `(*p).field` accesses, and never touches it after the owner
+// returns. `FilePollRef::inner` and `PollerPosix::fd_poll_mut` document their
+// `&mut FilePoll` as the only live reference to the slot; that is only true
+// while this holds.
 //
-// This lint pins, for each frame in CHAIN below (located by name, wherever it
-// lives):
+// For each frame in CHAIN (located by name, wherever it lives) this pins:
 //   - signature: the poll arrives as `*mut FilePoll` (a `self` receiver on the
 //     FilePoll methods counts as taking it by reference unless spelled
 //     `self: *mut Self`), and no parameter takes it as `&FilePoll` / `&mut
 //     FilePoll`;
-//   - body: no `let` binding holds it as a reference for the rest of the frame
-//     (a typed `&[mut] FilePoll` binding, or a `&mut *..` reborrow as the whole
-//     initializer; fn-long-mut-reborrow.test.ts bans the latter tree-wide for
-//     the usual parameter names). Statement-scoped reborrows (`(*p).flags`,
-//     `(*p).update_flags(..)`) are the intended shape and are not matched;
-//   - hand-off: the arms that pass the poll on to code which re-arms or
-//     deinits it (`rawHandoffs`) pass the pointer parameter itself, since a
-//     `&mut *poll` argument coerces to `*mut` and would compile.
+//   - hand-off: the frame itself calls the next frame(s) of the chain
+//     (`handsTo`), with its pointer as the first argument. This is what keeps
+//     the chain closed: a helper interposed between two frames, whether it
+//     takes `&mut FilePoll` or is a `&mut self` method called as
+//     `(*this).helper()`, means the frame no longer calls the next one
+//     directly and is reported; so is a `&mut *this` argument, which would
+//     coerce to `*mut` and compile. The entry point decodes the tagged pointer
+//     it gets from uSockets, so its pointer is the body's
+//     `let <name>: *mut FilePoll = ..` binding;
+//   - body: no `let` binding is a `&[mut] FilePoll`, or has a `&mut *..` /
+//     `unsafe { ...as_mut()... }` reborrow as its whole initializer, i.e. no
+//     frame holds a reference into the slot beyond a single statement.
+//     Statement-scoped accesses (`(*p).flags`, `(*p).update_flags(..)`) are
+//     the intended shape and are not matched.
 //
-// A new frame on the chain (or a new arm that hands the poll to re-entrant
-// code) goes into CHAIN. `FilePoll::deinit*` themselves (the owner's side of
-// the same contract) are converted in #37803, together with the two frames in
-// ALLOW below. Siblings: self-receiver-reclaim.test.ts,
-// fn-long-mut-reborrow.test.ts, writer-parent-mut-borrow.test.ts.
+// A new frame on the chain goes into CHAIN (and into the `handsTo` of the frame
+// above it); a new `__bun_run_file_poll` arm that passes the poll to a handler
+// goes into its `handsTo`. `FilePoll::deinit*` themselves (the owner's side of
+// the same contract) are converted in #37803. Siblings:
+// self-receiver-reclaim.test.ts, fn-long-mut-reborrow.test.ts,
+// writer-parent-mut-borrow.test.ts.
 
 interface Frame {
   /** Function name; unique across the Rust tree. */
@@ -57,53 +63,50 @@ interface Frame {
    * How the poll reaches the frame. `receiver`: a method on FilePoll itself.
    * `param`: a free function or a method on something else, with the poll as
    * an ordinary parameter. `tagged`: the entry point, which receives the
-   * tagged `void*` from uSockets and decodes it; only its body is checked.
+   * tagged `void*` from uSockets and decodes it in its body.
    */
   poll: "receiver" | "param" | "tagged";
-  /** Callees inside the body that must be passed the poll pointer parameter as-is. */
-  rawHandoffs?: string[];
+  /** The next frame(s) of the chain; each must be called with this frame's pointer as the first argument. */
+  handsTo: string[];
 }
 
 const CHAIN: Frame[] = [
-  { name: "Bun__internal_dispatch_ready_poll", poll: "tagged" },
-  { name: "on_kqueue_event", poll: "receiver" },
-  { name: "on_epoll_event", poll: "receiver" },
-  { name: "on_update", poll: "receiver" },
+  // Both calls are present in the source (one per `#[cfg]`), so both are checked
+  // whatever the host platform is.
+  { name: "Bun__internal_dispatch_ready_poll", poll: "tagged", handsTo: ["on_kqueue_event", "on_epoll_event"] },
+  { name: "on_kqueue_event", poll: "receiver", handsTo: ["on_update"] },
+  { name: "on_epoll_event", poll: "receiver", handsTo: ["on_update"] },
+  { name: "on_update", poll: "receiver", handsTo: ["__bun_run_file_poll"] },
   // Matches the definition in dispatch.rs and the `extern "Rust"` declaration
-  // in posix_event_loop.rs (declaration: signature only).
-  { name: "__bun_run_file_poll", poll: "param", rawHandoffs: ["on_dns_poll"] },
-  { name: "on_dns_poll", poll: "param" },
+  // in posix_event_loop.rs (declaration: signature only). `on_dns_poll` is the
+  // one arm that passes the poll on to a handler which re-arms or deinits it.
+  { name: "__bun_run_file_poll", poll: "param", handsTo: ["on_dns_poll"] },
+  { name: "on_dns_poll", poll: "param", handsTo: [] },
 ];
 
 // Documented, ratcheted exceptions: files allowed to report exactly N
-// violations. Prefer converting over adding an entry here.
-const ALLOW: Record<string, number> = {
-  // `__bun_run_file_poll` keeps a `&mut` into the slot for its `owner`/`hup`
-  // reads and hands `on_dns_poll` a `&mut *poll`; `on_dns_poll` takes it as
-  // `&mut FilePoll`. Both are converted in #37803 along with `FilePoll::deinit*`;
-  // delete these entries when it lands (the ratchet test below says so).
-  "src/runtime/dispatch.rs": 2,
-  "src/runtime/dns_jsc/dns.rs": 2,
-};
+// violations. Empty by design; prefer converting over adding an entry here.
+const ALLOW: Record<string, number> = {};
 
 const POLL_TYPE = String.raw`(?:[\w]+::)*(?:FilePoll|Self)\b`;
-const RAW_POLL_PARAM = new RegExp(
-  String.raw`^\s*(\w+)\s*:\s*(?:\*\s*mut\s+${POLL_TYPE}|(?:[\w]+::)*NonNull\s*<\s*${POLL_TYPE}\s*>)`,
-);
+const RAW_POLL_PARAM = new RegExp(String.raw`^\s*(\w+)\s*:\s*\*\s*mut\s+${POLL_TYPE}`);
 const REF_POLL_PARAM = new RegExp(String.raw`:\s*&\s*(?:'\w+\s+)?(?:mut\s+)?${POLL_TYPE}`);
 const RECEIVER = /^\s*(?:&\s*(?:'\w+\s+)?(?:mut\s+)?self\b|(?:mut\s+)?self\b)/;
 const RAW_RECEIVER = /^\s*self\s*:\s*\*\s*(?:mut|const)\b/;
+// The entry point's decoded pointer: `let file_poll: *mut FilePoll = ..`.
+const RAW_POLL_BINDING = new RegExp(String.raw`\blet\s+(\w+)\s*:\s*\*\s*mut\s+${POLL_TYPE}\s*=`);
 
 // `let x: &mut FilePoll = ..` / `let x: &FilePoll = ..`, any path prefix.
 const REF_POLL_BINDING = new RegExp(
   String.raw`\blet\s+(?:mut\s+)?\w+\s*:\s*&\s*(?:'\w+\s+)?(?:mut\s+)?${POLL_TYPE}`,
   "g",
 );
-// `let x = unsafe { &mut *p };` / `let x = &mut *p;`, i.e. the reborrow is the
-// whole initializer. `unsafe { &*loop_ }.current_ready_event()` and other
-// call-scoped reborrows continue past the `}` and do not match.
-const MUT_REBORROW_BINDING =
-  /\blet\s+(?:mut\s+)?\w+\s*(?::[^=;{}]*)?=\s*(?:unsafe\s*\{\s*&mut\s+\*[^;{}]*\}|&mut\s+\*[^;{}]*)\s*;/g;
+// A reborrow as the whole initializer: `let x = unsafe { &mut *p };`,
+// `let x = &mut *p;`, `let x = unsafe { p.as_mut().unwrap_unchecked() };`.
+// `unsafe { &*loop_ }.current_ready_event()` and other statement-scoped
+// reborrows continue past the `}` and do not match.
+const REBORROW_BINDING =
+  /\blet\s+(?:mut\s+)?\w+\s*(?::[^=;{}]*)?=\s*(?:unsafe\s*\{\s*&mut\s+\*[^;{}]*\}|&mut\s+\*[^;{}]*|unsafe\s*\{[^;{}]*\.as_mut\(\)[^;{}]*\})\s*;/g;
 
 function splitParams(params: string): string[] {
   const out: string[] = [];
@@ -111,8 +114,8 @@ function splitParams(params: string): string[] {
   let start = 0;
   for (let i = 0; i < params.length; i++) {
     const c = params[i];
-    if (c === "(" || c === "[" || c === "<") depth++;
-    else if (c === ")" || c === "]" || c === ">") depth--;
+    if (c === "(" || c === "[" || c === "<" || c === "{") depth++;
+    else if (c === ")" || c === "]" || c === ">" || c === "}") depth--;
     else if (c === "," && depth === 0) {
       out.push(params.slice(start, i));
       start = i + 1;
@@ -135,6 +138,10 @@ function matchDelimiter(text: string, open: number, openCh: string, closeCh: str
 
 function lineOf(text: string, offset: number): number {
   return text.slice(0, offset).split("\n").length;
+}
+
+function squash(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
 }
 
 interface Analysis {
@@ -160,16 +167,21 @@ function analyze(source: string, stripped: string): Analysis {
       const paramsEnd = matchDelimiter(stripped, paramsOpen, "(", ")");
       const params = splitParams(stripped.slice(paramsOpen + 1, paramsEnd - 1));
 
+      // The name this frame holds the pointer under; `undefined` until the
+      // signature (or, for the entry point, the body) provides one.
+      let pointer: string | undefined;
       if (frame.poll !== "tagged") {
         const receiver = params.length > 0 && RECEIVER.test(params[0]) ? params[0].trim() : null;
-        if (frame.poll === "receiver" && receiver !== null && !RAW_RECEIVER.test(receiver)) {
+        if (receiver !== null && RAW_RECEIVER.test(receiver)) {
+          pointer = "self";
+        } else if (receiver !== null && frame.poll === "receiver") {
           complain(`takes the poll as \`${receiver}\`; it must arrive as \`this: *mut FilePoll\``);
         }
         for (const p of params) {
-          if (REF_POLL_PARAM.test(p)) complain(`parameter \`${p.trim()}\` takes the poll by reference`);
+          if (REF_POLL_PARAM.test(p)) complain(`parameter \`${squash(p)}\` takes the poll by reference`);
+          pointer ??= RAW_POLL_PARAM.exec(p)?.[1];
         }
-        const hasRaw = params.some(p => RAW_POLL_PARAM.test(p)) || (receiver !== null && RAW_RECEIVER.test(receiver));
-        if (!hasRaw) complain("has no `*mut FilePoll` parameter");
+        if (pointer === undefined) complain("has no `*mut FilePoll` parameter");
       }
 
       // Declarations (`extern` blocks) end in `;` and have no body.
@@ -180,25 +192,33 @@ function analyze(source: string, stripped: string): Analysis {
       const body = stripped.slice(bodyOpen, matchDelimiter(stripped, bodyOpen, "{", "}"));
       const bodyLine = (offset: number) => lineOf(stripped, bodyOpen + offset);
 
-      for (const b of body.matchAll(REF_POLL_BINDING)) {
-        complain(`line ${bodyLine(b.index)} binds the poll as a reference: ${b[0].replace(/\s+/g, " ")}`);
-      }
-      for (const b of body.matchAll(MUT_REBORROW_BINDING)) {
-        complain(`line ${bodyLine(b.index)} holds a \`&mut\` reborrow: ${b[0].replace(/\s+/g, " ")}`);
+      if (frame.poll === "tagged") {
+        pointer = RAW_POLL_BINDING.exec(body)?.[1];
+        if (pointer === undefined) complain("does not bind the decoded poll as `let <name>: *mut FilePoll = ..`");
       }
 
-      for (const callee of frame.rawHandoffs ?? []) {
-        const pollParam = params.map(p => RAW_POLL_PARAM.exec(p)?.[1]).find(name => name !== undefined);
+      for (const b of body.matchAll(REF_POLL_BINDING)) {
+        complain(`line ${bodyLine(b.index)} binds the poll as a reference: ${squash(b[0])}`);
+      }
+      for (const b of body.matchAll(REBORROW_BINDING)) {
+        complain(`line ${bodyLine(b.index)} keeps a reborrow for the rest of the frame: ${squash(b[0])}`);
+      }
+
+      for (const callee of frame.handsTo) {
         const calls = [...body.matchAll(new RegExp(String.raw`\b${callee}\s*\(`, "g"))];
         if (calls.length === 0) {
-          complain(`never hands the poll to \`${callee}\`; update CHAIN if that arm moved`);
+          complain(`never calls \`${callee}\` itself; whatever now sits between them belongs in CHAIN`);
           continue;
         }
+        // Without a pointer to compare against (already reported above) the
+        // argument check would only repeat that complaint per call.
+        if (pointer === undefined) continue;
         for (const call of calls) {
           const argsOpen = call.index + call[0].length - 1;
-          const args = body.slice(argsOpen + 1, matchDelimiter(body, argsOpen, "(", ")") - 1).trim();
-          if (pollParam === undefined || args !== pollParam) {
-            complain(`line ${bodyLine(call.index)} hands \`${callee}\` \`${args}\` instead of the pointer parameter`);
+          const args = splitParams(body.slice(argsOpen + 1, matchDelimiter(body, argsOpen, "(", ")") - 1));
+          const first = squash(args[0] ?? "");
+          if (first !== pointer) {
+            complain(`line ${bodyLine(call.index)} passes \`${callee}\` \`${first}\` first, not \`${pointer}\``);
           }
         }
       }
@@ -259,184 +279,265 @@ test("scans a non-empty set of tracked Rust sources and finds every frame of the
   }
 });
 
-test("the analysis recognizes the spellings it claims to", () => {
-  const before = strip(`
-    impl FilePoll {
-        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
-        pub(crate) fn on_kqueue_event(&mut self, kqueue_event: &KQueueEvent) {
-            self.update_flags(Flags::from_kqueue_event(kqueue_event));
-            self.on_update(kqueue_event.data as i64);
-        }
-
-        pub(crate) fn on_epoll_event(&mut self, epoll_event: &bun_sys::linux::epoll_event) {
-            self.update_flags(Flags::from_epoll_event(epoll_event));
-            self.on_update(0);
-        }
-
-        pub(crate) fn on_update(&mut self, size_or_offset: i64) {
-            unsafe { __bun_run_file_poll(self, size_or_offset) };
-        }
-    }
-
-    unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
-        loop_: *mut Loop,
-        tagged_pointer: *mut c_void,
-    ) {
-        let tag = Pollable::from(tagged_pointer);
-        // SAFETY: tag matched FilePoll.
-        let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };
-        if file_poll.flags.contains(Flags::IgnoreUpdates) {
+// The chain as it was before the conversion.
+const BEFORE = strip(`
+impl FilePoll {
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    pub(crate) fn on_kqueue_event(&mut self, kqueue_event: &KQueueEvent) {
+        self.update_flags(Flags::from_kqueue_event(kqueue_event));
+        #[cfg(target_os = "macos")]
+        if kqueue_event.filter == bun_sys::darwin::EVFILT::MEMORYSTATUS {
+            self.on_update(kqueue_event.fflags as i64);
             return;
         }
-        let ev = unsafe { &*loop_ }.current_ready_event();
-        file_poll.on_epoll_event(&ev);
+        self.on_update(kqueue_event.data as i64);
     }
 
-    pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
-        let poll_ref = unsafe { &mut *poll };
-        let owner = poll_ref.owner;
-        match owner.tag() {
-            poll_tag::DNS_RESOLVER => {
-                let resolver = unsafe { &*owner.ptr.cast_const().cast::<DNSResolver>() };
-                resolver.on_dns_poll(unsafe { &mut *poll });
+    pub(crate) fn on_epoll_event(&mut self, epoll_event: &bun_sys::linux::epoll_event) {
+        self.update_flags(Flags::from_epoll_event(epoll_event));
+        self.on_update(0);
+    }
+
+    pub(crate) fn on_update(&mut self, size_or_offset: i64) {
+        unsafe { __bun_run_file_poll(self, size_or_offset) };
+    }
+}
+
+unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
+    loop_: *mut Loop,
+    tagged_pointer: *mut c_void,
+) {
+    let tag = Pollable::from(tagged_pointer);
+    // SAFETY: tag matched FilePoll.
+    let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };
+    if file_poll.flags.contains(Flags::IgnoreUpdates) {
+        return;
+    }
+    let ev = unsafe { &*loop_ }.current_ready_event();
+    #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+    file_poll.on_kqueue_event(&ev);
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    file_poll.on_epoll_event(&ev);
+}
+
+pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
+    let poll_ref = unsafe { &mut *poll };
+    let owner = poll_ref.owner;
+    match owner.tag() {
+        poll_tag::DNS_RESOLVER => {
+            let resolver = unsafe { &*owner.ptr.cast_const().cast::<DNSResolver>() };
+            resolver.on_dns_poll(unsafe { &mut *poll });
+        }
+        _ => {}
+    }
+}
+
+impl Resolver {
+    pub(crate) fn on_dns_poll(&self, poll: &mut FilePoll) {
+        poll.deinit();
+    }
+}
+`);
+
+// The chain as converted. Exercises a raw `self` receiver, a path-qualified
+// pointee type in the declaration, a return type before the body, the
+// statement-scoped spellings that must not match, and the non-chain arms of
+// `__bun_run_file_poll` (a macro binding, a shared reborrow of the owner, a
+// statement-scoped `&mut *poll` argument to a handler outside the chain).
+const AFTER = strip(`
+unsafe extern "Rust" {
+    fn __bun_run_file_poll(poll: *mut crate::FilePoll, size_or_offset: i64);
+}
+
+impl FilePoll {
+    pub(crate) unsafe fn on_kqueue_event(this: *mut FilePoll, kqueue_event: &KQueueEvent) {
+        // SAFETY: caller contract.
+        unsafe { (*this).update_flags(Flags::from_kqueue_event(kqueue_event)) };
+        syslog!("onKQueueEvent: {}", unsafe { &*this });
+        #[cfg(target_os = "macos")]
+        if kqueue_event.filter == bun_sys::darwin::EVFILT::MEMORYSTATUS {
+            unsafe { Self::on_update(this, kqueue_event.fflags as i64) };
+            return;
+        }
+        unsafe { Self::on_update(this, kqueue_event.data as i64) };
+    }
+
+    pub(crate) unsafe fn on_epoll_event(
+        this: *mut FilePoll,
+        epoll_event: &bun_sys::linux::epoll_event,
+    ) {
+        unsafe { (*this).update_flags(Flags::from_epoll_event(epoll_event)) };
+        unsafe { Self::on_update(this, 0) };
+    }
+
+    pub(crate) unsafe fn on_update(self: *mut Self, size_or_offset: i64) {
+        unsafe {
+            if (*self).flags.contains(Flags::OneShot) {
+                (*self).flags.insert(Flags::NeedsRearm);
             }
-            _ => {}
         }
+        unsafe { __bun_run_file_poll(self, size_or_offset) };
     }
+}
 
-    impl Resolver {
-        pub(crate) fn on_dns_poll(&self, poll: &mut FilePoll) {
-            poll.deinit();
-        }
+unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
+    loop_: *mut Loop,
+    tagged_pointer: *mut c_void,
+) -> () {
+    let tag = Pollable::from(tagged_pointer);
+    let file_poll: *mut FilePoll = tag.as_file_poll();
+    if unsafe { (*file_poll).flags.contains(Flags::IgnoreUpdates) } {
+        return;
     }
-  `);
-  expect(analyze("before.rs", before)).toEqual({
+    let ev = unsafe { &*loop_ }.current_ready_event();
+    unsafe {
+        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        FilePoll::on_kqueue_event(file_poll, &ev);
+        #[cfg(any(target_os = "linux", target_os = "android"))]
+        FilePoll::on_epoll_event(file_poll, &ev);
+    }
+}
+
+pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
+    let (owner, hup) = unsafe { ((*poll).owner, (*poll).flags.contains(PollFlag::Hup)) };
+    macro_rules! poll_arm {
+        ($Ty:ty, |$h:ident| $body:expr) => {{
+            let $h: *mut $Ty = owner.ptr.cast::<$Ty>();
+            $body;
+        }};
+    }
+    match owner.tag() {
+        poll_tag::MEMORY_PRESSURE => {
+            crate::node::memory_pressure::on_poll(unsafe { &mut *poll }, size_or_offset);
+        }
+        poll_tag::SHELL_BUFFERED_WRITER => poll_arm!(ShellBufferedWriterPoll, |h| {
+            unsafe { crate::shell::io_writer::on_poll(&mut *h, size_or_offset as isize, hup) }
+        }),
+        poll_tag::DNS_RESOLVER => {
+            let resolver = unsafe { &*owner.ptr.cast_const().cast::<DNSResolver>() };
+            unsafe { resolver.on_dns_poll(poll) };
+        }
+        _ => {}
+    }
+}
+
+impl Resolver {
+    pub(crate) unsafe fn on_dns_poll(&self, poll: *mut FilePoll) {
+        let fd = unsafe { (*poll).fd.native() };
+        let Some(channel) = self.channel.get() else {
+            unsafe { (*poll).deinit() };
+            return;
+        };
+        let (readable, writable) = unsafe { ((*poll).is_readable(), (*poll).is_writable()) };
+        unsafe { (*channel).process(fd, readable, writable) };
+    }
+}
+`);
+
+/** `AFTER` with `from` (which must occur exactly once) replaced by `to`. */
+function mutate(from: string, to: string): string {
+  const at = AFTER.indexOf(from);
+  expect(at).toBeGreaterThanOrEqual(0);
+  expect(AFTER.indexOf(from, at + 1)).toBe(-1);
+  return AFTER.slice(0, at) + to + AFTER.slice(at + from.length);
+}
+
+test("the analysis reports the pre-conversion chain", () => {
+  expect(analyze("before.rs", BEFORE)).toEqual({
     found: [
-      "before.rs:19: Bun__internal_dispatch_ready_poll",
+      "before.rs:24: Bun__internal_dispatch_ready_poll",
       "before.rs:4: on_kqueue_event",
-      "before.rs:9: on_epoll_event",
-      "before.rs:14: on_update",
-      "before.rs:33: __bun_run_file_poll",
-      "before.rs:46: on_dns_poll",
+      "before.rs:14: on_epoll_event",
+      "before.rs:19: on_update",
+      "before.rs:41: __bun_run_file_poll",
+      "before.rs:54: on_dns_poll",
     ],
     offenders: [
-      "before.rs:19: Bun__internal_dispatch_ready_poll: line 25 binds the poll as a reference: let file_poll: &mut FilePoll",
-      "before.rs:19: Bun__internal_dispatch_ready_poll: line 25 holds a `&mut` reborrow: let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };",
+      "before.rs:24: Bun__internal_dispatch_ready_poll: does not bind the decoded poll as `let <name>: *mut FilePoll = ..`",
+      "before.rs:24: Bun__internal_dispatch_ready_poll: line 30 binds the poll as a reference: let file_poll: &mut FilePoll",
+      "before.rs:24: Bun__internal_dispatch_ready_poll: line 30 keeps a reborrow for the rest of the frame: let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };",
       "before.rs:4: on_kqueue_event: takes the poll as `&mut self`; it must arrive as `this: *mut FilePoll`",
       "before.rs:4: on_kqueue_event: has no `*mut FilePoll` parameter",
-      "before.rs:9: on_epoll_event: takes the poll as `&mut self`; it must arrive as `this: *mut FilePoll`",
-      "before.rs:9: on_epoll_event: has no `*mut FilePoll` parameter",
-      "before.rs:14: on_update: takes the poll as `&mut self`; it must arrive as `this: *mut FilePoll`",
-      "before.rs:14: on_update: has no `*mut FilePoll` parameter",
-      "before.rs:33: __bun_run_file_poll: line 34 holds a `&mut` reborrow: let poll_ref = unsafe { &mut *poll };",
-      "before.rs:33: __bun_run_file_poll: line 39 hands `on_dns_poll` `unsafe { &mut *poll }` instead of the pointer parameter",
-      "before.rs:46: on_dns_poll: parameter `poll: &mut FilePoll` takes the poll by reference",
-      "before.rs:46: on_dns_poll: has no `*mut FilePoll` parameter",
+      "before.rs:14: on_epoll_event: takes the poll as `&mut self`; it must arrive as `this: *mut FilePoll`",
+      "before.rs:14: on_epoll_event: has no `*mut FilePoll` parameter",
+      "before.rs:19: on_update: takes the poll as `&mut self`; it must arrive as `this: *mut FilePoll`",
+      "before.rs:19: on_update: has no `*mut FilePoll` parameter",
+      "before.rs:41: __bun_run_file_poll: line 42 keeps a reborrow for the rest of the frame: let poll_ref = unsafe { &mut *poll };",
+      "before.rs:41: __bun_run_file_poll: line 47 passes `on_dns_poll` `unsafe { &mut *poll }` first, not `poll`",
+      "before.rs:54: on_dns_poll: parameter `poll: &mut FilePoll` takes the poll by reference",
+      "before.rs:54: on_dns_poll: has no `*mut FilePoll` parameter",
     ],
   });
+});
 
-  const after = strip(`
-    unsafe extern "Rust" {
-        fn __bun_run_file_poll(poll: *mut crate::FilePoll, size_or_offset: i64);
-    }
+test("the analysis accepts the converted chain", () => {
+  expect(analyze("after.rs", AFTER)).toEqual({
+    found: [
+      "after.rs:37: Bun__internal_dispatch_ready_poll",
+      "after.rs:7: on_kqueue_event",
+      "after.rs:19: on_epoll_event",
+      "after.rs:27: on_update",
+      "after.rs:3: __bun_run_file_poll",
+      "after.rs:55: __bun_run_file_poll",
+      "after.rs:79: on_dns_poll",
+    ],
+    offenders: [],
+  });
+});
 
-    impl FilePoll {
-        pub(crate) unsafe fn on_kqueue_event(this: *mut FilePoll, kqueue_event: &KQueueEvent) {
-            // SAFETY: caller contract.
-            unsafe { (*this).update_flags(Flags::from_kqueue_event(kqueue_event)) };
-            syslog!("onKQueueEvent: {}", unsafe { &*this });
-            unsafe { Self::on_update(this, kqueue_event.data as i64) };
-        }
-
-        pub(crate) unsafe fn on_epoll_event(
-            this: *mut FilePoll,
-            epoll_event: &bun_sys::linux::epoll_event,
-        ) {
-            unsafe { (*this).update_flags(Flags::from_epoll_event(epoll_event)) };
-            unsafe { Self::on_update(this, 0) };
-        }
-
-        pub(crate) unsafe fn on_update(self: *mut Self, size_or_offset: i64) {
-            unsafe {
-                if (*self).flags.contains(Flags::OneShot) {
-                    (*self).flags.insert(Flags::NeedsRearm);
-                }
-            }
-            unsafe { __bun_run_file_poll(self, size_or_offset) };
-        }
-    }
-
-    unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
-        loop_: *mut Loop,
-        tagged_pointer: *mut c_void,
-    ) -> () {
-        let tag = Pollable::from(tagged_pointer);
-        let file_poll: *mut FilePoll = tag.as_file_poll();
-        if unsafe { (*file_poll).flags.contains(Flags::IgnoreUpdates) } {
-            return;
-        }
-        let ev = unsafe { &*loop_ }.current_ready_event();
-        unsafe { FilePoll::on_epoll_event(file_poll, &ev) };
-    }
-
-    pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
-        let (owner, hup) = unsafe { ((*poll).owner, (*poll).flags.contains(PollFlag::Hup)) };
-        macro_rules! poll_arm {
-            ($Ty:ty, |$h:ident| $body:expr) => {{
-                let $h: *mut $Ty = owner.ptr.cast::<$Ty>();
-                $body;
-            }};
-        }
-        match owner.tag() {
-            poll_tag::MEMORY_PRESSURE => {
-                crate::node::memory_pressure::on_poll(unsafe { &mut *poll }, size_or_offset);
-            }
-            poll_tag::SHELL_BUFFERED_WRITER => poll_arm!(ShellBufferedWriterPoll, |h| {
-                unsafe { crate::shell::io_writer::on_poll(&mut *h, size_or_offset as isize, hup) }
-            }),
-            poll_tag::DNS_RESOLVER => {
-                let resolver = unsafe { &*owner.ptr.cast_const().cast::<DNSResolver>() };
-                unsafe { resolver.on_dns_poll(poll) };
-            }
-            _ => {}
-        }
-    }
-
-    impl Resolver {
-        pub(crate) unsafe fn on_dns_poll(&self, poll: *mut FilePoll) {
-            let fd = unsafe { (*poll).fd.native() };
-            let (readable, writable) = unsafe { ((*poll).is_readable(), (*poll).is_writable()) };
-            unsafe { (*channel).process(fd, readable, writable) };
-        }
-    }
-  `);
-  const afterAnalysis = analyze("after.rs", after);
-  expect(afterAnalysis.offenders).toEqual([]);
-  expect(afterAnalysis.found).toEqual([
-    "after.rs:32: Bun__internal_dispatch_ready_poll",
-    "after.rs:7: on_kqueue_event",
-    "after.rs:14: on_epoll_event",
-    "after.rs:22: on_update",
-    "after.rs:3: __bun_run_file_poll",
-    "after.rs:45: __bun_run_file_poll",
-    "after.rs:69: on_dns_poll",
+test("the analysis reports a reference frame re-introduced anywhere on the chain", () => {
+  // A helper taking `&mut FilePoll` interposed between on_update and the owner.
+  const helperParam = mutate(
+    "unsafe { __bun_run_file_poll(self, size_or_offset) };",
+    "Self::run_owner(unsafe { &mut *self }, size_or_offset);\n    }\n" +
+      "    fn run_owner(poll: &mut FilePoll, size_or_offset: i64) {\n" +
+      "        unsafe { __bun_run_file_poll(poll, size_or_offset) };",
+  );
+  expect(analyze("m.rs", helperParam).offenders).toEqual([
+    "m.rs:27: on_update: never calls `__bun_run_file_poll` itself; whatever now sits between them belongs in CHAIN",
   ]);
 
-  // `NonNull<FilePoll>` is a raw spelling too; an `on_dns_poll` that hands the
-  // pointer on under another name, or one whose caller wraps it, is not.
-  const variants = strip(`
-    pub(crate) unsafe fn on_dns_poll(&self, poll: ptr::NonNull<FilePoll>) {}
-
-    pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
-        let p = poll;
-        resolver.on_dns_poll(p);
-        resolver.on_dns_poll(poll.cast());
-    }
-  `);
-  expect(analyze("v.rs", variants).offenders).toEqual([
-    "v.rs:4: __bun_run_file_poll: line 6 hands `on_dns_poll` `p` instead of the pointer parameter",
-    "v.rs:4: __bun_run_file_poll: line 7 hands `on_dns_poll` `poll.cast()` instead of the pointer parameter",
+  // The same helper as a `&mut self` method invoked through the pointer.
+  const helperMethod = mutate(
+    "unsafe { __bun_run_file_poll(self, size_or_offset) };",
+    "unsafe { (*self).run_owner(size_or_offset) };\n    }\n" +
+      "    fn run_owner(&mut self, size_or_offset: i64) {\n" +
+      "        unsafe { __bun_run_file_poll(self, size_or_offset) };",
+  );
+  expect(analyze("m.rs", helperMethod).offenders).toEqual([
+    "m.rs:27: on_update: never calls `__bun_run_file_poll` itself; whatever now sits between them belongs in CHAIN",
   ]);
+
+  // A reborrow handed to the next frame on an edge other than the DNS one.
+  const reborrowArgument = mutate("Self::on_update(this, 0)", "Self::on_update(&mut *this, 0)");
+  expect(analyze("m.rs", reborrowArgument).offenders).toEqual([
+    "m.rs:19: on_epoll_event: line 24 passes `on_update` `&mut *this` first, not `this`",
+  ]);
+
+  // A fn-long reborrow spelled through `as_mut()` rather than `&mut *`.
+  const asMutBinding = mutate(
+    "unsafe { __bun_run_file_poll(self, size_or_offset) };",
+    "let slot = unsafe { self.as_mut().unwrap_unchecked() };\n" +
+      "        slot.flags.remove(Flags::Hup);\n" +
+      "        unsafe { __bun_run_file_poll(self, size_or_offset) };",
+  );
+  expect(analyze("m.rs", asMutBinding).offenders).toEqual([
+    "m.rs:27: on_update: line 33 keeps a reborrow for the rest of the frame: let slot = unsafe { self.as_mut().unwrap_unchecked() };",
+  ]);
+
+  // The entry point has to name the pointer's type for its hand-offs to be checkable.
+  const untypedEntry = mutate(
+    "let file_poll: *mut FilePoll = tag.as_file_poll();",
+    "let file_poll = tag.as_file_poll();",
+  );
+  expect(analyze("m.rs", untypedEntry).offenders).toEqual([
+    "m.rs:37: Bun__internal_dispatch_ready_poll: does not bind the decoded poll as `let <name>: *mut FilePoll = ..`",
+  ]);
+
+  // The chain is spelled `*mut FilePoll`; a `NonNull` would be dereferenced
+  // with `as_mut()`, which the body check only sees in the form above.
+  const nonNullParam = mutate("on_dns_poll(&self, poll: *mut FilePoll)", "on_dns_poll(&self, poll: NonNull<FilePoll>)");
+  expect(analyze("m.rs", nonNullParam).offenders).toEqual(["m.rs:79: on_dns_poll: has no `*mut FilePoll` parameter"]);
 });
 
 test("every frame of the FilePoll dispatch chain carries the poll as a raw pointer", () => {

--- a/test/internal/source-lints/file-poll-dispatch-raw.test.ts
+++ b/test/internal/source-lints/file-poll-dispatch-raw.test.ts
@@ -1,0 +1,452 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// Every frame between the event loop reporting a ready `FilePoll` and the
+// poll's owner running must hold the poll as `*mut FilePoll`, never as a
+// reference:
+//
+//   Bun__internal_dispatch_ready_poll            (src/io/posix_event_loop.rs)
+//     -> FilePoll::on_kqueue_event / on_epoll_event -> FilePoll::on_update
+//       -> __bun_run_file_poll                   (src/runtime/dispatch.rs)
+//         -> Resolver::on_dns_poll               (src/runtime/dns_jsc/dns.rs)
+//
+// The owner that runs at the bottom of that stack reaches the same slot through
+// the pointer it keeps itself (`FilePollRef`, `PollerPosix::Fd`, the resolver's
+// poll map, and for the DNS frame c-ares' socket-state callback from inside
+// `Channel::process`): a one-shot re-arm reads and clears the `NeedsRearm` that
+// `on_update` just set, a reader at EOF / an exited process / a closed c-ares
+// socket deinits the slot, and `Store::put` marks it `IgnoreUpdates`. Those are
+// accesses through a pointer foreign to any `&mut self` / `&mut FilePoll`
+// argument still live up the stack, and a reference argument is protected for
+// the whole call under both aliasing models (the same protector rule
+// self-receiver-reclaim.test.ts describes for frees; rustc also emits
+// `noalias` for such arguments). The chain therefore carries the raw pointer
+// all the way down, reads the slot only through statement-scoped `(*p).field`
+// accesses, and never touches it after the owner returns. `FilePollRef::inner`
+// and `PollerPosix::fd_poll_mut` document their `&mut FilePoll` as the only live
+// reference to the slot; that is only true while this holds.
+//
+// This lint pins, for each frame in CHAIN below (located by name, wherever it
+// lives):
+//   - signature: the poll arrives as `*mut FilePoll` (a `self` receiver on the
+//     FilePoll methods counts as taking it by reference unless spelled
+//     `self: *mut Self`), and no parameter takes it as `&FilePoll` / `&mut
+//     FilePoll`;
+//   - body: no `let` binding holds it as a reference for the rest of the frame
+//     (a typed `&[mut] FilePoll` binding, or a `&mut *..` reborrow as the whole
+//     initializer; fn-long-mut-reborrow.test.ts bans the latter tree-wide for
+//     the usual parameter names). Statement-scoped reborrows (`(*p).flags`,
+//     `(*p).update_flags(..)`) are the intended shape and are not matched;
+//   - hand-off: the arms that pass the poll on to code which re-arms or
+//     deinits it (`rawHandoffs`) pass the pointer parameter itself, since a
+//     `&mut *poll` argument coerces to `*mut` and would compile.
+//
+// A new frame on the chain (or a new arm that hands the poll to re-entrant
+// code) goes into CHAIN. `FilePoll::deinit*` themselves (the owner's side of
+// the same contract) are converted in #37803, together with the two frames in
+// ALLOW below. Siblings: self-receiver-reclaim.test.ts,
+// fn-long-mut-reborrow.test.ts, writer-parent-mut-borrow.test.ts.
+
+interface Frame {
+  /** Function name; unique across the Rust tree. */
+  name: string;
+  /**
+   * How the poll reaches the frame. `receiver`: a method on FilePoll itself.
+   * `param`: a free function or a method on something else, with the poll as
+   * an ordinary parameter. `tagged`: the entry point, which receives the
+   * tagged `void*` from uSockets and decodes it; only its body is checked.
+   */
+  poll: "receiver" | "param" | "tagged";
+  /** Callees inside the body that must be passed the poll pointer parameter as-is. */
+  rawHandoffs?: string[];
+}
+
+const CHAIN: Frame[] = [
+  { name: "Bun__internal_dispatch_ready_poll", poll: "tagged" },
+  { name: "on_kqueue_event", poll: "receiver" },
+  { name: "on_epoll_event", poll: "receiver" },
+  { name: "on_update", poll: "receiver" },
+  // Matches the definition in dispatch.rs and the `extern "Rust"` declaration
+  // in posix_event_loop.rs (declaration: signature only).
+  { name: "__bun_run_file_poll", poll: "param", rawHandoffs: ["on_dns_poll"] },
+  { name: "on_dns_poll", poll: "param" },
+];
+
+// Documented, ratcheted exceptions: files allowed to report exactly N
+// violations. Prefer converting over adding an entry here.
+const ALLOW: Record<string, number> = {
+  // `__bun_run_file_poll` keeps a `&mut` into the slot for its `owner`/`hup`
+  // reads and hands `on_dns_poll` a `&mut *poll`; `on_dns_poll` takes it as
+  // `&mut FilePoll`. Both are converted in #37803 along with `FilePoll::deinit*`;
+  // delete these entries when it lands (the ratchet test below says so).
+  "src/runtime/dispatch.rs": 2,
+  "src/runtime/dns_jsc/dns.rs": 2,
+};
+
+const POLL_TYPE = String.raw`(?:[\w]+::)*(?:FilePoll|Self)\b`;
+const RAW_POLL_PARAM = new RegExp(
+  String.raw`^\s*(\w+)\s*:\s*(?:\*\s*mut\s+${POLL_TYPE}|(?:[\w]+::)*NonNull\s*<\s*${POLL_TYPE}\s*>)`,
+);
+const REF_POLL_PARAM = new RegExp(String.raw`:\s*&\s*(?:'\w+\s+)?(?:mut\s+)?${POLL_TYPE}`);
+const RECEIVER = /^\s*(?:&\s*(?:'\w+\s+)?(?:mut\s+)?self\b|(?:mut\s+)?self\b)/;
+const RAW_RECEIVER = /^\s*self\s*:\s*\*\s*(?:mut|const)\b/;
+
+// `let x: &mut FilePoll = ..` / `let x: &FilePoll = ..`, any path prefix.
+const REF_POLL_BINDING = new RegExp(
+  String.raw`\blet\s+(?:mut\s+)?\w+\s*:\s*&\s*(?:'\w+\s+)?(?:mut\s+)?${POLL_TYPE}`,
+  "g",
+);
+// `let x = unsafe { &mut *p };` / `let x = &mut *p;`, i.e. the reborrow is the
+// whole initializer. `unsafe { &*loop_ }.current_ready_event()` and other
+// call-scoped reborrows continue past the `}` and do not match.
+const MUT_REBORROW_BINDING =
+  /\blet\s+(?:mut\s+)?\w+\s*(?::[^=;{}]*)?=\s*(?:unsafe\s*\{\s*&mut\s+\*[^;{}]*\}|&mut\s+\*[^;{}]*)\s*;/g;
+
+function splitParams(params: string): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < params.length; i++) {
+    const c = params[i];
+    if (c === "(" || c === "[" || c === "<") depth++;
+    else if (c === ")" || c === "]" || c === ">") depth--;
+    else if (c === "," && depth === 0) {
+      out.push(params.slice(start, i));
+      start = i + 1;
+    }
+  }
+  const last = params.slice(start);
+  if (last.trim() !== "") out.push(last);
+  return out;
+}
+
+/** Index just past the delimiter matching the opener at `open`. */
+function matchDelimiter(text: string, open: number, openCh: string, closeCh: string): number {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    if (text[i] === openCh) depth++;
+    else if (text[i] === closeCh && --depth === 0) return i + 1;
+  }
+  return text.length;
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+interface Analysis {
+  /** `file:line: name` for every frame definition or declaration seen. */
+  found: string[];
+  /** `file:line: name: reason` for every violation. */
+  offenders: string[];
+}
+
+/** Analyze one comment-stripped Rust file. */
+function analyze(source: string, stripped: string): Analysis {
+  const found: string[] = [];
+  const offenders: string[] = [];
+  for (const frame of CHAIN) {
+    const header = new RegExp(String.raw`\bfn\s+${frame.name}\s*(?:<[^>]*>)?\s*\(`, "g");
+    for (const m of stripped.matchAll(header)) {
+      const line = lineOf(stripped, m.index);
+      const where = `${source}:${line}: ${frame.name}`;
+      found.push(where);
+      const complain = (reason: string) => offenders.push(`${where}: ${reason}`);
+
+      const paramsOpen = m.index + m[0].length - 1;
+      const paramsEnd = matchDelimiter(stripped, paramsOpen, "(", ")");
+      const params = splitParams(stripped.slice(paramsOpen + 1, paramsEnd - 1));
+
+      if (frame.poll !== "tagged") {
+        const receiver = params.length > 0 && RECEIVER.test(params[0]) ? params[0].trim() : null;
+        if (frame.poll === "receiver" && receiver !== null && !RAW_RECEIVER.test(receiver)) {
+          complain(`takes the poll as \`${receiver}\`; it must arrive as \`this: *mut FilePoll\``);
+        }
+        for (const p of params) {
+          if (REF_POLL_PARAM.test(p)) complain(`parameter \`${p.trim()}\` takes the poll by reference`);
+        }
+        const hasRaw = params.some(p => RAW_POLL_PARAM.test(p)) || (receiver !== null && RAW_RECEIVER.test(receiver));
+        if (!hasRaw) complain("has no `*mut FilePoll` parameter");
+      }
+
+      // Declarations (`extern` blocks) end in `;` and have no body.
+      const afterParams = stripped.slice(paramsEnd);
+      const bodyRel = afterParams.search(/[;{]/);
+      if (bodyRel === -1 || afterParams[bodyRel] === ";") continue;
+      const bodyOpen = paramsEnd + bodyRel;
+      const body = stripped.slice(bodyOpen, matchDelimiter(stripped, bodyOpen, "{", "}"));
+      const bodyLine = (offset: number) => lineOf(stripped, bodyOpen + offset);
+
+      for (const b of body.matchAll(REF_POLL_BINDING)) {
+        complain(`line ${bodyLine(b.index)} binds the poll as a reference: ${b[0].replace(/\s+/g, " ")}`);
+      }
+      for (const b of body.matchAll(MUT_REBORROW_BINDING)) {
+        complain(`line ${bodyLine(b.index)} holds a \`&mut\` reborrow: ${b[0].replace(/\s+/g, " ")}`);
+      }
+
+      for (const callee of frame.rawHandoffs ?? []) {
+        const pollParam = params.map(p => RAW_POLL_PARAM.exec(p)?.[1]).find(name => name !== undefined);
+        const calls = [...body.matchAll(new RegExp(String.raw`\b${callee}\s*\(`, "g"))];
+        if (calls.length === 0) {
+          complain(`never hands the poll to \`${callee}\`; update CHAIN if that arm moved`);
+          continue;
+        }
+        for (const call of calls) {
+          const argsOpen = call.index + call[0].length - 1;
+          const args = body.slice(argsOpen + 1, matchDelimiter(body, argsOpen, "(", ")") - 1).trim();
+          if (pollParam === undefined || args !== pollParam) {
+            complain(`line ${bodyLine(call.index)} hands \`${callee}\` \`${args}\` instead of the pointer parameter`);
+          }
+        }
+      }
+    }
+  }
+  return { found, offenders };
+}
+
+function strip(content: string): string {
+  // Full-line comments (including `///` docs) out, newlines kept, so prose
+  // mentions of the banned spellings do not count and line numbers stay right.
+  return content.replace(/^[ \t]*\/\/.*$/gm, "");
+}
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+const found: string[] = [];
+const offenders: string[] = [];
+const counts: Record<string, number> = {};
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Cheap pre-filter; `analyze` re-locates the frames precisely.
+  if (!CHAIN.some(frame => content.includes(frame.name))) continue;
+  const analysis = analyze(source, strip(content));
+  found.push(...analysis.found);
+  if (analysis.offenders.length > 0) counts[source] = analysis.offenders.length;
+  offenders.push(...analysis.offenders.slice(ALLOW[source] ?? 0));
+}
+
+test("scans a non-empty set of tracked Rust sources and finds every frame of the chain", () => {
+  // Guards against the filters above over-firing, or a frame being renamed out
+  // from under CHAIN, either of which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+  const names = found.map(entry => entry.slice(entry.lastIndexOf(": ") + 2));
+  for (const frame of CHAIN) {
+    expect(names).toContain(frame.name);
+  }
+});
+
+test("the analysis recognizes the spellings it claims to", () => {
+  const before = strip(`
+    impl FilePoll {
+        #[cfg(any(target_os = "macos", target_os = "freebsd"))]
+        pub(crate) fn on_kqueue_event(&mut self, kqueue_event: &KQueueEvent) {
+            self.update_flags(Flags::from_kqueue_event(kqueue_event));
+            self.on_update(kqueue_event.data as i64);
+        }
+
+        pub(crate) fn on_epoll_event(&mut self, epoll_event: &bun_sys::linux::epoll_event) {
+            self.update_flags(Flags::from_epoll_event(epoll_event));
+            self.on_update(0);
+        }
+
+        pub(crate) fn on_update(&mut self, size_or_offset: i64) {
+            unsafe { __bun_run_file_poll(self, size_or_offset) };
+        }
+    }
+
+    unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
+        loop_: *mut Loop,
+        tagged_pointer: *mut c_void,
+    ) {
+        let tag = Pollable::from(tagged_pointer);
+        // SAFETY: tag matched FilePoll.
+        let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };
+        if file_poll.flags.contains(Flags::IgnoreUpdates) {
+            return;
+        }
+        let ev = unsafe { &*loop_ }.current_ready_event();
+        file_poll.on_epoll_event(&ev);
+    }
+
+    pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
+        let poll_ref = unsafe { &mut *poll };
+        let owner = poll_ref.owner;
+        match owner.tag() {
+            poll_tag::DNS_RESOLVER => {
+                let resolver = unsafe { &*owner.ptr.cast_const().cast::<DNSResolver>() };
+                resolver.on_dns_poll(unsafe { &mut *poll });
+            }
+            _ => {}
+        }
+    }
+
+    impl Resolver {
+        pub(crate) fn on_dns_poll(&self, poll: &mut FilePoll) {
+            poll.deinit();
+        }
+    }
+  `);
+  expect(analyze("before.rs", before)).toEqual({
+    found: [
+      "before.rs:19: Bun__internal_dispatch_ready_poll",
+      "before.rs:4: on_kqueue_event",
+      "before.rs:9: on_epoll_event",
+      "before.rs:14: on_update",
+      "before.rs:33: __bun_run_file_poll",
+      "before.rs:46: on_dns_poll",
+    ],
+    offenders: [
+      "before.rs:19: Bun__internal_dispatch_ready_poll: line 25 binds the poll as a reference: let file_poll: &mut FilePoll",
+      "before.rs:19: Bun__internal_dispatch_ready_poll: line 25 holds a `&mut` reborrow: let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };",
+      "before.rs:4: on_kqueue_event: takes the poll as `&mut self`; it must arrive as `this: *mut FilePoll`",
+      "before.rs:4: on_kqueue_event: has no `*mut FilePoll` parameter",
+      "before.rs:9: on_epoll_event: takes the poll as `&mut self`; it must arrive as `this: *mut FilePoll`",
+      "before.rs:9: on_epoll_event: has no `*mut FilePoll` parameter",
+      "before.rs:14: on_update: takes the poll as `&mut self`; it must arrive as `this: *mut FilePoll`",
+      "before.rs:14: on_update: has no `*mut FilePoll` parameter",
+      "before.rs:33: __bun_run_file_poll: line 34 holds a `&mut` reborrow: let poll_ref = unsafe { &mut *poll };",
+      "before.rs:33: __bun_run_file_poll: line 39 hands `on_dns_poll` `unsafe { &mut *poll }` instead of the pointer parameter",
+      "before.rs:46: on_dns_poll: parameter `poll: &mut FilePoll` takes the poll by reference",
+      "before.rs:46: on_dns_poll: has no `*mut FilePoll` parameter",
+    ],
+  });
+
+  const after = strip(`
+    unsafe extern "Rust" {
+        fn __bun_run_file_poll(poll: *mut crate::FilePoll, size_or_offset: i64);
+    }
+
+    impl FilePoll {
+        pub(crate) unsafe fn on_kqueue_event(this: *mut FilePoll, kqueue_event: &KQueueEvent) {
+            // SAFETY: caller contract.
+            unsafe { (*this).update_flags(Flags::from_kqueue_event(kqueue_event)) };
+            syslog!("onKQueueEvent: {}", unsafe { &*this });
+            unsafe { Self::on_update(this, kqueue_event.data as i64) };
+        }
+
+        pub(crate) unsafe fn on_epoll_event(
+            this: *mut FilePoll,
+            epoll_event: &bun_sys::linux::epoll_event,
+        ) {
+            unsafe { (*this).update_flags(Flags::from_epoll_event(epoll_event)) };
+            unsafe { Self::on_update(this, 0) };
+        }
+
+        pub(crate) unsafe fn on_update(self: *mut Self, size_or_offset: i64) {
+            unsafe {
+                if (*self).flags.contains(Flags::OneShot) {
+                    (*self).flags.insert(Flags::NeedsRearm);
+                }
+            }
+            unsafe { __bun_run_file_poll(self, size_or_offset) };
+        }
+    }
+
+    unsafe extern "C" fn Bun__internal_dispatch_ready_poll(
+        loop_: *mut Loop,
+        tagged_pointer: *mut c_void,
+    ) -> () {
+        let tag = Pollable::from(tagged_pointer);
+        let file_poll: *mut FilePoll = tag.as_file_poll();
+        if unsafe { (*file_poll).flags.contains(Flags::IgnoreUpdates) } {
+            return;
+        }
+        let ev = unsafe { &*loop_ }.current_ready_event();
+        unsafe { FilePoll::on_epoll_event(file_poll, &ev) };
+    }
+
+    pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
+        let (owner, hup) = unsafe { ((*poll).owner, (*poll).flags.contains(PollFlag::Hup)) };
+        macro_rules! poll_arm {
+            ($Ty:ty, |$h:ident| $body:expr) => {{
+                let $h: *mut $Ty = owner.ptr.cast::<$Ty>();
+                $body;
+            }};
+        }
+        match owner.tag() {
+            poll_tag::MEMORY_PRESSURE => {
+                crate::node::memory_pressure::on_poll(unsafe { &mut *poll }, size_or_offset);
+            }
+            poll_tag::SHELL_BUFFERED_WRITER => poll_arm!(ShellBufferedWriterPoll, |h| {
+                unsafe { crate::shell::io_writer::on_poll(&mut *h, size_or_offset as isize, hup) }
+            }),
+            poll_tag::DNS_RESOLVER => {
+                let resolver = unsafe { &*owner.ptr.cast_const().cast::<DNSResolver>() };
+                unsafe { resolver.on_dns_poll(poll) };
+            }
+            _ => {}
+        }
+    }
+
+    impl Resolver {
+        pub(crate) unsafe fn on_dns_poll(&self, poll: *mut FilePoll) {
+            let fd = unsafe { (*poll).fd.native() };
+            let (readable, writable) = unsafe { ((*poll).is_readable(), (*poll).is_writable()) };
+            unsafe { (*channel).process(fd, readable, writable) };
+        }
+    }
+  `);
+  const afterAnalysis = analyze("after.rs", after);
+  expect(afterAnalysis.offenders).toEqual([]);
+  expect(afterAnalysis.found).toEqual([
+    "after.rs:32: Bun__internal_dispatch_ready_poll",
+    "after.rs:7: on_kqueue_event",
+    "after.rs:14: on_epoll_event",
+    "after.rs:22: on_update",
+    "after.rs:3: __bun_run_file_poll",
+    "after.rs:45: __bun_run_file_poll",
+    "after.rs:69: on_dns_poll",
+  ]);
+
+  // `NonNull<FilePoll>` is a raw spelling too; an `on_dns_poll` that hands the
+  // pointer on under another name, or one whose caller wraps it, is not.
+  const variants = strip(`
+    pub(crate) unsafe fn on_dns_poll(&self, poll: ptr::NonNull<FilePoll>) {}
+
+    pub(crate) unsafe fn __bun_run_file_poll(poll: *mut FilePoll, size_or_offset: i64) {
+        let p = poll;
+        resolver.on_dns_poll(p);
+        resolver.on_dns_poll(poll.cast());
+    }
+  `);
+  expect(analyze("v.rs", variants).offenders).toEqual([
+    "v.rs:4: __bun_run_file_poll: line 6 hands `on_dns_poll` `p` instead of the pointer parameter",
+    "v.rs:4: __bun_run_file_poll: line 7 hands `on_dns_poll` `poll.cast()` instead of the pointer parameter",
+  ]);
+});
+
+test("every frame of the FilePoll dispatch chain carries the poll as a raw pointer", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still report exactly their documented count", () => {
+  // Ratchet: once an allowlisted frame is converted, delete its entry so a new
+  // violation cannot take its place.
+  for (const [source, n] of Object.entries(ALLOW)) {
+    expect(counts[source] ?? 0).toBe(n);
+  }
+});


### PR DESCRIPTION
### Problem
- Nothing user-visible: no crash is known from this. It is the same latent aliasing class as #37681, #37778 and #37803.
- When the event loop reports a ready poll, every frame from the dispatch entry down to the poll's owner held the poll as `&mut FilePoll` (or `&mut self`) while the owner ran underneath it.
- During that call the owner touches the same slot through its own pointer: a one-shot re-arm reads and clears the flag the dispatch just set, and a finished owner (pipe EOF, process exit, c-ares closing a socket) deinits the slot outright.
- A reference argument is protected until the call returns, so both aliasing models reject those accesses, even though nothing on the chain reads the slot after the owner returns.

### Fix
- Every frame of the chain now takes `*mut FilePoll`; each field access is scoped to one statement, and the DNS frame copies what it needs into locals before handing off. Same operations in the same order, so no behaviour change.
- This is sound because each frame only needs the slot to be live on entry: no frame reads it after the owner returns, so the owner may re-arm or deinit it freely.
- Overlaps with #37803 in two functions on purpose; whichever lands second rebases, and the lint passes with either side of each conflict.
- Verification: a source lint pins every frame of the chain to the pointer shape (13 findings on main, none here). A behavioural fail-before test is not possible, since the old code never used the references after the owner ran. The spawn, pipe and DNS suites that deinit or re-register the poll from inside a dispatch pass against a debug build.

### Background
- A `FilePoll` is bun's per-fd registration with kqueue or epoll. It lives in a slot in a store, and its owner (a pipe reader, a child process, the DNS resolver) keeps its own pointer to that slot.
- The dispatch chain is the stack of frames between the loop reporting an fd ready and the owner's handler; the handler runs with all of those frames still on the stack.
- Reader polls are registered one-shot: each event disarms the registration, the dispatch marks the poll as needing re-arm, and the owner re-arms it through its own pointer before returning.
- Under Stacked and Tree Borrows a `&mut` argument is exclusive for the whole call (rustc also emits `noalias`), so an access through any other pointer while that call is on the stack is undefined behaviour whether or not it misbehaves today.
- A source lint is a test under `test/internal/source-lints/` that scans the Rust tree for a shape and fails if it appears; it is how bun pins invariants the compiler does not check.

<details>
<summary>Original description</summary>

### What

The POSIX ready-poll dispatch chain held the poll being dispatched as a reference for the whole time its owner ran (line numbers on main):

```rust
// src/io/posix_event_loop.rs
let file_poll: &mut FilePoll = unsafe { &mut *tag.as_file_poll() };          // Bun__internal_dispatch_ready_poll, :1497
pub(crate) fn on_kqueue_event(&mut self, kqueue_event: &KQueueEvent)            // :351
pub(crate) fn on_epoll_event(&mut self, epoll_event: &epoll_event)              // :370
pub(crate) fn on_update(&mut self, size_or_offset: i64) {                       // :434
    unsafe { __bun_run_file_poll(self, size_or_offset) };
}

// src/runtime/dispatch.rs, __bun_run_file_poll
let poll_ref = unsafe { &mut *poll };                                            // :660
resolver.on_dns_poll(unsafe { &mut *poll });                                     // :744
// src/runtime/dns_jsc/dns.rs
pub(crate) fn on_dns_poll(&self, poll: &mut FilePoll)                           // :4786
```

Same receiver-shape class as #37681, #37778 and #37803. No crash is known from it.

### Why it is wrong

The `&mut self` of `on_kqueue_event` / `on_epoll_event` and of `on_update`, and the `&mut FilePoll` argument of `on_dns_poll`, are reference arguments: protected until those calls return, and the owner runs inside them. The owner does not use those references. It reaches the same slot through the pointer it keeps itself (`FilePollRef`, `PollerPosix::Fd`, the resolver's poll map), on the normal path, not only on teardown:

- Every reader poll is registered one-shot (`FilePollRef::register_with_fd` passes `OneShotFlag::Dispatch`), so `on_update` sets `NeedsRearm` and the owner's re-arm during the dispatch reads and clears it again (`register_with_fd_impl`, `unregister_with_fd_impl`) through its own pointer. The flag exists to be passed from this frame to the owner's call underneath it.
- An owner that is finished deinits the slot from inside the dispatch: pipe EOF (`PollOrFd::close_impl` -> `FilePollRef::deinit_force_unregister`), process exit (`Process::on_exit` -> `close` -> `PollerPosix`), and c-ares closing a socket, which happens inside the `Channel::process` call that `on_dns_poll` makes while its `&mut FilePoll` argument is live (`on_dns_socket_state` also re-registers the same poll through the map on every read/write transition).

Those are reads and writes through a pointer foreign to the protected references further up the stack, which both aliasing models reject (the protector rule the sibling PRs quote; rustc also marks the arguments `noalias`). `FilePollRef::inner` and `PollerPosix::fd_poll_mut` both document the `&mut FilePoll` they hand out as the only live reference to the slot; during a dispatch that was not true. It is latent today because nothing on the chain reads the slot after the owner returns, so there is nothing observable to assert on.

### Fix

The chain carries the pointer `Pollable` decodes all the way down, the shape `__bun_run_file_poll(poll: *mut FilePoll)` and `PosixBufferedReader::on_poll(this: *mut Self)` already have:

```rust
pub(crate) unsafe fn on_kqueue_event(this: *mut FilePoll, kqueue_event: &KQueueEvent)
pub(crate) unsafe fn on_epoll_event(this: *mut FilePoll, epoll_event: &epoll_event)
pub(crate) unsafe fn on_update(this: *mut FilePoll, size_or_offset: i64)
pub(crate) unsafe fn on_dns_poll(&self, poll: *mut FilePoll)
```

The entry point reads `IgnoreUpdates` through a statement-scoped access and passes the pointer on; `update_flags`, the `NeedsRearm` update, the kqueue `syslog!` and generation-number `debug_assert!`, and `__bun_run_file_poll`'s `owner`/`hup` reads become statement-scoped accesses; the DNS arm passes `poll` itself, and `on_dns_poll` reads `fd` / `is_readable()` / `is_writable()` into locals before `process` and does not touch the poll afterwards. Same operations in the same order, so no behaviour change.

The contract the chain relies on is only that the slot is live when each frame is entered: nothing on the chain reads it after the owner returns, so the comments say that rather than anything about the slot staying allocated for the duration of the call (deferred frees run from the after-tick callback, which a nested tick inside an owner's JS would also run).

Overlap with #37803: that PR converts the owner's side of the same contract (`FilePoll::deinit*` and its callers) and, to get there, also converts `on_dns_poll` and the `__bun_run_file_poll` reads; it leaves the four frames in posix_event_loop.rs to this PR. The two PRs therefore both touch `__bun_run_file_poll` and `on_dns_poll`, and a test merge conflicts in exactly those two functions (posix_event_loop.rs auto-merges). That is deliberate: whichever lands second rebases and takes either side of each conflict, and the lint below passes with both (checked with #37803's versions of dispatch.rs and dns.rs dropped onto this branch). An earlier revision of this PR instead allowlisted those two frames in the lint; since #37803 does not touch the lint file, that would have gone red on main after the second merge with nothing forcing anyone to notice, so the overlap is now textual.

The five src/io/PipeReader.rs comments about a protector "pre-existing on the parent chain" describe the reader's own `&mut self` entry points (`close`, `finish`, `start`, `watch`, and the Windows `on_read`), which parents call directly; converting this chain does not change them.

### Test

`test/internal/source-lints/file-poll-dispatch-raw.test.ts` locates every frame of the chain by name (`Bun__internal_dispatch_ready_poll`, `on_kqueue_event`, `on_epoll_event`, `on_update`, `__bun_run_file_poll` including its `extern "Rust"` declaration, `on_dns_poll`) and checks:

- signature: the poll arrives as `*mut FilePoll` (a `self` receiver on the FilePoll methods counts as by-reference unless it is a raw receiver), and no parameter takes it as `&FilePoll` / `&mut FilePoll`;
- hand-off: each frame calls the next frame(s) of the chain itself, with its pointer as the first argument (the entry point's pointer is its `let x: *mut FilePoll` binding). This is what keeps the chain closed: a helper interposed on any edge, whether it takes `&mut FilePoll` or is a `&mut self` method called as `(*this).helper()`, and a `&mut *this` argument (which coerces and would compile) are all reported;
- body: no `let` binding is a `&[mut] FilePoll` or a fn-long `&mut *..` / `unsafe { ..as_mut().. }` reborrow.

Fixtures cover the main spellings of all six frames (19 findings), the converted spellings (none), and six mutations of the converted chain (interposed `&mut FilePoll` helper, interposed `&mut self` helper, `&mut *this` argument on the epoll edge, `as_mut()` binding, untyped entry binding, `NonNull` parameter), with the expected line numbers written out by hand. On main it reports 13 lines across the three files (the six frames above); on this branch it is clean, and it also fails on the intermediate state where only posix_event_loop.rs is converted. The kqueue function is `#[cfg]`'d to macOS/FreeBSD, so the lint is also what pins that path from the Linux lanes.

A behavioural fail-before test is not possible for the reason given above (the old code never touched the references after the owner ran).

### Verification

- `cargo check` and `cargo clippy` for `bun_io` on x86_64-unknown-linux-gnu and aarch64-apple-darwin (the kqueue function, including the `syslog!` / `debug_assert!` spellings), `cargo check` on x86_64-unknown-freebsd; `cargo clippy -p bun_runtime`; `cargo fmt --check`; `test/internal/source-lints/` as a directory (88 pass).
- Against the debug build of this diff: `test/js/bun/spawn/spawn.test.ts`, `spawn-many-teardown.test.ts`, `spawn-pipe-stale-fd-unregister.test.ts` (pipe EOF and process exit deinit the poll from inside the dispatch), `test/js/node/dns/dns-tcp-bidirectional-poll.test.ts`, `dns-lookup-keepalive.test.ts`, `dns-resolver-concurrent-timeout.test.ts` (re-registration and deinit of the c-ares poll from inside `Channel::process`, i.e. the `on_dns_poll` path), `test/js/node/process/process-memory-pressure.test.ts`; earlier revision of the same code also ran `spawn-streaming-stdin.test.ts`, `spawn-stdin-destroy.test.ts` and the shell suites `pipeline_stack`, `epipe`, `shell-blocking-pipe`, `shell-pipe-read-fault`, `shell-write-fault`. `test/js/node/child_process/` passes except for the `$SHELL` test (the env `bun bd` runs tests with has no `SHELL`) and the 20-debug-child GC test hitting its 5 s budget on this machine (its fixture prints `OK` when run directly); `spawn-pipe-leak.test.ts` (750 debug children per test) hits its 30 s budget here the same way. #37803 reports the same local failures.

</details>
