### PR TITLE
shell: report expansion errors in assignment values on stderr

### DIFF
--- a/src/runtime/shell/IOWriter.rs
+++ b/src/runtime/shell/IOWriter.rs
@@ -86,6 +86,7 @@ pub enum WriterTag {
     Builtin,
     Cmd,
     CondExpr,
+    Assigns,
     /// `subproc::PipeReader::CapturedWriter` — heap-allocated, addressed via
     /// `ChildPtr::raw` rather than `node`.
     Subproc,
@@ -1225,12 +1226,15 @@ pub(crate) fn on_io_writer_chunk(
     err: Option<sys::SystemError>,
 ) -> Yield {
     use crate::shell::builtin::Builtin;
-    use crate::shell::states::{cmd, cond_expr};
+    use crate::shell::states::{assigns, cmd, cond_expr};
     match child.tag {
         WriterTag::Builtin => Builtin::on_io_writer_chunk(interp, child.node, written, err),
         WriterTag::Cmd => cmd::Cmd::on_io_writer_chunk(interp, child.node, written, err),
         WriterTag::CondExpr => {
             cond_expr::CondExpr::on_io_writer_chunk(interp, child.node, written, err)
+        }
+        WriterTag::Assigns => {
+            assigns::Assigns::on_io_writer_chunk(interp, child.node, written, err)
         }
         // The target is the subprocess PipeReader's `CapturedWriter`; it
         // lives outside the NodeId arena (heap-allocated PipeReader), so it

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -933,7 +933,7 @@ impl Interpreter {
             ast::Expr::Cmd(c) => Cmd::init(self, shell, *c, parent, io),
             ast::Expr::Binary(b) => Binary::init(self, shell, *b, parent, io),
             ast::Expr::Pipeline(p) => Pipeline::init(self, shell, *p, parent, io),
-            ast::Expr::Assign(a) => Assigns::init(self, shell, *a, parent, AssignCtx::Shell),
+            ast::Expr::Assign(a) => Assigns::init(self, shell, *a, parent, AssignCtx::Shell, io),
             ast::Expr::If(i) => If::init(self, shell, *i, parent, io),
             ast::Expr::CondExpr(c) => CondExpr::init(self, shell, *c, parent, io),
             ast::Expr::Subshell(s) => {

--- a/src/runtime/shell/states/Assigns.rs
+++ b/src/runtime/shell/states/Assigns.rs
@@ -3,10 +3,12 @@
 
 use crate::shell::ast;
 use crate::shell::interpreter::{Interpreter, Node, NodeId, ShellExecEnv, log};
+use crate::shell::io::{IO, OutKind};
+use crate::shell::io_writer;
 use crate::shell::states::base::Base;
 use crate::shell::states::expansion::Expansion;
 use crate::shell::yield_::Yield;
-use crate::shell::{EnvStr, ExitCode};
+use crate::shell::{EnvStr, ExitCode, ShellErr};
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum AssignCtx {
@@ -21,6 +23,9 @@ pub struct Assigns {
     pub node: bun_ptr::RawSlice<ast::Assign>,
     pub(crate) state: AssignsState,
     pub ctx: AssignCtx,
+    /// Only `stderr` is written to: an expansion error in a value is reported
+    /// the same way `Cmd` reports one in an argv word.
+    pub(crate) io: IO,
 }
 
 #[derive(Default)]
@@ -30,6 +35,9 @@ pub enum AssignsState {
     Expanding {
         idx: u32,
     },
+    /// An expansion error is being written to stderr; `on_io_writer_chunk`
+    /// finishes the node with exit 1.
+    WaitingWriteErr,
     Done,
 }
 
@@ -40,6 +48,7 @@ impl Assigns {
         node: &[ast::Assign],
         parent: NodeId,
         ctx: AssignCtx,
+        io: IO,
     ) -> NodeId {
         interp.alloc_node(Node::Assigns(Assigns {
             base: Base::new(parent, shell),
@@ -47,6 +56,7 @@ impl Assigns {
             node: bun_ptr::RawSlice::new(node),
             state: AssignsState::Idle,
             ctx,
+            io,
         }))
     }
 
@@ -75,6 +85,7 @@ impl Assigns {
                     let child = Expansion::init(interp, shell, atom, this);
                     return Expansion::start(interp, child);
                 }
+                AssignsState::WaitingWriteErr => return Yield::suspended(),
                 AssignsState::Done => {
                     let parent = interp.as_assigns(this).base.parent;
                     return interp.child_done(parent, this, 0);
@@ -91,10 +102,9 @@ impl Assigns {
     ) -> Yield {
         // Child is always an Expansion.
         if exit_code != 0 {
+            let err = Expansion::take_err(interp, child);
             interp.deinit_node(child);
-            interp.as_assigns_mut(this).state = AssignsState::Done;
-            let parent = interp.as_assigns(this).base.parent;
-            return interp.child_done(parent, this, 1);
+            return Self::fail(interp, this, err);
         }
 
         let out = Expansion::take_out(interp, child);
@@ -137,6 +147,66 @@ impl Assigns {
         value_ref.deref();
 
         Yield::Next(this)
+    }
+
+    /// A value failed to expand: report it on stderr and finish with exit 1.
+    /// Assignments before the failing one have already been applied, as in
+    /// bash; the ones after it are skipped.
+    fn fail(interp: &Interpreter, this: NodeId, err: Option<ShellErr>) -> Yield {
+        let Some(err) = err else {
+            debug_assert!(false, "Expansion child failed without an error");
+            return Self::finish_failed(interp, this);
+        };
+        let msg = format!("{err}\n");
+        // Same shape as `Builtin::cmd_write_failing_error`: an fd-backed
+        // stderr takes an async write and parks in `WaitingWriteErr`; a
+        // captured one is appended to synchronously. The clone ends the borrow
+        // of the node before its state is written.
+        match interp.as_assigns(this).io.stderr.clone() {
+            OutKind::Fd(fd) => {
+                interp.as_assigns_mut(this).state = AssignsState::WaitingWriteErr;
+                let child = io_writer::ChildPtr::new(this, io_writer::WriterTag::Assigns);
+                fd.writer.enqueue(child, fd.captured, msg.as_bytes())
+            }
+            OutKind::Pipe => {
+                // SAFETY: single trampoline frame; no other borrow of the env's
+                // (or its parent's) stderr buffer is live.
+                let stderr = unsafe {
+                    interp
+                        .as_assigns_mut(this)
+                        .base
+                        .shell_mut()
+                        .buffered_stderr_mut()
+                };
+                stderr.extend_from_slice(msg.as_bytes());
+                Self::finish_failed(interp, this)
+            }
+            OutKind::Ignore => Self::finish_failed(interp, this),
+        }
+    }
+
+    /// IOWriter completion callback for the message written by [`Self::fail`]:
+    /// throw on write failure, otherwise finish with exit 1.
+    pub(crate) fn on_io_writer_chunk(
+        interp: &Interpreter,
+        this: NodeId,
+        _written: usize,
+        err: Option<bun_sys::SystemError>,
+    ) -> Yield {
+        if let Some(err) = err {
+            interp.throw(ShellErr::from_system(err));
+            return Yield::failed();
+        }
+        debug_assert!(matches!(
+            interp.as_assigns(this).state,
+            AssignsState::WaitingWriteErr
+        ));
+        Self::finish_failed(interp, this)
+    }
+
+    fn finish_failed(interp: &Interpreter, this: NodeId) -> Yield {
+        let parent = interp.as_assigns(this).base.parent;
+        interp.child_done(parent, this, 1)
     }
 
     pub(crate) fn deinit(interp: &Interpreter, this: NodeId) {

--- a/src/runtime/shell/states/Cmd.rs
+++ b/src/runtime/shell/states/Cmd.rs
@@ -239,7 +239,9 @@ impl Cmd {
                 CmdState::Idle => {
                     if !n.assigns.is_empty() {
                         interp.as_cmd_mut(this).state = CmdState::ExpandingAssigns;
-                        let child = Assigns::init(interp, shell, n.assigns, this, AssignCtx::Cmd);
+                        let io = interp.as_cmd(this).io.clone();
+                        let child =
+                            Assigns::init(interp, shell, n.assigns, this, AssignCtx::Cmd, io);
                         return Assigns::start(interp, child);
                     }
                     interp.as_cmd_mut(this).state = CmdState::ExpandingRedirect { idx: 0 };
@@ -320,7 +322,8 @@ impl Cmd {
         if exit_code != 0 && matches!(child_kind, StateKind::Assign | StateKind::Expansion) {
             // Pull the expansion error out
             // before deiniting the child, then write it to stderr via
-            // `writeFailingError("{f}\n", err)` and finish with exit 1.
+            // `writeFailingError("{f}\n", err)` and finish with exit 1. An
+            // Assigns child has already written its own error (`Assigns::fail`).
             let err = if matches!(child_kind, StateKind::Expansion) {
                 Expansion::take_err(interp, child)
             } else {

--- a/test/js/bun/shell/bunshell.test.ts
+++ b/test/js/bun/shell/bunshell.test.ts
@@ -2981,6 +2981,69 @@ describe("interpolated values in assignment position", () => {
     .runAsTest("interpolated equals in argument position passes through");
 });
 
+describe("expansion error in an assignment value", () => {
+  // 16 alternatives in each of 5 groups is 16^5 = 1048576 words, over the
+  // interpreter's 65536 cap, so expanding this word fails.
+  const group = "{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p}";
+  const tooManyBraces = { raw: group.repeat(5) };
+  const braceError = "bun: too many brace expansions (1048576 > 65536)\n";
+
+  // Control: the same word in argument position.
+  TestBuilder.command`echo ${tooManyBraces}`
+    .stderr(braceError)
+    .exitCode(1)
+    .runAsTest("argument position reports the error");
+
+  // A standalone assignment and a command-prefix assignment both used to exit 1
+  // without writing anything. The message is written through a different path
+  // depending on whether stderr is a file descriptor or only captured
+  // (`.quiet()`), so cover both.
+  for (const quiet of [false, true]) {
+    const suffix = quiet ? " (quiet)" : "";
+    const command = (strings: TemplateStringsArray, ...exprs: any[]) => {
+      const builder = TestBuilder.command(strings, ...exprs);
+      return quiet ? builder.quiet() : builder;
+    };
+
+    command`FOO=${tooManyBraces}`
+      .stderr(braceError)
+      .exitCode(1)
+      .runAsTest(`standalone assignment reports the error and exits 1${suffix}`);
+
+    command`FOO=${tooManyBraces} echo hi`
+      .stderr(braceError)
+      .exitCode(1)
+      .runAsTest(`prefix assignment reports the error and does not run the command${suffix}`);
+  }
+
+  TestBuilder.command`FOO=${tooManyBraces} || echo fallback`
+    .stdout("fallback\n")
+    .stderr(braceError)
+    .runAsTest("failed standalone assignment has exit status 1 for || and the script continues");
+
+  TestBuilder.command`A=1 B=${tooManyBraces} C=2; echo "$A-$C"`
+    .stdout("1-\n")
+    .stderr(braceError)
+    .runAsTest("assignments before the failing one are applied, the ones after it are skipped");
+
+  test("a script file reports the error and exits 1", async () => {
+    using dir = tempDir("shell-assign-expansion-error", {
+      "script.sh": `FOO=${group.repeat(5)}\n`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [BUN, "script.sh"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe(braceError);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+});
+
 describe("interpolated values in reserved-word position", () => {
   TestBuilder.command`if true; then ${"if"} BUNISBAD; echo A; fi`
     .stdout("A\n")


### PR DESCRIPTION
### Problem
- In Bun Shell, `FOO=<word>` exits 1 and prints nothing when the value fails to expand. The same word as an argument prints `bun: too many brace expansions (1048576 > 65536)`.
- `FOO=<word> echo hi` also fails silently and `echo` never runs. Same from a `bun script.sh` file.
- Cause: the assignments node dropped the failed expansion's stored error and passed only exit 1 upward; no parent prints it either. Only argument words had a path that wrote the error to stderr.

### Fix
- The assignments node now gets the stderr of the statement or command it belongs to and writes the expansion error there before finishing with exit 1. One path covers standalone and prefix assignments.
- The write has the two shapes commands already use: async when stderr is an fd, a synchronous append when it is captured (`.quiet()`, command substitution).
- Property to check: a failing assignment value now behaves exactly like a failing argument word. Same message, exit 1, the script continues, assignments left of the failure are applied and those right of it skipped, as in bash.
- Verification: an argument-position control that passes before and after, plus seven cases that fail on the current release with empty stderr (standalone and prefix, fd and `.quiet()` stderr, `||`, partial application, script file). Existing shell suites still pass.

### Background
- Bun Shell is bun's built-in shell interpreter; `$` templates and `bun script.sh` both run through it, and a `{ raw }` interpolation is parsed as shell syntax, so brace expansion applies to it.
- The interpreter is a tree of state nodes (statement, command, assignments, expansion). A child reports only an exit code to its parent; the error object stays on the child until the parent takes it, and is lost when the child is freed.
- Expansion is the node that turns one word into its final strings. It caps brace expansion at 65536 results and stores the error when it fails.
- Shell stderr is either an fd, written through an async IOWriter that calls back into the owning node by a per-node-type tag (the node parks until then), or a captured buffer appended to directly.
- Assignments run as a standalone statement (`FOO=x`) or as a prefix on a command (`FOO=x cmd`). Before this change neither context handed the assignments node any IO.

<details>
<summary>Original description</summary>

### Repro

```ts
import { $ } from "bun";
// 16 alternatives in each of 5 groups: 16^5 = 1048576 words, over the 65536 brace expansion cap.
const word = { raw: "{a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p}".repeat(5) };

let r = await $`echo ${word}`.nothrow().quiet();
console.log(r.exitCode, JSON.stringify(r.stderr.toString()));
// 1 "bun: too many brace expansions (1048576 > 65536)\n"

r = await $`FOO=${word}`.nothrow().quiet();
console.log(r.exitCode, JSON.stringify(r.stderr.toString()));
// 1 ""                                        <- nothing explains the failure

r = await $`FOO=${word} echo hi`.nothrow().quiet();
console.log(r.exitCode, JSON.stringify(r.stdout.toString()), JSON.stringify(r.stderr.toString()));
// 1 "" ""                                     <- echo never runs, still nothing
```

Same for a script file: `bun script.sh` with `FOO=<that word>` in it exits 1 and prints nothing. The brace cap is just the easiest expansion error to trigger; any error the `Expansion` state ends in while expanding an assignment value behaves this way.

### Cause

`Assigns::child_done` (`src/runtime/shell/states/Assigns.rs`) handled a failed `Expansion` child by deiniting it and reporting 1 to its parent. It never called `Expansion::take_err`, so the `ShellErr` the expansion had stored was dropped unprinted. Neither parent prints anything either: for a standalone assignment the parent is `Stmt`/`Binary`, which only record the status, and for a prefix assignment `Cmd::child_done` only calls `take_err` when the failing child is itself an `Expansion`, so for an `Assigns` child it finished with exit 1 silently. Argument words go through `Cmd::child_done` with an `Expansion` child, which writes the error with `Builtin::cmd_write_failing_error`; that is the path the assignment cases were missing.

### Fix

`Assigns` now receives the `IO` it is spawned with (the statement's IO from `Interpreter::spawn_expr` for a standalone assignment, a clone of the command's IO for a prefix assignment) and reports the error itself: `child_done` takes the error out of the failed expansion and `Assigns::fail` writes `"{err}\n"` to that stderr, then finishes with exit 1. The write follows the shape `Cmd` and `CondExpr` already use: an fd-backed stderr gets an async `IOWriter` write and the node parks in a new `WaitingWriteErr` state until `on_io_writer_chunk` runs (new `WriterTag::Assigns` in the IOWriter dispatch); a captured stderr (`.quiet()`, command substitution) is appended to synchronously. Doing it in `Assigns` covers both contexts with one path. `Cmd::child_done` is unchanged apart from a comment: the nonzero status from its `Assigns` child still aborts the command with exit 1, and the message has already been written by then.

This makes a failing assignment value behave exactly like a failing argument word: same message, same status, the script continues with the next statement (`FOO=<bad> || echo fallback` prints `fallback`), and assignments to the left of the failing one have already been applied while the ones to its right are skipped, which is also what bash does when an assignment's expansion fails.

### Tests

New `expansion error in an assignment value` block in `test/js/bun/shell/bunshell.test.ts`. It has an argument-position control (passes before and after) and seven cases that fail on the current release with an empty stderr: standalone and prefix assignments, each with stderr going to the fd and with `.quiet()` (the two write paths above), `||` taking its branch after the failure, `A=1 B=<bad> C=2; echo "$A-$C"` printing `1-` with the error reported once, and `bun script.sh` printing the error and exiting 1 (no captured buffer at all in that mode). `bunshell.test.ts` and the other shell suites that use assignments still pass with the debug build.


</details>
