### PR TITLE
bundler: call the wrapped entry point in iife output

### DIFF
--- a/src/bundler/linker_context/postProcessJSChunk.rs
+++ b/src/bundler/linker_context/postProcessJSChunk.rs
@@ -711,6 +711,33 @@ pub(crate) fn post_process_js_chunk(
     Ok(())
 }
 
+/// `require_foo();` / `init_foo();` for an entry point whose body the linker
+/// put behind a `__commonJS` / `__esm` wrapper. Every other call of that
+/// wrapper sits inside code that only runs once the entry point is running, so
+/// unless the tail makes this call the entry point's code never executes.
+///
+/// `None` when the parser gave the file no wrapper symbol (`needs_wrapper_ref`:
+/// every top-level statement is hoistable). The linker then emits the file
+/// unwrapped, so there is nothing to call, and printing the missing ref would
+/// emit `__INVALID__REF__()`.
+fn call_wrapper_stmt(wrapper_ref: Ref) -> Option<Stmt> {
+    wrapper_ref.is_valid().then(|| {
+        Stmt::alloc(
+            S::SExpr {
+                value: Expr::init(
+                    E::Call {
+                        target: Expr::init_identifier(wrapper_ref, bun_ast::Loc::EMPTY),
+                        ..Default::default()
+                    },
+                    bun_ast::Loc::EMPTY,
+                ),
+                ..Default::default()
+            },
+            bun_ast::Loc::EMPTY,
+        )
+    })
+}
+
 // `js_printer::print` ties bump/Options/import_records/renamer to a
 // single `'a`, and `Renamer<'r, 'src>` is invariant in `'src` — so the caller's
 // renamer lifetime fixes `'a`. All by-ref params that flow into `print` must
@@ -784,22 +811,7 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                             ));
                         } else {
                             // "init_foo();"
-                            stmts.push(Stmt::alloc(
-                                S::SExpr {
-                                    value: Expr::init(
-                                        E::Call {
-                                            target: Expr::init_identifier(
-                                                ast.wrapper_ref,
-                                                bun_ast::Loc::EMPTY,
-                                            ),
-                                            ..Default::default()
-                                        },
-                                        bun_ast::Loc::EMPTY,
-                                    ),
-                                    ..Default::default()
-                                },
-                                bun_ast::Loc::EMPTY,
-                            ));
+                            stmts.extend(call_wrapper_stmt(ast.wrapper_ref));
                         }
                     }
 
@@ -1044,8 +1056,17 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
             }
         }
 
-        // TODO: iife
-        options::OutputFormat::Iife => {}
+        options::OutputFormat::Iife => match flags.wrap {
+            // "require_foo();" / "init_foo();"
+            //
+            // The result is dropped: there is no global name option to assign
+            // it to. Top-level await is a parse error in this format, so an ESM
+            // wrapper here is never async and the call needs no `await`.
+            crate::WrapKind::Cjs | crate::WrapKind::Esm => {
+                stmts.extend(call_wrapper_stmt(ast.wrapper_ref));
+            }
+            crate::WrapKind::None => {}
+        },
 
         options::OutputFormat::InternalBakeDev => {
             // nothing needs to be done here, as the exports are already
@@ -1080,24 +1101,9 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
                 }
                 crate::WrapKind::Esm => {
                     // "init_foo();"
-                    stmts.push(Stmt::alloc(
-                        S::SExpr {
-                            value: Expr::init(
-                                E::Call {
-                                    target: Expr::init_identifier(
-                                        ast.wrapper_ref,
-                                        bun_ast::Loc::EMPTY,
-                                    ),
-                                    ..Default::default()
-                                },
-                                bun_ast::Loc::EMPTY,
-                            ),
-                            ..Default::default()
-                        },
-                        bun_ast::Loc::EMPTY,
-                    ));
+                    stmts.extend(call_wrapper_stmt(ast.wrapper_ref));
                 }
-                _ => {}
+                crate::WrapKind::None => {}
             }
 
             // TODO:
@@ -1121,8 +1127,10 @@ pub(crate) fn generate_entry_point_tail_js<'a>(
     }
 
     let print_options = js_printer::Options {
-        // TODO: IIFE indent
         indent: Default::default(),
+        // The printer indents the tail by one level inside the IIFE wrapper,
+        // like it does for every file's code in the chunk.
+        module_type: c.options.output_format,
         has_run_symbol_renamer: true,
 
         to_esm_ref,

--- a/test/bundler/bundler_cjs.test.ts
+++ b/test/bundler/bundler_cjs.test.ts
@@ -597,4 +597,159 @@ describe("bundler", () => {
       stdout: "loaded ok",
     },
   });
+
+  // ============================================================================
+  // A wrapped entry point (__commonJS or __esm) is only ever invoked by the
+  // entry point tail. The iife format used to define the wrapper and never call
+  // it, so none of the entry point's code ran.
+  // ============================================================================
+
+  // Test 29: CommonJS entry point, format=iife
+  itBundled("cjs/__commonJS_entry_point_called_in_iife", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log("entry ran");
+        module.exports = { a: 1 };
+      `,
+    },
+    format: "iife",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("require_entry();");
+    },
+    run: {
+      stdout: "entry ran",
+    },
+  });
+
+  // Test 30: the entry point is only CommonJS because it require()s a bundled
+  // ESM file, format=iife
+  itBundled("cjs/__commonJS_entry_point_called_in_iife_require_esm", {
+    files: {
+      "/entry.js": /* js */ `
+        const m = require("./re.mjs");
+        console.log("entry ran", m.x);
+      `,
+      "/re.mjs": /* js */ `
+        export const x = 1;
+      `,
+    },
+    format: "iife",
+    run: {
+      stdout: "entry ran 1",
+    },
+  });
+
+  // Test 31: the tail call goes through the chunk's renamer, so it still names
+  // the wrapper after identifiers are minified
+  itBundled("cjs/__commonJS_entry_point_called_in_iife_minified", {
+    files: {
+      "/entry.js": /* js */ `
+        console.log("entry ran");
+        module.exports = { a: 1 };
+      `,
+    },
+    format: "iife",
+    minifyWhitespace: true,
+    minifyIdentifiers: true,
+    minifySyntax: true,
+    run: {
+      stdout: "entry ran",
+    },
+  });
+
+  // Test 32: every iife entry point gets its own tail call
+  itBundled("cjs/__commonJS_entry_point_called_in_iife_multiple_entry_points", {
+    files: {
+      "/a.js": /* js */ `
+        console.log("a ran");
+        module.exports = "a";
+      `,
+      "/b.js": /* js */ `
+        console.log("b ran");
+        module.exports = "b";
+      `,
+    },
+    entryPoints: ["/a.js", "/b.js"],
+    outdir: "/out",
+    format: "iife",
+    run: [
+      { file: "/out/a.js", stdout: "a ran" },
+      { file: "/out/b.js", stdout: "b ran" },
+    ],
+  });
+
+  // Test 33: an ESM entry point gets an __esm wrapper when a dependency
+  // require()s it back. The tail must call init_entry() in iife output too.
+  itBundled("cjs/__esm_entry_point_called_in_iife", {
+    files: {
+      "/entry.js": /* js */ `
+        import "./a.js";
+        console.log("entry ran");
+        export const foo = 1;
+      `,
+      "/a.js": /* js */ `
+        const entry = require("./entry.js");
+        console.log("a ran", typeof entry);
+      `,
+    },
+    format: "iife",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").toContain("init_entry();");
+    },
+    run: {
+      stdout: "a ran object\nentry ran",
+    },
+  });
+
+  // Tests 34 and 35: the parser does not create a wrapper symbol for an ESM
+  // file whose top-level statements can all be hoisted, even when the linker
+  // marks it as wrapped. There is no init_entry to call, and printing the
+  // missing ref used to emit `__INVALID__REF__();` in cjs output.
+  itBundled("cjs/__esm_entry_point_without_wrapper_in_cjs_format", {
+    files: {
+      "/entry.js": /* js */ `
+        export function load() {
+          return import("./a.js");
+        }
+      `,
+      "/a.js": /* js */ `
+        const entry = require("./entry.js");
+        console.log("a ran", typeof entry.load);
+      `,
+      "/test.js": /* js */ `
+        const entry = require("./out.js");
+        console.log("loaded", typeof entry.load);
+      `,
+    },
+    target: "node",
+    format: "cjs",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+    },
+    run: {
+      file: "/test.js",
+      stdout: "loaded function",
+    },
+  });
+
+  itBundled("cjs/__esm_entry_point_without_wrapper_in_iife", {
+    files: {
+      "/entry.js": /* js */ `
+        export function load() {
+          return import("./a.js");
+        }
+      `,
+      "/a.js": /* js */ `
+        const entry = require("./entry.js");
+        console.log("a ran", typeof entry.load);
+      `,
+    },
+    format: "iife",
+    onAfterBundle(api) {
+      api.expectFile("/out.js").not.toContain("__INVALID__REF__");
+    },
+    run: {
+      stdout: "",
+    },
+  });
 });


### PR DESCRIPTION
### Problem
- `bun build --format=iife` of a CommonJS entry point (or an ESM entry that a dependency `require()`s back) reports success, but running the output does nothing: none of the entry point's code executes.
- The linker wraps such an entry in `__commonJS` / `__esm` and relies on the entry point tail to call the wrapper. The esm and cjs tails do; the iife tail emitted nothing.
- Related hole in `--format=cjs`: an ESM entry marked as wrapped but given no wrapper symbol ends in a literal `__INVALID__REF__();`, and loading it throws `ReferenceError: __INVALID__REF__ is not defined`.

### Fix
- The iife tail now emits `require_entry();` / `init_entry();` for a wrapped entry, as esbuild does for iife output with no global name. Top-level await is a parse error in this format, so the call never needs `await`.
- All three tails build the call through one helper that emits nothing when the entry has no wrapper symbol, which also removes the cjs `__INVALID__REF__();`.
- The tail is now indented inside the iife; esm and cjs output is unchanged (diffed against the unfixed build).
- Verification: seven bundler tests added, six of which fail on the unfixed build; the existing esbuild and bundler suites pass on a debug build.

### Background
- The bundler puts a CommonJS file, or an ESM file that something `require()`s, behind a `__commonJS(...)` / `__esm(...)` closure. Its body runs only when that closure is called.
- A non-entry file is called by its importers. Nothing imports an entry point, so the "entry point tail", a few statements the linker appends per output format, has to make that call (and, in esm/cjs, export the result).
- The wrapper's name is a symbol the parser creates. A file whose top-level statements are all hoistable gets none and is emitted unwrapped even if marked as wrapped; printing the missing symbol yields `__INVALID__REF__`.
- `--format=iife` wraps the chunk in `(() => { ... })()`; there is no global name option, so the entry's exports go nowhere.

<details>
<summary>Original description</summary>

### Repro

```sh
printf 'console.log("entry ran");\nmodule.exports = { a: 1 };\n' > entry.js
bun build --format=iife entry.js --outfile=out.js && bun out.js   # prints nothing, exit 0
```

`out.js` on 1.4.0 and on main:

```js
(() => {
  var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);

  // entry.js
  var require_entry = __commonJS(function(exports, module) {
    console.log("entry ran");
    module.exports = { a: 1 };
  });
})();
```

The wrapper is defined and never called, so none of the entry point's code runs and the build reports success. Same thing when the entry is only CommonJS because it `require()`s a bundled ESM file, and for an ESM entry that a dependency `require()`s back (wrapped in `__esm`, `init_entry` is never called). ESM entries without a wrapper were fine, and the esm/cjs formats emit `export default require_entry();` / `module.exports = require_entry();` for the same input.

### Cause

`generate_entry_point_tail_js` in `src/bundler/linker_context/postProcessJSChunk.rs` had an empty arm for `OutputFormat::Iife` (`// TODO: iife`, inherited from the Zig version). The linker wraps a CommonJS entry point in iife and esm output (`scanImportsAndExports`, same rule as esbuild) on the assumption that the entry point tail invokes the wrapper; only the esm and cjs tails did.

While adding the iife arm I found the cjs arm has a related hole. The parser does not create a wrapper symbol for a file whose top-level statements are all hoistable (`needs_wrapper_ref`), and the linker then emits such a file unwrapped even when it is marked `WrapKind::Esm`. The esm tail checks `wrapper_ref.is_valid()` before emitting `init_entry()`; the cjs tail did not, so an entry like

```js
// entry.js
export function load() { return import("./a.js"); }
// a.js
const entry = require("./entry.js");
```

built with `--format=cjs` ends in a literal `__INVALID__REF__();` and throws `ReferenceError: __INVALID__REF__ is not defined` when loaded.

### Fix

The iife tail now emits `require_entry();` / `init_entry();` for a wrapped entry point, which is what esbuild emits for iife output without a global name (there is no global name option to assign the result to, and top-level await is a parse error in this format, so the call never needs to be awaited). The three places that build this call statement share one helper that returns nothing when the entry has no wrapper symbol, which also fixes the cjs `__INVALID__REF__();` case. The tail is printed with `module_type` set to the output format so the printer indents it inside the iife like the rest of the body; for esm and cjs output this changes nothing (verified by diffing outputs against the unfixed build).

Output for the repro is now:

```js
  var require_entry = __commonJS(function(exports, module) {
    console.log("entry ran");
    module.exports = { a: 1 };
  });
  require_entry();
})();
```

### Tests

Seven tests added to `test/bundler/bundler_cjs.test.ts`: CommonJS entry in iife (plain, via `require()` of ESM, minified so the call goes through the renamer, two entry points), `__esm`-wrapped entry in iife, and the no-wrapper-symbol entry in both cjs and iife output. Six of them fail on the unfixed build (the iife no-wrapper one guards the new arm). `esbuild/default`, `esbuild/importstar`, `esbuild/dce`, `esbuild/loader`, `bundler_edgecase`, `bundler_cjs2esm`, `bundler_minify`, `bundler_bun` and `bundler_regressions` pass with the debug build; the iife tests still marked `todo` in those suites depend on `globalName`, which is unchanged.

</details>
