### PR TITLE
bake: serve an HTML route's stylesheets in source order

### DIFF
--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -251,6 +251,27 @@ struct TempLookup {
     seen: bool,
 }
 
+/// A file's "imports" linked list while `process_chunk_dependencies` rebuilds
+/// it. Edges are appended in import record order because `trace_imports`
+/// walks this list to decide the order CSS files are emitted in, which has to
+/// match the source file (and therefore what `bun build` produces).
+#[derive(Default)]
+struct NewImports {
+    head: Option<EdgeIndex>,
+    tail: Option<EdgeIndex>,
+}
+
+impl NewImports {
+    fn append<const SIDE: bake::Side>(&mut self, edges: &mut [Edge<SIDE>], edge_index: EdgeIndex) {
+        edges[edge_index.get() as usize].next_import = None;
+        match self.tail {
+            Some(tail) => edges[tail.get() as usize].next_import = Some(edge_index),
+            None => self.head = Some(edge_index),
+        }
+        self.tail = Some(edge_index);
+    }
+}
+
 /// Parameterized via `adt_const_params` on `bake::Side`; `File` itself is
 /// still the folded union (see TODO above) until a trait dispatch picks the
 /// per-side layout.
@@ -819,11 +840,11 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         let quick_lookup_values_to_care_len = quick_lookup.count();
 
         // A new import linked list is constructed from scratch.
-        let mut new_imports: Option<EdgeIndex> = None;
+        let mut new_imports = NewImports::default();
 
         if mode == ProcessMode::Normal && matches!(SIDE, Side::Server) {
             if ctx.server_seen_bit_set.is_set(file_index.get() as usize) {
-                self.first_import[file_index.get() as usize] = new_imports;
+                self.first_import[file_index.get() as usize] = None;
                 return Ok(());
             }
             // RSC+SSR dual-index dispatch (`ctx.scbs.getSSRIndex`) is
@@ -860,7 +881,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             }
         }
 
-        self.first_import[file_index.get() as usize] = new_imports;
+        self.first_import[file_index.get() as usize] = new_imports.head;
 
         // Follow this file to the route / HMR root to mark it stale.
         self.trace_dependencies(
@@ -875,7 +896,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         &mut self,
         ctx: &mut HotUpdateContext<'_>,
         quick_lookup: &mut ArrayHashMap<FileIndex<SIDE>, TempLookup>,
-        new_imports: &mut Option<EdgeIndex>,
+        new_imports: &mut NewImports,
         file_index: FileIndex<SIDE>,
         index: bun_ast::Index,
     ) -> Result<(), crate::Error> {
@@ -913,7 +934,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         &mut self,
         ctx: &mut HotUpdateContext<'_>,
         quick_lookup: &mut ArrayHashMap<FileIndex<SIDE>, TempLookup>,
-        new_imports: &mut Option<EdgeIndex>,
+        new_imports: &mut NewImports,
         file_index: FileIndex<SIDE>,
         bundler_index: bun_ast::Index,
     ) -> Result<(), crate::Error> {
@@ -959,7 +980,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         &mut self,
         ctx: &mut HotUpdateContext<'_>,
         quick_lookup: &mut ArrayHashMap<FileIndex<SIDE>, TempLookup>,
-        new_imports: &mut Option<EdgeIndex>,
+        new_imports: &mut NewImports,
         file_index: FileIndex<SIDE>,
         ir_flags: bun_ast::ImportRecordFlags,
         ir_source_index: bun_ast::Index,
@@ -1020,19 +1041,17 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         }
 
         let gop = quick_lookup.get_or_put(imported_file_index)?;
-        if gop.found_existing {
+        let edge = if gop.found_existing {
             if gop.value_ptr.seen {
                 return Ok(EdgeAttachmentResult::Continue);
             }
             gop.value_ptr.seen = true;
-            let ei = gop.value_ptr.edge_index;
-            self.edges[ei.get() as usize].next_import = *new_imports;
-            *new_imports = Some(ei);
+            gop.value_ptr.edge_index
         } else {
             // A new edge is needed to represent the dependency and import.
             let first_dep = self.first_dep[imported_file_index.get() as usize];
             let edge = self.new_edge(Edge {
-                next_import: *new_imports,
+                next_import: None,
                 next_dependency: first_dep,
                 prev_dependency: None,
                 imported: imported_file_index,
@@ -1041,7 +1060,6 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             if let Some(dep) = first_dep {
                 self.edges[dep.get() as usize].prev_dependency = Some(edge);
             }
-            *new_imports = Some(edge);
             self.first_dep[imported_file_index.get() as usize] = Some(edge);
 
             self.dev_incremental_result().had_adjusted_edges = true;
@@ -1050,7 +1068,9 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                 edge_index: edge,
                 seen: true,
             };
-        }
+            edge
+        };
+        new_imports.append(&mut self.edges, edge);
         Ok(EdgeAttachmentResult::Continue)
     }
 

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -1,7 +1,7 @@
 // CSS tests concern bundling bugs with CSS files
 import { expect } from "bun:test";
 import assert from "node:assert";
-import { devTest, emptyHtmlFile, imageFixtures } from "../bake-harness";
+import { type Dev, devTest, emptyHtmlFile, imageFixtures, minimalFramework } from "../bake-harness";
 
 devTest("css file with syntax error does not kill old styles", {
   files: {
@@ -691,6 +691,96 @@ devTest("css import before create project relative", {
     await dev.fetch("/").expect.toContain("HELLO");
   },
 });
+
+// None of these `@import` anything, so the comment each served chunk starts
+// with names the file the HTML or script referenced.
+const orderedCssFiles = {
+  "one.css": `.one { color: red; }`,
+  "two.css": `.two { color: red; }`,
+  "three.css": `.three { color: red; }`,
+  "four.css": `.four { color: red; }`,
+  "five.css": `.five { color: red; }`,
+};
+// https://github.com/oven-sh/bun/issues/30488 (<link> tags were served in
+// reverse order) and https://github.com/oven-sh/bun/issues/28117 (same for CSS
+// imported from a script). `bun build` emits one.css through five.css in this
+// order.
+devTest("html route links stylesheets in source order", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: ["one.css", "two.css", "three.css"],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import "./four.css";
+      import "./five.css";
+    `,
+    ...orderedCssFiles,
+  },
+  async test(dev) {
+    expect(await linkedStylesheets(dev)).toEqual(["one.css", "two.css", "three.css", "four.css", "five.css"]);
+
+    // Rebuilding a file re-links the edges it already had in the same order.
+    await dev.writeNoChanges("index.html");
+    await dev.writeNoChanges("index.ts");
+    expect(await linkedStylesheets(dev)).toEqual(["one.css", "two.css", "three.css", "four.css", "five.css"]);
+
+    await dev.write(
+      "index.html",
+      emptyHtmlFile({
+        styles: ["three.css", "one.css", "two.css"],
+        scripts: ["index.ts"],
+      }),
+    );
+    expect(await linkedStylesheets(dev)).toEqual(["three.css", "one.css", "two.css", "four.css", "five.css"]);
+
+    await dev.write(
+      "index.ts",
+      `
+        import "./five.css";
+        import "./four.css";
+      `,
+    );
+    expect(await linkedStylesheets(dev)).toEqual(["three.css", "one.css", "two.css", "five.css", "four.css"]);
+  },
+});
+devTest("framework route lists styles in source order", {
+  framework: minimalFramework,
+  files: {
+    "routes/index.ts": `
+      import "../one.css";
+      import "../two.css";
+      import "../three.css";
+      export default function (req, meta) {
+        return Response.json(meta.styles);
+      }
+    `,
+    ...orderedCssFiles,
+  },
+  async test(dev) {
+    const styles: string[] = await dev.fetch("/").json();
+    expect(await stylesheetFileNames(dev, styles)).toEqual(["one.css", "two.css", "three.css"]);
+  },
+});
+
+/** The stylesheets the served HTML links, in the order it links them. */
+async function linkedStylesheets(dev: Dev): Promise<string[]> {
+  const html = await dev.fetch("/").text();
+  const hrefs = Array.from(html.matchAll(/<link rel="stylesheet" href="(\/_bun\/asset\/[^"]+\.css)">/g), m => m[1]);
+  return stylesheetFileNames(dev, hrefs);
+}
+
+/** Resolves served CSS chunk URLs to the file name in the comment each chunk starts with. */
+function stylesheetFileNames(dev: Dev, hrefs: string[]): Promise<string[]> {
+  return Promise.all(
+    hrefs.map(async href => {
+      const css = await dev.fetch(href).text();
+      const header = css.match(/^\/\* (.*) \*\/\n/);
+      if (!header) throw new Error(`${href} does not start with a file name comment:\n${css}`);
+      return header[1];
+    }),
+  );
+}
 
 function extractCssUrl(backgroundImage: string): string {
   const url = backgroundImage.match(/url\((['"])(.*?)\1\)/);


### PR DESCRIPTION
### Problem
- Fixes #30488
- Fixes #28117
- With `Bun.serve({ development: true })`, an HTML route's `<link>` tags are served in reverse order, and so are the stylesheets its scripts import; a framework route gets the same reversed list in `meta.styles`. `bun build` emits the same files in source order.
- The cascade breaks ties by source order, so a sheet that overrides an earlier one (a theme after its base sheet, two sheets in one `@layer`) resolves the other way around in development than in production.
- Cause: when the dev server rebuilds a file's import list it pushed each edge onto the front, so the list read back reversed, and the CSS emitters use list order as output order.

### Fix
- The rebuild appends through a tail pointer, so a file's import list is in import order. The route walk is depth first, so an HTML route now links its own tags in document order, then each script's imports, matching `bun build`.
- Safe because nothing else depends on the list's order: the other readers load it into a hash map or only free the edges. The reverse (dependencies) lists are untouched.
- Side effect: a route's initial client bundle is also concatenated in import order. It is an object keyed by module path, so only the byte order inside it changes.
- Verification: two new dev server tests, failing on 1.4.0 with the lists reversed and passing with this change; one also rebuilds and reorders the files and checks the served order follows. Related bake tests pass locally on a debug build.

### Background
- The dev server (bake) keeps an incremental graph: one node per file, one edge per import. A file's imports are a singly linked list of edges rebuilt from scratch whenever the file is re-bundled; each edge is also on the imported file's dependencies list, used only for invalidation.
- Serving an HTML route walks that graph depth first from the route, collects the CSS files it reaches, and emits one `<link>` per file in walk order. A framework route gets the same list as `meta.styles`.
- CSS cascade: of two rules with equal specificity, the later stylesheet wins, so link order is page behavior, not cosmetic.
- The graph exists once for the client side and once for the server side; the change is in code shared by both, hence the framework (server side) test.

<details>
<summary>Original description</summary>

Fixes #30488
Fixes #28117

### Reproduce

```html
<!-- index.html -->
<link rel="stylesheet" href="./one.css">
<link rel="stylesheet" href="./two.css">
<link rel="stylesheet" href="./three.css">
<script type="module" src="./index.ts"></script>
```

```ts
// index.ts
import "./four.css";
import "./five.css";
```

```ts
import index from "./index.html";
const server = Bun.serve({ port: 0, development: true, routes: { "/": index } });
const html = await (await fetch(server.url)).text();
for (const [, href] of html.matchAll(/<link rel="stylesheet" href="([^"]+)">/g)) {
  console.log((await (await fetch(new URL(href, server.url))).text()).split("\n")[0]);
}
```

bun 1.4.0 prints `/* five.css */`, `/* four.css */`, `/* three.css */`, `/* two.css */`, `/* one.css */`. `bun build ./index.html` concatenates the same files as one.css, two.css, three.css, four.css, five.css. Framework routes get the same reversed list in `meta.styles`.

Since the cascade resolves equally specific declarations by source order, every stylesheet that overrides an earlier one (a theme or override sheet linked after the base sheet, a later import overriding an earlier one, two sheets contributing to the same `@layer`) resolves the other way around in development than in production.

### Cause

`IncrementalGraph::process_chunk_dependencies` rebuilds a file's import list from its import records, and `process_edge_attachment` pushed every edge (new or re-linked) onto the head of the singly linked list, so `first_import` walked a file's imports in reverse record order. The old comment said this order does not matter, but `trace_imports(FindCss)` pushes CSS roots onto `current_css_files` in walk order, and `generate_html_payload` emits one `<link>` per entry in that order (`generate_css_js_array` does the same for a framework route's `meta.styles`).

### Fix

Keep a tail pointer while rebuilding the list (`NewImports`) and append, so a file's import list is in import record order. `trace_imports` is depth first, so an HTML route now emits its `<link>` tags in document order followed by the stylesheets each script imports, in import order, which is the order `find_imported_css_files_in_js_order` produces for `bun build` on the same files.

The other readers of `first_import` do not depend on its order: `process_chunk_dependencies` loads it into a hash map, and `disconnect_and_delete_file` / `on_file_deleted` only free the edges. `trace_imports(FindClientModules)` now also concatenates the modules of a route's initial client bundle in import order; that bundle is an object literal keyed by module path and its source map is assembled from the same list, so only the byte order inside the bundle changes. The `dependencies` lists (`first_dep`) are untouched: their order only affects which route gets invalidated first.

The earlier attempts at this (#28119, #30491, #30107) were closed against each other and predate the Rust port of the dev server; this is the same fix on the current graph.

### Tests

Two new cases in `test/bake/dev/css.test.ts`, both failing on bun 1.4.0 with the lists reversed and passing with this change:

- `html route links stylesheets in source order`: three `<link>` tags plus a script importing two more stylesheets, resolving each served chunk back to its file name. It then rebuilds both files unchanged (the re-link path for existing edges keeps the order), reorders the `<link>` tags, and reorders the script's imports, checking the served order follows each time.
- `framework route lists styles in source order`: the same check on `meta.styles` for a framework route, covering `generate_css_js_array` and the server side of the graph.

`test/bake/dev/{css,html,esm,sourcemap,server-sourcemap,bundle,hot,incremental-graph-edge-deletion}.test.ts` pass locally with a debug build.

While writing these I ran into two pre-existing problems in the same area that this PR does not try to fix (both reproduce on 1.4.0 without this change): two CSS roots bundled in the same bundle that share an `@import`ed file only get one edge to it, so editing the shared file only reloads one of them; and a framework route's cached `meta.styles` is never invalidated when its imports change unless an HMR client is connected. The framework test above therefore only checks the initial response.

</details>
