### PR TITLE
AbortSignal.timeout: cancel the signal's timer when the heap discards it unfired

### DIFF
--- a/src/jsc/AbortSignal.rs
+++ b/src/jsc/AbortSignal.rs
@@ -53,6 +53,7 @@ unsafe extern "C" {
     // the non-`repr(C)` interior of `EventLoopTimer` is irrelevant to FFI.
     #[allow(improper_ctypes)]
     safe fn WebCore__AbortSignal__getTimeout(arg0: &AbortSignal) -> *mut Timeout;
+    safe fn WebCore__AbortSignal__cancelTimer(arg0: &AbortSignal);
     safe fn WebCore__AbortSignal__signal(
         arg0: &AbortSignal,
         arg1: &JSGlobalObject,
@@ -355,6 +356,35 @@ impl Timeout {
         }
     }
 
+    /// The timer heap is dropping this timeout without firing it
+    /// (`useRealTimers()` / `clearAllTimers()` draining the fake heap, the
+    /// `--isolate` file swap, VM teardown).
+    ///
+    /// Routed through the owning signal's `cancelTimer()`, the same path firing
+    /// takes via `markAborted()`: it clears `m_timeout` and frees `this` through
+    /// [`AbortSignal__Timeout__deinit`] (which unlinks the node if it is still in
+    /// a heap). Unlinking the node alone is not enough: while `m_timeout` is set,
+    /// `JSAbortSignalOwner::isReachableFromOpaqueRoots` keeps an observed signal's
+    /// wrapper, and everything its abort listeners close over, alive for a timer
+    /// that can no longer fire.
+    ///
+    /// # Safety
+    /// `this` is a live boxed `Timeout` still owned by its signal; JS thread;
+    /// no borrow of the timer heap may be live (the deinit re-enters
+    /// `timer_remove`). `this` is freed when this returns.
+    pub unsafe fn discard(this: *mut Timeout) {
+        // SAFETY: `this` is live per the fn contract, and a live box implies a
+        // live owning signal (see the `signal` field doc).
+        let signal = AbortSignal::opaque_ref(unsafe { (*this).signal });
+        debug_assert!(
+            signal
+                .get_timeout()
+                .is_some_and(|owned| core::ptr::eq(owned, this)),
+            "AbortSignal.timeout timer is not the one its signal owns"
+        );
+        WebCore__AbortSignal__cancelTimer(signal);
+    }
+
     /// Fire the timeout. May free `this` (re-entrantly via `signal` →
     /// `~AbortSignal` → `AbortSignal__Timeout__deinit`).
     ///
@@ -369,17 +399,17 @@ impl Timeout {
 
             // The signal and its handlers belong to a previous isolated test
             // file's global; firing now would run them against the new global.
-            // The `Timeout` box is still owned by the signal and will be freed
-            // via `~AbortSignal` → `cancelTimer` when the wrapper is collected.
+            // (The file swap's `cancel_all_timeout_objects` normally discards
+            // such timers before they can come due.)
             if (*this).generation != (*vm).test_isolation_generation {
+                Self::discard(this);
                 return;
             }
 
             // `signal` is a raw back-pointer with no refcount of its own;
             // see the field doc for why it is valid here. `dispatch` may free
             // `this` re-entrantly (markAborted → cancelTimer → deinit), so
-            // capture the pointer first. Nulled at VM teardown; that path does
-            // not re-enter `run`.
+            // capture the pointer first.
             let signal_ptr: *mut AbortSignal = (*this).signal;
             debug_assert!(!signal_ptr.is_null());
             Self::dispatch(vm, signal_ptr);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5992,6 +5992,11 @@ extern "C" WebCore::AbortSignalTimeout WebCore__AbortSignal__getTimeout(WebCore:
     return abortSignal->getTimeout();
 }
 
+extern "C" void WebCore__AbortSignal__cancelTimer(WebCore::AbortSignal* abortSignal)
+{
+    abortSignal->cancelTimer();
+}
+
 extern "C" WebCore::AbortSignal* WebCore__AbortSignal__ref(WebCore::AbortSignal* abortSignal)
 {
     abortSignal->ref();

--- a/src/jsc/bindings/webcore/AbortSignal.h
+++ b/src/jsc/bindings/webcore/AbortSignal.h
@@ -102,6 +102,11 @@ public:
     }
 
     bool hasActiveTimeoutTimer() const { return m_timeout != nullptr; }
+    // Frees the AbortSignal.timeout() timer and clears m_timeout. Also reached from the timer heap
+    // (WebCore__AbortSignal__cancelTimer) when it discards the timer unfired: hasActiveTimeoutTimer()
+    // has to turn false then, or JSAbortSignalOwner::isReachableFromOpaqueRoots keeps an observed
+    // signal's wrapper alive for a timeout that can no longer fire.
+    void cancelTimer();
     bool hasAbortEventListener() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::HasAbortEventListener); }
     bool isFiringEventListeners() const { return m_flags & static_cast<uint8_t>(AbortSignalFlags::IsFiringEventListeners); }
 
@@ -164,7 +169,6 @@ private:
     void addSourceSignal(AbortSignal&);
     void addDependentSignal(AbortSignal&);
     void releaseSourceObserverCounts();
-    void cancelTimer();
 
     void applyFlags(uint8_t flags) { m_flags |= flags; }
     void setIsDependent(bool isDependent)

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1764,8 +1764,8 @@ fn stop_active_handles(vm: &mut VirtualMachine, reason: StopReason) -> SweepResu
     // `setTimeout` into the never-driven fake heap. Leave the heap itself
     // intact: `swap_global_for_test_isolation` runs `cancel_all_timeout_objects`
     // next, which walks both heaps and releases `TimeoutObject` pins and
-    // unlinks `AbortSignalTimeout` timers at a point where no user JS can touch
-    // the outgoing signals.
+    // discards `AbortSignalTimeout` timers at a point where no user JS can
+    // touch the outgoing signals.
     {
         let all = timer_all();
         // SAFETY: `state` is non-null so `timer_all()` is non-null; single

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -5,9 +5,10 @@ use bun_threading::RwLock;
 use bun_core::Environment;
 use bun_core::Timespec;
 use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSHostFn, JSValue, JsResult};
+use crate::jsc::virtual_machine::VirtualMachine;
 use crate::timer::{
-    ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag, InHeap,
-    TimerObjectInternals, TimeoutObject, TimerHeap,
+    AbortSignalTimeout, ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag,
+    InHeap, TimerObjectInternals, TimeoutObject, TimerHeap,
 };
 
 // JSMock C++ bindings (fake timers are only used by bun:test, so these stay local).
@@ -114,6 +115,39 @@ fn from_el_timespec(t: &ElTimespec) -> Timespec {
     Timespec { sec: t.sec, nsec: t.nsec }
 }
 
+/// Owners of the nodes [`FakeTimers::clear`] popped, still to be told their
+/// timer is gone. Released only once the `FakeTimers` borrow has ended: both
+/// paths re-enter `timer::All` (`TimerObjectInternals::cancel` → `All::remove`,
+/// `Timeout` deinit → `timer_remove`).
+#[derive(Default)]
+#[must_use]
+struct ClearedTimers {
+    /// Marking `state = CANCELLED` alone strands the `Box<TimeoutObject>`: its
+    /// refcount sticks at 2 (wrapper +1 from `init_with`, heap +1 from
+    /// `reschedule`) and `internals.this_value` still GC-roots the wrapper, so
+    /// neither side ever frees.
+    pinned: Vec<core::ptr::NonNull<TimerObjectInternals>>,
+    /// Likewise, an unlinked `AbortSignal.timeout()` timer is still its
+    /// signal's `m_timeout`, and `JSAbortSignalOwner::isReachableFromOpaqueRoots`
+    /// pins an observed signal's wrapper for as long as that is set. Only the
+    /// signal's `cancelTimer()` clears it (and frees the box).
+    signal_timeouts: Vec<*mut AbortSignalTimeout>,
+}
+
+impl ClearedTimers {
+    fn release(self, vm: *mut VirtualMachine) {
+        for p in self.pinned {
+            TimerObjectInternals::release_heap_pin(p, vm);
+        }
+        for t in self.signal_timeouts {
+            // SAFETY: `clear` popped `t` from the fake heap, so its box is
+            // still owned by a live signal; JS thread; the `FakeTimers` borrow
+            // ended before this call. `t` is freed by the call.
+            unsafe { AbortSignalTimeout::discard(t) };
+        }
+    }
+}
+
 impl FakeTimers {
     pub(crate) fn is_active(&self) -> bool {
         self.active
@@ -124,49 +158,51 @@ impl FakeTimers {
         CURRENT_TIME.set(global, &Timespec::EPOCH, Some(js_now));
     }
 
-    fn deactivate(
-        &mut self,
-        global: &JSGlobalObject,
-    ) -> Vec<core::ptr::NonNull<TimerObjectInternals>> {
-        let pinned = self.clear();
+    fn deactivate(&mut self, global: &JSGlobalObject) -> ClearedTimers {
+        let cleared = self.clear();
         CURRENT_TIME.clear(global);
         self.active = false;
-        pinned
+        cleared
     }
 
     /// Restore real timers without draining the fake heap. Used by the
     /// `--isolate` file boundary so `swap_global_for_test_isolation`'s
     /// `cancel_all_timeout_objects` (which runs after the outgoing global's
     /// JS has stopped) can walk the still-populated fake heap and release
-    /// `TimeoutObject` pins and unlink `AbortSignalTimeout` timers.
+    /// `TimeoutObject` pins and discard `AbortSignalTimeout` timers.
     pub(crate) fn reset_for_isolation(&mut self, global: &JSGlobalObject) {
         CURRENT_TIME.clear(global);
         self.active = false;
     }
 
-    /// Marking `state = CANCELLED` alone strands the `Box<TimeoutObject>`: its
-    /// refcount sticks at 2 (wrapper +1 from `init_with`, heap +1 from
-    /// `reschedule`) and `internals.this_value` still GC-roots the wrapper, so
-    /// neither side ever frees.
-    #[must_use]
-    fn clear(&mut self) -> Vec<core::ptr::NonNull<TimerObjectInternals>> {
-        let mut pinned = Vec::new();
+    /// Pop every fake timer. Popping only unlinks the nodes; the owners that
+    /// need to hear about it are returned for the caller to release.
+    fn clear(&mut self) -> ClearedTimers {
+        let mut cleared = ClearedTimers::default();
         while let Some(timer) = self.timers.delete_min() {
-            // SAFETY: `delete_min` returned a live node; the `TimeoutObject`
-            // it belongs to stays live until the caller's release pass.
+            // SAFETY: `delete_min` returned a live node; the owner it belongs
+            // to stays live until the caller's release pass.
             unsafe {
                 (*timer).in_heap = InHeap::None;
                 (*timer).state = EventLoopTimerState::CANCELLED;
-                if (*timer).tag == EventLoopTimerTag::TimeoutObject {
-                    let parent = TimeoutObject::from_timer_ptr(timer);
-                    pinned.push(core::ptr::NonNull::new_unchecked(
-                        core::ptr::addr_of_mut!((*parent).internals),
-                    ));
+                match (*timer).tag {
+                    EventLoopTimerTag::TimeoutObject => {
+                        let parent = TimeoutObject::from_timer_ptr(timer);
+                        cleared.pinned.push(core::ptr::NonNull::new_unchecked(
+                            core::ptr::addr_of_mut!((*parent).internals),
+                        ));
+                    }
+                    EventLoopTimerTag::AbortSignalTimeout => {
+                        cleared
+                            .signal_timeouts
+                            .push(AbortSignalTimeout::from_timer_ptr(timer));
+                    }
+                    _ => {}
                 }
             }
         }
 
-        pinned
+        cleared
     }
 
     fn execute_next(global: &JSGlobalObject) -> bool {
@@ -314,12 +350,9 @@ fn use_fake_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSVal
 
 #[bun_jsc::host_fn]
 fn use_real_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
-    // SAFETY: per-thread `timer::All`; the borrow ends before `release_heap_pin`.
-    let pinned = unsafe { (*timer_all()).fake_timers.deactivate(global) };
-    let vm = global.bun_vm_ptr();
-    for p in pinned {
-        TimerObjectInternals::release_heap_pin(p, vm);
-    }
+    // SAFETY: per-thread `timer::All`; the borrow ends before `release`.
+    let cleared = unsafe { (*timer_all()).fake_timers.deactivate(global) };
+    cleared.release(global.bun_vm_ptr());
 
     // Remove the setTimeout.clock marker when switching back to real timers.
     set_fake_timer_marker(global, false);
@@ -403,12 +436,9 @@ fn get_timer_count(global: &JSGlobalObject, _frame: &CallFrame) -> JsResult<JSVa
 fn clear_all_timers(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     error_unless_fake_timers(global)?;
 
-    // SAFETY: per-thread `timer::All`; the borrow ends before `release_heap_pin`.
-    let pinned = unsafe { (*timer_all()).fake_timers.clear() };
-    let vm = global.bun_vm_ptr();
-    for p in pinned {
-        TimerObjectInternals::release_heap_pin(p, vm);
-    }
+    // SAFETY: per-thread `timer::All`; the borrow ends before `release`.
+    let cleared = unsafe { (*timer_all()).fake_timers.clear() };
+    cleared.release(global.bun_vm_ptr());
 
     Ok(frame.this())
 }

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -1228,9 +1228,12 @@ impl All {
         }
     }
 
-    /// VM-teardown pass: `cancel()` every `TimeoutObject` / `ImmediateObject`
-    /// still linked in `timers` / `fake_timers.timers` so the in-heap `+1` ref
-    /// and the JS pin (`this_value` Strong) are released before the GC sweep.
+    /// VM-teardown / `--isolate` file-swap pass: `cancel()` every
+    /// `TimeoutObject` / `ImmediateObject` still linked in `timers` /
+    /// `fake_timers.timers` so the in-heap `+1` ref and the JS pin
+    /// (`this_value` Strong) are released before the GC sweep, and discard
+    /// every `AbortSignal.timeout()` timer through its signal so the signal
+    /// stops reporting an active timer.
     ///
     /// # Safety
     /// JS thread only, with the TLS `RuntimeState` still installed and `vm`
@@ -1238,7 +1241,7 @@ impl All {
     /// (`Zig__GlobalObject__destructOnExit` / `WebWorker__teardownJSCVM`) and
     /// BEFORE `runtime_state` is nulled — the GC sweep frees the
     /// `TimeoutObject` boxes whose `event_loop_timer` fields the heap nodes
-    /// alias.
+    /// alias, and the `AbortSignal`s that own the `AbortSignalTimeout` boxes.
     pub(crate) unsafe fn cancel_all_timeout_objects(
         this: *mut Self,
         vm: *mut crate::jsc::virtual_machine::VirtualMachine,
@@ -1298,23 +1301,18 @@ impl All {
             unsafe { (*internals).cancel(vm) };
         }
 
-        // `AbortSignal.timeout()` boxes are owned by the C++ `AbortSignal`
-        // (freed via `~AbortSignal` → `cancelTimer`), and the signal is kept
-        // alive by its JS wrapper. Unlink the timer here so `Timeout::deinit`'s
-        // `cancel` is a no-op against the already-destroyed heap, and null the
-        // back-pointer so `Timeout::run` cannot dereference a freed signal if
-        // an event-loop drain sneaks in before teardown.
+        // `AbortSignal.timeout()` boxes are owned by the C++ `AbortSignal`, so
+        // each one is handed back to its signal, which unlinks and frees it and
+        // clears `m_timeout`. Only unlinking the node here would leave every
+        // observed signal's wrapper (under `--isolate`: the retired global its
+        // listeners close over) pinned by `isReachableFromOpaqueRoots` for the
+        // rest of the process; see `Timeout::discard`.
         for t in signal_timeouts {
-            // SAFETY: each `t` was collected from the live heap above and is
-            // still owned by its `AbortSignal` (the box is freed by
-            // `cancelTimer()` at wrapper GC / `lastChanceToFinalize`). JS
-            // thread.
-            unsafe {
-                if (*t).event_loop_timer.state == EventLoopTimerState::ACTIVE {
-                    (*this).remove(core::ptr::addr_of_mut!((*t).event_loop_timer));
-                }
-                (*t).signal = core::ptr::null_mut();
-            }
+            // SAFETY: each `t` was collected from the live heap above, so its
+            // box (and therefore its owning signal) is still alive; JS thread;
+            // no borrow of `*this` is held across the call (`discard` re-enters
+            // `remove` through `timer_remove`). `t` is freed by the call.
+            unsafe { AbortSignalTimeout::discard(t) };
         }
     }
 }

--- a/test/cli/test/isolation.test.ts
+++ b/test/cli/test/isolation.test.ts
@@ -777,6 +777,11 @@ test.concurrent("--isolate: leaked AbortSignal.timeout does not fire in next fil
 // - setTimeout/setInterval: generation-stale timers only self-cancelled when
 //   they FIRED, so a module-scope long timer held a Strong on its wrapper
 //   until the deadline (effectively forever for hour-scale timers).
+// - AbortSignal.timeout with an abort listener: the swap unlinked the native
+//   timer but left the signal believing it still had one, and the GC keeps a
+//   pending timeout signal's wrapper (hence its listener, hence the global)
+//   alive for as long as the signal says so. Same story when the timer sat in
+//   the fake-timer heap of a file that never called useRealTimers().
 //
 // Each fixture runs 8 isolated files that leak one handle apiece, forces a
 // full GC, and counts live GlobalObject cells. Pinned globals accumulate
@@ -847,6 +852,28 @@ describe.concurrent("--isolate: collects globals pinned by leaked handles", () =
       makeLeakFixture(`
         setTimeout(() => {}, 3_600_000);
         setInterval(() => {}, 3_600_000);
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  });
+
+  test("AbortSignal.timeout with an abort listener left pending", async () => {
+    using dir = tempDir(
+      "isolate-leak-abort-timeout",
+      makeLeakFixture(`
+        AbortSignal.timeout(3_600_000).addEventListener("abort", () => {});
+      `),
+    );
+    expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);
+  });
+
+  test("AbortSignal.timeout with an abort listener left pending in a fake-timer heap", async () => {
+    using dir = tempDir(
+      "isolate-leak-abort-timeout-fake",
+      makeLeakFixture(`
+        import { vi } from "bun:test";
+        vi.useFakeTimers();
+        AbortSignal.timeout(3_600_000).addEventListener("abort", () => {});
       `),
     );
     expect(await maxLiveGlobals(String(dir))).toBeLessThanOrEqual(4);

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -1,3 +1,4 @@
+import { heapStats } from "bun:jsc";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 afterEach(() => vi.useRealTimers());
@@ -198,6 +199,78 @@ describe("clearAllTimers", () => {
   });
   test("throws error if fake timers not active", () => {
     expect(() => vi.clearAllTimers()).toThrow("Fake timers are not active");
+  });
+});
+describe("AbortSignal.timeout", () => {
+  const N = 500;
+
+  function liveAbortSignals(): number {
+    Bun.gc(true);
+    Bun.gc(true);
+    return heapStats().objectTypeCounts.AbortSignal ?? 0;
+  }
+
+  // A pending timeout signal with an abort listener is kept alive by the
+  // runtime itself (the listener has to run when the timer fires), so with no
+  // JS reference to them these wrappers live exactly as long as the runtime
+  // believes their timer is still pending. The bounds below leave room for the
+  // odd wrapper that conservative stack scanning keeps alive or lets go of.
+  function leakObservedTimeouts() {
+    for (let i = 0; i < N; i++) {
+      AbortSignal.timeout(1_000_000).addEventListener("abort", () => {});
+    }
+  }
+
+  test("pending signals stay alive while the fake heap holds their timer", () => {
+    vi.useFakeTimers();
+    const before = liveAbortSignals();
+    leakObservedTimeouts();
+    expect(vi.getTimerCount()).toBe(N);
+    expect(liveAbortSignals() - before).toBeGreaterThan(N * 0.9);
+  });
+
+  // useRealTimers() and clearAllTimers() drop the pending fake timers, so these
+  // signals can never abort anymore and nothing should keep them alive. They
+  // used to stay pinned (with their listeners) for the rest of the process.
+  test("useRealTimers() releases the signals whose timers it dropped", () => {
+    const before = liveAbortSignals();
+    vi.useFakeTimers();
+    leakObservedTimeouts();
+    vi.useRealTimers();
+    expect(liveAbortSignals() - before).toBeLessThan(N * 0.1);
+  });
+
+  test("clearAllTimers() releases the signals whose timers it cleared", () => {
+    vi.useFakeTimers();
+    const before = liveAbortSignals();
+    leakObservedTimeouts();
+    vi.clearAllTimers();
+    expect(vi.getTimerCount()).toBe(0);
+    expect(liveAbortSignals() - before).toBeLessThan(N * 0.1);
+  });
+
+  test("a signal the program still holds is left unaborted once its fake timer is dropped", () => {
+    vi.useFakeTimers();
+    const signal = AbortSignal.timeout(1);
+    vi.useRealTimers();
+    const dependent = AbortSignal.any([signal]);
+    signal.addEventListener("abort", () => {});
+    liveAbortSignals();
+    expect({ aborted: signal.aborted, dependentAborted: dependent.aborted }).toEqual({
+      aborted: false,
+      dependentAborted: false,
+    });
+  });
+
+  test("fires through advanceTimersByTime", () => {
+    vi.useFakeTimers();
+    const signal = AbortSignal.timeout(1000);
+    const reasons: string[] = [];
+    signal.addEventListener("abort", () => reasons.push(signal.reason.name));
+    vi.advanceTimersByTime(999);
+    expect({ aborted: signal.aborted, reasons }).toEqual({ aborted: false, reasons: [] });
+    vi.advanceTimersByTime(1);
+    expect({ aborted: signal.aborted, reasons }).toEqual({ aborted: true, reasons: ["TimeoutError"] });
   });
 });
 describe("isFakeTimers", () => {


### PR DESCRIPTION
### Problem
- An `AbortSignal.timeout()` signal with an abort listener stays in the heap for the rest of the process once its timer is dropped by `useRealTimers()` / `clearAllTimers()` or by the `bun test --isolate` file swap. In the repro in the original description, 500 such signals survive `Bun.gc(true)` on main.
- Under `--isolate` this pins the retired file's whole global object graph: 8 files that each leave one such signal pending climb to 8 live globals, where the other leaked-handle fixtures plateau at 1 to 3.
- Cause: the GC keeps an observed timeout signal alive for as long as the signal itself says it has a timer, and only the signal's `cancelTimer()` clears that. Both paths above pulled the timer out of the heap without going through the signal, so it kept reporting a timer that could never fire.
- The only remaining thing that clears it is the signal's destructor, which needs the GC to collect the signal first: a cycle.

### Fix
- Every place the heap drops an `AbortSignal.timeout` timer unfired (fake-heap drain, `--isolate` swap, VM teardown, and the generation-stale exit when a stale timer comes due) now hands it back to the signal's `cancelTimer()`, which clears the flag and frees the timer.
- Correct because it is the same path a firing timer already takes, and it produces the state these callers already wanted: an inert signal that never aborts and is collectable like any other. Dropped timers still never fire, and the existing `--isolate` "does not fire in next file" test still passes.
- Verification: new fake-timers tests (the `useRealTimers()` and `clearAllTimers()` cases fail on main with 500 survivors) and two new `--isolate` fixtures that hit 8 live globals on main and plateau with the fix. Teardown relies on an existing worker-terminate test; the related timer and abort suites pass under ASAN.
- Found while reviewing #37666; independent of it.

### Background
- `AbortSignal.timeout(n)` aborts with `TimeoutError` after n ms. So that `AbortSignal.timeout(n).addEventListener("abort", cb)` works with no JS reference held, the GC keeps the wrapper alive while the signal has both a pending timer and an observer (`JSAbortSignalOwner::isReachableFromOpaqueRoots`). "Pending timer" means the C++ signal's `m_timeout` is non-null.
- The native timer is a box owned by the C++ `AbortSignal` and linked as a node into bun's timer heap, with a back-pointer to the signal. Firing runs through the signal (`markAborted()` -> `cancelTimer()`), which clears `m_timeout` and frees the box; unlinking the heap node alone leaves `m_timeout` set.
- bun:test fake timers hold timers in a separate fake heap that only advances on `advanceTimersByTime` and friends; `useRealTimers()` / `clearAllTimers()` empty it, and a timer emptied that way is meant to never fire.
- `bun test --isolate` runs each file in a fresh global and, at the swap (and at VM teardown), cancels every timer still in either heap so a previous file's callbacks cannot run against the new global. Timers also carry a generation number so a stale one that comes due anyway is skipped.

<details>
<summary>Original description</summary>

### What

An `AbortSignal.timeout()` signal that has an abort listener (or any other observer) stays pinned in the heap for the rest of the process once its timer is dropped by `useRealTimers()` / `clearAllTimers()` or by the `bun test --isolate` file swap. Under `--isolate` that pins the retired file's whole global object graph, one global per file that leaves such a signal pending.

```ts
import { heapStats } from "bun:jsc";
import { test, vi } from "bun:test";

test("repro", () => {
  vi.useFakeTimers();
  for (let i = 0; i < 500; i++) AbortSignal.timeout(1_000_000).addEventListener("abort", () => {});
  vi.useRealTimers();
  Bun.gc(true);
  console.log(heapStats().objectTypeCounts.AbortSignal); // 500 on main; 0 (give or take a stack-conservative one) with this PR
});
```

`--isolate` variant: 8 files that each do `AbortSignal.timeout(3_600_000).addEventListener("abort", () => {})` at module scope and count `GlobalObject` cells after `Bun.gc(true)`. On main the count climbs 1, 2, ..., 8; the existing `setTimeout` / `Bun.serve` / `fs.watch` fixtures in the same describe block plateau at 1 to 3, and so does this one with the fix.

### Why

`JSAbortSignalOwner::isReachableFromOpaqueRoots` keeps a timeout signal's wrapper alive while `hasActiveTimeoutTimer() && hasTimeoutObserver()`. That is what makes `AbortSignal.timeout(n).addEventListener("abort", cb)` work with no JS reference to the signal, and it is only correct for as long as the timer can actually fire. `hasActiveTimeoutTimer()` is `m_timeout != nullptr`, and `m_timeout` is only cleared by `AbortSignal::cancelTimer()` (called from `markAborted()` and `~AbortSignal()`).

Two places on the Rust side took the timer away without going through the signal, so the signal kept claiming a timer it no longer had:

- `FakeTimers::clear()` (`useRealTimers()`, `clearAllTimers()`) popped every node out of the fake heap and only released `TimeoutObject` pins; `AbortSignalTimeout` nodes were just dropped.
- `All::cancel_all_timeout_objects` (the `--isolate` swap and VM teardown) unlinked `AbortSignalTimeout` nodes and nulled their back-pointer.

After either, the timer can never fire, `m_timeout` is still set, the observer is still there, and the wrapper (plus its listeners, plus whatever they close over) is unreachable for GC until the process exits. `~AbortSignal()` is the only remaining thing that would clear `m_timeout`, and it only runs once the wrapper is collected: a cycle through the GC's reachability rule.

The behavior these paths want is unchanged: a timer dropped by `useRealTimers()` never fires (same as a `setTimeout` created under fake timers, see the first test in `fake-timers.test.ts`), and `--isolate` must not fire a previous file's signal in the next file (`test/cli/test/isolation.test.ts`, "leaked AbortSignal.timeout does not fire in next file", still passes). The signal should simply end up as an inert, never-aborting signal that is collectable like any other, which is exactly the state `cancelTimer()` produces.

### How

- `AbortSignal::cancelTimer()` becomes public, exposed to Rust as `WebCore__AbortSignal__cancelTimer`.
- New `Timeout::discard(this)` in `src/jsc/AbortSignal.rs`: asserts the box is the one its signal owns and calls `cancelTimer()` on the signal, which clears `m_timeout` and frees the box via the existing `AbortSignal__Timeout__deinit` (which also unlinks the node if it is still in a heap). This is the same path a firing timer takes through `markAborted()`, so nothing new has to be kept in sync.
- `FakeTimers::clear()` now collects `AbortSignalTimeout` nodes alongside the `TimeoutObject` pins (small `ClearedTimers` struct, released by both callers after the `FakeTimers` borrow ends, same reason `release_heap_pin` was already deferred) and discards them.
- `cancel_all_timeout_objects` discards the signal timeouts instead of unlinking them and nulling `signal`; nulling is unnecessary now that the box is gone. At VM teardown this also means `~AbortSignal()` later finds `m_timeout` already cleared.
- The generation-stale early return in `Timeout::run` (a timer from a retired `--isolate` file that somehow comes due) discards too, instead of leaving the same pinned state behind. In practice the swap's `cancel_all_timeout_objects` handles these first; this just makes the remaining exit consistent.

### Tests

`test/js/bun/test/fake-timers/fake-timers.test.ts`, new `AbortSignal.timeout` block:
- control: 500 observed signals stay alive while the fake heap holds their timers (`getTimerCount() === 500`)
- `useRealTimers()` releases them; `clearAllTimers()` releases them (both fail on main with 500 survivors)
- a signal the program still holds is left unaborted and usable (`AbortSignal.any`, `addEventListener`) after its fake timer is dropped
- `advanceTimersByTime` still aborts the signal with `TimeoutError`

`test/cli/test/isolation.test.ts`, "collects globals pinned by leaked handles": two new fixtures, an observed `AbortSignal.timeout` left pending in the real heap and one left pending in the fake heap of a file that never called `useRealTimers()` (both reach 8 live globals on main, plateau with the fix).

VM teardown is covered by the existing `test/js/web/workers/worker-terminate-funnels.test.ts` (armed, observed `AbortSignal.timeout` in a terminated worker), which passes on the ASAN debug build along with `timer-gc-roots.test.ts`, `abort.test.ts`, `test-timers.test.ts`, the whole `fake-timers/` directory and `isolation.test.ts`. Also ran worker terminate x3 and `BUN_DESTRUCT_VM_ON_EXIT=1` (real and fake heap) with pending observed timeouts under ASAN by hand, clean.

Found while reviewing #37666; independent of it (that PR only removes the eager cancel in `eventListenersDidChange`, and this one does not touch that function).


</details>
