### PR TITLE
bun create: print single braces in the missing component export hint

### DIFF
--- a/src/runtime/cli/create/SourceFileProjectGenerator.rs
+++ b/src/runtime/cli/create/SourceFileProjectGenerator.rs
@@ -36,9 +36,9 @@ pub(crate) fn generate(
             b"\n\
               Please add an export to your file. For example:\n\
               \n\
-              \x20  export default function MyApp() {{\n\
+              \x20  export default function MyApp() {\n\
               \x20    return <div>Hello World</div>;\n\
-              \x20  }};\n\
+              \x20  }\n\
               \n",
         )?;
 

--- a/test/cli/create/create-jsx.test.ts
+++ b/test/cli/create/create-jsx.test.ts
@@ -1,7 +1,7 @@
 import type { Subprocess } from "bun";
 import { beforeEach, describe, expect, test } from "bun:test";
 import { cp, readdir } from "fs/promises";
-import { bunEnv, bunExe, isCI, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, isCI, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
 import path from "path";
 
 async function getServerUrl(process: Subprocess<any, "pipe", any>, all = { text: "" }) {
@@ -353,6 +353,39 @@ export default function Component() {
   const installLine = stdout.split("\n").find(line => line.includes("--only-missing install"));
   expect(installLine).toBeDefined();
   expect(installLine).toContain(" install -- ");
+});
+
+test("a file without a component export prints a hint with valid example code", async () => {
+  using dir = tempDir("create-no-export", {
+    "Component.tsx": `function Component() {
+  return <div>Hello</div>;
+}
+console.log(Component);
+`,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "create", "./Component.tsx"],
+    cwd: String(dir),
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stdout).toBe("");
+  expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+    "error: No component export found in "<dir>/Component.tsx"
+
+    Please add an export to your file. For example:
+
+       export default function MyApp() {
+         return <div>Hello World</div>;
+       }"
+  `);
+  expect(exitCode).toBe(1);
 });
 
 function normalizeHTMLFn(development: boolean = true) {


### PR DESCRIPTION
### Problem
- `bun create ./Component.tsx` on a `.tsx`/`.jsx` file with no component export prints a hint whose example has doubled braces (`{{`, `}};`), so the example is not valid as written.
- The hint is a plain byte literal, not a format string, so `{{` prints as written. The doubling is a format escape left over from the Zig version.

### Fix
- Spell the braces once and drop the stray `;`. Nothing else changes.
- Correct because nothing in the hint is interpolated, so the literal prints byte for byte and needs no escaping.
- Verified by a test that runs `bun create` on an export-less `.tsx` file and snapshots stderr. It fails on the current release and passes with this change; the path exits before any install, so no network.

### Background
- `bun create ./File.tsx` scaffolds a project around a component exported from a local file. With no export it prints this hint and exits 1 before installing or writing anything.
- In Rust, `{{` is an escape only in `format!`-style strings. In a byte literal passed to `write_all` it is two literal characters.

<details>
<summary>Original description</summary>

### What

`bun create ./Component.tsx` on a file with no component export prints a hint whose example code has doubled braces and a stray semicolon:

```
$ bun create ./Component.tsx
error: No component export found in "/tmp/x/Component.tsx"

Please add an export to your file. For example:

   export default function MyApp() {{
     return <div>Hello World</div>;
   }};
```

Repro: any `.jsx`/`.tsx` file where `find_react_component_export()` finds nothing, e.g.

```tsx
function Component() {
  return <div>Hello</div>;
}
console.log(Component);
```

### Why

In `src/runtime/cli/create/SourceFileProjectGenerator.rs` the hint is a plain byte literal handed to `write_all`, not a format string, so `{{` and `}}` are emitted as written. The doubling is a leftover format escape (the Zig version had the same `{{` inside a `writeAll` literal, and the port kept it). Nothing in the hint is interpolated, so the fix is to spell the braces once. The `;` after the function body is an empty statement in the example the user is told to copy, so it goes too. The example now reads the way the hint intends: a component file that `bun create` accepts as written.

### Test

Added a case to `test/cli/create/create-jsx.test.ts` that runs `bun create` on a `.tsx` file with no exports and snapshots stderr (plus empty stdout and exit code 1). It fails on the current release with the `{{` / `}};` lines and passes with this change. This error path exits before any install or file generation, so the test does not need the network.

</details>
