### PR TITLE
logger: align the caret with a left-trimmed line excerpt

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -625,7 +625,9 @@ pub struct Location {
     // arena-owned source text.
     pub file: Cow<'static, [u8]>,
     pub namespace: Str,
-    /// Text on the line, avoiding the need to refetch the source code
+    /// Text on the line, avoiding the need to refetch the source code.
+    /// May be just a window of a long line (see `init_or_null`), in which
+    /// case `line_text_column_offset` says where on the line it starts.
     pub line_text: Option<Cow<'static, [u8]>>,
     /// Number of bytes this location should highlight.
     /// 0 to just point at a single character
@@ -641,6 +643,12 @@ pub struct Location {
     // original docs: 0-based, in bytes.
     // but there is a place where this is emitted in output, implying one based character offset
     pub column: i32,
+    /// Number of columns (in the units of `column`) of the source line that
+    /// precede `line_text`: non-zero only when `line_text` is a window of a
+    /// long line that starts after the line's first character. `column` is
+    /// always relative to the whole line, so a caret drawn under `line_text`
+    /// goes `column - 1 - line_text_column_offset` characters in.
+    pub line_text_column_offset: u32,
 }
 
 // NOT `#[derive(Clone)]`. `file` / `line_text` are
@@ -657,6 +665,7 @@ impl Clone for Location {
             namespace: self.namespace,
             line: self.line,
             column: self.column,
+            line_text_column_offset: self.line_text_column_offset,
             length: self.length,
             line_text: self.line_text.as_deref().map(|t| Cow::Owned(t.to_vec())),
             offset: self.offset,
@@ -674,6 +683,7 @@ impl Default for Location {
             offset: 0,
             line: 0,
             column: 0,
+            line_text_column_offset: 0,
         }
     }
 }
@@ -716,6 +726,7 @@ impl Location {
             namespace: self.namespace,
             line: self.line,
             column: self.column,
+            line_text_column_offset: self.line_text_column_offset,
             length: self.length,
             line_text: self.line_text.as_deref().map(|t| Cow::Owned(t.to_vec())),
             offset: self.offset,
@@ -737,6 +748,7 @@ impl Location {
             namespace,
             line,
             column,
+            line_text_column_offset: 0,
             length: length as usize,
             line_text: line_text.map(Cow::Borrowed),
             offset: length as usize,
@@ -770,6 +782,7 @@ impl Location {
                     namespace: source.path.namespace,
                     line: -1,
                     column: -1,
+                    line_text_column_offset: 0,
                     length: 0,
                     line_text: Some(Cow::Borrowed(b"")),
                     offset: 0,
@@ -779,25 +792,34 @@ impl Location {
                 Some(tracker) => tracker.error_position(source, r.loc),
                 None => source.init_error_position(r.loc),
             };
-            let mut full_line = &source.contents[data.line_start..data.line_end];
-            // Window a long line to ~120 bytes around the error. Bounds are
-            // BYTE offsets; the gate keeps the original shape (no left trim for
-            // an error in the last 80 bytes) so `write_format`'s caret aligns.
+            let line = &source.contents[data.line_start..data.line_end];
             let offset_in_line = clamp_error_offset(&source.contents, r.loc)
                 .saturating_sub(data.line_start)
-                .min(full_line.len());
-            if full_line.len() > 80 + offset_in_line {
+                .min(line.len());
+            let mut line_text = line;
+            let mut line_text_column_offset: u32 = 0;
+            // Window a long line to ~120 bytes around the error. Bounds are
+            // BYTE offsets, snapped to UTF-8 char boundaries.
+            if line.len() > 80 + offset_in_line {
                 let mut lo = offset_in_line.saturating_sub(40);
-                let mut hi = (offset_in_line + 80).min(full_line.len());
-                while lo > 0 && !bun_core::strings::is_utf8_char_boundary(full_line[lo]) {
+                let mut hi = (offset_in_line + 80).min(line.len());
+                while lo > 0 && !bun_core::strings::is_utf8_char_boundary(line[lo]) {
                     lo -= 1;
                 }
-                while hi < full_line.len()
-                    && !bun_core::strings::is_utf8_char_boundary(full_line[hi])
-                {
+                while hi < line.len() && !bun_core::strings::is_utf8_char_boundary(line[hi]) {
                     hi += 1;
                 }
-                full_line = &full_line[lo..hi];
+                line_text = &line[lo..hi];
+                // Both scans start at column 1, so the difference is the width
+                // of `line[..lo]`. Measuring the ≤ 40 bytes kept in front of
+                // the error, rather than rescanning `line[..lo]`, keeps a long
+                // line with many diagnostics linear (the reason
+                // `LineColumnTracker` exists).
+                let mut kept = ErrorPositionState::default();
+                kept.advance(line, lo, offset_in_line);
+                line_text_column_offset =
+                    u32::try_from(data.column_count.saturating_sub(kept.column_number))
+                        .expect("int cast");
             }
 
             return Some(Location {
@@ -805,6 +827,7 @@ impl Location {
                 namespace: source.path.namespace,
                 line: usize2loc(data.line_count).start,
                 column: usize2loc(data.column_count).start,
+                line_text_column_offset,
                 length: if r.len > -1 {
                     u32::try_from(r.len).expect("int cast") as usize
                 } else {
@@ -813,10 +836,9 @@ impl Location {
                 // `source_backing` in `Transpiler::parse_*` is RAII and
                 // drops on the parse-error path *before* `process_fetch_log`
                 // clones the `Msg` into a `BuildMessage`, so own the bytes here
-                // instead of borrowing `source.contents`. `full_line` is
-                // bounded (≤ ~120 bytes) and only materialized on diagnostic
-                // paths.
-                line_text: Some(Cow::Owned(bun_core::trim_left(full_line, b"\n\r").to_vec())),
+                // instead of borrowing `source.contents`. This is only
+                // materialized on diagnostic paths.
+                line_text: Some(Cow::Owned(line_text.to_vec())),
                 offset: usize::try_from(r.loc.start.max(0)).expect("int cast"),
             });
         }
@@ -963,7 +985,9 @@ impl Data {
                 let line_text = bun_core::trim_left(line_text_right_trimmed, b"\n\r");
                 if location.column > 0 && !line_text.is_empty() {
                     let mut line_offset_for_second_line: usize =
-                        usize::try_from(location.column - 1).expect("int cast");
+                        usize::try_from(location.column - 1)
+                            .expect("int cast")
+                            .saturating_sub(location.line_text_column_offset as usize);
 
                     if location.line > -1 {
                         let bold = matches!(kind, Kind::Err | Kind::Warn);
@@ -2437,11 +2461,7 @@ impl ErrorPositionState {
 
     fn to_error_position(self, line_end: usize) -> ErrorPosition {
         ErrorPosition {
-            line_start: if self.line_start > 0 {
-                self.line_start - 1
-            } else {
-                self.line_start
-            },
+            line_start: self.line_start,
             line_end,
             line_count: self.line_count,
             column_count: self.column_number,

--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -625,9 +625,8 @@ pub struct Location {
     // arena-owned source text.
     pub file: Cow<'static, [u8]>,
     pub namespace: Str,
-    /// Text on the line, avoiding the need to refetch the source code.
-    /// May be just a window of a long line (see `init_or_null`), in which
-    /// case `line_text_column_offset` says where on the line it starts.
+    /// Text on the line (possibly a window of a long one, per
+    /// `line_text_column_offset`), avoiding a source refetch.
     pub line_text: Option<Cow<'static, [u8]>>,
     /// Number of bytes this location should highlight.
     /// 0 to just point at a single character
@@ -643,11 +642,9 @@ pub struct Location {
     // original docs: 0-based, in bytes.
     // but there is a place where this is emitted in output, implying one based character offset
     pub column: i32,
-    /// Number of columns (in the units of `column`) of the source line that
-    /// precede `line_text`: non-zero only when `line_text` is a window of a
-    /// long line that starts after the line's first character. `column` is
-    /// always relative to the whole line, so a caret drawn under `line_text`
-    /// goes `column - 1 - line_text_column_offset` characters in.
+    /// Columns (in `column`'s units) of the line preceding `line_text`;
+    /// `column` stays relative to the whole line, so subtract this to draw
+    /// a caret under `line_text`.
     pub line_text_column_offset: u32,
 }
 
@@ -798,8 +795,8 @@ impl Location {
                 .min(line.len());
             let mut line_text = line;
             let mut line_text_column_offset: u32 = 0;
-            // Window a long line to ~120 bytes around the error. Bounds are
-            // BYTE offsets, snapped to UTF-8 char boundaries.
+            // Window a long line to ~120 bytes around the error, snapped to
+            // UTF-8 char boundaries.
             if line.len() > 80 + offset_in_line {
                 let mut lo = offset_in_line.saturating_sub(40);
                 let mut hi = (offset_in_line + 80).min(line.len());
@@ -810,11 +807,9 @@ impl Location {
                     hi += 1;
                 }
                 line_text = &line[lo..hi];
-                // Both scans start at column 1, so the difference is the width
-                // of `line[..lo]`. Measuring the ≤ 40 bytes kept in front of
-                // the error, rather than rescanning `line[..lo]`, keeps a long
-                // line with many diagnostics linear (the reason
-                // `LineColumnTracker` exists).
+                // Columns before `lo` = the error's column minus the width of
+                // `line[lo..offset_in_line]`; measuring those ≤ 40 bytes avoids
+                // rescanning the whole prefix for every diagnostic.
                 let mut kept = ErrorPositionState::default();
                 kept.advance(line, lo, offset_in_line);
                 line_text_column_offset =
@@ -833,11 +828,8 @@ impl Location {
                 } else {
                     1
                 },
-                // `source_backing` in `Transpiler::parse_*` is RAII and
-                // drops on the parse-error path *before* `process_fetch_log`
-                // clones the `Msg` into a `BuildMessage`, so own the bytes here
-                // instead of borrowing `source.contents`. This is only
-                // materialized on diagnostic paths.
+                // Own the bytes: `source.contents` can drop before this `Msg`
+                // is cloned into a `BuildMessage` (`Transpiler::parse_*`).
                 line_text: Some(Cow::Owned(line_text.to_vec())),
                 offset: usize::try_from(r.loc.start.max(0)).expect("int cast"),
             });

--- a/test/js/bun/transpiler/parse-error-column.test.ts
+++ b/test/js/bun/transpiler/parse-error-column.test.ts
@@ -141,22 +141,99 @@ test.concurrent("long non-ASCII line's lineText window does not split a UTF-8 se
   });
 });
 
-test.concurrent("CLI caret stays under the token for an error at the end of a long line", async () => {
-  // `write_format` offsets the caret by `column - 1` with no knowledge of any
-  // left-trim, so the window gate must not left-trim this case.
-  using dir = tempDir("parse-col-caret", {
-    "long.js": Buffer.alloc(150, "a").toString() + "]",
-  });
+const fill = (count: number, char: string) => Buffer.alloc(count, char).toString();
+
+/**
+ * Runs `bun <args>` in a directory holding `files` and returns every source
+ * excerpt the logger printed (a `N | text` line followed by a caret line) along
+ * with the column the `^` landed on. The excerpt may be a window of a long line;
+ * the caret must land on the offending token inside the printed excerpt.
+ */
+async function printedExcerpts(args: string[], files: Record<string, string>) {
+  using dir = tempDir("parse-col-caret", files);
   await using proc = Bun.spawn({
-    cmd: [bunExe(), "build", "long.js"],
-    env: { ...bunEnv, NO_COLOR: "1" },
+    cmd: [bunExe(), ...args],
+    env: bunEnv,
     cwd: String(dir),
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [, stderr] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  const lines = stderr.split("\n");
-  const textLine = lines.find(l => l.includes("]"))!;
-  const caretLine = lines.find(l => l.trimEnd().endsWith("^"))!;
-  expect({ token: textLine.indexOf("]"), caret: caretLine.indexOf("^") }).toEqual({ token: 154, caret: 154 });
+  const [stderr] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+  const lines = stderr.split(/\r?\n/);
+  const excerpts: { excerpt: string; caret: number }[] = [];
+  for (let i = 0; i + 1 < lines.length; i++) {
+    if (/^\d+ \| /.test(lines[i]) && /^ *\^$/.test(lines[i + 1])) {
+      excerpts.push({ excerpt: lines[i], caret: lines[i + 1].indexOf("^") });
+    }
+  }
+  return { stderr, excerpts };
+}
+
+test.concurrent("CLI caret stays under the token for an error at the end of a long line", async () => {
+  // An error in the last 80 bytes of a line is never left-trimmed.
+  const { excerpts } = await printedExcerpts(["build", "long.js"], { "long.js": fill(150, "a") + "]" });
+  expect(excerpts).toEqual([{ excerpt: "1 | " + fill(150, "a") + "]", caret: 4 + 150 }]);
 });
+
+test.concurrent.each([["build"], ["run"]])(
+  "bun %s: CLI caret stays under the token when the excerpt is left-trimmed",
+  async subcommand => {
+    // `]` is at byte 100 of a 201-byte line, so the excerpt is the 120 bytes
+    // around it (40 before, 80 after) and the caret belongs 40 characters in,
+    // not at the token's column in the full line (which is past the end of
+    // the excerpt).
+    const { excerpts } = await printedExcerpts([subcommand, "long.js"], {
+      "long.js": "let ok = 1;\n" + fill(100, "a") + "]" + fill(100, "b") + "\n",
+    });
+    expect(excerpts).toEqual([{ excerpt: "2 | " + fill(40, "a") + "]" + fill(79, "b"), caret: 4 + 40 }]);
+  },
+);
+
+test.concurrent("CLI caret counts the left-trimmed prefix in columns, not bytes", async () => {
+  // U+00E9 is 2 UTF-8 bytes but 1 column (Buffer.alloc fills by bytes, so
+  // fill(200) is 100 characters). `]` is at byte 200 / column 101 of a
+  // 401-byte line; the window keeps the 40 bytes (20 characters) before it,
+  // so the caret belongs 20 characters in.
+  const { excerpts } = await printedExcerpts(["build", "long.js"], {
+    "long.js": fill(200, "\u00E9") + "]" + fill(200, "\u00E9"),
+  });
+  expect(excerpts).toEqual([{ excerpt: "1 | " + fill(40, "\u00E9") + "]" + fill(80, "\u00E9"), caret: 4 + 20 }]);
+});
+
+test.concurrent("CLI caret is aligned for both the error and its note on a long line", async () => {
+  // The redeclaration at byte 176 is left-trimmed; the note pointing at the
+  // original declaration (byte 6) is windowed without a left trim.
+  const source = "const x = 1; /* " + fill(150, "p") + " */ const x = 2; " + fill(100, "q") + "\n";
+  const { excerpts } = await printedExcerpts(["build", "long.js"], { "long.js": source });
+  expect(excerpts).toEqual([
+    { excerpt: "1 | " + fill(30, "p") + " */ const x = 2; " + fill(73, "q"), caret: 4 + 30 + " */ const ".length },
+    { excerpt: "1 | const x = 1; /* " + fill(70, "p"), caret: 4 + "const ".length },
+  ]);
+});
+
+test.concurrent("bun install points the caret at the token inside a long package.json line", async () => {
+  // The `}` is at column 179 of a 379-byte line. The excerpt starts 40 bytes
+  // before it (the caret used to be indented by the full 178 columns), while
+  // the `at file:line:col` suffix still reports the real column.
+  const { stderr, excerpts } = await printedExcerpts(["install"], {
+    "package.json": '{"name":"x",' + fill(150, " ") + '"dependencies": }' + fill(200, " ") + "\n",
+  });
+  expect(excerpts).toEqual([
+    { excerpt: "1 | " + fill(24, " ") + '"dependencies": }', caret: 4 + 24 + '"dependencies": '.length },
+  ]);
+  expect(stderr).toContain("package.json:1:179");
+});
+
+test.concurrent(
+  "excerpt of a line following a U+2028 line separator starts at the line's first character",
+  async () => {
+    // The logger used to slice the line from one byte before its start to pick
+    // up (and later trim) a preceding `\n`; after a three-byte U+2028 that byte
+    // is a stray UTF-8 continuation byte, which was printed before the text and
+    // pushed it one cell to the right of the caret.
+    const { excerpts } = await printedExcerpts(["build", "ls.js"], {
+      "ls.js": "let a = 1;\u2028let b = 2; ]",
+    });
+    expect(excerpts).toEqual([{ excerpt: "2 | let b = 2; ]", caret: 4 + "let b = 2; ".length }]);
+  },
+);

--- a/test/js/bun/transpiler/parse-error-column.test.ts
+++ b/test/js/bun/transpiler/parse-error-column.test.ts
@@ -200,6 +200,18 @@ test.concurrent("CLI caret counts the left-trimmed prefix in columns, not bytes"
   expect(excerpts).toEqual([{ excerpt: "1 | " + fill(40, "\u00E9") + "]" + fill(80, "\u00E9"), caret: 4 + 20 }]);
 });
 
+test.concurrent("CLI caret counts a left-trimmed astral prefix in UTF-16 units, like the column", async () => {
+  // U+10400 (a valid identifier character) is 4 UTF-8 bytes and 2 UTF-16
+  // units, and columns count UTF-16 units. 30 of them put `]` at byte 120 /
+  // column 61; the window keeps the 10 characters (20 units) before it, so
+  // the caret belongs 20 units in (10 if the trimmed width were counted in
+  // characters, 60 if it were not subtracted at all).
+  const { excerpts } = await printedExcerpts(["build", "long.js"], {
+    "long.js": fill(120, "\u{10400}") + "]" + fill(100, "b"),
+  });
+  expect(excerpts).toEqual([{ excerpt: "1 | " + fill(40, "\u{10400}") + "]" + fill(79, "b"), caret: 4 + 20 }]);
+});
+
 test.concurrent("CLI caret is aligned for both the error and its note on a long line", async () => {
   // The redeclaration at byte 176 is left-trimmed; the note pointing at the
   // original declaration (byte 6) is windowed without a left trim.


### PR DESCRIPTION
### Problem
- Every diagnostic the logger prints for a long line (`bun install`, `bun build`, running a file with a syntax error, TOML/JSON errors, notes) puts the `^` in the wrong place. In the repro a 45 character excerpt gets a 183 character caret line; a nested one-line `package.json` gets one tens of thousands of spaces long.
- The excerpt is a window of about 120 bytes around the error, but the caret is still indented by the error's column in the whole line, so it is only right when nothing was dropped on the left. Predates the Rust port.
- A line following a U+2028 or U+2029 terminator was excerpted from one byte early, so a stray UTF-8 continuation byte was printed before the text and pushed it one cell off the caret.

### Fix
- The location records how many columns of the line precede the excerpt (nonzero only when a prefix was dropped) and the caret is indented by the column minus that amount. The reported column and the `at file:line:col` suffix still refer to the whole line.
- The dropped width is measured from the at most 40 bytes kept in front of the error, with the same counter that produced the column, so a long line with many diagnostics stays linear.
- The excerpt starts at the line's first byte, so the newline trim that covered for the early start is gone; only the U+2028/U+2029 case prints differently.
- Verification: seven new tests (left-trimmed excerpt via build and run, non-ASCII and astral prefixes, error plus note on one line, the `bun install` repro, U+2028) fail on the current release and pass here; the existing end-of-line case still passes.

### Background
- A diagnostic carries a copy of its line's text, taken when it is created, and the printer draws `N | <text>` plus a caret line indented by the stored column without refetching the source.
- Windowing: when more than 80 bytes follow the error, the stored text is cut to about 40 bytes before it and 80 after. An error near the end of a line keeps the whole line, which is why the caret was right there.
- Columns are counted in UTF-16 units, not bytes or characters, so a trimmed prefix's width cannot be taken from its byte length.
- `LineColumnTracker` (#31273) finds line and column for many diagnostics in one file without rescanning from the top each time; rescanning the whole trimmed prefix per diagnostic would bring the quadratic cost back.
- U+2028 and U+2029 are three byte line terminators, so the byte before a line's start is not always `\n` or `\r`.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 7 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/parse-error-column.test.ts
bun test v1.4.0 (c80c6cd7b)

test/js/bun/transpiler/parse-error-column.test.ts:
(pass) JS parse error after astral characters reports UTF-16 column [1105.17ms]
(pass) long non-ASCII line's lineText window covers the error token [1130.32ms]
(pass) JS parse error column matches JSC runtime column for the same line [1828.33ms]
(pass) JS parse error column agrees for BMP vs astral lines of equal UTF-16 width [1959.55ms]
(pass) long non-ASCII line's lineText window does not split a UTF-8 sequence [1057.78ms]
(pass) CLI caret stays under the token for an error at the end of a long line [970.88ms]
183 |     // not at the token's column in the full line (which is past the end of
184 |     // the excerpt).
185 |     const { excerpts } = await printedExcerpts([subcommand, "long.js"], {
186 |       "long.js": "let ok = 1;\n" + fill(100, "a") + "]" + fill(100, "b") + "\n",
187 |     });
188 |     expect(excerpts).toEqual([{ excerpt: "2 | " + fill(40, "a") + "]" + fill(79, "b"), caret: 4 + 40 }]);
 
... (truncated)

release without fix: 7 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/bun/transpiler/parse-error-column.test.ts:
183 |     // not at the token's column in the full line (which is past the end of
184 |     // the excerpt).
185 |     const { excerpts } = await printedExcerpts([subcommand, "long.js"], {
186 |       "long.js": "let ok = 1;\n" + fill(100, "a") + "]" + fill(100, "b") + "\n",
187 |     });
188 |     expect(excerpts).toEqual([{ excerpt: "2 | " + fill(40, "a") + "]" + fill(79, "b"), caret: 4 + 40 }]);
                           ^
error: expect(received).toEqual(expected)

  [
    {
-     "caret": 44,
+     "caret": 104,
      "excerpt": "2 | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
    },
  ]

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/bun/transpiler/parse-error-column.test.ts:188:22)
215 | test.concurrent("CLI caret is aligned for both the error and its note on a long line", async () => {
216 |   // The redeclaration at byte 176 is left-trimmed; the note pointing at the
217 |   // original declaration (byte 6) is windowed without a left trim.
218 |   const source = 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/transpiler/parse-error-column.test.ts
bun test v1.4.0 (c80c6cd7b)

test/js/bun/transpiler/parse-error-column.test.ts:
(pass) JS parse error after astral characters reports UTF-16 column [700.97ms]
(pass) JS parse error column matches JSC runtime column for the same line [960.36ms]
(pass) long non-ASCII line's lineText window covers the error token [1013.22ms]
(pass) long non-ASCII line's lineText window does not split a UTF-8 sequence [826.43ms]
(pass) JS parse error column agrees for BMP vs astral lines of equal UTF-16 width [1481.26ms]
(pass) TOML parse error after astral characters reports UTF-16 column [1487.40ms]
(pass) CLI caret stays under the token for an error at the end of a long line [903.52ms]
(pass) bun build: CLI caret stays under the token when the excerpt is left-trimmed [872.08ms]
(pass) bun run: CLI caret stays under the token when the excerpt is left-trimmed [834.34ms]
(pass) CLI caret counts the left-trimmed prefix in columns, not bytes [860.48ms]
(pass) CLI caret counts a left-trimmed astral prefix in U
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c80c6cd7bd
  features     baseline

22 deps, 107 codegen, 1176 objects in 2830ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen bindgenv2
[2/1238] gen ErrorCode+*.h
[3/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[4/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1238] fetch zlib
[zlib] up to date
[6/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1238] fetch tinycc
[tinycc] up to date
[8/1237] gen .bind.ts → GeneratedBindings.cpp
[9/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[10/1237] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindin
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/ast/lib.rs                                    |  64 +++++++-----
 test/js/bun/transpiler/parse-error-column.test.ts | 115 +++++++++++++++++++---
 2 files changed, 140 insertions(+), 39 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                               reads  edits  tests
src/ast/lib.rs                                         2      1      0
test/js/bun/transpiler/parse-error-column.test.ts      0      0      0
```

</details>

**root cause** · written by the author bot

When a diagnostic's source line was longer than the display window, the line text was trimmed to roughly 120 bytes around the error but the caret column was still computed against the full line, so the caret pointed at the wrong position and the byte-based trim could also split multi-byte UTF-8 characters. The fix snaps the window bounds to UTF-8 character boundaries and records the column width of the trimmed left prefix in the Location, which is then subtracted when rendering so the caret aligns with the displayed snippet. Only the bytes between the window start and the error offset are m…

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Repro

```sh
printf '{"name":"x",%*s"dependencies": }%*s\n' 150 '' 200 '' > package.json
bun install 2>&1 | awk '{ print length($0) ": " $0 }'
```

```
45: 1 |                         "dependencies": }
183:                                                                               ...                ^
19: error: Unexpected }
37:     at /tmp/x/package.json:1:179
```

The excerpt is 45 characters wide, the caret line is 183: the `^` is indented by the column in the full line, not by where the token sits in the excerpt. Everything printed through the logger behaves the same (`bun build`, running a file with a syntax error, TOML/JSON errors, notes), and the caret line grows with the column: a deeply nested one-line `package.json` prints a 124 character excerpt followed by a caret line tens of thousands of spaces long.

### Cause

`Location::init_or_null` (`src/ast/lib.rs`) windows a long line to ~120 bytes around the error, dropping the bytes more than 40 before it, but `column` still refers to the full line and `Data::write_format` indents the caret by `column - 1`. The comment on the window claimed the gate keeps the caret aligned; that only holds when nothing is dropped on the left. This predates the Rust port.

### Fix

* `Location` gets `line_text_column_offset`: how many columns (same units as `column`) of the line precede `line_text`. `init_or_null` sets it when the window drops a prefix; every other constructor leaves it at 0 because their `line_text` is the whole line, so they are unaffected. `write_format` subtracts it when indenting the caret. `size_of::<Location>()` goes from 88 to 96 bytes; it is only built for diagnostics.
* `column` itself is deliberately unchanged: it is `position.column` on `BuildMessage`/`ResolveMessage` and the `at file:line:col` suffix, both of which must keep referring to the whole line (the existing test pinning `column: 81` next to a left-trimmed `lineText` still passes).
* The dropped width is `column_count - width(kept prefix)`, measuring the at most 40 bytes kept in front of the error with the same scanner that produced `column_count`, instead of rescanning `line[..lo]`. Rescanning would make a long line with many diagnostics quadratic again, which is what `LineColumnTracker` (#31273) was added to avoid.
* `to_error_position` no longer starts the line one byte early. That byte used to be trimmed as `\n`/`\r` afterwards, but after the three byte U+2028/U+2029 terminators it is a UTF-8 continuation byte, which was printed in front of the excerpt (`2 | \xA8let b = 2; ]`) and shifted the text one cell off the caret. The slice now starts at the line's first byte, so the trim is gone too. `ErrorPosition.line_start` has no other consumer.

Not changed here: the window still only trims when more than 80 bytes follow the error (an error at the very end of a long line still prints the whole line), and the dev server overlay underlines the same windowed `lineText` with `column - 1` and is misaligned the same way. Both can be addressed separately on top of the new field.

### Verification

`test/js/bun/transpiler/parse-error-column.test.ts` (the file covering the window) gets tests for a left-trimmed excerpt via `bun build` and via running the file, a non-ASCII prefix (dropped width counted in columns, not bytes), an astral prefix (counted in UTF-16 units, not characters), an error plus its note on the same long line (left-trimmed and untrimmed window in one message), the `bun install` repro above (caret inside the excerpt, `at package.json:1:179` unchanged), and the U+2028 case. All seven fail on the current release (caret at 104/182/180 instead of 44, 64 instead of 24, stray U+FFFD in the U+2028 excerpt) and pass with this change; the existing end-of-line case still passes.

Also run locally with the change: `bun-install.test.ts` (caret snapshots), `transpiler.test.js` (`position.offset`/`lineText`), `resolve-error`, `build-error`, `invalid-utf8-column`, `toml-crash`, the dev error page test in `serve.test.ts`, and `BunFrontendDevServer.test.ts` (line 3/5 `lineText` snapshots, which exercise the line start change). All green.

</details>
