### PR TITLE
bake: keep a route failed when the "use client" file it imports fails to bundle

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5883,13 +5883,9 @@ pub mod bv2_impl {
                 bun_core::scoped_log!(Bundle, "failed with error: {}", err.name());
                 resolve_result.resolve_queue.clear();
 
-                // With a separate SSR graph, a "use client" file is parsed for
-                // the browser even when a server file imported it (see
-                // `ParseTask`), so its resolution failures were reported to the
-                // client graph. The server-side half of the boundary is only
-                // created on success (`on_parse_task_complete`), so tell the
-                // dev server now; otherwise the server importers have nothing
-                // to attach to and the failure is unreachable from their routes.
+                // `ParseTask` retargets such a file to the browser, so its
+                // failure went to the client graph, while `on_parse_task_complete`
+                // only creates the server side of the boundary once a file resolves.
                 if let Some(dev) = this.dev_server {
                     if result.use_directive == crate::UseDirective::Client
                         && target == Target::Browser

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5883,9 +5883,7 @@ pub mod bv2_impl {
                 bun_core::scoped_log!(Bundle, "failed with error: {}", err.name());
                 resolve_result.resolve_queue.clear();
 
-                // `ParseTask` retargets such a file to the browser, so its
-                // failure went to the client graph, while `on_parse_task_complete`
-                // only creates the server side of the boundary once a file resolves.
+                // Retargeted to the browser by `ParseTask`: the failure is on the client graph.
                 if let Some(dev) = this.dev_server {
                     if result.use_directive == crate::UseDirective::Client
                         && target == Target::Browser

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5883,6 +5883,27 @@ pub mod bv2_impl {
                 bun_core::scoped_log!(Bundle, "failed with error: {}", err.name());
                 resolve_result.resolve_queue.clear();
 
+                // With a separate SSR graph, a "use client" file is parsed for
+                // the browser even when a server file imported it (see
+                // `ParseTask`), so its resolution failures were reported to the
+                // client graph. The server-side half of the boundary is only
+                // created on success (`on_parse_task_complete`), so tell the
+                // dev server now; otherwise the server importers have nothing
+                // to attach to and the failure is unreachable from their routes.
+                if let Some(dev) = this.dev_server {
+                    if result.use_directive == crate::UseDirective::Client
+                        && target == Target::Browser
+                        && this
+                            .framework
+                            .as_ref()
+                            .and_then(|framework| framework.server_components.as_ref())
+                            .is_some_and(|sc| sc.separate_ssr_graph)
+                    {
+                        dev.handle_client_component_boundary_failure(result.source.path.text)
+                            .expect("oom");
+                    }
+                }
+
                 // Preserve the parsed import_records on the graph so any plugin
                 // onResolve tasks already dispatched for *other* records in this
                 // same file can still dereference

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -325,6 +325,7 @@ bun_dispatch::link_interface! {
         fn log_for_resolution_failures(abs_path: &[u8], graph: bake_types::Graph) -> *mut bun_ast::Log;
         fn finalize_bundle(bv2: *mut bundle_v2::BundleV2<'_>, result: *mut bundle_v2::DevServerOutput<'_>) -> Result<(), crate::Error>;
         fn handle_parse_task_failure(err: crate::Error, graph: bake_types::Graph, abs_path: &[u8], log: *const bun_ast::Log, bv2: *mut bundle_v2::BundleV2<'_>) -> Result<(), crate::Error>;
+        fn handle_client_component_boundary_failure(abs_path: &[u8]) -> Result<(), crate::Error>;
         fn put_or_overwrite_asset(path: *const (), contents: &[u8], content_hash: u64) -> Result<(), crate::Error>;
         fn track_resolution_failure(import_source: &[u8], specifier: &[u8], renderer: bake_types::Graph, loader: bun_ast::Loader) -> Result<(), crate::Error>;
         fn is_file_cached(abs_path: &[u8], side: bake_types::Graph) -> Option<bake_types::CacheEntry>;

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4990,12 +4990,9 @@ impl DevServer {
         Ok(())
     }
 
-    /// A "use client" file whose imports failed to resolve. Its failure is on
-    /// the client graph node (`get_log_for_resolution_failures`); give it the
-    /// rest of a boundary's shape, which `finalize_bundle` only does for files
-    /// that bundled: the server node that server-side importers attach to and
-    /// that import traces cross into the client graph from, and the HMR root
-    /// flag that dependency traces cross back to the server graph from.
+    /// A "use client" file whose imports failed to resolve. The failure is on the client
+    /// node; this adds what `finalize_bundle` adds for a boundary that bundled, which is
+    /// what connects the file's server-side importers to that failure (and back).
     pub(crate) fn handle_client_component_boundary_failure(
         &mut self,
         abs_path: &[u8],

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2251,6 +2251,10 @@ fn check_route_failures(
     resp: DevResponse,
 ) -> crate::Result<CheckResult> {
     let mut gts = dev.init_graph_trace_state(0)?;
+    // The trace below collects into `failures_added`, which still holds the
+    // failures of the last bundle (it is only reset when the next one starts).
+    // Those may belong to files this route never imports.
+    dev.incremental_result.failures_added.clear();
     // Note: erase to a raw pointer so the deferred cleanup only fires on
     // scope exit when no other borrow of `dev` is live.
     let dev_ptr = std::ptr::from_mut::<DevServer>(dev);
@@ -4388,13 +4392,19 @@ pub(super) fn finalize_bundle(
         dev.incremental_result.html_routes_soft_affected.clear();
         ctx.gts.clear();
 
-        for index in &dev.incremental_result.client_components_affected {
+        // `trace_dependencies` appends every boundary it visits to this same
+        // list (their trace bit is set at that point, so visiting them again
+        // below is a no-op), so it must not be iterated through a borrow.
+        let mut i = 0;
+        while i < dev.incremental_result.client_components_affected.len() {
+            let index = dev.incremental_result.client_components_affected[i];
             dev.server_graph.trace_dependencies(
-                *index,
+                index,
                 ctx.gts,
                 incremental_graph::TraceDependencyGoal::NoStop,
-                *index,
+                index,
             )?;
+            i += 1;
         }
 
         for request in &dev.incremental_result.framework_routes_affected {
@@ -4981,6 +4991,42 @@ impl DevServer {
                 )?,
             }
         }
+        Ok(())
+    }
+
+    /// A "use client" file whose own imports failed to resolve. The failure
+    /// belongs to the client graph (the file was parsed for the browser, see
+    /// `get_log_for_resolution_failures`), but a boundary that bundles gets a
+    /// node on both sides: server-side importers attach their edges to the
+    /// server node, whose boundary flag makes import traces continue into the
+    /// client graph, and the client node is an HMR root so dependency traces
+    /// cross back to the server side. `finalize_bundle` only sets this up for
+    /// files that bundled, so do it here for the failed one; otherwise the
+    /// routes importing the file are never associated with its failure and get
+    /// served as if it had bundled.
+    pub(crate) fn handle_client_component_boundary_failure(
+        &mut self,
+        abs_path: &[u8],
+    ) -> Result<(), AllocError> {
+        let _g = self.graph_safety_lock.guard();
+
+        // This only looks the client node up: it was created for the
+        // resolution log, and its failure (inserted once the bundle finishes)
+        // is what marks it stale.
+        let client_index = self.client_graph.insert_stale(abs_path, false)?;
+        self.client_graph.bundled_files.values_mut()[client_index.get() as usize].is_hmr_root =
+            true;
+
+        // Nothing gets bundled for the server node until the file is fixed, so
+        // it must stay stale (`insert_stale` alone cannot set the bit for an
+        // index past the bitset's current length).
+        let server_index = self.server_graph.insert_stale(abs_path, false)?;
+        self.server_graph.ensure_stale_bit_capacity(true)?;
+        self.server_graph
+            .stale_files
+            .set(server_index.get() as usize);
+        self.server_graph.bundled_files.values_mut()[server_index.get() as usize]
+            .is_client_component_boundary = true;
         Ok(())
     }
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4990,9 +4990,7 @@ impl DevServer {
         Ok(())
     }
 
-    /// A "use client" file whose imports failed to resolve. The failure is on the client
-    /// node; this adds what `finalize_bundle` adds for a boundary that bundled, which is
-    /// what connects the file's server-side importers to that failure (and back).
+    /// Gives a "use client" file that failed to resolve the graph shape of a bundled boundary.
     pub(crate) fn handle_client_component_boundary_failure(
         &mut self,
         abs_path: &[u8],

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -2251,9 +2251,7 @@ fn check_route_failures(
     resp: DevResponse,
 ) -> crate::Result<CheckResult> {
     let mut gts = dev.init_graph_trace_state(0)?;
-    // The trace below collects into `failures_added`, which still holds the
-    // failures of the last bundle (it is only reset when the next one starts).
-    // Those may belong to files this route never imports.
+    // Still holds the last bundle's failures, which this route may not import.
     dev.incremental_result.failures_added.clear();
     // Note: erase to a raw pointer so the deferred cleanup only fires on
     // scope exit when no other borrow of `dev` is live.
@@ -4392,9 +4390,7 @@ pub(super) fn finalize_bundle(
         dev.incremental_result.html_routes_soft_affected.clear();
         ctx.gts.clear();
 
-        // `trace_dependencies` appends every boundary it visits to this same
-        // list (their trace bit is set at that point, so visiting them again
-        // below is a no-op), so it must not be iterated through a borrow.
+        // `trace_dependencies` appends to this list while it is being walked.
         let mut i = 0;
         while i < dev.incremental_result.client_components_affected.len() {
             let index = dev.incremental_result.client_components_affected[i];
@@ -4994,32 +4990,23 @@ impl DevServer {
         Ok(())
     }
 
-    /// A "use client" file whose own imports failed to resolve. The failure
-    /// belongs to the client graph (the file was parsed for the browser, see
-    /// `get_log_for_resolution_failures`), but a boundary that bundles gets a
-    /// node on both sides: server-side importers attach their edges to the
-    /// server node, whose boundary flag makes import traces continue into the
-    /// client graph, and the client node is an HMR root so dependency traces
-    /// cross back to the server side. `finalize_bundle` only sets this up for
-    /// files that bundled, so do it here for the failed one; otherwise the
-    /// routes importing the file are never associated with its failure and get
-    /// served as if it had bundled.
+    /// A "use client" file whose imports failed to resolve. Its failure is on
+    /// the client graph node (`get_log_for_resolution_failures`); give it the
+    /// rest of a boundary's shape, which `finalize_bundle` only does for files
+    /// that bundled: the server node that server-side importers attach to and
+    /// that import traces cross into the client graph from, and the HMR root
+    /// flag that dependency traces cross back to the server graph from.
     pub(crate) fn handle_client_component_boundary_failure(
         &mut self,
         abs_path: &[u8],
     ) -> Result<(), AllocError> {
         let _g = self.graph_safety_lock.guard();
 
-        // This only looks the client node up: it was created for the
-        // resolution log, and its failure (inserted once the bundle finishes)
-        // is what marks it stale.
         let client_index = self.client_graph.insert_stale(abs_path, false)?;
         self.client_graph.bundled_files.values_mut()[client_index.get() as usize].is_hmr_root =
             true;
 
-        // Nothing gets bundled for the server node until the file is fixed, so
-        // it must stay stale (`insert_stale` alone cannot set the bit for an
-        // index past the bitset's current length).
+        // `insert_stale` cannot set the bit for an index past the bitset's length.
         let server_index = self.server_graph.insert_stale(abs_path, false)?;
         self.server_graph.ensure_stale_bit_capacity(true)?;
         self.server_graph

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -714,8 +714,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                         && self.bundled_files.values()[file_index.get() as usize]
                             .is_client_component_boundary
                     {
-                        // The SSR graph imports a boundary as a plain module;
-                        // only its RSC parse says whether it is still one.
+                        // The SSR graph imports boundaries as plain modules; not a demotion.
                         // SAFETY: cross-graph access via `owner()`. We hold
                         // `&mut self` (server_graph); `client_graph` and
                         // `directory_watchers` are disjoint sibling fields.

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -710,9 +710,12 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                         self.dev_incremental_result()
                             .client_components_added
                             .push(ServerFileIndex::init(file_index.get()));
-                    } else if self.bundled_files.values()[file_index.get() as usize]
-                        .is_client_component_boundary
+                    } else if !is_ssr_graph
+                        && self.bundled_files.values()[file_index.get() as usize]
+                            .is_client_component_boundary
                     {
+                        // The SSR graph imports a boundary as a plain module;
+                        // only its RSC parse says whether it is still one.
                         // SAFETY: cross-graph access via `owner()`. We hold
                         // `&mut self` (server_graph); `client_graph` and
                         // `directory_watchers` are disjoint sibling fields.

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1171,6 +1171,11 @@ bun_bundler::link_impl_DevServerHandle! {
                 .handle_parse_task_failure(&err.into(), graph, abs_path, &*log, &mut *bv2)
                 .map_err(Into::into)
         },
+        handle_client_component_boundary_failure(abs_path) => {
+            (*this)
+                .handle_client_component_boundary_failure(abs_path)
+                .map_err(Into::into)
+        },
         put_or_overwrite_asset(path, contents, content_hash) => {
             // `path` was erased from `&bun_resolver::fs::Path<'_>` at the
             // `DevServerHandle::put_or_overwrite_asset_erased` call site. Re-wrap

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1005,6 +1005,65 @@ devTest('removing "use client" from a file that never bundled', {
     await dev.fetch("/").equals("page: server");
   },
 });
+// Deleting the file re-bundles the route (found through its edge to the server
+// side of the failed boundary), which now fails to resolve it. Re-creating the
+// file re-bundles both; the route, having failed before, is also bundled into
+// the SSR graph, where it imports the component as a plain SSR module. That
+// used to be taken as the component losing its directive and deleted the
+// client side of the boundary that the same bundle was adding.
+devTest('deleting and re-creating a "use client" file that never bundled', {
+  framework: separateSSRGraphFramework,
+  files: {
+    "routes/index.ts": `
+      import '../components/Sibling';
+      export default function (req, meta) {
+        return new Response('page');
+      }
+    `,
+    "components/Sibling.ts": `
+      "use client";
+      import './sibling-missing';
+      export const sibling = 1;
+    `,
+  },
+  async test(dev) {
+    await expectBuildFailed(dev.fetch("/"), `Could not resolve: "./sibling-missing"`);
+    await dev.delete("components/Sibling.ts", { errors: null });
+    await expectBuildFailed(dev.fetch("/"), `Could not resolve: "../components/Sibling"`);
+    await dev.write("components/Sibling.ts", `"use client"; export const sibling = 2;`, { errors: null });
+    await dev.fetch("/").equals("page");
+  },
+});
+// Same rule when everything bundles: the outer component's SSR copy imports the
+// inner component as a plain SSR module, in the same bundle that registers the
+// inner component as a boundary. Whether that used to delete the inner
+// component's client side depended on the order the files were parsed in.
+devTest('working "use client" file imported from another "use client" file', {
+  framework: separateSSRGraphFramework,
+  files: {
+    "routes/index.ts": `
+      import '../components/Comp';
+      export default function (req, meta) {
+        return new Response('page');
+      }
+    `,
+    "components/Comp.ts": `
+      "use client";
+      import './Sibling';
+      export const comp = 1;
+    `,
+    "components/Sibling.ts": `
+      "use client";
+      export const sibling = 1;
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("page");
+    // The inner component is still a boundary, so it is re-bundled as one.
+    await dev.write("components/Sibling.ts", `"use client"; export const sibling = 2;`, { errors: null });
+    await dev.fetch("/").equals("page");
+  },
+});
 // `checkRouteFailures` collects the errors reachable from a route into the
 // list that also holds the previous bundle's new errors. Without clearing it
 // first, a route that was marked as possibly failing by an earlier bundle

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -881,8 +881,9 @@ async function expectBuildFailed(response: Promise<Response>, error: string) {
   expect(html.match(/<title>(.*)<\/title>/)?.[1]).toBe("Bun - Build Failed");
   // The page embeds the serialized failures as base64; the messages are
   // stored as plain text inside of it.
-  const serializedFailures = atob(html.match(/atob\("([^"]*)"\)/)![1]);
-  expect(serializedFailures).toContain(error);
+  const encoded = html.match(/atob\("([^"]*)"\)/)?.[1];
+  expect(encoded).toBeString();
+  expect(atob(encoded!)).toContain(error);
   expect(res.status).toBe(500);
 }
 

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -978,6 +978,32 @@ devTest('"use client" file that fails to bundle, imported from another "use clie
     await dev.fetch("/").equals("page2");
   },
 });
+// The failed file is re-bundled from the server side like any other client
+// component. Dropping the directive while fixing it turns it into a plain
+// server module, which deletes the client side of the boundary that never
+// bundled. (Before the fix the file was re-bundled as a client module and the
+// route could not load it.)
+devTest('removing "use client" from a file that never bundled', {
+  framework: separateSSRGraphFramework,
+  files: {
+    "routes/index.ts": `
+      import { sibling } from '../components/Sibling';
+      export default function (req, meta) {
+        return new Response('page: ' + sibling);
+      }
+    `,
+    "components/Sibling.ts": `
+      "use client";
+      import './sibling-missing';
+      export const sibling = 1;
+    `,
+  },
+  async test(dev) {
+    await expectBuildFailed(dev.fetch("/"), `Could not resolve: "./sibling-missing"`);
+    await dev.write("components/Sibling.ts", `export const sibling = "server";`, { errors: null });
+    await dev.fetch("/").equals("page: server");
+  },
+});
 // `checkRouteFailures` collects the errors reachable from a route into the
 // list that also holds the previous bundle's new errors. Without clearing it
 // first, a route that was marked as possibly failing by an earlier bundle

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -865,3 +865,160 @@ devTest("barrel optimization: namespace re-export cycle through a star-exported 
     await c.expectMessage("result: object Y KEEP DEEP OTHER");
   },
 });
+
+const separateSSRGraphFramework = {
+  ...minimalFramework,
+  serverComponents: {
+    ...minimalFramework.serverComponents!,
+    separateSSRGraph: true,
+  },
+};
+
+/** The response for a framework route whose bundle has errors. */
+async function expectBuildFailed(response: Promise<Response>, error: string) {
+  const res = await response;
+  const html = await res.text();
+  expect(html.match(/<title>(.*)<\/title>/)?.[1]).toBe("Bun - Build Failed");
+  // The page embeds the serialized failures as base64; the messages are
+  // stored as plain text inside of it.
+  const serializedFailures = atob(html.match(/atob\("([^"]*)"\)/)![1]);
+  expect(serializedFailures).toContain(error);
+  expect(res.status).toBe(500);
+}
+
+// A "use client" file with a separate SSR graph is bundled for the browser
+// even when a server file imports it, so its errors are owned by the client
+// graph. The route importing it still has to be associated with them: both
+// right away and after unrelated hot updates, and regardless of whether the
+// route is re-bundled on request (BUN_ASSUME_PERFECT_INCREMENTAL=0) or the
+// graph is trusted (=1). Before the fix, the first hot update made the route
+// run against a server module that was never emitted ("Failed to load bundled
+// module 'components/Sibling.ts'").
+for (const mode of ["0", "1"]) {
+  devTest(`route importing a failing "use client" file (BUN_ASSUME_PERFECT_INCREMENTAL=${mode})`, {
+    framework: separateSSRGraphFramework,
+    env: { BUN_ASSUME_PERFECT_INCREMENTAL: mode },
+    files: {
+      "routes/index.ts": `
+        import { good } from '../good';
+        import '../components/Sibling';
+        export default function (req, meta) {
+          return new Response('page: ' + good);
+        }
+      `,
+      "good.ts": `export const good = "v1";`,
+      "components/Sibling.ts": `
+        "use client";
+        import './sibling-missing';
+        export const sibling = 1;
+      `,
+    },
+    async test(dev) {
+      const error = `Could not resolve: "./sibling-missing"`;
+      await expectBuildFailed(dev.fetch("/"), error);
+      await expectBuildFailed(dev.fetch("/"), error);
+
+      await dev.write("good.ts", `export const good = "v2";`, { errors: null });
+      await expectBuildFailed(dev.fetch("/"), error);
+
+      // Creating the missing file re-bundles Sibling.ts through the
+      // directory watcher, this time as a working client component.
+      await dev.write("components/sibling-missing.ts", `export {};`, { errors: null });
+      await dev.fetch("/").equals("page: v2");
+
+      // The same thing for a component that has already been bundled once.
+      const otherError = `Could not resolve: "./other-missing"`;
+      await dev.write(
+        "components/Sibling.ts",
+        `
+          "use client";
+          import './other-missing';
+          export const sibling = 2;
+        `,
+        { errors: null },
+      );
+      await expectBuildFailed(dev.fetch("/"), otherError);
+      await dev.write("good.ts", `export const good = "v3";`, { errors: null });
+      await expectBuildFailed(dev.fetch("/"), otherError);
+      await dev.write("components/other-missing.ts", `export {};`, { errors: null });
+      await dev.fetch("/").equals("page: v3");
+    },
+  });
+}
+// Here the failing file is only reachable through another client component.
+// Both boundaries end up in `client_components_affected`, and tracing them in
+// `finalize_bundle` appends to that list while it is being walked; walking it
+// through a slice read the list's old buffer after it grew (fails under ASAN).
+devTest('"use client" file that fails to bundle, imported from another "use client" file', {
+  framework: separateSSRGraphFramework,
+  files: {
+    "routes/index.ts": `
+      import '../components/Comp';
+      export default function (req, meta) {
+        return new Response('page');
+      }
+    `,
+    "components/Comp.ts": `
+      "use client";
+      import './Sibling';
+      export const comp = 1;
+    `,
+    "components/Sibling.ts": `
+      "use client";
+      import './sibling-missing';
+      export const sibling = 1;
+    `,
+  },
+  async test(dev) {
+    const error = `Could not resolve: "./sibling-missing"`;
+    await expectBuildFailed(dev.fetch("/"), error);
+    await dev.patch("routes/index.ts", { find: "'page'", replace: "'page2'", errors: null });
+    await expectBuildFailed(dev.fetch("/"), error);
+    await dev.write("components/sibling-missing.ts", `export {};`, { errors: null });
+    await dev.fetch("/").equals("page2");
+  },
+});
+// `checkRouteFailures` collects the errors reachable from a route into the
+// list that also holds the previous bundle's new errors. Without clearing it
+// first, a route that was marked as possibly failing by an earlier bundle
+// reports whatever the most recent bundle failed on, even when it does not
+// import any of it. (With BUN_ASSUME_PERFECT_INCREMENTAL=0 the stale entries
+// only cause a needless rebuild of the route.)
+devTest("route marked by an earlier failure does not report another route's errors", {
+  framework: minimalFramework,
+  env: { BUN_ASSUME_PERFECT_INCREMENTAL: "1" },
+  files: {
+    "routes/a.ts": `
+      import { shared } from '../shared';
+      import { a } from '../a';
+      export default function (req, meta) {
+        return new Response('a: ' + shared + a);
+      }
+    `,
+    "routes/b.ts": `
+      import { shared } from '../shared';
+      export default function (req, meta) {
+        return new Response('b: ' + shared);
+      }
+    `,
+    "shared.ts": `export const shared = "s";`,
+    "a.ts": `export const a = "a";`,
+  },
+  async test(dev) {
+    await dev.fetch("/a").equals("a: sa");
+    await dev.fetch("/b").equals("b: s");
+
+    // Both routes import shared.ts, so both get marked as possibly failing.
+    await dev.write("shared.ts", `import './missing'; export const shared = "s";`, { errors: null });
+    await expectBuildFailed(dev.fetch("/a"), `shared.ts`);
+    await expectBuildFailed(dev.fetch("/b"), `shared.ts`);
+
+    // Fixing it does not revisit the routes; they stay marked until requested.
+    await dev.write("shared.ts", `export const shared = "s";`, { errors: null });
+    // Only /a imports a.ts.
+    await dev.write("a.ts", `import './missing'; export const a = "a";`, { errors: null });
+
+    await dev.fetch("/b").equals("b: s");
+    await expectBuildFailed(dev.fetch("/a"), `a.ts`);
+  },
+});


### PR DESCRIPTION
### Problem
- Dev server with `serverComponents.separateSSRGraph = true`, a route imports a `"use client"` file whose own import is missing. The first requests get the "Bun - Build Failed" page; after any hot update in the route's graph the route runs instead, the server throws `error: Failed to load bundled module 'components/Sibling.ts'. This is not a dynamic import, and therefore is a bug in Bun's bundler.` and the user gets a generic 500 with the real error gone. Same with `BUN_ASSUME_PERFECT_INCREMENTAL=0` and `=1`.
- Cause: with a separate SSR graph such a file is bundled for the browser, so its failure lives on the client graph and the server graph has no node for it at all. Nothing connects the route to the failure. It looked right at first only because the route check reads a list still holding the previous bundle's failures; the hot update reset that list.
- The same stale list makes a route marked by an earlier failure report the latest bundle's errors even when it imports none of them (with `=0` it only causes a needless rebuild).
- Also on main: two nested working `"use client"` files can panic on the first request with `Server Incremental Graph is missing component for ""`, depending on parse order. A copy of a boundary arriving from the SSR graph was taken as the file dropping its directive, so its client side was deleted while the same bundle was adding it.

### Fix
- A `"use client"` file that fails to resolve (separate SSR graph only) now gets the graph shape a bundled boundary has: a stale server node flagged as a boundary, and a client node flagged as an HMR root. Property to check: every trace treats a failed boundary exactly like a bundled one, and the failure itself still lives on the client node, so fixing the file clears it through the normal path. For a boundary that bundled before this is a no-op.
- The route check clears the per-bundle failure list before tracing, so a route reports only failures reachable from its own imports.
- A copy of a file coming from the SSR graph no longer counts as it dropping `"use client"`; only its server-graph parse decides that. The walk over affected client components goes by index because the trace appends to the list being walked (ASAN reports the old buffer as a use-after-free; #31697 carries the same change).
- Verification: six new dev-server tests. Each fails on main as described in the original except the nested failing file case, which passes on main and only guards the list walk under ASAN; all pass on a debug/ASAN build. Left out, tracked separately: a server file that once failed is rebuilt into the SSR graph from then on, and a deleted failed client node keeps its failure entry.

### Background
- Bake's dev server keeps an incremental graph per side (server, client): a node per file, an edge per import, and each bundling failure attached to the node it happened on. A route gets the Build Failed page only if a failure is reachable by walking its imports; a failure with no path from the route is invisible to it.
- A `"use client"` boundary is a file with a node in both graphs: the server node is flagged as a boundary and the client node as an HMR root, and those two flags are what let a trace cross between the graphs.
- `separateSSRGraph` is a framework option that adds an SSR graph beside the server one. With it on, a `"use client"` file is bundled for the browser even when server code imports it, and SSR-side code imports it as a plain module, not as a boundary.
- `BUN_ASSUME_PERFECT_INCREMENTAL=0` re-bundles a route on each request; `=1` trusts the graph. The main test runs in both modes.
- Each bundle collects the failures it adds into a list that is reset when the next bundle starts; the route check reused that list as its scratch space.

<details>
<summary>Original description</summary>

### Repro

Dev server with a framework that sets `serverComponents.separateSSRGraph = true`:

```ts
// routes/index.ts
import { good } from '../good';
import '../components/Sibling';
export default () => new Response('page: ' + good);

// components/Sibling.ts
"use client";
import './sibling-missing';   // does not exist
```

The first requests to `/` correctly get the "Bun - Build Failed" page. After a hot update of `good.ts` (any file in the route's graph), the next request runs the route instead, the server runtime throws

```
error: Failed to load bundled module 'components/Sibling.ts'. This is not a dynamic import, and therefore is a bug in Bun's bundler.
GET - / failed
```

and the user gets a generic 500 with the real bundling error gone. Same with `BUN_ASSUME_PERFECT_INCREMENTAL=0` and `=1`. A `"use client"` component that had bundled once before it started failing was not affected, only one that never bundled. The same missing association also breaks the other things that happen to such a file: removing the directive while fixing it re-bundled it as a client module (route still unloadable), and deleting it did not re-bundle the route.

### Cause

With a separate SSR graph, `ParseTask` switches a `"use client"` file to the browser target even when a server file imported it, so its resolution failure is recorded on a client graph node (`get_log_for_resolution_failures`). The boundary bookkeeping that creates the server side of a boundary (reference proxy, `server_component_boundaries`) only runs for files that resolve, so the server graph had no node for `Sibling.ts` at all. `process_chunk_dependencies` for the route therefore attached no edge, `index_failures` could not reach the route from the failure, and `check_route_failures` (which traces the route's imports) found nothing.

It still looked right at first because `check_route_failures` collects into `incremental_result.failures_added`, and that list still held the previous bundle's failures (it is only reset when the next bundle starts). The hot update reset it, the trace found nothing, and the route was loaded. The same stale list also makes a route that was marked by an earlier bundle report the most recent bundle's errors even if it does not import any of them (with `=0` it only triggers a needless rebuild).

### Fix

- `run_resolution_for_parse_task` reports a `"use client"` file that failed to resolve to the dev server (new `handle_client_component_boundary_failure` callback, only under `separateSSRGraph`, where the retargeting happens). The dev server gives it the shape a bundled boundary has: a stale server node flagged as a client component boundary, so server importers attach their edges to it and import traces continue into the client graph, plus the client node marked as an HMR root so dependency traces cross back to the server side. The failure itself stays owned by the client node, so fixing the file removes it through the existing `receive_chunk` path, and the file is re-bundled from the server side exactly like an existing boundary (`invalidate` skips HMR roots on the client). For a boundary that had bundled before, all of this is already true and the call is a no-op.
- `check_route_failures` clears `failures_added` before tracing.
- `finalize_bundle` walks `client_components_affected` by index. `trace_dependencies` appends every boundary it visits to that list while the loop iterates it; with the failing file reachable through another boundary the list now grows past its capacity during the loop, which ASAN reports as a use-after-free of the old buffer (the new test hit it). #31697 contains the same change as part of a larger crash fix; it is needed here for this PR's own test.
- `receive_chunk` (server side) no longer treats a chunk coming from the SSR graph as the file having dropped its directive. A `"use client"` file imported by an SSR graph file is bundled there as a plain SSR module; only its RSC graph parse says whether it is still a boundary. Before, when such a chunk arrived in the same bundle that registered the boundary, the client side of the boundary was deleted while the bundle was still adding it, and processing the client chunk then panicked with `Server Incremental Graph is missing component for ""`. This is reachable on main with two nested working `"use client"` files (depends on parse order; it reproduces reliably on the released build here), and deterministically in the delete/re-create flow of a failed boundary once the first fix associates the route with it.

Why this is the right place: the route has to learn about the failure through the graph, since that is what every later decision (`index_failures`, `check_route_failures`, rebuilds, HMR notifications) is derived from. Attributing the failure to the server graph instead would leave client-side importers of the same file without an edge; creating both halves mirrors what a successful bundle produces and keeps a single failure entry per file.

Found but left out (tracked separately): a server file that had a resolution failure is marked `is_ssr` by `prepare_and_log_resolution_failures` and is rebuilt into the SSR graph from then on (this is what bundles the route into the SSR graph in the delete/re-create test); and a failed client node removed by `disconnect_and_delete_file` keeps its entry in `bundling_failures`.

### Verification

New tests in `test/bake/dev/bundle.test.ts`; each fails on main as described, except the one marked, and all pass with this branch on a debug/ASAN build:

- route importing a failing `"use client"` file, with `BUN_ASSUME_PERFECT_INCREMENTAL=0` and `=1`: Build Failed before and after an unrelated hot update, recovers when the missing file is created, and the same once the component has bundled once (main: generic 500 after the hot update)
- failing `"use client"` file that is only reachable through another `"use client"` file (passes on main; guards the list walk under ASAN, which the first fix makes reachable)
- removing `"use client"` from a file that never bundled (main: generic 500)
- deleting and re-creating a `"use client"` file that never bundled (main: generic 500 after the delete; with only the first fix: the panic above)
- working `"use client"` file imported from another `"use client"` file (main: the panic above on the first request)
- a route marked by an earlier failure does not report another route's error with `=1` (main: Build Failed page with the other route's error)

`test/bake/dev/bundle.test.ts` (28 tests), `esm`, `hot`, `css`, `plugins`, `incremental-graph-edge-deletion` and `test/bake/framework-router.test.ts` pass on the debug build.


</details>
