### PR TITLE
bunx: serialize concurrent installs into the shared cache dir with a file lock

### DIFF
--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -463,8 +463,18 @@ impl BunxCommand {
 
             if is_stale {
                 let _ = target_package_json.close();
-                // If delete fails, oh well. Hope installation takes care of it.
-                let _ = bun_sys::Dir::cwd().delete_tree(tempdir_name);
+                // Delete only while holding the exclusive lock, so the tree
+                // (lock file included) never vanishes under a process that
+                // is installing into or about to run from it. Contended or
+                // unlockable → skip; the reinstall refreshes the tree. If
+                // delete fails, oh well. Hope installation takes care of it.
+                if let Some(_lock) = Self::lock_cache_dir(
+                    tempdir_name,
+                    bun_sys::FileLockMode::Exclusive,
+                    /* nonblocking */ true,
+                ) {
+                    let _ = bun_sys::Dir::cwd().delete_tree(tempdir_name);
+                }
                 return Err(crate::Error::NeedToInstall);
             }
             let _ = target_package_json.close();
@@ -669,24 +679,24 @@ impl BunxCommand {
     }
 
     /// The lock taken on `.bunx-lock` only serializes anything if the path
-    /// still names the inode we locked — the stale-tree cleanup deletes the
-    /// whole cache dir, lock file included, so a lock on an unlinked inode
-    /// guards nothing. On Windows an open file can't be replaced out from
-    /// under us, so the first successful lock is always valid.
-    #[cfg(unix)]
+    /// still names the file we locked — the stale-tree cleanup deletes the
+    /// whole cache dir, lock file included (Windows included: `bun_sys`
+    /// opens with `FILE_SHARE_DELETE` and deletes with POSIX semantics), so
+    /// a lock on an unlinked file guards nothing. Compare identity via
+    /// `fstat` on the held fd and on a freshly opened probe fd: both map to
+    /// ino/dev on POSIX and NTFS file index/volume serial on Windows.
     fn lock_file_identity_ok(fd: Fd, path_z: &ZStr) -> bool {
-        match (bun_sys::fstat(fd), bun_sys::stat(path_z)) {
+        let probe = match bun_sys::openat(Fd::cwd(), path_z, O::RDONLY | O::CLOEXEC, 0) {
+            Ok(fd) => fd,
+            Err(_) => return false,
+        };
+        let probe_file = bun_sys::File::from_fd(probe);
+        match (bun_sys::fstat(fd), bun_sys::fstat(probe_file.fd())) {
             (Ok(held), Ok(on_disk)) => {
                 held.st_ino == on_disk.st_ino && held.st_dev == on_disk.st_dev
             }
             _ => false,
         }
-    }
-
-    #[cfg(not(unix))]
-    #[inline(always)]
-    fn lock_file_identity_ok(_fd: Fd, _path_z: &ZStr) -> bool {
-        true
     }
 
     /// Width of the zero-padded decimal timestamp stored in the lock file.
@@ -700,7 +710,10 @@ impl BunxCommand {
         let mut buf = [0u8; Self::LOCK_TIMESTAMP_LEN];
         let mut cursor: &mut [u8] = &mut buf[..];
         write!(cursor, "{:020}", bun_core::time::timestamp()).expect("unreachable");
-        let _ = bun_sys::pwrite(lock.fd(), &buf, 0);
+        // Best-effort: on failure waiters reinstall, so only log it.
+        if let Err(err) = bun_sys::pwrite(lock.fd(), &buf, 0) {
+            bun_output::scoped_log!(bunx, "failed to record install completion: {}", err);
+        }
     }
 
     /// Whether a concurrent `bun x` finished installing into this directory

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -668,6 +668,116 @@ impl BunxCommand {
         Global::exit(1);
     }
 
+    /// The lock taken on `.bunx-lock` only serializes anything if the path
+    /// still names the inode we locked — the stale-tree cleanup deletes the
+    /// whole cache dir, lock file included, so a lock on an unlinked inode
+    /// guards nothing. On Windows an open file can't be replaced out from
+    /// under us, so the first successful lock is always valid.
+    #[cfg(unix)]
+    fn lock_file_identity_ok(fd: Fd, path_z: &ZStr) -> bool {
+        match (bun_sys::fstat(fd), bun_sys::stat(path_z)) {
+            (Ok(held), Ok(on_disk)) => {
+                held.st_ino == on_disk.st_ino && held.st_dev == on_disk.st_dev
+            }
+            _ => false,
+        }
+    }
+
+    #[cfg(not(unix))]
+    #[inline(always)]
+    fn lock_file_identity_ok(_fd: Fd, _path_z: &ZStr) -> bool {
+        true
+    }
+
+    /// Width of the zero-padded decimal timestamp stored in the lock file.
+    /// Fixed-width so rewrites never need a truncation.
+    const LOCK_TIMESTAMP_LEN: usize = 20;
+
+    /// After a successful install, the exclusive lock holder records the
+    /// completion time in the lock file so waiters can tell the tree was
+    /// just (re)installed.
+    fn mark_install_completed(lock: &bun_sys::File) {
+        let mut buf = [0u8; Self::LOCK_TIMESTAMP_LEN];
+        let mut cursor: &mut [u8] = &mut buf[..];
+        write!(cursor, "{:020}", bun_core::time::timestamp()).expect("unreachable");
+        let _ = bun_sys::pwrite(lock.fd(), &buf, 0);
+    }
+
+    /// Whether a concurrent `bun x` finished installing into this directory
+    /// at or after `wait_start`. Rerunning `bun add` then (`--force` for
+    /// dist-tag installs) would mutate the tree out from under the process
+    /// that just started executing it, so the caller skips the install and
+    /// runs the freshly installed tree instead.
+    fn install_completed_while_waiting(lock: &bun_sys::File, wait_start: i64) -> bool {
+        let mut buf = [0u8; Self::LOCK_TIMESTAMP_LEN];
+        match bun_sys::pread(lock.fd(), &mut buf, 0) {
+            Ok(n) if n == buf.len() => {}
+            _ => return false,
+        }
+        let mut ts: i64 = 0;
+        for &b in &buf {
+            if !b.is_ascii_digit() {
+                return false;
+            }
+            ts = match ts
+                .checked_mul(10)
+                .and_then(|v| v.checked_add(i64::from(b - b'0')))
+            {
+                Some(v) => v,
+                None => return false,
+            };
+        }
+        ts >= wait_start
+    }
+
+    /// Opens (creating if needed) `<bunx_cache_dir>/.bunx-lock` and takes an
+    /// advisory lock on it. Returns `None` when the lock can't be acquired
+    /// (including contention in `nonblocking` mode). Dropping the returned
+    /// file releases the lock; the fd is CLOEXEC so exec'ing the target
+    /// binary releases it too.
+    ///
+    /// Concurrent `bun x` processes for the same package share one install
+    /// directory. The exclusive lock serializes installs so they don't
+    /// corrupt each other's node_modules; the shared lock keeps a process
+    /// from executing a tree another process is mutating mid-install.
+    fn lock_cache_dir(
+        bunx_cache_dir: &[u8],
+        mode: bun_sys::FileLockMode,
+        nonblocking: bool,
+    ) -> Option<bun_sys::File> {
+        let mut path = PathBuffer::uninit();
+        let len = {
+            let total = path.len();
+            let mut cursor: &mut [u8] = &mut path[..];
+            write!(
+                cursor,
+                "{dir}{sep}.bunx-lock",
+                dir = BStr::new(bunx_cache_dir),
+                sep = bun_paths::SEP as char,
+            )
+            .ok()?;
+            total - cursor.len()
+        };
+        path[len] = 0;
+        // SAFETY: path[len] == 0 written above
+        let path_z = ZStr::from_buf(&path[..], len);
+
+        for _ in 0..5 {
+            let fd =
+                bun_sys::openat(Fd::cwd(), path_z, O::CREAT | O::RDWR | O::CLOEXEC, 0o600).ok()?;
+            let file = bun_sys::File::from_fd(fd);
+            match bun_sys::flock(fd, mode, nonblocking) {
+                Ok(true) => {}
+                Ok(false) | Err(_) => return None,
+            }
+            if Self::lock_file_identity_ok(fd, path_z) {
+                return Some(file);
+            }
+            // Unlinked while we waited; `file` closes on drop. Reopen.
+        }
+        None
+    }
+
     pub(crate) fn exec(ctx: &mut ContextData, argv: &[&'static ZStr]) -> crate::Result<()> {
         // Don't log stuff
         ctx.debug.silent = true;
@@ -1060,6 +1170,7 @@ impl BunxCommand {
                 };
                 if let Some(destination) = dest_or_cache {
                     let out: &[u8] = destination.as_bytes();
+                    let mut cache_read_lock: Option<bun_sys::File> = None;
 
                     // If this directory was installed by bunx, we want to perform cache invalidation on it
                     // this way running `bunx hello` will update hello automatically to the latest version
@@ -1142,6 +1253,24 @@ impl BunxCommand {
                                 break 'try_run_existing;
                             }
                         }
+
+                        // Another bunx process may be mid-install into this
+                        // shared directory; running now risks a partially
+                        // copied tree. Busy → take the install path, which
+                        // waits for the installer to finish.
+                        cache_read_lock = Self::lock_cache_dir(
+                            bunx_cache_dir,
+                            bun_sys::FileLockMode::Shared,
+                            /* nonblocking */ true,
+                        );
+                        if cache_read_lock.is_none() {
+                            bun_output::scoped_log!(
+                                bunx,
+                                "install in progress for {}, waiting",
+                                BStr::new(bunx_cache_dir)
+                            );
+                            break 'try_run_existing;
+                        }
                     }
 
                     bun_output::scoped_log!(
@@ -1150,6 +1279,7 @@ impl BunxCommand {
                         BStr::new(destination.as_bytes())
                     );
                     let stored = fs.dirname_store.append_slice(out)?;
+                    drop(cache_read_lock);
                     Run::run_binary(
                         ctx,
                         stored,
@@ -1248,7 +1378,30 @@ impl BunxCommand {
                                         do_cache_bust = true;
                                         break 'try_run_existing;
                                     }
+                                    // Same mid-install guard as the first
+                                    // cache probe.
+                                    let cache_read_lock =
+                                        if strings::has_prefix(out, bunx_cache_dir) {
+                                            match Self::lock_cache_dir(
+                                                bunx_cache_dir,
+                                                bun_sys::FileLockMode::Shared,
+                                                /* nonblocking */ true,
+                                            ) {
+                                                Some(lock) => Some(lock),
+                                                None => {
+                                                    bun_output::scoped_log!(
+                                                        bunx,
+                                                        "install in progress for {}, waiting",
+                                                        BStr::new(bunx_cache_dir)
+                                                    );
+                                                    break 'try_run_existing;
+                                                }
+                                            }
+                                        } else {
+                                            None
+                                        };
                                     let stored = fs.dirname_store.append_slice(out)?;
+                                    drop(cache_read_lock);
                                     Run::run_binary(
                                         ctx,
                                         stored,
@@ -1310,115 +1463,165 @@ impl BunxCommand {
             Global::exit(1);
         }
 
-        'create_package_json: {
-            // create package.json, but only if it doesn't exist
-            let package_json = match bun_sys::File::create(
-                bunx_install_dir.fd,
-                b"package.json",
-                /* truncate */ true,
-            ) {
-                Ok(f) => f,
-                Err(_) => break 'create_package_json,
-            };
-            let _ = package_json.write_all(b"{}\n");
-        }
-
-        let install_args: [&[u8]; 4] = [
-            bun_core::self_exe_path()?.as_bytes(),
-            b"add",
-            install_param.as_slice(),
-            b"--no-summary",
-        ];
-        let mut args: BoundedArray<&[u8], 8> =
-            BoundedArray::from_slice(&install_args).expect("unreachable"); // upper bound is known
-
-        if do_cache_bust {
-            // disable the manifest cache when a tag is specified
-            // so that @latest is fetched from the registry
-            args.append(b"--no-cache").expect("unreachable"); // upper bound is known
-
-            // forcefully re-install packages in this mode too
-            args.append(b"--force").expect("unreachable"); // upper bound is known
-        }
-
-        if opts.verbose_install {
-            args.append(b"--verbose").expect("unreachable"); // upper bound is known
-        }
-
-        if opts.silent_install {
-            args.append(b"--silent").expect("unreachable"); // upper bound is known
-        }
-
-        let argv_to_use = args.slice();
-
-        bun_output::scoped_log!(
-            bunx,
-            "installing package: {}",
-            bun_core::fmt::fmt_slice(argv_to_use, " "),
+        // Serialize concurrent `bun x` installs into this shared directory.
+        // Without the lock, simultaneous cold-cache spawns of the same
+        // package install into the same node_modules at once and fail with
+        // EEXIST/ENOENT ("failed copying files from cache to destination")
+        // or execute a half-written tree. Held (blocking) through the
+        // install and the post-install bin probes; released right before
+        // exec'ing the target. On failure, fall back to the old unlocked
+        // behavior rather than refusing to run.
+        let install_wait_start = bun_core::time::timestamp();
+        let mut install_lock = Self::lock_cache_dir(
+            bunx_cache_dir,
+            bun_sys::FileLockMode::Exclusive,
+            /* nonblocking */ false,
         );
-        env_loader
-            .map
-            .put(b"BUN_INTERNAL_BUNX_INSTALL", b"true")
-            .expect("oom");
+        if install_lock.is_none() {
+            bun_output::scoped_log!(
+                bunx,
+                "could not lock {}, installing without the lock",
+                BStr::new(bunx_cache_dir)
+            );
+        }
 
-        let envp = env_loader.map.create_null_delimited_env_map()?;
-
-        let spawn_result = match proc_sync::spawn(&proc_sync::Options {
-            argv: argv_to_use.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
-
-            envp: Some(envp.as_ptr().cast::<*const ::core::ffi::c_char>()),
-
-            cwd: Box::<[u8]>::from(bunx_cache_dir),
-            stderr: proc_sync::SyncStdio::Inherit,
-            stdout: proc_sync::SyncStdio::Inherit,
-            stdin: proc_sync::SyncStdio::Inherit,
-
-            #[cfg(windows)]
-            windows: proc_sync::WindowsOptions {
-                loop_: bun_jsc::EventLoopHandle::init_mini(
-                    bun_event_loop::MiniEventLoop::init_global(
-                        // `this_transpiler.env` is the process-lifetime loader
-                        // singleton populated during transpiler init.
-                        //
-                        // Aliasing: do NOT call `this_transpiler.env_mut()` here —
-                        // `env_loader` (line 594) is still live and is used again below at the
-                        // post-install `Run::run_binary` calls. A second `env_mut()` would
-                        // `unsafe { &mut *self.env }` from the raw field, popping `env_loader`'s
-                        // Unique tag under Stacked Borrows (UB on later use). Instead reborrow
-                        // *through* `env_loader` so the new `&mut` is a child of its tag; the
-                        // child is consumed by `init_global` (converted to `NonNull`) before
-                        // `env_loader` is touched again.
-                        // SAFETY: `env_loader` is a valid `&'static mut Loader`; this is a
-                        // stacked reborrow, not a sibling alias.
-                        Some(unsafe { &mut *(env_loader as *mut _) }),
-                        None,
-                    ),
-                ),
-                ..Default::default()
-            },
-            ..Default::default()
-        }) {
-            Err(err) => {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r>: bunx failed to install <b>{}<r> due to error <b>{}<r>",
-                    BStr::new(&install_param),
-                    err.name(),
-                );
-                Global::exit(1);
+        let skip_install = match &install_lock {
+            Some(lock) => Self::install_completed_while_waiting(lock, install_wait_start),
+            None => false,
+        };
+        if skip_install {
+            bun_output::scoped_log!(
+                bunx,
+                "concurrent bunx finished installing {}, skipping reinstall",
+                BStr::new(&install_param)
+            );
+        } else {
+            'create_package_json: {
+                // create package.json, but only if it doesn't exist
+                let package_json = match bun_sys::File::create(
+                    bunx_install_dir.fd,
+                    b"package.json",
+                    /* truncate */ true,
+                ) {
+                    Ok(f) => f,
+                    Err(_) => break 'create_package_json,
+                };
+                let _ = package_json.write_all(b"{}\n");
             }
-            Ok(maybe) => match maybe {
-                bun_sys::Result::Err(_err) => {
+
+            let install_args: [&[u8]; 4] = [
+                bun_core::self_exe_path()?.as_bytes(),
+                b"add",
+                install_param.as_slice(),
+                b"--no-summary",
+            ];
+            let mut args: BoundedArray<&[u8], 8> =
+                BoundedArray::from_slice(&install_args).expect("unreachable"); // upper bound is known
+
+            if do_cache_bust {
+                // disable the manifest cache when a tag is specified
+                // so that @latest is fetched from the registry
+                args.append(b"--no-cache").expect("unreachable"); // upper bound is known
+
+                // forcefully re-install packages in this mode too
+                args.append(b"--force").expect("unreachable"); // upper bound is known
+            }
+
+            if opts.verbose_install {
+                args.append(b"--verbose").expect("unreachable"); // upper bound is known
+            }
+
+            if opts.silent_install {
+                args.append(b"--silent").expect("unreachable"); // upper bound is known
+            }
+
+            let argv_to_use = args.slice();
+
+            bun_output::scoped_log!(
+                bunx,
+                "installing package: {}",
+                bun_core::fmt::fmt_slice(argv_to_use, " "),
+            );
+            env_loader
+                .map
+                .put(b"BUN_INTERNAL_BUNX_INSTALL", b"true")
+                .expect("oom");
+
+            let envp = env_loader.map.create_null_delimited_env_map()?;
+
+            let spawn_result = match proc_sync::spawn(&proc_sync::Options {
+                argv: argv_to_use.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
+
+                envp: Some(envp.as_ptr().cast::<*const ::core::ffi::c_char>()),
+
+                cwd: Box::<[u8]>::from(bunx_cache_dir),
+                stderr: proc_sync::SyncStdio::Inherit,
+                stdout: proc_sync::SyncStdio::Inherit,
+                stdin: proc_sync::SyncStdio::Inherit,
+
+                #[cfg(windows)]
+                windows: proc_sync::WindowsOptions {
+                    loop_: bun_jsc::EventLoopHandle::init_mini(
+                        bun_event_loop::MiniEventLoop::init_global(
+                            // `this_transpiler.env` is the process-lifetime loader
+                            // singleton populated during transpiler init.
+                            //
+                            // Aliasing: do NOT call `this_transpiler.env_mut()` here —
+                            // `env_loader` (line 594) is still live and is used again below at the
+                            // post-install `Run::run_binary` calls. A second `env_mut()` would
+                            // `unsafe { &mut *self.env }` from the raw field, popping `env_loader`'s
+                            // Unique tag under Stacked Borrows (UB on later use). Instead reborrow
+                            // *through* `env_loader` so the new `&mut` is a child of its tag; the
+                            // child is consumed by `init_global` (converted to `NonNull`) before
+                            // `env_loader` is touched again.
+                            // SAFETY: `env_loader` is a valid `&'static mut Loader`; this is a
+                            // stacked reborrow, not a sibling alias.
+                            Some(unsafe { &mut *(env_loader as *mut _) }),
+                            None,
+                        ),
+                    ),
+                    ..Default::default()
+                },
+                ..Default::default()
+            }) {
+                Err(err) => {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r>: bunx failed to install <b>{}<r> due to error <b>{}<r>",
+                        BStr::new(&install_param),
+                        err.name(),
+                    );
                     Global::exit(1);
                 }
-                bun_sys::Result::Ok(result) => result,
-            },
-        };
+                Ok(maybe) => match maybe {
+                    bun_sys::Result::Err(_err) => {
+                        Global::exit(1);
+                    }
+                    bun_sys::Result::Ok(result) => result,
+                },
+            };
 
-        match &spawn_result.status {
-            SpawnStatus::Exited(exited) => {
-                // Any non-zero byte (incl. RT signals >31) is a valid signal.
-                // `signal_code()` would drop RT signals, so check the raw byte directly.
-                if exited.signal != 0 {
+            match &spawn_result.status {
+                SpawnStatus::Exited(exited) => {
+                    // Any non-zero byte (incl. RT signals >31) is a valid signal.
+                    // `signal_code()` would drop RT signals, so check the raw byte directly.
+                    if exited.signal != 0 {
+                        if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN
+                            .get()
+                            .unwrap_or(false)
+                        {
+                            bun_crash_handler::suppress_reporting();
+                        }
+
+                        Global::raise_ignoring_panic_handler_raw(core::ffi::c_int::from(
+                            exited.signal,
+                        ));
+                    }
+
+                    if exited.code != 0 {
+                        Global::exit(exited.code as u32);
+                    }
+                }
+                SpawnStatus::Signaled(sig) => {
                     if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN
                         .get()
                         .unwrap_or(false)
@@ -1426,35 +1629,25 @@ impl BunxCommand {
                         bun_crash_handler::suppress_reporting();
                     }
 
-                    Global::raise_ignoring_panic_handler_raw(core::ffi::c_int::from(exited.signal));
+                    // RT signals (>31) are valid payloads; forward the
+                    // raw byte instead of lossy `signal_code()` so this arm always
+                    // diverges with the *actual* signal.
+                    Global::raise_ignoring_panic_handler_raw(core::ffi::c_int::from(*sig));
                 }
+                SpawnStatus::Err(err) => {
+                    bun_core::pretty_errorln!(
+                        "<r><red>error<r>: bunx failed to install <b>{}<r> due to error:\n{}",
+                        BStr::new(&install_param),
+                        err,
+                    );
+                    Global::exit(1);
+                }
+                _ => {}
+            }
 
-                if exited.code != 0 {
-                    Global::exit(exited.code as u32);
-                }
+            if let Some(lock) = &install_lock {
+                Self::mark_install_completed(lock);
             }
-            SpawnStatus::Signaled(sig) => {
-                if bun_core::env_var::feature_flag::BUN_INTERNAL_SUPPRESS_CRASH_IN_BUN_RUN
-                    .get()
-                    .unwrap_or(false)
-                {
-                    bun_crash_handler::suppress_reporting();
-                }
-
-                // RT signals (>31) are valid payloads; forward the
-                // raw byte instead of lossy `signal_code()` so this arm always
-                // diverges with the *actual* signal.
-                Global::raise_ignoring_panic_handler_raw(core::ffi::c_int::from(*sig));
-            }
-            SpawnStatus::Err(err) => {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r>: bunx failed to install <b>{}<r> due to error:\n{}",
-                    BStr::new(&install_param),
-                    err,
-                );
-                Global::exit(1);
-            }
-            _ => {}
         }
 
         absolute_in_cache_dir = {
@@ -1494,6 +1687,7 @@ impl BunxCommand {
             // Bail out to the generic error rather than execute it.
             if Self::is_trusted_cached_binary(destination, uid) {
                 let stored = fs.dirname_store.append_slice(out)?;
+                drop(install_lock.take());
                 Run::run_binary(
                     ctx,
                     stored,
@@ -1554,6 +1748,7 @@ impl BunxCommand {
                         // Same TOCTOU hardening as the post-install probe above.
                         if Self::is_trusted_cached_binary(destination, uid) {
                             let stored = fs.dirname_store.append_slice(out)?;
+                            drop(install_lock.take());
                             Run::run_binary(
                                 ctx,
                                 stored,

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1662,10 +1662,14 @@ impl BunxCommand {
                 }
                 _ => {}
             }
+        }
 
-            if let Some(lock) = &install_lock {
-                Self::mark_install_completed(lock);
-            }
+        // Stamp on the skip path too: a skipping waiter holds the exclusive
+        // lock past the recorded second, and without a refresh a chain of
+        // skippers can make a late arriver's wait_start exceed the stored
+        // time and force-reinstall under processes already running the tree.
+        if let Some(lock) = &install_lock {
+            Self::mark_install_completed(lock);
         }
 
         absolute_in_cache_dir = {

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -716,6 +716,16 @@ impl BunxCommand {
         }
     }
 
+    /// Stamp the completion time and release the exclusive lock. The stamp
+    /// must be the last write before release: a waiter that arrived while
+    /// the holder ran its post-install probes compares its own start time
+    /// against it, and an earlier stamp can land in the previous second.
+    fn release_install_lock(install_lock: &mut Option<bun_sys::File>) {
+        if let Some(lock) = install_lock.take() {
+            Self::mark_install_completed(&lock);
+        }
+    }
+
     /// Whether a concurrent `bun x` finished installing into this directory
     /// at or after `wait_start`. Rerunning `bun add` then (`--force` for
     /// dist-tag installs) would mutate the tree out from under the process
@@ -1664,14 +1674,6 @@ impl BunxCommand {
             }
         }
 
-        // Stamp on the skip path too: a skipping waiter holds the exclusive
-        // lock past the recorded second, and without a refresh a chain of
-        // skippers can make a late arriver's wait_start exceed the stored
-        // time and force-reinstall under processes already running the tree.
-        if let Some(lock) = &install_lock {
-            Self::mark_install_completed(lock);
-        }
-
         absolute_in_cache_dir = {
             let mut cursor: &mut [u8] = &mut absolute_in_cache_dir_buf[..];
             write!(
@@ -1709,7 +1711,7 @@ impl BunxCommand {
             // Bail out to the generic error rather than execute it.
             if Self::is_trusted_cached_binary(destination, uid) {
                 let stored = fs.dirname_store.append_slice(out)?;
-                drop(install_lock.take());
+                Self::release_install_lock(&mut install_lock);
                 Run::run_binary(
                     ctx,
                     stored,
@@ -1770,7 +1772,7 @@ impl BunxCommand {
                         // Same TOCTOU hardening as the post-install probe above.
                         if Self::is_trusted_cached_binary(destination, uid) {
                             let stored = fs.dirname_store.append_slice(out)?;
-                            drop(install_lock.take());
+                            Self::release_install_lock(&mut install_lock);
                             Run::run_binary(
                                 ctx,
                                 stored,

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1384,28 +1384,27 @@ impl BunxCommand {
                                     }
                                     // Same mid-install guard as the first
                                     // cache probe.
-                                    let cache_read_lock =
-                                        if !opts.no_install
-                                            && strings::has_prefix(out, bunx_cache_dir)
-                                        {
-                                            match Self::lock_cache_dir(
-                                                bunx_cache_dir,
-                                                bun_sys::FileLockMode::Shared,
-                                                /* nonblocking */ true,
-                                            ) {
-                                                Some(lock) => Some(lock),
-                                                None => {
-                                                    bun_output::scoped_log!(
-                                                        bunx,
-                                                        "install in progress for {}, waiting",
-                                                        BStr::new(bunx_cache_dir)
-                                                    );
-                                                    break 'try_run_existing;
-                                                }
+                                    let cache_read_lock = if !opts.no_install
+                                        && strings::has_prefix(out, bunx_cache_dir)
+                                    {
+                                        match Self::lock_cache_dir(
+                                            bunx_cache_dir,
+                                            bun_sys::FileLockMode::Shared,
+                                            /* nonblocking */ true,
+                                        ) {
+                                            Some(lock) => Some(lock),
+                                            None => {
+                                                bun_output::scoped_log!(
+                                                    bunx,
+                                                    "install in progress for {}, waiting",
+                                                    BStr::new(bunx_cache_dir)
+                                                );
+                                                break 'try_run_existing;
                                             }
-                                        } else {
-                                            None
-                                        };
+                                        }
+                                    } else {
+                                        None
+                                    };
                                     let stored = fs.dirname_store.append_slice(out)?;
                                     drop(cache_read_lock);
                                     Run::run_binary(

--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1257,19 +1257,23 @@ impl BunxCommand {
                         // Another bunx process may be mid-install into this
                         // shared directory; running now risks a partially
                         // copied tree. Busy → take the install path, which
-                        // waits for the installer to finish.
-                        cache_read_lock = Self::lock_cache_dir(
-                            bunx_cache_dir,
-                            bun_sys::FileLockMode::Shared,
-                            /* nonblocking */ true,
-                        );
-                        if cache_read_lock.is_none() {
-                            bun_output::scoped_log!(
-                                bunx,
-                                "install in progress for {}, waiting",
-                                BStr::new(bunx_cache_dir)
+                        // waits for the installer to finish. With
+                        // --no-install the install path is a hard error, so
+                        // keep the old behavior and run what was found.
+                        if !opts.no_install {
+                            cache_read_lock = Self::lock_cache_dir(
+                                bunx_cache_dir,
+                                bun_sys::FileLockMode::Shared,
+                                /* nonblocking */ true,
                             );
-                            break 'try_run_existing;
+                            if cache_read_lock.is_none() {
+                                bun_output::scoped_log!(
+                                    bunx,
+                                    "install in progress for {}, waiting",
+                                    BStr::new(bunx_cache_dir)
+                                );
+                                break 'try_run_existing;
+                            }
                         }
                     }
 
@@ -1381,7 +1385,9 @@ impl BunxCommand {
                                     // Same mid-install guard as the first
                                     // cache probe.
                                     let cache_read_lock =
-                                        if strings::has_prefix(out, bunx_cache_dir) {
+                                        if !opts.no_install
+                                            && strings::has_prefix(out, bunx_cache_dir)
+                                        {
                                             match Self::lock_cache_dir(
                                                 bunx_cache_dir,
                                                 bun_sys::FileLockMode::Shared,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1052,8 +1052,9 @@ impl error::IntoErrnoInt for bun_windows_sys::NTSTATUS {
     }
 }
 
-/// Mode for [`flock`] — an advisory whole-file lock (`flock(2)` on POSIX,
-/// `LockFileEx` on Windows). The lock is released when the fd is closed.
+/// Mode for [`flock`] — a whole-file lock: advisory `flock(2)` on POSIX,
+/// mandatory `LockFileEx` on Windows (other handles' reads and writes into
+/// the locked range fail there). Released when the fd is closed.
 #[derive(Clone, Copy, PartialEq, Eq)]
 pub enum FileLockMode {
     Shared,
@@ -3669,7 +3670,8 @@ mod windows_impl {
         }
         Ok(bytes_written as usize)
     }
-    /// Advisory whole-file lock via `LockFileEx`. Returns `Ok(false)` when
+    /// Whole-file lock via `LockFileEx` (mandatory on Windows: other
+    /// handles' reads and writes into the range fail). Returns `Ok(false)` when
     /// `nonblocking` and the lock is held elsewhere. Unlike POSIX `flock`,
     /// `LockFileEx` does not upgrade/downgrade an already-held lock, but the
     /// only caller pattern is acquire-once/close, which behaves identically.

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1052,6 +1052,14 @@ impl error::IntoErrnoInt for bun_windows_sys::NTSTATUS {
     }
 }
 
+/// Mode for [`flock`] — an advisory whole-file lock (`flock(2)` on POSIX,
+/// `LockFileEx` on Windows). The lock is released when the fd is closed.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum FileLockMode {
+    Shared,
+    Exclusive,
+}
+
 /// `Exchange` and `NoReplace` are mutually exclusive at the kernel level.
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub enum RenameMode {
@@ -1393,6 +1401,7 @@ impl Tag {
     #[cfg(not(windows))]
     pub(crate) const setrlimit: Tag = Tag(106);
     pub const clone3: Tag = Tag(107);
+    pub const flock: Tag = Tag(108);
     // `inotify_init1`/`inotify_add_watch` fold under the generic `.watch`
     // tag; `INotifyWatcher.rs` spells it `.inotify`. Alias to `.watch`
     // so the JS-facing `err.syscall == "watch"` string stays node-compatible.
@@ -1400,7 +1409,7 @@ impl Tag {
     /// The tag name — spelling is frozen (JS-facing
     /// `err.syscall` string; node-compat code matches on it).
     pub fn name(self) -> &'static str {
-        const NAMES: [&str; 108] = [
+        const NAMES: [&str; 109] = [
             "TODO",
             "dup",
             "access",
@@ -1510,6 +1519,7 @@ impl Tag {
             "getrlimit",
             "setrlimit",
             "clone3",
+            "flock",
         ];
         NAMES.get(self.0 as usize).copied().unwrap_or("unknown")
     }
@@ -2646,6 +2656,32 @@ mod posix_impl {
         check!(safe_libc::ftruncate(fd.native(), len), Tag::ftruncate);
         Ok(())
     }
+    /// Advisory whole-file lock. Returns `Ok(false)` when `nonblocking` and
+    /// the lock is held elsewhere; retries `EINTR` internally.
+    pub fn flock(fd: Fd, mode: FileLockMode, nonblocking: bool) -> Maybe<bool> {
+        let mut op = match mode {
+            FileLockMode::Shared => libc::LOCK_SH,
+            FileLockMode::Exclusive => libc::LOCK_EX,
+        };
+        if nonblocking {
+            op |= libc::LOCK_NB;
+        }
+        loop {
+            // SAFETY: `fd` is a live descriptor; `op` is a valid flock op.
+            let rc = unsafe { libc::flock(fd.native(), op) };
+            if rc == 0 {
+                return Ok(true);
+            }
+            let e = last_errno();
+            if e == libc::EINTR {
+                continue;
+            }
+            if nonblocking && (e == libc::EWOULDBLOCK || e == libc::EAGAIN) {
+                return Ok(false);
+            }
+            return Err(Error::from_code_int(e, Tag::flock).with_fd(fd));
+        }
+    }
     pub fn getcwd(buf: &mut [u8]) -> Maybe<usize> {
         // SAFETY: `buf` is a valid exclusive slice; `getcwd` writes at most
         // `buf.len()` bytes (including the NUL).
@@ -3633,6 +3669,33 @@ mod windows_impl {
         }
         Ok(bytes_written as usize)
     }
+    /// Advisory whole-file lock via `LockFileEx`. Returns `Ok(false)` when
+    /// `nonblocking` and the lock is held elsewhere. Unlike POSIX `flock`,
+    /// `LockFileEx` does not upgrade/downgrade an already-held lock, but the
+    /// only caller pattern is acquire-once/close, which behaves identically.
+    pub fn flock(fd: Fd, mode: FileLockMode, nonblocking: bool) -> Maybe<bool> {
+        let mut flags: w::DWORD = 0;
+        if mode == FileLockMode::Exclusive {
+            flags |= w::kernel32::LOCKFILE_EXCLUSIVE_LOCK;
+        }
+        if nonblocking {
+            flags |= w::kernel32::LOCKFILE_FAIL_IMMEDIATELY;
+        }
+        let mut overlapped: w::OVERLAPPED = bun_core::ffi::zeroed();
+        // SAFETY: FFI; `fd.native()` is a valid HANDLE and `overlapped` is a
+        // valid out-param selecting range start 0.
+        let rc = unsafe {
+            w::kernel32::LockFileEx(fd.native(), flags, 0, u32::MAX, u32::MAX, &mut overlapped)
+        };
+        if rc != 0 {
+            return Ok(true);
+        }
+        let er = w::Win32Error::get();
+        if nonblocking && er == w::Win32Error::LOCK_VIOLATION {
+            return Ok(false);
+        }
+        Err(Error::new(er.to_e(), Tag::flock).with_fd(fd))
+    }
     pub fn pread(fd: Fd, buf: &mut [u8], off: i64) -> Maybe<usize> {
         // Positioned-I/O lowering:
         // libuv path for uv-kind fds, kernel32 ReadFile+OVERLAPPED for system
@@ -3675,7 +3738,7 @@ mod windows_impl {
             return Ok(amount_read as usize);
         }
     }
-    pub(crate) fn pwrite(fd: Fd, buf: &[u8], off: i64) -> Maybe<usize> {
+    pub fn pwrite(fd: Fd, buf: &[u8], off: i64) -> Maybe<usize> {
         // Same lowering as `pread`: kernel32 WriteFile with an
         // `OVERLAPPED.Offset` for HANDLE-kind fds.
         if fd.kind() == FdKind::Uv {

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -886,7 +886,7 @@ pub mod kernel32 {
         pub fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *mut DWORD) -> BOOL;
         /// `FlushFileBuffers` — fsync(2)-equivalent for HANDLE-backed files.
         pub fn FlushFileBuffers(hFile: HANDLE) -> BOOL;
-        /// `LockFileEx` (`fileapi.h`) — advisory byte-range lock. The
+        /// `LockFileEx` (`fileapi.h`) — mandatory byte-range lock. The
         /// `lpOverlapped` out-param is required even for synchronous handles
         /// (its `Offset`/`OffsetHigh` select the range start).
         pub fn LockFileEx(

--- a/src/windows_sys/externs.rs
+++ b/src/windows_sys/externs.rs
@@ -832,6 +832,10 @@ pub mod kernel32 {
     pub const PAGE_EXECUTE_WRITECOPY: u32 = 0x80;
     pub const PAGE_GUARD: u32 = 0x100;
 
+    // `LockFileEx` dwFlags (`minwinbase.h`).
+    pub const LOCKFILE_FAIL_IMMEDIATELY: DWORD = 0x0000_0001;
+    pub const LOCKFILE_EXCLUSIVE_LOCK: DWORD = 0x0000_0002;
+
     #[cfg_attr(windows, link(name = "kernel32"))]
     unsafe extern "system" {
         /// No preconditions; reads thread-local Win32 error slot.
@@ -882,6 +886,17 @@ pub mod kernel32 {
         pub fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *mut DWORD) -> BOOL;
         /// `FlushFileBuffers` — fsync(2)-equivalent for HANDLE-backed files.
         pub fn FlushFileBuffers(hFile: HANDLE) -> BOOL;
+        /// `LockFileEx` (`fileapi.h`) — advisory byte-range lock. The
+        /// `lpOverlapped` out-param is required even for synchronous handles
+        /// (its `Offset`/`OffsetHigh` select the range start).
+        pub fn LockFileEx(
+            hFile: HANDLE,
+            dwFlags: DWORD,
+            dwReserved: DWORD,
+            nNumberOfBytesToLockLow: DWORD,
+            nNumberOfBytesToLockHigh: DWORD,
+            lpOverlapped: *mut OVERLAPPED,
+        ) -> BOOL;
         /// `CreateProcessW` (`processthreadsapi.h`).
         pub fn CreateProcessW(
             lpApplicationName: LPCWSTR,

--- a/test/cli/install/bunx-concurrent.test.ts
+++ b/test/cli/install/bunx-concurrent.test.ts
@@ -141,11 +141,7 @@ test("concurrent bunx spawns of the same package do not corrupt the shared insta
   );
   const results = await Promise.all(
     procs.map(async proc => {
-      const [stdout, stderr, exitCode] = await Promise.all([
-        proc.stdout.text(),
-        proc.stderr.text(),
-        proc.exited,
-      ]);
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       return { stdout, stderr, exitCode };
     }),
   );

--- a/test/cli/install/bunx-concurrent.test.ts
+++ b/test/cli/install/bunx-concurrent.test.ts
@@ -152,4 +152,6 @@ test("concurrent bunx spawns of the same package do not corrupt the shared insta
     expect(stdout).toContain("OK-37830 600");
     expect(exitCode).toBe(0);
   }
+  // Outlier timeout: 8 serialized cold-cache installs of ~600 files each;
+  // shrinking the workload loses the repro on unfixed builds.
 }, 60_000);

--- a/test/cli/install/bunx-concurrent.test.ts
+++ b/test/cli/install/bunx-concurrent.test.ts
@@ -1,0 +1,159 @@
+import { gzipSync, spawn } from "bun";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
+
+// https://github.com/oven-sh/bun/issues/37830
+// Concurrent `bun x <pkg>` processes share one install directory
+// (<tmpdir>/bunx-<uid>-<pkg>@<ver>). With a cold cache they all installed
+// into it at the same time and raced each other: some died with
+// "EEXIST/ENOENT: failed copying files from cache to destination", others
+// executed a half-written node_modules ("Cannot find module ...").
+
+/** Minimal ustar + gzip writer: enough for an npm package tarball. */
+function makeTarball(files: Record<string, string>): Uint8Array {
+  const blocks: Uint8Array[] = [];
+  const encoder = new TextEncoder();
+  for (const [name, contents] of Object.entries(files)) {
+    const data = encoder.encode(contents);
+    const header = new Uint8Array(512);
+    const put = (offset: number, value: string) => header.set(encoder.encode(value), offset);
+    put(0, `package/${name}`);
+    put(100, "0000755\0"); // mode: executable so bin entries work without chmod
+    put(108, "0000000\0"); // uid
+    put(116, "0000000\0"); // gid
+    put(124, data.length.toString(8).padStart(11, "0") + "\0");
+    put(136, "00000000000\0"); // mtime
+    header[156] = 0x30; // typeflag: regular file
+    put(257, "ustar\0"); // magic
+    put(263, "00"); // version
+    // checksum: sum of the header with the checksum field filled with spaces
+    header.fill(0x20, 148, 156);
+    let sum = 0;
+    for (const byte of header) sum += byte;
+    put(148, sum.toString(8).padStart(6, "0") + "\0 ");
+    blocks.push(header, data);
+    const partial = data.length % 512;
+    if (partial !== 0) blocks.push(new Uint8Array(512 - partial));
+  }
+  blocks.push(new Uint8Array(1024)); // end-of-archive
+  const flat = new Uint8Array(blocks.reduce((n, b) => n + b.length, 0));
+  let offset = 0;
+  for (const block of blocks) {
+    flat.set(block, offset);
+    offset += block.length;
+  }
+  return gzipSync(flat);
+}
+
+// A dependency with many files widens the cache-to-destination copy window
+// so the racing processes reliably overlap.
+const FILE_COUNT = 300;
+const filler = Buffer.alloc(1024, "x").toString();
+function manyFilesPackage(name: string): Record<string, string> {
+  const files: Record<string, string> = {
+    "package.json": JSON.stringify({ name, version: "1.0.0", main: "index.js" }),
+    "index.js":
+      Array.from({ length: FILE_COUNT }, (_, i) => `require("./file${i}.js");`).join("\n") +
+      `\nmodule.exports = ${FILE_COUNT};\n`,
+  };
+  for (let i = 0; i < FILE_COUNT; i++) {
+    files[`file${i}.js`] = `module.exports = ${i}; // ${filler}\n`;
+  }
+  return files;
+}
+
+test("concurrent bunx spawns of the same package do not corrupt the shared install dir", async () => {
+  const packages: Record<string, { tarball: Uint8Array; meta: object }> = {};
+  const registerPackage = (name: string, files: Record<string, string>, extra: object = {}) => {
+    packages[name] = {
+      tarball: makeTarball(files),
+      meta: { name, version: "1.0.0", ...extra },
+    };
+  };
+
+  registerPackage("dep-a-37830", manyFilesPackage("dep-a-37830"));
+  registerPackage("dep-b-37830", manyFilesPackage("dep-b-37830"));
+  registerPackage(
+    "pkg-37830",
+    {
+      "package.json": JSON.stringify({
+        name: "pkg-37830",
+        version: "1.0.0",
+        bin: { "pkg-37830": "cli.js" },
+        dependencies: { "dep-a-37830": "1.0.0", "dep-b-37830": "1.0.0" },
+      }),
+      "cli.js": `#!/usr/bin/env node\nconsole.log("OK-37830", require("dep-a-37830") + require("dep-b-37830"));\n`,
+    },
+    {
+      bin: { "pkg-37830": "cli.js" },
+      dependencies: { "dep-a-37830": "1.0.0", "dep-b-37830": "1.0.0" },
+    },
+  );
+
+  await using server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const path = decodeURIComponent(new URL(req.url).pathname);
+      const tarballMatch = path.match(/^\/([^/]+)-1\.0\.0\.tgz$/);
+      if (tarballMatch && packages[tarballMatch[1]]) {
+        return new Response(packages[tarballMatch[1]].tarball);
+      }
+      const name = path.slice(1);
+      if (packages[name]) {
+        return Response.json({
+          name,
+          "dist-tags": { latest: "1.0.0" },
+          versions: {
+            "1.0.0": {
+              ...packages[name].meta,
+              dist: { tarball: `http://localhost:${server.port}/${name}-1.0.0.tgz` },
+            },
+          },
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  // A fresh temp dir gives this run its own bunx install dir
+  // (<tmpdir>/bunx-<uid>-pkg-37830@latest) and a cold install cache.
+  const tmp = tmpdirSync();
+  const cache = tmpdirSync();
+  const cwd = tmpdirSync();
+  const env = {
+    ...bunEnv,
+    TMPDIR: tmp,
+    BUN_TMPDIR: tmp,
+    TEMP: tmp,
+    BUN_INSTALL_CACHE_DIR: cache,
+    npm_config_registry: `http://localhost:${server.port}/`,
+  };
+
+  const CONCURRENCY = 8;
+  const procs = Array.from({ length: CONCURRENCY }, () =>
+    spawn({
+      cmd: [bunExe(), "x", "pkg-37830"],
+      env,
+      cwd,
+      stdout: "pipe",
+      stderr: "pipe",
+    }),
+  );
+  const results = await Promise.all(
+    procs.map(async proc => {
+      const [stdout, stderr, exitCode] = await Promise.all([
+        proc.stdout.text(),
+        proc.stderr.text(),
+        proc.exited,
+      ]);
+      return { stdout, stderr, exitCode };
+    }),
+  );
+
+  for (const { stdout, stderr, exitCode } of results) {
+    expect(stderr).not.toContain("failed copying files from cache to destination");
+    expect(stderr).not.toContain("Cannot find module");
+    expect(stdout).toContain("OK-37830 600");
+    expect(exitCode).toBe(0);
+  }
+}, 60_000);

--- a/test/cli/install/bunx-concurrent.test.ts
+++ b/test/cli/install/bunx-concurrent.test.ts
@@ -1,6 +1,6 @@
 import { gzipSync, spawn } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 
 // https://github.com/oven-sh/bun/issues/37830
 // Concurrent `bun x <pkg>` processes share one install directory
@@ -117,15 +117,15 @@ test("concurrent bunx spawns of the same package do not corrupt the shared insta
 
   // A fresh temp dir gives this run its own bunx install dir
   // (<tmpdir>/bunx-<uid>-pkg-37830@latest) and a cold install cache.
-  const tmp = tmpdirSync();
-  const cache = tmpdirSync();
-  const cwd = tmpdirSync();
+  using tmp = tempDir("bunx-concurrent-tmp", {});
+  using cache = tempDir("bunx-concurrent-cache", {});
+  using cwd = tempDir("bunx-concurrent-cwd", {});
   const env = {
     ...bunEnv,
-    TMPDIR: tmp,
-    BUN_TMPDIR: tmp,
-    TEMP: tmp,
-    BUN_INSTALL_CACHE_DIR: cache,
+    TMPDIR: String(tmp),
+    BUN_TMPDIR: String(tmp),
+    TEMP: String(tmp),
+    BUN_INSTALL_CACHE_DIR: String(cache),
     npm_config_registry: `http://localhost:${server.port}/`,
   };
 
@@ -134,7 +134,7 @@ test("concurrent bunx spawns of the same package do not corrupt the shared insta
     spawn({
       cmd: [bunExe(), "x", "pkg-37830"],
       env,
-      cwd,
+      cwd: String(cwd),
       stdout: "pipe",
       stderr: "pipe",
     }),


### PR DESCRIPTION
### Problem
- Several `bun x <pkg>` of one package started at once with a cold cache all fail, with `EEXIST`/`ENOENT: failed copying files from cache to destination` or `Error: Cannot find module './v1'` from a half-written node_modules.
- All of them install into the same directory, and nothing keeps two from installing into it at once.
- A bare `bunx <pkg>` installs with `--force`, so the first process to finish starts running the tree while the others rewrite it underneath.
- #37830 was closed as fixed in 1.4.0-canary.1, but that check used a warm cache, which skips the install and never races.
- Fixes #37830

### Fix
- bunx holds an exclusive lock on a `.bunx-lock` file in the install dir from before the install until just before it execs the target, so at most one process writes the directory at a time.
- The holder writes the completion time into the lock file as the last step before releasing it; a process that blocked and then sees a completion at or after the time it started waiting skips its own install, so a fresh tree is never force-reinstalled under a process already running it.
- Before running an already-cached bin, bunx tries a nonblocking shared lock; failure means an install is in flight, so it waits instead of running a tree mid-copy. If no lock can be taken, or with `--no-install`, behavior is unchanged.
- Verification: the real-package repro goes from 6/6 spawns failing to 6/6 passing, and a new 8-way concurrent test fails 5/5 on unfixed bun and passes with the fix on linux and Windows. macOS was only `cargo check`ed.

### Background
- `bun x` runs `bun add` into a shared per-user temp dir, `<tmpdir>/bunx-<uid>-<pkg>@<ver>`, then execs the package's bin; a later run that finds the bin skips the install.
- Installing a dist tag (`bunx pkg`, no version) passes `--no-cache --force` to `bun add` so newer versions are picked up, which rewrites node_modules even when it is already populated.
- `flock(2)` (`LockFileEx` on Windows) is a whole-file lock released when the fd closes; the fd is CLOEXEC, so exec releases it. A lock on an unlinked file guards nothing, and stale-tree cleanup deletes the whole dir, so after locking, the held fd's identity is compared against a fresh open of the path (ino/dev on POSIX, NTFS file index/volume serial on Windows), and the stale-tree delete itself only runs while holding the exclusive lock.

<details>
<summary>Original description</summary>

Fixes #37830 (closed as "fixed in 1.4.0-canary.1", but it still reproduces on that exact commit with a cold cache; the verification in the issue ran with a warm cache, where the existing-binary fast path hides the race).

### Repro

Cold install cache + concurrent spawns of the same package:

```sh
export BUN_INSTALL_CACHE_DIR=$(mktemp -d)
rm -rf /tmp/bunx-$(id -u)-@gongrzhe*
for i in 1 2 3 4 5 6; do
  bun x @gongrzhe/server-calendar-autoauth-mcp &
done
wait
```

On `1.4.0` and current main, all six spawns fail:

```
EEXIST: failed copying files from cache to destination for package @gongrzhe/server-calendar-autoauth-mcp
ENOENT: failed copying files from cache to destination for package googleapis
Error: Cannot find module './v1'   (half-written node_modules)
```

### Cause

All `bun x <pkg>` processes for the same user and package share one install directory, `<tmpdir>/bunx-<uid>-<pkg>@<ver>`, with no cross-process coordination:

1. Concurrent `bun add` runs install into the same `node_modules` at once, colliding on copies (EEXIST) and observing each other's half-written or replaced trees (ENOENT).
2. Bare `bunx <pkg>` is a dist-tag install, which passes `--force` to `bun add`; a process that finishes first starts executing the tree while the remaining processes force-reinstall it, deleting files out from under the running binary (`Cannot find module './v1'`).

### Fix

- Add `bun_sys::flock` (`flock(2)` on POSIX, `LockFileEx` on Windows, released on close; the fd is CLOEXEC).
- `bunx` takes an exclusive advisory lock on `<dir>/.bunx-lock` around the install, held through the post-install bin probes and released right before exec'ing the target. The lock file lives inside the uid-owned, trust-checked cache dir; after acquisition the fd is re-verified against the path so a lock on an unlinked inode (stale-tree cleanup) is retried. If the lock can't be taken, bunx falls back to the previous unlocked behavior.
- Before running an already-cached binary, bunx probes the lock shared/nonblocking; if an install is in flight it takes the install path and waits instead of executing a tree mid-mutation.
- The exclusive holder records the install completion time in the lock file. A waiter that blocked while another process finished installing skips its own re-install (a `--force` one for dist-tag installs) and runs the freshly installed tree, instead of mutating it out from under the process that just started executing it.

### Verification

- Real-package repro above: before, 6/6 spawns fail; after, 6/6 (and 8/8 across repeated cold-cache rounds) reach the package's own expected output.
- New test `test/cli/install/bunx-concurrent.test.ts` spawns 8 concurrent `bun x` of a local-registry package with two 300-file dependencies: fails 5/5 runs on unfixed bun (linux and Windows, release and debug), passes 7/7 with the fix on linux and 4/4 on Windows x64.
- `cargo check -p bun_runtime` for `x86_64-pc-windows-msvc`, `aarch64-pc-windows-msvc`, and `x86_64-apple-darwin`.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bunx-concurrent.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bunx-concurrent.test.ts:
145 |       return { stdout, stderr, exitCode };
146 |     }),
147 |   );
148 | 
149 |   for (const { stdout, stderr, exitCode } of results) {
150 |     expect(stderr).not.toContain("failed copying files from cache to destination");
                             ^
error: expect(received).not.toContain(expected)

Expected to not contain: "failed copying files from cache to destination"
Received: "Resolving dependencies\nResolved, downloaded and extracted [12]\nENOENT: failed copying files from cache to destination for package dep-a-37830\n"

      at <anonymous> (/workspace/bun/test/cli/install/bunx-concurrent.test.ts:150:24)
(fail) concurrent bunx spawns of the same package do not corrupt the shared install dir [7919.75ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [10.52s]
error: script "bd" exited with code 1
__F:1:S:0

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (4448a2e21)

test/cli/install/bunx-concurrent.test.ts:
145 |       return { stdout, stderr, exitCode };
146 |     }),
147 |   );
148 | 
149 |   for (const { stdout, stderr, exitCode } of results) {
150 |     expect(stderr).not.toContain("failed copying files from cache to destination");
                             ^
error: expect(received).not.toContain(expected)

Expected to not contain: "failed copying files from cache to destination"
Received: "Resolving dependencies\nResolved, downloaded and extracted [10]\nENOENT: failed copying files from cache to destination for package dep-a-37830\nENOENT: failed copying files from cache to destination for package dep-b-37830\n"

      at <anonymous> (/workspace/bun/test/cli/install/bunx-concurrent.test.ts:150:24)
(fail) concurrent bunx spawns of the same package do not corrupt the shared install dir [639.95ms]

 0 pass
 1 fail
 1 expect() calls
Ran 1 test across 1 file. [814.00ms]
__F:1:S:0
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bunx-concurrent.test.ts
bun test v1.4.1 (4448a2e21)

test/cli/install/bunx-concurrent.test.ts:
(pass) concurrent bunx spawns of the same package do not corrupt the shared install dir [2747.64ms]

 1 pass
 0 fail
 32 expect() calls
Ran 1 test across 1 file. [6.14s]
__F:0:S:0

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     be950c4968
  features     baseline

23 deps, 129 codegen, 1172 objects in 792ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1244] install /workspace/bun
bun install v1.4.0-canary.1 (4448a2e21)

Checked 26 installs across 63 packages (no changes) [19.00ms]
[2/1244] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (4448a2e21)

Checked 1 install across 2 packages (no changes) [3.00ms]
[3/1244] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (4448a2e21)

Checked 111 installs across 104 packages (no changes) [13.00ms]
[4/1244] gen ErrorCode+*.h
[5/1244] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[6/1217] gen node-fallbacks/react-refresh.js
Bundled 1 module in 25ms

  react-refresh.js  4.81 KB  (entry point)

[7/1217] fetch zlib
[zlib] up to date
[8/1217] gen bindgenv2
[9/1217] gen .bind.ts → GeneratedBindings.cpp
[10/1217] fetch tinycc
[tinycc] up to date
[11/1216] gen bake.{client,server,error}.js
-> bake.client.js, bake.serv
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/cli/bunx_command.rs          | 461 +++++++++++++++++++++++--------
 src/sys/lib.rs                           |  69 ++++-
 src/windows_sys/externs.rs               |  15 +
 test/cli/install/bunx-concurrent.test.ts | 157 +++++++++++
 4 files changed, 579 insertions(+), 123 deletions(-)
```

</details>

**gate history** · 5 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                      reads  edits  tests
src/runtime/cli/bunx_command.rs              13     19      0
src/sys/lib.rs                                5      9      0
src/windows_sys/externs.rs                    3      5      0
test/cli/install/bunx-concurrent.test.ts      3      5      0
```

</details>

**root cause** · written by the author bot

Concurrent `bun x` processes of the same package raced on the shared install cache without any coordination, so one process could read or copy files from a cache directory that another process was still populating or replacing, producing the intermittent FileNotFound error during the copy to the destination. The fix introduces cross-platform whole-file locking, using POSIX advisory locks and LockFileEx on Windows, and integrates it into the bunx cache path so that installs are serialized under an exclusive lock while probes of cached binaries take a shared lock and wait for any in-progress …

<!-- robobun:evidence:end -->
