### PR TITLE
Bun.write: reject with EPIPE when a FIFO's reader goes away mid-write (Linux)

### DIFF
--- a/src/io/lib.rs
+++ b/src/io/lib.rs
@@ -1662,26 +1662,17 @@ impl Poll {
             return;
         }
         let poll = poll.as_ptr();
+        // EPOLLERR, like EPOLLHUP, is readiness: the errno comes out of the
+        // owner's next read()/write(). (`epoll_ctl` failures go through
+        // `FileAction::on_error` in `tick_epoll`.)
+        let events = event.events;
+        log!("ready(events = {:#x})", events);
         // CYCLEBREAK: owner (ReadFile/WriteFile) is T6; dispatch via link-time
         // `extern "Rust"` defined in `bun_runtime::dispatch`. The
         // container_of(io_poll) recovery happens there.
-        if event.events & linux::EPOLL_ERR != 0 {
-            let errno = sys::get_errno(event.events as isize);
-            log!("error() = {:?}", errno);
-            // SAFETY: poll is the `io_poll` field of a live owner; link-time
-            // extern body matches on `tag`.
-            unsafe {
-                __bun_io_pollable_on_io_error(
-                    tag,
-                    poll,
-                    &sys::Error::from_code(errno, sys::Tag::epoll_ctl),
-                )
-            };
-        } else {
-            log!("ready()");
-            // SAFETY: as above.
-            unsafe { __bun_io_pollable_on_ready(tag, poll) };
-        }
+        // SAFETY: poll is the `io_poll` field of a live owner; link-time
+        // extern body matches on `tag`.
+        unsafe { __bun_io_pollable_on_ready(tag, poll) };
     }
 
     #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it, test } from "bun:test";
+import { randomBytes } from "crypto";
 import fs, { mkdirSync } from "fs";
 import {
   bunEnv,
@@ -7,10 +8,12 @@ import {
   exampleSite,
   gcTick,
   isASAN,
+  isMacOS,
   isWindows,
   tempDir,
   withoutAggressiveGC,
 } from "harness";
+import { mkfifo } from "mkfifo";
 import { once } from "node:events";
 import http from "node:http";
 import path, { join } from "path";
@@ -537,6 +540,106 @@ const IS_UV_FS_COPYFILE_DISABLED =
       resolved: String(size),
     });
     expect(exitCode).toBe(0);
+  });
+
+  // A Bun.write() into a FIFO fills the pipe buffer and then waits for the
+  // reader. The payload is past the synchronous fast path's 256 KiB limit and
+  // many pipe buffers long, so the write waits several times however quickly
+  // the pipe is drained. The destination is the FIFO's write end as an fd: a
+  // path destination is opened (and, by the fast path, closed) by Bun.write()
+  // itself, which is a different set of problems (#36025).
+  describe.skipIf(isWindows)("Bun.write() into a FIFO that is full", () => {
+    const payload = randomBytes(1024 * 1024);
+
+    // Both ends of a fresh FIFO, read end first (opening the write end fails
+    // with ENXIO until a reader exists). Neither end blocks, so the test can
+    // probe the pipe from either side.
+    function openFifo(dir) {
+      const fifo = join(String(dir), "out.fifo");
+      mkfifo(fifo);
+      return {
+        reader: fs.openSync(fifo, fs.constants.O_RDONLY | fs.constants.O_NONBLOCK),
+        writer: fs.openSync(fifo, fs.constants.O_WRONLY | fs.constants.O_NONBLOCK),
+        closeReader() {
+          if (this.reader === -1) return;
+          fs.closeSync(this.reader);
+          this.reader = -1;
+        },
+        [Symbol.dispose]() {
+          this.closeReader();
+          fs.closeSync(this.writer);
+        },
+      };
+    }
+
+    function startWrite(writer) {
+      const dest = Bun.file(writer);
+      // fstat()s the fd: Bun.write() only waits on a destination it knows is not a regular file.
+      dest.size;
+      return Bun.write(dest, payload).then(
+        written => ({ written }),
+        err => ({ code: err.code, syscall: err.syscall }),
+      );
+    }
+
+    it("completes once the reader drains the pipe", async () => {
+      using dir = tempDir("bun-write-fifo-drain", {});
+      using fifo = openFifo(dir);
+      const settled = startWrite(fifo.writer);
+      let outcome;
+      settled.then(result => (outcome = result));
+
+      const chunks = [];
+      let received = 0;
+      const buffer = Buffer.alloc(64 * 1024);
+      while (received < payload.length) {
+        let n;
+        try {
+          n = fs.readSync(fifo.reader, buffer);
+        } catch (err) {
+          if (err.code !== "EAGAIN") throw err;
+          // An empty pipe after the write has settled is all we are getting.
+          if (outcome) break;
+          await Bun.sleep(1);
+          continue;
+        }
+        if (n === 0) throw new Error(`EOF after ${received} bytes, but the write end is still open`);
+        chunks.push(Buffer.from(buffer.subarray(0, n)));
+        received += n;
+      }
+
+      expect({ ...(await settled), received, intact: Buffer.concat(chunks).equals(payload) }).toEqual({
+        written: payload.length,
+        received: payload.length,
+        intact: true,
+      });
+    });
+
+    // Used to reject with a made-up "Unknown Error" (errno 0, syscall
+    // "epoll_ctl"): the io thread read epoll's events bitmask as an errno.
+    // Not on macOS: a named pipe's kqueue write filter only fires when the
+    // pipe gains free space, which a full pipe nobody reads from never does,
+    // so the write never settles there.
+    it.skipIf(isMacOS)("rejects with EPIPE when the last reader closes while it is waiting", async () => {
+      using dir = tempDir("bun-write-fifo-epipe", {});
+      using fifo = openFifo(dir);
+      const settled = startWrite(fifo.writer);
+
+      // Once a write of our own is refused, the pipe is full: Bun.write() has
+      // written as much as fits and is waiting for the reader.
+      for (;;) {
+        try {
+          fs.writeSync(fifo.writer, "x");
+        } catch (err) {
+          if (err.code !== "EAGAIN") throw err;
+          break;
+        }
+        await Bun.sleep(1);
+      }
+      fifo.closeReader();
+
+      expect(await settled).toEqual({ code: "EPIPE", syscall: "write" });
+    });
   });
 
   it("Bun.file(0) survives GC", async () => {

--- a/test/js/bun/util/bun-file-read.test.ts
+++ b/test/js/bun/util/bun-file-read.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -54,3 +54,52 @@ describe("Bun.file read-loop target selection", () => {
     expect(Bun.hash(buf)).toBe(Bun.hash(bytes.subarray(start, end)));
   });
 });
+
+// A read that is waiting on the io thread when its fd turns into an error
+// condition used to reject with a made-up "Unknown Error" (errno 0, syscall
+// "epoll_ctl"): the io thread read epoll's events bitmask as an errno. The
+// error the fd actually has is what the retried recv() reports. Linux only:
+// that dispatch is epoll's, and so is what produces the error condition here,
+// closing a unix socket (the child's stdin is one) with unread data in it
+// resets the peer instead of ending it.
+it.skipIf(!isLinux)(
+  "Bun.stdin.text() reports the socket's error when stdin is reset while the read is waiting",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const read = Bun.stdin.text().then(
+         text => ({ resolved: text }),
+         err => ({ code: err.code, syscall: err.syscall }),
+       );
+       // Unread by the parent, so that closing its end resets ours.
+       require("fs").writeSync(0, "x");
+       process.stdout.write("reading\\n");
+       process.stdout.write(JSON.stringify(await read));`,
+      ],
+      env: bunEnv,
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    const stdout: Uint8Array[] = [];
+    const marker = Buffer.from("reading\n");
+    let closed = false;
+    for await (const chunk of proc.stdout) {
+      stdout.push(chunk);
+      if (!closed && Buffer.concat(stdout).indexOf(marker) !== -1) {
+        closed = true;
+        proc.stdin.end();
+      }
+    }
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect({ stdout: Buffer.concat(stdout).toString(), stderr }).toEqual({
+      stdout: "reading\n" + JSON.stringify({ code: "ECONNRESET", syscall: "recv" }),
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  },
+);


### PR DESCRIPTION
### Problem
- A `Bun.write()` into a full FIFO waits for the reader. If the last reader closes, the write must reject with EPIPE. On Linux it rejects with `Unknown Error, epoll_ctl` (code undefined, errno 0).
- Cause: `Poll::on_update_epoll` (`src/io/lib.rs:1665`) turns the `EPOLLERR` events bitmask into an errno. The bitmask is never `-1`, so the errno is always 0. `EPOLLERR` carries no errno. A waiting `Bun.stdin.text()` on a socket that gets reset takes the same path.

### Fix
- `on_update_epoll` delivers every event, `EPOLLERR` included, as "ready". The owner retries its syscall and gets the real errno: EPIPE for the write, ECONNRESET for the stdin read.
- No error path is lost. A failing `epoll_ctl` is reported synchronously at registration in `tick_epoll`.
- Verified: `test/js/bun/io/bun-write.test.js` ("Bun.write() into a FIFO that is full") and `test/js/bun/util/bun-file-read.test.ts` (stdin ECONNRESET). Both new cases fail on the released binary. Also the rest of `bun-write.test.js`, `bun-file-fd-read.test.ts` and `bun-stdin-slice.test.ts`.

### Background
- A FIFO (named pipe, `mkfifo`) is a pipe with a filesystem path. A write to a pipe with no reader fails with EPIPE.
- `Bun.write()` to anything that is not a regular file runs its write loop on a pool thread. On EAGAIN it hands the fd to the io thread (epoll on Linux) and resumes when told the fd is writable.
- `EPOLLERR` and `EPOLLHUP` are readiness flags, not error codes. The errno for whatever happened comes from the next syscall on the fd.

<details><summary>Notes</summary>

This revision is the rebase onto main that was requested. It drops the macOS half of the earlier revision. On macOS the kqueue write filter for a FIFO never fires when the reader closes, so the write never settles there. The earlier revision waited in `select(2)` on the pool thread instead, and ran that loop outside the job's VM borrow so a worker's teardown did not wait for the reader.

That shape cannot work on main any more. Since #38299 a `Job` holds a `Ticket` for its whole trip, and `VmHandle::close_and_wait` waits, without a bound, for every ticket. The only way to end a parked `Bun.write()` is `JobContext::cancel`, which unparks a wait on the io thread through `IoParking`. A `select(2)` on a pool thread cannot be cancelled that way, so the earlier revision's own worker-teardown test would hang on the darwin lanes.

The right place for the macOS write side is the io thread. #40099 adds a `select(2)` watcher thread (`src/io/fifo_select.rs`) for the read side of named pipes and delivers readiness back into the owner's kqueue, so `IoParking` cancel keeps working. The write side is a write set on that same thread. I can do that on top of #40099 once it lands.

The EPIPE test is `skipIf(isMacOS)` for that reason. The drain test runs everywhere. The `st_dev` and worker-teardown tests from the earlier revision are gone with the macOS code they covered.

Another scenario the same hunk fixes: a pty slave parked in `Bun.file(slave).text()` whose master closes. The kernel reports `EPOLLIN|EPOLLHUP|EPOLLERR` at once and `read()` then returns 0 with the buffered bytes. On 1.4.1 the call rejects with `Unknown Error, epoll_ctl` and drops the bytes.

Fail-before: both new cases fail on the released binary here. With the debug build, the FIFO block passes 10 of 10 reruns. In the full `bun-write.test.js` run, "copyFileRange is not available > on large files" exceeded its 5 s budget once under concurrent load (6.3 s) and passed alone at 4.7 s. It is a copy path this change does not touch.

Original description of the earlier revision, for the macOS analysis and XNU references: see the PR history before the rebase.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/util/bun-file-read.test.ts, test/js/bun/io/bun-write.test.js

<!-- robobun:evidence:end -->