### PR TITLE
event loop: sanitize the stack on every tick so objects dropped by earlier turns get collected

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -462,9 +462,15 @@ void us_loop_run(struct us_loop_t *loop) {
     }
 }
 
+extern void Bun__JSC_onLoopTick(void * _Nonnull jsc_vm);
 extern void Bun__JSC_onBeforeWait(void * _Nonnull jsc_vm, uint64_t now_ns);
 
 void us_loop_run_bun_tick(struct us_loop_t *loop, const struct timespec* timeout, uint64_t now_ns) {
+    /* Every tick, whether or not this one parks (Bun__JSC_onBeforeWait below is
+     * only for the ones that do) or even has anything to poll. */
+    if (loop->data.jsc_vm)
+        Bun__JSC_onLoopTick(loop->data.jsc_vm);
+
     if (loop->num_polls == 0)
         return;
 

--- a/packages/bun-usockets/src/eventing/libuv.c
+++ b/packages/bun-usockets/src/eventing/libuv.c
@@ -322,7 +322,13 @@ void us_internal_poll_set_type(struct us_poll_t *p, int poll_type) {
 
 LIBUS_SOCKET_DESCRIPTOR us_poll_fd(struct us_poll_t *p) { return p->fd; }
 
+extern void Bun__JSC_onLoopTick(void *jsc_vm);
+extern void Bun__JSC_onBeforeWait(void *jsc_vm, uint64_t now_ns);
+
 void us_loop_pump(struct us_loop_t *loop) {
+  if (loop->data.jsc_vm)
+    Bun__JSC_onLoopTick(loop->data.jsc_vm);
+
   /* POSIX parity: us_loop_run_bun_tick polls epoll/kqueue and dispatches
    * regardless of ref state (it only early-outs on num_polls == 0). libuv's
    * uv_run() skips its body when uv__loop_alive() is 0, so IOCP completions
@@ -395,8 +401,6 @@ void us_loop_free(struct us_loop_t *loop) {
   us_free(loop);
 }
 
-extern void Bun__JSC_onBeforeWait(void *jsc_vm, uint64_t now_ns);
-
 void us_loop_run(struct us_loop_t *loop) {
   us_loop_integrate(loop);
   uv_update_time(loop->uv_loop);
@@ -405,6 +409,7 @@ void us_loop_run(struct us_loop_t *loop) {
    * first), making this the JS thread's park hook, the counterpart of
    * us_loop_run_bun_tick's. jsc_vm is only set on the JS thread's loop. */
   if (loop->data.jsc_vm) {
+    Bun__JSC_onLoopTick(loop->data.jsc_vm);
     /* uv_update_time() above just refreshed libuv's cached monotonic clock, so
      * uv_now() reads that cache rather than taking the clock again. */
     Bun__JSC_onBeforeWait(loop->data.jsc_vm, (uint64_t) uv_now(loop->uv_loop) * 1000000ULL);

--- a/src/jsc/bindings/BunJSCEventLoop.cpp
+++ b/src/jsc/bindings/BunJSCEventLoop.cpp
@@ -23,6 +23,28 @@ extern "C" uint64_t us_internal_monotonic_ns(void);
 // it as an atomic rather than through a plain `int`.
 extern "C" std::atomic<int32_t> Bun__defaultRemainingRunsUntilSkipReleaseAccess;
 
+// Called once per tick of the JS thread's event loop, whether or not the tick
+// is going to park.
+//
+// sanitizeStackForVM zeroes the stack between the deepest point JSC last
+// sanitized at and the current stack pointer. Called between turns, that is
+// the region the previous turn's frames occupied, which the GC scans
+// conservatively. JSC's own sanitize sites (allocation slow paths, call
+// linking, the collector itself) all run inside JS, below the frames holding a
+// turn's JSValues, so they never clear it. Bun__JSC_onBeforeWait used to do
+// this on every tick as a side effect (heap.stopIfNecessary() sanitizes while
+// the mutator holds the GC conn); since it only runs on ticks that park, a loop
+// kept busy by setImmediate found the same stale pointers on every GC, and dead
+// objects survived until unrelated code happened to overwrite those slots.
+extern "C" void Bun__JSC_onLoopTick(JSC::VM* _Nonnull vm)
+{
+    ASSERT(vm);
+    // use-after-free sanity check, as in Bun__JSC_onBeforeWait
+    ASSERT(vm->refCount() > 0);
+    JSC::sanitizeStackForVM(*vm);
+}
+
+// Called only on ticks that are about to park.
 extern "C" void Bun__JSC_onBeforeWait(JSC::VM* _Nonnull vm, uint64_t nowNs)
 {
     ASSERT(vm);

--- a/test/js/node/test/parallel/test-fs-filehandle.js
+++ b/test/js/node/test/parallel/test-fs-filehandle.js
@@ -1,0 +1,44 @@
+// Flags: --expose-gc --no-warnings --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const { open } = require('fs/promises');
+
+// Bun does not expose internalBinding('fs').openFileHandle, which node uses
+// here only to create a FileHandle that is immediately unreachable. The public
+// fs.promises.open() produces the same state -- a FileHandle that is garbage
+// collected without having been closed -- so the behaviour under test is
+// reached that way instead.
+// const { internalBinding } = require('internal/test/binding');
+// const fs = internalBinding('fs');
+// const { stringToFlags } = require('internal/fs/utils');
+
+const filepath = path.toNamespacedPath(__filename);
+
+// Verifies that the FileHandle object is garbage collected and that an
+// error is thrown if it is not closed.
+let raised = false;
+process.on('uncaughtException', common.mustCall((err) => {
+  raised = true;
+  assert.strictEqual(err.code, 'ERR_INVALID_STATE');
+  assert.match(err.message, /^A FileHandle object was closed during/);
+  assert.match(err.message, new RegExp(RegExp.escape(filepath)));
+}));
+
+async function openAndAbandon() {
+  const fh = await open(filepath, 'r');
+  assert.strictEqual(typeof fh.fd, 'number');
+  // fh intentionally goes out of scope without being closed.
+}
+
+// Node reaches the collection through a native handle with no JS references at
+// all; here the handle is only unreachable once the async frame above is gone,
+// so collection is retried instead of assumed to happen on the first sweep.
+openAndAbandon().then(common.mustCall(async () => {
+  for (let i = 0; i < 20 && !raised; i++) {
+    globalThis.gc();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}));

--- a/test/js/web/timers/timer-gc-roots.test.ts
+++ b/test/js/web/timers/timer-gc-roots.test.ts
@@ -70,6 +70,61 @@ describe.concurrent("Strong handles are backed by StrongRootBlock", () => {
   }
 });
 
+// Every event-loop tick sanitizes the stack region the previous turns used
+// (Bun__JSC_onLoopTick), so a GC run from a later turn does not conservatively
+// find JSValues those turns left behind in it. That used to happen only on
+// ticks that were about to park (as a side effect of Bun__JSC_onBeforeWait), so
+// a loop kept busy by setImmediate never got it: the finished async function
+// below (its generator, found through a stale slot, still pins `list` and both
+// objects) survived ~17 consecutive Bun.gc(true) calls, until unrelated stack
+// traffic overwrote the slot. The same loop driven by setTimeout(0) parks on
+// every turn and collected it on the first GC.
+describe.concurrent("objects dropped by an earlier turn are collected by the next GC", () => {
+  const yields = {
+    setImmediate: "new Promise(r => setImmediate(r))",
+    setTimeout: "new Promise(r => setTimeout(r, 0))",
+  };
+  for (const garbageYield of Object.keys(yields) as (keyof typeof yields)[]) {
+    for (const loopYield of Object.keys(yields) as (keyof typeof yields)[]) {
+      test(`garbage made across ${garbageYield} turns, GC loop yielding via ${loopYield}`, async () => {
+        const src = `
+          const refs = [];
+          async function makeGarbage() {
+            const list = [];
+            for (let i = 0; i < 2; i++) {
+              const o = { i };
+              list.push(o);
+              refs.push(new WeakRef(o));
+              await ${yields[garbageYield]};
+            }
+            await Promise.all(list.map(o => Promise.resolve(o.i)));
+          }
+          await makeGarbage();
+          let gcs = 0;
+          do {
+            await ${yields[loopYield]};
+            Bun.gc(true);
+            gcs++;
+          } while (gcs < 8 && refs.some(ref => ref.deref() !== undefined));
+          console.log(JSON.stringify({ gcs, alive: refs.filter(ref => ref.deref() !== undefined).length }));
+        `;
+        await using proc = Bun.spawn({ cmd: [bunExe(), "-e", src], env: bunEnv, stderr: "pipe" });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        const { gcs, alive } = JSON.parse(stdout);
+        expect(alive).toBe(0);
+        // The sanitize sits between a tick's immediates and its poll, so garbage
+        // dropped in the timer phase is still on the stack for a GC run from the
+        // next tick's immediates (setTimeout garbage + setImmediate loop takes 2).
+        // A GC leaves the stack sanitized down to its own depth, so the GC after
+        // the next tick can never see it: 2 is a hard bound, unfixed needs ~17.
+        expect(gcs).toBeLessThanOrEqual(2);
+        expect(exitCode).toBe(0);
+      });
+    }
+  }
+});
+
 describe.concurrent("AbortSignal.timeout is released when its wrapper is collected", () => {
   test("dropped signals without listeners free their native timer", async () => {
     const src = `


### PR DESCRIPTION
### Problem
- Objects that are already unreachable survive `Bun.gc(true)` for many turns (usually 17, sometimes 8 or 51) when the event loop is kept busy by `setImmediate`. The same loop driven by `setTimeout(0)` collects them on the first GC, so GC and leak tests that poll via `setImmediate` converge slowly or look like leaks (`test-fs-filehandle.js` was deleted in #35356 over this).
- Cause: a finished async function's generator is still pinned by a stale word in the stack region earlier turns used. Every turn re-enters JSC's microtask runner at the same depth, so the slot sits under the live frame and the conservative scan finds it on every GC.
- JSC leaves zeroing that region between turns to the embedder. Bun only did it as a side effect of `Bun__JSC_onBeforeWait`, which on POSIX since #26821 runs only on ticks that park, and which stops zeroing after a synchronous GC hands the GC conn back (the Windows case #35356 hit). A loop that is always ready never parks, so the region is never cleared.

### Fix
- Add `Bun__JSC_onLoopTick`, which calls `JSC::sanitizeStackForVM` once per tick, and call it from the POSIX and Windows tick paths whether or not the tick parks. The park-only hook is unchanged.
- Correct because the sanitize now runs at the loop's own depth, above every frame a turn used, so a GC after the next tick cannot see anything a previous turn dropped. The bound is 2 GCs: garbage dropped in the timers phase is still visible to a GC from the next tick's immediates, which run before that tick's sanitize.
- Cost: the sanitize returns at once unless something ran deeper since the last tick, and JSC's own in-turn sanitizes then zero nothing until it does, so the zeroing moves to the tick boundary rather than being added. On a 50-turn `setImmediate` chain it zeroed on 8 of 48 calls.
- Verification: a new 2x2 test (garbage made across, and GC loop yielding via, `setImmediate` or `setTimeout`) asserts collection within 2 GCs. Both `setImmediate` loop cells fail deterministically on main; with the fix the cells take 1, 2, 1, 1 GCs on Linux and Windows. `test-fs-filehandle.js` is restored unchanged and passes on both.

### Background
- JSC's GC scans the machine stack conservatively: any word that looks like a heap pointer keeps that object alive, including a stale value left in a slot by a frame that has since returned.
- `sanitizeStackForVM` zero-fills the stack between the deepest point JSC last sanitized and the current stack pointer, then records the new mark, so it is a no-op when nothing has run deeper since. Its callers inside JSC all sit below the frames that hold a turn's values.
- In WebKit the between-turns sanitize falls out of releasing the JSLock at each task boundary. Bun holds the JSLock and heap access for the life of the thread, so its event loop has to supply that sanitize itself.
- The GC conn is a token passed between the mutator and the collector thread; `heap.stopIfNecessary()` sanitizes only while the mutator holds it, and a synchronous collection hands it to the collector.
- `us_loop_run_bun_tick` (epoll/kqueue) and `us_loop_run` / `us_loop_pump` (libuv on Windows) are the per-tick entry points of the JS thread's usockets loop; `Bun__JSC_onBeforeWait` is called from them only when the tick is about to block.

<details>
<summary>Original description</summary>

### What

Objects that are already unreachable keep surviving `Bun.gc(true)` for many event loop turns when the loop is being driven by `setImmediate`, while the same loop driven by `setTimeout(0)` collects them on the first GC. GC/leak tests that poll with `Bun.gc(true); await new Promise(r => setImmediate(r))` converge very slowly or look like leaks (that is how this was found, while writing a `Bun.serve` leak test; the `Bun.gc(false); await setImmediate` preludes in `bun-server.test.ts` and the deletion of `test-fs-filehandle.js` in #35356 are the same thing).

```ts
const yieldVia = kind => new Promise(r => kind === "timeout" ? setTimeout(r, 0) : setImmediate(r));
const refs = [];
async function makeGarbage() {
  const list = [];
  for (let i = 0; i < 2; i++) {
    const o = { i }; list.push(o); refs.push(new WeakRef(o));
    await yieldVia(process.argv[2]);
  }
  await Promise.all(list.map(o => Promise.resolve(o.i)));
}
await makeGarbage();
let gcs = 0;
do { await yieldVia(process.argv[3]); Bun.gc(true); gcs++; }
while (gcs < 60 && refs.some(r => r.deref()));
console.log(`loop via ${process.argv[3]}: collected after ${gcs} GCs`);
```

On main (Linux x64, release and debug), any combination where the GC loop yields via `setImmediate` takes 17 GCs (sometimes 8, once 51); yielding via `setTimeout` takes 1. The 17 does not move with wall time (busy-waiting 20 ms per iteration leaves it at 17); it lines up with the module's code block reaching its baseline JIT threshold at that point, after which the changed stack traffic happens to overwrite the slot.

### Cause

`Bun.generateHeapSnapshot()` shows the two objects held by `list`, held by the finished async function's `AsyncFunctionGenerator`, which has no retainer at all. Scanning the machine stack at every `gatherFromCurrentThread` in a debug build finds exactly one word equal to that generator's address, at the same address for all 17 collections, and it is gone on the collection that finally frees them. Walking the frame chain puts that word inside the frame of JSC's `runInternalMicrotask`: the `AsyncFunctionResume` case wrote the generator into one of its locals while resuming `makeGarbage` in an earlier turn; every later turn runs the module continuation (`AsyncModuleExecutionResume`) through the same native path, so the same frame lands at the same address, that local belongs to a switch arm that is not taken, and the conservative scan of the live frame sees the stale value on every `Bun.gc(true)`.

JSC relies on the embedder to clean this up between turns. Its own `sanitizeStackForVM` calls (allocation slow paths, `llint_default_call` / `operationDefaultCall`, `Heap::runCurrentPhase`) zero the stack between the last sanitize point and the current stack pointer, and all of them run inside JS, below the frames that hold a turn's values, so none of them can ever reach this region. In WebKit the task boundary does it: releasing the JSLock releases heap access, which relinquishes the GC conn, which sanitizes at the shallow depth of the run loop. Bun holds the lock and heap access for the life of the thread, and instead calls `heap.stopIfNecessary()` from `Bun__JSC_onBeforeWait`, which sanitizes as a side effect while the mutator holds the conn. That covers less than it looks like, in two ways:

1. Since #26821 the POSIX tick only calls the hook when it is about to park. A loop kept busy by `setImmediate` (or by anything else that is always ready) never parks, so nothing shallow ever sanitizes. This is the case above. Two experiments pin it down: `BUN_GC_RUNS_UNTIL_SKIP_RELEASE_ACCESS=0`, which only disables that `stopIfNecessary()` call, makes the `setTimeout`-driven loop take exactly 17 GCs as well; and tracing `sanitizeStackForVM` in the failing case shows every call between collections happening at least 0x4500 bytes below the event loop frame while the stale slot sits 0x31f0 below it.
2. `stopIfNecessary()` only sanitizes while the mutator holds the conn, and a synchronous collection (`Bun.gc(true)`, `collectSync`) hands it back in `Heap::waitForCollector`. So after the first sync GC the hook stops sanitizing even on parking ticks, until some asynchronous collection takes the conn again. This is what #35356 hit on Windows, where the hook does run on every `us_loop_run` (its notes record that an explicit `sanitizeStackForVM` at the hook made the test pass).

REVIEW.md's rule that this is never the scanner's fault holds here: the scanner is doing what it is documented to do, and the missing piece is Bun's, the sanitize between turns that every other embedder gets from its lock/access cycle.

### Fix

Add `Bun__JSC_onLoopTick`, which calls `JSC::sanitizeStackForVM` once per tick, and call it from `us_loop_run_bun_tick` (POSIX, before the `num_polls` early-out) and from `us_loop_run` and `us_loop_pump` (Windows), whether or not the tick parks. `Bun__JSC_onBeforeWait` and #26821's zero-timeout poll are unchanged: `stopIfNecessary()` and the idle sweep still only run on ticks that park.

Cost: `sanitizeStackForVMImpl` compares the saved low-water mark against the stack pointer and returns when nothing ran deeper since the previous tick; otherwise it zero-fills the stack the turn actually used and records the new mark, after which JSC's own in-turn sanitizes zero nothing until the stack is deeper again, so the zeroing moves to the tick boundary rather than being added. With `BUN_JSC_verboseSanitizeStack=1` on a 50-turn `setImmediate` chain (debug build), the hook ran 48 times and zeroed anything on 8 of them.

After this, anything dropped by a turn is gone by the GC that follows the next tick. The one case that takes two collections is garbage dropped in the timers phase being collected from the following tick's immediates phase, which runs before that tick's poll; after that GC the stack is sanitized down to the collector's own depth, so the collection after the next tick cannot see it. Measured (Linux debug, 15 to 20 runs per cell, identical values in every run; the same values on Windows): garbage made across `setImmediate` or `setTimeout` turns, loop via `setImmediate`: 1 and 2 GCs; loop via `setTimeout`: 1 and 1. The original reproduction goes from 8 to 17 iterations to 1.

### Tests

- `test/js/web/timers/timer-gc-roots.test.ts`: the 2x2 matrix above, asserting collection within 2 GCs. On main the two `setImmediate`-loop cells fail deterministically (both objects still alive after 8 GCs; 5/5 runs on release, 3/3 on debug+ASAN); the two `setTimeout` cells pass on main and document that both primitives now behave the same.
- `test/js/node/test/parallel/test-fs-filehandle.js` is restored unchanged from before #35356, which deleted it because of this; it passes on Linux and Windows here. The `Bun.gc(false); await setImmediate` preludes #35356 added to four drain loops in `bun-server.test.ts` are no longer needed for the same reason, but are left alone in this PR.
- Ran the timers, workers, node timers, `test/js/bun/gc` and `serve-body-leak` suites on Linux debug; the only failures are the same ones the unmodified tree has in this container (the `setTimeout`/`setInterval` leak fixtures, which key their ASAN threshold off the binary name, and four slow-machine timeouts in `worker.test.ts`). Built and ran the new test, the restored test and the reproduction on Windows x64.

</details>
