### PR TITLE
ipc: read a sent handle's descriptor when its message is written, not at send()

### DIFF
--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -664,10 +664,7 @@ pub(crate) fn get_nack_packet(mode: Mode) -> &'static [u8] {
 pub type Socket = bun_uws::SocketHandler<false>;
 
 pub struct Handle {
-    pub fd: Fd,
-    pub js: Protected,
-    pub close_on_complete: bool,
-    pub owns_fd: bool,
+    source: HandleSource,
     pub cluster_seq: Option<i32>,
     #[cfg(windows)]
     pub win_export_hex: Option<Box<[u8]>>,
@@ -675,56 +672,111 @@ pub struct Handle {
     pub peer_pid: u32,
 }
 
+enum HandleSource {
+    /// A cluster handle. The cluster layer hands over a bare descriptor number
+    /// that it may close (and the kernel reuse) while the message is still
+    /// queued, so the descriptor is pinned at send time: on POSIX this is a
+    /// dup(2) owned here, on Windows the message carries the export made at
+    /// send time and the number is only needed to export again on a NACK retry.
+    Raw(Fd),
+    /// The native object behind the `net.Server` / `net.Socket` /
+    /// `dgram.Socket` passed to `send()`. It keeps its descriptor open, so the
+    /// descriptor is read from it when the message reaches the wire, as node
+    /// does: queued messages cost the sender no descriptors, and an object
+    /// closed while queued is never shipped as a recycled number. In that case
+    /// `without_handle`, the message serialized without the NODE_HANDLE
+    /// envelope, is written instead (node delivers the same thing).
+    Native {
+        js: Protected,
+        close_on_complete: bool,
+        without_handle: StreamBuffer,
+    },
+}
+
+/// What goes out with the first byte of a handle message.
+pub(crate) enum HandleWire {
+    Fd(Fd),
+    /// The handle is gone; these bytes replace the message, which then goes
+    /// out (and completes) like a message that never had a handle.
+    WithoutHandle(StreamBuffer),
+}
+
 impl Handle {
-    pub fn init(fd: Fd, js: JSValue) -> Self {
-        Self {
-            fd,
-            js: js.protected(),
-            close_on_complete: false,
-            owns_fd: false,
-            cluster_seq: None,
-            #[cfg(windows)]
-            win_export_hex: None,
-            #[cfg(windows)]
-            peer_pid: 0,
-        }
-    }
-
-    pub fn init_close_on_complete(fd: Fd, js: JSValue) -> Self {
-        Self {
-            fd,
-            js: js.protected(),
-            close_on_complete: true,
-            owns_fd: false,
-            cluster_seq: None,
-            #[cfg(windows)]
-            win_export_hex: None,
-            #[cfg(windows)]
-            peer_pid: 0,
-        }
-    }
-
-    pub fn init_dup(fd: Fd, js: JSValue, close_on_complete: bool) -> Result<Self, bun_sys::Error> {
-        let wire_fd = bun_sys::dup(fd)?;
-        Ok(Self {
-            fd: wire_fd,
+    pub fn native(js: JSValue, close_on_complete: bool, without_handle: StreamBuffer) -> Self {
+        Self::new(HandleSource::Native {
             js: js.protected(),
             close_on_complete,
-            owns_fd: true,
+            without_handle,
+        })
+    }
+
+    #[cfg(not(windows))]
+    pub fn dup_raw(fd: Fd) -> Result<Self, bun_sys::Error> {
+        Ok(Self::new(HandleSource::Raw(bun_sys::dup(fd)?)))
+    }
+
+    #[cfg(windows)]
+    pub fn raw(fd: Fd) -> Self {
+        Self::new(HandleSource::Raw(fd))
+    }
+
+    fn new(source: HandleSource) -> Self {
+        Self {
+            source,
             cluster_seq: None,
             #[cfg(windows)]
             win_export_hex: None,
             #[cfg(windows)]
             peer_pid: 0,
-        })
+        }
+    }
+
+    pub(crate) fn take_for_wire(&mut self) -> HandleWire {
+        match &mut self.source {
+            HandleSource::Raw(fd) => HandleWire::Fd(*fd),
+            HandleSource::Native {
+                js, without_handle, ..
+            } => match crate::ipc_host::native_handle_fd(js.value()) {
+                Some(fd) => HandleWire::Fd(fd),
+                None => HandleWire::WithoutHandle(core::mem::take(without_handle)),
+            },
+        }
+    }
+
+    /// The descriptor to export again for a retry; `None` once a native object
+    /// has been closed (the retry then goes out without the handle).
+    #[cfg(windows)]
+    fn current_fd(&self) -> Option<Fd> {
+        match &self.source {
+            HandleSource::Raw(fd) => Some(*fd),
+            HandleSource::Native { js, .. } => crate::ipc_host::native_handle_fd(js.value()),
+        }
+    }
+
+    /// node's postSend: the sender's copy of a `net.Socket` sent without
+    /// `keepOpen` is closed once the message is done with.
+    fn close_detached_socket(&self, global: &JSGlobalObject) {
+        let HandleSource::Native {
+            js,
+            close_on_complete: true,
+            ..
+        } = &self.source
+        else {
+            return;
+        };
+        let js = js.value();
+        if js.is_object() {
+            let _ = JSValue::call_next_tick_1(close_sent_handle_fn(global), global, js);
+        }
     }
 }
 
+#[cfg(not(windows))]
 impl Drop for Handle {
     fn drop(&mut self) {
-        if self.owns_fd {
-            // Owned dup/received descriptors may legitimately be 0-2 (stdio closed); close them regardless.
-            let _ = self.fd.close_allowing_standard_io(None);
+        if let HandleSource::Raw(fd) = &self.source {
+            // The dup may legitimately have landed on 0-2 (stdio closed); close it regardless.
+            let _ = fd.close_allowing_standard_io(None);
         }
     }
 }
@@ -810,12 +862,7 @@ impl SendHandle {
     /// Call the callback and deinit
     pub(crate) fn complete(mut self, global: &JSGlobalObject) {
         if let Some(handle) = &self.handle {
-            if handle.close_on_complete {
-                let js = handle.js.value();
-                if js.is_object() {
-                    let _ = JSValue::call_next_tick_1(close_sent_handle_fn(global), global, js);
-                }
-            }
+            handle.close_detached_socket(global);
         }
         let _ = self.callbacks.call_next_tick(global); // TODO: properly propagate exception upwards
         // self drops here → data/callbacks/handle Drop.
@@ -823,12 +870,7 @@ impl SendHandle {
 
     pub fn abort_unsent(self, global: &JSGlobalObject) {
         if let Some(handle) = &self.handle {
-            if handle.close_on_complete {
-                let js = handle.js.value();
-                if js.is_object() {
-                    let _ = JSValue::call_next_tick_1(close_sent_handle_fn(global), global, js);
-                }
-            }
+            handle.close_detached_socket(global);
         }
     }
 }
@@ -1378,9 +1420,9 @@ impl SendQueue {
                             let handle = item.handle.as_mut().unwrap();
                             if handle.peer_pid != 0 {
                                 if let Some(old_hex) = handle.win_export_hex.take() {
-                                    if let Some(new_hex) =
-                                        windows_export_socket_hex(handle.fd, handle.peer_pid)
-                                    {
+                                    if let Some(new_hex) = handle.current_fd().and_then(|fd| {
+                                        windows_export_socket_hex(fd, handle.peer_pid)
+                                    }) {
                                         if let Some(pos) =
                                             bun_core::memmem(&item.data.list, &old_hex)
                                         {
@@ -1494,7 +1536,7 @@ impl SendQueue {
         }
         let waiting_for_ack = self.waiting_for_ack.get().is_some();
         let next = self.queue.with_mut(|queue| {
-            let Some(first) = queue.first() else {
+            let Some(first) = queue.first_mut() else {
                 return Next::Nothing; // nothing to send
             };
             if waiting_for_ack && !first.is_ack_nack() {
@@ -1506,16 +1548,28 @@ impl SendQueue {
                 // the last message isn't fully sent yet, we're waiting for a writable event
                 return Next::Nothing;
             }
+            // The descriptor rides along with the first byte of the message (a partial write has sent it).
+            let wire = if first.data.cursor == 0 {
+                first.handle.as_mut().map(Handle::take_for_wire)
+            } else {
+                None
+            };
+            let fd = match wire {
+                None => None,
+                Some(HandleWire::Fd(fd)) => Some(fd),
+                Some(HandleWire::WithoutHandle(data)) => {
+                    log!("handle closed while queued; sending the message without it");
+                    first.data = data;
+                    first.handle = None;
+                    None
+                }
+            };
             let to_send_len = first.data.list.len() - first.data.cursor;
             if to_send_len == 0 {
                 // item's length is 0, remove it and continue sending. this should rarely (never?) happen.
                 return Next::EmptyItem(queue.remove(0));
             }
-            Next::Send(if first.data.cursor == 0 {
-                first.handle.as_ref().map(|h| h.fd)
-            } else {
-                None
-            })
+            Next::Send(fd)
         });
         match next {
             Next::Nothing => {

--- a/src/runtime/ipc_host.rs
+++ b/src/runtime/ipc_host.rs
@@ -7,6 +7,7 @@ use crate::ipc::{
     self as IPC, DecodedIPCMessage, Handle, IsInternal, SendQueue, SerializeAndSendResult,
 };
 use bun_core::String as BunString;
+use bun_io::StreamBuffer;
 use bun_jsc::{CallFrame, JSGlobalObject, JSValue, JsClass, JsResult};
 
 use crate::api::bun::subprocess::Subprocess;
@@ -164,76 +165,6 @@ pub(crate) fn do_send(
         }
     }
 
-    let mut zig_handle: Option<Handle> = None;
-    let mut pause_target = JSValue::UNDEFINED;
-    #[cfg_attr(windows, allow(unused_mut, unused_variables))]
-    let mut dup_err: Option<bun_sys::Error> = None;
-    if !handle.is_undefined_or_null() {
-        if let Some(listener) = Listener::from_js(handle) {
-            log!("got listener");
-            // SAFETY: from_js returned a non-null `*mut Listener`; the JS
-            // wrapper holds it alive for the call.
-            match unsafe { (*listener).listener.get() } {
-                crate::socket::listener::ListenerType::Uws(socket_uws) => {
-                    // may need to handle ssl case
-                    // SAFETY: `socket_uws` is a live non-null `*mut ListenSocket`
-                    // owned by uSockets; `get_socket` only reinterpret-casts to
-                    // `&mut us_socket_t` and `get_fd` is a read-only FFI call.
-                    let fd = unsafe { &mut *socket_uws }.get_socket().get_fd();
-                    #[cfg(not(windows))]
-                    match Handle::init_dup(fd, handle, false) {
-                        Ok(h) => zig_handle = Some(h),
-                        Err(e) => dup_err = Some(e),
-                    }
-                    #[cfg(windows)]
-                    {
-                        zig_handle = Some(Handle::init(fd, handle));
-                    }
-                }
-                crate::socket::listener::ListenerType::NamedPipe(_named_pipe) => {}
-                crate::socket::listener::ListenerType::None => {}
-            }
-        } else if let Some(socket) = crate::socket::TCPSocket::from_js(handle) {
-            // SAFETY: from_js returned a non-null pointer; the JS wrapper
-            let fd = unsafe { (*socket).socket.get().fd() };
-            if fd != bun_sys::Fd::INVALID {
-                log!("got tcp socket fd");
-                let keep_open = !options_.is_undefined_or_null()
-                    && options_
-                        .get(global_object, "keepOpen")?
-                        .is_some_and(|v| v.to_boolean());
-                if !keep_open {
-                    pause_target = handle;
-                }
-                #[cfg(not(windows))]
-                match Handle::init_dup(fd, handle, !keep_open) {
-                    Ok(h) => zig_handle = Some(h),
-                    Err(e) => dup_err = Some(e),
-                }
-                #[cfg(windows)]
-                {
-                    zig_handle = Some(if keep_open {
-                        Handle::init(fd, handle)
-                    } else {
-                        Handle::init_close_on_complete(fd, handle)
-                    });
-                }
-            }
-        } else if let Some(udp) = handle.as_class_ref::<crate::socket::UDPSocket>() {
-            if let Some(fd) = udp.native_fd() {
-                log!("got udp socket fd");
-                #[cfg(not(windows))]
-                match Handle::init_dup(fd, handle, false) {
-                    Ok(h) => zig_handle = Some(h),
-                    Err(e) => dup_err = Some(e),
-                }
-                #[cfg(windows)]
-                {
-                    zig_handle = Some(Handle::init(fd, handle));
-                }
-            }
-        }
-    }
     // serialize() already detached a non-keepOpen net.Socket; if it is not sent after all, close it here (node: postSend on error).
     let close_detached = |global_object: &JSGlobalObject, target: JSValue| {
         if target.is_object() {
@@ -249,21 +180,50 @@ pub(crate) fn do_send(
         }
     };
 
-    #[cfg(not(windows))]
-    if let Some(e) = dup_err {
-        use bun_jsc::SysErrorJsc as _;
-        close_detached(global_object, pause_target);
-        return do_send_err(global_object, callback, e.to_js(global_object), from);
-    }
-
-    #[cfg(windows)]
-    if let Some(h) = &mut zig_handle {
-        match attach_windows_socket_payload(global_object, message, h.fd, peer_pid) {
-            Some(hex) => {
-                h.win_export_hex = Some(hex);
-                h.peer_pid = peer_pid;
+    let mut zig_handle: Option<Handle> = None;
+    let mut pause_target = JSValue::UNDEFINED;
+    if let Some(fd) = native_handle_fd(handle) {
+        log!("sending handle {:?}", fd);
+        let mut close_on_complete = false;
+        if handle.as_class_ref::<crate::socket::TCPSocket>().is_some() {
+            let keep_open = !options_.is_undefined_or_null()
+                && options_
+                    .get(global_object, "keepOpen")?
+                    .is_some_and(|v| v.to_boolean());
+            if !keep_open {
+                pause_target = handle;
+                close_on_complete = true;
             }
-            None => zig_handle = None,
+        }
+        // The handle is read again when the message is actually written; if it
+        // was closed by then the message goes out on its own, so that form of
+        // it is serialized up front (node serializes at write time instead).
+        let mut without_handle = StreamBuffer::default();
+        if IPC::serialize(
+            ipc_data.mode,
+            &mut without_handle,
+            global_object,
+            original_message,
+            is_internal,
+        )
+        .is_err()
+        {
+            close_detached(global_object, pause_target);
+            return send_failed(global_object, callback, from);
+        }
+        #[cfg(windows)]
+        {
+            zig_handle =
+                attach_windows_socket_payload(global_object, message, fd, peer_pid).map(|hex| {
+                    let mut h = Handle::native(handle, close_on_complete, without_handle);
+                    h.win_export_hex = Some(hex);
+                    h.peer_pid = peer_pid;
+                    h
+                });
+        }
+        #[cfg(not(windows))]
+        {
+            zig_handle = Some(Handle::native(handle, close_on_complete, without_handle));
         }
     }
     if zig_handle.is_none() {
@@ -292,13 +252,7 @@ pub(crate) fn do_send(
 
     if status == SerializeAndSendResult::Failure {
         close_detached(global_object, pause_target);
-        let ex = global_object.create_type_error_instance(format_args!("process.send() failed"));
-        ex.put(
-            global_object,
-            b"syscall",
-            bun_jsc::bun_string_jsc::to_js(&BunString::static_(b"write"), global_object)?,
-        );
-        return do_send_err(global_object, callback, ex, from);
+        return send_failed(global_object, callback, from);
     }
 
     // in the success or backoff case, serializeAndSend will handle calling the callback
@@ -307,6 +261,36 @@ pub(crate) fn do_send(
     } else {
         JSValue::FALSE
     })
+}
+
+fn send_failed(
+    global_object: &JSGlobalObject,
+    callback: JSValue,
+    from: FromEnum,
+) -> JsResult<JSValue> {
+    let ex = global_object.create_type_error_instance(format_args!("process.send() failed"));
+    ex.put(
+        global_object,
+        b"syscall",
+        bun_jsc::bun_string_jsc::to_js(&BunString::static_(b"write"), global_object)?,
+    );
+    do_send_err(global_object, callback, ex, from)
+}
+
+/// The descriptor currently behind the native object `Ipc.ts`'s `serialize()`
+/// picked out of a `net.Server`, `net.Socket` or `dgram.Socket`; `None` once
+/// it has been closed (or for anything else).
+pub(crate) fn native_handle_fd(handle: JSValue) -> Option<bun_sys::Fd> {
+    if let Some(listener) = handle.as_class_ref::<Listener>() {
+        return listener.native_fd();
+    }
+    if let Some(socket) = handle.as_class_ref::<crate::socket::TCPSocket>() {
+        let fd = socket.socket.get().fd();
+        return (fd != bun_sys::Fd::INVALID).then_some(fd);
+    }
+    handle
+        .as_class_ref::<crate::socket::UDPSocket>()?
+        .native_fd()
 }
 
 #[bun_jsc::host_fn]

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -124,14 +124,14 @@ pub(crate) fn send_helper_primary(global: &JSGlobalObject, frame: &CallFrame) ->
             ) else {
                 return Ok(JSValue::NULL);
             };
-            let mut h = crate::ipc::Handle::init(native_fd, handle);
+            let mut h = crate::ipc::Handle::raw(native_fd);
             h.win_export_hex = Some(hex);
             h.peer_pid = peer_pid;
             native_handle = Some(h);
         }
         #[cfg(not(windows))]
         {
-            native_handle = match crate::ipc::Handle::init_dup(native_fd, handle, false) {
+            native_handle = match crate::ipc::Handle::dup_raw(native_fd) {
                 Ok(h) => Some(h),
                 Err(_) => return Ok(JSValue::NULL),
             };

--- a/src/runtime/socket/Listener.rs
+++ b/src/runtime/socket/Listener.rs
@@ -1000,20 +1000,32 @@ impl Listener {
         JSValue::js_number(*port as f64)
     }
 
+    /// The listening socket's descriptor, or `None` once closed (or for a
+    /// named pipe, which has none). IPC ships this for a `net.Server` handle.
+    pub(crate) fn native_fd(&self) -> Option<Fd> {
+        let ListenerType::Uws(uws_listener) = self.listener.get() else {
+            return None;
+        };
+        // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
+        Some(
+            bun_opaque::opaque_deref_mut(uws_listener)
+                .socket::<false>()
+                .fd(),
+        )
+    }
+
     #[bun_jsc::host_fn(getter)]
     pub(crate) fn get_fd(this: &Self, _global: &JSGlobalObject) -> JSValue {
-        match this.listener.get() {
-            ListenerType::Uws(uws_listener) => {
-                // S008: `ListenSocket` is an `opaque_ffi!` ZST — safe deref.
-                let socket = bun_opaque::opaque_deref_mut(uws_listener).socket::<false>();
+        match this.native_fd() {
+            Some(fd) => {
                 // On Windows the listening socket fd is a system-kind SOCKET
                 // handle; routing it through `.uv()` panics for anything but
                 // stdio. The sys_jsc helper branches on kind
                 // (system→u64, uv→i32, posix→i32).
                 use bun_sys_jsc::FdJsc as _;
-                socket.fd().to_js_without_making_lib_uv_owned()
+                fd.to_js_without_making_lib_uv_owned()
             }
-            _ => JSValue::js_number(-1.0),
+            None => JSValue::js_number(-1.0),
         }
     }
 

--- a/test/js/node/child_process/child_process_ipc_handle.test.ts
+++ b/test/js/node/child_process/child_process_ipc_handle.test.ts
@@ -655,4 +655,127 @@ const server = net.createServer().listen(0, '127.0.0.1', () => {
     });
     expect(exitCode).toBe(0);
   });
+
+  // Only one handle message can be in flight (the next waits for the NODE_HANDLE_ACK), so every
+  // send() after the first one here is queued. node keeps a reference to the handle object and reads
+  // its descriptor when the message is finally written; the sender's descriptor table must not grow
+  // with the backlog (it used to gain one dup(2) per queued message, held until that message's ack).
+  test.concurrent("queued handle messages hold no descriptors in the sender", async () => {
+    using dir = tempDir("ipc-handle-queued-fds", {
+      "parent.js": `
+const { fork } = require('node:child_process');
+const net = require('node:net');
+const { readdirSync } = require('node:fs');
+const COUNT = 32;
+const openDescriptors = () => readdirSync('/dev/fd').length;
+const child = fork('child.js');
+const server = net.createServer();
+server.listen(0, '127.0.0.1', () => {
+  const before = openDescriptors();
+  let lastSendReturned;
+  for (let i = 0; i < COUNT; i++) lastSendReturned = child.send({ count: COUNT }, server);
+  const descriptorGrowth = openDescriptors() - before;
+  child.on('message', received => {
+    console.log(JSON.stringify({ lastSendReturned, descriptorGrowth, received }));
+    child.kill();
+    process.exit(0);
+  });
+});
+`,
+      "child.js": `
+const net = require('node:net');
+let servers = 0;
+process.on('message', (m, handle) => {
+  if (!(handle instanceof net.Server)) return process.send({ error: 'message ' + servers + ' arrived with ' + typeof handle });
+  handle.close();
+  if (++servers === m.count) process.send({ servers });
+});
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+      out: { lastSendReturned: false, descriptorGrowth: 0, received: { servers: 32 } },
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  // node reads the handle when the message is written, not when send() is called: a handle that was
+  // closed while its message sat in the queue is dropped and the message is delivered on its own
+  // (its callback still succeeds). https://github.com/nodejs/node/blob/v26.3.0/lib/internal/child_process.js
+  test.concurrent("a handle closed while its message is queued is delivered as a plain message", async () => {
+    using dir = tempDir("ipc-handle-closed-while-queued", {
+      "parent.js": `
+const { fork } = require('node:child_process');
+const net = require('node:net');
+const dgram = require('node:dgram');
+const child = fork('child.js');
+const callbacks = [];
+const callback = name => err => callbacks.push(name + ':' + (err === null ? 'null' : err.code));
+const accepted = [];
+const server = net.createServer(socket => {
+  accepted.push(socket);
+  if (accepted.length < 2) return;
+  const udp = dgram.createSocket('udp4');
+  udp.bind(0, '127.0.0.1', () => {
+    const sendReturned = [
+      child.send('first', accepted[0], callback('first')),
+      child.send('server', server, callback('server')),
+      child.send('socket', accepted[1], { keepOpen: true }, callback('socket')),
+      child.send('dgram', udp, callback('dgram')),
+      child.send('plain', callback('plain')),
+    ];
+    server.close();
+    accepted[1].destroy();
+    udp.close();
+    child.on('message', childGot => {
+      console.log(JSON.stringify({ sendReturned, callbacks, childGot }));
+      child.kill();
+      process.exit(0);
+    });
+  });
+});
+server.listen(0, '127.0.0.1', () => {
+  for (let i = 0; i < 2; i++) net.connect(server.address().port, '127.0.0.1').on('error', () => {});
+});
+`,
+      "child.js": `
+const net = require('node:net');
+const dgram = require('node:dgram');
+const got = [];
+process.on('message', (m, handle) => {
+  let kind = typeof handle;
+  if (handle instanceof net.Server) { kind = 'net.Server'; handle.close(); }
+  else if (handle instanceof net.Socket) { kind = 'net.Socket'; handle.destroy(); }
+  else if (handle instanceof dgram.Socket) { kind = 'dgram.Socket'; handle.close(); }
+  got.push(m + ':' + kind);
+  if (m === 'plain') process.send(got);
+});
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "parent.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ out: JSON.parse(stdout.trim()), stderr }).toEqual({
+      out: {
+        sendReturned: [true, true, false, false, false],
+        callbacks: ["first:null", "server:null", "socket:null", "dgram:null", "plain:null"],
+        childGot: ["first:net.Socket", "server:undefined", "socket:undefined", "dgram:undefined", "plain:undefined"],
+      },
+      stderr: "",
+    });
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- `child.send(msg, handle)` / `process.send(msg, handle)` cost the sender one open descriptor per queued handle message: 32 sends of one server in a loop leave 32 extra descriptors open until they are acked. Node leaves 0. Follow-up to #31829.
- With a stalled child the parent's descriptor table grows by one per `send()`, and near `RLIMIT_NOFILE` the sends themselves fail with `EMFILE` from `dup`.
- Cause: the descriptor was duplicated when `send()` was called and held until the message completed. Node reads it only when the message is actually written.

### Fix
- A queued handle message now keeps the (already protected) server or socket object and reads its descriptor when the message reaches the head of the queue (also on a NACK retry), so a queued message holds no descriptors.
- A handle closed while queued is not shipped, since its number may have been reused: the message goes out without the handle envelope and completes like a plain message, which is what node delivers. That plain form is serialized up front so the send queue never runs JS.
- The cluster path still duplicates at send time: it is handed bare descriptor numbers that may be closed while queued, and it keeps one connection in flight per worker, so its backlog is bounded already.
- Verification: two new tests whose expected output is what node v26.3.0 prints for the same fixtures; on main the first reports `descriptorGrowth: 32` and the second receives handles. Existing IPC, cluster and vendored node handle tests were run on a debug build; Windows `cargo check` is clean.

### Background
- Handle passing: `send()` can carry a `net.Server`, `net.Socket` or `dgram.Socket`. On POSIX the descriptor rides along with the first byte of the message on the IPC socket; on Windows an export of the socket for the peer pid is embedded in the message.
- Handle messages are acked: only one is in flight and the next waits for `NODE_HANDLE_ACK`, so every `send()` after the first in a synchronous loop sits in the sender's queue. A NACK makes the sender write it again.
- A `net.Socket` sent without `keepOpen` is closed on the sender's side once its message completes, so the message already had to hold the JS object.
- Cluster: the primary forwards accepted connections to workers over the same IPC path, but hands over raw descriptor numbers rather than JS objects.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/child_process/child_process_ipc_handle.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

Follow-up to #31829. `child.send(msg, handle)` / `process.send(msg, handle)` cost the sender one descriptor per queued handle message.

### Repro

Only one handle message can be in flight (the next one waits for the `NODE_HANDLE_ACK`), so every `send()` after the first in a synchronous loop is queued:

```js
const { fork } = require("node:child_process"), net = require("node:net"), fs = require("node:fs");
const fds = () => fs.readdirSync("/dev/fd").length;
const child = fork("child.js");
net.createServer().listen(0, function () {
  const before = fds();
  for (let i = 0; i < 32; i++) child.send({ i }, this);
  console.log(fds() - before);
});
```

Before: `32` (one per queued message, released as each message is acked; with a stalled child the parent's table grows by one per `send()`, a `net.Socket` handed off costs two descriptors instead of one, and near `RLIMIT_NOFILE` the sends themselves fail with `EMFILE` from `dup`). node v26.3.0 and this branch: `0`.

### Cause

`do_send` in `src/runtime/ipc_host.rs` called `Handle::init_dup` at `send()` time (`fcntl(F_DUPFD_CLOEXEC)`), and the `Handle` owned that copy until the message completed. Node's `_handleQueue` keeps the handle object and reads its descriptor in `handleConversion[type].send` when the message is actually written.

### Fix

The `Handle` for a user handle now keeps the (already protected) native object and reads its descriptor when the message reaches the head of the queue (`Handle::take_for_wire`, also on a NACK retry), so queued messages hold no descriptors. A `net.Server` / `net.Socket` / `dgram.Socket` that was closed while its message was queued cannot be shipped (its number may have been reused), so the message is written without the `NODE_HANDLE` envelope and completes like a plain message, which is what node delivers in that situation. That form of the message is serialized up front in `do_send` (one extra serialization per handle message) so nothing in the send queue runs JS.

`Handle` is now an enum of the two sources: `Native` (user handles, both platforms) and `Raw` (the cluster path in `send_helper_primary`, unchanged: still a `dup(2)` at send time on POSIX, the `WSADuplicateSocketW` export on Windows). The cluster path is intentionally left as is: it gets bare descriptor numbers that `SharedHandle` may close while a reply is still queued, and `RoundRobinHandle` keeps one `newconn` in flight per worker, so it is bounded by its own protocol. `Listener` gains `native_fd()`, shared by the existing `fd` getter and IPC.

The "RR primary burns 2 fds per forwarded connection" consequence from the report does not apply for that reason; the amplification was specific to user-level `send()` backlogs.

### Verification

Two tests in `test/js/node/child_process/child_process_ipc_handle.test.ts`, both of whose expected output is what node v26.3.0 prints for the same fixtures:

- "queued handle messages hold no descriptors in the sender": 32 queued server sends, descriptor count unchanged, all 32 delivered. On main: `descriptorGrowth: 32`.
- "a handle closed while its message is queued is delivered as a plain message": a server closed, a `keepOpen` socket destroyed and a dgram socket closed while queued behind an un-acked socket arrive as plain messages, callbacks succeed, order preserved. On main they arrive with handles (`server:net.Server`, `socket:net.Socket`, `dgram.Socket`).

Also run with the debug build: the rest of that file, `spawn.ipc*.test.ts`, `cluster.test.ts` (two tests exceed the 5s default on this machine because three debug processes take over 5s to start here; their fixtures print the expected output), and the vendored `test-child-process-fork-net-server`, `fork-net-socket`, `send-keep-open`, `internal`, `pass-fd` (at N=8, 80 debug processes do not fit in the container), `test-cluster-net-send`, `send-handle-large-payload`, `send-socket-to-worker-http-server`, `dgram-1/2/reuse/bind-fd`, `shared-leak`, `worker-handle-close`, `rr-handle-close`, `server-restart-rr/none`, `disconnect-unshared-tcp/udp`. `cargo check` for `x86_64-pc-windows-msvc` and clippy are clean.

Sending a handle and closing the sender's copy right away still delivers it when nothing is queued (the in-flight `sendmsg` holds the reference), so #37802's fixture still receives its server on this branch.

</details>
