### PR TITLE
pretty_fmt: keep rewriting markup after an escaped `{{`

### DIFF
--- a/src/bun_core/output.rs
+++ b/src/bun_core/output.rs
@@ -1991,6 +1991,13 @@ pub fn pretty_fmt_runtime(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                 i += 1;
             }
             b'{' => {
+                // `{{` is an escaped literal brace, not the start of a
+                // placeholder: the text after it is still subject to markup.
+                if fmt.get(i + 1) == Some(&b'{') {
+                    out.extend_from_slice(b"{{");
+                    i += 2;
+                    continue;
+                }
                 while i < fmt.len() && fmt[i] != b'}' {
                     out.push(fmt[i]);
                     i += 1;
@@ -2941,6 +2948,55 @@ mod pretty_fmt_tests {
     }
 
     #[test]
+    fn markup_after_escaped_brace_is_rewritten() {
+        // `{{` is a literal brace, not the start of a spec: tags between it
+        // and the next `}` must still be converted / stripped.
+        assert_eq!(
+            pretty_fmt!(
+                "<r><green>\"{}\"<r>: {{\n  <green>\"bun\"<r>: <green>\"latest\"<r>\n}}",
+                false
+            ),
+            "\"{}\": {{\n  \"bun\": \"latest\"\n}}"
+        );
+        assert_eq!(pretty_fmt!("{{<green>x<r>}}", true), "{{\x1b[32mx\x1b[0m}}");
+        assert_eq!(pretty_fmt!("{{<green>x<r>}}", false), "{{x}}");
+        assert_eq!(pretty_fmt!("{{{{<r>", false), "{{{{");
+        // The escapes pass through untouched, so the output is still a valid
+        // `format_args!` template, including when an escape abuts a spec.
+        assert_eq!(
+            format!(pretty_fmt!("{{ <green>{s}<r> }}", false), "bun"),
+            "{ bun }"
+        );
+        assert_eq!(pretty_fmt!("<b>{{{s}}}<r>", false), "{{{}}}");
+        assert_eq!(format!(pretty_fmt!("<b>{{{s}}}<r>", false), "bun"), "{bun}");
+        // A spec after the escape is still shielded from the tag parser.
+        assert_eq!(pretty_fmt!("{{<d>{:<4}<r>}}", false), "{{{:<4}}}");
+    }
+
+    #[test]
+    fn runtime_markup_after_escaped_brace_is_rewritten() {
+        assert_eq!(
+            pretty_fmt_runtime(b"{{<green>x<r>}}", true),
+            b"{{\x1b[32mx\x1b[0m}}"
+        );
+        assert_eq!(pretty_fmt_runtime(b"{{<green>x<r>}}", false), b"{{x}}");
+        assert_eq!(
+            format!(
+                "{}",
+                super::pretty_fmt_args("{{ <green>{s}<r> }}", false, ("bun",))
+            ),
+            "{ bun }"
+        );
+        assert_eq!(
+            format!(
+                "{}",
+                super::pretty_fmt_args("{{ <green>{s}<r> }}", true, ("bun",))
+            ),
+            "{ \x1b[32mbun\x1b[0m }"
+        );
+    }
+
+    #[test]
     fn concat_and_stringify_inputs() {
         assert_eq!(
             pretty_fmt!(concat!("<r><d>[", stringify!(http), "]<r> "), true),
@@ -3008,5 +3064,7 @@ mod pretty_fmt_tests {
         check!(
             "  <b><blue>link<r>      <d>[\\<package\\>]<r>          Register or link a local npm package\n"
         );
+        check!("<r><green>\"{}\"<r>: {{\n  <green>\"bun\"<r>: <green>\"latest\"<r>\n}}");
+        check!("{{{{<r>{{<d>{:<4}<r>}}");
     }
 }

--- a/src/bun_core_macros/lib.rs
+++ b/src/bun_core_macros/lib.rs
@@ -114,6 +114,13 @@ fn rewrite(fmt: &str, is_enabled: bool) -> Result<String, String> {
                 i += 1;
             }
             b'{' => {
+                // `{{` is `format_args!`'s escaped literal brace, not the start
+                // of a spec: the text after it is still subject to markup.
+                if bytes.get(i + 1) == Some(&b'{') {
+                    out.push_str("{{");
+                    i += 2;
+                    continue;
+                }
                 // copy `{ ... }` verbatim, optionally rewriting legacy specs
                 let start = i;
                 while i < bytes.len() && bytes[i] != b'}' {

--- a/src/clap_macros/lib.rs
+++ b/src/clap_macros/lib.rs
@@ -298,6 +298,11 @@ fn pretty_rewrite(fmt: &[u8], is_enabled: bool) -> Vec<u8> {
                 i += 1;
             }
             b'{' => {
+                if fmt.get(i + 1) == Some(&b'{') {
+                    out.extend_from_slice(b"{{");
+                    i += 2;
+                    continue;
+                }
                 while i < fmt.len() && fmt[i] != b'}' {
                     out.push(fmt[i]);
                     i += 1;

--- a/test/cli/install/__snapshots__/bun-install.test.ts.snap
+++ b/test/cli/install/__snapshots__/bun-install.test.ts.snap
@@ -14,7 +14,7 @@ exports[`should report error on invalid format for dependencies 1`] = `
                                     ^
 error: dependencies expects a map of specifiers, e.g.
   "dependencies": {
-    <green>"bun"<r>: <green>"latest"<r>
+    "bun": "latest"
   }
     at [dir]/package.json:1:33
 "
@@ -49,7 +49,7 @@ exports[`bun-install should report error on invalid format for dependencies 1`] 
                                     ^
 error: dependencies expects a map of specifiers, e.g.
   "dependencies": {
-    <green>"bun"<r>: <green>"latest"<r>
+    "bun": "latest"
   }
     at [dir]/package.json:1:33
 "

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -8,6 +8,7 @@ import {
   bunEnv as env,
   isWindows,
   joinP,
+  normalizeBunSnapshot,
   readdirSorted,
   runBunInstall,
   tempDir,
@@ -4965,7 +4966,7 @@ describe.concurrent("bun-install", () => {
         `                                    ^`,
         `error: optionalDependencies expects a map of specifiers, e.g.`,
         `  "optionalDependencies": {`,
-        `    <green>"bun"<r>: <green>"latest"<r>`,
+        `    "bun": "latest"`,
         `  }`,
         `    at [dir]/package.json:1:33`,
       ]);
@@ -4973,6 +4974,52 @@ describe.concurrent("bun-install", () => {
       expect(out).toEqual(expect.stringContaining("bun install v1."));
       expect(await exited).toBe(1);
     });
+  });
+
+  it("should report error on non-string specifier in dependencies", async () => {
+    using dir = tempDir("invalid-dependency-specifier", {
+      "package.json": JSON.stringify({ name: "foo", version: "0.0.1", dependencies: { bun: 1 } }),
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "1 | {"name":"foo","version":"0.0.1","dependencies":{"bun":1}}
+                                                                ^
+      error: dependencies expects a map of specifiers, e.g.
+        "dependencies": {
+          "bun": "latest"
+        }
+          at <dir>/package.json:1:55"
+    `);
+    expect(stdout).toContain("bun install v1.");
+    expect(exitCode).toBe(1);
+  });
+
+  it("should color the example in the invalid dependencies error when colors are enabled", async () => {
+    using dir = tempDir("invalid-dependencies-color", {
+      "package.json": JSON.stringify({ name: "foo", version: "0.0.1", dependencies: [] }),
+    });
+
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: { ...env, FORCE_COLOR: "1" },
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toContain(`\n    \x1b[32m"bun"\x1b[0m: \x1b[32m"latest"\x1b[0m\n`);
+    expect(stderr).not.toContain("<green>");
+    expect(exitCode).toBe(1);
   });
 
   test.serial("should report error on invalid format for workspaces", async () => {


### PR DESCRIPTION
### Problem
- `bun install` prints raw markup in its "expects a map of specifiers" error, with colors on or off: the example line comes out as `<green>"bun"<r>: <green>"latest"<r>`.
- Same output for `optionalDependencies` and for a non-string specifier; the install snapshot was asserting the leaked text.
- Cause: the markup rewriter shields format specs by copying from a `{` to the next `}` verbatim, and it treated the `{{` escape as the start of a spec, so the example body up to its first `}` was copied through unrewritten.

### Fix
- On a doubled `{{` the rewriter emits it unchanged and keeps rewriting what follows; only a single `{` starts the verbatim copy. A lone `}` was already passed through, so `}}` needs nothing. Applied to all three copies of the rewriter.
- This is `format_args!`'s own left to right reading of the template (`{{` is a literal brace, what follows is ordinary text), so the emitted template means what the source template says.
- Of the 97 string literals under `src/` containing `{{`, only the three `Package.rs` templates change their expansion; the rest expand byte for byte as before, and the workspace still compiles.
- Verification: new unit tests for the rewriters (run under miri), plus four install tests, one with `FORCE_COLOR=1` asserting real ANSI codes, that fail against the released binary and pass with the fix.

### Background
- bun's Rust code formats user-facing text through `pretty_fmt!` templates: `<green>...<r>` style tags are rewritten into ANSI codes (colors on) or dropped (colors off), and the result becomes a `format_args!` template.
- In a `format_args!` template `{...}` is a placeholder and `{{` / `}}` are escapes for literal braces. The rewriter must leave placeholders such as `{:<16}` alone, since a `<` inside one is not a tag.
- The rewrite exists three times: a proc macro for compile-time templates, a runtime copy for templates built at runtime, and a copy in the clap macros that produces the plain form of help text. A parity test checks the macro and runtime copies agree.

<details>
<summary>Original description</summary>

### What

`bun install` prints raw markup tags in the "expects a map of specifiers" error, with colors on or off:

```
$ printf '{"name":"foo","version":"0.0.1","dependencies":[]}' > package.json && bun install
error: dependencies expects a map of specifiers, e.g.
  "dependencies": {
    <green>"bun"<r>: <green>"latest"<r>
  }
```

Same output for a non-object value (`"optionalDependencies": "bar"`) and for an object with a non-string specifier (`"dependencies": {"bun": 1}`); all three share the template in `src/install/lockfile/Package.rs`. The tags on the first line of the example (`<r><green>"{0}"<r>`) are rewritten, only the ones after the `{{` survive. `test/cli/install/__snapshots__/bun-install.test.ts.snap` and the `optionalDependencies` test were asserting the leaked output.

### Why

The templates go through `pretty_fmt!` (via `add_error_pretty!`), whose output is a `format_args!` template. The rewriter's `{` arm exists to shield format specs such as `{:<16}` from the tag parser, and it does that by copying everything from a `{` up to the next `}` verbatim. It did not know about `format_args!`'s `{{` / `}}` escapes, so for

```
<r><green>"{0}"<r>: {{\n    <green>"bun"<r>: <green>"latest"<r>\n  }}
```

the scan starting at `{{` runs to the first `}` of the closing `}}` and emits the whole example body untouched. `{{` is a literal brace in the template language the macro emits (and in the one `pretty_fmt_args` / `substitute_template` consume at runtime, which already unescape `{{`), so the text after it is ordinary text and has to be rewritten like any other text. Matching `format_args!`'s own left to right pairing (`{{` is an escape, any other `{` opens a spec) is the only interpretation under which the emitted template means the same thing as the source template. A lone `}` was already copied through, so `}}` needs no special case.

### Fix

- `src/bun_core_macros/lib.rs` (`rewrite`): on `{{`, emit `{{` and continue rewriting; only an undoubled `{` starts the verbatim spec copy.
- `src/bun_core/output.rs` (`pretty_fmt_runtime`): same change, so the runtime rewriter and the proc-macro keep producing identical output (the `macro_matches_runtime` test now covers brace escapes too).
- `src/clap_macros/lib.rs` (`pretty_rewrite`): same change. It is documented as a 1:1 copy of `pretty_fmt_runtime` and produces the plain form of a help description while `pretty_fmt_runtime` produces the colored form of the same string, so the two have to agree.

I scanned every string literal under `src/` containing `{{` (97 of them) through the old and new algorithm; the only ones whose expansion changes are the three `Package.rs` templates. The other `{{` templates that reach a pretty macro (`Timings.rs`, `unlink_command.rs`, `S3File.rs`, `S3Client.rs`, `JSBundler.rs`) have no markup after the escape and expand byte for byte as before. The workspace also still compiles, which rules out any template that had been using `{{ ... }}` to hide a literal `<...>` from the tag parser (that would now be a compile error).

### Tests

- `src/bun_core/output.rs`: `markup_after_escaped_brace_is_rewritten` and `runtime_markup_after_escaped_brace_is_rewritten` (escape followed by tags, escape abutting a spec, spec with `<` after an escape, `pretty_fmt_args` end to end), plus two brace templates in the macro/runtime parity check. `cargo miri test -p bun_core -- pretty_fmt`: 11 pass (the `bun_core` test binary does not link on its own, so miri is how these run).
- `test/cli/install/bun-install.test.ts`: updated the `dependencies` snapshot and the `optionalDependencies` expectation, added a test for the third path (object with a non-string specifier) and one with `FORCE_COLOR=1` asserting the example is rendered as `\x1b[32m"bun"\x1b[0m: \x1b[32m"latest"\x1b[0m`. The four affected tests fail against the released binary (`USE_SYSTEM_BUN=1`) and pass with `bun bd test`.

</details>
