### PR TITLE
node:fs: post the stat watcher's JS-thread hops through the watcher's own pointer

### DIFF
--- a/src/runtime/node/node_fs_stat_watcher.rs
+++ b/src/runtime/node/node_fs_stat_watcher.rs
@@ -405,7 +405,8 @@ impl StatWatcherScheduler {
 
             if time_since >= interval.saturating_sub(500) {
                 w.last_check.set(now);
-                w.restat();
+                // SAFETY: live, we hold the queue's ref on it (see above).
+                unsafe { StatWatcher::restat(watcher.as_ptr()) };
             } else {
                 closest_next_check = (interval - time_since).min(closest_next_check);
             }
@@ -664,22 +665,27 @@ impl StatWatcher {
         unsafe { VirtualMachine::event_loop_ctx(self.ctx.as_ptr()) }
     }
 
-    /// `self`'s address as `*mut Self` for `ConcurrentTask` ctx slots. The
-    /// callbacks deref it as `&*const` (shared) — see
-    /// `swap_and_call_listener_on_main_thread` etc. — so no write provenance
-    /// is required; the `*mut` spelling is purely to match the C ABI.
-    #[inline]
-    fn as_ctx_ptr(&self) -> *mut Self {
-        std::ptr::from_ref::<Self>(self).cast_mut()
-    }
-
-    /// Pool thread → JS thread: `hop` runs there and consumes one ref on
-    /// `self`. Posted from counted (embedded) pool work, so always queued; a
-    /// VM tearing down releases the ref from its queue instead of running it.
-    fn post_to_js_thread(&self, hop: StatWatcherHop) {
-        self.pending_hop.set(hop as u8);
-        let task = ConcurrentTask::create(Task::init(self.as_ctx_ptr()));
-        let bun_jsc::vm_handle::Posted::Queued = self.loop_handle.post_task(task) else {
+    /// Pool thread → JS thread: `hop` runs there and releases the ref the
+    /// caller holds for it. Posted from counted (embedded) pool work, so
+    /// always queued; a VM tearing down releases the ref from its queue
+    /// instead of running it.
+    ///
+    /// # Safety
+    /// `this` is a live watcher (the allocation's own pointer, which is what
+    /// the hop's `deref` frees through) and the caller owns one ref on it,
+    /// which the posted hop takes over. Once the task is queued the JS thread
+    /// may release that ref, so the caller must not touch `*this` afterwards
+    /// unless it holds another ref.
+    unsafe fn post_to_js_thread(this: *mut Self, hop: StatWatcherHop) {
+        // The handle is cloned out so that the post itself holds no reference
+        // into the watcher: the hop may free it before `post_task` returns.
+        // SAFETY: fn contract; both accesses end before the post.
+        let handle = unsafe {
+            (*this).pending_hop.set(hop as u8);
+            (*this).loop_handle.clone()
+        };
+        let task = ConcurrentTask::create(Task::init(this));
+        let bun_jsc::vm_handle::Posted::Queued = handle.post_task(task) else {
             unreachable!("VM handle closed with stat-watcher pool work outstanding");
         };
     }
@@ -687,7 +693,7 @@ impl StatWatcher {
     /// JS thread dispatch of a [`post_to_js_thread`](Self::post_to_js_thread) hop.
     ///
     /// # Safety
-    /// `this` is the watcher the pool posted (ref held for the hop).
+    /// `this` is the pointer the pool posted (ref held for the hop).
     pub(crate) unsafe fn run_hop(this: *mut StatWatcher) -> bun_event_loop::JsResult<()> {
         // SAFETY: fn contract.
         let hop = unsafe { (*this).pending_hop.get() };
@@ -922,17 +928,25 @@ impl StatWatcher {
         result.map(drop).map_err(Into::into)
     }
 
-    /// Called from any thread
-    fn restat(&self) {
+    /// Pool thread: re-stat the path and, if anything but atime changed, hand
+    /// the JS thread a ref to call the listener with.
+    ///
+    /// # Safety
+    /// `this` is a live watcher (the caller holds the queue's ref on it).
+    unsafe fn restat(this: *mut StatWatcher) {
         log!("recalling stat");
-        let stat = restat_impl(&self.path);
+        // BACKREF, live per fn contract. R-2: shared `&` only (the JS thread may
+        // be reading the same watcher); `ParentRef` Deref gives that `&` for the
+        // stat bookkeeping. The hand-over at the end is made through `this`.
+        let this_ref = ParentRef::from(NonNull::new(this).expect("restat: watcher"));
+        let stat = restat_impl(&this_ref.path);
         let res = match stat {
             Ok(res) => res,
             // SAFETY: all-zero is a valid PosixStat (POD #[repr(C)])
             Err(_) => bun_core::ffi::zeroed::<PosixStat>(),
         };
 
-        let last_stat = self.get_last_stat();
+        let last_stat = this_ref.get_last_stat();
 
         // Ignore atime changes when comparing stats
         // Compare field-by-field to avoid false positives from padding bytes
@@ -956,12 +970,12 @@ impl StatWatcher {
             return;
         }
 
-        self.set_last_stat(&res);
-        // R-2: derive the ctx pointer from `&self` — the callback derefs it as
-        // shared (`&*const`), so no write provenance is required.
-        let this_ptr: *mut StatWatcher = self.as_ctx_ptr();
-        Self::ref_(this_ptr);
-        self.post_to_js_thread(StatWatcherHop::Changed);
+        this_ref.set_last_stat(&res);
+        // The hop's ref; `swap_and_call_listener_on_main_thread` releases it.
+        Self::ref_(this);
+        // SAFETY: `this` is live per fn contract and the ref just taken is the
+        // hop's. The caller's queue ref keeps the watcher alive past the post.
+        unsafe { Self::post_to_js_thread(this, StatWatcherHop::Changed) };
     }
 
     /// After a restat found the file changed, this calls the listener function.
@@ -1239,12 +1253,11 @@ impl InitialStatTask {
         let this: *mut StatWatcher = self.watcher;
         // BACKREF — `this` is kept alive by the intrusive ref taken in
         // `create_and_schedule`. We only need shared access here — `closed` is
-        // read-only, `path` is borrowed, and `set_last_stat`/
-        // `enqueue_task_concurrent` take `&self` (mutation goes through
-        // `Guarded`/atomics). The main thread may concurrently run
-        // `close()`/`finalize()` after `init()` returns the watcher to JS;
-        // both also deref as shared (R-2), so aliased `&` is sound.
-        // `ParentRef` Deref gives that shared `&`.
+        // read-only, `path` is borrowed, and `set_last_stat` takes `&self`
+        // (mutation goes through `Guarded`/atomics). The main thread may
+        // concurrently run `close()`/`finalize()` after `init()` returns the
+        // watcher to JS; both also deref as shared (R-2), so aliased `&` is
+        // sound. `ParentRef` Deref gives that shared `&`.
         let this_ref = ParentRef::from(NonNull::new(this).expect("run_owned: watcher"));
         let handle = this_ref.loop_handle.clone();
         let _finished = scopeguard::guard((), |()| handle.embedded_work_finished());
@@ -1256,24 +1269,26 @@ impl InitialStatTask {
             return;
         }
 
-        let stat = restat_impl(&this_ref.path);
-        match stat {
+        let hop = match restat_impl(&this_ref.path) {
             Ok(ref res) => {
                 // we store the stat, but do not call the callback
                 this_ref.set_last_stat(res);
-                this_ref.post_to_js_thread(StatWatcherHop::InitialStatSuccess);
+                StatWatcherHop::InitialStatSuccess
             }
             Err(_) => {
                 // on enoent, eperm, we call cb with two zeroed stat objects
                 // and store previous stat as a zeroed stat object, and then call the callback.
                 // SAFETY: all-zero is a valid PosixStat (POD #[repr(C)])
                 this_ref.set_last_stat(&bun_core::ffi::zeroed::<PosixStat>());
-                this_ref.post_to_js_thread(StatWatcherHop::InitialStatError);
+                StatWatcherHop::InitialStatError
             }
-        }
-        // ref ownership transferred to main-thread callback
-        // (`initial_stat_*_on_main_thread` calls deref()). Nothing to forget —
-        // `watcher` is a raw pointer.
+        };
+        // SAFETY: `this` is live and the `create_and_schedule` ref is ours to
+        // hand over. This may be the watcher's last ref (the JS side can have
+        // closed and finalized it meanwhile), so the hop may free the watcher
+        // as soon as it is queued; nothing below touches it (`_finished` runs
+        // on the cloned handle).
+        unsafe { StatWatcher::post_to_js_thread(this, hop) };
     }
 }
 

--- a/test/internal/source-lints/ctx-ptr-publish.test.ts
+++ b/test/internal/source-lints/ctx-ptr-publish.test.ts
@@ -1,0 +1,197 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// An `as_ctx_ptr()` pointer must not be posted as a task. `as_ctx_ptr()`
+// (the inherent helpers, and `bun_ptr::AsCtxPtr`) is `ptr::from_ref(self)
+// .cast_mut()`: its contract, stated in src/ptr/lib.rs, is that the pointer
+// carries the shared provenance of the `&self` it was spelled from and that
+// whoever receives it only reads through it. A task post is the opposite kind
+// of hand-over: the thread that drains the queue owns whatever the task
+// carries, and every task arm in src/runtime/dispatch.rs writes to, releases
+// a ref on, or frees the object behind the pointer it is handed. So
+//
+//   ConcurrentTask::create(Task::init(self.as_ctx_ptr()))
+//   let this_ptr: *mut Self = self.as_ctx_ptr(); ... Task::init(this_ptr)
+//
+// hands over a pointer that cannot do what the consumer does with it:
+//
+//   - When the consumer releases the ref the task carries and it is the last
+//     one, the object is freed through a pointer derived from a shared
+//     reference. Both aliasing models reject that regardless of when it
+//     happens: Tree Borrows (what `bun run rust:miri` uses) reports
+//     "deallocation through <tag> is forbidden ... has state Frozen", Stacked
+//     Borrows "trying to retag ... for Unique permission, but that tag only
+//     grants SharedReadOnly permission", each pointing at the
+//     `from_ref(self)` inside the helper.
+//   - When it happens while the posting method is still running (the consumer
+//     thread can run the task the moment it is queued), it also deallocates
+//     memory that the method's `&self` argument, and the `&self` of whatever
+//     field the post goes through, protect for the duration of their calls;
+//     codegen marks those arguments dereferenceable for the whole call.
+//
+// `StatWatcher::post_to_js_thread(&self)` in src/runtime/node/
+// node_fs_stat_watcher.rs was the instance this was written for: both of the
+// stat watcher's pool-to-JS hops posted `self.as_ctx_ptr()`, and the hop's
+// ref is the watcher's last one whenever JS closed and collected it while the
+// stat was in flight. The pointer the consumer needs is the one the caller
+// already had before it formed `&self` (the work-pool task's field, the queue
+// entry), so the fix is to keep it: the posting function takes
+// `this: *mut Self`, finishes its own field accesses, clones the loop handle
+// out, and posts `this`. `post_to_js_thread` / `restat` there, and `post_job`
+// in src/jsc/VmHandle.rs, are the templates.
+//
+// Scope: an `as_ctx_ptr()` call, or a local bound to one in the same
+// function, as the pointer argument of the task constructors (`Task::init`,
+// `Task::new(tag, ptr)`, `ConcurrentTask::create_from`, `::from_callback`,
+// and the intrusive `.from(ptr, ..)`). A pointer spelled out of `self`
+// directly is the sibling self-receiver lints' job; the same hand-over through
+// any other helper is the same bug, convert it on sight.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// The task constructors, however the path in front is spelled (`jsc::`,
+// `bun_event_loop::ConcurrentTask::`, the `ConcurrentTaskItem` alias),
+// optionally turbofished, positioned just before their pointer argument:
+// the first argument of `Task::init` / `create_from` / `from_callback` / the
+// intrusive `.from`, the second of `Task::new(tag, ptr)` (a tag path never
+// contains a comma or a paren). `\s*` after the paren so a rustfmt-wrapped
+// argument still matches; `\b` before `Task` keeps `NapiFinalizerTask::init(`
+// and similar constructors out.
+const POINTER_SLOT = [
+  String.raw`(?:\bTask::init|\bConcurrentTask\w*::(?:create_from|from_callback)|\.from)(?:::<[^>]*>)?\(\s*`,
+  String.raw`\bTask::new\(\s*[^,()]+,\s*`,
+].join("|");
+
+// `x.as_ctx_ptr()` for any receiver (`self`, a `&Self` local, a field): the
+// helper's result has shared provenance whatever it was called on. Anchored
+// at the front only, so a trailing `.cast::<()>()` still matches.
+const CTX_PTR_CALL = String.raw`[\w.]+\.as_ctx_ptr\(\)`;
+
+const DIRECT = new RegExp(`(?:${POINTER_SLOT})(?:${CTX_PTR_CALL})`, "g");
+
+// `let this_ptr: *mut Self = self.as_ctx_ptr();` and then that local in a
+// pointer slot further down the same function, which ends at the next `fn`
+// item (a closure inside it is the same function for this purpose).
+const BINDING = new RegExp(String.raw`let\s+(?:mut\s+)?(\w+)\s*(?::[^=;]*)?=\s*${CTX_PTR_CALL}\s*;`, "g");
+const FN_ITEM = /^[ \t]*(?:pub(?:\([^)]*\))?\s+)?(?:(?:const|async|unsafe|extern\s+"[^"]*")\s+)*fn\s/m;
+
+function postOfBinding(name: string): RegExp {
+  return new RegExp(`(?:${POINTER_SLOT})${name}\\b`);
+}
+
+/** Byte offsets (into `stripped`) of every banned post in one file. */
+function findPosts(stripped: string): number[] {
+  const hits: number[] = [];
+  for (const m of stripped.matchAll(DIRECT)) hits.push(m.index);
+  for (const binding of stripped.matchAll(BINDING)) {
+    const start = binding.index + binding[0].length;
+    const rest = stripped.slice(start);
+    const fnEnd = rest.search(FN_ITEM);
+    const body = fnEnd === -1 ? rest : rest.slice(0, fnEnd);
+    const post = body.search(postOfBinding(binding[1]));
+    if (post !== -1) hits.push(start + post);
+  }
+  return hits.sort((a, b) => a - b);
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+const offenders: string[] = [];
+let scanned = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including the in-tree comments
+  // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
+  // newlines and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  for (const offset of findPosts(stripped)) {
+    offenders.push(`${source}:${lineOf(stripped, offset)}`);
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources", () => {
+  // Guards against the tracked/realpath filters above over-firing and leaving
+  // nothing to scan, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+});
+
+test("the patterns match the banned spellings and nothing else", () => {
+  const banned = [
+    // `StatWatcher::post_to_js_thread(&self)` as it was.
+    "let task = ConcurrentTask::create(Task::init(self.as_ctx_ptr()));",
+    // The other constructors, other path spellings, a turbofish, a wrapped
+    // argument, a cast after the call.
+    "let ct = jsc::ConcurrentTask::create_from(self.as_ctx_ptr());",
+    "bun_event_loop::ConcurrentTask::ConcurrentTask::from_callback(self.as_ctx_ptr(), Self::resume)",
+    "let task = ConcurrentTaskItem::create_from::<Self>(self.as_ctx_ptr());",
+    "loop_.enqueue_task(Task::init(\n    self.as_ctx_ptr(),\n));",
+    "Task::new(task_tag::StatWatcherHop, self.as_ctx_ptr().cast::<()>())",
+    "Task::new(\n    <Self as bun_event_loop::Taskable>::TAG,\n    self.as_ctx_ptr().cast(),\n)",
+    // The intrusive form.
+    "let ct = self.concurrent_task.from(self.as_ctx_ptr(), AutoDeinit::ManualDeinit);",
+    // Any receiver: the helper's result has shared provenance whatever it
+    // was called on.
+    "let ct = ConcurrentTask::create_from(this_ref.as_ctx_ptr());",
+    "Task::init(self.inner.as_ctx_ptr())",
+    // Through a local, with and without a type annotation.
+    "let this_ptr: *mut StatWatcher = self.as_ctx_ptr();\nSelf::ref_(this_ptr);\nlet task = ConcurrentTask::create(Task::init(this_ptr));",
+    "let p = self.as_ctx_ptr();\nif done {\n    return;\n}\nloop_.enqueue_task(Task::init(p));",
+    "let p = self.as_ctx_ptr();\nlet ct = self.concurrent_task.from(p, AutoDeinit::ManualDeinit);",
+    "let p = self.as_ctx_ptr();\nlet task = Task::new(Self::TAG, p.cast());",
+  ];
+  const allowed = [
+    // Posting the pointer the caller handed over is the intended shape.
+    "let task = ConcurrentTask::create(Task::init(this));",
+    "let ct = ConcurrentTask::create_from(this);",
+    "(*this).concurrent_task.from(this, AutoDeinit::ManualDeinit)",
+    "let ct = ConcurrentTask::create(Task::new(Self::TAG, holder.cast::<()>()));",
+    // `as_ctx_ptr()` in the ctx slots it is for: refcount brackets, C
+    // callback userdata, back-pointers stored in a child.
+    "let _guard = unsafe { bun_ptr::ScopedRef::adopt(self.as_ctx_ptr()) };",
+    "Self::deref(self.as_ctx_ptr());",
+    "uws_socket_set_ext(socket, self.as_ctx_ptr().cast());",
+    "let this_ptr: *mut Self = self.as_ctx_ptr();\nlet poll = UvDnsPoll::new(this_ptr, fd);",
+    "let interp_ptr: *mut Interpreter = interp.as_ctx_ptr();\nstdout_writer.set_interp(interp_ptr);",
+    // A different local is what gets posted.
+    "let p = self.as_ctx_ptr();\nregister(p);\nlet ct = ConcurrentTask::create_from(holder);",
+    // A name that merely starts with the bound one.
+    "let p = self.as_ctx_ptr();\nregister(p);\nlet ct = ConcurrentTask::create_from(ptr);",
+    // The local is posted in the next function, where it is a raw-pointer
+    // parameter of the same name.
+    "let this_ptr = self.as_ctx_ptr();\nregister(this_ptr);\n}\n\nunsafe fn resume(this_ptr: *mut Self) {\n    let ct = ConcurrentTask::create_from(this_ptr);\n}",
+    // Constructors whose names merely end in `Task`, and path calls to `from`.
+    "NapiFinalizerTask::init(self.as_ctx_ptr());",
+    "let s = String::from(self.as_ctx_ptr() as usize);",
+  ];
+  expect(banned.map(s => findPosts(s).length)).toEqual(banned.map(() => 1));
+  expect(allowed.map(s => findPosts(s).length)).toEqual(allowed.map(() => 0));
+});
+
+test("no as_ctx_ptr() pointer is posted as a task", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- Nothing breaks for users today. This is a latent soundness bug in `fs.watchFile`, same class as #37723 and #37703, reduced with Miri rather than observed.
- Both pool-to-JS hops (initial stat, periodic change) posted a pointer spelled from `&self`; the scheduler's queue entries were copies of it. When the ref released through it is the last one (JS closed and collected the watcher during the initial stat), the watcher is freed through a shared-reference-derived pointer.
- Miri rejects that under both aliasing models: `deallocation through <tag> ... is forbidden` (Tree Borrows), `trying to retag ... for Unique permission` (Stacked Borrows).
- The JS thread may run a hop the moment it is queued, so the free can also land while the posting method's `&self`, and the `&loop_handle` it posted through, are still live call arguments. That is UB on its own.

### Fix
- Both posting functions take the watcher's raw pointer instead of `&self`. The callers already hold it (the work-pool task's field, the scheduler's queue entry), and that pointer is what gets posted. The `&self`-to-pointer helper is deleted with its last users.
- The poster finishes its field accesses and clones the loop handle out before posting, so once the task is queued nothing in the poster refers into the watcher, and every ref release in the file goes through the allocation's own pointer. Refs are taken and released at the same points and on the same threads as before.
- Verification is structural: a new source lint fails on the previous version of the file and has no other hits in the tree. No behavioural test, ASAN included, can tell the two pointers apart. Miri reductions of both shapes run clean after the change; the watchFile tests and the related Node tests pass; clippy is clean.

### Background
- `fs.watchFile` in bun is a `StatWatcher`: a work-pool thread stats the path on an interval and hands the JS thread a "hop" (a task carrying a pointer to the watcher) to run the listener. The watcher is intrusively refcounted; each hop carries one ref, released on the JS thread, and the last release frees it.
- Pointer provenance: a raw pointer made from `&T` may only be used to read. Freeing through it is UB under both of Rust's aliasing models even if nothing ever races with it, and Miri reports it. See "Pointer provenance at FFI boundaries" in src/CLAUDE.md.
- Reference arguments are also protected for the whole call (codegen marks them `dereferenceable`), so another thread freeing the pointee before the call returns is UB even if the callee never touches it again. Cloning the loop handle out and posting through the clone is the existing pattern for this (`post_job` in VmHandle.rs).
- `as_ctx_ptr()` is bun's helper for the read-only case (`from_ref(self).cast_mut()` for ctx slots), so posting its result as a task is wrong by definition. That is the rule the new lint encodes.
- `test/internal/source-lints/` holds tests that grep the tree for banned spellings; they stand in for a regression test where no runtime test can observe the bug.

<details>
<summary>Original description</summary>

### Problem

`StatWatcher::post_to_js_thread(&self)` in `src/runtime/node/node_fs_stat_watcher.rs` queued the pool-to-JS hop as

```rust
let task = ConcurrentTask::create(Task::init(self.as_ctx_ptr()));   // as_ctx_ptr = ptr::from_ref(self).cast_mut()
let Posted::Queued = self.loop_handle.post_task(task) else { ... };
```

The JS thread runs the hop (`run_hop`, or `release_unrun` when the VM is torn down first) and releases the ref the hop carries through that pointer: `WatcherRefGuard` / `release_hop` end in `ThreadSafeRefCount::deref(this)`, whose zero path is `deinit(this)` -> `heap::take(this)`. Two things are wrong with the pointer it was given:

* It has the provenance of the `&self` it was spelled from. When the hop's ref is the last one, the watcher is freed through a shared-reference-derived pointer, which both aliasing models reject regardless of when the free happens (src/CLAUDE.md, "Pointer provenance at FFI boundaries"). The hop's ref is the last one whenever JS closes and collects the watcher while the initial stat is in flight: `InitialStatTask::run_owned` hands the `create_and_schedule` ref to the hop, and `finalize` may already have dropped the wrapper's ref.
* On that path the free can also happen while `post_to_js_thread`'s `&self`, and the `&self.loop_handle` that `post_task` was called on, are still live arguments: the JS thread can run the task as soon as it is pushed, before `post_task` returns. Reference arguments are protected for the duration of their call (and annotated `dereferenceable` for it), so deallocating what they point at during the call is UB even though nothing reads them afterwards.

The periodic path had the first problem too: `restat(&self)` took the hop's ref on `self.as_ctx_ptr()` and posted through the same function. And because `initial_stat_*_on_main_thread` pass the posted pointer on to `StatWatcherScheduler::append`, the scheduler's queue entries carried the same provenance, so the queue's own releases in `work_pool_callback` and `shutdown_for_exit` (which can also be the last ref) went through it as well.

Nothing in the poster reads the watcher after the push today, so this is latent: a soundness bug of the same class as #37723 and #37703, reduced below with Miri. Same area as #37768 (the scheduler's `WorkPool::schedule(&raw mut self.task)` sites, different functions, no overlapping hunks) and #37591 (carries these refs as `OwnedRef` values; note that its post still goes through a `&loop_handle` inside the watcher, the second point above).

<details>
<summary>Miri reductions of the two shapes (Tree Borrows, which <code>bun run rust:miri</code> uses, and Stacked Borrows)</summary>

Initial-stat shape, `&self` method posts `self.as_ctx_ptr()`, hop releases the last ref (the consumer is invoked from inside `post_task`, one of the legal interleavings of the JS thread):

```
error: Undefined Behavior: deallocation through <462> at alloc246[0x8] is forbidden
    = help: the accessed tag <462> is a child of the conflicting tag <429>
    = help: the conflicting tag <429> has state Frozen which forbids this deallocation (acting as a child write access)
help: the conflicting tag <429> was created here, in the initial state Cell
  28 |         std::ptr::from_ref::<Self>(self).cast_mut()
   ...
             3: Watcher::deref
             4: Watcher::run_hop
             5: Handle::post_task
             6: Watcher::post_to_js_thread
```

```
error: Undefined Behavior: trying to retag from <448> for Unique permission at alloc246[0x8], but that tag only grants SharedReadOnly permission for this location
help: <448> was created by a SharedReadOnly retag at offsets [0x8..0x14]
  28 |         std::ptr::from_ref::<Self>(self).cast_mut()
```

Periodic shape, `restat(&self)` takes the hop's ref on `self.as_ctx_ptr()`, the queue ref is released on a later pass, then the hop's ref (no protector involved; the provenance alone is enough):

```
error: Undefined Behavior: deallocation through <452> at alloc242[0x8] is forbidden
    = help: the conflicting tag <416> has state Frozen which forbids this deallocation (acting as a child write access)
help: the conflicting tag <416> was created here, in the initial state Cell
  14 |         std::ptr::from_ref::<Self>(self).cast_mut()
```

The fixed shape (`post_to_js_thread(this: *mut Self)` cloning the handle out, `restat(this: *mut Self)`, both paths) runs clean under both models.
</details>

### Fix

The callers already hold the allocation's pointer: `run_owned` has it in the task's `watcher` field (it came from `heap::into_raw` in `init`), and `work_pool_callback` has the queue entry. So the two functions take it instead of forming `&self`:

* `post_to_js_thread(this: *mut Self, hop)` sets `pending_hop` and clones `loop_handle` out through `(*this)` accesses that end before the post, then posts `this` through the cloned handle. Nothing referring into the watcher is live once the task is queued, and the pointer the hop releases through is the allocation's own. This is the shape `post_job` in `src/jsc/VmHandle.rs` already uses ("clone the handle out first").
* `restat(this: *mut Self)` does its stat bookkeeping through the file's usual `ParentRef` view and takes the hop's ref on, and posts, `this`. `work_pool_callback` passes `watcher.as_ptr()`.
* `run_owned` picks the hop in the match and posts once afterwards; the `embedded_work_finished` guard already ran on a cloned handle for the same reason.
* `as_ctx_ptr` is deleted with its last two users.

Since the initial hop now carries the real pointer, `append` and the queue get it too, so every release of a watcher ref in the file goes through the allocation's pointer. Refs are taken and released at the same points and on the same threads as before.

### Test

`test/internal/source-lints/ctx-ptr-publish.test.ts` bans posting an `as_ctx_ptr()` pointer as a task, directly or via a local in the same function: `as_ctx_ptr()` is documented (`bun_ptr::AsCtxPtr`) as a shared-provenance pointer for read-only ctx slots, and a task post hands the object to a consumer that writes to, releases or frees it, so the two never go together. It fails on the previous version of this file (`src/runtime/node/node_fs_stat_watcher.rs:681`) and has no other hits in the tree, so there is no allowlist. A behavioural test cannot tell the two pointers apart (ASAN included), which is why the proof is structural, as in the sibling PRs.

### Verification

* `bun bd test test/js/node/watch/fs.watchFile.test.ts`: 10 pass, 2 skip (covers watch/unwatch, 1000-watcher stress with unwatch during initial stats, worker termination with queued hops, ENOENT initial callback, change callbacks after unwatch). `test-fs-watchfile.js`, `test-fs-watchfile-bigint.js`, `test-fs-watchfile-ref-unref.js`, `test-worker-fs-stat-watcher.js`, `test-fs-watch-file-enoent-after-deletion.js` from the Node suite exit 0 under the debug build.
* `bun test test/internal/source-lints/`: 85 pass; the new lint fails with `src/` reverted and passes with it.
* `cargo clippy -p bun_runtime --no-deps` and rustfmt are clean.

</details>
