### PR TITLE
bundler: fail the build instead of panicking when onLoad contents cannot be converted

### DIFF
--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1601,25 +1601,25 @@ pub mod js_bundler {
             }
         } else {
             let loader = api::Loader::from_raw(loader_as_int.as_int32() as u8);
-            let global = bv2_plugin(this.bv2).global_object();
-            let source_code = match crate::node::StringOrBuffer::from_js_to_owned_slice(
-                global,
+            let plugin = bv2_plugin(this.bv2);
+            this.value = match crate::node::StringOrBuffer::from_js_to_owned_slice(
+                plugin.global_object(),
                 source_code_value,
             ) {
-                Ok(s) => s,
+                Ok(source_code) => LoadValue::Success(LoadSuccess {
+                    loader: bun_ast::Loader::from_api(loader),
+                    source_code: source_code.into(),
+                }),
+                // `contents` passed the JS-side type check but converting it
+                // threw (JSC throws its Out of memory error when a rope string
+                // cannot be flattened). Answer the load with that error the way
+                // `JSBundlerPlugin__addError` does: the bundler is still waiting
+                // on this request, so it must be answered either way.
                 Err(err) => {
-                    match err {
-                        JsError::OutOfMemory => bun_core::out_of_memory(),
-                        JsError::Thrown => {}
-                        JsError::Terminated => {}
-                    }
-                    panic!("Unexpected: source_code is not a string");
+                    let exception = plugin.global_object().take_exception(err);
+                    LoadValue::Err(plugin_msg_from_js(plugin, &this.path, exception))
                 }
             };
-            this.value = LoadValue::Success(LoadSuccess {
-                loader: bun_ast::Loader::from_api(loader),
-                source_code: source_code.into(),
-            });
         }
 
         bv2_mut(this.bv2).on_load_async(this);

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -141,6 +141,28 @@ describe("bundler", () => {
       "/foo.magic": [`123`],
     },
   });
+  itBundled("plugin/LoadContentsStringConversionThrows", {
+    files: loadFixture,
+    plugins(builder) {
+      builder.onLoad({ filter: /\.magic$/ }, () => {
+        // A 16-bit rope string of the maximum length (2^31 - 1 chars). Building
+        // it only allocates rope nodes, but flattening it needs a 4GB buffer
+        // that WTF::StringImpl refuses to allocate, so the first thing to read
+        // it (the bundler, converting `contents` to bytes) gets JSC's
+        // "Out of memory" RangeError. That used to panic inside onLoadAsync.
+        let contents = "\u0100";
+        for (let i = 0; i < 30; i++) contents = contents + contents + "\u0100";
+        expect(contents.length).toBe(2 ** 31 - 1);
+        return { contents, loader: "js" };
+      });
+    },
+    bundleErrors: {
+      "/foo.magic": [`Out of memory`],
+    },
+    onAfterApiBundle(build) {
+      expect(build.success).toBe(false);
+    },
+  });
   itBundled("plugin/ResolveAndLoadDefaultExport", {
     files: {
       "index.ts": /* ts */ `


### PR DESCRIPTION
### Problem
- An onLoad plugin returning a `contents` string JSC cannot flatten (a maximum-length 16-bit rope, about 30 MB RSS) crashes the process: `panic: Unexpected: source_code is not a string`.
- No real memory pressure is involved: WTF refuses the flatten buffer, so the first reader gets JSC's ordinary, catchable `RangeError: Out of memory`.
- The load thunk treated the conversion as infallible because the JS side had already type-checked `contents`, so a throw fell through to the panic.
- On that path the load request was never answered, and the bundle thread is blocked waiting for it.

### Fix
- When converting `contents` throws, the exception is taken off the VM and reported as a load error at that file, the same path used when a plugin callback itself throws.
- Property to check: every exit of the thunk now answers the request, so the build ends with `success: false` plus the error, and a later `Bun.build` in the same process works.
- Verification: a new bundler plugin test crashes the test process on the current release and passes with this change, also under `BUN_JSC_validateExceptionChecks=1`.

### Background
- onLoad plugins: a `Bun.build` plugin can register an `onLoad` callback that supplies a file's `contents` (string or typed array) and a loader in place of the file on disk.
- The bundler runs on its own thread. Each plugin request runs on the JS thread and must be answered with a success or an error, or the bundle thread waits forever.
- Rope strings: JSC builds `a + b` as a tree of pieces without copying. The copy into one buffer happens on first read and throws when WTF will not allocate one that large. That throw is a normal JS exception, not an allocation failure in bun.
- `take_exception` moves the pending JS exception off the VM so it can be reported. A termination exception is returned but stays pending, so terminations still propagate.
- `plugin_msg_from_js` turns a JS exception into a bundler log message; it is what `JSBundlerPlugin__addError` already uses when a plugin callback throws.

<details>
<summary>Original description</summary>

### Repro

An onLoad plugin returns a `contents` string that JSC cannot flatten. A 16-bit rope of the maximum string length is enough: building it only allocates rope nodes, flattening it asks WTF for a buffer it refuses to allocate (`StringImpl::isValidLength<char16_t>` caps a few characters below `String::MaxLength`), so the first reader gets JSC's `RangeError: Out of memory`. No actual memory pressure is involved; the script peaks at about 30 MB RSS.

```ts
let contents = "\u0100";
for (let i = 0; i < 30; i++) contents = contents + contents + "\u0100"; // length 2**31 - 1

const result = await Bun.build({
  entrypoints: ["./entry.ts"],
  throw: false,
  plugins: [{ name: "huge", setup(b) { b.onLoad({ filter: /entry\.ts$/ }, () => ({ contents, loader: "js" })); } }],
});
```

Before (Bun 1.4.0 canary):

```
panic: Unexpected: source_code is not a string
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

After:

```
success: false
log: error "Out of memory" /path/to/entry.ts
```

and a following `Bun.build` in the same process works, i.e. the exception was taken off the VM.

### Cause

`JSBundlerPlugin__onLoadAsync` (`src/runtime/api/JSBundler.rs`) converts `contents` with `StringOrBuffer::from_js_to_owned_slice`. The `Err` arm handled `OutOfMemory` and let `Thrown` / `Terminated` fall through to `panic!("Unexpected: source_code is not a string")`. The message assumes the JS side's type check (`runOnLoadPlugins` in `BundlerPlugin.ts` only lets a string or a typed array through) makes the conversion infallible, but `String::from_js` on a string still fails when flattening the rope throws. The `Load` was also never answered on that arm.

### Fix

The `Err` arm now takes the pending exception (`take_exception`, which for a termination exception returns it without clearing it, same as the C++ `matchOnLoad` fallback) and turns it into a `LoadValue::Err` through `plugin_msg_from_js`, exactly what `JSBundlerPlugin__addError` does for an exception thrown by the plugin callback itself. Control then reaches `on_load_async` as on the success path, so the bundler's pending counter is decremented and the build fails with that message at the file being loaded.

Why this is the right answer rather than the panic: the bundle thread is blocked waiting for this request, so every exit of the thunk has to answer it; a plugin result whose `contents` cannot be read is a plugin error like a callback that throws, and the build already has a path for reporting those. The Out of memory error JSC throws here is an ordinary catchable exception about one oversized allocation (user code can catch it and carry on), not a process-level allocation failure, so failing the build is the proportionate response. `plugin_msg_from_js` already covers the case where the exception itself cannot be stringified and keeps a termination exception pending, which is why no new handling is needed for `Terminated`.

`JSBundlerPlugin__onResolveAsync` has `.expect(...)` calls of the same shape, but they are not what fails there: its conversion goes through `to_slice_clone`, whose C++ shim (`JSC__JSString__toZigString`) ignores the flatten failure and returns an empty string with the exception still pending (release builds answer the resolve with an empty path, debug builds trip `releaseAssertNoException`). That is a different defect in the string helper and is tracked separately; this PR leaves the resolve thunk alone.

This touches the same function that #37746 restructures; the change here is confined to the `Err` arm and applies either way.

### Verification

`test/bundler/bundler_plugin.test.ts`, `plugin/LoadContentsStringConversionThrows`: crashes the test process with the panic above on the current release, passes with this change (also under `BUN_JSC_validateExceptionChecks=1`). The rest of the file passes unchanged, which also covers that the VM is left in a usable state after the failed build.

</details>
