### PR TITLE
bake: give every CSS root in a bundle edges to the files it imports

### DIFF
--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -920,8 +920,10 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         debug_assert!(bundler_index.is_valid());
         debug_assert!(ctx.loaders[bundler_index.get() as usize].is_css());
 
-        // Queue avoids stack overflow; tracing bits in `process_edge_attachment`
-        // prevent infinite recursion.
+        // A CSS root gets a direct edge to every file it transitively imports,
+        // so editing any of them re-bundles the root. Queue avoids stack
+        // overflow; `process_edge_attachment` returns `Stop` for files this
+        // root already attached, which terminates `@import` cycles.
         let mut queue: Vec<bun_ast::Index> = Vec::new();
         queue.push(bundler_index);
 
@@ -975,23 +977,19 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         }
 
         // Locate the FileIndex from bundle_v2's Source.Index.
-        let (imported_file_index, kind): (FileIndex<SIDE>, FileKind) = 'brk: {
+        let imported_file_index: FileIndex<SIDE> = 'brk: {
             if ir_source_index.is_valid() {
-                let kind = if mode == EdgeAttachmentMode::Css {
-                    if ctx.loaders[ir_source_index.get() as usize].is_css() {
+                if let Some(i) = ctx.get_cached_index(SIDE, ir_source_index).unwrap::<SIDE>() {
+                    break 'brk i;
+                } else if mode == EdgeAttachmentMode::Css {
+                    let kind = if ctx.loaders[ir_source_index.get() as usize].is_css() {
                         FileKind::Css
                     } else {
                         FileKind::Asset
-                    }
-                } else {
-                    FileKind::Unknown
-                };
-                if let Some(i) = ctx.get_cached_index(SIDE, ir_source_index).unwrap::<SIDE>() {
-                    break 'brk (i, kind);
-                } else if mode == EdgeAttachmentMode::Css {
+                    };
                     let index = self.insert_empty(key, kind)?.index;
                     ctx.gts.resize(SIDE, index.get() as usize + 1)?;
-                    break 'brk (index, kind);
+                    break 'brk index;
                 }
             }
             match mode {
@@ -999,7 +997,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                 EdgeAttachmentMode::Css => return Ok(EdgeAttachmentResult::Stop),
                 // Check IncrementalGraph for a file from a prior build.
                 EdgeAttachmentMode::JsOrHtml => match self.bundled_files.get_index(key) {
-                    Some(i) => (FileIndex::<SIDE>::init(i as u32), FileKind::Unknown),
+                    Some(i) => FileIndex::<SIDE>::init(i as u32),
                     None => return Ok(EdgeAttachmentResult::Continue),
                 },
             }
@@ -1007,22 +1005,14 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
 
         debug_assert!((imported_file_index.get() as usize) < self.bundled_files.count());
 
-        // For CSS visiting CSS, prevent infinite recursion via tracing bits.
-        if mode == EdgeAttachmentMode::Css && kind == FileKind::Css {
-            if ctx
-                .gts
-                .bits(SIDE)
-                .is_set(imported_file_index.get() as usize)
-            {
-                return Ok(EdgeAttachmentResult::Stop);
-            }
-            ctx.gts.bits(SIDE).set(imported_file_index.get() as usize);
-        }
-
         let gop = quick_lookup.get_or_put(imported_file_index)?;
         if gop.found_existing {
+            // Already attached by this file. Being per file, `quick_lookup` is
+            // also the visited set for CSS `@import` cycles. `ctx.gts` is not
+            // usable for that: it is shared by every chunk in the bundle, so a
+            // file visited through one CSS root would be skipped by the next.
             if gop.value_ptr.seen {
-                return Ok(EdgeAttachmentResult::Continue);
+                return Ok(EdgeAttachmentResult::Stop);
             }
             gop.value_ptr.seen = true;
             let ei = gop.value_ptr.edge_index;

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -1,7 +1,7 @@
 // CSS tests concern bundling bugs with CSS files
 import { expect } from "bun:test";
 import assert from "node:assert";
-import { devTest, emptyHtmlFile, imageFixtures } from "../bake-harness";
+import { type Dev, devTest, emptyHtmlFile, imageFixtures } from "../bake-harness";
 
 devTest("css file with syntax error does not kill old styles", {
   files: {
@@ -476,6 +476,72 @@ devTest("multiple stylesheets importing same dependency", {
 
     await c1.style(".shared").color.expect.toBe("#ff0");
     await c2.style(".shared").color.expect.toBe("#ff0");
+
+    // The reload above re-bundled both stylesheets together. Each must keep
+    // its edge to `shared.css`, or the next edit only reaches one of them.
+    await dev.write(
+      "shared.css",
+      `
+        .shared { color: red; }
+      `,
+    );
+
+    await c1.style(".shared").color.expect.toBe("red");
+    await c2.style(".shared").color.expect.toBe("red");
+  },
+});
+// Here both stylesheets are in the same bundle from the start (one HTML file
+// links both). Each root must get its own edge to `shared.css`, otherwise
+// editing it only re-bundles the first root.
+devTest("stylesheets bundled together both update when a shared import changes", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: ["a.css", "b.css"],
+    }),
+    "a.css": `
+      @import "./shared.css";
+      .a { color: red; }
+    `,
+    "b.css": `
+      @import "./shared.css";
+      .b { color: blue; }
+    `,
+    "shared.css": `
+      .shared { color: green; }
+    `,
+  },
+  async test(dev) {
+    expect(await linkedStylesheetColors(dev, ".shared")).toEqual(["green", "green"]);
+
+    await dev.write("shared.css", `.shared { color: yellow; }`);
+    expect(await linkedStylesheetColors(dev, ".shared")).toEqual(["#ff0", "#ff0"]);
+
+    // The re-bundle above processed both roots together again; the edges
+    // must survive it.
+    await dev.write("shared.css", `.shared { color: red; }`);
+    expect(await linkedStylesheetColors(dev, ".shared")).toEqual(["red", "red"]);
+  },
+});
+devTest("stylesheet importing another linked stylesheet updates when it changes", {
+  files: {
+    // `base.css` is linked first so it is processed (and its dependents
+    // traced) before `theme.css` attaches its import of it.
+    "index.html": emptyHtmlFile({
+      styles: ["base.css", "theme.css"],
+    }),
+    "base.css": `
+      .base { color: green; }
+    `,
+    "theme.css": `
+      @import "./base.css";
+      .theme { color: blue; }
+    `,
+  },
+  async test(dev) {
+    expect(await linkedStylesheetColors(dev, ".base")).toEqual(["green", "green"]);
+
+    await dev.write("base.css", `.base { color: yellow; }`);
+    expect(await linkedStylesheetColors(dev, ".base")).toEqual(["#ff0", "#ff0"]);
   },
 });
 devTest("removing and re-adding css import", {
@@ -698,4 +764,23 @@ function extractCssUrl(backgroundImage: string): string {
     throw new Error("No url found in background-image: " + backgroundImage);
   }
   return url[2];
+}
+
+/**
+ * Fetches every stylesheet linked from "/" (one bundled chunk per CSS root)
+ * and returns the `color` each one declares for `selector`.
+ */
+async function linkedStylesheetColors(dev: Dev, selector: string): Promise<string[]> {
+  const html = await dev.fetch("/").text();
+  const hrefs = Array.from(html.matchAll(/<link rel="stylesheet" href="([^"]+)">/g), m => m[1]);
+  return Promise.all(
+    hrefs.map(async href => {
+      const css = await dev.fetch(href).text();
+      const rule = css.match(new RegExp(`^${selector.replaceAll(".", "\\.")}\\s*\\{\\s*color:\\s*([^;]+);`, "m"));
+      if (!rule) {
+        throw new Error(`No ${selector} rule in ${href}:\n${css}`);
+      }
+      return rule[1];
+    }),
+  );
 }


### PR DESCRIPTION
### Problem
- Dev server: when several CSS roots that import the same file are bundled together, editing that file re-bundles only the first root (`Reloaded in 1ms: a.css`). The other root's served chunk keeps the old content until that root itself is edited. Reproduced on `main` and on the released build.
- Roots that start out bundled separately hit it on the second edit: the first edit re-bundles both roots together, which removes one root's existing edge as if the import had been deleted, so the next edit reaches only one of them.
- A linked stylesheet that imports another stylesheet linked before it never gets an edge to that file, so editing the imported file leaves the importer's chunk stale.
- Cause: the cycle guard for a root's `@import` walk used a visited set shared by every root in the bundle, so a file already reached through one root attached nothing for the next. The Zig implementation had the same logic; this is not a port regression.

### Fix
- The `@import` walk now uses the per-root record of imports it has already attached as its visited set, so every root in a bundle gets its own edge to every file it transitively imports.
- This still terminates cycles: an import already attached for this root has already had its own imports queued, so stopping at it loses nothing, and one root's walk is invisible to the next root's.
- Edge attachment no longer writes the bundle-wide trace bitset, so tracing a root that a later root imports is no longer cut short either. JS and HTML edge diffing does not read the changed return value, so it is unchanged.
- Verification: three dev-server tests (one existing test extended, two new) fail on the released build, with one of the two chunks keeping the previous color, and pass with the fix. The rest of the bake dev tests pass.

### Background
- The dev server keeps an incremental graph of files with edges from importers to imports. Editing a file re-bundles only its direct importers; it does not walk further up.
- A CSS root is a stylesheet linked from HTML. It is served as one chunk containing its whole `@import` tree, so it needs a direct edge to every file in that tree, not only the files it imports directly.
- Each bundle re-processes every root in it and diffs the imports it sees against the root's existing edges; an import that is not seen has its edge removed.
- The trace bitset marks files already traced during one bundle and is shared by every root processed in that bundle, which is why it cannot double as a per-root visited set.

<details>
<summary>Original description</summary>

### Problem

In the dev server, when two CSS roots that depend on the same file are processed in the same bundle, only the first root ends up with an edge to that file. Editing the file then re-bundles just that one root (`Reloaded in 1ms: a.css`), and the other root's served chunk keeps the old content until the root itself is edited.

This is hit in three ways, all reproduced on `main` and on the released build (`USE_SYSTEM_BUN=1`):

- One HTML file links `a.css` and `b.css`, both `@import "./shared.css"`. Both roots are in the initial bundle; editing `shared.css` only updates `a.css`'s chunk.
- Two HTML routes each link their own stylesheet importing `shared.css` (the existing "multiple stylesheets importing same dependency" test). The roots are bundled separately at first, so both have edges and the first edit of `shared.css` reaches both. That edit re-bundles both roots together, which drops one of the edges, so the second edit of `shared.css` only reaches one of them.
- `theme.css` does `@import "./base.css"` and the HTML links `base.css` before `theme.css`. `theme.css` never gets an edge to `base.css`, so editing `base.css` leaves `theme.css`'s chunk stale.

<details>
<summary>Repro (fetch only, no client needed)</summary>

```ts
devTest("shared import", {
  files: {
    "index.html": emptyHtmlFile({ styles: ["a.css", "b.css"] }),
    "a.css": `@import "./shared.css"; .a { color: red; }`,
    "b.css": `@import "./shared.css"; .b { color: blue; }`,
    "shared.css": `.shared { color: green; }`,
  },
  async test(dev) {
    await dev.fetch("/").text();
    await dev.write("shared.css", `.shared { color: yellow; }`);
    // a.css's chunk now has `.shared { color: #ff0 }`, b.css's chunk still has `green`
  },
});
```

</details>

### Cause

`process_css_chunk_import_records` walks a CSS root's transitive `@import`s and attaches a direct edge from the root to every file it finds, so that editing any of them re-bundles the root (`invalidate` only looks one level up from the edited file). To stop on `@import` cycles, `process_edge_attachment` used `ctx.gts`, the graph trace bitset, as its visited set.

`ctx.gts` is created once per bundle in `finalize_bundle` and shared by every `process_chunk_dependencies` call in pass 2, including the `trace_dependencies` each of them ends with. So the first CSS root to reach `shared.css` sets its bit, and every later root in the same bundle gets `Stop` for it and attaches nothing. For that later root the import is then left unseen in its `quick_lookup`, so if it had an edge from an earlier bundle, the edge is removed as if the import had been deleted (the second scenario above). A root that is itself imported by a later root hits the same thing through the bit `trace_dependencies` sets on it (third scenario). The Zig implementation had the same logic, so this is not a port regression.

### Fix

Use the `quick_lookup` map as the visited set. It is built per file being processed, and every import attached for that file is marked `seen` in it, so an import that is already `seen` has had its records queued already: returning `Stop` for it terminates cycles exactly as before while keeping the set scoped to one root. `ctx.gts` is no longer touched by edge attachment, so its bits only mean "traced" again, and `trace_dependencies` for a root that an earlier root imports is no longer short-circuited either. The `EdgeAttachmentResult` of the already-seen case is only inspected by the CSS walk; `process_chunk_import_records` ignores it, so JS/HTML edge diffing is unchanged.

The `gts` sizing in `finalize_bundle` and the `resize` after `insert_empty` are left as they are: the bitsets still have to cover the files pass 2 inserts for the traces that run after it.

Independent of #37845, which changes the order edges are linked in; this one is about edges missing entirely.

### Tests

`test/bake/dev/css.test.ts`:

- "multiple stylesheets importing same dependency" now edits `shared.css` a second time, after the first edit has re-bundled both roots together.
- "stylesheets bundled together both update when a shared import changes": both roots in one bundle from the start, edited twice.
- "stylesheet importing another linked stylesheet updates when it changes": a root imported by a later root in the same bundle.

All three fail with `USE_SYSTEM_BUN=1` (one of the two chunks keeps the previous color) and pass with `bun bd test`. The rest of `css.test.ts` (including the circular import test), `html.test.ts`, `hot.test.ts`, `dev-and-prod.test.ts` and `incremental-graph-edge-deletion.test.ts` pass with the change.


</details>
