### PR TITLE
test(tls): run fewer destroySoon connections under debug/ASAN

### DIFF
--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import { readFileSync, realpathSync } from "fs";
-import { bunEnv, bunExe, tls as cert1, isDebug } from "harness";
+import { bunEnv, bunExe, tls as cert1, isASAN, isDebug } from "harness";
 import https from "https";
 import net, { AddressInfo } from "net";
 import { createTest } from "node-harness";
@@ -1314,9 +1314,12 @@ describe("tls.Server socket destroySoon", () => {
   // destroySoon() after end(big) must deliver every byte even when the TLS write
   // batcher's final flush spills (#31584). The spill/kernel-buffer race hits ~4% of
   // connections at this payload, so loop (mirrors test-tls-client-destroy-soon.js).
+  // Under debug/ASAN each connection costs ~50-150ms (connection setup and teardown,
+  // not the payload), so 64 of them overran the 5s default timeout.
+  const connections = isDebug || isASAN ? 8 : 64;
   it("delivers the whole stream when destroySoon follows end", async () => {
     const big = Buffer.alloc(2 * 1024 * 1024, "Y");
-    for (let i = 0; i < 64; i++) {
+    for (let i = 0; i < connections; i++) {
       const { promise, resolve, reject } = Promise.withResolvers<number>();
       const server = createServer(COMMON_CERT, socket => {
         socket.on("error", reject);


### PR DESCRIPTION
### Problem
- `tls.Server socket destroySoon > delivers the whole stream when destroySoon follows end` fails intermittently on debug/ASAN builds with `this test timed out after 5000ms`. Every iteration that completes delivers the full byte count; the code under test is fine.
- The test opens 64 sequential 2 MiB TLS connections. Under debug/ASAN the time goes into per-connection setup and teardown, not the payload, and 64 connections take 4s to 9s depending on host load.
- Shrinking the payload would save at most about 20% per connection and would move the test off the one payload at which the race it guards against (#32719) was measured.

### Fix
- Run 8 connections on debug or ASAN builds, 64 elsewhere. The payload is unchanged.
- Release builds, where the race is observable and a connection costs 2-6ms, still run the full loop. CI runs ASAN only on Linux, where the race did not reproduce, so that loop only exercises the path under the sanitizer, which 8 connections still do.
- Verification: manual timings on a debug build only. Before, 5.3s to 9.6s per run (one timed out); after, 2.2s to 2.7s in isolation and about 1s inside the whole file, rest of the file unchanged.

### Background
- `destroySoon()` closes a socket once pending writes flush. The test calls `end(big)` then `destroySoon()` and checks the client got every byte; the TLS write batcher's final flush used to truncate about 4% of connections at this payload, which is why the test loops.
- `isDebug` and `isASAN` from the test harness mark the slow build flavors; other iteration-heavy tests in this suite already scale their loop counts on them.
- Under debug/ASAN the first `net` and `tls` connection in a process pays about 1s of one-time initialization, so this test runs slower in isolation than inside the file.

<details>
<summary>Original description</summary>

### What does this PR do?

Test-only. `tls.Server socket destroySoon > delivers the whole stream when destroySoon follows end` in `test/js/node/tls/node-tls-server.test.ts` streams 2 MiB over 64 sequential TLS connections. Under a debug/ASAN build that takes longer than the 5s default test timeout often enough to fail intermittently, with nothing wrong in the code under test (every iteration that completes delivers the full byte count).

On an unmodified checkout (`9a543cc18f`), `bun bd test test/js/node/tls/node-tls-server.test.ts -t "delivers the whole stream when destroySoon follows end"` took 5351ms, 7745ms, 8450ms and 9617ms across four runs with `--timeout 30000`, and with the default timeout:

```
(fail) tls.Server socket destroySoon > delivers the whole stream when destroySoon follows end [5006.35ms]
  ^ this test timed out after 5000ms.
```

### Cause

The time goes into per-connection setup and teardown, not the payload. Measured with the debug build on this (busy) machine, sequential connections following the test's exact pattern cost:

| payload | ms per connection |
|---|---|
| 0 KiB | ~35 |
| 256 KiB | ~33-41 |
| 2 MiB | ~45-65 |

On top of that the first TLS connection in a process pays roughly 1s of one-time initialization under debug/ASAN (about 0.7s for the first `net` connection, another 0.4s for the first `tls` one), which the test's own timer absorbs when it is run in isolation. Inside the test runner the steady-state cost per connection varied between ~65ms and ~130ms depending on host load, so 64 connections land anywhere between ~4s and ~9s.

Shrinking the payload (the other obvious lever) would save at most ~20% per connection, and it would also change the one configuration this test is calibrated for: the spill race it guards against (#32719) was measured at ~4% of connections with exactly this 2 MiB payload, which is also the payload of Node's `test-tls-client-destroy-soon.js`. I could not re-measure that rate at other payloads from here: with the #32719 close-path fix removed again locally, the truncation did not reproduce at all on Linux (0 of 1200 connections at 128 KiB through 4 MiB), which is consistent with the original report of it being a macOS loopback timing race.

### Fix

Keep the payload and keep 64 connections on release builds, where the race is actually observable and the loop costs well under a second (about 2-6ms per connection). Run 8 connections on debug/ASAN builds (`isDebug || isASAN`, the same pattern other iteration-heavy tests in the suite use). CI only runs ASAN on Linux, where the race does not fire and the loop only serves to exercise the path under the sanitizer, which 8 connections still do.

### Verification

Debug build, this machine (load average ~150-170 throughout):

- in isolation (`-t "delivers the whole stream..."`): 2161ms, 2476ms, 2660ms, of which ~1.1s is the one-time TLS/net initialization described above
- as part of the whole file: 973ms, 1111ms for this test; file otherwise unchanged (67 pass)

The one failure in the full-file run, `SNICallback runs even when the requested servername matches the bind hostname` (`connect ECONNREFUSED 127.0.0.1:...`), is pre-existing, unrelated to this test, and already addressed by #35160.


</details>
