### PR TITLE
bake: retract a client component's bundling failure when it is demoted

### DIFF
--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -516,6 +516,27 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         directory_watchers
             .remove_dependencies_for_file(&self.bundled_files.keys()[file_index.get() as usize]);
 
+        // The slot is never received again, so what it owns is released here:
+        // its content, and its failure, which `index_failures` publishes as
+        // removed later in this bundle.
+        let mut file =
+            core::mem::take(&mut self.bundled_files.values_mut()[file_index.get() as usize]);
+        let key = bun_ptr::RawSlice::new(&*self.bundled_files.keys()[file_index.get() as usize]);
+        self.free_file_content(key.slice(), &mut file, FreeCssMode::UnrefCss);
+        file.kind = FileKind::Unknown;
+        if file.failed {
+            file.failed = false;
+            let owner = serialized_failure::OwnerPacked::new(SIDE, file_index.get());
+            let kv = self.dev_bundling_failures().fetch_swap_remove(&owner);
+            let kv = kv.unwrap_or_else(|| {
+                bun_core::Output::panic(format_args!(
+                    "Missing SerializedFailure in IncrementalGraph",
+                ))
+            });
+            self.dev_incremental_result().failures_removed.push(kv.1);
+        }
+        self.bundled_files.values_mut()[file_index.get() as usize] = file;
+
         // Free the key string and tombstone the slot. Cannot swap-remove since
         // FrameworkRouter / SerializedFailure hold FileIndices into this graph.
         // Tombstoned slots are not reused; a free-list is a pending idea.

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -516,9 +516,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         directory_watchers
             .remove_dependencies_for_file(&self.bundled_files.keys()[file_index.get() as usize]);
 
-        // The slot is never received again, so what it owns is released here:
-        // its content, and its failure, which `index_failures` publishes as
-        // removed later in this bundle.
+        // Nothing receives this slot again, so its failure is retracted here.
         let mut file =
             core::mem::take(&mut self.bundled_files.values_mut()[file_index.get() as usize]);
         let key = bun_ptr::RawSlice::new(&*self.bundled_files.keys()[file_index.get() as usize]);

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -1,6 +1,7 @@
 // Bundle tests are tests concerning bundling bugs that only occur in DevServer.
+import type { Bake } from "bun";
 import { expect } from "bun:test";
-import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
+import { devTest, emptyHtmlFile, minimalFramework, type Dev } from "../bake-harness";
 
 devTest("import identifier doesnt get renamed", {
   framework: minimalFramework,
@@ -414,45 +415,63 @@ function decodeErrorsPacket(data: Uint8Array) {
   }
   return { removed, added: decodeSerializedFailures(data.subarray(5 + removedCount * 4)) };
 }
+/**
+ * Subscribes the harness socket to the errors topic and records every errors
+ * packet. Each `dev.write` resolves only after a later message on this socket,
+ * so by then the packets of that rebuild have been recorded.
+ */
+function recordErrorsPackets(dev: Dev) {
+  const packets: ReturnType<typeof decodeErrorsPacket>[] = [];
+  dev.on("hmr", (data: Uint8Array) => {
+    if (data[0] === "e".charCodeAt(0)) packets.push(decodeErrorsPacket(data));
+  });
+  dev.socket!.send("sre");
+  return packets;
+}
+// separateSSRGraph makes a "use client" file's own bundling failures belong to
+// the client graph's node, which is the node deleted when the file is demoted.
+const separateSSRGraphFramework: Bake.Framework = {
+  ...minimalFramework,
+  serverComponents: {
+    ...minimalFramework.serverComponents!,
+    separateSSRGraph: true,
+  },
+};
+// The route sees a client reference object while Comp.ts is a client
+// component boundary and the exported string once it is demoted.
+const demotionFiles = {
+  "routes/index.ts": `
+    import * as Comp from '../components/Comp';
+    export default function (req, meta) {
+      return new Response('marker: ' + typeof Comp.marker);
+    }
+  `,
+  "components/Comp.ts": `
+    "use client";
+    export const marker = "initial";
+  `,
+};
+devTest("removing 'use client' from a working component", {
+  framework: separateSSRGraphFramework,
+  files: demotionFiles,
+  async test(dev) {
+    const errorPackets = recordErrorsPackets(dev);
+    await dev.fetch("/").equals("marker: object");
+    await dev.write("components/Comp.ts", `export const marker = "plain";`);
+    await dev.fetch("/").equals("marker: string");
+    expect(errorPackets).toEqual([]);
+  },
+});
 // When a client component boundary is demoted, the server graph deletes the
 // client graph's node for it (disconnectAndDeleteFile). If that node was
 // failing, its failure used to stay behind in dev.bundling_failures: error
 // overlays were never told to drop it and every later "Build Failed" page
 // listed it again.
 devTest("removing 'use client' from a failing component retracts its bundling failure", {
-  // separateSSRGraph is required for the failure to be owned by the client
-  // graph's node, which is the node that gets deleted on demotion.
-  framework: {
-    ...minimalFramework,
-    serverComponents: {
-      ...minimalFramework.serverComponents!,
-      separateSSRGraph: true,
-    },
-  },
-  files: {
-    "routes/index.ts": `
-      import * as Comp from '../components/Comp';
-      export default function (req, meta) {
-        return new Response('marker: ' + typeof Comp.marker);
-      }
-    `,
-    "components/Comp.ts": `
-      "use client";
-      export const marker = "initial";
-    `,
-  },
+  framework: separateSSRGraphFramework,
+  files: demotionFiles,
   async test(dev) {
-    const errorPackets: ReturnType<typeof decodeErrorsPacket>[] = [];
-    dev.on("hmr", (data: Uint8Array) => {
-      if (data[0] === "e".charCodeAt(0)) errorPackets.push(decodeErrorsPacket(data));
-    });
-    // Subscribe the harness socket to the errors topic as well. Every
-    // `dev.write` below resolves only after a later message on this socket,
-    // so by then any errors packet from that rebuild has been recorded.
-    dev.socket!.send("sre");
-
-    // Comp.ts is bundled as a client component boundary: the route sees a
-    // client reference object instead of the string.
+    const errorPackets = recordErrorsPackets(dev);
     await dev.fetch("/").equals("marker: object");
     expect(errorPackets).toEqual([]);
 
@@ -512,6 +531,68 @@ devTest("removing 'use client' from a failing component retracts its bundling fa
         messages: ['Could not resolve: "./does-not-exist"'],
       },
     ]);
+  },
+});
+// Same demotion as above, observed from a browser sitting on the "Build
+// Failed" page: the retraction is what lets it drop the error and reload.
+devTest("removing 'use client' from a failing component clears the error overlay", {
+  framework: {
+    fileSystemRouterTypes: [
+      {
+        root: "routes",
+        style: "nextjs-pages",
+        serverEntryPoint: "./framework/server.ts",
+        clientEntryPoint: "./framework/client.ts",
+      },
+    ],
+    serverComponents: {
+      separateSSRGraph: true,
+      serverRuntimeImportSource: "./framework/server.ts",
+      serverRegisterClientReferenceExport: "registerClientReference",
+    },
+  },
+  files: {
+    "framework/server.ts": `
+      export function render(req, meta) {
+        const scripts = meta.modules.map(src => '<script type="module" src="' + src + '"></script>').join("");
+        return new Response("<!DOCTYPE html><html><body>" + meta.pageModule.default() + scripts + "</body></html>", {
+          headers: { "Content-Type": "text/html" },
+        });
+      }
+      export function registerClientReference(value, file, uid) {
+        return { value, file, uid };
+      }
+    `,
+    "framework/client.ts": `
+      console.log("marker: " + document.body.textContent);
+    `,
+    "routes/index.ts": `
+      import * as Comp from '../components/Comp';
+      export default () => typeof Comp.marker;
+    `,
+    "components/Comp.ts": `
+      "use client";
+      export const marker = "initial";
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").expect.toInclude("<body>object<");
+    await dev.write(
+      "components/Comp.ts",
+      `
+        "use client";
+        import './missing';
+        export const marker = "initial";
+      `,
+      { errors: null },
+    );
+    await using c = await dev.client("/", {
+      errors: ['components/Comp.ts:2:8: error: Could not resolve: "./missing"'],
+    });
+    await c.expectReload(async () => {
+      await dev.write("components/Comp.ts", `export const marker = "plain";`);
+    });
+    await c.expectMessage("marker: string");
   },
 });
 devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -358,6 +358,162 @@ devTest("removing 'use client' from a component with a pending resolution failur
     expect(res).toBeInstanceOf(Response);
   },
 });
+/**
+ * Decodes concatenated `SerializedFailure`s (see
+ * src/runtime/bake/dev_server/serialized_failure.rs). This is the layout of
+ * both the "added" tail of a `MessageId.errors` packet and the payload embedded
+ * in the "Build Failed" page.
+ */
+function decodeSerializedFailures(bytes: Uint8Array) {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let pos = 0;
+  const u32 = () => {
+    const value = view.getUint32(pos, true);
+    pos += 4;
+    return value;
+  };
+  const string32 = () => {
+    const length = u32();
+    const text = new TextDecoder().decode(bytes.subarray(pos, pos + length));
+    pos += length;
+    return text;
+  };
+  const logData = () => {
+    const text = string32();
+    // A zero line means there is no location.
+    if (u32() !== 0) {
+      u32(); // column
+      u32(); // length
+      string32(); // line text
+    }
+    return text;
+  };
+  const failures: { owner: number; file: string; messages: string[] }[] = [];
+  while (pos < bytes.byteLength) {
+    const owner = u32();
+    const file = string32();
+    const messages: string[] = [];
+    for (let messageCount = u32(); messageCount > 0; messageCount--) {
+      pos += 1; // ErrorKind
+      messages.push(logData());
+      for (let noteCount = u32(); noteCount > 0; noteCount--) {
+        logData();
+      }
+    }
+    failures.push({ owner, file, messages });
+  }
+  return failures;
+}
+/** Decodes a `MessageId.errors` packet from the HMR socket. */
+function decodeErrorsPacket(data: Uint8Array) {
+  const view = new DataView(data.buffer, data.byteOffset, data.byteLength);
+  const removedCount = view.getUint32(1, true);
+  const removed: number[] = [];
+  for (let i = 0; i < removedCount; i++) {
+    removed.push(view.getUint32(5 + i * 4, true));
+  }
+  return { removed, added: decodeSerializedFailures(data.subarray(5 + removedCount * 4)) };
+}
+// When a client component boundary is demoted, the server graph deletes the
+// client graph's node for it (disconnectAndDeleteFile). If that node was
+// failing, its failure used to stay behind in dev.bundling_failures: error
+// overlays were never told to drop it and every later "Build Failed" page
+// listed it again.
+devTest("removing 'use client' from a failing component retracts its bundling failure", {
+  // separateSSRGraph is required for the failure to be owned by the client
+  // graph's node, which is the node that gets deleted on demotion.
+  framework: {
+    ...minimalFramework,
+    serverComponents: {
+      ...minimalFramework.serverComponents!,
+      separateSSRGraph: true,
+    },
+  },
+  files: {
+    "routes/index.ts": `
+      import * as Comp from '../components/Comp';
+      export default function (req, meta) {
+        return new Response('marker: ' + typeof Comp.marker);
+      }
+    `,
+    "components/Comp.ts": `
+      "use client";
+      export const marker = "initial";
+    `,
+  },
+  async test(dev) {
+    const errorPackets: ReturnType<typeof decodeErrorsPacket>[] = [];
+    dev.on("hmr", (data: Uint8Array) => {
+      if (data[0] === "e".charCodeAt(0)) errorPackets.push(decodeErrorsPacket(data));
+    });
+    // Subscribe the harness socket to the errors topic as well. Every
+    // `dev.write` below resolves only after a later message on this socket,
+    // so by then any errors packet from that rebuild has been recorded.
+    dev.socket!.send("sre");
+
+    // Comp.ts is bundled as a client component boundary: the route sees a
+    // client reference object instead of the string.
+    await dev.fetch("/").equals("marker: object");
+    expect(errorPackets).toEqual([]);
+
+    // Break the component while it is still a boundary. The unresolvable
+    // import is attributed to the client graph's node.
+    await dev.write(
+      "components/Comp.ts",
+      `
+        "use client";
+        import './missing';
+        export const marker = "initial";
+      `,
+      { errors: null },
+    );
+    expect(errorPackets).toEqual([
+      {
+        removed: [],
+        added: [
+          {
+            owner: expect.any(Number),
+            file: "components/Comp.ts",
+            messages: ['Could not resolve: "./missing"'],
+          },
+        ],
+      },
+    ]);
+    const compOwner = errorPackets[0].added[0].owner;
+    errorPackets.length = 0;
+
+    // Demote the component and fix it in the same edit. Only the server
+    // re-bundles the file; the client graph's node is deleted along with
+    // the failure it owned, which must be announced as removed.
+    await dev.write("components/Comp.ts", `export const marker = "plain";`);
+    expect(errorPackets).toEqual([{ removed: [compOwner], added: [] }]);
+    await dev.fetch("/").equals("marker: string");
+
+    // An unrelated failure later on renders every failure the dev server
+    // still tracks. The retracted one must not be among them.
+    await dev.write(
+      "routes/index.ts",
+      `
+        import * as Comp from '../components/Comp';
+        import './does-not-exist';
+        export default function (req, meta) {
+          return new Response('marker: ' + typeof Comp.marker);
+        }
+      `,
+      { errors: null },
+    );
+    const response = await dev.fetch("/");
+    expect(response.status).toBe(500);
+    const [, encodedFailures] = (await response.text()).match(/atob\("([^"]*)"\)/)!;
+    expect(decodeSerializedFailures(Buffer.from(encodedFailures, "base64"))).toEqual([
+      {
+        owner: expect.any(Number),
+        file: "routes/index.ts",
+        messages: ['Could not resolve: "./does-not-exist"'],
+      },
+    ]);
+  },
+});
 devTest("deinit with a free-list slot in DirectoryWatchStore.dependencies", {
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),


### PR DESCRIPTION
### Problem
- Dev server with `serverComponents.separateSSRGraph` on: a `"use client"` file breaks (`Could not resolve: "./missing"`), then one edit removes both the directive and the bad import. The route serves again, but no errors packet retracting the failure is sent, so browser overlays keep showing it.
- The dev server keeps it too: the next unrelated "Build Failed" page lists it again, and the "any failures?" checks that gate hot updates keep taking the failure path.
- Cause: demotion deletes the client graph's node for the file instead of re-bundling it, and deletion released neither the node's recorded failure nor its old code and source map. Every other way a node stops failing does both. The Zig original had the same gap.

### Fix
- Deleting a client node now frees its content and, if it was failing, moves its failure from the tracked set onto the current bundle's removed list, as a clean re-bundle would.
- That is enough because deletion only happens inside a bundle, and every bundle publishes its removed list in the errors packet it sends anyway; owner ids stay unambiguous because tombstoned slots are never reused.
- The rest of the tombstone is left alone, so a still-reachable one still hits the existing `Server Incremental Graph is missing component for ""` panic.
- Verification: a new dev-server test decodes the HMR errors packets. On the released build the demoting edit publishes nothing and a later "Build Failed" page lists both failures; with the change it publishes exactly one removal. Passes on a debug/ASAN build.

### Background
- Bake is bun's dev server. It keeps an incremental graph per side (server, client) with one node per bundled file, and an edit re-bundles only the nodes it invalidates.
- A `"use client"` file is a boundary with a node in both graphs. Removing the directive (demotion) makes the server graph delete the client node; that node is an HMR root, so the edit never re-bundles it. `separateSSRGraph` is what makes the failure belong to the client node.
- Failures live in one set keyed by (side, node index). Each bundle publishes the set's added and removed entries as an errors packet on the HMR socket; the "Build Failed" page renders the whole set.
- Deleted nodes are tombstoned, not removed, because routes and failures hold indices into the graph. A tombstone is never bundled again, so whatever it owns must be released when it is deleted.

<details>
<summary>Original description</summary>

### Repro

Dev server with a framework that sets `serverComponents.separateSSRGraph = true` (bun-framework-react does). `routes/index.ts` imports `components/Comp.ts`, which starts out as a `"use client"` file and bundles fine. Then, in two edits:

```ts
// 1. break it while it is still a client component
"use client";
import './missing';
export const marker = "initial";

// 2. drop the directive and the bad import in the same edit
export const marker = "plain";
```

Edit 1 produces a `Could not resolve: "./missing"` failure owned by the client graph's node for `Comp.ts`, and an errors packet adding it is published on the HMR socket. After edit 2 the route serves fine again, but no errors packet removing the failure is ever published, so browsers keep the entry in the error overlay, and `dev.bundling_failures` still holds it for the rest of the process: the next unrelated failure (say in `routes/index.ts`) renders a "Build Failed" page listing both the new error and the long fixed `Comp.ts` one, and the `bundling_failures.is_empty()` checks in `finalize_bundle` (hot-update route list, "Reloaded in" line) and in the route state machine keep taking the failure path.

### Cause

Edit 2 re-bundles `Comp.ts` on the server only (the client node is an HMR root, so `invalidate` skips it). `server_graph.receive_chunk` sees a file that was a boundary and no longer is, and calls `client_graph.disconnect_and_delete_file` on the client node. That function disconnects the node's edges and tombstones its key, but leaves the node's `failed` entry in `dev.bundling_failures` and never pushes it to `incremental_result.failures_removed`. Every other place a node stops failing (`receive_chunk` on both sides, `insert_failure` replacing an entry) does both; this is the one path where a node goes away without being received again, so nothing later can clean it up. It also left the node's last bundled code and source map behind, a small leak per demotion. The Zig original had the same omissions.

### Fix

`disconnect_and_delete_file` now releases what the node owns before tombstoning it: `free_file_content`, and if the node was failing, `fetch_swap_remove` its `OwnerPacked(side, index)` entry from `bundling_failures` onto `failures_removed`, the same sequence `receive_chunk` uses. The function only runs from `receive_chunk`, i.e. inside `finalize_bundle` pass 1, and `index_failures` drains `failures_removed` after pass 2 of the same bundle, so the removal is published in the same errors packet the bundle would send anyway, keyed by the owner id the client already has (tombstoned indices are never reused, so the id stays unambiguous).

The rest of the tombstoned `File` is intentionally left as it was. In particular it keeps `is_hmr_root`, so a tombstone that is still reachable keeps hitting the existing `Server Incremental Graph is missing component for ""` panic instead of being silently traced as a dead end; this change is only about the failure and content the slot owned.

### Verification

Three tests added to `test/bake/dev/bundle.test.ts`:

- "removing 'use client' from a failing component retracts its bundling failure": subscribes the harness socket to the errors topic and decodes the packets. Edit 1 publishes exactly one added failure for `components/Comp.ts`, edit 2 publishes exactly `{ removed: [that owner], added: [] }` and the route then serves the demoted module, and a later unrelated failure's "Build Failed" page lists only that failure. On the released build the second step receives no packet at all and the page lists both failures.
- "removing 'use client' from a failing component clears the error overlay": the same edits with a browser (harness client) sitting on the Build Failed page; after edit 2 the overlay is empty and the page reloads onto the working route. On the released build the overlay still shows the `Comp.ts` error and no reload happens.
- "removing 'use client' from a working component": the non-failing demotion, which now frees the node's code and source map under ASAN and must publish nothing.

Runs:

- released build (`USE_SYSTEM_BUN=1`): the first two fail as described, the third passes
- debug/ASAN build with the change: the whole file passes (24 tests, including the existing demotion test, which now also goes through the new code)
- cherry-picked onto #37850, which makes a `"use client"` file that never bundled take this same demotion path: demoting such a file publishes `{ removed, added: [] }` and later error pages no longer list it, so the two changes compose (on main alone that scenario never reaches `disconnect_and_delete_file`, and this PR leaves it unchanged)

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.0 (502492326)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-ek3jdh
[0;30mdev|[0m Started development server: http://localhost:35047
[0;30mdev|[0m [32mBundled page in 254ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 67ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 112ms
... (truncated)

release without fix: 2 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-vyB62A
[0;30mdev|[0m Started development server: http://localhost:45335
[0;30mdev|[0m [32mBundled page in 4ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 8ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 2ms[0m[2m:[0m routes/index.ts
(pass)  DEV:bundle-1: import identifier doesnt get renamed [251.97ms]
[0;30mdev|[0m Started development server: http://localhos
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.0 (502492326)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-MGJ8ub
[0;30mdev|[0m Started development server: http://localhost:43633
[0;30mdev|[0m [32mBundled page in 209ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 55ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 68ms[
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     502492326c
  features     baseline

22 deps, 107 codegen, 1176 objects in 3576ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] gen .bind.ts → GeneratedBindings.cpp
[4/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1237] gen ProcessBindingBuffer.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingBuffer.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingBuffer.cpp
[8/1237] fetch zlib
[zlib] up to date
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h 
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/dev_server/incremental_graph.rs |  19 ++
 test/bake/dev/bundle.test.ts                     | 239 ++++++++++++++++++++++-
 2 files changed, 257 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/runtime/bake/dev_server/incremental_graph.rs     10      4      0
test/bake/dev/bundle.test.ts                          3      5      0
```

</details>

<!-- robobun:evidence:end -->