### PR TITLE
test(bake): report client exits that happen while the client is being disposed

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -827,7 +827,6 @@ export class Client extends EventEmitter {
   #proc: Subprocess;
   output: OutputLineStream;
   exited = false;
-  exitCode: string | number | null = null;
   messages: any[] = [];
   #hmrChunk: string | null = null;
   suppressInteractivePrompt: boolean = false;
@@ -859,15 +858,16 @@ export class Client extends EventEmitter {
       },
       onExit: (subprocess, exitCode, signalCode, error) => {
         danglingProcesses.delete(subprocess);
+        let code: string | number;
         if (exitCode !== null) {
-          this.exitCode = exitCode;
+          code = exitCode;
         } else if (signalCode !== null) {
           console.log("THE SIGNAL CODE IS", signalCode);
-          this.exitCode = `${signalCode}`;
+          code = `${signalCode}`;
         } else {
-          this.exitCode = "unknown";
+          code = "unknown";
         }
-        this.emit("exit", this.exitCode, error);
+        this.emit("exit", code, error);
         this.exited = true;
         if (activeClient === this) {
           activeClient = null;
@@ -930,12 +930,18 @@ export class Client extends EventEmitter {
       this.#proc.send({ type: "exit" });
     } catch (e) {}
     await this.#proc.exited;
-    if (this.exitCode !== null && this.exitCode !== "0") {
+    // `exited` settles before `onExit` runs, so when the client exits during
+    // dispose nothing `onExit` records is usable here yet; the subprocess
+    // itself already carries the status.
+    const { exitCode, signalCode } = this.#proc;
+    if (exitCode !== 0) {
       let code;
-      if (exitCodeMapStrings[this.exitCode]) {
-        code = ": " + JSON.stringify(exitCodeMapStrings[this.exitCode]);
+      if (exitCode === null) {
+        code = ` with signal ${signalCode}`;
+      } else if (exitCodeMapStrings[exitCode]) {
+        code = ": " + JSON.stringify(exitCodeMapStrings[exitCode]);
       } else {
-        code = " with " + (typeof this.exitCode === "number" ? `code ${this.exitCode}` : `signal ${this.exitCode}`);
+        code = ` with code ${exitCode}`;
       }
       throw new Error(`Client exited${code}`);
     }

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -236,12 +236,14 @@ devTest("css url resolve error on hot reload is recoverable", {
           errors: ['styles.css:2:21: error: Could not resolve: "./missing.png"'],
         },
       );
-      expect((await dev.fetch("/")).status).toBe(500);
     }
-    // Recovery is checked without a connected client: when a failed CSS root
-    // recovers, the patch currently ships the HTML route as a JS module
-    // without the route-reload flag, which trips a client-side debug assert
-    // (tracked in https://github.com/oven-sh/bun/issues/31908).
+    // The rest runs without a connected client: both requesting the failed
+    // route and recovering the CSS root currently ship the HTML route to
+    // clients as a JS module without the route-reload flag, which trips a
+    // client-side debug assert (tracked in
+    // https://github.com/oven-sh/bun/issues/31908) and fails the client's
+    // dispose.
+    expect((await dev.fetch("/")).status).toBe(500);
     await dev.write(
       "styles.css",
       `

--- a/test/bake/dev/harness.test.ts
+++ b/test/bake/dev/harness.test.ts
@@ -1,0 +1,73 @@
+// Tests for the behavior of bake-harness.ts itself.
+import { expect } from "bun:test";
+import { devTest, emptyHtmlFile } from "../bake-harness";
+
+const files = {
+  "index.html": emptyHtmlFile({
+    scripts: ["index.ts"],
+    body: "<h1>Hello</h1>",
+  }),
+  "index.ts": `
+    console.log("loaded");
+    import.meta.hot.accept();
+  `,
+};
+
+/**
+ * Awaits `promise` like `await using` does and returns the rejection message.
+ *
+ * Not `expect(promise).rejects`: that matcher waits by ticking the event loop
+ * from inside the matcher call, and a client exit processed that way runs
+ * `onExit` before the `await proc.exited` continuation in `Client`'s dispose,
+ * which is the opposite of the order a plain `await` observes.
+ */
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (err: any) {
+    return err.message;
+  }
+  throw new Error("Expected the promise to reject");
+}
+
+devTest("disposing a client reports an exit code the client produces while it is being disposed", {
+  files,
+  async test(dev) {
+    const c = await dev.client("/");
+    await c.expectMessage("loaded");
+
+    // Leave the client fixture expecting a reload that never happens. Its exit
+    // handler then turns the exit(0) requested by dispose into
+    // exitCodeMap.reloadNotCalled, so the non-zero exit happens while dispose
+    // is waiting for the process.
+    expect(await rejectionMessage(c.expectReload(() => Promise.reject(new Error("abort before reloading"))))).toBe(
+      "abort before reloading",
+    );
+
+    expect(await rejectionMessage(c[Symbol.asyncDispose]())).toBe('Client exited: "Reload not called"');
+  },
+});
+
+devTest("disposing a client reports an exit code the client produced earlier", {
+  files,
+  async test(dev) {
+    const c = await dev.client("/");
+    await c.expectMessage("loaded");
+
+    // index.ts self-accepts, so the update is evaluated in place and the
+    // fixture exits with exitCodeMap.consoleError as soon as the new module
+    // logs an error: the client is gone before dispose starts.
+    expect(
+      await rejectionMessage(
+        dev.write(
+          "index.ts",
+          `
+            console.error("boom");
+          `,
+        ),
+      ),
+    ).toBe("Client exited while applying hot update: Runtime error");
+
+    expect(await rejectionMessage(c[Symbol.asyncDispose]())).toBe('Client exited: "Runtime error"');
+  },
+});


### PR DESCRIPTION
### Problem
- Nearly every `test/bake` client is still running when its test disposes it, and a failing exit code produced during dispose (assertion failed, console error, reload not called, ...) was swallowed: the test passed. Only clients that died before dispose were reported.
- Cause: dispose read a field the harness's own `onExit` callback fills in, but Bun settles `proc.exited` before calling `onExit`, so the `await` resumed while the field was still `null`.
- The check also compared a number against the string `"0"`, so a client that had exited 0 earlier was reported as `Client exited with code 0`.
- One existing test relied on this: once exits are reported, `css url resolve error on hot reload is recoverable` fails on debug builds with `Trace: ASSERTION FAILED` in `replaceModules` (known bug #31908, tripped while the client is disposed).

### Fix
- After awaiting `exited`, dispose reads `exitCode` / `signalCode` off the subprocess itself and compares numerically. Those are set by the time `exited` settles, so the result no longer depends on whether `onExit` has run. The harness already does this for the dev server process.
- The field `onExit` wrote is removed (no other readers); `onExit` still emits the `"exit"` event the reload helpers consume.
- The css test now fetches the failed route after its client is gone, so the #31908 assert cannot fire during dispose.
- Verification: a new harness test with a client that exits non-zero during dispose fails without the harness change (`Expected the promise to reject`); a second pins the already-working exited-earlier case. The other client-using `test/bake` files pass unchanged on a debug build.

### Background
- The `test/bake` harness starts a dev server per test; `dev.client(path)` spawns a happy-dom subprocess that loads the page and talks to the test over IPC. Dispose asks it over IPC to exit and waits for the process.
- The client fixture reports failures as exit codes (`exit-code-map.mjs`); its exit handler can replace the `exit(0)` dispose asked for with one of them, and the harness maps the code back to a message.
- `Bun.spawn` exposes exit status three ways: the `exited` promise, `exitCode` / `signalCode` on the subprocess, and the `onExit` callback. `exited` resolves before `onExit` is called, and on an idle event loop the `await exited` continuation runs in between.
- `expect(p).rejects` ticks the event loop from inside the matcher, which processes the exit in the other order (`onExit` first) and hides the bug; the new tests use a plain `await`, as `await using` does.

<details>
<summary>Original description</summary>

### What

`Client[Symbol.asyncDispose]` in `test/bake/bake-harness.ts` sends `{type: "exit"}` to the happy-dom client, awaits `proc.exited`, and then checks `this.exitCode`, a field that is only written by the `Bun.spawn` `onExit` callback. Bun stores the exit status on the subprocess and resolves `exited` before it calls `onExit` (`Subprocess::on_process_exit` in `src/runtime/api/bun/subprocess.rs`), and when the exit is picked up by an otherwise idle event loop the microtasks are drained in between, so the continuation of `await this.#proc.exited` runs with `this.exitCode` still `null`:

```ts
const proc = Bun.spawn({
  cmd: ["node", "-e", "process.on('message', () => process.exit(32))"],
  serialization: "json",
  ipc() {},
  onExit(_, code) { console.log("onExit", code); },
});
await Bun.sleep(300);
proc.send("exit");
await proc.exited;
console.log("after await:", proc.exitCode); // prints "after await: 32", and only then "onExit 32"
```

That is exactly the shape of dispose: every client that is still running when dispose starts (which is nearly all of them, the harness disposes ~100 clients across `test/bake` with `await using`) can exit with any of the codes in `exit-code-map.mjs` (assertion failed, unexpected reload, console error, reload not called, ...) during dispose and the test still passes. Only clients that had already died before dispose was called were reported. The check also compared a number against the string `"0"`, so a client that had exited 0 earlier was reported as `Client exited with code 0`.

### Fix

After awaiting `exited`, read `exitCode` / `signalCode` from the subprocess itself, which is populated in both orderings, and compare numerically. This is what `Dev.gracefulExit` already does for the dev server process. The `Client.exitCode` field had no other readers, so it is gone; `onExit` still emits the `"exit"` event with the same value, which is what `waitForHotReload`, `expectReload`, etc. consume. No other place in the harness reads `onExit`-populated state after awaiting `exited` (`OutputLineStream` uses the promise value).

### Fallout in the existing suite

With the harness fixed, `css url resolve error on hot reload is recoverable` (`test/bake/dev/css.test.ts`) fails on debug builds:

```
web| Trace: ASSERTION FAILED
web|     at replaceModules (http://localhost:46691/_bun/client/index-00000000e224e8c6.js:2486:15)
error: Client exited: "Assertion failed"
```

Requesting the failed route ships the HTML route module to the connected client as a JS hot update (#31908, fix in #31915), the client trips the debug assert and exits 32 while it is being disposed, and the old dispose swallowed that. The test already did the recovery write without a connected client for the same reason; it now also fetches the failed route after the client block. Every other client-using file in `test/bake` passes unchanged with the fix: `dev-and-prod`, `bundle`, `css`, `ecosystem`, `esm`, `hot`, `html`, `import-meta-inline`, `incremental-graph-edge-deletion`, `react-spa`, `sourcemap`, `ssg-pages-router` and `stress`, 114 tests including the two new ones, run with a debug build.

### Tests

`test/bake/dev/harness.test.ts` (new, tests for the harness itself):

- a client that exits non-zero while being disposed: the fixture is left expecting a reload, so its `exit` handler turns the `exit(0)` requested by dispose into `reloadNotCalled`. With the harness hunk reverted this fails with `Expected the promise to reject`; with it, dispose rejects with `Client exited: "Reload not called"`.
- a client that exited before dispose (`console.error` in a hot-updated module): `dev.write` rejects with `Client exited while applying hot update: Runtime error` and dispose with `Client exited: "Runtime error"`. This passes before and after; it pins the path that already worked and the message format.

The tests await dispose directly instead of through `expect(...).rejects`: that matcher waits by ticking the event loop from inside the matcher call (`wait_for_promise`), the exit is then processed with the event loop already entered, `onExit` runs before the `await` continuation, and the old code happens to pass. `await using` in real tests is a plain `await`, which is the order the first test reproduces.


</details>
