### PR TITLE
Headers: snapshot values in the iterator so iteration is not quadratic

### DIFF
--- a/src/jsc/bindings/webcore/FetchHeaders.cpp
+++ b/src/jsc/bindings/webcore/FetchHeaders.cpp
@@ -207,6 +207,7 @@ ExceptionOr<Ref<FetchHeaders>> FetchHeaders::create(std::optional<Init>&& header
 
 ExceptionOr<void> FetchHeaders::fill(const Init& headerInit)
 {
+    ++m_updateCounter;
     return fillHeaderMap(m_headers, headerInit, m_guard);
 }
 
@@ -218,10 +219,10 @@ ExceptionOr<void> FetchHeaders::fill(const FetchHeaders& otherHeaders)
         headers.uncommonHeaders().appendVector(otherHeaders.m_headers.uncommonHeaders());
         headers.getSetCookieHeaders().appendVector(otherHeaders.m_headers.getSetCookieHeaders());
         setInternalHeaders(WTF::move(headers));
-        m_updateCounter++;
         return {};
     }
 
+    ++m_updateCounter;
     for (auto& header : otherHeaders.m_headers) {
         auto result = appendToHeaderMap(header, m_headers, m_guard);
         if (result.hasException())
@@ -320,66 +321,48 @@ ExceptionOr<void> FetchHeaders::set(const String& name, const String& value)
     return {};
 }
 
+// https://webidl.spec.whatwg.org/#es-iterable: each next() reads the current
+// list of value pairs to iterate over (for Headers, "sort and combine" of the
+// header list) at the iterator's index, so a mutation between two next() calls
+// is observed from the current index onwards. The list is materialized as
+// (name, value) pairs and only rebuilt after a mutation, so a full iteration
+// costs one sort rather than one header-map lookup per step.
 std::optional<KeyValuePair<String, String>> FetchHeaders::Iterator::next()
 {
-    if (m_keys.isEmpty() || m_updateCounter != m_headers->m_updateCounter) {
-        bool hasSetCookie = !m_headers->getSetCookieHeaders().isEmpty();
-        m_keys.resize(0);
-        m_keys.reserveCapacity(m_headers->m_headers.size() + (hasSetCookie ? 1 : 0));
+    if (!m_hasEntries || m_updateCounter != m_headers->m_updateCounter) {
+        auto& headers = m_headers->m_headers;
+
+        m_entries.resize(0);
+        m_entries.reserveCapacity(headers.size());
         if (m_lowerCaseKeys) {
-            for (auto& header : m_headers->m_headers)
-                m_keys.unsafeAppendWithoutCapacityCheck(header.asciiLowerCaseName());
+            for (auto& header : headers)
+                m_entries.unsafeAppendWithoutCapacityCheck({ header.asciiLowerCaseName(), header.value });
         } else {
-            for (auto& header : m_headers->m_headers)
-                m_keys.unsafeAppendWithoutCapacityCheck(header.name());
+            for (auto& header : headers)
+                m_entries.unsafeAppendWithoutCapacityCheck({ header.name(), header.value });
         }
-        std::sort(m_keys.begin(), m_keys.end(), WTF::codePointCompareLessThan);
-        if (hasSetCookie)
-            m_keys.unsafeAppendWithoutCapacityCheck(String());
+        // Names are unique within a header map, so the order is fully determined.
+        std::sort(m_entries.begin(), m_entries.end(), [](const auto& a, const auto& b) {
+            return WTF::codePointCompareLessThan(a.key, b.key);
+        });
+        // One entry per set-cookie value, after the combined headers.
+        for (auto& value : headers.getSetCookieHeaders())
+            m_entries.unsafeAppendWithoutCapacityCheck({ WTF::httpHeaderNameStringImpl(HTTPHeaderName::SetCookie), value });
 
-        m_currentIndex += m_cookieIndex;
-        if (hasSetCookie) {
-            size_t setCookieKeyIndex = m_keys.size() - 1;
-            if (m_currentIndex < setCookieKeyIndex)
-                m_cookieIndex = 0;
-            else {
-                m_cookieIndex = std::min(m_currentIndex - setCookieKeyIndex, m_headers->getSetCookieHeaders().size());
-                m_currentIndex -= m_cookieIndex;
-            }
-        } else
-            m_cookieIndex = 0;
-
+        m_hasEntries = true;
         m_updateCounter = m_headers->m_updateCounter;
     }
 
-    auto& setCookieHeaders = m_headers->m_headers.getSetCookieHeaders();
+    if (m_currentIndex >= m_entries.size())
+        return std::nullopt;
 
-    while (m_currentIndex < m_keys.size()) {
-        auto key = m_keys[m_currentIndex];
-
-        if (key.isNull()) {
-            if (m_cookieIndex < setCookieHeaders.size()) {
-                String value = setCookieHeaders[m_cookieIndex++];
-                return KeyValuePair<String, String> { WTF::httpHeaderNameStringImpl(HTTPHeaderName::SetCookie), WTF::move(value) };
-            }
-            m_currentIndex++;
-            continue;
-        }
-
-        m_currentIndex++;
-        auto value = m_headers->m_headers.get(key);
-        if (!value.isNull())
-            return KeyValuePair<String, String> { WTF::move(key), WTF::move(value) };
-    }
-
-    return std::nullopt;
+    return m_entries[m_currentIndex++];
 }
 
-FetchHeaders::Iterator::Iterator(FetchHeaders& headers, bool lowerCaseKeys = true)
+FetchHeaders::Iterator::Iterator(FetchHeaders& headers, bool lowerCaseKeys)
     : m_headers(headers)
+    , m_lowerCaseKeys(lowerCaseKeys)
 {
-    m_cookieIndex = 0;
-    m_lowerCaseKeys = lowerCaseKeys;
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/FetchHeaders.h
+++ b/src/jsc/bindings/webcore/FetchHeaders.h
@@ -82,23 +82,27 @@ public:
 
     String fastGet(HTTPHeaderName name) const { return m_headers.get(name); }
     bool fastHas(HTTPHeaderName name) const { return m_headers.contains(name); }
-    bool fastRemove(HTTPHeaderName name) { return m_headers.remove(name); }
-    void fastSet(HTTPHeaderName name, const String& value) { m_headers.set(name, value); }
+    bool fastRemove(HTTPHeaderName name)
+    {
+        ++m_updateCounter;
+        return m_headers.remove(name);
+    }
 
     const Vector<String, 0>& getSetCookieHeaders() const { return m_headers.getSetCookieHeaders(); }
 
     class Iterator {
     public:
-        explicit Iterator(FetchHeaders&);
         Iterator(FetchHeaders&, bool lowerCaseKeys);
         std::optional<KeyValuePair<String, String>> next();
 
     private:
         Ref<FetchHeaders> m_headers;
         size_t m_currentIndex { 0 };
-        Vector<String> m_keys;
+        // The sorted-and-combined header list as of m_updateCounter. Rebuilt by
+        // next() once the headers have been mutated since it was taken.
+        Vector<KeyValuePair<String, String>> m_entries;
         uint64_t m_updateCounter { 0 };
-        size_t m_cookieIndex { 0 };
+        bool m_hasEntries { false };
         bool m_lowerCaseKeys { true };
     };
     Iterator createIterator(bool lowerCaseKeys = true)
@@ -111,7 +115,11 @@ public:
         return Iterator(*this, true);
     }
 
-    void setInternalHeaders(HTTPHeaderMap&& headers) { m_headers = WTF::move(headers); }
+    void setInternalHeaders(HTTPHeaderMap&& headers)
+    {
+        ++m_updateCounter;
+        m_headers = WTF::move(headers);
+    }
     const HTTPHeaderMap& internalHeaders() const { return m_headers; }
 
     void setGuard(Guard);
@@ -120,11 +128,13 @@ public:
     FetchHeaders(Guard, HTTPHeaderMap&&);
     explicit FetchHeaders(const FetchHeaders&);
 
-    uint64_t m_updateCounter { 0 };
-
 private:
     Guard m_guard;
     HTTPHeaderMap m_headers;
+    // Incremented by every member function that mutates m_headers; Iterator
+    // compares it against the value it cached to decide whether its snapshot of
+    // the header list is still current.
+    uint64_t m_updateCounter { 0 };
 };
 
 inline FetchHeaders::FetchHeaders(Guard guard, HTTPHeaderMap&& headers)

--- a/test/js/web/fetch/headers.test.ts
+++ b/test/js/web/fetch/headers.test.ts
@@ -2,6 +2,7 @@ import { beforeAll, describe, expect, test } from "bun:test";
 // Namespace import so a missing binding fails only the kernel tests below
 // (accessing an absent export is `undefined`), not the whole file.
 import * as internalForTesting from "bun:internal-for-testing";
+import { isDebug } from "harness";
 
 beforeAll(() => {
   // expect(Headers).toBeDefined();
@@ -519,6 +520,189 @@ describe("Headers", () => {
       ]);
     });
   });
+
+  // entries()/keys()/values()/forEach()/for-of share one native iterator. Per
+  // Web IDL, each next() reads the current sort-and-combine list of the headers
+  // at the iterator's index, so a mutation between two next() calls is visible
+  // from that index on and never rewinds or fast-forwards the iterator. Node
+  // yields the same sequences for every case in this block.
+  describe("mutation during iteration", () => {
+    test("a header added past the index is yielded", () => {
+      const headers = new Headers({ a: "1", b: "2", c: "3" });
+      const it = headers.entries();
+      const first = it.next().value;
+      headers.set("d", "4");
+      expect([first, ...it]).toEqual([
+        ["a", "1"],
+        ["b", "2"],
+        ["c", "3"],
+        ["d", "4"],
+      ]);
+    });
+
+    test("values changed past the index are yielded with their new value", () => {
+      const headers = new Headers({ a: "1", b: "2", c: "3" });
+      const it = headers.entries();
+      const first = it.next().value;
+      headers.append("b", "x");
+      headers.set("c", "changed");
+      expect([first, ...it]).toEqual([
+        ["a", "1"],
+        ["b", "2, x"],
+        ["c", "changed"],
+      ]);
+    });
+
+    test("deleting a header before the index shifts the list under the index", () => {
+      const headers = new Headers({ a: "1", b: "2", c: "3" });
+      const it = headers.entries();
+      const first = it.next().value;
+      headers.delete("a");
+      expect([first, ...it]).toEqual([
+        ["a", "1"],
+        ["c", "3"],
+      ]);
+    });
+
+    test("adding a header before the index shifts the list under the index", () => {
+      const headers = new Headers({ b: "2", c: "3" });
+      const it = headers.keys();
+      const first = it.next().value;
+      headers.set("a", "1");
+      expect([first, ...it]).toEqual(["b", "b", "c"]);
+    });
+
+    test("deleting every header ends the iteration", () => {
+      const headers = new Headers({ a: "1", b: "2", c: "3" });
+      const it = headers.keys();
+      const first = it.next().value;
+      for (const name of ["a", "b", "c"]) headers.delete(name);
+      expect([first, ...it]).toEqual(["a"]);
+    });
+
+    test("forEach observes mutations made by its callback", () => {
+      const headers = new Headers({ a: "1", b: "2", c: "3" });
+      const seen: string[] = [];
+      headers.forEach((value, name) => {
+        seen.push(`${name}=${value}`);
+        if (name === "a") {
+          headers.set("c", "c2");
+          headers.set("e", "5");
+        }
+        if (name === "b") headers.delete("a");
+      });
+      expect(seen).toEqual(["a=1", "b=2", "e=5"]);
+    });
+
+    // set-cookie is iterated as one entry per value. The other names used
+    // below sort before "set-cookie", so these sequences do not depend on
+    // where the set-cookie entries are placed relative to the other headers.
+    test("a set-cookie value appended past the index is yielded", () => {
+      const headers = new Headers();
+      headers.append("a", "1");
+      headers.append("set-cookie", "k1=1");
+      headers.append("set-cookie", "k2=2");
+      const it = headers.entries();
+      const seen = [it.next().value, it.next().value];
+      headers.append("set-cookie", "k3=3");
+      expect([...seen, ...it]).toEqual([
+        ["a", "1"],
+        ["set-cookie", "k1=1"],
+        ["set-cookie", "k2=2"],
+        ["set-cookie", "k3=3"],
+      ]);
+    });
+
+    test("deleting set-cookie before reaching it removes all of its entries", () => {
+      const headers = new Headers();
+      headers.append("a", "1");
+      headers.append("b", "2");
+      headers.append("set-cookie", "k1=1");
+      headers.append("set-cookie", "k2=2");
+      const it = headers.keys();
+      const first = it.next().value;
+      headers.delete("set-cookie");
+      expect([first, ...it]).toEqual(["a", "b"]);
+    });
+
+    test("deleting a header before the index while inside the set-cookie entries skips one value", () => {
+      const headers = new Headers();
+      headers.append("a", "1");
+      headers.append("set-cookie", "k1=1");
+      headers.append("set-cookie", "k2=2");
+      headers.append("set-cookie", "k3=3");
+      const it = headers.values();
+      const seen = [it.next().value, it.next().value];
+      headers.delete("a");
+      expect([...seen, ...it]).toEqual(["1", "k1=1", "k3=3"]);
+    });
+
+    test("replacing the set-cookie values with set() shortens the list", () => {
+      const headers = new Headers();
+      headers.append("set-cookie", "k1=1");
+      headers.append("set-cookie", "k2=2");
+      headers.append("set-cookie", "k3=3");
+      const it = headers.values();
+      const first = it.next().value;
+      headers.set("set-cookie", "only=1");
+      expect([first, ...it]).toEqual(["k1=1"]);
+    });
+  });
+
+  // The iterator used to look each name up in the header map as it yielded it
+  // (a linear scan per entry), making a full iteration quadratic in the header
+  // count. Both workloads below yield LARGE entries: LARGE/SMALL passes over a
+  // SMALL-header object versus one pass over a LARGE-header object. When the
+  // per-entry cost is independent of the map size only the sort differs
+  // between them, which bounds the ratio at about 2 (measured 1.1-1.25 on
+  // release and 1.5-1.9 on debug+ASAN, where string comparisons are at their
+  // most expensive). With the per-entry scan the large pass searches a 32x
+  // bigger map for every entry: measured 10-16 on release and 18-21 on
+  // debug+ASAN. Equal allocation and back-to-back timing cancel machine speed
+  // and GC settings out of each repetition's ratio, and the median over the
+  // repetitions discards the ones disturbed by other processes. The timeout is
+  // a ceiling: passing takes 2-3s on a debug build, while the quadratic version
+  // needs 30-45s there to reach the failing assertion (or times out, which
+  // fails as well).
+  test("per-entry iteration cost does not grow with the number of headers", () => {
+    const SMALL = 32;
+    const LARGE = 1024;
+    // A repetition costs ~0.5s on a debug build and well under 1ms on release.
+    const repetitions = isDebug ? 5 : 10;
+
+    function build(count: number) {
+      const headers = new Headers();
+      for (let i = 0; i < count; i++) headers.append(`x-${i}`, `${i}`);
+      return headers;
+    }
+    function drain(headers: Headers) {
+      let yielded = 0;
+      for (const _ of headers.keys()) yielded++;
+      return yielded;
+    }
+    const small = build(SMALL);
+    const large = build(LARGE);
+
+    const ratios: number[] = [];
+    for (let rep = 0; rep < repetitions; rep++) {
+      let start = performance.now();
+      let yielded = 0;
+      for (let i = 0; i < LARGE / SMALL; i++) yielded += drain(small);
+      const smallMs = performance.now() - start;
+      expect(yielded).toBe(LARGE);
+
+      start = performance.now();
+      yielded = drain(large);
+      const largeMs = performance.now() - start;
+      expect(yielded).toBe(LARGE);
+
+      ratios.push(largeMs / smallMs);
+    }
+
+    ratios.sort((a, b) => a - b);
+    expect(ratios[ratios.length >> 1]).toBeLessThan(4);
+  }, 60_000);
+
   describe("Bun.inspect()", () => {
     const it = "toJSON" in new Headers() ? test : test.skip;
     it("can convert to json when empty", () => {


### PR DESCRIPTION
### Problem
- Iterating a `Headers` object is quadratic in the number of headers: on a release build of main one `keys()` pass takes 2.5ms for 1000 headers, 7.5ms for 2000 and 32ms for 4000; on a debug build 1000 headers take about 6.7s.
- Every iteration surface is affected (`entries()`, `keys()`, `values()`, `forEach()`, `for...of`, `Object.fromEntries`), and so is the pass that flattens the headers when `fetch()` sends a request, since it uses the same native iterator.
- Cause: the native iterator sorts the names once, but looks each name's value up in the header map as it yields it, and that lookup is a linear scan of the map. One scan per entry over n entries is O(n^2).
- The layout is inherited from WebKit, where header counts are small enough for this not to matter.

### Fix
- The iterator stores `(name, value)` pairs when it builds its sorted list, with the set-cookie values appended one per entry where they were yielded before, and each step indexes into that list. The values are refs to strings the map already holds and die with the iterator, so `Headers` objects do not grow.
- Why it is correct: the list was already rebuilt (index kept) whenever the update counter changed, and between two rebuilds the map is unmodified, so a value stored at rebuild time is what a lookup at yield time would return.
- That property needs every mutation to bump the counter. Three internal paths (hop-by-hop stripping, wholesale map replacement, fill from an init) now do; before, only the JS-facing `append`/`set`/`delete` did.
- Verification: a timing test that fails on main and passes with the fix on release and debug+ASAN; 10 mutation-during-iteration tests that pass on main too and were checked against Node; `for...of` over 4000 headers goes from 64ms to 1.3ms on release. Where set-cookie entries sort (Bun puts them last, the spec sorts them in place) is unchanged and left to #33125.

### Background
- bun's `Headers` is WebKit's `FetchHeaders`. The JS iteration methods and the request-serialization path in `fetch()` share one native iterator whose `next()` yields one `(name, value)` pair per call.
- The storage underneath is `HTTPHeaderMap`: a vector of headers with well-known names, a vector of uncommon ones, and a separate vector of set-cookie values (which are never combined). There is no hash index, so looking a name up is a linear scan.
- "Sort and combine" is the Fetch spec's name for the list an iteration walks: names sorted, the values of a repeated name joined with `, `, and one entry per set-cookie value.
- Web IDL iterators are an index into whatever the current list is: a mutation between two `next()` calls is visible from the current index onward, and the index itself never moves.
- The update counter is how `FetchHeaders` notices a mutation: every mutating member bumps it, and the iterator rebuilds its list when the value it cached no longer matches.

<details>
<summary>Original description</summary>

Iterating a `Headers` object is quadratic in the number of headers. Every iteration surface is affected (`entries()`, `keys()`, `values()`, `forEach()`, `for...of`, `Object.fromEntries(headers)`), and so is the `count` + `copyTo` pass that flattens a `Headers` object when `fetch()` sends a request, since it uses the same native iterator.

```js
for (const n of [1000, 2000, 4000]) {
  const headers = new Headers();
  for (let i = 0; i < n; i++) headers.set(`x-${i}`, `${i}`);
  const t = performance.now();
  [...headers.keys()];
  console.log(n, (performance.now() - t).toFixed(2) + "ms");
}
// release build of main: 1000 2.5ms, 2000 7.5ms, 4000 32ms (4x per doubling)
// debug build of main: keys() over 1000 headers takes ~6.7s
```

### Cause

`FetchHeaders::Iterator::next()` (`src/jsc/bindings/webcore/FetchHeaders.cpp`) builds and sorts the list of names on its first call, but then, for every name it yields, calls `HTTPHeaderMap::get(name)` to fetch the value. `HTTPHeaderMap` stores headers in plain vectors, so that lookup is `findHTTPHeaderName` plus a linear `equalIgnoringASCIICase` scan of the uncommon headers (or of the common headers for known names): O(n) per step, O(n^2) per iteration. The structure is inherited from WebKit, where header counts are small enough not to matter.

### Fix

The iterator now materializes the sorted-and-combined list as `(name, value)` pairs when it is (re)built and `next()` just indexes into it. The values are refs to the same `String`s the map holds, so the snapshot costs one extra ref per entry and no copies, and it is freed with the iterator, so `Headers` objects themselves don't grow. The set-cookie values are appended to the same list, one entry per value, exactly where they were yielded before; that makes the iterator's position a plain index into the list and replaces the index rebasing arithmetic that used to reconcile the set-cookie position after a rebuild.

Why this is correct: Web IDL specifies that each `next()` reads the current "value pairs to iterate over" (for `Headers`, sort-and-combine of the header list) at the iterator's index. The previous code already implemented that by rebuilding its name list whenever `m_updateCounter` changed and keeping the index; this change keeps that exact mechanism, it only stores the value next to the name at rebuild time instead of looking it up at yield time. Between two rebuilds the map is unmodified, so the stored values are the ones a lookup would return. For that to hold for every mutation path, `fastRemove` (used when the server strips hop-by-hop headers from a response object), `setInternalHeaders` and `fill` now bump `m_updateCounter` as well; previously only the JS-facing `append`/`set`/`delete` did. `fastSet` had no callers and is removed rather than given a bump. `m_updateCounter` moves to the private section next to the map it guards (the nested `Iterator` still has access).

A script exercising thirteen mutation-between-`next()`-calls scenarios (add/delete/change before and after the index, with and without set-cookie entries, `forEach` mutating from its callback) produces byte-identical output on main and on this branch, and identical output on Node for every scenario that does not involve the position of set-cookie entries. The set-cookie position itself (Bun puts them last, the spec sorts them in place) is a separate pre-existing difference handled by #33125 and is deliberately left unchanged here.

### Numbers

Release build, time per full iteration (best of 5 batches), names like `x-header-N`:

| headers | `for...of` before | after | `keys()` before | after |
| ------: | ----------------: | ----: | --------------: | ----: |
| 8 | 2.0us | 1.6us | 1.5us | 1.1us |
| 32 | 12.4us | 7.2us | 10.1us | 5.5us |
| 64 | 35.5us | 14.8us | 31.3us | 12.9us |
| 256 | 298us | 60us | 275us | 43us |
| 1000 | 5.16ms | 0.42ms | 4.70ms | 0.33ms |
| 4000 | 64.2ms | 1.31ms | 62.6ms | 1.01ms |

Small sizes get slightly faster too because the per-step `findHTTPHeaderName` + scan is gone. Node v26 does 4000 in 0.2-0.4ms; the remaining gap is that Bun rebuilds the list once per iterator while undici caches it on the headers list, which would need per-object state and is not attempted here. On a debug build, the `Headers` case of `test/js/bun/util/heap-snapshot.test.ts` (which iterates 1000 headers) goes from a 5s timeout to about 2s (#37835 is changing that test independently).

### Tests (`test/js/web/fetch/headers.test.ts`)

- `per-entry iteration cost does not grow with the number of headers`: times 32 passes over a 32-header object against one pass over a 1024-header object (same number of entries yielded, same allocation), and asserts the median per-repetition ratio is below 4. With a size-independent per-entry cost only the sort differs, so the ratio is bounded at about 2: measured 1.1-1.25 on release and 1.5-1.9 on debug+ASAN, and still 1.0-1.3 (release, 10 repetitions) / 1.3-1.7 (debug, 5 repetitions) with the CPU oversubscribed 2x by other processes. With the per-step lookup it measures about 10-16 on release and 18-21 on debug+ASAN. Fails on main, passes with the fix, on both build types.
- `mutation during iteration` (10 tests): pin the sequences yielded when headers are added, changed or deleted before or after the iterator's index, including with set-cookie entries, and when `forEach`'s callback mutates the object. These pass on main too (they pin the behavior the rewrite has to preserve); the set-cookie cases only use names that sort before `set-cookie`, so they are valid under both the current and the spec order and are verified against Node.

Also ran `headers.undici.test.ts`, `headers-case.test.ts` (the non-lowercasing `copyTo` path), `deno/fetch/headers.test.ts`, `fetch_headers.test.js`, the Headers/cookie tests in `fetch.test.ts`, `response.test.ts`, `cookies.test.ts` and the WebSocket custom header tests against a debug build.

</details>
