### PR TITLE
bake test harness: check the error overlay once instead of polling for a second per connect and write

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -319,28 +319,33 @@ export class Dev extends EventEmitter {
     const b = {
       write: resetSeenFilesWithResolvers,
       [Symbol.asyncDispose]: async () => {
-        if (wantsHmrEvent && interactive) {
-          await seenFiles.promise;
-        } else if (wantsHmrEvent) {
-          await Promise.race([seenFiles.promise]);
-        }
-        // One Bun.write can surface as several watcher events (notably on
-        // Windows); let them coalesce so releasing the batch bundles once.
-        await Bun.sleep(50);
-
-        dev.off("watch_synchronization", onSeenFiles);
-
-        this.socket!.send("H");
-        await wait;
-
-        let errors = options.errors;
-        if (errors !== null) {
-          errors ??= [];
-          for (const client of this.connectedClients) {
-            await client.expectErrorOverlay(errors, options.snapshot);
+        // The batch ends even when the wait or the overlay check below throws,
+        // so a test that expects one write to reject can keep using `dev`.
+        try {
+          if (wantsHmrEvent && interactive) {
+            await seenFiles.promise;
+          } else if (wantsHmrEvent) {
+            await Promise.race([seenFiles.promise]);
           }
+          // One Bun.write can surface as several watcher events (notably on
+          // Windows); let them coalesce so releasing the batch bundles once.
+          await Bun.sleep(50);
+
+          dev.off("watch_synchronization", onSeenFiles);
+
+          this.socket!.send("H");
+          await wait;
+
+          let errors = options.errors;
+          if (errors !== null) {
+            errors ??= [];
+            for (const client of this.connectedClients) {
+              await client.expectErrorOverlay(errors, options.snapshot);
+            }
+          }
+        } finally {
+          this.batchingChanges = null;
         }
-        this.batchingChanges = null;
       },
     };
     this.batchingChanges = b;
@@ -547,7 +552,7 @@ export class Dev extends EventEmitter {
       this.output.on("panic", onPanic);
       if (this.nodeEnv === "development") {
         try {
-          await client.output.waitForLine(hmrClientInitRegex);
+          await client.waitForPageLoad();
         } catch (e) {
           this.output.off("panic", onPanic);
           try {
@@ -892,13 +897,38 @@ export class Client extends EventEmitter {
     return withAnnotatedStack(snapshotCallerLocation(), async () => {
       await maybeWaitInteractive("hard-reload");
       if (this.exited) throw new Error("Client is not running.");
-      this.#proc.send({ type: "hard-reload" });
-
-      if (this.hmr) {
-        await this.output.waitForLine(hmrClientInitRegex);
-        await this.expectErrorOverlay(options.errors ?? []);
+      if (!this.hmr) {
+        this.#proc.send({ type: "hard-reload" });
+        return;
       }
+      const loaded = this.waitForPageLoad();
+      this.#proc.send({ type: "hard-reload" });
+      await loaded;
+      await this.expectErrorOverlay(options.errors ?? []);
     });
+  }
+
+  /**
+   * Resolves once the page being loaded has connected its HMR socket and the
+   * fixture acked it, which it only does after the page's stylesheets loaded.
+   * Call this before the load starts so the ack cannot be missed. The line
+   * wait adds a timeout and the fixture's output when it dies while loading.
+   */
+  async waitForPageLoad(): Promise<void> {
+    const acked = new Promise<void>((resolve, reject) => {
+      const onAck = () => {
+        this.off("exit", onExit);
+        resolve();
+      };
+      const onExit = (code: number | string) => {
+        this.off("received-hmr-event", onAck);
+        const mapped = exitCodeMapStrings[code];
+        reject(new Error(`Client exited while loading the page${mapped ? `: ${mapped}` : ` (${code})`}`));
+      };
+      this.once("received-hmr-event", onAck);
+      this.once("exit", onExit);
+    });
+    await Promise.all([this.output.waitForLine(hmrClientInitRegex), acked]);
   }
 
   elemText(selector: string): Promise<string> {
@@ -910,6 +940,35 @@ export class Client extends EventEmitter {
       `;
       if (text == null) throw new Error(`Element found but has no text content: ${selector}`);
       return text;
+    });
+  }
+
+  /**
+   * Waits until the element's innerHTML is `text`. For DOM that a framework
+   * updates asynchronously after the harness has already synchronized with the
+   * dev server, e.g. React committing a server-side route reload.
+   */
+  expectElemText(selector: string, text: string): Promise<void> {
+    return withAnnotatedStack(snapshotCallerLocation(), async () => {
+      await this.js`
+        const read = () => document.querySelector(${selector})?.innerHTML;
+        if (read() === ${text}) return;
+        await new Promise((resolve, reject) => {
+          const observer = new MutationObserver(() => {
+            if (read() !== ${text}) return;
+            observer.disconnect();
+            clearTimeout(timer);
+            resolve();
+          });
+          // Observe the document itself: a re-render may replace <html> rather
+          // than patch it, which an observer on the old root would never see.
+          observer.observe(document, { subtree: true, childList: true, characterData: true });
+          const timer = setTimeout(() => {
+            observer.disconnect();
+            reject(new Error("Expected " + ${selector} + " to become " + JSON.stringify(${text}) + ", last saw " + JSON.stringify(read())));
+          }, ${interactive ? interactive_timeout : 2000 * WAIT_MULTIPLIER});
+        });
+      `;
     });
   }
 
@@ -1046,59 +1105,43 @@ export class Client extends EventEmitter {
   expectErrorOverlay(errors: ErrorSpec[], caller: string | null = null) {
     return withAnnotatedStack(caller ?? snapshotCallerLocationMayFail(), async () => {
       this.suppressInteractivePrompt = true;
-      let retries = 0;
-      let hasVisibleModal = false;
-      while (retries < 5) {
-        hasVisibleModal = await this.js`document.querySelector("bun-hmr")?.style.display === "block"`;
-        if (hasVisibleModal) break;
-        await Bun.sleep(200);
-        retries++;
+      let hasVisibleModal: boolean;
+      try {
+        hasVisibleModal = await this.#hasVisibleErrorOverlay();
+        // Build errors are already on the page when callers get here: the error
+        // page renders them before its socket connects, and after a write the
+        // fixture acks the build only after the runtime handled the errors
+        // frame. Only runtime errors reach the overlay later (the runtime remaps
+        // them through /_bun/report_error first), so polling is only useful when
+        // errors are expected.
+        for (let retries = 0; errors.length > 0 && !hasVisibleModal && retries < 5; retries++) {
+          await Bun.sleep(200);
+          hasVisibleModal = await this.#hasVisibleErrorOverlay();
+        }
+      } finally {
+        this.suppressInteractivePrompt = false;
       }
-      this.suppressInteractivePrompt = false;
-      if (errors && errors.length > 0) {
-        if (!hasVisibleModal) {
-          await maybeWaitInteractive("expectErrorOverlay");
-          throw new Error("Expected errors, but none found");
-        }
-
-        // Create unique message ID for this evaluation
-        const messageId = Math.random().toString(36).slice(2);
-
-        // Send the evaluation request and wait for response
-        this.#proc.send({
-          type: "get-errors",
-          args: [messageId],
-        });
-
-        const [result] = await EventEmitter.once(this, `get-errors-result-${messageId}`);
-
-        if (result.error) {
-          throw new Error(result.error);
-        }
-        const actualErrors = result.value;
-        const expectedErrors = [...errors].sort();
-        expect(actualErrors).toEqual(expectedErrors);
-      } else {
-        if (hasVisibleModal) {
-          // Create unique message ID for this evaluation
-          const messageId = Math.random().toString(36).slice(2);
-
-          // Send the evaluation request and wait for response
-          this.#proc.send({
-            type: "get-errors",
-            args: [messageId],
-          });
-
-          const [result] = await EventEmitter.once(this, `get-errors-result-${messageId}`);
-
-          if (result.error) {
-            throw new Error(result.error);
-          }
-          const actualErrors = result.value;
-          expect(actualErrors).toEqual([]);
-        }
+      if (!hasVisibleModal) {
+        if (errors.length === 0) return;
+        await maybeWaitInteractive("expectErrorOverlay");
+        throw new Error("Expected errors, but none found");
       }
+
+      const messageId = Math.random().toString(36).slice(2);
+      this.#proc.send({
+        type: "get-errors",
+        args: [messageId],
+      });
+      const [result] = await EventEmitter.once(this, `get-errors-result-${messageId}`);
+      if (result.error) {
+        throw new Error(result.error);
+      }
+      expect(result.value).toEqual([...errors].sort());
     });
+  }
+
+  #hasVisibleErrorOverlay() {
+    return this.js<boolean>`document.querySelector("bun-hmr")?.style.display === "block"`;
   }
 
   getStringMessage(): Promise<string> {

--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -915,20 +915,20 @@ export class Client extends EventEmitter {
    * wait adds a timeout and the fixture's output when it dies while loading.
    */
   async waitForPageLoad(): Promise<void> {
-    const acked = new Promise<void>((resolve, reject) => {
-      const onAck = () => {
-        this.off("exit", onExit);
-        resolve();
-      };
-      const onExit = (code: number | string) => {
-        this.off("received-hmr-event", onAck);
-        const mapped = exitCodeMapStrings[code];
-        reject(new Error(`Client exited while loading the page${mapped ? `: ${mapped}` : ` (${code})`}`));
-      };
-      this.once("received-hmr-event", onAck);
-      this.once("exit", onExit);
-    });
-    await Promise.all([this.output.waitForLine(hmrClientInitRegex), acked]);
+    const acked = Promise.withResolvers<void>();
+    const onAck = () => acked.resolve();
+    const onExit = (code: number | string) => {
+      const mapped = exitCodeMapStrings[code];
+      acked.reject(new Error(`Client exited while loading the page${mapped ? `: ${mapped}` : ` (${code})`}`));
+    };
+    this.once("received-hmr-event", onAck);
+    this.once("exit", onExit);
+    try {
+      await Promise.all([this.output.waitForLine(hmrClientInitRegex), acked.promise]);
+    } finally {
+      this.off("received-hmr-event", onAck);
+      this.off("exit", onExit);
+    }
   }
 
   elemText(selector: string): Promise<string> {

--- a/test/bake/client-fixture.mjs
+++ b/test/bake/client-fixture.mjs
@@ -32,15 +32,16 @@ let expectingReload = false;
 let webSockets = [];
 let pendingReload = null;
 let pendingReloadTimer = null;
-let isUpdating = null;
+// Bumped whenever the current window is abandoned (reload requested, or a new
+// window created). Acks captured by an older window are dropped: the harness
+// expects exactly one "received-hmr-event" per build per client, and after a
+// reload that one ack comes from the new window once it has connected.
+let windowGeneration = 0;
 let objectURLRegistry = new Map();
 let internalAPIs;
 
 function reset() {
-  if (isUpdating !== null) {
-    clearImmediate(isUpdating);
-    isUpdating = null;
-  }
+  windowGeneration++;
   for (const ws of webSockets) {
     ws.onclose = () => {};
     ws.onerror = () => {};
@@ -71,15 +72,21 @@ function createWindow(windowUrl) {
     height: 768,
   });
 
+  const generation = ++windowGeneration;
+  const ackToHarness = () => {
+    if (generation !== windowGeneration) return;
+    process.send({ type: "received-hmr-event", args: [] });
+  };
+
   // The HMR runtime reads this symbol-keyed callback off `globalThis` (which is
   // `window` inside happy-dom's script context) and passes its internal hooks.
   let hmrEventHookInstalled = false;
-  let pendingHotUpdateAcks = 0;
+  let pendingBuildAcks = 0;
   let hmrScriptQueued = false;
-  const sendHmrAck = () => {
-    if (pendingHotUpdateAcks === 0) return;
-    pendingHotUpdateAcks--;
-    process.send({ type: "received-hmr-event", args: [] });
+  const ackBuild = () => {
+    if (pendingBuildAcks === 0) return;
+    pendingBuildAcks--;
+    ackToHarness();
   };
   window[Symbol.for("bun testing api, may change at any time")] = internal => {
     window.internal = internal;
@@ -88,9 +95,10 @@ function createWindow(windowUrl) {
       // Ack a hot update only once the new module code has actually run. Node's
       // Blob.arrayBuffer() resolves on a later macrotask than the WS listener's
       // setImmediate, so acking from the WS listener would race the eval.
-      // Full reloads are not acked here; the new window acks from the
-      // `[Bun] Hot-module-reloading socket connected` handler after loadPage.
-      internal.onEvent("bun:afterUpdate", sendHmrAck);
+      // Updates that end in a full reload are acked by the new window's
+      // "socket connected" handler instead; this window's generation is stale
+      // by the time its runtime gets here.
+      internal.onEvent("bun:afterUpdate", ackBuild);
     }
   };
 
@@ -110,25 +118,29 @@ function createWindow(windowUrl) {
       webSockets.push(this);
       this.addEventListener("message", event => {
         const data = new Uint8Array(event.data);
-        if (data[0] === "u".charCodeAt(0) && hmrEventHookInstalled) {
+        const kind = String.fromCharCode(data[0]);
+        // One ack per build, for the last frame it sends this page. finalize_bundle
+        // (DevServer.rs) publishes errors ("e") before the hot update ("u") and,
+        // while a page running the HMR runtime is connected, always ends with
+        // "u", so those pages ack "u" only; acking "e" would release the harness
+        // before the update behind it is applied. The bundling error page only
+        // subscribes to errors, so its last frame is "e", applied synchronously
+        // by the runtime's own listener right after this one. ("u" without the
+        // hook means the runtime lost its onEvent testing export; acking keeps
+        // that a test failure instead of a hang.)
+        if (hmrEventHookInstalled ? kind === "u" : kind === "e" || kind === "u") {
           // JS updates queue a script tag and ack via bun:afterUpdate once it
-          // evals; everything else (CSS, reloads, route reloads) acks here on
-          // the next tick when no script was queued.
-          pendingHotUpdateAcks++;
+          // evals; everything else (CSS, errors, server-side route reloads)
+          // acks on the next tick when no script was queued.
+          pendingBuildAcks++;
           hmrScriptQueued = false;
-          isUpdating = setImmediate(() => {
-            isUpdating = null;
-            if (!hmrScriptQueued) sendHmrAck();
-          });
-        } else if (data[0] === "e".charCodeAt(0) || data[0] === "u".charCodeAt(0)) {
-          isUpdating = setImmediate(() => {
-            process.send({ type: "received-hmr-event", args: [] });
-            isUpdating = null;
+          setImmediate(() => {
+            if (!hmrScriptQueued) ackBuild();
           });
         }
         if (!allowWebSocketMessages) {
           const allowedTypes = ["n", "r"];
-          if (allowedTypes.includes(String.fromCharCode(data[0]))) {
+          if (allowedTypes.includes(kind)) {
             return;
           }
           dumpWebSocketMessage("[E] WebSocket message received while messages are not allowed", data);
@@ -230,9 +242,7 @@ function createWindow(windowUrl) {
 
           // If no stylesheets of any kind, just emit the event
           if (styleLinks.length === 0 && styleTags.length === 0 && adoptedSheets.length === 0) {
-            process.nextTick(() => {
-              process.send({ type: "received-hmr-event", args: [] });
-            });
+            process.nextTick(ackToHarness);
             return;
           }
 
@@ -270,9 +280,7 @@ function createWindow(windowUrl) {
             if (checkAttempts >= MAX_CHECK_ATTEMPTS && !allLoaded) {
               console.warn("[W] Reached maximum CSS load check attempts, proceeding anyway");
             }
-            process.nextTick(() => {
-              process.send({ type: "received-hmr-event", args: [] });
-            });
+            process.nextTick(ackToHarness);
           } else {
             // Wait a bit and check again
             console.info(

--- a/test/bake/dev-and-prod.test.ts
+++ b/test/bake/dev-and-prod.test.ts
@@ -295,10 +295,11 @@ devTest("hmr handles rapid consecutive edits", {
     // `num_subscribers(HotUpdate) == 0` / `active_viewers == 0` and the
     // hot_update is dropped server-side (DevServer.rs finalize_bundle), so
     // the sentinel never reaches the client. Re-writing on each
-    // `received-hmr-event` (which fires on socket open and on every 'u'/'e'
-    // WS frame) guarantees that at least one sentinel write lands after the
-    // server has a subscriber. The same-content writes are idempotent and
-    // the loop terminates the moment waitForMessage resolves below.
+    // `received-hmr-event` (which the fixture sends when a page's socket has
+    // connected and once per hot update it applies) guarantees that at least
+    // one sentinel write lands after the server has a subscriber. The
+    // same-content writes are idempotent and the loop terminates the moment
+    // waitForMessage resolves below.
     const sentinelContent = hmrSelfAcceptingModule("render sentinel");
     const rewriteSentinel = () => writeFileSync(target, sentinelContent);
     client.on("reload", rewriteSentinel);

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -633,12 +633,68 @@ devTest("dev.write resolves only after the new module body has run", {
         globalThis.marker = "updated";
         import.meta.hot.accept();
       `,
-      // errors: null skips the post-write expectErrorOverlay poll (5 * 200ms),
-      // which would otherwise mask a premature ack.
-      { errors: null },
     );
     // dev.write resolves on bun:afterUpdate, i.e. after replaceModules has
     // awaited the 500ms TLA. Acking on WS receipt would see "initial" here.
     expect(await c.js`globalThis.marker`).toBe("updated");
+  },
+});
+
+devTest("dev.client rejects when the page has a build error the test did not expect", {
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `import "./missing";`,
+  },
+  async test(dev) {
+    await expect(dev.client("/")).rejects.toThrow("index.ts:1:8: error: Could not resolve");
+  },
+});
+
+devTest("dev.write rejects on an unexpected build error and resolves once the fix has been applied", {
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `
+      globalThis.marker = "initial";
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    expect(await c.js`globalThis.marker`).toBe("initial");
+
+    await expect(dev.write("index.ts", `import "./missing";`)).rejects.toThrow(
+      "index.ts:1:8: error: Could not resolve",
+    );
+
+    // The build that fixes the error sends an errors frame (hiding the overlay)
+    // followed by the hot update. dev.write must resolve on the update, after
+    // the 200ms top-level await below, not as soon as the overlay is gone.
+    await dev.write(
+      "index.ts",
+      `
+        await new Promise(r => setTimeout(r, 200));
+        globalThis.marker = "fixed";
+        import.meta.hot.accept();
+      `,
+    );
+    expect(await c.js`globalThis.marker`).toBe("fixed");
+  },
+});
+
+devTest("dev.write resolves only after a reload it triggers has loaded the new page", {
+  files: {
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    // Not self-accepting, so updating it falls back to a full reload.
+    "index.ts": `globalThis.marker = "v1";`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    expect(await c.js`globalThis.marker`).toBe("v1");
+
+    await c.expectReload(() => dev.write("index.ts", `globalThis.marker = "v2";`));
+    // This build is acked by the reloaded page once it has connected, so its
+    // scripts have run. The abandoned page still evaluates the update and emits
+    // bun:afterUpdate before that; acking from there would see undefined here.
+    expect(await c.js`globalThis.marker`).toBe("v2");
   },
 });

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,5 +1,6 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
 import { expect } from "bun:test";
+import { runWithErrorPromise } from "harness";
 import { renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { devTest, emptyHtmlFile } from "../bake-harness";
 
@@ -646,7 +647,11 @@ devTest("dev.client rejects when the page has a build error the test did not exp
     "index.ts": `import "./missing";`,
   },
   async test(dev) {
-    await expect(dev.client("/")).rejects.toThrow("index.ts:1:8: error: Could not resolve");
+    // runWithErrorPromise rather than expect().rejects: on Windows that matcher
+    // does not deliver the client's IPC messages while it waits, so anything
+    // the harness resolves from an IPC message hangs inside it.
+    const error = await runWithErrorPromise(() => dev.client("/"));
+    expect(error?.message).toContain("index.ts:1:8: error: Could not resolve");
   },
 });
 
@@ -662,9 +667,8 @@ devTest("dev.write rejects on an unexpected build error and resolves once the fi
     await using c = await dev.client("/");
     expect(await c.js`globalThis.marker`).toBe("initial");
 
-    await expect(dev.write("index.ts", `import "./missing";`)).rejects.toThrow(
-      "index.ts:1:8: error: Could not resolve",
-    );
+    const error = await runWithErrorPromise(() => dev.write("index.ts", `import "./missing";`));
+    expect(error?.message).toContain("index.ts:1:8: error: Could not resolve");
 
     // The build that fixes the error sends an errors frame (hiding the overlay)
     // followed by the hot update. dev.write must resolve on the update, after

--- a/test/bake/dev/ssg-pages-router.test.ts
+++ b/test/bake/dev/ssg-pages-router.test.ts
@@ -157,7 +157,9 @@ devTest("SSG pages router - hot reload on page changes", {
 
     // this %c%s%c is a react devtools thing and I don't know how to turn it off
     await c.expectMessage("%c%s%c updated load");
-    expect(await c.elemText("h1")).toBe("Updated Content");
+    // dev.write() resolves once the client received the route reload; fetching
+    // the new page and committing it is asynchronous on the framework side.
+    await c.expectElemText("h1", "Updated Content");
   },
 });
 


### PR DESCRIPTION
### Problem
- The `test/bake` dev tests are slow for no reason: `dev/bundle.test.ts` takes ~43s for 21 tests on main, and `bundle`, `css` and `hot` sit at 41-56s on every CI lane.
- Cause: after every client connect, and after every write for every connected client, the harness polled for an error overlay 5 x 200ms and only stopped early when one was visible, so the common case (no errors expected, none present) always paid the full second.
- That second was also hiding ordering bugs in the harness: the client fixture acked a build on the errors frame, before the update behind it was applied; a window abandoned by a reload still acked, and the new window acked again; connect waited for a log line rather than the page-loaded ack. Removing the poll alone made one css and one ssg test fail.
- Split out of #37827, which left this lever for a separate PR; #34691 removed the other fixed sleeps on this path.

### Fix
- The overlay is checked once; the short poll is kept only when the caller expects errors. This is enough because build errors are on the page before the harness asks: the error page renders the overlay before opening its socket, and after a write the errors frame arrives before the update frame the fixture acks. Only a runtime error arriving within a second of a test's last connect or write is no longer caught, and no test relies on that.
- The fixture now acks exactly once per build per client: pages running the HMR runtime ack the update frame, not the errors frame, and acks carry a window generation, so after a reload only the new window acks, once it has connected. A reload the test did not allow now rejects the pending write.
- Connect and hard reload wait for that ack instead of a log line; a failed overlay check no longer leaves the write batch open; the one test that asserts DOM right after a server-side route reload now waits for the DOM to change.
- Verification: test infrastructure only, no `src/` change. Of three new `hot` tests, two fail 3/3 with the matching fixture hunk reverted; all of `test/bake` passes with the release binary (189/189), and with debug+ASAN apart from `production.test.ts` cases that also time out on main; the whole directory went from 277s to 138s in single runs on a shared box.

### Background
- Bake is bun's dev server with hot module reloading. `test/bake` drives it through a harness: `dev.write()` edits a file and waits for the rebuild, `dev.client()` loads a page in a child process running happy-dom (the client fixture).
- The fixture acks to the harness over IPC (`received-hmr-event`) when a page has connected and its stylesheets loaded, and when it has applied a build. `dev.client()` and `dev.write()` resolve on that ack, so ack timing is the tests' only synchronization with the page.
- Per build, the dev server's HMR socket sends an errors frame (`"e"`) and then a hot update frame (`"u"`); while a page running the HMR runtime is connected a build always ends with `"u"`. The page served for a route that fails to bundle subscribes to errors only.
- The error overlay is the `<bun-hmr>` element. Build errors reach it as part of the frames above; runtime errors are first sent to `/_bun/report_error` and rendered afterwards, which is why only they can show up late.
- A hot update to a module that does not accept itself (`import.meta.hot.accept()`) falls back to a full page reload; in the fixture that creates a new window while the old one may still be finishing the update.

<details>
<summary>Original description</summary>

### What

`Client.expectErrorOverlay()` in `test/bake/bake-harness.ts` polled `bun-hmr` visibility up to 5 times with `Bun.sleep(200)` in between and only stopped early when an overlay was visible. The harness calls it with an empty list on every `dev.client()` in dev mode and, for every connected client, at the end of every `dev.write()` / `patch()` / `delete()` that does not pass `errors: null`. So the common case, no errors expected and none present, paid the full second every time. On main (`USE_SYSTEM_BUN=1`, this machine) `bundle.test.ts` makes 32 such calls and takes ~43s for 21 tests; a connect-only case is ~1.5s of which ~1s is this poll, and each write with a client attached adds ~1.07s. `test/expected-durations.json` shows the same 41-56s for `bundle`, `css` and `hot` on the release, ASAN, musl and Windows lanes, which is what fixed sleeps look like. #37827 restructures `bundle.test.ts` itself and leaves this harness lever for a separate PR; this is that PR. #34691 removed the other fixed sleeps on this path.

### Why one check is enough

Build errors are on the page before the harness can ask about them:

- On connect, a route with bundling failures is served the error page (`hmr-runtime-error.ts`), which renders the overlay synchronously before it opens the socket the harness waits for.
- After a write, `finalize_bundle` (`DevServer.rs`) publishes the errors frame before the hot update frame on the same socket, and the harness only gets to the check after the fixture acked the build.

Only runtime errors reach the overlay later (`onRuntimeError` awaits `/_bun/report_error` before rendering), so the short poll is kept for callers that pass a non-empty `errors` list, where it already returned early on success. A synchronous throw during module evaluation still exits the fixture through `console.error`, which `dev.client()` / `dev.write()` report. What is given up: an asynchronous runtime error that surfaces within a second of the last connect or write of a test, with no later write to observe it, is no longer caught. No test relies on that; a passing test cannot.

### What the sleep was hiding

Removing it made `css.test.ts` "changing html file with link tag works" and `ssg-pages-router.test.ts` "hot reload on page changes" fail, and reading `client-fixture.mjs` against `finalize_bundle` turned up two more ordering problems the poll had absorbed. Each is replaced with the signal it was standing in for:

1. **Errors frame acked too early** (`client-fixture.mjs`). The fixture acked `"e"` frames immediately. While a page running the HMR runtime is connected the dev server always ends the build with a `"u"` frame after the `"e"` (`will_hear_hot_update` in `finalize_bundle`), so a write that fixed an error resolved when the overlay disappeared, before the update behind it had been applied; a second ack followed later. Pages with the runtime now ack only `"u"` (via `bun:afterUpdate` as before, or the next tick when no script was queued); the error page, which is only subscribed to errors, still acks `"e"`. One ack per build per client.
2. **Reloaded windows kept acking** (`client-fixture.mjs`). After `location.reload()` the abandoned window still ran the rest of `replaceModules` and acked from `bun:afterUpdate` (or from its pending immediate), and the new window acked again on connect. The harness resolved the write on the first one, before the new page existed, and the second one was a straggler that could satisfy the next write's wait as soon as it was registered; the poll used to absorb it. Acks now carry the window generation: `reset()` (called for every reload request, permitted or not) invalidates the current window, so only the live window acks, and a build that reloads the page is acked once, by the new window after it connected. This also replaces the `isUpdating` immediate cancellation. A reload the test did not allow now rejects the pending `dev.write()` via the existing exit handler instead of acking and failing later.
3. **Connect waited for the log line, not the ack** (`bake-harness.ts`). `dev.client()` and `Client.hardReload()` returned once `[Bun] Hot-module-reloading socket connected` was printed. The fixture's own ack for a page load is sent after its stylesheets have loaded (`checkCSSLoaded`), and `hardReload()` could even match the line left over from an earlier reload. Both now go through `Client.waitForPageLoad()`, which registers for the ack before the load starts and keeps the line wait for its timeout and exit diagnostics. This is the css-13 failure.
4. **Server-side route reloads are applied asynchronously**. For the React framework, `dev.write()` resolves when the client received the route reload; the framework then fetches the RSC payload and React commits it from its scheduler (a `setTimeout(0)` under happy-dom), so asserting the DOM right after the write was only passing because of the second of slack. The one test that does this (ssg-4) now uses the new `Client.expectElemText()`, which resolves from a `MutationObserver` on the document (React can replace `<html>` rather than patch it when the reload lands during hydration, which is why the observer is on the document and not `documentElement`; with it on `documentElement` the test still failed about 1 in 10 runs).
5. `Dev.batchChanges()` left `batchingChanges` set when the overlay check threw, so any later write in the same test ran unsynchronized. The dispose body now clears it in a `finally`, which the new `dev.write` rejection test depends on.

`expectErrorOverlay` itself is restructured so both branches share the single `get-errors` round trip; `expect(actual).toEqual([...expected].sort())` covers the empty case as before.

### Tests

`test/bake/dev/hot.test.ts`, next to the existing ack-timing test from #34691 (which no longer needs `errors: null`, since the default path no longer sleeps):

- `dev.client` rejects on a build error the test did not expect (single connect check still detects the error page).
- `dev.write` rejects on an unexpected build error, and the write that fixes it resolves only after the fixed module's 200ms top-level await has run. With the fixture's old unconditional `"e"` ack this fails 3/3 with `Received: "initial"`.
- `dev.write` that triggers a full reload resolves only after the new page has run. Without the generation check this fails 3/3 with `Received: undefined`.

The two rejection tests capture the error with `runWithErrorPromise` rather than `expect(...).rejects`: the first CI run hung both of them on the two Windows lanes only, and bisecting on a Windows box showed that `expect(promise).rejects` / `.resolves` does not deliver a child's IPC messages while it waits, even with the unmodified harness from main (a working write wrapped in `.resolves` hangs the same way), and `dev.client()` / `dev.write()` resolve from the fixture's IPC acks. That is a bun:test bug on Windows, reported separately with a standalone repro; with the matcher avoided, `hot.test.ts` passes on Windows (13 pass, 1 todo, 10s).

This is a test-infrastructure change with no `src/` diff, so there is no fail-before build to show; the checks above were done by reverting the corresponding fixture hunks. If #37863 lands first, these belong in the `harness.test.ts` it adds.

### Verification

Whole `test/bake` (24 files): 186/186 on main, 189/189 here with the release binary; with a debug + ASAN build everything passes except the same `production.test.ts` cases that also exceed their 5s default timeout on main in this container. ssg-4 passed 25/25 in a loop after the `expectElemText` change. Single runs on a shared box, release binary, so the numbers move around by a few seconds between runs:

| file | main | this PR |
| --- | --- | --- |
| `dev/bundle.test.ts` | 43.6s | 16.6s (11.0s on a quieter run) |
| `dev/css.test.ts` | 53.7s | 17.2s |
| `dev/hot.test.ts` | 53.3s (11 tests) | 15.1s (14 tests) |
| `dev/html.test.ts` | 15.8s | 5.0s |
| `dev/esm.test.ts` | 14.1s | 7.5s |
| `dev/react-spa.test.ts` | 14.0s | 5.3s |
| `dev/ssg-pages-router.test.ts` | 38.3s | 21.5s |
| all of `test/bake` | 277s | 138s |

`test/expected-durations.json` is left for the scheduled job to regenerate. Local runs were done under a throwaway uid because root's inotify instance budget on this host is shared with other containers and intermittently makes every dev server fail to start with `EMFILE`; that affects main identically and is unrelated to this change.


</details>
