### PR TITLE
bake: refresh a framework route's meta.styles when its imports change

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4322,6 +4322,37 @@ pub(super) fn finalize_bundle(
 
     let mut has_route_bits_set = false;
 
+    // Framework routes whose server-side files (or anything those import) were
+    // re-bundled; a layout counts for every route below it. Routes affected
+    // through client components are traced separately below. The `meta.styles`
+    // of these routes was traced through the old graph, so it is dropped here
+    // whether or not anybody is listening for hot updates: only the payload
+    // built below depends on listeners.
+    let mut framework_route_bits = DynamicBitSet::init_empty(dev.route_bundles.len())?;
+    for request in &dev.incremental_result.framework_routes_affected {
+        let route = dev.router.route_ptr(request.route_index());
+        if let Some(id) = route.bundle {
+            framework_route_bits.set(id.get() as usize);
+        }
+        if request.should_recurse_when_visiting() {
+            mark_all_route_children(
+                &dev.router,
+                &mut [&mut framework_route_bits],
+                request.route_index(),
+            );
+        }
+    }
+    {
+        let mut it = framework_route_bits.iterator::<true, true>();
+        while let Some(bundled_route_index) = it.next() {
+            dev.route_bundles[bundled_route_index]
+                .data
+                .framework_mut()
+                .cached_css_file_array
+                .clear_without_deallocation();
+        }
+    }
+
     let mut hot_update_payload: Vec<u8> = Vec::with_capacity(65536);
     hot_update_payload.push(MessageId::HotUpdate.char());
 
@@ -4352,15 +4383,7 @@ pub(super) fn finalize_bundle(
     {
         has_route_bits_set = true;
 
-        for request in &dev.incremental_result.framework_routes_affected {
-            let route = dev.router.route_ptr(request.route_index());
-            if let Some(id) = route.bundle {
-                route_bits.set(id.get() as usize);
-            }
-            if request.should_recurse_when_visiting() {
-                mark_all_route_children(&dev.router, &mut [&mut route_bits], request.route_index());
-            }
-        }
+        framework_route_bits.copy_into(&mut route_bits);
         for route_bundle_index in &dev.incremental_result.html_routes_hard_affected {
             route_bits.set(route_bundle_index.get() as usize);
             route_bits_client.set(route_bundle_index.get() as usize);
@@ -4434,10 +4457,10 @@ pub(super) fn finalize_bundle(
         has_route_bits_set = true;
     }
 
-    // `route_bits` will have all of the routes that were modified.
-    if has_route_bits_set && (will_hear_hot_update || dev.incremental_result.had_adjusted_edges) {
-        // Note: copy out before the loop so the `&mut RouteBundle` borrow
-        // below doesn't overlap a `&dev.incremental_result` read.
+    // `route_bits` will have all of the routes that were modified. Their
+    // caches were invalidated above and in `invalidate_client_bundle`; what is
+    // left is telling their viewers which CSS files the routes have now.
+    if has_route_bits_set && will_hear_hot_update {
         let had_adjusted_edges = dev.incremental_result.had_adjusted_edges;
         let mut it = route_bits.iterator::<true, true>();
         // List 2
@@ -4448,24 +4471,14 @@ pub(super) fn finalize_bundle(
             let route_bundle: *mut RouteBundle = dev.route_bundle_ptr(route_bundle::Index::init(
                 u32::try_from(i).expect("int cast"),
             ));
-            if had_adjusted_edges {
-                // SAFETY: `route_bundle` points into `dev.route_bundles` (not
-                // resized in this loop); the exclusive borrow is scoped to this match.
-                match unsafe { &mut (*route_bundle).data } {
-                    route_bundle::Data::Framework(fw_bundle) => {
-                        fw_bundle.cached_css_file_array.clear_without_deallocation()
-                    }
-                    route_bundle::Data::Html(html) => html.cached_response = None,
-                }
-            }
             // SAFETY: statement-scoped read; no `&mut` into `*route_bundle` is live.
-            if unsafe { (*route_bundle).active_viewers } == 0 || !will_hear_hot_update {
+            if unsafe { (*route_bundle).active_viewers } == 0 {
                 continue;
             }
             w_int!(i32, i32::try_from(i).expect("int cast"));
 
             // If no edges were changed, then it is impossible to
-            // change the list of CSS files.
+            // change the set of CSS files.
             if had_adjusted_edges {
                 ctx.gts.clear();
                 dev.client_graph.current_css_files.clear();

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4322,12 +4322,9 @@ pub(super) fn finalize_bundle(
 
     let mut has_route_bits_set = false;
 
-    // Framework routes whose server-side files (or anything those import) were
-    // re-bundled; a layout counts for every route below it. Routes affected
-    // through client components are traced separately below. The `meta.styles`
-    // of these routes was traced through the old graph, so it is dropped here
-    // whether or not anybody is listening for hot updates: only the payload
-    // built below depends on listeners.
+    // Framework routes whose server-side files were re-bundled (a layout counts
+    // for every route below it) lose their cached `meta.styles` whether or not
+    // anybody listens for hot updates; only the payload below depends on that.
     let mut framework_route_bits = DynamicBitSet::init_empty(dev.route_bundles.len())?;
     for request in &dev.incremental_result.framework_routes_affected {
         let route = dev.router.route_ptr(request.route_index());
@@ -4457,9 +4454,8 @@ pub(super) fn finalize_bundle(
         has_route_bits_set = true;
     }
 
-    // `route_bits` will have all of the routes that were modified. Their
-    // caches were invalidated above and in `invalidate_client_bundle`; what is
-    // left is telling their viewers which CSS files the routes have now.
+    // `route_bits` will have all of the routes that were modified. Tell their
+    // viewers which CSS files these routes have now.
     if has_route_bits_set && will_hear_hot_update {
         let had_adjusted_edges = dev.incremental_result.had_adjusted_edges;
         let mut it = route_bits.iterator::<true, true>();

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4322,9 +4322,8 @@ pub(super) fn finalize_bundle(
 
     let mut has_route_bits_set = false;
 
-    // Framework routes whose server-side files were re-bundled (a layout counts
-    // for every route below it) lose their cached `meta.styles` whether or not
-    // anybody listens for hot updates; only the payload below depends on that.
+    // Unlike the payload below, this must not depend on anybody listening for
+    // hot updates: the cached `meta.styles` of these routes are stale either way.
     let mut framework_route_bits = DynamicBitSet::init_empty(dev.route_bundles.len())?;
     for request in &dev.incremental_result.framework_routes_affected {
         let route = dev.router.route_ptr(request.route_index());
@@ -4454,9 +4453,10 @@ pub(super) fn finalize_bundle(
         has_route_bits_set = true;
     }
 
-    // `route_bits` will have all of the routes that were modified. Tell their
-    // viewers which CSS files these routes have now.
+    // `route_bits` will have all of the routes that were modified.
     if has_route_bits_set && will_hear_hot_update {
+        // Note: copy out before the loop so the `&mut RouteBundle` borrow
+        // below doesn't overlap a `&dev.incremental_result` read.
         let had_adjusted_edges = dev.incremental_result.had_adjusted_edges;
         let mut it = route_bits.iterator::<true, true>();
         // List 2

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4322,8 +4322,7 @@ pub(super) fn finalize_bundle(
 
     let mut has_route_bits_set = false;
 
-    // Unlike the payload below, this must not depend on anybody listening for
-    // hot updates: the cached `meta.styles` of these routes are stale either way.
+    // Unlike the payload below, this must not depend on anybody listening for hot updates.
     let mut framework_route_bits = DynamicBitSet::init_empty(dev.route_bundles.len())?;
     for request in &dev.incremental_result.framework_routes_affected {
         let route = dev.router.route_ptr(request.route_index());

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -31,9 +31,8 @@ pub struct Framework {
     pub(crate) cached_module_list: jsc::StrongOptional,
     /// Embeds `client_script_generation`; cleared by `invalidate_client_bundle`.
     pub(crate) cached_client_bundle_url: jsc::StrongOptional,
-    /// `meta.styles`, traced through the route's server files and the client
-    /// components they reach. Cleared by `invalidate_client_bundle` and, when
-    /// any of the route's server files were re-bundled, by `finalize_bundle`.
+    /// `meta.styles`; cleared by `invalidate_client_bundle` and, for
+    /// server-side changes, by `finalize_bundle`.
     pub(crate) cached_css_file_array: jsc::StrongOptional,
 }
 
@@ -127,10 +126,8 @@ impl Data {
 }
 
 impl RouteBundle {
-    /// Called when a client-side file of the route was re-bundled. Drops the
-    /// client bundle along with what the route serves that is derived from
-    /// it: the bundle URL and `meta.styles` of a framework route, the rendered
-    /// page of an HTML route. They are rebuilt on the next request.
+    /// Called when a client-side file of the route was re-bundled: drops the
+    /// client bundle and what the route serves derived from it.
     ///
     /// Note: takes `&mut SourceMapStore` rather than `&mut DevServer` —
     /// only `dev.source_maps` is touched, and the two keystone

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -29,10 +29,7 @@ pub struct Framework {
     pub(crate) route_index: framework_router::RouteIndex,
     /// Only depends on the router, which does not change after startup.
     pub(crate) cached_module_list: jsc::StrongOptional,
-    /// Embeds `client_script_generation`; cleared by `invalidate_client_bundle`.
     pub(crate) cached_client_bundle_url: jsc::StrongOptional,
-    /// `meta.styles`; cleared by `invalidate_client_bundle` and, for
-    /// server-side changes, by `finalize_bundle`.
     pub(crate) cached_css_file_array: jsc::StrongOptional,
 }
 
@@ -126,9 +123,6 @@ impl Data {
 }
 
 impl RouteBundle {
-    /// Called when a client-side file of the route was re-bundled: drops the
-    /// client bundle and what the route serves derived from it.
-    ///
     /// Note: takes `&mut SourceMapStore` rather than `&mut DevServer` —
     /// only `dev.source_maps` is touched, and the two keystone
     /// `DevServer` structs (`dev_server::DevServer` / `dev_server_body::DevServer`)
@@ -148,6 +142,7 @@ impl RouteBundle {
         match &mut self.data {
             Data::Framework(fw) => {
                 fw.cached_client_bundle_url.clear_without_deallocation();
+                // `meta.styles` includes the CSS imported by client components.
                 fw.cached_css_file_array.clear_without_deallocation();
             }
             Data::Html(html) => html.cached_response = None,

--- a/src/runtime/bake/dev_server/route_bundle.rs
+++ b/src/runtime/bake/dev_server/route_bundle.rs
@@ -27,8 +27,13 @@ pub enum State {
 
 pub struct Framework {
     pub(crate) route_index: framework_router::RouteIndex,
+    /// Only depends on the router, which does not change after startup.
     pub(crate) cached_module_list: jsc::StrongOptional,
+    /// Embeds `client_script_generation`; cleared by `invalidate_client_bundle`.
     pub(crate) cached_client_bundle_url: jsc::StrongOptional,
+    /// `meta.styles`, traced through the route's server files and the client
+    /// components they reach. Cleared by `invalidate_client_bundle` and, when
+    /// any of the route's server files were re-bundled, by `finalize_bundle`.
     pub(crate) cached_css_file_array: jsc::StrongOptional,
 }
 
@@ -100,6 +105,12 @@ impl Data {
             Data::Html(_) => unreachable!("expected .framework"),
         }
     }
+    pub(crate) fn framework_mut(&mut self) -> &mut Framework {
+        match self {
+            Data::Framework(f) => f,
+            Data::Html(_) => unreachable!("expected .framework"),
+        }
+    }
     /// `Html` payload accessor (asserts active variant).
     pub(crate) fn html(&self) -> &Html {
         match self {
@@ -116,6 +127,11 @@ impl Data {
 }
 
 impl RouteBundle {
+    /// Called when a client-side file of the route was re-bundled. Drops the
+    /// client bundle along with what the route serves that is derived from
+    /// it: the bundle URL and `meta.styles` of a framework route, the rendered
+    /// page of an HTML route. They are rebuilt on the next request.
+    ///
     /// Note: takes `&mut SourceMapStore` rather than `&mut DevServer` —
     /// only `dev.source_maps` is touched, and the two keystone
     /// `DevServer` structs (`dev_server::DevServer` / `dev_server_body::DevServer`)
@@ -133,7 +149,10 @@ impl RouteBundle {
             u32::from_ne_bytes(buf)
         };
         match &mut self.data {
-            Data::Framework(fw) => fw.cached_client_bundle_url.clear_without_deallocation(),
+            Data::Framework(fw) => {
+                fw.cached_client_bundle_url.clear_without_deallocation();
+                fw.cached_css_file_array.clear_without_deallocation();
+            }
             Data::Html(html) => html.cached_response = None,
         }
     }

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -1,7 +1,7 @@
 // CSS tests concern bundling bugs with CSS files
 import { expect } from "bun:test";
 import assert from "node:assert";
-import { devTest, emptyHtmlFile, imageFixtures } from "../bake-harness";
+import { type Dev, devTest, emptyHtmlFile, imageFixtures, minimalFramework } from "../bake-harness";
 
 devTest("css file with syntax error does not kill old styles", {
   files: {
@@ -698,4 +698,110 @@ function extractCssUrl(backgroundImage: string): string {
     throw new Error("No url found in background-image: " + backgroundImage);
   }
   return url[2];
+}
+
+const cssImports = (...files: string[]) => files.map(file => `import "../${file}";`).join("\n");
+const routeRespondingWithStyles = (...cssFiles: string[]) => `
+  ${cssImports(...cssFiles)}
+  export default function (req, meta) {
+    return Response.json(meta.styles);
+  }
+`;
+
+// `meta.styles` is computed from the import graph on a route's first request
+// and cached on the route bundle. Until the last part of this test nothing is
+// subscribed to hot updates (only `dev.fetch` and the harness's watch
+// synchronization socket talk to the server), which used to leave that cache
+// in place forever.
+devTest("framework route styles follow the css imports of the route and its layout", {
+  framework: {
+    ...minimalFramework,
+    fileSystemRouterTypes: [{ ...minimalFramework.fileSystemRouterTypes[0], layouts: true }],
+  },
+  files: {
+    "routes/_layout.ts": ``,
+    "routes/index.ts": routeRespondingWithStyles("one.css"),
+    "routes/other.ts": routeRespondingWithStyles(),
+    "one.css": `.one { color: red; }`,
+    "two.css": `.two { color: red; }`,
+    "three.css": `.three { color: red; }`,
+    "four.css": `.four { color: red; }`,
+  },
+  async test(dev) {
+    expect(await routeStyles(dev, "/")).toEqual(["one.css"]);
+    expect(await routeStyles(dev, "/other")).toEqual([]);
+
+    await dev.write("routes/index.ts", routeRespondingWithStyles("one.css", "two.css"));
+    const withTwo = await routeStyles(dev, "/");
+    expect(withTwo.toSorted()).toEqual(["one.css", "two.css"]);
+
+    // The same two imports swapped: the route's edges in the graph stay the
+    // same, only their order changes.
+    await dev.write("routes/index.ts", routeRespondingWithStyles("two.css", "one.css"));
+    expect(await routeStyles(dev, "/")).toEqual(withTwo.toReversed());
+
+    await dev.write("routes/index.ts", routeRespondingWithStyles("two.css"));
+    expect(await routeStyles(dev, "/")).toEqual(["two.css"]);
+
+    // The layout's stylesheets belong to both routes, and both routes have a
+    // cached list by now.
+    await dev.write("routes/_layout.ts", cssImports("three.css"));
+    expect((await routeStyles(dev, "/")).toSorted()).toEqual(["three.css", "two.css"]);
+    expect(await routeStyles(dev, "/other")).toEqual(["three.css"]);
+
+    // Now with a hot update subscriber looking at "/", first while an
+    // unrelated route has a bundling error and then after it is fixed.
+    using _hmr = await viewRouteOverHmr(dev, "/");
+    await dev.write("routes/other.ts", `export default function (`);
+    expect((await dev.fetch("/other")).status).toBe(500);
+    await dev.write("routes/index.ts", routeRespondingWithStyles("four.css"));
+    expect((await routeStyles(dev, "/")).toSorted()).toEqual(["four.css", "three.css"]);
+
+    await dev.write("routes/other.ts", routeRespondingWithStyles("one.css"));
+    expect((await routeStyles(dev, "/other")).toSorted()).toEqual(["one.css", "three.css"]);
+    await dev.write("routes/index.ts", routeRespondingWithStyles());
+    expect(await routeStyles(dev, "/")).toEqual(["three.css"]);
+  },
+});
+
+/** Fetches a route written with `routeRespondingWithStyles` and resolves each stylesheet url to its file name. */
+async function routeStyles(dev: Dev, route: string): Promise<string[]> {
+  const hrefs: string[] = await dev.fetch(route).json();
+  return Promise.all(
+    hrefs.map(async href => {
+      const css = await dev.fetch(href).text();
+      const header = css.match(/^\/\* (.*) \*\/\n/);
+      if (!header) throw new Error(`${href} does not start with a file name comment:\n${css}`);
+      return header[1];
+    }),
+  );
+}
+
+/**
+ * Performs the handshake the HMR runtime performs in a browser: subscribes to
+ * hot updates and errors, then tells the dev server which route is being
+ * viewed. Resolves once the server has acknowledged the route.
+ */
+async function viewRouteOverHmr(dev: Dev, route: string): Promise<Disposable> {
+  const ws = new WebSocket(dev.baseUrl + "/_bun/hmr");
+  ws.binaryType = "arraybuffer";
+  const viewing = Promise.withResolvers<void>();
+  ws.onerror = () => viewing.reject(new Error("hmr websocket errored"));
+  ws.onclose = () => viewing.reject(new Error("hmr websocket closed"));
+  ws.onmessage = event => {
+    const data = new Uint8Array(event.data as ArrayBuffer);
+    if (data[0] === "V".charCodeAt(0)) {
+      ws.send("she");
+      ws.send("n" + route);
+    } else if (data[0] === "n".charCodeAt(0)) {
+      viewing.resolve();
+    }
+  };
+  await viewing.promise;
+  return {
+    [Symbol.dispose]() {
+      ws.onclose = null;
+      ws.close();
+    },
+  };
 }

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -843,9 +843,11 @@ async function viewRouteOverHmr(dev: Dev, route: string) {
   const viewing = Promise.withResolvers<number>();
   const unreadHotUpdates: ArrayBuffer[] = [];
   let reader: PromiseWithResolvers<ArrayBuffer> | null = null;
+  let failure: Error | null = null;
   const fail = (reason: string) => {
-    viewing.reject(new Error(reason));
-    reader?.reject(new Error(reason));
+    failure = new Error(reason);
+    viewing.reject(failure);
+    reader?.reject(failure);
   };
   ws.onerror = () => fail("hmr websocket errored");
   ws.onclose = () => fail("hmr websocket closed");
@@ -874,6 +876,7 @@ async function viewRouteOverHmr(dev: Dev, route: string) {
     async nextHotUpdate(): Promise<HotUpdateRouteLists> {
       let payload = unreadHotUpdates.shift();
       if (!payload) {
+        if (failure) throw failure;
         reader = Promise.withResolvers<ArrayBuffer>();
         payload = await reader.promise;
       }

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -749,24 +749,42 @@ devTest("framework route styles follow the css imports of the route and its layo
     expect((await routeStyles(dev, "/")).toSorted()).toEqual(["three.css", "two.css"]);
     expect(await routeStyles(dev, "/other")).toEqual(["three.css"]);
 
-    // Now with a hot update subscriber looking at "/", first while an
-    // unrelated route has a bundling error and then after it is fixed.
-    using _hmr = await viewRouteOverHmr(dev, "/");
+    // Now with a hot update subscriber looking at "/". Every rebuild publishes
+    // one hot update to it.
+    using hmr = await viewRouteOverHmr(dev, "/");
     await dev.write("routes/other.ts", `export default function (`);
-    expect((await dev.fetch("/other")).status).toBe(500);
+    await hmr.nextHotUpdate();
     await dev.write("routes/index.ts", routeRespondingWithStyles("four.css"));
+    // While another route has a bundling error, viewers are not told to reload
+    // or restyle anything (they are shown the error instead). The styles the
+    // server renders with are refreshed all the same.
+    expect(await hmr.nextHotUpdate()).toEqual({ reloadedRoutes: [], routeCss: {} });
     expect((await routeStyles(dev, "/")).toSorted()).toEqual(["four.css", "three.css"]);
 
     await dev.write("routes/other.ts", routeRespondingWithStyles("one.css"));
+    await hmr.nextHotUpdate();
     expect((await routeStyles(dev, "/other")).toSorted()).toEqual(["one.css", "three.css"]);
+
+    // With the error gone, the viewer of "/" is told to reload it and which
+    // stylesheets it has now, and those are the ones the server renders with.
     await dev.write("routes/index.ts", routeRespondingWithStyles());
-    expect(await routeStyles(dev, "/")).toEqual(["three.css"]);
+    const update = await hmr.nextHotUpdate();
+    const hrefs: string[] = await dev.fetch("/").json();
+    expect(await stylesheetFileNames(dev, hrefs)).toEqual(["three.css"]);
+    expect(update).toEqual({
+      reloadedRoutes: [hmr.routeBundleIndex],
+      routeCss: { [hmr.routeBundleIndex]: hrefs.map(href => href.match(/^\/_bun\/asset\/([0-9a-f]{16})\.css$/)![1]) },
+    });
   },
 });
 
-/** Fetches a route written with `routeRespondingWithStyles` and resolves each stylesheet url to its file name. */
+/** Fetches a route written with `routeRespondingWithStyles` and resolves the stylesheets to file names. */
 async function routeStyles(dev: Dev, route: string): Promise<string[]> {
-  const hrefs: string[] = await dev.fetch(route).json();
+  return stylesheetFileNames(dev, await dev.fetch(route).json());
+}
+
+/** Resolves served stylesheet urls to the file name in the comment each chunk starts with. */
+function stylesheetFileNames(dev: Dev, hrefs: string[]): Promise<string[]> {
   return Promise.all(
     hrefs.map(async href => {
       const css = await dev.fetch(href).text();
@@ -777,28 +795,90 @@ async function routeStyles(dev: Dev, route: string): Promise<string[]> {
   );
 }
 
+/** The route lists at the start of a hot update payload (see "List 1" and "List 2" in DevServer.rs's finalize_bundle). */
+interface HotUpdateRouteLists {
+  /** Route bundles whose server-side code changed; viewers re-request them. */
+  reloadedRoutes: number[];
+  /** For each viewed route bundle that changed, its stylesheet ids, or `null` if no import was added or removed. */
+  routeCss: Record<number, string[] | null>;
+}
+
+function decodeRouteLists(payload: ArrayBuffer): HotUpdateRouteLists {
+  const view = new DataView(payload);
+  let offset = 1; // MessageId.hot_update
+  const i32 = () => {
+    const value = view.getInt32(offset, true);
+    offset += 4;
+    return value;
+  };
+  const reloadedRoutes: number[] = [];
+  for (let route = i32(); route !== -1; route = i32()) {
+    reloadedRoutes.push(route);
+  }
+  const routeCss: Record<number, string[] | null> = {};
+  for (let route = i32(); route !== -1; route = i32()) {
+    const count = i32();
+    if (count === -1) {
+      routeCss[route] = null;
+      continue;
+    }
+    const ids: string[] = [];
+    for (let i = 0; i < count; i++) {
+      ids.push(Buffer.from(payload, offset, 16).toString());
+      offset += 16;
+    }
+    routeCss[route] = ids;
+  }
+  return { reloadedRoutes, routeCss };
+}
+
 /**
  * Performs the handshake the HMR runtime performs in a browser: subscribes to
  * hot updates and errors, then tells the dev server which route is being
  * viewed. Resolves once the server has acknowledged the route.
  */
-async function viewRouteOverHmr(dev: Dev, route: string): Promise<Disposable> {
+async function viewRouteOverHmr(dev: Dev, route: string) {
   const ws = new WebSocket(dev.baseUrl + "/_bun/hmr");
   ws.binaryType = "arraybuffer";
-  const viewing = Promise.withResolvers<void>();
-  ws.onerror = () => viewing.reject(new Error("hmr websocket errored"));
-  ws.onclose = () => viewing.reject(new Error("hmr websocket closed"));
+  const viewing = Promise.withResolvers<number>();
+  const unreadHotUpdates: ArrayBuffer[] = [];
+  let reader: PromiseWithResolvers<ArrayBuffer> | null = null;
+  const fail = (reason: string) => {
+    viewing.reject(new Error(reason));
+    reader?.reject(new Error(reason));
+  };
+  ws.onerror = () => fail("hmr websocket errored");
+  ws.onclose = () => fail("hmr websocket closed");
   ws.onmessage = event => {
-    const data = new Uint8Array(event.data as ArrayBuffer);
-    if (data[0] === "V".charCodeAt(0)) {
-      ws.send("she");
-      ws.send("n" + route);
-    } else if (data[0] === "n".charCodeAt(0)) {
-      viewing.resolve();
+    const payload = event.data as ArrayBuffer;
+    switch (new Uint8Array(payload)[0]) {
+      case "V".charCodeAt(0): // version
+        ws.send("she"); // subscribe to hot updates and errors
+        ws.send("n" + route); // set_url
+        break;
+      case "n".charCodeAt(0): // set_url_response
+        viewing.resolve(new DataView(payload).getUint32(1, true));
+        break;
+      case "u".charCodeAt(0): // hot_update
+        if (reader) {
+          reader.resolve(payload);
+          reader = null;
+        } else {
+          unreadHotUpdates.push(payload);
+        }
+        break;
     }
   };
-  await viewing.promise;
   return {
+    routeBundleIndex: await viewing.promise,
+    async nextHotUpdate(): Promise<HotUpdateRouteLists> {
+      let payload = unreadHotUpdates.shift();
+      if (!payload) {
+        reader = Promise.withResolvers<ArrayBuffer>();
+        payload = await reader.promise;
+      }
+      return decodeRouteLists(payload);
+    },
     [Symbol.dispose]() {
       ws.onclose = null;
       ws.close();


### PR DESCRIPTION
### Problem
- In `bun dev` with a framework, a route's `meta.styles` goes stale when its CSS imports change: an added import is missing, a removed one is still served, a reorder keeps the old order, and a CSS import added to a `_layout` never reaches the routes below it. The route module itself does reload.
- It stays stale until a browser with the HMR runtime connects and the route is rebuilt again. Plain `fetch` with no HMR client never recovers.
- Cause: the styles array is computed once per route and cached, and the cache was only dropped under the conditions for sending a hot update to browsers (a subscriber, no bundling errors, an import edge added or removed). With no browser, or on a pure reorder, it was never dropped.
- Routes invalidated through client component changes dropped their cached bundle URL but not the styles array.

### Fix
- After every rebuild, collect the framework routes whose server files were re-bundled (plus every route below an affected layout) and drop their cached styles array, before deciding whether any hot update is sent at all. Client component invalidation drops it too, since a route's styles include the CSS its client components import.
- Property to check: dropping the cache no longer depends on any condition about listeners; the hot update payload reuses the same route set and keeps all of its old conditions, so what browsers receive is unchanged.
- Cost is one trace over the route's imports on its next request after a rebuild that touched it. The cached module list is left alone; it only depends on the router, which does not change after startup.
- Verification: a new test covers add, reorder, remove and layout imports with nothing subscribed, then subscribes an HMR socket and decodes each hot update to confirm the payload did not change. It fails on bun 1.4.0 at the first step after the initial response (`["one.css"]` instead of both files) and passes with this change. The rest of `test/bake/dev` was run locally against a debug build.

### Background
- Bake is bun's dev server for frameworks. A framework route handler receives a `meta` object; `meta.styles` is the list of stylesheet URLs reachable from the route's imports, which the framework renders into the page.
- Each route has a server-side route bundle that caches derived values, the styles array among them, between requests. Rebuilds are incremental, and each one reports which framework routes it affected.
- `_layout` files wrap every route below them, so a layout change affects all of its child routes.
- After a rebuild, browsers subscribed on the `/_bun/hmr` websocket get one hot update payload. It opens with two lists: List 1 names the routes to reload, List 2 gives each viewed route's current stylesheet ids. Both are only written when a browser is listening.
- Client components are route code that also runs in the browser; a change to one invalidates the routes reaching it through a separate path from the server-side rebuild.

<details>
<summary>Original description</summary>

### Reproduce

A framework route (the `minimalFramework` from `test/bake/bake-harness.ts` is enough) that responds with the `meta.styles` it was given, fetched with plain `fetch` and no HMR client connected:

```ts
// routes/index.ts
import "../one.css";
export default (req, meta) => Response.json(meta.styles);
```

1. `fetch("/")` responds with one stylesheet.
2. Add `import "../two.css";` to `routes/index.ts`, wait for the rebuild, `fetch("/")` again.

bun 1.4.0 still responds with only `one.css`. Removing an import keeps serving it, swapping two imports keeps the old order, and a CSS import added to a `_layout` does not show up on any route below it. The route module itself is reloaded (a changed response body shows up), only `styles` is stale. It stays stale until a browser with the HMR runtime connects and the route is rebuilt again.

### Cause

`compute_arguments_for_framework_request` builds the styles array by tracing the route's imports and caches it in `route_bundle::Framework.cached_css_file_array`. The only place that cleared it was the "List 2" loop in `finalize_bundle`, which iterates `route_bits`. The routes a rebuilt server file belongs to were only added to `route_bits` inside the block that writes "List 1" of the hot update payload, and that block is skipped when nobody is subscribed to hot updates, when there are bundling failures, or when the bundle was not started by a file change. The clearing itself was also conditional on `had_adjusted_edges`, which a reorder of existing imports does not set even though the order of the array is what the framework renders. The cache invalidation was tied to the conditions for talking to browsers, and with no browser it never ran. (`invalidate_client_bundle`, which runs for routes affected through client components, cleared the cached bundle URL but not the styles array either.)

### Fix

* `finalize_bundle` now collects the framework routes whose server-side files were re-bundled (including every route below an affected layout, via the existing `mark_all_route_children`) before it starts on the payload, and drops their cached styles array unconditionally. The List 1 block reuses that bit set, so the payload that subscribed clients receive is byte for byte what it was before: List 1 and List 2 are still only written under the old conditions. Keeping those conditions matters for List 2 in particular, because the HMR runtime sends `set_url` on `pushState`, so a route being bundled for the first time during a client-side navigation already has a viewer, and telling that viewer about the new route's CSS while the old page is still showing would disable the old page's stylesheets early.
* `invalidate_client_bundle` also clears the styles array. A route's styles include the CSS imported by the client components it reaches, so the path that invalidates routes for client component changes has the same cache to drop. With both of these in place the clearing inside the List 2 loop was redundant and is removed, so that loop is now only about the payload.

Recomputing the array is one trace over the route's imports on its next request after a rebuild that touched it, which is what HTML routes already do for their rendered page on every soft change. `cached_module_list` on the same struct is left alone: it only depends on the router, which is not modified after startup.

The test in #37845 (stylesheet order) notes this bug and works around it by only checking the initial response; the two changes are independent, and the test here compares the lists in an order-insensitive way so it passes with or without that change.

### Tests

`framework route styles follow the css imports of the route and its layout` in `test/bake/dev/css.test.ts` resolves the served URLs back to file names and covers adding, reordering and removing an import on the route, and adding one to the layout (checked on two routes that both had a cached list), all with nothing subscribed to hot updates. It then subscribes a socket that views the route (the handshake the HMR runtime performs) and decodes the route lists of every hot update: while another route has a syntax error the payload names no routes but the styles are refreshed anyway, and after the error is fixed the payload names the viewed route in List 1 and carries exactly the stylesheet ids the route then responds with in List 2, which pins down that the payload did not change. It fails on bun 1.4.0 at the first step after the initial response (`["one.css"]` instead of both files) and passes with this change.

Also ran `test/bake/dev/{css,bundle,esm,html,hot,incremental-graph-edge-deletion,react-spa,response-to-bake-response,ssg-pages-router,react-response}.test.ts` locally against a debug build.


</details>
