### PR TITLE
bake: speed up the css dev server tests by sharing servers and asserting served stylesheets

### DIFF
--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -51,7 +51,18 @@ async function servedCss(dev: Dev, route: string): Promise<string> {
   return fetchCss(dev, urls[0]);
 }
 
-/** A route with a bundling error anywhere in its graph serves the error page instead of the HTML. */
+/**
+ * A route with a bundling error anywhere in its graph serves the error page
+ * instead of the HTML.
+ *
+ * Requesting such a route re-bundles it, and when the HTML file itself still
+ * compiles (the failure is in a stylesheet) the HTML module is pushed to
+ * connected clients as a plain JS hot update, which kills a client that has
+ * that page loaded (https://github.com/oven-sh/bun/issues/31908). Clients on
+ * other routes and clients showing the error page are unaffected, and recovery
+ * writes never push the HTML module. So: only call this for a route whose page
+ * no connected client has loaded, unless the HTML file is the failing file.
+ */
 async function expectBuildFailed(dev: Dev, route: string) {
   const res = await dev.fetch(route);
   expect(res.status).toBe(500);
@@ -494,11 +505,7 @@ devTest("bundling errors in stylesheets and recovering from them", {
         );
         await c.style("body").color.expect.toBe("red");
       }
-      // The failing route is fetched, and the recovery is checked, without a
-      // connected client: re-bundling the route while its CSS root is failing
-      // or recovering currently ships the HTML route as a JS module without
-      // the route-reload flag, which trips a client-side debug assert
-      // (tracked in https://github.com/oven-sh/bun/issues/31908).
+      // The client that had this page loaded is gone, see expectBuildFailed.
       await expectBuildFailed(dev, "/resolve");
       await dev.write(
         "resolve.css",
@@ -533,9 +540,8 @@ devTest("bundling errors in stylesheets and recovering from them", {
           errors: ["keep.css:4:1: error: Unexpected end of input"],
         },
       );
-      // The route is not fetched while it is broken: that re-bundles the HTML
-      // file, and the recovery below would then reload the page instead of
-      // hot-swapping the stylesheet (https://github.com/oven-sh/bun/issues/31908).
+      // Not fetched while broken: this client has the page loaded and has to
+      // survive until the stylesheet is hot-swapped back in (see expectBuildFailed).
       await c.style("body").color.expect.toBe("red");
 
       await dev.write(
@@ -568,6 +574,7 @@ devTest("bundling errors in stylesheets and recovering from them", {
 
     // css file with initial syntax error gets recovered
     {
+      let blue: string;
       {
         await using c = await dev.client("/initial", {
           errors: ["initial.css:3:3: error: Unexpected end of input"],
@@ -594,7 +601,8 @@ devTest("bundling errors in stylesheets and recovering from them", {
           { errors: null },
         );
         await c.style("body").color.expect.toBe("#00f");
-        expect(await servedCss(dev, "/initial")).toMatchInlineSnapshot(`
+        blue = await servedCss(dev, "/initial");
+        expect(blue).toMatchInlineSnapshot(`
           "/* initial.css */
           body {
             color: #00f;
@@ -613,8 +621,19 @@ devTest("bundling errors in stylesheets and recovering from them", {
           },
         );
       }
-      // Fetched after the client is gone for the same reason as above.
+      // The client that had this page loaded is gone, see expectBuildFailed.
       await expectBuildFailed(dev, "/initial");
+      // Recovering a second time serves the stylesheet again (and leaves the
+      // shared server without failures, like the other cases in this group).
+      await dev.write(
+        "initial.css",
+        `
+          body {
+            color: blue;
+          }
+        `,
+      );
+      expect(await servedCss(dev, "/initial")).toBe(blue);
     }
   },
 });
@@ -655,7 +674,6 @@ devTest("stylesheets created after the server starts, changing html link tags", 
           errors: ['before.css:2:21: error: Could not resolve: "before.png". Maybe you need to "bun install"?'],
         },
       );
-      await expectBuildFailed(dev, "/before");
       await c.expectReload(async () => {
         await dev.write("before.png", imageFixtures.bun);
       });
@@ -691,7 +709,12 @@ devTest("stylesheets created after the server starts, changing html link tags", 
       await dev.write("relink.html", emptyHtmlFile({ styles: ["relink-other.css"] }), {
         errors: ['relink.html: error: Could not resolve: "relink-other.css". Maybe you need to "bun install"?'],
       });
+      // The HTML file itself is what fails here, so fetching is safe with the
+      // page loaded, and the page keeps its old stylesheet meanwhile. (Checking
+      // that also drains the ack the client sent for the rebuild the fetch
+      // triggered, before the next write waits for acks of its own.)
       await expectBuildFailed(dev, "/relink");
+      await c.style(".test").color.expect.toBe("#00f");
       await c.expectReload(async () => {
         await dev.write(
           "relink-other.css",
@@ -954,10 +977,9 @@ devTest("css hot update carries the edited stylesheet when another root fails in
       }
       "
     `);
+    // Both clients are gone by now, see expectBuildFailed. A fresh load of
+    // either page after the fix is checked over HTTP below.
     await expectBuildFailed(dev, "/first");
-
-    // Recovery happens with no client connected, see
-    // https://github.com/oven-sh/bun/issues/31908.
     await dev.write(
       "first.css",
       `

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -5,9 +5,9 @@
 // the browser), while the server state the cases assert on (served HTML, the
 // stylesheet chunks, build failures) is read over plain HTTP. Build errors are
 // reported to every connected client, so cases that produce errors run with no
-// other client connected and clean up after themselves. Cases whose bug depends
-// on the exact contents of the server (the asset table layout, a bunfig plugin)
-// keep a server to themselves.
+// other client connected and clean up after themselves. Cases that cannot share
+// a server (the asset table layout, a bunfig plugin, a nested HTML file; see
+// their comments) keep one to themselves.
 //
 // By default every write made while a client is connected ends with the
 // harness checking that client for an error overlay, which costs a second when
@@ -628,13 +628,6 @@ devTest("stylesheets created after the server starts, changing html link tags", 
         <div>HELLO</div>
       `,
     }),
-    // css import before create project relative
-    "html/index.html": emptyHtmlFile({
-      styles: ["/style/styles.css"],
-      body: `
-        <div>HELLO</div>
-      `,
-    }),
     // changing html file with link tag works
     "relink.html": emptyHtmlFile({ styles: ["relink.css"] }),
     "relink.css": `
@@ -645,8 +638,6 @@ devTest("stylesheets created after the server starts, changing html link tags", 
     `,
   },
   async test(dev) {
-    dev.mkdir("style"); // (See DevServer.zig "BUN-10968")
-
     // css import before create
     {
       await using c = await dev.client("/before", {
@@ -672,51 +663,6 @@ devTest("stylesheets created after the server starts, changing html link tags", 
       assert(backgroundImage);
       await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
       await dev.fetch("/before").expect.toContain("HELLO");
-    }
-
-    // css import before create project relative
-    {
-      await using c = await dev.client("/html", {
-        errors: ['html/index.html: error: Could not resolve: "/style/styles.css"'],
-      });
-      await expectBuildFailed(dev, "/html");
-      await dev.write(
-        "style/styles.css",
-        `
-          body {
-            background-image: url(/assets/bun.png);
-          }
-        `,
-        {
-          errors: ['style/styles.css:2:21: error: Could not resolve: "/assets/bun.png"'],
-        },
-      );
-      // Unlike the HTML's "/style/styles.css" link, an absolute url() in CSS is
-      // not resolved against the project root, so creating that file is not a
-      // change the stylesheet depends on.
-      await c.expectNoWebSocketActivity(async () => {
-        await dev.write("assets/bun.png", imageFixtures.bun, { errors: null });
-        await dev.delete("assets/bun.png", { errors: null });
-      });
-      await expectBuildFailed(dev, "/html");
-      await dev.write(
-        "style/styles.css",
-        `
-          body {
-            background-image: url(../assets/bun.png);
-          }
-        `,
-        {
-          errors: ['style/styles.css:2:21: error: Could not resolve: "../assets/bun.png"'],
-        },
-      );
-      await c.expectReload(async () => {
-        await dev.write("assets/bun.png", imageFixtures.bun);
-      });
-      const backgroundImage = await c.style("body").backgroundImage;
-      assert(backgroundImage);
-      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-      await dev.fetch("/html").expect.toContain("HELLO");
     }
 
     // changing html file with link tag works
@@ -789,6 +735,65 @@ devTest("stylesheets created after the server starts, changing html link tags", 
       const chunks = await Promise.all(urls.map(url => fetchCss(dev, url)));
       expect(chunks.sort()).toEqual([otherCss, testCss].sort());
     }
+  },
+});
+
+devTest("css import before create project relative", {
+  // The HTML file has to live in a subdirectory for the "/style/..." link to
+  // tell project-relative resolution apart from HTML-relative resolution, and
+  // the harness only registers nested HTML files correctly on Windows when they
+  // are the server's single (catch-all) route, so this case keeps its own server.
+  files: {
+    "html/index.html": emptyHtmlFile({
+      styles: ["/style/styles.css"],
+      body: `
+        <div>HELLO</div>
+      `,
+    }),
+  },
+  async test(dev) {
+    dev.mkdir("style"); // (See DevServer.zig "BUN-10968")
+    await using c = await dev.client("/", {
+      errors: ['html/index.html: error: Could not resolve: "/style/styles.css"'],
+    });
+    await expectBuildFailed(dev, "/");
+    await dev.write(
+      "style/styles.css",
+      `
+        body {
+          background-image: url(/assets/bun.png);
+        }
+      `,
+      {
+        errors: ['style/styles.css:2:21: error: Could not resolve: "/assets/bun.png"'],
+      },
+    );
+    // Unlike the HTML's "/style/styles.css" link, an absolute url() in CSS is
+    // not resolved against the project root, so creating that file is not a
+    // change the stylesheet depends on.
+    await c.expectNoWebSocketActivity(async () => {
+      await dev.write("assets/bun.png", imageFixtures.bun, { errors: null });
+      await dev.delete("assets/bun.png", { errors: null });
+    });
+    await expectBuildFailed(dev, "/");
+    await dev.write(
+      "style/styles.css",
+      `
+        body {
+          background-image: url(../assets/bun.png);
+        }
+      `,
+      {
+        errors: ['style/styles.css:2:21: error: Could not resolve: "../assets/bun.png"'],
+      },
+    );
+    await c.expectReload(async () => {
+      await dev.write("assets/bun.png", imageFixtures.bun);
+    });
+    const backgroundImage = await c.style("body").backgroundImage;
+    assert(backgroundImage);
+    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+    await dev.fetch("/").expect.toContain("HELLO");
   },
 });
 

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -1,293 +1,797 @@
 // CSS tests concern bundling bugs with CSS files
+//
+// Most cases here share a dev server: each case gets its own HTML route (and
+// its own happy-dom client where the case is about applying a hot update in
+// the browser), while the server state the cases assert on (served HTML, the
+// stylesheet chunks, build failures) is read over plain HTTP. Build errors are
+// reported to every connected client, so cases that produce errors run with no
+// other client connected and clean up after themselves. Cases whose bug depends
+// on the exact contents of the server (the asset table layout, a bunfig plugin)
+// keep a server to themselves.
+//
+// By default every write made while a client is connected ends with the
+// harness checking that client for an error overlay, which costs a second when
+// there is none. Writes pass `errors: null` to skip that check when the
+// assertion that follows can only pass if the rebuild succeeded and reached the
+// client: a stylesheet that fails to rebuild keeps its old rules in the page
+// (the "does not kill old styles" case asserts exactly that), and page reloads
+// are only sent while nothing is failing. Writes that recover from an error keep
+// the default, since the overlay going away is the point of those.
 import { expect } from "bun:test";
 import assert from "node:assert";
+import type { Dev } from "../bake-harness";
 import { devTest, emptyHtmlFile, imageFixtures } from "../bake-harness";
 
-devTest("css file with syntax error does not kill old styles", {
+/**
+ * Fetches an HTML route and returns the stylesheet URLs the dev server injected
+ * into it. Source `<link>` tags are ignored: a route that was bundled while its
+ * stylesheet was failing currently keeps its source tag after the stylesheet
+ * recovers (#37844). On these multi-route servers that leftover tag is a 404,
+ * which is also why the page reload after such a recovery sits through the
+ * client fixture's stylesheet-load check before it is acknowledged.
+ */
+async function stylesheetUrls(dev: Dev, route: string): Promise<string[]> {
+  const res = await dev.fetch(route);
+  expect(res.status).toBe(200);
+  const html = await res.text();
+  return [...html.matchAll(/<link rel="stylesheet" href="(\/_bun\/asset\/[0-9a-f]{16}\.css)">/g)].map(m => m[1]);
+}
+
+async function fetchCss(dev: Dev, url: string): Promise<string> {
+  const res = await dev.fetch(url);
+  expect(res.status).toBe(200);
+  expect(res.headers.get("Content-Type")).toBe("text/css;charset=utf-8");
+  return res.text();
+}
+
+/** The exact stylesheet served for a route that links exactly one stylesheet. */
+async function servedCss(dev: Dev, route: string): Promise<string> {
+  const urls = await stylesheetUrls(dev, route);
+  expect(urls).toHaveLength(1);
+  return fetchCss(dev, urls[0]);
+}
+
+/** A route with a bundling error anywhere in its graph serves the error page instead of the HTML. */
+async function expectBuildFailed(dev: Dev, route: string) {
+  const res = await dev.fetch(route);
+  expect(res.status).toBe(500);
+  expect(await res.text()).toContain("<title>Bun - Build Failed</title>");
+}
+
+devTest("hot updates through @import graphs", {
   files: {
-    "styles.css": `
+    // css import another css file
+    "import.html": emptyHtmlFile({ styles: ["import.css"] }),
+    "import.css": `
+      @import "./imported.css";
       body {
         color: red;
       }
     `,
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
+    "imported.css": `
+      h1 {
+        color: blue;
+      }
+    `,
+    // circular css imports handle hot reload
+    "circular.html": emptyHtmlFile({
+      styles: ["circular-a.css"],
+      body: `
+        <div class="a">hello</div>
+        <div class="b">hello</div>
+      `,
     }),
+    "circular-a.css": `
+      @import "./circular-b.css";
+      .a { color: red; }
+    `,
+    "circular-b.css": `
+      @import "./circular-a.css";
+      .b { color: blue; }
+    `,
+    // removing and re-adding css import
+    "toggle.html": emptyHtmlFile({ styles: ["toggle.css"] }),
+    "toggle.css": `
+      @import "./toggle-colors.css";
+      .main { background: white; }
+    `,
+    "toggle-colors.css": `
+      .colored { color: blue; }
+    `,
   },
   async test(dev) {
-    await using c = await dev.client("/");
-    await c.style("body").color.expect.toBe("red");
-    await dev.write(
-      "styles.css",
-      `
+    // css import another css file
+    {
+      await using c = await dev.client("/import");
+      await c.style("h1").color.expect.toBe("#00f");
+      await c.style("body").color.expect.toBe("red");
+      expect(await servedCss(dev, "/import")).toMatchInlineSnapshot(`
+        "/* imported.css */
+        h1 {
+          color: #00f;
+        }
+
+        /* import.css */
         body {
           color: red;
-          background-color
         }
-      `,
-      {
-        errors: ["styles.css:4:1: error: Unexpected end of input"],
-      },
-    );
-    await c.style("body").color.expect.toBe("red");
-    await dev.write(
-      "styles.css",
-      `
+        "
+      `);
+
+      await dev.write(
+        "imported.css",
+        `
+          h1 {
+            color: green;
+          }
+        `,
+        { errors: null },
+      );
+      await c.style("h1").color.expect.toBe("green");
+      await c.style("body").color.expect.toBe("red");
+      // A fresh load of the page gets the updated chunk too.
+      expect(await servedCss(dev, "/import")).toMatchInlineSnapshot(`
+        "/* imported.css */
+        h1 {
+          color: green;
+        }
+
+        /* import.css */
         body {
           color: red;
-          background-color: blue;
         }
-      `,
-    );
-    await c.style("body").backgroundColor.expect.toBe("#00f");
-    await dev.write("styles.css", ` `, { dedent: false });
-    await c.style("body").notFound();
+        "
+      `);
+    }
+
+    // circular css imports handle hot reload
+    {
+      await using c = await dev.client("/circular");
+      await c.style(".a").color.expect.toBe("red");
+      await c.style(".b").color.expect.toBe("#00f");
+      expect(await servedCss(dev, "/circular")).toMatchInlineSnapshot(`
+        "/* circular-b.css */
+        .b {
+          color: #00f;
+        }
+
+        /* circular-a.css */
+        .a {
+          color: red;
+        }
+        "
+      `);
+
+      await dev.write(
+        "circular-a.css",
+        `
+          @import "./circular-b.css";
+          .a { color: green; }
+        `,
+        { errors: null },
+      );
+      await c.style(".a").color.expect.toBe("green");
+      await c.style(".b").color.expect.toBe("#00f");
+      expect(await servedCss(dev, "/circular")).toMatchInlineSnapshot(`
+        "/* circular-b.css */
+        .b {
+          color: #00f;
+        }
+
+        /* circular-a.css */
+        .a {
+          color: green;
+        }
+        "
+      `);
+    }
+
+    // removing and re-adding css import
+    {
+      await using c = await dev.client("/toggle");
+      await c.style(".colored").color.expect.toBe("#00f");
+      const withImport = await servedCss(dev, "/toggle");
+      expect(withImport).toMatchInlineSnapshot(`
+        "/* toggle-colors.css */
+        .colored {
+          color: #00f;
+        }
+
+        /* toggle.css */
+        .main {
+          background: #fff;
+        }
+        "
+      `);
+
+      await dev.write(
+        "toggle.css",
+        `
+          /* @import "./toggle-colors.css"; */
+          .main { background: white; }
+        `,
+        { errors: null },
+      );
+      await c.style(".colored").notFound();
+      await c.style(".main").backgroundColor.expect.toBe("#fff");
+      const withoutImport = await servedCss(dev, "/toggle");
+      expect(withoutImport).toMatchInlineSnapshot(`
+        "/* toggle.css */
+        .main {
+          background: #fff;
+        }
+        "
+      `);
+
+      // Editing the file that is no longer imported must not rebuild the
+      // stylesheet nor notify the client (the client exits on any socket
+      // message inside this block, so the overlay cannot change either).
+      await c.expectNoWebSocketActivity(async () => {
+        await dev.write("toggle-colors.css", `.colored { color: yellow; }`, { errors: null });
+        await dev.write("toggle-colors.css", `.colored { color: blue; }`, { errors: null });
+      });
+      await c.style(".colored").notFound();
+      expect(await servedCss(dev, "/toggle")).toBe(withoutImport);
+
+      await dev.write(
+        "toggle.css",
+        `
+          @import "./toggle-colors.css";
+          .main { background: white; }
+        `,
+        { errors: null },
+      );
+      await c.style(".colored").color.expect.toBe("#00f");
+      await c.style(".main").backgroundColor.expect.toBe("#fff");
+      expect(await servedCss(dev, "/toggle")).toBe(withImport);
+    }
   },
 });
-devTest("css file with initial syntax error gets recovered", {
+
+devTest("hot updates through shared imports, assets and script imports", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
+    // multiple stylesheets importing same dependency
+    "shared-first.html": emptyHtmlFile({
+      styles: ["shared-first.css"],
+      body: `
+        <div class="first">hello</div>
+        <div class="shared">hello</div>
+      `,
+    }),
+    "shared-second.html": emptyHtmlFile({
+      styles: ["shared-second.css"],
+      body: `
+        <div class="second">hello</div>
+        <div class="shared">hello</div>
+      `,
+    }),
+    "shared-first.css": `
+      @import "./shared.css";
+      .first { color: red; }
+    `,
+    "shared-second.css": `
+      @import "./shared.css";
+      .second { color: blue; }
+    `,
+    "shared.css": `
+      .shared { color: green; }
+    `,
+    // asset referenced in css
+    "asset.html": emptyHtmlFile({ styles: ["asset.css"] }),
+    "asset.css": `
+      body {
+        background-image: url(./asset.png);
+      }
+    `,
+    "asset.png": imageFixtures.bun,
+    // add new css import later
+    "script.html": emptyHtmlFile({
+      scripts: ["script.ts"],
       body: `hello world`,
     }),
-    "styles.css": `
+    "script.ts": `
+      // import "./script.css";
+      export default function () {
+        return "hello world";
+      }
+      import.meta.hot.accept();
+    `,
+    "script.css": `
+      body {
+        color: red;
+      }
+    `,
+  },
+  async test(dev) {
+    // multiple stylesheets importing same dependency
+    {
+      await using c1 = await dev.client("/shared-first");
+      await using c2 = await dev.client("/shared-second");
+      await c1.style(".first").color.expect.toBe("red");
+      await c2.style(".second").color.expect.toBe("#00f");
+      await c1.style(".shared").color.expect.toBe("green");
+      await c2.style(".shared").color.expect.toBe("green");
+      expect(await servedCss(dev, "/shared-first")).toMatchInlineSnapshot(`
+        "/* shared.css */
+        .shared {
+          color: green;
+        }
+
+        /* shared-first.css */
+        .first {
+          color: red;
+        }
+        "
+      `);
+      expect(await servedCss(dev, "/shared-second")).toMatchInlineSnapshot(`
+        "/* shared.css */
+        .shared {
+          color: green;
+        }
+
+        /* shared-second.css */
+        .second {
+          color: #00f;
+        }
+        "
+      `);
+
+      await dev.write(
+        "shared.css",
+        `
+          .shared { color: yellow; }
+        `,
+        { errors: null },
+      );
+      await c1.style(".shared").color.expect.toBe("#ff0");
+      await c2.style(".shared").color.expect.toBe("#ff0");
+      await c1.style(".first").color.expect.toBe("red");
+      await c2.style(".second").color.expect.toBe("#00f");
+      // Both roots were rebuilt on the server, not just patched in the clients.
+      expect(await servedCss(dev, "/shared-first")).toMatchInlineSnapshot(`
+        "/* shared.css */
+        .shared {
+          color: #ff0;
+        }
+
+        /* shared-first.css */
+        .first {
+          color: red;
+        }
+        "
+      `);
+      expect(await servedCss(dev, "/shared-second")).toMatchInlineSnapshot(`
+        "/* shared.css */
+        .shared {
+          color: #ff0;
+        }
+
+        /* shared-second.css */
+        .second {
+          color: #00f;
+        }
+        "
+      `);
+    }
+
+    // asset referenced in css
+    {
+      await using c = await dev.client("/asset");
+      let backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+      await dev.fetch(extractCssUrl(await servedCss(dev, "/asset"))).expectFile(imageFixtures.bun);
+
+      await dev.write("asset.png", imageFixtures.bun2, { errors: null });
+      backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun2);
+      await dev.fetch(extractCssUrl(await servedCss(dev, "/asset"))).expectFile(imageFixtures.bun2);
+    }
+
+    // add new css import later
+    {
+      await using c = await dev.client("/script");
+      await c.style("body").notFound();
+      expect(await stylesheetUrls(dev, "/script")).toEqual([]);
+
+      await dev.patch("script.ts", { find: "// import", replace: "import", errors: null });
+      await c.style("body").color.expect.toBe("red");
+      expect(await servedCss(dev, "/script")).toMatchInlineSnapshot(`
+        "/* script.css */
+        body {
+          color: red;
+        }
+        "
+      `);
+
+      await dev.patch("script.ts", { find: "import", replace: "// import", errors: null });
+      await c.style("body").notFound();
+      expect(await stylesheetUrls(dev, "/script")).toEqual([]);
+    }
+  },
+});
+
+devTest("bundling errors in stylesheets and recovering from them", {
+  files: {
+    // syntax error crash
+    "crash.html": emptyHtmlFile({ styles: ["crash.css"], body: `hello world` }),
+    "crash.css": `
+      body {
+        background-image: url
+      }
+    `,
+    // css url resolve error on hot reload is recoverable
+    "resolve.html": emptyHtmlFile({ styles: ["resolve.css"], body: `hello world` }),
+    "resolve.css": `
+      body {
+        color: red;
+      }
+    `,
+    // css file with syntax error does not kill old styles
+    "keep.html": emptyHtmlFile({ styles: ["keep.css"], body: `hello world` }),
+    "keep.css": `
+      body {
+        color: red;
+      }
+    `,
+    // css file with initial syntax error gets recovered
+    "initial.html": emptyHtmlFile({ styles: ["initial.css"], body: `hello world` }),
+    "initial.css": `
       body {
         color: red;
       }}
     `,
   },
   async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ["styles.css:3:3: error: Unexpected end of input"],
-    });
-    // hard reload to dismiss the error overlay
-    await c.expectReload(async () => {
+    // syntax error crash
+    {
+      expect(await servedCss(dev, "/crash")).toMatchInlineSnapshot(`
+        "/* crash.css */
+        body {
+          background-image: url;
+        }
+        "
+      `);
+      // previously: panic(main thread): Asset double unref: 0000000000000000
+      await dev.patch("crash.css", { find: "url\n", replace: "url(\n" });
+      await expectBuildFailed(dev, "/crash");
       await dev.write(
-        "styles.css",
+        "crash.css",
         `
           body {
             color: red;
           }
         `,
       );
-    });
-    await c.style("body").color.expect.toBe("red");
-    await dev.write(
-      "styles.css",
-      `
+      expect(await servedCss(dev, "/crash")).toMatchInlineSnapshot(`
+        "/* crash.css */
         body {
-          color: blue;
+          color: red;
         }
-      `,
-    );
-    await c.style("body").color.expect.toBe("#00f");
-    await dev.write(
-      "styles.css",
-      `
-        body {
-          color: blue;
-        }}
-      `,
-      {
-        errors: ["styles.css:3:3: error: Unexpected end of input"],
-      },
-    );
-  },
-});
-devTest("add new css import later", {
-  files: {
-    "index.html": emptyHtmlFile({
-      scripts: ["index.ts"],
-      body: `hello world`,
-    }),
-    "index.ts": `
-      // import "./styles.css";
-      export default function () {
-        return "hello world";
-      }
-      import.meta.hot.accept();
-    `,
-    "styles.css": `
-      body {
-        color: red;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style("body").notFound();
-    await dev.patch("index.ts", { find: "// import", replace: "import" });
-    await c.style("body").color.expect.toBe("red");
-    await dev.patch("index.ts", { find: "import", replace: "// import" });
-    await c.style("body").notFound();
-  },
-});
-devTest("css import another css file", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-    }),
-    "styles.css": `
-      @import "./second.css";
-      body {
-        color: red;
-      }
-    `,
-    "second.css": `
-      h1 {
-        color: blue;
-      }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    // Verify initial build
-    await c.style("h1").color.expect.toBe("#00f");
-    await c.style("body").color.expect.toBe("red");
+        "
+      `);
+    }
 
-    // Hot reload
-    await dev.write(
-      "second.css",
-      `
-        h1 {
-          color: green;
-        }
-      `,
-    );
-    await c.style("h1").color.expect.toBe("green");
-    await c.style("body").color.expect.toBe("red");
-
-    // Check that the styles still work after a reload
-    await c.hardReload();
-    await c.style("h1").color.expect.toBe("green");
-    await c.style("body").color.expect.toBe("red");
-  },
-});
-devTest("asset referenced in css", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-    }),
-    "styles.css": `
-      body {
-        background-image: url(./bun.png);
-      }
-    `,
-    "bun.png": imageFixtures.bun,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    let backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-    await dev.write("bun.png", imageFixtures.bun2);
-    backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun2);
-  },
-});
-devTest("syntax error crash", {
-  files: {
-    "styles.css": `
-      body {
-        background-image: url
-      }
-    `,
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
-    }),
-  },
-  async test(dev) {
-    expect((await dev.fetch("/")).status).toBe(200);
-    // previously: panic(main thread): Asset double unref: 0000000000000000
-    await dev.patch("styles.css", { find: "url\n", replace: "url(\n" });
-    expect((await dev.fetch("/")).status).toBe(500);
-  },
-});
-devTest("css url resolve error on hot reload is recoverable", {
-  files: {
-    "styles.css": `
-      body {
-        color: red;
-      }
-    `,
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `hello world`,
-    }),
-  },
-  async test(dev) {
+    // css url resolve error on hot reload is recoverable
     {
-      await using c = await dev.client("/");
-      await c.style("body").color.expect.toBe("red");
-      // A CSS file that parses but fails import resolution must fail the
-      // rebuild with an error instead of being treated as a valid CSS chunk.
-      // previously: panic: assertion failed: !chunk.content.is_css()
+      {
+        await using c = await dev.client("/resolve");
+        await c.style("body").color.expect.toBe("red");
+        // A CSS file that parses but fails import resolution must fail the
+        // rebuild with an error instead of being treated as a valid CSS chunk.
+        // previously: panic: assertion failed: !chunk.content.is_css()
+        await dev.write(
+          "resolve.css",
+          `
+            body {
+              background-image: url(./missing.png);
+            }
+          `,
+          {
+            errors: ['resolve.css:2:21: error: Could not resolve: "./missing.png"'],
+          },
+        );
+        await c.style("body").color.expect.toBe("red");
+      }
+      // The failing route is fetched, and the recovery is checked, without a
+      // connected client: re-bundling the route while its CSS root is failing
+      // or recovering currently ships the HTML route as a JS module without
+      // the route-reload flag, which trips a client-side debug assert
+      // (tracked in https://github.com/oven-sh/bun/issues/31908).
+      await expectBuildFailed(dev, "/resolve");
       await dev.write(
-        "styles.css",
+        "resolve.css",
         `
           body {
-            background-image: url(./missing.png);
+            color: blue;
+          }
+        `,
+      );
+      expect(await servedCss(dev, "/resolve")).toMatchInlineSnapshot(`
+        "/* resolve.css */
+        body {
+          color: #00f;
+        }
+        "
+      `);
+    }
+
+    // css file with syntax error does not kill old styles
+    {
+      await using c = await dev.client("/keep");
+      await c.style("body").color.expect.toBe("red");
+      await dev.write(
+        "keep.css",
+        `
+          body {
+            color: red;
+            background-color
           }
         `,
         {
-          errors: ['styles.css:2:21: error: Could not resolve: "./missing.png"'],
+          errors: ["keep.css:4:1: error: Unexpected end of input"],
         },
       );
-      expect((await dev.fetch("/")).status).toBe(500);
-    }
-    // Recovery is checked without a connected client: when a failed CSS root
-    // recovers, the patch currently ships the HTML route as a JS module
-    // without the route-reload flag, which trips a client-side debug assert
-    // (tracked in https://github.com/oven-sh/bun/issues/31908).
-    await dev.write(
-      "styles.css",
-      `
+      // The route is not fetched while it is broken: that re-bundles the HTML
+      // file, and the recovery below would then reload the page instead of
+      // hot-swapping the stylesheet (https://github.com/oven-sh/bun/issues/31908).
+      await c.style("body").color.expect.toBe("red");
+
+      await dev.write(
+        "keep.css",
+        `
+          body {
+            color: red;
+            background-color: blue;
+          }
+        `,
+      );
+      await c.style("body").backgroundColor.expect.toBe("#00f");
+      expect(await servedCss(dev, "/keep")).toMatchInlineSnapshot(`
+        "/* keep.css */
         body {
-          color: blue;
+          color: red;
+          background-color: #00f;
         }
-      `,
-    );
-    expect((await dev.fetch("/")).status).toBe(200);
+        "
+      `);
+
+      await dev.write("keep.css", ` `, { dedent: false, errors: null });
+      await c.style("body").notFound();
+      expect(await servedCss(dev, "/keep")).toMatchInlineSnapshot(`
+        "/* keep.css */
+
+        "
+      `);
+    }
+
+    // css file with initial syntax error gets recovered
+    {
+      {
+        await using c = await dev.client("/initial", {
+          errors: ["initial.css:3:3: error: Unexpected end of input"],
+        });
+        // hard reload to dismiss the error overlay
+        await c.expectReload(async () => {
+          await dev.write(
+            "initial.css",
+            `
+              body {
+                color: red;
+              }
+            `,
+          );
+        });
+        await c.style("body").color.expect.toBe("red");
+        await dev.write(
+          "initial.css",
+          `
+            body {
+              color: blue;
+            }
+          `,
+          { errors: null },
+        );
+        await c.style("body").color.expect.toBe("#00f");
+        expect(await servedCss(dev, "/initial")).toMatchInlineSnapshot(`
+          "/* initial.css */
+          body {
+            color: #00f;
+          }
+          "
+        `);
+        await dev.write(
+          "initial.css",
+          `
+            body {
+              color: blue;
+            }}
+          `,
+          {
+            errors: ["initial.css:3:3: error: Unexpected end of input"],
+          },
+        );
+      }
+      // Fetched after the client is gone for the same reason as above.
+      await expectBuildFailed(dev, "/initial");
+    }
   },
 });
-devTest("circular css imports handle hot reload", {
+
+devTest("stylesheets created after the server starts, changing html link tags", {
   files: {
-    "index.html": emptyHtmlFile({
-      styles: ["a.css"],
+    // css import before create
+    "before.html": emptyHtmlFile({
+      styles: ["before.css"],
       body: `
-        <div class="a">hello</div>
-        <div class="b">hello</div>
+        <div>HELLO</div>
       `,
     }),
-    "a.css": `
-      @import "./b.css";
-      .a { color: red; }
-    `,
-    "b.css": `
-      @import "./a.css";
-      .b { color: blue; }
+    // css import before create project relative
+    "html/index.html": emptyHtmlFile({
+      styles: ["/style/styles.css"],
+      body: `
+        <div>HELLO</div>
+      `,
+    }),
+    // changing html file with link tag works
+    "relink.html": emptyHtmlFile({ styles: ["relink.css"] }),
+    "relink.css": `
+      .test {
+        color: blue;
+        font-size: 24px;
+      }
     `,
   },
   async test(dev) {
-    await using client = await dev.client("/");
-    await client.style(".a").color.expect.toBe("red");
-    await client.style(".b").color.expect.toBe("#00f");
+    dev.mkdir("style"); // (See DevServer.zig "BUN-10968")
 
-    // Modify one of the circular dependencies
-    await dev.write(
-      "a.css",
-      `
-        @import "./b.css";
-        .a { color: green; }
-      `,
-    );
-    await client.style(".a").color.expect.toBe("green");
-    await client.style(".b").color.expect.toBe("#00f");
+    // css import before create
+    {
+      await using c = await dev.client("/before", {
+        errors: ['before.html: error: Could not resolve: "before.css". Maybe you need to "bun install"?'],
+      });
+      await expectBuildFailed(dev, "/before");
+      await dev.write(
+        "before.css",
+        `
+          body {
+            background-image: url(before.png);
+          }
+        `,
+        {
+          errors: ['before.css:2:21: error: Could not resolve: "before.png". Maybe you need to "bun install"?'],
+        },
+      );
+      await expectBuildFailed(dev, "/before");
+      await c.expectReload(async () => {
+        await dev.write("before.png", imageFixtures.bun);
+      });
+      const backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+      await dev.fetch("/before").expect.toContain("HELLO");
+    }
+
+    // css import before create project relative
+    {
+      await using c = await dev.client("/html", {
+        errors: ['html/index.html: error: Could not resolve: "/style/styles.css"'],
+      });
+      await expectBuildFailed(dev, "/html");
+      await dev.write(
+        "style/styles.css",
+        `
+          body {
+            background-image: url(/assets/bun.png);
+          }
+        `,
+        {
+          errors: ['style/styles.css:2:21: error: Could not resolve: "/assets/bun.png"'],
+        },
+      );
+      // Unlike the HTML's "/style/styles.css" link, an absolute url() in CSS is
+      // not resolved against the project root, so creating that file is not a
+      // change the stylesheet depends on.
+      await c.expectNoWebSocketActivity(async () => {
+        await dev.write("assets/bun.png", imageFixtures.bun, { errors: null });
+        await dev.delete("assets/bun.png", { errors: null });
+      });
+      await expectBuildFailed(dev, "/html");
+      await dev.write(
+        "style/styles.css",
+        `
+          body {
+            background-image: url(../assets/bun.png);
+          }
+        `,
+        {
+          errors: ['style/styles.css:2:21: error: Could not resolve: "../assets/bun.png"'],
+        },
+      );
+      await c.expectReload(async () => {
+        await dev.write("assets/bun.png", imageFixtures.bun);
+      });
+      const backgroundImage = await c.style("body").backgroundImage;
+      assert(backgroundImage);
+      await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
+      await dev.fetch("/html").expect.toContain("HELLO");
+    }
+
+    // changing html file with link tag works
+    {
+      await using c = await dev.client("/relink");
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+      const testCss = await servedCss(dev, "/relink");
+      expect(testCss).toMatchInlineSnapshot(`
+        "/* relink.css */
+        .test {
+          color: #00f;
+          font-size: 24px;
+        }
+        "
+      `);
+
+      // Rewriting the HTML file unchanged reloads the page; the stylesheet survives the rebuild.
+      await c.expectReload(async () => {
+        await dev.write("relink.html", dev.read("relink.html"), { dedent: false, errors: null });
+      });
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+      expect(await servedCss(dev, "/relink")).toBe(testCss);
+
+      await dev.write("relink.html", emptyHtmlFile({ styles: ["relink-other.css"] }), {
+        errors: ['relink.html: error: Could not resolve: "relink-other.css". Maybe you need to "bun install"?'],
+      });
+      await expectBuildFailed(dev, "/relink");
+      await c.expectReload(async () => {
+        await dev.write(
+          "relink-other.css",
+          `
+            .other {
+              color: red;
+            }
+          `,
+        );
+      });
+      await c.style(".other").color.expect.toBe("red");
+      await c.style(".test").notFound();
+      const otherCss = await servedCss(dev, "/relink");
+      expect(otherCss).toMatchInlineSnapshot(`
+        "/* relink-other.css */
+        .other {
+          color: red;
+        }
+        "
+      `);
+
+      await c.expectReload(async () => {
+        await dev.write("relink.html", emptyHtmlFile({ styles: ["relink.css"] }), { errors: null });
+      });
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+      await c.style(".other").notFound();
+      expect(await servedCss(dev, "/relink")).toBe(testCss);
+
+      await c.expectReload(async () => {
+        await dev.write("relink.html", emptyHtmlFile({ styles: ["relink-other.css", "relink.css"] }), {
+          errors: null,
+        });
+      });
+      await c.style(".other").color.expect.toBe("red");
+      await c.style(".test").color.expect.toBe("#00f");
+      await c.style(".test").fontSize.expect.toBe("24px");
+      // Each <link> becomes its own chunk. The order they are injected in is
+      // covered by the source-order case (#37845); only the set is asserted here.
+      const urls = await stylesheetUrls(dev, "/relink");
+      const chunks = await Promise.all(urls.map(url => fetchCss(dev, url)));
+      expect(chunks.sort()).toEqual([otherCss, testCss].sort());
+    }
   },
 });
+
 devTest("asset index stays valid after another css root is freed", {
   // Two independent CSS roots each get an entry in `DevServer.Assets`.
   // When the first one is freed (via a syntax error), its slot is removed
@@ -313,12 +817,22 @@ devTest("asset index stays valid after another css root is freed", {
   async test(dev) {
     // Bundle /first before /second so that `first.css` is registered at
     // a lower asset index than `second.css`.
-    {
-      await using c1 = await dev.client("/first");
-      await c1.style(".first").color.expect.toBe("red");
-    }
+    expect(await servedCss(dev, "/first")).toMatchInlineSnapshot(`
+      "/* first.css */
+      .first {
+        color: red;
+      }
+      "
+    `);
     await using c2 = await dev.client("/second");
     await c2.style(".second").color.expect.toBe("#00f");
+    expect(await servedCss(dev, "/second")).toMatchInlineSnapshot(`
+      "/* second.css */
+      .second {
+        color: #00f;
+      }
+      "
+    `);
 
     // Failing `first.css` frees its asset slot via `unrefByPath`, which
     // swap-removes it and moves the data for `second.css` into its slot.
@@ -341,6 +855,14 @@ devTest("asset index stays valid after another css root is freed", {
       { errors: null },
     );
     await c2.style(".second").color.expect.toBe("green");
+    const greenSecond = await servedCss(dev, "/second");
+    expect(greenSecond).toMatchInlineSnapshot(`
+      "/* second.css */
+      .second {
+        color: green;
+      }
+      "
+    `);
 
     // Fix the first file and ensure both pages still work afterwards.
     await dev.write(
@@ -350,12 +872,17 @@ devTest("asset index stays valid after another css root is freed", {
       `,
     );
     await c2.style(".second").color.expect.toBe("green");
-    {
-      await using c1 = await dev.client("/first");
-      await c1.style(".first").color.expect.toBe("#ff0");
-    }
+    expect(await servedCss(dev, "/second")).toBe(greenSecond);
+    expect(await servedCss(dev, "/first")).toMatchInlineSnapshot(`
+      "/* first.css */
+      .first {
+        color: #ff0;
+      }
+      "
+    `);
   },
 });
+
 devTest("css hot update carries the edited stylesheet when another root fails in the same rebuild", {
   files: {
     "bunfig.toml": `
@@ -414,281 +941,32 @@ devTest("css hot update carries the edited stylesheet when another root fails in
       await c2.style(".second").color.expect.toBe("green");
       await c1.style(".second").notFound();
     }
+    const greenSecond = await servedCss(dev, "/second");
+    expect(greenSecond).toMatchInlineSnapshot(`
+      "/* second.css */
+      .second {
+        color: green;
+      }
+      "
+    `);
+    await expectBuildFailed(dev, "/first");
 
+    // Recovery happens with no client connected, see
+    // https://github.com/oven-sh/bun/issues/31908.
     await dev.write(
       "first.css",
       `
         .first { color: yellow; }
       `,
     );
-    {
-      await using c2 = await dev.client("/second");
-      await c2.style(".second").color.expect.toBe("green");
-    }
-    {
-      await using c1 = await dev.client("/first");
-      await c1.style(".first").color.expect.toBe("#ff0");
-    }
-  },
-});
-devTest("multiple stylesheets importing same dependency", {
-  files: {
-    "first.html": emptyHtmlFile({
-      styles: ["first.css"],
-      body: `
-        <div class="first">hello</div>
-        <div class="shared">hello</div>
-      `,
-    }),
-    "second.html": emptyHtmlFile({
-      styles: ["second.css"],
-      body: `
-        <div class="second">hello</div>
-        <div class="shared">hello</div>
-      `,
-    }),
-    "first.css": `
-      @import "./shared.css";
-      .first { color: red; }
-    `,
-    "second.css": `
-      @import "./shared.css";
-      .second { color: blue; }
-    `,
-    "shared.css": `
-      .shared { color: green; }
-    `,
-  },
-  async test(dev) {
-    await using c1 = await dev.client("/first");
-    await using c2 = await dev.client("/second");
-    await c1.style(".first").color.expect.toBe("red");
-    await c2.style(".second").color.expect.toBe("#00f");
-    await c1.style(".shared").color.expect.toBe("green");
-    await c2.style(".shared").color.expect.toBe("green");
-
-    await dev.write(
-      "shared.css",
-      `
-        .shared { color: yellow; }
-      `,
-    );
-
-    await c1.style(".shared").color.expect.toBe("#ff0");
-    await c2.style(".shared").color.expect.toBe("#ff0");
-  },
-});
-devTest("removing and re-adding css import", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["main.css"],
-    }),
-    "main.css": `
-      @import "./colors.css";
-      .main { background: white; }
-    `,
-    "colors.css": `
-      .colored { color: blue; }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style(".colored").color.expect.toBe("#00f");
-
-    // Remove the import
-    await dev.write(
-      "main.css",
-      `
-        /* @import "./colors.css"; */
-        .main { background: white; }
-      `,
-    );
-    await c.style(".colored").notFound();
-
-    // A change to 'colors.css' should not trigger a rebuild of 'main.css', nor notify any clients.
-    await c.expectNoWebSocketActivity(async () => {
-      await dev.write(
-        "colors.css",
-        `
-          .colored { color: yellow; }
-        `,
-      );
-      await dev.write(
-        "colors.css",
-        `
-          .colored { color: blue; }
-        `,
-      );
-    });
-    await c.style(".colored").notFound();
-
-    // Re-add the import
-    await dev.write(
-      "main.css",
-      `
-        @import "./colors.css";
-        .main { background: white; }
-      `,
-    );
-    await c.style(".colored").color.expect.toBe("#00f");
-    await c.style(".main").backgroundColor.expect.toBe("#fff");
-  },
-});
-devTest("changing html file with link tag works", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-    }),
-    "styles.css": `
-      .test {
-        color: blue;
-        font-size: 24px;
+    expect(await servedCss(dev, "/second")).toBe(greenSecond);
+    expect(await servedCss(dev, "/first")).toMatchInlineSnapshot(`
+      "/* first.css */
+      .first {
+        color: #ff0;
       }
-    `,
-  },
-  async test(dev) {
-    await using c = await dev.client("/");
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-
-    await c.expectReload(async () => {
-      await dev.writeNoChanges("index.html");
-    });
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-
-    await c.hardReload();
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-
-    await dev.write(
-      "index.html",
-      emptyHtmlFile({
-        styles: ["other.css"],
-      }),
-      {
-        errors: ['index.html: error: Could not resolve: "other.css". Maybe you need to "bun install"?'],
-      },
-    );
-    await c.expectReload(async () => {
-      await dev.write(
-        "other.css",
-        `
-          .other {
-            color: red;
-          }
-        `,
-      );
-    });
-    await c.style(".other").color.expect.toBe("red");
-    await c.style(".test").notFound();
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.html",
-        emptyHtmlFile({
-          styles: ["styles.css"],
-        }),
-      );
-    });
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-    await c.style(".other").notFound();
-    await c.expectReload(async () => {
-      await dev.write(
-        "index.html",
-        emptyHtmlFile({
-          styles: ["other.css", "styles.css"],
-        }),
-      );
-    });
-    await c.style(".other").color.expect.toBe("red");
-    await c.style(".test").color.expect.toBe("#00f");
-    await c.style(".test").fontSize.expect.toBe("24px");
-  },
-});
-devTest("css import before create", {
-  files: {
-    "index.html": emptyHtmlFile({
-      styles: ["styles.css"],
-      body: `
-        <div>HELLO</div>
-      `,
-    }),
-  },
-  async test(dev) {
-    await using c = await dev.client("/", {
-      errors: ['index.html: error: Could not resolve: "styles.css". Maybe you need to "bun install"?'],
-    });
-    await dev.fetch("/").expect.not.toContain("HELLO");
-    await dev.write(
-      "styles.css",
-      `
-        body {
-          background-image: url(bun.png);
-        }
-      `,
-      {
-        errors: ['styles.css:2:21: error: Could not resolve: "bun.png". Maybe you need to "bun install"?'],
-      },
-    );
-    await c.expectReload(async () => {
-      await dev.write("bun.png", imageFixtures.bun);
-    });
-    const backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-    await dev.fetch("/").expect.toContain("HELLO");
-  },
-});
-devTest("css import before create project relative", {
-  files: {
-    "html/index.html": emptyHtmlFile({
-      styles: ["/style/styles.css"],
-      body: `
-        <div>HELLO</div>
-      `,
-    }),
-  },
-  async test(dev) {
-    dev.mkdir("style"); // (See DevServer.zig "BUN-10968")
-    await using c = await dev.client("/", {
-      errors: ['html/index.html: error: Could not resolve: "/style/styles.css"'],
-    });
-    await dev.fetch("/").expect.not.toContain("HELLO");
-    await dev.write(
-      "style/styles.css",
-      `
-        body {
-          background-image: url(/assets/bun.png);
-        }
-      `,
-      {
-        errors: ['style/styles.css:2:21: error: Could not resolve: "/assets/bun.png"'],
-      },
-    );
-    await c.expectNoWebSocketActivity(async () => {
-      await dev.write("assets/bun.png", imageFixtures.bun, { errors: null });
-      await dev.delete("assets/bun.png", { errors: null });
-    });
-    await dev.fetch("/").expect.not.toContain("HELLO");
-    await dev.write(
-      "style/styles.css",
-      `
-        body {
-          background-image: url(../assets/bun.png);
-        }
-      `,
-      {
-        errors: ['style/styles.css:2:21: error: Could not resolve: "../assets/bun.png"'],
-      },
-    );
-    await c.expectReload(async () => {
-      await dev.write("assets/bun.png", imageFixtures.bun);
-    });
-    const backgroundImage = await c.style("body").backgroundImage;
-    assert(backgroundImage);
-    await dev.fetch(extractCssUrl(backgroundImage)).expectFile(imageFixtures.bun);
-    await dev.fetch("/").expect.toContain("HELLO");
+      "
+    `);
   },
 });
 


### PR DESCRIPTION
### Problem
- `test/bake/dev/css.test.ts` is one of the ten slowest non-integration test files: 52-61s per lane in `test/expected-durations.json`, about the same on release and ASAN lanes.
- The time is fixed waits in the harness, not bundling. Every client connect, and every write made while a client is attached, ends in a 5 x 200ms poll for an error overlay; the old file did that 41 times, about 41s of a 56s local release run.
- The file also booted 15 dev servers, about 2s each for boot plus exit on a debug/ASAN build. Bundling itself is a few ms per step.

### Fix
- Test-only change. Cases whose fixtures do not interact share one dev server with one HTML route per case, so 15 servers become 7. Three cases keep their own server (asset-table order, a bunfig plugin, a nested HTML file the harness only routes correctly on POSIX).
- Server state is asserted over plain HTTP: each case pins the exact stylesheet chunk it serves as an inline snapshot, and a failing route must serve the "Build Failed" page. Clients and `hardReload`s that only loaded a page once become fetches (clients 20 to 16, overlay polls 41 to 19).
- Writes pass `errors: null` to skip the overlay poll only where the next assertion can only pass if the rebuild succeeded: a stylesheet that fails to rebuild keeps its old rules in the page, and reloads are only sent while nothing is failing. Writes that recover from an error keep the poll.
- Verification: no case is deleted, skipped or made todo; the table below maps every old assertion to its new home. Interleaved local runs of the old and the pushed file on the same machine: 92.1s to 53.9s on debug+ASAN and 54.2s to 31.5s on release (earlier rounds under heavier load: 120-135s to about 74s, 65-68s to about 39s). Every local run of the new file passed (for the pushed revision: 3 release, 2 debug; 16 more across the earlier revisions, which differ only in the points listed under "Review follow-ups").

### Background
- `devTest` (in `test/bake/bake-harness.ts`) boots one dev server per case from a map of fixture files. A fixture with several HTML files gets one route per file, which is what lets unrelated cases share a server.
- `dev.client(route)` attaches a happy-dom browser in a node process that receives hot updates over a websocket. `dev.fetch(route)` is a plain HTTP request, so served HTML and chunks can be asserted without a client.
- After each connect, and each write made while a client is attached, the harness checks that client for an error overlay, polling 5 x 200ms when there is none. `errors: [...]` asserts specific messages; `errors: null` skips the check.
- Build errors are pushed to every connected client, so error cases run with no other client attached and every case on a shared server ends with its files recovered (the dev server sends no page reloads to anyone while any failure exists). Fetching a route whose stylesheet is failing re-bundles it and, because the HTML still compiles, pushes the HTML module to clients as a plain JS hot update, which kills a client that has that page loaded (#31908); clients on other routes or on the error page are unaffected, recovery writes never push it, and a route whose HTML file is itself the failing file pushes nothing. Verified all four with probes; the rule is documented once on `expectBuildFailed` and every fetch of a broken route in the file satisfies it.
- Injected stylesheets are served at `/_bun/asset/<hash>.css`. The helpers only look at those links because a route bundled while its stylesheet was failing keeps its source `<link>` after recovery (#37844).

<details>
<summary>Original description</summary>

### What

`test/bake/dev/css.test.ts` is one of the ten slowest non-integration test files (61s on the Windows 11 aarch64 lane, 52-56s on the others per `test/expected-durations.json`). The numbers barely differ between release and ASAN lanes because the time is mostly fixed waits in the harness, not bundling. Measured on a local release run of the old file (56s for 15 cases):

- Every `dev.client()` and every `dev.write()`/`patch()` made while a client is attached ends in `Client.expectErrorOverlay`, which polls 5 x 200ms when no overlay is visible. The old file made 41 such calls (17 connects, 22 writes, 2 `hardReload`s), about 41s of the 56s. Each connect costs ~1.45s (node + happy-dom + the poll), each write with a client attached ~1.07s; the bundling work itself is a few ms per step.
- Under the debug/ASAN build a dev server boot plus graceful exit costs about 2s, and the file booted 15 of them.

This PR only changes the test file. The poll in `bake-harness.ts` is the remaining shared lever for this file, `bundle.test.ts` (#37827 is the same pass over that file) and `hot.test.ts`, and is being looked at separately; after this change the file still pays it 19 times (13 connects without expected errors, 6 writes that recover from an error), which is about 19s of the remaining ~37s.

### Changes

- Cases whose fixtures do not interact share a dev server, one HTML route per case: the three `@import` graph cases, the shared-dependency/asset/script-import cases, the four error cases, and the "stylesheet appears after the server started" and "link tag changes" cases. 15 servers become 7. Three cases keep their own server: the asset-table swap-remove case (needs `first.css` and `second.css` to be the only two entries, in that order) and the bunfig-plugin case, which both keep their operation sequence, and the project-relative case, whose HTML file has to stay in a subdirectory (that is what makes its `/style/styles.css` link project-relative rather than HTML-relative) while the harness's multi-route branch only registers nested HTML files correctly on POSIX (it builds the route key from `path.relative` output without normalizing separators, so on Windows it would be `/html\index`; a separate harness fix). On its own server it takes the single-file catch-all route exactly as on main.
- One happy-dom client remains per case that asserts the browser side of a hot update (16 clients instead of 20). Clients that only existed to load a page once (the first and last clients of the asset-table case, the two fresh clients at the end of the plugin case) and the two `hardReload`s are replaced by fetching the route and asserting what a fresh load gets.
- Server state is asserted over HTTP with three small helpers: `servedCss` fetches a route's HTML, requires exactly one injected stylesheet link, and returns the chunk (asserting 200 and `text/css`), so each case pins the exact served stylesheet as an inline snapshot (chunk order of `@import`ed files, how a circular import is printed, what an emptied stylesheet serves, which root gets rebuilt); `stylesheetUrls` asserts how many stylesheets a route links; `expectBuildFailed` asserts a failing route serves the 500 "Build Failed" page rather than just a status, replacing the `not.toContain("HELLO")` checks. These add ~20ms to the whole file.
- Writes pass `errors: null` when the assertion right after them can only pass if the rebuild succeeded and reached the client. This is sound for mechanical reasons, not just faster: a stylesheet that fails to rebuild keeps its old rules in the page (the "does not kill old styles" case asserts exactly that, so a `toBe(newValue)` or `notFound()` after the write proves the rebuild landed), and the dev server only emits the route reload list while `bundling_failures` is empty (`DevServer.rs`, the List 1 block in `finalize_bundle`), so a passing `expectReload` proves nothing is failing. Writes that recover from an error keep the default check, because the overlay disappearing is what those steps assert. The header comment in the file states the convention. The two writes inside `expectNoWebSocketActivity` in the remove/re-add case also pass `errors: null`: the client fixture exits on any socket message inside that block, so the overlay check there could not observe anything (the project-relative case already did this).
- A route whose stylesheet is failing is only fetched while no connected client has that page loaded (see the Background bullet on #31908 for the exact rule, which is also the doc comment of `expectBuildFailed`). The old "css url resolve error" case fetched its broken route with the page's client attached and only passed because the client was disposed before it applied the pushed update (with a debug build the client fixture prints `ASSERTION FAILED ... at replaceModules` and exits, which the harness's dispose does not notice; a harness fix for that is being handled separately). The restructured case asserts the same three things (overlay text, 500, recovery) with the fetch after the dispose; the "does not kill old styles" case does not fetch its route while broken, since its client has to survive until the stylesheet is hot-swapped back in; the link-tag case does fetch while broken, because there the HTML file itself is what fails.
- Two things are intentionally not pinned because they are being fixed separately: the order the dev server injects several `<link>`s in (currently reversed; #37845 fixes it and adds a dedicated case, so the two-link step here asserts the set of chunks), and whether a root that fails to resolve a `url()` through a plugin keeps its old rules on the client (it currently does not, while the builtin resolver does; the plugin case asserts what the original asserted). The helpers only look at injected `/_bun/asset/` links because a route bundled while its stylesheet was failing currently keeps its source `<link>` after recovery (#37844). On the shared servers that leftover tag is a 404, so the recovery reload of the initial-error case currently sits through the client fixture's 1s stylesheet-load check before acknowledging (visible as a "Reached maximum CSS load check attempts" line in the output); the old single-route servers answered that URL with the HTML page instead. #37844 removes that second.

### Where each original case's assertions live

| # | Original case | Now | Kept | Added / changed |
|---|---|---|---|---|
| 1 | css file with syntax error does not kill old styles | "bundling errors", `/keep` | red; overlay text `keep.css:4:1`; still red while broken; fix applies (overlay check kept); emptied stylesheet removes the rule | exact chunk after the fix and when emptied (`/* keep.css */` header only). Route is not fetched while broken, see above |
| 2 | css file with initial syntax error gets recovered | "bundling errors", `/initial` | overlay text on load; reload on fix (check kept); red; blue; overlay text when broken again | exact chunk while blue; route is the Build Failed page after the final break (fetched after the client is gone); a second recovery serves the identical chunk again, so the shared server ends without failures. Blue write passes `errors: null` |
| 3 | add new css import later | "shared imports, assets and script imports", `/script` | no rule, rule after the import is added, gone after it is removed | served HTML links no stylesheet before and after, exactly one while imported, with its exact chunk. Patches pass `errors: null` |
| 4 | css import another css file | "@import graphs", `/import` | h1 `#00f` and body red; after editing the imported file h1 green, body still red | `hardReload` ("still works after a reload") is now the exact chunk a fresh load gets, asserted before and after the edit. Write passes `errors: null` |
| 5 | asset referenced in css | "shared imports, assets and script imports", `/asset` | client's `url()` resolves to `bun.png`, then to the replacement image after rewriting it | the served chunk's `url()` resolves to the same bytes at both points. Write passes `errors: null` |
| 6 | syntax error crash | "bundling errors", `/crash` | 200 before, 500 after the patch (the double-unref panic killed the server) | exact chunk before (`background-image: url;`); the 500 is the Build Failed page; fixing the file serves the new chunk (also leaves the shared server clean) |
| 7 | css url resolve error on hot reload is recoverable | "bundling errors", `/resolve` | red; overlay text `resolve.css:2:21`; route 500; recovery with no client attached | old rule still applied after the failed rebuild; 500 is the Build Failed page; recovery asserts the exact chunk, not only 200. The 500 fetch happens after the client is disposed, see above |
| 8 | circular css imports handle hot reload | "@import graphs", `/circular` | `.a` red / `.b` `#00f`; after the edit `.a` green / `.b` `#00f` | exact chunk before and after (the cycle is printed once, b then a). Write passes `errors: null` |
| 9 | asset index stays valid after another css root is freed | own server, same operation order | client on `/second`; `first.css` broken (`errors: null` as before); the `second.css` edit reaches the client; fix write keeps its overlay check; still green afterwards | the first client on `/first` (only there to bundle it first) and the final fresh client on `/first` are fetches asserting the exact chunk; exact `/second` chunk initially, right after the edit (reads the moved asset slot directly) and unchanged after the fix |
| 10 | css hot update carries the edited stylesheet when another root fails in the same rebuild | own server (bunfig plugin), same batch | both clients' initial rules; the batch; `.second` green on c2; no `.second` on c1; recovery with no clients attached | the two fresh clients after the fix are fetches asserting both routes' exact chunks; exact green `/second` chunk right after the batch; `/first` is the Build Failed page before the fix |
| 11 | multiple stylesheets importing same dependency | "shared imports, assets and script imports", `/shared-first` + `/shared-second`, both clients | all four initial rules; both clients see `#ff0` after editing `shared.css` | each root's own rule is unaffected; exact chunks of both routes before and after (both roots rebuilt on the server). Write passes `errors: null` |
| 12 | removing and re-adding css import | "@import graphs", `/toggle` | `.colored` present; gone after removing the import; no websocket activity while the orphaned file is edited twice; still gone; back (plus `.main`) after re-adding | exact chunk with and without the import, unchanged after the orphan edits, byte-identical to the original once re-added. The two toggling writes and the two writes inside the no-activity block pass `errors: null` |
| 13 | changing html file with link tag works | "stylesheets created after the server starts", `/relink` | initial styles; rewriting the HTML unchanged reloads and the styles survive; overlay text for the unresolvable link; creating the file reloads (check kept) into `.other` red / no `.test`; switching back reloads into `.test` / no `.other`; both links give both | exact chunk initially, byte-identical after the rewrite reload and after switching back, exact `.other` chunk, and with two links the served set is exactly those two chunks; route is the Build Failed page while the link is unresolvable and the loaded page keeps its old stylesheet meanwhile. `hardReload` is covered by the chunk assertion after the rewrite reload; the three non-recovery rewrites pass `errors: null` (`writeNoChanges` is inlined to pass it); link order left to #37845 |
| 14 | css import before create | "stylesheets created after the server starts", `/before` | overlay text on load; error text `before.css:2:21` after creating the stylesheet; reload when the image appears (check kept); client's `url()` resolves to the image; `HELLO` served | "page does not contain HELLO" becomes "route is the Build Failed page" (asserted once, at the stage the old case checked; the CSS-stage 500 page is covered by cases 2, 6 and 7) |
| 15 | css import before create project relative | own server as on main (`html/index.html` at the catch-all route, `style/`/`assets/` layout unchanged) | `mkdir`, both overlay texts, the no-activity create/delete block (`errors: null` as before), reload, image bytes, `HELLO` | same not-HELLO replacement (asserted at both error stages) |

No case is deleted, skipped or made todo.

### Timing

Same machine, same binaries, old and new file run back to back in alternation. Host load varied a lot during the session (load average 50 to 210 on a 12 CPU quota), so absolute numbers move between rounds, but every interleaved pair shows the same ratio. The debug numbers run the binary that `bun bd test` builds, invoked directly under a separate uid, because this sandbox's shared inotify instance limit stops dev servers from starting as root (the old file fails identically when that happens; #37827 hit the same thing).

| build | old file (15 cases) | new file (7 cases, as pushed) | host load |
|---|---|---|---|
| linux debug + ASAN | 92.1s | 53.9s | ~55-70 |
| linux release | 54.2s | 31.5s | ~55-70 |
| linux debug + ASAN | 135.5s, 120.2s | 73.6s, 74.3s (previous revision) | ~170-210 |
| linux release | 67.8s, 65.2s | 39.7s, 38.0s (previous revision) | ~170-210 |

Dev server boots 15 -> 7, happy-dom clients 20 -> 16, `hardReload`s 2 -> 0, overlay polls 41 -> 19 (13 connects without expected errors and the 6 writes that recover from an error), `expect()` calls 76 -> 264 (25 of them inline snapshots of served stylesheets). Every local run of the new file passed (3 release and 2 debug/ASAN runs of the pushed revision, 16 across the two earlier revisions), with no client assertion traces or "not accepted" hot updates in any log. The largest group takes ~7-10s in release against the harness's 30s per-case floor; everything in it is event driven (acks and reload events), with no timing-based waits added. The remaining 19 polls are what #37866 (harness) removes.

### Review follow-ups

- 3d6385d: the project-relative case is back on its own single-HTML server. On a shared server its nested `html/index.html` would be registered as `/html\index` on Windows (the harness's multi-route branch does not normalize `path.sep`; separate harness fix), and moving the HTML to the top level would have removed the thing the case tests.
- 4f96628: the initial-error case recovers once more at the end, so every case on the shared error server ends without failures, as the header comment claims (the dev server sends page reloads to nobody while any failure exists, so a case appended after a still-broken one would fail in a confusing way). The fetch-while-broken rule is stated once on `expectBuildFailed` after probing what actually triggers it (see Background), replacing three comments that each described it differently. The before-create case's second fetch of its broken route is dropped: the rebuild it triggered made the client send an ack that the recovery write right after it would have counted. The link-tag case keeps its fetch (its HTML file is the failing file) and asserts the loaded page still has its stylesheet afterwards, which also consumes that ack before the next write.

`test/expected-durations.json` is left alone; the scheduled job regenerates it from CI. #37844, #37845, #37859, #37867, #37051 and #33405 add cases to the end of this file; the file still ends with the untouched `extractCssUrl`, so those apply on top of this apart from the import line.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/bake/dev/css.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/bake/dev/css.test.ts
bun test v1.4.0 (2613c6b7d)

test/bake/dev/css.test.ts:
Dev server testing directory: /tmp/bun-dev-test-p8jV8W
[0;30mdev|[0m Started development server: http://localhost:37617
[0;30mdev|[0m [32mBundled page in 179ms[0m[2m:[0m import.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 112ms[0m[2m:[0m import.css
[0;30mdev|[0m [32mBundled page in 63ms[0m[2m:[0m circular.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 37ms[0m[2m:[0m circular-a.css
[0;30mdev|[0m [32mBundled page in 30ms[0m[2m:[0m toggle.html
[0;30mweb|[0m [I] [Bun] Hot-module-reloading socket connected, waiting for changes...
[0;30mdev|[0m [32mReloaded in 32ms[0m[2m:[0m toggle.css
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m nothing to bundle
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m modified files: /tmp/bun-dev-test-p8jV8W/css1/toggle-colors.css
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m modified dirs: /tmp/bun-dev-test-p8jV8W/css1/
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m nothing to bundle
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m modified files: /tmp/bun-dev-test-p8jV8W/css1/toggle-colors.css
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m modified dirs: /tmp/bun-dev-test-p8jV8W/css1/
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m nothing to bundle
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m modified files: /tmp/bun-dev-test-p8jV8W/css1/toggle-colors.css
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m modified dirs: /tmp/bun-dev-test-p8jV8W/css1/
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m nothing to bundle
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m modified files: /tmp/bun-dev-test-p8jV8W/css1/toggle-colors.css
[0;30mdev|[0m [33mdebug warn[0m[2m:[0m modified dirs: /tmp/bun-dev-test-p8jV8W/
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/bake/dev/css.test.ts | 1261 ++++++++++++++++++++++++++++-----------------
 1 file changed, 783 insertions(+), 478 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                       reads  edits  tests
test/bake/dev/css.test.ts     25     43      0
```

</details>

<!-- robobun:evidence:end -->