### PR TITLE
bundler: release a failed onLoad request before giving its scan unit back

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4415,7 +4415,24 @@ pub mod bv2_impl {
     }
 
     impl<'a> BundleV2<'a> {
+        /// Bundle thread: a plugin answered `load` (or none matched).
         pub(crate) fn on_load(load: &mut jsc_api::JSBundler::Load, this: &mut BundleV2) {
+            let parse_scheduled = Self::apply_load_answer(load, this);
+            if !parse_scheduled {
+                // Last, once `apply_load_answer` has released `load`: in the dev
+                // server this decrement can finish the bundle
+                // (`finish_from_bake_dev_server`), which drops the arena `load` is
+                // allocated in along with `this`. Neither may be touched afterwards.
+                this.decrement_scan_counter();
+            }
+        }
+
+        /// Feeds the answer into the graph and releases everything `load` owns.
+        ///
+        /// Returns whether the file's parse task was scheduled. The load carries
+        /// that task's scan-counter unit: once scheduled, the task gives it back
+        /// on completion; otherwise the file failed and the caller gives it back.
+        fn apply_load_answer(load: &mut jsc_api::JSBundler::Load, this: &mut BundleV2) -> bool {
             this.graph.outstanding_loads.unlink(load);
             load.deferred = false;
             // `Load` is arena-allocated (no Drop); free its owned heap fields on every exit path.
@@ -4458,7 +4475,7 @@ pub mod bv2_impl {
                     // The file could be on disk.
                     if source.path.is_file() {
                         this.graph.pool().schedule(load.parse_task_mut());
-                        return;
+                        return true;
                     }
 
                     // When it's not a file, this is a build error and we should report it.
@@ -4472,9 +4489,7 @@ pub mod bv2_impl {
                             bun_core::fmt::quote(source.path.namespace),
                         ),
                     );
-
-                    // An error occurred, prevent spinning the event loop forever
-                    this.decrement_scan_counter();
+                    false
                 }
                 jsc_api::JSBundler::LoadValue::Success(code) => {
                     // `code`: LoadSuccess { source_code, loader }
@@ -4561,6 +4576,7 @@ pub mod bv2_impl {
                             }
                         }
                     }
+                    true
                 }
                 jsc_api::JSBundler::LoadValue::Err(msg) => {
                     if let Some(dev) = this.dev_server {
@@ -4589,9 +4605,7 @@ pub mod bv2_impl {
                         log.errors += (kind == bun_ast::Kind::Err) as u32;
                         log.warnings += (kind == bun_ast::Kind::Warn) as u32;
                     }
-
-                    // An error occurred, prevent spinning the event loop forever
-                    this.decrement_scan_counter();
+                    false
                 }
                 jsc_api::JSBundler::LoadValue::Pending
                 | jsc_api::JSBundler::LoadValue::Consumed => unreachable!(),
@@ -4618,6 +4632,9 @@ pub mod bv2_impl {
             this.graph.outstanding_resolves.unlink(resolve);
             // RAII guard captures `this`
             // as a raw pointer so it does not hold a unique borrow across the body.
+            // Declared before `_resolve_deinit` so that it drops after it: as in
+            // `on_load`, the decrement can finish the bundle and free the arena
+            // `resolve` is allocated in.
             let _dec_guard = this.decrement_scan_counter_on_drop();
             // `Resolve` is arena-allocated (no Drop); free its owned heap fields on every exit path.
             struct ResolveDeinitGuard(*mut jsc_api::JSBundler::Resolve);

--- a/test/bake/dev/plugins.test.ts
+++ b/test/bake/dev/plugins.test.ts
@@ -1,5 +1,6 @@
 // Plugin tests concern plugins in development mode.
-import { devTest, minimalFramework } from "../bake-harness";
+import { expect } from "bun:test";
+import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 // Note: more in depth testing of plugins is done in test/bundler/bundler_plugin.test.ts
 devTest("onResolve", {
@@ -108,6 +109,74 @@ devTest("onResolve + onLoad virtual file", {
       },
       "file-on-disk",
     ]);
+  },
+});
+// The two ways an onLoad answer fails its file: the callback threw, or nothing answered
+// for a module outside the file namespace. Each plugin below awaits `defer()` first, which
+// resolves once nothing else in the bundle is pending, so its answer is what finishes the
+// bundle: the dev server then tears the bundle down (including the arena that the request
+// being answered lives in) while that answer is still being handled. MIMALLOC_PURGE_DELAY=0
+// makes a touch of the torn-down arena fault instead of reading memory that still happens
+// to look intact.
+function failingOnLoadFiles(plugin: string, entry: string) {
+  return {
+    "bunfig.toml": `
+      [serve.static]
+      plugins = ["./plugin.ts"]
+    `,
+    "plugin.ts": plugin,
+    "index.html": emptyHtmlFile({ scripts: ["entry.ts"] }),
+    "entry.ts": entry,
+  };
+}
+devTest("onLoad callback that throws fails the route and leaves the dev server usable", {
+  env: { MIMALLOC_PURGE_DELAY: "0" },
+  files: failingOnLoadFiles(
+    `
+      export default {
+        name: "throwing-onload",
+        setup(build) {
+          build.onLoad({ filter: /entry\\.ts$/ }, async ({ defer }) => {
+            await defer();
+            throw new Error("onLoad failed on purpose");
+          });
+        },
+      };
+    `,
+    `console.log("never bundled");`,
+  ),
+  async test(dev) {
+    expect((await dev.fetch("/")).status).toBe(500);
+    await dev.output.waitForLine(/onLoad failed on purpose/);
+    // Bundles the route again, so the dev server has to be intact after the failed bundle.
+    expect((await dev.fetch("/")).status).toBe(500);
+  },
+});
+devTest("onLoad that does not answer for a module outside the file namespace leaves the dev server usable", {
+  env: { MIMALLOC_PURGE_DELAY: "0" },
+  files: failingOnLoadFiles(
+    `
+      export default {
+        name: "declining-onload",
+        setup(build) {
+          build.onResolve({ filter: /^virtual:config$/ }, () => ({ path: "config", namespace: "virtual" }));
+          // Registered so that the bundler asks this plugin to load the module; answering
+          // nothing leaves a module outside the file namespace with nothing to load it from.
+          build.onLoad({ filter: /.*/, namespace: "virtual" }, async ({ defer }) => {
+            await defer();
+            return undefined;
+          });
+        },
+      };
+    `,
+    `import "virtual:config";`,
+  ),
+  async test(dev) {
+    // Only the error being reported is asserted here: this failure is logged against the
+    // bundle rather than the file, so unlike a thrown callback it does not fail the route.
+    await dev.fetch("/");
+    await dev.output.waitForLine(/Module not found "virtual:config" in namespace "virtual"/);
+    await dev.fetch("/");
   },
 });
 // devTest("onLoad with watchFile", {


### PR DESCRIPTION
### Problem
- A dev server (`Bun.serve({ development: true })`) with a `[serve.static]` plugin whose `onLoad` throws, or answers nothing for a module outside the `file` namespace, crashes the bundler when that file is the last thing the bundle was waiting on.
- Debug build: `AddressSanitizer: SEGV` in `<BundleV2::on_load::LoadDeinitGuard as Drop>::drop` under `BundleV2::on_load`. Release builds read and write the same freed memory silently.
- Cause: in the dev server, handing a failed load's scan unit back can finish the bundle, and finishing the bundle frees the arena the load request lives in. `on_load` handed the unit back from inside the failure arm and only then released the request, so the release touched a freed arena.
- `on_resolve` already runs its decrement last, but only through guard declaration order that nothing documented. `Bun.build` is unaffected: its bundle is never finished from inside `on_load`.

### Fix
- The body of `on_load` moves into a helper that applies the answer, releases the request, and reports whether a parse task was scheduled. `on_load` hands the scan unit back only when none was, as its last statement, after the request is gone.
- Correct because nothing reads the request after it is released: it is unlinked from the outstanding list first, and that list is the only way the bundle reaches a dispatched request. Logging and failure reporting still happen before the decrement, so the observable order is unchanged.
- `on_resolve` gets a comment saying its guard order is load bearing.
- Verification: two new dev-server tests, one per failing arm, each awaiting `defer()` so the failing file is what finishes the bundle. Both fail on a debug (ASAN) build of main with the SEGV above and pass with the fix. Release mimalloc does not trap on the stale access, so there they are functional coverage only.

### Background
- The dev server (bake) bundles a route on request and owns the in-flight bundle plus an arena; when the bundle finishes, its cleanup drops both synchronously, from within whatever call finished it.
- Scan counter: the bundle counts outstanding units of work (resolves, loads, parse tasks) and is done when it reaches zero. A successful load passes its unit to the parse task it schedules; a failed load has to hand it back itself.
- Plugin `Load` requests are allocated in the bundle arena, so they have no `Drop`; the fields they own are freed by an explicit guard when the handler returns.
- `NoMatch` is a failure only for modules outside the `file` namespace: a file on disk can still be parsed normally, a virtual module has nothing to fall back to.
- `MIMALLOC_PURGE_DELAY=0` returns freed pages to the OS immediately, and debug mimalloc also `mprotect`s them, which is what turns the stale access into a trap in the debug build.

<details>
<summary>Original description</summary>

### Repro

Dev server (`Bun.serve({ development: true })` with an HTML route), a `[serve.static]` plugin whose `onLoad` fails the file, and `MIMALLOC_PURGE_DELAY=0` so the freed arena faults instead of reading back intact:

```toml
# bunfig.toml
[serve.static]
plugins = ["./plugin.ts"]
```

```ts
// plugin.ts
export default {
  name: "repro",
  setup(build) {
    build.onLoad({ filter: /entry\.ts$/ }, () => {
      throw new Error("onLoad failed on purpose");
    });
  },
};
```

```ts
// server.ts   (index.html is an empty page with <script type="module" src="./entry.ts">)
import html from "./index.html";
const server = Bun.serve({ port: 0, development: true, routes: { "/": html }, fetch: () => new Response("fallback") });
const res = await fetch(server.url);
console.log(JSON.stringify({ status: res.status }));
await server.stop(true);
```

`MIMALLOC_PURGE_DELAY=0 bun-debug run server.ts` should print `{"status":500}` and exit 0. On main it dies inside the bundler:

```
ERROR: AddressSanitizer: SEGV on unknown address ... (READ)
    #0 core::mem::replace::<Box<[u8]>>
    #2 <BundleV2::on_load::LoadDeinitGuard as Drop>::drop    src/bundler/bundle_v2.rs:4428
    #4 BundleV2::on_load
    #5 bundle_v2::on_load_from_js_loop  <- ManagedTask::run <- dispatch::run_task
```

The same thing happens when an `onLoad` registered for a non-file namespace answers nothing (`LoadValue::NoMatch` for a module that cannot be read from disk). Without `MIMALLOC_PURGE_DELAY=0` the accesses are the same, they just land on pages mimalloc has not given back yet, so release builds read (and write `LoadValue::Consumed` into) freed memory silently. `Bun.build` is unaffected: its bundle is not `asynchronous`, so the decrement never finishes the bundle from inside `on_load`.

### Cause

`Load` requests are allocated in the bundle arena (`arena_create` in `enqueue_on_load_plugin_if_needed_impl`). `BundleV2::on_load` installs `LoadDeinitGuard`, which frees the request's owned `path` / `namespace` / `value` when the function returns, and its `NoMatch` (non-file) and `Err` arms call `decrement_scan_counter()` from inside the arm.

In a dev server bundle that decrement is not just arithmetic: `decrement_scan_counter` -> `on_after_decrement_scan_counter` -> `is_done()` -> `finish_from_bake_dev_server` -> `DevServer::finalize_bundle`, whose cleanup (`finalize_bundle_cleanup`, src/runtime/bake/DevServer.rs) runs `bv2.deinit_without_freeing_arena()` and sets `dev.current_bundle = None`, dropping `CurrentBundle.heap` (the arena every in-flight `Load` lives in) together with the `Box<BundleV2>`. When the failing file is the last thing the bundle was waiting on, all of that happens synchronously inside the arm; control then returns to `on_load`, whose guard `mem::take`s the fields out of the freed arena and writes `Consumed` back into it.

`on_resolve` already has the right shape: its `ScanCounterGuard` is declared before `ResolveDeinitGuard`, so it drops after it and the decrement is the last thing that runs. Nothing there documented that the order is load bearing.

### Fix

`on_load` is split: `apply_load_answer` does everything the function did before (unlink, feed the answer into the graph, release the request through `LoadDeinitGuard`) and returns whether the file's parse task was scheduled, i.e. whether the scan unit the load carried now belongs to that task. `on_load` gives the unit back itself only when it was not, as its last statement, after the request has been released. The arena and the `BundleV2` may be gone once `decrement_scan_counter` returns, and nothing is touched after it; the comment on the call says so. `on_resolve` gets a comment stating why its guard order matters.

The order of events is otherwise unchanged: the same log / `handle_parse_task_failure` calls happen before the decrement in the two failing arms, and the `Success` and `NoMatch`-on-a-file arms still schedule the parse task without touching the counter. Releasing the request before the decrement is always fine because nothing reads it afterwards: it was unlinked from `outstanding_loads` at the top, and that list is the only way the pass reaches a request once it has been dispatched (`drain_deferred_tasks`, `fail_outstanding_plugin_requests`); `deinit_without_freeing_arena` does not look at requests at all.

### Verification

New tests in `test/bake/dev/plugins.test.ts`, one per failing arm (a callback that throws, and one that answers nothing for a module in a plugin namespace). Each plugin awaits `defer()` before failing, so by construction the failing file is the only pending item and its answer is what finishes the bundle (the runtime source is parsed concurrently at bundle start, so without `defer()` this would depend on timing; the plain repro above still crashed 5/5 here). The tests run the dev server with `MIMALLOC_PURGE_DELAY=0`, fetch the route twice and, through the harness, tear the server down at the end; the first test also checks the route fails with 500 and that the plugin error is reported.

- debug (ASAN) build of main: both new tests fail with the `LoadDeinitGuard` SEGV above; the three existing tests in the file pass.
- with this change: the file passes (5/5); `test/bundler/bundler_plugin.test.ts` (53 pass, covers the `Success` / `NoMatch` / `Err` arms under `Bun.build`) and `test/bundler/bundler_defer.test.ts` (10 pass) pass on the debug build; `cargo clippy -p bun_bundler` and `cargo fmt --check` are clean.

The fail-before needs the debug build: debug mimalloc (`MI_DEBUG`) also `mprotect`s purged pages, while release mimalloc only `madvise`s them, so the stale accesses do not trap there. In release the new tests are plain functional coverage of the two failure paths.

The second test does not assert the route's status: today that `NoMatch` error is only logged against the bundle and the route is still served with 200, which is a separate (pre-existing) issue tracked on its own.


</details>
