### PR TITLE
bake: align the error overlay underline with a windowed line excerpt

### DIFF
--- a/src/runtime/bake/client/error-serialization.ts
+++ b/src/runtime/bake/client/error-serialization.ts
@@ -19,10 +19,17 @@ export interface BundlerMessage {
 export interface BundlerMessageLocation {
   /** One-based */
   line: number;
-  /** One-based */
+  /** One-based, relative to the whole source line (not to `lineText`) */
   column: number;
   /** Byte length */
   length: number;
+  /**
+   * Number of columns of the source line that precede `lineText`. Non-zero
+   * when `lineText` is only a window of a long line, so the highlight starts
+   * `column - 1 - lineTextColumnOffset` characters into `lineText`.
+   */
+  lineTextColumnOffset: number;
+  /** The source line, or a window of it around the highlighted range. */
   lineText: string;
 }
 
@@ -71,12 +78,14 @@ function readBundlerMessageLocationOrNull(r: DataViewReader): BundlerMessageLoca
 
   const column = r.u32();
   const length = r.u32();
+  const lineTextColumnOffset = r.u32();
   const lineText = r.string32();
 
   return {
     line,
     column,
     length,
+    lineTextColumnOffset,
     lineText,
   };
 }

--- a/src/runtime/bake/client/overlay.ts
+++ b/src/runtime/bake/client/overlay.ts
@@ -624,7 +624,11 @@ function renderCodeLine(location: BundlerMessageLocation, level: BundlerMessageL
       elem("div", { class: "view" }, [
         mapCodePreviewLine(syntaxHighlight(location.lineText)),
         elem("div", { class: "highlight-wrap log-" + bundleLogLevelToName[level] }, [
-          elemText("span", { class: "space" }, "_".repeat(location.column - 1)),
+          elemText(
+            "span",
+            { class: "space" },
+            "_".repeat(Math.max(0, location.column - 1 - location.lineTextColumnOffset)),
+          ),
           elemText("span", { class: "line" }, "_".repeat(location.length)),
         ]),
       ]),

--- a/src/runtime/bake/dev_server/serialized_failure.rs
+++ b/src/runtime/bake/dev_server/serialized_failure.rs
@@ -198,7 +198,7 @@ pub enum ErrorKind {
     JsAggregate,
 }
 
-// All "write" functions get a corresponding "read" function in ./client/error.ts
+// All "write" functions get a corresponding "read" function in ../client/error-serialization.ts
 type Writer = Vec<u8>;
 
 fn write_log_msg(msg: &bun_ast::Msg, w: &mut Writer) {
@@ -231,6 +231,10 @@ fn write_log_data(data: &bun_ast::Data, w: &mut Writer) {
         _ = w.write_int_le::<u32>(u32::try_from(loc.column).expect("int cast"));
         _ = w.write_int_le::<u32>(u32::try_from(loc.length).expect("int cast"));
 
+        // `line_text` may be a window of a long line (`Location::init_or_null`)
+        // while `column` is relative to the whole line; the client needs the
+        // width of the dropped prefix to put the underline under the window.
+        _ = w.write_int_le::<u32>(loc.line_text_column_offset);
         // TODO: syntax highlighted line text + give more context lines
         write_string32(loc.line_text.as_deref().unwrap_or(b""), w);
 

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -450,6 +450,33 @@ devTest("importing bun on the client", {
     });
   },
 });
+devTest("error overlay underlines an error deep inside a long line", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `let ok = 1;\n${"a".repeat(100)}]${"b".repeat(100)}`,
+  },
+  async test(dev) {
+    // The `]` is at column 101 of a 201 character line. The overlay only shows
+    // a window of the line that starts 40 characters before the error, so the
+    // underline (what the `:41` below is measured from) has to start 40
+    // characters in rather than 100.
+    await using c = await dev.client("/", {
+      errors: ['index.ts:2:41: error: Expected ";" but found "]"'],
+    });
+    const { excerpt, underlineStart } = await c.js<{ excerpt: string; underlineStart: number }>`{
+      const msg = document.querySelector("bun-hmr").shadowRoot.querySelector(".b-msg");
+      return {
+        excerpt: msg.querySelector(".view > pre").textContent,
+        underlineStart: msg.querySelector(".highlight-wrap > .space").textContent.length,
+      };
+    }`;
+    expect(excerpt).toBe(`${"a".repeat(40)}]${"b".repeat(79)}`);
+    expect(excerpt[underlineStart]).toBe("]");
+  },
+});
 devTest("import.meta.main", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/cli/inspect/BunFrontendDevServer.test.ts
+++ b/test/cli/inspect/BunFrontendDevServer.test.ts
@@ -443,6 +443,7 @@ describe.if(isPosix)("BunFrontendDevServer inspector protocol", () => {
                 "length": 1,
                 "line": 3,
                 "lineText": "      export function brokenFunction(name: string {",
+                "lineTextColumnOffset": 0,
               },
               "message": "Expected ")" but found "{"",
               "notes": [],
@@ -455,6 +456,7 @@ describe.if(isPosix)("BunFrontendDevServer inspector protocol", () => {
                 "length": 1,
                 "line": 5,
                 "lineText": "      }",
+                "lineTextColumnOffset": 0,
               },
               "message": "Unexpected }",
               "notes": [],
@@ -464,6 +466,113 @@ describe.if(isPosix)("BunFrontendDevServer inspector protocol", () => {
         },
       ]
     `);
+
+    // Fix the file so subsequent tests don't fail
+    fs.writeFileSync(
+      join(tempdir, "utils.ts"),
+      `
+      // Fixed utility module
+      export function greet(name: string) {
+        return \`Hello, \${name}!\`;
+      }
+    `,
+    );
+  });
+
+  test("bundleFailed locations on a long line carry the column offset of the lineText window", async () => {
+    // For an error deep inside a long line, `lineText` is only a window of the
+    // line (40 bytes in front of the error, 80 after it) while `column` still
+    // counts from the start of the line. `lineTextColumnOffset` is the width of
+    // the part the window dropped, so the overlay underlines `lineText` at
+    // `column - 1 - lineTextColumnOffset`. Like `column`, it counts UTF-16 code
+    // units (JS string indices), not bytes: 170 bytes of the second line are
+    // dropped but they are only 91 characters.
+    const asciiLine = `let a = 1;/*${"-".repeat(96)}*/let a = 2;/*${"-".repeat(96)}*/`;
+    const unicodeLine = `let b = 1;/*${"é".repeat(96)}*/let b = 2;/*${"é".repeat(96)}*/`;
+    const secondDeclaration = asciiLine.lastIndexOf("let ") + "let ".length; // 114, same on both lines
+
+    const bundleFailedPromise = session.waitForEvent("BunFrontendDevServer.bundleFailed");
+    // The file is already part of the graph, so the watcher rebundles it on its own.
+    fs.writeFileSync(join(tempdir, "utils.ts"), `${asciiLine}\n${unicodeLine}\n`);
+
+    const { buildErrorsPayloadBase64 } = await bundleFailedPromise;
+    const buffer = Uint8Array.from(atob(buildErrorsPayloadBase64), c => c.charCodeAt(0));
+    const reader = new DataViewReader(new DataView(buffer.buffer), 0);
+    const failures: Array<ReturnType<typeof decodeAndAppendServerError>> = [];
+    while (reader.hasMoreData()) {
+      failures.push(decodeAndAppendServerError(reader));
+    }
+
+    expect(failures.map(({ file, messages }) => ({ file, messages }))).toEqual([
+      {
+        file: "utils.ts",
+        messages: [
+          {
+            kind: "bundler",
+            level: 0,
+            message: '"a" has already been declared',
+            location: {
+              line: 1,
+              column: secondDeclaration + 1,
+              length: 1,
+              lineTextColumnOffset: secondDeclaration - 40,
+              lineText: asciiLine.slice(secondDeclaration - 40, secondDeclaration + 80),
+            },
+            notes: [
+              {
+                message: '"a" was originally declared here',
+                location: {
+                  line: 1,
+                  column: 5,
+                  length: 1,
+                  lineTextColumnOffset: 0,
+                  lineText: asciiLine.slice(0, 4 + 80),
+                },
+              },
+            ],
+          },
+          {
+            kind: "bundler",
+            level: 0,
+            message: '"b" has already been declared',
+            location: {
+              line: 2,
+              column: secondDeclaration + 1,
+              length: 1,
+              // The 40 bytes kept in front of `b` are "*/let " plus 17 two-byte
+              // "é", so the window drops "let b = 1;/*" and the other 79 "é".
+              lineTextColumnOffset: "let b = 1;/*".length + 79,
+              lineText: `${"é".repeat(17)}*/let b = 2;/*${"é".repeat(36)}`,
+            },
+            notes: [
+              {
+                message: '"b" was originally declared here',
+                location: {
+                  line: 2,
+                  column: 5,
+                  length: 1,
+                  lineTextColumnOffset: 0,
+                  lineText: `let b = 1;/*${"é".repeat(36)}`,
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+
+    // What the overlay relies on: the offset is where `lineText` starts in the
+    // line, in string indices, so the underline lands on the declared name.
+    const [aMessage, bMessage] = failures[0].messages;
+    for (const [name, line, message] of [
+      ["a", asciiLine, aMessage],
+      ["b", unicodeLine, bMessage],
+    ] as const) {
+      for (const { location } of [message, ...message.notes]) {
+        expect(line.indexOf(location.lineText)).toBe(location.lineTextColumnOffset);
+        expect(location.lineText[location.column - 1 - location.lineTextColumnOffset]).toBe(name);
+      }
+    }
 
     // Fix the file so subsequent tests don't fail
     fs.writeFileSync(


### PR DESCRIPTION
### Problem
- In the dev server error overlay, an error deep inside a long line (anything minified) shows a short excerpt of the line, but the red underline lands well to the right of the error, or past the end of the excerpt. Notes have the same problem.
- Cause: the excerpt is a window cut out of the line, but the column sent with it still counts from the start of the whole line, and the payload says nothing about how much was cut off in front.
- The terminal caret had the same bug. #37848 fixes that side; this PR is stacked on it and only touches the overlay.

### Fix
- Each serialized location gains one field: the width of the prefix the window dropped (0 when the excerpt is the whole line). The client subtracts it from the column when padding the underline, clamped at 0 so a negative count cannot throw and take the overlay down.
- This lines up because the column and the offset are both counted in UTF-16 code units, the unit the client indexes the excerpt in, so non-ASCII prefixes work too. The column on the wire keeps its whole-line meaning, as in #37848.
- Adding a field is safe because the payload has one writer and one reader in the same binary; the inspector's `bundleFailed` event passes the same bytes through untouched.
- Verification: a dev server test renders the repro and checks the underline lands under the `]` in the excerpt, and an inspector test decodes the payload for a long ASCII line and a long `é` line and checks the offset is where the excerpt starts in the line. Both fail without the fix. The other overlay position tests were run locally and are unchanged.

### Background
- The dev server behind `bun ./index.html` ("bake" in the tree) does not only print bundle errors to the terminal: it serializes them into a binary payload, embedded in the error page and pushed to the HMR client, which draws the in-browser overlay.
- That payload has one Rust writer in the dev server and one TypeScript reader in the client, and no version field. The same bytes are also handed to inspector clients as `BunFrontendDevServer.bundleFailed`.
- A message location is a line, a 1-based column, a length and a line text. For long lines the line text is a window of about 120 bytes around the error (about 40 before, 80 after), while the column still counts from the start of the line.
- #37848 added `line_text_column_offset` to that location, the width of the dropped prefix in the same units as the column, and used it for the terminal caret. This PR carries the value to the overlay.
- The overlay draws the underline as a second line of text under the excerpt: `column - 1` filler characters, then `length` underline characters.

<details>
<summary>Original description</summary>

Stacked on #37848 (this PR's base is that branch, so the diff here is only this PR's own commit). #37848 adds `Location.line_text_column_offset` and fixes the terminal caret; it leaves the dev server overlay alone, which is what this PR does.

### Repro

```sh
mkdir x && cd x
printf 'let ok = 1;\n%s]%s\n' "$(printf 'a%.0s' $(seq 100))" "$(printf 'b%.0s' $(seq 100))" > index.ts
echo '<script type="module" src="./index.ts"></script>' > index.html
bun ./index.html
```

Open the page. The overlay shows the second line as a 120 character window starting 40 characters before the `]` (`aaaa...a]bbbb...b`), but the red underline is drawn 100 characters in, under a `b` 60 characters to the right of the `]`. With a longer line (anything minified) it is drawn past the end of the shown text altogether. Same for notes. Decoding the payload the page embeds shows why: `column: 101` next to a `lineText` that only has 40 characters in front of the `]`.

### Cause

`Location::init_or_null` (`src/ast/lib.rs`) windows a long line to about 120 bytes around the error, but `column` stays relative to the whole line. `write_log_data` in `src/runtime/bake/dev_server/serialized_failure.rs` serializes both as they are, and `renderCodeLine` in `src/runtime/bake/client/overlay.ts` pads the underline with `column - 1` characters under the windowed `lineText`. That is the overlay's copy of the caret bug #37848 fixes in `Data::write_format`.

### Fix

* `write_log_data` writes `loc.line_text_column_offset` (the width of the part of the line the window dropped, 0 whenever `line_text` is the whole line) as a `u32` after the length. The format has one writer and one reader, both shipped in the same binary (the HMR client and the embedded error page; the inspector's `BunFrontendDevServer.bundleFailed` payload is the same bytes and is passed through opaquely), so adding a field is safe.
* `readBundlerMessageLocationOrNull` reads it into `BundlerMessageLocation.lineTextColumnOffset`.
* `renderCodeLine` pads with `column - 1 - lineTextColumnOffset` (saturated at 0, like `write_format` does; a negative count would throw out of `repeat` and take the whole overlay down).

`column` itself is deliberately left alone rather than being rewritten to a window-relative value on the wire: it keeps meaning the same thing as `BuildMessage.position.column` and the logger's `at file:line:col`, which is also what #37848 chose, and a consumer of the inspector payload that wants to show a real column can still do so. Both values are in UTF-16 code units (`ErrorPositionState` counts columns that way and the offset is derived from the same scan), which is exactly the unit `lineText` is indexed in on the client, so the padding lines up for non-ASCII prefixes too. The window is not otherwise changed, and like the terminal output the overlay does not mark the truncation.

### Verification

* `test/cli/inspect/BunFrontendDevServer.test.ts`: the existing `bundleFailed` snapshot gains `lineTextColumnOffset: 0` for its two short lines, and a new test rewrites `utils.ts` with two 220 character lines (ASCII and one padded with `é`), each with a redeclared binding, and decodes the payload with the client's own decoder. It pins the error and note locations of both lines (`column: 115` with `lineTextColumnOffset: 74` and `91`, the notes with `0` and an untrimmed window) and checks that `line.indexOf(lineText) === lineTextColumnOffset` and that `lineText[column - 1 - lineTextColumnOffset]` is the declared name. Fails without the change (field missing), passes with it.
* `test/bake/dev/bundle.test.ts`: renders the repro above in the dev server client harness and checks that the underline starts 40 characters in (`index.ts:2:41` in the harness's underline-derived format, previously `2:101`) and that the character under it in the shown excerpt is the `]`.

Also run locally with the change: the rest of `BunFrontendDevServer.test.ts`, and `bundle`, `css`, `hot` and `html` in `test/bake/dev` (the other tests that assert overlay positions; every location they cover has an offset of 0, so they are unchanged).

While looking at this I noticed that a message whose `Location.line` is `0` (a throwing dev server plugin produces one) is written with its column/length/text while the client stops reading after the line, which desyncs the rest of the payload. That predates this change and is being handled separately.

</details>
