### PR TITLE
spawn: stop the forced waiter thread from spinning on macOS (park on a wake fd instead of sigwait)

### DIFF
--- a/test/js/bun/spawn/spawn_waiter_thread-fixture.js
+++ b/test/js/bun/spawn/spawn_waiter_thread-fixture.js
@@ -1,4 +1,9 @@
-const { spawn } = require("child_process");
+// Spawns a child that stays alive, then reports how much CPU this process (every
+// thread, so a waiter thread counts) burns over a window in which the only thing
+// left to do is wait for that child. Measured in-process rather than through the
+// parent's resourceUsage() so startup and module loading, which cost over a second
+// of CPU on a debug build, stay out of the number.
+import { readdirSync, readFileSync } from "fs";
 
 if (!process.env.WITHOUT_WAITER_THREAD) {
   if (!process.env.BUN_GARBAGE_COLLECTOR_LEVEL || !process.env.BUN_FEATURE_FLAG_FORCE_WAITER_THREAD) {
@@ -6,4 +11,39 @@ if (!process.env.WITHOUT_WAITER_THREAD) {
   }
 }
 
-spawn(process.argv0, ["-e", "Bun.sleepSync(999999999)"]);
+// Alive until its stdin is closed, so it is being watched for the whole window.
+const child = Bun.spawn({
+  cmd: [process.execPath, "-e", "await Bun.stdin.text()"],
+  stdin: "pipe",
+  stdout: "ignore",
+  stderr: "inherit",
+});
+
+// The waiter thread names itself "Waitpid". Linux exposes thread names, so there the
+// report also proves which of the two modes was actually running.
+function hasWaiterThread() {
+  if (process.platform !== "linux") return null;
+  return readdirSync("/proc/self/task").some(
+    tid => readFileSync(`/proc/self/task/${tid}/comm`, "utf8").trim() === "Waitpid",
+  );
+}
+
+// Start the window once the event loop has been around once, so the work that
+// follows evaluating the entrypoint is not counted.
+setImmediate(() => {
+  const wall0 = process.hrtime.bigint();
+  const cpu0 = process.cpuUsage();
+
+  setTimeout(async () => {
+    const { user, system } = process.cpuUsage(cpu0);
+    const wallUs = Number((process.hrtime.bigint() - wall0) / 1000n);
+    const waiterThread = hasWaiterThread();
+
+    // The child exits only now, after whatever watches it has been idle for the whole
+    // window, so its exit has to wake that watcher up.
+    child.stdin.end();
+    const exitCode = await child.exited;
+
+    console.log(JSON.stringify({ cpuUs: user + system, wallUs, waiterThread, exitCode }));
+  }, 500);
+});

--- a/test/js/bun/spawn/spawn_waiter_thread.test.ts
+++ b/test/js/bun/spawn/spawn_waiter_thread.test.ts
@@ -1,47 +1,105 @@
 import { spawn } from "bun";
 import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, tempDir } from "harness";
 import { join } from "path";
 
-async function run(withWaiterThread: boolean) {
-  const proc = spawn({
-    env: {
-      ...bunEnv,
-      ...(withWaiterThread
-        ? { BUN_GARBAGE_COLLECTOR_LEVEL: "1", BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" }
-        : { WITHOUT_WAITER_THREAD: "1" }),
-    },
-    stderr: "inherit",
-    stdout: "inherit",
+// Bun only falls back to the waiter thread on its own on Linux kernels without pidfd;
+// this flag forces it everywhere else (it is only read when BUN_GARBAGE_COLLECTOR_LEVEL
+// is also set). The thread itself exists on every unix, so it is tested on every unix.
+const waiterThreadEnv = {
+  ...bunEnv,
+  BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+  BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1",
+};
+const defaultWatcherEnv = {
+  ...bunEnv,
+  BUN_GARBAGE_COLLECTOR_LEVEL: "0",
+  BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: undefined,
+  WITHOUT_WAITER_THREAD: "1",
+};
+
+// https://github.com/oven-sh/bun/issues/9404: a process with a live child used a full
+// core while waiting on it. The fixture spawns such a child and reports the CPU this
+// process used over a window spent only waiting: a spinning watcher puts cpuUs at
+// ~100% of wallUs, while a watcher that sleeps measures ~0.2% on a release build and
+// a few percent on a debug build.
+async function expectIdleWhileWaitingOnChild(withWaiterThread: boolean) {
+  await using proc = spawn({
+    cmd: [bunExe(), join(import.meta.dir, "spawn_waiter_thread-fixture.js")],
+    env: withWaiterThread ? waiterThreadEnv : defaultWatcherEnv,
     stdin: "ignore",
-    cmd: [bunExe(), join(__dirname, "spawn_waiter_thread-fixture.js")],
+    stdout: "pipe",
+    stderr: "pipe",
   });
 
-  setTimeout(
-    () => {
-      proc.kill(process.platform !== "win32" ? "SIGKILL" : undefined);
-    },
-    isWindows ? 5000 : 1000,
-  ).unref();
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  await proc.exited;
-
-  const resourceUsage = proc.resourceUsage();
-
-  // Assert we didn't use 100% of CPU time
-  console.log(resourceUsage.cpuTime);
-  expect(resourceUsage?.cpuTime.total).toBeLessThan(750_000n * (isWindows ? 5n : 1n));
+  expect(stderr).toBe("");
+  const report = JSON.parse(stdout);
+  expect(report).toEqual({
+    cpuUs: expect.any(Number),
+    wallUs: expect.any(Number),
+    waiterThread: isLinux ? withWaiterThread : null,
+    exitCode: 0,
+  });
+  expect(report.wallUs).toBeGreaterThanOrEqual(400_000);
+  const cpuPercent = (100 * report.cpuUs) / report.wallUs;
+  expect(cpuPercent, `cpuUs=${report.cpuUs} wallUs=${report.wallUs}`).toBeLessThan(50);
+  expect(exitCode).toBe(0);
 }
 
-test(
-  "issue #9404",
-  async () => {
-    const promises = [run(false)];
-    if (process.platform === "linux") {
-      promises.push(run(true));
-    }
-
-    await Promise.all(promises);
-  },
-  isWindows ? 6_000 : 5_000,
+// Serial on purpose: a spinning fixture sharing a core with another one would only
+// measure ~50% and could slip under the limit.
+test.serial("issue #9404: default process watcher is idle while a child runs", () =>
+  expectIdleWhileWaitingOnChild(false),
 );
+
+test.serial.skipIf(isWindows)("issue #9404: waiter thread is idle while a child runs", () =>
+  expectIdleWhileWaitingOnChild(true),
+);
+
+test.skipIf(isWindows)("waiter thread is woken up for exits and for newly spawned processes", async () => {
+  using dir = tempDir("spawn-waiter-thread-wake", {
+    "wake-fixture.js": `
+      const cat = () => Bun.spawn({ cmd: ["cat"], stdin: "pipe", stdout: "ignore" });
+
+      // "parked" is handed to the waiter thread first. By the time "settle" has been reported
+      // as exited, the thread has also scanned "parked", found it alive and gone back to
+      // sleep, so the exit below reaches us through the SIGCHLD wakeup.
+      const parked = cat();
+      const settle = cat();
+      settle.stdin.end();
+      await settle.exited;
+      parked.stdin.end();
+      const parkedExit = await parked.exited;
+
+      // The thread is asleep with nothing left to watch: a newly spawned process has to
+      // wake it up to be noticed.
+      const later = cat();
+      later.stdin.end();
+      const laterExit = await later.exited;
+
+      // Many wakeups (spawns and SIGCHLDs) arriving together coalesce in the wake channel.
+      const burst = Array.from({ length: 8 }, cat);
+      for (const proc of burst) proc.stdin.end();
+      const burstExits = await Promise.all(burst.map(proc => proc.exited));
+
+      console.log(JSON.stringify({ parkedExit, laterExit, burstExits }));
+    `,
+  });
+
+  await using proc = spawn({
+    cmd: [bunExe(), "wake-fixture.js"],
+    cwd: String(dir),
+    env: waiterThreadEnv,
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ parkedExit: 0, laterExit: 0, burstExits: new Array(8).fill(0) });
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- With the waiter thread forced on macOS or FreeBSD (`BUN_GARBAGE_COLLECTOR_LEVEL=0 BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1`, as some darwin-lane tests do), the process burns a full core for the rest of its life, even after the last child exits. Exits are still noticed, so those tests pass today.
- Cause: outside Linux the thread idles in `sigwait` on an empty signal set. Nothing can wake it (no SIGCHLD handler, no wake path from `append()`), and xnu returns `EINVAL` at once, so the loop becomes a tight `wait4(WNOHANG)` poll.
- This is the non-Linux half of #9404; Linux got an eventfd plus a SIGCHLD handler back then. Bun never selects the waiter thread on its own outside Linux, so only the test flag reaches this.

### Fix
- Every unix now uses the Linux design: the thread owns a wake fd (eventfd on Linux, a non-blocking pipe elsewhere), `append()` and the SIGCHLD handler write to it, and the thread blocks in `poll()` on it between scans. Only the fd constructor stays platform specific.
- Property to check: both events the thread must react to (a new pid, a child exit) write to the fd, and the thread rescans if anything arrived mid-scan, so it can neither spin nor park past a wakeup.
- Two deliberate Linux changes: the SIGCHLD handler gets `SA_RESTART` and preserves `errno`, and startup becomes a `std::sync::Once`, closing a race where a second thread's `append()` could hit `panic!("Failed to write to eventfd")` before the fd existed.
- Verification: the rewritten #9404 test measures CPU over a 500 ms idle window and now covers the waiter thread on every unix; it fails on macOS without the fix. A second test exercises both wake paths but passes before and after. The first push is tests only so the darwin lanes record the failure; the fix follows on top.

### Background
- Bun has to learn when children exit. Linux with pidfd, and macOS/FreeBSD via `EVFILT_PROC`, get that through the event loop; the waiter thread (named `Waitpid`) is the fallback for Linux kernels without pidfd and calls `wait4` on each watched pid itself.
- The force flag is read only when `BUN_GARBAGE_COLLECTOR_LEVEL` is also set; it turns that fallback on for any unix, which is how tests reach it.
- `sigwait` on an empty set can never deliver a signal, and xnu rejects it with `EINVAL` immediately, so a loop around it is a busy loop.
- A wake fd lets other threads and a signal handler wake a thread parked in `poll()`; wakeups coalesce, and a full pipe is already readable, so a failed wake write is safe to ignore.
- `SA_RESTART` makes a syscall interrupted by the handler resume instead of failing with `EINTR`. It matters once the handler exists on macOS, where Bun's syscall wrappers do not retry `EINTR` as the Linux ones do.

<details>
<summary>Original description</summary>

### Problem

When the waiter thread is forced on a non-Linux unix (`BUN_GARBAGE_COLLECTOR_LEVEL=0 BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1`, which several tests do on the darwin lanes: `spawnsync-no-microtask-drain.test.ts`, `worker-refused-completion.test.ts`), its idle wait in `waiter_thread_posix::loop_` was:

```rust
sigemptyset(&mut mask);
sigwait(&mask, &mut signal);
```

Nothing can wake that: `append()` has no wake path on non-Linux and no SIGCHLD handler is installed there. On xnu, `sigwait` on an empty set returns `EINVAL` immediately, so the loop degenerates into `wait4(WNOHANG)` over every watched process in a tight loop, burning a core for the rest of the process lifetime (it keeps spinning after the last child has exited). Child exits were still noticed, which is why the tests above pass on macOS today; they just burn a core while they run. This is the non-Linux half of #9404: the Linux branch got an eventfd plus a SIGCHLD handler back then, the other branch kept the `sigwait`.

Bun never picks the waiter thread on its own outside Linux (macOS and FreeBSD use `EVFILT_PROC`), so this is only reachable through the test flag. Found while rewriting the #9404 test in #37761, which keeps its waiter-thread case Linux-only because of this.

### Fix

Use the Linux design on every unix. `WaiterThreadPosix` holds a wake channel: the eventfd on Linux, a non-blocking close-on-exec pipe elsewhere. `append()` and the SIGCHLD handler write to it; the thread scans, drains it (rescanning if anything came in during the scan), and otherwise blocks in `poll()` on it. The Linux and non-Linux branches of `append`, `reload_handlers`, the handler and the loop collapse into one code path; only the two-line channel constructor is platform specific.

Two things changed on Linux as a consequence, both deliberate:

- The SIGCHLD handler is installed with `SA_RESTART` (this is also how libuv installs its SIGCHLD handler). With a handler installed, every child exit interrupts whichever thread the kernel picks; without `SA_RESTART` that thread's blocking syscall fails with `EINTR`. The Linux `bun_sys` wrappers retry `EINTR`, the Darwin `$NOCANCEL` ones do not, so this matters once the handler exists on macOS. The handler also saves and restores `errno`, since `write(2)` on a full pipe sets it. The waiter thread itself is woken through the fd, never through `EINTR`, so `SA_RESTART` does not affect it.
- `init()` is a `std::sync::Once`. Previously the `started` flag was set before the eventfd was created, so a second thread (a Worker spawning at the same moment as the main thread) whose `append()` lost that race wrote to `Fd::INVALID` and hit `panic!("Failed to write to eventfd")`. Now it blocks until the channel exists. The wake write itself is best effort: the only expected failure is `EAGAIN` on a full pipe, and a full pipe is already readable.

### Tests

`test/js/bun/spawn/spawn_waiter_thread.test.ts` (the #9404 test):

- The fixture now measures `process.cpuUsage()` in-process over a 500 ms window that starts after startup (same approach as #37761; the previous whole-process rusage budget was mostly startup cost on debug builds) and checks the child's exit is delivered after the idle window. On Linux it also reports whether a `Waitpid` thread exists, so each of the two modes is proven to be the one under test. The waiter-thread case now runs on every unix instead of Linux only; this is the case that fails on macOS before the fix (the thread spins, so `cpuUs` is about `wallUs`).
- A second test forces the thread and checks the two wake paths that replace the spin: a child that exits after the thread has scanned it and parked (SIGCHLD wakeup), a child spawned while the thread is parked with nothing to watch (`append()` wakeup), and a burst of eight at once. This one passes before and after on every platform (the spin noticed everything too); it is coverage for the new mechanism, not a repro.

The first push of this PR carries only the test commit so the darwin lanes record the failure against the unfixed binary; the fix is pushed on top once they have. Both halves behave identically on Linux before and after (Linux already had this design), so on Linux the new tests pass either way; the behavior change is only observable on macOS.

Verified on Linux with the debug build: `spawn_waiter_thread.test.ts`, `spawnsync-no-microtask-drain.test.ts`, the `ProcessWaiterThreadTask` row of `worker-refused-completion.test.ts`, the whole of `spawn.test.ts` with the thread forced (139 pass), and the `(waiter thread)` lifecycle-script tests in `bun-install-lifecycle-scripts.test.ts` (the `bun install` mini event loop path). `cargo check`/`clippy` clean for `aarch64-apple-darwin`, `x86_64-apple-darwin` and `x86_64-unknown-freebsd`.


</details>
