### PR TITLE
node:http: release NodeHTTPResponse refs through its pointer instead of freeing under &self

### DIFF
--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -22,9 +22,10 @@ use crate::webcore::AutoFlusher;
 
 bun_core::declare_scope!(NodeHTTPResponse, visible);
 
-/// Intrusive ref-counted; `ref_count` is managed by `ref_` / `deref` below
-/// (FFI rule — `*mut NodeHTTPResponse` is the m_ctx payload of a
-/// `.classes.ts` wrapper). `deinit` runs when count hits zero.
+/// Intrusive ref-counted (`#[derive(CellRefCounted)]` supplies `ref_()` and
+/// `unsafe fn deref(*mut Self)`; FFI rule — `*mut NodeHTTPResponse` is the
+/// m_ctx payload of a `.classes.ts` wrapper). [`Self::deinit`] frees the
+/// allocation when the count hits zero.
 ///
 /// `#[JsClass(no_constructor)]` wires the import-side `${T}__fromJS` /
 /// `__fromJSDirect` / `__create` externs into a `JsClass` impl plus an
@@ -33,6 +34,8 @@ bun_core::declare_scope!(NodeHTTPResponse, visible);
 // R-2 (host-fn re-entrancy): every JS-exposed method takes `&self`; per-field
 // interior mutability via `Cell` (Copy) / `JsCell` (non-Copy).
 #[bun_jsc::JsClass(no_constructor)]
+#[derive(bun_ptr::CellRefCounted)]
+#[ref_count(destroy = Self::deinit)]
 pub struct NodeHTTPResponse {
     pub(crate) ref_count: Cell<u32>,
 
@@ -80,9 +83,6 @@ pub struct NodeHTTPResponse {
 
     pub(crate) auto_flusher: JsCell<AutoFlusher>,
 }
-
-// Intrusive refcount methods (`ref_` / `deref`) are hand-rolled below over the
-// `ref_count` field; `deinit` is the destructor invoked when count hits zero.
 
 bitflags! {
     #[repr(transparent)]
@@ -331,10 +331,17 @@ fn on_drain_shim(this: *mut NodeHTTPResponse, off: u64, resp: uws::AnyResponse) 
 // generated is local. Body discharges its own preconditions; a safe
 // `extern "C" fn` coerces to the `DeferredRepeatingTask` pointer at `post_task`.
 extern "C" fn on_auto_flush_trampoline(ctx: *mut c_void) -> bool {
-    // SAFETY: `ctx` is the `*const NodeHTTPResponse` registered by
-    // `register_auto_flush`; `DeferredTaskQueue::run` feeds it back unchanged
-    // on the JS thread. `on_auto_flush` takes `&self`.
-    unsafe { (*(ctx.cast_const().cast::<NodeHTTPResponse>())).on_auto_flush() }
+    let this = ctx.cast::<NodeHTTPResponse>();
+    // For the ref `register_auto_flush` took for the task. `unregister_auto_flush`
+    // removes the task before releasing it, so it is still held here; the guard
+    // releases it after `on_auto_flush` (`&self`) has returned, since that
+    // release may free the allocation.
+    // SAFETY: `ctx` is the response registered by `register_auto_flush`, fed
+    // back unchanged by `DeferredTaskQueue::run` on the JS thread; `adopt`
+    // consumes the task's ref on drop.
+    let _task_ref = unsafe { bun_ptr::ScopedRef::<NodeHTTPResponse>::adopt(this) };
+    // SAFETY: `_task_ref` holds the allocation alive for the call.
+    unsafe { (*this.cast_const()).on_auto_flush() }
 }
 
 /// Unpack the `AnyServer` tagged-pointer u64 handed across FFI from C++.
@@ -752,10 +759,16 @@ impl NodeHTTPResponse {
 
         server.on_request_complete();
 
-        if had_async_promise {
-            self.deref();
+        // SAFETY: `self` is the live m_ctx allocation; this frame owns the
+        // server-handler ref (witnessed by `had_async_promise`) and the
+        // IS_REQUEST_PENDING ref it releases here, and `self` is not used
+        // after the last release, which may free the allocation.
+        unsafe {
+            if had_async_promise {
+                Self::deref(self.as_ctx_ptr());
+            }
+            Self::deref(self.as_ctx_ptr());
         }
-        self.deref();
     }
 
     pub(crate) fn mark_request_as_done_if_necessary(&self) {
@@ -1121,7 +1134,10 @@ impl NodeHTTPResponse {
         // JS (string coercions, drain callbacks), which could drop the last
         // reference to this response mid-call.
         let this = bun_ptr::BackRef::from(ptr::NonNull::from(self));
-        this.ref_();
+        // SAFETY: `self` is the live m_ctx payload (the wrapper's ref is held
+        // for the duration of this host call); the guard's own ref is released
+        // when it drops, after the last use of `this` below.
+        let _keep_alive = unsafe { bun_ptr::ScopedRef::<Self>::new(self.as_ctx_ptr()) };
 
         let raw_response = this.raw_response.get();
         let mut result: JsResult<JSValue> = Ok(JSValue::UNDEFINED);
@@ -1148,9 +1164,6 @@ impl NodeHTTPResponse {
             }
         }
 
-        // Explicit `.get()` so the inherent refcount `NodeHTTPResponse::deref`
-        // is selected, matching cork() (see its note).
-        this.get().deref();
         result
     }
 }
@@ -1349,7 +1362,9 @@ impl NodeHTTPResponse {
             self.mark_request_as_done_if_necessary();
             self.raw_response.set(None);
         }
-        self.deref();
+        // SAFETY: releases the ref taken by `self.ref_()` above; `self` is the
+        // live m_ctx allocation and is not used after this, which may free it.
+        unsafe { Self::deref(self.as_ctx_ptr()) };
     }
 
     #[uws::uws_callback(export = "Bun__NodeHTTPResponse_onClose")]
@@ -1502,9 +1517,13 @@ impl NodeHTTPResponse {
 fn node_http_request_on_resolve(global_object: &JSGlobalObject, callframe: &CallFrame) -> JSValue {
     scoped_log!(NodeHTTPResponse, "onResolve");
     let arguments = callframe.arguments_as_array::<2>();
-    // arguments[1] is the JSNodeHTTPResponse cell from the resolve callback.
-    // R-2: deref shared — `maybe_stop_reading_body`/`on_request_complete` re-enter.
-    let this: &NodeHTTPResponse = arguments[1].as_class_ref::<NodeHTTPResponse>().unwrap();
+    // arguments[1] is the JSNodeHTTPResponse cell from the resolve callback;
+    // its m_ctx pointer is what the release at the tail goes through.
+    let this_ptr: *mut NodeHTTPResponse = arguments[1].as_::<NodeHTTPResponse>().unwrap();
+    // SAFETY: `as_` returned the payload of the wrapper cell the callframe
+    // holds, and that wrapper owns a ref for as long as it is alive. R-2:
+    // shared — `maybe_stop_reading_body`/`on_request_complete` re-enter.
+    let this: &NodeHTTPResponse = unsafe { &*this_ptr };
     // `promise` non-empty is the ownership token for the server-handler ref;
     // `mark_request_as_done` may have already released it on abort.
     let had_promise = this.promise.with_mut(|p| {
@@ -1537,7 +1556,10 @@ fn node_http_request_on_resolve(global_object: &JSGlobalObject, callframe: &Call
     }
 
     if had_promise {
-        this.deref();
+        // SAFETY: releases the server-handler ref the promise token stood for;
+        // `this_ptr` is live because the wrapper in the callframe still holds
+        // its own ref.
+        unsafe { NodeHTTPResponse::deref(this_ptr) };
     }
     JSValue::UNDEFINED
 }
@@ -1546,9 +1568,11 @@ fn node_http_request_on_resolve(global_object: &JSGlobalObject, callframe: &Call
 fn node_http_request_on_reject(global_object: &JSGlobalObject, callframe: &CallFrame) -> JSValue {
     let arguments = callframe.arguments_as_array::<2>();
     let err = arguments[0];
-    // arguments[1] is the JSNodeHTTPResponse cell from the reject callback.
-    // R-2: deref shared — `maybe_stop_reading_body`/`on_request_complete` re-enter.
-    let this: &NodeHTTPResponse = arguments[1].as_class_ref::<NodeHTTPResponse>().unwrap();
+    // arguments[1] is the JSNodeHTTPResponse cell from the reject callback;
+    // its m_ctx pointer is what the release at the tail goes through.
+    let this_ptr: *mut NodeHTTPResponse = arguments[1].as_::<NodeHTTPResponse>().unwrap();
+    // SAFETY: see `node_http_request_on_resolve`.
+    let this: &NodeHTTPResponse = unsafe { &*this_ptr };
     // `promise` non-empty is the ownership token for the server-handler ref;
     // `mark_request_as_done` may have already released it on abort.
     let had_promise = this.promise.with_mut(|p| {
@@ -1588,7 +1612,8 @@ fn node_http_request_on_reject(global_object: &JSGlobalObject, callframe: &CallF
 
     let _ = bun_vm_mut(global_object).uncaught_exception(global_object, err, true);
     if had_promise {
-        this.deref();
+        // SAFETY: see `node_http_request_on_resolve`.
+        unsafe { NodeHTTPResponse::deref(this_ptr) };
     }
     JSValue::UNDEFINED
 }
@@ -1750,7 +1775,10 @@ impl NodeHTTPResponse {
                 self.body_read_ref.with_mut(|r| r.unref(vm_get()));
                 self.mark_request_as_done_if_necessary();
             }
-            self.deref();
+            // SAFETY: releases the ref taken by `self.ref_()` above; `self` is
+            // the live m_ctx allocation and is not used after this, which may
+            // free it.
+            unsafe { Self::deref(self.as_ctx_ptr()) };
         }
     }
 
@@ -1844,19 +1872,19 @@ impl NodeHTTPResponse {
 
     fn on_drain_corked(&self, offset: u64) {
         scoped_log!(NodeHTTPResponse, "onDrainCorked({})", offset);
-        self.ref_();
-        // defer this.deref(); — moved to tail.
+        // SAFETY: `self` is the live m_ctx allocation; the guard's own ref keeps
+        // it alive across the onwritable callback and is released on every exit
+        // below, after the last use of `self`.
+        let _keep_alive = unsafe { bun_ptr::ScopedRef::<Self>::new(self.as_ctx_ptr()) };
 
         let this_value = self.get_this_value();
         let Some(on_writable) = js::on_writable_get_cached(this_value) else {
-            self.deref();
             return;
         };
         // Slot may hold UNDEFINED (WantMore) or anything the `.onwritable`
         // setter stored; non-cells can't be callable or AsyncContextFrame,
         // so skip instead of surfacing a spurious "not a function" uncaught.
         if !on_writable.is_cell() {
-            self.deref();
             return;
         }
         let vm = vm_get();
@@ -1869,8 +1897,6 @@ impl NodeHTTPResponse {
             JSValue::UNDEFINED,
             &[JSValue::js_number_from_uint64(offset)],
         );
-
-        self.deref();
     }
 
     fn on_drain(&self, offset: u64, response: uws::AnyResponse) -> bool {
@@ -2373,8 +2399,9 @@ impl NodeHTTPResponse {
         self.write_or_end::<false>(global_object, arguments, JSValue::ZERO)
     }
 
+    /// Deferred-task body; `on_auto_flush_trampoline` releases the task's ref
+    /// once this returns.
     fn on_auto_flush(&self) -> bool {
-        // defer this.deref(); — moved to tail.
         let flags = self.flags.get();
         if !flags.contains(Flags::SOCKET_CLOSED) && !flags.contains(Flags::UPGRADED) {
             if let Some(raw_response) = self.raw_response.get() {
@@ -2382,18 +2409,19 @@ impl NodeHTTPResponse {
             }
         }
         self.auto_flusher.get().registered.set(false);
-        self.deref();
         false
     }
 
     // R-2: inlined `AutoFlusher::register_deferred_microtask_with_type_unchecked`
     // — that helper now takes `&T`, but this type has its own
-    // `on_auto_flush_trampoline` (extra `self.ref_()`) so the inline body
-    // stays.
+    // `on_auto_flush_trampoline` (which owns the ref taken here) so the inline
+    // body stays.
     fn register_auto_flush(&self) {
         if self.auto_flusher.get().registered.get() {
             return;
         }
+        // Released by `on_auto_flush_trampoline` or `unregister_auto_flush`,
+        // whichever runs.
         self.ref_();
         debug_assert!(!self.auto_flusher.get().registered.get());
         self.auto_flusher.get().registered.set(true);
@@ -2417,7 +2445,10 @@ impl NodeHTTPResponse {
             .unregister_task(ctx);
         debug_assert!(removed);
         self.auto_flusher.get().registered.set(false);
-        self.deref();
+        // SAFETY: releases the ref `register_auto_flush` took, which the task
+        // just removed above can no longer release; `self` is the live m_ctx
+        // allocation and is not used after this.
+        unsafe { Self::deref(self.as_ctx_ptr()) };
     }
 
     pub(crate) fn flush_headers(
@@ -2573,10 +2604,12 @@ impl NodeHTTPResponse {
         // that forced `self` to memory and blocked inlining/regalloc of the
         // cork prologue.
         let this = bun_ptr::BackRef::from(ptr::NonNull::from(self));
-        // BACKREF: `this` is the live `m_ctx` heap payload; `ref_()` keeps it
-        // alive across re-entry.
-        this.ref_();
-        // defer this.deref(); — moved to tail.
+        // BACKREF: `this` is the live `m_ctx` heap payload; the guard's ref
+        // keeps it alive across re-entry and is released once `ret` has been
+        // computed, after the last use of `this`.
+        // SAFETY: `self` is that payload, and the wrapper's own ref is held for
+        // the duration of this host call.
+        let _keep_alive = unsafe { bun_ptr::ScopedRef::<Self>::new(self.as_ctx_ptr()) };
 
         // Snapshot before re-entry; `raw_response` is `Copy`.
         let raw_response = this.raw_response.get();
@@ -2603,95 +2636,54 @@ impl NodeHTTPResponse {
             Ok(result)
         };
 
-        // BACKREF: `this` held alive by the `ref_()` above; this is the
-        // balancing release. Explicit `.get()` so the inherent refcount
-        // `NodeHTTPResponse::deref(&self)` is selected, not `<BackRef as Deref>::deref`.
-        this.get().deref();
         ret
     }
 
     pub(crate) fn finalize(self: Box<Self>) {
         // The JS wrapper is being collected; drop the raw backref so a late
         // body delivery cannot read through a dead cell.
-        self.armed_this_value.set(JSValue::ZERO);
-        bun_ptr::finalize_js_box_noop(self);
+        bun_ptr::finalize_js_box(self, |this| this.armed_this_value.set(JSValue::ZERO));
     }
 
-    /// Called by intrusive RefCount when count reaches zero.
-    fn deinit(&self) {
-        debug_assert!(!self.body_read_ref.get().has);
-        debug_assert!(!self.poll_ref.get().has);
-        debug_assert!(!self.pending_pinned_write.get().is_some());
-        let flags = self.flags.get();
-        debug_assert!(!flags.contains(Flags::IS_REQUEST_PENDING));
-        debug_assert!(
-            flags.contains(Flags::SOCKET_CLOSED)
-                || flags.contains(Flags::REQUEST_HAS_COMPLETED)
-                // A tunneled response can be finalized while its socket lives.
-                || flags.contains(Flags::TUNNELED)
-        );
+    /// `CellRefCounted::destroy` target: the last ref was just released.
+    ///
+    /// Takes the allocation's pointer rather than `&self`: a reference
+    /// receiver stays live (and protected) until the function returns, so
+    /// freeing the allocation underneath it is undefined behaviour even when
+    /// nothing reads it afterwards. The shared borrow below ends before the
+    /// free.
+    ///
+    /// # Safety
+    /// `this` is the `heap::into_raw` allocation from
+    /// `NodeHTTPResponse__createForJS` and its refcount is zero.
+    unsafe fn deinit(this: *mut Self) {
+        {
+            // SAFETY: caller contract — the allocation is still live; this
+            // borrow is dropped before the free below.
+            let response = unsafe { &*this };
+            debug_assert!(!response.body_read_ref.get().has);
+            debug_assert!(!response.poll_ref.get().has);
+            debug_assert!(!response.pending_pinned_write.get().is_some());
+            let flags = response.flags.get();
+            debug_assert!(!flags.contains(Flags::IS_REQUEST_PENDING));
+            debug_assert!(
+                flags.contains(Flags::SOCKET_CLOSED)
+                    || flags.contains(Flags::REQUEST_HAS_COMPLETED)
+                    // A tunneled response can be finalized while its socket lives.
+                    || flags.contains(Flags::TUNNELED)
+            );
 
-        self.buffered_request_body_data_during_pause
-            .with_mut(|b| b.clear_and_free());
-        self.poll_ref.with_mut(|r| r.unref(vm_get()));
-        self.body_read_ref.with_mut(|r| r.unref(vm_get()));
+            response
+                .buffered_request_body_data_during_pause
+                .with_mut(|b| b.clear_and_free());
+            response.poll_ref.with_mut(|r| r.unref(vm_get()));
+            response.body_read_ref.with_mut(|r| r.unref(vm_get()));
 
-        self.promise.with_mut(|p| p.deinit());
-        // SAFETY: self was allocated via `heap::into_raw` in `createForJS`;
-        // refcount is zero so no other references remain — `self` is the unique
-        // owner at count==0, so the `*const → *mut` cast is sound.
-        unsafe { drop(bun_core::heap::take(self.as_ctx_ptr())) };
-    }
-
-    // Intrusive refcount helpers.
-    #[inline]
-    fn ref_(&self) {
-        self.ref_count.set(self.ref_count.get() + 1);
-    }
-
-    #[inline]
-    pub(crate) fn deref(&self) {
-        let n = self.ref_count.get() - 1;
-        self.ref_count.set(n);
-        if n == 0 {
-            self.deinit();
+            response.promise.with_mut(|p| p.deinit());
         }
-    }
-}
-
-// `AnyRefCounted` bridge so `bun_ptr::finalize_js_box*` / `RefPtr` accept this
-// type. Hand-written (not `#[derive(CellRefCounted)]`) because the existing
-// `&self`-receiver `deref()` above is called from ~10 sites that route through
-// `as_ctx_ptr()`-derived provenance; converting them to `unsafe deref(*mut)`
-// is a separate sweep.
-impl bun_ptr::AnyRefCounted for NodeHTTPResponse {
-    type DestructorCtx = ();
-    #[inline]
-    unsafe fn rc_ref(this: *mut Self) {
-        // SAFETY: caller contract — `this` is live; touches only the
-        // interior-mutable `Cell<u32>` field.
-        unsafe { (*this).ref_() }
-    }
-    #[inline]
-    unsafe fn rc_deref_with_context(this: *mut Self, (): ()) {
-        // SAFETY: caller contract — `this` is live; `deref()` touches only
-        // `Cell`/`JsCell` fields and on zero frees via `heap::take`.
-        unsafe { (*this).deref() }
-    }
-    #[inline]
-    unsafe fn rc_has_one_ref(this: *const Self) -> bool {
-        // SAFETY: caller contract — `this` is live.
-        unsafe { (*this).ref_count.get() == 1 }
-    }
-    #[inline]
-    unsafe fn rc_assert_no_refs(this: *const Self) {
-        // SAFETY: caller contract — `this` is live.
-        debug_assert_eq!(unsafe { (*this).ref_count.get() }, 0);
-    }
-    #[cfg(debug_assertions)]
-    #[inline]
-    unsafe fn rc_debug_data(_this: *mut Self) -> *mut dyn bun_ptr::ref_count::DebugDataOps {
-        bun_ptr::ref_count::noop_debug_data()
+        // SAFETY: caller contract — `this` came from `heap::into_raw` and no
+        // ref (or borrow, see above) of it remains.
+        unsafe { drop(bun_core::heap::take(this)) };
     }
 }
 

--- a/src/runtime/server/mod.rs
+++ b/src/runtime/server/mod.rs
@@ -1518,8 +1518,11 @@ impl<const SSL: bool, const DEBUG: bool> NewServer<SSL, DEBUG> {
             unsafe { (*vm).drain_microtasks() };
         }
         if !is_async && !node_http_response.is_null() {
-            // SAFETY: out-param ref taken in C++; synchronous path drops it.
-            unsafe { &*node_http_response }.deref();
+            // SAFETY: releases the server-handler ref `createForJS` handed back
+            // through the out-param (the async path hands it to the promise
+            // reactions instead); `node_http_response` is that allocation and
+            // nothing here uses it afterwards, so it may be freed by this.
+            unsafe { NodeHTTPResponse::deref(node_http_response) };
         }
     }
 

--- a/test/internal/source-lints/self-receiver-reclaim.test.ts
+++ b/test/internal/source-lints/self-receiver-reclaim.test.ts
@@ -6,8 +6,8 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 
 // A method must not reclaim its own receiver's allocation: `heap::take` /
 // `heap::destroy` / `Box::from_raw` applied to `self` or to a pointer spelled
-// from `self` (`ptr::from_mut(self)`, `self as *mut _`, `&raw mut *self`, ...)
-// inside a `&self` / `&mut self` method is banned.
+// from `self` (`ptr::from_mut(self)`, `self as *mut _`, `&raw mut *self`,
+// `self.as_ctx_ptr()`, ...) inside a `&self` / `&mut self` method is banned.
 //
 // Two things are wrong with that shape, independently of whether the receiver
 // really is a heap allocation:
@@ -26,7 +26,13 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 //     `this: *mut Self` (see `ReadBytesHandler::on_read_bytes` in
 //     src/runtime/webcore/Blob.rs, `ReadFileCompletion::run` in
 //     src/runtime/webcore/blob/read_file.rs, and the comments on `deinit` in
-//     src/sql_jsc/postgres/PostgresSQLConnection.rs).
+//     src/sql_jsc/postgres/PostgresSQLConnection.rs and
+//     src/runtime/server/NodeHTTPResponse.rs).
+//
+// `self.as_ctx_ptr()` counts as one of those spellings: `bun_ptr::AsCtxPtr` is
+// blanket-implemented, and its result is `self`'s own address with (per its
+// doc) shared provenance, meant for C-shaped ctx slots, not for freeing.
+// `NodeHTTPResponse::deinit(&self)` used to free itself through it.
 //
 // Scope: the single-expression spellings below, with `self` as the receiver.
 // A self-derived pointer stashed in a local and freed later, a helper that
@@ -69,6 +75,11 @@ const SELF_AS_POINTER = [
   String.raw`self\s+as\s+\*(?:mut|const)\b`,
   String.raw`&\s*(?:raw\s+(?:mut|const)|mut)\s+\*\s*self\b(?!\s*\.)`,
   String.raw`(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*\*\s*self\s*\)`,
+  // `self.as_ctx_ptr()` / `AsCtxPtr::as_ctx_ptr(self)` (bun_ptr's blanket
+  // "`self`'s address as `*mut Self`"). `self.field.as_ctx_ptr()` is a
+  // field's pointee and stays out, like the other `self.` forms.
+  String.raw`self\s*\.\s*as_ctx_ptr\s*\(\s*\)`,
+  String.raw`(?:[\w:]+::)?as_ctx_ptr\s*\(\s*self\s*\)`,
 ].join("|");
 
 const BANNED = new RegExp(`${RECLAIM}(?:${SELF_AS_POINTER})`, "g");
@@ -133,9 +144,14 @@ test("the pattern recognizes the spellings it claims to", () => {
     "drop(unsafe { Box::from_raw(&mut *self) });",
     "unsafe { heap::destroy(core::ptr::addr_of_mut!(*self)) }",
     "unsafe { Box::from_non_null(NonNull::from(self)) }",
+    // `NodeHTTPResponse::deinit(&self)`, as it was before it took the pointer.
+    "unsafe { drop(bun_core::heap::take(self.as_ctx_ptr())) };",
+    "unsafe { bun_core::heap::destroy(bun_ptr::AsCtxPtr::as_ctx_ptr(self)) };",
+    "drop(unsafe { Box::from_raw(self.as_ctx_ptr()) });",
     // rustfmt-wrapped calls.
     "unsafe {\n    bun_core::heap::take(\n        std::ptr::from_mut::<Blob>(self),\n    )\n}",
     "unsafe {\n    bun_core::heap::destroy(\n        self,\n    )\n}",
+    "unsafe {\n    drop(bun_core::heap::take(\n        self.as_ctx_ptr(),\n    ))\n}",
   ];
   const allowed = [
     // Freeing something the receiver owns is fine.
@@ -145,15 +161,20 @@ test("the pattern recognizes the spellings it claims to", () => {
     "drop(unsafe { Box::from_raw(self.walker) });",
     "drop(unsafe { Box::from_raw(&raw mut *self.inner) });",
     "unsafe { heap::take(std::ptr::from_mut(self.inner)) }",
+    "unsafe { drop(bun_core::heap::take(self.route.as_ctx_ptr())) };",
     // Raw-pointer receivers and other parameters are the intended shape /
     // out of scope.
     "unsafe { drop(bun_core::heap::take(this)) };",
     "unsafe { heap::take(self_ptr) }",
     "unsafe { bun_core::heap::destroy(std::ptr::from_mut::<Blob>(self_)) };",
     "unsafe { heap::take(ptr::from_mut(other)) }",
+    "unsafe { heap::destroy(owner.as_ctx_ptr()) }",
     // Producing a pointer from `self` without reclaiming it is fine.
     "let this = std::ptr::from_ref::<Blob>(self).cast_mut();",
     "Self::finalize(core::ptr::from_mut(self));",
+    "raw_response.on_data(on_data_shim, self.as_ctx_ptr());",
+    "unsafe { Self::deref(self.as_ctx_ptr()) };",
+    "let _keep_alive = unsafe { bun_ptr::ScopedRef::<Self>::new(self.as_ctx_ptr()) };",
   ];
   expect(banned.filter(s => !matches(s))).toEqual([]);
   expect(allowed.filter(matches)).toEqual([]);


### PR DESCRIPTION
### Problem
- Nothing is observable today; this is latent. `NodeHTTPResponse` released its refcount through a `&self` method, and on the last release that method freed the allocation through a pointer taken from `&self`.
- A reference argument stays live and protected until the call returns, so freeing what it points to is undefined behaviour under both Stacked Borrows and Tree Borrows (what `bun run rust:miri` checks), whether or not anything reads it afterwards. #37672 has a standalone reduction of this shape.
- The pointer came from `as_ctx_ptr()`, whose own doc says it has shared provenance and exists to fill C-shaped ctx slots, so it is not a pointer the allocation can be freed through.
- Same shape as `Blob::deinit` (#37672) and `ReadBytesHandler::on_read_bytes` (#37681); a tree-wide grep finds this as the only remaining site.

### Fix
- The type now uses the shared `CellRefCounted` derive, like `CronJob` and `PostgresSQLConnection`, so release is `deref(*mut Self)` and `deinit` takes the raw pointer. Teardown runs inside a scoped borrow that ends before the free.
- Every release goes through a pointer. Sites that already hold one use it, keep-alive ref/deref brackets become a `ScopedRef` guard, and sites with only `&self` call `Self::deref(self.as_ctx_ptr())`, so that shortcut is visible at each site instead of hidden inside a safe `deref(&self)`.
- Property to check: refcount arithmetic is unchanged, each `ref_()` keeps the same single release on the same paths. The one ordering change is the auto-flush release, now made when the trampoline's guard drops, right after `on_auto_flush` returns.
- Verification: no behavioural reproducer exists, the bug is the shape of the free. The source lint from #37681 now counts `self.as_ctx_ptr()` as a spelling of the receiver: on `main` it reports exactly this one line, with the fix nothing. The node:http suites listed in the original pass on the debug ASAN build (one failure is pre-existing, #37442).

### Background
- Intrusive refcount: the count is a field of the heap object and whoever drops it to zero frees the object. `#[derive(bun_ptr::CellRefCounted)]` generates `ref_()`, `unsafe fn deref(*mut Self)` and the bridge `ScopedRef` and `finalize_js_box` need, and calls the named `destroy` function at zero.
- Classes declared in `.classes.ts` are a JS wrapper cell holding a raw pointer (m_ctx) to the Rust object; the wrapper owns one ref and gives it up in `finalize` when GC collects it. `value.as_::<T>()` returns that raw pointer, `as_class_ref` a `&T` to the same object.
- `as_ctx_ptr()` is a blanket helper returning `self`'s address as `*mut Self`, meant for handing the object to C callbacks that take a `void*` ctx.
- `bun_ptr::ScopedRef` is a guard holding one ref and releasing it on drop; `new` takes a fresh ref, `adopt` takes over a ref someone else already took.
- Under Rust's aliasing models (Stacked Borrows and Tree Borrows, both run by Miri) a `&self` argument is protected for the whole call, so a free is only allowed from a frame that holds the object as a raw pointer.

<details>
<summary>Original description</summary>

### Problem

`NodeHTTPResponse` (src/runtime/server/NodeHTTPResponse.rs) hand-rolled its intrusive refcount as `deref(&self)`, which on zero called `deinit(&self)`, which ended in

```rust
unsafe { drop(bun_core::heap::take(self.as_ctx_ptr())) };
```

That frees the allocation through a pointer derived from `&self`, while `&self` is still a live argument of both the `deinit` and the `deref` frame. Two things are wrong with it, independent of whether anything reads `self` afterwards (nothing does today, so this is latent):

* `as_ctx_ptr()` is `bun_ptr::AsCtxPtr`'s "address of `self` as `*mut`" helper; its own doc says the result has shared provenance and exists to fill C-shaped ctx slots. Deallocating through it is not something a `&self`-derived pointer can do.
* A reference argument is protected for the duration of the call, and deallocating protected memory is rejected by both Stacked Borrows and Tree Borrows (the model `bun run rust:miri` uses). #37672 has a standalone reduction of exactly this shape.

The comment on the hand-written `AnyRefCounted` impl already described converting the callers to a pointer-taking `deref` as a separate sweep; this is that sweep. The same shape in `Blob::deinit` is #37672, and `ReadBytesHandler::on_read_bytes` was #37681. The tree-wide grep for a reclaim through `as_ctx_ptr()` finds only this site.

### Fix

* The struct becomes `#[derive(bun_ptr::CellRefCounted)]` with `#[ref_count(destroy = Self::deinit)]`, the same arrangement as `CronJob`, `NativeZlib`, `PostgresSQLConnection` and `JSMySQLConnection`. The derive supplies `ref_()`, `unsafe fn deref(this: *mut Self)` and the `AnyRefCounted` bridge, so the hand-written bridge and the `ref_`/`deref` pair are deleted. `deinit` now takes `this: *mut Self`: the teardown runs through a scoped shared borrow, and `heap::take(this)` runs after that borrow ends, through the pointer the count was released on.
* Every release site now goes through a pointer rather than a `&self` method call:
  * the synchronous dispatch tail in `on_node_http_request*` (src/runtime/server/mod.rs) releases the server-handler ref through the `*mut NodeHTTPResponse` out-param it already holds, and `Bun__NodeHTTPRequest__onResolve` / `onReject` through the wrapper's m_ctx pointer (`as_::<NodeHTTPResponse>()` instead of `as_class_ref`);
  * `on_auto_flush_trampoline` adopts the task's ref as a `ScopedRef` on the ctx pointer the deferred-task queue hands it, so the release happens after `on_auto_flush(&self)` has returned; `on_auto_flush` no longer releases anything itself;
  * the `ref_()`/`deref()` keep-alive brackets in `cork`, `write_head_and_end` and `on_drain_corked` become a `ScopedRef` guard (the last of these had three exits, each with its own `deref()`);
  * the sites that only have `&self` (`mark_request_as_done`, `handle_abort_or_timeout`, `on_data_or_aborted`, `unregister_auto_flush`) call `Self::deref(self.as_ctx_ptr())` explicitly, as `PostgresSQLConnection` and `websocket_client` do. Those methods are reached from `&self` host functions and uws callbacks, so they have no better pointer to offer; the change here is that the frame that frees is `deref`/`deinit` holding the raw pointer, not a `&self` method, and the shortcut is visible at each site instead of hidden inside a safe `deref(&self)`.
* `finalize` uses `finalize_js_box` for its pre-release work (clearing `armed_this_value`), as the other derive users do.

Refcount arithmetic is unchanged at every site: each `ref_()` still has the same single release on the same paths, and the order of the teardown steps in `deinit` is the same. The only ordering change is the auto-flush release, which now happens when the trampoline's guard drops, immediately after `on_auto_flush` returns, instead of as its last statement.

### Test

test/internal/source-lints/self-receiver-reclaim.test.ts (the lint from #37681) now treats `self.as_ctx_ptr()` and `as_ctx_ptr(self)` as spellings of the receiver, with positive and negative examples (`self.field.as_ctx_ptr()`, handing the pointer to `on_data`, `Self::deref(self.as_ctx_ptr())` and a `ScopedRef` over it stay allowed). With this test change and `main`'s `src/`, the lint reports exactly

```
src/runtime/server/NodeHTTPResponse.rs:2643: heap::take(self.as_ctx_ptr()
```

and with the fix the tree is at zero. Per-type `as_ptr(&self) -> *mut Self` helpers (for example `FileResponseStream`'s) are deliberately not added: `heap::take(x.as_ptr())` is also how smart-pointer newtypes free their pointee, and none of them reclaims the receiver today.

There is no behavioural reproducer; the bug is the shape of the free, not something observable before the allocator happens to reuse the memory.

### Verification

On the debug (ASAN) build: test/js/node/http/{node-http,node-http-uaf,node-http-server-abort-events,node-http-nested-cork,node-http-pinned-write,node-http-backpressure,node-http-backpressure-max,node-http-server-timeouts,node-http-ondata-reregister-leak,node-http-req-socket-pause,node-http-server-socket-end-drain,node-http-connect,node-http-with-ws,node-http-transfer-encoding,node-http-res-settimeout-unref,node-http.compress.leak,node-http-parser,node-http-maxHeaderSize,node-http-syscall-fault,client-timeout-error,early-hints-crlf-injection,numeric-header}.test.ts, test/js/bun/http/{node-http-halfclose-midupload,request-smuggling}.test.ts, and 44 of the ported Node suites under test/js/node/test/parallel (`test-http-abort*`, `test-http-flush*`, `test-http-pipeline*`, `test-http-response-{close,cork,readable}`, `test-http-server-close*`, `test-http-server-request-timeout*`, `test-http-upgrade*`, `test-http-set-timeout*`, and a few others) all pass. These cover the abort, timeout, flushHeaders (auto-flush), onwritable drain, sync and async handler, upgrade, CONNECT and pipelining release paths. The one failure seen, `request via http proxy, issue#4295` in node-http.test.ts, fails identically on the unmodified release build in this container (`listen(0, "localhost")` binds `::1` while the client connects to `127.0.0.1`; the class #37442 describes) and is unrelated. Several of the node:http child-process tests need more than the default 5 s timeout on this debug build because importing `node:http` alone takes about 2.7 s here; they pass with `--timeout 60000`.

`bun test test/internal/source-lints/` passes; `cargo clippy -p bun_runtime --no-deps` and `cargo fmt -p bun_runtime -- --check` are clean.


</details>
