### PR TITLE
ipc: deliver messages sent right before child exit on the waiter-thread path

### DIFF
--- a/packages/bun-usockets/src/libusockets.h
+++ b/packages/bun-usockets/src/libusockets.h
@@ -738,6 +738,11 @@ int us_socket_set_tos(us_socket_r s, int tos);
 int us_socket_get_tos(us_socket_r s);
 void us_socket_resume(us_socket_r s);
 void us_socket_pause(us_socket_r s);
+/* Synchronously dispatch a hangup readable event: delivers data still queued
+ * in the kernel buffer (on_data / on_fd), then ends and closes the socket as
+ * the real hangup event would. For when the peer process is known dead but
+ * its final event has not been dispatched yet. */
+void us_socket_drain_hangup(us_socket_r s) nonnull_fn_decl;
 
 #ifdef __cplusplus
 }

--- a/packages/bun-usockets/src/socket.c
+++ b/packages/bun-usockets/src/socket.c
@@ -704,6 +704,20 @@ int us_socket_ipc_write_fd(struct us_socket_t *s, const char *data, int length, 
 }
 #endif
 
+/* The owner learned out-of-band (e.g. waitpid) that the peer process is dead,
+ * but the socket's final readable/hangup event has not been dispatched yet.
+ * Closing the socket now would discard whatever the peer wrote before dying,
+ * so run the hangup dispatch synchronously: it drains the kernel receive
+ * buffer through on_data/on_fd and then ends + closes the socket exactly like
+ * the real event would. No-op when there is nothing left to deliver (closed /
+ * EOF already seen) or the owner paused reading. */
+void us_socket_drain_hangup(struct us_socket_t *s) {
+    if (us_socket_is_closed(s) || s->read_eof || s->flags.is_paused) {
+        return;
+    }
+    us_internal_dispatch_ready_poll(&s->p, 0, 1, LIBUS_SOCKET_READABLE);
+}
+
 __attribute__((always_inline)) void *us_socket_ext(struct us_socket_t *s) {
     return s + 1;
 }

--- a/src/runtime/api/bun/subprocess.rs
+++ b/src/runtime/api/bun/subprocess.rs
@@ -1188,6 +1188,13 @@ impl Subprocess<'_> {
         if !did_update_has_pending_activity {
             self.update_has_pending_activity();
         }
+        // The exit can reach the loop before the IPC socket's readable event
+        // (waiter-thread path): deliver anything the child wrote before it
+        // exited, or the deferred close below drops it (#37849).
+        #[cfg(not(windows))]
+        if let Some(ipc_data) = self.ipc() {
+            ipc_data.drain_after_peer_exit();
+        }
         self.disconnect_ipc(true);
         self.deref();
     }

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -1260,6 +1260,20 @@ impl SendQueue {
         let _ = unsafe { bun_core::heap::take(windows) };
     }
 
+    /// The peer process exited, reported out-of-band (waitpid / the waiter
+    /// thread) rather than through this socket's own readable event. Bytes
+    /// the peer wrote right before exiting may still sit unread in the kernel
+    /// buffer, and the exit path's deferred close would discard them; deliver
+    /// them now, like node reads the channel to EOF before tearing it down.
+    /// Dispatches on_data/on_fd and, at EOF, the normal end/close handlers.
+    #[cfg(not(windows))]
+    pub fn drain_after_peer_exit(&self) {
+        if let SocketUnion::Open(socket) = *self.socket.get() {
+            log!("SendQueue#drainAfterPeerExit");
+            socket.drain_hangup();
+        }
+    }
+
     pub fn close_socket_next_tick(&self, next_tick: bool) {
         log!("SendQueue#closeSocketNextTick");
         if !self.socket_is_open() {

--- a/src/uws_sys/socket.rs
+++ b/src/uws_sys/socket.rs
@@ -346,6 +346,17 @@ impl<const IS_SSL: bool> NewSocketHandler<IS_SSL> {
         )
     }
 
+    /// The peer process is known dead but the socket's final readable/hangup
+    /// event has not been dispatched yet: run that dispatch synchronously so
+    /// data still queued in the kernel buffer is delivered before the socket
+    /// is ended and closed. May re-enter the socket's handlers and close it.
+    /// No-op for non-uSockets transports.
+    pub fn drain_hangup(&self) {
+        if let InternalSocket::Connected(s) = self.socket {
+            sock(s).drain_hangup();
+        }
+    }
+
     /// The JS wrapper that owns this socket is being finalized: whatever the
     /// close below unwinds must not reach back into JS objects.
     pub fn prepare_for_finalize(&self) {

--- a/src/uws_sys/us_socket_t.rs
+++ b/src/uws_sys/us_socket_t.rs
@@ -90,6 +90,20 @@ impl us_socket_t {
         c::us_socket_shutdown(self);
     }
 
+    /// The peer process is known dead but its final readable/hangup event has
+    /// not been dispatched yet: run that dispatch synchronously so data still
+    /// queued in the kernel buffer is delivered (on_data / on_fd) before the
+    /// socket is ended and closed. May re-enter the socket's handlers and
+    /// close `self`.
+    pub fn drain_hangup(&mut self) {
+        bun_core::scoped_log!(uws, "us_socket_drain_hangup({:p})", self);
+        unsafe {
+            // SAFETY: self is a live us_socket_t; a close inside the dispatch
+            // defers the free to the loop's closed-sockets sweep.
+            c::us_socket_drain_hangup(self);
+        }
+    }
+
     pub(crate) fn shutdown_read(&mut self) {
         c::us_socket_shutdown_read(self);
     }
@@ -554,6 +568,7 @@ mod c {
             reason: *mut c_void,
         ) -> *mut us_socket_t;
         pub(super) safe fn us_socket_shutdown(s: &mut us_socket_t);
+        pub(super) fn us_socket_drain_hangup(s: *mut us_socket_t);
         pub(super) safe fn us_socket_is_closed(s: &us_socket_t) -> i32;
         pub(super) fn us_socket_write_check_error(
             s: &us_socket_t,

--- a/test/js/bun/spawn/spawn-ipc-exit-message.test.ts
+++ b/test/js/bun/spawn/spawn-ipc-exit-message.test.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isWindows, tempDir } from "harness";
+
+// https://github.com/oven-sh/bun/issues/37849
+// A child that sends an IPC message and then exits must still get the message
+// delivered, even when the parent learns of the exit before it polls the IPC
+// socket. That is always the case on the waiter-thread process-exit path
+// (BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1, also taken when pidfd is
+// unavailable): the exit's deferred socket close used to win against the
+// readable event and drop the message.
+//
+// The fixture makes the race deterministic: the child writes a sentinel file
+// after process.send(), and the parent stays off its event loop (blocking in
+// spawnSync) until the sentinel exists plus one extra spawnSync, so the child
+// has fully exited before the parent processes either event.
+const fixture = `
+import { existsSync, rmSync } from "node:fs";
+
+const N = 4;
+let delivered = 0, lost = 0;
+for (let i = 0; i < N; i++) {
+  const sentinel = "sentinel-" + i;
+  rmSync(sentinel, { force: true });
+  const { promise, resolve } = Promise.withResolvers();
+  const child = Bun.spawn({
+    cmd: [
+      process.execPath,
+      "-e",
+      'process.send("hello"); require("fs").writeFileSync("' + sentinel + '", "x"); Promise.resolve().then(() => process.exit(0));',
+    ],
+    ipc: resolve,
+    stdio: ["inherit", "inherit", "inherit"],
+  });
+  while (!existsSync(sentinel)) {
+    Bun.spawnSync({ cmd: [process.execPath, "-e", "0"] });
+  }
+  Bun.spawnSync({ cmd: [process.execPath, "-e", "0"] });
+  (await Promise.race([promise, Bun.sleep(3000).then(() => "TIMEOUT")])) === "hello" ? delivered++ : lost++;
+  await child.exited;
+  rmSync(sentinel, { force: true });
+}
+console.log(JSON.stringify({ delivered, lost }));
+`;
+
+async function run(extraEnv: Record<string, string>) {
+  using dir = tempDir("ipc-exit-message", { "parent.ts": fixture });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "parent.ts"],
+    cwd: String(dir),
+    env: { ...bunEnv, ...extraEnv },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  expect(JSON.parse(stdout)).toEqual({ delivered: 4, lost: 0 });
+  expect(exitCode).toBe(0);
+}
+
+test.concurrent.skipIf(isWindows)(
+  "ipc message sent right before child exit is delivered (waiter thread)",
+  async () => {
+    // The feature flag is only read when BUN_GARBAGE_COLLECTOR_LEVEL is set.
+    await run({ BUN_GARBAGE_COLLECTOR_LEVEL: "1", BUN_FEATURE_FLAG_FORCE_WAITER_THREAD: "1" });
+  },
+  30_000,
+);
+
+test.concurrent.skipIf(isWindows)(
+  "ipc message sent right before child exit is delivered (pidfd)",
+  async () => {
+    await run({});
+  },
+  30_000,
+);


### PR DESCRIPTION
### What does this PR do?

Fixes #37849. An IPC message sent by a child right before it exits was dropped when Bun uses the waiter-thread process-exit fallback (`BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1`, which is also the production path when pidfd is unavailable) and the parent only reaches its event loop after the child has already exited. Affects both `Bun.spawn({ ipc })` and `node:child_process.fork()`.

Repro (from the issue, parent kept off its event loop with `spawnSync`):

```ts
const { promise, resolve } = Promise.withResolvers();
const a = Bun.spawn({
  cmd: [process.execPath, "-e", `process.send("hello"); Promise.resolve().then(() => process.exit(0));`],
  ipc: resolve,
});
Bun.spawnSync({ cmd: [process.execPath, "-e", "0"] });
await promise; // lost with BUN_FEATURE_FLAG_FORCE_WAITER_THREAD=1
```

Before: `{ delivered: 5, lost: 5 }` (varies). After: `{ delivered: 10, lost: 0 }` in both modes, matching Node, which reads the IPC channel to EOF regardless of when it notices the exit.

### Cause

On the waiter-thread path the exit arrives as a task posted to the event loop, which runs before the loop polls the IPC socket. The exit handler in `subprocess.rs` calls `disconnect_ipc(true)` -> `SendQueue::close_socket_next_tick`, and the deferred close runs before the socket's readable event is ever dispatched, discarding the child's final bytes still queued in the kernel buffer. On the pidfd path both events come through epoll and the read wins, so nothing was lost there.

### Fix

New `us_socket_drain_hangup` in uSockets: when the owner learns out-of-band that the peer process is dead, synchronously run the hangup readable dispatch (`us_internal_dispatch_ready_poll` with the eof hint). That drains the kernel buffer through the normal `on_data`/`on_fd` handlers (including SCM_RIGHTS handle passing) and then ends and closes the socket exactly like the real event would. The subprocess exit path calls it (POSIX only) before scheduling the IPC close.

### Verification

New test `test/js/bun/spawn/spawn-ipc-exit-message.test.ts` makes the race deterministic (child touches a sentinel file after `process.send()`, parent blocks in `spawnSync` until the child has fully exited): fails 4/4 iterations on the unfixed build in waiter-thread mode, passes with the fix in both waiter-thread and pidfd modes.

Also ran: `test/js/bun/spawn/spawn.test.ts` (140 pass), the `child_process` IPC suites (`child_process_ipc`, `ipc_handle`, `ipc_large_disconnect`, `send_cb`: 15 pass), the upstream `test-cluster-*` exit/disconnect/message tests, and `cargo check` for the Windows target.

This unblocks removing the serialization workaround noted in #37834.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-ipc-exit-message.test.ts

<!-- robobun:evidence:end -->