### PR TITLE
Bun.write: don't cap a file-to-file copy at the destination's cached size

### DIFF
--- a/src/jsc/webcore_types.rs
+++ b/src/jsc/webcore_types.rs
@@ -129,6 +129,11 @@ pub struct Blob {
     pub charset: Cell<AsciiStatus>,
     /// Was it created via the `File` constructor?
     pub is_jsdom_file: Cell<bool>,
+    /// Set when `size` is a window the caller asked for with `slice()`. A
+    /// file-backed blob otherwise holds `MAX_SIZE` there until something
+    /// (`.size`, `exists()`, ...) caches the file's stat size into it, and a
+    /// cached stat size must not be mistaken for a window.
+    pub size_is_explicit: Cell<bool>,
     /// `bun.ptr.RawRefCount(u32, .single_threaded)` — counts in-flight `*Blob`
     /// borrows handed to async readers; not the JS GC retain count. Zero while
     /// the JS cell is the sole owner.
@@ -162,6 +167,7 @@ impl Default for Blob {
             content_type_was_set: Cell::new(false),
             charset: Cell::new(AsciiStatus::Unknown),
             is_jsdom_file: Cell::new(false),
+            size_is_explicit: Cell::new(false),
             ref_count: bun_ptr::RawRefCount::init(0),
             global_this: Cell::new(core::ptr::null()),
             last_modified: Cell::new(0.0),
@@ -375,6 +381,7 @@ impl Blob {
             content_type_was_set: Cell::new(self.content_type_was_set.get()),
             charset: Cell::new(self.charset.get()),
             is_jsdom_file: Cell::new(self.is_jsdom_file.get()),
+            size_is_explicit: Cell::new(self.size_is_explicit.get()),
             ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
             global_this: Cell::new(self.global_this.get()),
             last_modified: Cell::new(self.last_modified.get()),

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -780,10 +780,15 @@ impl BlobExt for Blob {
                 writer.write_int_le::<u32>(stored_name.len() as u32)?;
                 writer.write_all(stored_name)?;
             } else {
-                // Version 4: a file-backed slice's window end. Written before
-                // resolve_size() so an unresolved blob stays MAX_SIZE (unknown)
-                // on the wire and the receiver stats it locally, like v3.
-                writer.write_int_le::<u64>(self.size.get())?;
+                // Version 4: the window end of a sliced file-backed blob. An
+                // unsliced blob puts MAX_SIZE on the wire even once it has
+                // cached a stat size, so the receiver stats the file itself
+                // (like v3) instead of turning that stale size into a window.
+                writer.write_int_le::<u64>(if self.size_is_explicit.get() {
+                    self.size.get()
+                } else {
+                    MAX_SIZE
+                })?;
                 self.resolve_size();
                 store.serialize(writer)?;
             }
@@ -1948,6 +1953,9 @@ impl BlobExt for Blob {
         let blob = self.dupe();
         blob.offset.set(offset);
         blob.size.set(len);
+        // `slice()` of a still-unresolved file blob yields `MAX_SIZE`, which
+        // is not a window.
+        blob.size_is_explicit.set(len != MAX_SIZE);
 
         let content_type_was_allocated = content_type.is_owned() && !content_type.is_empty();
         // infer the content type if it was not specified
@@ -3305,6 +3313,7 @@ impl BlobExt for Blob {
                                     ),
                                     charset: Cell::new(blob.charset.get()),
                                     is_jsdom_file: Cell::new(blob.is_jsdom_file.get()),
+                                    size_is_explicit: Cell::new(blob.size_is_explicit.get()),
                                     ref_count: bun_ptr::RawRefCount::init(0), // setNotHeapAllocated
                                     global_this: Cell::new(blob.global_this.get()),
                                     last_modified: Cell::new(blob.last_modified.get()),
@@ -4210,6 +4219,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
         // resolve_size() clamps this to the actual file size on first use.
         if size != MAX_SIZE {
             blob.size.set(size as SizeType);
+            blob.size_is_explicit.set(true);
         }
     }
     if let Some(store) = blob.store.get() {
@@ -4685,6 +4695,15 @@ pub(crate) fn write_file_with_source_destination(
     }
     // If this is file <> file, we can just copy the file
     else if destination_type == store::DataTag::File && source_type == store::DataTag::File {
+        // Only a slice() window on the destination bounds the copy. Otherwise
+        // `size` is at most the stat size that `.size` / `exists()` cached, and
+        // passing it would cut the copy to the destination's old length (0 when
+        // it did not exist yet) instead of replacing the file.
+        let max_length = if destination_blob.size_is_explicit.get() {
+            destination_blob.size.get()
+        } else {
+            MAX_SIZE
+        };
         #[cfg(windows)]
         {
             return Ok(copy_file::CopyFileWindows::init(
@@ -4692,7 +4711,7 @@ pub(crate) fn write_file_with_source_destination(
                 source_store,
                 ctx.bun_vm().event_loop_shared(),
                 options.mkdirp_if_not_exists.unwrap_or(true),
-                destination_blob.size.get(),
+                max_length,
                 options.mode,
             ));
         }
@@ -4702,7 +4721,7 @@ pub(crate) fn write_file_with_source_destination(
                 destination_store,
                 source_store,
                 destination_blob.offset.get(),
-                destination_blob.size.get(),
+                max_length,
                 ctx,
                 options.mkdirp_if_not_exists.unwrap_or(true),
                 options.mode,

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -7,6 +7,7 @@ import {
   exampleSite,
   gcTick,
   isASAN,
+  isLinux,
   isWindows,
   tempDir,
   withoutAggressiveGC,
@@ -273,6 +274,140 @@ const IS_UV_FS_COPYFILE_DISABLED =
       await gcTick();
       expect(await Bun.file(tmpbase + "fetch.js.in").text()).toBe(exampleHtml);
     }
+  });
+
+  // The file -> file copy took the destination blob's `size` as the number of
+  // bytes to copy. On an unsliced Bun.file() that field only holds the stat
+  // size cached by `.size` / `exists()`, so the copy was cut to the
+  // destination's previous length: 0 bytes for the `exists()` guard in #4930.
+  describe("Bun.file -> Bun.file is not capped by the destination's cached size", () => {
+    const source = Buffer.alloc(100_000, "S").toString();
+
+    // uv_fs_copyfile (Windows) and fcopyfile over an existing file (macOS)
+    // resolve with 0 regardless of this fix, so only Linux checks the count.
+    function expectCopiedWhole(destPath, written) {
+      expect(fs.statSync(destPath).size).toBe(source.length);
+      expect(fs.readFileSync(destPath, "utf8")).toBe(source);
+      if (isLinux) expect(written).toBe(source.length);
+    }
+
+    // Each primer caches the destination's current size onto a blob and
+    // returns the blob to write to. The cached size lives on the blob, so the
+    // clone and the whole-file slice have to be the destination themselves.
+    const primers = [
+      [
+        "f.size",
+        (f, size) => {
+          expect(f.size).toBe(size);
+          return f;
+        },
+      ],
+      [
+        "await f.exists()",
+        async f => {
+          expect(await f.exists()).toBe(true);
+          return f;
+        },
+      ],
+      [
+        "expect(f).toHaveLength()",
+        (f, size) => {
+          expect(f).toHaveLength(size);
+          return f;
+        },
+      ],
+      [
+        "structuredClone(f), which stats f while serializing it",
+        f => {
+          structuredClone(f);
+          return f;
+        },
+      ],
+      [
+        "f.size, writing to structuredClone(f)",
+        (f, size) => {
+          expect(f.size).toBe(size);
+          return structuredClone(f);
+        },
+      ],
+      [
+        "f.slice().size, writing to the whole-file slice",
+        (f, size) => {
+          const whole = f.slice();
+          expect(whole.size).toBe(size);
+          return whole;
+        },
+      ],
+    ];
+
+    describe.each([
+      ["shorter", "short"],
+      ["empty", ""],
+    ])("%s existing destination", (_, existing) => {
+      it.each(primers)("primed by %s", async (_, prime) => {
+        using dir = tempDir("bun-write-dest-size-cached", { "src.bin": source, "dest.bin": existing });
+        const destPath = join(String(dir), "dest.bin");
+        const dest = await prime(Bun.file(destPath), existing.length);
+
+        const written = await Bun.write(dest, Bun.file(join(String(dir), "src.bin")));
+        expectCopiedWhole(destPath, written);
+      });
+    });
+
+    it("primed by exists() on a destination that does not exist yet (#4930)", async () => {
+      using dir = tempDir("bun-write-dest-exists-guard", { "in.txt": source });
+      const outPath = join(String(dir), "out.txt");
+      const out = Bun.file(outPath);
+      expect(await out.exists()).toBe(false);
+
+      const written = await Bun.write(out, Bun.file(join(String(dir), "in.txt")));
+      expectCopiedWhole(outPath, written);
+    });
+
+    it("primed by .size on an fd destination", async () => {
+      using dir = tempDir("bun-write-fd-dest-size-cached", { "src.bin": source, "dest.bin": "short" });
+      const destPath = join(String(dir), "dest.bin");
+      const fd = fs.openSync(destPath, "r+");
+      let written;
+      try {
+        const dest = Bun.file(fd);
+        expect(dest.size).toBe(5);
+        written = await Bun.write(dest, Bun.file(join(String(dir), "src.bin")));
+      } finally {
+        fs.closeSync(fd);
+      }
+      expectCopiedWhole(destPath, written);
+    });
+
+    // The cached size is also wrong in the other direction: the Windows copy
+    // padded the shorter copy back out to it.
+    it("primed by .size, a shorter source replaces a longer destination", async () => {
+      using dir = tempDir("bun-write-dest-shrinks", {
+        "src.bin": "tiny",
+        "dest.bin": Buffer.alloc(1000, "D").toString(),
+      });
+      const destPath = join(String(dir), "dest.bin");
+      const dest = Bun.file(destPath);
+      expect(dest.size).toBe(1000);
+
+      const written = await Bun.write(dest, Bun.file(join(String(dir), "src.bin")));
+      expect(fs.readFileSync(destPath, "utf8")).toBe("tiny");
+      if (isLinux) expect(written).toBe(4);
+    });
+
+    // A window the caller asked for with slice() still bounds the copy, and
+    // survives structuredClone.
+    it.each([
+      ["f.slice(0, 4)", f => f.slice(0, 4)],
+      ["structuredClone(f.slice(0, 4))", f => structuredClone(f.slice(0, 4))],
+    ])("a destination sliced with %s is still bounded by the slice", async (_, slice) => {
+      using dir = tempDir("bun-write-dest-window", { "src.bin": source, "dest.bin": "0123456789" });
+      const destPath = join(String(dir), "dest.bin");
+
+      const written = await Bun.write(slice(Bun.file(destPath)), Bun.file(join(String(dir), "src.bin")));
+      expect(fs.readFileSync(destPath, "utf8")).toBe("SSSS");
+      if (isLinux) expect(written).toBe(4);
+    });
   });
 
   it("Bun.file", async () => {


### PR DESCRIPTION
### Problem
- `Bun.write(Bun.file(dest), Bun.file(src))` copies only as many bytes as `dest` used to have, once anything has read `dest`'s size (`.size`, `exists()`, `toHaveLength()`, structured clone). With the usual `exists()` guard on a missing file, the copy leaves an empty file behind.
- Only file to file is affected; string, buffer and Blob sources never look at the destination's size. Reproduced on 1.4.0 on Linux; the macOS and Windows copy paths consume the same value, and Windows also padded a shorter copy back out to the old length.
- Cause: a file-backed blob keeps one size field for two things, a `slice()` window and the cached stat size. The copy treated whatever was in it as a window, so a destination that had merely been stat'ed was written as if it were `dest.slice(0, oldSize)`.
- Fixes #4930
- Fixes #22456

### Fix
- The blob now records whether its size came from `slice()`. The copy is bounded by the destination only in that case; otherwise it is bounded by the source, as a fresh `Bun.file(dest)` or a path destination already was.
- Structured clone puts a size on the wire only for sliced blobs and treats a received size as a window, so a clone of a stat'ed whole-file blob stays unbounded and a clone of a real slice keeps its window. No wire format change.
- A destination the caller sliced behaves exactly as before; only the cases that lost data change.
- Verification: new tests prime the destination each of the six ways, plus the missing-file guard, an fd destination, a shrinking copy and sliced destinations. 14 of 17 fail on the release bun, all pass with the fix. The returned byte count is asserted only on Linux; macOS and Windows resolve with 0 over an existing file regardless of this change (#33715).

### Background
- `Bun.file(path)` is a lazy blob: it holds a path or fd and does not stat the file until asked. `.size`, `exists()`, `toHaveLength()` and structured clone all stat it and cache the size on that blob object.
- `blob.slice(start, end)` is a new blob over a byte window of the same file. As a `Bun.write` destination it means "write into these bytes only", and existing tests rely on it capping a copy.
- Before the stat, the size field holds `MAX_SIZE`, the sentinel for unknown. The per-platform copy routines (Linux, macOS, Windows) take a max length, and `MAX_SIZE` there means the source decides; all three were being handed the destination's size field.

<details>
<summary>Original description</summary>

`Bun.write(Bun.file(dest), Bun.file(src))` copies only as many bytes as `dest` used to have once anything has resolved `dest`'s size. The common shape is an `exists()` guard, which leaves an empty file behind (#4930, open since 1.0); the other is overwriting a shorter file after `exists()` / `.size` (#22456).

### Repro

```js
import fs from "fs";
fs.writeFileSync("src.bin", Buffer.alloc(300000, "S"));
fs.writeFileSync("dest.bin", "short");

const f = Bun.file("dest.bin");
f.size;                                               // or: await f.exists()
console.log(await Bun.write(f, Bun.file("src.bin"))); // 5, expected 300000
console.log(fs.statSync("dest.bin").size);            // 5, expected 300000

const out = Bun.file("missing.bin");
await out.exists();                                   // false
await Bun.write(out, Bun.file("src.bin"));
console.log(fs.statSync("missing.bin").size);         // 0: the #4930 shape
```

Without the `.size` / `exists()` line both copies are complete. Only the file to file path is affected; string, buffer and Blob sources go through `WriteFile`, which never looks at the destination's size. Reproduces on 1.4.0 on Linux; the macOS (`clonefile` / `fcopyfile` + `ftruncate`) and Windows (`CopyFileWindows::on_complete` truncate) arms consume the same value. On Windows the cached size also works the other way round: copying a shorter file into a longer one padded it back out to the old length.

### Cause

`Blob.size` holds two different things for a file-backed blob: the window set by `slice()`, and, once `resolve_size()` has run, the file's stat size. `.size`, `exists()`, `expect(f).toHaveLength()` and structured-clone serialization all run `resolve_size()` on the blob itself. `write_file_with_source_destination` (`src/runtime/webcore/Blob.rs`) then handed `destination_blob.size` to `CopyFile::create` / `CopyFileWindows::init` as the copy length, so a destination whose stat size merely got cached was copied into as if the caller had written `Bun.file(dest).slice(0, oldSize)`.

### Fix

Add `Blob::size_is_explicit`, set by `slice()` (and by `dupe()` / the other field-copy), and have the copy take the destination window only when it is set; otherwise it passes `MAX_SIZE` and the copy is bounded by the source like a fresh `Bun.file(dest)` or a path destination already is. `slice()` with no bounds on an unresolved file blob produces `MAX_SIZE`, which is not a window, so that case stays unbounded too.

Structured clone writes the v4 size field only for sliced blobs (the format already defines `MAX_SIZE` there as "receiver stats it itself") and sets the flag when it reads a concrete one. Without that, a clone of a primed whole-file blob would arrive looking like a slice of the old length, and a clone of a real slice would lose its window under the new check. No wire format change.

An explicitly sliced destination behaves exactly as before (`bun-write.test.js` already relies on `Bun.file(fd).slice(0, 5)` and `Bun.stdout.slice(0, 100)` capping the copy), so unlike the attempts that changed what a destination slice means, this only changes the cases that were losing data. It is also independent of which size ends up being consulted later: #31515 / #32859 (copy the source slice instead) would make the call-site hunk here redundant, and #33360 / #33659 add the same field for the read paths and the getters; whichever of those lands second has a one-line conflict on the field declaration.

### Verification

`test/js/bun/io/bun-write.test.js`, new `describe` next to the existing file to file test: the six ways of priming the destination (`.size`, `exists()`, `toHaveLength()`, serializing it, writing to a clone of a primed blob, writing to a whole-file `slice()`) against a shorter and an empty existing file, the missing-destination `exists()` guard from #4930, an fd destination, a shorter source over a longer destination, and guards that `slice(0, 4)` and `structuredClone(slice(0, 4))` destinations are still bounded. The resolved byte count is only asserted on Linux because `uv_fs_copyfile` and `fcopyfile` over an existing file resolve with 0 independently of this (#33715).

```
$ USE_SYSTEM_BUN=1 bun test test/js/bun/io/bun-write.test.js -t "not capped by the destination"
 3 pass, 14 fail
$ bun bd test test/js/bun/io/bun-write.test.js -t "not capped by the destination"
 17 pass, 0 fail
```

Also green with the debug build: the rest of `bun-write.test.js` (the subprocess tests there only time out when run concurrently under ASAN here, same as on main), `structured-clone-blob-file.test.ts`, `blob.test.ts`, `blob-write.test.ts`, `blob-cow.test.ts`, `bun-file*.test.ts`, `bun-serve-file.test.ts` and the `serve.test.ts` Content-Range suite. `cargo check -p bun_runtime` passes for `x86_64-pc-windows-msvc`.

Fixes #4930
Fixes #22456

</details>
