### PR TITLE
bake: unsubscribe the HMR socket from topics dropped by a re-subscribe

### DIFF
--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -306,7 +306,7 @@ impl HmrSocket {
             }
             if field.contains(HmrTopic::MemoryVisualizer.as_bit()) {
                 dev.emit_memory_visualizer_events -= 1;
-                if dev.emit_incremental_visualizer_events == 0
+                if dev.emit_memory_visualizer_events == 0
                     && dev.memory_visualizer_timer.state == EventLoopTimerState::ACTIVE
                 {
                     // Note (jsc/runtime crate cycle): `vm.timer` is `()` on the low-tier

--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -146,10 +146,7 @@ impl HmrSocket {
                                 _ => {}
                             }
                         }
-                    } else if new_bits.contains(bit) && !self.subscriptions.contains(bit) {
-                        // Note: this `else if` condition is identical to the `if`
-                        // above and is therefore unreachable; likely a bug
-                        // (intended: `!new && old` → unsubscribe).
+                    } else if !new_bits.contains(bit) && self.subscriptions.contains(bit) {
                         let _ = ws.unsubscribe(&field.uws_topic());
                     }
                 }

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,7 +1,7 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
 import { expect } from "bun:test";
 import { renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { devTest, emptyHtmlFile } from "../bake-harness";
+import { Dev, devTest, emptyHtmlFile } from "../bake-harness";
 
 devTest("import.meta.hot.accept basic", {
   files: {
@@ -612,82 +612,116 @@ devTest("hot update frames are not delivered to application websocket topics", {
   },
 });
 
+// Two routes, so that `roundTrip` below always has a different route to switch to.
+const hmrSubscriptionFiles = {
+  "a.html": emptyHtmlFile({ scripts: ["a.ts"], body: "<h1>A</h1>" }),
+  "b.html": emptyHtmlFile({ body: "<h1>B</h1>" }),
+  "a.ts": `
+    console.log(0);
+  `,
+};
+
+/**
+ * Opens a raw connection to the dev server's hmr socket, in addition to the
+ * one the harness holds in `dev.socket`, and records the id byte of every
+ * frame published to it.
+ */
+async function openHmrSocket(dev: Dev) {
+  const received: string[] = [];
+  const probeReplies: PromiseWithResolvers<void>[] = [];
+  const opened = Promise.withResolvers<void>();
+  let failure: Error | undefined;
+  const fail = (why: string) => {
+    failure ??= new Error(why);
+    opened.reject(failure);
+    for (const reply of probeReplies.splice(0)) reply.reject(failure);
+  };
+  const ws = new WebSocket(dev.baseUrl.replace("http", "ws") + "/_bun/hmr");
+  ws.binaryType = "arraybuffer";
+  ws.onerror = () => fail("hmr websocket errored");
+  ws.onclose = () => fail("hmr websocket closed");
+  ws.onmessage = event => {
+    const id = String.fromCharCode(new Uint8Array(event.data as ArrayBuffer)[0]);
+    if (id === "V") {
+      opened.resolve();
+    } else if (id === "n") {
+      probeReplies.shift()!.resolve();
+    } else {
+      received.push(id);
+    }
+  };
+  await opened.promise;
+
+  let probeRoute = "/a";
+  return {
+    received,
+    send: (frame: string) => ws.send(frame),
+    /**
+     * The dev server answers SetUrl ('n' + route) directly on this socket,
+     * after handling every frame sent before it and after any frame it had
+     * already published to this socket. It only answers when the route
+     * changes, hence the alternation.
+     */
+    async roundTrip() {
+      if (failure) throw failure;
+      probeRoute = probeRoute === "/a" ? "/b" : "/a";
+      const reply = Promise.withResolvers<void>();
+      probeReplies.push(reply);
+      ws.send("n" + probeRoute);
+      await reply.promise;
+    },
+    [Symbol.dispose]() {
+      ws.onclose = null;
+      ws.close();
+    },
+  };
+}
+
 devTest("re-subscribing the hmr socket with fewer topics stops delivery of the dropped topics", {
-  files: {
-    // Two routes, so the SetUrl probe below always has a different route to switch to.
-    "a.html": emptyHtmlFile({ scripts: ["a.ts"], body: "<h1>A</h1>" }),
-    "b.html": emptyHtmlFile({ body: "<h1>B</h1>" }),
-    "a.ts": `
-      console.log(0);
-    `,
-  },
+  files: hmrSubscriptionFiles,
   async test(dev) {
     // Bundle the route once so that editing a.ts triggers rebuilds. The
     // harness's own hmr socket stays subscribed to the watch synchronization
     // topic ('r') throughout, so every rebuild below publishes to that topic;
     // whether the second socket receives it depends only on its subscription.
     await dev.fetch("/a").expect.toInclude("<h1>A</h1>");
+    using socket = await openHmrSocket(dev);
 
-    const received: string[] = [];
-    const probeReplies: PromiseWithResolvers<void>[] = [];
-    const opened = Promise.withResolvers<void>();
-    const ws = new WebSocket(dev.baseUrl.replace("http", "ws") + "/_bun/hmr");
-    ws.binaryType = "arraybuffer";
-    try {
-      let failure: Error | undefined;
-      const fail = (why: string) => {
-        failure ??= new Error(why);
-        opened.reject(failure);
-        for (const reply of probeReplies.splice(0)) reply.reject(failure);
-      };
-      ws.onerror = () => fail("hmr websocket errored");
-      ws.onclose = () => fail("hmr websocket closed");
-      ws.onmessage = event => {
-        const id = String.fromCharCode(new Uint8Array(event.data as ArrayBuffer)[0]);
-        if (id === "V") {
-          opened.resolve();
-        } else if (id === "n") {
-          probeReplies.shift()!.resolve();
-        } else {
-          received.push(id);
-        }
-      };
-      await opened.promise;
-
-      // The dev server answers SetUrl ('n' + route) directly on this socket,
-      // after handling every frame sent before it and after any frame it had
-      // already published to this socket. It only answers when the route
-      // changes, hence the alternation.
-      let probeRoute = "/a";
-      async function roundTrip() {
-        if (failure) throw failure;
-        probeRoute = probeRoute === "/a" ? "/b" : "/a";
-        const reply = Promise.withResolvers<void>();
-        probeReplies.push(reply);
-        ws.send("n" + probeRoute);
-        await reply.promise;
-      }
-
-      let edit = 0;
-      /** Subscribes to `topics`, rebuilds, and returns the message ids this socket was sent. */
-      async function messagesDuringRebuild(topics: string) {
-        ws.send("s" + topics);
-        await roundTrip();
-        received.length = 0;
-        await dev.write("a.ts", `console.log(${++edit});`);
-        await roundTrip();
-        return [...new Set(received)].sort();
-      }
-
-      // 'h' delivers hot updates ('u'), 'r' delivers watch synchronization ('r').
-      expect(await messagesDuringRebuild("hr")).toEqual(["r", "u"]);
-      expect(await messagesDuringRebuild("r")).toEqual(["r"]);
-      expect(await messagesDuringRebuild("")).toEqual([]);
-      expect(await messagesDuringRebuild("hr")).toEqual(["r", "u"]);
-    } finally {
-      ws.onclose = null;
-      ws.close();
+    let edit = 0;
+    /** Subscribes to `topics`, rebuilds, and returns the message ids the socket was sent. */
+    async function messagesDuringRebuild(topics: string) {
+      socket.send("s" + topics);
+      await socket.roundTrip();
+      socket.received.length = 0;
+      await dev.write("a.ts", `console.log(${++edit});`);
+      await socket.roundTrip();
+      return [...new Set(socket.received)].sort();
     }
+
+    // 'h' delivers hot updates ('u'), 'r' delivers watch synchronization ('r').
+    expect(await messagesDuringRebuild("hr")).toEqual(["r", "u"]);
+    expect(await messagesDuringRebuild("r")).toEqual(["r"]);
+    expect(await messagesDuringRebuild("")).toEqual([]);
+    expect(await messagesDuringRebuild("hr")).toEqual(["r", "u"]);
+  },
+});
+
+devTest("unsubscribing the last memory visualizer socket stops its timer", {
+  files: hmrSubscriptionFiles,
+  async test(dev) {
+    // On builds with the visualizer hooks compiled in, subscribing to 'M'
+    // arms a timer, and subscribing again while it is still armed fails an
+    // assertion that closes the dev server. Unsubscribing has to disarm it
+    // based on the number of 'M' subscribers, which the 'v' subscriber held
+    // open here must not affect. On other builds the hooks are no-ops.
+    using incremental = await openHmrSocket(dev);
+    incremental.send("sv");
+    await incremental.roundTrip();
+    using memory = await openHmrSocket(dev);
+    memory.send("sM");
+    memory.send("s");
+    memory.send("sM");
+    await memory.roundTrip();
   },
 });
 

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -612,6 +612,85 @@ devTest("hot update frames are not delivered to application websocket topics", {
   },
 });
 
+devTest("re-subscribing the hmr socket with fewer topics stops delivery of the dropped topics", {
+  files: {
+    // Two routes, so the SetUrl probe below always has a different route to switch to.
+    "a.html": emptyHtmlFile({ scripts: ["a.ts"], body: "<h1>A</h1>" }),
+    "b.html": emptyHtmlFile({ body: "<h1>B</h1>" }),
+    "a.ts": `
+      console.log(0);
+    `,
+  },
+  async test(dev) {
+    // Bundle the route once so that editing a.ts triggers rebuilds. The
+    // harness's own hmr socket stays subscribed to the watch synchronization
+    // topic ('r') throughout, so every rebuild below publishes to that topic;
+    // whether the second socket receives it depends only on its subscription.
+    await dev.fetch("/a").expect.toInclude("<h1>A</h1>");
+
+    const received: string[] = [];
+    const probeReplies: PromiseWithResolvers<void>[] = [];
+    const opened = Promise.withResolvers<void>();
+    const ws = new WebSocket(dev.baseUrl.replace("http", "ws") + "/_bun/hmr");
+    ws.binaryType = "arraybuffer";
+    try {
+      let failure: Error | undefined;
+      const fail = (why: string) => {
+        failure ??= new Error(why);
+        opened.reject(failure);
+        for (const reply of probeReplies.splice(0)) reply.reject(failure);
+      };
+      ws.onerror = () => fail("hmr websocket errored");
+      ws.onclose = () => fail("hmr websocket closed");
+      ws.onmessage = event => {
+        const id = String.fromCharCode(new Uint8Array(event.data as ArrayBuffer)[0]);
+        if (id === "V") {
+          opened.resolve();
+        } else if (id === "n") {
+          probeReplies.shift()!.resolve();
+        } else {
+          received.push(id);
+        }
+      };
+      await opened.promise;
+
+      // The dev server answers SetUrl ('n' + route) directly on this socket,
+      // after handling every frame sent before it and after any frame it had
+      // already published to this socket. It only answers when the route
+      // changes, hence the alternation.
+      let probeRoute = "/a";
+      async function roundTrip() {
+        if (failure) throw failure;
+        probeRoute = probeRoute === "/a" ? "/b" : "/a";
+        const reply = Promise.withResolvers<void>();
+        probeReplies.push(reply);
+        ws.send("n" + probeRoute);
+        await reply.promise;
+      }
+
+      let edit = 0;
+      /** Subscribes to `topics`, rebuilds, and returns the message ids this socket was sent. */
+      async function messagesDuringRebuild(topics: string) {
+        ws.send("s" + topics);
+        await roundTrip();
+        received.length = 0;
+        await dev.write("a.ts", `console.log(${++edit});`);
+        await roundTrip();
+        return [...new Set(received)].sort();
+      }
+
+      // 'h' delivers hot updates ('u'), 'r' delivers watch synchronization ('r').
+      expect(await messagesDuringRebuild("hr")).toEqual(["r", "u"]);
+      expect(await messagesDuringRebuild("r")).toEqual(["r"]);
+      expect(await messagesDuringRebuild("")).toEqual([]);
+      expect(await messagesDuringRebuild("hr")).toEqual(["r", "u"]);
+    } finally {
+      ws.onclose = null;
+      ws.close();
+    }
+  },
+});
+
 devTest("dev.write resolves only after the new module body has run", {
   files: {
     "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),


### PR DESCRIPTION
### Problem
- Re-subscribing an HMR socket with fewer topics does not stop the dropped topics: on a released build a socket that re-subscribed with no topics keeps getting `u` (hot update) frames on every edit.
- On a debug build the first edit after that aborts the dev server with `panic: assertion failed: ref_count > 0` in `SourceMapStore::put_or_increment_ref_count`, from `finalize_bundle`. A release build keeps a zero-reference source map entry instead.
- Cause: the unsubscribe branch of the subscribe handler had the same condition as the subscribe branch, so it never ran. The socket's own record of its topics was updated, the uws subscription was not, and the two disagreed from then on.
- Second slip, debug builds only: unsubscribing a memory visualizer socket checked the incremental visualizer counter before disarming the memory timer. With an incremental socket open, unsubscribe then re-subscribe of a memory socket hit `panic: assertion failed: dev.memory_visualizer_timer.state != EventLoopTimerState::ACTIVE`.

### Fix
- The unsubscribe guard becomes "in the old set and not in the new set", so a re-subscribe drops the uws topics it no longer names.
- Property to check: after any subscribe frame, the uws subscriptions equal the socket's own record, which is what publishing and the source map reference count both assume.
- The memory visualizer unsubscribe now checks the memory counter, matching the subscribe side that arms the timer.
- Verification: two tests added. Without the first commit the first still receives `u` after dropping the topic (checked on release and debug builds); without the second commit the second trips the timer assertion on a debug build and is a no-op on builds without the hooks. No in-tree client sends a second subscribe frame today.

### Background
- The dev server behind `Bun.serve({ development: true })` (bake) serves a WebSocket at `/_bun/hmr`. Frames start with a one-byte id: `s` plus topic letters subscribes, `n` plus a route sets the page URL and is answered directly, and the server publishes ids such as `u` (hot update) and `r` (watch synchronization).
- A subscribe frame replaces the socket's whole topic set, so the handler must subscribe added topics and unsubscribe dropped ones.
- The set is tracked twice: uws (the WebSocket library) holds per-topic subscriptions and does the publishing; `HmrSocket.subscriptions` is the dev server's own bitset. `finalize_bundle` uses the uws count to decide whether to publish a hot update and the bitset to take one source map reference per receiving socket.
- The source map store reference counts a chunk's source map by the sockets it went to, so publishing to a socket that no reference was taken for can produce a count of 0.
- The `M` (memory) and `v` (incremental) visualizer topics exist only on builds with `BAKE_DEBUGGING_FEATURES`; since #36184 they only maintain counters and a timer.

<details>
<summary>Original description</summary>

### Repro

Against a dev server (here `Bun.serve({ development: true, routes: { "/a": html } })` with `a.html` loading `a.ts`, run from the project directory), connect to the HMR socket, subscribe, then re-subscribe with fewer topics, and edit a file:

```js
const ws = new WebSocket(`${server.url}_bun/hmr`);
ws.binaryType = "arraybuffer";
ws.onmessage = e => {
  const id = String.fromCharCode(new Uint8Array(e.data)[0]);
  console.log(id);
  if (id === "V") {
    ws.send("sh"); // subscribe: hot updates
    ws.send("s");  // re-subscribe with no topics
    // ... then edit a.ts
  }
};
```

Released build: the socket keeps logging `u` (a hot update frame) on every edit, for the rest of the connection. Debug build: the dev server aborts on the first edit with

```
panic: assertion failed: ref_count > 0
    SourceMapStore::put_or_increment_ref_count  src/runtime/bake/dev_server/source_map_store.rs:466
    finalize_bundle                              src/runtime/bake/DevServer.rs:4550
```

### Cause

In the `IncomingMessageId::Subscribe` handler in `src/runtime/bake/dev_server/hmr_socket.rs`, the branch meant to call `ws.unsubscribe` was guarded by the same condition as the `ws.subscribe` branch above it (`new && !old` twice), so it never ran. A comment next to it already said so. The condition was carried over unchanged from the Zig version of the file.

The handler otherwise treats the frame as a replacement of the whole set: `on_unsubscribe` is called with the dropped bits and `HmrSocket.subscriptions` is overwritten with the new set. Only the uws subscription was left behind, so from then on the socket's bookkeeping and uws disagreed. `finalize_bundle` relies on the two agreeing: `num_subscribers(HotUpdate)` (uws) decides whether to build and publish a hot update at all, while the source map reference for the chunk is taken once per socket whose `is_subscribed(HotUpdate)` bit (bookkeeping) is set. With a stale uws subscription the payload is published to a socket that no reference was taken for; when that socket was the only listener and the chunk's script id is new, `put_or_increment_ref_count` is handed a count of 0, which is the assertion above in debug builds and a zero-reference entry that nothing removes in release builds.

### Fix

The guard is now `!new && old`, so a re-subscribe unsubscribes the dropped uws topics, and the two views of the subscription set stay in sync in every case (added, dropped, unchanged). None of the in-tree clients send a second subscribe frame today, so this is about the protocol behaving as documented by its own handler rather than something the shipped runtime triggers.

The second commit fixes the same kind of slip in `on_unsubscribe`, two lines below (raised in review): it decrements `emit_memory_visualizer_events` but then checked `emit_incremental_visualizer_events` before disarming `memory_visualizer_timer`. The subscribe path arms the timer when the memory count goes 0 to 1 and asserts it is not already armed, so with an incremental visualizer socket connected, unsubscribing and re-subscribing a memory visualizer socket failed

```
panic: assertion failed: dev.memory_visualizer_timer.state != EventLoopTimerState::ACTIVE
```

These hooks only exist on builds with `BAKE_DEBUGGING_FEATURES`, and since #36184 removed the visualizer routes they only maintain the counters and the timer, so this is bookkeeping consistency rather than anything a user can reach.

### Verification

Two tests in `test/bake/dev/hot.test.ts`, sharing a small helper that opens a second raw `/_bun/hmr` socket and records the id byte of every frame published to it. Ordering uses SetUrl round trips on that socket rather than timing: the server answers `n` only after processing the frames sent before it, and after anything it had already published to the socket.

"re-subscribing the hmr socket with fewer topics stops delivery of the dropped topics": for each subscription set `hr`, `r`, none, and `hr` again, rebuilds a file and checks which message ids arrived. The harness's own socket stays subscribed to `r`, so the `r` publishes still happen during every rebuild and the only variable is whether the second socket receives them. Without the first commit the `r` step receives `["r", "u"]` and the none step receives `["r", "u"]` (checked separately, on the released build and on an unfixed debug build); with it all four steps match, and the snippet above reloads three times without tripping the assertion.

"unsubscribing the last memory visualizer socket stops its timer": holds a `v` subscriber open, then on a second socket sends `sM`, `s`, `sM` and waits for a round trip. On a debug build without the second commit the dev server fails the assertion above and the test reports the socket closing; with it the round trip completes. On builds without the hooks the frames are no-ops and the test passes either way.

The whole of `hot.test.ts` (13 tests) passes on a debug build.

</details>
