### PR TITLE
s3: post the streaming download's final task through a copy of the handle

### DIFF
--- a/src/runtime/webcore/s3/download_stream.rs
+++ b/src/runtime/webcore/s3/download_stream.rs
@@ -278,28 +278,31 @@ impl S3HttpDownloadStreamingTask {
         // concurrent reference and `mutex` serializes against `on_response`. `async_http` is the
         // live HTTP-thread copy, non-null for the callback's duration. Borrows scoped to the call.
         let is_done = !result.has_more;
-        // The final callback is where the HTTP thread hands the request back
-        // (`embedded_work_finished` below, after `this` may have been freed).
-        // SAFETY: `this` is live for the duration of the request.
-        let done_handle = is_done.then(|| unsafe { (*this).loop_handle.clone() });
+        // On the final callback `on_response` frees `*this` as soon as it can observe the final
+        // state: once the task posted below is queued or, if one is already queued, once
+        // `process_http_callback` unlocks. The post and the hand-back therefore go through this
+        // copy: a call through the field would hold a `&` into the allocation while the JS thread
+        // frees it (as `release_at_shutdown` and `S3HttpSimpleTask::http_callback`).
+        // SAFETY: `this` is live; both of those points come later in this function.
+        let handle = unsafe { (*this).loop_handle.clone() };
         // SAFETY: as above; the HTTP thread is the only one touching it here.
         if unsafe { (*this).process_http_callback(&mut *async_http, result) } {
             // we are always unlocked here and its safe to enqueue
-            // SAFETY: same exclusivity as above; `task` is the inline `concurrent_task` field of
-            // this heap request and the queue takes ownership of its `next` link. The VM waits
-            // for its S3 requests (embedded work) before closing its handle: always queued.
-            unsafe {
-                let task = core::ptr::NonNull::from(
+            // SAFETY: `process_http_callback` returned true, so no task is queued and nothing
+            // can free `*this` before the post below; `task` is the inline `concurrent_task`
+            // field of this heap request and the queue takes ownership of its `next` link.
+            let task = unsafe {
+                core::ptr::NonNull::from(
                     (*this).concurrent_task.from(this, AutoDeinit::ManualDeinit),
-                );
-                let bun_jsc::vm_handle::Posted::Queued = (*this).loop_handle.post_task(task) else {
-                    unreachable!(
-                        "VM handle closed with an S3 download outstanding on the HTTP thread"
-                    );
-                };
-            }
+                )
+            };
+            // The VM waits for its S3 requests (embedded work) before closing its handle:
+            // always queued.
+            let bun_jsc::vm_handle::Posted::Queued = handle.post_task(task) else {
+                unreachable!("VM handle closed with an S3 download outstanding on the HTTP thread");
+            };
         }
-        if let Some(handle) = done_handle {
+        if is_done {
             handle.embedded_work_finished();
         }
     }

--- a/test/internal/source-lints/s3-post-through-handle-field.test.ts
+++ b/test/internal/source-lints/s3-post-through-handle-field.test.ts
@@ -1,0 +1,162 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// In src/runtime/webcore/s3/ the HTTP thread hands a request back to the JS
+// thread by posting the request's own allocation (`S3HttpSimpleTask`,
+// `S3HttpDownloadStreamingTask`: the inline `concurrent_task` carries the
+// object that embeds it), and the JS thread frees that allocation as soon as
+// it observes the final state (`on_response` in both files): from the moment
+// `VmHandle::post` has pushed the task or, on the streaming download's final
+// callback, from the moment `process_http_callback` unlocks if a task is
+// already queued. Either way the allocation can be gone while the HTTP thread
+// is still inside the call that handed it over. So in these files
+//
+//   (*this).loop_handle.post_task(task)
+//   (*this).loop_handle.embedded_work_finished()
+//
+// is banned: both calls take `&(*this).loop_handle`, a reference into that
+// allocation, as an argument, and a reference argument is protected for the
+// duration of its call. Freeing memory a protected reference points into is UB
+// under both aliasing models whether or not the callee reads through it again.
+// Miri, on a reduction of this exact shape (free on a second thread while the
+// poster is still inside `post_task(&self)`), reports it under Tree Borrows
+// (the model `bun run rust:miri` uses) as "deallocation through <tag> is
+// forbidden ... protected tags must never be Disabled" and under Stacked
+// Borrows as "not granting access ... would remove [SharedReadOnly for <tag>]
+// which is strongly protected", pointing at `&self` both times; codegen relies
+// on the same thing (the argument is annotated dereferenceable for the whole
+// call). The shape every other hand-off in the directory uses copies the
+// handle out first and posts and hands back through the copy:
+//
+//   let handle = (*this).loop_handle.clone();
+//   ... handle.post_task(task) ...
+//   handle.embedded_work_finished();
+//
+// `embedded_work_scheduled()` through the field is fine: it runs on the JS
+// thread, before the request is handed to the HTTP thread.
+//
+// Scope: src/runtime/webcore/s3/, where the rule holds for every object that
+// stores a `LoopHandle`. Elsewhere a post through a stored handle is
+// sometimes sound (the poster holds a ref or a lock that outlives the post),
+// so the same spelling cannot be banned tree-wide by a regex; the sites of
+// this class outside the directory are converted one at a time. Within the
+// directory, a reference to the field parked in a local
+// (`let h = &(*this).loop_handle;`) or returned by a helper is the same bug
+// spelled in a way this lint does not see; convert it on sight. Sibling
+// guard for the receiver-spelled forms of the same hand-over:
+// self-receiver-reclaim.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const SCOPE = "src/runtime/webcore/s3/";
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// The two calls that follow a hand-off.
+const AFTER_HANDOFF = String.raw`(?:post_task|embedded_work_finished)`;
+
+const BANNED = new RegExp(
+  [
+    // `x.loop_handle.post_task(..)`, whatever `x` is (`(*this)`, `self`, `task`),
+    // including rustfmt's one-segment-per-line wrapping of the chain.
+    String.raw`\.\s*loop_handle\s*\.\s*${AFTER_HANDOFF}\s*\(`,
+    // The same call spelled as a path call: `LoopHandle::post_task(&(*this).loop_handle, task)`,
+    // `LoopHandle::embedded_work_finished(&self.loop_handle)`.
+    String.raw`\b${AFTER_HANDOFF}\s*\(\s*&\s*(?:\(\s*\*+\s*[\w.]+\s*\)|[\w.]+)\s*\.\s*loop_handle\b`,
+  ].join("|"),
+  "g",
+);
+
+// What keeps the ban from passing vacuously: the scanned files still store
+// the handle under this name (a rename would otherwise silently blind the
+// regex above) and still post through it.
+const HANDLE_FIELD = /\bloop_handle\s*:\s*(?:[\w:]+::)?LoopHandle\b/g;
+const HANDOFF = /\.post_task\s*\(/g;
+
+const offenders: string[] = [];
+const scanned: string[] = [];
+let handleFields = 0;
+let handoffs = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  if (!source.startsWith(SCOPE)) continue;
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned.push(source);
+  const content = await file(abs).text();
+  // Strip full-line comments so prose (like the comments describing this very
+  // hazard) doesn't count. `[ \t]*`, not `\s*`: `\s` crosses newlines and
+  // would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  handleFields += [...stripped.matchAll(HANDLE_FIELD)].length;
+  handoffs += [...stripped.matchAll(HANDOFF)].length;
+  for (const m of stripped.matchAll(BANNED)) {
+    const line = stripped.slice(0, m.index).split("\n").length;
+    offenders.push(`${source}:${line}: ${m[0].replace(/\s+/g, " ")}`);
+  }
+}
+
+function matches(snippet: string): boolean {
+  BANNED.lastIndex = 0;
+  return BANNED.test(snippet);
+}
+
+test("scans the hand-off sites it is about", () => {
+  expect(scanned).toContain(`${SCOPE}download_stream.rs`);
+  expect(scanned).toContain(`${SCOPE}simple_request.rs`);
+  // Both task types still keep their handle in a field called `loop_handle`
+  // and still post through it; otherwise the regexes below match nothing and
+  // the ban would need re-anchoring rather than passing for free.
+  expect(handleFields).toBeGreaterThan(0);
+  expect(handoffs).toBeGreaterThan(0);
+});
+
+test("the pattern recognizes the spellings it claims to", () => {
+  const banned = [
+    // `S3HttpDownloadStreamingTask::http_callback`, as it was.
+    "let bun_jsc::vm_handle::Posted::Queued = (*this).loop_handle.post_task(task) else {",
+    "self.loop_handle.post_task(ct)",
+    "task.loop_handle.embedded_work_finished();",
+    "unsafe { (*this).loop_handle.embedded_work_finished() };",
+    // rustfmt-wrapped chains.
+    "(*this)\n    .loop_handle\n    .post_task(task)",
+    "this.loop_handle\n    .embedded_work_finished();",
+    // Path-call spellings of the same thing.
+    "bun_jsc::LoopHandle::post_task(&(*this).loop_handle, task)",
+    "LoopHandle::embedded_work_finished(&self.loop_handle)",
+  ];
+  const allowed = [
+    // The required shape: copy out, then post and hand back through the copy.
+    "let handle = (*this).loop_handle.clone();",
+    "let bun_jsc::vm_handle::Posted::Queued = handle.post_task(task) else {",
+    "done_handle.embedded_work_finished();",
+    // A copy that happens to be called `loop_handle` is a local, not the field.
+    "let loop_handle = (*this).loop_handle.clone();\nloop_handle.post_task(task);",
+    // JS thread, before the request leaves it.
+    "task.loop_handle.embedded_work_scheduled();",
+    "unsafe { (*task_ptr).loop_handle.embedded_work_scheduled() };",
+    // Capturing the handle at construction.
+    "loop_handle: VirtualMachine::get().loop_handle(),",
+    "pub(crate) loop_handle: bun_jsc::LoopHandle,",
+  ];
+  expect(banned.filter(s => !matches(s))).toEqual([]);
+  expect(allowed.filter(matches)).toEqual([]);
+});
+
+test("S3 hand-offs post and hand back through a copy of the handle, not the field", () => {
+  expect(offenders).toEqual([]);
+});


### PR DESCRIPTION
### Problem
- No crash is known. On the final chunk of every streaming S3 download (`s3file.stream()`, or reading an `S3File` as a `ReadableStream`) the HTTP thread posts its hand-back task by calling `post_task` on the `loop_handle` field stored inside the request's own allocation.
- The JS thread frees that allocation as soon as it sees the final chunk, which can be while `post_task` is still running on the HTTP thread with `&self` pointing into it. Freeing memory behind a live reference argument is undefined behaviour whether or not the callee reads through it again.
- A standalone reduction of this shape fails under Miri with Tree Borrows (`deallocation through <tag> ... is forbidden`, `protected tags must never be Disabled`) and with Stacked Borrows; the same reduction posting through a copy of the handle passes.
- This site copied the VM pointer out before #37075 moved it to `LoopHandle`. The other three hand-offs in the directory already post through a clone.

### Fix
- Clone the handle out before processing the callback, then post the task and hand the request back through the clone. The separate clone taken only on the final callback goes away, since one copy serves both calls.
- Correct because the clone lives on the HTTP thread's stack, so nothing borrows the request allocation at either point where the JS thread may free it. The same task reaches the same queue at the same point; the cost is one Arc increment and decrement per non-final callback.
- Adds a source lint over `src/runtime/webcore/s3/` that bans posting or handing back through a stored `loop_handle`. On `main` it reports exactly the one line this PR changes.
- Verification: the Miri failure is on the reduction, not on bun. On bun itself an ASAN streaming stress script and the S3 test files pass with the change; there was no failing repro to flip.

### Background
- `LoopHandle`: a cloneable, Arc backed handle to a JS VM's event loop. `post_task` queues a task for the JS thread and wakes it; `embedded_work_finished` tells the VM one piece of off-thread work is done, which the VM waits for before closing.
- S3 requests carry their own task node: the request struct embeds a `concurrent_task`, so posting it hands the JS thread the very allocation the handle field lives in, and the JS side (`on_response`) frees that allocation on the final delivery.
- Protected references: under Rust's aliasing models (Stacked Borrows, Tree Borrows) a `&self` argument must stay valid for the whole call, and codegen marks it `dereferenceable`. Freeing the memory it points into mid-call is UB even from another thread and even if the callee never touches it again.
- Miri (`bun run rust:miri`) is the interpreter that checks those models; it reports this class of bug where ASAN and normal tests see nothing.
- `test/internal/source-lints/` holds regex tests over the source tree that stop a fixed pattern from coming back. This one is scoped to the s3 directory because the same spelling is sound in places where something else keeps the object alive across the post.

<details>
<summary>Original description</summary>

### Problem

`S3HttpDownloadStreamingTask::http_callback` (src/runtime/webcore/s3/download_stream.rs) is how the HTTP thread delivers each chunk of a streaming S3 download (`s3file.stream()`, anything else that reads an `S3File` as a `ReadableStream`). It posted the task with

```rust
let bun_jsc::vm_handle::Posted::Queued = (*this).loop_handle.post_task(task) else { ... };
```

The task it posts is the request's own allocation (the inline `concurrent_task` field), and on the final callback the JS-thread consumer, `on_response`, frees that allocation (`drop(heap::take(this_ptr))`) as soon as it observes `has_more == false`, which it can do the moment `VmHandle::post` has pushed the task and woken the loop. `post_task(&self)` and the `VmHandle::post(&self, ..)` it calls are still running on the HTTP thread at that point, and their `&self` is `&(*this).loop_handle`: a reference into the allocation being freed. A reference argument is protected for the duration of its call, and freeing memory a protected reference points into is UB under both aliasing models whether or not the callee reads through it again (codegen relies on the same contract: the argument is annotated dereferenceable for the whole call). Nothing does read through it after the push today, so no crash is known; the contract is what is wrong, and it is wrong on the final callback of every streaming download.

The function already clones the handle for the `embedded_work_finished()` that follows the post, for exactly this reason ("after `this` may have been freed"), and the directory's other hand-offs (`release_at_shutdown` in the same file, and both `S3HttpSimpleTask::http_callback` and its `release_at_shutdown` in simple_request.rs) already post through the clone. Before #37075 this site copied the VM pointer out before enqueueing; the move to `LoopHandle` turned that into a call through the field.

A reduction of this exact shape (the consumer on a second thread frees the allocation while the poster is still inside `post_task(&self)`, and `post_task` reads nothing from the allocation after the push) fails under Miri with Tree Borrows, the model `bun run rust:miri` uses:

```
error: Undefined Behavior: deallocation through <9276> at alloc1564[0x0] is forbidden
  = help: the accessed tag <9276> is foreign to the protected tag <6549> (i.e., it is not a child)
  = help: this deallocation (acting as a foreign write access) would cause the protected tag <6549> (currently Frozen) to become Disabled
  = help: protected tags must never be Disabled
help: the protected tag <6549> was created here, in the initial state Frozen
   |     fn post_task(&self, task: SendPtr) {
   |                  ^^^^^
```

and under Stacked Borrows with `not granting access to tag <2994> because that would remove [SharedReadOnly for <6802>] which is strongly protected`, where `<6802>` is the same `&self`. The same reduction posting through a copy of the handle passes under both.

<details>
<summary>Reduction run under Miri</summary>

```rust
use std::sync::{mpsc, Arc, Mutex};
use std::thread;

struct SendPtr(*mut Task);
unsafe impl Send for SendPtr {}

// `VmHandle`: an Arc to shared state the VM keeps alive; `LoopHandle` clones it.
struct Shared {
    queue: Mutex<mpsc::Sender<SendPtr>>,
    freed: Mutex<mpsc::Receiver<()>>,
}
#[derive(Clone)]
struct LoopHandle(Arc<Shared>);

impl LoopHandle {
    // `LoopHandle::post_task(&self, task)`: push, wake the loop, return. The JS
    // thread may run the task (and free it) at any point after the push; the
    // `recv` pins that interleaving, standing in for the work `VmHandle::post`
    // still does after the push (wakeup, dropping its access guard).
    fn post_task(&self, task: SendPtr) {
        // As `VmHandle::post`: everything it needs from the handle is read
        // before the push (its `Access` guard holds a `&Shared` into the Arc
        // payload, which the VM keeps alive); after the push it touches only
        // that. Nothing reads the handle field itself after the push.
        let shared: &Shared = &self.0;
        shared.queue.lock().unwrap().send(task).unwrap();
        shared.freed.lock().unwrap().recv().unwrap();
    }
}

// `S3HttpDownloadStreamingTask`: the handle lives inside the allocation the
// task hands over.
struct Task {
    loop_handle: LoopHandle,
    state: u64,
}

// main
fn http_callback_before(this: *mut Task) {
    unsafe { (*this).state = 0 };
    unsafe { (*this).loop_handle.post_task(SendPtr(this)) };
}

// this PR
fn http_callback_after(this: *mut Task) {
    let handle = unsafe { (*this).loop_handle.clone() };
    unsafe { (*this).state = 0 };
    handle.post_task(SendPtr(this));
}

fn main() {
    let (queue, tasks) = mpsc::channel::<SendPtr>();
    let (freed_tx, freed) = mpsc::channel::<()>();
    let vm = LoopHandle(Arc::new(Shared {
        queue: Mutex::new(queue),
        freed: Mutex::new(freed),
    }));
    // The JS thread: `on_response` sees the final state and frees the task.
    let js_thread = thread::spawn(move || {
        let task = tasks.recv().unwrap();
        drop(unsafe { Box::from_raw(task.0) });
        freed_tx.send(()).unwrap();
    });
    let task = Box::into_raw(Box::new(Task {
        loop_handle: vm.clone(),
        state: 1,
    }));
    if std::env::args().nth(1).as_deref() == Some("after") {
        http_callback_after(task);
    } else {
        http_callback_before(task);
    }
    js_thread.join().unwrap();
}
```

`MIRIFLAGS=-Zmiri-tree-borrows cargo miri run -- before` and the default (Stacked Borrows) run both exit 1 with the errors quoted above; `-- after` exits 0 under both.

</details>

### Fix

`http_callback` clones the handle out unconditionally before `process_http_callback`, posts through the clone, and calls `embedded_work_finished()` on it when `is_done`, the shape of the three sibling hand-offs. The conditional `done_handle` is gone since the one copy now serves both calls; on non-final callbacks this adds one Arc increment and decrement per callback, next to the mutex that callback already takes. Behaviour is unchanged: the same task goes to the same queue at the same point, and the request is handed back at the same point.

The same spelling exists outside this directory and is not part of this change. Sites where it is the same bug each have their own fix: the two Windows mkdirp completions in blob/copy_file.rs and blob/write_file.rs (#37705), `napi_async_work::post_to_js_thread` (#37750), `FetchTasklet::deref_from_thread` (posts through a `&self` helper; reported separately) and `StatWatcher::post_to_js_thread` (reported separately; #37591 reshapes it). The others post while something else keeps the object alive (the bundler's plugin-dispatch thunk in js_bundle_completion_task.rs during the build, the stat watcher scheduler, the threadsafe function under its lock, AsyncModule's leaked `WakeContext`, the `FetchTasklet` helper's other two callers, which hold a ref), which is why the spelling cannot simply be banned tree-wide; the `FSWatcher::post` helper in node_fs_watcher.rs was not examined here beyond noting that its batch holds an activity ref across the post.

### Tests

`test/internal/source-lints/s3-post-through-handle-field.test.ts` bans `post_task` and `embedded_work_finished` through a stored `loop_handle` (method-call and path-call spellings, including rustfmt-wrapped chains) in src/runtime/webcore/s3/, where every object storing a handle is freed by the JS thread on delivery, so the rule holds unconditionally and the allowlist is empty. `embedded_work_scheduled()` through the field, `.clone()` and posting through a local are allowed, and the file checks its pattern against both lists. It also checks that the scanned files still declare the field and still post, so a rename cannot blind it silently. Against `main` it reports exactly

```
src/runtime/webcore/s3/download_stream.rs:295: .loop_handle.post_task(
```

and passes with this branch.

### Verification

On the debug (ASAN) build: a script streaming, 150 rounds of 6 concurrent downloads each, a 512 KiB body, an empty body, a 64-chunk trickled body, the same two with the consumer deliberately late (so that the final callback can arrive with a task already queued, the path where the earlier task is the one that frees), and a 404 whose XML error is reported on the final callback, with GC between rounds, completes without a sanitizer report. test/js/bun/s3/{s3-stream-cancel-leak,s3-stream-error-gc,s3-connection-close,s3-insecure,s3-requester-pays,s3-storage-class,s3-list-objects,s3-list-checksum-algorithm,s3-fd-validation,s3-argument-validation}.test.ts pass (the connection-close and list-objects files only with `--timeout` raised: their concurrent debug-build subprocesses take 7 to 15 s each in this container, with or without this change; the credentialed s3.test.ts streaming coverage runs in CI). `bun test test/internal/source-lints/` (19 files) passes; rustfmt is clean on the changed file.


</details>
