### PR TITLE
Make deepEquals and toEqual compare Headers with several set-cookie values

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1814,24 +1814,8 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                 auto headers1 = dynamicDowncast<JSFetchHeaders>(c1);
                 auto headers2 = dynamicDowncast<JSFetchHeaders>(c2);
                 if (headers1 && headers2) {
-                    auto& wrapped1 = headers1->wrapped();
-                    const auto& wrapped2 = headers2->wrapped();
-                    if (wrapped1.size() != wrapped2.size()) {
+                    if (headers1->wrapped().internalHeaders() != headers2->wrapped().internalHeaders()) {
                         return false;
-                    }
-
-                    auto iter1 = wrapped1.createIterator();
-                    while (const auto& maybePair = iter1.next()) {
-                        const auto& key = maybePair->key;
-                        const auto& value = maybePair->value;
-                        const auto& maybeValue = wrapped2.get(key);
-                        if (maybeValue.hasException()) {
-                            return false;
-                        }
-
-                        if (maybeValue.returnValue() != value) {
-                            return false;
-                        }
                     }
 
                     goto compareAsNormalValue;

--- a/src/jsc/bindings/webcore/HTTPHeaderMap.h
+++ b/src/jsc/bindings/webcore/HTTPHeaderMap.h
@@ -201,18 +201,18 @@ public:
     const_iterator begin() const { return const_iterator(*this, m_commonHeaders.begin(), m_uncommonHeaders.begin(), m_setCookieHeaders.begin()); }
     const_iterator end() const { return const_iterator(*this, m_commonHeaders.end(), m_uncommonHeaders.end(), m_setCookieHeaders.end()); }
 
+    // Names are unordered (iteration sorts them), but Set-Cookie values are an ordered list:
+    // getSetCookie() exposes the order, and of two cookies with the same name the later one wins.
     friend bool operator==(const HTTPHeaderMap& a, const HTTPHeaderMap& b)
     {
-        if (a.m_commonHeaders.size() != b.m_commonHeaders.size() || a.m_uncommonHeaders.size() != b.m_uncommonHeaders.size() || a.m_setCookieHeaders.size() != b.m_setCookieHeaders.size())
+        if (a.m_commonHeaders.size() != b.m_commonHeaders.size() || a.m_uncommonHeaders.size() != b.m_uncommonHeaders.size())
+            return false;
+
+        if (a.m_setCookieHeaders != b.m_setCookieHeaders)
             return false;
 
         for (auto& commonHeader : a.m_commonHeaders) {
             if (b.get(commonHeader.key) != commonHeader.value)
-                return false;
-        }
-
-        for (auto& uncommonHeader : a.m_setCookieHeaders) {
-            if (b.m_setCookieHeaders.find(uncommonHeader) == notFound)
                 return false;
         }
 

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -49,6 +49,64 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
     expect(deepEquals(b, a)).toBe(false);
   });
 
+  describe("Headers", () => {
+    const headers = (...setCookies: string[]) => {
+      const result = new Headers({ "content-type": "text/plain", "x-a": "1" });
+      for (const cookie of setCookies) result.append("set-cookie", cookie);
+      return result;
+    };
+
+    it("compares every set-cookie value", () => {
+      expect(deepEquals(headers(), headers())).toBe(true);
+      expect(deepEquals(headers("k=1"), headers("k=1"))).toBe(true);
+      expect(deepEquals(headers("k=1", "j=2"), headers("k=1", "j=2"))).toBe(true);
+      expect(deepEquals(headers("k=1", "j=2", "i=3"), headers("k=1", "j=2", "i=3"))).toBe(true);
+      expect(deepEquals(headers("k=1", "j=2"), new Headers(headers("k=1", "j=2")))).toBe(true);
+      expect(
+        deepEquals(
+          headers("k=1", "j=2"),
+          new Headers([
+            ["Set-Cookie", "k=1"],
+            ["X-A", "1"],
+            ["set-cookie", "j=2"],
+            ["Content-Type", "text/plain"],
+          ]),
+        ),
+      ).toBe(true);
+      expect(deepEquals({ headers: headers("k=1", "j=2") }, { headers: headers("k=1", "j=2") })).toBe(true);
+
+      expect(deepEquals(headers("k=1", "j=2"), headers("k=1", "j=3"))).toBe(false);
+      expect(deepEquals(headers("k=1", "j=2"), headers("k=1"))).toBe(false);
+      expect(deepEquals(headers("k=1"), headers("k=1", "j=2"))).toBe(false);
+      expect(deepEquals(headers("k=1", "j=2"), headers("k=1, j=2"))).toBe(false);
+      expect(deepEquals(headers("k=1", "j=2"), headers())).toBe(false);
+      // set-cookie order is observable through getSetCookie() and iteration
+      expect(deepEquals(headers("k=1", "j=2"), headers("j=2", "k=1"))).toBe(false);
+      expect(deepEquals(headers("k=1", "k=1"), headers("k=1", "j=2"))).toBe(false);
+    });
+
+    it("still compares the other headers when set-cookie values match", () => {
+      const differentContentType = headers("k=1", "j=2");
+      differentContentType.set("content-type", "text/html");
+      expect(deepEquals(headers("k=1", "j=2"), differentContentType)).toBe(false);
+
+      const differentCustomHeader = headers("k=1", "j=2");
+      differentCustomHeader.set("x-a", "2");
+      expect(deepEquals(headers("k=1", "j=2"), differentCustomHeader)).toBe(false);
+
+      const extraHeader = headers("k=1", "j=2");
+      extraHeader.set("x-b", "2");
+      expect(deepEquals(headers("k=1", "j=2"), extraHeader)).toBe(false);
+      expect(deepEquals(extraHeader, headers("k=1", "j=2"))).toBe(false);
+
+      // same number of entries overall, distributed differently
+      const oneCookieOneExtraHeader = headers("k=1");
+      oneCookieOneExtraHeader.set("x-b", "2");
+      expect(deepEquals(headers("k=1", "j=2"), oneCookieOneExtraHeader)).toBe(false);
+      expect(deepEquals(oneCookieOneExtraHeader, headers("k=1", "j=2"))).toBe(false);
+    });
+  });
+
   // we may change this in the future
   it("functions that are not reference-equal are never equal", () => {
     function foo() {}

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -293,6 +293,67 @@ describe("expect()", () => {
       expect(new Headers({ "a": "1" })).not.toEqual(new Headers({ "b": "1" }));
       expect(new Headers({ "a": "1" })).not.toEqual(new Headers({ "a": "2" }));
       expect(new Headers({ "a": "1" })).not.toEqual(new Headers({ "a": "1", "b": "2" }));
+      expect(new Headers({ "a": "" })).not.toEqual(new Headers({ "b": "" }));
+      // insertion order and name casing are not observable, so they don't matter
+      expect(new Headers({ "a": "1", "content-type": "text/plain" })).toEqual(
+        new Headers({ "Content-Type": "text/plain", "A": "1" }),
+      );
+      expect(new Headers({ "content-type": "text/plain" })).not.toEqual(new Headers({ "content-type": "text/html" }));
+      expect(new Headers({ "content-type": "text/plain" })).not.toEqual(new Headers({ "accept": "text/plain" }));
+      // appending a non-cookie header combines it into one value
+      expect(
+        new Headers([
+          ["accept", "x"],
+          ["accept", "y"],
+        ]),
+      ).toEqual(new Headers({ "accept": "x, y" }));
+    });
+
+    test("Headers with several set-cookie values", () => {
+      /** @param {...string} values */
+      const cookies = (...values) => {
+        const headers = new Headers({ "content-type": "text/plain", "x-a": "1" });
+        for (const value of values) headers.append("set-cookie", value);
+        return headers;
+      };
+
+      expect(cookies("k=1")).toEqual(cookies("k=1"));
+      expect(cookies("k=1", "j=2")).toEqual(cookies("k=1", "j=2"));
+      expect(cookies("k=1", "j=2")).toStrictEqual(cookies("k=1", "j=2"));
+      expect(cookies("k=1", "j=2", "i=3")).toEqual(cookies("k=1", "j=2", "i=3"));
+      expect(cookies("k=1", "j=2")).toEqual(new Headers(cookies("k=1", "j=2")));
+      expect(cookies("k=1", "j=2")).toEqual(
+        new Headers([
+          ["Set-Cookie", "k=1"],
+          ["X-A", "1"],
+          ["set-cookie", "j=2"],
+          ["Content-Type", "text/plain"],
+        ]),
+      );
+      expect([cookies("k=1", "j=2")]).toContainEqual(cookies("k=1", "j=2"));
+      expect({ headers: cookies("k=1", "j=2") }).toEqual({ headers: cookies("k=1", "j=2") });
+
+      expect(cookies("k=1", "j=2")).not.toEqual(cookies("k=1", "j=3"));
+      expect(cookies("k=1", "j=2")).not.toEqual(cookies("k=1"));
+      expect(cookies("k=1")).not.toEqual(cookies("k=1", "j=2"));
+      expect(cookies("k=1", "j=2")).not.toEqual(cookies("k=1, j=2"));
+      // set-cookie order is observable through getSetCookie() and iteration
+      expect(cookies("k=1", "j=2")).not.toEqual(cookies("j=2", "k=1"));
+      expect(cookies("k=1", "j=2")).not.toStrictEqual(cookies("j=2", "k=1"));
+      expect(cookies("k=1", "k=1")).not.toEqual(cookies("k=1", "j=2"));
+
+      const differentCommonHeader = cookies("k=1", "j=2");
+      differentCommonHeader.set("content-type", "text/html");
+      expect(cookies("k=1", "j=2")).not.toEqual(differentCommonHeader);
+
+      const differentUncommonHeader = cookies("k=1", "j=2");
+      differentUncommonHeader.set("x-a", "2");
+      expect(cookies("k=1", "j=2")).not.toEqual(differentUncommonHeader);
+
+      // same number of entries overall, distributed differently
+      const oneCookieOneExtraHeader = cookies("k=1");
+      oneCookieOneExtraHeader.set("x-b", "2");
+      expect(cookies("k=1", "j=2")).not.toEqual(oneCookieOneExtraHeader);
     });
 
     // TODO: FormData

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -78,6 +78,13 @@ function argumentsObject(...values: unknown[]) {
   })(...values);
 }
 
+function headersWithTwoSetCookies() {
+  const headers = new Headers({ "content-type": "text/plain" });
+  headers.append("set-cookie", "k=1");
+  headers.append("set-cookie", "j=2");
+  return headers;
+}
+
 const cases: Case[] = [
   // Loose mode compares primitives with ==, strict mode with Object.is.
   { name: "0 and -0", a: () => 0, b: () => -0, strict: false, loose: true, looseBug: "reports not equal" },
@@ -638,6 +645,14 @@ const cases: Case[] = [
     name: "two equal arguments objects",
     a: () => argumentsObject(1),
     b: () => argumentsObject(1),
+    strict: true,
+    loose: true,
+  },
+  {
+    // Unlike Node, Bun compares Headers by their entries; identical entries must still be equal.
+    name: "two Headers with the same set-cookie values",
+    a: headersWithTwoSetCookies,
+    b: headersWithTwoSetCookies,
     strict: true,
     loose: true,
   },


### PR DESCRIPTION
### Problem
- Two `Headers` with identical contents compare unequal (`Bun.deepEquals`, `toEqual`, `toStrictEqual`, `assert.deepStrictEqual`, `util.isDeepStrictEqual`) once both carry two or more `set-cookie` values. With zero or one they compare equal.
- Cause: one side was walked entry by entry, one entry per cookie, and each entry was checked against `get()` on the other side, which returns all cookies joined with `", "`. Every cookie entry mismatched.
- The size pre-check missed it because both sides count cookies individually.

### Fix
- The `Headers` branch of deep equality now compares the two underlying header maps with their existing, previously unused `==`.
- That `==` checked cookies by membership, so `["k=1", "k=1"]` would match `["k=1", "j=2"]`; it now compares the cookie lists element-wise. Cookie order is observable through `getSetCookie()` and iteration, and Jest and Vitest agree. Name order and casing still do not matter.
- Verification: new tests fail on the released build and pass with this change; the expect cases also pass under Vitest on Node.

### Background
- `Headers` keeps `set-cookie` as a list of separate values; every other repeated header is merged into one comma-joined value. Iteration yields one entry per cookie, but `get("set-cookie")` returns the joined string.
- `HTTPHeaderMap` is the WebCore map behind `Headers`: three buckets (well-known names, other names, the cookie list), compared bucket by bucket by its `==`. This diff changes only the cookie bucket.
- `specialObjectsDequal` is where every deep-equality entry point in bun handles built-in types such as `Headers`, so one change covers them all; when it passes, ordinary own-property comparison still runs.

<details>
<summary>Original description</summary>

## Repro

```js
const a = new Headers({ a: "1" });
a.append("set-cookie", "k=1");
a.append("set-cookie", "j=2");
const b = new Headers([["a", "1"], ["Set-Cookie", "k=1"], ["set-cookie", "j=2"]]);

Bun.deepEquals(a, b); // false, expected true
expect(a).toEqual(b); // fails the same way, as do toStrictEqual, assert.deepStrictEqual and util.isDeepStrictEqual
```

Two `Headers` with identical contents compare unequal as soon as both carry two or more `set-cookie` values. With zero or one value they compare equal.

## Cause

The `Headers` branch of `specialObjectsDequal` in `src/jsc/bindings/bindings.cpp` iterated one side with `FetchHeaders::createIterator()`, which yields one entry per `set-cookie` value (`"k=1"`, then `"j=2"`), and compared each entry against `get(key)` on the other side, which for `set-cookie` returns every value joined with `", "` (`"k=1, j=2"`). Every cookie entry mismatched, so the branch returned `false`. The `size()` pre-check did not catch it because both sides count cookies individually.

## Fix

Compare the two `HTTPHeaderMap`s directly. `HTTPHeaderMap::operator==` already existed (it had no callers); its `set-cookie` loop, which looked each value up with `find()` and so would also have accepted `["k=1", "k=1"]` against `["k=1", "j=2"]`, is replaced with an element-wise comparison of the two lists. Header names remain order-insensitive and case-insensitive, and values of repeated non-cookie headers are still compared in their combined form, exactly as before.

Why `set-cookie` order matters while name order does not: name order is not observable through `Headers` (iteration sorts names), but the order of `set-cookie` values is, through `getSetCookie()` and iteration, and it carries meaning on the wire (when two cookies share a name the later one wins). This also matches what Jest and Vitest report for the same `Headers` values, since their `toEqual` compares iterables entry by entry; the new `expect.test.js` cases pass under Vitest on Node as well as under Bun.

All entry points share this branch (`Bun.deepEquals` in both modes, `toEqual`, `toStrictEqual`, `toContainEqual`, `assert.deepEqual`/`deepStrictEqual`, `util.isDeepStrictEqual`), so the one change covers all of them.

## Verification

The new cases in `test/js/bun/test/expect.test.js`, `test/js/bun/bun-object/deep-equals.test.ts` and `test/js/node/assert/deep-equal.test.ts` fail on the released build (`USE_SYSTEM_BUN=1`) and pass with this change. The full `expect.test.js`, `deep-equal.test.ts` and `test/js/web/fetch/headers.test.ts` suites pass with the debug build.

Out of scope here, to be fixed separately: the `URLSearchParams` branch right above has the same iterate-vs-`get()` problem for repeated keys, and `toMatchObject` does not look inside nested `Headers` at all (it goes through `Bun__deepMatch`, which this change does not touch).


</details>
