### PR TITLE
bake: serialize bundler messages with line 0 as having no location

### DIFF
--- a/src/runtime/bake/dev_server/serialized_failure.rs
+++ b/src/runtime/bake/dev_server/serialized_failure.rs
@@ -198,7 +198,7 @@ pub enum ErrorKind {
     JsAggregate,
 }
 
-// All "write" functions get a corresponding "read" function in ./client/error.ts
+// All "write" functions get a corresponding "read" function in ../client/error-serialization.ts
 type Writer = Vec<u8>;
 
 fn write_log_msg(msg: &bun_ast::Msg, w: &mut Writer) {
@@ -221,7 +221,10 @@ fn write_log_msg(msg: &bun_ast::Msg, w: &mut Writer) {
 fn write_log_data(data: &bun_ast::Data, w: &mut Writer) {
     write_string32(data.text.as_ref(), w);
     if let Some(loc) = &data.location {
-        if loc.line < 0 {
+        // `line <= 0` carries no position (e.g. a plugin exception), and
+        // `readBundlerMessageLocationOrNull` stops after a zero line, so the
+        // column/length/line text must not be written for it.
+        if loc.line <= 0 {
             _ = w.write_int_le::<u32>(0);
             return;
         }

--- a/test/bake/dev/plugins.test.ts
+++ b/test/bake/dev/plugins.test.ts
@@ -1,5 +1,8 @@
 // Plugin tests concern plugins in development mode.
-import { devTest, minimalFramework } from "../bake-harness";
+import { DataViewReader } from "bake/data-view";
+import { decodeSerializedError } from "bake/error-serialization";
+import { expect } from "bun:test";
+import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 // Note: more in depth testing of plugins is done in test/bundler/bundler_plugin.test.ts
 devTest("onResolve", {
@@ -108,6 +111,146 @@ devTest("onResolve + onLoad virtual file", {
       },
       "file-on-disk",
     ]);
+  },
+});
+
+/**
+ * Decodes the bundling failures embedded in the dev server's "Build Failed"
+ * page the same way the error overlay does (`decodeAndAppendServerError` in
+ * `src/runtime/bake/client/overlay.ts`), so a payload the overlay would
+ * misread (an extra failure, or garbage after the first message) fails here.
+ * Failures are sorted by file since plugins finish in no particular order.
+ */
+function decodeBuildFailedPage(html: string) {
+  const base64 = html.match(/atob\("([A-Za-z0-9+/=]*)"\)/)?.[1];
+  expect(base64).toBeString();
+  const bytes = Uint8Array.from(atob(base64!), c => c.charCodeAt(0));
+  const reader = new DataViewReader(new DataView(bytes.buffer), 0);
+  const failures = [];
+  while (reader.hasMoreData()) {
+    reader.u32(); // owner, an incremental graph index
+    const file = reader.string32() || null;
+    const messageCount = reader.u32();
+    const messages = [];
+    for (let i = 0; i < messageCount; i++) {
+      messages.push(decodeSerializedError(reader));
+    }
+    failures.push({ file, messages });
+  }
+  return failures.sort((a, b) => (a.file ?? "").localeCompare(b.file ?? ""));
+}
+
+function bundlerError(message: string) {
+  return { kind: "bundler", level: 0, message, location: null, notes: [] };
+}
+
+// An exception thrown by a plugin becomes a bundler message whose location has
+// no line (`line: 0`). The error payload has to encode that as "no location",
+// otherwise the overlay reads the rest of the message as further failures.
+devTest("exceptions thrown from onLoad are reported without a location", {
+  framework: minimalFramework,
+  pluginFile: `
+    import * as path from 'path';
+    export default [
+      {
+        name: 'a',
+        setup(build) {
+          build.onLoad({ filter: /trigger/ }, (args) => {
+            throw new Error('cannot load ' + path.basename(args.path));
+          });
+        },
+      }
+    ];
+  `,
+  files: {
+    "first.trigger.ts": `
+      export const first = 1;
+    `,
+    "second.trigger.ts": `
+      export const second = 2;
+    `,
+    "routes/index.ts": `
+      import { first } from '../first.trigger.ts';
+      import { second } from '../second.trigger.ts';
+
+      export default function (req, meta) {
+        return new Response('value: ' + (first + second));
+      }
+    `,
+  },
+  async test(dev) {
+    const response = await dev.fetch("/");
+    expect(response.status).toBe(500);
+    expect(decodeBuildFailedPage(await response.text())).toEqual([
+      { file: "first.trigger.ts", messages: [bundlerError("cannot load first.trigger.ts")] },
+      { file: "second.trigger.ts", messages: [bundlerError("cannot load second.trigger.ts")] },
+    ]);
+  },
+});
+devTest("exception thrown from onResolve is reported without a location", {
+  framework: minimalFramework,
+  pluginFile: `
+    export default [
+      {
+        name: 'a',
+        setup(build) {
+          build.onResolve({ filter: /^trigger$/ }, () => {
+            throw new Error('onResolve boom');
+          });
+        },
+      }
+    ];
+  `,
+  files: {
+    "routes/index.ts": `
+      import { value } from 'trigger';
+
+      export default function (req, meta) {
+        return new Response('value: ' + value);
+      }
+    `,
+  },
+  async test(dev) {
+    const response = await dev.fetch("/");
+    expect(response.status).toBe(500);
+    expect(decodeBuildFailedPage(await response.text())).toEqual([
+      { file: "routes/index.ts", messages: [bundlerError("onResolve boom")] },
+    ]);
+  },
+});
+// Every failure the client decodes has to be one the server knows about and
+// can later remove, otherwise the error page never reloads once the real
+// failure is gone.
+devTest("error page reloads once a plugin exception is fixed", {
+  files: {
+    "bunfig.toml": `
+      [serve.static]
+      plugins = ["./plugin.ts"]
+    `,
+    "plugin.ts": `
+      export default {
+        name: "a",
+        setup(build) {
+          build.onResolve({ filter: /^trigger$/ }, () => {
+            throw new Error("onResolve boom");
+          });
+        },
+      };
+    `,
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `
+      import { value } from "trigger";
+      console.log("value: " + value);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/", {
+      errors: ["index.ts: error: onResolve boom"],
+    });
+    await c.expectReload(async () => {
+      await dev.write("index.ts", `console.log("fixed");`);
+    });
+    await c.expectMessage("fixed");
   },
 });
 // devTest("onLoad with watchFile", {


### PR DESCRIPTION
### Problem
- In a Bake dev server, a plugin that throws from `onLoad` or `onResolve` makes the error overlay show an extra empty file group per failure; with notes or several messages per file the payload decodes as garbage.
- The extra entry is keyed by owner `0`, which the server never removes, so the error page does not reload once the real error is fixed.
- Cause: a bundler message with `line == 0` was written with column, length and line text, but the client stops reading after a zero line, so the leftover bytes decode as further failures.
- Plugin exceptions are the common source of such messages; `Location::default()` and native plugin logs produce them too.

### Fix
- The writer now treats `line <= 0` (previously only `line < 0`) as "no location" and writes a lone `0`.
- The client reader already returns `null` for `line == 0` and `bun_ast::Location` documents `line <= 0` as "no position", so the writer was the one side out of contract.
- Not changed: the terminal still prints `at file.ts:0`, and native plugin logs with `line > 0` but `column <= 0` still break; tracked separately.
- Verification: three new dev server tests (onLoad throw, onResolve throw, error page reloads after a fix) fail on 1.4.0 with `USE_SYSTEM_BUN=1` and pass with this change. Existing tests for real locations and `line: -1` still pass.

### Background
- Bake is bun's dev server for HTML and framework routes. On a failed bundle it serves a 500 "Build Failed" page with the failures embedded, and pushes later ones to the overlay over the HMR socket.
- That payload is a hand-written binary format with no field tags: each write function in the Rust serializer has a matching read function in the client, so a field written but not read shifts every later byte.
- Each failure is keyed by an owner, an index into the dev server's incremental graph; the server removes failures by owner as files rebuild, and the page reloads once none are left.
- `bun_ast::Location` lines are 1-based; `line <= 0` means no position. Plugin exceptions yield `line: 0`, resolution errors `line: -1`.

<details>
<summary>Original description</summary>

### What

In a Bake dev server (`bun ./index.html`, `Bun.serve({ development: true })`), a bundler message whose `Location.line == 0` was serialized with more fields than the error overlay reads, so the overlay decoded the rest of the message as further failures.

Plugin exceptions are the common way to get such a message: `bun_ast_jsc::msg_from_js` (used for `onLoad` / `onResolve` throws) builds a `Location` with `line: 0`, as does `Location::default()`, and the `bun-native-plugin` crate fills `BunLogOptions` with `line: 0` for every log.

Repro: a plugin that throws from `onLoad` or `onResolve` while serving an HTML route or a framework route.

```ts
build.onResolve({ filter: /^trigger$/ }, () => {
  throw new Error("onResolve boom");
});
```

Decoding the payload embedded in the 500 page (or sent as `BunFrontendDevServer.bundleFailed` / over the HMR socket) with the real client decoder yields, on 1.4.0:

```
[
  { file: "index.ts", messages: [{ message: "onResolve boom", location: null, notes: [] }] },
  { file: null, messages: [] },   // leftover column / length / lineText bytes
]
```

User visible effects:

- the overlay shows an extra empty file group per failure (with notes or more than one message per file, the rest of the payload is garbage and decoding throws);
- the bogus entry is keyed by owner `0`, which the server never removes, so `buildErrors` never empties and the error page does not reload after the error is fixed. The new "error page reloads once a plugin exception is fixed" test fails on 1.4.0 with `location.reload() was not called` even though the server logged `Reloaded in 2ms: index.ts`.

### Why

`write_log_data` in `serialized_failure.rs` short-circuited only on `line < 0`. `readBundlerMessageLocationOrNull` in `client/error-serialization.ts` returns `null` for `line == 0` after reading just the line, and `bun_ast::Location` documents `line <= 0` as "no line and column information" (it is 1-based). The writer is the side that disagrees with both the reader and the documented contract, so it now writes a lone `0` for any `line <= 0`. Fixing the producers instead (e.g. making `msg_from_js` use `-1`) would change the public `BuildMessage.position` of `Bun.build` and would still leave `Location::default()` and native plugin logs broken, and the wire format has no way to express a line of 0 anyway.

Left alone on purpose: the terminal printer prints `at file.ts:0` for these messages (cosmetic, unrelated to the wire format), and native plugin logs with `line > 0` but `column <= 0` still panic the writer / throw in the overlay; that is a different defect and is tracked separately.

### Tests

`test/bake/dev/plugins.test.ts`:

- `exceptions thrown from onLoad are reported without a location`: two failing files, decodes the error page payload with `decodeSerializedError` from the client and asserts exactly those two failures and nothing else in the payload;
- `exception thrown from onResolve is reported without a location`: same for the resolve path (the failure belongs to the importer);
- `error page reloads once a plugin exception is fixed`: `[serve.static]` plugin with an HTML route, loads the error page in the harness client, fixes the import and asserts the page reloads.

All three fail with `USE_SYSTEM_BUN=1` (the first two decode an extra `{ file: null, messages: [] }` per failure, the third times out waiting for the reload) and pass with `bun bd test`. `test/cli/inspect/BunFrontendDevServer.test.ts` and `test/bake/dev/bundle.test.ts` (messages with real locations, and resolution errors with `line: -1`) still pass.

</details>
