### PR TITLE
bake: keep the client's stylesheet when a CSS root fails after parsing

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -5291,6 +5291,27 @@ pub mod bv2_impl {
 
                 let asts = self.graph.ast.slice();
                 let css_asts = asts.items_css();
+
+                // Find CSS entry points. Originally, this was computed up front, but
+                // failed files do not remember their loader, and plugins can
+                // asynchronously decide a file is CSS.
+                //
+                // This runs before the loop below so that a root the loop removes
+                // (its parts were cleared by a resolution failure reported after
+                // parsing, such as one that went through a plugin's onResolve, or
+                // `scan_css_imports` rejected one of its imports) stays removed
+                // instead of getting a chunk anyway.
+                for entry_point in &self.graph.entry_points {
+                    if css_asts[entry_point.get() as usize].is_some() {
+                        start.css_entry_points.put(
+                            Index::init(entry_point.get()),
+                            CssEntryPointMeta {
+                                imported_on_server: false,
+                            },
+                        )?;
+                    }
+                }
+
                 // SoA columns are physically disjoint slabs but rustc cannot
                 // see that through `&Slice`. Route the two columns we mutate (`parts`,
                 // `import_records`) through `split_raw()` (root-provenance `*mut [T]`,
@@ -5410,21 +5431,6 @@ pub mod bv2_impl {
                         let _ = start
                             .css_entry_points
                             .swap_remove(&Index::init(u32::try_from(index).expect("int cast")));
-                    }
-                }
-
-                // Find CSS entry points. Originally, this was computed up front, but
-                // failed files do not remember their loader, and plugins can
-                // asynchronously decide a file is CSS.
-                let css = asts.items_css();
-                for entry_point in &self.graph.entry_points {
-                    if css[entry_point.get() as usize].is_some() {
-                        start.css_entry_points.put(
-                            Index::init(entry_point.get()),
-                            CssEntryPointMeta {
-                                imported_on_server: false,
-                            },
-                        )?;
                     }
                 }
 

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4491,9 +4491,16 @@ pub(super) fn finalize_bundle(
     let css_chunks = &*css_chunks_mut;
     if will_hear_hot_update {
         if dev.client_graph.current_chunk_len > 0 || !css_chunks.is_empty() {
-            // Send CSS mutations
+            // Send CSS mutations. The count is patched in afterwards because
+            // a root that failed after Pass 1 stored its chunk (for example a
+            // resolution failure reported through a plugin's onResolve) had
+            // its asset released by `insert_failure`. Nothing is sent for it:
+            // the client keeps the stylesheet it already has, exactly as it
+            // does for roots that fail before producing a chunk.
             dev.assets.reindex_if_needed()?;
-            w_int!(u32, u32::try_from(css_chunks.len()).expect("int cast"));
+            let css_count_offset = hot_update_payload.len();
+            w_int!(u32, 0);
+            let mut css_count: u32 = 0;
             use bun_bundler::Graph::InputFileColumns as _;
             let sources = bv2.graph.input_files.items_source();
             for chunk in css_chunks {
@@ -4501,16 +4508,19 @@ pub(super) fn finalize_bundle(
                     .path
                     .key_for_incremental_graph();
                 let content_hash = hash(key);
+                let Some(route) = dev.assets.get(content_hash) else {
+                    continue;
+                };
+                let css_data: &[u8] = &route.blob.internal_blob().bytes;
+                css_count += 1;
                 let mut hex = [0u8; 16];
                 let n = bun_core::fmt::bytes_to_hex_lower(&content_hash.to_ne_bytes(), &mut hex);
                 w_all!(&hex[..n]);
-                let css_data: &[u8] = match dev.assets.get(content_hash) {
-                    Some(route) => &route.blob.internal_blob().bytes,
-                    None => b"",
-                };
                 w_int!(u32, u32::try_from(css_data.len()).expect("int cast"));
                 w_all!(css_data);
             }
+            hot_update_payload[css_count_offset..css_count_offset + ::core::mem::size_of::<u32>()]
+                .copy_from_slice(&css_count.to_le_bytes());
 
             // Send the JS chunk
             if dev.client_graph.current_chunk_len > 0 {

--- a/test/bake/dev/css.test.ts
+++ b/test/bake/dev/css.test.ts
@@ -253,6 +253,133 @@ devTest("css url resolve error on hot reload is recoverable", {
     expect((await dev.fetch("/")).status).toBe(200);
   },
 });
+// The next three tests fail a stylesheet's rebuild after it has been parsed
+// (rather than with a syntax error) and check that the client keeps the rules
+// it already has, the same as "css file with syntax error does not kill old
+// styles". Previously the failed root still produced a CSS chunk, and the hot
+// update either emptied the stylesheet on the client (the failure had released
+// its asset) or applied the rejected stylesheet.
+const failedRootKeepsOldStylesFiles = {
+  "index.html": emptyHtmlFile({
+    styles: ["styles.css"],
+    body: `<div class="a">hello</div>`,
+  }),
+  "styles.css": `
+    .a { color: red; }
+  `,
+};
+devTest("css url that falls through a plugin onResolve and fails to resolve keeps old styles", {
+  files: {
+    ...failedRootKeepsOldStylesFiles,
+    "bunfig.toml": `
+      [serve.static]
+      plugins = ["./css-plugin.ts"]
+    `,
+    "css-plugin.ts": `
+      export default {
+        name: "css-plugin",
+        setup(build) {
+          build.onResolve({ filter: /missing\\.png$/ }, () => undefined);
+        },
+      };
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.style(".a").color.expect.toBe("red");
+    await dev.write(
+      "styles.css",
+      `
+        .a { background-image: url(./missing.png); }
+      `,
+      {
+        errors: ['styles.css:1:24: error: Could not resolve: "./missing.png"'],
+      },
+    );
+    await c.style(".a").color.expect.toBe("red");
+
+    await dev.write(
+      "styles.css",
+      `
+        .a { color: green; }
+      `,
+    );
+    await c.style(".a").color.expect.toBe("green");
+    expect((await dev.fetch("/")).status).toBe(200);
+  },
+});
+devTest("css url whose plugin onResolve throws keeps old styles", {
+  files: {
+    ...failedRootKeepsOldStylesFiles,
+    "bunfig.toml": `
+      [serve.static]
+      plugins = ["./css-plugin.ts"]
+    `,
+    "css-plugin.ts": `
+      export default {
+        name: "css-plugin",
+        setup(build) {
+          build.onResolve({ filter: /missing\\.png$/ }, () => {
+            throw new Error("css-plugin rejected this url");
+          });
+        },
+      };
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.style(".a").color.expect.toBe("red");
+    await dev.write(
+      "styles.css",
+      `
+        .a { background-image: url(./missing.png); }
+      `,
+      {
+        errors: ["styles.css: error: css-plugin rejected this url"],
+      },
+    );
+    await c.style(".a").color.expect.toBe("red");
+
+    await dev.write(
+      "styles.css",
+      `
+        .a { color: green; }
+      `,
+    );
+    await c.style(".a").color.expect.toBe("green");
+    expect((await dev.fetch("/")).status).toBe(200);
+  },
+});
+devTest("css root that imports a non-css file keeps old styles", {
+  files: {
+    ...failedRootKeepsOldStylesFiles,
+    "not-css.js": `export const x = 1;`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.style(".a").color.expect.toBe("red");
+    await dev.write(
+      "styles.css",
+      `
+        @import "./not-css.js";
+        .a { color: blue; }
+      `,
+      {
+        errors: ['styles.css:1:1: error: Cannot import a ".jsx" file into a CSS file'],
+      },
+    );
+    await c.style(".a").color.expect.toBe("red");
+
+    await dev.write(
+      "styles.css",
+      `
+        .a { color: green; }
+      `,
+    );
+    await c.style(".a").color.expect.toBe("green");
+    expect((await dev.fetch("/")).status).toBe(200);
+  },
+});
 devTest("circular css imports handle hot reload", {
   files: {
     "index.html": emptyHtmlFile({
@@ -413,6 +540,8 @@ devTest("css hot update carries the edited stylesheet when another root fails in
       }
       await c2.style(".second").color.expect.toBe("green");
       await c1.style(".second").notFound();
+      // The failed root keeps the rules it had before the rebuild.
+      await c1.style(".first").color.expect.toBe("red");
     }
 
     await dev.write(


### PR DESCRIPTION
### Problem
- Dev server, HTML route linking `styles.css`, a `serve.static` plugin whose `onResolve` returns `undefined` (or throws) for a `url()` in it. Hot-editing the sheet reports `error: Could not resolve: "./missing.png"` as it should, but the page also loses every rule of `styles.css` while the error is up. The same failure with no plugin, or a syntax error, keeps the old rules.
- With no plugin, hot-editing a CSS root to `@import "./not-css.js"` reports `Cannot import a ".jsx" file into a CSS file` and applies the rejected stylesheet anyway.
- Bundler side: the loop that drops failed CSS roots from the entry point set is followed by a step that adds back every entry point with a parsed stylesheet, so a root that failed after parsing still gets a chunk.
- Dev server side: that chunk's asset is stored, then released when the failure is recorded; the hot update finds no asset for the hash and sends an empty stylesheet (the fallback from #36165), which wipes the page. In the `@import` case the rejected chunk is sent as is.

### Fix
- The bundler collects CSS entry points before the per-file loop, so a removal in the loop is final and a failed root produces no chunk. Only other difference: an entry point also imported on the server in the same bundle now keeps that flag.
- The hot update skips CSS chunks whose asset no longer exists and patches the count in afterwards (covers the plugin-throws case, which still prints a chunk). The client keeps its current sheet, as it already does for JS files that fail after being received.
- Why this is right: a failed rebuild has no new content, and the syntax error and builtin resolver paths already define the outcome as overlay plus the old rules until a rebuild succeeds. The plugin and `@import` paths now match them.
- Verification: three new dev server tests (plugin falls through, plugin throws, root imports a non-CSS file) plus one tightened existing test, each checking the overlay text, that the old rules still apply, and that fixing the file restyles the client. All four fail on the release build; either source change alone leaves one failing.

### Background
- A CSS root is a stylesheet the dev server bundles as its own entry point into one CSS chunk. Its `url()` and `@import` references are resolved as part of that root's build, so a bad reference fails the whole root.
- On each edit the dev server rebuilds the affected roots and sends connected clients a hot update listing CSS chunks by content hash. The chunk bytes live in an asset store keyed by that hash, so the payload writer looks each one up.
- Recording a failure for a file puts it in the overlay and releases any asset registered for it. A syntax error leaves no parsed stylesheet; a resolution error routed through a plugin arrives after parsing, so the parsed sheet is still there when entry points are collected.
- `serve.static` plugins are bunfig plugins loaded into the dev server's bundler. An `onResolve` that returns `undefined` falls through to the builtin resolver; one that throws fails the importing file with the thrown message.

<details>
<summary>Original description</summary>

### Repro

Dev server, an HTML route linking `styles.css`, and a `serve.static` plugin whose `onResolve` matches `missing.png` and returns `undefined` (so resolution falls through to the builtin resolver and fails). With a client connected, change the stylesheet to

```css
.a { background-image: url(./missing.png); }
```

The terminal and the overlay report `error: Could not resolve: "./missing.png"`, as they do without the plugin, but the page also loses every rule of `styles.css` while the error is up. Without the plugin, and for a syntax error, the client keeps the rules it had (`css.test.ts` "css file with syntax error does not kill old styles"). The same happens when the plugin's `onResolve` throws, and a related form shows up without any plugin: hot-editing a CSS root to `@import "./not-css.js"` reports `Cannot import a ".jsx" file into a CSS file` and applies the rejected stylesheet anyway.

### Cause

`finish_from_bake_dev_server` walks every file and removes CSS roots that failed from `css_entry_points` (a root whose resolution failure was reported asynchronously has had its parts cleared by `run_resolver`; a root with an invalid import is removed after `scan_css_imports`). It then adds every entry point that has a parsed stylesheet, which puts those roots straight back, so a failed root still gets a CSS chunk. The synchronous resolver path never hit this because it drops the stylesheet before it reaches the graph.

In `finalize_bundle`, pass 1 stores that chunk's asset and registers the file, `prepare_and_log_resolution_failures` then marks the file failed, which releases the asset again, and the hot update's CSS list looks the asset up by hash, finds nothing, and sends an empty stylesheet (the `b""` fallback added in #36165 when this lookup was made hash based), which is what wipes the page. For the `@import` case the chunk's content is what gets applied, and registering the chunk also cleared the failure that had just been inserted for it.

### Fix

- `bundle_v2.rs`: seed `css_entry_points` from the entry points before the per-file loop, so the removals in that loop are final. Same comment and semantics as before; the only other difference is that an entry point imported on the server in the same bundle now keeps `imported_on_server: true` instead of having it reset by the late `put`.
- `DevServer.rs`: the hot update payload skips CSS chunks whose asset no longer exists and patches the count in afterwards. A missing asset means the root failed after pass 1 stored its chunk (the plugin-throws case still prints a chunk since nothing clears its parts); there is nothing to send for it, and the client keeps its current sheet, which is what `take_js_bundle_to_list` already does for JS files that fail after being received.

This is the right behavior to have because a stylesheet that fails to rebuild has no new content for the client, and the dev server already defines the outcome for that situation on the syntax error and builtin resolver paths: overlay plus the previously applied rules, replaced when a rebuild succeeds. The plugin path only differed because the failed root still produced a chunk.

Related open PRs: #31945 (June) gates the same re-add on the file having parts. It was written for the debug crash that #31905 has since fixed at the source, and its gate would also cover the plugin fall-through case here, but not a root removed by `scan_css_imports` (parts intact) and not the payload side (plugin throws), which are the other two tests in this PR; moving the seeding above the loop makes every removal in the loop final, so this PR supersedes that diff. #37039 handles roots that fail to print and keeps failed roots in the route's CSS list; the asset check here also covers its print-failed chunks (their failure releases the asset in pass 1), so its `css_chunk_printed` filter becomes redundant once both land. #37844 edits the same loop in `finish_from_bake_dev_server` and is independent of this change.

### Verification

Three new tests in `test/bake/dev/css.test.ts` (plugin falls through, plugin throws, root imports a non-CSS file), each asserting the overlay text, that the old rules are still applied, and that fixing the file restyles the connected client and serves 200 again. The existing "another root fails in the same rebuild" test now also asserts the failed root's rules on its client. All four fail on the release build (`Selector '.a' was not found` / `Received: "#00f"` / `Selector '.first' was not found`) and pass on the debug build. Each source change is needed: with only the `bundle_v2.rs` change, the plugin-throws test still fails; with only the `DevServer.rs` change, the non-CSS import test still fails. `test/bake/dev` css, html, plugins, bundle, hot and incremental-graph-edge-deletion suites pass on the debug build.

The new tests do not request the route while it is failed with a client connected: with `BUN_ASSUME_PERFECT_INCREMENTAL=0` (the harness default) that rebuilds the route and ships the HTML module to the client, which is #31908 and unrelated to this change.

</details>
