### PR TITLE
Make deepEquals and toEqual compare every URLSearchParams entry, not just the first value per name

### DIFF
--- a/src/jsc/bindings/URLSearchParams.h
+++ b/src/jsc/bindings/URLSearchParams.h
@@ -56,6 +56,7 @@ public:
     void updateFromAssociatedURL();
     void sort();
     size_t size() const { return m_pairs.size(); }
+    const Vector<KeyValuePair<String, String>>& pairs() const { return m_pairs; }
     size_t memoryCost() const;
 
     class Iterator {
@@ -71,7 +72,6 @@ public:
     Iterator createIterator(const ScriptExecutionContext* context) { return Iterator { *this }; }
 
 private:
-    const Vector<KeyValuePair<String, String>>& pairs() const { return m_pairs; }
     URLSearchParams(const String&, DOMURL*);
     URLSearchParams(const Vector<KeyValuePair<String, String>>&);
     void updateURL();

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1779,20 +1779,10 @@ std::optional<bool> specialObjectsDequal(JSC::JSGlobalObject* globalObject, Mark
                 auto urlSearchParams1 = dynamicDowncast<JSURLSearchParams>(c1);
                 auto urlSearchParams2 = dynamicDowncast<JSURLSearchParams>(c2);
                 if (urlSearchParams1 && urlSearchParams2) {
-                    auto& wrapped1 = urlSearchParams1->wrapped();
-                    const auto& wrapped2 = urlSearchParams2->wrapped();
-                    if (wrapped1.size() != wrapped2.size()) {
+                    // An ordered list of (name, value) tuples in which names may repeat, so it is
+                    // compared positionally (as jest's iterableEquality does), not by get(name).
+                    if (urlSearchParams1->wrapped().pairs() != urlSearchParams2->wrapped().pairs()) {
                         return false;
-                    }
-
-                    auto iter1 = wrapped1.createIterator();
-                    while (const auto& maybePair = iter1.next()) {
-                        const auto& key = maybePair->key;
-                        const auto& value = maybePair->value;
-                        const auto& maybeValue = wrapped2.get(key);
-                        if (!maybeValue || maybeValue != value) {
-                            return false;
-                        }
                     }
 
                     goto compareAsNormalValue;

--- a/test/js/bun/bun-object/deep-equals.test.ts
+++ b/test/js/bun/bun-object/deep-equals.test.ts
@@ -59,6 +59,67 @@ describe.each([true, false])("Bun.deepEquals(a, b, strict: %p)", strict => {
     expect(deepEquals(foo, baz)).toBe(false);
   });
 
+  describe("URLSearchParams", () => {
+    it.each([
+      ["a=1&a=2", "a=1&a=2"],
+      ["a=1&b=2&a=3", "a=1&b=2&a=3"],
+      ["a=1&a", "a=1&a="],
+      ["a=1&b=2", "a=1&b=2"],
+      ["", ""],
+    ])("%p equals %p", (a, b) => {
+      expect(deepEquals(new URLSearchParams(a), new URLSearchParams(b))).toBe(true);
+      expect(deepEquals(new URLSearchParams(b), new URLSearchParams(a))).toBe(true);
+    });
+
+    it.each([
+      ["a=1&a=2", "a=1&a=3"],
+      ["a=1&a=2", "a=2&a=1"],
+      ["a=1&a=2", "a=1"],
+      ["a=1&a=1", "a=1"],
+      // Same size and every get() agrees, but the entries differ.
+      ["a=1&a=1&b=2", "a=1&b=2&b=2"],
+      // Entries are an ordered list: sort() is observable.
+      ["a=1&b=2", "b=2&a=1"],
+    ])("%p does not equal %p", (a, b) => {
+      expect(deepEquals(new URLSearchParams(a), new URLSearchParams(b))).toBe(false);
+      expect(deepEquals(new URLSearchParams(b), new URLSearchParams(a))).toBe(false);
+    });
+
+    it("compares the same entries however they were built", () => {
+      const appended = new URLSearchParams();
+      appended.append("a", "1");
+      appended.append("a", "2");
+      expect(deepEquals(appended, new URLSearchParams("a=1&a=2"))).toBe(true);
+      expect(
+        deepEquals(
+          appended,
+          new URLSearchParams([
+            ["a", "1"],
+            ["a", "2"],
+          ]),
+        ),
+      ).toBe(true);
+      expect(deepEquals(appended, new URLSearchParams({ a: "1" }))).toBe(false);
+    });
+
+    it("compares the current entries of a URL's searchParams", () => {
+      const url = new URL("https://example.com/?a=1");
+      const searchParams = url.searchParams;
+      expect(deepEquals(searchParams, new URLSearchParams("a=1&a=2"))).toBe(false);
+      url.search = "?a=1&a=2";
+      expect(deepEquals(searchParams, new URLSearchParams("a=1&a=2"))).toBe(true);
+      searchParams.append("a", "3");
+      expect(deepEquals(searchParams, new URLSearchParams("a=1&a=2"))).toBe(false);
+      expect(deepEquals(searchParams, new URL("https://example.com/?a=1&a=2&a=3").searchParams)).toBe(true);
+    });
+
+    it("still compares own properties once the entries match", () => {
+      const withExtra = () => Object.assign(new URLSearchParams("a=1&a=2"), { extra: 1 });
+      expect(deepEquals(withExtra(), withExtra())).toBe(true);
+      expect(deepEquals(withExtra(), new URLSearchParams("a=1&a=2"))).toBe(false);
+    });
+  });
+
   describe("global object", () => {
     let contexts: [vm.Context, vm.Context];
 

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -281,6 +281,48 @@ describe("expect()", () => {
       expect(new URLSearchParams("a=1&b=2")).not.toEqual(new URLSearchParams("a=1&"));
     });
 
+    test("URLSearchParams with a repeated name", () => {
+      expect(new URLSearchParams("a=1&a=2")).toEqual(new URLSearchParams("a=1&a=2"));
+      expect(new URLSearchParams("a=1&a=2")).toStrictEqual(new URLSearchParams("a=1&a=2"));
+      expect(new URLSearchParams("a=1&b=2&a=3")).toEqual(new URLSearchParams("a=1&b=2&a=3"));
+      expect(new URLSearchParams("a=1&a")).toEqual(new URLSearchParams("a=1&a="));
+
+      expect(new URLSearchParams("a=1&a=2")).not.toEqual(new URLSearchParams("a=1&a=3"));
+      expect(new URLSearchParams("a=1&a=2")).not.toEqual(new URLSearchParams("a=2&a=1"));
+      expect(new URLSearchParams("a=1&a=2")).not.toEqual(new URLSearchParams("a=1"));
+      // Same size and every get() agrees, but the entries differ.
+      expect(new URLSearchParams("a=1&a=1&b=2")).not.toEqual(new URLSearchParams("a=1&b=2&b=2"));
+      expect(new URLSearchParams("a=1&a=1&b=2")).not.toStrictEqual(new URLSearchParams("a=1&b=2&b=2"));
+    });
+
+    test("URLSearchParams entries are ordered", () => {
+      expect(new URLSearchParams("b=2&a=1")).not.toEqual(new URLSearchParams("a=1&b=2"));
+      expect(new URLSearchParams("b=2&a=1")).not.toStrictEqual(new URLSearchParams("a=1&b=2"));
+
+      const sorted = new URLSearchParams("b=2&a=1");
+      sorted.sort();
+      expect(sorted).toEqual(new URLSearchParams("a=1&b=2"));
+    });
+
+    test("URLSearchParams built through different paths", () => {
+      const appended = new URLSearchParams();
+      appended.append("a", "1");
+      appended.append("a", "2");
+      expect(appended).toEqual(new URLSearchParams("a=1&a=2"));
+      expect(appended).toEqual(
+        new URLSearchParams([
+          ["a", "1"],
+          ["a", "2"],
+        ]),
+      );
+      expect(new URL("https://example.com/?a=1&a=2").searchParams).toEqual(new URLSearchParams("a=1&a=2"));
+
+      const url = new URL("https://example.com/?a=1");
+      const searchParams = url.searchParams;
+      url.search = "?a=1&a=2";
+      expect(searchParams).toEqual(new URLSearchParams("a=1&a=2"));
+    });
+
     if (isBun) {
       test("URL", () => {
         expect(new URL("https://example.com")).toEqual(new URL("https://example.com"));

--- a/test/js/node/assert/deep-equal.test.ts
+++ b/test/js/node/assert/deep-equal.test.ts
@@ -641,6 +641,13 @@ const cases: Case[] = [
     strict: true,
     loose: true,
   },
+  {
+    name: "two URLSearchParams with a repeated name",
+    a: () => new URLSearchParams("a=1&a=2"),
+    b: () => new URLSearchParams("a=1&a=2"),
+    strict: true,
+    loose: true,
+  },
 ];
 
 function caught(fn: () => void): (Error & { code?: string }) | null {


### PR DESCRIPTION
### Problem
- `Bun.deepEquals(new URLSearchParams("a=1&a=2"), new URLSearchParams("a=1&a=2"))` returns false. `toEqual`, `toStrictEqual`, `assert.deepStrictEqual` and `util.isDeepStrictEqual` fail the same way. With unique names the two compare equal.
- The reverse also happens: `a=1&a=1&b=2` compares equal to `a=1&b=2&b=2`.
- Cause: the comparison looked each entry up by name on the other side, and a name lookup only ever sees the first value for that name. The size pre-check does not help because both sides have the same count.

### Fix
- Compare the two entry lists position by position instead of one name lookup per entry. The own-property comparison and the strict-mode type-mismatch handling around it are unchanged.
- Correct because two instances now compare equal exactly when they hold the same pairs in the same order, which is what `toString()` and iteration expose and what Jest and Vitest compute for `toEqual`.
- Behavior change to know about: `a=1&b=2` and `b=2&a=1` used to compare equal and no longer do. Jest and Vitest already report them unequal, and `sort()` now changes the result the same way it changes `toString()`. `Headers` stays name-order-insensitive; its similar bug is #37881.
- Verification: new tests for `Bun.deepEquals`, `expect` and `node:assert` fail on the released build (22 failures) and pass with this build. The new `expect` cases also pass unchanged under Vitest on Node. The existing expect, assert, deep-equals and URL suites still pass.

### Background
- `URLSearchParams` holds an ordered list of (name, value) pairs in which a name may repeat. `get(name)` returns only the first value for that name; `sort()` reorders the list, so order is observable.
- `Bun.deepEquals`, the `expect` equality matchers, `node:assert` and `util.isDeepStrictEqual` all share one native routine that special-cases some built-in objects and then falls through to the ordinary own-property comparison, so one change covers all of them.
- Node's `util.isDeepStrictEqual` has no `URLSearchParams` handling (any two instances compare equal), so comparing contents is bun behavior from #15195; Jest and Vitest are the reference for which pairs are unequal.
- The native object already kept the pair list for its iterator; the diff makes that accessor public and compares two lists element by element.

<details>
<summary>Original description</summary>

## Repro

```js
const a = new URLSearchParams("a=1&a=2");
const b = new URLSearchParams("a=1&a=2");

Bun.deepEquals(a, b); // false, expected true
expect(a).toEqual(b); // fails the same way, as do toStrictEqual, assert.deepStrictEqual and util.isDeepStrictEqual

// The same lookup also accepts lists that differ:
Bun.deepEquals(new URLSearchParams("a=1&a=1&b=2"), new URLSearchParams("a=1&b=2&b=2")); // true, expected false
```

Two `URLSearchParams` with identical contents compare unequal as soon as a name appears more than once. With unique names they compare equal.

## Cause

The `URLSearchParams` branch of `specialObjectsDequal` in `src/jsc/bindings/bindings.cpp` iterated one side's entries and compared each one against `get(name)` on the other side. `get()` returns the first value for a name, so the second `a` entry (`"2"`) was compared against `"1"` and the branch returned `false`. The `size()` pre-check does not catch it because both sides count entries individually. The same lookup is why `a=1&a=1&b=2` passed against `a=1&b=2&b=2`: every entry finds a matching first value on the other side.

## Fix

Expose the pair list that `URLSearchParams` already keeps (`pairs()`, previously private and used by its iterator) and compare the two lists with `Vector::operator==`, which compares `KeyValuePair<String, String>` element by element by string contents. The existing fall-through to the own-property comparison is unchanged, as is the strict/non-strict type-mismatch handling below it. This also makes the comparison linear instead of one `get()` scan per entry.

## Why positional

A `URLSearchParams` is an ordered list of (name, value) tuples: the order is what `toString()`, iteration and the owning `URL`'s `href` serialize, and `sort()` exists to change it. Comparing the lists positionally is the equality that agrees with those, and it is what Jest and Vitest compute for `toEqual`/`toStrictEqual` on a `URLSearchParams` (their `iterableEquality` walks both iterables in lockstep). `test/js/bun/test/expect.test.js` is meant to run under Jest and Vitest as well as Bun; the new cases there pass unchanged under Vitest 4.1.9 on Node, including the ones below.

One consequence to be aware of: `new URLSearchParams("a=1&b=2")` and `new URLSearchParams("b=2&a=1")` used to compare equal and no longer do. That case was only equal because of the per-name lookup; Jest and Vitest report it unequal, `Bun.deepEquals` already reports the two `URL`s that carry those queries unequal (it compares `href`), and a `sort()` call now changes the result the same way it changes `toString()`. This differs from `Headers` (#37881), where name order is not observable, so that comparison stays name-order-insensitive.

Node's `util.isDeepStrictEqual` has no `URLSearchParams` handling at all (any two instances compare equal, checked on Node 26), so it is not a reference for the unequal cases; content comparison for these objects is Bun behavior from #15195. It does require identical instances to compare equal, which Bun currently violates; the new row in the `node:assert` matrix pins that for `assert.deepEqual`, `assert.deepStrictEqual` and `util.isDeepStrictEqual`.

All entry points share this branch (`Bun.deepEquals` in both modes, `toEqual`, `toStrictEqual`, `toContainEqual`, `assert.deepEqual`/`deepStrictEqual`, `util.isDeepStrictEqual`), so the one change covers all of them. The `Headers` branch below it has the same shape of bug for `set-cookie`; that is fixed separately in #37881, and this PR does not touch it.

## Verification

New cases in `test/js/bun/test/expect.test.js` (3 tests), `test/js/bun/bun-object/deep-equals.test.ts` (8 per strict mode) and `test/js/node/assert/deep-equal.test.ts` (1 matrix row, 3 tests) fail on the released build (`USE_SYSTEM_BUN=1`, 3 + 16 + 3 failures, nothing else in those files fails) and pass with the debug build. They cover: repeated names (equal, differing value, swapped values, subset, the same-size false positive above), different paths that build the same entries (`append`, sequence init, parsing, `url.searchParams` including after `url.search` is reassigned), `sort()`, empty values (`a` vs `a=`), and that own properties are still compared once the entries match. The full `expect.test.js` (418 pass), `deep-equal.test.ts` (308 pass), `deep-equals.test.ts`, `test/js/web/url/url.test.ts` and the vendored `test-whatwg-url-custom-searchparams*.js` tests pass with the debug build.

</details>
