### PR TITLE
bake: retract a file's bundling failure when the file is deleted

### DIFF
--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -1555,6 +1555,19 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             );
         }
 
+        // Nothing will `receive_chunk` this node again to clear a failure from
+        // its last bundle, so retract it here; `index_failures` publishes the
+        // removal at the end of this bundle.
+        if self.bundled_files.values()[index.get() as usize].failed {
+            self.bundled_files.values_mut()[index.get() as usize].failed = false;
+            let owner = serialized_failure::OwnerPacked::new(SIDE, index.get());
+            let kv = self.dev_bundling_failures().fetch_swap_remove(&owner);
+            let kv = kv.unwrap_or_else(|| {
+                bun_core::Output::panic(format_args!("Missing failure in IncrementalGraph"))
+            });
+            self.dev_incremental_result().failures_removed.push(kv.1);
+        }
+
         // Bust the resolution cache of the dir containing this file.
         let dirname = bun_paths::dirname(abs_path).unwrap_or(abs_path);
         let _ = bv2.transpiler.resolver.bust_dir_cache(dirname);

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -274,6 +274,101 @@ devTest("deleting imported file shows error then recovers", {
     });
   },
 });
+// Deleting a file whose last bundle failed used to leave that failure in
+// dev.bundling_failures: the overlay kept showing it next to the importer's new
+// resolution error and every later "Build Failed" page listed it again.
+devTest("deleting a file that failed to bundle retracts its failure", {
+  skip: [
+    "win32", // unlinkSync is having weird behavior
+  ],
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import { value } from "./other";
+      console.log(value);
+    `,
+    "other.ts": `
+      export const value = 123;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage(123);
+    await dev.write("other.ts", `export const value = ;`, {
+      errors: ["other.ts:1:22: error: Unexpected ;"],
+    });
+    // The errors packet for this rebuild has to retract other.ts's failure
+    // along with adding index.ts's resolution failure.
+    await dev.delete("other.ts", {
+      errors: ['index.ts:1:23: error: Could not resolve: "./other"'],
+    });
+    // A fresh page load lists every failure the dev server still tracks.
+    await c.hardReload({
+      errors: ['index.ts:1:23: error: Could not resolve: "./other"'],
+    });
+    // Dropping the import fixes the last remaining failure, so the error page
+    // reloads into the working page. A stale other.ts entry would keep it
+    // stuck on the error page.
+    await c.expectReload(async () => {
+      await dev.write("index.ts", `console.log("without other");`);
+    });
+    await c.expectMessage("without other");
+    // Recreating the file reuses its node in the incremental graph, which no
+    // longer owns a failure.
+    await dev.write(
+      "index.ts",
+      `
+        import { value } from "./other";
+        console.log(value);
+      `,
+      { errors: ['index.ts:1:23: error: Could not resolve: "./other"'] },
+    );
+    await c.expectReload(async () => {
+      await dev.write("other.ts", `export const value = 456;`);
+    });
+    await c.expectMessage(456);
+  },
+});
+// Same as above for a file that only the server graph knows about.
+devTest("deleting a server file that failed to bundle retracts its failure", {
+  skip: [
+    "win32", // unlinkSync is having weird behavior
+  ],
+  framework: minimalFramework,
+  files: {
+    "routes/index.ts": `
+      import { value } from '../db';
+      export default function (req, meta) {
+        return new Response('value: ' + value);
+      }
+    `,
+    "db.ts": `export const value = 123;`,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("value: 123");
+    await dev.write("db.ts", `export const value = ;`, { errors: null });
+    {
+      // This client sits on the "Build Failed" page, which only listens for
+      // failures being added and removed.
+      await using c = await dev.client("/", {
+        errors: ["db.ts:1:22: error: Unexpected ;"],
+      });
+      await dev.delete("db.ts", {
+        errors: [`routes/index.ts:1:23: error: Could not resolve: "../db"`],
+      });
+      await using fresh = await dev.client("/", {
+        errors: [`routes/index.ts:1:23: error: Could not resolve: "../db"`],
+      });
+    }
+    // Recreating the file reuses its node in the incremental graph, which no
+    // longer owns a failure.
+    await dev.write("db.ts", `export const value = 456;`);
+    await dev.fetch("/").equals("value: 456");
+  },
+});
 // Regression test: DirectoryWatchStore.Dep.source_file_path borrows the key
 // string from IncrementalGraph.bundled_files. When a client-component boundary
 // is demoted (its "use client" directive is removed) the server graph calls


### PR DESCRIPTION
### Problem
- Dev server: break a file so it fails to bundle (`other.ts:1:22: error: Unexpected ;`), then delete it. The importer's `Could not resolve: "./other"` error is added, but the deleted file's error is never retracted: the overlay and every fresh "Build Failed" page list both, and the error page never reloads once the importer drops the import. Reproduces on the released build.
- Cause: deleting a node disconnects it but leaves its failure recorded and publishes no removal. A failure is only cleared when the file is bundled again, and a deleted file never is, so the entry lives for the rest of the process.
- Predates the Rust port; the Zig code did the same.

### Fix
- Deleting a node now does what a rebundle does for a node that stops failing: clear its failed flag, drop its entry from the failure map, and queue that entry as a removal.
- Property to check: the flag and the map entry move together. Other paths look the entry up whenever the flag is set, so clearing one alone leaks the entry or panics when the file is recreated.
- The removal is queued mid-bundle, as a replaced failure already is, so it goes out in the same errors packet as the importers' new failures. The node is kept, as before, so a recreated file reuses it.
- Deletion counterpart of #37862 (same omission for demoted client components); the changes do not overlap.
- Verification: two new dev-server tests, client graph and server graph, fail on the released build at the delete step with the deleted file's error still listed, and pass with the change on a debug/ASAN build.

### Background
- The dev server (bake) keeps an incremental graph per side, client and server: one node per bundled file plus importer edges, so an edit re-bundles only that file and its importers.
- A node carries a `failed` flag; the failure text lives in one process-wide map keyed by (side, node index), which overlays and fresh "Build Failed" pages are rendered from.
- After each bundle the dev server sends one errors packet of failures added and removed. The overlay and error page update from those packets; the error page reloads only when no failure is left.

<details>
<summary>Original description</summary>

### Problem

The remaining `Batch::from(..)` sites that hand an intrusive task to a thread pool projected the `*mut Task` out of a reference to the object instead of out of the object's pointer:

| site | shape |
| --- | --- |
| `PatchTask::schedule(&mut self, ..)` (src/install/patch_install.rs) | `Batch::from(&raw mut self.task)` |
| `AsyncHTTP::schedule(&mut self, ..)` and `preconnect` (src/http/AsyncHTTP.rs) | `Batch::from(addr_of_mut!(self.task))`, `addr_of_mut!(async_http.task)` with `async_http: &mut AsyncHTTP` |
| isolated-install `Installer::start_task` (src/install/isolated_install/Installer.rs) | `Batch::from(&raw mut task.task)` with `task = &mut self.tasks[i]` |
| `ThreadPool::each` / `each_ptr` (src/threading/ThreadPool.rs) | `Batch::from(addr_of_mut!(runner_task.task))` from `tasks.iter_mut()` |
| `compute_data_for_source_map` (src/bundler/LinkerContext.rs) | `Batch::from(&raw mut line_offset.thread_task)` from `iter_mut()`, twice |
| `generate_chunks_in_parallel` (src/bundler/linker_context/generateChunksInParallel.rs) | `push(..); Batch::from(&raw mut tasks.last_mut().unwrap().task)` per element, four loops |

In every case the pool calls back with exactly that pointer and the callback recovers the object from it with container-of and then uses the rest of the object: `PatchTask::from_task_ptr` (`run_from_thread_pool`), `from_field_ptr!(Task, ..)` (isolated install, which also writes `result` and links `next`), `from_field_ptr!(RunnerTask, ..)` (`each`, reads `i` and `ctx`), `from_field_ptr!(SourceMapDataTask, ..)`, `from_field_ptr!(PrepareCssAstTask, ..)` and `pending_part_range_prologue`. For `AsyncHTTP` it happens before the task is even queued: `HTTPThread::schedule` container-ofs every task in the batch on the calling thread, links the object into `queued_tasks` through the result, and `start_queued_task` later `ptr::read`s the whole struct through it. `bun_core::container_of` documents that this requires a pointer derived from the object's pointer ("a `&mut field` reborrow does not suffice"), and `WorkPool::schedule_owned` projects out of the `Box::into_raw` pointer for that reason. The other `Batch::from` sites in the tree already do this, either inline (`&raw mut (*parse_task).task`, `addr_of_mut!((*task).task)`) or by passing a pointer a helper projected that way (`&raw mut (*task).threadpool_task` in the package manager's enqueue helpers); `WorkPool::schedule` forwards its argument, and the one site that narrows through an accessor is #37865's.

The reference-based spelling does not meet that contract. rustc retags the result of `&raw mut <place>` unless the place is based on a raw pointer, and under Stacked Borrows that retag covers the projected field only, so the callback's first sibling-field access is out of range. The `push` + `last_mut()` loops in `generate_chunks_in_parallel` have a second problem: every `last_mut()` goes through `Vec::deref_mut`, which reborrows the whole buffer and invalidates the pointers already in the batch, so `Batch::push` itself trips when it links the next task onto the previous one (projecting through `ptr::from_mut(last_mut())` is not enough there; the batch has to be built after the Vec is filled). Reduction below. Tree Borrows, which is what `bun run rust:miri` checks, accepts all of these shapes, none of the crates involved are in its crate set, and no crash is known or expected from today's codegen: the addresses are right, and this only matters to the aliasing model. It is the same contract violation as #37768 (the `WorkPool::schedule` population, which deliberately leaves `Batch::from` out of its lint) and #37865 (`NewTaskQueue::push`, the one `Batch::from` site that narrows through an accessor; not touched here), in the one spelling neither of them covers.

<details>
<summary>Reduction under Miri (miri 0.1.0 9f36de775b), one mode per shape</summary>

`ref` is the `&raw mut task.task` / `&raw mut self.task` shape, `iter_mut` the `addr_of_mut!(runner_task.task)` shape, `last_mut` the chunk loops; `last_mut_from_mut` is the chunk loop with only the projection fixed; `from_mut`, `as_mut_ptr` and `raw` are the three shapes this PR converts to. The pool side is `container_of` followed by a sibling-field read and write, run on another thread. The trailing comments on the `-->` lines name the statement at each location.

```
=== Stacked Borrows: ref
error: Undefined Behavior: attempting a read access using <2295> at alloc929[0x10], but that tag does not exist in the borrow stack for this location
  --> src/main.rs:72:25                                   let i = (*job).i;          // the callback
help: <2295> was created by a SharedReadWrite retag at offsets [0x8..0x10]
  --> src/main.rs:87:16                                   batch.push(&raw mut task.task);
=== Stacked Borrows: iter_mut
error: Undefined Behavior: attempting a read access using <2079> at alloc842[0x10], but that tag does not exist in the borrow stack for this location
help: <2079> was created by a SharedReadWrite retag at offsets [0x8..0x10]
  --> src/main.rs:123:28                                  batch.push(std::ptr::addr_of_mut!(j.task));
=== Stacked Borrows: last_mut
error: Undefined Behavior: attempting a write access using <1941> at alloc836[0x8], but that tag does not exist in the borrow stack for this location
  --> src/main.rs:48:22                                   (*self.tail).node.next = task   // Batch::push, calling thread
help: <1941> was created by a SharedReadWrite retag at offsets [0x8..0x10]
help: <1941> was later invalidated at offsets [0x0..0x30] by a Unique retag
  --> src/main.rs:133:41                                  jobs.last_mut()                 // next iteration
=== Stacked Borrows: last_mut_from_mut
error: Undefined Behavior: attempting a write access using <1958> at alloc840[0x8], but that tag does not exist in the borrow stack for this location
  --> src/main.rs:48:22                                   (*self.tail).node.next = task
help: <1958> was created by a SharedReadWrite retag at offsets [0x0..0x18]
help: <1958> was later invalidated at offsets [0x0..0x30] by a Unique retag
  --> src/main.rs:135:48                                  jobs.last_mut()
=== Stacked Borrows: from_mut
from_mut: ok [1, 2, 3]
=== Stacked Borrows: as_mut_ptr
as_mut_ptr: ok [1, 2, 3]
=== Stacked Borrows: raw
raw: ok [1, 2, 3]

Tree Borrows (-Zmiri-tree-borrows): all seven modes ok
```

</details>

### Fix

Same pointer values as before at every site, so no behaviour change; what changes is which pointer they are projected from.

* `PatchTask::schedule` becomes `unsafe fn schedule(this: *mut Self, batch)` and projects out of `this`. Its only caller, `flush_patch_task_queue`, already holds the `*mut PatchTask` it popped from the fifo and now reads the callback kind through it instead of forming a `&mut PatchTask`.
* `AsyncHTTP::schedule` keeps `&mut self` (its callers, `send_sync`, `NetworkTask`, `FetchTasklet`, S3, hold the object by reference or value, and `HTTPThread::schedule` recovers an `AsyncHTTP`, which a `&mut AsyncHTTP` does cover) and projects through `ptr::from_mut(self)`, a reborrow of the whole object. `preconnect` goes through it instead of projecting by hand, so the http crate has one projection site.
* `Installer::start_task` and `compute_data_for_source_map` project through `ptr::from_mut` of the slot they just wrote.
* `ThreadPool::each_impl` and the two batches in `generate_chunks_in_parallel` fill their `Vec` first and then build the batch in one loop from `as_mut_ptr().add(i)`; the three copies of the `last_mut()` push in the chunk loop collapse into that one loop, and the with-capacity comments that justified taking pointers mid-fill go away with the pattern.

### Verification

`test/internal/source-lints/thread-pool-batch-projection.test.ts` bans `&raw mut` / `&raw const` / `addr_of_mut!` / `addr_of!` of a field path rooted at a binding as the argument of any `Batch::from(` call (however the type is spelled, including the `PoolBatch` / `ThreadPoolBatch` aliases), with a self-test over the spellings of every site in the tree and the converted shapes. Against main it reports exactly the eleven sites above:

```
src/bundler/linker_context/generateChunksInParallel.rs:117, :203, :226, :248
src/bundler/LinkerContext.rs:589, :590
src/http/AsyncHTTP.rs:391, :530
src/install/isolated_install/Installer.rs:171
src/install/patch_install.rs:711
src/threading/ThreadPool.rs:560
```

and passes on this branch with no allowlist. It is deliberately disjoint from #37865's lint, which bans the reference / accessor / `from_mut` shapes in the same argument and reports only `src/install/PackageInstall.rs:475` both on main and on this branch (checked by running it here), so the two can land in either order without sharing an allowlist; #37768's lint covers `WorkPool::schedule`, and both of those also report nothing on this branch.

The converted paths are exercised by existing tests, all run against the debug build of this branch: `test/cli/install/bun-install-patch.test.ts` (18 pass) and `bun-patch.test.ts` (31 pass) for `PatchTask::schedule` and the registry downloads that go through `NetworkTask` → `AsyncHTTP::schedule`; `test/cli/install/isolated-install.test.ts` (62 pass) for `start_task`; `test/cli/install/bun-audit.test.ts` (17 pass) for the `send_sync` path; `test/js/web/fetch/fetch-redirect.test.ts` (30 pass) and `client-fetch.test.ts` (34 pass) for the fetch path; `test/bundler/bundler_html.test.ts` (22 pass; JS, CSS and HTML part ranges plus the CSS AST batch), `test/bundler/css/css-modules.test.ts` (6 pass), `test/bundler/bundler_splitting.test.ts` (11 pass; many chunks through `each_ptr`), `test/bundler/bun-build-api.test.ts` (52 pass; source maps) and `test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts` (22 pass). `fetch.preconnect` was checked directly with a local listener (the preconnect opens the connection before the first `fetch`); `test/js/web/fetch/fetch-preconnect.test.ts` itself cannot run in this container because `localhost` resolves to `::1` first here, which makes it fail identically on the released binary, and that is tracked separately. `cargo clippy --no-deps` on `bun_threading`, `bun_http`, `bun_install` and `bun_bundler` is clean and `cargo fmt` is clean.


</details>
