### PR TITLE
http: classify idle connections by request message state, not response end

### DIFF
--- a/packages/bun-uws/src/App.h
+++ b/packages/bun-uws/src/App.h
@@ -397,9 +397,10 @@ public:
         return std::move(*this);
     }
 
-    /** Closes all connections connected to this server which are not sending a request or waiting for a response. Does not close the listen socket.
+    /** Closes all connections connected to this server which are idle (HttpResponseData::isIdle: between request messages, with no response in flight
+     * or queued). Does not close the listen socket.
      * With closeWhenIdle set, connections that are busy right now are marked to close as soon as their in-flight work completes (graceful shutdown);
-     * upgraded WebSockets and CONNECT/Upgrade tunnels never become idle, so they are left alone either way.
+     * upgraded WebSockets and node:http CONNECT/Upgrade tunnels never become idle, so they are left alone either way.
      * Returns the number of connections closed. */
     size_t closeIdle(bool closeWhenIdle = false) {
         auto *group = httpContext->getSocketGroup();
@@ -410,7 +411,7 @@ public:
              * adopted into its own group), so the ext block is an HttpResponseData. */
             auto *data = (HttpResponseData<SSL> *) ((AsyncSocket<SSL> *) s)->getAsyncSocketData();
             struct us_socket_t *next = s->next;
-            if (data->isIdle) {
+            if (data->isIdle()) {
                 us_socket_close(s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, 0);
                 closed++;
             } else if (closeWhenIdle) {

--- a/packages/bun-uws/src/AsyncSocketData.h
+++ b/packages/bun-uws/src/AsyncSocketData.h
@@ -149,7 +149,6 @@ struct AsyncSocketData {
 
     /* Or empty */
     AsyncSocketData() = default;
-    bool isIdle = false;
     bool isAuthorized = false; // per-socket TLS authorization status
     bool peerCertVerified = false;
     const char *peerCertVerifyErrorCode = nullptr;

--- a/packages/bun-uws/src/HttpContext.h
+++ b/packages/bun-uws/src/HttpContext.h
@@ -334,11 +334,6 @@ private:
         httpContextData->flags.isParsingHttp = true;
         struct us_socket_t *prevParsingSocket = httpContextData->parsingSocket;
         httpContextData->parsingSocket = s;
-        httpResponseData->isIdle = false;
-
-        /* node:http compat: maintain the headers/request timeout window (see
-         * the requestHandler/dataHandler hooks and the post-parse check). */
-        const bool trackNodeHttpTimings = IsNodeHttp && !httpResponseData->isConnectRequest;
 
         // clients need to know the cursor after http parse, not servers!
         // how far did we read then? we need to know to continue with websocket parsing data? or?
@@ -377,17 +372,20 @@ private:
                 }
             }
 
-            /* node:http compat: the request head has been fully parsed, so only
-             * requestTimeout (not headersTimeout) applies from here on. A
-             * pipelined request whose head sits mid-buffer never went through
-             * onData with an idle connection, so open its window here too. */
+            /* A request message is being received until its body completes (the
+             * dataHandler's fin below), whether or not a response finishes before
+             * then. node:http compat: the head has been fully parsed, so only
+             * requestTimeout (not headersTimeout) applies from here on; a
+             * pipelined request whose head sits mid-buffer never went through the
+             * post-parse check below, so its window opens here. */
             if constexpr (IsNodeHttp) {
                 auto *nodeHttpResponseData = (HttpResponseData<SSL, true> *) httpResponseData;
-                if (nodeHttpResponseData->lastMessageStartMs == 0) {
+                if (nodeHttpResponseData->betweenRequests) {
                     nodeHttpResponseData->lastMessageStartMs = nodeCompatMonotonicMs();
                 }
                 nodeHttpResponseData->headersCompleted = true;
             }
+            httpResponseData->betweenRequests = false;
 
             /* Are we not ready for another request yet? Terminate the connection.
              * Important for denying async pipelining until, if ever, we want to support it.
@@ -523,15 +521,14 @@ private:
                 switchToTunnelAfterThisChunk = fin && !httpResponseData->isConnectRequest && (httpResponseData->state & HttpResponseData<SSL>::HTTP_NODE_TUNNEL_AFTER_BODY);
             }
 
-            /* node:http compat: the request message (head + body) has been fully
-             * received - the connection is idle for the headers/request timeout
-             * sweeps until the next message starts. */
-            if constexpr (IsNodeHttp) {
-                if (fin && !httpResponseData->isConnectRequest) {
-                    auto *nodeHttpResponseData = (HttpResponseData<SSL, true> *) httpResponseData;
-                    nodeHttpResponseData->lastMessageStartMs = 0;
-                    nodeHttpResponseData->headersCompleted = false;
-                }
+            /* The request message (head + body) has been fully received: the
+             * connection is between requests until the next one starts arriving
+             * (HttpResponseData::isIdle() for the closeIdle sweeps and
+             * HTTP_CLOSE_WHEN_IDLE; the node:http headers/request timeout sweep).
+             * Set before the chunk is delivered so a response completing from
+             * within the delivery already finds the connection idle. */
+            if (fin) {
+                httpResponseData->betweenRequests = true;
             }
 
             if (httpResponseData->isConnectRequest && httpResponseData->socketData && httpContextData->onSocketData) {
@@ -622,14 +619,16 @@ private:
             /* We don't want open sockets to keep the event loop alive between HTTP requests */
             us_socket_unref((us_socket_t *) returnedData);
 
-            /* node:http compat: a partial request head was left in the fallback
-             * buffer by this read (either fresh bytes on an idle connection or a
-             * pipelined request after the previous message completed) - its
-             * headers timeout window opens now. */
-            if constexpr (IsNodeHttp) {
-                auto *nodeHttpResponseData = (HttpResponseData<SSL, true> *) httpResponseData;
-                if (trackNodeHttpTimings && nodeHttpResponseData->lastMessageStartMs == 0
-                    && httpResponseData->hasBufferedPartialRequestHeaders()) {
+            /* A partial request head was left in the fallback buffer by this read
+             * (either fresh bytes on an idle connection or a pipelined request
+             * behind the message that just completed): the next message has
+             * started arriving, so the connection is not idle, and must not be
+             * closed as such by the gate below or by a closeIdle() sweep.
+             * node:http compat: its headers timeout window opens now. */
+            if (httpResponseData->betweenRequests && httpResponseData->hasBufferedPartialRequestHeaders()) {
+                httpResponseData->betweenRequests = false;
+                if constexpr (IsNodeHttp) {
+                    auto *nodeHttpResponseData = (HttpResponseData<SSL, true> *) httpResponseData;
                     nodeHttpResponseData->lastMessageStartMs = nodeCompatMonotonicMs();
                     nodeHttpResponseData->headersCompleted = false;
                 }

--- a/packages/bun-uws/src/HttpParser.h
+++ b/packages/bun-uws/src/HttpParser.h
@@ -1405,7 +1405,13 @@ struct HttpResponseData;
                     consumedTotal += consumed;
                 }
             } else if (contentLengthStringLen) {
-                if constexpr (!ConsumeMinimally) {
+                /* In the ConsumeMinimally (fallback buffer) pass the body bytes are not
+                 * in this buffer: consumePostPadded streams them from the caller's data
+                 * afterwards, but only while remainingStreamingBytes is non-zero. So a
+                 * Content-Length: 0 message must be completed here in either pass (as
+                 * the no-body branch below always is), or it never gets its fin chunk
+                 * and the connection never counts as between requests. */
+                if (!ConsumeMinimally || remainingStreamingBytes == 0) {
                     unsigned int emittable = (unsigned int) std::min<uint64_t>(remainingStreamingBytes, length);
                     void *returnedUser = dataHandler(user, std::string_view(data, emittable), emittable == remainingStreamingBytes);
                     remainingStreamingBytes -= emittable;

--- a/packages/bun-uws/src/HttpResponse.h
+++ b/packages/bun-uws/src/HttpResponse.h
@@ -203,7 +203,7 @@ public:
             } else {
                 Super::write("0\r\n\r\n", 5);
             }
-            httpResponseData->markDone(this);
+            httpResponseData->markDone();
 
             /* We need to check if we should close this socket here now */
             if (!Super::isCorked()) {
@@ -272,7 +272,7 @@ public:
 
             /* Remove onAborted function if we reach the end */
             if (httpResponseData->offset == totalSize) {
-                httpResponseData->markDone(this);
+                httpResponseData->markDone();
 
                 /* We need to check if we should close this socket here now */
                 if (!Super::isCorked()) {

--- a/packages/bun-uws/src/HttpResponseData.h
+++ b/packages/bun-uws/src/HttpResponseData.h
@@ -44,7 +44,7 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     using OnDataCallback = void (*)(uWS::HttpResponse<SSL>* response, const char* chunk, size_t chunk_length, bool, void*);
 
     /* When we are done with a response we mark it like so */
-    void markDone(uWS::HttpResponse<SSL> *uwsRes) {
+    void markDone() {
         onAborted = nullptr;
         /* Also remove onWritable so that we do not emit when draining behind the scenes. */
         onWritable = nullptr;
@@ -57,11 +57,6 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
 
         /* We are done with this request */
         this->state &= ~HttpResponseData<SSL>::HTTP_RESPONSE_PENDING;
-
-        HttpResponseData<SSL> *httpResponseData = uwsRes->getHttpResponseData();
-        /* A queued pipelined response (node:http) still owes output on this
-         * connection, so it is not idle between the responses. */
-        httpResponseData->isIdle = httpResponseData->nodeHttpQueuedPipelinedCount == 0;
     }
 
     /* Caller of onWritable. It is possible onWritable calls markDone so we need to borrow it. */
@@ -166,9 +161,6 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
      * keep-alive socket; only the connection-scoped bits are carried over. */
     void resetResponseState() {
         state = (state & HTTP_CONNECTION_SCOPED) | HTTP_RESPONSE_PENDING;
-        /* A response is in flight again (a new request dispatched, or a queued
-         * pipelined response activated), so the connection is not idle. */
-        this->isIdle = false;
     }
 
     /* Set or clear a flag from a runtime bool. */
@@ -208,6 +200,13 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
     /* The parser writes this through a bool& (getHeaders / consumePostPadded),
      * so it cannot live in `state`. */
     bool isConnectRequest = false;
+    /* No request message is being received: set when a message has been fully
+     * received (head and body), cleared as soon as the next one starts arriving
+     * (its head is parsed, or a partial head is left buffered). Starts out false:
+     * like Node's ConnectionsList (which registers the parser as active when the
+     * connection is set up), a connection that has not sent its first request
+     * yet is waiting on headersTimeout, not idle. Maintained by HttpContext. */
+    bool betweenRequests = false;
 
     /* Chunk-extension bytes consumed on the current chunk-size line, reset per
      * chunk (llhttp's on_chunk_header); capped at MAX_CHUNK_EXTENSION_SIZE for
@@ -221,12 +220,27 @@ struct HttpResponseData : AsyncSocketData<SSL>, HttpParser {
      * flood). */
     uint32_t nodeHttpQueuedPipelinedCount = 0;
 
+    /* An idle keep-alive connection, as Node's server.closeIdleConnections()
+     * defines it (ConnectionsList::idle() plus its _httpMessage.finished check):
+     * between request messages, with the current response (if any) completed and
+     * no pipelined response queued behind it. This is what App::closeIdle() and
+     * HTTP_CLOSE_WHEN_IDLE act on. A connection that became a CONNECT/Upgrade
+     * tunnel receives no further request messages, so only its response state
+     * counts: a node:http tunnel keeps the response it was created from pending
+     * for as long as it lives (never idle), whereas a Bun.serve CONNECT that has
+     * been answered has nothing left to do on the connection. */
+    bool isIdle() const {
+        return (betweenRequests || isConnectRequest)
+            && !(state & HTTP_RESPONSE_PENDING)
+            && nodeHttpQueuedPipelinedCount == 0;
+    }
+
     /* Whether the connection should be torn down once the in-flight response (if
      * any) has completed and all buffered outgoing data has been flushed. */
     bool shouldCloseConnection() const {
         return (state & HTTP_CONNECTION_CLOSE)
             || ((state & HTTP_NODE_RECEIVED_FIN) && nodeHttpQueuedPipelinedCount == 0)
-            || ((state & HTTP_CLOSE_WHEN_IDLE) && this->isIdle);
+            || ((state & HTTP_CLOSE_WHEN_IDLE) && isIdle());
     }
 
 #ifdef UWS_WITH_PROXY
@@ -249,10 +263,11 @@ template <bool SSL>
 struct HttpResponseData<SSL, true> : HttpResponseData<SSL, false> {
     /* lastMessageStartMs: when the request currently being received started
      * arriving (or when the connection was accepted, before its first
-     * request); 0 once the message has been fully received (idle).
+     * request); only meaningful while !betweenRequests.
      * headersCompleted: whether that request's head has been fully parsed.
-     * Mirrors last_message_start_/headers_completed_ in Node's http parser
-     * ConnectionsList, which back server.headersTimeout/requestTimeout. */
+     * Together with betweenRequests this mirrors last_message_start_ /
+     * headers_completed_ in Node's http parser ConnectionsList, which back
+     * server.headersTimeout/requestTimeout. */
     uint64_t lastMessageStartMs = 0;
     /* Trailer fields set via response.addTrailers(), pre-rendered as
      * "name: value\r\n" lines. Written between the terminating 0 chunk and the

--- a/packages/bun-uws/src/WebSocketData.h
+++ b/packages/bun-uws/src/WebSocketData.h
@@ -70,8 +70,6 @@ public:
                 inflationStream = new InflationStream(compressOptions);
             }
         }
-        // never close websocket sockets when closing idle connections
-        this->isIdle = false;
         this->socketData = socketData;
         this->onSocketClosed = onSocketClosed;
     }

--- a/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
+++ b/src/jsc/bindings/node/JSNodeHTTPServerSocket.cpp
@@ -276,11 +276,12 @@ static bool isRequestTimedOutImpl(us_socket_t* socket, uint64_t headersTimeoutMs
         // like Node freeing the parser for upgraded connections.
         return false;
     }
-    uint64_t start = httpResponseData->lastMessageStartMs;
-    if (start == 0) {
-        // Idle: no request message is currently being received.
+    if (httpResponseData->betweenRequests) {
+        // No request message is currently being received (Node's
+        // ConnectionsList::idle() set); lastMessageStartMs is stale.
         return false;
     }
+    uint64_t start = httpResponseData->lastMessageStartMs;
     uint64_t now = uWS::nodeCompatMonotonicMs();
     uint64_t elapsed = now > start ? now - start : 0;
     if (headersTimeoutMs > 0 && !httpResponseData->headersCompleted && elapsed > headersTimeoutMs) {

--- a/src/uws_sys/libuwsockets.cpp
+++ b/src/uws_sys/libuwsockets.cpp
@@ -1337,7 +1337,7 @@ extern "C"
       auto *data = uwsRes->getHttpResponseData();
       data->offset = offset;
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
-      data->markDone(uwsRes);
+      data->markDone();
       uwsRes->resetTimeout();
     }
     else
@@ -1346,7 +1346,7 @@ extern "C"
       auto *data = uwsRes->getHttpResponseData();
       data->offset = offset;
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
-      data->markDone(uwsRes);
+      data->markDone();
       uwsRes->resetTimeout();
     }
   }
@@ -1418,7 +1418,7 @@ extern "C"
         uwsRes->AsyncSocket<true>::write("\r\n", 2);
       }
       data->state |= uWS::HttpResponseData<true>::HTTP_END_CALLED;
-      data->markDone(uwsRes);
+      data->markDone();
       uwsRes->resetTimeout();
       /* No close gate here: callers (FileResponseStream::finish,
        * DevServer/HTMLBundle error paths) keep using the response after this
@@ -1446,7 +1446,7 @@ extern "C"
         uwsRes->AsyncSocket<false>::write("\r\n", 2);
       }
       data->state |= uWS::HttpResponseData<false>::HTTP_END_CALLED;
-      data->markDone(uwsRes);
+      data->markDone();
       uwsRes->resetTimeout();
       /* No close gate here; see the SSL arm above. */
     }

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -1157,6 +1157,77 @@ describe.concurrent("server.stop() drain promise counts open connections", () =>
     });
   });
 
+  test("a connection whose response finished while its request body is still arriving is not idle", async () => {
+    // "Sending a request" includes the body: responding early (without reading
+    // the upload) does not make the connection idle until the upload has been
+    // received. Closing it mid-upload would also reset the connection while the
+    // client is still writing, which can discard the response on the client's
+    // side. Once the body has arrived the connection is idle again, which is
+    // what the close-when-idle mark left by a graceful stop() acts on.
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const net = require("net");
+          const server = Bun.serve({
+            port: 0,
+            hostname: "127.0.0.1",
+            idleTimeout: 255,
+            fetch: () => new Response("ok"),
+          });
+          function dial() {
+            const c = net.connect(server.port, "127.0.0.1");
+            const state = { c, buf: "", closed: false };
+            c.on("data", d => (state.buf += d));
+            c.on("close", () => (state.closed = true));
+            c.on("error", () => {});
+            return new Promise((resolve, reject) => {
+              c.on("connect", () => resolve(state));
+              c.on("error", reject);
+            });
+          }
+          const countOks = s => (s.buf.match(/\\r\\nok/g) || []).length;
+          const tick = () => new Promise(r => setImmediate(r));
+          // Two uploads answered after 3 of their 10 body bytes.
+          const a = await dial();
+          a.c.write("POST /upload HTTP/1.1\\r\\nHost: x\\r\\nContent-Length: 10\\r\\n\\r\\nabc");
+          while (countOks(a) < 1) await tick();
+          const b = await dial();
+          b.c.write("POST /upload HTTP/1.1\\r\\nHost: x\\r\\nContent-Length: 10\\r\\n\\r\\nabc");
+          while (countOks(b) < 1) await tick();
+
+          const closedWhileUploading = server.closeIdleConnections();
+
+          // a finishes its upload and reuses the connection: the rest of the body
+          // is consumed as body and the request behind it is served.
+          a.c.write("defghijGET /next HTTP/1.1\\r\\nHost: x\\r\\n\\r\\n");
+          while (countOks(a) < 2 && !a.closed) await tick();
+          const aServedAfterSweep = countOks(a) === 2;
+
+          // a is idle now and is closed by the graceful stop() itself; b is still
+          // uploading, so it is only marked, and closes once its body has arrived
+          // (the client never hangs up), which is what lets the drain resolve.
+          const stopped = server.stop(false);
+          b.c.write("defghij");
+          await stopped;
+          const until = Date.now() + 2000;
+          while (!(a.closed && b.closed) && Date.now() < until) await tick();
+          console.log(JSON.stringify({ closedWhileUploading, aServedAfterSweep, aClosed: a.closed, bClosed: b.closed }));
+        `,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, out: JSON.parse(stdout.trim() || "null"), exitCode }).toEqual({
+      stderr: "",
+      out: { closedWhileUploading: 0, aServedAfterSweep: true, aClosed: true, bClosed: true },
+      exitCode: 0,
+    });
+  });
+
   test("websocket-only server: a second stop() returns the still-pending promise", async () => {
     // After upgrade() the filter fires -1, so a websocket-only server has
     // active_connection_count == 0 and only the has_active_web_sockets() term

--- a/test/js/node/http/node-http-server-timeouts.test.ts
+++ b/test/js/node/http/node-http-server-timeouts.test.ts
@@ -217,4 +217,66 @@ describe("node:http server timeout enforcement", () => {
       server.close();
     }
   });
+
+  test("requestTimeout does not fire on an idle connection after a Content-Length: 0 request whose head arrived in two reads", async () => {
+    // Completing a Content-Length: 0 head out of the bytes buffered from an
+    // earlier read takes a different parser path than a single-read request;
+    // it used to leave the request's timeout window open, so the next sweep
+    // answered 408 on a connection that was idle. The second connection stalls
+    // mid-body on purpose: once the sweep has reaped it, the same sweep has
+    // also looked at the first connection, which by then had been (wrongly)
+    // open for longer, so a request on it proves it survived.
+    const server = http.createServer({ connectionsCheckingInterval: 25, keepAliveTimeout: 0 }, (req, res) => {
+      req.resume();
+      res.end("ok");
+    });
+    server.headersTimeout = 100;
+    server.requestTimeout = 100;
+    const port = await listen(server);
+    const idle = net.connect(port, "127.0.0.1");
+    let stalled: net.Socket | undefined;
+    try {
+      let received = "";
+      const { promise: idleClosed, resolve: onIdleClosed } = Promise.withResolvers<string>();
+      idle.setNoDelay(true);
+      idle.on("error", () => {});
+      idle.on("close", () => onIdleClosed("closed by the server"));
+      idle.on("data", chunk => {
+        received += chunk.toString("latin1");
+      });
+      const responses = (count: number) =>
+        new Promise<string>(resolve => {
+          const check = () => {
+            if ((received.match(/\r\n\r\nok/g) ?? []).length >= count) {
+              idle.off("data", check);
+              resolve(`${count} responses`);
+            }
+          };
+          idle.on("data", check);
+          check();
+        });
+      await once(idle, "connect");
+      idle.write("GET /1 HTTP/1.1\r\nHost: a\r\n\r\nPOST /2 HTTP/1.1\r\nHost: a\r\nContent-Length: 0\r\n");
+      await responses(1);
+      idle.write("\r\n");
+      await responses(2);
+
+      stalled = net.connect(port, "127.0.0.1");
+      stalled.setNoDelay(true);
+      stalled.on("error", () => {});
+      stalled.resume();
+      const stalledClosed = once(stalled, "close");
+      await once(stalled, "connect");
+      stalled.write("POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 50\r\n\r\nab");
+      await stalledClosed;
+
+      idle.write("GET /3 HTTP/1.1\r\nHost: a\r\n\r\n");
+      expect(await Promise.race([responses(3), idleClosed])).toBe("3 responses");
+    } finally {
+      idle.destroy();
+      stalled?.destroy();
+      server.closeAllConnections();
+      server.close();
+    }
+  });
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -23,7 +23,7 @@ import http, {
   validateHeaderValue,
 } from "node:http";
 import https, { createServer as createHttpsServer } from "node:https";
-import type { AddressInfo } from "node:net";
+import type { AddressInfo, Socket } from "node:net";
 import { connect, createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import * as path from "node:path";
@@ -4137,5 +4137,280 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     await closed;
     expect(requestHandlerRan).toBe(false);
     expect(serverSide.destroyed).toBe(true);
+  }
+});
+
+// Helpers for the closeIdleConnections() tests below: raw TCP connections, one per connection
+// state, with Content-Length framed responses read off them one at a time.
+interface RawConnection {
+  socket: Socket;
+  received: string;
+  consumed: number;
+  /** Settles once the server has closed the connection (FIN or reset). */
+  gone: Promise<"destroyed">;
+}
+
+function dialRaw(port: number): Promise<RawConnection> {
+  const socket = connect({ port, host: "127.0.0.1" });
+  socket.setNoDelay(true);
+  const conn: RawConnection = {
+    socket,
+    received: "",
+    consumed: 0,
+    gone: new Promise(resolve => {
+      socket.on("error", () => resolve("destroyed"));
+      socket.on("close", () => resolve("destroyed"));
+    }),
+  };
+  // Registered before any reader's 'data' listener, so readers see the appended bytes.
+  socket.on("data", chunk => (conn.received += chunk.toString("latin1")));
+  return new Promise((resolve, reject) => {
+    socket.once("connect", () => resolve(conn));
+    socket.once("error", reject);
+  });
+}
+
+// Resolves once `marker` has been received past everything read so far, or rejects if the server
+// closes the connection first.
+function readUntil(conn: RawConnection, marker: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      const index = conn.received.indexOf(marker, conn.consumed);
+      if (index === -1) return;
+      conn.consumed = index + marker.length;
+      conn.socket.off("data", check);
+      resolve();
+    };
+    conn.socket.on("data", check);
+    conn.gone.then(() =>
+      reject(
+        new Error(
+          `connection closed while waiting for ${JSON.stringify(marker)}; unread: ${JSON.stringify(conn.received.slice(conn.consumed))}`,
+        ),
+      ),
+    );
+    check();
+  });
+}
+
+// Resolves with the body of the next response on the connection, or rejects if the server closes
+// the connection before one has arrived.
+function readResponse(conn: RawConnection): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const check = () => {
+      const raw = conn.received.slice(conn.consumed);
+      const headersEnd = raw.indexOf("\r\n\r\n");
+      if (headersEnd === -1) return;
+      const contentLength = /\r\ncontent-length: (\d+)/i.exec(raw.slice(0, headersEnd));
+      if (!contentLength) {
+        conn.socket.off("data", check);
+        reject(new Error(`expected a Content-Length framed response, got: ${JSON.stringify(raw)}`));
+        return;
+      }
+      const bodyStart = headersEnd + 4;
+      const bodyEnd = bodyStart + Number(contentLength[1]);
+      if (raw.length < bodyEnd) return;
+      conn.consumed += bodyEnd;
+      conn.socket.off("data", check);
+      resolve(raw.slice(bodyStart, bodyEnd));
+    };
+    conn.socket.on("data", check);
+    conn.gone.then(() =>
+      reject(
+        new Error(
+          `connection closed before a response arrived; unread: ${JSON.stringify(conn.received.slice(conn.consumed))}`,
+        ),
+      ),
+    );
+    check();
+  });
+}
+
+// Takes the connection's next step and reports whether the server still serves it ("served <body>")
+// or has closed it ("destroyed"). Either way the answer is a positive signal, so no timers.
+function outcome(conn: RawConnection, step: () => void): Promise<string> {
+  const served = readResponse(conn).then(
+    body => `served ${body}`,
+    () => conn.gone,
+  );
+  step();
+  return Promise.race([served, conn.gone]);
+}
+
+// Node only considers a connection idle between requests: from accept until its first request has
+// been fully received, and again from the first byte of every later request, it is busy (left to
+// headersTimeout/requestTimeout instead), whether or not its response has already been sent; a
+// received request whose response has not finished keeps it busy as well. For connections accepted
+// by listen(), Bun used to go by "a response has finished and no bytes have arrived since", which
+// destroyed connections still receiving a request body or the head of their next request, and never
+// reclaimed a connection whose body finished arriving after the response.
+it("closeIdleConnections() only destroys accepted connections that are between requests", async () => {
+  const heldResponse = Promise.withResolvers<ServerResponse>();
+  const lateBodyReceived = Promise.withResolvers<void>();
+  const server = createServer({ keepAliveTimeout: 0 }, (req, res) => {
+    switch (req.url) {
+      case "/hold":
+        heldResponse.resolve(res);
+        break;
+      case "/body":
+        // Respond while the request body is still arriving; the rest of it is sent after the sweep.
+        res.end("early");
+        break;
+      case "/bodydone":
+        // Respond while the request body is still arriving; the rest of it arrives before the sweep.
+        res.end("early");
+        req.on("end", () => lateBodyReceived.resolve());
+        req.resume();
+        break;
+      default:
+        res.end(`served ${req.url}`);
+    }
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const names = ["fresh", "partial", "body", "hold", "reused", "idle", "bodydone", "emptyBodySplitHead"] as const;
+  const conns = {} as Record<(typeof names)[number], RawConnection>;
+  try {
+    for (const name of names) conns[name] = await dialRaw(port);
+
+    // Each state is confirmed through something the server does after reaching it (a response, the
+    // held handler, the body's 'end'). A partially sent head that has to be known to have reached the
+    // server is written together with a complete request in front of it, whose response proves it.
+    conns.partial.socket.write("GET /partial HTTP/1.1\r\nHost: x\r\n");
+    conns.body.socket.write("POST /body HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+    expect(await readResponse(conns.body)).toBe("early");
+    conns.hold.socket.write("GET /hold HTTP/1.1\r\nHost: x\r\n\r\n");
+    const held = await heldResponse.promise;
+    conns.reused.socket.write("GET /reused-1 HTTP/1.1\r\nHost: x\r\n\r\nGET /reused-2 HTTP/1.1\r\n");
+    expect(await readResponse(conns.reused)).toBe("served /reused-1");
+    conns.idle.socket.write("GET /idle HTTP/1.1\r\nHost: x\r\n\r\n");
+    expect(await readResponse(conns.idle)).toBe("served /idle");
+    conns.bodydone.socket.write("POST /bodydone HTTP/1.1\r\nHost: x\r\nContent-Length: 10\r\n\r\nabc");
+    expect(await readResponse(conns.bodydone)).toBe("early");
+    conns.bodydone.socket.write("defghij");
+    await lateBodyReceived.promise;
+    // A Content-Length: 0 request whose head is completed out of the bytes buffered from an earlier
+    // read completes its (empty) message on a different parser path than one received in a single
+    // read; it has to end up between requests all the same.
+    conns.emptyBodySplitHead.socket.write(
+      "GET /split-1 HTTP/1.1\r\nHost: x\r\n\r\nPOST /split-2 HTTP/1.1\r\nHost: x\r\nContent-Length: 0\r\n",
+    );
+    expect(await readResponse(conns.emptyBodySplitHead)).toBe("served /split-1");
+    conns.emptyBodySplitHead.socket.write("\r\n");
+    expect(await readResponse(conns.emptyBodySplitHead)).toBe("served /split-2");
+
+    server.closeIdleConnections();
+
+    const request = (url: string) => `GET ${url} HTTP/1.1\r\nHost: x\r\n\r\n`;
+    expect({
+      fresh: await outcome(conns.fresh, () => conns.fresh.socket.write(request("/fresh"))),
+      partial: await outcome(conns.partial, () => conns.partial.socket.write("\r\n")),
+      body: await outcome(conns.body, () => conns.body.socket.write("defghij" + request("/body-next"))),
+      hold: await outcome(conns.hold, () => held.end("held")),
+      reused: await outcome(conns.reused, () => conns.reused.socket.write("Host: x\r\n\r\n")),
+      idle: await outcome(conns.idle, () => conns.idle.socket.write(request("/idle-2"))),
+      bodydone: await outcome(conns.bodydone, () => conns.bodydone.socket.write(request("/bodydone-2"))),
+      emptyBodySplitHead: await outcome(conns.emptyBodySplitHead, () =>
+        conns.emptyBodySplitHead.socket.write(request("/split-3")),
+      ),
+    }).toEqual({
+      fresh: "served served /fresh",
+      partial: "served served /partial",
+      body: "served served /body-next",
+      hold: "served held",
+      reused: "served served /reused-2",
+      idle: "destroyed",
+      bodydone: "destroyed",
+      emptyBodySplitHead: "destroyed",
+    });
+
+    // The connections that were kept are between requests now, and close() runs the same sweep.
+    server.close();
+    const kept = ["fresh", "partial", "body", "hold", "reused"] as const;
+    const afterClose: Record<string, string> = {};
+    for (const name of kept) {
+      afterClose[name] = await outcome(conns[name], () => conns[name].socket.write(request("/after-close")));
+    }
+    expect(afterClose).toEqual({
+      fresh: "destroyed",
+      partial: "destroyed",
+      body: "destroyed",
+      hold: "destroyed",
+      reused: "destroyed",
+    });
+  } finally {
+    for (const name of names) conns[name]?.socket.destroy();
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
+// The request handler runs from the parser's headers-complete callback, i.e. while the request is
+// still being received, so "respond, then close the server" inside a handler does not destroy the
+// connection being responded on. As in Node, that connection is left to the keep-alive timeout, or
+// to a later sweep once the request has been fully received.
+it("closeIdleConnections() run from a request handler spares the handler's own connection", async () => {
+  const server = createServer({ keepAliveTimeout: 0 }, (req, res) => {
+    res.end(`served ${req.url}`);
+    if (req.url === "/sweep") server.closeIdleConnections();
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const conn = await dialRaw(port);
+  const request = (url: string) => `GET ${url} HTTP/1.1\r\nHost: x\r\n\r\n`;
+  try {
+    expect(await outcome(conn, () => conn.socket.write(request("/sweep")))).toBe("served served /sweep");
+    expect(await outcome(conn, () => conn.socket.write(request("/next")))).toBe("served served /next");
+    server.closeIdleConnections();
+    expect(await outcome(conn, () => conn.socket.write(request("/late")))).toBe("destroyed");
+  } finally {
+    conn.socket.destroy();
+    server.closeAllConnections();
+    server.close();
+  }
+});
+
+// Connections handed to 'upgrade' or 'connect' have left HTTP (Node frees their parser): the sweep
+// must leave them alone no matter how long they go without traffic.
+it("closeIdleConnections() leaves 'upgrade' and 'connect' tunnels alone", async () => {
+  const server = createServer({ keepAliveTimeout: 0 }, (req, res) => res.end(`served ${req.url}`));
+  const openTunnel = (socket: Socket, head: string) => {
+    socket.write(`${head}\r\n\r\n`);
+    socket.on("data", chunk => socket.write(`echo:${chunk}`));
+    socket.on("error", () => {});
+  };
+  server.on("upgrade", (req, socket) =>
+    openTunnel(socket, "HTTP/1.1 101 Switching Protocols\r\nConnection: Upgrade\r\nUpgrade: echo"),
+  );
+  server.on("connect", (req, socket) => openTunnel(socket, "HTTP/1.1 200 Connection Established"));
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  const { port } = server.address() as AddressInfo;
+  const upgrade = await dialRaw(port);
+  const tunnel = await dialRaw(port);
+  const idle = await dialRaw(port);
+  try {
+    upgrade.socket.write("GET /echo HTTP/1.1\r\nHost: x\r\nConnection: Upgrade\r\nUpgrade: echo\r\n\r\n");
+    await readUntil(upgrade, "\r\n\r\n");
+    tunnel.socket.write("CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n");
+    await readUntil(tunnel, "\r\n\r\n");
+    idle.socket.write("GET /one HTTP/1.1\r\nHost: x\r\n\r\n");
+    expect(await readResponse(idle)).toBe("served /one");
+
+    server.closeIdleConnections();
+
+    upgrade.socket.write("ping");
+    await readUntil(upgrade, "echo:ping");
+    tunnel.socket.write("ping");
+    await readUntil(tunnel, "echo:ping");
+    expect(await outcome(idle, () => idle.socket.write("GET /two HTTP/1.1\r\nHost: x\r\n\r\n"))).toBe("destroyed");
+  } finally {
+    upgrade.socket.destroy();
+    tunnel.socket.destroy();
+    idle.socket.destroy();
+    server.closeAllConnections();
+    server.close();
   }
 });


### PR DESCRIPTION
### Problem
- `closeIdleConnections()` (node:http and `Bun.serve`, so also `server.close()` and graceful `stop()`) destroys a keep-alive connection whose response was sent while the request body is still arriving. Closing a socket with unread inbound data resets it, which can discard the response the client was about to read.
- It also destroys a connection that has the head of its next request already buffered, and it keeps one whose body finished arriving after an early response, so `close()` waits on that connection until the client or the keep-alive timeout ends it.
- Cause: bun judged "idle" from the response side (a response finished and no bytes since). Node judges it from the request side: between request messages, with any assigned response finished. The two disagree in both directions, per the table in the original.
- Related: a `Content-Length: 0` request whose head arrived split across reads never counted as complete, so the next `requestTimeout` sweep answered `408 Request Timeout` on an idle keep-alive connection (reproduced on 1.4.0; node keeps it).
### Fix
- Each connection now carries a "between requests" bit: set when a request message (head and body) has been fully received, cleared as soon as the next head is parsed or partially buffered, false until the first request arrives. Idle is derived from it: between requests, no response in flight, no pipelined response queued. CONNECT/Upgrade tunnels get no further messages, so they are judged by response state alone, which keeps their behaviour as before.
- The idle sweep, the close-when-idle mark and the node:http headers/request timeout sweep all read this one bit, so the three facts are each maintained in one place and every row of the table matches node by construction. The old per-socket flag is removed. The parser now completes a split-head `Content-Length: 0` request in the same pass, as the no-body branch already did.
- Behaviour change: `res.end(); server.close()` from inside a handler no longer closes the handler's own connection (the request is still being received), as in node.
- Verification: a state matrix test that passes verbatim under node v26.3.0 and, without the fix, fails on exactly the three divergent rows plus the in-handler case; a timeouts test and a `Bun.serve` test that also fail without the fix. The existing http, serve and websocket suites and 50 vendored node tests were run; the only failures also fail on an unmodified build.

### Background
- On a keep-alive connection a request message is head plus body. A handler runs at headers-complete, so a response can finish while the body is still arriving, and a client can pipeline the next request behind the current one.
- Node's `ConnectionsList` tracks whether a message is currently being received; `closeIdleConnections()` and the `headersTimeout`/`requestTimeout` sweep both read that state, and a connection that has never sent a request counts as busy.
- Both node:http and `Bun.serve` sit on uWS in `packages/bun-uws`; one per-connection data block holds parser state, response-pending state and the pipelined-response count, so an idle definition built from those applies to both servers. Connections accepted by `listen()` take this native path; #37717 covers the JS fallback path (`server.emit("connection")`, http2 `allowHTTP1`).
- Graceful `stop()` marks busy connections close-when-idle, and the same idle definition decides when that mark fires.
- A head that arrives split across reads is finished out of a fallback buffer, a different parser pass from the usual single-read one.

<details>
<summary>Original description</summary>

### What

`http.Server#closeIdleConnections()` (and therefore `server.close()`), `Bun.serve`'s `server.closeIdleConnections()` and the close-when-idle mark left by a graceful `server.stop()` all go through uWS `App::closeIdle`. It decided "idle" from a per-socket flag that meant "a response has finished and no bytes have arrived since". Node decides it from the request side: a connection is idle only between request messages (`ConnectionsList::idle()`, i.e. the last message completed and the next one has not started; a connection that has not sent its first request yet counts as busy), and only if the response assigned to it, if any, has finished.

The two definitions disagree in both directions. One real TCP connection per state, one `closeIdleConnections()` call, node v26.3.0 vs bun 1.4.0 / main:

| connection state | node | bun before | bun after |
| --- | --- | --- | --- |
| connected, nothing sent | kept | kept | kept |
| partial request head | kept | kept | kept |
| response sent, request body still arriving | kept | **destroyed** | kept |
| request received, response not finished | kept | kept | kept |
| exchange done, head of the next request already buffered | kept | **destroyed** | kept |
| exchange done, nothing since | destroyed | destroyed | destroyed |
| response sent early, body finished arriving afterwards | destroyed | **kept** | destroyed |
| `closeIdleConnections()` called from inside the request handler | handler's connection kept | destroyed | kept |

Every kept connection still gets served afterwards (node and bun after), and `close()` afterwards takes all of them. The "body still arriving" case is the harmful one: closing a socket that still has unread inbound data resets it, which can discard the response the client was about to read. The "body finished afterwards" case leaves `close()` waiting on a connection that is idle by every definition until the client or the keep-alive timeout closes it.

This is the same divergence #37717 fixes for the JS fallback path (`server.emit("connection")`, http2 `allowHTTP1`); this PR is the native path for connections accepted by `listen()`. Once both are in, the two matrix tests can be folded into one parameterized over the transport.

### Cause

`AsyncSocketData::isIdle` was set in `markDone()` (response end) and cleared at the top of `onData` (any bytes). Nothing re-armed it when a request message completed, and a response ending mid-message set it regardless. The request-side state node keys on already existed on the node:http ext block (`lastMessageStartMs`, stamped at accept / head parsed / partial head buffered and zeroed at message complete, used by the headersTimeout/requestTimeout sweep), it just was not what the idle sweep looked at.

### Fix

* `HttpResponseData` gets a `betweenRequests` bit, maintained at exactly the points the node:http timing already used, for both server personalities: the data handler's fin sets it (before the chunk is delivered, so a response completing from inside the delivery already sees the connection idle), a parsed request head clears it, a partial head left in the fallback buffer after a read clears it, and it starts out false (node registers the parser as active at setup, so a connection that never sends anything is `headersTimeout`'s problem, not an idle one).
* `isIdle()` is derived from it: `betweenRequests && !HTTP_RESPONSE_PENDING && nodeHttpQueuedPipelinedCount == 0`. `App::closeIdle` and the `HTTP_CLOSE_WHEN_IDLE` gate (`shouldCloseConnection()`) use it; the `isIdle` flag, its maintenance in `markDone()`/`resetResponseState()`/`onData`, the `markDone(uwsRes)` parameter that existed only to set it, and the dead `WebSocketData` write are gone. A connection that became a CONNECT/Upgrade tunnel has no further request messages, so it is judged by response state alone: node:http tunnels keep the response they were created from pending (never idle, as before), a Bun.serve CONNECT that was answered stays reclaimable (as before).
* The node:http timeout sweep (`isRequestTimedOut`) reads `betweenRequests` instead of `lastMessageStartMs == 0`, so the idle sweep and the timeout sweep share one definition of "between requests", which is how node's `ConnectionsList` serves both `checkConnections()` and `closeIdleConnections()`. `lastMessageStartMs` is now purely the timestamp.
* `HttpParser`: a `Content-Length: 0` request whose head is completed out of the fallback buffer (head split across reads) never got its empty fin chunk: the fallback pass skips the body dispatch and the caller only streams a body while `remainingStreamingBytes` is non-zero. Without the fin such a connection would never return to `betweenRequests`; today the same gap leaves the request's timeout window open, so the next `requestTimeout` sweep answers `408 Request Timeout` on an idle keep-alive connection (reproduced on 1.4.0, node keeps the connection). It now completes the message in that pass too, the same way the no-body branch next to it always has; the single-read path already delivered this chunk, so consumers see nothing new.

Why this is the right shape rather than patching the flag: "idle" is now computed from three facts that are each maintained in one place (message boundaries, response in flight, responses queued), and it is the definition node uses, so the rows above match by construction rather than by approximation. For Bun.serve the declared contract ("not currently sending a request or waiting for a response", #37074) was already this; the implementation now matches it, which also fixes the graceful `stop()` analogue of the last table row (it no longer waits for `idleTimeout` on a connection whose upload finished after the response).

Behaviour change worth knowing about: `res.end(); server.close()` from inside a request handler no longer closes that handler's own connection; the request is still being received at that point (the handler runs from headers-complete), so, exactly as in node, the connection is left to `keepAliveTimeout` or the client. The existing test suites did not depend on the old behaviour (see below). Unchanged: a response whose bytes are still draining keeps `HTTP_RESPONSE_PENDING`, so it is still kept where node would destroy it mid-flush; `closeIdle`'s iteration over the group is untouched (its cached-`next` hazard is tracked separately).

### Tests

* `test/js/node/http/node-http.test.ts`: the matrix above (plus a `Content-Length: 0` split-head row for the parser change), each state confirmed through something the server does after reaching it, each verdict read as a positive signal (a response, or the connection going away) so there are no timers; then `close()` over the kept ones. Plus the in-handler case and a test that `'upgrade'`/`'connect'` tunnels survive the sweep. The same code passes verbatim under node v26.3.0. On the unfixed build the matrix fails on exactly the `body`/`reused`/`bodydone` rows and the in-handler test fails on its second request.
* `test/js/node/http/node-http-server-timeouts.test.ts`: after a split-head `Content-Length: 0` exchange, a second connection is left to be reaped by `requestTimeout`; once it has been, the first connection must still serve a request (unfixed: it has been answered 408 and closed by the same sweep).
* `test/js/bun/http/bun-server.test.ts`: two early-answered uploads; `closeIdleConnections()` must close 0 (unfixed: 2), the first connection must still serve a request behind the rest of its upload, and a graceful `stop()` must resolve once the second upload's body arrives.

Also run against this build: the full `node-http.test.ts`, the rest of `node-http-server-timeouts.test.ts`, `node-http-backpressure.test.ts`, the rest of `test/js/node/http/`, `bun-server.test.ts`, `serve.test.ts`, `websocket-server.test.ts`, and 50 vendored node tests covering `server-close-idle`/`close-all`, every `headers-timeout`/`request-timeout` variant, keep-alive, pipelining, CONNECT and upgrade. The only failures are ones that fail identically on an unmodified build in this environment (the http proxy test, IPv6 `requestIP`, root-range port, `/bun:info`, `#6583`, `localhost` upload abort, and a handful of 5 s / 10 s debug-build timeouts that reproduce on an unmodified debug build; the `node:http` fuzz fixture's `server.close()` was timed at ~85 ms with this change).


</details>
