### PR TITLE
test(bake): reject pending client requests when the happy-dom client exits

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -488,8 +488,7 @@ export class Dev extends EventEmitter {
         // failure surfaces at the dev.write() call instead of timing out.
         const exitHandler = (code: number | string) => {
           cleanup();
-          const mapped = exitCodeMapStrings[code];
-          reject(new Error(`Client exited while applying hot update${mapped ? `: ${mapped}` : ` (${code})`}`));
+          reject(clientExitedWhile("applying hot update", code));
         };
         client.on("received-hmr-event", socketEventHandler);
         client.on("exit", exitHandler);
@@ -807,7 +806,7 @@ class StylePromise extends Promise<Record<string, string>> {
           } else {
             reject(new Error(`Selector '${this.selector}' was found: ${JSON.stringify(style)}`));
           }
-        });
+        }, reject);
       });
     });
   }
@@ -817,6 +816,11 @@ const node = process.env.BUN_DEV_SERVER_CLIENT_EXECUTABLE ?? Bun.which("node");
 expect(node, "test will fail if this is not node").not.toBe(process.execPath);
 
 const danglingProcesses = new Set<Subprocess>();
+
+function clientExitedWhile(activity: string, code: number | string): Error {
+  const reason = exitCodeMapStrings[code];
+  return new Error(`Client exited while ${activity}${reason ? `: ${reason}` : ` (${code})`}`);
+}
 
 /**
  * Controls a subprocess that uses happy-dom as a lightweight browser. It is
@@ -1060,43 +1064,56 @@ export class Client extends EventEmitter {
           await maybeWaitInteractive("expectErrorOverlay");
           throw new Error("Expected errors, but none found");
         }
-
-        // Create unique message ID for this evaluation
-        const messageId = Math.random().toString(36).slice(2);
-
-        // Send the evaluation request and wait for response
-        this.#proc.send({
-          type: "get-errors",
-          args: [messageId],
-        });
-
-        const [result] = await EventEmitter.once(this, `get-errors-result-${messageId}`);
-
-        if (result.error) {
-          throw new Error(result.error);
-        }
-        const actualErrors = result.value;
         const expectedErrors = [...errors].sort();
-        expect(actualErrors).toEqual(expectedErrors);
+        expect(await this.#overlayErrors()).toEqual(expectedErrors);
       } else {
         if (hasVisibleModal) {
-          // Create unique message ID for this evaluation
-          const messageId = Math.random().toString(36).slice(2);
-
-          // Send the evaluation request and wait for response
-          this.#proc.send({
-            type: "get-errors",
-            args: [messageId],
-          });
-
-          const [result] = await EventEmitter.once(this, `get-errors-result-${messageId}`);
-
-          if (result.error) {
-            throw new Error(result.error);
-          }
-          const actualErrors = result.value;
-          expect(actualErrors).toEqual([]);
+          expect(await this.#overlayErrors()).toEqual([]);
         }
+      }
+    });
+  }
+
+  #overlayErrors() {
+    return this.#request<string[]>("get-errors", "get-errors-result", [], "reading the error overlay");
+  }
+
+  /**
+   * Sends a request to client-fixture.mjs and waits for the `{value}` or
+   * `{error}` it replies with as the `${resultType}-${messageId}` event. The
+   * fixture reports every failure by exiting, in which case no reply comes, so
+   * an exit rejects the request with the exit reason instead of leaving the
+   * caller waiting until the test times out.
+   */
+  #request<T>(type: string, resultType: string, args: unknown[], activity: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      if (this.exited) {
+        const { exitCode, signalCode } = this.#proc;
+        reject(clientExitedWhile(activity, exitCode ?? signalCode ?? "unknown"));
+        return;
+      }
+      const messageId = Math.random().toString(36).slice(2);
+      const resultEvent = `${resultType}-${messageId}`;
+      const onResult = (result: { value?: T; error?: string }) => {
+        this.off("exit", onExit);
+        if (result.error) {
+          reject(new Error(result.error));
+        } else {
+          resolve(result.value as T);
+        }
+      };
+      const onExit = (code: number | string) => {
+        this.off(resultEvent, onResult);
+        reject(clientExitedWhile(activity, code));
+      };
+      this.once(resultEvent, onResult);
+      this.once("exit", onExit);
+      try {
+        this.#proc.send({ type, args: [messageId, ...args] });
+      } catch (err) {
+        this.off(resultEvent, onResult);
+        this.off("exit", onExit);
+        reject(err);
       }
     });
   }
@@ -1139,52 +1156,12 @@ export class Client extends EventEmitter {
     );
     return withAnnotatedStack(snapshotCallerLocationMayFail(), async () => {
       if (!this.suppressInteractivePrompt) await maybeWaitInteractive("js");
-      return new Promise((resolve, reject) => {
-        // Create unique message ID for this evaluation
-        const messageId = Math.random().toString(36).slice(2);
-
-        // Set up one-time handler for the response
-        const handler = (result: any) => {
-          if (result.error) {
-            reject(new Error(result.error));
-          } else {
-            resolve(result.value);
-          }
-        };
-
-        this.once(`js-result-${messageId}`, handler);
-
-        // Send the evaluation request
-        this.#proc.send({
-          type: "evaluate",
-          args: [messageId, code],
-        });
-      });
+      return this.#request<T>("evaluate", "js-result", [code], "evaluating JS");
     });
   }
 
   jsInteractive(code: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-      // Create unique message ID for this evaluation
-      const messageId = Math.random().toString(36).slice(2);
-
-      // Set up one-time handler for the response
-      const handler = (result: any) => {
-        if (result.error) {
-          reject(new Error(result.error));
-        } else {
-          resolve(result.value);
-        }
-      };
-
-      this.once(`js-result-${messageId}`, handler);
-
-      // Send the evaluation request
-      this.#proc.send({
-        type: "evaluate",
-        args: [messageId, code, "interactive"],
-      });
-    });
+    return this.#request<string>("evaluate", "js-result", [code, "interactive"], "evaluating JS");
   }
 
   async click(selector: string) {
@@ -1230,25 +1207,12 @@ export class Client extends EventEmitter {
     return new Proxy(
       new StylePromise(
         (resolve, reject) => {
-          // Create unique message ID for this evaluation
-          const messageId = Math.random().toString(36).slice(2);
-
-          // Set up one-time handler for the response
-          const handler = (result: any) => {
-            if (result.error) {
-              reject(new Error(result.error));
-            } else {
-              resolve(result.value);
-            }
-          };
-
-          this.once(`get-style-result-${messageId}`, handler);
-
-          // Send the evaluation request
-          this.#proc.send({
-            type: "get-style",
-            args: [messageId, selector],
-          });
+          this.#request<Record<string, string>>(
+            "get-style",
+            "get-style-result",
+            [selector],
+            `reading the style of ${JSON.stringify(selector)}`,
+          ).then(resolve, reject);
         },
         selector,
         snapshotCallerLocation(),

--- a/test/bake/dev/harness.test.ts
+++ b/test/bake/dev/harness.test.ts
@@ -1,0 +1,103 @@
+// Tests for the behavior of bake-harness.ts itself.
+import { expect } from "bun:test";
+import { devTest, emptyHtmlFile } from "../bake-harness";
+
+const files = {
+  "index.html": emptyHtmlFile({
+    scripts: ["index.ts"],
+    body: "<h1>Hello</h1>",
+  }),
+  "index.ts": `
+    console.log("loaded");
+    import.meta.hot.accept();
+  `,
+};
+
+async function rejectionMessage(promise: Promise<unknown>): Promise<string> {
+  try {
+    await promise;
+  } catch (err: any) {
+    return err.message;
+  }
+  throw new Error("Expected the promise to reject");
+}
+
+// The tests below kill the client by evaluating `console.error(...)` in the
+// page: client-fixture.mjs exits with exitCodeMap.consoleError ("Runtime
+// error") from inside the page's console.error, so the request that ran it is
+// never answered.
+
+devTest("requests that are in flight when the client exits reject with the exit reason", {
+  files,
+  async test(dev) {
+    const c = await dev.client("/");
+    await c.expectMessage("loaded");
+
+    // jsInteractive sends its request synchronously and the fixture handles
+    // requests in order, so the client exits while handling this one and the
+    // requests sent after it are still waiting for a reply when it does.
+    const crash = c.jsInteractive('console.error("boom")');
+    const style = c.style("h1").color;
+    const notFound = c.style(".missing").notFound();
+    const overlay = c.expectErrorOverlay([]);
+    const js = c.js`1 + 1`;
+
+    expect(await rejectionMessage(crash)).toBe("Client exited while evaluating JS: Runtime error");
+    expect(await rejectionMessage(style)).toBe('Client exited while reading the style of "h1": Runtime error');
+    expect(await rejectionMessage(notFound)).toBe('Client exited while reading the style of ".missing": Runtime error');
+    expect(await rejectionMessage(overlay)).toBe("Client exited while evaluating JS: Runtime error");
+    expect(await rejectionMessage(js)).toBe("Client exited while evaluating JS: Runtime error");
+
+    expect(await rejectionMessage(c[Symbol.asyncDispose]())).toBe('Client exited: "Runtime error"');
+  },
+});
+
+devTest("requests made after the client exited reject with the exit reason", {
+  files,
+  async test(dev) {
+    const c = await dev.client("/");
+    await c.expectMessage("loaded");
+
+    expect(await rejectionMessage(c.js`console.error("boom")`)).toBe(
+      "Client exited while evaluating JS: Runtime error",
+    );
+
+    expect(await rejectionMessage(c.js`1 + 1`)).toBe("Client exited while evaluating JS: Runtime error");
+    expect(await rejectionMessage(c.elemText("h1"))).toBe("Client exited while evaluating JS: Runtime error");
+    expect(await rejectionMessage(c.style("h1").color)).toBe(
+      'Client exited while reading the style of "h1": Runtime error',
+    );
+    expect(await rejectionMessage(c.style(".missing").notFound())).toBe(
+      'Client exited while reading the style of ".missing": Runtime error',
+    );
+    expect(await rejectionMessage(c.expectErrorOverlay([]))).toBe("Client exited while evaluating JS: Runtime error");
+
+    expect(await rejectionMessage(c[Symbol.asyncDispose]())).toBe('Client exited: "Runtime error"');
+  },
+});
+
+devTest("dev.write() reports a client that exits while its error overlay is being checked", {
+  files,
+  async test(dev) {
+    const c = await dev.client("/");
+    await c.expectMessage("loaded");
+
+    // Once the clients have acknowledged a hot update, dev.write() asks each of
+    // them whether the error overlay is visible, using document.querySelector.
+    // The updated module makes that query the thing that kills the client, so
+    // it exits while dev.write() is waiting for the answer.
+    expect(
+      await rejectionMessage(
+        dev.write(
+          "index.ts",
+          `
+            import.meta.hot.accept();
+            document.querySelector = () => console.error("boom");
+          `,
+        ),
+      ),
+    ).toBe("Client exited while evaluating JS: Runtime error");
+
+    expect(await rejectionMessage(c[Symbol.asyncDispose]())).toBe('Client exited: "Runtime error"');
+  },
+});


### PR DESCRIPTION
### Problem
- A `test/bake` test whose happy-dom client dies (page `console.error`, failed `console.assert`, unexpected reload, banned websocket message) while a `js`, `jsInteractive`, `style` or error-overlay request is pending hangs until the test timeout, up to 9 minutes on a debug ASAN lane, and fails as a timeout instead of with the exit reason.
- Cause: the fixture reports every failure by exiting, so no reply ever comes, and these four requests waited only for the reply, never for the exit. The harness's other waits already watch for the exit.
- Every helper built on these requests inherits the hang, including the overlay check `dev.write()` / `patch()` / `delete()` run against each connected client.
- Separately, `StylePromise.notFound()` dropped rejections of the style request, so it never settled on any style error.

### Fix
- The four requests share one helper that waits for the reply or the client's `"exit"` event, whichever comes first, and on exit rejects with the mapped reason in the `Client exited while ...` format `waitForHotReload` already uses.
- A request made after the exit rejects immediately with the same reason, read from the subprocess so it does not depend on `Client.exitCode`, which #37863 removes. `notFound()` now forwards rejections.
- Property to check: the fixture always either replies or exits, and every request now settles on whichever happens, so no request outlives its client.
- Verification: three new harness tests kill the client with `console.error` and check the rejection messages. With the harness hunk reverted all three time out; with it they pass on release and debug builds, and the existing client-using bake tests (112) still pass.

### Background
- The bake dev-server tests drive a real page inside a happy-dom subprocess (`client-fixture.mjs`). The test talks to it over IPC: each request carries a random id and the reply comes back as a `<type>-result-<id>` event on the `Client` holding `{value}` or `{error}`.
- The fixture has no failure reply. Anything it treats as a failure makes it `process.exit()` with a code from `exit-code-map.mjs`; the `Client` emits the code as its `"exit"` event and the harness maps it to a string such as `Runtime error`.
- `dev.write()` / `patch()` / `delete()` apply a hot update and then ask every connected client for its error overlay, so a client dying during that query hung the write itself.
- `client.style(selector)` returns a Promise subclass; `.notFound()` wraps it in a new promise settled from inside a `then` fulfillment callback, so a rejection of the style request never reached the wrapper.

<details>
<summary>Original description</summary>

### What

In `test/bake/bake-harness.ts`, `Client.js()`, `Client.jsInteractive()`, `Client.style()` and the `get-errors` request in `Client.expectErrorOverlay()` send an IPC request to the happy-dom client (`client-fixture.mjs`) and register a listener for the reply, and nothing else. Every failure the fixture detects (a `console.error` on the page, a failed `console.assert`, an unexpected `location.reload()`, a banned websocket message, ...) is reported by calling `process.exit()` with a code from `exit-code-map.mjs`, so a client that fails while one of these requests is pending never replies, and the request stays pending until the test times out (30s times `WAIT_MULTIPLIER`, up to 9 minutes on a debug ASAN lane). The output is then a timeout rather than the client's exit reason. This reaches every helper built on these methods: `elemText`, `elemsText`, `click`, `reactRefreshComponentHash`, `style(...).notFound()`, and `expectErrorOverlay()`, which `dev.client()` and every `dev.write()` / `patch()` / `delete()` run against each connected client.

Smallest repro, with `index.ts` being any client module:

```ts
const c = await dev.client("/");
await c.js`console.error("boom")`; // the fixture exits 31 from inside console.error; this never settles
```

`expectMessage`, `getMostRecentHmrChunk`, `expectReload` and `Dev.waitForHotReload` already subscribe to the client's `"exit"` event; these four requests did not.

### Fix

The four requests go through one `Client.#request()` helper. It rejects up front if the client has already exited, otherwise it listens for the reply and for the `"exit"` event, whichever comes first, and on exit rejects with the mapped reason in the same format `waitForHotReload` uses (`Client exited while evaluating JS: Runtime error`, `Client exited while reading the style of "h1": Runtime error`, ...); that formatting is shared through `clientExitedWhile()`. The listener for the other outcome is removed either way, and a synchronous `send()` failure removes both and rejects.

The already-exited branch reads the status from the subprocess rather than from a field, so it does not depend on `Client.exitCode`, which #37863 removes. Without that branch a request made after the exit rejects with `Subprocess.send() cannot be used after the process has exited.` instead of the reason.

`StylePromise.notFound()` only passed a fulfillment handler to `then`, so the promise it returns never settled when the style request rejected (the new exit rejection, or the fixture's own `{error}` reply); it forwards rejections now.

### Tests

`test/bake/dev/harness.test.ts` (tests for the harness itself). Each one kills the client by evaluating `console.error(...)` on the page and checks the rejection messages, then that disposing the client still reports the exit:

- requests in flight when the client exits: `jsInteractive` (sent synchronously, so it is the request the fixture exits on), `style().color`, `style().notFound()`, `expectErrorOverlay([])` and `js` are all pending when the exit arrives and all reject with the reason.
- requests made after the client exited: `js`, `elemText`, `style().color`, `style().notFound()` and `expectErrorOverlay([])` reject immediately with the reason.
- `dev.write()` whose hot update replaces `document.querySelector` with a `console.error` call, so the client exits while `dev.write()` is inside `expectErrorOverlay` waiting for the overlay query to be answered; the write rejects with the reason.

With the `bake-harness.ts` hunk reverted all three time out (30s each locally); with it they pass under both the released Bun and a debug build. The existing client-using files under `test/bake` (`dev-and-prod`, `bundle`, `css`, `ecosystem`, `esm`, `hot`, `html`, `import-meta-inline`, `incremental-graph-edge-deletion`, `react-spa`, `sourcemap`, `ssg-pages-router`, `stress`, 112 tests) pass with the changed harness; `css.test.ts` also with a debug build.

### Overlap with open harness PRs

- #37863 adds the same new `harness.test.ts` with two unrelated tests and the same fixture; whichever lands second keeps both sets of tests.
- #37866 restructures `expectErrorOverlay()` and still reads the overlay with a bare `EventEmitter.once`; on top of it, its single `get-errors` block becomes `expect(await this.#overlayErrors()).toEqual([...errors].sort())`, and the exit handling it adds in `waitForPageLoad()` can use `clientExitedWhile()`.

</details>
