### PR TITLE
Fix crashes when a property lookup throws while formatting an object

### DIFF
--- a/src/jsc/bindings/BunObject.cpp
+++ b/src/jsc/bindings/BunObject.cpp
@@ -320,9 +320,6 @@ static JSValue defaultBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, vm.propertyNames->defaultKeyword));
 }
@@ -332,9 +329,6 @@ static JSValue constructBunSQLObject(VM& vm, JSObject* bunObject)
     auto scope = DECLARE_THROW_SCOPE(vm);
     auto* globalObject = defaultGlobalObject(bunObject->globalObject());
     JSValue sqlValue = globalObject->internalModuleRegistry()->requireId(globalObject, vm, InternalModuleRegistry::BunSql);
-#if BUN_DEBUG
-    if (scope.exception()) globalObject->reportUncaughtExceptionAtEventLoop(globalObject, scope.exception());
-#endif
     RETURN_IF_EXCEPTION(scope, {});
     auto clientData = WebCore::clientData(vm);
     RELEASE_AND_RETURN(scope, sqlValue.getObject()->get(globalObject, clientData->builtinNames().SQLPublicName()));

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -5605,10 +5605,11 @@ restart:
                 }
 
                 JSC::PropertySlot slot(object, PropertySlot::InternalMethodType::Get);
-                if (!object->getPropertySlot(globalObject, property, slot))
-                    continue;
+                bool hasProperty = object->getPropertySlot(globalObject, property, slot);
                 // Ignore exceptions from "Get" proxy traps.
                 CLEAR_IF_EXCEPTION(scope);
+                if (!hasProperty)
+                    continue;
 
                 if ((slot.attributes() & PropertyAttribute::DontEnum) != 0) {
                     if (property == propertyNames->underscoreProto
@@ -5680,7 +5681,11 @@ restart:
                 break;
             if (iterating == globalObject)
                 break;
-            iterating = iterating->getPrototype(globalObject).getObject();
+            JSValue prototype = iterating->getPrototype(globalObject);
+            // Ignore exceptions from Proxy "getPrototypeOf" traps (the result is empty when one threw).
+            if (scope.exception()) [[unlikely]]
+                break;
+            iterating = prototype.getObject();
         }
     }
 

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -928,3 +928,74 @@ describe.skipIf(!isASAN)("object mutated while being formatted", () => {
     expect(exitCode).toBe(0);
   });
 });
+
+describe("property lookup throws while being formatted", () => {
+  async function run(fixture) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  }
+
+  it.concurrent("Proxy traps in the prototype chain", async () => {
+    const [stdout, stderr, exitCode] = await run(`
+      {
+        const proto = new Proxy({ a: 1 }, {
+          getPrototypeOf() {
+            throw new Error("getPrototypeOf");
+          },
+        });
+        console.log(Bun.inspect(Object.create(proto)));
+        console.log(Object.create(proto));
+      }
+      {
+        // The exception from looking up "a" must not leak into the lookup of
+        // "b" or into the walk up the prototype chain that follows.
+        const proto = new Proxy({ a: 1, b: 2 }, {
+          get(target, key, receiver) {
+            if (key === "a") throw new Error("get a");
+            return Reflect.get(target, key, receiver);
+          },
+        });
+        console.log(Bun.inspect(Object.create(proto)));
+        console.log(Object.create(proto));
+      }
+    `);
+
+    expect(stdout).toMatchInlineSnapshot(`
+      "{
+        a: 1,
+      }
+      {
+        a: 1,
+      }
+      {
+        b: 2,
+      }
+      {
+        b: 2,
+      }
+      "
+    `);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+  });
+
+  it.concurrent("lazily initialized properties of Bun", async () => {
+    // Some of Bun's properties ($, sql, ...) are initialized on first access by
+    // code that calls the global Symbol, so clobbering it makes those
+    // initializers throw while the rest of the object is still being formatted.
+    // Archive and version are listed after them and must still be printed.
+    const [stdout, , exitCode] = await run(`
+      globalThis.Symbol = 0;
+      const text = Bun.inspect(Bun);
+      console.log(text.includes("Archive: [class Archive]"), text.includes("version:"));
+    `);
+
+    expect(stdout).toBe("true true\n");
+    expect(exitCode).toBe(0);
+  });
+});

--- a/test/js/bun/util/inspect.test.js
+++ b/test/js/bun/util/inspect.test.js
@@ -990,6 +990,9 @@ describe("property lookup throws while being formatted", () => {
     // initializers throw while the rest of the object is still being formatted.
     // Archive and version are listed after them and must still be printed.
     const [stdout, , exitCode] = await run(`
+      // Loads node:util's inspect now. On Windows, Bun.env has an inspect.custom
+      // hook, and the formatter cannot load that module once Symbol is gone.
+      Bun.inspect({ [Bun.inspect.custom]: () => "" });
       globalThis.Symbol = 0;
       const text = Bun.inspect(Bun);
       console.log(text.includes("Archive: [class Archive]"), text.includes("version:"));


### PR DESCRIPTION
### What does this PR do?

Fixes a fuzzer-found crash in the native object formatter (`Bun.inspect`, `console.log`), plus a user-reachable segfault on the same lines.

`JSC__JSValue__forEachPropertyImpl` (the slow path, used for objects with static property tables, Proxies in the prototype chain, indexed properties, etc.) did this for every property name it collected:

```cpp
if (!object->getPropertySlot(globalObject, property, slot))
    continue;
CLEAR_IF_EXCEPTION(scope);
```

When the lookup throws, `getPropertySlot` returns false, so the `continue` skipped the clear and the exception stayed pending while the loop moved on to the next property. Two ways a lookup throws here: a Proxy `get` trap in the prototype chain, or a lazily initialized static property whose initializer throws (`setUpStaticFunctionSlot` reports the slot as missing in that case). Consequences of the stale exception:

- The next property's lookup runs with an exception already pending. For a lazy property on `Bun` that is the assertion the fuzzer hit (`releaseAssertNoException` in the `Archive` initializer, right after the `$` initializer threw). In release builds every following lookup just fails, so the output silently loses properties.
- At the end of the loop, `iterating->getPrototype(globalObject).getObject()` was called. `ProxyObject::performGetPrototype` bails out on the pending exception and returns an empty `JSValue`, and `JSValue::getObject()` on an empty value dereferences a null cell. The same line crashes without any stale exception when a `getPrototypeOf` trap throws. This one is a plain segfault in release builds:

```js
const proto = new Proxy({ a: 1 }, { getPrototypeOf() { throw new Error("x"); } });
Bun.inspect(Object.create(proto)); // panic(main thread): Segmentation fault at address 0x5
```

The fix in `bindings.cpp` is the two hunks in that function: clear the exception before deciding whether to skip the property, and stop walking the prototype chain when `getPrototype` threw instead of calling `getObject()` on its result. Both match what the fast path of the same function already does for getters and for the `getPrototype` trap.

With that fixed, the fuzzer's scenario (a clobbered `Symbol` global, then formatting `Bun`) reached the `sql` / `SQL` / `postgres` initializers and tripped a second, debug-only crash: `defaultBunSQLObject` and `constructBunSQLObject` had a `#if BUN_DEBUG` block that passed the module load error to `reportUncaughtExceptionAtEventLoop` while it was still pending on the VM, which asserts inside the uncaught exception handler (`Structure::storedPrototype` via `process` property reification). Plain `Bun.sql` access aborts the same way in a debug build whenever the module fails to load. The block is not needed to surface the error: `setUpStaticFunctionSlot` propagates an initializer's exception to the caller, so `Bun.sql` throws the load error (release builds already do this, and the debug build does too once the block is gone). This PR deletes the block rather than keeping a second reporting path for the same error.

Fuzzilli fingerprint `dee846b77f24e65f`. The original crash depended on an earlier REPRL script having done `Symbol = 0`, which is why it was flagged as flaky; `globalThis.Symbol = 0; Bun.inspect(Bun)` reproduces it deterministically on an unfixed debug build.

### How did you verify your code works?

Two tests added to `test/js/bun/util/inspect.test.js` (`property lookup throws while being formatted`), each formatting in a child process:

- `Proxy traps in the prototype chain`: a throwing `getPrototypeOf` trap, and a `get` trap that throws for `a` but not `b` (checks that `b: 2` is still printed, i.e. the exception from `a` did not leak into the next lookup). Unfixed release build: the child segfaults, stdout is empty.
- `lazily initialized properties of Bun`: `globalThis.Symbol = 0` then `Bun.inspect(Bun)`, asserting that `Archive` and `version`, which are listed after the throwing `$` and `sql` initializers, are still printed. Unfixed release build prints `false false`; unfixed debug build aborts on the assertion from the report.

Both fail with `USE_SYSTEM_BUN=1 bun test` and pass with `bun bd test`. The rest of `inspect.test.js` (76 tests) and `test/js/bun/console/` pass with the debug build. `Bun.sql` with a failing module load now throws the load error in the debug build instead of asserting.

Not changed here: `napi_get_all_property_names` in `napi.cpp` has the same `getPrototype(globalObject).getObject()` pattern in its descriptor filter loop; it needs a native addon to reach and is tracked separately.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/inspect.test.js

<!-- robobun:evidence:end -->