### PR TITLE
bake test harness: derive multi-HTML route keys from posix paths

### DIFF
--- a/test/bake/bake-harness.ts
+++ b/test/bake/bake-harness.ts
@@ -101,7 +101,12 @@ export interface DevServerTest {
 
   /** Starting files */
   files?: FileObject;
-  /** Manually specify which html files to serve */
+  /**
+   * Manually specify which html files to serve. Defaults to every `*.html` in
+   * `files`. A single file is served at `/*`; several are served at the routes
+   * `bun ./a.html ./b.html` would give them (`index.html` at `/`,
+   * `docs/index.html` at `/docs`, `docs/guide.html` at `/docs/guide`).
+   */
   htmlFiles?: string[];
   /**
    * Framework to use. Consider `minimalFramework` if possible.
@@ -1779,23 +1784,23 @@ class OutputLineStream extends EventEmitter {
   }
 }
 
+/** Same routes as `bun ./index.html ./docs/index.html ./docs/guide.html`: "/", "/docs", "/docs/guide". */
+function htmlFileRoute(posixRelativePath: string) {
+  const segments = posixRelativePath.replace(/\.html$/, "").split("/");
+  if (segments.at(-1) === "index") segments.pop();
+  return "/" + segments.join("/");
+}
+
+/** `htmlFiles` are relative to the directory the script is written to, in the platform's separator. */
 export function indexHtmlScript(htmlFiles: string[]) {
+  const files = htmlFiles.map(file => file.replaceAll(path.sep, "/"));
   return [
-    ...htmlFiles.map((file, i) => `import html${i} from ${JSON.stringify("./" + file.replaceAll(path.sep, "/"))};`),
+    ...files.map((file, i) => `import html${i} from ${JSON.stringify("./" + file)};`),
     "export default {",
     "  static: {",
-    ...(htmlFiles.length === 1
+    ...(files.length === 1
       ? [`    '/*': html0,`]
-      : htmlFiles.map(
-          (file, i) =>
-            `    ${JSON.stringify(
-              "/" +
-                file
-                  .replace(/\.html$/, "")
-                  .replace("/index", "")
-                  .replace(/\/$/, ""),
-            )}: html${i},`,
-        )),
+      : files.map((file, i) => `    ${JSON.stringify(htmlFileRoute(file))}: html${i},`)),
     "  },",
     "  fetch(req) {",
     "    return new Response('Not Found', { status: 404 });",

--- a/test/bake/dev/html.test.ts
+++ b/test/bake/dev/html.test.ts
@@ -370,3 +370,19 @@ devTest("error report endpoint blanks stray non-text bytes in reported frames", 
     await dev.fetch("/").expect.toInclude("<h1>Frame Bytes</h1>");
   },
 });
+
+devTest("multiple html files are served at the routes bun derives from their paths", {
+  files: {
+    "index.html": emptyHtmlFile({ body: "<h1>home</h1>" }),
+    "about.html": emptyHtmlFile({ body: "<h1>about</h1>" }),
+    "docs/index.html": emptyHtmlFile({ body: "<h1>docs</h1>" }),
+    "docs/guide.html": emptyHtmlFile({ body: "<h1>guide</h1>" }),
+  },
+  async test(dev) {
+    await dev.fetch("/").expect.toInclude("<h1>home</h1>");
+    await dev.fetch("/about").expect.toInclude("<h1>about</h1>");
+    await dev.fetch("/docs").expect.toInclude("<h1>docs</h1>");
+    await dev.fetch("/docs/guide").expect.toInclude("<h1>guide</h1>");
+    await dev.fetch("/docs/index").expect404();
+  },
+});


### PR DESCRIPTION
### Problem
- On Windows, a bake harness fixture with several HTML files answered the harness's 404 fallback for any nested one (`GET /docs`, `GET /docs/guide`).
- On every platform, a top-level `index.html` in such a fixture was served at `/index`, not `/`.
- The route keys were built from platform-native paths, so on Windows they came out as `"/docs\\index"`; the `/index` strip was a first-occurrence substring replace, so it missed a top-level `index.html`.
- Surfaced in #37868, which keeps one case on a separate server to work around this.

### Fix
- Normalize separators once, before both imports and keys are built, then derive each key per segment: strip `.html`, drop a trailing `index` segment.
- Correct because the keys are now the routes `bun ./index.html ./docs/index.html ./docs/guide.html` itself serves (`/`, `/docs`, `/docs/guide`), which is what this branch imitates.
- No test on `main` depends on the old keys: existing multi-HTML fixtures use flat files, whose routes are unchanged.
- Verification: a new test fetches `/`, `/about`, `/docs`, `/docs/guide` and expects 404 at `/docs/index`. It fails without the harness change on every platform and passes on linux-x64 and windows-x64; the other tests using this code path were re-run on both and pass.

### Background
- The bake harness behind `devTest`/`prodTest` writes a `bun.app.ts` per fixture that imports each HTML file and exports a server config; this PR only changes that generated file.
- In that config, `static` maps a route string to an imported HTML module. String keys match exactly, so a key with a backslash in it is never hit.
- One HTML file goes on the `/*` catch-all; several get one exact route each, imitating `bun ./a.html ./b.html`, which serves a file at its path minus `.html` and an `index.html` at its directory (`docs/bundler/html-static.mdx`).
- The relative paths come from `path.relative`, which uses the platform separator, so on Windows nested paths carry backslashes until converted.

<details>
<summary>Original description</summary>

### What

`test/bake/bake-harness.ts` generates a `bun.app.ts` for every `devTest`/`prodTest` fixture that contains HTML files. With one HTML file it registers a `/*` catch-all; with several, `indexHtmlScript` registers one static route per file and derives each key from the result of `path.relative(mainDir, file)`. Only the `import` line normalized `path.sep`; the key derivation did not, so on Windows any nested HTML file on a multi-route server was registered under a key containing a backslash and was unreachable. The same line also mapped a top-level `index.html` to `/index`.

Generated `bun.app.ts` for a fixture with `about.html`, `docs/index.html` and `docs/guide.html` on the Windows box, before this change (`GET /docs` and `GET /docs/guide` both returned the harness's 404 fallback):

```ts
import html0 from "./about.html";
import html1 from "./docs/index.html";
import html2 from "./docs/guide.html";
export default {
  static: {
    "/about": html0,
    "/docs\\index": html1,
    "/docs\\guide": html2,
  },
  ...
```

After: `"/about"`, `"/docs"`, `"/docs/guide"`.

### Fix

Normalize the separators once for both the import specifiers and the route keys, and derive the key per path segment (strip `.html`, drop a trailing `index` segment). That gives the routes `bun ./index.html ./docs/index.html ./docs/guide.html` itself would serve (`/`, `/docs`, `/docs/guide`, see `docs/bundler/html-static.mdx` and `src/js/internal/html.ts`), which is what the multi-route branch was imitating. The previous `.replace("/index", "")` was also a non-anchored first-occurrence replace, so it would have turned e.g. `docs/index-page.html` into `/docs-page`; the segment version does not have that problem.

Nothing on `main` depends on the old keys: the only multi-HTML fixtures are three tests in `test/bake/dev/css.test.ts` using flat `first.html`/`second.html`, which still map to `/first`/`/second`. The one fixture that has a top-level `index.html` next to another HTML file (`bundle.test.ts`, "importing html file with text loader") passes `htmlFiles: ["index.html"]` and therefore still takes the `/*` branch. The `htmlFiles` option doc now states both behaviors so the next multi-route test does not have to read `indexHtmlScript` to find out which routes it gets.

This surfaced while restructuring the css tests in #37868, which currently keeps the `html/index.html` case on its own server because of this; with this change it can join a shared server.

### Test

`test/bake/dev/html.test.ts`, "multiple html files are served at the routes bun derives from their paths": `index.html`, `about.html`, `docs/index.html`, `docs/guide.html`, each with a distinct body, fetched at `/`, `/about`, `/docs`, `/docs/guide`, plus a 404 for `/docs/index` to show these are exact routes rather than the single-file catch-all.

Without the harness change it fails on every platform at `/` (`index.html` was registered as `/index`); a variant of the same fixture without `index.html` fails only on Windows, at `/docs` (the output above). With the change it passes on linux-x64 (`bun bd test`, and `USE_SYSTEM_BUN=1`) and on windows-x64 (`USE_SYSTEM_BUN=1`, canary 9a543cc18).

Also re-ran the other consumers of `indexHtmlScript` with the change, on both linux (`bun bd test`) and windows: the three multi-route css tests, "css import before create project relative" (nested single file), bundle.test.ts "directory cache bust case #17576" (`mainDir`, so the import specifier is `../web/index.html`) and "importing html file with text loader" (explicit `htmlFiles`), and react-spa.test.ts (fixture directory branch). All pass.


</details>
