### PR TITLE
Response.redirect(""): store an empty Location value instead of a null one

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -2433,7 +2433,12 @@ extern "C" void WebCore__FetchHeaders__put(WebCore::FetchHeaders* headers, HTTPH
     auto throwScope = DECLARE_THROW_SCOPE(global->vm());
     throwScope.assertNoException(); // can't throw an exception when there's already one.
     // `toWTFString()` refs a `WTFStringImpl`-tagged value instead of copying it.
-    WebCore::propagateException(*global, throwScope, headers->set(name, arg2->toWTFString()));
+    WTF::String value = arg2->toWTFString();
+    // An empty BunString converts to the null String, which HTTPHeaderMap stores
+    // but `get()` and iteration report as absent while `has()` reports present.
+    if (value.isNull())
+        value = WTF::emptyString();
+    WebCore::propagateException(*global, throwScope, headers->set(name, value));
 }
 void WebCore__FetchHeaders__fastRemove_(WebCore::FetchHeaders* headers, unsigned char headerName)
 {

--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -49,7 +49,7 @@ describe("2-arg form", () => {
 test("print size", () => {
   expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
     .toMatchInlineSnapshot(`
-    "Response (8.0 KB) {
+    "Response (9.63 KB) {
       ok: true,
       url: "",
       status: 200,
@@ -129,6 +129,44 @@ test("Response.redirect keeps a non-absolute url as-is in Location", () => {
   expect(Response.redirect("/login?next=1#a").headers.get("location")).toBe("/login?next=1#a");
   // non-ASCII must round-trip, not come back as a latin-1 view of the UTF-8 bytes
   expect(Response.redirect("/café").headers.get("location")).toBe("/café");
+});
+
+// An empty url used to reach the header map as a null string: `has()` said the
+// header was there, but `get()` returned null and iteration skipped it.
+test.each([
+  ["Response.redirect('')", () => Response.redirect("")],
+  // @ts-expect-error the types require a url; the runtime treats a missing one as ""
+  ["Response.redirect()", () => Response.redirect()],
+  ["Response.redirect('', 307)", () => Response.redirect("", 307)],
+  ["Response.redirect('', { status: 308 })", () => Response.redirect("", { status: 308 })],
+  ["Response.redirect('', { headers })", () => Response.redirect("", { headers: { "x-extra": "1" } })],
+  ["Response.redirect('').clone()", () => Response.redirect("").clone()],
+])("%s stores an empty Location header value", (_, makeResponse) => {
+  const { headers } = makeResponse();
+  const entries = [...headers].filter(([name]) => name === "location");
+  const visited: [string, string][] = [];
+  headers.forEach((value, name) => {
+    if (name === "location") visited.push([name, value]);
+  });
+
+  expect({
+    has: headers.has("location"),
+    get: headers.get("location"),
+    entries,
+    visited,
+    copied: new Headers(headers).get("location"),
+  }).toEqual({
+    has: true,
+    get: "",
+    entries: [["location", ""]],
+    visited: [["location", ""]],
+    copied: "",
+  });
+});
+
+test("Response.redirect('') produces the same Headers as an explicit empty Location", () => {
+  expect(Response.redirect("").headers).toEqual(new Headers({ location: "" }));
+  expect(Response.redirect("").headers).toEqual(new Response(null, { status: 302, headers: { location: "" } }).headers);
 });
 
 test("Response.redirect rejects a non-absolute url that is not a valid header value", () => {


### PR DESCRIPTION
### Problem
- `Response.redirect("")` (or `Response.redirect()`) gives headers where `has("location")` is true but `get("location")` is `null` and iteration, `forEach` and `new Headers(h)` skip it. `new Headers({ location: "" })` reads back as `""` everywhere.
- Cause: the native header `put` path stores an empty value as WTF's null string, and the header map reads a null value as "absent" in `get()` and iteration but not in `has()`.
- Only `put` is affected; the JS `set` / `append` / constructor paths go through WebIDL and never produce a null string. Predates #33126.

### Fix
- `put` swaps a null conversion result for the empty string before storing. Other `put` callers skip empty values or never pass one, so only `Response.redirect` and the dev server's `Response.render("")` change.
- Check: `Response.redirect("").headers` now equals `new Headers({ location: "" })`. The wire already sent an empty `Location:`, so only the in-memory object changes.
- Storing `""` rather than throwing follows Bun's rule of keeping non-absolute redirect targets verbatim; Node throws here, but also throws for `Response.redirect("/login")`, which Bun accepts.
- Verification: 7 new test cases fail on the released binary and pass with the change; existing headers and dev server tests still pass on a debug build.

### Background
- Bun's `Headers` is WebKit's `FetchHeaders` over an `HTTPHeaderMap`, which treats a null value as "absent" in `get()` and its iterator while `contains()` (behind `has()`) still finds the entry.
- `WTF::String` has a null string distinct from the empty string; both have length 0, only `isNull()` differs.
- `BunString` is the string type crossing the Zig/C++ boundary. Its one `Empty` tag converts to the null `WTF::String`.
- `WebCore__FetchHeaders__put` is the binding Zig uses to set a header directly, bypassing the WebIDL conversion that JS `headers.set()` gets.

<details>
<summary>Original description</summary>

### Reproduction

```js
const h = Response.redirect("").headers;   // same with Response.redirect()
h.has("location");   // true
h.get("location");   // null      (expected "")
[...h];              // []        (expected [["location", ""]])
```

`size()` and `has()` say the header exists, but `get()` returns `null` and `entries()` / `forEach` / `new Headers(h)` never yield it. `headers.set("location", "")`, `new Headers({ location: "" })` and `Response.redirect("  ")` (trimmed to empty) all produce a Headers object that reads back as `""` everywhere.

### Cause

`WebCore__FetchHeaders__put` (`bindings.cpp`) converts the value with `BunString::toWTFString()`. A `BunString` has exactly one representation of the empty string, the `Empty` tag, and `toWTFString()` maps it to the null `WTF::String`. `FetchHeaders::set` stores it as-is, and `HTTPHeaderMap` uses a null value to mean "no such header" in `get()` and in `FetchHeaders::Iterator::next()`, while `contains()` still finds the entry. `put` is the only way a `BunString` reaches the header map; the JS-facing `set` / `append` / constructor paths go through WebIDL conversion and always get a non-null string, which is why `headers.set("location", "")` works.

This predates #33126: the previous `Zig::toStringCopy` on a zero-length `ZigString` returned the null String as well.

### Fix

The binding turns a null conversion result into `WTF::emptyString()` before calling `FetchHeaders::set`. That covers every `put` caller with an empty value (`Response.redirect("")`, `Response.redirect()` and `Response.render("")` in the dev server); the content-type callers already skip empty values and the S3 Location is never empty, so nothing else changes.

Storing `""` rather than throwing is the consistent choice for Bun: non-absolute redirect targets are documented to be stored verbatim, and `""` is just the degenerate one. Node throws a `TypeError` here, but it throws for `Response.redirect("/login")` for the same reason, which Bun deliberately accepts, so rejecting only `""` would be an arbitrary carve-out. The response on the wire already sent `Location: ` with an empty value before this change (`toUWSResponse` writes the entry), so this only makes the in-memory Headers object agree with what is sent and with every other way of producing the same header.

### Tests

`test/js/web/fetch/response.test.ts`: each `Response.redirect` arity with an empty url (plus no argument, and `clone()`) is checked through `has()`, `get()`, iteration, `forEach` and copying into a new `Headers`, and compared against `new Headers({ location: "" })`. All 7 new cases fail on the released binary and pass with this change. The self-referential `print size` snapshot in the same file is bumped for the added bytes, as in earlier changes to this file.

Also ran `headers.test.ts`, `fetch_headers.test.js`, `headers-case.test.ts`, `headers.undici.test.ts` and `test/bake/dev/react-response.test.ts` (covers `Response.render` / `Response.redirect` in the dev server) against the debug build with no failures.


</details>
