### PR TITLE
Project thread-pool batch tasks out of the object's pointer, not a reference

### DIFF
--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -586,13 +586,10 @@ impl<'a> LinkerContext<'a> {
                     callback: SourceMapDataTask::run_quoted_source_contents,
                 },
             };
-            // `run_line_offset` / `run_quoted_source_contents` recover the
-            // `SourceMapDataTask` from its `thread_task` pointer, so project
-            // through the element pointer rather than the `&mut` above.
             let line_offset = std::ptr::from_mut(line_offset);
             let quoted = std::ptr::from_mut(quoted);
-            // SAFETY: both point at the slice elements borrowed by this
-            // iteration; field projections only.
+            // SAFETY: field projections of the two live elements; the callbacks
+            // recover the whole `SourceMapDataTask` from these pointers.
             unsafe {
                 batch.push(ThreadPoolLib::Batch::from(
                     &raw mut (*line_offset).thread_task,

--- a/src/bundler/LinkerContext.rs
+++ b/src/bundler/LinkerContext.rs
@@ -586,8 +586,19 @@ impl<'a> LinkerContext<'a> {
                     callback: SourceMapDataTask::run_quoted_source_contents,
                 },
             };
-            batch.push(ThreadPoolLib::Batch::from(&raw mut line_offset.thread_task));
-            second_batch.push(ThreadPoolLib::Batch::from(&raw mut quoted.thread_task));
+            // `run_line_offset` / `run_quoted_source_contents` recover the
+            // `SourceMapDataTask` from its `thread_task` pointer, so project
+            // through the element pointer rather than the `&mut` above.
+            let line_offset = std::ptr::from_mut(line_offset);
+            let quoted = std::ptr::from_mut(quoted);
+            // SAFETY: both point at the slice elements borrowed by this
+            // iteration; field projections only.
+            unsafe {
+                batch.push(ThreadPoolLib::Batch::from(
+                    &raw mut (*line_offset).thread_task,
+                ));
+                second_batch.push(ThreadPoolLib::Batch::from(&raw mut (*quoted).thread_task));
+            }
         }
 
         // line offsets block sooner and are faster to compute, so we should schedule those first

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -98,7 +98,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
 
             debug!(" START {} prepare CSS ast (total count)", total_count);
 
-            let mut batch = ThreadPoolLib::Batch::default();
             let mut tasks: Vec<PrepareCssAstTask> = Vec::with_capacity(total_count);
             for chunk in chunks.iter_mut() {
                 if chunk.content.is_css() {
@@ -112,12 +111,21 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                         // (raw ptr is invariant); `.cast()` erases the inner `'a` to satisfy it.
                         linker: std::ptr::from_mut::<LinkerContext>(c).cast(),
                     });
-                    // Capacity pre-reserved → push never reallocates → ptr stays stable.
-                    let task = tasks.last_mut().unwrap();
-                    batch.push(ThreadPoolLib::Batch::from(&raw mut task.task));
                 }
             }
             debug_assert_eq!(tasks.len(), total_count);
+            // Fill the Vec first, then take the addresses (`tasks` is not touched
+            // again until `wait_for_all` returns). `prepare_css_asts_for_chunk`
+            // recovers the whole `PrepareCssAstTask` from the pointer, so it is
+            // projected through the element pointer, not through a `&mut` element.
+            let tasks_ptr = tasks.as_mut_ptr();
+            let mut batch = ThreadPoolLib::Batch::default();
+            for i in 0..tasks.len() {
+                // SAFETY: `i < tasks.len()`, so `tasks_ptr.add(i)` is a live element.
+                batch.push(ThreadPoolLib::Batch::from(unsafe {
+                    &raw mut (*tasks_ptr.add(i)).task
+                }));
+            }
             // SAFETY: `parse_graph` is the `BundleV2.graph` backref (valid for
             // the link step); `pool` is the arena-allocated bundler ThreadPool.
             let worker_pool = c.worker_pool();
@@ -176,10 +184,7 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
             debug_assert_eq!(chunks.len(), chunk_contexts.len());
 
             debug!(" START {} compiling part ranges", total_count);
-            // Pre-reserved to `total_count` so pushes never reallocate; the
-            // batch holds raw pointers into this buffer.
             let mut combined_part_ranges: Vec<PendingPartRange> = Vec::with_capacity(total_count);
-            let mut batch = ThreadPoolLib::Batch::default();
             for (chunk, chunk_ctx) in chunks.iter_mut().zip(chunk_contexts.iter_mut()) {
                 match &chunk.content {
                     crate::chunk::Content::Javascript(js) => {
@@ -200,9 +205,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                     bun_ptr::detach_lifetime_ref::<GenerateChunkCtx>(chunk_ctx)
                                 },
                             });
-                            batch.push(ThreadPoolLib::Batch::from(
-                                &raw mut combined_part_ranges.last_mut().unwrap().task,
-                            ));
                         }
                     }
                     crate::chunk::Content::Css(css) => {
@@ -223,9 +225,6 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                     bun_ptr::detach_lifetime_ref::<GenerateChunkCtx>(chunk_ctx)
                                 },
                             });
-                            batch.push(ThreadPoolLib::Batch::from(
-                                &raw mut combined_part_ranges.last_mut().unwrap().task,
-                            ));
                         }
                     }
                     crate::chunk::Content::Html => {
@@ -245,13 +244,22 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                                 bun_ptr::detach_lifetime_ref::<GenerateChunkCtx>(chunk_ctx)
                             },
                         });
-                        batch.push(ThreadPoolLib::Batch::from(
-                            &raw mut combined_part_ranges.last_mut().unwrap().task,
-                        ));
                     }
                 }
             }
             debug_assert_eq!(combined_part_ranges.len(), total_count);
+            // Same as the CSS batch above: the `generate_compile_result_for_*_chunk`
+            // callbacks recover the whole `PendingPartRange` from the pointer, and
+            // `combined_part_ranges` is not touched again until `wait_for_all`.
+            let part_ranges_ptr = combined_part_ranges.as_mut_ptr();
+            let mut batch = ThreadPoolLib::Batch::default();
+            for i in 0..combined_part_ranges.len() {
+                // SAFETY: `i < combined_part_ranges.len()`, so `part_ranges_ptr.add(i)`
+                // is a live element.
+                batch.push(ThreadPoolLib::Batch::from(unsafe {
+                    &raw mut (*part_ranges_ptr.add(i)).task
+                }));
+            }
             // SAFETY: `parse_graph` is the `BundleV2.graph` backref (valid for
             // the link step); `pool` is the arena-allocated bundler ThreadPool.
             let worker_pool = c.worker_pool();

--- a/src/bundler/linker_context/generateChunksInParallel.rs
+++ b/src/bundler/linker_context/generateChunksInParallel.rs
@@ -114,14 +114,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 }
             }
             debug_assert_eq!(tasks.len(), total_count);
-            // Fill the Vec first, then take the addresses (`tasks` is not touched
-            // again until `wait_for_all` returns). `prepare_css_asts_for_chunk`
-            // recovers the whole `PrepareCssAstTask` from the pointer, so it is
-            // projected through the element pointer, not through a `&mut` element.
             let tasks_ptr = tasks.as_mut_ptr();
             let mut batch = ThreadPoolLib::Batch::default();
             for i in 0..tasks.len() {
-                // SAFETY: `i < tasks.len()`, so `tasks_ptr.add(i)` is a live element.
+                // SAFETY: `i < tasks.len()`; the callback recovers the whole
+                // `PrepareCssAstTask` from this element pointer.
                 batch.push(ThreadPoolLib::Batch::from(unsafe {
                     &raw mut (*tasks_ptr.add(i)).task
                 }));
@@ -248,14 +245,11 @@ pub(crate) fn generate_chunks_in_parallel<const IS_DEV_SERVER: bool>(
                 }
             }
             debug_assert_eq!(combined_part_ranges.len(), total_count);
-            // Same as the CSS batch above: the `generate_compile_result_for_*_chunk`
-            // callbacks recover the whole `PendingPartRange` from the pointer, and
-            // `combined_part_ranges` is not touched again until `wait_for_all`.
             let part_ranges_ptr = combined_part_ranges.as_mut_ptr();
             let mut batch = ThreadPoolLib::Batch::default();
             for i in 0..combined_part_ranges.len() {
-                // SAFETY: `i < combined_part_ranges.len()`, so `part_ranges_ptr.add(i)`
-                // is a live element.
+                // SAFETY: `i < combined_part_ranges.len()`; the callbacks recover
+                // the whole `PendingPartRange` from this element pointer.
                 batch.push(ThreadPoolLib::Batch::from(unsafe {
                     &raw mut (*part_ranges_ptr.add(i)).task
                 }));

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -388,7 +388,9 @@ pub fn preconnect(url: URL<'static>, is_url_owned: bool) {
         ));
         async_http.client.flags.is_preconnect_only = true;
 
-        crate::HTTPThread::schedule(Batch::from(core::ptr::addr_of_mut!(async_http.task)));
+        let mut batch = Batch::default();
+        async_http.schedule(&mut batch);
+        crate::HTTPThread::schedule(batch);
     }
 }
 
@@ -526,8 +528,13 @@ impl<'a> AsyncHTTP<'a> {
         )
     }
 
+    /// Queue `self` for [`crate::HTTPThread::schedule`], which recovers the
+    /// whole `AsyncHTTP` from the `task` pointer, so the pointer is projected
+    /// out of `self`'s address rather than out of the `task` field.
     pub fn schedule(&mut self, batch: &mut Batch) {
-        batch.push(Batch::from(core::ptr::addr_of_mut!(self.task)));
+        let this = core::ptr::from_mut(self);
+        // SAFETY: `this` is `self`; only a field projection is formed.
+        batch.push(Batch::from(unsafe { &raw mut (*this).task }));
     }
 }
 

--- a/src/http/AsyncHTTP.rs
+++ b/src/http/AsyncHTTP.rs
@@ -528,12 +528,10 @@ impl<'a> AsyncHTTP<'a> {
         )
     }
 
-    /// Queue `self` for [`crate::HTTPThread::schedule`], which recovers the
-    /// whole `AsyncHTTP` from the `task` pointer, so the pointer is projected
-    /// out of `self`'s address rather than out of the `task` field.
     pub fn schedule(&mut self, batch: &mut Batch) {
         let this = core::ptr::from_mut(self);
-        // SAFETY: `this` is `self`; only a field projection is formed.
+        // SAFETY: field projection of `self`; `HTTPThread::schedule` recovers
+        // the whole `AsyncHTTP` from this pointer.
         batch.push(Batch::from(unsafe { &raw mut (*this).task }));
     }
 }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1610,8 +1610,7 @@ pub fn flush_patch_task_queue(this: &mut PackageManager) {
         } else {
             &mut this.patch_calc_hash_batch
         };
-        // SAFETY: same pointer as above; `schedule` projects the pool task out
-        // of it so the pool's container-of covers the whole `PatchTask`.
+        // SAFETY: as above.
         unsafe { PatchTask::schedule(patch_task, batch) };
     }
 }

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1604,12 +1604,15 @@ pub fn flush_patch_task_queue(this: &mut PackageManager) {
     while let Some(patch_task) = this.patch_task_fifo.read_item() {
         // SAFETY: fifo stores live `*mut PatchTask` pushed by
         // `enqueue_patch_task`; exclusive ownership transferred here.
-        let pt = unsafe { &mut *patch_task };
-        pt.schedule(if matches!(pt.callback, PatchTaskCallback::Apply(_)) {
+        let is_apply = unsafe { (*patch_task).callback.is_apply() };
+        let batch = if is_apply {
             &mut this.patch_apply_batch
         } else {
             &mut this.patch_calc_hash_batch
-        });
+        };
+        // SAFETY: same pointer as above; `schedule` projects the pool task out
+        // of it so the pool's container-of covers the whole `PatchTask`.
+        unsafe { PatchTask::schedule(patch_task, batch) };
     }
 }
 

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -166,10 +166,9 @@ impl<'a> Installer<'a> {
         ));
 
         task.result = Result::None;
-        // `Task::callback` recovers the whole `Task` from the pool task
-        // pointer, so project it out of the task's address, not the field.
         let task = std::ptr::from_mut(task);
-        // SAFETY: `task` is the live `tasks[entry_id]` slot borrowed above.
+        // SAFETY: field projection of the live `tasks[entry_id]` slot;
+        // `Task::callback` recovers the whole `Task` from this pointer.
         manager
             .thread_pool
             .schedule(thread_pool::Batch::from(unsafe { &raw mut (*task).task }));

--- a/src/install/isolated_install/Installer.rs
+++ b/src/install/isolated_install/Installer.rs
@@ -166,9 +166,13 @@ impl<'a> Installer<'a> {
         ));
 
         task.result = Result::None;
+        // `Task::callback` recovers the whole `Task` from the pool task
+        // pointer, so project it out of the task's address, not the field.
+        let task = std::ptr::from_mut(task);
+        // SAFETY: `task` is the live `tasks[entry_id]` slot borrowed above.
         manager
             .thread_pool
-            .schedule(thread_pool::Batch::from(&raw mut task.task));
+            .schedule(thread_pool::Batch::from(unsafe { &raw mut (*task).task }));
     }
 
     pub(crate) fn on_package_extracted(&mut self, task_id: crate::package_manager_task::Id) {

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -707,8 +707,15 @@ impl PatchTask {
         Some(hasher.final_())
     }
 
-    pub(crate) fn schedule(&mut self, batch: &mut Batch) {
-        batch.push(Batch::from(&raw mut self.task));
+    /// Takes the task's pointer rather than `&mut self`: `run_from_thread_pool`
+    /// recovers the whole `PatchTask` from the `task` pointer the pool hands
+    /// back, so that pointer has to be projected out of the task's pointer.
+    ///
+    /// # Safety
+    /// `this` must be the live heap `PatchTask` handed out by `enqueue_patch_task`.
+    pub(crate) unsafe fn schedule(this: *mut Self, batch: &mut Batch) {
+        // SAFETY: `this` is live per the fn contract; only a field projection is formed.
+        batch.push(Batch::from(unsafe { &raw mut (*this).task }));
     }
 
     pub(crate) fn new_calc_patch_hash(

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -707,14 +707,11 @@ impl PatchTask {
         Some(hasher.final_())
     }
 
-    /// Takes the task's pointer rather than `&mut self`: `run_from_thread_pool`
-    /// recovers the whole `PatchTask` from the `task` pointer the pool hands
-    /// back, so that pointer has to be projected out of the task's pointer.
-    ///
     /// # Safety
-    /// `this` must be the live heap `PatchTask` handed out by `enqueue_patch_task`.
+    /// `this` must be the live heap `PatchTask` handed out by `enqueue_patch_task`;
+    /// `run_from_thread_pool` recovers the whole task from the pointer queued here.
     pub(crate) unsafe fn schedule(this: *mut Self, batch: &mut Batch) {
-        // SAFETY: `this` is live per the fn contract; only a field projection is formed.
+        // SAFETY: field projection of the live task (fn contract).
         batch.push(Batch::from(unsafe { &raw mut (*this).task }));
     }
 

--- a/src/install/patch_install.rs
+++ b/src/install/patch_install.rs
@@ -708,10 +708,10 @@ impl PatchTask {
     }
 
     /// # Safety
-    /// `this` must be the live heap `PatchTask` handed out by `enqueue_patch_task`;
-    /// `run_from_thread_pool` recovers the whole task from the pointer queued here.
+    /// `this` must be the live heap `PatchTask` handed out by `enqueue_patch_task`.
     pub(crate) unsafe fn schedule(this: *mut Self, batch: &mut Batch) {
-        // SAFETY: field projection of the live task (fn contract).
+        // SAFETY: field projection of the live task; `run_from_thread_pool`
+        // recovers the whole task from this pointer.
         batch.push(Batch::from(unsafe { &raw mut (*this).task }));
     }
 

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -554,13 +554,10 @@ impl ThreadPool {
                 ctx: bun_ptr::BackRef::new(&wait_context),
             });
         }
-        // Fill the Vec first, then take the addresses: nothing reallocates or
-        // reborrows the buffer between here and `wait_for_all`. `call` recovers
-        // each `RunnerTask` from its `task` pointer, so project through the
-        // element pointer rather than a `&mut RunnerTask`.
         let runner_tasks = tasks.as_mut_ptr();
         for i in 0..tasks.len() {
-            // SAFETY: `i < tasks.len()`, so `runner_tasks.add(i)` is a live element.
+            // SAFETY: `i < tasks.len()`; `call` recovers the whole `RunnerTask`
+            // from this element pointer.
             batch.push(Batch::from(unsafe { &raw mut (*runner_tasks.add(i)).task }));
         }
         self.schedule(batch);

--- a/src/threading/ThreadPool.rs
+++ b/src/threading/ThreadPool.rs
@@ -554,10 +554,14 @@ impl ThreadPool {
                 ctx: bun_ptr::BackRef::new(&wait_context),
             });
         }
-        // Push to the Vec first (no realloc: capacity reserved), then take
-        // stable addresses.
-        for runner_task in tasks.iter_mut() {
-            batch.push(Batch::from(ptr::addr_of_mut!(runner_task.task)));
+        // Fill the Vec first, then take the addresses: nothing reallocates or
+        // reborrows the buffer between here and `wait_for_all`. `call` recovers
+        // each `RunnerTask` from its `task` pointer, so project through the
+        // element pointer rather than a `&mut RunnerTask`.
+        let runner_tasks = tasks.as_mut_ptr();
+        for i in 0..tasks.len() {
+            // SAFETY: `i < tasks.len()`, so `runner_tasks.add(i)` is a live element.
+            batch.push(Batch::from(unsafe { &raw mut (*runner_tasks.add(i)).task }));
         }
         self.schedule(batch);
         self.wait_for_all();

--- a/test/internal/source-lints/thread-pool-batch-projection.test.ts
+++ b/test/internal/source-lints/thread-pool-batch-projection.test.ts
@@ -45,9 +45,12 @@ import { globAllSources } from "../../../scripts/glob-sources.ts";
 // Scope: the argument of every `Batch::from(` call (however the type is
 // reached, including the `PoolBatch` / `ThreadPoolBatch` aliases), when it is
 // `&raw mut` / `&raw const` / `addr_of_mut!` / `addr_of!` of a field path whose
-// base is a binding rather than a `(*p)` deref. A local holding a pointer
-// projected elsewhere is out of scope, as is whether the pointer a function was
-// handed is itself whole-object (that is its caller's business). The other
+// base is a binding rather than a `(*p)` deref. The `(*p)` spelling is taken
+// to mean `p` is a raw pointer, which is the only reason to write it (a
+// reference auto-derefs, and clippy's `explicit_auto_deref` rejects `(*r).f`),
+// so a `(*r).f` through a reference would not be reported. A local holding a
+// pointer projected elsewhere is out of scope, as is whether the pointer a
+// function was handed is itself whole-object (that is its caller's business). The other
 // ways of narrowing the same argument, a `&mut` formed in the argument, an
 // accessor returning `&mut Task`, `ptr::from_mut(..)` of either, are banned by
 // the sibling lint from #37865 and deliberately not repeated here, so the two

--- a/test/internal/source-lints/thread-pool-batch-projection.test.ts
+++ b/test/internal/source-lints/thread-pool-batch-projection.test.ts
@@ -1,0 +1,247 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// The `*mut Task` a `Batch::from(..)` hands to the thread pool must be
+// projected out of a raw pointer to the object that embeds the task, not out
+// of a reference to that object:
+//
+//   Batch::from(&raw mut self.task)                              // `self: &mut Self`
+//   Batch::from(&raw mut task.task)                              // `task: &mut T` (a slot, an iter_mut item)
+//   Batch::from(addr_of_mut!(runner_task.task))
+//   Batch::from(&raw mut combined_part_ranges.last_mut().unwrap().task)
+//
+// are banned; the accepted spellings project through a raw pointer:
+//
+//   Batch::from(&raw mut (*this).task)                           // `this: *mut T`, or `ptr::from_mut(t)`
+//   Batch::from(&raw mut (*tasks.as_mut_ptr().add(i)).task)      // a Vec of tasks, filled first
+//   Batch::from(addr_of_mut!((*task).task))
+//
+// The pool calls back with exactly the pointer it was given, and every
+// callback behind a `Batch::from` site (`from_task_ptr`, `from_field_ptr!`)
+// container-ofs it back to the embedding object and then reads and writes the
+// object's other fields through the result; `HTTPThread::schedule` does the
+// container-of on the calling thread before the batch is even queued.
+// `bun_core::container_of` documents that this needs a pointer derived from the
+// object's pointer, and a raw borrow of a field taken through a reference does
+// not give one: rustc retags `&raw mut <place>` unless the place is based on a
+// raw pointer, and under Stacked Borrows that retag covers the field only, so
+// the callback's first sibling-field access is UB ("created by a
+// SharedReadWrite retag at offsets [<the task field>]"). The push-then-
+// `last_mut()` loop is worse: each `last_mut()` reborrows the whole buffer and
+// invalidates the pointers already in the batch, so `Batch::push` itself trips
+// when it links the next task onto the previous one. `&raw mut (*p).f` with
+// `p` raw is not retagged and keeps `p`'s range; `ptr::from_mut(t)` is a
+// reborrow of the whole object, so projecting through it is equivalent. Tree
+// Borrows, which is what `bun run rust:miri` runs, accepts the banned shapes,
+// and none of the crates involved are in its crate set, so this lint is what
+// reports a regression. The sites this was written for (install's
+// `PatchTask::schedule` and isolated-install `start_task`,
+// `AsyncHTTP::schedule` and `preconnect`, `ThreadPool::each`, the bundler's
+// source-map and chunk batches) are the templates for the accepted shapes.
+//
+// Scope: the argument of every `Batch::from(` call (however the type is
+// reached, including the `PoolBatch` / `ThreadPoolBatch` aliases), when it is
+// `&raw mut` / `&raw const` / `addr_of_mut!` / `addr_of!` of a field path whose
+// base is a binding rather than a `(*p)` deref. A local holding a pointer
+// projected elsewhere is out of scope, as is whether the pointer a function was
+// handed is itself whole-object (that is its caller's business). The other
+// ways of narrowing the same argument, a `&mut` formed in the argument, an
+// accessor returning `&mut Task`, `ptr::from_mut(..)` of either, are banned by
+// the sibling lint from #37865 and deliberately not repeated here, so the two
+// never share an allowlist; `WorkPool::schedule(..)`, the other hand-over, is
+// the subject of #37768's lint. Siblings: self-receiver-reclaim.test.ts,
+// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+// `Batch::from(`, however the type is reached: `thread_pool::Batch::from(`,
+// `ThreadPoolLib::Batch::from(`, and the `use .. Batch as PoolBatch` /
+// `ThreadPoolBatch` aliases in the tree.
+const BATCH_FROM = /\b\w*Batch::from\s*\(/g;
+
+// A place rooted at a binding and ending in a field: `self.task`,
+// `task.task`, `self.inner.task`, `v.last_mut().unwrap().task`,
+// `self.tasks[i].task`. A place rooted at a raw pointer is spelled `(*p).f`
+// (or `(*p.add(i)).f`) and starts with `(`, so it never matches; neither does
+// a bare deref such as `*self.task_ptr`, which is a pointer the object holds
+// rather than a projection through the object.
+const FIELD_PLACE = String.raw`\w+(?:\.\w+(?:\([^()]*\))?|\[[^\[\]]*\])*\.\w+`;
+
+const RAW_BORROW = new RegExp(String.raw`^&\s*raw\s+(?:mut|const)\s+${FIELD_PLACE}$`);
+const ADDR_OF = new RegExp(String.raw`^(?:[\w:]+::)?addr_of(?:_mut)?!\s*\(\s*${FIELD_PLACE}\s*\)$`);
+
+/** The argument text of the call whose opening paren is at `open`, or null if unbalanced. */
+function argumentAt(source: string, open: number): string | null {
+  for (let depth = 0, i = open; i < source.length; i++) {
+    const c = source[i];
+    if (c === "(" || c === "{" || c === "[") depth++;
+    else if (c === ")" || c === "}" || c === "]") {
+      if (--depth === 0) return source.slice(open + 1, i);
+    }
+  }
+  return null;
+}
+
+function normalize(argument: string): string {
+  let arg = argument.replace(/\s+/g, " ").trim().replace(/,$/, "").trim();
+  const unsafeBlock = /^unsafe\s*\{(.*)\}$/.exec(arg);
+  if (unsafeBlock) arg = unsafeBlock[1].trim();
+  return arg;
+}
+
+function isBanned(argument: string): boolean {
+  const arg = normalize(argument);
+  return RAW_BORROW.test(arg) || ADDR_OF.test(arg);
+}
+
+/** Byte offsets (into `stripped`) of every banned `Batch::from` call in one file. */
+function findBannedBatches(stripped: string): number[] {
+  const hits: number[] = [];
+  for (const m of stripped.matchAll(BATCH_FROM)) {
+    const argument = argumentAt(stripped, m.index + m[0].length - 1);
+    if (argument !== null && isBanned(argument)) hits.push(m.index);
+  }
+  return hits;
+}
+
+function lineOf(text: string, offset: number): number {
+  return text.slice(0, offset).split("\n").length;
+}
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape. Prefer converting over adding an entry here.
+const ALLOW: Record<string, number> = {};
+
+const counts: Record<string, number> = {};
+const offenders: string[] = [];
+let scanned = 0;
+let batchSites = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const content = await file(abs).text();
+  // Strip full-line comments so prose mentions (including the in-tree comments
+  // describing this hazard) don't count. `[ \t]*`, not `\s*`: `\s` crosses
+  // newlines and would swallow blank lines, shifting the reported line numbers.
+  const stripped = content.replace(/^[ \t]*\/\/.*$/gm, "");
+  batchSites += [...stripped.matchAll(BATCH_FROM)].length;
+  for (const offset of findBannedBatches(stripped)) {
+    counts[source] = (counts[source] ?? 0) + 1;
+    if (counts[source] > (ALLOW[source] ?? 0)) {
+      offenders.push(`${source}:${lineOf(stripped, offset)}`);
+    }
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources containing Batch::from calls", () => {
+  // Guards against the tracked/realpath filters (or the call pattern) failing
+  // to match anything, which would make the ban below pass vacuously.
+  expect(scanned).toBeGreaterThan(0);
+  expect(batchSites).toBeGreaterThan(0);
+});
+
+test("the classifier recognizes the spellings it claims to", () => {
+  const banned = [
+    // The instances this was written for, as they were.
+    "&raw mut self.task",
+    "core::ptr::addr_of_mut!(self.task)",
+    "core::ptr::addr_of_mut!(async_http.task)",
+    "&raw mut task.task",
+    "ptr::addr_of_mut!(runner_task.task)",
+    "&raw mut line_offset.thread_task",
+    "\n                                &raw mut combined_part_ranges.last_mut().unwrap().task,\n                            ",
+    // Other spellings of the same projection.
+    "&raw const self.task",
+    "addr_of_mut!(this.task)",
+    "std::ptr::addr_of!(self.task)",
+    "&raw mut self.inner.task",
+    "&raw mut self.tasks[i].task",
+    "&raw mut tasks[i].task",
+    "&raw mut self.tasks.last_mut().unwrap().task",
+    "unsafe { &raw mut this.task }",
+    "unsafe {\n    core::ptr::addr_of_mut!(self.task)\n}",
+    "core::ptr::addr_of_mut!(\n    task.task\n)",
+  ];
+  const allowed = [
+    // The converted shapes.
+    "unsafe { &raw mut (*this).task }",
+    "unsafe { &raw mut (*task).task }",
+    "\n                    &raw mut (*line_offset).thread_task,\n                ",
+    "unsafe { &raw mut (*runner_tasks.add(i)).task }",
+    "unsafe {\n                    &raw mut (*tasks_ptr.add(i)).task\n                }",
+    // The raw projections that were already in the tree.
+    "&raw mut (*parse_task).task",
+    "&raw mut (*parse_task).io_task",
+    "unsafe { core::ptr::addr_of_mut!((*task).task) }",
+    "unsafe {\n                        core::ptr::addr_of_mut!((*task).task)\n                    }",
+    "core::ptr::addr_of_mut!(\n                            (*this.parse_task.as_ptr()).task\n                        )",
+    "core::ptr::addr_of_mut!(\n                    (*this).drain_task\n                )",
+    "unsafe { TaskType::field_of(task) }",
+    // A pointer projected elsewhere, or one the object holds, is out of scope.
+    "task",
+    "queued",
+    "&raw mut *self.task",
+    // Narrowed through a reference or an accessor rather than a raw borrow:
+    // #37865's lint, not this one.
+    "&mut self.task",
+    "this.task()",
+    "unsafe { std::ptr::from_mut::<WorkPoolTask>((*task).task()) }",
+    "ptr::from_mut(&mut self.task)",
+  ];
+  expect(banned.filter(s => !isBanned(s))).toEqual([]);
+  expect(allowed.filter(s => isBanned(s))).toEqual([]);
+});
+
+test("the call matcher finds every spelling of the call and takes its whole argument", () => {
+  const source = [
+    "fn schedule(&mut self, batch: &mut Batch) {",
+    "    batch.push(Batch::from(&raw mut self.task));",
+    "    batch.push(thread_pool::Batch::from(unsafe { &raw mut (*task).task }));",
+    "    batch.push(ThreadPoolLib::Batch::from(",
+    "        &raw mut combined_part_ranges.last_mut().unwrap().task,",
+    "    ));",
+    "    crate::HTTPThread::schedule(Batch::from(core::ptr::addr_of_mut!(async_http.task)));",
+    "    let batch = PoolBatch::from(unsafe { core::ptr::addr_of_mut!((*task).task) });",
+    "    manager.task_batch.push(ThreadPoolBatch::from(queued));",
+    "    batch.push(Batch::from(unsafe {",
+    "        &raw mut (*runner_tasks.add(i)).task",
+    "    }));",
+    "    // batch.push(Batch::from(&raw mut self.task));",
+    "}",
+  ].join("\n");
+  const stripped = source.replace(/^[ \t]*\/\/.*$/gm, "");
+  expect(findBannedBatches(stripped).map(offset => lineOf(stripped, offset))).toEqual([2, 4, 7]);
+});
+
+test("no Batch::from call projects the task through a reference to the object", () => {
+  expect(offenders).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: once an allowlisted instance is converted, delete its entry so
+  // a new one cannot take its place.
+  for (const [f, n] of Object.entries(ALLOW)) {
+    expect({ file: f, count: counts[f] ?? 0 }).toEqual({ file: f, count: n });
+  }
+});


### PR DESCRIPTION
### Problem
- Eleven places that hand an embedded thread-pool task to a `Batch` (patch install, isolated install, async HTTP, `ThreadPool::each`, the bundler's source-map and chunk batches) take the task pointer out of a `&mut` reference to the object that embeds it.
- The pool calls back with exactly that pointer, and every callback recovers the whole object from it with container-of and then touches the object's other fields. For async HTTP this happens on the calling thread, before the batch is even queued.
- Under Stacked Borrows a raw borrow taken through a reference covers only the task field, so the callback's first sibling-field access is undefined behaviour. The bundler's push-then-`last_mut()` loops are worse: each `last_mut()` invalidates the pointers already in the batch, so `Batch::push` itself trips.
- No crash is known or expected from today's codegen; the addresses are right and only the aliasing model objects. Tree Borrows, which is what `bun run rust:miri` checks, accepts these shapes. Same contract violation as #37768 and #37865, in the one spelling neither covers.

### Fix
- Every site now projects the task field out of a raw pointer to the whole object: a `*mut` the caller already holds, `ptr::from_mut` of the slot just written, or `as_mut_ptr().add(i)` in a second loop that runs after the Vec is full.
- This is correct because a projection through a raw pointer keeps that pointer's whole-object range, and building the batch after the Vec is filled means nothing reborrows the buffer once pointers into it exist. The pointer values are the same as before at every site, so there is no behaviour change.
- Two signatures move with it: `PatchTask::schedule` takes `*mut Self`, since its one caller already holds the raw pointer, and HTTP `preconnect` now goes through `AsyncHTTP::schedule` so the http crate has one projection site.
- Verification: a new source lint bans this spelling in any `Batch::from` argument, reports exactly the eleven sites on main and nothing here, and is disjoint from #37865's lint. Existing install, fetch, bundler and source-map tests pass on this branch's debug build; `fetch.preconnect` was checked by hand.

### Background
- Embedded task: the object that wants work done embeds a `Task` node (callback plus `next` link), a `Batch` is a linked list threaded through those nodes, and the pool calls each callback with the node's own pointer. The pool allocates nothing.
- container-of: the callback subtracts the field offset from the `*mut Task` to get the embedding object back. `bun_core::container_of` documents that this needs a pointer derived from the object's pointer; a reborrow of just the field does not qualify.
- Stacked Borrows and Tree Borrows are the two aliasing models Miri checks against. Stacked Borrows retags `&raw mut obj.field` taken through a reference down to that field; `&raw mut (*p).field` through a raw pointer keeps `p`'s range. Tree Borrows is looser and is what bun's Miri run uses, so it misses this class.
- Source lints (`test/internal/source-lints/`) are bun tests that scan the Rust tree for a banned spelling, with a per-file allowlist that only ratchets down. They are how a pattern Miri does not cover is kept out of the tree.

<details>
<summary>Original description</summary>

### Problem

The remaining `Batch::from(..)` sites that hand an intrusive task to a thread pool projected the `*mut Task` out of a reference to the object instead of out of the object's pointer:

| site | shape |
| --- | --- |
| `PatchTask::schedule(&mut self, ..)` (src/install/patch_install.rs) | `Batch::from(&raw mut self.task)` |
| `AsyncHTTP::schedule(&mut self, ..)` and `preconnect` (src/http/AsyncHTTP.rs) | `Batch::from(addr_of_mut!(self.task))`, `addr_of_mut!(async_http.task)` with `async_http: &mut AsyncHTTP` |
| isolated-install `Installer::start_task` (src/install/isolated_install/Installer.rs) | `Batch::from(&raw mut task.task)` with `task = &mut self.tasks[i]` |
| `ThreadPool::each` / `each_ptr` (src/threading/ThreadPool.rs) | `Batch::from(addr_of_mut!(runner_task.task))` from `tasks.iter_mut()` |
| `compute_data_for_source_map` (src/bundler/LinkerContext.rs) | `Batch::from(&raw mut line_offset.thread_task)` from `iter_mut()`, twice |
| `generate_chunks_in_parallel` (src/bundler/linker_context/generateChunksInParallel.rs) | `push(..); Batch::from(&raw mut tasks.last_mut().unwrap().task)` per element, four loops |

In every case the pool calls back with exactly that pointer and the callback recovers the object from it with container-of and then uses the rest of the object: `PatchTask::from_task_ptr` (`run_from_thread_pool`), `from_field_ptr!(Task, ..)` (isolated install, which also writes `result` and links `next`), `from_field_ptr!(RunnerTask, ..)` (`each`, reads `i` and `ctx`), `from_field_ptr!(SourceMapDataTask, ..)`, `from_field_ptr!(PrepareCssAstTask, ..)` and `pending_part_range_prologue`. For `AsyncHTTP` it happens before the task is even queued: `HTTPThread::schedule` container-ofs every task in the batch on the calling thread, links the object into `queued_tasks` through the result, and `start_queued_task` later `ptr::read`s the whole struct through it. `bun_core::container_of` documents that this requires a pointer derived from the object's pointer ("a `&mut field` reborrow does not suffice"), and `WorkPool::schedule_owned` projects out of the `Box::into_raw` pointer for that reason. The other `Batch::from` sites in the tree already do this, either inline (`&raw mut (*parse_task).task`, `addr_of_mut!((*task).task)`) or by passing a pointer a helper projected that way (`&raw mut (*task).threadpool_task` in the package manager's enqueue helpers); `WorkPool::schedule` forwards its argument, and the one site that narrows through an accessor is #37865's.

The reference-based spelling does not meet that contract. rustc retags the result of `&raw mut <place>` unless the place is based on a raw pointer, and under Stacked Borrows that retag covers the projected field only, so the callback's first sibling-field access is out of range. The `push` + `last_mut()` loops in `generate_chunks_in_parallel` have a second problem: every `last_mut()` goes through `Vec::deref_mut`, which reborrows the whole buffer and invalidates the pointers already in the batch, so `Batch::push` itself trips when it links the next task onto the previous one (projecting through `ptr::from_mut(last_mut())` is not enough there; the batch has to be built after the Vec is filled). Reduction below. Tree Borrows, which is what `bun run rust:miri` checks, accepts all of these shapes, none of the crates involved are in its crate set, and no crash is known or expected from today's codegen: the addresses are right, and this only matters to the aliasing model. It is the same contract violation as #37768 (the `WorkPool::schedule` population, which deliberately leaves `Batch::from` out of its lint) and #37865 (`NewTaskQueue::push`, the one `Batch::from` site that narrows through an accessor; not touched here), in the one spelling neither of them covers.

<details>
<summary>Reduction under Miri (miri 0.1.0 9f36de775b), one mode per shape</summary>

`ref` is the `&raw mut task.task` / `&raw mut self.task` shape, `iter_mut` the `addr_of_mut!(runner_task.task)` shape, `last_mut` the chunk loops; `last_mut_from_mut` is the chunk loop with only the projection fixed; `from_mut`, `as_mut_ptr` and `raw` are the three shapes this PR converts to. The pool side is `container_of` followed by a sibling-field read and write, run on another thread. The trailing comments on the `-->` lines name the statement at each location.

```
=== Stacked Borrows: ref
error: Undefined Behavior: attempting a read access using <2295> at alloc929[0x10], but that tag does not exist in the borrow stack for this location
  --> src/main.rs:72:25                                   let i = (*job).i;          // the callback
help: <2295> was created by a SharedReadWrite retag at offsets [0x8..0x10]
  --> src/main.rs:87:16                                   batch.push(&raw mut task.task);
=== Stacked Borrows: iter_mut
error: Undefined Behavior: attempting a read access using <2079> at alloc842[0x10], but that tag does not exist in the borrow stack for this location
help: <2079> was created by a SharedReadWrite retag at offsets [0x8..0x10]
  --> src/main.rs:123:28                                  batch.push(std::ptr::addr_of_mut!(j.task));
=== Stacked Borrows: last_mut
error: Undefined Behavior: attempting a write access using <1941> at alloc836[0x8], but that tag does not exist in the borrow stack for this location
  --> src/main.rs:48:22                                   (*self.tail).node.next = task   // Batch::push, calling thread
help: <1941> was created by a SharedReadWrite retag at offsets [0x8..0x10]
help: <1941> was later invalidated at offsets [0x0..0x30] by a Unique retag
  --> src/main.rs:133:41                                  jobs.last_mut()                 // next iteration
=== Stacked Borrows: last_mut_from_mut
error: Undefined Behavior: attempting a write access using <1958> at alloc840[0x8], but that tag does not exist in the borrow stack for this location
  --> src/main.rs:48:22                                   (*self.tail).node.next = task
help: <1958> was created by a SharedReadWrite retag at offsets [0x0..0x18]
help: <1958> was later invalidated at offsets [0x0..0x30] by a Unique retag
  --> src/main.rs:135:48                                  jobs.last_mut()
=== Stacked Borrows: from_mut
from_mut: ok [1, 2, 3]
=== Stacked Borrows: as_mut_ptr
as_mut_ptr: ok [1, 2, 3]
=== Stacked Borrows: raw
raw: ok [1, 2, 3]

Tree Borrows (-Zmiri-tree-borrows): all seven modes ok
```

</details>

### Fix

Same pointer values as before at every site, so no behaviour change; what changes is which pointer they are projected from.

* `PatchTask::schedule` becomes `unsafe fn schedule(this: *mut Self, batch)` and projects out of `this`. Its only caller, `flush_patch_task_queue`, already holds the `*mut PatchTask` it popped from the fifo and now reads the callback kind through it instead of forming a `&mut PatchTask`.
* `AsyncHTTP::schedule` keeps `&mut self` (its callers, `send_sync`, `NetworkTask`, `FetchTasklet`, S3, hold the object by reference or value, and `HTTPThread::schedule` recovers an `AsyncHTTP`, which a `&mut AsyncHTTP` does cover) and projects through `ptr::from_mut(self)`, a reborrow of the whole object. `preconnect` goes through it instead of projecting by hand, so the http crate has one projection site.
* `Installer::start_task` and `compute_data_for_source_map` project through `ptr::from_mut` of the slot they just wrote.
* `ThreadPool::each_impl` and the two batches in `generate_chunks_in_parallel` fill their `Vec` first and then build the batch in one loop from `as_mut_ptr().add(i)`; the three copies of the `last_mut()` push in the chunk loop collapse into that one loop, and the with-capacity comments that justified taking pointers mid-fill go away with the pattern.

### Verification

`test/internal/source-lints/thread-pool-batch-projection.test.ts` bans `&raw mut` / `&raw const` / `addr_of_mut!` / `addr_of!` of a field path rooted at a binding as the argument of any `Batch::from(` call (however the type is spelled, including the `PoolBatch` / `ThreadPoolBatch` aliases), with a self-test over the spellings of every site in the tree and the converted shapes. Against main it reports exactly the eleven sites above:

```
src/bundler/linker_context/generateChunksInParallel.rs:117, :203, :226, :248
src/bundler/LinkerContext.rs:589, :590
src/http/AsyncHTTP.rs:391, :530
src/install/isolated_install/Installer.rs:171
src/install/patch_install.rs:711
src/threading/ThreadPool.rs:560
```

and passes on this branch with no allowlist. It is deliberately disjoint from #37865's lint, which bans the reference / accessor / `from_mut` shapes in the same argument and reports only `src/install/PackageInstall.rs:475` both on main and on this branch (checked by running it here), so the two can land in either order without sharing an allowlist; #37768's lint covers `WorkPool::schedule`, and both of those also report nothing on this branch.

The converted paths are exercised by existing tests, all run against the debug build of this branch: `test/cli/install/bun-install-patch.test.ts` (18 pass) and `bun-patch.test.ts` (31 pass) for `PatchTask::schedule` and the registry downloads that go through `NetworkTask` → `AsyncHTTP::schedule`; `test/cli/install/isolated-install.test.ts` (62 pass) for `start_task`; `test/cli/install/bun-audit.test.ts` (17 pass) for the `send_sync` path; `test/js/web/fetch/fetch-redirect.test.ts` (30 pass) and `client-fetch.test.ts` (34 pass) for the fetch path; `test/bundler/bundler_html.test.ts` (22 pass; JS, CSS and HTML part ranges plus the CSS AST batch), `test/bundler/css/css-modules.test.ts` (6 pass), `test/bundler/bundler_splitting.test.ts` (11 pass; many chunks through `each_ptr`), `test/bundler/bun-build-api.test.ts` (52 pass; source maps) and `test/js/bun/sourcemap/internal-sourcemap-roundtrip.test.ts` (22 pass). `fetch.preconnect` was checked directly with a local listener (the preconnect opens the connection before the first `fetch`); `test/js/web/fetch/fetch-preconnect.test.ts` itself cannot run in this container because `localhost` resolves to `::1` first here, which makes it fail identically on the released binary, and that is tracked separately. `cargo clippy --no-deps` on `bun_threading`, `bun_http`, `bun_install` and `bun_bundler` is clean and `cargo fmt` is clean.

</details>
