### PR TITLE
install: print version before package name in the minimum-release-age error

### DIFF
--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -832,10 +832,10 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                 None,
                                                 bun_ast::Loc::EMPTY,
                                                 "No version matching \"{}\" found for specifier \"{}\"<r> <d>(blocked by minimum-release-age: {} seconds)<r>",
-                                                bstr::BStr::new(this.lockfile.str(&name)),
                                                 bstr::BStr::new(
                                                     this.lockfile.str(&version.literal)
                                                 ),
+                                                bstr::BStr::new(this.lockfile.str(&name)),
                                                 age_gate_ms / MS_PER_S,
                                             );
                                         }

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -931,11 +931,60 @@ describe("minimum-release-age", () => {
       const exitCode = await proc.exited;
       const stderr = await proc.stderr.text();
 
-      // Should fail because 3.0.0 is too recent
-      expect(exitCode).toBe(1);
-      expect(stderr.toLowerCase()).toMatch(
-        /blocked.*npm.*minimal.*age.*gate|blocked.*minimum.*release.*age|too.*recent/,
+      // Should fail because 3.0.0 is too recent; same argument order as the "(but package exists)" error.
+      expect(stderr).toContain(
+        `error: No version matching "3.0.0" found for specifier "regular-package" (blocked by minimum-release-age: ${5 * SECONDS_PER_DAY} seconds)`,
       );
+      expect(exitCode).toBe(1);
+    });
+
+    test("reports the range and package name when every version in a range is too recent", async () => {
+      using dir = tempDir("range-all-too-recent", {
+        "package.json": JSON.stringify({
+          dependencies: { "regular-package": "^2.1.0" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      // 2.1.0 is 6 days old and 3.0.0 is 1 day old; ^2.1.0 excludes 1.0.0 and 2.0.0.
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--minimum-release-age", `${10 * SECONDS_PER_DAY}`, "--no-verify"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain(
+        `error: No version matching "^2.1.0" found for specifier "regular-package" (blocked by minimum-release-age: ${10 * SECONDS_PER_DAY} seconds)`,
+      );
+      expect(exitCode).toBe(1);
+    });
+
+    test("reports the package name and tag when every version behind a dist-tag is too recent", async () => {
+      using dir = tempDir("dist-tag-all-too-recent", {
+        "package.json": JSON.stringify({
+          dependencies: { "all-future-package": "latest" },
+        }),
+        ".npmrc": `registry=${mockRegistryUrl}`,
+      });
+
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install", "--minimum-release-age", `${5 * SECONDS_PER_DAY}`, "--no-verify"],
+        cwd: String(dir),
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+
+      const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+      expect(stderr).toContain(
+        `error: Package "all-future-package" with tag "latest" not found (all versions blocked by minimum-release-age: ${5 * SECONDS_PER_DAY} seconds)`,
+      );
+      expect(exitCode).toBe(1);
     });
   });
 
@@ -1547,9 +1596,10 @@ describe("minimum-release-age", () => {
       const stderr = await proc.stderr.text();
 
       // Should fail gracefully
+      expect(stderr).toContain(
+        'error: No version matching "99.0.0" found for specifier "regular-package" (but package exists)',
+      );
       expect(exitCode).toBe(1);
-      // Error message varies but should indicate version not found
-      expect(stderr.toLowerCase()).toMatch(/not found|no version matching|failed to resolve/);
     });
   });
 
@@ -2400,8 +2450,10 @@ describe("minimum-release-age", () => {
       const [exitCode, stderr] = await Promise.all([proc.exited, proc.stderr.text()]);
 
       // Should fail - no versions pass the age gate
+      expect(stderr).toContain(
+        `error: No version matching "*" found for specifier "all-future-package" (blocked by minimum-release-age: ${5 * SECONDS_PER_DAY} seconds)`,
+      );
       expect(exitCode).toBe(1);
-      expect(stderr.toLowerCase()).toMatch(/no version|blocked|failed to resolve/);
     });
   });
 


### PR DESCRIPTION
### Problem
- When `--minimum-release-age` (or `install.minimumReleaseAge`) blocks every version that satisfies a dependency, `bun install` prints the package name and the requested version in each other's slots: `No version matching "regular-package" found for specifier "3.0.0" (blocked by minimum-release-age: 432000 seconds)`.
- The neighbouring `(but package exists)` error fills the same template the other way round, so the two errors a user can get for one dependency disagree.
- Cause: the age-gate branch passes the two format arguments in the opposite order to the branch beside it. It has been this way since #22801, and this is the only place the message is produced.

### Fix
- Swap the two arguments. The message now reads `No version matching "3.0.0" found for specifier "regular-package" (blocked by minimum-release-age: 432000 seconds)`.
- Property to check: in both errors the first slot is what a version had to match and the second is the package name. The dist-tag variant already had that shape and is untouched.
- Verification: the tests that matched this error with a loose regex now pin the full text against the mock registry; the three age-gate assertions fail without the change and pass with it.

### Background
- `--minimum-release-age N` makes install ignore versions published less than N seconds ago. If nothing that satisfies the dependency remains, install fails rather than taking a newer version.
- One template, `No version matching "X" found for specifier "Y"`, serves both "nothing satisfies X" and "the age gate blocked everything that does"; only the trailing parenthetical differs.
- A dependency written as a dist-tag (`latest`) fails through a separate message naming the package and tag, so it is not affected.

<details>
<summary>Original description</summary>

### What

When `--minimum-release-age` (or `install.minimumReleaseAge`) blocks every version that satisfies a range, `bun install` printed the package name and the range in the wrong slots:

```
error: No version matching "regular-package" found for specifier "3.0.0" (blocked by minimum-release-age: 432000 seconds)
```

The sibling error for a range that nothing satisfies fills the same template the other way around, and that is the order the rest of the install tests already assert on (`bun-install.test.ts`, `bun-install-registry.test.ts`):

```
error: No version matching "^9" found for specifier "regular-package" (but package exists)
```

After this change the age-gate variant reads the same way:

```
error: No version matching "3.0.0" found for specifier "regular-package" (blocked by minimum-release-age: 432000 seconds)
```

### Why

The first slot of the template is the thing a version has to match, so it can only sensibly hold the requested version or range; the `TooRecentVersion` branch in `PackageManagerEnqueue.rs` passed `name` there and `version.literal` second. The `NoMatchingVersion` branch a few lines above passes them the other way around, so the two errors a user sees for the same dependency disagreed with each other. The dist-tag variant (`Package "x" with tag "latest" not found (all versions blocked ...)`) was already in the right order and is unchanged. This has been the case since the feature landed in #22801; it is the only place the message is produced, and nothing else in the repo (docs, other tests) depends on the old order.

### Repro

```sh
# registry serves regular-package 1.0.0 (30 days old) and 3.0.0 (1 day old)
echo '{"dependencies":{"regular-package":"3.0.0"}}' > package.json
bun install --minimum-release-age 432000
```

### Fix

Swap the two format arguments in the `TooRecentVersion` branch of `enqueue_dependency_with_main_and_success_fn` so they line up with the template and with the `NoMatchingVersion` branch.

### Tests

`test/cli/install/minimum-release-age.test.ts` only matched this error with a loose regex. It now pins the full text for:

- an exact version that is too recent (`FindVersionError::TooRecent`), fails before this change
- a range whose every match is too recent, both `^2.1.0` and `*` (`FindVersionError::AllVersionsTooRecent`), fails before this change
- the dist-tag variant and the `(but package exists)` variant, whose order was already correct, so the three messages are asserted side by side

```
USE_SYSTEM_BUN=1 bun test test/cli/install/minimum-release-age.test.ts   # 3 fail (the three age-gate assertions), 48 pass
bun bd test test/cli/install/minimum-release-age.test.ts                 # 51 pass
```

</details>
