### PR TITLE
cluster: hand TLS workers their connections on Windows instead of sharing the listening socket

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4100,9 +4100,7 @@ function listenInCluster(
     readableAll,
     writableAll,
     ...options,
-    // A TLS server accepts natively, so it wants a copy of the primary's listening socket. Not on Windows,
-    // where two processes accepting on copies of one socket block in accept() and livelock its polls
-    // (oven-sh/bun#37896): there the primary hands TLS workers connections too and tls.Server wraps them.
+    // Not on Windows: two processes cannot accept on copies of one listening socket there (oven-sh/bun#37896).
     sharedOnly: tls && process.platform !== "win32" ? true : undefined,
   };
   const listeningId = (server[kClusterListeningId] = (server[kClusterListeningId] || 0) + 1);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4100,12 +4100,9 @@ function listenInCluster(
     readableAll,
     writableAll,
     ...options,
-    // A TLS server asks for a copy of the primary's listening socket so it can accept and handshake
-    // natively. Not on Windows: copies of one listening socket polled from two processes block the
-    // loser of each accept() race inside accept() and keep the processes' exclusive AFD polls
-    // cancelling each other (libuv avoids both with AcceptEx, which our listen sockets do not use), so
-    // there a TLS worker takes the primary's connections like a plain server does and tls.Server wraps
-    // each one in its 'connection' listener, which is how node's tls.Server works everywhere.
+    // A TLS server accepts natively, so it wants a copy of the primary's listening socket. Not on Windows,
+    // where two processes accepting on copies of one socket block in accept() and livelock its polls
+    // (oven-sh/bun#37896): there the primary hands TLS workers connections too and tls.Server wraps them.
     sharedOnly: tls && process.platform !== "win32" ? true : undefined,
   };
   const listeningId = (server[kClusterListeningId] = (server[kClusterListeningId] || 0) + 1);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -4100,7 +4100,13 @@ function listenInCluster(
     readableAll,
     writableAll,
     ...options,
-    sharedOnly: tls ? true : undefined,
+    // A TLS server asks for a copy of the primary's listening socket so it can accept and handshake
+    // natively. Not on Windows: copies of one listening socket polled from two processes block the
+    // loser of each accept() race inside accept() and keep the processes' exclusive AFD polls
+    // cancelling each other (libuv avoids both with AcceptEx, which our listen sockets do not use), so
+    // there a TLS worker takes the primary's connections like a plain server does and tls.Server wraps
+    // each one in its 'connection' listener, which is how node's tls.Server works everywhere.
+    sharedOnly: tls && process.platform !== "win32" ? true : undefined,
   };
   const listeningId = (server[kClusterListeningId] = (server[kClusterListeningId] || 0) + 1);
   // https://github.com/nodejs/node/blob/v26.3.0/lib/net.js#L2080-L2102

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3941,10 +3941,10 @@ Server.prototype[kRealListen] = function (
   }
 
   if (contexts) {
-    for (const [name, context] of contexts) {
+    for (const [name, { context }] of contexts) {
       // tls.ts stores the InternalSecureContext wrapper; the native side wants
       // the native SSL_CTX wrapper at `.context`.
-      addServerName(this._handle, name, context.context ?? context);
+      addServerName(this._handle, name, context.context);
     }
   }
 

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1159,6 +1159,22 @@ function buildSharedCreds(server) {
   ));
 }
 
+// The addContext() entry for a servername, matched the way node's default SNICallback does: a `*`
+// in the name stands for part of one label, and the newest matching entry wins.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1571-L1611
+function matchContext(contexts: Map<string, typeof InternalSecureContext>, servername: string) {
+  let match;
+  for (const { 0: name, 1: context } of contexts) {
+    const source = RegExpPrototypeSymbolReplace.$call(
+      /\*/g,
+      RegExpPrototypeSymbolReplace.$call(/([.^$+?\-\\[\]{}])/g, name, "\\$1"),
+      "[^.]*",
+    );
+    if (RegExpPrototypeExec.$call(new RegExp(`^${source}$`), servername) !== null) match = context;
+  }
+  return match;
+}
+
 function Server(options, secureConnectionListener): void {
   if (!(this instanceof Server)) {
     return new Server(options, secureConnectionListener);
@@ -1222,15 +1238,36 @@ function Server(options, secureConnectionListener): void {
     if (!(context instanceof InternalSecureContext)) {
       context = new InternalSecureContext(context, true);
     }
+    // Kept like node's _contexts (a later listen() loads them into its listener again) and, for a
+    // connection that never passed through a native listener of this server, consulted by
+    // wrappedSNICallback below. Re-adding a name moves it to the end: the newest entry wins.
+    if (!contexts) contexts = new Map();
+    else contexts.delete(hostname);
+    contexts.set(hostname, context);
     const handle = this._handle;
-    if (handle) {
+    // A cluster worker fed by the primary listens on node's faux handle, which has no SNI tree.
+    if (handle && typeof handle.stop === "function") {
       // Pass the native SSL_CTX wrapper, not the JS InternalSecureContext —
       // the native side detects it via SecureContext.fromJS and up_refs.
       addServerName(handle, hostname, context.context);
-    } else {
-      if (!contexts) contexts = new Map();
-      contexts.set(hostname, context);
     }
+  };
+
+  const server = this;
+  // SNI for a connection this server wraps itself (server.emit('connection'), or one handed off by the
+  // cluster primary): no listener SNI tree is involved, so the addContext() entries are resolved here.
+  // They apply behind a user SNICallback that selects nothing, as with our native listener (node's
+  // own default would not consult them once an SNICallback is set). `this` is the wrapping TLSSocket.
+  const wrappedSNICallback = function (servername, callback) {
+    const userCallback = server._SNICallback;
+    if (typeof userCallback !== "function") {
+      callback(null, matchContext(contexts, servername));
+      return;
+    }
+    userCallback.$call(this, servername, (err, context) => {
+      if (err || context != null) callback(err, context);
+      else callback(null, matchContext(contexts, servername));
+    });
   };
 
   this.setSecureContext = function (options) {
@@ -1501,7 +1538,7 @@ function Server(options, secureConnectionListener): void {
       isServer: true,
       requestCert: this._requestCert,
       rejectUnauthorized: this._rejectUnauthorized,
-      SNICallback: this._SNICallback,
+      SNICallback: contexts ? wrappedSNICallback : this._SNICallback,
       ALPNProtocols: this.ALPNProtocols,
       ALPNCallback: this._ALPNCallback,
     });

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1159,8 +1159,7 @@ function buildSharedCreds(server) {
   ));
 }
 
-// Node's default SNICallback: `*` spans part of one label, the newest matching entry wins.
-// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1571-L1611
+// Matches like node's default SNICallback: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1571-L1611
 function matchContext(contexts: Map<string, typeof InternalSecureContext>, servername: string) {
   let match;
   for (const { 0: name, 1: context } of contexts) {
@@ -1250,8 +1249,7 @@ function Server(options, secureConnectionListener): void {
   };
 
   const server = this;
-  // SNI for the connections this server wraps itself (no listener SNI tree). addContext() entries apply
-  // behind a user SNICallback that selects nothing, like on our native listener (node's would not).
+  // Like our native listener (and unlike node), addContext() entries apply when the SNICallback selects nothing.
   const wrappedSNICallback = function (servername, callback) {
     const userCallback = server._SNICallback;
     if (typeof userCallback !== "function") {

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1159,8 +1159,7 @@ function buildSharedCreds(server) {
   ));
 }
 
-// The addContext() entry for a servername, matched the way node's default SNICallback does: a `*`
-// in the name stands for part of one label, and the newest matching entry wins.
+// Node's default SNICallback: `*` spans part of one label, the newest matching entry wins.
 // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1571-L1611
 function matchContext(contexts: Map<string, typeof InternalSecureContext>, servername: string) {
   let match;
@@ -1238,10 +1237,8 @@ function Server(options, secureConnectionListener): void {
     if (!(context instanceof InternalSecureContext)) {
       context = new InternalSecureContext(context, true);
     }
-    // Kept like node's _contexts (a later listen() loads them into its listener again) and, for a
-    // connection that never passed through a native listener of this server, consulted by
-    // wrappedSNICallback below. Re-adding a name moves it to the end: the newest entry wins.
-    contexts.delete(hostname);
+    // Kept like node's _contexts: reloaded by the next listen(), matched for connections wrapped below.
+    contexts.delete(hostname); // a re-added name becomes the newest entry
     contexts.set(hostname, context);
     const handle = this._handle;
     // A cluster worker fed by the primary listens on node's faux handle, which has no SNI tree.
@@ -1253,10 +1250,8 @@ function Server(options, secureConnectionListener): void {
   };
 
   const server = this;
-  // SNI for a connection this server wraps itself (server.emit('connection'), or one handed off by the
-  // cluster primary): no listener SNI tree is involved, so the addContext() entries are resolved here.
-  // They apply behind a user SNICallback that selects nothing, as with our native listener (node's
-  // own default would not consult them once an SNICallback is set). `this` is the wrapping TLSSocket.
+  // SNI for the connections this server wraps itself (no listener SNI tree). addContext() entries apply
+  // behind a user SNICallback that selects nothing, like on our native listener (node's would not).
   const wrappedSNICallback = function (servername, callback) {
     const userCallback = server._SNICallback;
     if (typeof userCallback !== "function") {

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1159,16 +1159,22 @@ function buildSharedCreds(server) {
   ));
 }
 
-// Matches like node's default SNICallback: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1571-L1611
-function matchContext(contexts: Map<string, typeof InternalSecureContext>, servername: string) {
+// An addContext() entry, matched like node's: https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1571-L1611
+type ServerContext = { re: RegExp; context: InstanceType<typeof InternalSecureContext> };
+
+function contextMatcher(hostname: string): RegExp {
+  const source = RegExpPrototypeSymbolReplace.$call(
+    /\*/g,
+    RegExpPrototypeSymbolReplace.$call(/([.^$+?\-\\[\]{}])/g, hostname, "\\$1"),
+    "[^.]*",
+  );
+  return new RegExp(`^${source}$`);
+}
+
+function matchContext(contexts: Map<string, ServerContext>, servername: string) {
   let match;
-  for (const { 0: name, 1: context } of contexts) {
-    const source = RegExpPrototypeSymbolReplace.$call(
-      /\*/g,
-      RegExpPrototypeSymbolReplace.$call(/([.^$+?\-\\[\]{}])/g, name, "\\$1"),
-      "[^.]*",
-    );
-    if (RegExpPrototypeExec.$call(new RegExp(`^${source}$`), servername) !== null) match = context;
+  for (const { 1: entry } of contexts) {
+    if (RegExpPrototypeExec.$call(entry.re, servername) !== null) match = entry.context;
   }
   return match;
 }
@@ -1227,7 +1233,7 @@ function Server(options, secureConnectionListener): void {
   this.ALPNProtocols = undefined;
   this._sharedCreds = undefined;
 
-  const contexts: Map<string, typeof InternalSecureContext> = new Map();
+  const contexts: Map<string, ServerContext> = new Map();
 
   this.addContext = function (hostname, context) {
     if (typeof hostname !== "string") {
@@ -1238,7 +1244,7 @@ function Server(options, secureConnectionListener): void {
     }
     // Kept like node's _contexts: reloaded by the next listen(), matched for connections wrapped below.
     contexts.delete(hostname); // a re-added name becomes the newest entry
-    contexts.set(hostname, context);
+    contexts.set(hostname, { re: contextMatcher(hostname), context });
     const handle = this._handle;
     // A cluster worker fed by the primary listens on node's faux handle, which has no SNI tree.
     if (handle && typeof handle.stop === "function") {

--- a/src/js/node/tls.ts
+++ b/src/js/node/tls.ts
@@ -1229,7 +1229,7 @@ function Server(options, secureConnectionListener): void {
   this.ALPNProtocols = undefined;
   this._sharedCreds = undefined;
 
-  let contexts: Map<string, typeof InternalSecureContext> | null = null;
+  const contexts: Map<string, typeof InternalSecureContext> = new Map();
 
   this.addContext = function (hostname, context) {
     if (typeof hostname !== "string") {
@@ -1241,8 +1241,7 @@ function Server(options, secureConnectionListener): void {
     // Kept like node's _contexts (a later listen() loads them into its listener again) and, for a
     // connection that never passed through a native listener of this server, consulted by
     // wrappedSNICallback below. Re-adding a name moves it to the end: the newest entry wins.
-    if (!contexts) contexts = new Map();
-    else contexts.delete(hostname);
+    contexts.delete(hostname);
     contexts.set(hostname, context);
     const handle = this._handle;
     // A cluster worker fed by the primary listens on node's faux handle, which has no SNI tree.
@@ -1538,7 +1537,7 @@ function Server(options, secureConnectionListener): void {
       isServer: true,
       requestCert: this._requestCert,
       rejectUnauthorized: this._rejectUnauthorized,
-      SNICallback: contexts ? wrappedSNICallback : this._SNICallback,
+      SNICallback: contexts.size !== 0 ? wrappedSNICallback : this._SNICallback,
       ALPNProtocols: this.ALPNProtocols,
       ALPNCallback: this._ALPNCallback,
     });

--- a/test/js/node/cluster.test.ts
+++ b/test/js/node/cluster.test.ts
@@ -11,7 +11,9 @@ import {
   tempDirWithFiles,
   tls as tlsCerts,
 } from "harness";
+import { readFileSync } from "node:fs";
 import net from "node:net";
+import { join } from "node:path";
 
 test.concurrent("cloneable and transferable equals", async () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -174,9 +176,13 @@ process.send("regular message");
   expect(exitCode).toBe(0);
 });
 
-test("TLS worker listening on a key already owned by a round-robin handle fails with EINVAL", async () => {
-  const dir = tempDirWithFiles("bun-test", {
-    "main.ts": `
+// TLS workers only ask for a shared listening socket on POSIX; on Windows the primary hands them
+// connections like plain workers (see the Windows test further down), so nothing is refused there.
+test.skipIf(isWindows)(
+  "TLS worker listening on a key already owned by a round-robin handle fails with EINVAL",
+  async () => {
+    const dir = tempDirWithFiles("bun-test", {
+      "main.ts": `
 const cluster = require("node:cluster");
 const net = require("node:net");
 const tls = require("node:tls");
@@ -200,11 +206,14 @@ if (cluster.isPrimary) {
   server.listen(0);
 }
 `,
-  });
-  const { stdout } = await bunRun(joinP(dir, "main.ts"), bunEnv);
-  expect(stdout).toContain("tls listen error code: EINVAL");
-  expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
-});
+    });
+    const { stdout } = await bunRun(joinP(dir, "main.ts"), bunEnv);
+    expect(stdout).toContain("tls listen error code: EINVAL");
+    expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
+  },
+  // Three debug processes, two of them loading node:tls, like its two siblings below.
+  30_000,
+);
 
 test("cluster pipe listen error carries no port suffix", async () => {
   const dir = tempDirWithFiles("bun-test", {
@@ -807,11 +816,14 @@ if (cluster.isPrimary) {
   expect(stdout).toContain("reply: echo:hi");
 }, 30_000);
 
-test("plain worker listening on a key already owned by a TLS shared-only handle fails with EINVAL", async () => {
-  const dir = tempDirWithFiles("bun-test", {
-    "cert.pem": tlsCerts.cert,
-    "key.pem": tlsCerts.key,
-    "main.ts": `
+// Not on Windows: no shared-only handle exists there (see the next test).
+test.skipIf(isWindows)(
+  "plain worker listening on a key already owned by a TLS shared-only handle fails with EINVAL",
+  async () => {
+    const dir = tempDirWithFiles("bun-test", {
+      "cert.pem": tlsCerts.cert,
+      "key.pem": tlsCerts.key,
+      "main.ts": `
 const cluster = require("node:cluster");
 const net = require("node:net");
 const tls = require("node:tls");
@@ -839,11 +851,157 @@ if (cluster.isPrimary) {
   server.listen(0);
 }
 `,
+    });
+    const { stdout } = await bunRun(joinP(dir, "main.ts"), bunEnv);
+    expect(stdout).toContain("net listen error code: EINVAL");
+    expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
+  },
+  30_000,
+);
+
+// On Windows, TLS workers used to accept on copies of one listening socket like SCHED_NONE workers,
+// whatever the policy. Two processes accepting on one Windows socket do not work: the worker losing
+// the race for a connection blocked inside accept() until the next connection arrived (it stopped
+// answering IPC and never reacted to disconnect()), and the two workers' exclusive AFD polls kept
+// cancelling each other while idle. TLS workers there now take the primary's connections in turn,
+// like plain workers do, and wrap each one themselves, which also has to honor addContext() (there is
+// no native listener in the worker to attach the contexts to).
+test.skipIf(!isWindows)(
+  "Windows: two TLS workers on one port are served by the primary in turn, honor addContext() and keep answering IPC",
+  async () => {
+    const tlsFixtures = join(import.meta.dir, "tls", "fixtures");
+    using dir = tempDir("cluster-windows-tls-workers", {
+      "cert.pem": tlsCerts.cert,
+      "key.pem": tlsCerts.key,
+      "alt-cert.pem": readFileSync(join(tlsFixtures, "rsa_cert.crt"), "utf8"),
+      "alt-key.pem": readFileSync(join(tlsFixtures, "rsa_private.pem"), "utf8"),
+      "main.ts": `
+const cluster = require("node:cluster");
+const tls = require("node:tls");
+const fs = require("node:fs");
+const path = require("node:path");
+const { X509Certificate } = require("node:crypto");
+const key = fs.readFileSync(path.join(__dirname, "key.pem"));
+const cert = fs.readFileSync(path.join(__dirname, "cert.pem"));
+const altKey = fs.readFileSync(path.join(__dirname, "alt-key.pem"));
+const altCert = fs.readFileSync(path.join(__dirname, "alt-cert.pem"));
+const ALT_NAME = "alt.example.com";
+
+if (cluster.isPrimary) {
+  const CONNECTIONS = 40;
+  const fingerprints = {
+    cert: new X509Certificate(cert).fingerprint256,
+    altCert: new X509Certificate(altCert).fingerprint256,
+  };
+  const workers = [cluster.fork({ ADD_CONTEXT: "before-listen" }), cluster.fork({ ADD_CONTEXT: "after-listen" })];
+  const ports = new Set();
+  const exits = [];
+  let listening = 0;
+
+  function fail(message) {
+    console.log(message);
+    for (const worker of workers) worker.process.kill();
+    process.exit(1);
+  }
+
+  for (const worker of workers) {
+    worker.on("message", message => {
+      if (message?.error) fail("worker " + worker.id + " error: " + message.error);
+    });
+  }
+
+  cluster.on("listening", (worker, address) => {
+    ports.add(address.port);
+    if (++listening !== workers.length) return;
+    run(address.port).catch(err => fail("error: " + err.message));
   });
-  const { stdout } = await bunRun(joinP(dir, "main.ts"), bunEnv);
-  expect(stdout).toContain("net listen error code: EINVAL");
-  expect(stdout).toContain("TLS and non-TLS cluster workers cannot share");
-}, 30_000);
+
+  cluster.on("exit", (worker, code, signal) => {
+    exits.push(code ?? signal);
+    if (exits.length === workers.length) console.log("exits:", exits.join(","));
+  });
+
+  // Returns "<worker id>:<which certificate the client was shown>".
+  function connectOnce(port, servername) {
+    return new Promise((resolve, reject) => {
+      const client = tls.connect({ port, host: "127.0.0.1", servername, rejectUnauthorized: false });
+      let shown = "no certificate";
+      let data = "";
+      client.setEncoding("utf8");
+      client.on("secureConnect", () => {
+        const fingerprint = client.getPeerCertificate().fingerprint256;
+        shown = Object.keys(fingerprints).find(name => fingerprints[name] === fingerprint) ?? "unknown certificate";
+      });
+      client.on("data", chunk => (data += chunk));
+      client.on("error", reject);
+      client.on("close", () => (data ? resolve(data + ":" + shown) : reject(new Error("no reply from the worker"))));
+    });
+  }
+
+  function pingWorkers(connection) {
+    return Promise.all(
+      workers.map(worker => {
+        return new Promise(resolve => {
+          // A worker blocked inside accept() produces no event at all; name it instead of timing out.
+          const stuck = setTimeout(() => fail("worker " + worker.id + " stopped answering after connection " + connection), 10_000);
+          worker.once("message", () => {
+            clearTimeout(stuck);
+            resolve();
+          });
+          worker.send("ping");
+        });
+      }),
+    );
+  }
+
+  async function run(port) {
+    const servedBy = [];
+    const wrongCertificates = [];
+    for (let connection = 1; connection <= CONNECTIONS; connection++) {
+      // Two connections in a row per name, so each worker (they alternate) sees both names.
+      const useAlt = (connection >> 1) & 1;
+      const [workerId, shown] = (await connectOnce(port, useAlt ? ALT_NAME : "localhost")).split(":");
+      servedBy.push(workerId);
+      const expected = useAlt ? "altCert" : "cert";
+      if (shown !== expected) wrongCertificates.push("connection " + connection + " expected " + expected + ", got " + shown);
+      await pingWorkers(connection);
+    }
+    console.log("served:", servedBy.length, "ports:", ports.size);
+    const alternating = servedBy.every((id, i) => i === 0 || id !== servedBy[i - 1]);
+    console.log("distribution:", alternating ? "alternating" : servedBy.join(""));
+    console.log("certificates:", wrongCertificates.length === 0 ? "ok" : wrongCertificates.join("; "));
+    for (const worker of workers) worker.disconnect();
+  }
+} else {
+  const server = tls.createServer({ key, cert }, socket => socket.end(String(cluster.worker.id)));
+  server.on("error", err => process.send({ error: err.message }));
+  server.on("tlsClientError", err => process.send({ error: "tlsClientError: " + err.message }));
+  if (process.env.ADD_CONTEXT === "before-listen") server.addContext(ALT_NAME, { key: altKey, cert: altCert });
+  server.listen(0, "127.0.0.1", () => {
+    if (process.env.ADD_CONTEXT === "after-listen") server.addContext(ALT_NAME, { key: altKey, cert: altCert });
+  });
+  process.on("message", message => {
+    if (message === "ping") process.send("pong");
+  });
+}
+`,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "served: 40 ports: 1\ndistribution: alternating\ncertificates: ok\nexits: 0,0\n",
+      stderr: expect.any(String),
+      exitCode: 0,
+    });
+  },
+  30_000,
+);
 
 test.skipIf(isWindows)(
   "SCHED_NONE listen({fd:2}) fails EINVAL like node and does not close the primary's stderr",

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1,6 +1,6 @@
 import crypto from "crypto";
 import { readFileSync, realpathSync } from "fs";
-import { bunEnv, bunExe, tls as cert1, isDebug } from "harness";
+import { bunEnv, bunExe, tls as cert1, expiredTls, isDebug } from "harness";
 import https from "https";
 import net, { AddressInfo } from "net";
 import { createTest } from "node-harness";
@@ -1308,6 +1308,138 @@ it("an asynchronous SNICallback resolving cb(null, null) still honors addContext
   await once(client, "close");
   server.close();
   await once(server, "close");
+});
+
+describe("addContext() on connections the server wraps itself", () => {
+  // Connections handed in with server.emit('connection') (and, in a cluster
+  // worker fed by the primary, every connection) never pass through a listener's
+  // SNI tree, so tls.Server has to resolve its addContext() entries itself.
+  const defaultFingerprint = new crypto.X509Certificate(COMMON_CERT.cert).fingerprint256;
+  const altFingerprint = new crypto.X509Certificate(cert).fingerprint256;
+  const expiredFingerprint = new crypto.X509Certificate(expiredTls.cert).fingerprint256;
+  const altContext = { key: rawKey, cert };
+
+  async function serverCertificateFor(port: number, servername: string) {
+    const client = connect({ port, host: "127.0.0.1", servername, rejectUnauthorized: false });
+    try {
+      await once(client, "secureConnect");
+      return client.getPeerCertificate().fingerprint256;
+    } finally {
+      client.destroy();
+    }
+  }
+
+  async function withInjectingServer(tlsServer: Server, run: (port: number) => Promise<void>) {
+    tlsServer.on("secureConnection", socket => socket.end());
+    const rawServer = net.createServer(raw => tlsServer.emit("connection", raw));
+    rawServer.listen(0, "127.0.0.1");
+    await once(rawServer, "listening");
+    try {
+      await run((rawServer.address() as AddressInfo).port);
+    } finally {
+      rawServer.close();
+      tlsServer.close();
+    }
+  }
+
+  it("selects the addContext() entry matching the servername, node's way", async () => {
+    const tlsServer = createServer(COMMON_CERT);
+    tlsServer.addContext("alt.example.com", altContext);
+    tlsServer.addContext("*.wild.example.com", altContext);
+    // A name added twice ends up with the last context given for it.
+    tlsServer.addContext("readded.example.com", { ...expiredTls });
+    tlsServer.addContext("readded.example.com", altContext);
+    await withInjectingServer(tlsServer, async port => {
+      expect({
+        exact: await serverCertificateFor(port, "alt.example.com"),
+        wildcard: await serverCertificateFor(port, "a.wild.example.com"),
+        readded: await serverCertificateFor(port, "readded.example.com"),
+        // `*` covers a single label.
+        twoLabels: await serverCertificateFor(port, "a.b.wild.example.com"),
+        unknown: await serverCertificateFor(port, "other.example.com"),
+      }).toEqual({
+        exact: altFingerprint,
+        wildcard: altFingerprint,
+        readded: altFingerprint,
+        twoLabels: defaultFingerprint,
+        unknown: defaultFingerprint,
+      });
+    });
+  });
+
+  it("consults addContext() only for servernames the SNICallback selects nothing for", async () => {
+    // Same precedence as the native listener (see the asynchronous cb(null, null)
+    // test above); node's own default stops consulting addContext() entries once
+    // an SNICallback is configured.
+    const picked = tls.createSecureContext({ ...expiredTls });
+    const seen: string[] = [];
+    const tlsServer = createServer({
+      ...COMMON_CERT,
+      SNICallback(name, cb) {
+        seen.push(name);
+        // Resolve asynchronously too: the fallback has to work with either style.
+        if (name === "picked.example.com") setImmediate(cb, null, picked);
+        else cb(null, undefined);
+      },
+    });
+    tlsServer.addContext("alt.example.com", altContext);
+    // The callback is consulted even for a name addContext() knows.
+    tlsServer.addContext("picked.example.com", altContext);
+    await withInjectingServer(tlsServer, async port => {
+      expect({
+        picked: await serverCertificateFor(port, "picked.example.com"),
+        alt: await serverCertificateFor(port, "alt.example.com"),
+        unknown: await serverCertificateFor(port, "other.example.com"),
+        seen,
+      }).toEqual({
+        picked: expiredFingerprint,
+        alt: altFingerprint,
+        unknown: defaultFingerprint,
+        seen: ["picked.example.com", "alt.example.com", "other.example.com"],
+      });
+    });
+  });
+
+  it("an SNICallback error is reported as tlsClientError even when addContext() knows the name", async () => {
+    const tlsServer = createServer({
+      ...COMMON_CERT,
+      SNICallback: (_name, cb) => cb(new Error("refused by SNICallback")),
+    });
+    tlsServer.addContext("alt.example.com", altContext);
+    const clientError = Promise.withResolvers<Error>();
+    tlsServer.on("tlsClientError", clientError.resolve);
+    await withInjectingServer(tlsServer, async port => {
+      const client = connect({ port, host: "127.0.0.1", servername: "alt.example.com", rejectUnauthorized: false });
+      client.on("error", () => {});
+      try {
+        expect((await clientError.promise).message).toBe("refused by SNICallback");
+      } finally {
+        client.destroy();
+      }
+    });
+  });
+
+  it("addContext() after listen() still reaches the native listener, and a later listen() reloads every entry", async () => {
+    const server = createServer(COMMON_CERT);
+    server.on("secureConnection", socket => socket.end());
+    try {
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      server.addContext("alt.example.com", altContext);
+      const whileListening = await serverCertificateFor((server.address() as AddressInfo).port, "alt.example.com");
+      server.close();
+      await once(server, "close");
+      server.listen(0, "127.0.0.1");
+      await once(server, "listening");
+      const afterRelisten = await serverCertificateFor((server.address() as AddressInfo).port, "alt.example.com");
+      expect({ whileListening, afterRelisten }).toEqual({
+        whileListening: altFingerprint,
+        afterRelisten: altFingerprint,
+      });
+    } finally {
+      server.close();
+    }
+  });
 });
 
 describe("tls.Server socket destroySoon", () => {


### PR DESCRIPTION
### Problem
- On Windows, `tls.createServer(...).listen(port)` in two or more cluster workers hangs workers: after a few connections a worker stops answering IPC and never reacts to `disconnect()`. Two such workers also burn 0.8s to 1.5s of CPU each per 3s while idle.
- Since #31829 a TLS worker always gets a copy of the primary's listening socket and calls `accept()` on it itself. Two processes cannot do that on Windows: the loser of each accept race blocks inside `accept()` until the next connection, and the two processes' AFD polls cancel each other in a loop while idle.
- #37815 fixes the same two problems for plain TCP servers and leaves TLS to this PR.
- The path where the primary hands a worker an accepted connection ignored `addContext()`: entries added before `listen()` never applied, and `addContext()` after `listen()` threw `Expected a Listener instance`.

### Fix
- On Windows a TLS worker no longer asks for a shared socket. The primary accepts every connection and hands it over, and the worker wraps it in a server-side `TLSSocket`, as `server.emit('connection', socket)` already does and as node's `tls.Server` does for every cluster connection. Only one process accepts on the socket, so neither symptom can occur. POSIX is unchanged.
- `tls.Server` keeps its `addContext()` entries itself, loads them into the handle only when that is a native listener (so a later `listen()` reloads them), and picks the entry for a wrapped connection with node's matching rules: `*` covers part of one label, newest entry wins.
- Entries still apply when a user SNICallback selects nothing. Node's default stops at the callback; this keeps the wrapped path identical to Bun's native listener, which the same app takes on POSIX.
- Verification: a Windows-only cluster test (two workers, contexts added before and after `listen()`, 40 connections with IPC pings) fails on the canary after 3 connections and passed 10/10 on a fixed debug build. Tests that run everywhere cover `addContext()` on wrapped connections and fail without the fix. `http2.createSecureServer` and `pauseOnConnect` in Windows workers, and node v26.3.0's matching and distribution, were checked by hand.
- Not changed: with an explicit `SCHED_NONE`, a Windows primary still shares the socket for TLS and plain servers alike; #37815 covers that.

### Background
- `node:cluster` spreads one port over workers two ways. Round-robin: the primary owns the listening socket, accepts, and sends each connection to a worker over IPC; the worker's server sits on a faux handle with no socket behind it. Shared: every worker gets a copy of the socket and accepts itself. `sharedOnly` in `listenInCluster` forces the shared kind whatever `cluster.schedulingPolicy` says.
- Bun's TLS listener accepts and handshakes natively, which is why TLS workers were forced onto the shared kind. A connection that arrives as an already-accepted plain socket instead goes through `tls.Server`'s `'connection'` listener, which wraps it in a `TLSSocket` driven from JS.
- On Windows the primary copies a socket into a worker with `WSADuplicateSocketW` and libuv watches it with AFD polls. libuv drives its own shared listening sockets with `AcceptEx`; Bun's listen sockets do not use it.
- `server.addContext(name, ctx)` registers an extra certificate for one SNI name. A native listener holds these in its own SNI table; a wrapped connection has none, so the server must choose the context itself, through the same `SNICallback` hook a user can supply.

<details>
<summary>Original description</summary>

On Windows, `tls.createServer(...).listen(port)` in two or more cluster workers hangs workers and burns CPU while idle. Found while working on #37815, which fixes the same two problems for plain TCP listens and leaves the TLS path to this PR.

### Repro

Two workers running `tls.createServer({ key, cert }, s => s.end(String(cluster.worker.id))).listen(0)`, the primary making sequential TLS connections and pinging both workers over IPC after each one (this is the new test in `test/js/node/cluster.test.ts`). On the 9a543cc18 canary on Windows x64:

```
worker 1 stopped answering after connection 3     (another run: after connection 16)
```

The stuck worker never answers IPC again and never reacts to `disconnect()`. Two such workers sitting idle on one port use about 0.8s and 1.5s of CPU per worker per 3s (`process.cpuUsage()`); with the fix both read 0ms.

### Cause

#31829 made a TLS server in a worker always ask for a shared handle (`sharedOnly` in `listenInCluster`), whatever `cluster.schedulingPolicy` is, because its accept and handshake are native: the primary `WSADuplicateSocketW`s one listening socket into every worker and each worker polls its copy with `uv_poll` and calls `accept()`. With more than one process on a Windows listening socket that does not work, as described in #37815: AFD reports a new connection to every process, the one that loses the `accept()` race blocks inside `accept()` (its copy being non-blocking notwithstanding) until the next connection arrives, and libuv's exclusive AFD poll requests from the two processes cancel each other in a loop while nothing happens. libuv itself drives shared listening sockets with `AcceptEx`, which our listen sockets do not use.

### Fix

The fix is the `sharedOnly` line in `listenInCluster` (`src/js/node/net.ts`): on Windows a TLS server no longer sets `sharedOnly`, so the primary gives it a `RoundRobinHandle` exactly like a plain server, accepts every connection itself and hands the connection over. In the worker `onClusterConnection` emits a plain socket as `'connection'` and `tls.Server`'s existing `'connection'` listener wraps it in a server-side `TLSSocket` (the path `server.emit('connection', socket)` already uses), which is also how node's `tls.Server` receives every cluster connection. Only one process accepts on the socket, so neither problem can occur; POSIX keeps the native shared path as before.

That makes the handoff path the only TLS cluster path on Windows, and it did not honor `addContext()`: entries added before `listen()` were only ever loaded into a native listener, and `addContext()` after `listen()` called `addServerName` on the cluster's faux handle and threw `Expected a Listener instance`. `src/js/node/tls.ts` now keeps every entry on the server (like node's `_contexts`, so a later `listen()` reloads them too), only pushes them into `_handle` when that is a native listener, and gives wrapped connections an SNICallback that resolves them with node's matching rules (`*` covers part of one label, newest entry wins, the RegExp built once per `addContext()` as in [wrap.js#L1571-L1611](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1571-L1611)); the entries are stored as `{ re, context }`, which is the other `net.ts` hunk (the `addServerName` loop in `kRealListen`). A user SNICallback that selects nothing falls through to the entries, which is what our native listener already does (`node-tls-server.test.ts`, "asynchronous SNICallback resolving cb(null, null) still honors addContext entries"); node's default would stop at the callback, and keeping the two Bun paths identical seemed more useful than that difference, since the same app takes the native path on POSIX and this one on Windows. Verified against node v26.3.0 that `addContext()` entries apply to `server.emit('connection')` connections with exactly the matching the new test asserts, and that node distributes TLS cluster connections round-robin (`1212...`) under the default policy.

### Tests

- `cluster.test.ts`, Windows only: two TLS workers, one adding its context before `listen()` and one after, 40 sequential connections alternating between the default name and the added one, IPC pings after each, then `disconnect()`. Asserts the primary's strict alternation between the workers (the shared socket's kernel distribution never produces that), the certificate each connection was shown, and both exit codes. Canary: `worker 1 stopped answering after connection 3`; fixed debug build: 10/10 runs pass in about 3.0s each (2.3s of that is starting three debug processes).
- The two EINVAL tests for mixing a TLS and a plain worker on one key are POSIX-only now (there is no shared-only handle on Windows; node does not refuse this either). The first one gets the 30s budget its siblings have, since it starts three debug processes too.
- `node-tls-server.test.ts`, runs everywhere, exercising the wrap path through `server.emit('connection')`: exact, wildcard, two-label-under-wildcard, unknown and re-added names (fails before: default certificate for every name); the entries behind a sync and an async SNICallback (fails before); an SNICallback error still reaching `tlsClientError`; and `addContext()` after a native `listen()` plus a `close()`/`listen()` cycle (the relisten half fails before: the entry used to be lost).

### Verification

Windows x64 debug build of this branch: `cluster.test.ts` and `node-tls-server.test.ts` 94 pass / 11 skip / 0 fail; `http2.createSecureServer` in two workers serves requests round-robin and both workers exit cleanly; a `pauseOnConnect: true` TLS server in a worker behaves the same as on the native path (socket paused at `secureConnection`, data delivered after `resume()`, server `'close'` once the connections drain). Linux x64 debug build: the new `node-tls-server` tests pass and the cluster tests are unaffected (the `net.ts` condition folds back to the old value off Windows).

Not changed here: with `cluster.schedulingPolicy = SCHED_NONE` set explicitly, a Windows primary still creates a shared handle for TLS and plain servers alike; #37815 routes those through the primary as well, and once it lands its `sharedOnly` exclusion simply never fires on Windows (its new Windows SCHED_NONE EINVAL test then needs to go, since the plain worker is no longer refused). Driving the shared socket itself with `AcceptEx` would be the way to make sharing real on Windows and would let both workarounds go.


</details>
