### PR TITLE
bake: fail the route when an onLoad plugin does not answer for a module in a plugin namespace

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -4463,15 +4463,37 @@ pub mod bv2_impl {
 
                     // When it's not a file, this is a build error and we should report it.
                     // we have no way of loading non-files.
-                    let _ = log.add_error_fmt(
-                        Some(source),
-                        bun_ast::Loc::EMPTY,
-                        format_args!(
-                            "Module not found {} in namespace {}",
-                            bun_core::fmt::quote(source.path.pretty),
-                            bun_core::fmt::quote(source.path.namespace),
-                        ),
-                    );
+                    fn add_module_not_found(log: &mut bun_ast::Log, source: &bun_ast::Source) {
+                        log.add_error_fmt(
+                            Some(source),
+                            bun_ast::Loc::EMPTY,
+                            format_args!(
+                                "Module not found {} in namespace {}",
+                                bun_core::fmt::quote(source.path.pretty),
+                                bun_core::fmt::quote(source.path.namespace),
+                            ),
+                        );
+                    }
+                    match this.dev_server {
+                        Some(dev) => {
+                            // Attribute the error to this module, as the `Err` arm
+                            // below does, so the routes importing it fail; the
+                            // bundle-wide log is only printed. Not
+                            // `Error::ModuleNotFound`: `handle_parse_task_failure`
+                            // treats that as the file having been deleted.
+                            let mut temp_log = bun_ast::Log::init();
+                            add_module_not_found(&mut temp_log, source);
+                            dev.handle_parse_task_failure(
+                                crate::Error::Plugin,
+                                load.bake_graph(),
+                                source.path.key_for_incremental_graph(),
+                                &raw const temp_log,
+                                this,
+                            )
+                            .expect("oom");
+                        }
+                        None => add_module_not_found(log, source),
+                    }
 
                     // An error occurred, prevent spinning the event loop forever
                     this.decrement_scan_counter();

--- a/test/bake/dev/plugins.test.ts
+++ b/test/bake/dev/plugins.test.ts
@@ -1,5 +1,6 @@
 // Plugin tests concern plugins in development mode.
-import { devTest, minimalFramework } from "../bake-harness";
+import { expect } from "bun:test";
+import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 // Note: more in depth testing of plugins is done in test/bundler/bundler_plugin.test.ts
 devTest("onResolve", {
@@ -108,6 +109,63 @@ devTest("onResolve + onLoad virtual file", {
       },
       "file-on-disk",
     ]);
+  },
+});
+// An onResolve answer puts a module in a plugin namespace, and the onLoad registered for that
+// namespace answers nothing. Nothing else can load such a module, so this is the same kind of
+// failure as an onLoad callback that throws: the routes importing the module must fail instead
+// of being served with an import that has no module behind it.
+const decliningOnLoadPlugin = /* ts */ `
+  {
+    name: "declining-onload",
+    setup(build) {
+      build.onResolve({ filter: /^virtual-config$/ }, () => ({ path: "config.ts", namespace: "virtual" }));
+      build.onLoad({ filter: /.*/, namespace: "virtual" }, () => undefined);
+    },
+  }
+`;
+const decliningOnLoadError = 'virtual:config.ts: error: Module not found "virtual:config.ts" in namespace "virtual"';
+devTest("onLoad that does not answer for a module outside the file namespace fails the html route", {
+  files: {
+    "bunfig.toml": `
+      [serve.static]
+      plugins = ["./plugin.ts"]
+    `,
+    "plugin.ts": `export default ${decliningOnLoadPlugin};`,
+    "index.html": emptyHtmlFile({ scripts: ["entry.ts"] }),
+    "entry.ts": `
+      import "virtual-config";
+      console.log("entry ran");
+    `,
+  },
+  async test(dev) {
+    {
+      await using _ = await dev.client("/", { errors: [decliningOnLoadError] });
+    }
+    // The failure is recorded against the module itself, which the route imports, so the route
+    // keeps failing when it is requested again rather than being served from the graph.
+    expect((await dev.fetch("/")).status).toBe(500);
+  },
+});
+devTest("onLoad that does not answer for a module outside the file namespace fails the server route", {
+  framework: minimalFramework,
+  pluginFile: `export default [${decliningOnLoadPlugin}];`,
+  files: {
+    "routes/index.ts": `
+      import "virtual-config";
+
+      export default function (req, meta) {
+        return new Response("route ran");
+      }
+    `,
+  },
+  async test(dev) {
+    for (let i = 0; i < 2; i++) {
+      const res = await dev.fetch("/");
+      expect(await res.text()).toContain("Build Failed");
+      expect(res.status).toBe(500);
+    }
+    await dev.output.waitForLine(/Module not found "virtual:config.ts" in namespace "virtual"/);
   },
 });
 // devTest("onLoad with watchFile", {

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -141,6 +141,23 @@ describe("bundler", () => {
       "/foo.magic": [`123`],
     },
   });
+  // A module in a plugin namespace can only come from an onLoad callback, so the
+  // registered callback answering nothing fails the build against that module.
+  // The dev server counterpart is in test/bake/dev/plugins.test.ts.
+  itBundled("plugin/LoadNoAnswerInPluginNamespace", {
+    files: {
+      "index.ts": /* ts */ `
+        import "virtual-config";
+      `,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /^virtual-config$/ }, () => ({ path: "config.ts", namespace: "virtual" }));
+      builder.onLoad({ filter: /.*/, namespace: "virtual" }, () => undefined);
+    },
+    bundleErrors: {
+      "virtual:config.ts": [`Module not found "virtual:config.ts" in namespace "virtual"`],
+    },
+  });
   itBundled("plugin/ResolveAndLoadDefaultExport", {
     files: {
       "index.ts": /* ts */ `


### PR DESCRIPTION
### Problem
- Dev server, with a plugin whose `onResolve` puts a module in its own namespace and whose `onLoad` for that namespace returns nothing: the route is still served with a 200. The console only prints `error: Module not found "virtual:missing" in namespace "virtual"`.
- The served bundle still imports the module, so the browser fails with `Error: Failed to load bundled module 'virtual:missing'. This is not a dynamic import, and therefore is a bug in Bun's bundler.` A framework route importing it fails the same way, as a runtime 500.
- Cause: the error went only to the bundle-wide log, which the dev server prints when the bundle ends and then clears. No failure was recorded against the module, so the bundle counted as a success.
- An `onLoad` that throws already fails the route, because that path records the failure against the module. `Bun.build` already fails the build for the same plugin.

### Fix
- Under the dev server, the no-answer case now records the `Module not found` error against the module, the same way a throwing `onLoad` does. Without a dev server the error still goes to the build log, so `Bun.build` and `bun build` are unchanged.
- It is recorded as a plugin error, not a module-not-found error: the dev server treats module-not-found as "the file was deleted" and would drop the module from the graph instead of failing the route.
- Property to check: the module is what failed (its importer resolved it, and nothing but a plugin can load a non-file module), so every route importing it fails on the first request and stays failed on later ones instead of being served from the graph.
- Verification: two new dev server tests (an HTML route and a framework route) fail on the released build and pass with this change; a new `Bun.build` test pins the unchanged non-dev behaviour; the manual repro now returns 500 with the error printed once.

### Background
- The dev server (bake) bundles incrementally: it keeps a graph of modules and their importers, and a route is served from that graph unless a module it depends on has a failure recorded against it. Only recorded failures produce the build error page and overlay.
- Under the dev server the bundle-wide log is separate from that graph. It is printed once per bundle and cleared, so an error written only there never fails a route.
- A plugin's `onResolve` may place a module in a namespace other than `file`. Bun cannot read such a module from disk, so an `onLoad` callback is its only possible source, and one that returns nothing leaves it with none.

<details>
<summary>Original description</summary>

### Repro

Dev server with a `[serve.static]` plugin whose `onResolve` puts a module in its own namespace, while the `onLoad` registered for that namespace returns nothing:

```toml
# bunfig.toml
[serve.static]
plugins = ["./plugin.ts"]
```

```ts
// plugin.ts
export default {
  name: "repro",
  setup(build) {
    build.onResolve({ filter: /^virtual:missing$/ }, () => ({ path: "missing", namespace: "virtual" }));
    build.onLoad({ filter: /.*/, namespace: "virtual" }, () => undefined);
  },
};
```

```ts
// entry.ts (loaded by index.html through <script type="module" src="./entry.ts">)
import "virtual:missing";

// server.ts
import html from "./index.html";
const server = Bun.serve({ port: 0, development: true, routes: { "/": html } });
const res = await fetch(server.url);
console.log(res.status);
```

On 1.4.0 this prints

```
error: Module not found "virtual:missing" in namespace "virtual"
    at missing
Bundled page in 7ms: index.html
200
```

and the served bundle still imports the module, so the browser fails at runtime with:

```
Error: Failed to load bundled module 'virtual:missing'. This is not a dynamic import, and therefore is a bug in Bun's bundler.
```

A framework route importing such a module fails the same way, as a runtime 500 with that error while handling the request. `Bun.build` fails the build with the `Module not found` error for the same plugin, and in the dev server an `onLoad` callback that throws already fails the route with the build error page.

### Cause

`BundleV2::on_load` (src/bundler/bundle_v2.rs), `LoadValue::NoMatch` arm, non-file namespace: the error was added to `this.transpiler.log`, the bundle-wide log. Under the dev server that log is `DevServer.log`, which is shared by all three transpilers and is only printed at the end of the bundle (`prepare_and_log_resolution_failures`, with a debug-build warning that nothing should write to it) and then cleared. Nothing ever attached the error to the module in the incremental graph, so the bundle finished as a success and the route was served. The `LoadValue::Err` arm a few lines below (a throwing `onLoad` callback) does attach its error to the module through `DevServer::handle_parse_task_failure`, which is why that case already fails the route.

### Fix

The `NoMatch` arm now does the same as the `Err` arm under the dev server: the `Module not found` message goes into a one-message `Log` that is handed to `handle_parse_task_failure` with `Error::Plugin`, keyed by the module's incremental graph key. The kind matters: `handle_parse_task_failure` treats `ModuleNotFound`/`ENOENT` as "the file was deleted" and would just drop the file from the graph instead of recording a failure, so the arm uses `Error::Plugin` like the `Err` arm (the module was claimed by a plugin and no plugin loaded it). Without a dev server the error still goes to the build log, so `Bun.build` and `bun build` are unchanged. The scan counter decrement stays the last thing in the arm, as before.

This is the right place for the error because the module itself is what failed: the importer resolved it successfully through the plugin, and there is no other way to load a module outside the file namespace. Recording the failure against the module is also what makes the route keep failing on later requests: the importer's chunk gets an edge to the failed file, so `check_route_failures` finds it (or, without `BUN_ASSUME_PERFECT_INCREMENTAL`, rebundles and fails again) instead of serving the route from the graph. With the module's failure recorded, the first request gets the build error page and the overlay shows

```
virtual:config.ts: error: Module not found "virtual:config.ts" in namespace "virtual"
```

Related but separate: #37871 fixes the stale access of the `Load` request after the decrement in this arm and the `Err` arm; the two changes touch the same arm but are independent (this one keeps the decrement where it was).

### Verification

- `test/bake/dev/plugins.test.ts`: two new tests, an HTML route (client graph, checks the error overlay contents and that a second request is still a 500) and a framework route (server graph, checks the build error page rather than the runtime 500). On the released build the first fails with the overlay showing the runtime `Failed to load bundled module` error, the second with the runtime error page; both pass with this change (`bun bd test test/bake/dev/plugins.test.ts`: 5 pass).
- `test/bundler/bundler_plugin.test.ts`: one new test pinning the `Bun.build` behaviour of the same arm, which is unchanged (54 pass).
- The repro above prints 500 and the error once; with `BUN_ASSUME_PERFECT_INCREMENTAL=1` repeated requests also get 500 without rebundling, same as a throwing `onLoad`.
- `cargo clippy -p bun_bundler` and `cargo fmt --check` are clean.


</details>
