### PR TITLE
spawn(windows): free the buffer-stdin writer when its uv_write fails inside start()

### DIFF
--- a/src/bun_core/env_var.rs
+++ b/src/bun_core/env_var.rs
@@ -274,6 +274,9 @@ pub mod feature_flag {
     new_feature_flag!(pub BUN_INTERNAL_BUNX_INSTALL, "BUN_INTERNAL_BUNX_INSTALL", {});
     // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts.
     new_feature_flag!(pub BUN_INTERNAL_FAIL_PIPE_READER_START, "BUN_INTERNAL_FAIL_PIPE_READER_START", {});
+    // Debug-only fault injection for test/js/bun/spawn/spawn-pipe-start-error.test.ts:
+    // every stream write the Windows buffered pipe writer issues fails synchronously.
+    new_feature_flag!(pub BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE, "BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE", {});
     // Test-only: bypass the stdin isatty gate in `bun update --interactive` so
     // tests can drive the multi-select by writing keystrokes to a pipe.
     new_feature_flag!(pub BUN_INTERNAL_INTERACTIVE_ASSUME_TTY, "BUN_INTERNAL_INTERACTIVE_ASSUME_TTY", {});

--- a/src/install/PackageManager/security_scanner.rs
+++ b/src/install/PackageManager/security_scanner.rs
@@ -970,7 +970,7 @@ pub(crate) type StaticPipeWriter = subprocess::StaticPipeWriter<SecurityScanSubp
 // Wire the writer's `on_close` callback back to this type. Raw `*mut Self`
 // because the call is re-entrant: it may fire synchronously inside
 // `StaticPipeWriter::start()` while `finish_spawn` still has `&mut self` on
-// the stack (small JSON fits the pipe buffer → write completes → close).
+// the stack (Windows: the write fails synchronously and the writer closes).
 impl<'a> subprocess::StaticPipeWriterProcess for SecurityScanSubprocess<'a> {
     const POLL_OWNER_TAG: bun_io::PollTag = bun_io::PollTag::SecurityScanStaticPipeWriter;
     unsafe fn on_close_io(this: *mut Self, kind: subprocess::StdioKind) {
@@ -1306,8 +1306,8 @@ impl<'a> SecurityScanSubprocess<'a> {
             (*parent).process = Some(process);
         }
 
-        // Assign the field BEFORE `start()`. `start()` may complete the write synchronously
-        // (small JSON fits the 64KB pipe buffer on POSIX) and re-enter
+        // Assign the field BEFORE `start()`. On Windows a write that fails
+        // synchronously closes the writer inside `start()`, re-entering
         // `on_close_io` via the `parent` backref; that callback must observe
         // `json_writer.is_some()` to decrement `remaining_fds`, otherwise
         // `is_done()` never returns true and `sleep_until` hangs.
@@ -1333,23 +1333,27 @@ impl<'a> SecurityScanSubprocess<'a> {
         });
 
         let writer_ptr = writer_local.as_ptr();
-        // SAFETY: `writer_local` holds a live ref; `start()` mutates the writer
-        // in place (raw intrusive object — no Rust aliasing across the RefPtr).
-        let start_result = unsafe { (*writer_ptr).start() };
+        // SAFETY: `writer_local` holds a ref, so the writer stays live across
+        // and after `start()` whatever it does (it may re-enter `on_close_io`
+        // and release its own ref; see `StaticPipeWriter::start`).
+        let start_result = unsafe { StaticPipeWriter::start(writer_ptr) };
+        // The writer's lifetime is owned by `json_writer`, not by start()'s
+        // ref: claim that ref through the `started` token, the same token the
+        // writer's own release sites check, so its close path doesn't release
+        // it again. `start()` leaves the token unset when it already released
+        // the ref itself (it failed, or the write failed synchronously).
+        // SAFETY: `writer_local` keeps `*writer_ptr` live.
+        if unsafe { core::mem::replace(&mut (*writer_ptr).started, false) } {
+            // SAFETY: `started` was the token for the outstanding start() ref;
+            // cleared above so no other site releases it. Not the last ref.
+            unsafe { RefCount::<StaticPipeWriter>::deref(writer_ptr) };
+        }
         if let Err(e) = start_result {
             Output::err_generic(
                 "Failed to start security scanner JSON pipe writer: {}",
                 (e,),
             );
             return Err(crate::Error::JSONPipeWriterFailed);
-        }
-        // The writer's lifetime is owned by `json_writer`, not by its own
-        // `started` ref: release the ref `start()` took and clear the flag so
-        // its close path doesn't release it again.
-        // SAFETY: `writer_local` keeps `*writer_ptr` live.
-        unsafe {
-            RefCount::<StaticPipeWriter>::deref(writer_ptr);
-            (*writer_ptr).started = false;
         }
         drop(writer_local);
 

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1711,15 +1711,26 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
             self.pending_payload_size = buffer_len;
             self.write_buffer = write_buf;
             let self_ptr = self as *mut Self;
-            if let Some(write_err) = self
-                .write_req
-                // SAFETY: `p` is `self_ptr`; libuv invokes on the loop thread with no
-                // other Rust borrow of `*p` live, so `&mut *p` is the sole alias.
-                .write(stream_raw, &self.write_buffer, self_ptr, |p, s| unsafe {
-                    (*p).on_write_complete(s)
-                })
-                .to_error(sys::Tag::write)
-            {
+            let write_err = 'issue: {
+                // Debug-only fault injection for
+                // test/js/bun/spawn/spawn-pipe-start-error.test.ts: a uv_write
+                // that fails synchronously on a freshly spawned stdio pipe (its
+                // other end already closed) cannot be arranged from JS.
+                #[cfg(debug_assertions)]
+                if bun_core::env_var::feature_flag::BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE.get()
+                    == Some(true)
+                {
+                    break 'issue Some(sys::Error::from_code(sys::E::PIPE, sys::Tag::write));
+                }
+                self.write_req
+                    // SAFETY: `p` is `self_ptr`; libuv invokes on the loop thread with no
+                    // other Rust borrow of `*p` live, so `&mut *p` is the sole alias.
+                    .write(stream_raw, &self.write_buffer, self_ptr, |p, s| unsafe {
+                        (*p).on_write_complete(s)
+                    })
+                    .to_error(sys::Tag::write)
+            };
+            if let Some(write_err) = write_err {
                 self.close();
                 self.parent_on_error(write_err);
             } else {

--- a/src/io/PipeWriter.rs
+++ b/src/io/PipeWriter.rs
@@ -1641,6 +1641,18 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
         Self::r(this).on_write_complete(uv::ReturnCode::zero());
     }
 
+    /// Debug-only fault injection (`BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE`) for
+    /// test/js/bun/spawn/spawn-pipe-start-error.test.ts: stands in for a
+    /// `uv_write` that fails synchronously, which JS cannot arrange.
+    fn injected_write_error() -> Option<sys::Error> {
+        #[cfg(debug_assertions)]
+        if bun_core::env_var::feature_flag::BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE.get() == Some(true)
+        {
+            return Some(sys::Error::from_code(sys::E::PIPE, sys::Tag::write));
+        }
+        None
+    }
+
     pub fn write(&mut self) {
         let buffer = self.get_buffer_internal();
         // if we are already done or if we have some pending payload we just wait until next write
@@ -1711,17 +1723,9 @@ impl<Parent: WindowsBufferedWriterParent> WindowsBufferedWriter<Parent> {
             self.pending_payload_size = buffer_len;
             self.write_buffer = write_buf;
             let self_ptr = self as *mut Self;
-            let write_err = 'issue: {
-                // Debug-only fault injection for
-                // test/js/bun/spawn/spawn-pipe-start-error.test.ts: a uv_write
-                // that fails synchronously on a freshly spawned stdio pipe (its
-                // other end already closed) cannot be arranged from JS.
-                #[cfg(debug_assertions)]
-                if bun_core::env_var::feature_flag::BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE.get()
-                    == Some(true)
-                {
-                    break 'issue Some(sys::Error::from_code(sys::E::PIPE, sys::Tag::write));
-                }
+            let write_err = if let Some(err) = Self::injected_write_error() {
+                Some(err)
+            } else {
                 self.write_req
                     // SAFETY: `p` is `self_ptr`; libuv invokes on the loop thread with no
                     // other Rust borrow of `*p` live, so `&mut *p` is the sole alias.

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1751,7 +1751,11 @@ fn spawn_maybe_sync(
     }
 
     if let Writable::Buffer(buffer) = subprocess.stdin.get() {
-        if let Err(err) = Writable::buffer_writer_mut(buffer).start() {
+        // SAFETY: `buffer` holds `create()`'s ref on a live writer. `start()`
+        // may free the writer (a write that fails synchronously on Windows),
+        // in which case `on_close_io` has already replaced this stdin slot;
+        // neither `buffer` nor the writer is used after the call.
+        if let Err(err) = unsafe { Subprocess::StaticPipeWriter::start(buffer.as_ptr()) } {
             let _ = subprocess.try_kill(subprocess.kill_signal);
             return Err(global_this.throw_value(err.to_js(global_this)));
         }

--- a/src/runtime/shell/subproc.rs
+++ b/src/runtime/shell/subproc.rs
@@ -857,12 +857,18 @@ impl ShellSubprocess {
             }
         }
 
-        // SAFETY: borrow of the stdin slot scoped to this match; single-threaded.
-        let stdin_start_err = match unsafe { &(*subprocess).stdin } {
-            // SAFETY: single-threaded; the writer is uniquely reachable here.
-            Writable::Buffer(buffer) => unsafe { buffer_mut(buffer) }.start().err(),
+        // SAFETY: borrow of the stdin slot scoped to this match; it ends before
+        // `start()` below, which may overwrite the slot through `on_close_io`.
+        let stdin_writer = match unsafe { &(*subprocess).stdin } {
+            Writable::Buffer(buffer) => Some(buffer.as_ptr()),
             _ => None,
         };
+        let stdin_start_err = stdin_writer.and_then(|writer| {
+            // SAFETY: the slot holds `create()`'s ref on a live writer. `start()`
+            // may free it (a write that fails synchronously on Windows, reported
+            // through `on_close_io`); nothing touches it afterwards.
+            unsafe { StaticPipeWriter::start(writer) }.err()
+        });
         if let Some(err) = stdin_start_err {
             let sys_err = err.to_shell_system_error();
             // SAFETY: scoped `&mut` for the kill; `abort_after_failed_start`

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -213,8 +213,9 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
             // On POSIX `StdioResult` is an `Option<Fd>`. The buffered writer's
             // `start()` only registers the poll and never reports to the
             // parent, so nothing in this arm can close or free the writer.
-            // SAFETY: live; each borrow is confined to its own statement.
+            // SAFETY: live; the borrow ends before the match body runs.
             let fd = unsafe { (*this).stdio_result.unwrap() };
+            // SAFETY: live; the borrow of the field ends when the call returns.
             match unsafe { (*this).writer.start(fd, true) } {
                 bun_sys::Result::Err(err) => {
                     // `started` stays false so no release site fires; release

--- a/src/spawn/static_pipe_writer.rs
+++ b/src/spawn/static_pipe_writer.rs
@@ -10,6 +10,8 @@ use bun_sys;
 use crate::process::StdioKind;
 use crate::subprocess::{Source, StdioResult};
 
+// `BUN_DEBUG_StaticPipeWriter=1`; test/js/bun/spawn/spawn-pipe-start-error.test.ts
+// counts the `create()` / `deinit()` lines to check writers are freed.
 bun_output::declare_scope!(StaticPipeWriter, hidden);
 
 /// Trait bound for the owning process type `P` of [`StaticPipeWriter`].
@@ -146,6 +148,11 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
             }
         }
         let this = bun_core::heap::into_raw(boxed);
+        bun_output::scoped_log!(
+            StaticPipeWriter,
+            "StaticPipeWriter(0x{:x}) create()",
+            this as usize
+        );
         // SAFETY: `this` was just leaked above; borrow scoped to registering
         // the parent backref.
         unsafe { (*this).writer.set_parent(this) };
@@ -153,51 +160,79 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         unsafe { RefPtr::from_raw(this) }
     }
 
-    pub fn start(&mut self) -> bun_sys::Result<()> {
+    /// Takes start()'s `+1` (tracked by `started`) and begins writing.
+    ///
+    /// Raw `this` rather than `&mut self`: on Windows a `uv_write` that fails
+    /// synchronously closes the writer inside this call. `on_close` then runs
+    /// while `started` is still unset, so it releases nothing, and the owner's
+    /// `on_close_io` empties its slot and drops `create()`'s ref. Nothing can
+    /// claim start()'s `+1` after that, so this function releases it itself,
+    /// which frees `*this`.
+    ///
+    /// # Safety
+    /// `this` must point to a live writer whose owner holds `create()`'s ref.
+    /// `*this` may be freed when this returns (see above), so the caller must
+    /// not touch it afterwards; the owner is notified through `on_close_io`.
+    pub unsafe fn start(this: *mut Self) -> bun_sys::Result<()> {
         bun_output::scoped_log!(
             StaticPipeWriter,
             "StaticPipeWriter(0x{:x}) start()",
-            std::ptr::from_ref(self) as usize
+            this as usize
         );
-        // Intrusive-refcount increment.
-        // SAFETY: `self` is a live `Self` (created via `create()`/`heap::alloc`).
-        unsafe { RefCount::<Self>::ref_(std::ptr::from_mut::<Self>(self)) };
-        // Self-borrow into `self.source` — see `buffer` field invariant.
-        self.buffer = RawSlice::new(self.source.slice());
+        // SAFETY: caller contract: `this` is live.
+        unsafe { RefCount::<Self>::ref_(this) };
+        // Self-borrow into `source`; see the `buffer` field invariant.
+        // SAFETY: live; the borrow is confined to this statement.
+        unsafe { (*this).buffer = RawSlice::new((*this).source.slice()) };
         #[cfg(windows)]
         {
-            let r = self.writer.start_with_current_pipe();
-            self.started = r.is_ok();
-            if r.is_err() {
-                // start() failed: `started` stays false so no release site
-                // fires — release start()'s `+1` here.
-                // SAFETY: `self` is the live `Self` we ref'd at the top of
-                // `start()`; the caller's `RefPtr` keeps it alive and
-                // `started` is false so no other site re-derefs.
-                unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
+            // SAFETY: the ref taken above keeps `*this` live across the call
+            // even when it closes the writer (see the doc comment); the borrow
+            // of the field ends when the call returns.
+            let result = unsafe { (*this).writer.start_with_current_pipe() };
+            // SAFETY: still live, see above.
+            if result.is_err() || unsafe { (*this).writer.is_done() } {
+                // `Err`: nothing was closed; the owner still holds `create()`'s
+                // ref and tears the writer down when the caller reports the
+                // error. Closed: the write failed synchronously and has been
+                // reported through `on_error`/`on_close` just like a write
+                // that fails asynchronously, so the caller sees `Ok`; the
+                // owner's ref is already gone and this release frees the
+                // writer. Either way `started` stays false, so no other site
+                // releases start()'s `+1`.
+                // SAFETY: releases the ref taken above; last use of `this`.
+                unsafe { RefCount::<Self>::deref(this) };
+                return result;
             }
-            return r;
+            // SAFETY: live: the writer is open, so the owner still holds its ref.
+            unsafe { (*this).started = true };
+            bun_sys::Result::Ok(())
         }
         #[cfg(not(windows))]
         {
-            // On POSIX `StdioResult` is an `Option<Fd>`.
-            match self.writer.start(self.stdio_result.unwrap(), true) {
+            // On POSIX `StdioResult` is an `Option<Fd>`. The buffered writer's
+            // `start()` only registers the poll and never reports to the
+            // parent, so nothing in this arm can close or free the writer.
+            // SAFETY: live; each borrow is confined to its own statement.
+            let fd = unsafe { (*this).stdio_result.unwrap() };
+            match unsafe { (*this).writer.start(fd, true) } {
                 bun_sys::Result::Err(err) => {
-                    // start() failed: `started` stays false so no release
-                    // site fires — release start()'s `+1` here.
-                    // SAFETY: `self` is the live `Self` we ref'd at the top
-                    // of `start()`; the caller's `RefPtr` keeps it alive
-                    // and `started` is false so no other site re-derefs.
-                    unsafe { RefCount::<Self>::deref(std::ptr::from_mut::<Self>(self)) };
+                    // `started` stays false so no release site fires; release
+                    // start()'s `+1` here. Not the last ref: the owner still
+                    // holds `create()`'s.
+                    // SAFETY: releases the ref taken above; last use of `this`.
+                    unsafe { RefCount::<Self>::deref(this) };
                     bun_sys::Result::Err(err)
                 }
                 bun_sys::Result::Ok(()) => {
-                    self.started = true;
+                    // SAFETY: live, see above.
+                    unsafe { (*this).started = true };
                     #[cfg(unix)]
                     {
                         // `handle` is `PollOrFd` (enum); flag mutation goes
                         // through the FilePoll vtable shim.
-                        if let Some(poll) = self.writer.handle.get_poll() {
+                        // SAFETY: live, see above.
+                        if let Some(poll) = unsafe { (*this).writer.handle.get_poll() } {
                             poll.set_flag(bun_io::FilePollFlag::Socket);
                         }
                     }
@@ -265,7 +300,9 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
         );
         // Still set only after a failed write (every other path takes the token
         // before closing). Must be taken before `on_close_io` empties the slot:
-        // nothing can reach this writer afterwards.
+        // nothing can reach this writer afterwards. A write that fails
+        // synchronously inside `start()` lands here before `started` is set,
+        // so `start()` releases its own ref for that case.
         let release_start_ref = core::mem::replace(&mut self.started, false);
         // `buffer` aliases `self.source`'s storage; clear it before detach()
         // frees that storage so no dangling slice survives the close.
@@ -297,6 +334,11 @@ impl<P: StaticPipeWriterProcess> StaticPipeWriter<P> {
 /// The heap free is handled by `RefPtr` after `drop` returns.
 impl<P: StaticPipeWriterProcess> Drop for StaticPipeWriter<P> {
     fn drop(&mut self) {
+        bun_output::scoped_log!(
+            StaticPipeWriter,
+            "StaticPipeWriter(0x{:x}) deinit()",
+            std::ptr::from_ref(self) as usize
+        );
         self.writer.end();
         // `buffer` aliases `self.source`'s storage; clear it before detach()
         // frees that storage (upholds the field's documented invariant).

--- a/test/js/bun/spawn/buffer-stdin-owners-fixture.ts
+++ b/test/js/bun/spawn/buffer-stdin-owners-fixture.ts
@@ -1,0 +1,36 @@
+// Runs one child per owner of a buffer-stdin writer in this process (Bun.spawn,
+// Bun.spawnSync, the shell's `< ${buffer}` redirect). Each child prints how many
+// stdin bytes it received; the results go out as one "RESULT <json>" line.
+// spawn-pipe-start-error.test.ts runs this with BUN_DEBUG_StaticPipeWriter set and
+// counts the writers this process creates and frees.
+import { $ } from "bun";
+
+const input = Buffer.alloc(4096, "x");
+const cmd = [process.execPath, "-e", "console.log((await Bun.stdin.bytes()).length)"];
+// The children must neither inherit the fault injection (their own stdio is not
+// under test) nor log writer events into the stdout this process is measured by.
+const env = Object.fromEntries(
+  Object.entries(process.env).filter(
+    ([key]) => key !== "BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE" && key !== "BUN_DEBUG_StaticPipeWriter",
+  ),
+);
+
+const results: Record<string, { stdout: string; exitCode: number }> = {};
+
+{
+  await using proc = Bun.spawn({ cmd, env, stdin: input, stdout: "pipe", stderr: "inherit" });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  results.spawn = { stdout: stdout.trim(), exitCode };
+}
+
+{
+  const { stdout, exitCode } = Bun.spawnSync({ cmd, env, stdin: input, stdout: "pipe", stderr: "inherit" });
+  results.spawnSync = { stdout: stdout.toString().trim(), exitCode };
+}
+
+{
+  const { stdout, exitCode } = await $`${cmd} < ${input}`.env(env).quiet();
+  results.shell = { stdout: stdout.toString().trim(), exitCode };
+}
+
+console.log("RESULT " + JSON.stringify(results));

--- a/test/js/bun/spawn/spawn-pipe-start-error.test.ts
+++ b/test/js/bun/spawn/spawn-pipe-start-error.test.ts
@@ -1,5 +1,6 @@
-import { expect, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, isWindows } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isDebug, isWindows, tempDir } from "harness";
+import path from "node:path";
 
 // On Windows, when the initial uv_read_start on a subprocess stdout/stderr
 // pipe fails (observed from libuv as UV_EINVAL after a bad FileAccessInformation
@@ -62,3 +63,96 @@ try {
     expect(exitCode).toBe(0);
   },
 );
+
+// The writer behind a Buffer/Blob stdin (StaticPipeWriter) issues its single
+// uv_write from start(). On Windows that uv_write fails synchronously when the
+// child's end of the pipe is already gone, and the writer closes itself inside
+// start(): on_close runs before start() has recorded its own ref, so it releases
+// nothing, and the owner (Subprocess, ShellSubprocess) drops its ref and forgets
+// the writer. start() has to release its own ref when it finds the writer closed
+// underneath it; without that the writer stays allocated for the rest of the
+// process (created 3, freed 0 below).
+//
+// The security scanner's JSON writer is the third owner. It releases start()'s
+// ref itself right after start() returns, and must not when start() already
+// has; otherwise the release in start() is one release too many for it.
+//
+// The failing uv_write cannot be arranged from JS either, so the same kind of
+// debug-only fault injection is used; the writers are counted through the
+// create()/deinit() lines of the StaticPipeWriter debug scope. The non-injected
+// variants check the counting itself and the ordinary path of the same code.
+describe.skipIf(!isWindows || !isDebug)("buffer stdin writer whose uv_write fails synchronously (windows)", () => {
+  function writerCounts(output: string) {
+    return {
+      created: output.match(/StaticPipeWriter\(0x[0-9a-f]+\) create\(\)/g)?.length ?? 0,
+      freed: output.match(/StaticPipeWriter\(0x[0-9a-f]+\) deinit\(\)/g)?.length ?? 0,
+    };
+  }
+
+  function env(failWrite: boolean) {
+    return failWrite
+      ? { ...bunEnv, BUN_DEBUG_StaticPipeWriter: "1", BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE: "1" }
+      : { ...bunEnv, BUN_DEBUG_StaticPipeWriter: "1" };
+  }
+
+  test.concurrent.each([true, false])(
+    "Bun.spawn, Bun.spawnSync and the shell free the writer (write fails: %p)",
+    async failWrite => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), path.join(import.meta.dir, "buffer-stdin-owners-fixture.ts")],
+        env: env(failWrite),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      // With the write failing the child only ever sees EOF; this also proves the
+      // injection fired. The fixture's Buffer is 4096 bytes.
+      const child = { stdout: failWrite ? "0" : "4096", exitCode: 0 };
+      const result = stdout.split(/\r?\n/).find(line => line.startsWith("RESULT "));
+      expect(result, stderr).toBeDefined();
+      expect(JSON.parse(result!.slice("RESULT ".length))).toEqual({ spawn: child, spawnSync: child, shell: child });
+      // Scoped debug logging goes to stdout; search both streams anyway.
+      expect(writerCounts(stdout + stderr)).toEqual({ created: 3, freed: 3 });
+      expect(exitCode).toBe(0);
+    },
+  );
+
+  test.concurrent.each([true, false])(
+    "bun install frees the security scanner's JSON writer (write fails: %p)",
+    async failWrite => {
+      using dir = tempDir("scanner-json-writer", {
+        "package.json": JSON.stringify({ name: "scanner-json-writer", version: "1.0.0" }),
+        "bunfig.toml": `[install.security]\nscanner = "./scanner.js"\n`,
+        // bun install runs the scanner even with nothing to scan, so no registry is needed.
+        "scanner.js": `module.exports = {
+          scanner: {
+            version: "1",
+            scan: async ({ packages }) => {
+              console.log("scanner received " + packages.length + " packages");
+              return [];
+            },
+          },
+        };`,
+      });
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: env(failWrite),
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      if (failWrite) {
+        // The scanner reads its package list from the pipe the failed write closed,
+        // so it gets an empty document; this also proves the injection fired.
+        expect(stderr).toContain("Failed to parse packages JSON");
+      } else {
+        expect(stdout).toContain("scanner received 0 packages");
+      }
+      expect(writerCounts(stdout + stderr)).toEqual({ created: 1, freed: 1 });
+      expect(exitCode).toBe(failWrite ? 1 : 0);
+    },
+  );
+});


### PR DESCRIPTION
### Problem
- On Windows, a child given a Buffer or Blob `stdin` (`Bun.spawn`, `Bun.spawnSync`, the shell's `< ${buffer}` redirect, or the install security scanner) leaks its stdin writer for the rest of the process when the child's end of the pipe is already gone by the time the write is issued.
- Cause: on Windows `start()` is what issues the `uv_write`, and a synchronous failure closes the writer inside that call, before `start()` has recorded the extra ref it took. The close therefore releases nothing, the owner drops its own ref and forgets the writer, and the ref `start()` took has no release site left.
- Trace from the original: `ref 1 -> 2`, `onClose()`, `deref 2 -> 1`, `onError(err=EPIPE: Broken pipe (write()))`; the count stays at 1.
- Sibling of #35297 (the same write failing asynchronously) and #37774 (the POSIX error path, which names this case as the remaining gap).

### Fix
- On Windows, after starting the buffered writer, `start()` checks whether the writer already closed underneath it; if so it releases its own ref there, leaves `started` unset and returns `Ok`. Property to check: on every path exactly one site releases the ref `start()` took, and `started` says which one.
- `Ok` rather than `Err` because the owner was already told through `on_error` and `on_close`, the same as for an asynchronous failure; `Err` would make `Bun.spawn` kill the child and throw on an ordinary EPIPE.
- Since that release can free the writer, `start()` takes a raw pointer and none of its three callers touch the writer afterwards. The security scanner, which releases `start()`'s ref itself, now does so only while the `started` token is set; without that it released one ref too many and `bun install` hung. POSIX behaviour is unchanged.
- Verification: the failure cannot be produced from JS, so a debug-only `BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE` flag fails the write synchronously and a new test (Windows debug builds only) counts writers created and freed across all three owners. The injected spawn case fails without the fix (`created: 3, freed: 0`) and 5/5 pass with it. Those tests do not run on this PR's CI lanes; the existing spawn, shell, scanner and child_process suites were run by hand on Windows and Linux (details in the original).

- Rebase notes: #37774 made `on_close` release the `started` token on every platform; the resolution keeps that unconditional release (a write failing synchronously inside `start()` reaches `on_close` before the token is set, so `start()` still releases its own ref). #40478 replaced `IntrusiveRc` with a `RefPtr` that releases on Drop; the scanner call site now relies on that Drop on its error path instead of a manual deref, and its token-gated claim replaces main's unconditional post-start release. Re-verified after each rebase: 5/5 on Windows debug, #37774's leak test and the 43 scanner provider tests green on Linux.

### Background
- `StaticPipeWriter` is the object behind a Buffer or Blob `stdin`: it writes the bytes into the child's stdin pipe once, then closes. One implementation serves `Bun.spawn`/`spawnSync`, the `$` shell and the install security scanner; each of these is an owner holding a slot that points at it.
- The writer is intrusively refcounted. The owner holds the ref from `create()`; `start()` takes a second one for the duration of the write, and the boolean `started` records that this second ref is outstanding. Whichever release site sees `started` set clears it and releases that ref, so exactly one site does.
- On Windows the pipe is driven by libuv. `uv_write` normally reports later through a callback, but returns an error immediately if the far end is already closed; Bun's Windows buffered writer then closes and reports the error on the spot, so the owner's close callback runs re-entrantly inside `start()`. On POSIX, `start()` only registers the fd with the event loop, so nothing runs re-entrantly.
- `BUN_INTERNAL_*` flags compiled only under `cfg(debug_assertions)` are the repo's existing way to exercise error paths JS cannot reach; release builds contain none of the injection.

<details>
<summary>Original description</summary>

On Windows, the writer that pumps a Buffer/Blob `stdin` into a child (`StaticPipeWriter`: used by `Bun.spawn`/`Bun.spawnSync`, by the shell's `cmd < ${buffer}` redirect and by the security scanner for its package-list pipe) is leaked when its `uv_write` fails synchronously inside `start()`, i.e. when the child's end of the pipe is already gone by the time the write is issued. Sibling of #35297, which fixed the asynchronous failure of the same write, and of #37774, which fixes the POSIX error path and names this case as the remaining gap.

### Cause

`StaticPipeWriter::start()` takes a ref on the writer, starts the buffered writer, and then records the ref in `started`. On Windows starting the buffered writer is what issues the `uv_write` (`WindowsBufferedWriter::start_with_current_pipe` -> `write()` in src/io/PipeWriter.rs), and when that returns an error, `write()` closes the writer on the spot. So, still inside `start()`:

```
StaticPipeWriter(0x..) start()
0x..   ref 1 -> 2                        start()'s ref
StaticPipeWriter(0x..) onClose()         `started` is still false, so this releases nothing
0x.. deref 2 -> 1                        owner's on_close_io drops create()'s ref and empties its slot
StaticPipeWriter(0x..) onError(err=EPIPE: Broken pipe (write()))
```

`start_with_current_pipe()` returns `Ok` regardless, and `start()` set `started = true` on a writer no owner could reach any more: `Subprocess::take_pending_start_writer` looks in the (now empty) stdin slot, and the shell has no release site for this ref on Windows at all. The count stays at 1 for the rest of the process.

### Fix

* `StaticPipeWriter::start()` (src/spawn/static_pipe_writer.rs): after starting the buffered writer, if the writer is already closed (`is_done()`, which at this point only a failed write can have set), release start()'s ref right there and return `Ok` with `started` left unset. The `is_done()` check is the fixing line. `Ok` is deliberate: the failure has already been delivered to the owner through `on_error`/`on_close`, exactly as an asynchronous failure of the same write is, and returning `Err` would make `Bun.spawn` kill the child and throw over an ordinary EPIPE. That release frees the writer for `Subprocess` and `ShellSubprocess`, so `start()` takes `this: *mut Self` instead of `&mut self` (the shape #36571 and #37879 use for the reader's equivalent entry points); the three callers pass the slot's pointer and do not touch the writer afterwards. The POSIX arm behaves as before: the buffered writer's `start()` there only registers the poll and never reports to the parent, so nothing can close the writer underneath it.
* `SecurityScanSubprocess::finish_spawn` (src/install/PackageManager/security_scanner.rs): this owner releases start()'s ref itself right after `start()` returns. It now claims it through the `started` token, the same token `on_write`/`on_close`/`take_pending_start_writer` use, so it skips the release when `start()` has already done it. Without this hunk the change above would make it release one ref too many on the synchronous-failure path (checked: with only the `start()` hunk applied, the scanner test below hangs `bun install` after the writer it still holds is freed). The same check covers `start()` returning `Err`, where the scanner was already releasing one ref too many (the `security_scanner.rs` half of #31032; that path is unreachable on Windows and needs poll registration to fail on POSIX). The two comments in that file that describe the re-entrancy as "the write completes synchronously" are corrected at the same time: neither platform completes the write inside `start()`; the synchronous failure on Windows is what re-enters.

### Test

The failing `uv_write` cannot be arranged from JS (the child's end of a pipe created microseconds earlier would have to be closed already), so this follows #35150, which had the same problem for the reader: a debug-only `BUN_INTERNAL_FAIL_PIPE_WRITER_WRITE` makes the buffered writer's stream write fail synchronously (src/io/PipeWriter.rs, under `cfg(debug_assertions)`), and `create()`/`deinit()` lines are added to the existing `StaticPipeWriter` debug scope so a test can count writers, the way the websocket and tsconfig leak tests count `alloc` lines. Release builds get no test-only code.

`test/js/bun/spawn/spawn-pipe-start-error.test.ts` (Windows debug builds, next to the reader's test) drives all three owners, each with and without the injection: a fixture running `Bun.spawn`, `Bun.spawnSync` and a shell `< ${buf}` redirect (the children report how many stdin bytes they received: 0 with the injection, 4096 without, which also shows the injection fired), and `bun install` with a local scanner (it runs even with nothing to scan, so no registry is involved; with the injection the scanner reports the empty package list it gets). Every case asserts created == freed.

On Windows x64 (debug build), with everything but the two fixing lines applied:

```
(fail) ... > Bun.spawn, Bun.spawnSync and the shell free the writer (write fails: true)
         expect(received).toEqual(expected)   "created": 3,  - "freed": 3,  + "freed": 0
(pass) ... > Bun.spawn, Bun.spawnSync and the shell free the writer (write fails: false)
(pass) ... > bun install frees the security scanner's JSON writer (write fails: true)    (the scanner was balanced before, its release did not depend on the token)
(pass) ... > bun install frees the security scanner's JSON writer (write fails: false)
```

With only the `start()` hunk, the scanner's injected case fails instead (`bun install` never finishes). With both, 5/5 pass, and the trace of an injected `Bun.spawn` writer continues the one above with `deref 1 -> 0` and `deinit()`.

The new tests need a Windows debug build, so they are skipped on the lanes this PR's CI builds; what runs there is the existing coverage. Also run against the fixed build: on Windows x64, `spawn.test.ts`, `spawnSync.test.ts`, `spawn-empty-arrayBufferOrBlob.test.ts`, `spawn-stdin-pipe-fd-leak.test.ts` and `spawn-streaming-stdin.test.ts` (135 pass, 0 fail), `bunshell.test.ts` + `bunshell-instance.test.ts` + the shell `leak.test.ts` (458 pass; the 8 failures are 5 tilde-expansion tests that need `HOME` set and 3 tests that hit their timeouts when the three files run together and pass when run alone, none of them involving stdin), the two security-scanner suites (46/46) and `child_process.test.ts` + `child-process-stdio.test.js` (58 pass, 0 fail). On Linux: the shell suites, the scanner suites and, with `BUN_FEATURE_FLAG_DISABLE_MEMFD=1` so that `Bun.spawn` reaches the writer, `spawn.test.ts`, all without failures; the source lints pass. `cargo check --workspace` is clean for the four Linux targets and macOS x64, and the touched crates check clean for macOS arm64, Windows x64/arm64, FreeBSD and both Android targets (Windows x64 was also built natively for the runs above).

Open PRs nearby: #37774 (POSIX error path), #37755 and #37799 edit `on_close` in the same file and compose with this (only a comment changes there here); #37879 converts the reader's `start()` to the same raw-pointer shape and touches the adjacent lines of `js_bun_spawn_bindings.rs`, so whichever of the two lands second needs a trivial rebase.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/bun/spawn/spawn-pipe-start-error.test.ts

<!-- robobun:evidence:end -->

