### PR TITLE
bake: keep a module bundled when a plugin fall-through resolution failure is inside try/catch

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2357,39 +2357,15 @@ pub mod bv2_impl {
                                         [import_record.importer_source_index as usize],
                                 )
                                 .expect("oom");
-
-                                // Turn this into an invalid AST, so that incremental mode skips it when printing.
-                                // SAFETY: truncating to len 0 never exposes uninitialized elements.
-                                unsafe {
-                                    self.graph.ast.items_parts_mut()
-                                        [import_record.importer_source_index as usize]
-                                        .set_len((0) as usize)
-                                };
                             }
                         }
 
-                        let handles_import_errors;
-                        // reshaped for borrowck — `log_for_resolution_failures` borrows
-                        // `&mut self`; the returned log is backed by either a DevServer-owned slot or
-                        // `*self.transpiler.log` (both raw-pointer-derived), so detach the lifetime
-                        // so `self.graph.*` / `self.transpiler.*` reads below type-check.
-                        // SAFETY: log lives in DevServer / transpiler, disjoint from `self.graph`.
-                        let log: &mut bun_ast::Log = unsafe {
-                            bun_ptr::detach_lifetime_mut(self.log_for_resolution_failures(
-                                &import_record.source_file,
-                                target.bake_graph(),
-                            ))
-                        };
-
-                        {
+                        let handles_import_errors = {
                             let record: &mut ImportRecord =
                                 &mut self.graph.ast.items_import_records_mut()
                                     [import_record.importer_source_index as usize]
                                     .as_mut_slice()
                                     [import_record.import_record_index as usize];
-                            handles_import_errors = record
-                                .flags
-                                .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS);
 
                             // Disable failing packages from being printed.
                             // This may cause broken code to write.
@@ -2399,61 +2375,88 @@ pub mod bv2_impl {
                             record
                                 .flags
                                 .insert(bun_ast::ImportRecordFlags::WAS_UNRESOLVED);
-                        }
-                        let source: Option<&bun_ast::Source> = Some(
-                            &self.graph.input_files.items_source()
-                                [import_record.importer_source_index as usize],
-                        );
+                            record
+                                .flags
+                                .contains(bun_ast::ImportRecordFlags::HANDLES_IMPORT_ERRORS)
+                        };
 
-                        if err == _resolver::Error::ModuleNotFound {
+                        if err == _resolver::Error::ModuleNotFound
+                            && !handles_import_errors
+                            && !self.transpiler.options.ignore_module_resolution_errors
+                        {
+                            if self.dev_server.is_some() {
+                                // Turn this into an invalid AST, so that incremental mode skips it
+                                // when printing. Only valid because a failure is logged for the
+                                // importer below: a file with no parts and no failure (e.g. a
+                                // `try { require() }` of a missing file) would otherwise vanish
+                                // from the incremental graph instead of being bundled.
+                                // SAFETY: truncating to len 0 never exposes uninitialized elements.
+                                unsafe {
+                                    self.graph.ast.items_parts_mut()
+                                        [import_record.importer_source_index as usize]
+                                        .set_len(0)
+                                };
+                            }
+
+                            // reshaped for borrowck — `log_for_resolution_failures` borrows
+                            // `&mut self`; the returned log is backed by either a DevServer-owned slot or
+                            // `*self.transpiler.log` (both raw-pointer-derived), so detach the lifetime
+                            // so the `self.graph.*` read below type-checks.
+                            // SAFETY: log lives in DevServer / transpiler, disjoint from `self.graph`.
+                            let log: &mut bun_ast::Log = unsafe {
+                                bun_ptr::detach_lifetime_mut(self.log_for_resolution_failures(
+                                    &import_record.source_file,
+                                    target.bake_graph(),
+                                ))
+                            };
+                            let source: Option<&bun_ast::Source> = Some(
+                                &self.graph.input_files.items_source()
+                                    [import_record.importer_source_index as usize],
+                            );
                             let add_error = bun_ast::Log::add_resolve_error_with_text_dupe;
                             let path_to_use = &import_record.specifier;
 
-                            if !handles_import_errors
-                                && !self.transpiler.options.ignore_module_resolution_errors
-                            {
-                                if is_package_path(&import_record.specifier) {
-                                    if target == Target::Browser
-                                        && options::is_node_builtin(path_to_use)
-                                    {
-                                        add_error(
-                                            log,
-                                            source,
-                                            import_record.range,
-                                            format_args!(
-                                                "Browser build cannot {} Node.js module: \"{}\". To use Node.js builtins, set target to 'node' or 'bun'",
-                                                bstr::BStr::new(import_record.kind.error_label()),
-                                                bstr::BStr::new(path_to_use)
-                                            ),
-                                            path_to_use,
-                                            import_record.kind,
-                                        );
-                                    } else {
-                                        add_error(
-                                            log,
-                                            source,
-                                            import_record.range,
-                                            format_args!(
-                                                "Could not resolve: \"{}\". Maybe you need to \"bun install\"?",
-                                                bstr::BStr::new(path_to_use)
-                                            ),
-                                            path_to_use,
-                                            import_record.kind,
-                                        );
-                                    }
+                            if is_package_path(&import_record.specifier) {
+                                if target == Target::Browser
+                                    && options::is_node_builtin(path_to_use)
+                                {
+                                    add_error(
+                                        log,
+                                        source,
+                                        import_record.range,
+                                        format_args!(
+                                            "Browser build cannot {} Node.js module: \"{}\". To use Node.js builtins, set target to 'node' or 'bun'",
+                                            bstr::BStr::new(import_record.kind.error_label()),
+                                            bstr::BStr::new(path_to_use)
+                                        ),
+                                        path_to_use,
+                                        import_record.kind,
+                                    );
                                 } else {
                                     add_error(
                                         log,
                                         source,
                                         import_record.range,
                                         format_args!(
-                                            "Could not resolve: \"{}\"",
+                                            "Could not resolve: \"{}\". Maybe you need to \"bun install\"?",
                                             bstr::BStr::new(path_to_use)
                                         ),
                                         path_to_use,
                                         import_record.kind,
                                     );
                                 }
+                            } else {
+                                add_error(
+                                    log,
+                                    source,
+                                    import_record.range,
+                                    format_args!(
+                                        "Could not resolve: \"{}\"",
+                                        bstr::BStr::new(path_to_use)
+                                    ),
+                                    path_to_use,
+                                    import_record.kind,
+                                );
                             }
                         }
                         // assume other errors are already in the log

--- a/test/bake/dev/plugins.test.ts
+++ b/test/bake/dev/plugins.test.ts
@@ -1,5 +1,5 @@
 // Plugin tests concern plugins in development mode.
-import { devTest, minimalFramework } from "../bake-harness";
+import { devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 // Note: more in depth testing of plugins is done in test/bundler/bundler_plugin.test.ts
 devTest("onResolve", {
@@ -147,3 +147,70 @@ devTest("onResolve + onLoad virtual file", {
 //     await dev.fetch("/").expect('value: 2');
 //   },
 // });
+
+// When an onResolve callback returns nothing, the specifier falls through to
+// the builtin resolver (BundleV2::run_resolver). Resolution failures on that
+// path must behave like the synchronous resolver: a failure that the importer
+// handles itself (require inside try/catch) is not an error, so the importer
+// must still be bundled. Previously the importer's AST was invalidated before
+// checking for try/catch, so it was silently dropped from the bundle and the
+// browser failed with "Failed to load bundled module".
+const onResolveFallThroughPlugin = {
+  "bunfig.toml": `
+    [serve.static]
+    plugins = ["./plugin.ts"]
+  `,
+  "plugin.ts": `
+    export default {
+      name: "fall-through",
+      setup(build) {
+        build.onResolve({ filter: /optional-dep|missing/ }, () => undefined);
+      },
+    };
+  `,
+};
+devTest("onResolve fall-through keeps a module whose missing require is in try/catch", {
+  files: {
+    ...onResolveFallThroughPlugin,
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `
+      let value = "fallback";
+      try {
+        value = require("./optional-dep").value;
+      } catch {}
+      console.log("v1 " + value);
+      import.meta.hot.accept();
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("v1 fallback");
+
+    // The module is in the incremental graph, so editing it is a hot update.
+    await dev.patch("index.ts", { find: "v1", replace: "v2" });
+    await c.expectMessage("v2 fallback");
+
+    // The failed resolution is still tracked: creating the file re-bundles the importer.
+    await dev.write("optional-dep.ts", `export const value = "dep";`);
+    await c.expectMessage("v2 dep");
+  },
+});
+devTest("onResolve fall-through still reports an unresolvable import", {
+  files: {
+    ...onResolveFallThroughPlugin,
+    "index.html": emptyHtmlFile({ scripts: ["index.ts"] }),
+    "index.ts": `
+      import { value } from "./missing";
+      console.log(value);
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/", {
+      errors: [`index.ts:1:23: error: Could not resolve: "./missing"`],
+    });
+    await c.expectReload(async () => {
+      await dev.write("missing.ts", `export const value = "found";`);
+    });
+    await c.expectMessage("found");
+  },
+});

--- a/test/bake/dev/plugins.test.ts
+++ b/test/bake/dev/plugins.test.ts
@@ -149,12 +149,9 @@ devTest("onResolve + onLoad virtual file", {
 // });
 
 // When an onResolve callback returns nothing, the specifier falls through to
-// the builtin resolver (BundleV2::run_resolver). Resolution failures on that
-// path must behave like the synchronous resolver: a failure that the importer
-// handles itself (require inside try/catch) is not an error, so the importer
-// must still be bundled. Previously the importer's AST was invalidated before
-// checking for try/catch, so it was silently dropped from the bundle and the
-// browser failed with "Failed to load bundled module".
+// the builtin resolver (BundleV2::run_resolver). A resolution failure on that
+// path that the importer handles itself (require inside try/catch) is not an
+// error, so the importer must still be bundled.
 const onResolveFallThroughPlugin = {
   "bunfig.toml": `
     [serve.static]

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -466,6 +466,40 @@ describe("bundler", () => {
       },
     };
   });
+  // An onResolve callback that returns nothing falls through to the builtin
+  // resolver (BundleV2::run_resolver), which has to treat a file it cannot find
+  // the same way the synchronous resolver does.
+  itBundled("plugin/ResolveFallThroughMissingRequireInTryCatch", {
+    files: {
+      "index.ts": /* ts */ `
+        let value = "fallback";
+        try {
+          value = require("./optional-dep").value;
+        } catch {}
+        console.log(value);
+      `,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /optional-dep/ }, () => undefined);
+    },
+    run: {
+      stdout: "fallback",
+    },
+  });
+  itBundled("plugin/ResolveFallThroughMissingImport", {
+    files: {
+      "index.ts": /* ts */ `
+        import { value } from "./missing";
+        console.log(value);
+      `,
+    },
+    plugins(builder) {
+      builder.onResolve({ filter: /missing/ }, () => undefined);
+    },
+    bundleErrors: {
+      "/index.ts": [`Could not resolve: "./missing"`],
+    },
+  });
   itBundled("plugin/ResolveOnceWhenSameFile", ({ root }) => {
     let onResolveCount = 0;
     return {


### PR DESCRIPTION
### Problem
- Dev server with a `[serve.static]` plugin whose `onResolve` matches but returns nothing: a client module that does `require("./optional-dep")` in `try/catch`, for a file that does not exist, is silently dropped from the route bundle. Nothing is logged; the browser fails with `Error: Failed to load bundled module 'index.ts'. This is not a dynamic import, and therefore is a bug in Bun's bundler.`
- Without the plugin the same project works: the `require` throws and the `catch` runs.
- Cause: on the resolver path taken after a plugin falls through, a missing module under the dev server emptied the importer before checking whether the import handles its own errors. With `try/catch` no error is then logged, so the file has neither content nor a recorded failure and is left out of the bundle.
- The no-plugin path only empties the importer when it also logs the error.

### Fix
- The fall-through path now empties the importer only in the branch that also logs a `Could not resolve` error.
- Property to check: an importer is emptied exactly when a failure is recorded against it. A handled failure leaves the file bundled with that import disabled, so the `require` throws at runtime as on the no-plugin path. Error messages are unchanged.
- The missing specifier is still tracked, so creating the file later still re-bundles the importer.
- Verification: a dev-server test that fails on the current release with the error above and passes with this change, plus one checking a plain `import` of a missing file still shows the `Could not resolve` overlay. Two `Bun.build` cases cover the non-dev-server side and pass before and after.

### Background
- Bake is bun's dev server. It keeps an incremental graph of every file it has bundled and re-bundles only what changed on an edit.
- A `[serve.static]` plugin in `bunfig.toml` is a bundler plugin loaded into the dev server. An `onResolve` callback that returns nothing falls through to the builtin resolver on a different code path from the no-plugin case. This PR makes the two agree.
- A `require` inside `try/catch` marks its import record as handling its own errors: the bundler leaves it unresolved, logs nothing, and it throws at runtime. `ignore_module_resolution_errors` does the same for every import.
- Under the dev server, truncating a file's parsed parts to zero marks it invalid: the printer skips it and the graph treats it as failed. That is only safe if a failure is logged for the file at the same time.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/bundler_plugin.test.ts

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### What does this PR do?

With a `[serve.static]` plugin whose `onResolve` matches a specifier and returns nothing (falling through to the builtin resolver), a client module that does

```ts
let value = "fallback";
try {
  value = require("./optional-dep").value; // ./optional-dep does not exist
} catch {}
console.log(value);
import.meta.hot.accept();
```

is silently dropped from the dev server's route bundle. The dev server prints `Bundled page ...: index.html` with no error, and the browser fails with:

```
Error: Failed to load bundled module 'index.ts'. This is not a dynamic import, and therefore is a bug in Bun's bundler.
```

Without the plugin the same project works: the `require` throws at runtime, the `catch` runs and the page renders the fallback.

**Cause.** `BundleV2::run_resolver` is the resolver path used after a plugin falls through. When the dev server is active and the resolver returns `ModuleNotFound`, it emptied the importer's `parts` ("turn this into an invalid AST so incremental mode skips it") before looking at the import record's `HANDLES_IMPORT_ERRORS` flag. For a `require()` inside `try/catch` that flag is set, so no error is logged, but the importer's parts are already gone: `finish_from_bake_dev_server` filters the file out as failed, while `prepare_and_log_resolution_failures` has no failure to record for it (the per-file log it obtained is empty). The file is left stale in the incremental graph with neither content nor a failure, and the route's bundle is generated without it. The synchronous path (`resolve_import_records`) only fails the importer when it actually logs the error, which is why the builtin-resolver-only setup works.

**Fix.** `run_resolver` now only invalidates the importer's AST (and only obtains the per-file resolution log, which also registers the file as stale) in the branch that actually logs a "Could not resolve" error, i.e. when the record does not handle import errors and `ignore_module_resolution_errors` is off. This matches `resolve_import_records`: an importer whose failed resolution is not reported is a successfully bundled file with a disabled import record, and the unresolved `require` throws at runtime as it does without plugins. `track_resolution_failure` is still called unconditionally, as on the synchronous path, so creating the missing file later still re-bundles the importer. Error reporting for unhandled imports is unchanged; the emitted messages are the same, only restructured so the invalidation and the log share one condition.

### How did you verify your code works?

- `test/bake/dev/plugins.test.ts`, "onResolve fall-through keeps a module whose missing require is in try/catch": fails on the current release (`USE_SYSTEM_BUN=1`, client dies with the `Failed to load bundled module 'index.ts'` error above) and passes with this change. It also checks that a later edit of the module is a hot update and that creating `optional-dep.ts` re-bundles the importer (the directory watch is still registered) and the `require` then succeeds.
- `test/bake/dev/plugins.test.ts`, "onResolve fall-through still reports an unresolvable import": a plain `import` of a missing file through the same plugin still shows the `Could not resolve` error overlay and reloads once the file is created (the branch that still invalidates the importer).
- `test/bundler/bundler_plugin.test.ts`, `plugin/ResolveFallThroughMissingRequireInTryCatch` and `plugin/ResolveFallThroughMissingImport`: the same two cases through `Bun.build`, covering the non-dev-server side of the restructured code (these pass before and after; the dropped module only happened under the dev server).
- `bun bd test test/bake/dev/plugins.test.ts`, `test/bake/dev/bundle.test.ts` and `test/bundler/bundler_plugin.test.ts` pass.

</details>

