### PR TITLE
node:http: honor server.maxHeadersCount on HTTP/1 fallback connections

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -6,6 +6,9 @@ const { SafeSet } = require("internal/primordials");
 
 const kHttp1Connections = Symbol("http1Connections");
 const kHttp1ActiveRequests = Symbol("http1ActiveRequests");
+// node:_http_common's MAX_HEADER_PAIRS: what a freelist parser carries when
+// server.maxHeadersCount is left at null. This path constructs its parser directly.
+const MAX_HEADER_PAIRS = 2000;
 
 function createHttp1FallbackResponseHandle(socket, shouldKeepAlive, keepAliveTimeout) {
   const { _checkInvalidHeaderChar: checkInvalidHeaderChar } = require("node:_http_common");
@@ -263,9 +266,7 @@ function connectionListenerHTTP1(server, socket, options) {
   parser.socket = socket;
   socket.parser = parser;
   const { maxHeadersCount } = server;
-  if (typeof maxHeadersCount === "number") {
-    parser.maxHeaderPairs = maxHeadersCount << 1;
-  }
+  parser.maxHeaderPairs = typeof maxHeadersCount === "number" ? maxHeadersCount << 1 : MAX_HEADER_PAIRS;
 
   let req = null;
   let pendingUpgrade = null;
@@ -291,7 +292,12 @@ function connectionListenerHTTP1(server, socket, options) {
     req.url = url;
     req.method = typeof methodNum === "number" ? allMethods[methodNum] : methodNum;
     req.upgrade = upgrade;
-    req._addHeaderLines(rawHeaders, rawHeaders.length);
+    // Node's parserOnHeadersComplete: maxHeaderPairs <= 0 means unlimited. Only the
+    // count fed into req.headers is clamped; req.rawHeaders keeps every field.
+    let headerCount = rawHeaders.length;
+    const maxHeaderPairs = parser.maxHeaderPairs;
+    if (maxHeaderPairs > 0 && headerCount > maxHeaderPairs) headerCount = maxHeaderPairs;
+    req._addHeaderLines(rawHeaders, headerCount);
 
     // Node's parserOnIncoming: upgrade only sticks for CONNECT or when an 'upgrade' listener
     // exists; otherwise fall through to normal dispatch. Returning 2 makes llhttp stop after

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,39 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+it("connectionListener applies server.maxHeadersCount to req.headers like Node", async () => {
+  // Sockets served through server.emit("connection", ...) take the JS fallback
+  // parser. Node's parserOnHeadersComplete clamps the number of header lines it
+  // folds into req.headers to parser.maxHeaderPairs (server.maxHeadersCount * 2,
+  // 0 = unlimited, null = the parser's 2000-pair default); req.rawHeaders keeps
+  // every field either way.
+  const rawHeaders = ["Host", "example", "X-A", "1", "X-B", "2", "Connection", "close"];
+  const results: unknown[] = [];
+  for (const maxHeadersCount of [1, 2, 3, 0, null]) {
+    const seen = Promise.withResolvers<{ headers: string[]; rawHeaders: string[] }>();
+    const server = createServer((req, res) => {
+      seen.resolve({ headers: Object.keys(req.headers), rawHeaders: req.rawHeaders });
+      res.end();
+    });
+    server.maxHeadersCount = maxHeadersCount;
+    const [clientSide, serverSide] = duplexPair();
+    try {
+      server.emit("connection", serverSide);
+      const maxHeaderPairs = (serverSide as any).parser.maxHeaderPairs;
+      clientSide.resume();
+      clientSide.write("GET / HTTP/1.1\r\nHost: example\r\nX-A: 1\r\nX-B: 2\r\nConnection: close\r\n\r\n");
+      results.push({ maxHeadersCount, maxHeaderPairs, ...(await seen.promise) });
+    } finally {
+      clientSide.destroy();
+      serverSide.destroy();
+    }
+  }
+  expect(results).toEqual([
+    { maxHeadersCount: 1, maxHeaderPairs: 2, headers: ["host"], rawHeaders },
+    { maxHeadersCount: 2, maxHeaderPairs: 4, headers: ["host", "x-a"], rawHeaders },
+    { maxHeadersCount: 3, maxHeaderPairs: 6, headers: ["host", "x-a", "x-b"], rawHeaders },
+    { maxHeadersCount: 0, maxHeaderPairs: 0, headers: ["host", "x-a", "x-b", "connection"], rawHeaders },
+    { maxHeadersCount: null, maxHeaderPairs: 2000, headers: ["host", "x-a", "x-b", "connection"], rawHeaders },
+  ]);
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4365,6 +4365,49 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+it("http2 allowHTTP1 fallback applies server.maxHeadersCount to req.headers like Node", async () => {
+  // Same clamp as Node's parserOnHeadersComplete on an http.Server: only the
+  // first maxHeadersCount fields reach req.headers (0 = unlimited, unset = the
+  // parser's 2000-pair default) while req.rawHeaders keeps all of them.
+  async function requestWithMaxHeadersCount(maxHeadersCount) {
+    const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true }, (req, res) => {
+      res.end(
+        JSON.stringify({
+          maxHeaderPairs: req.socket.parser.maxHeaderPairs,
+          headers: Object.keys(req.headers),
+          rawHeaders: req.rawHeaders,
+        }),
+      );
+    });
+    if (maxHeadersCount !== undefined) server.maxHeadersCount = maxHeadersCount;
+    await new Promise(resolve => server.listen(0, resolve));
+    try {
+      const { promise, resolve, reject } = Promise.withResolvers();
+      const socket = tls.connect(
+        { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+        () => socket.write("GET / HTTP/1.1\r\nHost: example\r\nX-A: 1\r\nX-B: 2\r\nConnection: close\r\n\r\n"),
+      );
+      const chunks = [];
+      socket.on("error", reject);
+      socket.on("data", chunk => chunks.push(chunk));
+      socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
+      const raw = await promise;
+      return JSON.parse(raw.slice(raw.indexOf("\r\n\r\n") + 4));
+    } finally {
+      server.close();
+    }
+  }
+
+  const rawHeaders = ["Host", "example", "X-A", "1", "X-B", "2", "Connection", "close"];
+  expect(
+    await Promise.all([requestWithMaxHeadersCount(1), requestWithMaxHeadersCount(0), requestWithMaxHeadersCount()]),
+  ).toEqual([
+    { maxHeaderPairs: 2, headers: ["host"], rawHeaders },
+    { maxHeaderPairs: 0, headers: ["host", "x-a", "x-b", "connection"], rawHeaders },
+    { maxHeaderPairs: 2000, headers: ["host", "x-a", "x-b", "connection"], rawHeaders },
+  ]);
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().


### PR DESCRIPTION
### Problem
- `server.maxHeadersCount` has no effect on connections served by the JS HTTP/1 fallback: sockets passed to `http.Server#emit("connection", socket)` and HTTP/1.1 connections on `http2.createSecureServer({ allowHTTP1: true })`. With `maxHeadersCount = 1`, a request carrying `Host`, `X-A`, `Connection` shows up as `req.headers = { host, x-a, connection }`; Node v26.3.0 gives `{ host }`. The native (uWS) `node:http` server is not affected.
- `connectionListenerHTTP1` (`src/js/internal/http1_server_fallback.ts`) stores the limit as `parser.maxHeaderPairs` but its `kOnHeadersComplete` handler then calls `req._addHeaderLines(rawHeaders, rawHeaders.length)`, so the stored value is never read. `maxHeaderPairs` is a plain JS property that only Node's JS layer consumes; neither Node's `node_http_parser.cc` nor Bun's `HTTPParser` binding (`src/jsc/bindings/node/http/NodeHTTPParser.cpp`) knows about it, so the clamp has to happen in this handler.

### Fix
- `kOnHeadersComplete` clamps the count passed to `_addHeaderLines` to `parser.maxHeaderPairs` when that is `> 0`, exactly what Node's `parserOnHeadersComplete` does (`lib/_http_common.js`; Bun's own port in `src/js/node/_http_common.ts` does the same for the client). `req.rawHeaders` keeps every field, as in Node, because `_addHeaderLines` stores the full array and only the processed count is clamped.
- `parser.maxHeaderPairs` is now always seeded: `maxHeadersCount << 1` when it is a number (so `0` still means unlimited), otherwise the 2000-pair default a parser from `_http_common`'s freelist carries in Node. This parser is constructed directly, so it did not get that default before; `socket.parser.maxHeaderPairs` now reads `2000` on a server left at the default, as in Node.
- Why this is correct: it matches Node. The `server.maxHeadersCount` contract (limit the fields folded into `req.headers`, `0` = unlimited, `rawHeaders` untouched) is implemented in Node by the same two lines in `parserOnHeadersComplete`; this copies them into the fallback's equivalent handler. The expected values in both tests were checked against Node v26.3.0 with the same requests.
- Scope: requests with 32 or more fields still only surface the parser's last block in this fallback (it does not register `kOnHeaders`; that is a separate bug with its own open PR, #33540). The clamp is applied to whatever array reaches `_addHeaderLines`, so it composes with that fix once the blocks are concatenated.
- Tests: `test/js/node/http/node-http.test.ts` ("connectionListener applies server.maxHeadersCount to req.headers like Node", `emit("connection")` over a `duplexPair` with `maxHeadersCount` of 1, 2, 3, 0 and null) and `test/js/node/http2/node-http2.test.js` ("http2 allowHTTP1 fallback applies server.maxHeadersCount to req.headers like Node", raw HTTP/1.1 over TLS with ALPN `http/1.1` for 1, 0 and unset). Both fail on main (all fields reach `req.headers`, `maxHeaderPairs` is `undefined` when unset) and pass with this change.
- Also run: the full `node-http2.test.js` (358 pass), `node-http.test.ts` (144 pass; `request via http proxy, issue#4295` fails identically without this change here because `localhost` resolves to `::1` first in this container, and Node fails the same way), and the vendored Node tests that drive this path: `test-http-generic-streams`, `test-http-max-header-size-per-stream`, `test-http-insecure-parser-per-stream`, `test-http-server-unconsume-consume`, `test-http2-https-fallback`, `test-http2-https-fallback-http-server-options`, `test-http2-allow-http1`, `test-http2-autoselect-protocol` (all exit 0).

### Background
- `http.Server` parses the sockets it accepts itself natively (uWS) and builds `req.headers` from there. Anything else that reaches the `connection` event (a Duplex a proxy hands in via `server.emit("connection", s)`, or a TLS socket that negotiated `http/1.1` on an `allowHTTP1` HTTP/2 server) is served by `connectionListenerHTTP1`, a JS port of Node's `connectionListener` that drives the llhttp-based `HTTPParser` binding with its own callbacks instead of the shared ones in `_http_common`.
- `HTTPParser` calls `kOnHeadersComplete` with a flat `[name, value, name, value, ...]` array. `IncomingMessage#_addHeaderLines(headers, n)` stores the whole array as `req.rawHeaders` and records `n`; the lazy `req.headers` getter only folds in the first `n` entries. That split is what lets `maxHeadersCount` limit `req.headers` without dropping anything from `req.rawHeaders`.
- `parser.maxHeaderPairs` is Node's name for the limit on the parser object: `server.maxHeadersCount * 2` (entries, not fields), `<= 0` meaning unlimited, defaulting to `MAX_HEADER_PAIRS = 2000` for parsers taken from the freelist.

<details>
<summary>Repro (Node v26.3.0 vs Bun 1.4.0 / main)</summary>

```js
const http = require("http");
const { duplexPair } = require("stream");
for (const max of [1, 2]) {
  const server = http.createServer((req, res) => {
    console.log(max, Object.keys(req.headers));
    res.end();
  });
  server.maxHeadersCount = max;
  const [c, s] = duplexPair();
  server.emit("connection", s);
  c.resume();
  c.write("GET / HTTP/1.1\r\nHost: a\r\nX-A: 1\r\nConnection: close\r\n\r\n");
}
```

```
node:  1 [ 'host' ]                         2 [ 'host', 'x-a' ]
bun:   1 [ 'host', 'x-a', 'connection' ]    2 [ 'host', 'x-a', 'connection' ]
```

`socket.parser.maxHeaderPairs` right after `emit("connection")`, for `maxHeadersCount` unset / 0 / 3 / null:

```
node:  {"unset":2000,"zero":0,"three":6,"nullv":2000}
bun:   {"zero":0,"three":6}            (undefined for unset and null)
```
</details>
