### PR TITLE
shell(cat): stop reading stdin while no cat is listening

### DIFF
--- a/src/runtime/shell/IOReader.rs
+++ b/src/runtime/shell/IOReader.rs
@@ -41,6 +41,8 @@ pub(crate) type ReaderImpl = bun_io::BufferedReader;
 
 struct State {
     fd: Fd,
+    /// Bytes the underlying reader produced while `readers` was empty, handed
+    /// to the next listener ahead of anything read for it. See `deliver`.
     buf: Vec<u8>,
     readers: Readers,
     /// The raw `sys::Error`. `SystemError` is not `Clone`
@@ -89,12 +91,14 @@ impl IOReader {
         // held by the bun_io read loop never overlaps a `&mut State` derived in a
         // vtable callback (see struct doc comment).
         //
-        // MUST NOT be invoked from within a `BufferedReaderParent` vtable
-        // callback (`on_read_chunk_cb`/`on_reader_done_cb`/`on_reader_error`):
-        // the read loop already holds a live `&mut ReaderImpl` on its stack
-        // while the callback runs (PipeReader.rs aliasing contract), so
-        // re-deriving here would create two simultaneous `&mut` to the same
-        // BufferedReader = Stacked-Borrows UB.
+        // Reached from inside `on_read_chunk_cb` / `on_reader_done_cb` only
+        // through `pause()`: the posix read loops dispatch both through a raw
+        // pointer and a copied vtable, holding no borrow across the dispatch,
+        // and `WindowsBufferedReader::on_read_chunk` launders its receiver
+        // around the dispatch so that the parent can pause it from there (as
+        // `FileReader::set_flowing` does). Must not be reached from
+        // `on_reader_error`: `start()` receives that one from inside
+        // `ReaderImpl::start()`, i.e. under its `&mut self`.
         unsafe { &mut *self.reader.get() }
     }
 
@@ -193,11 +197,15 @@ impl IOReader {
         let _ = reading;
     }
 
-    /// Idempotent function to start the reading.
+    /// Idempotent function to start the reading; also resumes after `pause()`.
+    /// Anything in `State::buf` is deliberately not delivered from here but
+    /// from the next read callback (`flush_buffered`): the caller is running
+    /// inside the trampoline, and delivering would re-enter it.
     pub(crate) fn start(&self) -> Yield {
         #[cfg(not(windows))]
         {
             let r = self.reader();
+            r.unpause();
             let need_start = match &r.handle {
                 bun_io::pipes::PollOrFd::Closed => true,
                 bun_io::pipes::PollOrFd::Poll(p) => !p.is_registered(),
@@ -215,6 +223,10 @@ impl IOReader {
         {
             let s = self.state();
             if s.is_reading {
+                // The read issued for the previous listener is still in
+                // flight (`pause()` could not cancel it); clearing the pause
+                // lets its completion re-arm for the new listener.
+                self.reader().unpause();
                 return Yield::suspended();
             }
             s.is_reading = true;
@@ -237,9 +249,21 @@ impl IOReader {
     /// Unregister a listener; no-op if it was never added.
     pub(crate) fn remove_reader(&self, reader: ChildPtr) {
         let s = self.state();
-        if let Some(idx) = s.readers.iter().position(|r| *r == reader) {
-            s.readers.swap_remove(idx);
+        let Some(idx) = s.readers.iter().position(|r| *r == reader) else {
+            return;
+        };
+        s.readers.swap_remove(idx);
+        if s.readers.is_empty() {
+            self.pause();
         }
+    }
+
+    /// Nobody is listening any more, so stop consuming the fd: what has not
+    /// been read yet stays in it for whatever reads it next (a later `cat` on
+    /// this reader, or a subprocess inheriting the fd), as it would after a
+    /// real `cat` exited. `start()` resumes.
+    fn pause(&self) {
+        self.reader().pause();
     }
 
     /// The `BufferedReader.onReadChunk` hook.
@@ -250,6 +274,36 @@ impl IOReader {
         // memory.
         let _keepalive = self.keepalive();
         self.set_reading(false);
+        self.flush_buffered();
+        self.deliver(chunk);
+
+        // No re-arm here: the posix read loop re-arms from the `bool` we
+        // return, and on Windows `on_file_read` re-arms unless the reader is
+        // paused (`WindowsBufferedReader::on_read` also clears the chunk
+        // buffer). A listener-less reader was paused by `deliver` /
+        // `remove_reader`, so the `false` returned for it is only advisory.
+        let should_continue =
+            has_more != bun_io::ReadState::Eof && !self.state().readers.is_empty();
+        if should_continue {
+            self.set_reading(true);
+        }
+        should_continue
+    }
+
+    /// Hands `chunk` to the listeners, or keeps it if there are none.
+    ///
+    /// Chunks can arrive without listeners: `pause()` does not stop a read
+    /// that is already in flight (Windows), and the posix loop drains a
+    /// hung-up pipe to EOF regardless of what we return. Bytes the kernel has
+    /// already given us cannot be put back, so they wait in `State::buf` for
+    /// the next listener (`flush_buffered`) instead of being dropped.
+    fn deliver(&self, chunk: &[u8]) {
+        let s = self.state();
+        if s.readers.is_empty() {
+            s.buf.extend_from_slice(chunk);
+            self.pause();
+            return;
+        }
         // NOTE: reshaped for borrowck — `dispatch_read_chunk`/`run_yield`
         // both re-derive `state()` (and the interpreter callback may re-enter
         // `add_reader`/`remove_reader`), so we must NOT hold a long-lived
@@ -262,32 +316,25 @@ impl IOReader {
             let mut remove = false;
             self.run_yield(dispatch_read_chunk(r, chunk, &mut remove, interp));
             if remove {
-                self.state().readers.swap_remove(i);
+                self.remove_reader(r);
             } else {
                 i += 1;
             }
         }
+    }
 
-        let should_continue = has_more != bun_io::ReadState::Eof;
-        if should_continue && !self.state().readers.is_empty() {
-            self.set_reading(true);
-            // NOTE: no explicit re-arm (`registerPoll()` on posix /
-            // `startWithCurrentPipe()` on windows) here: that would re-derive
-            // a second `&mut ReaderImpl` while the bun_io read loop still
-            // holds one on its stack (PipeReader.rs aliasing contract) —
-            // Stacked-Borrows UB.
-            // On posix the re-arm is redundant: the read loop re-registers
-            // itself after the callback returns based on the `bool` we return
-            // (PipeReader.rs:731/755/846/920/986). On Windows the re-arm is
-            // also handled by the caller (`on_file_read`'s defer block /
-            // `uv_read_start` for streams) — but `startWithCurrentPipe()` had
-            // a SECOND load-bearing side effect: `buffer().clearRetainingCapacity()`,
-            // which keeps `WindowsBufferedReader._buffer` bounded between
-            // chunks. That clear is now performed by
-            // `WindowsBufferedReader::on_read` after the streaming chunk is
-            // consumed, so we still do nothing here.
+    /// Delivers what `deliver` set aside once there is a listener again,
+    /// ahead of the next chunk or the EOF of the read `start()` issued for it.
+    /// Not ahead of a read error: `start()` can report one synchronously from
+    /// inside `ReaderImpl::start()` (see `reader()`), and a `cat` discards its
+    /// pending output on a read error anyway.
+    fn flush_buffered(&self) {
+        let s = self.state();
+        if s.buf.is_empty() || s.readers.is_empty() {
+            return;
         }
-        should_continue
+        let buffered = core::mem::take(&mut s.buf);
+        self.deliver(&buffered);
     }
 
     fn on_reader_error(&self, err: &sys::Error) {
@@ -315,6 +362,7 @@ impl IOReader {
         // Hold a strong ref across the body.
         let _keepalive = self.keepalive();
         self.set_reading(false);
+        self.flush_buffered();
         let s = self.state();
         let readers: Vec<ChildPtr> = s.readers.clone();
         let interp = s.interp;

--- a/test/js/bun/shell/commands/cat.test.ts
+++ b/test/js/bun/shell/commands/cat.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, isLinux, isWindows } from "harness";
+
+// The builtin `cat` is the default on Windows; on POSIX it needs this flag,
+// otherwise `cat` is the system binary.
+const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+// Runs, in a child bun, a script whose first `cat` reads the script's stdin and
+// dies on its first chunk, then (once the test allows the script to go on) a
+// second reader of the same stdin. Prints the script's stdout followed by an
+// `exit=<code>` trailer. The script's stdout is not captured, so `echo` goes
+// through the event loop and the second reader only starts after the test has
+// seen `ready`.
+//
+// The `fetch` in the middle blocks the script between the two readers for as
+// long as the test wants: everything written to stdin in the meantime arrives
+// while no builtin is reading it, and a real shell would leave it in the fd
+// for the second reader.
+const childCode = `
+  const result = await Bun.$\`\${{ raw: process.env.FIRST_READER }};
+    \${process.execPath} -e \${"await (await fetch(process.env.RELEASE_URL)).text()"};
+    echo ready;
+    \${{ raw: process.env.SECOND_READER }}\`.nothrow();
+  process.stdout.write("exit=" + result.exitCode + "\\n");
+`;
+
+// Several reads' worth on every platform (the posix reader reads up to 256 KiB
+// at a time, the Windows one 64 KiB), so the second reader also has to keep
+// reading after the first chunk it gets.
+const input = Buffer.alloc(300_000, "second reader's input\n").toString();
+
+const decoder = new TextDecoder();
+
+async function runScript(
+  firstReader: string,
+  secondReader: string,
+  { writeInputAfter }: { writeInputAfter: "first reader died" | "second reader started" },
+) {
+  const pinged = Promise.withResolvers<(response: Response) => void>();
+  await using server = Bun.serve({
+    port: 0,
+    fetch: () => new Promise<Response>(release => pinged.resolve(release)),
+  });
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", childCode],
+    env: {
+      ...builtinEnv,
+      FIRST_READER: firstReader,
+      SECOND_READER: secondReader,
+      RELEASE_URL: server.url.href,
+    },
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  let stdout = "";
+  const ready = Promise.withResolvers<void>();
+  const stdoutClosed = (async () => {
+    for await (const chunk of proc.stdout) {
+      stdout += decoder.decode(chunk, { stream: true });
+      if (stdout.includes("ready\n")) ready.resolve();
+    }
+  })();
+  const exitedEarly = proc.exited.then(code => {
+    throw new Error(
+      `the child exited with code ${code} before printing ready; stdout so far: ${JSON.stringify(stdout)}`,
+    );
+  });
+
+  // The first reader gets this line, tries to write it and dies; the script
+  // reaches the `fetch` only once it has.
+  proc.stdin.write("first reader's input\n");
+  proc.stdin.flush();
+  const release = await Promise.race([pinged.promise, exitedEarly]);
+  if (writeInputAfter === "first reader died") {
+    // Not flushed to completion here: more than the pipe holds is written, and
+    // the rest can only go out once the second reader is consuming.
+    proc.stdin.write(input);
+    proc.stdin.flush();
+  }
+  release(new Response());
+  await Promise.race([ready.promise, exitedEarly]);
+  if (writeInputAfter === "second reader started") {
+    proc.stdin.write(input);
+  }
+  await proc.stdin.end();
+
+  const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited, stdoutClosed]);
+  return { stdout, stderr, exitCode };
+}
+
+const expectedStdout = `ready\n${input}exit=0\n`;
+
+function expectAllOfTheInput(result: Awaited<ReturnType<typeof runScript>>) {
+  expect(result.stderr).toBe("");
+  // Sizes first: when the second reader misses part of the input, a diff of
+  // 300 KB of identical lines says less than the two sizes do.
+  expect(result.stdout.length).toBe(expectedStdout.length);
+  expect(result).toEqual({ stdout: expectedStdout, stderr: "", exitCode: 0 });
+}
+
+describe("cat (builtin) that stops reading stdin leaves the rest of stdin to the next reader", () => {
+  describe.each([
+    // `true` exits at once, so the first cat's write of its first chunk fails
+    // with EPIPE later, from the event loop, after the read that delivered the
+    // chunk was already re-armed.
+    ["fails to write to a pipe nobody reads", "cat | true", true],
+    // The write to /dev/full fails synchronously, while the chunk is being
+    // delivered, so the first cat is gone before the read that delivered it
+    // decides whether to re-arm.
+    ["fails to write to /dev/full", "cat > /dev/full", isLinux],
+  ])("first cat %s", (_, firstReader, supported) => {
+    test.concurrent.skipIf(!supported)("a later builtin cat prints the input written in between", async () => {
+      expectAllOfTheInput(await runScript(firstReader, "cat", { writeInputAfter: "first reader died" }));
+    });
+
+    // On Windows the read that was in flight when the first cat died cannot be
+    // cancelled, so the shell keeps that one chunk for a later builtin only; a
+    // subprocess seeing everything is a POSIX guarantee.
+    test.concurrent.skipIf(!supported || isWindows)(
+      "a later subprocess prints the input written in between",
+      async () => {
+        expectAllOfTheInput(await runScript(firstReader, "/bin/cat", { writeInputAfter: "first reader died" }));
+      },
+    );
+
+    test.concurrent.skipIf(!supported)("a later builtin cat reads input written after it started", async () => {
+      expectAllOfTheInput(await runScript(firstReader, "cat", { writeInputAfter: "second reader started" }));
+    });
+  });
+});


### PR DESCRIPTION
### Problem

- Builtin `cat` (the default on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX) reading a script's stdin. When the cat that is currently reading goes away before EOF (its first write fails: `cat | true`, `cat > /dev/full`), the shell keeps reading stdin and throws the bytes away until the next `cat` registers. A later `cat` in the same script, or a later subprocess, sees only what arrives after it started, often nothing. A real shell leaves everything the dead `cat` had not read in the fd for the next command.
- Cause, `src/runtime/shell/IOReader.rs`: `remove_reader()` only removes the list entry, and `on_read_chunk_cb` returns `has_more != Eof` whether or not anyone is left in `readers`, so the bun_io read stays armed (POSIX: the read loop re-registers the poll after every chunk; Windows: `on_file_read` issues the next `uv_fs_read` unless the reader is paused). Every chunk that arrives while the list is empty is dropped by the dispatch loop. Same logic as the Zig version, so inherited rather than a porting bug.

<details>
<summary>Repro shape (what the new test automates)</summary>

Child, with the builtin enabled and stdin piped from the parent:

```js
await Bun.$`cat | true; ${process.execPath} -e ${"await (await fetch(process.env.RELEASE_URL)).text()"}; echo ready; cat`;
```

The parent writes one line (the first cat reads it, fails to write it, dies), waits for the `fetch` to arrive (so the first cat is gone), writes 300 KB, lets the `fetch` return, waits for `ready`, closes stdin. A shell prints the 300 KB from the second `cat`; bun prints nothing from it (the 300 KB were read and dropped while the script was parked on the `fetch`). Same with `/bin/cat` as the second reader, and with `cat > /dev/full` as the first.

</details>

### Fix

- `remove_reader()` pauses the bun_io reader when it removes the last listener. On POSIX that unregisters the poll, so bytes not read yet stay in the kernel for whoever reads the fd next (a later builtin `cat`, or a subprocess inheriting the fd); on Windows it sets the paused flag, so the completion of the read that is in flight does not issue another one (and tries to cancel it).
- `start()` unpauses before its existing (re)arm logic. On Windows, when the read issued for the previous listener is still in flight (`is_reading`), it now clears the pause so that read's completion re-arms for the new listener instead of stopping after it.
- Chunks that still arrive with nobody listening are kept in the (previously unused) `State::buf` and handed to the next listener ahead of the next chunk or the EOF of the read `start()` issued for it (`deliver` / `flush_buffered`). Two sources: on Windows the `uv_fs_read` that was already blocked in the threadpool when the cat died completes with data; on POSIX, after a hang-up, bun_io drains the pipe to EOF regardless of what the parent returns. They are delivered from the read callbacks rather than from `start()` because `start()` is called from inside the trampoline (same reason `IOWriter::write` returns a synchronous error instead of dispatching it).
- `on_read_chunk_cb` returns `false` as well when nobody is listening, and a listener asking to be removed via the `remove` flag goes through `remove_reader`, so that path pauses too.
- Why this is the right shape: which bytes belong to whom follows what a real shell does. Bytes handed to a cat that then dies were consumed by it (a real `cat` had `read()` them too); bytes the kernel handed us with nobody to give them to are kept for the next reader; bytes nobody asked for stay in the fd. `pause()`/`unpause()` is the contract bun_io already provides for a parent that wants to stop consuming (`FileReader::set_flowing` uses it from inside the data callback for `process.stdin.pause()`; the read loops, `try_register_poll`, `on_poll` and `on_file_read` all honor it), and the shell's `IOReader` is the layer that knows whether anyone is listening, so nothing in bun_io changes.
- Not changed: bun_io's drain after HUP ignores the parent's return value on purpose (the shell's subprocess `PipeReader` relies on that to reach EOF), so after a hang-up the remaining bytes end up in `State::buf` rather than in the fd. That differs from a real shell only for a subprocess reading after a builtin cat died during such a drain, and needs more than one read's worth (256 KiB) of input plus the hang-up in the same wakeup, which a default Linux pipe or socketpair cannot even hold; that is also why no test covers the POSIX side of the buffer.
- Verified with `test/js/bun/shell/commands/cat.test.ts` (new file; #37752, #37743 and #35337 create the same file for their own cat fixes, the helpers are independent, whichever lands later appends its cases). Matrix: first cat dies from the event loop (EPIPE from `cat | true`, all platforms) or synchronously inside the chunk dispatch (`cat > /dev/full`, Linux) x {a later builtin cat gets the input written while nobody was listening; a later subprocess gets it (POSIX, since on Windows the in-flight read holds one chunk for builtins only); input written only after the later cat started, which exercises the resume paths including the Windows in-flight branch and passes before the fix too}. On the released bun the four "written in between" cases fail deterministically (10/10 runs; the second reader prints nothing: `Expected: 300013, Received: 13`), the two resume guards pass; all six pass with the debug build.
- Windows (x64, where the builtin is the default): with the released bun the `cat | true` "written in between" case fails the same way (`Received: 13`); with a debug build of this branch the two cases that apply there pass, 6 runs out of 6. That case goes through the in-flight read: the 300 KB start arriving in the `uv_fs_read` that was blocked when the first cat died, so its completion takes the `deliver`-with-no-listener path and the second cat gets those bytes from `flush_buffered`; the "written after it started" case goes through the new `is_reading` branch of `start()`.
- Also ran `test/js/bun/shell/bunshell.test.ts`: 418 pass. With `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` exported, 5 of its tests fail; all of them read a regular file through the builtin and fail identically on the released bun (#35337's bug).
- Overlaps textually with #37752 (the `start()` condition and the done/error callbacks) and #37743 (`start()` returning its error) but is independent of both: they change when a finished read is restarted and how a start failure is reported, this changes what happens while nobody is listening. #37752's description lists this bug as out of its scope.

### Background

- `IOReader`: one per fd a script reads (the script's stdin, a pipeline stage's stdin, a `< file`), shared by every builtin `cat` that reads that fd during the script. A cat registers with `add_reader` + `start()` and receives chunks / EOF through the `BufferedReaderParent` vtable; `Cat::on_io_writer_chunk` unregisters it with `remove_reader` when its output fails. The stdin reader outlives the individual cats.
- bun_io `BufferedReader`, POSIX: a one-shot readable poll. After each chunk the read loop re-registers the poll unless the parent returned `false`; once the poll reported HUP it instead loops reading until EOF, ignoring the return value. `pause()` unregisters the poll and turns `register_poll` / `on_poll` into no-ops; `unpause()` only clears the flag, the parent re-arms (here: `start()`).
- bun_io `BufferedReader`, Windows: one `uv_fs_read` at a time; its completion callback issues the next one unless the reader is paused. `pause()` sets the flag and attempts `uv_cancel`, which fails for a read the threadpool is already blocked in, so that read still completes with data later; `unpause()` clears the flag and issues a read only if none is in flight.
- Yield trampoline: shell state functions return a continuation that `Yield::run` drives; event-loop callbacks (like the read callbacks here) start a run with `run_yield`, while code that is itself running inside a continuation (like `start()`, called from `Cat::next`) must not start a nested run. That is why the kept bytes are delivered from the callbacks.
