### PR TITLE
bake: don't panic or break the error overlay on a log location without a column

### DIFF
--- a/src/jsc/bindings/JSBundlerPlugin.cpp
+++ b/src/jsc/bindings/JSBundlerPlugin.cpp
@@ -370,9 +370,12 @@ JSC_DEFINE_HOST_FUNCTION(jsBundlerPluginFunction_onBeforeParse, (JSC::JSGlobalOb
         return {};
     }
     WTF::String on_before_parse_symbol = on_before_parse_symbol_js.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
 
     // The dlopen *void handle is attached to the node_addon as a NapiExternal
-    Bun::NapiExternal* napi_external = dynamicDowncast<Bun::NapiExternal>(node_addon.getObject()->get(globalObject, WebCore::builtinNames(vm).napiDlopenHandlePrivateName()));
+    JSC::JSValue napi_external_value = node_addon.getObject()->get(globalObject, WebCore::builtinNames(vm).napiDlopenHandlePrivateName());
+    RETURN_IF_EXCEPTION(scope, {});
+    Bun::NapiExternal* napi_external = dynamicDowncast<Bun::NapiExternal>(napi_external_value);
     if (!napi_external) [[unlikely]] {
         Bun::throwError(globalObject, scope, ErrorCode::ERR_INVALID_ARG_TYPE, "Expected node_addon (2nd argument) to have a napiDlopenHandle property"_s);
         return {};

--- a/src/runtime/bake/client/error-serialization.ts
+++ b/src/runtime/bake/client/error-serialization.ts
@@ -19,7 +19,7 @@ export interface BundlerMessage {
 export interface BundlerMessageLocation {
   /** One-based */
   line: number;
-  /** One-based */
+  /** One-based. 0 when the message has a line but no column; nothing is underlined then. */
   column: number;
   /** Byte length */
   length: number;

--- a/src/runtime/bake/client/overlay.ts
+++ b/src/runtime/bake/client/overlay.ts
@@ -623,10 +623,14 @@ function renderCodeLine(location: BundlerMessageLocation, level: BundlerMessageL
       elem("div", { class: "gutter" }, [elemText("div", null, `${location.line}`)]),
       elem("div", { class: "view" }, [
         mapCodePreviewLine(syntaxHighlight(location.lineText)),
-        elem("div", { class: "highlight-wrap log-" + bundleLogLevelToName[level] }, [
-          elemText("span", { class: "space" }, "_".repeat(location.column - 1)),
-          elemText("span", { class: "line" }, "_".repeat(location.length)),
-        ]),
+        ...(location.column > 0
+          ? [
+              elem("div", { class: "highlight-wrap log-" + bundleLogLevelToName[level] }, [
+                elemText("span", { class: "space" }, "_".repeat(location.column - 1)),
+                elemText("span", { class: "line" }, "_".repeat(location.length)),
+              ]),
+            ]
+          : []),
       ]),
     ]),
   ];

--- a/src/runtime/bake/dev_server/serialized_failure.rs
+++ b/src/runtime/bake/dev_server/serialized_failure.rs
@@ -226,8 +226,7 @@ fn write_log_data(data: &bun_ast::Data, w: &mut Writer) {
             return;
         }
         _ = w.write_int_le::<i32>(loc.line);
-        // One-based; 0 means the message has a line but no column (native plugins
-        // can log such a location), which the client renders without an underline.
+        // One-based; 0 means "no column" and the client then draws no underline.
         _ = w.write_int_le::<u32>(loc.column.max(0) as u32);
         _ = w.write_int_le::<u32>(u32::try_from(loc.length).expect("int cast"));
 

--- a/src/runtime/bake/dev_server/serialized_failure.rs
+++ b/src/runtime/bake/dev_server/serialized_failure.rs
@@ -225,10 +225,10 @@ fn write_log_data(data: &bun_ast::Data, w: &mut Writer) {
             _ = w.write_int_le::<u32>(0);
             return;
         }
-        debug_assert!(loc.column >= 0); // zero based and not negative
-
         _ = w.write_int_le::<i32>(loc.line);
-        _ = w.write_int_le::<u32>(u32::try_from(loc.column).expect("int cast"));
+        // One-based; 0 means the message has a line but no column (native plugins
+        // can log such a location), which the client renders without an underline.
+        _ = w.write_int_le::<u32>(loc.column.max(0) as u32);
         _ = w.write_int_le::<u32>(u32::try_from(loc.length).expect("int cast"));
 
         // TODO: syntax highlighted line text + give more context lines

--- a/test/bake/dev/native-plugin-log-location.c
+++ b/test/bake/dev/native-plugin-log-location.c
@@ -1,0 +1,55 @@
+// Native bundler plugin for plugins.test.ts. It is a napi module only so that
+// `require()` accepts it; each exported onBeforeParse hook just logs one error
+// whose location has a line but a different kind of column.
+#include <bun-native-bundler-plugin-api/bundler_plugin.h>
+#include <string.h>
+
+#ifdef _WIN32
+#define PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define PLUGIN_EXPORT __attribute__((visibility("default")))
+#endif
+
+PLUGIN_EXPORT const char *BUN_PLUGIN_NAME = "log-location";
+
+PLUGIN_EXPORT void *napi_register_module_v1(void *env, void *exports) {
+  (void)env;
+  return exports;
+}
+
+static void log_error(const OnBeforeParseArguments *args,
+                      const OnBeforeParseResult *result, const char *message,
+                      const char *line_text, int line, int column,
+                      int column_end) {
+  BunLogOptions options;
+  memset(&options, 0, sizeof(options));
+  options.__struct_size = sizeof(options);
+  options.message_ptr = (const uint8_t *)message;
+  options.message_len = strlen(message);
+  options.path_ptr = args->path_ptr;
+  options.path_len = args->path_len;
+  options.source_line_text_ptr = (const uint8_t *)line_text;
+  options.source_line_text_len = strlen(line_text);
+  options.level = BUN_LOG_LEVEL_ERROR;
+  options.line = line;
+  options.lineEnd = line;
+  options.column = column;
+  options.columnEnd = column_end;
+  result->log(args, &options);
+}
+
+// Column 7 is the `a`, one-based.
+PLUGIN_EXPORT void log_with_column(const OnBeforeParseArguments *args,
+                                   OnBeforeParseResult *result) {
+  log_error(args, result, "with column", "const a = 1;", 1, 7, 8);
+}
+
+PLUGIN_EXPORT void log_zero_column(const OnBeforeParseArguments *args,
+                                   OnBeforeParseResult *result) {
+  log_error(args, result, "zero column", "const b = 2;", 2, 0, 0);
+}
+
+PLUGIN_EXPORT void log_negative_column(const OnBeforeParseArguments *args,
+                                       OnBeforeParseResult *result) {
+  log_error(args, result, "negative column", "const c = 3;", 3, -1, -1);
+}

--- a/test/bake/dev/plugins.test.ts
+++ b/test/bake/dev/plugins.test.ts
@@ -1,5 +1,11 @@
 // Plugin tests concern plugins in development mode.
-import { devTest, minimalFramework } from "../bake-harness";
+import { DataViewReader } from "bake/data-view";
+import { decodeSerializedError } from "bake/error-serialization";
+import { describe, expect } from "bun:test";
+import { compileFixture } from "harness";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { Client, devTest, emptyHtmlFile, minimalFramework } from "../bake-harness";
 
 // Note: more in depth testing of plugins is done in test/bundler/bundler_plugin.test.ts
 devTest("onResolve", {
@@ -147,3 +153,157 @@ devTest("onResolve + onLoad virtual file", {
 //     await dev.fetch("/").expect('value: 2');
 //   },
 // });
+
+/** Decodes the failures a "Build Failed" page embeds, with the client's own decoder. */
+function decodeBuildFailedPage(html: string) {
+  const base64 = html.match(/atob\("([^"]*)"\)/)?.[1];
+  if (base64 === undefined) throw new Error("not a build failure page:\n" + html);
+  const bytes = Uint8Array.from(atob(base64), c => c.charCodeAt(0));
+  const reader = new DataViewReader(new DataView(bytes.buffer), 0);
+  const failures: { file: string; messages: unknown[] }[] = [];
+  while (reader.hasMoreData()) {
+    reader.u32(); // owner handle
+    const file = reader.string32();
+    const messages = Array.from({ length: reader.u32() }, () => decodeSerializedError(reader));
+    failures.push({ file, messages });
+  }
+  return failures.sort((a, b) => a.file.localeCompare(b.file));
+}
+
+let nativeLogPlugin: string | null = null;
+try {
+  nativeLogPlugin = compileFixture(path.join(import.meta.dir, "native-plugin-log-location.c"), {
+    flags: ["-I" + path.join(import.meta.dir, "../../../packages")],
+  });
+} catch (e) {
+  if (!(e instanceof Error) || !e.message.includes("no C compiler")) throw e;
+  console.warn(`[plugins.test] native plugin tests skipped: ${e.message}`);
+}
+
+describe.skipIf(!nativeLogPlugin)("native plugin log locations", () => {
+  if (!nativeLogPlugin) return;
+
+  // A native plugin fills in `BunLogOptions` by hand, so unlike the parser it
+  // can log a location with a line but no (zero or negative) column. The dev
+  // server used to panic serializing a negative column, and the overlay used to
+  // throw out of `"_".repeat(column - 1)` for column 0, rendering no errors at
+  // all. The harness formats a message as `file:line:column` only when it has an
+  // underline, hence the two shapes in `errors`.
+  const errors = [
+    "with-column.ts:1:7: error: with column",
+    "zero-column.ts: error: zero column",
+    "negative-column.ts: error: negative column",
+  ];
+  const decodedFailures = [
+    {
+      file: "negative-column.ts",
+      messages: [
+        {
+          kind: "bundler",
+          level: 0,
+          message: "negative column",
+          location: { line: 3, column: 0, length: 0, lineText: "const c = 3;" },
+          notes: [],
+        },
+      ],
+    },
+    {
+      file: "with-column.ts",
+      messages: [
+        {
+          kind: "bundler",
+          level: 0,
+          message: "with column",
+          location: { line: 1, column: 7, length: 1, lineText: "const a = 1;" },
+          notes: [],
+        },
+      ],
+    },
+    {
+      file: "zero-column.ts",
+      messages: [
+        {
+          kind: "bundler",
+          level: 0,
+          message: "zero column",
+          location: { line: 2, column: 0, length: 0, lineText: "const b = 2;" },
+          notes: [],
+        },
+      ],
+    },
+  ];
+  // What the overlay renders for each message: the line number and line text
+  // always, the underline (and where it starts) only when the column is known.
+  const renderedCodeLines = [
+    { file: "negative-column.ts", line: "3", lineText: "const c = 3;", underline: null },
+    { file: "with-column.ts", line: "1", lineText: "const a = 1;", underline: { start: 6, length: 1 } },
+    { file: "zero-column.ts", line: "2", lineText: "const b = 2;", underline: null },
+  ];
+  function readRenderedCodeLines(client: Client): Promise<typeof renderedCodeLines> {
+    return client.js`{
+      const overlay = document.querySelector("bun-hmr").shadowRoot;
+      return [...overlay.querySelectorAll(".b-msg")]
+        .map(msg => {
+          const underline = msg.querySelector(".highlight-wrap");
+          return {
+            file: msg.closest(".b-group").querySelector(".file-name").textContent,
+            line: msg.querySelector(".gutter").textContent,
+            lineText: msg.querySelector(".view > pre").textContent,
+            underline: underline && {
+              start: underline.querySelector(".space").textContent.length,
+              length: underline.querySelector(".line").textContent.length,
+            },
+          };
+        })
+        .sort((a, b) => a.file.localeCompare(b.file));
+    }`;
+  }
+
+  devTest("messages with a line but no column reach the overlay", {
+    files: {
+      "bunfig.toml": `
+        [serve.static]
+        plugins = ["./log-location-plugin.ts"]
+      `,
+      "log-location-plugin.ts": `
+        const napiModule = require("./log-location.node");
+        export default {
+          name: "log-location",
+          setup(build) {
+            build.onBeforeParse({ filter: /with-column\\.ts$/ }, { napiModule, symbol: "log_with_column" });
+            build.onBeforeParse({ filter: /zero-column\\.ts$/ }, { napiModule, symbol: "log_zero_column" });
+            build.onBeforeParse({ filter: /negative-column\\.ts$/ }, { napiModule, symbol: "log_negative_column" });
+          },
+        };
+      `,
+      "log-location.node": readFileSync(nativeLogPlugin),
+      "ok.html": emptyHtmlFile({ scripts: ["ok.ts"] }),
+      "ok.ts": `export const ok = true;`,
+      "errors.html": emptyHtmlFile({ scripts: ["errors.ts"] }),
+      "errors.ts": `
+        import "./with-column.ts";
+        import "./zero-column.ts";
+        import "./negative-column.ts";
+      `,
+      "with-column.ts": `export const a = 1;`,
+      "zero-column.ts": `export const b = 2;`,
+      "negative-column.ts": `export const c = 3;`,
+    },
+    async test(dev) {
+      await using openPage = await dev.client("/ok");
+
+      // What the dev server serializes into the error page...
+      const response = await dev.fetch("/errors");
+      expect(decodeBuildFailedPage(await response.text())).toEqual(decodedFailures);
+      expect(response.status).toBe(500);
+
+      // ...and pushes over the HMR socket to the page that was already open.
+      await openPage.expectErrorOverlay(errors);
+      expect(await readRenderedCodeLines(openPage)).toEqual(renderedCodeLines);
+
+      // The error page renders the same thing from its embedded copy.
+      await using errorPage = await dev.client("/errors", { errors });
+      expect(await readRenderedCodeLines(errorPage)).toEqual(renderedCodeLines);
+    },
+  });
+});


### PR DESCRIPTION
### Problem

- A native `onBeforeParse` plugin that logs a message with a line but a negative column (`BunLogOptions { line: 3, column: -1 }`) takes the whole Bake dev server down (`bun ./index.html`, `Bun.serve({ development: true })`) as soon as that file's failure is serialized: `panic: int cast: TryFromIntError(NegOverflow)` in release, `debug_assert!(loc.column >= 0)` in debug. The request gets `ECONNRESET`.
- The same message with column `0` is serialized, but the error overlay throws `RangeError: Invalid count value: -1` from `"_".repeat(location.column - 1)` in `renderCodeLine`. On the error page that happens before the HMR socket is opened; over the socket it happens inside `onServerErrorPayload`. Either way none of the errors in that update are rendered, including the ones with good locations.
- Cause: `write_log_data` (`src/runtime/bake/dev_server/serialized_failure.rs:228-231`) assumed a `Location` with a line always has a column `>= 0` and wrote it through `u32::try_from(...).expect(...)`, and `renderCodeLine` (`src/runtime/bake/client/overlay.ts:627`) assumed it is always `>= 1`. Neither holds for plugin-supplied locations: `BunLogOptions::append` (`src/bundler/ParseTask.rs:1777`) deliberately keeps `column.max(-1)`, and the C header documents no base at all, so `0` is what a plugin that only fills in `line` sends.
- The writer's comment also called the column zero-based while the reader's interface says one-based.
- Found by the new test on the ASAN lane, which runs with `BUN_JSC_validateExceptionChecks=1`: `jsBundlerPluginFunction_onBeforeParse` (`src/jsc/bindings/JSBundlerPlugin.cpp:372-375`) converts the symbol name and reads the addon's dlopen handle property without an exception check after either call, so the dev server aborts with `ASSERTION FAILED: exception check validation failed ... unchecked as of this scope: jsBundlerPluginFunction_onBeforeParse` as soon as a native plugin is registered. `test/bundler/native-plugin.test.ts`, the only other test that registers one, is on `test/no-validate-exceptions.txt` for an unrelated reason (its addon's `Init()`), so nothing had exercised this binding under validation before.

### Fix

- `write_log_data` writes `column.max(0)`; on the wire `0` now means "line known, column unknown". The writer comment and `BundlerMessageLocation.column` both say so.
- `renderCodeLine` only adds the underline row when `column > 0`; the line number and line text are still shown.
- Why this is the right shape: every other consumer of `Location.column` already treats it as one-based with `<= 0` meaning "no column": the terminal logger draws its caret only when `column > 0` and prints `at file:3` for `-1` (`Data::write_format`), and the `BuildMessage` / `ResolveMessage` `.column` getters clamp with `(column - 1).max(0)`. The dev server payload and the overlay were the only consumers that panicked or threw instead; this makes them degrade the same way (no caret / no underline). Serializing such a message as "no location" instead would drop the line number the plugin did provide. `ParseTask`'s `column.max(-1)` is left alone because `-1` is the value the terminal output already relies on.
- The wire format itself is unchanged (same fields, same widths); `0` was previously unreachable-by-design for the column field, so existing decoders (overlay, error page, the `BunFrontendDevServer.bundleFailed` payload, which is the same bytes) keep working.
- `jsBundlerPluginFunction_onBeforeParse` gets a `RETURN_IF_EXCEPTION` after `toWTFString` and after the property `get`, which is what the validation asks for (a `get` can run arbitrary JS; once an exception is pending the function must not continue into `dlsym` and the registration). Behaviour when nothing throws is identical. `jsBundlerPluginFunction_addFilter` in the same file has no throw scope at all and is left as is: validation does not flag it and its arguments are produced by the builtin. Covered by the new test running on the ASAN lane (it aborted there without this, see the first CI run); locally `BUN_JSC_validateExceptionChecks=1 BUN_JSC_dumpSimulatedThrows=1 bun bd test test/bake/dev/plugins.test.ts` reproduces the abort without the change and passes with it.
- Verified with `test/bake/dev/plugins.test.ts` ("native plugin log locations"): a ~50 line C plugin (`test/bake/dev/native-plugin-log-location.c`, built at test time with `compileFixture` from the harness, no node-gyp) exposes three `onBeforeParse` hooks logging column `7`, `0` and `-1`. The test loads a working route, requests a route whose entry imports one file per hook, and asserts (a) the exact decoded error page payload using the client's own decoder (`column: 7` / `0` / `0`), (b) what the overlay renders on the already open page, which received the failures over the HMR socket, and on the error page itself: line number and line text for all three, an underline starting at offset 6 of length 1 for column 7 and no underline for the other two.
  - `bun bd test test/bake/dev/plugins.test.ts`: passes (3 runs).
  - With `src/` stashed: the dev server crashes on the negative column (stack through `write_log_data` -> `insert_failure` -> `handle_parse_task_failure`) and the fetch fails with `ECONNRESET`.
  - With only `overlay.ts` reverted: the open page's client dies with `RangeError: Invalid count value: -1 at renderCodeLine ... at onServerErrorPayload`, so each half of the fix is covered on its own.
  - Also run: `test/bake/dev/bundle.test.ts` (overlay positions for parser errors) and `test/cli/inspect/BunFrontendDevServer.test.ts` (snapshots the decoded payload), both unchanged and passing.
- Related, not covered here: #37885 handles messages with `line <= 0` in the same writer (its tests add an equivalent `decodeBuildFailedPage` helper to this test file; whichever PR lands second drops its copy), and #37872 handles the underline offset for valid columns on windowed lines.

### Background

- Bake dev server failures: when a file fails to bundle, its log messages are serialized once into a binary payload (`SerializedFailure`), which is embedded base64-encoded into the "Build Failed" page, pushed to connected pages over the HMR websocket, and handed to the inspector. `src/runtime/bake/client/error-serialization.ts` is the single decoder and `overlay.ts` renders the result.
- `bun_ast::Location` is the position attached to a bundler log message. The parser always produces a one-based column; native plugins (`packages/bun-native-bundler-plugin-api/bundler_plugin.h`) hand Bun a `BunLogOptions` struct whose `line`/`column` are whatever the plugin put there, and `BunLogOptions::append` turns that into a `Location` with `line`/`column` clamped to `-1` at the low end.

<details>
<summary>Repro against the 1.4.0 release build (the fixture from the test, one symbol per run)</summary>

```
=== log_with_column ===
1 | const a = 1;
          ^
error: with column
    at /tmp/repro/entry.ts:1:7
{"status":500}
=== log_zero_column ===
error: zero column
    at /tmp/repro/entry.ts:2:0
{"status":500}            # page served; overlay then throws RangeError in renderCodeLine
=== log_negative_column ===
panic: int cast: TryFromIntError(NegOverflow)
oh no: Bun has crashed. This indicates a bug in Bun, not your code.
```

</details>
