### PR TITLE
s3: read HTTP_PROXY after the option objects in unlink and list

### DIFF
--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -33,6 +33,10 @@ bun_core::define_scoped_log!(debug, Blob, visible);
 /// buffer. Owned (not borrowed) because the env loader's `URL<'_>` ties the
 /// `href` slice to a `&mut Loader` borrow that we cannot keep open across the
 /// S3 request setup.
+///
+/// Call it after every option object has been read: a getter on one of them
+/// can assign `process.env.HTTP_PROXY`, which replaces (and frees) the map
+/// entry a value read earlier would point into.
 #[inline]
 fn http_proxy_href(global: &JSGlobalObject) -> Option<Vec<u8>> {
     // `Transpiler::env_mut` is the safe accessor for the process-singleton

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -20,7 +20,6 @@ use crate::webcore::s3::client::{
 };
 use bun_core::{ZigString, strings};
 use bun_http_types::MimeType::MimeType;
-use bun_url::URL;
 
 #[cfg(unix)]
 use super::SizeType;
@@ -332,17 +331,9 @@ impl S3Ext for S3 {
 
         let promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
-        // `Transpiler::env_mut` is the safe accessor for the process-singleton
-        // dotenv loader (never null once the VM is initialised).
-        let proxy_url: Option<URL<'_>> = global_this
-            .bun_vm()
-            .as_mut()
-            .transpiler
-            .env_mut()
-            .get_http_proxy(true, None, None);
-        let proxy = proxy_url.as_ref().map(|url| url.href);
         let aws_options = self.get_credentials_with_options(extra_options, global_this)?;
         // `defer aws_options.deinit()` → Drop handles it.
+        let proxy = super::http_proxy_href(global_this);
 
         s3_client::delete(
             &aws_options.credentials,
@@ -356,7 +347,7 @@ impl S3Ext for S3 {
                 global: bun_ptr::BackRef::new(global_this),
             }))
             .cast::<c_void>(),
-            proxy,
+            proxy.as_deref(),
             aws_options.request_payer,
         )?;
 
@@ -427,19 +418,11 @@ impl S3Ext for S3 {
 
         let promise = bun_jsc::JSPromiseStrong::init(global_this);
         let value = promise.value();
-        // `Transpiler::env_mut` is the safe accessor for the process-singleton
-        // dotenv loader (never null once the VM is initialised).
-        let proxy_url: Option<URL<'_>> = global_this
-            .bun_vm()
-            .as_mut()
-            .transpiler
-            .env_mut()
-            .get_http_proxy(true, None, None);
-        let proxy = proxy_url.as_ref().map(|url| url.href);
         let aws_options = self.get_credentials_with_options(extra_options, global_this)?;
         // `defer aws_options.deinit()` → Drop handles it.
 
         let options = s3_client::get_list_objects_options_from_js(global_this, list_options)?;
+        let proxy = super::http_proxy_href(global_this);
 
         // `S3ListObjectsOptions` is not `Clone` (it owns `Utf8Slice`s);
         // box the wrapper first so the options live on the heap, then hand a
@@ -462,7 +445,7 @@ impl S3Ext for S3 {
             unsafe { &(*wrapper).resolved_list_options },
             Wrapper::resolve,
             wrapper.cast::<c_void>(),
-            proxy,
+            proxy.as_deref(),
         )?;
 
         Ok(value)

--- a/test/js/bun/s3/s3-proxy.test.ts
+++ b/test/js/bun/s3/s3-proxy.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe } from "harness";
+
+// An S3 operation reads HTTP_PROXY out of the process env map and reads the
+// caller's option objects, whose getters run arbitrary JS. A getter that assigns
+// process.env.HTTP_PROXY replaces (and frees) the value in the map, so the proxy
+// has to be read after the options. Each fixture runs two stub proxies and has
+// the getter assign a different one on every call; the request must arrive at
+// the one assigned last, and nowhere else.
+
+const env = { ...bunEnv };
+for (const key of ["HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy", "NO_PROXY", "no_proxy"]) delete env[key];
+// Current when the operation starts; the getter replaces it before the request is sent.
+env.HTTP_PROXY = "http://127.0.0.1:1/";
+
+function fixture(operation: string) {
+  return `
+const requests = [];
+const proxies = [0, 1].map(proxy =>
+  Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(req) {
+      requests.push({ proxy, method: req.method, path: new URL(req.url).pathname });
+      return req.method === "GET"
+        ? new Response("<ListBucketResult/>", { headers: { "Content-Type": "application/xml" } })
+        : new Response(null, { status: 204 });
+    },
+  }),
+);
+
+let assignments = 0;
+let lastProxy = null;
+function reassignProxy() {
+  lastProxy = assignments++ % 2;
+  process.env.HTTP_PROXY = "http://127.0.0.1:" + proxies[lastProxy].port + "/";
+}
+
+// The endpoint is never connected to directly: every request goes to whichever
+// stub proxy HTTP_PROXY names at the time the request is sent.
+const credentials = { secretAccessKey: "test", bucket: "my_bucket", endpoint: "http://s3.example.invalid/" };
+const client = new Bun.S3Client({ ...credentials, accessKeyId: "test" });
+
+function reentrantCredentials(base = {}) {
+  return {
+    ...base,
+    get accessKeyId() {
+      reassignProxy();
+      return "test";
+    },
+  };
+}
+
+let error = null;
+try {
+  await (${operation});
+} catch (e) {
+  error = String(e);
+}
+for (const proxy of proxies) proxy.stop(true);
+console.log(JSON.stringify({ lastProxy, error, requests }));
+`;
+}
+
+describe("S3 requests use the HTTP_PROXY assigned while their options are being read", () => {
+  test.concurrent.each([
+    ["S3File#unlink", "DELETE", "/my_bucket/object", `client.file("object").unlink(reentrantCredentials())`],
+    ["S3Client#unlink", "DELETE", "/my_bucket/object", `client.unlink("object", reentrantCredentials())`],
+    [
+      "S3Client.unlink",
+      "DELETE",
+      "/my_bucket/object",
+      `Bun.S3Client.unlink("object", reentrantCredentials(credentials))`,
+    ],
+    ["S3Client#list with a credentials getter", "GET", "/my_bucket/", `client.list(undefined, reentrantCredentials())`],
+    [
+      "S3Client#list with a list options getter",
+      "GET",
+      "/my_bucket/",
+      `client.list({ get prefix() { reassignProxy(); return "photos/"; } })`,
+    ],
+    ["S3Client.list", "GET", "/my_bucket/", `Bun.S3Client.list(undefined, reentrantCredentials(credentials))`],
+  ])("%s", async (_name, method, path, operation) => {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture(operation)],
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    const result = JSON.parse(stdout);
+    expect(result.lastProxy).not.toBeNull();
+    expect(result).toEqual({
+      lastProxy: result.lastProxy,
+      error: null,
+      requests: [{ proxy: result.lastProxy, method, path }],
+    });
+    expect(exitCode).toBe(0);
+  });
+});


### PR DESCRIPTION
### Problem

- `S3::unlink` and `S3::list_objects` (src/runtime/webcore/blob/Store.rs) captured `get_http_proxy(..).href`, a slice into the env map's `HTTP_PROXY` entry, and only then read the caller's option objects (`get_credentials_with_options`; for list also `get_list_objects_options_from_js`). Those reads run user getters.
- A getter that assigns `process.env.HTTP_PROXY` reaches `Bun__setEnvValue` -> `Map::put` (src/runtime/api/BunObject.rs, src/dotenv/env_loader.rs), which replaces the map entry and frees the bytes the captured slice points at. The request is then built from freed memory.
- ASAN build: `AddressSanitizer: heap-use-after-free` READ in `execute_simple_s3_request` (src/runtime/webcore/s3/simple_request.rs:645, reached from `S3Ext::unlink`) and in `s3_client::list_objects` (src/runtime/webcore/s3/client.rs:320, reached from `S3Ext::list_objects`); freed by `Bun__setEnvValue` -> `Map::put`. Report excerpt below.
- Release build: the proxy URL is whatever the freed bytes now hold, the request goes nowhere and the call rejects with a generic `S3Error`.
- Reachable from `S3File#unlink` / `delete`, `S3Client#unlink`, `S3Client.unlink`, `S3Client#list` and `S3Client.list` whenever a proxy variable is set.

### Fix

- Both sites read the proxy through `http_proxy_href`, the owned-copy helper the other S3 entry points in Blob.rs already use, and do so after the last option object has been read. The helper's doc comment now states that ordering rule. The unused `bun_url::URL` import in Store.rs goes away.
- Correct because nothing runs JS between that read and `s3_client::delete` / `list_objects` copying the value into the request task, and the value is an owned copy in any case, so no pointer into the env map is held across a point where JS can mutate the map.
- Reading after the options also means the value assigned while they were read is the one used, matching the `Bun.write` to S3 paths in Blob.rs (which already take the proxy after the credentials) and fetch, which resolves the proxy when the request is built.
- Verified with test/js/bun/s3/s3-proxy.test.ts. It spawns bun with `HTTP_PROXY` set, runs two stub proxies in the child, and has an option getter assign a different stub on every call; each of the six entry points above must send its request to the stub assigned last. Without the fix all six fail on the ASAN debug build (reports above) and on the release binary (`USE_SYSTEM_BUN=1`: generic `S3Error`, no stub reached); with the fix all six pass.
- Also ran with the fix: s3-list-objects, s3-connection-close, s3-requester-pays, s3-argument-validation, s3-list-checksum-algorithm and s3-list-encode-overflow.
- The test is a new file because the existing S3 files are each scoped to one topic (and s3.test.ts boots MinIO). It has the same name as the proxy test added by #32046, which reworks S3 proxy resolution and would replace these lines of Store.rs if it lands.

### Background

- The env map: `bun_dotenv::Loader` keeps the process environment in a map whose values are `Box<[u8]>`. `Loader::get_http_proxy` returns a `URL` whose `href` borrows directly from that box. The `process.env` setters for the proxy variables write through to this map (`Bun__setEnvValue`) so native consumers observe runtime changes, and `Map::put` on an existing key drops the previous box.
- Option reading: the S3 option parsers use `get_truthy` and friends on user objects, so arbitrary user JS (getters, Proxy traps) runs inside the S3 call before the request is dispatched.
- Request setup: `execute_simple_s3_request` and `list_objects` copy the proxy into the request task at dispatch, so the only hazard is the window between reading the env value and that copy.

<details>
<summary>ASAN report without the fix (unlink; the list variant differs only in the frames under Store.rs)</summary>

```
ERROR: AddressSanitizer: heap-use-after-free on address 0x6dc2c6062860
READ of size 23 at 0x6dc2c6062860 thread T0
    #0 __asan_memcpy
    ...
    #7 <alloc::boxed::Box<[u8]> as core::convert::From<&[u8]>>::from
    #8 bun_runtime::webcore::__s3_simple_request::execute_simple_s3_request src/runtime/webcore/s3/simple_request.rs:645:13
    #9 bun_runtime::webcore::__s3_client::delete src/runtime/webcore/s3/client.rs:161:5
    #10 <bun_jsc::webcore_types::store::S3 as bun_runtime::webcore::blob::store::S3Ext>::unlink src/runtime/webcore/blob/Store.rs:347:9
    #11 <bun_runtime::webcore::s3_client::S3Client>::unlink src/runtime/webcore/S3Client.rs:664:28

freed by thread T0 here:
    #0 free
    ...
    #11 core::ptr::drop_glue::<bun_dotenv::env_loader::HashTableValue>
    #12 <bun_collections::array_hash_map::StringArrayHashMap<bun_dotenv::env_loader::HashTableValue>>::put src/collections/array_hash_map.rs
    #13 <bun_dotenv::env_loader::Map>::put src/dotenv/env_loader.rs
    #14 Bun__setEnvValue src/runtime/api/BunObject.rs:2224:38
    #15 Bun::jsSetterProxyEnvironmentVariable(JSC::JSGlobalObject*, long, long, JSC::PropertyName)
```

</details>
