### PR TITLE
Make toMatchObject and Bun.deepMatch compare Headers and URLSearchParams by their entries

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1978,6 +1978,22 @@ bool Bun__deepMatch(
     JSObject* obj = objValue.getObject();
     JSObject* subsetObj = subsetValue.getObject();
 
+    // Headers, URLSearchParams and URL keep their contents in C++. The property
+    // walk below only sees their prototype members, which are the same for every
+    // instance, so first run the content comparison toEqual uses (in both
+    // directions, like Bun__deepEquals does).
+    uint8_t subsetType = subsetObj->type();
+    if ((subsetType == JSDOMWrapperType || subsetType == JSAsJSONType) && obj->type() == subsetType) {
+        Vector<std::pair<JSValue, JSValue>, 16> stack;
+        MarkedArgumentBuffer contentsGCBuffer;
+        std::optional<bool> contentsEqual = specialObjectsDequal<false, enableAsymmetricMatchers, false>(globalObject, contentsGCBuffer, stack, throwScope, subsetObj, obj);
+        RETURN_IF_EXCEPTION(throwScope, false);
+        if (contentsEqual.has_value()) return *contentsEqual;
+        contentsEqual = specialObjectsDequal<false, enableAsymmetricMatchers, false>(globalObject, contentsGCBuffer, stack, throwScope, obj, subsetObj);
+        RETURN_IF_EXCEPTION(throwScope, false);
+        if (contentsEqual.has_value()) return *contentsEqual;
+    }
+
     PropertyNameArrayBuilder subsetProps(vm, PropertyNameMode::StringsAndSymbols, PrivateSymbolMode::Include);
     subsetObj->getPropertyNames(globalObject, subsetProps, DontEnumPropertiesMode::Exclude);
     RETURN_IF_EXCEPTION(throwScope, false);

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1978,8 +1978,7 @@ bool Bun__deepMatch(
     JSObject* obj = objValue.getObject();
     JSObject* subsetObj = subsetValue.getObject();
 
-    // Headers/URLSearchParams/URL keep their entries in C++, invisible to the
-    // property walk below, so compare those first the way Bun__deepEquals does.
+    // The property walk below cannot see the entries of Headers/URLSearchParams/URL; compare those first.
     uint8_t subsetType = subsetObj->type();
     if ((subsetType == JSDOMWrapperType || subsetType == JSAsJSONType) && obj->type() == subsetType) {
         Vector<std::pair<JSValue, JSValue>, 16> stack;

--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1978,10 +1978,8 @@ bool Bun__deepMatch(
     JSObject* obj = objValue.getObject();
     JSObject* subsetObj = subsetValue.getObject();
 
-    // Headers, URLSearchParams and URL keep their contents in C++. The property
-    // walk below only sees their prototype members, which are the same for every
-    // instance, so first run the content comparison toEqual uses (in both
-    // directions, like Bun__deepEquals does).
+    // Headers/URLSearchParams/URL keep their entries in C++, invisible to the
+    // property walk below, so compare those first the way Bun__deepEquals does.
     uint8_t subsetType = subsetObj->type();
     if ((subsetType == JSDOMWrapperType || subsetType == JSAsJSONType) && obj->type() == subsetType) {
         Vector<std::pair<JSValue, JSValue>, 16> stack;

--- a/test/js/bun/bun-object/deep-match.spec.ts
+++ b/test/js/bun/bun-object/deep-match.spec.ts
@@ -77,6 +77,12 @@ describe("Bun.deepMatch", () => {
       new Set(["a", "b", "c"]),
       new Set(["a", "b", "c"]),
     ],
+
+    // Headers / URLSearchParams are compared by their entries
+    [new Headers({ a: "1", b: "2" }), new Headers({ b: "2", a: "1" })],
+    [{ headers: new Headers({ a: "1" }) }, { headers: new Headers({ a: "1" }), status: 200 }],
+    [new URLSearchParams("a=1&b=2"), new URLSearchParams("a=1&b=2")],
+    [{ query: new URLSearchParams("a=1") }, { query: new URLSearchParams("a=1"), path: "/" }],
   ])("Bun.deepMatch(%p, %p) === true", (a, b) => {
     expect(Bun.deepMatch(a, b)).toBe(true);
   });
@@ -133,6 +139,14 @@ describe("Bun.deepMatch", () => {
     //   new Set(["a", "b", "c"]),
     //   new Set(["a", "b", "d"]),
     // ],
+
+    // Headers / URLSearchParams: every entry has to match, the entries themselves are not subset-matched
+    [new Headers({ a: "1" }), new Headers({ a: "2" })],
+    [{ headers: new Headers({ a: "1" }) }, { headers: new Headers({ b: "1" }), status: 200 }],
+    [{ headers: new Headers({ a: "1" }) }, { headers: new Headers({ a: "1", b: "2" }) }],
+    [new URLSearchParams("a=1"), new URLSearchParams("a=2")],
+    [{ query: new URLSearchParams("a=1") }, { query: new URLSearchParams("b=1"), path: "/" }],
+    [{ query: new URLSearchParams("a=1") }, { query: new URLSearchParams("a=1&b=2") }],
   ])("Bun.deepMatch(%p, %p) === false", (a, b) => {
     expect(Bun.deepMatch(a, b)).toBe(false);
   });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3357,7 +3357,9 @@ describe("expect()", () => {
       expect({ h: new Headers({ a: "1" }) }).not.toMatchObject({ h: new Headers() });
       expect({ h: new Headers() }).not.toMatchObject({ h: new Headers({ a: "1" }) });
 
-      expect({ res: { headers: new Headers({ a: "1" }) } }).toMatchObject({ res: { headers: new Headers({ a: "1" }) } });
+      expect({ res: { headers: new Headers({ a: "1" }) } }).toMatchObject({
+        res: { headers: new Headers({ a: "1" }) },
+      });
       expect({ res: { headers: new Headers({ a: "1" }) } }).not.toMatchObject({
         res: { headers: new Headers({ a: "2" }) },
       });
@@ -3379,7 +3381,9 @@ describe("expect()", () => {
       expect({ p: new URLSearchParams("a=1") }).not.toMatchObject({ p: new URLSearchParams("a=1&b=2") });
       expect({ p: new URLSearchParams("a=1&b=2") }).not.toMatchObject({ p: new URLSearchParams("a=1") });
 
-      expect({ req: { query: new URLSearchParams("a=1") } }).toMatchObject({ req: { query: new URLSearchParams("a=1") } });
+      expect({ req: { query: new URLSearchParams("a=1") } }).toMatchObject({
+        req: { query: new URLSearchParams("a=1") },
+      });
       expect({ req: { query: new URLSearchParams("a=1") } }).not.toMatchObject({
         req: { query: new URLSearchParams("a=2") },
       });

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3340,6 +3340,97 @@ describe("expect()", () => {
         expect(Bun.deepMatch({ a: 1 }, { a: 1, b: 2 })).toBe(true);
       });
     }
+
+    // Headers and URLSearchParams have no own properties: their entries live in
+    // native code, so an expected value of one of these types has to be compared
+    // by its entries (all of them, like toEqual), not by property walking.
+    test("Headers on the expected side are compared by their entries", () => {
+      expect({ h: new Headers({ a: "1" }) }).toMatchObject({ h: new Headers({ a: "1" }) });
+      expect({ h: new Headers({ a: "1", b: "2" }) }).toMatchObject({ h: new Headers({ b: "2", a: "1" }) });
+      expect({ h: new Headers({ a: "1" }) }).toMatchObject({ h: expect.any(Headers) });
+      expect({ h: new Headers({ a: "1" }), other: 1 }).toMatchObject({ h: new Headers({ a: "1" }) });
+
+      expect({ h: new Headers({ a: "1" }) }).not.toMatchObject({ h: new Headers({ a: "2" }) });
+      expect({ h: new Headers({ a: "1" }) }).not.toMatchObject({ h: new Headers({ b: "1" }) });
+      expect({ h: new Headers({ a: "1" }) }).not.toMatchObject({ h: new Headers({ a: "1", b: "2" }) });
+      expect({ h: new Headers({ a: "1", b: "2" }) }).not.toMatchObject({ h: new Headers({ a: "1" }) });
+      expect({ h: new Headers({ a: "1" }) }).not.toMatchObject({ h: new Headers() });
+      expect({ h: new Headers() }).not.toMatchObject({ h: new Headers({ a: "1" }) });
+
+      expect({ res: { headers: new Headers({ a: "1" }) } }).toMatchObject({ res: { headers: new Headers({ a: "1" }) } });
+      expect({ res: { headers: new Headers({ a: "1" }) } }).not.toMatchObject({
+        res: { headers: new Headers({ a: "2" }) },
+      });
+
+      expect([new Headers({ a: "1" })]).toMatchObject([new Headers({ a: "1" })]);
+      expect([new Headers({ a: "1" })]).not.toMatchObject([new Headers({ a: "2" })]);
+
+      expect(new Headers({ a: "1" })).toMatchObject(new Headers({ a: "1" }));
+      expect(new Headers({ a: "1" })).not.toMatchObject(new Headers({ a: "2" }));
+    });
+
+    test("URLSearchParams on the expected side are compared by their entries", () => {
+      expect({ p: new URLSearchParams("a=1") }).toMatchObject({ p: new URLSearchParams("a=1") });
+      expect({ p: new URLSearchParams("a=1&b=2") }).toMatchObject({ p: new URLSearchParams("a=1&b=2") });
+      expect({ p: new URLSearchParams("a=1") }).toMatchObject({ p: expect.any(URLSearchParams) });
+
+      expect({ p: new URLSearchParams("a=1") }).not.toMatchObject({ p: new URLSearchParams("a=2") });
+      expect({ p: new URLSearchParams("a=1") }).not.toMatchObject({ p: new URLSearchParams("b=1") });
+      expect({ p: new URLSearchParams("a=1") }).not.toMatchObject({ p: new URLSearchParams("a=1&b=2") });
+      expect({ p: new URLSearchParams("a=1&b=2") }).not.toMatchObject({ p: new URLSearchParams("a=1") });
+
+      expect({ req: { query: new URLSearchParams("a=1") } }).toMatchObject({ req: { query: new URLSearchParams("a=1") } });
+      expect({ req: { query: new URLSearchParams("a=1") } }).not.toMatchObject({
+        req: { query: new URLSearchParams("a=2") },
+      });
+
+      expect([new URLSearchParams("a=1")]).toMatchObject([new URLSearchParams("a=1")]);
+      expect([new URLSearchParams("a=1")]).not.toMatchObject([new URLSearchParams("a=2")]);
+
+      expect(new URLSearchParams("a=1")).toMatchObject(new URLSearchParams("a=1"));
+      expect(new URLSearchParams("a=1")).not.toMatchObject(new URLSearchParams("a=2"));
+    });
+
+    if (isBun) {
+      test("URL on the expected side is compared by href", () => {
+        expect({ u: new URL("https://example.com/a") }).toMatchObject({ u: new URL("https://example.com/a") });
+        expect({ u: new URL("https://example.com/a") }).not.toMatchObject({ u: new URL("https://example.com/b") });
+      });
+
+      test("Bun.deepMatch compares Headers and URLSearchParams by their entries", () => {
+        expect(Bun.deepMatch({ h: new Headers({ a: "1" }) }, { h: new Headers({ a: "1" }) })).toBe(true);
+        expect(Bun.deepMatch({ h: new Headers({ a: "1" }) }, { h: new Headers({ a: "2" }) })).toBe(false);
+        expect(Bun.deepMatch({ h: new Headers({ a: "1" }) }, { h: new Headers({ a: "1", b: "2" }) })).toBe(false);
+        expect(Bun.deepMatch(new Headers({ a: "1" }), new Headers({ a: "1" }))).toBe(true);
+        expect(Bun.deepMatch(new Headers({ a: "1" }), new Headers({ a: "2" }))).toBe(false);
+
+        expect(Bun.deepMatch({ p: new URLSearchParams("a=1") }, { p: new URLSearchParams("a=1") })).toBe(true);
+        expect(Bun.deepMatch({ p: new URLSearchParams("a=1") }, { p: new URLSearchParams("a=2") })).toBe(false);
+        // same size and every entry of one side is found on the other side, but not the other way around
+        expect(Bun.deepMatch({ p: new URLSearchParams("a=1&b=1") }, { p: new URLSearchParams("a=1&a=1") })).toBe(false);
+        expect(Bun.deepMatch({ p: new URLSearchParams("a=1&a=1") }, { p: new URLSearchParams("a=1&b=1") })).toBe(false);
+        expect(Bun.deepMatch(new URLSearchParams("a=1"), new URLSearchParams("a=1"))).toBe(true);
+        expect(Bun.deepMatch(new URLSearchParams("a=1"), new URLSearchParams("a=2"))).toBe(false);
+      });
+
+      test("snapshot property matchers compare Headers and URLSearchParams by their entries", () => {
+        expect(() =>
+          expect({ h: new Headers({ a: "1" }) }).toMatchInlineSnapshot({ h: new Headers({ a: "2" }) }, `unreachable`),
+        ).toThrow("to match properties from received object");
+        expect(() =>
+          expect({ p: new URLSearchParams("a=1") }).toMatchInlineSnapshot(
+            { p: new URLSearchParams("a=2") },
+            `unreachable`,
+          ),
+        ).toThrow("to match properties from received object");
+      });
+
+      test("expect.objectContaining with a Headers sample matches by its entries", () => {
+        expect(new Headers({ a: "1" })).toEqual(expect.objectContaining(new Headers({ a: "1" })));
+        expect(new Headers({ a: "1" })).not.toEqual(expect.objectContaining(new Headers({ a: "2" })));
+      });
+    }
+
     test("with expect matcher", () => {
       const f = Symbol.for("foo");
       const b = Symbol.for("bar");


### PR DESCRIPTION
### Problem
- `toMatchObject`, `Bun.deepMatch`, `expect.objectContaining` and snapshot property matchers accept any `Headers` for any other `Headers`, and any `URLSearchParams` for any other `URLSearchParams` (same entry count):
  ```js
  expect({ h: new Headers({ a: "1" }) }).toMatchObject({ h: new Headers({ a: "2" }) });   // passes
  expect(new URLSearchParams("a=1")).toMatchObject(new URLSearchParams("a=2"));           // passes
  Bun.deepMatch({ h: new Headers({ a: "1" }) }, { h: new Headers({ a: "2" }) });          // true
  ```
  Jest and Vitest fail these (`iterableEquality` compares the entries); `toEqual` in Bun already fails them.
- Cause: `Bun__deepMatch` (`src/jsc/bindings/bindings.cpp:1960`) only walks the enumerable properties of the expected value. `Headers`, `URLSearchParams` and `URL` keep their state in C++ and expose nothing but prototype members, which are the same function objects on every instance, so the walk has nothing that reflects the entries. (`URL` happens to work already because its prototype members are accessors; `Headers.count` / `URLSearchParams.size` are why a different entry count was already rejected.)

### Fix
- Before the property walk, when the expected value and the received value are wrapper objects of the same JSType (`JSDOMWrapperType`: Headers, URL; `JSAsJSONType`: URLSearchParams), run `specialObjectsDequal`, the content comparison `toEqual` / `Bun.deepEquals` use, in both directions the way `Bun__deepEquals` does. A verdict (different entries) is returned; no verdict (same entries, or a wrapper type it does not know) falls through to the existing property walk, so expando properties are still subset matched and every other wrapper type behaves exactly as before.
- Why this shape:
  - It is the comparison `toEqual` uses for the same values, so `toMatchObject` and `toEqual` agree on these leaves, and it matches Jest, which compares iterable leaves by their entries and does not subset match inside them. Follow-up fixes to that comparison (#37881 set-cookie, #37887 repeated URLSearchParams names) apply here automatically; until #37887 lands, a repeated-name `URLSearchParams` leaf is rejected the same way `toEqual` rejects it today.
  - Routing these leaves through `Bun__deepEquals` as a whole would regress the other wrapper classes: `deepEquals` only looks at own properties for them, while today's property walk reads prototype getters, so `{ b: new Blob(["a"]) }` vs `{ b: new Blob(["abc"]) }` and `Response` with a different status would start to match. The same-JSType gate also keeps mixed pairs (`Headers` vs `URLSearchParams`, plain object vs `Headers`) on the property walk, where they fail as before.
  - Placing it at the entry of `Bun__deepMatch` rather than in the recursion covers the top level (`expect(headers).toMatchObject(headers2)`, `Bun.deepMatch(h1, h2)`), which Jest also fails.
- Verified:
  - `test/js/bun/test/expect.test.js` (describe `toMatchObject`): 5 new tests fail on the released binary, pass with this change; the two unguarded ones also pass under Vitest 4.1.9.
  - `test/js/bun/bun-object/deep-match.spec.ts`: 4 of the new rows fail on the released binary, all pass with this change.
  - Full `expect.test.js`, `deep-match.spec.ts`, `deep-equals.test.ts`, `url.test.ts`, `headers.test.ts`, `filesystem_router.test.ts`, snapshot tests: unchanged results. A grep of `test/` found no existing test that passes a `Headers`, `URLSearchParams` or `URL` instance as a `toMatchObject` / `objectContaining` expected value, so nothing else changes behavior.
- Not in this PR: a top-level asymmetric matcher passed directly to `toMatchObject` is still not applied, and `Headers` still pretty-prints as `Headers {}` in the failure diff; both are pre-existing and tracked separately. #32870 (open) handles the Date/Error/Set/Map leaves with a different rule (full `deepEquals`), which is right for those types because Jest's `subsetEquality` excludes them entirely; the two changes are independent.

### Background
- `Bun__deepMatch` is the engine behind `toMatchObject`, `Bun.deepMatch`, `expect.objectContaining` and the property-matcher argument of `toMatchSnapshot` / `toMatchInlineSnapshot`. It enumerates the expected value's enumerable properties (including inherited ones) and, for object-valued properties, recurses; values are only compared through those properties.
- `specialObjectsDequal` is the helper `Bun__deepEquals` calls first for types whose equality is not defined by their properties (Set, Map, ArrayBuffer, Date, ...). For the wrapper branch it returns `false` when URL hrefs or Headers / URLSearchParams entries differ and `std::nullopt` otherwise, meaning "nothing special, go on comparing properties". `Bun__deepEquals` calls it with the arguments in both orders because some comparisons (today's URLSearchParams one) only iterate the first argument.
- JSType: JSC lets embedders tag objects with a type byte. WebCore-style wrappers built from IDL use `JSDOMWrapperType` (Headers, URL, FormData, and Bun's generated classes such as Blob, Request, Response); `JSAsJSONType` marks wrappers that print via `toJSON()` (URLSearchParams, Cookie, CookieMap). `specialObjectsDequal` keys its wrapper branch on these two values, so the new check uses the same two.

<details>
<summary>Behavior on the released binary vs this branch (probe output)</summary>

```
                                                    1.4.0      this branch   vitest 4.1.9
{h: Headers a=1} toMatchObject {h: Headers a=2}     pass       fail          fail
{h: Headers a=1} toMatchObject {h: Headers b=1}     pass       fail          fail
{h: Headers a=1} toMatchObject {h: Headers a=1}     pass       pass          pass
[Headers a=1]    toMatchObject [Headers a=2]        pass       fail          fail
Headers a=1      toMatchObject Headers a=2          pass       fail          fail
{p: USP a=1}     toMatchObject {p: USP a=2}         pass       fail          fail
{u: URL a}       toMatchObject {u: URL b}           fail       fail          pass (vacuous)
{h: {}}          toMatchObject {h: Headers}         fail       fail          pass (vacuous)
{x: Headers}     toMatchObject {x: URLSearchParams} fail       fail          fail
{b: Blob "a"}    toMatchObject {b: Blob "abc"}      fail       fail          pass (vacuous)
{r: Response 200} toMatchObject {r: Response 404}   fail       fail          pass (vacuous)
Bun.deepMatch({h: Headers a=1}, {h: Headers a=2})   true       false         n/a
```
</details>
