### PR TITLE
Throw DataCloneError when structured-cloning an S3File

### DIFF
--- a/docs/runtime/s3.mdx
+++ b/docs/runtime/s3.mdx
@@ -599,6 +599,8 @@ Like `Bun.file()`, `S3File` extends [`Blob`](https://developer.mozilla.org/en-US
 
 That means `S3File` instances work with `fetch()`, `Response`, and other web APIs that accept `Blob` instances.
 
+The exception is structured cloning. An `S3File` is bound to the credentials and options of the client that created it, so `structuredClone()` and `postMessage()` throw a `DataCloneError` instead of cloning it. To use a file from a worker, send the key and call `file()` on a client in the worker.
+
 ### Partial reads with `slice`
 
 To read a partial range of a file, use the `slice` method.

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -176,11 +176,16 @@ pub trait BlobExt {
         global: &JSGlobalObject,
     );
     fn get_content_type(&self) -> Option<ZigStringSlice>;
-    fn _on_structured_clone_serialize<W: bun_io::Write>(&self, writer: &mut W)
-    -> crate::Result<()>;
+    /// `store_tag` is `structured_clone_store_tag(self)`, which is `None`
+    /// (nothing to write) for the stores the record cannot describe.
+    fn _on_structured_clone_serialize<W: bun_io::Write>(
+        &self,
+        store_tag: store::SerializeTag,
+        writer: &mut W,
+    ) -> crate::Result<()>;
     fn on_structured_clone_serialize(
         &self,
-        _global_this: &JSGlobalObject,
+        global_this: &JSGlobalObject,
         ctx: *mut c_void,
         write_bytes: crate::generated_classes::WriteBytesFn,
     );
@@ -738,13 +743,10 @@ impl BlobExt for Blob {
     }
     fn _on_structured_clone_serialize<W: bun_io::Write>(
         &self,
+        store_tag: store::SerializeTag,
         writer: &mut W,
     ) -> crate::Result<()> {
-        let is_memory_backed = if let Some(store) = self.store.get() {
-            matches!(store.data, store::Data::Bytes(_))
-        } else {
-            false
-        };
+        let is_memory_backed = matches!(store_tag, store::SerializeTag::Bytes);
 
         writer.write_int_le::<u8>(SERIALIZATION_VERSION)?;
         writer.write_int_le::<u64>(if is_memory_backed {
@@ -757,16 +759,6 @@ impl BlobExt for Blob {
         writer.write_int_le::<u32>(ct.len() as u32)?;
         writer.write_all(ct)?;
         writer.write_int_le::<u8>(self.content_type_was_set.get() as u8)?;
-
-        let store_tag: store::SerializeTag = if let Some(store) = self.store.get() {
-            if matches!(store.data, store::Data::File(_)) {
-                store::SerializeTag::File
-            } else {
-                store::SerializeTag::Bytes
-            }
-        } else {
-            store::SerializeTag::Empty
-        };
 
         writer.write_int_le::<u8>(store_tag as u8)?;
 
@@ -785,7 +777,9 @@ impl BlobExt for Blob {
                 // on the wire and the receiver stats it locally, like v3.
                 writer.write_int_le::<u64>(self.size.get())?;
                 self.resolve_size();
-                store.serialize(writer)?;
+                // Borrowed only after resolve_size(), which stats the file and
+                // writes the result into this same store.
+                store.data.as_file().serialize(writer)?;
             }
         }
 
@@ -808,15 +802,26 @@ impl BlobExt for Blob {
 
     fn on_structured_clone_serialize(
         &self,
-        _global_this: &JSGlobalObject,
+        global_this: &JSGlobalObject,
         ctx: *mut c_void,
         write_bytes: crate::generated_classes::WriteBytesFn,
     ) {
+        let Some(store_tag) = structured_clone_store_tag(self) else {
+            // CloneSerializer checks for a pending exception after this hook
+            // returns and fails the whole clone with it.
+            let _ = global_this.throw_dom_exception(
+                bun_jsc::DOMExceptionCode::DataCloneError,
+                format_args!(
+                    "S3File cannot be cloned: it is bound to the credentials and options of the S3Client that created it. Pass the key instead and open it again with s3.file() where it is needed."
+                ),
+            );
+            return;
+        };
         let mut writer = StructuredCloneWriter {
             ctx,
             impl_: write_bytes,
         };
-        let _ = self._on_structured_clone_serialize(&mut writer);
+        let _ = self._on_structured_clone_serialize(store_tag, &mut writer);
     }
 
     fn on_structured_clone_transfer(
@@ -4029,6 +4034,20 @@ impl bun_io::Write for StructuredCloneWriter {
     }
 }
 
+/// `None` for an S3 store: the record has no form for the credentials and
+/// options of the S3Client it is bound to, and a clone that reopened the key
+/// under whatever the receiver's environment holds would not be a clone.
+fn structured_clone_store_tag(blob: &Blob) -> Option<store::SerializeTag> {
+    let Some(store) = blob.store() else {
+        return Some(store::SerializeTag::Empty);
+    };
+    match store.data.tag() {
+        store::DataTag::Bytes => Some(store::SerializeTag::Bytes),
+        store::DataTag::File => Some(store::SerializeTag::File),
+        store::DataTag::S3 => None,
+    }
+}
+
 // Only ever called with f64 (Blob.last_modified). A concrete impl
 // because Rust forbids `[u8; size_of::<F>()]`
 // without `generic_const_exprs`. Bit-cast → native-endian bytes.
@@ -4135,7 +4154,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                     break 'file Blob::new(Blob::find_or_create_file_from_path(
                         &mut path_or_fd,
                         global_this,
-                        true,
+                        false,
                     ));
                 }
                 PathOrFileDescriptorSerializeTag::Path => {
@@ -4145,6 +4164,12 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                     // enforces: a NUL-embedded path cannot be handed to the
                     // syscall layer (`ZStr::as_cstr` would truncate / panic).
                     if strings::index_of_char(&path, 0).is_some() {
+                        return Err(crate::Error::InvalidValue);
+                    }
+                    // No serializer writes one (`structured_clone_store_tag` refuses
+                    // S3 stores), so this is a crafted record; honoring it would hand
+                    // out an S3File signed with this process's environment credentials.
+                    if path.starts_with(b"s3://") {
                         return Err(crate::Error::InvalidValue);
                     }
                     // The owned `CowSlice`
@@ -4157,7 +4182,7 @@ fn on_structured_clone_deserialize<B: AsRef<[u8]>>(
                     break 'file Blob::new(Blob::find_or_create_file_from_path(
                         &mut dest,
                         global_this,
-                        true,
+                        false,
                     ));
                 }
             }

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -58,7 +58,6 @@ pub trait StoreExt {
     fn init_mmap(slice: &'static mut [u8]) -> StoreRef
     where
         Self: Sized;
-    fn serialize(&self, writer: &mut impl bun_io::Write) -> Result<(), crate::Error>;
 }
 
 pub trait S3Ext {
@@ -88,6 +87,9 @@ pub trait S3Ext {
 
 pub trait FileExt {
     fn unlink(&self, global_this: &JSGlobalObject) -> JsResult<JSValue>;
+    /// Body of a `SerializeTag::File` structured-clone record, read back by
+    /// `Blob::on_structured_clone_deserialize`.
+    fn serialize(&self, writer: &mut impl bun_io::Write) -> Result<(), crate::Error>;
 }
 
 pub trait BytesExt {
@@ -173,52 +175,6 @@ impl StoreExt for Store {
             is_all_ascii: None,
         }))
     }
-
-    fn serialize(&self, writer: &mut impl bun_io::Write) -> Result<(), crate::Error> {
-        match &self.data {
-            Data::File(file) => {
-                let pathlike_tag: PathOrFileDescriptorSerializeTag =
-                    if matches!(file.pathlike, PathOrFileDescriptor::Fd(_)) {
-                        PathOrFileDescriptorSerializeTag::Fd
-                    } else {
-                        PathOrFileDescriptorSerializeTag::Path
-                    };
-                writer.write_int_le::<u8>(pathlike_tag as u8)?;
-
-                match &file.pathlike {
-                    PathOrFileDescriptor::Fd(fd) => {
-                        // Write the raw bytes of the FD wrapper. `bun_sys::Fd` is
-                        // `#[repr(transparent)]` over an integer (`i32` posix /
-                        // `u64` windows), so its native-endian byte image is
-                        // exactly the inner field's `to_ne_bytes()`.
-                        writer.write_all(&fd.0.to_ne_bytes())?;
-                    }
-                    PathOrFileDescriptor::Path(path) => {
-                        let path_slice = path.slice();
-                        writer.write_int_le::<u32>(path_slice.len() as u32)?;
-                        writer.write_all(path_slice)?;
-                    }
-                }
-            }
-            Data::S3(s3) => {
-                let pathlike_tag = PathOrFileDescriptorSerializeTag::Path;
-                writer.write_int_le::<u8>(pathlike_tag as u8)?;
-
-                let path_slice = s3.pathlike.slice();
-                writer.write_int_le::<u32>(path_slice.len() as u32)?;
-                writer.write_all(path_slice)?;
-            }
-            Data::Bytes(bytes) => {
-                let slice = bytes.slice();
-                writer.write_int_le::<u32>(slice.len() as u32)?;
-                writer.write_all(slice)?;
-
-                writer.write_int_le::<u32>(bytes.stored_name.len() as u32)?;
-                writer.write_all(&bytes.stored_name)?;
-            }
-        }
-        Ok(())
-    }
 }
 
 impl FileExt for File {
@@ -254,6 +210,32 @@ impl FileExt for File {
                 )),
             )),
         }
+    }
+
+    fn serialize(&self, writer: &mut impl bun_io::Write) -> Result<(), crate::Error> {
+        let pathlike_tag: PathOrFileDescriptorSerializeTag =
+            if matches!(self.pathlike, PathOrFileDescriptor::Fd(_)) {
+                PathOrFileDescriptorSerializeTag::Fd
+            } else {
+                PathOrFileDescriptorSerializeTag::Path
+            };
+        writer.write_int_le::<u8>(pathlike_tag as u8)?;
+
+        match &self.pathlike {
+            PathOrFileDescriptor::Fd(fd) => {
+                // Write the raw bytes of the FD wrapper. `bun_sys::Fd` is
+                // `#[repr(transparent)]` over an integer (`i32` posix /
+                // `u64` windows), so its native-endian byte image is
+                // exactly the inner field's `to_ne_bytes()`.
+                writer.write_all(&fd.0.to_ne_bytes())?;
+            }
+            PathOrFileDescriptor::Path(path) => {
+                let path_slice = path.slice();
+                writer.write_int_le::<u32>(path_slice.len() as u32)?;
+                writer.write_all(path_slice)?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/test/js/web/structured-clone-blob-file.test.ts
+++ b/test/js/web/structured-clone-blob-file.test.ts
@@ -1,6 +1,8 @@
+import { structuredCloneAdvanced } from "bun:internal-for-testing";
 import { deserialize, serialize } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN, isWindows, rss } from "harness";
+import { bunEnv, bunExe, isASAN, isWindows, rss, tempDir } from "harness";
+import { join } from "node:path";
 import v8 from "node:v8";
 
 describe("structuredClone with Blob and File", () => {
@@ -358,6 +360,180 @@ describe("structuredClone with Blob and File", () => {
 
       const cloned = structuredClone(obj);
       expect(cloned.file).toBeInstanceOf(File);
+    });
+  });
+
+  describe("S3File structured clone", () => {
+    // An S3File is bound to the credentials and options of the client that
+    // made it, and the Blob wire record has no form for those, so serializing
+    // one is refused up front with a DataCloneError. Before that, the record
+    // went out under the wrong store tag: every reader failed with "Unable to
+    // deserialize data." and postMessage() lost the message instead of
+    // throwing. Nothing here performs S3 I/O; the endpoint is never contacted.
+    const credentials = {
+      accessKeyId: "test-access-key",
+      secretAccessKey: "test-secret-key",
+      bucket: "bucket",
+      endpoint: "http://127.0.0.1:1",
+    };
+
+    const dataCloneError = {
+      type: "DOMException",
+      name: "DataCloneError",
+      code: DOMException.DATA_CLONE_ERR,
+      message:
+        "S3File cannot be cloned: it is bound to the credentials and options of the S3Client that created it. Pass the key instead and open it again with s3.file() where it is needed.",
+    };
+
+    function thrownBy(fn: () => unknown) {
+      try {
+        fn();
+      } catch (e: any) {
+        return { type: e.constructor.name, name: e.name, code: e.code, message: e.message };
+      }
+      return "did not throw";
+    }
+
+    test.each([
+      ["Bun.s3.file(key, options)", () => Bun.s3.file("key.txt", credentials)],
+      ["Bun.s3.file(s3:// url, options)", () => Bun.s3.file("s3://bucket/key.txt", credentials)],
+      ["new Bun.S3Client(options).file(key)", () => new Bun.S3Client(credentials).file("key.txt")],
+      ["Bun.S3Client.file(key, options)", () => Bun.S3Client.file("key.txt", credentials)],
+      ["Bun.file(s3:// url)", () => Bun.file("s3://bucket/key.txt")],
+      ["S3File.slice()", () => new Bun.S3Client(credentials).file("key.txt").slice(1, 3)],
+    ])("structuredClone() of %s throws a DataCloneError", (_name, make) => {
+      const file = make();
+      expect(Object.prototype.toString.call(file)).toBe("[object S3File]");
+      const nameBefore = file.name;
+
+      expect(thrownBy(() => structuredClone(file))).toEqual(dataCloneError);
+
+      // The refused clone leaves the source file usable.
+      expect({ tag: Object.prototype.toString.call(file), name: file.name }).toEqual({
+        tag: "[object S3File]",
+        name: nameBefore,
+      });
+    });
+
+    test.each([
+      ["structuredClone()", (value: unknown) => structuredClone(value)],
+      ["bun:jsc serialize()", (value: unknown) => serialize(value)],
+      ["node:v8 serialize()", (value: unknown) => v8.serialize(value)],
+      [
+        "MessagePort.postMessage()",
+        (value: unknown) => {
+          const { port1, port2 } = new MessageChannel();
+          try {
+            port1.postMessage(value);
+          } finally {
+            port1.close();
+            port2.close();
+          }
+        },
+      ],
+      [
+        "Worker.postMessage()",
+        (value: unknown) => {
+          const url = URL.createObjectURL(new Blob([""], { type: "application/javascript" }));
+          const worker = new Worker(url);
+          try {
+            worker.postMessage(value);
+          } finally {
+            worker.terminate();
+            URL.revokeObjectURL(url);
+          }
+        },
+      ],
+    ])("%s throws the DataCloneError at the sender", (_name, entryPoint) => {
+      expect(thrownBy(() => entryPoint(Bun.s3.file("key.txt", credentials)))).toEqual(dataCloneError);
+      expect(thrownBy(() => entryPoint({ files: [new Blob(["ok"]), Bun.s3.file("key.txt", credentials)] }))).toEqual(
+        dataCloneError,
+      );
+    });
+
+    test("serializing for storage is refused too; cross-process transfer degrades to {} like every Blob", () => {
+      const s3 = Bun.s3.file("key.txt", credentials);
+      expect(thrownBy(() => structuredCloneAdvanced(s3, [], false, true, "default"))).toEqual(dataCloneError);
+
+      // Blob is not transferable across processes, so the IPC-style
+      // serialization never reaches the Blob serializer: an S3File arrives as
+      // an empty object exactly like Bun.file() does, instead of throwing.
+      expect(structuredCloneAdvanced(s3, [], true, false, "default")).toStrictEqual({});
+      expect(structuredCloneAdvanced(Bun.file("unused.txt"), [], true, false, "default")).toStrictEqual({});
+    });
+
+    test("an S3File anywhere in the graph fails the whole clone; the rest still clones without it", async () => {
+      using dir = tempDir("s3-clone-graph", { "local.txt": "local bytes" });
+      const local = Bun.file(join(String(dir), "local.txt"));
+      const blob = new Blob(["blob bytes"], { type: "text/plain" });
+      const graph = { blob, local, deeper: { list: [1, "two", Bun.s3.file("key.txt", credentials)] } };
+
+      expect(thrownBy(() => structuredClone(graph))).toEqual(dataCloneError);
+      expect(thrownBy(() => serialize(graph))).toEqual(dataCloneError);
+
+      const cloned = structuredClone({ blob, local });
+      expect({
+        blob: await cloned.blob.text(),
+        local: await cloned.local.text(),
+        source: { blob: await blob.text(), local: await local.text() },
+      }).toEqual({
+        blob: "blob bytes",
+        local: "local bytes",
+        source: { blob: "blob bytes", local: "local bytes" },
+      });
+    });
+
+    test("every other kind of Blob store still clones", async () => {
+      using dir = tempDir("blob-store-kinds", { "data.txt": "0123456789" });
+      const path = join(String(dir), "data.txt");
+      const cloned = structuredClone({
+        empty: new Blob([]),
+        bytes: new Blob(["bytes"], { type: "text/plain" }),
+        file: new File(["file"], "named.txt"),
+        bunFile: Bun.file(path),
+        bunFileSlice: Bun.file(path).slice(2, 5),
+      });
+      expect({
+        empty: await cloned.empty.text(),
+        bytes: await cloned.bytes.text(),
+        file: [cloned.file.name, await cloned.file.text()],
+        bunFile: await cloned.bunFile.text(),
+        bunFileSlice: await cloned.bunFileSlice.text(),
+      }).toEqual({
+        empty: "",
+        bytes: "bytes",
+        file: ["named.txt", "file"],
+        bunFile: "0123456789",
+        bunFileSlice: "234",
+      });
+    });
+
+    test("a File record naming an s3:// path is rejected at deserialize", () => {
+      // Bun never writes one (S3 stores are refused above); honoring a
+      // hand-built one would hand out an S3File signed with this process's
+      // environment credentials. Build it by overwriting the path of a real
+      // file-backed record with an s3:// URL of the same length, so the
+      // framing stays whatever the current build emits.
+      const s3Path = "s3://bucket/key";
+      const placeholder = Buffer.alloc(s3Path.length, "p").toString();
+      const good = Buffer.from(serialize(Bun.file(placeholder)));
+      const at = good.indexOf(placeholder);
+      expect(at).toBeGreaterThan(0);
+      expect(Object.prototype.toString.call(deserialize(good))).toBe("[object Blob]");
+
+      const bad = Buffer.from(good);
+      bad.write(s3Path, at, "latin1");
+
+      const rejected = {
+        type: "TypeError",
+        name: "TypeError",
+        code: undefined,
+        message: "Unable to deserialize data.",
+      };
+      expect({
+        "bun:jsc": thrownBy(() => deserialize(bad)),
+        "node:v8": thrownBy(() => v8.deserialize(bad)),
+      }).toEqual({ "bun:jsc": rejected, "node:v8": rejected });
     });
   });
 


### PR DESCRIPTION
### Problem
- `structuredClone(Bun.s3.file(...))` throws `TypeError: Unable to deserialize data.`; `bun:jsc` / `node:v8` `serialize()` return a buffer that `deserialize()` rejects with the same error; `MessagePort.postMessage()` and `Worker.postMessage()` return normally, the receiver throws that error and the message is lost. Same on bun 1.4.0 and main. The Zig version had the same logic, so this never worked.
- Cause, `src/runtime/webcore/Blob.rs` `_on_structured_clone_serialize`: the store tag was chosen with `if File { File } else { Bytes }`, so an S3 store went out tagged `Bytes`, while the body writer took the non-Bytes branch and wrote the u64 size followed by `Store::serialize`'s S3 arm (`src/runtime/webcore/blob/Store.rs`, a pathlike tag plus the key). The reader sees `Bytes`, takes the low 32 bits of the size as the byte length and fails.

### Fix
- `structured_clone_store_tag()` maps the store kind to a wire tag with an exhaustive match and returns `None` for an S3 store; the serialize hook then throws a `DataCloneError` DOMException (`S3File cannot be cloned: it is bound to the credentials and options of the S3Client that created it. ...`) and writes nothing. `CloneSerializer` already does `RETURN_IF_EXCEPTION` after every Bun-type hook (the route the MessagePort case uses), so `structuredClone()`, both `serialize()`s and both `postMessage()`s now throw synchronously at the sender. The tag is passed into `_on_structured_clone_serialize`, so the tag and the body can no longer come from two different conditionals.
- Why refuse instead of making it work: an S3 store is a key plus `S3Credentials` and options (endpoint, bucket, region, ACL, storage class, part size). The record only carried the key as the user typed it, so reconstructing from it would rebind the clone to whatever credentials the receiver's environment holds, and for a bare key (`client.file("key")`) would have produced a local `Bun.file("key")`. Putting the credentials on the wire would embed secrets in every `serialize()` buffer instead. `DataCloneError` at serialize time is what the structured clone algorithm specifies for a platform object that cannot be serialized, and what Bun already throws for e.g. a `Response`. Nothing can depend on the old behavior because every consumer failed.
- `Store::serialize` becomes `File::serialize` (the File arm, moved verbatim). Its S3 arm was the other half of this bug and its Bytes arm was unreachable: the Blob serializer writes the Bytes body inline so a slice ships only its own window.
- Receiving side: the deserializer no longer asks `find_or_create_file_from_path` to look for `s3://`, and a File record whose path starts with `s3://` is rejected like the NUL and negative-fd records next to it. No File store ever has such a path (`Bun.file("s3://...")` builds an S3 store, which the serializer now refuses), so the only source is a hand-built buffer, and it used to come back as a live `S3File` signed with the receiving process's environment credentials.
- Unchanged on purpose: serialization for cross-process transfer (`process.send`) turns every Blob into `{}` before reaching the Blob serializer, so an S3File still arrives as `{}` there like `Bun.file()` does. Asserted in the tests.
- One sentence added to `docs/runtime/s3.mdx`.
- Tests: `test/js/web/structured-clone-blob-file.test.ts`, block "S3File structured clone". Covers every way to get an S3File (`Bun.s3.file` with a key and with an `s3://` URL, `S3Client` instance and static `file()`, `Bun.file("s3://...")`, `slice()`), every entry point (`structuredClone`, `bun:jsc` and `node:v8` `serialize`, `MessagePort` and `Worker` `postMessage`, the for-storage flag), an S3File nested in a larger graph, the for-transfer `{}` contract, a matrix showing bytes, `File`, `Bun.file()`, sliced and empty blobs still clone, and the crafted `s3://` File record rejected by both `deserialize` entry points. 14 of the 15 new tests fail on the unfixed build (the still-clones matrix is the guard for the refactor); the file's 57 tests pass with the fix.
- Also green with the fix: `test/js/web/workers/structured-clone.test.ts`, `test/js/web/workers/structuredClone-classes.test.ts`, `test/js/bun/jsc/bun-jsc.test.ts`; the repro run under `BUN_JSC_validateExceptionChecks=1` reports nothing; `cargo clippy -p bun_runtime` is clean.

### Background
- Blob wire record: version, offset, content type, store tag, store body, trailer. Store tags are `File` (a path or fd that the receiver reopens locally), `Bytes` (the bytes themselves) and `Empty`; there is no S3 tag.
- Blob stores: `Blob.Store.data` is `Bytes | File | S3`. An S3 store holds the key as given plus a refcounted `S3Credentials` and the upload options; every S3-backed blob, slices included, is wrapped as `S3File` in JS.
- Bun-type serialize hooks: a class marked `structuredClone` in its `.classes.ts` gets a Rust hook that writes raw bytes into the `CloneSerializer`. The hook has no return value; a pending JS exception is how it reports failure, because the serializer checks for one after each terminal and converts it to `ExistingExceptionError`, which every caller (`structuredClone`, `postMessage`, `serialize`, the worker's non-throwing error path) already handles.
- `DataCloneError`: the DOMException the structured clone algorithm throws for a value it cannot serialize.
- Relation to #37295: that PR rejects File records that arrive in raw buffers; this one is about what the serializer writes and also applies to in-process clones. They touch different lines of the deserializer's File arm and compose.
