### PR TITLE
bun:test: name toHaveLastReturnedWith correctly in its failure messages

### DIFF
--- a/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
+++ b/src/runtime/test_runner/expect/toHaveLastReturnedWith.rs
@@ -16,7 +16,7 @@ pub(crate) fn to_have_last_returned_with(
     let (this, returns, _value) = this.mock_prologue(
         global_this,
         callframe.this(),
-        "toHaveBeenLastReturnedWith",
+        "toHaveLastReturnedWith",
         "<green>expected<r>",
         super::mock::MockKind::Returns,
     )?;
@@ -58,13 +58,13 @@ pub(crate) fn to_have_last_returned_with(
     // Handle failure
     let mut formatter = Formatter::new(global_this).with_quote_strings(true);
 
-    let signature = Expect::get_signature("toHaveBeenLastReturnedWith", "<green>expected<r>", false);
+    let signature = Expect::get_signature("toHaveLastReturnedWith", "<green>expected<r>", false);
 
     if this.flags.get().not() {
         return throw!(
             this,
             global_this,
-            Expect::get_signature("toHaveBeenLastReturnedWith", "<green>expected<r>", true),
+            Expect::get_signature("toHaveLastReturnedWith", "<green>expected<r>", true),
             concat!(
                 "\n\n",
                 "Expected mock function not to have last returned: <green>{}<r>\n",

--- a/test/js/bun/test/spyMatchers.test.ts
+++ b/test/js/bun/test/spyMatchers.test.ts
@@ -25,7 +25,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
  */
 
-import { describe, expect, jest, expect as jestExpect, test } from "bun:test";
+import { describe, expect, jest, expect as jestExpect, type Matchers, test } from "bun:test";
 import * as Immutable from "immutable";
 import type { FunctionLike } from "jest-mock";
 
@@ -1342,6 +1342,56 @@ describe.each(["toHaveLastReturnedWith", "toHaveNthReturnedWith", "toHaveReturne
 
         expect(() => jestExpect(fn)[returnedWith]("foo")).toThrow();
       }
+    });
+
+    test("failure messages name the matcher that was called", () => {
+      function failureHeader(matchers: Matchers<unknown>, expected: unknown): string {
+        try {
+          if (isToHaveNth(returnedWith)) {
+            matchers[returnedWith](1, expected);
+          } else {
+            matchers[returnedWith](expected);
+          }
+        } catch (error) {
+          return Bun.stripANSI((error as Error).message).split("\n")[0];
+        }
+        throw new Error(`${returnedWith} was expected to fail`);
+      }
+
+      const returnsFoo = jest.fn(() => "foo");
+      returnsFoo();
+
+      const uncalled = jest.fn();
+
+      const throws = jest.fn(() => {
+        throw new Error("Error!");
+      });
+      try {
+        throws();
+      } catch {
+        // ignore error
+      }
+
+      const params = isToHaveNth(returnedWith) ? "n, expected" : "expected";
+      const signature = (chain = "") => `expect(received).${chain}${returnedWith}(${params})`;
+
+      expect({
+        stringMismatch: failureHeader(jestExpect(returnsFoo), "bar"),
+        nonStringMismatch: failureHeader(jestExpect(returnsFoo), 1),
+        neverCalled: failureHeader(jestExpect(uncalled), "foo"),
+        lastCallThrew: failureHeader(jestExpect(throws), "foo"),
+        negated: failureHeader(jestExpect(returnsFoo).not, "foo"),
+        resolvesOnNonPromise: failureHeader(jestExpect(returnsFoo).resolves, "foo"),
+        rejectsOnNonPromise: failureHeader(jestExpect(returnsFoo).rejects, "foo"),
+      }).toEqual({
+        stringMismatch: signature(),
+        nonStringMismatch: signature(),
+        neverCalled: signature(),
+        lastCallThrew: signature(),
+        negated: signature("not."),
+        resolvesOnNonPromise: signature("resolves."),
+        rejectsOnNonPromise: signature("rejects."),
+      });
     });
   },
 );


### PR DESCRIPTION
### Problem
- A failing `expect(fn).toHaveLastReturnedWith(x)` prints `error: expect(received).toHaveBeenLastReturnedWith(expected)`. No matcher of that name exists in `bun:test` (`jest.classes.ts`, `packages/bun-types/test.d.ts`), jest, or vitest; the real name is `toHaveLastReturnedWith` (alias `lastReturnedWith`).
- Every failure path is affected: value mismatch, `.not`, mock never called, last call threw, and the `.resolves` / `.rejects` "Expected promise" error. The sibling matchers `toHaveReturnedWith` and `toHaveNthReturnedWith` already print their own names.
- Cause: three hard-coded `"toHaveBeenLastReturnedWith"` literals in `src/runtime/test_runner/expect/toHaveLastReturnedWith.rs` (the name passed to `mock_prologue`, and the two `Expect::get_signature` calls). The typo dates back to the matcher's original implementation (#21363) and was carried through the Rust port.

### Fix
- Replace the three literals with `"toHaveLastReturnedWith"`. No logic changes.
- Correct because the header line exists to tell the user which assertion failed, and `toHaveLastReturnedWith` is the only name this function is registered under (the `lastReturnedWith` alias maps to the same function, like the other aliases in `jest.classes.ts`). This also matches jest, whose header for this matcher is `expect(jest.fn()).toHaveLastReturnedWith(expected)`.
- No other code, test, snapshot, doc, or type declaration referenced the old string.
- Test: `test/js/bun/test/spyMatchers.test.ts`, new case in the `describe.each` over the three `toHave*ReturnedWith` matchers. It strips ANSI codes from the thrown message and checks the header line for a string mismatch, a non-string mismatch, a never-called mock, a mock whose last call threw, `.not`, `.resolves`, and `.rejects`. The `toHaveLastReturnedWith` case fails on the released binary on all seven paths and passes with this change; the two sibling cases pass both ways and guard against the same slip there.
- Also ran `test/js/bun/test/spyMatchers.test.ts`, `test/js/bun/test/expect/toHaveReturnedWith.test.ts`, and `test/js/bun/test/mock-fn.test.js` against the debug build: all pass. `tsc` over the test file reports the same pre-existing errors as on main and none in the new code.

### Background
- Every `expect()` matcher failure in bun starts with a "signature" header, `expect(received).<chain><matcher>(<params>)`, where `<chain>` is `not.`, `resolves.`, `rejects.`, or empty. `Expect::get_signature` renders the header for the synchronous failure paths; the name passed to `mock_prologue` flows through `matcher_prelude` into `process_promise`, which renders the same shape of header for `.resolves` / `.rejects` errors. The matcher name is a plain string literal each matcher supplies about itself, so a typo there is invisible to the compiler.

<details>
<summary>Before / after</summary>

```ts
import { expect, jest, test } from "bun:test";
test("x", () => {
  const fn = jest.fn(() => "foo");
  fn();
  expect(fn).toHaveLastReturnedWith("bar");
});
```

Before (bun 1.4.0):

```
error: expect(received).toHaveBeenLastReturnedWith(expected)
```

After:

```
error: expect(received).toHaveLastReturnedWith(expected)
```

</details>
