### PR TITLE
shell rm: drop a DirTask's own count from a pointer-only frame

### DIFF
--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -582,6 +582,22 @@ pub enum EntryKindHint {
     Dir,
 }
 
+/// What a walk of a [`DirTask`] ([`ShellRmTask::remove_entry`],
+/// [`ShellRmTask::remove_entry_dir_after_children`]) leaves for the caller,
+/// which holds the task by pointer, to do with it once the walk has returned
+/// (see [`DirTask::subtask_count`]).
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum EntryOutcome {
+    /// The entry was removed, skipped or failed without anything being
+    /// enqueued under it: the task still holds its only count, which
+    /// [`DirTask::post_run`] drops.
+    Done,
+    /// Child DirTasks may have been enqueued under the directory, so it can
+    /// only be removed once they are gone: [`DirTask::drop_own_count`] drops
+    /// the count the walk held and whoever drops the last one removes it.
+    AwaitChildren,
+}
+
 /// One per filepath argument; owns the root
 /// [`DirTask`] and tracks the cross-thread error state.
 pub struct ShellRmTask {
@@ -622,9 +638,20 @@ pub struct DirTask {
     pub(crate) parent_task: *mut DirTask,
     pub path: ZBox,
     pub(crate) is_absolute: bool,
+    /// One count held by the thread working on the task plus one per child
+    /// DirTask enqueued under it. A child drops its count in
+    /// [`DirTask::post_run`]; the working thread drops its own in
+    /// [`DirTask::drop_own_count`] once its walk has returned. Whichever
+    /// thread takes the count to 0 owns the task again and removes the
+    /// now-empty directory ([`DirTask::delete_after_waiting_for_children`]);
+    /// its `post_run` then frees a child, or hands the root back to the main
+    /// thread, which frees the whole [`ShellRmTask`] (root DirTask included).
+    /// So from the moment a thread's own decrement lands, another thread may
+    /// be freeing this task and everything it points at: the functions that
+    /// decrement hold it by raw pointer only, and every frame that borrowed
+    /// it or the `ShellRmTask` (the `remove_entry*` walk, `&self` throughout)
+    /// has returned by then.
     pub(crate) subtask_count: AtomicUsize,
-    pub(crate) need_to_wait: AtomicBool,
-    pub(crate) deleting_after_waiting_for_children: AtomicBool,
     pub(crate) kind_hint: EntryKindHint,
     pub(crate) deleted_entries: Vec<u8>,
     /// Intrusive node for the verbose-write bounce-back to the main thread.
@@ -639,7 +666,7 @@ pub struct DirTask {
 unsafe impl Send for ShellRmTask {}
 // SAFETY: `task_manager` / `parent_task` point at heap allocations kept alive
 // by the `subtask_count` / `pending_main_callbacks` atomic protocol; non-atomic
-// fields are single-owner per the `need_to_wait` handoff (see
+// fields are single-owner per the `subtask_count` hand-off (see
 // `verbose_deleted`).
 unsafe impl Send for DirTask {}
 
@@ -664,8 +691,6 @@ impl ShellRmTask {
             path: ZBox::from_bytes(root_path),
             is_absolute: false,
             subtask_count: AtomicUsize::new(1),
-            need_to_wait: AtomicBool::new(false),
-            deleting_after_waiting_for_children: AtomicBool::new(false),
             kind_hint: EntryKindHint::Idk,
             deleted_entries: Vec::new(),
             concurrent_task: bun_event_loop::EventLoopTask::from_event_loop(evtloop),
@@ -785,7 +810,9 @@ impl ShellRmTask {
         if self.error_signal().load(Ordering::SeqCst) {
             return;
         }
-        // SAFETY: `parent_dir` is live for the duration of its run_from_thread_pool_impl.
+        // SAFETY: `parent_dir` holds its own `subtask_count` until its walk
+        // (our caller) returns, so it is live; `path` is read-only after
+        // construction.
         let parent_path = unsafe { (*parent_dir).path.as_bytes() };
         let new_path = self.join(&[parent_path, path], is_absolute);
         self.enqueue_no_join(parent_dir, new_path, kind_hint);
@@ -806,8 +833,6 @@ impl ShellRmTask {
             path,
             is_absolute: false,
             subtask_count: AtomicUsize::new(1),
-            need_to_wait: AtomicBool::new(false),
-            deleting_after_waiting_for_children: AtomicBool::new(false),
             kind_hint,
             deleted_entries: Vec::new(),
             concurrent_task: bun_event_loop::EventLoopTask::from_event_loop(self.event_loop),
@@ -836,14 +861,14 @@ impl ShellRmTask {
         }
         // SAFETY: a DirTask's non-atomic fields are single-owner-at-a-time.
         // Ownership starts on the worker that runs `remove_entry*` and is
-        // handed off via `subtask_count`: the parent's final append here is
-        // sequenced-before its `subtask_count.fetch_sub(SeqCst)` in
-        // `remove_entry_dir`, and the child taking the counter to 0 in
-        // `post_run` acquire-reads from that release sequence before
-        // re-entering via `delete_after_waiting_for_children`. That pair
-        // makes prior `deleted_entries` writes visible to the new owner, so
-        // this `&mut` is exclusive and race-free. The reborrow is also
-        // disjoint from every other live borrow (`&self`, `path`).
+        // handed off via `subtask_count`: the walk's final append here is
+        // sequenced-before that worker's `subtask_count.fetch_sub(SeqCst)` in
+        // `DirTask::drop_own_count`, and the thread taking the counter to 0
+        // (there or in `post_run`) acquire-reads from that release sequence
+        // before re-entering via `delete_after_waiting_for_children`.
+        // That pair makes prior `deleted_entries` writes visible to the new
+        // owner, so this `&mut` is exclusive and race-free. The reborrow is
+        // also disjoint from every other live borrow (`&self`, `path`).
         let entries = unsafe { &mut (*dir_task).deleted_entries };
         if entries.is_empty() {
             // `output_count` is a `BackRef` into the boxed `Rm` ExecState.
@@ -901,50 +926,53 @@ impl ShellRmTask {
         e.with_path(path)
     }
 
-    /// Returns `Ok(true)` when [`remove_entry_dir`] handed `dir_task` off to
-    /// a child (its `subtask_count` slot was released without reaching 0).
-    /// Once that happens, a child finishing on another thread may run
-    /// [`DirTask::delete_after_waiting_for_children`] → `post_run` → `deinit`
-    /// (or, for the root, the main thread may free the whole
-    /// [`ShellRmTask`]). Callers must therefore treat `dir_task` as
-    /// potentially-freed when this returns `Ok(true)`. The bool is threaded
-    /// out locally instead of re-reading the atomic so the caller never
-    /// dereferences `dir_task` to find out.
-    fn remove_entry(&self, dir_task: *mut DirTask, is_absolute: bool) -> bun_sys::Maybe<bool> {
-        let mut waiting = false;
+    /// The walk of one [`DirTask`], run by the worker that holds the task's
+    /// own count ([`DirTask::run_from_thread_pool_impl`]). That count is what
+    /// keeps `dir_task`, `self` and everything they own alive for the
+    /// duration, and it is only dropped after this returns, so `&self` and
+    /// the borrows of `dir_task.path` taken below are all gone by the time
+    /// another thread can free either object. An `Err` means nothing was
+    /// enqueued under `dir_task` (a failure after children were enqueued is
+    /// recorded by [`remove_entry_dir`] itself, which still reports
+    /// [`EntryOutcome::AwaitChildren`]).
+    fn remove_entry(
+        &self,
+        dir_task: *mut DirTask,
+        is_absolute: bool,
+    ) -> bun_sys::Maybe<EntryOutcome> {
         let mut buf = bun_paths::PathBuffer::uninit();
-        // SAFETY: `dir_task` is live; this thread owns it. `kind_hint` /
-        // `path` are read-only after construction.
+        // SAFETY: `dir_task` is live (see above). `kind_hint` / `path` are
+        // read-only after construction.
         let (kind_hint, path) = unsafe { ((*dir_task).kind_hint, (*dir_task).path.as_zstr()) };
         match kind_hint {
             EntryKindHint::Idk => {
+                let mut outcome = EntryOutcome::Done;
                 let mut vtable = RemoveFileVTable {
                     task: self,
                     on_dir: OnDir::Recurse {
-                        need_to_wait_out: &mut waiting,
+                        outcome: &mut outcome,
                     },
                 };
                 self.remove_entry_file(dir_task, path, is_absolute, &mut buf, &mut vtable)?;
+                Ok(outcome)
             }
-            EntryKindHint::Dir => {
-                self.remove_entry_dir(dir_task, is_absolute, &mut buf, &mut waiting)?;
-            }
+            EntryKindHint::Dir => self.remove_entry_dir(dir_task, is_absolute, &mut buf),
         }
-        Ok(waiting)
     }
 
-    /// `need_to_wait_out` is left `true` only when the hand-off in this
-    /// function gave ownership of `dir_task` to a child; see
-    /// [`remove_entry`] for why the caller needs this on its own stack
-    /// rather than reading it back from `dir_task`.
+    /// Removes the directory `dir_task` stands for: directly when it is not
+    /// being walked (`-d`, or it turned out not to be a directory), otherwise
+    /// by unlinking its files and enqueuing a child DirTask per subdirectory,
+    /// after which removing the directory itself is left to whoever drops
+    /// its last count ([`EntryOutcome::AwaitChildren`]).
     fn remove_entry_dir(
         &self,
         dir_task: *mut DirTask,
         is_absolute: bool,
         buf: &mut bun_paths::PathBuffer,
-        need_to_wait_out: &mut bool,
-    ) -> bun_sys::Maybe<()> {
-        // SAFETY: `dir_task` is live; this thread owns it.
+    ) -> bun_sys::Maybe<EntryOutcome> {
+        // SAFETY: `dir_task` is live and its `path` read-only for the
+        // duration of the walk (see `remove_entry`).
         let path = unsafe { (*dir_task).path.as_zstr() };
         let dirfd = self.cwd;
 
@@ -958,11 +986,12 @@ impl ShellRmTask {
             };
             if state.treat_as_dir {
                 match bun_sys::rmdirat(dirfd, path) {
-                    Ok(()) => return Ok(()),
+                    Ok(()) => return Ok(EntryOutcome::Done),
                     Err(e) => match e.get_errno() {
                         E::ENOENT => {
                             if self.opts.force {
-                                return self.verbose_deleted(dir_task, path.as_bytes());
+                                self.verbose_deleted(dir_task, path.as_bytes())?;
+                                return Ok(EntryOutcome::Done);
                             }
                             return Err(self.error_with_path(&e, path.as_bytes()));
                         }
@@ -970,7 +999,7 @@ impl ShellRmTask {
                             state.treat_as_dir = false;
                             self.remove_entry_file(dir_task, path, is_absolute, buf, &mut state)?;
                             if !state.treat_as_dir {
-                                return Ok(());
+                                return Ok(EntryOutcome::Done);
                             }
                         }
                         _ => return Err(self.error_with_path(&e, path.as_bytes())),
@@ -995,28 +1024,27 @@ impl ShellRmTask {
             Err(e) => match e.get_errno() {
                 E::ENOENT => {
                     if self.opts.force {
-                        return self.verbose_deleted(dir_task, path.as_bytes());
+                        self.verbose_deleted(dir_task, path.as_bytes())?;
+                        return Ok(EntryOutcome::Done);
                     }
                     return Err(self.error_with_path(&e, path.as_bytes()));
                 }
                 E::ENOTDIR => {
                     let mut dummy = DummyRemoveFile;
-                    return self.remove_entry_file(dir_task, path, is_absolute, buf, &mut dummy);
+                    self.remove_entry_file(dir_task, path, is_absolute, buf, &mut dummy)?;
+                    return Ok(EntryOutcome::Done);
                 }
                 _ => return Err(self.error_with_path(&e, path.as_bytes())),
             },
         };
 
-        // On posix we can close the fd whenever, but on Windows we need to
-        // close it BEFORE we delete.
-        let mut _close_fd = scopeguard::guard(Some(fd), |fd| {
-            if let Some(fd) = fd {
-                fd.close();
-            }
-        });
+        // Closed when this returns, which is before the caller drops the
+        // directory's count: whoever then removes the directory (on Windows
+        // that needs every handle to it closed first) finds it closed.
+        let _close_fd = scopeguard::guard(fd, |fd| fd.close());
 
         if self.error_signal().load(Ordering::SeqCst) {
-            return Ok(());
+            return Ok(EntryOutcome::Done);
         }
 
         let mut iterator = dir_iterator::iterate(fd);
@@ -1027,11 +1055,12 @@ impl ShellRmTask {
 
         // The loop may have already enqueued child DirTasks (bumping
         // `dir_task.subtask_count`) when a readdir/unlink error or an
-        // `error_signal` from another worker aborts it. Returning from
-        // inside the loop would skip the `need_to_wait` hand-off below,
-        // so the last child's `post_run` would never drive
-        // `delete_after_waiting_for_children` on this dir and the owning
-        // `ShellRmTask` would never be freed.
+        // `error_signal` from another worker aborts it. Returning `Err` from
+        // inside the loop would make the caller treat the directory as
+        // `Done` and skip the hand-off, so the last child's `post_run` would
+        // never drive `delete_after_waiting_for_children` on this dir and
+        // the owning `ShellRmTask` would never be freed; the error is
+        // recorded below instead.
         let mut i: usize = 0;
         let loop_result: bun_sys::Maybe<()> = loop {
             let current = match iterator.next() {
@@ -1074,78 +1103,27 @@ impl ShellRmTask {
             }
         };
 
-        // Stash any loop error before the hand-off — once `need_to_wait`
-        // is published `self` may be freed, and `handle_err` takes a
-        // mutex so it must not sit inside the hand-off below. The
-        // `error_signal` check afterwards covers the no-children early-out.
         if let Err(e) = loop_result {
             self.handle_err(e);
         }
-
-        // Hand off to children. Publish `need_to_wait` first, then release
-        // this task's own slot on `subtask_count` with the same `fetch_sub`
-        // the children use: whoever takes the counter to 0 owns the rmdir.
-        // A load-then-store here had a lost-wakeup window where the last
-        // child could decrement and read `need_to_wait == false` between
-        // the two operations, stranding `dir_task` forever.
-        //
-        // SAFETY: `dir_task` is live until `subtask_count` drains to 0, and
-        // we still hold one count. Atomics through a short-lived `&DirTask`
-        // — interior mutability.
-        unsafe {
-            let dt = &*dir_task;
-            *need_to_wait_out = true;
-            dt.need_to_wait.store(true, Ordering::SeqCst);
-            if dt.subtask_count.fetch_sub(1, Ordering::SeqCst) != 1 {
-                // A child still holds a count. It (or a later child) will
-                // take the counter to 0 and drive
-                // `delete_after_waiting_for_children`; nothing after this
-                // may dereference `dir_task`. The directory fd is closed by
-                // the `close_fd` scopeguard on return — that touches only a
-                // stack local, not `dir_task`.
-                return Ok(());
-            }
-            // Every child already released its count (each saw the counter
-            // > 1 and so did not take ownership). `dir_task` is exclusively
-            // ours again: restore the invariants `post_run` expects and
-            // fall through to delete inline.
-            dt.subtask_count.store(1, Ordering::SeqCst);
-            dt.need_to_wait.store(false, Ordering::SeqCst);
-            *need_to_wait_out = false;
-        }
-
-        if self.error_signal().load(Ordering::SeqCst) {
-            return Ok(());
-        }
-
-        #[cfg(windows)]
-        {
-            // Close BEFORE deleting on Windows.
-            if let Some(f) = _close_fd.take() {
-                f.close();
-            }
-        }
-
-        match bun_sys::unlinkat_with_flags(self.cwd, path, bun_sys::AT_REMOVEDIR) {
-            Ok(()) => self.verbose_deleted(dir_task, path.as_bytes()),
-            Err(e) => match e.get_errno() {
-                E::ENOENT => {
-                    if self.opts.force {
-                        return self.verbose_deleted(dir_task, path.as_bytes());
-                    }
-                    Err(self.error_with_path(&e, path.as_bytes()))
-                }
-                _ => Err(e),
-            },
-        }
+        Ok(EntryOutcome::AwaitChildren)
     }
 
-    /// Returns `Ok(true)` if the
-    /// directory was deleted (or force-ignored), `Ok(false)` if a subtask was
-    /// enqueued and the caller should not run `post_run` yet.
-    fn remove_entry_dir_after_children(&self, dir_task: *mut DirTask) -> bun_sys::Maybe<bool> {
+    /// Removes the directory itself once
+    /// [`DirTask::delete_after_waiting_for_children`] has established that
+    /// everything under it is gone. Like [`remove_entry`], runs while the
+    /// caller holds the task's own count and returns before that count is
+    /// dropped. On non-Linux systems the entry may turn out to have been
+    /// replaced by a directory that is not empty, in which case a fresh
+    /// child DirTask is enqueued for it and the directory has to be waited
+    /// for again ([`EntryOutcome::AwaitChildren`]).
+    fn remove_entry_dir_after_children(
+        &self,
+        dir_task: *mut DirTask,
+    ) -> bun_sys::Maybe<EntryOutcome> {
         let dirfd = self.cwd;
-        // SAFETY: `dir_task` is live; this thread owns it.
+        // SAFETY: `dir_task` is live (see above); `path` / `is_absolute` are
+        // not written once the walk has started.
         let (path, is_abs) = unsafe { ((*dir_task).path.as_zstr(), (*dir_task).is_absolute) };
         let mut state = RemoveFileParent {
             treat_as_dir: true,
@@ -1157,14 +1135,14 @@ impl ShellRmTask {
             if state.treat_as_dir {
                 match bun_sys::rmdirat(dirfd, path) {
                     Ok(()) => {
-                        let _ = self.verbose_deleted(dir_task, path.as_bytes());
-                        return Ok(true);
+                        self.verbose_deleted(dir_task, path.as_bytes())?;
+                        return Ok(EntryOutcome::Done);
                     }
                     Err(e) => match e.get_errno() {
                         E::ENOENT => {
                             if self.opts.force {
-                                let _ = self.verbose_deleted(dir_task, path.as_bytes());
-                                return Ok(true);
+                                self.verbose_deleted(dir_task, path.as_bytes())?;
+                                return Ok(EntryOutcome::Done);
                             }
                             return Err(self.error_with_path(&e, path.as_bytes()));
                         }
@@ -1179,12 +1157,12 @@ impl ShellRmTask {
                 let mut buf = bun_paths::PathBuffer::uninit();
                 self.remove_entry_file(dir_task, path, is_abs, &mut buf, &mut state)?;
                 if state.enqueued {
-                    return Ok(false);
+                    return Ok(EntryOutcome::AwaitChildren);
                 }
                 if state.treat_as_dir {
                     continue;
                 }
-                return Ok(true);
+                return Ok(EntryOutcome::Done);
             }
         }
     }
@@ -1282,6 +1260,16 @@ impl ShellRmTask {
             self.error_signal().store(true, Ordering::SeqCst);
         }
     }
+
+    /// Records a failed walk step's error. Both steps ([`remove_entry`],
+    /// [`remove_entry_dir_after_children`]) only fail before enqueuing
+    /// anything, so a failed one leaves the task [`EntryOutcome::Done`].
+    fn record_outcome(&self, step: bun_sys::Maybe<EntryOutcome>) -> EntryOutcome {
+        step.unwrap_or_else(|err| {
+            self.handle_err(err);
+            EntryOutcome::Done
+        })
+    }
 }
 
 impl Drop for ShellRmTask {
@@ -1304,65 +1292,72 @@ impl DirTask {
         };
     }
 
+    /// Walks the task's directory, then drops the count the task holds on
+    /// itself. Holds the task and its [`ShellRmTask`] by pointer only: the
+    /// walk borrows them inside [`ShellRmTask::remove_entry`], which has
+    /// returned before the count is dropped, and dropping it is what lets
+    /// another thread free them (see [`DirTask::subtask_count`]).
+    ///
     /// # Safety
-    /// `this` is a live DirTask (root or heap child); the calling worker
-    /// thread has exclusive access to its non-atomic fields.
+    /// `this` is a live DirTask (root or heap child) holding its own count;
+    /// the calling worker thread has exclusive access to its non-atomic
+    /// fields.
     unsafe fn run_from_thread_pool_impl(this: *mut DirTask) {
-        // Stay on the raw pointer throughout: `remove_entry` re-derives
-        // `&mut *this` internally (via `verbose_deleted` / `remove_entry_dir`)
-        // and schedules child DirTasks that concurrently touch our atomics, so
-        // holding a long-lived `&mut *this` across that call would alias under
-        // Stacked Borrows.
-        //
-        // SAFETY: caller contract — `this` is a live DirTask; this worker
-        // thread has exclusive access to its non-atomic fields (`task_manager`
-        // / `parent_task` / `path` / `is_absolute`). `tm_ptr` is live until
-        // `pending_main_callbacks` hits 0.
-        let (tm_ptr, is_absolute): (*mut ShellRmTask, bool) = unsafe {
-            let tm_ptr = (*this).task_manager;
+        // SAFETY: caller contract. `task_manager` outlives the task's whole
+        // tree (it is freed by the main thread after the root's `post_run`),
+        // so it is live for as long as this thread holds the count.
+        let (tm, is_absolute): (*mut ShellRmTask, bool) = unsafe {
+            let tm = (*this).task_manager;
             let abs = Platform::AUTO.is_absolute((*this).path.as_bytes());
             (*this).is_absolute = abs;
-            (tm_ptr, abs)
+            (tm, abs)
         };
+        // SAFETY: as above; the `&ShellRmTask` borrows last for these two
+        // calls, which return before the count is dropped.
+        let outcome = unsafe { (*tm).record_outcome((*tm).remove_entry(this, is_absolute)) };
+        // SAFETY: this thread holds the task's own count and, per the
+        // contract of `drop_own_count`, touches neither object afterwards.
+        unsafe { Self::drop_own_count(this, outcome) };
+    }
 
-        // SAFETY: `task_manager` is live until pending_main_callbacks hits 0.
-        // `root_task` lives in a separate allocation, so this borrow does not
-        // overlap any DirTask and the field-level `&mut` taken inside
-        // `verbose_deleted` cannot pop its tag under Stacked Borrows.
-        let tm = unsafe { &*tm_ptr };
-        let waiting = match tm.remove_entry(this, is_absolute) {
-            Ok(waiting) => waiting,
-            Err(err) => {
-                tm.handle_err(err);
-                // `need_to_wait` is only stored on the `Ok(())` return path
-                // of `remove_entry_dir`, so an `Err` return guarantees
-                // ownership of `this` was not handed off.
-                false
+    /// Drops the count the calling thread holds on `this` (see
+    /// [`subtask_count`](DirTask::subtask_count)), now that the walk that
+    /// produced `outcome` has returned.
+    ///
+    /// # Safety
+    /// `this` is a live DirTask and the calling thread holds its own count,
+    /// which this drops: the caller must not touch `this` or its
+    /// `task_manager` afterwards, as either may be freed by another thread
+    /// (or, for the root, the main thread) by the time this returns.
+    unsafe fn drop_own_count(this: *mut DirTask, outcome: EntryOutcome) {
+        match outcome {
+            // SAFETY: fn contract.
+            EntryOutcome::Done => unsafe { Self::post_run(this) },
+            EntryOutcome::AwaitChildren => {
+                // The same `fetch_sub` the children use in `post_run`:
+                // whoever takes the counter to 0 removes the directory. If
+                // that is a child, it may be freeing `this` (and, cascading
+                // up to the root, the whole `ShellRmTask`) as soon as this
+                // decrement lands; only the atomic is borrowed here, and
+                // only for the decrement.
+                // SAFETY: fn contract.
+                if unsafe { (*this).subtask_count.fetch_sub(1, Ordering::SeqCst) } == 1 {
+                    // SAFETY: we dropped the last count, so `this` is ours
+                    // again and no other thread references it.
+                    unsafe { Self::delete_after_waiting_for_children(this) };
+                }
             }
-        };
-
-        // Re-reading `this` here to decide whether to skip `post_run` would
-        // be a use-after-free race: once `remove_entry_dir` publishes
-        // `need_to_wait = true`, the last child may run
-        // `delete_after_waiting_for_children(this)` → `post_run` → `deinit`
-        // (or, for the root, the main thread may drop the whole
-        // `ShellRmTask`) before we get here. So the hand-off is threaded out
-        // as a stack-local bool via `remove_entry`'s return value and `this`
-        // is never touched again when set. When `waiting` is false the
-        // hand-off never happened, so `deleting_after_waiting_for_children`
-        // (only ever stored by a child that observed `need_to_wait == true`)
-        // is necessarily false and `post_run` is both safe and required.
-        if !waiting {
-            // SAFETY: `waiting == false` ⇒ `need_to_wait` was never published,
-            // so no other thread can have driven `delete_after_waiting_for_children`
-            // / `deinit` on `this`; it is still live and owned by this worker.
-            unsafe { Self::post_run(this) };
         }
     }
 
+    /// The task is finished (nothing is enqueued under it): drops its last
+    /// count, flushes or frees it, and releases the count it holds on its
+    /// parent (or, for the root, hands the rm back to the main thread).
+    ///
     /// # Safety
-    /// `this` is a live DirTask; called from a worker thread that just
-    /// finished its body.
+    /// `this` is a live DirTask; the calling worker thread holds its own
+    /// count on it and nothing else does (`EntryOutcome::Done`), and does
+    /// not touch `this` or its `task_manager` after this returns.
     unsafe fn post_run(this: *mut DirTask) {
         // SAFETY: caller contract — `this` is a live DirTask owned by the
         // calling worker thread. `me` is held only over atomic / read-only
@@ -1374,94 +1369,81 @@ impl DirTask {
         // reclaims `this`'s Box; `finish_concurrently` may free the root.
         unsafe {
             let me = &*this;
-            // This is true if the directory has subdirectories that need to be deleted.
-            if me.need_to_wait.load(Ordering::SeqCst) {
+            let previous = me.subtask_count.fetch_sub(1, Ordering::SeqCst);
+            debug_assert_eq!(previous, 1, "post_run with child DirTasks still counted");
+            if previous != 1 {
                 return;
             }
-            // We have executed all the children of this task.
-            if me.subtask_count.fetch_sub(1, Ordering::SeqCst) == 1 {
-                let tm = &*me.task_manager;
-                // If a verbose write will be queued, take a pending count on the
-                // ShellRmTask now — before decrementing the parent (children) or
-                // calling finish_concurrently (root) — so the main thread can't
-                // free it out from under write_verbose.
-                let will_queue_verbose = tm.opts.verbose && !me.deleted_entries.is_empty();
-                if will_queue_verbose {
-                    tm.pending_main_callbacks.fetch_add(1, Ordering::SeqCst);
-                }
-
-                // The verbose hop is posted while the rm task is still counted
-                // work of its VM — i.e. before anything below can let the root
-                // `finish_concurrently` (which releases that count) run: our
-                // parent decrement can cascade into it, and for the root it is
-                // the next statement. `this` may be freed by the JS thread once
-                // posted, so what we still need is captured first.
-                let (parent_task, task_manager) = (me.parent_task, me.task_manager);
-                if will_queue_verbose {
-                    Self::queue_for_write(this);
-                } else if !parent_task.is_null() {
-                    Self::deinit(this);
-                }
-
-                // If we have a parent and we are the last child, now we can delete the parent.
-                if !parent_task.is_null() {
-                    let p = &*parent_task;
-                    // The parent releases its own slot on this counter in
-                    // `remove_entry_dir`; whoever takes it to 0 owns the
-                    // parent's rmdir. The parent's `fetch_sub` is sequenced
-                    // after its final `deleted_entries` write and its
-                    // `need_to_wait.store(true)`, and every decrement is a
-                    // SeqCst RMW, so reading 1 here synchronizes-with the
-                    // parent's release and makes those writes visible to
-                    // `delete_after_waiting_for_children`.
-                    if p.subtask_count.fetch_sub(1, Ordering::SeqCst) == 1 {
-                        Self::delete_after_waiting_for_children(parent_task);
-                    }
-                    return;
-                }
-
-                // Root task: hand it back. It may be freed at any time after
-                // this unless the verbose hop's pending count keeps it.
-                ShellRmTask::finish_concurrently(task_manager);
+            let tm = &*me.task_manager;
+            // If a verbose write will be queued, take a pending count on the
+            // ShellRmTask now — before decrementing the parent (children) or
+            // calling finish_concurrently (root) — so the main thread can't
+            // free it out from under write_verbose.
+            let will_queue_verbose = tm.opts.verbose && !me.deleted_entries.is_empty();
+            if will_queue_verbose {
+                tm.pending_main_callbacks.fetch_add(1, Ordering::SeqCst);
             }
+
+            // The verbose hop is posted while the rm task is still counted
+            // work of its VM — i.e. before anything below can let the root
+            // `finish_concurrently` (which releases that count) run: our
+            // parent decrement can cascade into it, and for the root it is
+            // the next statement. `this` may be freed by the JS thread once
+            // posted, so what we still need is captured first.
+            let (parent_task, task_manager) = (me.parent_task, me.task_manager);
+            if will_queue_verbose {
+                Self::queue_for_write(this);
+            } else if !parent_task.is_null() {
+                Self::deinit(this);
+            }
+
+            // If we have a parent and we are the last child, now we can delete the parent.
+            if !parent_task.is_null() {
+                // The parent dropped its own count in `drop_own_count`, after
+                // its walk's last `deleted_entries` write; every decrement is
+                // a SeqCst RMW, so reading 1 here synchronizes-with the
+                // parent's release and makes those writes visible to
+                // `delete_after_waiting_for_children`. If this is not the
+                // last count, whoever drops it may free the parent at once.
+                if (*parent_task).subtask_count.fetch_sub(1, Ordering::SeqCst) == 1 {
+                    Self::delete_after_waiting_for_children(parent_task);
+                }
+                return;
+            }
+
+            // Root task: hand it back. It may be freed at any time after
+            // this unless the verbose hop's pending count keeps it.
+            ShellRmTask::finish_concurrently(task_manager);
         }
-        // Otherwise need to wait.
     }
 
+    /// Runs on whichever thread dropped the last count on `this` (a child
+    /// finishing in [`post_run`], or the directory's own walk in
+    /// [`drop_own_count`] when the children were already gone): everything
+    /// under the directory has been dealt with, so remove the directory
+    /// itself.
+    ///
     /// # Safety
-    /// `this` is a live DirTask; called from a worker thread.
+    /// `this` is a live DirTask whose `subtask_count` the calling thread just
+    /// took to 0, so no other thread references it; the caller does not touch
+    /// `this` or its `task_manager` after this returns.
     unsafe fn delete_after_waiting_for_children(this: *mut DirTask) {
-        // SAFETY: caller contract. Stay on raw `this` —
-        // `remove_entry_dir_after_children` reborrows `(*this).deleted_entries`
-        // mutably (via `verbose_deleted`), so we never materialise a
-        // long-lived `&DirTask` covering that field. The two atomic stores
-        // and the `task_manager` read use raw place projection only.
-        // `task_manager` lives in a separate allocation, so `tm: &ShellRmTask`
-        // does not overlap any DirTask borrow.
+        // SAFETY: caller contract. Re-taking the count makes this step look
+        // like the walk did to `drop_own_count`: the thread working on the
+        // task holds a count on it, and a re-enqueued child holds another.
+        // The `&ShellRmTask` borrows last for the calls they are formed for,
+        // which return before the count is dropped; `task_manager` is live
+        // for as long as this thread holds the count (see
+        // `run_from_thread_pool_impl`).
         unsafe {
-            // `run_from_thread_pool_impl` has a `defer post_run` so set this to skip that.
-            (*this)
-                .deleting_after_waiting_for_children
-                .store(true, Ordering::SeqCst);
-            (*this).need_to_wait.store(false, Ordering::SeqCst);
-            // The caller just took `subtask_count` to 0; restore the slot
-            // `post_run`'s own decrement expects.
             (*this).subtask_count.store(1, Ordering::SeqCst);
-            let tm = &*(*this).task_manager;
-            let mut do_post_run = true;
-            if !tm.error_signal().load(Ordering::SeqCst) {
-                match tm.remove_entry_dir_after_children(this) {
-                    Err(e) => tm.handle_err(e),
-                    Ok(deleted) => {
-                        if !deleted {
-                            do_post_run = false;
-                        }
-                    }
-                }
-            }
-            if do_post_run {
-                Self::post_run(this);
-            }
+            let tm = (*this).task_manager;
+            let outcome = if (*tm).error_signal().load(Ordering::SeqCst) {
+                EntryOutcome::Done
+            } else {
+                (*tm).record_outcome((*tm).remove_entry_dir_after_children(this))
+            };
+            Self::drop_own_count(this, outcome);
         }
     }
 
@@ -1602,10 +1584,10 @@ enum OnDir<'a> {
     /// ([`ShellRmTask::remove_entry_dir`]): enqueue it as its own [`DirTask`].
     Enqueue,
     /// The entry is the [`DirTask`] itself ([`ShellRmTask::remove_entry`]):
-    /// recurse into [`ShellRmTask::remove_entry_dir`] here. The out-param lets
-    /// `remove_entry` learn that `need_to_wait` was published without
-    /// re-reading the (possibly already-freed) DirTask.
-    Recurse { need_to_wait_out: &'a mut bool },
+    /// recurse into [`ShellRmTask::remove_entry_dir`] here and report its
+    /// outcome through the out-param, since the [`RemoveFileHandler`]
+    /// signatures have no room for it.
+    Recurse { outcome: &'a mut EntryOutcome },
 }
 
 impl RemoveFileVTable<'_> {
@@ -1625,9 +1607,9 @@ impl RemoveFileVTable<'_> {
                 );
                 Ok(())
             }
-            OnDir::Recurse { need_to_wait_out } => {
-                self.task
-                    .remove_entry_dir(parent, is_absolute, buf, need_to_wait_out)
+            OnDir::Recurse { outcome } => {
+                **outcome = self.task.remove_entry_dir(parent, is_absolute, buf)?;
+                Ok(())
             }
         }
     }

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -582,19 +582,15 @@ pub enum EntryKindHint {
     Dir,
 }
 
-/// What a walk of a [`DirTask`] ([`ShellRmTask::remove_entry`],
-/// [`ShellRmTask::remove_entry_dir_after_children`]) leaves for the caller,
-/// which holds the task by pointer, to do with it once the walk has returned
-/// (see [`DirTask::subtask_count`]).
+/// What a walk of a [`DirTask`] leaves for the caller to do with the count
+/// it holds on the task (see [`DirTask::subtask_count`]).
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum EntryOutcome {
-    /// The entry was removed, skipped or failed without anything being
-    /// enqueued under it: the task still holds its only count, which
-    /// [`DirTask::post_run`] drops.
+    /// Nothing was enqueued under the entry: the caller's count is the only
+    /// one, dropped via [`DirTask::post_run`].
     Done,
-    /// Child DirTasks may have been enqueued under the directory, so it can
-    /// only be removed once they are gone: [`DirTask::drop_own_count`] drops
-    /// the count the walk held and whoever drops the last one removes it.
+    /// Child DirTasks may hold counts: [`DirTask::drop_own_count`] drops the
+    /// caller's, and whoever drops the last one removes the directory.
     AwaitChildren,
 }
 
@@ -639,18 +635,15 @@ pub struct DirTask {
     pub path: ZBox,
     pub(crate) is_absolute: bool,
     /// One count held by the thread working on the task plus one per child
-    /// DirTask enqueued under it. A child drops its count in
-    /// [`DirTask::post_run`]; the working thread drops its own in
-    /// [`DirTask::drop_own_count`] once its walk has returned. Whichever
-    /// thread takes the count to 0 owns the task again and removes the
-    /// now-empty directory ([`DirTask::delete_after_waiting_for_children`]);
-    /// its `post_run` then frees a child, or hands the root back to the main
-    /// thread, which frees the whole [`ShellRmTask`] (root DirTask included).
-    /// So from the moment a thread's own decrement lands, another thread may
-    /// be freeing this task and everything it points at: the functions that
-    /// decrement hold it by raw pointer only, and every frame that borrowed
-    /// it or the `ShellRmTask` (the `remove_entry*` walk, `&self` throughout)
-    /// has returned by then.
+    /// DirTask enqueued under it. The worker drops its own count once its
+    /// walk has returned ([`DirTask::drop_own_count`]); children drop theirs
+    /// in [`DirTask::post_run`]. Whichever thread reaches 0 removes the
+    /// now-empty directory ([`DirTask::delete_after_waiting_for_children`])
+    /// and then frees the task, or for the root hands the whole
+    /// [`ShellRmTask`] back to the main thread. So once a thread's own
+    /// decrement lands, another thread may be freeing this task and
+    /// everything it points at: the decrementing functions hold it by raw
+    /// pointer with no outstanding borrows.
     pub(crate) subtask_count: AtomicUsize,
     pub(crate) kind_hint: EntryKindHint,
     pub(crate) deleted_entries: Vec<u8>,
@@ -859,16 +852,12 @@ impl ShellRmTask {
         if !self.opts.verbose {
             return Ok(());
         }
-        // SAFETY: a DirTask's non-atomic fields are single-owner-at-a-time.
-        // Ownership starts on the worker that runs `remove_entry*` and is
-        // handed off via `subtask_count`: the walk's final append here is
-        // sequenced-before that worker's `subtask_count.fetch_sub(SeqCst)` in
-        // `DirTask::drop_own_count`, and the thread taking the counter to 0
-        // (there or in `post_run`) acquire-reads from that release sequence
-        // before re-entering via `delete_after_waiting_for_children`.
-        // That pair makes prior `deleted_entries` writes visible to the new
-        // owner, so this `&mut` is exclusive and race-free. The reborrow is
-        // also disjoint from every other live borrow (`&self`, `path`).
+        // SAFETY: a DirTask's non-atomic fields are single-owner-at-a-time
+        // per the `subtask_count` hand-off: this append is sequenced-before
+        // the owner's decrement, and the thread that reaches 0 acquire-reads
+        // from that release sequence, so the `&mut` is exclusive and the
+        // writes are visible to the next owner. The reborrow is disjoint
+        // from every other live borrow (`&self`, `path`).
         let entries = unsafe { &mut (*dir_task).deleted_entries };
         if entries.is_empty() {
             // `output_count` is a `BackRef` into the boxed `Rm` ExecState.
@@ -926,15 +915,12 @@ impl ShellRmTask {
         e.with_path(path)
     }
 
-    /// The walk of one [`DirTask`], run by the worker that holds the task's
-    /// own count ([`DirTask::run_from_thread_pool_impl`]). That count is what
-    /// keeps `dir_task`, `self` and everything they own alive for the
-    /// duration, and it is only dropped after this returns, so `&self` and
-    /// the borrows of `dir_task.path` taken below are all gone by the time
-    /// another thread can free either object. An `Err` means nothing was
-    /// enqueued under `dir_task` (a failure after children were enqueued is
-    /// recorded by [`remove_entry_dir`] itself, which still reports
-    /// [`EntryOutcome::AwaitChildren`]).
+    /// The walk of one [`DirTask`]. Runs while the caller holds the task's
+    /// own count (see [`DirTask::subtask_count`]), which keeps `dir_task` and
+    /// `self` alive until this returns. An `Err` means nothing was enqueued
+    /// under `dir_task`; a failure after children were enqueued is recorded
+    /// by [`remove_entry_dir`] itself, which still reports
+    /// [`EntryOutcome::AwaitChildren`].
     fn remove_entry(
         &self,
         dir_task: *mut DirTask,
@@ -962,9 +948,8 @@ impl ShellRmTask {
 
     /// Removes the directory `dir_task` stands for: directly when it is not
     /// being walked (`-d`, or it turned out not to be a directory), otherwise
-    /// by unlinking its files and enqueuing a child DirTask per subdirectory,
-    /// after which removing the directory itself is left to whoever drops
-    /// its last count ([`EntryOutcome::AwaitChildren`]).
+    /// by unlinking its files and enqueuing a child DirTask per subdirectory
+    /// ([`EntryOutcome::AwaitChildren`]).
     fn remove_entry_dir(
         &self,
         dir_task: *mut DirTask,
@@ -1038,9 +1023,8 @@ impl ShellRmTask {
             },
         };
 
-        // Closed when this returns, which is before the caller drops the
-        // directory's count: whoever then removes the directory (on Windows
-        // that needs every handle to it closed first) finds it closed.
+        // Closed on return, before the rmdir: Windows cannot remove a
+        // directory with an open handle to it.
         let _close_fd = scopeguard::guard(fd, |fd| fd.close());
 
         if self.error_signal().load(Ordering::SeqCst) {
@@ -1053,14 +1037,10 @@ impl ShellRmTask {
             on_dir: OnDir::Enqueue,
         };
 
-        // The loop may have already enqueued child DirTasks (bumping
-        // `dir_task.subtask_count`) when a readdir/unlink error or an
-        // `error_signal` from another worker aborts it. Returning `Err` from
-        // inside the loop would make the caller treat the directory as
-        // `Done` and skip the hand-off, so the last child's `post_run` would
-        // never drive `delete_after_waiting_for_children` on this dir and
-        // the owning `ShellRmTask` would never be freed; the error is
-        // recorded below instead.
+        // The loop may have already enqueued child DirTasks when an error or
+        // `error_signal` aborts it, so it must still report `AwaitChildren`:
+        // returning `Err` would read as `Done` and strand the children's
+        // counts. The error is recorded below instead.
         let mut i: usize = 0;
         let loop_result: bun_sys::Maybe<()> = loop {
             let current = match iterator.next() {
@@ -1109,14 +1089,11 @@ impl ShellRmTask {
         Ok(EntryOutcome::AwaitChildren)
     }
 
-    /// Removes the directory itself once
-    /// [`DirTask::delete_after_waiting_for_children`] has established that
-    /// everything under it is gone. Like [`remove_entry`], runs while the
-    /// caller holds the task's own count and returns before that count is
-    /// dropped. On non-Linux systems the entry may turn out to have been
-    /// replaced by a directory that is not empty, in which case a fresh
-    /// child DirTask is enqueued for it and the directory has to be waited
-    /// for again ([`EntryOutcome::AwaitChildren`]).
+    /// Removes the directory itself once everything under it is gone. Like
+    /// [`remove_entry`], runs while the caller holds the task's own count.
+    /// On non-Linux systems the entry may have been replaced by a non-empty
+    /// directory, in which case a fresh child DirTask is enqueued and the
+    /// wait starts over ([`EntryOutcome::AwaitChildren`]).
     fn remove_entry_dir_after_children(
         &self,
         dir_task: *mut DirTask,
@@ -1261,9 +1238,8 @@ impl ShellRmTask {
         }
     }
 
-    /// Records a failed walk step's error. Both steps ([`remove_entry`],
-    /// [`remove_entry_dir_after_children`]) only fail before enqueuing
-    /// anything, so a failed one leaves the task [`EntryOutcome::Done`].
+    /// Records a failed walk step's error. A failing step never enqueues
+    /// children, so the task is left [`EntryOutcome::Done`].
     fn record_outcome(&self, step: bun_sys::Maybe<EntryOutcome>) -> EntryOutcome {
         step.unwrap_or_else(|err| {
             self.handle_err(err);
@@ -1293,57 +1269,49 @@ impl DirTask {
     }
 
     /// Walks the task's directory, then drops the count the task holds on
-    /// itself. Holds the task and its [`ShellRmTask`] by pointer only: the
-    /// walk borrows them inside [`ShellRmTask::remove_entry`], which has
-    /// returned before the count is dropped, and dropping it is what lets
-    /// another thread free them (see [`DirTask::subtask_count`]).
+    /// itself (see [`DirTask::subtask_count`]).
     ///
     /// # Safety
     /// `this` is a live DirTask (root or heap child) holding its own count;
     /// the calling worker thread has exclusive access to its non-atomic
     /// fields.
     unsafe fn run_from_thread_pool_impl(this: *mut DirTask) {
-        // SAFETY: caller contract. `task_manager` outlives the task's whole
-        // tree (it is freed by the main thread after the root's `post_run`),
-        // so it is live for as long as this thread holds the count.
+        // SAFETY: caller contract; `task_manager` is live for as long as
+        // this thread holds the count.
         let (tm, is_absolute): (*mut ShellRmTask, bool) = unsafe {
             let tm = (*this).task_manager;
             let abs = Platform::AUTO.is_absolute((*this).path.as_bytes());
             (*this).is_absolute = abs;
             (tm, abs)
         };
-        // SAFETY: as above; the `&ShellRmTask` borrows last for these two
-        // calls, which return before the count is dropped.
+        // SAFETY: as above; the `&ShellRmTask` borrows end when these calls
+        // return, before the count is dropped.
         let outcome = unsafe { (*tm).record_outcome((*tm).remove_entry(this, is_absolute)) };
-        // SAFETY: this thread holds the task's own count and, per the
-        // contract of `drop_own_count`, touches neither object afterwards.
+        // SAFETY: this thread holds the task's own count and touches neither
+        // object afterwards.
         unsafe { Self::drop_own_count(this, outcome) };
     }
 
     /// Drops the count the calling thread holds on `this` (see
-    /// [`subtask_count`](DirTask::subtask_count)), now that the walk that
-    /// produced `outcome` has returned.
+    /// [`subtask_count`](DirTask::subtask_count)).
     ///
     /// # Safety
-    /// `this` is a live DirTask and the calling thread holds its own count,
-    /// which this drops: the caller must not touch `this` or its
-    /// `task_manager` afterwards, as either may be freed by another thread
-    /// (or, for the root, the main thread) by the time this returns.
+    /// `this` is a live DirTask whose own count the calling thread holds.
+    /// After this returns `this` and its `task_manager` may be freed by
+    /// another thread, so the caller must not touch either.
     unsafe fn drop_own_count(this: *mut DirTask, outcome: EntryOutcome) {
         match outcome {
             // SAFETY: fn contract.
             EntryOutcome::Done => unsafe { Self::post_run(this) },
             EntryOutcome::AwaitChildren => {
-                // The same `fetch_sub` the children use in `post_run`:
-                // whoever takes the counter to 0 removes the directory. If
-                // that is a child, it may be freeing `this` (and, cascading
-                // up to the root, the whole `ShellRmTask`) as soon as this
-                // decrement lands; only the atomic is borrowed here, and
-                // only for the decrement.
+                // Same `fetch_sub` as the children's in `post_run`: whoever
+                // reaches 0 removes the directory. Only the atomic is
+                // borrowed, only for the decrement; a child reaching 0 may
+                // free `this` at once.
                 // SAFETY: fn contract.
                 if unsafe { (*this).subtask_count.fetch_sub(1, Ordering::SeqCst) } == 1 {
-                    // SAFETY: we dropped the last count, so `this` is ours
-                    // again and no other thread references it.
+                    // SAFETY: we dropped the last count, so no other thread
+                    // references `this`.
                     unsafe { Self::delete_after_waiting_for_children(this) };
                 }
             }
@@ -1355,18 +1323,15 @@ impl DirTask {
     /// parent (or, for the root, hands the rm back to the main thread).
     ///
     /// # Safety
-    /// `this` is a live DirTask; the calling worker thread holds its own
-    /// count on it and nothing else does (`EntryOutcome::Done`), and does
-    /// not touch `this` or its `task_manager` after this returns.
+    /// `this` is a live DirTask whose only remaining count the calling
+    /// thread holds ([`EntryOutcome::Done`]); the caller must not touch
+    /// `this` or its `task_manager` after this returns.
     unsafe fn post_run(this: *mut DirTask) {
-        // SAFETY: caller contract — `this` is a live DirTask owned by the
-        // calling worker thread. `me` is held only over atomic / read-only
-        // field access; `task_manager` is a separate allocation live until
-        // `pending_main_callbacks` hits 0; `parent_task` is live until its
-        // `subtask_count` drains. `delete_after_waiting_for_children` and
-        // `queue_for_write` re-derive from raw `*mut` (no overlap with `me`,
-        // which is a `&` over atomics + Copy fields). Non-root `deinit`
-        // reclaims `this`'s Box; `finish_concurrently` may free the root.
+        // SAFETY: caller contract. `me` is held only over atomic /
+        // read-only field access; `task_manager` is live until
+        // `pending_main_callbacks` hits 0, `parent_task` until its
+        // `subtask_count` drains. Non-root `deinit` reclaims `this`'s Box;
+        // `finish_concurrently` may free the root.
         unsafe {
             let me = &*this;
             let previous = me.subtask_count.fetch_sub(1, Ordering::SeqCst);
@@ -1375,21 +1340,16 @@ impl DirTask {
                 return;
             }
             let tm = &*me.task_manager;
-            // If a verbose write will be queued, take a pending count on the
-            // ShellRmTask now — before decrementing the parent (children) or
-            // calling finish_concurrently (root) — so the main thread can't
-            // free it out from under write_verbose.
+            // Take the pending count before anything below can let the main
+            // thread free the ShellRmTask out from under `write_verbose`.
             let will_queue_verbose = tm.opts.verbose && !me.deleted_entries.is_empty();
             if will_queue_verbose {
                 tm.pending_main_callbacks.fetch_add(1, Ordering::SeqCst);
             }
 
-            // The verbose hop is posted while the rm task is still counted
-            // work of its VM — i.e. before anything below can let the root
-            // `finish_concurrently` (which releases that count) run: our
-            // parent decrement can cascade into it, and for the root it is
-            // the next statement. `this` may be freed by the JS thread once
-            // posted, so what we still need is captured first.
+            // Post the verbose hop before anything below can release the
+            // VM's count on this rm task; `this` may be freed once posted,
+            // so capture what we still need first.
             let (parent_task, task_manager) = (me.parent_task, me.task_manager);
             if will_queue_verbose {
                 Self::queue_for_write(this);
@@ -1399,12 +1359,10 @@ impl DirTask {
 
             // If we have a parent and we are the last child, now we can delete the parent.
             if !parent_task.is_null() {
-                // The parent dropped its own count in `drop_own_count`, after
-                // its walk's last `deleted_entries` write; every decrement is
-                // a SeqCst RMW, so reading 1 here synchronizes-with the
-                // parent's release and makes those writes visible to
-                // `delete_after_waiting_for_children`. If this is not the
-                // last count, whoever drops it may free the parent at once.
+                // SeqCst RMWs make the parent walk's writes (released by its
+                // own decrement in `drop_own_count`) visible when we read 1.
+                // If this is not the last count, whoever drops it may free
+                // the parent at once.
                 if (*parent_task).subtask_count.fetch_sub(1, Ordering::SeqCst) == 1 {
                     Self::delete_after_waiting_for_children(parent_task);
                 }
@@ -1417,24 +1375,17 @@ impl DirTask {
         }
     }
 
-    /// Runs on whichever thread dropped the last count on `this` (a child
-    /// finishing in [`post_run`], or the directory's own walk in
-    /// [`drop_own_count`] when the children were already gone): everything
-    /// under the directory has been dealt with, so remove the directory
-    /// itself.
+    /// Runs on the thread that took `subtask_count` to 0: everything under
+    /// the directory is gone, so remove the directory itself.
     ///
     /// # Safety
-    /// `this` is a live DirTask whose `subtask_count` the calling thread just
-    /// took to 0, so no other thread references it; the caller does not touch
-    /// `this` or its `task_manager` after this returns.
+    /// `this` is a live DirTask whose `subtask_count` the calling thread
+    /// just took to 0, so no other thread references it; the caller must not
+    /// touch `this` or its `task_manager` after this returns.
     unsafe fn delete_after_waiting_for_children(this: *mut DirTask) {
-        // SAFETY: caller contract. Re-taking the count makes this step look
-        // like the walk did to `drop_own_count`: the thread working on the
-        // task holds a count on it, and a re-enqueued child holds another.
-        // The `&ShellRmTask` borrows last for the calls they are formed for,
-        // which return before the count is dropped; `task_manager` is live
-        // for as long as this thread holds the count (see
-        // `run_from_thread_pool_impl`).
+        // SAFETY: caller contract. Re-taking the count puts this step in the
+        // same position as the walk: the counts keep `this` and
+        // `task_manager` alive until `drop_own_count`.
         unsafe {
             (*this).subtask_count.store(1, Ordering::SeqCst);
             let tm = (*this).task_manager;
@@ -1584,9 +1535,8 @@ enum OnDir<'a> {
     /// ([`ShellRmTask::remove_entry_dir`]): enqueue it as its own [`DirTask`].
     Enqueue,
     /// The entry is the [`DirTask`] itself ([`ShellRmTask::remove_entry`]):
-    /// recurse into [`ShellRmTask::remove_entry_dir`] here and report its
-    /// outcome through the out-param, since the [`RemoveFileHandler`]
-    /// signatures have no room for it.
+    /// recurse into [`ShellRmTask::remove_entry_dir`] and report its outcome
+    /// through the out-param.
     Recurse { outcome: &'a mut EntryOutcome },
 }
 

--- a/test/internal/source-lints/self-receiver-count-drop.test.ts
+++ b/test/internal/source-lints/self-receiver-count-drop.test.ts
@@ -1,0 +1,372 @@
+import { file } from "bun";
+import { expect, test } from "bun:test";
+import { realpathSync } from "fs";
+import path from "path";
+import { globAllSources } from "../../../scripts/glob-sources.ts";
+
+// A pool fan-out (`fs.promises.cp`, recursive `fs.promises.readdir`, the
+// shell's `rm -r`) is heap state shared by every pool thread working on it and
+// kept alive by a count of the parties holding it (`subtask_count`). As soon
+// as a thread's own decrement lands, whichever party drops the last count is
+// free to finish the object and free it (the `rm` tree frees the directory
+// task, and through the cascade up to the root the whole `ShellRmTask`, whose
+// `path` the walk was borrowing). Under both aliasing models a reference
+// passed as an argument is protected until its call returns, and freeing
+// protected memory from another thread is UB whether or not the reference is
+// used again (Tree Borrows, the model `bun run rust:miri` uses: "protected
+// tags must never be Disabled"; Stacked Borrows: "deallocating while item is
+// strongly protected"). So the decrement has to sit in a frame that holds the
+// object by raw pointer, with the borrowing work done in callees that have
+// returned first: `NewAsyncCpTask::on_subtask_done(this: *mut Self)` in
+// src/runtime/node/node_fs.rs and `DirTask::{drop_own_count, post_run}` in
+// src/runtime/shell/builtin/rm.rs are the shape.
+//
+// Banned: a function whose body decrements one of the COUNTS while taking a
+// receiver, or any reference parameter, or no raw pointer at all. Every
+// reference is banned, not just `&Self`: which objects the last drop frees is
+// not something the parameter types say (`rm`'s drop frees two types), and a
+// reference to caller-owned data is cheap to turn into a value or a pointer.
+// A drop that is not inside any function (a module-level macro) is banned too,
+// since it cannot be attributed to a frame.
+//
+// Scope: the text of the function containing the `<count>.fetch_sub(` call,
+// macros defined inside it included. A drop delegated to a helper is checked
+// at the helper, which is where the frame shape matters; the caller holding a
+// reference while calling the helper is the bug self-receiver-fan-out.test.ts
+// guards the known entry points against (#37861).
+//
+// Siblings: self-receiver-reclaim.test.ts (freeing the receiver),
+// fn-long-mut-reborrow.test.ts, frozen-nonnull-reborrow.test.ts.
+
+const root = path.resolve(import.meta.dir, "..", "..", "..");
+const rustSources = globAllSources().rust.filter(p => p.endsWith(".rs"));
+
+// Only scan files tracked in HEAD (a `git stash` round-trip can leave stray
+// `.rs` files in the working tree; CI runs on a clean checkout). Same guard as
+// dead-code-escapes.test.ts.
+const tracked: Set<string> | null = (() => {
+  const r = Bun.spawnSync({
+    cmd: ["git", "-C", root, "ls-tree", "-r", "--name-only", "-z", "HEAD"],
+    stdout: "pipe",
+    stderr: "ignore",
+  });
+  if (!r.success) return null;
+  return new Set(r.stdout.toString().split("\0").filter(Boolean));
+})();
+
+/** The fields whose last decrement frees the object they count for. */
+const COUNTS = ["subtask_count"];
+
+const DROP = new RegExp(String.raw`\b(?:${COUNTS.join("|")})\s*\.\s*fetch_sub\s*\(`, "g");
+
+// Documented, ratcheted exceptions: files allowed to keep exactly N of the
+// shape. Prefer converting over adding an entry here.
+const ALLOW: Record<string, number> = {
+  // The recursive readdir scan drops its counts from `perform_work(&mut self)`
+  // and `write_results(&mut self)`. #37861 moves them into
+  // `on_subtask_done(this: *mut Self)`; delete this entry when it lands.
+  "src/runtime/node/node_fs.rs": 2,
+};
+
+/**
+ * Blanks out comments, string literals and char literals (keeping their
+ * length and newlines) so that the brace matching below only sees code.
+ */
+function neutralize(source: string): string {
+  const re =
+    // block comment | line comment | raw (byte) string | (byte) string | (byte) char
+    /\/\*[\s\S]*?\*\/|\/\/[^\n]*|b?r(#*)"[\s\S]*?"\1|b?"(?:\\[\s\S]|[^"\\])*"|b?'(?:\\(?:x[0-9a-fA-F]{2}|u\{[0-9a-fA-F_]+\}|[\s\S])|[^\\'\n])'/g;
+  return source.replace(re, m => m.replace(/[^\n]/g, " "));
+}
+
+interface Fn {
+  name: string;
+  /** Offset of the `fn` keyword. */
+  offset: number;
+  params: string;
+  bodyStart: number;
+  bodyEnd: number;
+}
+
+/** Index just past the bracket matching the one at `open`, or -1. */
+function matching(text: string, open: number, opener: string, closer: string): number {
+  let depth = 0;
+  for (let i = open; i < text.length; i++) {
+    const c = text[i];
+    if (c === opener) depth++;
+    else if (c === closer && --depth === 0) return i + 1;
+  }
+  return -1;
+}
+
+/** Every function with a body in (neutralized) `text`. */
+function functions(text: string): Fn[] {
+  const out: Fn[] = [];
+  for (const m of text.matchAll(/\bfn\s+([A-Za-z_]\w*)\s*/g)) {
+    let i = m.index + m[0].length;
+    if (text[i] === "<") {
+      // Generics: `>` closes a level except as the arrow of an `Fn() -> T` bound.
+      let depth = 0;
+      for (; i < text.length; i++) {
+        const c = text[i];
+        if (c === "<") depth++;
+        else if (c === ">" && text[i - 1] !== "-" && --depth === 0) break;
+      }
+      i = text.indexOf("(", i);
+      if (i === -1) continue;
+    }
+    if (text[i] !== "(") continue;
+    const paramsEnd = matching(text, i, "(", ")");
+    if (paramsEnd === -1) continue;
+    const params = text.slice(i + 1, paramsEnd - 1);
+    // The body's `{` is the first one after the return type / where clause;
+    // a `;` at bracket depth 0 first means a bodiless declaration.
+    let j = paramsEnd;
+    let depth = 0;
+    let bodyStart = -1;
+    for (; j < text.length; j++) {
+      const c = text[j];
+      if (c === "(" || c === "[" || c === "<") depth++;
+      else if (c === ")" || c === "]" || (c === ">" && text[j - 1] !== "-")) depth--;
+      else if (depth <= 0 && c === ";") break;
+      else if (depth <= 0 && c === "{") {
+        bodyStart = j;
+        break;
+      }
+    }
+    if (bodyStart === -1) continue;
+    const bodyEnd = matching(text, bodyStart, "{", "}");
+    if (bodyEnd === -1) continue;
+    out.push({ name: m[1]!, offset: m.index, params, bodyStart, bodyEnd });
+  }
+  return out;
+}
+
+// A receiver: `self`, `mut self`, `&self`, `&'a mut self`, `self: Box<Self>`.
+const RECEIVER = /^\s*(?:&\s*(?:'\w+\s+)?(?:mut\s+)?)?(?:mut\s+)?self\b/;
+const RAW_POINTER = /\*\s*(?:mut|const)\b|\bNonNull\s*</;
+
+/** Why a drop frame with these parameters is banned, or null when it is the pointer shape. */
+function bannedBecause(params: string): string | null {
+  if (RECEIVER.test(params)) return "receiver";
+  if (params.includes("&")) return "reference parameter";
+  if (!RAW_POINTER.test(params)) return "no raw pointer";
+  return null;
+}
+
+interface Offender {
+  line: number;
+  /** `fn name(params)`, or null for a drop outside every function. */
+  frame: string | null;
+  reason: string;
+}
+
+/** The count drops in `source` that do not sit in a pointer-holding frame. */
+function dropOffenders(source: string): { drops: number; offenders: Offender[] } {
+  const text = neutralize(source);
+  const drops = [...text.matchAll(DROP)];
+  if (drops.length === 0) return { drops: 0, offenders: [] };
+  const fns = functions(text);
+  const offenders: Offender[] = [];
+  for (const drop of drops) {
+    const at = drop.index;
+    const line = text.slice(0, at).split("\n").length;
+    // Innermost enclosing function: the containing body that starts last.
+    let frame: Fn | undefined;
+    for (const fn of fns) {
+      if (fn.bodyStart < at && at < fn.bodyEnd && (!frame || fn.bodyStart > frame.bodyStart)) frame = fn;
+    }
+    if (!frame) {
+      offenders.push({ line, frame: null, reason: "outside every function" });
+      continue;
+    }
+    const reason = bannedBecause(frame.params);
+    if (reason !== null) {
+      const params = frame.params.replace(/\s+/g, " ").trim().replace(/,$/, "");
+      offenders.push({ line, frame: `fn ${frame.name}(${params})`, reason });
+    }
+  }
+  return { drops: drops.length, offenders };
+}
+
+const counts: Record<string, number> = {};
+const reported: string[] = [];
+let scanned = 0;
+let dropsInTree = 0;
+for (const abs of rustSources) {
+  const source = path.relative(root, abs).replaceAll(path.sep, "/");
+  // `src/cli` is a symlink into `src/runtime/cli`; count each file once under
+  // its canonical path.
+  if (path.relative(root, realpathSync(abs)).replaceAll(path.sep, "/") !== source) continue;
+  if (tracked !== null && !tracked.has(source)) continue;
+  scanned++;
+  const { drops, offenders } = dropOffenders(await file(abs).text());
+  dropsInTree += drops;
+  counts[source] = offenders.length;
+  if (offenders.length > (ALLOW[source] ?? 0)) {
+    for (const { line, frame, reason } of offenders)
+      reported.push(`${source}:${line}: ${frame ?? "<no fn>"}: ${reason}`);
+  }
+}
+
+test("scans a non-empty set of tracked Rust sources containing count drops", () => {
+  // Guards against the tracked/realpath filters over-firing, and against the
+  // COUNTS names going stale, either of which would make the ban below pass
+  // vacuously.
+  expect(scanned).toBeGreaterThan(0);
+  expect(dropsInTree).toBeGreaterThan(0);
+});
+
+test("neutralize keeps offsets and line structure while blanking literals and comments", () => {
+  const src = "let a = \"{\"; // {\nlet b = '{'; let c = b'}'; let d = r#\"}\"#; /* {\n{ */ let e: &'a T;";
+  const out = neutralize(src);
+  expect(out.length).toBe(src.length);
+  expect(out.split("\n").length).toBe(src.split("\n").length);
+  expect(out).not.toContain("{");
+  expect(out).not.toContain("}");
+  // Lifetimes are not char literals.
+  expect(out).toContain("&'a T");
+});
+
+test("functions() finds bodies through generics, return types and nested items", () => {
+  const src = neutralize(
+    [
+      "fn a<F: Fn() -> u8>(f: F) -> [u8; 4] { [0; 4] }",
+      "fn b(x: &str);",
+      "fn c(this: *mut Self) -> impl Fn() -> u8 {",
+      '    fn inner(&self) { let s = "}"; }',
+      "    || b'}' as u8",
+      "}",
+    ].join("\n"),
+  );
+  const fns = functions(src);
+  expect(fns.map(f => f.name)).toEqual(["a", "c", "inner"]);
+  const [a, c, inner] = fns as [Fn, Fn, Fn];
+  expect(a.params).toBe("f: F");
+  expect(src.slice(a.bodyStart, a.bodyEnd)).toBe("{ [0; 4] }");
+  expect(c.params).toBe("this: *mut Self");
+  expect(inner.params).toBe("&self");
+  expect(c.bodyStart).toBeLessThan(inner.bodyStart);
+  expect(inner.bodyEnd).toBeLessThan(c.bodyEnd);
+});
+
+test("the frame check bans receivers and references and requires a pointer", () => {
+  const banned: [string, string][] = [
+    // `ShellRmTask::remove_entry_dir` and `AsyncReaddirRecursiveTask::perform_work`, as they were.
+    ["&self, dir_task: *mut DirTask, is_absolute: bool, buf: &mut PathBuffer", "receiver"],
+    ["&mut self, basename: &ZStr", "receiver"],
+    ["self: Box<Self>", "receiver"],
+    ["mut self", "receiver"],
+    ["&'a self", "receiver"],
+    // A reference under another name is the same frame.
+    ["this: &mut Self", "reference parameter"],
+    ["this: &'a AsyncReaddirRecursiveTask", "reference parameter"],
+    // A reference alongside the pointer still protects something.
+    ["this: *mut Self, scan: &Self", "reference parameter"],
+    ["this: *mut DirTask, buf: &mut PathBuffer", "reference parameter"],
+    ["this: *mut Self, name: Option<&ZStr>", "reference parameter"],
+    // Nothing to reach the object through.
+    ["", "no raw pointer"],
+    ["count: usize", "no raw pointer"],
+    ["task: Box<DirTask>", "no raw pointer"],
+  ];
+  const allowed = [
+    "this: *mut DirTask",
+    "this: *mut Self, outcome: EntryOutcome",
+    "this: *const Self",
+    "this: NonNull<Self>, flag: bool",
+    // rustfmt-wrapped.
+    "\n        this: *mut DirTask,\n        outcome: EntryOutcome,\n    ",
+    // A parameter whose name merely starts with `self`.
+    "self_ptr: *mut Self",
+  ];
+  expect(banned.map(([p]) => bannedBecause(p))).toEqual(banned.map(([, why]) => why));
+  expect(allowed.map(bannedBecause)).toEqual(allowed.map(() => null));
+});
+
+test("dropOffenders attributes each drop to its innermost function", () => {
+  const impl = (body: string) => `impl DirTask {\n${body}\n}\n`;
+  const flagged = (src: string) => dropOffenders(src).offenders.map(o => `${o.line}: ${o.frame}: ${o.reason}`);
+  // The hand-off as it was in rm.rs: the decrement inside a `&self` walk.
+  expect(
+    flagged(
+      impl(
+        [
+          "    fn remove_entry_dir(",
+          "        &self,",
+          "        dir_task: *mut DirTask,",
+          "    ) -> bun_sys::Maybe<()> {",
+          "        unsafe {",
+          "            let dt = &*dir_task;",
+          "            if dt.subtask_count.fetch_sub(1, Ordering::SeqCst) != 1 {",
+          "                return Ok(());",
+          "            }",
+          "        }",
+          "        Ok(())",
+          "    }",
+        ].join("\n"),
+      ),
+    ),
+  ).toEqual(["8: fn remove_entry_dir(&self, dir_task: *mut DirTask): receiver"]);
+  // A drop inside a macro defined in the function body belongs to that function.
+  expect(
+    flagged(
+      impl(
+        [
+          "    fn perform_work(&mut self) {",
+          "        macro_rules! impl_tag {",
+          "            ($T:ty) => {{",
+          "                if self.subtask_count.fetch_sub(1, Ordering::Relaxed) == 1 {}",
+          "            }};",
+          "        }",
+          "    }",
+        ].join("\n"),
+      ),
+    ),
+  ).toEqual(["5: fn perform_work(&mut self): receiver"]);
+  // A nested pointer-taking function inside a `&self` method is judged on its own parameters.
+  expect(
+    flagged(
+      impl(
+        [
+          "    fn outer(&self) {",
+          "        unsafe fn drop_count(this: *mut DirTask) {",
+          "            unsafe { (*this).subtask_count.fetch_sub(1, Ordering::SeqCst) };",
+          "        }",
+          "    }",
+        ].join("\n"),
+      ),
+    ),
+  ).toEqual([]);
+  // A drop outside every function cannot be attributed to a frame.
+  expect(
+    flagged("macro_rules! done {\n    ($t:expr) => { $t.subtask_count.fetch_sub(1, Ordering::SeqCst) };\n}\n"),
+  ).toEqual(["2: null: outside every function"]);
+  // Prose and strings do not count; neither do other operations on the count.
+  const clean = impl(
+    [
+      "    /// Drops `subtask_count.fetch_sub(1)`'s worth of ownership.",
+      "    fn enqueue(&self, parent: *mut DirTask) {",
+      '        let _ = "subtask_count.fetch_sub(";',
+      "        unsafe { (*parent).subtask_count.fetch_add(1, Ordering::Relaxed) };",
+      "        self.other_count.fetch_sub(1, Ordering::Relaxed);",
+      "    }",
+      "    unsafe fn post_run(this: *mut DirTask) {",
+      "        unsafe { (*this).subtask_count.fetch_sub(1, Ordering::SeqCst) };",
+      "    }",
+    ].join("\n"),
+  );
+  expect(dropOffenders(clean)).toEqual({ drops: 1, offenders: [] });
+});
+
+test("every count drop sits in a frame that holds its object by pointer", () => {
+  expect(reported).toEqual([]);
+});
+
+test("allowlisted files still carry exactly their documented count", () => {
+  // Ratchet: once an allowlisted instance is converted, delete its entry so
+  // a new one cannot take its place.
+  for (const [f, n] of Object.entries(ALLOW)) {
+    expect(counts[f] ?? 0).toBe(n);
+  }
+});

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -145,12 +145,69 @@ foo/
     }
   });
 
-  // The DirTask parent/child hand-off had a lost-wakeup window between
-  // `subtask_count.load() > 1` and `need_to_wait.store(true)`: the last
-  // child could decrement and read `need_to_wait == false` in between,
-  // stranding the parent DirTask forever. A directory with exactly one
-  // subdirectory is the minimal trigger; the window is a few instructions
-  // so this is a stress probe rather than a deterministic repro.
+  // Every directory, including an empty one, is removed by whichever thread
+  // drops its last `subtask_count` after its walk has returned, and reports
+  // itself once; files are reported by the directory walk that unlinked them.
+  test.each([
+    ["-rv", true],
+    ["-r", false],
+  ])("recursive rm %s removes a tree of nested, empty and leaf directories", async (flag, verbose) => {
+    using tempdir = tempDir("rm-tree", {
+      "tree/f0": "",
+      "tree/f1": "",
+      "tree/empty": {},
+      "tree/a/f": "",
+      "tree/a/empty": {},
+      "tree/a/b/f": "",
+      "tree/a/b/c/f": "",
+      "tree/a/b/c/g": "",
+      "tree/a/b/c/d": {},
+      "tree/x/f": "",
+      "tree/y/z/f": "",
+    });
+    const root = path.join(String(tempdir), "tree");
+    const entries = [
+      "",
+      "f0",
+      "f1",
+      "empty",
+      "a",
+      "a/f",
+      "a/empty",
+      "a/b",
+      "a/b/f",
+      "a/b/c",
+      "a/b/c/f",
+      "a/b/c/g",
+      "a/b/c/d",
+      "x",
+      "x/f",
+      "y",
+      "y/z",
+      "y/z/f",
+    ].map(rel => path.join(root, rel));
+
+    const { stdout, stderr, exitCode } = await $`rm ${flag} ${root}`;
+    expect({
+      stdout: sortedShellOutput(stdout.toString()),
+      stderr: stderr.toString(),
+      exitCode,
+      remains: existsSync(root),
+    }).toEqual({
+      stdout: verbose ? entries.sort() : [],
+      stderr: "",
+      exitCode: 0,
+      remains: false,
+    });
+  });
+
+  // A directory's walk (`DirTask::drop_own_count`) and its last child
+  // (`DirTask::post_run`) race to drop the directory's final `subtask_count`;
+  // whichever wins has to remove the directory, or the rm never resolves
+  // (#34032 was a lost wakeup in an earlier, load-then-store version of this
+  // hand-off). A directory with exactly one subdirectory is the minimal
+  // trigger; the window is a few instructions wide, so this is a stress probe
+  // rather than a deterministic repro.
   test("recursive rm never hangs on the DirTask hand-off", async () => {
     using base = tempDir("rm-handoff", {});
     const fixture = /* ts */ `


### PR DESCRIPTION
### Problem

- The shell's `rm -r` fans each directory out as a `DirTask` (src/runtime/shell/builtin/rm.rs) kept alive by `subtask_count`: one count for the walk, one per child directory enqueued under it. Whichever thread drops the last count removes the directory and drops the parent's count in turn; when that reaches the root, `post_run` posts the `ShellRmTask` to the main thread, which frees it together with the root `DirTask` (`decr_pending_and_maybe_deinit`).
- The walk's own count was dropped from inside the walk: `remove_entry_dir(&self, ..)` published `need_to_wait` and did the `fetch_sub` itself, then returned through `remove_entry(&self, ..)` (and, for the root, `remove_entry_file(&self, path: &ZStr, ..)` with `path` pointing into the root `DirTask`'s buffer, plus `RemoveFileVTable::on_dir`). Once that decrement lands, the last child can remove the directory, free the `DirTask` and cascade to the root, and the main thread can free the `ShellRmTask`, while those frames are still unwinding.
- A reference argument is protected until its call returns, and freeing memory a protected reference covers is UB under both aliasing models whether or not the reference is used again (Tree Borrows, which `bun run rust:miri` uses: "protected tags must never be Disabled"; Stacked Borrows: "strongly protected"). The code carefully made no access after the decrement (#32617, #34032), so no crash is known; the contract shape is what is wrong. Same class as #37681 / #37705 / #37768 / #37787 / #37820 / #37861; found by the work on #37861 and handed off from there, since `rm` is its own fan-out.

<details>
<summary>Standalone reduction under Miri</summary>

`Manager` stands for `ShellRmTask`, `Dir` for `DirTask`; the spawned thread is the child directory's worker, and the thread it spawns at the end is the main thread freeing the `ShellRmTask`. A channel pins the interleaving where the child completes while the parent's walk frames are still on the stack (the parent was descheduled right after its decrement), which the real code produces whenever the child is faster than the parent's return path.

```rust
// Shared by both shapes.
unsafe fn post_run(this: *mut Dir) {                       // DirTask::post_run
    assert_eq!((*this).subtask_count.fetch_sub(1, SeqCst), 1);
    let (parent, manager) = ((*this).parent, (*this).manager);
    if !parent.is_null() {
        drop(Box::from_raw(this));
        if (*parent).subtask_count.fetch_sub(1, SeqCst) == 1 { delete_after_waiting_for_children(parent); }
        return;
    }
    thread::spawn(move || drop(Box::from_raw(manager)))   // main thread: decr_pending_and_maybe_deinit
        .join().unwrap();                                   // (drops the root Dir too)
}

// As it was: the walk, &self = &Manager, drops the count itself.
impl Manager {
    fn remove_entry(&self, dir: *mut Dir) { self.remove_entry_dir(dir) }
    fn remove_entry_dir(&self, dir: *mut Dir) {
        let child = enqueue(dir, go_rx);                   // subtask_count += 1, child thread waits for `go`
        if (*dir).subtask_count.fetch_sub(1, SeqCst) != 1 {
            go.send(()); child.join();                      // child removes the tree and frees *self meanwhile
            return;
        }
    }
}
// Tree Borrows:   error: Undefined Behavior: deallocation through <13423> at alloc303[0x0] is forbidden
//                 help: the accessed tag <13423> is foreign to the protected tag <497> (i.e., it is not a child)
//                 help: protected tags must never be Disabled
//                 help: the protected tag <497> was created here: `fn remove_entry_dir(&self, dir: *mut Dir)`
// Stacked Borrows: error: Undefined Behavior: not granting access to tag <508> because that would remove
//                 [SharedReadOnly for <513>] which is strongly protected

// As it is: the walk returns an outcome; a frame holding only pointers drops the count.
impl Manager {
    fn remove_entry(&self, dir: *mut Dir) -> Outcome { self.remove_entry_dir(dir) }
    fn remove_entry_dir(&self, dir: *mut Dir) -> Outcome { stash(enqueue(dir, go_rx)); Outcome::AwaitChildren }
}
unsafe fn run(dir: *mut Dir) {                             // DirTask::run_from_thread_pool_impl + drop_own_count
    let outcome = (*(*dir).manager).remove_entry(dir);     // the &Manager ends here
    match outcome {
        Outcome::AwaitChildren => if (*dir).subtask_count.fetch_sub(1, SeqCst) != 1 { go.send(()); child.join(); }
    }
}
// Both models: clean.
```

</details>

### Fix

- `remove_entry` and `remove_entry_dir_after_children` (still `&self`: the walk is the borrowing phase) return an `EntryOutcome` instead of touching the count: `Done` when nothing was enqueued under the task, `AwaitChildren` after a directory has been iterated (or, on non-Linux, re-enqueued). An `Err` from either still means nothing was enqueued; `remove_entry_dir` records a loop error itself and reports `AwaitChildren`, as before.
- `DirTask::run_from_thread_pool_impl` holds the task and its `ShellRmTask` as raw pointers, borrows the `ShellRmTask` only for the `remove_entry` / `record_outcome` calls, and then calls the new `DirTask::drop_own_count(this, outcome)`: `post_run` for `Done`, the `fetch_sub` for `AwaitChildren`, with `delete_after_waiting_for_children` when it reaches 0. By then every frame that borrowed either object has returned, and the decrement is the thread's last access, which is what the models require; this is the shape `NewAsyncCpTask::on_subtask_done` (and #37861's readdir) use. Correctness of the hand-off itself is unchanged: it is the same single SeqCst `fetch_sub` on both sides that #34032 introduced, and the `deleted_entries` publication argument in `verbose_deleted` is the same release sequence, now anchored in `drop_own_count`.
- `delete_after_waiting_for_children` is now the one place a directory is removed: when the walk's own decrement is the last one (the children were already gone, previously an inline copy of the rmdir at the end of `remove_entry_dir`) it runs the same code as when a child's is. It also ends in `drop_own_count`, so the non-Linux re-enqueue (`RemoveFileParent::on_dir_not_empty`, when the entry was swapped for a non-empty directory under us) now hands the directory off again; before, it returned without dropping the count, so the re-enqueued child's decrement could never reach 0 and that `rm` never resolved. This was already the case in the Zig version; it is reachable only through that swap race on macOS / Windows, so there is no test for it.
- Behaviour differences, all on paths that previously existed: the directory fd is closed when `remove_entry_dir` returns, i.e. before the count is dropped, so a child that wins the race never tries to remove a directory the parent still has open (this also removes the Windows-specific close ordering); the rmdir of a directory whose children finished first goes through `rmdirat` + the ENOTDIR retry of `remove_entry_dir_after_children` instead of a second copy (`rmdirat` is `unlinkat(AT_REMOVEDIR)`, and the error already carries the path, so messages are unchanged); `post_run`'s own decrement is now asserted (debug only) to be the last count, which the outcome contract guarantees.
- Deleted: `DirTask::need_to_wait` and `deleting_after_waiting_for_children`. Since #34032 made the counter carry the hand-off, `need_to_wait` was only ever read in `post_run` at points where it had just been stored `false`, and the other flag was never read. Also the bool out-parameter threaded through `OnDir::Recurse`, which now carries the outcome instead.
- Verified: `bun bd test test/js/bun/shell/commands/rm.test.ts` (9 pass, including the 800-iteration hand-off probe and the symlink swap race, which was the ASan leak reproducer for a stranded task in #32617; ASan build, no reports), `test/js/bun/shell/bunshell.test.ts` (418 pass), `test/js/bun/shell/leak.test.ts -t rm` (fd and RSS probes over 100 `rm -rfv` runs), `bun test test/internal/source-lints/` (89 pass), `cargo check -p bun_runtime` for `aarch64-apple-darwin` and `x86_64-pc-windows-msvc` (the re-enqueue path is cfg'd out on Linux), `cargo clippy -p bun_runtime`, `rustfmt --check`, and the Miri reduction above in both models.

### Tests

- `test/internal/source-lints/self-receiver-count-drop.test.ts`: every function whose body contains `subtask_count.fetch_sub(` must take its object as a raw pointer and have no receiver and no reference parameter (every reference, not just `&Self`, since here the last drop frees two types). With `src/` at main it reports exactly `rm.rs:1099: fn remove_entry_dir(&self, ..): receiver`; on this branch it passes. `node_fs.rs` is allowlisted at its current 2 (`perform_work(&mut self)`, `write_results(&mut self)`), which #37861 converts; the ratchet test fails the moment that lands so the entry gets deleted then. It complements #37861's lint, which checks named entry points; this one checks wherever the decrement physically lives, which is how it catches a drop that moved into a helper. The self-tests cover the receiver spellings, references next to the pointer, a drop inside a macro defined in the function, nested functions, a module-level macro, and prose / string mentions.
- `test/js/bun/shell/commands/rm.test.ts`: `rm -rv` and `rm -r` of a tree with nested, empty and leaf directories and files at several depths, asserting the exact verbose listing (every directory, empty ones included, now goes through `delete_after_waiting_for_children`), empty stderr, exit 0 and removal. These pass before and after, as intended: the behavioural coverage of the conversion is these plus the existing hand-off probe, whose comment is updated since it named the deleted flag. A test racing two `rm -rf` of one tree was tried and dropped: it exposed a pre-existing `-f` gap (readdir of a concurrently removed directory fails with ENOENT on overlayfs and is reported), which is filed separately.

### Background

- Protected references: in Rust's aliasing models (Stacked Borrows, and Tree Borrows, the one `bun run rust:miri` runs), a reference passed as a function argument, `&self` included, is "protected" for the duration of that call. Any foreign write to the memory it covers, and in particular its deallocation by another thread, is UB even if the callee never touches the reference again. So a frame that lets another thread free an object must not have that object (or anything freed along with it) behind any of its reference arguments; it holds a raw pointer, and the borrowing work happens in callees that have already returned.
- `subtask_count` hand-off: a `DirTask` starts with one count for the thread walking it; `enqueue` adds one per child directory; a child drops its count on the parent in `post_run` when it is completely done; the walk drops its own in `drop_own_count`. Whoever takes the count to 0 runs `delete_after_waiting_for_children`, which takes the count back (store 1), removes the now-empty directory, and drops it again through `drop_own_count`, so the re-enqueue case is just another `AwaitChildren`. `post_run` on a task with no children drops the last count, queues the task's verbose output (or frees a non-root task) and moves up to the parent; for the root it hands the `ShellRmTask` to the main thread.
- `pending_main_callbacks` on the `ShellRmTask` is the separate count of main-thread callbacks (the completion plus one per queued verbose flush); the last one frees the `ShellRmTask` and, with it, the root `DirTask`. It is untouched here; it is why "the main thread frees it" can happen as soon as the root's count hits 0.
- Related but different: #36176 re-anchors the walk on directory fds and keeps this hand-off shape, so whichever of the two lands second needs a mechanical rebase of `remove_entry_dir`'s tail; #37861 is the readdir scan's version of this change and owns the allowlist entry above.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 5 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/rm.test.ts

<!-- robobun:evidence:end -->