### PR TITLE
logger: make Log::default() follow the configured log level (Workers ignored bunfig logLevel)

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1379,11 +1379,7 @@ impl Default for Log {
             warnings: 0,
             errors: 0,
             msgs: Vec::new(),
-            level: if cfg!(debug_assertions) {
-                Level::Info
-            } else {
-                Level::Warn
-            },
+            level: DEFAULT_LOG_LEVEL.load(),
             clone_line_text: false,
             owned_strings: Vec::new(),
             line_column_tracker: None,
@@ -1448,7 +1444,7 @@ bun_core::comptime_string_map! {
 }
 
 // PORTING.md §Global mutable state: written by CLI startup, read by every
-// `Log::init()` (including from bundler worker threads). `AtomicCell<Level>`
+// `Log` constructor (including from bundler worker threads). `AtomicCell<Level>`
 // — Acquire/Release, no `unsafe` at call sites.
 pub static DEFAULT_LOG_LEVEL: bun_core::AtomicCell<Level> = bun_core::AtomicCell::new(Level::Warn);
 
@@ -1504,13 +1500,9 @@ impl Log {
         (self.warnings + self.errors) > 0
     }
 
+    #[inline]
     pub fn init() -> Log {
-        let level = DEFAULT_LOG_LEVEL.load();
-        Log {
-            msgs: Vec::new(),
-            level,
-            ..Default::default()
-        }
+        Log::default()
     }
 
     /// Alias of [`Log::init`].

--- a/test/cli/run/log-test.test.ts
+++ b/test/cli/run/log-test.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from "bun";
-import { expect, it } from "bun:test";
+import { expect, it, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 
 it("should not log .env when quiet", async () => {
@@ -32,3 +32,128 @@ it("should log .env by default", async () => {
 
   expect(stderr?.toString().includes(".env")).toBe(false);
 });
+
+// A Worker's VM gets its own Log. Its level has to be the one the process was
+// configured with, the same as the main thread's, in every build type.
+const logLevels: [name: string, bunfig: string, debug: boolean][] = [
+  ["the default log level", "", false],
+  ['logLevel = "error"', 'logLevel = "error"', false],
+  ['logLevel = "debug"', 'logLevel = "debug"', true],
+];
+
+// stderr is split at this marker: everything the main thread logs while it
+// starts up comes before it, everything the Worker logs comes after it.
+const marker = "--- main thread done ---\n";
+
+function splitAtMarker(stderr: string): [mainThread: string, worker: string] {
+  const index = stderr.indexOf(marker);
+  if (index === -1) throw new Error(`the main thread never printed the marker. stderr:\n${stderr}`);
+  return [stderr.slice(0, index), stderr.slice(index + marker.length)];
+}
+
+function countOccurrences(haystack: string, needle: string | RegExp): number {
+  return haystack.split(needle).length - 1;
+}
+
+test.concurrent.each(logLevels)(
+  "a Worker prints the .env files it loaded under %s exactly when the main thread does",
+  async (_, bunfig, debug) => {
+    using dir = tempDir("log-test-worker-env", {
+      ".env": "FOO=bar",
+      "bunfig.toml": bunfig,
+      "index.ts": `
+        console.error(${JSON.stringify(marker.trimEnd())});
+        const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+        worker.onmessage = ({ data }) => {
+          console.log(data);
+          worker.terminate();
+        };
+        worker.onerror = event => {
+          console.log("worker error: " + event.message);
+          worker.terminate();
+        };
+      `,
+      "worker.ts": `postMessage("worker sees FOO=" + process.env.FOO);`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const [mainThreadStderr, workerStderr] = splitAtMarker(stderr);
+    expect({
+      stdout,
+      mainThreadEnvLines: countOccurrences(mainThreadStderr, /"\.env"/),
+      workerEnvLines: countOccurrences(workerStderr, /"\.env"/),
+      exitCode,
+    }).toEqual({
+      stdout: "worker sees FOO=bar\n",
+      mainThreadEnvLines: debug ? 1 : 0,
+      workerEnvLines: debug ? 1 : 0,
+      exitCode: 0,
+    });
+  },
+);
+
+test.concurrent.each(logLevels)(
+  "fetch() inside a Worker prints the verbose request under %s exactly when the main thread does",
+  async (_, bunfig, debug) => {
+    await using server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("ok"),
+    });
+    const url = server.url.href;
+
+    using dir = tempDir("log-test-worker-fetch", {
+      "bunfig.toml": bunfig,
+      "index.ts": `
+        const response = await fetch(${JSON.stringify(url)});
+        console.log("main thread got " + (await response.text()));
+        console.error(${JSON.stringify(marker.trimEnd())});
+        const worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+        worker.onmessage = ({ data }) => {
+          console.log(data);
+          worker.terminate();
+        };
+        worker.onerror = event => {
+          console.log("worker error: " + event.message);
+          worker.terminate();
+        };
+      `,
+      "worker.ts": `
+        const response = await fetch(${JSON.stringify(url)});
+        postMessage("worker got " + (await response.text()));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.ts"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // The verbose dump is written by the HTTP thread before the response is
+    // handed to JS, so each thread's request line lands on its side of the marker.
+    const requestLine = `HTTP/1.1 GET ${url}`;
+    const [mainThreadStderr, workerStderr] = splitAtMarker(stderr);
+    expect({
+      stdout,
+      mainThreadRequestLines: countOccurrences(mainThreadStderr, requestLine),
+      workerRequestLines: countOccurrences(workerStderr, requestLine),
+      exitCode,
+    }).toEqual({
+      stdout: "main thread got ok\nworker got ok\n",
+      mainThreadRequestLines: debug ? 1 : 0,
+      workerRequestLines: debug ? 1 : 0,
+      exitCode: 0,
+    });
+  },
+);


### PR DESCRIPTION
### Problem

- A Worker's log level ignores bunfig `logLevel` and depends on the build type instead. With a `.env` in the cwd and `logLevel = "debug"`, a release build prints `[0.02ms] ".env"` for the main thread and nothing for the Worker; a debug or asan build prints that line for every Worker at the default level while the main thread stays quiet. With `logLevel = "debug"`, `fetch()` on the main thread dumps the request and response headers to stderr and `fetch()` inside a Worker prints nothing, in both build types.
- Cause: `bun_ast::Log` has two constructors that disagree. `Log::init()` reads `DEFAULT_LOG_LEVEL`, which `Arguments.rs:1673` fills from bunfig/CLI and which the main VM's `ctx.log` carries. `impl Default for Log` (`src/ast/lib.rs:1382`) hardcodes `Info` under `cfg!(debug_assertions)` and `Warn` otherwise.
- `VirtualMachine::init` boxes `Log::default()` when the caller passes no log (`src/jsc/VirtualMachine.rs:2348`). Every Worker does that (`web_worker.rs` passes `Options::default()` to `init_worker`), and so does the debugger thread's VM (`Debugger.rs:437`). The main thread passes `ctx.log`, which is why it behaves correctly.
- That VM log's level is what `Transpiler::init` turns into `env_loader.quiet` (`src/bundler/transpiler.rs:1254`), what `fetch()` reads to decide on verbose output (`src/runtime/webcore/fetch.rs:430`), and what decides which message kinds the VM log collects.
- Same pattern at the other `Log::default()` sites that consult the level: the resolve swap log in `VirtualMachine.rs:4576` (its twin in `jsc_hooks.rs:5432` already uses `init()`), `VirtualMachine.rs:5692`, `web_worker.rs:284`, and `Task::uninit()` in `src/install/PackageManagerTask.rs:66`, which three of the five install Task constructors rely on (the other two set `Log::init()` explicitly). In the Zig version all of these were `Log.init`, i.e. the configured level.

### Fix

- `impl Default for Log` reads `DEFAULT_LOG_LEVEL` too, and `Log::init()` delegates to it. A `Log` now starts at the level the process was configured with no matter how it was constructed.
- Why the constructor and not the call sites: nothing wants a level derived from the build type. Of the eight `Log::default()` callers, the placeholder logs (`parse_entry.rs`, `JSTranspiler.rs` where it is overwritten, `bundle_v2.rs` where the messages are pre-built) never consult the level, and every other one wants the configured level. Fixing the constructor fixes all of them at once and leaves no second constructor to pick by mistake; it also makes `Log::default()` and `Log::new()` agree, which is what Rust callers assume anyway.
- What changes for users: only which configuration selects which behaviour. For message collection `Info` and `Debug` gate identically (`Kind::should_print`), so a Worker under `logLevel = "debug"` collects exactly what debug builds collected before, and a Worker at the default level collects what release builds collected before. On top of that a Worker now prints the `.env` timing line and verbose `fetch()` output under `logLevel = "debug"` and drops warnings under `logLevel = "error"`, all matching the main thread. Hot reload verbosity reads the main VM's log and is unaffected; `DEFAULT_LOG_LEVEL` is stored during argument parsing, before any Worker or install Task exists.
- Test: `test/cli/run/log-test.test.ts`. Two new matrices (default level, `logLevel = "error"`, `logLevel = "debug"`) run a script that spawns a Worker and compare what the main thread and the Worker print, split at a marker the main thread writes before creating the Worker: the `".env"` timing line per thread, and the verbose request line per thread for one `fetch()` on each thread against a `port: 0` server in the test process. (The request line is matched without its `> ` marker; `print_request` currently drops it, which is being fixed separately.)
- Release `bun` (`USE_SYSTEM_BUN=1`): the two `logLevel = "debug"` rows fail, the Worker side reports 0. Unfixed debug build: the default and `"error"` `.env` rows fail (the Worker prints the line) and the fetch `"debug"` row fails. Fixed `bun bd`: 8/8, stable over 8 runs.
- Also run against the fixed build: `test/cli/run/env.test.ts`, the tsconfig `logLevel` tests in `test/cli/install/bun-run.test.ts`, `test/config/bunfig/bunfig-errors.test.ts`, the `logLevel` tests in `test/bundler/transpiler/transpiler.test.js`, `test/js/node/worker_threads/worker_threads.test.ts`, a few `test/cli/install` files that extract tarballs, `test/internal/source-lints`; all pass. `test/js/web/workers/worker.test.ts` passes except for the three timing-bound tests from #37075 that fail on every debug build (worker startup is about 160ms there), which are being addressed on their own.
- #37766 pins the old build-dependent Worker value in its own rows of this test file; once this lands those rows need to expect the main thread's value (its description already says so).

### Background

- `bun_ast::Log` collects diagnostics (errors, warnings, notes, debug messages) for the transpiler, resolver, bundler and each VM. Its `level` decides which kinds the `add_*` methods keep, and a few places read it directly as "how chatty should I be": the env loader's timing line, and `fetch()` for verbose output.
- `DEFAULT_LOG_LEVEL` is a process-wide atomic in `bun_ast`. It starts at `Warn`; `Arguments.rs` stores the bunfig/CLI `logLevel` into it during startup and patches the CLI log that was created earlier. Everything created afterwards through `Log::init()` (`Bun.build`, `Bun.Transpiler`, the per-module transpile logs) inherits it; until now anything created through `Default` did not.
- Each Worker runs its own `VirtualMachine` on its own thread. `VirtualMachine::init` either adopts a log the caller hands in (the CLI does this for the main thread, macros do it so their errors land in the bundle log) or boxes a fresh one; Workers and the debugger thread take the second path.

<details>
<summary>Repro output (main.ts creates a Worker that posts a message; cwd has a .env)</summary>

```
=== release, default level ===
main: start
main: got hi
=== release, logLevel=debug ===
[0.02ms] ".env"            <- main thread only
main: start
main: got hi
=== debug build, default level ===
main: start
[0.11ms] ".env"            <- Worker only
main: got hi
=== debug build, logLevel=debug ===
[0.13ms] ".env"
main: start
[0.12ms] ".env"
main: got hi
```

With this change both builds print the two lines under `logLevel = "debug"` and nothing otherwise. A Worker calling `fetch()` under `logLevel = "debug"` printed nothing on either build before; now it prints the same header dump the main thread prints.

</details>
