### PR TITLE
install: support name@version entries in minimumReleaseAgeExcludes

### DIFF
--- a/docs/pm/cli/install.mdx
+++ b/docs/pm/cli/install.mdx
@@ -277,9 +277,14 @@ You can also configure this in `bunfig.toml`:
 # Only install package versions published at least 3 days ago
 minimumReleaseAge = 259200 # seconds
 
-# Exclude trusted packages from the age gate
-minimumReleaseAgeExcludes = ["@types/node", "typescript"]
+# Exclude trusted packages, or individual versions you have vetted, from the age gate
+minimumReleaseAgeExcludes = ["@types/node", "typescript@5.4.5", "esbuild@0.21.4 || 0.21.5"]
 ```
+
+`minimumReleaseAgeExcludes` accepts two kinds of entries:
+
+- A package name (`"typescript"`) exempts every version of that package, including versions published in the future.
+- A package name followed by one or more exact versions (`"typescript@5.4.5"`, `"@types/node@20.11.0"`, `"esbuild@0.21.4 || 0.21.5"`) exempts only those versions. Other versions of the package still go through the age gate, so you can install a specific release early without disabling the gate for the package. Exempted versions are installed as-is: they also skip the stability check described below. Entries whose versions are not exact (`"typescript@^5"`, `"typescript@latest"`, `"typescript@"`) are ignored with a warning.
 
 When the minimum age filter is active:
 

--- a/docs/runtime/bunfig.mdx
+++ b/docs/runtime/bunfig.mdx
@@ -756,14 +756,16 @@ See [Minimum release age](/pm/cli/install#minimum-release-age).
 
 ### `install.minimumReleaseAgeExcludes`
 
-An array of package names that are exempt from the `minimumReleaseAge` check. Default `[]`.
+An array of packages that are exempt from the `minimumReleaseAge` check. A package name exempts every version of the package; `name@version` (or `name@1.0.0 || 1.0.1`) exempts only the listed exact versions. Default `[]`.
 
 ```toml title="bunfig.toml" icon="settings"
 [install]
 minimumReleaseAge = 259200
-# These packages will bypass the 3-day minimum age requirement
-minimumReleaseAgeExcludes = ["@types/bun", "typescript"]
+# Every version of @types/bun, and only typescript 5.4.5, bypass the 3-day minimum age requirement
+minimumReleaseAgeExcludes = ["@types/bun", "typescript@5.4.5"]
 ```
+
+See [Minimum release age](/pm/cli/install#minimum-release-age).
 
 ## `bun run`
 

--- a/src/install/PackageManager/PackageManagerEnqueue.rs
+++ b/src/install/PackageManager/PackageManagerEnqueue.rs
@@ -1068,15 +1068,18 @@ pub fn enqueue_dependency_with_main_and_success_fn(
                                                 if let Some(min_age_ms) =
                                                     this.options.minimum_release_age_ms
                                                 {
-                                                    if !loaded_manifest
-                                                        .as_ref()
-                                                        .unwrap()
-                                                        .should_exclude_from_age_filter(
-                                                            this.options.minimum_release_age_excludes,
-                                                        )
-                                                        && Npm::PackageManifest::is_package_version_too_recent(
-                                                            find_result.package, min_age_ms,
-                                                        )
+                                                    let manifest =
+                                                        loaded_manifest.as_ref().unwrap();
+                                                    let excludes =
+                                                        this.options.minimum_release_age_excludes;
+                                                    if !manifest
+                                                        .should_exclude_from_age_filter(excludes)
+                                                        && manifest
+                                                            .is_version_blocked_by_age_filter(
+                                                                find_result,
+                                                                min_age_ms,
+                                                                excludes,
+                                                            )
                                                     {
                                                         let package_name = this.lockfile.str(&name);
                                                         let min_age_seconds = min_age_ms / MS_PER_S;

--- a/src/install/PackageManager/PackageManagerOptions.rs
+++ b/src/install/PackageManager/PackageManagerOptions.rs
@@ -87,8 +87,8 @@ pub struct Options {
     // Minimum release age in ms (security feature)
     // Only install packages published at least N ms ago
     pub minimum_release_age_ms: Option<f64>,
-    // Packages to exclude from minimum release age checking
-    pub minimum_release_age_excludes: Option<&'static [&'static [u8]]>,
+    // Packages and package versions to exclude from minimum release age checking
+    pub minimum_release_age_excludes: Option<&'static Npm::MinimumReleaseAgeExcludes>,
 
     /// Override CPU architecture for optional dependencies filtering
     pub cpu: Npm::Architecture,
@@ -564,8 +564,9 @@ impl Options {
                     exclusions.iter().map(|e| leak_static(e)).collect();
                 // Parked for the lifetime of the install command (config arena
                 // equivalent), same as `leak_static` above.
-                self.minimum_release_age_excludes =
-                    Some(&*bun_core::heap::release(leaked.into_boxed_slice()));
+                self.minimum_release_age_excludes = Some(&*bun_core::heap::release(Box::new(
+                    Npm::MinimumReleaseAgeExcludes::parse(&leaked, log),
+                )));
             }
 
             // `PnpmMatcher` is move-only; `config` is `&` here so the matchers

--- a/src/install/audit_fix.rs
+++ b/src/install/audit_fix.rs
@@ -11,7 +11,7 @@ use bun_semver::{self as Semver, SlicedString};
 use crate::dependency::Behavior;
 use crate::lockfile::Lockfile;
 use crate::lockfile::package::PackageColumns as _;
-use crate::npm::PackageManifest;
+use crate::npm::{FindResult, PackageManifest};
 use crate::package_manager::Options::{Do, Enable, LogLevel};
 use crate::package_manager_real::enqueue_dependency_with_main;
 use crate::package_manager_real::populate_manifest_cache::{self, Packages};
@@ -846,9 +846,13 @@ pub fn plan_fixes(manager: &mut PackageManager, advisories: &[Advisory]) -> crat
                 edges,
                 downgrade: candidate.downgrade,
                 too_recent: age_limit.is_some_and(|limit| {
-                    PackageManifest::is_package_version_too_recent(
-                        &release_pkgs[candidate.index],
+                    manifest.is_version_blocked_by_age_filter(
+                        FindResult {
+                            version: candidate.version,
+                            package: &release_pkgs[candidate.index],
+                        },
                         limit,
+                        excludes,
                     )
                 }),
                 edits,
@@ -1199,18 +1203,16 @@ pub fn prepare_install(manager: &mut PackageManager, plan: &FixPlan) -> crate::R
     package_json_edits::apply(manager, plan)?;
 
     if plan.fixes.iter().any(|fix| fix.too_recent) {
-        let mut names: Vec<&'static [u8]> = manager
+        let mut excludes = manager
             .options
             .minimum_release_age_excludes
-            .map_or_else(Vec::new, <[_]>::to_vec);
-        names.extend(
-            plan.fixes
-                .iter()
-                .filter(|fix| fix.too_recent)
-                .map(|fix| &*bun_core::heap::release(fix.name.clone())),
-        );
+            .cloned()
+            .unwrap_or_default();
+        for fix in plan.fixes.iter().filter(|fix| fix.too_recent) {
+            excludes.exclude_package(bun_core::heap::release(fix.name.clone()));
+        }
         manager.options.minimum_release_age_excludes =
-            Some(&*bun_core::heap::release(names.into_boxed_slice()));
+            Some(&*bun_core::heap::release(Box::new(excludes)));
     }
 
     manager.audit_fix_pins = plan

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1517,22 +1517,16 @@ impl FindResult<'_> {
     }
 }
 
-/// `install.minimumReleaseAgeExcludes` from bunfig. Same entry grammar as
-/// pnpm's `minimumReleaseAgeExclude`: `"name"` exempts every version of the
-/// package from the age gate, `"name@1.2.3"` and `"name@1.2.3 || 1.2.4"`
-/// exempt only the listed versions.
+/// `minimumReleaseAgeExcludes` entries (pnpm grammar): `name` exempts a package, `name@1.2.3 || 1.2.4` only those versions.
 #[derive(Clone, Default)]
 pub struct MinimumReleaseAgeExcludes {
     packages: Vec<&'static [u8]>,
-    /// One element per listed version. Matched with `Version::eql`, which
-    /// compares the prerelease tag by hash, so no string buffer is kept.
+    /// Matched with `Version::eql`, which compares tags by hash, so no string buffer is kept.
     versions: Vec<(&'static [u8], Semver::Version)>,
 }
 
 impl MinimumReleaseAgeExcludes {
-    /// Entries whose version list is not exclusively exact versions are
-    /// dropped with a warning rather than widened into a whole-package
-    /// exclusion, so `"foo@"` or `"foo@^1"` never exempts more than intended.
+    /// A malformed entry (`foo@`, `foo@^1`) is dropped with a warning, never widened to the bare name.
     pub(crate) fn parse(
         entries: &[&'static [u8]],
         log: &mut bun_ast::Log,
@@ -1587,8 +1581,7 @@ impl MinimumReleaseAgeExcludes {
     }
 }
 
-/// Anything other than a single complete version (a range, a dist-tag, an
-/// empty string, trailing garbage) is rejected.
+/// Ranges, dist-tags, empty input, and trailing bytes are all rejected.
 fn parse_exact_version(spec: &[u8]) -> Option<Semver::Version> {
     let spec = strings::trim(spec, &strings::WHITESPACE_CHARS);
     let parsed = Semver::Version::parse_utf8(spec);
@@ -1669,8 +1662,7 @@ impl PackageManifest {
         exclusions.is_some_and(|excludes| excludes.excludes_version(self.name(), version))
     }
 
-    /// `is_package_version_too_recent`, unless `result.version` itself is
-    /// listed in `exclusions`.
+    /// Too recent for the gate and not listed in `exclusions`.
     pub(crate) fn is_version_blocked_by_age_filter(
         &self,
         result: FindResult<'_>,
@@ -1715,10 +1707,7 @@ impl PackageManifest {
             let version = versions[i];
             if group.satisfies(version, group_buf, &self.string_buf) {
                 let package = &packages[i];
-                // Excluded versions are handled like stable ones (`is_stable`
-                // below): no age gate, and they replace a newer `best_version`,
-                // which only ever holds an unstable fallback. Subjecting them to
-                // the stability check instead could walk past the listed version.
+                // Listed versions count as stable: no age gate, and they replace an unstable fallback in `best_version`.
                 if self.is_version_excluded_from_age_filter(version, exclusions) {
                     best_version = Some(FindResult { version, package });
                     break;

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1715,9 +1715,10 @@ impl PackageManifest {
             let version = versions[i];
             if group.satisfies(version, group_buf, &self.string_buf) {
                 let package = &packages[i];
-                // An explicitly excluded version is taken as-is: it skips the
-                // age gate and the stability check, which would otherwise walk
-                // past it to an older version.
+                // Excluded versions are handled like stable ones (`is_stable`
+                // below): no age gate, and they replace a newer `best_version`,
+                // which only ever holds an unstable fallback. Subjecting them to
+                // the stability check instead could walk past the listed version.
                 if self.is_version_excluded_from_age_filter(version, exclusions) {
                     best_version = Some(FindResult { version, package });
                     break;

--- a/src/install/npm.rs
+++ b/src/install/npm.rs
@@ -1517,6 +1517,90 @@ impl FindResult<'_> {
     }
 }
 
+/// `install.minimumReleaseAgeExcludes` from bunfig. Same entry grammar as
+/// pnpm's `minimumReleaseAgeExclude`: `"name"` exempts every version of the
+/// package from the age gate, `"name@1.2.3"` and `"name@1.2.3 || 1.2.4"`
+/// exempt only the listed versions.
+#[derive(Clone, Default)]
+pub struct MinimumReleaseAgeExcludes {
+    packages: Vec<&'static [u8]>,
+    /// One element per listed version. Matched with `Version::eql`, which
+    /// compares the prerelease tag by hash, so no string buffer is kept.
+    versions: Vec<(&'static [u8], Semver::Version)>,
+}
+
+impl MinimumReleaseAgeExcludes {
+    /// Entries whose version list is not exclusively exact versions are
+    /// dropped with a warning rather than widened into a whole-package
+    /// exclusion, so `"foo@"` or `"foo@^1"` never exempts more than intended.
+    pub(crate) fn parse(
+        entries: &[&'static [u8]],
+        log: &mut bun_ast::Log,
+    ) -> MinimumReleaseAgeExcludes {
+        let mut excludes = MinimumReleaseAgeExcludes::default();
+
+        for &entry in entries {
+            // Skip a scope's leading `@` so `@types/node@20.0.0` splits after the name.
+            let name_start = usize::from(strings::starts_with_char(entry, b'@'));
+            let Some(at) = strings::index_of_char_usize(&entry[name_start..], b'@') else {
+                excludes.exclude_package(entry);
+                continue;
+            };
+            let name = &entry[..name_start + at];
+            let specs = &entry[name_start + at + 1..];
+
+            let first_of_entry = excludes.versions.len();
+            for spec in strings::split(specs, b"||") {
+                let Some(version) = parse_exact_version(spec) else {
+                    excludes.versions.truncate(first_of_entry);
+                    log.add_warning_fmt(
+                        None,
+                        bun_ast::Loc::EMPTY,
+                        format_args!(
+                            "Ignoring minimumReleaseAgeExcludes entry {}: expected a package name or exact versions, e.g. \"{name}@1.2.3\" or \"{name}@1.2.3 || 1.2.4\"",
+                            bun_fmt::quote(entry),
+                            name = bstr::BStr::new(name),
+                        ),
+                    );
+                    break;
+                };
+                excludes.versions.push((name, version));
+            }
+        }
+
+        excludes
+    }
+
+    /// Exempts every version of `name`, like a bare bunfig entry.
+    pub(crate) fn exclude_package(&mut self, name: &'static [u8]) {
+        self.packages.push(name);
+    }
+
+    fn excludes_package(&self, name: &[u8]) -> bool {
+        self.packages.contains(&name)
+    }
+
+    fn excludes_version(&self, name: &[u8], version: Semver::Version) -> bool {
+        self.versions
+            .iter()
+            .any(|&(package, excluded)| package == name && excluded.eql(version))
+    }
+}
+
+/// Anything other than a single complete version (a range, a dist-tag, an
+/// empty string, trailing garbage) is rejected.
+fn parse_exact_version(spec: &[u8]) -> Option<Semver::Version> {
+    let spec = strings::trim(spec, &strings::WHITESPACE_CHARS);
+    let parsed = Semver::Version::parse_utf8(spec);
+    if !parsed.valid
+        || parsed.wildcard != Semver::query::Wildcard::None
+        || parsed.len as usize != spec.len()
+    {
+        return None;
+    }
+    Some(parsed.version.min())
+}
+
 impl PackageManifest {
     pub(crate) fn find_by_version(&self, version: Semver::Version) -> Option<FindResult<'_>> {
         let list = if !version.tag.has_pre() {
@@ -1569,20 +1653,36 @@ impl PackageManifest {
         None
     }
 
-    pub(crate) fn should_exclude_from_age_filter(&self, exclusions: Option<&[&[u8]]>) -> bool {
-        if let Some(excl) = exclusions {
-            let pkg_name = self.name();
-            for excluded in excl {
-                if pkg_name == *excluded {
-                    return true;
-                }
-            }
-        }
-        false
+    /// Whether every version of this package bypasses the minimum release age.
+    pub(crate) fn should_exclude_from_age_filter(
+        &self,
+        exclusions: Option<&MinimumReleaseAgeExcludes>,
+    ) -> bool {
+        exclusions.is_some_and(|excludes| excludes.excludes_package(self.name()))
+    }
+
+    fn is_version_excluded_from_age_filter(
+        &self,
+        version: Semver::Version,
+        exclusions: Option<&MinimumReleaseAgeExcludes>,
+    ) -> bool {
+        exclusions.is_some_and(|excludes| excludes.excludes_version(self.name(), version))
+    }
+
+    /// `is_package_version_too_recent`, unless `result.version` itself is
+    /// listed in `exclusions`.
+    pub(crate) fn is_version_blocked_by_age_filter(
+        &self,
+        result: FindResult<'_>,
+        minimum_release_age_ms: f64,
+        exclusions: Option<&MinimumReleaseAgeExcludes>,
+    ) -> bool {
+        Self::is_package_version_too_recent(result.package, minimum_release_age_ms)
+            && !self.is_version_excluded_from_age_filter(result.version, exclusions)
     }
 
     #[inline]
-    pub(crate) fn is_package_version_too_recent(
+    fn is_package_version_too_recent(
         package_version: &PackageVersion,
         minimum_release_age_ms: f64,
     ) -> bool {
@@ -1598,6 +1698,7 @@ impl PackageManifest {
         group: &Semver::query::Group,
         group_buf: &[u8],
         minimum_release_age_ms: f64,
+        exclusions: Option<&MinimumReleaseAgeExcludes>,
         newest_filtered: &mut Option<Semver::Version>,
     ) -> Option<FindVersionResult<'a>> {
         let mut prev_package_blocked_from_age: Option<&PackageVersion> = None;
@@ -1614,6 +1715,13 @@ impl PackageManifest {
             let version = versions[i];
             if group.satisfies(version, group_buf, &self.string_buf) {
                 let package = &packages[i];
+                // An explicitly excluded version is taken as-is: it skips the
+                // age gate and the stability check, which would otherwise walk
+                // past it to an older version.
+                if self.is_version_excluded_from_age_filter(version, exclusions) {
+                    best_version = Some(FindResult { version, package });
+                    break;
+                }
                 if Self::is_package_version_too_recent(package, minimum_release_age_ms) {
                     if newest_filtered.is_none() {
                         *newest_filtered = Some(version);
@@ -1707,7 +1815,7 @@ impl PackageManifest {
         &self,
         tag: &[u8],
         minimum_release_age_ms: Option<f64>,
-        exclusions: Option<&[&[u8]]>,
+        exclusions: Option<&MinimumReleaseAgeExcludes>,
     ) -> FindVersionResult<'_> {
         let Some(dist_result) = self.find_by_dist_tag(tag) else {
             return FindVersionResult::Err(FindVersionError::NotFound);
@@ -1726,8 +1834,7 @@ impl PackageManifest {
         let seven_days_ms: f64 = 7.0 * bun_core::time::MS_PER_DAY as f64;
         let stability_window_ms = min_age_ms.min(seven_days_ms);
 
-        let dist_too_recent = Self::is_package_version_too_recent(dist_result.package, min_age_ms);
-        if !dist_too_recent {
+        if !self.is_version_blocked_by_age_filter(dist_result, min_age_ms, exclusions) {
             return FindVersionResult::Found(dist_result);
         }
 
@@ -1782,6 +1889,12 @@ impl PackageManifest {
                 }
             }
 
+            // See `search_version_list`.
+            if self.is_version_excluded_from_age_filter(version, exclusions) {
+                best_version = Some(FindResult { version, package });
+                break;
+            }
+
             if Self::is_package_version_too_recent(package, min_age_ms) {
                 prev_package_blocked_from_age = Some(package);
                 continue;
@@ -1834,7 +1947,7 @@ impl PackageManifest {
         group: &Semver::query::Group,
         group_buf: &[u8],
         minimum_release_age_ms: Option<f64>,
-        exclusions: Option<&[&[u8]]>,
+        exclusions: Option<&MinimumReleaseAgeExcludes>,
     ) -> FindVersionResult<'_> {
         let min_age_gate_ms = match minimum_release_age_ms {
             Some(min_age_ms) if !self.should_exclude_from_age_filter(exclusions) => {
@@ -1857,7 +1970,7 @@ impl PackageManifest {
         if left.op == Semver::range::Op::Eql {
             let result = self.find_by_version(left.version);
             if let Some(r) = result {
-                if Self::is_package_version_too_recent(r.package, min_age_ms) {
+                if self.is_version_blocked_by_age_filter(r, min_age_ms, exclusions) {
                     return FindVersionResult::Err(FindVersionError::TooRecent);
                 }
                 return FindVersionResult::Found(r);
@@ -1867,7 +1980,7 @@ impl PackageManifest {
 
         if let Some(result) = self.find_by_dist_tag(b"latest") {
             if group.satisfies(result.version, group_buf, &self.string_buf) {
-                if Self::is_package_version_too_recent(result.package, min_age_ms) {
+                if self.is_version_blocked_by_age_filter(result, min_age_ms, exclusions) {
                     newest_filtered = Some(result.version);
                 }
                 if newest_filtered.is_none() {
@@ -1892,6 +2005,7 @@ impl PackageManifest {
             group,
             group_buf,
             min_age_ms,
+            exclusions,
             &mut newest_filtered,
         ) {
             return result;
@@ -1904,6 +2018,7 @@ impl PackageManifest {
                 group,
                 group_buf,
                 min_age_ms,
+                exclusions,
                 &mut newest_filtered,
             ) {
                 return result;

--- a/src/install/update_transitive.rs
+++ b/src/install/update_transitive.rs
@@ -12,7 +12,7 @@ use crate::dedupe;
 use crate::dependency::{self, Behavior};
 use crate::lockfile::package::PackageColumns as _;
 use crate::lockfile::{Lockfile, PackageIndexEntry};
-use crate::npm::PackageManifest;
+use crate::npm::{MinimumReleaseAgeExcludes, PackageManifest};
 use crate::package_manager::Options::LogLevel;
 use crate::package_manager::ROOT_PACKAGE_JSON_PATH;
 use crate::package_manager_real::populate_manifest_cache::{self, Packages};
@@ -1242,7 +1242,7 @@ fn later_than(
     manifest: &PackageManifest,
     v: Semver::Version,
     min_age: Option<f64>,
-    excludes: Option<&[&[u8]]>,
+    excludes: Option<&MinimumReleaseAgeExcludes>,
 ) -> Box<[u8]> {
     if v.tag.has_pre() {
         return Box::default();

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -1198,7 +1198,10 @@ pub struct ParseResult<T: VersionInt> {
     pub wildcard: Wildcard,
     pub valid: bool,
     pub version: Partial<T>,
-    pub(crate) len: u32,
+    /// Where parsing stopped. Less than the input length when the input has
+    /// trailing bytes that are not part of the version (whitespace, a range
+    /// operator, an invalid character).
+    pub len: u32,
 }
 
 impl<T: VersionInt> Default for ParseResult<T> {

--- a/src/semver/Version.rs
+++ b/src/semver/Version.rs
@@ -1198,9 +1198,7 @@ pub struct ParseResult<T: VersionInt> {
     pub wildcard: Wildcard,
     pub valid: bool,
     pub version: Partial<T>,
-    /// Where parsing stopped. Less than the input length when the input has
-    /// trailing bytes that are not part of the version (whitespace, a range
-    /// operator, an invalid character).
+    /// Where parsing stopped; shorter than the input when trailing bytes are not part of the version.
     pub len: u32,
 }
 

--- a/test/cli/install/bun-audit.test.ts
+++ b/test/cli/install/bun-audit.test.ts
@@ -2529,6 +2529,23 @@ describe("`bun audit fix`", () => {
     await expectInstall(dir, "--frozen-lockfile", "--minimum-release-age", "3153600000");
   });
 
+  test.concurrent("a fix version listed in minimumReleaseAgeExcludes is not newer than the gate", async () => {
+    await using server = startRegistry({ "a-dep": [adv("<1.0.4")] });
+    using dir = await setupVulnerableADep(server);
+    await writeBunfig(dir, server, undefined, { minimumReleaseAgeExcludes: ["a-dep@1.0.4"] });
+
+    const { stdout, stderr, exitCode } = await auditFix(dir, "--minimum-release-age", "3153600000");
+    expect(stdout).toContain("  ^ a-dep 1.0.2 -> 1.0.4");
+    expect(stdout).not.toContain("newer than --minimum-release-age");
+    expect(stdout).toContain("Fixed 1 vulnerability in 1 package");
+    expect(stderr).not.toContain("error:");
+    expect(exitCode).toBe(0);
+    expect(await lock(dir)).toContain('"a-dep@1.0.4"');
+    expect(await installedVersion(dir, "a-dep")).toBe("1.0.4");
+
+    await expectInstall(dir, "--frozen-lockfile", "--minimum-release-age", "3153600000");
+  });
+
   test.concurrent(
     "the lowest safe release is taken even when only it is newer than --minimum-release-age",
     async () => {

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1394,6 +1394,22 @@ describe("minimum-release-age", () => {
         expect(exitCode).toBe(0);
       });
 
+      // With a 1.2 day gate, 1.0.3 is blocked and 1.0.2 passes the gate but was
+      // released only 1 day before 1.0.3, so the walk keeps it as a fallback and
+      // continues; without an exemption it ends on 1.0.0. A listed 1.0.1 ends
+      // the walk there, taking precedence over the unstable fallback the same
+      // way a stable version does.
+      test.concurrent.each([
+        ["*", "range"],
+        ["latest", "dist-tag"],
+      ])("a listed version is preferred over a newer unstable fallback (%s dependency)", async (spec, label) => {
+        using dir = project(`fallback-${label}`, { "bugfix-package": spec }, 1.2, ["bugfix-package@1.0.1"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({ "bugfix-package": "bugfix-package@1.0.1" });
+        expect(exitCode).toBe(0);
+      });
+
       test.concurrent("dist-tag dependency falls back to a listed version", async () => {
         using dir = project("dist-tag-walk", { "bugfix-package": "latest" }, 1.8, ["bugfix-package@1.0.2"]);
         const { stderr, exitCode, resolved } = await install(String(dir));

--- a/test/cli/install/minimum-release-age.test.ts
+++ b/test/cli/install/minimum-release-age.test.ts
@@ -1,6 +1,8 @@
 import type { Server } from "bun";
 import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
 
 // These tests drive real `bun install` runs against a mock registry, which is
 // slow under the debug/ASAN build — give them the same generous timeout the
@@ -1279,6 +1281,214 @@ describe("minimum-release-age", () => {
       // regular-package should be filtered (2.1.0 not 3.0.0)
       expect(lockfile).toContain("regular-package@2.1.0");
       expect(lockfile).not.toContain("regular-package@3.0.0");
+    });
+
+    // https://github.com/oven-sh/bun/issues/28967: "name@version" entries exempt
+    // one version instead of every current and future version of the package.
+    //
+    // Fixture ages: excluded-package 1.0.0 (10d), 1.0.1 (12h, latest);
+    // @scope/scoped-package 1.0.0 (20d), 1.5.0 (8d), 2.0.0 (1d, latest);
+    // bugfix-package 1.0.0 (8d), 1.0.1 (2.5d), 1.0.2 (1.5d), 1.0.3 (12h, latest);
+    // canary-package 2.0.0-canary.3 (5d), canary.4 (2d), canary.5 (12h, dist-tag "canary").
+    describe("name@version entries", () => {
+      function project(
+        name: string,
+        dependencies: Record<string, string>,
+        minimumReleaseAgeDays: number,
+        minimumReleaseAgeExcludes: string[],
+      ) {
+        return tempDir(`exclusions-${name}`, {
+          "package.json": JSON.stringify({ dependencies }),
+          "bunfig.toml": Bun.TOML.stringify({
+            install: {
+              minimumReleaseAge: minimumReleaseAgeDays * SECONDS_PER_DAY,
+              minimumReleaseAgeExcludes,
+              registry: mockRegistryUrl,
+            },
+          }),
+        });
+      }
+
+      // Every project gets its own manifest cache so the resolution path a
+      // test exercises does not depend on which tests ran before it.
+      // --no-verify: the fixture manifests carry placeholder integrity values.
+      async function install(dir: string, { args = [] as string[], env = {} as Record<string, string> } = {}) {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "install", "--no-verify", ...args],
+          cwd: dir,
+          env: { ...bunEnv, BUN_INSTALL_CACHE_DIR: join(dir, ".bun-cache"), ...env },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+        const lockfile = Bun.file(join(dir, "bun.lock"));
+        let resolved: Record<string, string> | null = null;
+        if (await lockfile.exists()) {
+          const { packages } = Bun.JSONC.parse(await lockfile.text()) as { packages: Record<string, [string]> };
+          resolved = Object.fromEntries(Object.entries(packages).map(([name, [resolution]]) => [name, resolution]));
+        }
+        return { stderr, exitCode, resolved };
+      }
+
+      test.concurrent("exempts only the listed version", async () => {
+        using dir = project("pinned", { "excluded-package": "*", "regular-package": "*" }, 5, [
+          "excluded-package@1.0.1",
+        ]);
+        const { stderr, exitCode, resolved } = await install(String(dir), { args: ["--verbose"] });
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({
+          // Too recent for the gate, but listed.
+          "excluded-package": "excluded-package@1.0.1",
+          // Not listed: still gated (3.0.0 is 1 day old).
+          "regular-package": "regular-package@2.1.0",
+        });
+        // Installing a listed version is not a downgrade, so only
+        // regular-package is reported as filtered.
+        expect(stderr.split(/\r?\n/).filter(line => line.includes("[minimum-release-age]"))).toEqual([
+          `[minimum-release-age] regular-package@>=0.0.0 selected 2.1.0 instead of 3.0.0 due to ${5 * SECONDS_PER_DAY}-second filter`,
+        ]);
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("does not exempt other versions of the package", async () => {
+        using dir = project("other-version", { "excluded-package": "*" }, 5, ["excluded-package@0.9.0"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({ "excluded-package": "excluded-package@1.0.0" });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("scoped package", async () => {
+        using dir = project("scoped-pinned", { "@scope/scoped-package": "*" }, 5, ["@scope/scoped-package@2.0.0"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({ "@scope/scoped-package": "@scope/scoped-package@2.0.0" });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("bare scoped package name still exempts every version", async () => {
+        using dir = project("scoped-bare", { "@scope/scoped-package": "*" }, 5, ["@scope/scoped-package"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({ "@scope/scoped-package": "@scope/scoped-package@2.0.0" });
+        expect(exitCode).toBe(0);
+      });
+
+      // With a 1.8 day gate and no exemption, bugfix-package resolves to 1.0.0:
+      // 1.0.3 and 1.0.2 are too recent, 1.0.1 passes the gate but was released
+      // only 1 day after 1.0.2 so the stability check walks on to 1.0.0.
+      test.concurrent("a listed version that is too recent is installed", async () => {
+        using dir = project("too-recent", { "bugfix-package": "*" }, 1.8, ["bugfix-package@1.0.2"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({ "bugfix-package": "bugfix-package@1.0.2" });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("a listed version that passes the gate is not skipped by the stability check", async () => {
+        using dir = project("stability", { "bugfix-package": "*" }, 1.8, ["bugfix-package@1.0.1"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({ "bugfix-package": "bugfix-package@1.0.1" });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("dist-tag dependency falls back to a listed version", async () => {
+        using dir = project("dist-tag-walk", { "bugfix-package": "latest" }, 1.8, ["bugfix-package@1.0.2"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({ "bugfix-package": "bugfix-package@1.0.2" });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("dist-tag dependency pointing at a listed version", async () => {
+        using dir = project("dist-tag-target", { "excluded-package": "latest" }, 5, ["excluded-package@1.0.1"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({ "excluded-package": "excluded-package@1.0.1" });
+        expect(exitCode).toBe(0);
+      });
+
+      // Without the exemption the "canary" tag (canary.5) is too recent and the
+      // walk lands on canary.3, see "filters canary versions correctly".
+      test.concurrent("prerelease version", async () => {
+        using dir = project("prerelease", { "canary-package": "canary" }, 3, ["canary-package@2.0.0-canary.4"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({ "canary-package": "canary-package@2.0.0-canary.4" });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("exact dependency on a listed version", async () => {
+        using dir = project("exact", { "excluded-package": "1.0.1" }, 5, ["excluded-package@1.0.1"]);
+
+        const first = await install(String(dir));
+        expect(first.stderr).not.toContain("error:");
+        expect(first.resolved).toEqual({ "excluded-package": "excluded-package@1.0.1" });
+        expect(first.exitCode).toBe(0);
+
+        // The first install cached the manifest. With manifest cache-control
+        // disabled (BUN_MANIFEST_CACHE=1) the cached copy counts as expired, and
+        // an exact version found in an expired cached manifest is resolved
+        // before any registry request, through a separate age check.
+        rmSync(join(String(dir), "bun.lock"));
+        rmSync(join(String(dir), "node_modules"), { recursive: true });
+        const second = await install(String(dir), { env: { BUN_MANIFEST_CACHE: "1" } });
+        expect(second.stderr).not.toContain("error:");
+        expect(second.resolved).toEqual({ "excluded-package": "excluded-package@1.0.1" });
+        expect(second.exitCode).toBe(0);
+      });
+
+      test.concurrent("exact dependency on a version that is not listed is still blocked", async () => {
+        using dir = project("exact-blocked", { "excluded-package": "1.0.1" }, 5, ["excluded-package@1.0.0"]);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).toContain(`blocked by minimum-release-age: ${5 * SECONDS_PER_DAY} seconds`);
+        expect(resolved).toBeNull();
+        expect(exitCode).toBe(1);
+      });
+
+      test.concurrent("several versions joined with ||", async () => {
+        using dir = project(
+          "union",
+          { "bugfix-package": "*", "@scope/scoped-package": "*" },
+          1.8,
+          // The version that matters is last in one entry and first in the
+          // other, so both halves of each entry have to be honored.
+          ["bugfix-package@1.0.1 || 1.0.2", "@scope/scoped-package@2.0.0||1.0.0"],
+        );
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(resolved).toEqual({
+          "bugfix-package": "bugfix-package@1.0.2",
+          "@scope/scoped-package": "@scope/scoped-package@2.0.0",
+        });
+        expect(exitCode).toBe(0);
+      });
+
+      test.concurrent("entries that are not exact versions are ignored with a warning", async () => {
+        const entries = [
+          "excluded-package@",
+          "excluded-package@latest",
+          "excluded-package@^1.0.0",
+          "excluded-package@1.x",
+          "excluded-package@1.0.1 || ^1.0.0",
+          "excluded-package@1.0.1 junk",
+        ];
+        using dir = project("malformed", { "excluded-package": "*" }, 5, entries);
+        const { stderr, exitCode, resolved } = await install(String(dir));
+        expect(stderr).not.toContain("error:");
+        expect(stderr.split(/\r?\n/).filter(line => line.includes("minimumReleaseAgeExcludes"))).toEqual(
+          entries.map(
+            entry =>
+              `warn: Ignoring minimumReleaseAgeExcludes entry "${entry}": expected a package name or exact versions, e.g. "excluded-package@1.2.3" or "excluded-package@1.2.3 || 1.2.4"`,
+          ),
+        );
+        // "excluded-package@" must not turn into a whole-package exemption, and
+        // the 1.0.1 in the rejected entries must not be honored either.
+        expect(resolved).toEqual({ "excluded-package": "excluded-package@1.0.0" });
+        expect(exitCode).toBe(0);
+      });
     });
   });
 


### PR DESCRIPTION
Replaces #28970, which implemented this in the Zig sources that no longer exist. Closes #28967.

### Problem
- `install.minimumReleaseAgeExcludes` only accepts package names, and a name exempts every current and future version of that package from `minimumReleaseAge`. To install one vetted version early, users have to turn the gate off for the whole package and remember to turn it back on (#28967).
- `PackageManifest::should_exclude_from_age_filter` (`src/install/npm.rs`) compares the manifest name against each entry, so `"typescript@5.4.5"` today silently matches nothing.

### Fix
- Entries may now be `name`, `name@1.2.3`, or `name@1.2.3 || 1.2.4` (the grammar pnpm uses for `minimumReleaseAgeExclude`). A bare name behaves exactly as before; versioned entries exempt only the listed versions, and other versions of the same package stay gated.
- `Options::load` parses the list once into `Npm::MinimumReleaseAgeExcludes` (bare names, plus one `(name, Version)` per listed version). The find functions take `Option<&MinimumReleaseAgeExcludes>` instead of `Option<&[&[u8]]>`; `bun outdated`, `bun update` (including `update_transitive.rs`, where only the `later_than` helper's parameter type changes), `bun update -i`, and `format_later_version_in_cache` pass the options field through and pick the behavior up.
- An entry whose version part is not made only of exact versions (`foo@`, `foo@^1`, `foo@latest`, `foo@1.0.0 || ^1`) is dropped and logged as a warning. It never falls back to a bare name, so a typo cannot widen an exemption. The split happens at the first `@` after the scope, so `@types/node@20.0.0` works; `Dependency::split_name_and_maybe_version` was not reused because it turns `foo@` into the bare name `foo`.
- Versions are matched with `Version::eql` (major.minor.patch plus the prerelease tag hash, build metadata ignored), the same comparison `find_by_version` uses for exact dependencies. `parse_exact_version` requires `Version::parse` to be valid, wildcard free, and to consume the whole trimmed string; for that, `ParseResult::len` in `bun_semver` becomes `pub`.
- The age gate is consulted for a single version in five places: dist-tag target in `find_by_dist_tag_with_filter`, the exact branch and the `latest` fast path in `find_best_version_with_filter`, the cached-manifest exact-version path in `PackageManagerEnqueue.rs`, and the `too_recent` flag in `audit_fix::plan_fixes`. All five now call `is_version_blocked_by_age_filter`, which is `is_package_version_too_recent && !listed`, and `is_package_version_too_recent` itself becomes private. The `latest` fast path matters for reporting: without it a listed `latest` is still installed but reported as filtered (`--verbose` prints "selected 1.0.1 instead of 1.0.1", `bun outdated` marks it). For `bun audit fix` it means a fix whose exact version is listed is neither annotated "(newer than --minimum-release-age)" nor given the temporary whole-package exemption; fixes that are not listed keep today's behavior.
- `bun audit fix` builds that temporary exemption by extending the configured list, so the struct derives `Clone` and `Default` and exposes `exclude_package`; `prepare_install` clones the configured excludes, adds the fixed package names, and parks the result the same way `Options::load` does.
- The two version walks (`search_version_list` and the loop in `find_by_dist_tag_with_filter`) return a listed version as soon as they reach it, before the age check and the stability check. Treating a listed version as merely "not too recent" is not enough: the stability check would see it was published shortly after a blocked version and walk on to an older release, so the user would list `1.0.2` and get `1.0.0` (the leapfrog case found in review of #28970). The same rule means a listed version replaces a newer version the walk was only holding as an unstable fallback, exactly as a stable version does; guarding that assignment instead would install the fallback, a version the unlisted walk itself rejects (worked example in the resolved review thread, pinned by the two "preferred over a newer unstable fallback" tests).
- Tests: `test/cli/install/minimum-release-age.test.ts` gains an `exclusions > name@version entries` block (15 tests; on the released bun 12 fail and the 3 backwards-compatibility / negative cases pass; the file passes 64/64 with this change). `test/cli/install/bun-audit.test.ts` gains one test for the listed fix version, which fails on current main with the annotation printed. Each changed site has a test aimed at it; the `latest` fast path and the enqueue fast path were additionally confirmed by reverting that site alone (the enqueue path is reached by a second install with `BUN_MANIFEST_CACHE=1`, which makes the cached manifest count as expired). After rebasing onto current main: `minimum-release-age`, `bun-audit`, `bun-update-transitive`, and `bun-update` pass together (577 tests), plus `test/internal/source-lints`, `cargo clippy -p bun_install -p bun_semver`, and `cargo fmt --check`.
- Docs updated in `docs/pm/cli/install.mdx` and `docs/runtime/bunfig.mdx`.

### Background
- `minimumReleaseAge` makes `bun install` skip npm versions published less than N seconds ago, using the per-version `time` data from the registry manifest. `minimumReleaseAgeExcludes` (bunfig only, no CLI flag) lists exemptions.
- Stability check: when the newest matching version is blocked by the gate, bun walks to older versions and also skips versions released within the gate window of a blocked version (rapid re-releases are treated as unstable), for up to 7 days past the gate. The walk lives in `search_version_list` (ranges) and `find_by_dist_tag_with_filter` (tags such as `latest`). While walking it keeps the newest unstable version as a fallback in `best_version` and replaces it when it reaches a stable one.
- `FindVersionResult::FoundWithFilter { newest_filtered }` records that a newer version was skipped; it drives the `--verbose` "selected X instead of Y" line and the asterisk in `bun outdated`. A listed version only produces it when something newer than it was actually filtered.
- `bun audit fix` (new on main since this PR was opened) picks the lowest safe release for each vulnerable package; if that release is newer than the gate it marks the fix `too_recent`, prints the annotation, and adds the package to the excludes for the install it then runs, so the fix can be installed anyway.
- `Semver::Version` stores prerelease and build tags as `ExternalString`s, which are offsets into whichever buffer the version was parsed from plus a content hash. `Version::eql` compares by hash, which is why the listed versions can be compared against manifest versions without carrying a string buffer around.
- `Options` fields are process-lifetime data; this keeps the existing `leak_static` / `heap::release` pattern the old `&'static [&'static [u8]]` field used, so the field stays `Copy` for the callers that copy it into a local.

<details>
<summary>Rebase onto current main (replaces the earlier merge commit)</summary>

- `src/install/npm.rs`: textual conflict only; main added `impl FindResult` (`tarball_url`) at the spot where this PR adds `MinimumReleaseAgeExcludes`, both kept.
- `src/install/audit_fix.rs` (new on main): compiled against the old slice type. `plan_fixes` now uses `is_version_blocked_by_age_filter`; `prepare_install` uses `Clone` + `exclude_package` instead of copying a slice. Behavior for unlisted fixes is unchanged and still covered by the existing audit tests.
- `src/install/update_transitive.rs` (new on main): `later_than` takes `Option<&MinimumReleaseAgeExcludes>`; no behavior change.

</details>

<details>
<summary>Fail-before output (released bun, minimum-release-age tests only)</summary>

```
$ USE_SYSTEM_BUN=1 bun test test/cli/install/minimum-release-age.test.ts -t "name@version entries"
(pass) ... exact dependency on a version that is not listed is still blocked
(fail) ... exact dependency on a listed version
(fail) ... a listed version that is too recent is installed
(pass) ... does not exempt other versions of the package
(fail) ... exempts only the listed version
(fail) ... dist-tag dependency pointing at a listed version
(fail) ... scoped package
(fail) ... dist-tag dependency falls back to a listed version
(fail) ... prerelease version
(fail) ... a listed version that passes the gate is not skipped by the stability check
(fail) ... a listed version is preferred over a newer unstable fallback (* dependency)
(fail) ... a listed version is preferred over a newer unstable fallback (latest dependency)
(fail) ... entries that are not exact versions are ignored with a warning
(pass) ... bare scoped package name still exempts every version
(fail) ... several versions joined with ||
```

</details>

<details>
<summary>Warning for a rejected entry</summary>

```
warn: Ignoring minimumReleaseAgeExcludes entry "typescript@^5": expected a package name or exact versions, e.g. "typescript@1.2.3" or "typescript@1.2.3 || 1.2.4"
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 4 · 10 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 13 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-audit.test.ts test/cli/install/minimum-release-age.test.ts
bun test v1.4.0 (8326d1bd3)

test/cli/install/minimum-release-age.test.ts:
(pass) minimum-release-age > basic filtering > filters packages by minimum release age [253.36ms]
(pass) minimum-release-age > basic filtering > respects float values for days [153.89ms]
(pass) minimum-release-age > basic filtering > handles exact version requests [155.64ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes and selects stable version [189.76ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes with dist-tag (latest) [157.04ms]
(pass) minimum-release-age > stability checks > gives up after searching 7 days beyond age gate [186.02ms]
(pass) minimum-release-age > prerelease handling > filters canary versions correctly [179.39ms]
(pass) minimum-release-age > prerelease handling > compares only base prerelease tag (canary vs beta) [151.35ms]
(pass) minimum-release-age > prerelease handling > handles latest with prerelease dist-tag
... (truncated)

release without fix: 13 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/cli/install/minimum-release-age.test.ts:
(pass) minimum-release-age > basic filtering > filters packages by minimum release age [8.14ms]
(pass) minimum-release-age > basic filtering > respects float values for days [4.06ms]
(pass) minimum-release-age > basic filtering > handles exact version requests [3.03ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes and selects stable version [5.03ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes with dist-tag (latest) [3.63ms]
(pass) minimum-release-age > stability checks > gives up after searching 7 days beyond age gate [4.86ms]
(pass) minimum-release-age > prerelease handling > filters canary versions correctly [4.60ms]
(pass) minimum-release-age > prerelease handling > compares only base prerelease tag (canary vs beta) [3.79ms]
(pass) minimum-release-age > prerelease handling > handles latest with prerelease dist-tag [3.97ms]
(pass) minimum-release-age > 7-day give-up threshold > stops searching after 7 days beyond minimum age [4.92ms]
(pass) minimum-release-age > 7-day give-up threshold > with daily releases, gets the latest within
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/cli/install/bun-audit.test.ts test/cli/install/minimum-release-age.test.ts
bun test v1.4.0 (8326d1bd3)

test/cli/install/minimum-release-age.test.ts:
(pass) minimum-release-age > basic filtering > filters packages by minimum release age [264.16ms]
(pass) minimum-release-age > basic filtering > respects float values for days [159.97ms]
(pass) minimum-release-age > basic filtering > handles exact version requests [158.18ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes and selects stable version [194.50ms]
(pass) minimum-release-age > stability checks > detects rapid bugfixes with dist-tag (latest) [457.82ms]
(pass) minimum-release-age > stability checks > gives up after searching 7 days beyond age gate [191.41ms]
(pass) minimum-release-age > prerelease handling > filters canary versions correctly [202.52ms]
(pass) minimum-release-age > prerelease handling > compares only base prerelease tag (canary vs beta) [152.24ms]
(pass) minimum-release-age > prerelease handling > handles latest with prerelease dist-tag
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     cdc114e586
  features     baseline

22 deps, 120 codegen, 1174 objects in 711ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1236] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 26 installs across 63 packages (no changes) [8.00ms]
[2/1236] gen ErrorCode+*.h
[3/1236] gen bindgenv2
[4/1236] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1236] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 111 installs across 104 packages (no changes) [6.00ms]
[6/1236] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1236] fetch zlib
[zlib] up to date
[8/1236] fetch tinycc
[tinycc] up to date
[9/1235] gen .bind.ts → GeneratedBindings.cpp
[10/1235] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[11/1235] gen ProcessBindingConstants.lut.h
Gene
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
docs/pm/cli/install.mdx                            |   9 +-
 docs/runtime/bunfig.mdx                            |   8 +-
 .../PackageManager/PackageManagerEnqueue.rs        |  21 +-
 .../PackageManager/PackageManagerOptions.rs        |   9 +-
 src/install/audit_fix.rs                           |  26 +--
 src/install/npm.rs                                 | 139 +++++++++++--
 src/install/update_transitive.rs                   |   4 +-
 src/semver/Version.rs                              |   3 +-
 test/cli/install/bun-audit.test.ts                 |  17 ++
 test/cli/install/minimum-release-age.test.ts       | 226 +++++++++++++++++++++
 10 files changed, 412 insertions(+), 50 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 4

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
docs/pm/cli/install.mdx                                  1      1      0
docs/runtime/bunfig.mdx                                  1      1      0
src/install/PackageManager/PackageManagerEnqueue.rs      6      3      0
src/install/PackageManager/PackageManagerOptions.rs      2      2      0
src/install/audit_fix.rs                                 2      3      0
src/install/npm.rs                                      12     23      0
src/install/update_transitive.rs                         1      2      0
src/semver/Version.rs                                    7      4      0
test/cli/install/bun-audit.test.ts                       1      2      0
test/cli/install/minimum-release-age.test.ts             9     14      0
```

</details>

<!-- robobun:evidence:end -->