### PR TITLE
response.test: reach the stack limit without creating a Response per frame

### DIFF
--- a/test/js/web/fetch/response.test.ts
+++ b/test/js/web/fetch/response.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { normalizeBunSnapshot } from "harness";
+import { normalizeBunSnapshot, tempDir } from "harness";
+import { join } from "node:path";
 
 test("zero args returns an otherwise empty 200 response", () => {
   const response = new Response();
@@ -47,9 +48,12 @@ describe("2-arg form", () => {
 });
 
 test("print size", () => {
-  expect(normalizeBunSnapshot(Bun.inspect(new Response(Bun.file(import.meta.filename)))), import.meta.dir)
-    .toMatchInlineSnapshot(`
-    "Response (8.0 KB) {
+  // The size is read from the file on disk, so use a fixture with a fixed size
+  // instead of this test file, whose size changes with every edit.
+  using dir = tempDir("response-print-size", { "body.js": "export default 1;\n" });
+  const response = new Response(Bun.file(join(String(dir), "body.js")));
+  expect(normalizeBunSnapshot(Bun.inspect(response), String(dir))).toMatchInlineSnapshot(`
+    "Response (18 bytes) {
       ok: true,
       url: "",
       status: 200,
@@ -59,7 +63,7 @@ test("print size", () => {
       },
       redirected: false,
       bodyUsed: false,
-      FileRef ("<cwd>/test/js/web/fetch/response.test.ts") {
+      FileRef ("<dir>/body.js") {
         type: "text/javascript;charset=utf-8"
       }
     }"
@@ -149,18 +153,28 @@ test("new Response(123, { method: 456 }) does not throw", () => {
   expect(() => new Response("123", { method: 456 })).not.toThrow();
 });
 
-test("handle stack overflow", () => {
-  function f0(a1, a2) {
-    const v4 = new Response();
-    // @ts-ignore
-    const v5 = v4.text(a2, a2, v4, f0, f0);
-    a1(a1); // Recursive call causes stack overflow
-    return v5;
+test("handle stack overflow", async () => {
+  // #23961: a native promise-returning method called with the JS stack
+  // exhausted must still hand back a promise instead of leaking the overflow.
+  // Recurse with cheap frames until the stack runs out, then create the
+  // Responses from the deepest frames on the way back out. Creating one in
+  // every frame instead takes several seconds on a debug build.
+  const overflows: unknown[] = [];
+  const texts: Promise<string>[] = [];
+  function recurse() {
+    try {
+      recurse();
+    } catch (e) {
+      overflows.push(e);
+    }
+    if (texts.length < 32) {
+      texts.push(new Response().text());
+    }
   }
-  expect(() => {
-    // @ts-ignore
-    f0(f0);
-  }).toThrow("Maximum call stack size exceeded.");
+  recurse();
+
+  expect(overflows.map(String)).toEqual(["RangeError: Maximum call stack size exceeded."]);
+  expect(await Promise.all(texts)).toEqual(new Array(32).fill(""));
 });
 
 describe("clone()", () => {


### PR DESCRIPTION
### Problem
- `bun bd test test/js/web/fetch/response.test.ts` fails on main: `(fail) handle stack overflow` / `this test timed out after 5000ms`. The test takes 5 to 8 seconds on a debug build (~365ms on the release binary), so the file is not a usable pass/fail signal for changes to Response when run the way CLAUDE.md says to.
- The test (added in #23961) creates a `Response` and calls `.text()` in every frame of a recursion that only overflows after ~26k frames (`test/js/web/fetch/response.test.ts:152` on main). A debug build spends ~0.2ms per frame in the constructor and `text()`, which is where the time goes.
- CI does not see this because `scripts/runner.node.mjs` passes a much larger per-test timeout.
- Same file, second source of spurious diffs: `print size` inspects `Bun.file(import.meta.filename)`, so its inline snapshot encodes the byte size of the test file itself and has had to be bumped by every change to this file so far (6 of 6, and again by this one).

### Fix
- `handle stack overflow` now recurses with empty frames, catches the overflow in the deepest frame, and calls `new Response().text()` only from the 32 deepest frames on the way back out. It asserts that exactly one `RangeError: Maximum call stack size exceeded.` was thrown and that all 32 promises resolve to `""`.
- This keeps what #23961 needs: the deepest frame is, by construction, the one where the JS stack is exhausted (its own recursive call just failed the stack check), so the native `text()` path runs with no JS stack left in each of those frames. The old shape only reached that state in the last few of its ~26k frames; the rest were padding.
- Host calls do not check the JS stack limit themselves, so the number of caught errors is deterministic. Checked with the JIT disabled and with `ulimit -s 1024` and `unlimited` as well.
- The old test only asserted that something threw the overflow message; it never looked at what `text()` returned in the frames at the limit. The new one does.
- For what it is worth, on the JSC we ship today neither shape reaches the exact branch #23961 added: `JSPromise::resolvedPromise` is now plain C++ for a non-object result (`vendor/WebKit/Source/JavaScriptCore/runtime/JSPromise.cpp`, `promiseResolve` -> `resolvePromise` -> `fulfillPromise`) and cannot throw there, so on main `text()` in the deepest frames returns fulfilled promises too (checked with `Bun.peek.status` on both builds), and the only overflow the old test saw came from its own JS recursion. What both shapes verify is that the native path survives being called with the JS stack exhausted; the new one does it at the deepest frame deterministically and checks the promises it gets back.
- `print size` inspects a fixture of fixed size in a `tempDir` instead of the test file, so the snapshot stops depending on this file's length. (It also passes the directory to `normalizeBunSnapshot`; before, `import.meta.dir` was being passed to `expect()` by mistake, and the `<cwd>` replacement happened to cover for it.)
- Verified: `bun bd test test/js/web/fetch/response.test.ts` passes 23/23. `handle stack overflow` takes 36 to 51ms on the debug build and 4 to 7ms on release. 10 debug runs and 30 release runs of the file, all green.
- Related: #32044 fattens this test's frames as a side change of an unrelated fix (still ~600 Response allocations per run, ~0.6s on debug); #37893 bumps the `print size` snapshot. Both hunks conflict trivially with this.

### Background
- JSC checks the stack limit in the prologue of every JS function. When a call fails that check it throws `RangeError: Maximum call stack size exceeded.` into the caller, which is left intact and can catch it. Calls from JS into host (native) functions such as the `Response` constructor and `Response.prototype.text` do not perform that check; they run in the stack space JSC keeps in reserve below the JS limit. That is why the deepest frame can still create a Response after catching the overflow, and why doing it there exercises "native promise-returning method called with the JS stack exhausted", the condition #23961 was about.
- `JSPromise.wrap` (`src/jsc/JSPromise.rs`, backed by `JSC__JSPromise__wrap` in `src/jsc/bindings/bindings.cpp`) is the path `text()` takes on an empty body: it runs the native body conversion and wraps the result in a promise. #23961 made it convert an exception raised while creating that promise into a rejected promise instead of leaving it pending.

<details>
<summary>Measurements (debug build in this container)</summary>

`bun bd test test/js/web/fetch/response.test.ts -t "handle stack overflow"` on main: 7560ms, reported as `this test timed out after 5000ms`. The report that prompted this saw 8029ms, 7655ms and 5081ms on another machine. The recursion alone, run as a script with the debug binary: 7288ms, 5254ms, 4936ms.

Cost of different test shapes, same debug binary:

```
shape                                              debug     release
Response + text() in every frame (main)            5231 ms    16 ms
try/finally in every frame, 32 allocations         1518 ms     7 ms
catch in deepest frame, 32 allocations (this PR)     44 ms     5 ms
plain recursion, no allocations                     278 ms     4 ms
```
</details>
