### PR TITLE
css: report parser warnings with 1-based line numbers

### DIFF
--- a/src/ast/lib.rs
+++ b/src/ast/lib.rs
@@ -1862,23 +1862,13 @@ impl Log {
         )
     }
 
+    /// For producers that already know the (1-based) line and column of the
+    /// warning but have no `Source` to compute a `Range` against, such as the
+    /// CSS parser.
     #[cold]
-    pub fn add_warning_fmt_line_col(
+    pub fn add_warning_fmt_with_location(
         &mut self,
-        filepath: Str,
-        line: u32,
-        col: u32,
-        args: fmt::Arguments<'_>,
-    ) {
-        self.add_warning_fmt_line_col_with_notes(filepath, line, col, args, Box::default())
-    }
-
-    #[cold]
-    pub fn add_warning_fmt_line_col_with_notes(
-        &mut self,
-        filepath: Str,
-        line: u32,
-        col: u32,
+        location: Location,
         args: fmt::Arguments<'_>,
         notes: Box<[Data]>,
     ) {
@@ -1887,18 +1877,9 @@ impl Log {
         }
         self.warnings += 1;
 
-        // TODO: do this properly
-
         let data = Data {
             text: alloc_print(args),
-            location: Some(Location {
-                // `Location.file` borrows the lifetime-erased `Str`; see the
-                // module-level OWNERSHIP note.
-                file: Cow::Borrowed(filepath),
-                line: i32::try_from(line).expect("int cast"),
-                column: i32::try_from(col).expect("int cast"),
-                ..Default::default()
-            }),
+            location: Some(location),
         }
         .clone_line_text(self.clone_line_text);
 

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -153,15 +153,6 @@ impl VendorPrefix {
 pub use crate::SourceLocation;
 
 impl SourceLocation {
-    pub(crate) fn to_logger_location(self, file: &'static [u8]) -> bun_ast::Location {
-        bun_ast::Location {
-            file: std::borrow::Cow::Borrowed(file),
-            line: i32::try_from(self.line).expect("int cast"),
-            column: i32::try_from(self.column).expect("int cast"),
-            ..Default::default()
-        }
-    }
-
     /// Create a new BasicParseError at this location for an unexpected token
     pub(crate) fn new_basic_unexpected_token_error(self, token: Token) -> ParseError<ParserError> {
         BasicParseError {
@@ -2941,41 +2932,38 @@ pub struct ParserOptions<'a> {
 }
 
 impl<'a> ParserOptions<'a> {
-    pub(crate) fn warn(&self, warning: &ParseError<ParserError>) {
-        if let Some(lg) = self.logger {
-            // SAFETY: `logger` was constructed from a unique `&'a mut Log` (see
-            // `default`); the pointee outlives `'a` and no other borrow of the
-            // Log exists for the duration of parsing.
-            let lg: &mut Log = unsafe { &mut *lg.as_ptr() };
-            lg.add_warning_fmt_line_col(
-                self.filename,
-                warning.location.line,
-                warning.location.column,
-                format_args!("{}", warning.kind),
-            );
+    /// Every warning (and warning note) crosses into the logger through here,
+    /// like errors do through `ErrorLocation::to_location`: `SourceLocation`
+    /// lines are 0-based, `bun_ast::Location` lines are 1-based.
+    pub(crate) fn logger_location(&self, loc: SourceLocation) -> bun_ast::Location {
+        bun_ast::Location {
+            file: std::borrow::Cow::Borrowed(self.filename),
+            line: i32::try_from(loc.line + 1).expect("int cast"),
+            column: i32::try_from(loc.column).expect("int cast"),
+            ..Default::default()
         }
     }
 
-    pub(crate) fn warn_fmt(&self, args: fmt::Arguments<'_>, line: u32, column: u32) {
-        if let Some(lg) = self.logger {
-            // SAFETY: see `warn` — `logger` carries `*mut Log` provenance from a
-            // unique `&'a mut Log`; no other borrow exists during this call.
-            let lg: &mut Log = unsafe { &mut *lg.as_ptr() };
-            lg.add_warning_fmt_line_col(self.filename, line, column, args);
-        }
+    pub(crate) fn warn(&self, warning: &ParseError<ParserError>) {
+        self.warn_fmt(format_args!("{}", warning.kind), warning.location);
+    }
+
+    pub(crate) fn warn_fmt(&self, args: fmt::Arguments<'_>, loc: SourceLocation) {
+        self.warn_fmt_with_notes(args, loc, Box::default());
     }
 
     pub(crate) fn warn_fmt_with_notes(
         &self,
         args: fmt::Arguments<'_>,
-        line: u32,
-        column: u32,
+        loc: SourceLocation,
         notes: Box<[bun_ast::Data]>,
     ) {
         if let Some(lg) = self.logger {
-            // SAFETY: see `warn`.
+            // SAFETY: `logger` was constructed from a unique `&'a mut Log` (see
+            // `default`); the pointee outlives `'a` and no other borrow of the
+            // Log exists for the duration of parsing.
             let lg: &mut Log = unsafe { &mut *lg.as_ptr() };
-            lg.add_warning_fmt_line_col_with_notes(self.filename, line, column, args, notes);
+            lg.add_warning_fmt_with_location(self.logger_location(loc), args, notes);
         }
     }
 

--- a/src/css/declaration.rs
+++ b/src/css/declaration.rs
@@ -357,20 +357,18 @@ where
                 css::ComposesState::DisallowNested(info) => {
                     options.warn_fmt(
                         format_args!("\"composes\" is not allowed inside nested selectors"),
-                        info.line,
-                        info.column,
+                        info,
                     );
                 }
                 css::ComposesState::DisallowNotSingleClass(info) => {
                     options.warn_fmt_with_notes(
                         format_args!("\"composes\" only works inside single class selectors"),
-                        source_location.line,
-                        source_location.column,
+                        source_location,
                         Box::new([bun_ast::Data {
                             text: b"The parent selector is not a single class selector because of the syntax here:"
                                 .as_slice()
                                 .into(),
-                            location: Some(info.to_logger_location(options.filename)),
+                            location: Some(options.logger_location(info)),
                         }]),
                     );
                 }

--- a/test/bundler/css/css-modules.test.ts
+++ b/test/bundler/css/css-modules.test.ts
@@ -1,3 +1,6 @@
+import { describe, expect, test } from "bun:test";
+import { bunEnv, bunExe, normalizeBunSnapshot, tempDir } from "harness";
+import { join } from "node:path";
 import { itBundled } from "../expectBundled";
 
 describe("css", () => {
@@ -211,5 +214,133 @@ describe("css", () => {
       const betaOwn = beta![1].split(" ").find(name => name.startsWith("betaGamma_"))!;
       expect(css).toContain(`.${betaOwn}`);
     },
+  });
+});
+
+describe.concurrent("css parser warning locations", () => {
+  // The CSS parser tracks lines 0-based internally. Parse errors are converted
+  // to the logger's 1-based lines; warnings (and their notes) must be too.
+  test("warnings and notes report 1-based lines, like errors", async () => {
+    using dir = tempDir("css-module-warnings", {
+      "styles.module.css": [
+        /*  1 */ "@unknownrule foo;",
+        /*  2 */ ".base { color: red; }",
+        /*  3 */ ".outer {",
+        /*  4 */ "  .inner {",
+        /*  5 */ "    composes: base;",
+        /*  6 */ "  }",
+        /*  7 */ "}",
+        /*  8 */ ".a .b {",
+        /*  9 */ "  color: blue;",
+        /* 10 */ "  composes: base;",
+        /* 11 */ "}",
+        /* 12 */ ".c::custom-thing { color: green; }",
+        /* 13 */ "@other bar;",
+      ].join("\n"),
+    });
+
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "styles.module.css")],
+      throw: false,
+    });
+
+    const toPlain = (log: { message: string; position: Position | null }) => ({
+      message: log.message,
+      file: log.position!.file,
+      line: log.position!.line,
+      column: log.position!.column,
+    });
+    // The `.notes` getter is not declared in bun-types yet.
+    type WithNotes = BuildMessage & { notes: BuildMessage[] };
+    const warnings = result.logs
+      // The misplaced `composes` declarations also make printing the stylesheet fail.
+      .filter(log => log.level !== "error")
+      .map(log => ({ ...toPlain(log), notes: (log as WithNotes).notes.map(toPlain) }));
+
+    expect(warnings).toEqual([
+      {
+        message: "invalid @ rule encountered: '@unknownrule'",
+        file: "styles.module.css",
+        line: 1,
+        column: 13,
+        notes: [],
+      },
+      {
+        message: '"composes" is not allowed inside nested selectors',
+        file: "styles.module.css",
+        line: 4,
+        column: 3,
+        notes: [],
+      },
+      {
+        message: '"composes" only works inside single class selectors',
+        file: "styles.module.css",
+        line: 10,
+        column: 12,
+        notes: [
+          {
+            message: "The parent selector is not a single class selector because of the syntax here:",
+            file: "styles.module.css",
+            line: 8,
+            column: 1,
+          },
+        ],
+      },
+      {
+        message: "Invalid selector. Unsupported pseudo-class or pseudo-element 'custom-thing'",
+        file: "styles.module.css",
+        line: 12,
+        column: 4,
+        notes: [],
+      },
+      {
+        message: "invalid @ rule encountered: '@other'",
+        file: "styles.module.css",
+        line: 13,
+        column: 7,
+        notes: [],
+      },
+    ]);
+  });
+
+  test("warnings in a stylesheet that is not a CSS module report 1-based lines", async () => {
+    using dir = tempDir("css-warnings", {
+      "styles.css": "@unknownrule foo;\n.a { color: red; }\n\n@other bar;\n",
+    });
+
+    const result = await Bun.build({
+      entrypoints: [join(String(dir), "styles.css")],
+      throw: false,
+    });
+
+    expect(result.logs.map(log => [log.message, log.position!.line, log.position!.column])).toEqual([
+      ["invalid @ rule encountered: '@unknownrule'", 1, 13],
+      ["invalid @ rule encountered: '@other'", 4, 7],
+    ]);
+    expect(result.success).toBe(true);
+  });
+
+  test("bun build prints warning locations as file:line:column", async () => {
+    using dir = tempDir("css-module-warnings-cli", {
+      "styles.module.css": "@unknownrule foo;\n.a { color: red; }\n@other bar;\n",
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", "./styles.module.css"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+
+    expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+      "warn: invalid @ rule encountered: '@unknownrule'
+         at styles.module.css:1:13
+
+      warn: invalid @ rule encountered: '@other'
+         at styles.module.css:3:7"
+    `);
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem

- Every warning the CSS parser reports (`invalid @ rule encountered`, unsupported pseudo-class/element, deprecated `@nest`, the two css-modules `composes` warnings and the note attached to one of them) points one line too early. A warning on the first line of a file is reported as line 0, which the logger prints as `at x.module.css:0` (no column), which `Bun.build()` exposes as `position.line === 0`, and which the dev server's error overlay payload cannot represent (see #37885 for the writer side of that).
- Errors in the same file are correct. `src/css/error.rs` `ErrorLocation::to_location` adds 1 when it builds the logger location, because the parser's `SourceLocation` / `Location` lines are 0-based (`src/css/lib.rs`, "line is 0-based") while `bun_ast::Location.line` is 1-based with `line <= 0` meaning "no position" (`src/ast/lib.rs`).
- The warning paths skipped that conversion: `ParserOptions::warn` / `warn_fmt` / `warn_fmt_with_notes` (`src/css/css_parser.rs`) passed the raw line into `Log::add_warning_fmt_line_col[_with_notes]` (`src/ast/lib.rs`), which stored it verbatim, and `SourceLocation::to_logger_location` (used for the `composes` note in `src/css/declaration.rs`) did the same.

```
$ printf '@unknownrule foo;\n.a { color: red; }\n\n@other bar;\n' > x.module.css
$ bun build ./x.module.css
warn: invalid @ rule encountered: '@unknownrule'
   at x.module.css:0          <- line 1
warn: invalid @ rule encountered: '@other'
   at x.module.css:3:7        <- line 4
```

### Fix

- `ParserOptions::logger_location(SourceLocation)` is now the single place a parser location becomes a `bun_ast::Location` for a warning; it adds 1 like `ErrorLocation::to_location` does. `warn` and `warn_fmt` funnel into `warn_fmt_with_notes`, which uses it, and the `composes` note uses it too. `warn_fmt` / `warn_fmt_with_notes` take a `SourceLocation` instead of a bare `line, column` pair so a caller cannot hand the logger an unconverted line again.
- `Log::add_warning_fmt_line_col` / `add_warning_fmt_line_col_with_notes` (only the CSS parser used them) are replaced by `add_warning_fmt_with_location(Location, args, notes)`: the logger stores a `Location` whose field documentation defines the contract instead of a line number of unspecified base.
- This is correct because it makes warnings follow the same 0-based to 1-based conversion the crate already applies at its other boundaries (`ErrorLocation::to_location`, `dependencies::Location::from_source_location`), and it matches lightningcss, which this parser is a port of: `lightningcss@1.30.2` `transform()` reports the two warnings from the repro above at `{ line: 1, column: 13 }` and `{ line: 4, column: 7 }`, exactly what bun prints with this change (its `Warning.loc` type documents `line` as 1-based). Columns were already 1-based and are unchanged.
- Side effects: the 0-based `BuildMessage.line` getter (which subtracts 1) becomes correct as well, and a first-line CSS warning no longer produces a line 0 location for the dev server overlay serializer. The terminal output of a first-line warning changes from `at x.module.css:0` to `at x.module.css:1:13`.
- Not changed here (pre-existing, reported separately): warnings in non-module `.css` files still carry no file name because the bundler only sets `ParserOptions.filename` for css modules, and warnings still have no `line_text`, so they print without a code frame.
- Verified with three tests added to `test/bundler/css/css-modules.test.ts`: one `Bun.build()` test covering all three emission paths plus the note in one `.module.css` file (every expected line is exactly one higher than what 1.4.0 reports), one for a non-module stylesheet, and one checking the `bun build` stderr format. All three fail with `USE_SYSTEM_BUN=1` and pass with `bun bd test`.
- Also run on the debug build: `test/bundler/esbuild/css.test.ts`, the other `test/bundler/css/*.test.ts` files, `test/js/bun/css/css.test.ts`, `test/bake/dev/css.test.ts`; `cargo clippy -p bun_css -p bun_ast` is clean.

### Background

- `bun_ast::Log` is the diagnostics sink shared by the bundler, the CLI and `Bun.build()`; a `Msg` carries a `Data { text, location }` plus notes (more `Data`). A `Location` is file / 1-based line / column / optional `line_text`; the printer emits `file:line:column` only when `line > 0`, `BuildMessage.position` exposes it as is, and the dev server overlay serializes it per message.
- The CSS parser (`src/css`, a port of lightningcss on top of a cssparser-style tokenizer) tracks positions as `SourceLocation { line (0-based), column (1-based) }`. Fatal problems come back as `Err<ParserError>` and the bundler converts them with `ErrorLocation::to_location(source)`; non-fatal ones are written into the `Log` during parsing through `ParserOptions.logger`, which is the path this PR fixes.

<details>
<summary>Fail-before output of the new tests on bun 1.4.0</summary>

```
(fail) css parser warning locations > warnings and notes report 1-based lines, like errors
-     "line": 1,      +     "line": 0,     invalid @ rule encountered: '@unknownrule'
-     "line": 4,      +     "line": 3,     "composes" is not allowed inside nested selectors
-     "line": 10,     +     "line": 9,     "composes" only works inside single class selectors
-         "line": 8,  +         "line": 7, (note) The parent selector is not a single class selector ...
-     "line": 12,     +     "line": 11,    Unsupported pseudo-class or pseudo-element 'custom-thing'
-     "line": 13,     +     "line": 12,    invalid @ rule encountered: '@other'
(fail) css parser warning locations > warnings in a stylesheet that is not a CSS module report 1-based lines
(fail) css parser warning locations > bun build prints warning locations as file:line:column
-    at styles.module.css:1:13
+    at styles.module.css:0
-    at styles.module.css:3:7
+    at styles.module.css:2:7
```

</details>
