### PR TITLE
bun:test: apply an asymmetric matcher passed as the whole toMatchObject or snapshot property matchers argument

### DIFF
--- a/src/jsc/bindings/bindings.cpp
+++ b/src/jsc/bindings/bindings.cpp
@@ -1974,6 +1974,36 @@ bool Bun__deepMatch(
     ASSERT(subsetValue.isCell());
     // fast path for reference equality.
     if (objValue == subsetValue) return true;
+
+    if constexpr (enableAsymmetricMatchers) {
+        // The whole expected (or received) value may itself be a matcher, e.g.
+        // `toMatchObject(expect.objectContaining({...}))`. A matcher object has
+        // no enumerable properties, so walking it as the subset below would
+        // match anything. Skipped for the sample of `expect.objectContaining()`,
+        // which (as in Jest) is always walked as a plain object.
+        if (!isMatchingObjectContaining) {
+            if (subsetValue.asCell()->type() == JSC::JSType(JSDOMWrapperType)) {
+                switch (matchAsymmetricMatcher(globalObject, subsetValue, objValue, throwScope)) {
+                case AsymmetricMatcherResult::FAIL:
+                    return false;
+                case AsymmetricMatcherResult::PASS:
+                    return true;
+                case AsymmetricMatcherResult::NOT_MATCHER:
+                    break;
+                }
+            } else if (objValue.asCell()->type() == JSC::JSType(JSDOMWrapperType)) {
+                switch (matchAsymmetricMatcher(globalObject, objValue, subsetValue, throwScope)) {
+                case AsymmetricMatcherResult::FAIL:
+                    return false;
+                case AsymmetricMatcherResult::PASS:
+                    return true;
+                case AsymmetricMatcherResult::NOT_MATCHER:
+                    break;
+                }
+            }
+        }
+    }
+
     VM& vm = globalObject->vm();
     JSObject* obj = objValue.getObject();
     JSObject* subsetObj = subsetValue.getObject();

--- a/test/js/bun/test/expect-extend.test.js
+++ b/test/js/bun/test/expect-extend.test.js
@@ -170,6 +170,18 @@ it("defines asymmetric variadic matchers that can be prefixed by not", () => {
   ).not.toThrow();
 });
 
+it("applies an asymmetric matcher passed as the whole toMatchObject argument", () => {
+  expect({ value: 2 }).toMatchObject(expect._toCustomEqual({ value: 2 }));
+  expect({ value: 2 }).not.toMatchObject(expect._toCustomEqual({ value: 3 }));
+  expect(() => expect({ value: 2 }).toMatchObject(expect._toCustomEqual({ value: 3 }))).toThrow();
+
+  expect({ value: 2 }).toMatchObject(expect.not._toCustomEqual({ value: 3 }));
+  expect({ value: 2 }).not.toMatchObject(expect.not._toCustomEqual({ value: 2 }));
+
+  // the matcher receives the whole object, which is not a number
+  expect({ value: 2 }).not.toMatchObject(expect._toBeDivisibleBy(2));
+});
+
 it("prints the Symbol into the error message", () => {
   const foo = Symbol("foo");
   const bar = Symbol("bar");

--- a/test/js/bun/test/expect.test.js
+++ b/test/js/bun/test/expect.test.js
@@ -3558,6 +3558,48 @@ describe("expect()", () => {
       expect(a1).not.toMatchObject({ 1: 1 });
       expect(a1).toMatchObject(a1);
     });
+
+    test("with an asymmetric matcher as the whole expected value", () => {
+      expect({ a: 1, b: 2 }).toMatchObject(expect.objectContaining({ a: 1 }));
+      expect({ a: 1, b: 2 }).not.toMatchObject(expect.objectContaining({ a: 2 }));
+      expect({ a: 1, b: 2 }).not.toMatchObject(expect.objectContaining({ c: 3 }));
+      expect(() => expect({ a: 1, b: 2 }).toMatchObject(expect.objectContaining({ a: 2 }))).toThrow();
+      expect(() => expect({ a: 1, b: 2 }).not.toMatchObject(expect.objectContaining({ a: 1 }))).toThrow();
+
+      expect({ a: 1 }).toMatchObject(expect.any(Object));
+      expect({ a: 1 }).not.toMatchObject(expect.any(Array));
+      expect(() => expect({ a: 1 }).toMatchObject(expect.any(Array))).toThrow();
+      expect(() => expect({ a: 1 }).not.toMatchObject(expect.any(Object))).toThrow();
+
+      expect({ a: 1 }).toMatchObject(expect.anything());
+      expect([1, 2]).toMatchObject(expect.any(Array));
+      expect([1, 2]).toMatchObject(expect.arrayContaining([2]));
+      expect([1, 2]).not.toMatchObject(expect.arrayContaining([3]));
+
+      // matchers that can never match an object
+      expect({ a: 1 }).not.toMatchObject(expect.closeTo(1));
+      expect({ a: 1 }).not.toMatchObject(expect.stringContaining("a"));
+      expect({ a: 1 }).not.toMatchObject(expect.stringMatching(/a/));
+
+      // expect.not.* inverts the matcher itself
+      expect({ a: 1 }).toMatchObject(expect.not.objectContaining({ a: 2 }));
+      expect({ a: 1 }).not.toMatchObject(expect.not.objectContaining({ a: 1 }));
+      expect(() => expect({ a: 1 }).toMatchObject(expect.not.objectContaining({ a: 1 }))).toThrow();
+
+      // nested matchers inside a top-level matcher
+      expect({ a: { b: 1 }, c: "x" }).toMatchObject(expect.objectContaining({ a: { b: expect.any(Number) } }));
+      expect({ a: { b: 1 }, c: "x" }).not.toMatchObject(expect.objectContaining({ a: { b: expect.any(String) } }));
+    });
+
+    test("with an asymmetric matcher as the received value", () => {
+      expect(expect.any(Object)).toMatchObject({ a: 1 });
+      expect(expect.any(Array)).not.toMatchObject({ a: 1 });
+      expect(() => expect(expect.any(Array)).toMatchObject({ a: 1 })).toThrow();
+      expect(expect.objectContaining({ a: 1 })).toMatchObject({ a: 1, b: 2 });
+      expect(expect.objectContaining({ a: 2 })).not.toMatchObject({ a: 1, b: 2 });
+      expect(expect.arrayContaining([1])).toMatchObject([1, 2]);
+      expect(expect.arrayContaining([3])).not.toMatchObject([1, 2]);
+    });
   });
 
   describe("toMatch()", () => {

--- a/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
+++ b/test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts
@@ -371,6 +371,51 @@ test("basic unchanging inline snapshot", () => {
   );
 });
 
+test("property matchers argument can itself be an asymmetric matcher", async () => {
+  const formattedReceived = '\n{\n  "a": 1,\n  "b": "two",\n}\n';
+  const inlineSnapshot = "`" + formattedReceived + "`";
+  using dir = tempDir("snapshot-top-level-matcher", {
+    "snap.test.ts": /*js*/ `
+      import { expect, test } from "bun:test";
+      const received = { a: 1, b: "two" };
+      test("file pass", () => {
+        expect(received).toMatchSnapshot(expect.objectContaining({ a: expect.any(Number) }));
+      });
+      test("file fail", () => {
+        expect(received).toMatchSnapshot(expect.objectContaining({ a: 2 }));
+      });
+      test("inline pass", () => {
+        expect(received).toMatchInlineSnapshot(expect.any(Object), ${inlineSnapshot});
+      });
+      test("inline fail", () => {
+        expect(received).toMatchInlineSnapshot(expect.any(Array), ${inlineSnapshot});
+      });
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", "./snap.test.ts"],
+    env: { ...bunEnv, CI: "false" },
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const output = stdout + stderr;
+
+  expect(output).toContain("(pass) file pass");
+  expect(output).toContain("(fail) file fail");
+  expect(output).toContain("(pass) inline pass");
+  expect(output).toContain("(fail) inline fail");
+  expect(output.match(/Expected propertyMatchers to match properties from received object/g)).toHaveLength(2);
+  expect(exitCode).toBe(1);
+
+  // a passing top-level matcher stores the received value as-is; a failing one stores nothing
+  expect(await Bun.file(`${dir}/__snapshots__/snap.test.ts.snap`).text()).toBe(
+    "// Bun Snapshot v1, https://bun.sh/docs/test/snapshots\n\nexports[`file pass 1`] = `" + formattedReceived + "`;\n",
+  );
+});
+
 class InlineSnapshotTester {
   tmpdir: string;
   tmpid: number;


### PR DESCRIPTION
### Problem
- `toMatchObject` ignores an asymmetric matcher passed as the whole expected value, so these assertions pass in Bun 1.4.0 and on main (Jest and Vitest 4.1.9 fail both):
  ```js
  expect({ a: 1, b: 2 }).toMatchObject(expect.objectContaining({ a: 2 }));
  expect({ a: 1 }).toMatchObject(expect.any(Array));
  ```
- The property matchers argument of `toMatchSnapshot` / `toMatchInlineSnapshot` goes through the same code, so `toMatchInlineSnapshot(expect.any(Array), ...)` on an object also skips straight to the snapshot comparison, and `toMatchSnapshot(expect.objectContaining({ a: 2 }))` records a snapshot instead of failing.
- The mirror case is wrong the other way: `expect(expect.any(Object)).toMatchObject({ a: 1 })` always fails, while Jest applies the received-side matcher.
- Cause: `Bun__deepMatch` (`src/jsc/bindings/bindings.cpp:1960`) only checks for matchers inside its per-property loop. When the matcher is the `subset` argument itself it is walked like a plain object; the `Expect*` matcher classes keep their state in internal fields and have no enumerable properties, so the walk is empty and the match is vacuously true. `Bun__deepEquals` (`toEqual`) already checks both values for a matcher before comparing structurally (`bindings.cpp:748`), which is why `toEqual(expect.objectContaining(...))` works.

### Fix
- Before the property walk, when asymmetric matchers are enabled, run `matchAsymmetricMatcher` on the expected value and, failing that, on the received value, and return its PASS/FAIL verdict; `NOT_MATCHER` falls through to the existing walk. This is the same check `Bun__deepEquals` does at its top and the per-property loop does for each property, so nesting behaves as before.
- Matches Jest: `toMatchObject` and the snapshot property matchers both call `equals(received, expected, [iterableEquality, subsetEquality])`, and `equals` applies an asymmetric matcher on either side before anything else, at the top level included.
- The check is skipped while matching the sample of `expect.objectContaining()` (`isMatchingObjectContaining`). Jest's `ObjectContaining` always walks its sample's keys, so `objectContaining` behavior is unchanged for `toEqual`, `toHaveBeenCalledWith`, etc. `Bun.deepMatch` is unaffected because it instantiates the template with matchers disabled.
- `replacePropsWithAsymmetricMatchers` has nothing to do at the top level (there is no parent property to rewrite), so a passing top-level matcher in a snapshot assertion stores the received value as-is. Jest's `deepMerge` crashes inside pretty-format in that situation, so there is no behavior to mirror there; the failing case fails like Jest.
- Verified:
  - `test/js/bun/test/expect.test.js` (`toMatchObject` describe): two new tests, expected-side and received-side matchers, including `expect.not.*` inversion and nested matchers inside a top-level `objectContaining`. Both fail on the released binary and pass with this change; the same assertions pass under Vitest 4.1.9.
  - `test/js/bun/test/expect-extend.test.js`: a custom (`expect.extend`) asymmetric matcher used as the whole `toMatchObject` argument, also verified under Vitest. Fails on the released binary.
  - `test/js/bun/test/snapshot-tests/snapshots/snapshot.test.ts`: spawns a test file using a top-level matcher as the property matchers of `toMatchSnapshot` and `toMatchInlineSnapshot`, passing and failing each, and checks the resulting `.snap` file. Fails on the released binary (all four cases pass there and the failing `toMatchSnapshot` writes a snapshot).
  - Full `expect.test.js` (417 pass), `expect-extend.test.js`, `spyMatchers.test.ts`, `jest-extended.test.js`, the snapshot test directory and the `objectContaining` regression tests are unchanged, also with `BUN_JSC_validateExceptionChecks=1`.
- Overlaps textually with #37904 (a content comparison for Headers/URLSearchParams added a few lines below this check); the two are independent, and this check has to run first so that `toMatchObject(expect.any(Headers))` on a `Headers` applies the matcher.

### Background
- Asymmetric matchers (`expect.any()`, `expect.objectContaining()`, matchers created by `expect.extend`) are instances of the `Expect*` classes defined in `src/runtime/test_runner/jest.classes.ts`. They all carry the `JSDOMWrapperType` JSType, which is how `Bun__deepEquals` / `Bun__deepMatch` cheaply decide whether to call `matchAsymmetricMatcher`; that function returns `NOT_MATCHER` for any other wrapper object (Headers, Blob, ...) and handles `expect.not.*` inversion itself.
- `Bun__deepMatch<enableAsymmetricMatchers>` is the subset comparison behind `toMatchObject`, the property matchers argument of the snapshot matchers, `expect.objectContaining()` (with `isMatchingObjectContaining`, which switches nested objects to exact `deepEquals`) and `Bun.deepMatch` (matchers disabled). It walks the enumerable properties of the expected value and compares each against the received value.
- `replacePropsWithAsymmetricMatchers` is set by `toMatchObject` and the snapshot matchers: when a property-level matcher passes, the received property is overwritten with the matcher so that the failure diff and the stored snapshot print `Any<Date>` instead of the volatile value.
