### PR TITLE
test: remove the timer race from the fetch redirect + Connection: close test

### DIFF
--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -2817,68 +2817,71 @@ describe("fetch should allow duplex", () => {
   });
 });
 
-it("should allow to follow redirect if connection is closed, abort should work even if the socket was closed before the redirect", async () => {
-  for (const type of ["normal", "delay"]) {
-    await using server = net.createServer(socket => {
+describe("redirect whose response closes the connection", () => {
+  // The 308 says "Connection: close" and the server ends the socket with it, so
+  // the client cannot reuse that connection for the hop: following the redirect
+  // means connecting again, and the abort handling has to move to the new
+  // connection with it (#15623).
+  async function listen(onRedirectedRequest: (socket: net.Socket) => void) {
+    const server = net.createServer(socket => {
       // Raw test server: tolerate client aborts, surface anything unexpected.
       socket.on("error", (err: NodeJS.ErrnoException) => {
         if (err.code !== "ECONNRESET" && err.code !== "EPIPE" && err.code !== "ECONNABORTED") throw err;
       });
-      let body = "";
-      socket.on("data", data => {
-        body += data.toString("utf8");
-
-        const headerEndIndex = body.indexOf("\r\n\r\n");
-        if (headerEndIndex !== -1) {
-          // headers received
-          const headers = body.split("\r\n\r\n")[0];
-          const path = headers.split("\r\n")[0].split(" ")[1];
-          if (path === "/redirect") {
-            socket.end(
-              "HTTP/1.1 308 Permanent Redirect\r\nCache-Control: public, max-age=0, must-revalidate\r\nContent-Type: text/plain\r\nLocation: /\r\nConnection: close\r\n\r\n",
-            );
-          } else {
-            if (type === "delay") {
-              setTimeout(() => {
-                if (!socket.destroyed)
-                  socket.end(
-                    "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 9\r\nConnection: close\r\n\r\nHello Bun",
-                  );
-              }, 200);
-            } else {
-              socket.end(
-                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 9\r\nConnection: close\r\n\r\nHello Bun",
-              );
-            }
-          }
+      let request = "";
+      socket.on("data", function onData(data) {
+        request += data.toString("utf8");
+        if (!request.includes("\r\n\r\n")) return;
+        socket.off("data", onData);
+        const path = request.split(" ")[1];
+        if (path === "/redirect") {
+          socket.end("HTTP/1.1 308 Permanent Redirect\r\nLocation: /\r\nConnection: close\r\n\r\n");
+        } else {
+          onRedirectedRequest(socket);
         }
       });
     });
-    await once(server.listen(0), "listening");
-
-    try {
-      let { address, port } = server.address() as AddressInfo;
-      if (address === "::") {
-        address = "[::]";
-      }
-      const response = await fetch(`http://${address}:${port}/redirect`, {
-        signal: AbortSignal.timeout(150),
-      });
-      if (type === "delay") {
-        console.error(response, type);
-        expect.unreachable();
-      } else {
-        expect(response.status).toBe(200);
-        expect(await response.text()).toBe("Hello Bun");
-      }
-    } catch (err) {
-      if (type === "delay") {
-        expect((err as Error).name).toBe("TimeoutError");
-      } else {
-        expect.unreachable();
-      }
-    }
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    return server;
   }
+
+  it("follows the redirect on a new connection", async () => {
+    // Never aborted: the signal has to survive the reconnect without firing.
+    const controller = new AbortController();
+    await using server = await listen(socket => {
+      socket.end("HTTP/1.1 200 OK\r\nContent-Length: 9\r\nConnection: close\r\n\r\nHello Bun");
+    });
+    const { port } = server.address() as AddressInfo;
+
+    const response = await fetch(`http://127.0.0.1:${port}/redirect`, { signal: controller.signal });
+    expect(response.status).toBe(200);
+    expect(response.redirected).toBe(true);
+    expect(await response.text()).toBe("Hello Bun");
+  });
+
+  it("can still be aborted once the redirected request is in flight", async () => {
+    const controller = new AbortController();
+    // The redirected request is never answered; only the abort can end it.
+    const redirected = Promise.withResolvers<net.Socket>();
+    await using server = await listen(redirected.resolve);
+    const { port } = server.address() as AddressInfo;
+
+    const pending = fetch(`http://127.0.0.1:${port}/redirect`, { signal: controller.signal });
+    const socket = await redirected.promise;
+    // Aborting also has to tear down the connection the redirect opened. Not
+    // events.once(): the client may reset the connection, and the resulting
+    // ECONNRESET "error" event would reject it before "close" arrives.
+    const closed = new Promise<void>(resolve => socket.once("close", resolve));
+    controller.abort();
+
+    const error = await pending.then(
+      () => expect.unreachable(),
+      (err: unknown) => err,
+    );
+    expect(error).toBeInstanceOf(DOMException);
+    expect((error as DOMException).name).toBe("AbortError");
+    await closed;
+  });
 });
 
 it("rejects a response with an unparseable Content-Length instead of treating it as empty", async () => {


### PR DESCRIPTION
### Problem
- `test/js/web/fetch/fetch.test.ts`, "should allow to follow redirect if connection is closed, abort should work even if the socket was closed before the redirect", fails on every run of a debug build:
  ```
  UnreachableError: reached unreachable code
      at <anonymous> (test/js/web/fetch/fetch.test.ts:2878:16)
  ```
- Its success case passes `signal: AbortSignal.timeout(150)` to a fetch that has to complete a 308 hop plus a second connection against a `node:net` server. On a debug build that takes 250 to 650 ms (first use of `node:net` alone is a few hundred ms), so the timeout wins, the fetch rejects, and the `catch` branch hits `expect.unreachable()`. The same budget is a flake source on loaded release lanes; `--timeout` scaling does not help because the 150 ms is wall clock inside the test.
- Its abort case raced two timers as well: a 200 ms server-side `setTimeout` against the 150 ms client timeout.
- The `try`/`catch` shape also turned any failed assertion inside the `try` into `UnreachableError`, hiding the real failure.
- The server listened on the wildcard address and the test fetched `http://[::]:port`, unlike the neighbouring raw-server tests which bind `127.0.0.1`. In an environment with `HTTP_PROXY` set, `[::]` is also not covered by the usual `NO_PROXY` entries, so the request leaves through the proxy and the test fails for an unrelated reason.

### Fix
- Test-only change; no runtime code is touched.
- Replaces the loop with two tests under `describe("redirect whose response closes the connection")` that share a `listen()` helper; each test starts its own raw `net` server and passes in its own handler for the redirected request. The server shape that matters is unchanged: the 308 carries `Connection: close` and the socket is ended with it, so the client has to open a new connection for the hop (the scenario from #15623).
- "follows the redirect on a new connection": awaits the fetch (with a never-aborted signal attached) and checks status, `redirected`, and body. No deadline.
- "can still be aborted once the redirected request is in flight": the server never answers the redirected request; the test waits until that request has arrived, aborts, and checks the `AbortError` rejection plus the close of the connection the redirect opened. No timers at all, and the abort is guaranteed to happen after the hop, which the old 150 ms timer only made likely.
- Why the abort test still covers the original bug: the fetch promise is only rejected after the HTTP thread closes the socket it finds in the abort tracker (`src/http/HTTPThread.rs` `drain_queued_shutdowns`, `src/runtime/webcore/fetch/FetchTasklet.rs` `abort_task`). `do_redirect` and `on_close` unregister the tracker entry (`src/http/lib.rs`), and `on_open` on the new connection registers it again. If that re-registration broke, the abort would find no socket, the promise would never settle, and the test would fail.
- Binds the server to `127.0.0.1` and fetches that address, matching the tests around it.
- Verified:
  - `bun bd test test/js/web/fetch/fetch.test.ts -t "redirect whose response closes the connection"`: 2 pass (about 440 ms + 90 ms on the debug build).
  - Same filter with the release binary (`USE_SYSTEM_BUN=1`), 5 runs: 2 pass each time, about 10 ms + 3 ms.
  - Old test on the same debug build, 3 runs: fails every time (547 ms, 643 ms, 616 ms against the 150 ms budget); it passes on the release binary.
  - Full `fetch.test.ts` on the debug build: both new tests pass in the middle of the file as well.

### Background
- `AbortSignal.timeout(ms)` rejects the fetch with a `TimeoutError` once `ms` of wall clock pass; a test that expects the fetch to succeed while such a signal is attached is asserting a speed, not a behaviour.
- The abort tracker is a map on the HTTP thread from request id to the socket currently carrying that request. Aborting from JS queues a shutdown for the id; the HTTP thread closes whatever socket the map holds and only then reports the failure back, which is what rejects the promise. A redirect replaces the socket, so the entry has to be dropped and re-added for the new connection.
- `events.once(socket, "close")` rejects if the emitter emits `"error"` first. The client resets the connection on abort, so the server side sees `ECONNRESET` before `"close"`; the test listens for `"close"` directly for that reason.

