### PR TITLE
jsc: report the flatten exception from JSString conversions; answer onResolve once

### DIFF
--- a/src/jsc/JSGlobalObject.rs
+++ b/src/jsc/JSGlobalObject.rs
@@ -599,7 +599,10 @@ impl JSGlobalObject {
         let actual_type = if value.js_type().is_array() {
             bun_core::ZigString::static_(b"array")
         } else {
-            value.js_type_string(self).get_zig_string(self)
+            match value.js_type_string(self).get_zig_string(self) {
+                Ok(s) => s,
+                Err(e) => return e,
+            }
         };
         self.err(
             JscError::INVALID_ARG_TYPE,
@@ -644,7 +647,10 @@ impl JSGlobalObject {
     ) -> JsError {
         // `ZigStringSlice` is RAII: `Owned` frees
         // its `Vec<u8>`, `WTF` derefs the backing `WTFStringImpl` in `Drop`.
-        let ty_str = value.js_type_string(self).to_slice(self);
+        let ty_str = match value.js_type_string(self).to_slice(self) {
+            Ok(s) => s,
+            Err(e) => return e,
+        };
         self.err(
             JscError::INVALID_ARG_TYPE,
             format_args!(

--- a/src/jsc/JSString.rs
+++ b/src/jsc/JSString.rs
@@ -33,8 +33,18 @@ impl JSString {
         JSValue::from_cell(self)
     }
 
-    pub(crate) fn to_zig_string(&self, global: &JSGlobalObject, zig_str: &mut ZigString) {
-        JSC__JSString__toZigString(self, global, zig_str)
+    /// Flattening a rope can throw (JSC throws its "Out of memory" `RangeError`
+    /// when the flat buffer cannot be allocated). The C++ shim returns an empty
+    /// string in that case and leaves the exception on the VM, so it is observed
+    /// here, the same way `JSValue::to_zig_string` does.
+    pub(crate) fn to_zig_string(
+        &self,
+        global: &JSGlobalObject,
+        zig_str: &mut ZigString,
+    ) -> JsResult<()> {
+        crate::from_js_host_call_generic(global, || {
+            JSC__JSString__toZigString(self, global, zig_str)
+        })
     }
 
     pub fn ensure_still_alive(&self) {
@@ -42,22 +52,20 @@ impl JSString {
         core::hint::black_box(std::ptr::from_ref::<Self>(self));
     }
 
-    pub fn get_zig_string(&self, global: &JSGlobalObject) -> ZigString {
+    pub fn get_zig_string(&self, global: &JSGlobalObject) -> JsResult<ZigString> {
         let mut out = ZigString::init(b"");
-        self.to_zig_string(global, &mut out);
-        out
+        self.to_zig_string(global, &mut out)?;
+        Ok(out)
     }
 
     #[inline]
-    pub fn view(&self, global: &JSGlobalObject) -> ZigString {
+    pub fn view(&self, global: &JSGlobalObject) -> JsResult<ZigString> {
         self.get_zig_string(global)
     }
 
     /// doesn't always allocate
-    pub fn to_slice(&self, global: &JSGlobalObject) -> ZigStringSlice {
-        let mut str = ZigString::init(b"");
-        self.to_zig_string(global, &mut str);
-        str.to_slice()
+    pub fn to_slice(&self, global: &JSGlobalObject) -> JsResult<ZigStringSlice> {
+        Ok(self.get_zig_string(global)?.to_slice())
     }
 
     // `to_slice_clone` always allocates
@@ -66,9 +74,7 @@ impl JSString {
     // callers a use-after-free once the cell is collected.
 
     pub fn to_slice_clone(&self, global: &JSGlobalObject) -> JsResult<ZigStringSlice> {
-        let mut str = ZigString::init(b"");
-        self.to_zig_string(global, &mut str);
-        Ok(str.to_slice_clone())
+        Ok(self.get_zig_string(global)?.to_slice_clone())
     }
 
     // `to_slice_z` guarantees a trailing NUL

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -6748,13 +6748,19 @@ fn wrap_unhandled_rejection_error_for_uncaught_exception(
     if reason_str.is_string() {
         // SAFETY: `as_string()` returns a non-null `*mut JSString` when
         // `is_string()` is true; `view()` borrows it for the `write!` below.
-        let view = unsafe { (*reason_str.as_string()).view(global_object) };
-        return global_object
-            .err(
-                crate::ErrorCode::ERR_UNHANDLED_REJECTION,
-                format_args!("{MSG_1}{view}\"."),
-            )
-            .to_js();
+        match unsafe { (*reason_str.as_string()).view(global_object) } {
+            Ok(view) => {
+                return global_object
+                    .err(
+                        crate::ErrorCode::ERR_UNHANDLED_REJECTION,
+                        format_args!("{MSG_1}{view}\"."),
+                    )
+                    .to_js();
+            }
+            // The reason is a string that cannot be flattened; report it the
+            // same way as a reason that could not be stringified at all.
+            Err(_) => global_object.clear_exception(),
+        }
     }
     global_object
         .err(

--- a/src/runtime/api/JSBundler.rs
+++ b/src/runtime/api/JSBundler.rs
@@ -1455,24 +1455,35 @@ pub mod js_bundler {
         {
             resolve.value = ResolveValue::NoMatch;
         } else {
-            let global = bv2_plugin(resolve.bv2).global_object();
+            let plugin = bv2_plugin(resolve.bv2);
+            let global = plugin.global_object();
             // `to_slice_clone` already heap-allocates; `into_vec` moves that
             // buffer out instead of allocating a second copy.
-            let path = path_value
-                .to_slice_clone(global)
-                .expect("Unexpected: path is not a string")
-                .into_vec()
-                .into_boxed_slice();
-            let namespace = namespace_value
-                .to_slice_clone(global)
-                .expect("Unexpected: namespace is not a string")
-                .into_vec()
-                .into_boxed_slice();
-            resolve.value = ResolveValue::Success(ResolveSuccess {
-                path,
-                namespace,
-                external: external_value.to_boolean(),
+            let strings = path_value.to_slice_clone(global).and_then(|path| {
+                let namespace = namespace_value.to_slice_clone(global)?;
+                Ok((path, namespace))
             });
+            resolve.value = match strings {
+                Ok((path, namespace)) => ResolveValue::Success(ResolveSuccess {
+                    path: path.into_vec().into_boxed_slice(),
+                    namespace: namespace.into_vec().into_boxed_slice(),
+                    external: external_value.to_boolean(),
+                }),
+                // Both values are strings (BundlerPlugin.ts checked), but
+                // flattening one can still throw. The exception has to be taken
+                // here: left pending, it rejects `runOnResolvePlugins`, whose
+                // rejection handler calls `JSBundlerPlugin__addError` and
+                // answers this same request a second time. Report it the way
+                // `addError` would have instead.
+                Err(err) => {
+                    let exception = global.take_exception(err);
+                    ResolveValue::Err(plugin_msg_from_js(
+                        plugin,
+                        &resolve.import_record.source_file,
+                        exception,
+                    ))
+                }
+            };
         }
 
         bv2_mut(resolve.bv2).on_resolve_async(resolve);

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8046,7 +8046,7 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_str.to_slice(global_object);
+                    let value_slice = value_str.to_slice(global_object)?;
                     let value = value_slice.slice();
 
                     if let Some(ret) = handle_encode(this, value, never_index)? {
@@ -8080,7 +8080,7 @@ impl H2FrameParser {
                     }
                 };
 
-                let value_slice = value_str.to_slice(global_object);
+                let value_slice = value_str.to_slice(global_object)?;
                 let value = value_slice.slice();
                 bun_output::scoped_log!(
                     H2FrameParser,
@@ -8447,7 +8447,7 @@ impl H2FrameParser {
                 };
                 let mut encode_value = |item: JSValue| -> JsResult<Option<JSValue>> {
                     let value_str = item.to_js_string(global_object)?;
-                    let value_slice = value_str.to_slice(global_object);
+                    let value_slice = value_str.to_slice(global_object)?;
                     let value = value_slice.slice();
                     if !is_valid_header_value(value) {
                         return Err(global_object
@@ -8852,7 +8852,7 @@ impl H2FrameParser {
                     }
 
                     let name_str = name_js.to_js_string(global_object)?;
-                    let name_slice = name_str.to_slice(global_object);
+                    let name_slice = name_str.to_slice(global_object)?;
                     let name = name_slice.slice();
                     if name.is_empty() {
                         continue;
@@ -8920,7 +8920,7 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_str.to_slice(global_object);
+                    let value_slice = value_str.to_slice(global_object)?;
                     let value = value_slice.slice();
                     if !is_valid_header_value(value) {
                         return Err(global_object
@@ -9087,7 +9087,7 @@ impl H2FrameParser {
                             }
                         };
 
-                        let value_slice = value_str.to_slice(global_object);
+                        let value_slice = value_str.to_slice(global_object)?;
                         let value = value_slice.slice();
                         if !is_valid_header_value(value) {
                             return Err(global_object
@@ -9157,7 +9157,7 @@ impl H2FrameParser {
                         }
                     };
 
-                    let value_slice = value_str.to_slice(global_object);
+                    let value_slice = value_str.to_slice(global_object)?;
                     let value = value_slice.slice();
                     if !is_valid_header_value(value) {
                         return Err(global_object

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4993,7 +4993,7 @@ impl Resolver {
                 if record_type_str.length() == 0 {
                     break 'brk RecordType::DEFAULT;
                 }
-                match RECORD_TYPE_MAP.get(record_type_str.to_slice(global_this).slice()) {
+                match RECORD_TYPE_MAP.get(record_type_str.to_slice(global_this)?.slice()) {
                     Some(r) => *r,
                     None => {
                         return Err(global_this.throw_invalid_argument_property_value(
@@ -5186,7 +5186,7 @@ impl Resolver {
             };
         }
 
-        let name = name_str.to_slice(global_this);
+        let name = name_str.to_slice(global_this)?;
         let resolver = global_resolver(global_this);
 
         resolver.do_lookup(name.slice(), port, options, global_this)
@@ -5966,7 +5966,7 @@ impl Resolver {
                 "non-empty string",
             ));
         }
-        let addr_slice = addr_str.to_slice(global_this);
+        let addr_slice = addr_str.to_slice(global_this)?;
         let addr_s = addr_slice.slice();
 
         let port_value = arguments[1];

--- a/src/runtime/ipc.rs
+++ b/src/runtime/ipc.rs
@@ -2022,7 +2022,13 @@ fn import_windows_socket_payload(global: &JSGlobalObject, msg_data: JSValue) -> 
             return None;
         }
     };
-    let hex = jsc::JSString::opaque_ref(info_value.as_string()).to_slice(global);
+    let hex = match jsc::JSString::opaque_ref(info_value.as_string()).to_slice(global) {
+        Ok(hex) => hex,
+        Err(_) => {
+            global.clear_exception();
+            return None;
+        }
+    };
     let expected = bun_uws::socket_transfer::bsd_socket_export_size() as usize;
     let mut info = vec![0u8; expected];
     let decoded = strings::decode_hex_to_bytes_truncate(&mut info, hex.slice());

--- a/src/runtime/node/node_cluster_binding.rs
+++ b/src/runtime/node/node_cluster_binding.rs
@@ -334,7 +334,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let atype = address_type.to_int32();
 
         let host_owned: Vec<u8> = if address.is_string() {
-            let s = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global);
+            let s = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global)?;
             let mut v = s.slice().to_vec();
             v.push(0);
             v
@@ -422,7 +422,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let mut is_udp = false;
         let atype: i32;
         if address_type.is_string() {
-            let s = bun_jsc::JSString::opaque_ref(address_type.as_string()).to_slice(global);
+            let s = bun_jsc::JSString::opaque_ref(address_type.as_string()).to_slice(global)?;
             is_udp = true;
             atype = if s.slice() == b"udp6" { 6 } else { 4 };
         } else {
@@ -447,7 +447,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
             if !address.is_string() {
                 return Err(global.throw_invalid_argument_type_value("address", "string", address));
             }
-            let path_slice = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global);
+            let path_slice = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global)?;
             let path_bytes = path_slice.slice();
             // SAFETY: sockaddr_un is plain C data; all-zero is a valid value.
             let mut sun: libc::sockaddr_un = unsafe { bun_core::ffi::zeroed_unchecked() };
@@ -599,7 +599,7 @@ pub(crate) fn cluster_raw_bind(global: &JSGlobalObject, frame: &CallFrame) -> Js
         let fd: c_int;
         let bound_family: c_int;
         if address.is_string() {
-            let addr_slice = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global);
+            let addr_slice = bun_jsc::JSString::opaque_ref(address.as_string()).to_slice(global)?;
             let addr_bytes = addr_slice.slice();
             let mut addr_z: [u8; 256] = [0; 256];
             if addr_bytes.len() >= addr_z.len() {

--- a/src/runtime/node/node_util_binding.rs
+++ b/src/runtime/node/node_util_binding.rs
@@ -237,7 +237,7 @@ pub(crate) fn parse_env(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<
 
     // `validate_string` accepts StringObject, so coerce to a primitive JSString
     // before slicing.
-    let str = content.to_js_string(global)?.to_slice(global);
+    let str = content.to_js_string(global)?.to_slice(global)?;
 
     let mut p = envloader::Loader::init();
     p.load_from_string::<true, false>(str.slice())?;

--- a/src/runtime/node/node_zlib_binding.rs
+++ b/src/runtime/node/node_zlib_binding.rs
@@ -115,10 +115,10 @@ pub(crate) fn crc32(global_this: &JSGlobalObject, callframe: &CallFrame) -> JsRe
             // `is_string_literal()` guarantees `as_string()` is non-null and points to a
             // live JSString cell on the JSC heap. `JSString` is an `opaque_ffi!`
             // ZST handle; `opaque_ref` is the centralised deref proof.
-            break 'blk bun_jsc::JSString::opaque_ref(data.as_string()).to_slice(global_this);
+            break 'blk bun_jsc::JSString::opaque_ref(data.as_string()).to_slice(global_this)?;
         }
         let Some(buffer) = data.as_array_buffer(global_this) else {
-            let ty_str = data.js_type_string(global_this).to_slice(global_this);
+            let ty_str = data.js_type_string(global_this).to_slice(global_this)?;
             // ty_str drops at end of scope
             return Err(global_this
                 .err(

--- a/src/runtime/node/util/validators.rs
+++ b/src/runtime/node/util/validators.rs
@@ -3,10 +3,10 @@ use core::fmt;
 use bun_core::ZigString;
 use bun_jsc::{self as jsc, JSGlobalObject, JSValue, JsError, JsResult};
 
-fn get_type_name(global_object: &JSGlobalObject, value: JSValue) -> ZigString {
+fn get_type_name(global_object: &JSGlobalObject, value: JSValue) -> JsResult<ZigString> {
     let js_type = value.js_type();
     if js_type.is_array() {
-        return ZigString::static_("array");
+        return Ok(ZigString::static_("array"));
     }
     value
         .js_type_string(global_object)
@@ -43,7 +43,10 @@ pub(crate) fn throw_err_invalid_arg_type(
     expected_type: &str,
     value: JSValue,
 ) -> JsError {
-    let actual_type = get_type_name(global_this, value);
+    let actual_type = match get_type_name(global_this, value) {
+        Ok(actual_type) => actual_type,
+        Err(e) => return e,
+    };
     throw_err_invalid_arg_type_with_message(
         global_this,
         format_args!(
@@ -395,7 +398,7 @@ pub(crate) fn validate_array(
     min_length: Option<i32>,
 ) -> JsResult<()> {
     if !value.js_type().is_array() {
-        let actual_type = get_type_name(global_this, value);
+        let actual_type = get_type_name(global_this, value)?;
         return Err(throw_err_invalid_arg_type_with_message(
             global_this,
             format_args!(

--- a/src/runtime/server/ServerWebSocket.rs
+++ b/src/runtime/server/ServerWebSocket.rs
@@ -882,7 +882,7 @@ impl ServerWebSocket {
 
         {
             let js_string = message_value.to_js_string(global_this)?;
-            let view = js_string.view(global_this);
+            let view = js_string.view(global_this)?;
             let slice = view.to_slice();
 
             let ret = self.do_publish(
@@ -936,7 +936,7 @@ impl ServerWebSocket {
         }
 
         let js_string = message_value.to_js_string(global_this)?;
-        let view = js_string.view(global_this);
+        let view = js_string.view(global_this)?;
         let slice = view.to_slice();
 
         let ret = self.do_publish(
@@ -1121,7 +1121,7 @@ impl ServerWebSocket {
 
         {
             let js_string = message_value.to_js_string(global_this)?;
-            let view = js_string.view(global_this);
+            let view = js_string.view(global_this)?;
             let slice = view.to_slice();
 
             let buffer = slice.slice();
@@ -1166,7 +1166,7 @@ impl ServerWebSocket {
         }
 
         let js_string = message_value.to_js_string(global_this)?;
-        let view = js_string.view(global_this);
+        let view = js_string.view(global_this)?;
         let slice = view.to_slice();
 
         let buffer = slice.slice();
@@ -1287,7 +1287,7 @@ impl ServerWebSocket {
                     return Ok(ret);
                 } else if value.is_string() {
                     // SAFETY: to_js_string returns a non-null *mut JSString on the Ok path.
-                    let string_value = value.to_js_string(global_this)?.to_slice(global_this);
+                    let string_value = value.to_js_string(global_this)?.to_slice(global_this)?;
                     let buffer = string_value.slice();
                     if buffer.len() > MAX_CONTROL_FRAME_PAYLOAD {
                         return Err(throw_control_frame_too_large(global_this, buffer.len()));

--- a/src/runtime/server/server_body.rs
+++ b/src/runtime/server/server_body.rs
@@ -1720,7 +1720,7 @@ where
 
         {
             let js_string = message_value.to_js_string(global)?;
-            let view = js_string.view(global);
+            let view = js_string.view(global)?;
             let slice = view.to_slice();
             // Keep `js_string` alive, not `message_value`:
             // when the input was not already a JSString, `to_js_string` allocates

--- a/src/runtime/socket/udp_socket.rs
+++ b/src/runtime/socket/udp_socket.rs
@@ -1431,7 +1431,7 @@ impl UDPSocket {
                 // plain cast (no `toPrimitive`, no user JS). `JSString` is an
                 // `opaque_ffi!` ZST — `opaque_ref` is the safe deref.
                 string_slices
-                    .push(bun_jsc::JSString::opaque_ref(val.as_string()).to_slice(global_this));
+                    .push(bun_jsc::JSString::opaque_ref(val.as_string()).to_slice(global_this)?);
                 break 'brk string_slices.last().unwrap().slice();
             };
             payloads[slice_idx] = slice.as_ptr();
@@ -1528,7 +1528,9 @@ impl UDPSocket {
                 // and `this.socket orelse throw` below handles a
                 // close-during-`toPrimitive`.
                 // SAFETY: to_js_string returned non-null on success path.
-                payload_str = payload_arg.to_js_string(global_this)?.to_slice(global_this);
+                payload_str = payload_arg
+                    .to_js_string(global_this)?
+                    .to_slice(global_this)?;
                 break 'brk payload_str.slice();
             } else {
                 return Err(global_this.throw_invalid_arguments(format_args!(

--- a/src/runtime/test_runner/expect.rs
+++ b/src/runtime/test_runner/expect.rs
@@ -1388,7 +1388,11 @@ impl Expect {
                     let type_name = if matcher_fn.is_null() {
                         bun_core::String::static_("null")
                     } else {
-                        bun_core::String::init(matcher_fn.js_type_string(global_this).get_zig_string(global_this))
+                        bun_core::String::init(
+                            matcher_fn
+                                .js_type_string(global_this)
+                                .get_zig_string(global_this)?,
+                        )
                     };
                     return Err(global_this.throw_invalid_arguments(format_args!(
                         "expect.extend: `{}` is not a valid matcher. Must be a function, is \"{}\"",

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -276,7 +276,7 @@ impl SubscriptionCtx {
                 // `JSString` is an `opaque_ffi!` ZST — `opaque_ref` is the safe
                 // deref (`as_string()` returns a live cell for string values).
                 bun_jsc::JSString::opaque_ref(channel_name.as_string())
-                    .get_zig_string(global_object)
+                    .get_zig_string(global_object)?
             );
             return Ok(());
         };

--- a/src/runtime/webcore/Sink.rs
+++ b/src/runtime/webcore/Sink.rs
@@ -496,7 +496,7 @@ impl<T: JsSinkType> JSSink<T> {
         }
 
         let str_ = arg.to_js_string(global)?;
-        let view = str_.view(global);
+        let view = str_.view(global)?;
         if view.is_empty() {
             return Ok(JSValue::js_number(0.0));
         }

--- a/src/semver_jsc/SemverObject.rs
+++ b/src/semver_jsc/SemverObject.rs
@@ -28,8 +28,8 @@ fn order(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let left_string = arguments[0].to_js_string(global)?;
     let right_string = arguments[1].to_js_string(global)?;
 
-    let left = left_string.to_slice(global);
-    let right = right_string.to_slice(global);
+    let left = left_string.to_slice(global)?;
+    let right = right_string.to_slice(global)?;
 
     if !strings::is_all_ascii(left.slice()) {
         return Ok(JSValue::js_number_from_int32(0));
@@ -77,8 +77,8 @@ fn satisfies(global: &JSGlobalObject, frame: &CallFrame) -> JsResult<JSValue> {
     let left_string = arguments[0].to_js_string(global)?;
     let right_string = arguments[1].to_js_string(global)?;
 
-    let left = left_string.to_slice(global);
-    let right = right_string.to_slice(global);
+    let left = left_string.to_slice(global)?;
+    let right = right_string.to_slice(global)?;
 
     if !strings::is_all_ascii(left.slice()) {
         return Ok(JSValue::FALSE);

--- a/test/bundler/bundler_plugin.test.ts
+++ b/test/bundler/bundler_plugin.test.ts
@@ -234,6 +234,49 @@ describe("bundler", () => {
     },
   });
 
+  // A 16-bit rope string of the maximum length (2^31 - 1 chars). Building it
+  // only allocates rope nodes, but a flat 16-bit buffer of that length fails
+  // WTF::StringImpl::isValidLength, so the first thing to read the string gets
+  // JSC's "Out of memory" RangeError without any allocation being attempted.
+  // Returned from onResolve with `external: true`, nothing on the JS side reads
+  // it, so the first read is the bundler converting the result to bytes. That
+  // used to leave the exception pending and answer the resolve with an empty
+  // string.
+  function unflattenableString() {
+    let str = "\u0100";
+    for (let i = 0; i < 30; i++) str = str + str + "\u0100";
+    expect(str.length).toBe(2 ** 31 - 1);
+    return str;
+  }
+  itBundled("plugin/ResolvePathStringConversionThrows", {
+    files: resolveFixture,
+    plugins(builder) {
+      builder.onResolve({ filter: /\.magic$/ }, () => {
+        return { path: unflattenableString(), external: true };
+      });
+    },
+    bundleErrors: {
+      "/index.ts": [`Out of memory`],
+    },
+    onAfterApiBundle(build) {
+      expect(build.success).toBe(false);
+    },
+  });
+  itBundled("plugin/ResolveNamespaceStringConversionThrows", {
+    files: resolveFixture,
+    plugins(builder) {
+      builder.onResolve({ filter: /\.magic$/ }, () => {
+        return { path: "foo", namespace: unflattenableString(), external: true };
+      });
+    },
+    bundleErrors: {
+      "/index.ts": [`Out of memory`],
+    },
+    onAfterApiBundle(build) {
+      expect(build.success).toBe(false);
+    },
+  });
+
   //
   itBundled("plugin/ResolvePrefix", ({ root }) => {
     let onResolveCount = 0;

--- a/test/js/bun/websocket/websocket-server.test.ts
+++ b/test/js/bun/websocket/websocket-server.test.ts
@@ -1580,6 +1580,68 @@ it("server.upgrade() with Sec-WebSocket-Protocol in options.headers does not use
   expect(exitCode).toBe(0);
 });
 
+it("send()/publish() with a string that cannot be flattened throw and send nothing", async () => {
+  // A 16-bit rope string of the maximum length (2^31 - 1 chars). Building it
+  // only allocates rope nodes, but a flat 16-bit buffer of that length fails
+  // WTF::StringImpl::isValidLength, so reading the string throws JSC's
+  // "Out of memory" RangeError without any allocation being attempted. The
+  // native side used to ignore that exception, write an empty text frame to
+  // the peer, and only then let the exception surface.
+  let huge = "\u0100";
+  for (let i = 0; i < 30; i++) huge = huge + huge + "\u0100";
+  expect(huge.length).toBe(2 ** 31 - 1);
+
+  // Each entry is either what the call returned or { name, message } of what it threw.
+  const outcomes: unknown[] = [];
+  await using server = serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    fetch(req, srv) {
+      if (srv.upgrade(req)) return;
+      return new Response("no", { status: 400 });
+    },
+    websocket: {
+      publishToSelf: true,
+      open(ws) {
+        ws.subscribe("topic");
+        for (const attempt of [
+          () => ws.send(huge),
+          () => ws.sendText(huge),
+          () => ws.publish("topic", huge),
+          () => ws.publishText("topic", huge),
+          () => server.publish("topic", huge),
+        ]) {
+          try {
+            outcomes.push(attempt());
+          } catch (e) {
+            outcomes.push({ name: (e as Error).name, message: (e as Error).message });
+          }
+        }
+        ws.send("done");
+      },
+      message() {},
+    },
+  });
+
+  const received: string[] = [];
+  const done = Promise.withResolvers<void>();
+  const client = new WebSocket(`ws://127.0.0.1:${server.port}/`);
+  client.onmessage = e => {
+    received.push(e.data);
+    if (e.data === "done") done.resolve();
+  };
+  client.onerror = () => done.reject(new Error("client websocket errored"));
+  client.onclose = () => done.reject(new Error("client websocket closed before receiving 'done'"));
+  await done.promise;
+  client.onclose = null;
+  client.close();
+
+  expect({ received, outcomes }).toEqual({
+    received: ["done"],
+    outcomes: Array(5).fill({ name: "RangeError", message: "Out of memory" }),
+  });
+});
+
 // publish() fans out to N subscribers and must report backpressure/drops the
 // same way ws.send() does for a single socket.
 describe.concurrent("publish() return value reflects subscriber backpressure", () => {


### PR DESCRIPTION
### Problem

- An onResolve plugin that returns a `path` or `namespace` string JSC cannot flatten makes a debug build abort with `ASSERTION FAILED: Unexpected exception observed ... Error Exception: Out of memory` / `!exception()` in `JSC::ExceptionScope::releaseAssertNoException()` once `jsBundlerPluginFunction_onResolveAsync` returns.
- Release builds are worse than "the path is read as empty": the exception left on the VM rejects the async wrapper in `runOnResolvePlugins` (`src/js/builtins/BundlerPlugin.ts`), whose rejection handler calls `addError` for the same request, so the one `Resolve` is answered twice (`Success` with an empty string, then `Err`). Running the repro below 40 times in a loop on the current canary (da3851e57) segfaults or panics; a single run reports `success: true` or the error depending on timing.
- Cause: `JSC__JSString__toZigString` (`src/jsc/bindings/bindings.cpp`) calls `JSString::value()`, which on a failed flatten throws and returns the null string; the shim hands back an empty `ZigString` with the exception still pending, and `JSString::to_zig_string` (`src/jsc/JSString.rs`) never checks for it. So `get_zig_string`, `view`, `to_slice` and `to_slice_clone` on `JSString` (and `JSValue::to_slice_clone`, which goes through it) reported success with an empty string. The `.expect("Unexpected: path is not a string")` in `JSBundlerPlugin__onResolveAsync` (`src/runtime/api/JSBundler.rs`) never fired because the helper never reported the failure.
- The same swallow is reachable from the other callers of these helpers. For example `ws.send(str)` / `ws.publish(topic, str)` / `server.publish(topic, str)` wrote an empty text frame to the peer before the error surfaced, and `Bun.semver`, `zlib.crc32`, `util.parseEnv`, `dns.lookup`, `udpSocket.send`, `http2` header encoding and `FileSink`/`ArrayBufferSink.write` all carried on with an empty string. `JSValue::to_zig_string` (the `JSValue` flavour of the same helper) already handled this correctly, so `JSValue::get_zig_string` / `to_slice` callers were not affected.

### Fix

- `JSString::to_zig_string` wraps the FFI call in `from_js_host_call_generic`, exactly as `JSValue::to_zig_string` does, and returns `JsResult<()>`; `get_zig_string`, `view` and `to_slice` become `JsResult` too and `to_slice_clone` propagates instead of always returning `Ok`. This is correct because flattening a rope is a fallible JSC operation and this wrapper is the layer that turns a pending exception into a `JsResult`; a C++ shim leaving the exception on the VM is the normal JSC convention.
- Every caller now propagates the error: host functions use `?` (their callers already unwind on a pending exception), the `JsError`-returning helpers in `JSGlobalObject.rs` / `validators.rs` return the pending exception instead of building a second error on top of it, and the two non-throwing contexts keep their existing behaviour for "could not read the string" (`wrap_unhandled_rejection_error_for_uncaught_exception` falls through to its existing `undefined` message, `import_windows_socket_payload` clears and returns `None`, matching the `Err` arm a few lines above it).
- `JSBundlerPlugin__onResolveAsync` turns an `Err` into `ResolveValue::Err(plugin_msg_from_js(...))`, which is what `JSBundlerPlugin__addError` does for an exception thrown by the callback itself, and still reaches `on_resolve_async`. Taking the exception (`take_exception`) is what removes the second answer: the host function returns with nothing pending, so `runOnResolvePlugins` no longer rejects. The build fails with `error: Out of memory` at the importing file, and the next `Bun.build` in the process works. This keeps the JSBundler.rs change to the one branch since #37746 / #37709 restructure these thunks; #37858 does the equivalent for the onLoad thunk and explicitly leaves this one alone.
- Verified with `test/bundler/bundler_plugin.test.ts` (`plugin/ResolvePathStringConversionThrows`, `plugin/ResolveNamespaceStringConversionThrows`) and `test/js/bun/websocket/websocket-server.test.ts` (`send()/publish() with a string that cannot be flattened throw and send nothing`, which covers `ws.send`, `ws.sendText`, `ws.publish`, `ws.publishText` and `server.publish`). Without the src change, a debug build aborts on the assertion in all three tests; the release canary fails the path test (`success: true`; the namespace variant depends on which of the two answers the bundler thread sees first) and the websocket test (five empty frames delivered before `"done"`). With it, all pass, also under `BUN_JSC_validateExceptionChecks=1`.
- Also run with the change: the rest of `bundler_plugin.test.ts` and `websocket-server.test.ts`, `test/cli/install/semver.test.ts`, `test/js/node/zlib/zlib.test.js`, `test/js/node/util/util.test.js`, `test/js/bun/util/arraybuffersink.test.ts`, `test/js/bun/test/expect-extend-preload.test.ts`, `test/js/bun/udp/udp_socket.test.ts`, `test/js/node/http2/node-http2.test.js`, and the node parallel tests for `zlib.crc32`, `util.parseEnv` and unhandled rejections. `cargo check` of `bun_runtime` for `x86_64-pc-windows-msvc` and `aarch64-apple-darwin` covers the two `cfg(windows)` call sites; `cargo fmt` and clippy are clean on the touched files.

### Background

- Rope strings: JSC represents the result of string concatenation as a tree of fibers (`JSRopeString`) and only builds the flat character buffer when something needs to read it ("flattening", `JSRopeString::resolveRope`). Building a rope of length `2^31 - 1` only allocates tree nodes (the repro peaks around 30 MB RSS), while flattening it as 16-bit text needs a buffer larger than `WTF::StringImpl` allows (`isValidLength<char16_t>` caps it a few characters below `String::MaxLength`), so `resolveRope` throws a `RangeError` with the message `Out of memory` without attempting an allocation. It is an ordinary catchable exception about one oversized value, not a process-level allocation failure, which is why failing the call (or the build) is the proportionate response. An 8-bit rope of the same length would instead try a real 2 GB allocation, hence the `\u0100` characters in the tests.
- Pending exceptions: JSC reports a throw by storing the exception on the VM; the C++ caller is expected to check it (`RETURN_IF_EXCEPTION`). On the Rust side this check is `from_js_host_call_generic` / `TopExceptionScope`, which turns a pending exception into `Err(JsError::Thrown)`. A host function that returns normally with an exception pending is an assertion failure in debug builds; in release JSC throws it into the calling JS frame after the host function returns, which is what produced the second `addError` answer here.
- Plugin resolve requests: the bundler thread parks a `Resolve` and blocks on it until the JS thread answers exactly once by setting `resolve.value` and calling `on_resolve_async`, which hands it back to the bundler thread. `JSBundlerPlugin__addError` is the existing answer path for a callback that threw; `plugin_msg_from_js` converts the exception into the `logger.Msg` that `on_resolve` logs against the importing file.

<details>
<summary>Repro (entry.ts contains <code>import "huge";</code>)</summary>

```ts
let huge = "\u0100";
for (let i = 0; i < 30; i++) huge = huge + huge + "\u0100"; // length 2**31 - 1, never flattened by JS
const r = await Bun.build({
  entrypoints: ["./entry.ts"],
  throw: false,
  plugins: [{ name: "x", setup(b) { b.onResolve({ filter: /^huge$/ }, () => ({ path: huge, external: true })); } }],
});
console.log(r.success, r.logs.map(l => l.message));
```

`external: true` matters: with it the JS side never reads the string, so the first flatten happens in `onResolveAsync`. `{ path: "/x", namespace: huge, external: true }` behaves the same.

Before, debug build:

```
ASSERTION FAILED: Unexpected exception observed on thread ...
Error Exception: Out of memory
!exception()
.../JavaScriptCore/ExceptionScope.h(62) : void JSC::ExceptionScope::releaseAssertNoException()
```

Before, release canary da3851e57, single run: `true []`. The same build in a `for` loop of 40 iterations:

```
panic: Segmentation fault at address 0x0
```

(sometimes `panic: infallible: runtime export`, depending on which answer the bundler thread sees first).

After (debug and release): `false [ "Out of memory" ]`, reported at `entry.ts`, 40 out of 40 iterations, and a following `Bun.build` in the same process succeeds.

Other callers, before the change on the release canary, `ws.send(huge)` delivered an empty text message to the client and then threw; after the change it throws without sending anything (`websocket-server.test.ts` asserts the client only receives the `"done"` sent afterwards). `Bun.semver.order(huge, "1.0.0")` aborted debug builds on the same assertion before and throws the `RangeError` now.
</details>
