### PR TITLE
build: retry dep downloads for ~3 minutes and report the underlying failure

### DIFF
--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -8,10 +8,25 @@
  *
  * ## Retry behavior
  *
- * Exponential backoff (1s → 2s → 4s → 8s → cap at 30s), 5 attempts. GitHub
- * releases (our main source) are usually reliable, but CI sees transient
- * CDN failures often enough that no-retry means flaky builds. The cap at
- * 30s means worst-case we spend ~60s total before giving up.
+ * `downloadRetry`: 10 attempts, backoff doubling from 2s and capped at 30s,
+ * so a download keeps trying through ~3 minutes of backoff (plus whatever
+ * the failing attempts themselves take).
+ *
+ * The window is sized for github.com being unreachable from a CI agent, not
+ * for one bad request. Every download starts at github.com (archives and
+ * release assets both 302 from there), and every dep whose pin moved after
+ * the CI images were baked misses the prefetch cache below, so each build
+ * makes on the order of a hundred live github.com downloads (several deps at
+ * any given time, plus WebKit, which is bumped more often than the images
+ * are rebaked). The outages CI actually hits are agent-wide: every
+ * github.com connection from one agent failing for 30s to over two minutes
+ * while the rest of the build is fine. The previous 5 attempts / ~30s gave
+ * up inside those and took a random build lane with them.
+ *
+ * 408/429 are retried along with 5xx and network errors; the other 4xx are
+ * deterministic and fail immediately. Retry lines and the final error name
+ * the underlying failure (`describeError`), since `fetch` itself only says
+ * "fetch failed".
  *
  * ## Atomic writes
  *
@@ -37,7 +52,7 @@ import { basename, resolve } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeWebReadable } from "node:stream/web";
-import { BuildError, assert } from "./error.ts";
+import { BuildError, assert, describeError } from "./error.ts";
 
 // On Windows, prefer the OS-shipped bsdtar. Git-for-Windows / MSYS put GNU tar
 // earlier in PATH, and GNU tar parses `C:\...` as an rsh `host:path` spec
@@ -132,15 +147,36 @@ async function chmodRecursiveWritable(root: string): Promise<void> {
   for (const e of await readdir(root)) await chmodRecursiveWritable(resolve(root, e));
 }
 
+/** Retry schedule for one download. Sizing rationale: "Retry behavior" above. */
+export interface RetryPolicy {
+  /** Total tries, including the first. */
+  attempts: number;
+  /** Delay before try number `attempt` (2..attempts). */
+  backoffMs(attempt: number): number;
+}
+
+export const downloadRetry: RetryPolicy = {
+  attempts: 10,
+  backoffMs: attempt => Math.min(1000 * 2 ** (attempt - 1), 30_000),
+};
+
 /**
  * Download a URL to a file with retry. Atomic: temp file → rename on success.
  *
  * Checks `prefetchDir/by-url/` first — on a CI image with a warm prefetch
  * cache the network is never touched for matching URLs.
  *
- * @param logPrefix Shown in progress/retry messages: `[<logPrefix>] retry 2/5`
+ * @param logPrefix Unused: under ninja, stream.ts already prefixes every line
+ *   with the dep name.
+ * @param retry Tests pass a schedule with no backoff to drive the full
+ *   attempt count without sleeping through it.
  */
-export async function downloadWithRetry(url: string, dest: string, logPrefix: string): Promise<void> {
+export async function downloadWithRetry(
+  url: string,
+  dest: string,
+  logPrefix: string,
+  retry: RetryPolicy = downloadRetry,
+): Promise<void> {
   const prefetched = prefetchPathForUrl(url);
   if (prefetched !== undefined && existsSync(prefetched)) {
     console.log(`using prefetch cache: ${prefetched}`);
@@ -153,14 +189,14 @@ export async function downloadWithRetry(url: string, dest: string, logPrefix: st
     return;
   }
 
-  const maxAttempts = 5;
+  const maxAttempts = retry.attempts;
   let lastError: unknown;
   let permanent = false;
 
   for (let attempt = 1; attempt <= maxAttempts && !permanent; attempt++) {
     if (attempt > 1) {
-      const backoffMs = Math.min(1000 * Math.pow(2, attempt - 1), 30000);
-      console.log(`retry ${attempt}/${maxAttempts} in ${backoffMs}ms`);
+      const backoffMs = retry.backoffMs(attempt);
+      console.log(`retry ${attempt}/${maxAttempts} in ${backoffMs}ms (${describeError(lastError)})`);
       await new Promise(r => setTimeout(r, backoffMs));
     }
 
@@ -169,9 +205,10 @@ export async function downloadWithRetry(url: string, dest: string, logPrefix: st
       const res = await fetch(url, { headers: { "User-Agent": "bun-build-system" } });
       if (!res.ok || res.body === null) {
         lastError = new BuildError(`HTTP ${res.status} ${res.statusText} for ${url}`);
-        // 4xx is deterministic — a bad URL/missing artifact won't succeed on
-        // retry. Only loop on 5xx/network where the CDN may recover.
-        permanent = res.status >= 400 && res.status < 500;
+        // 4xx is deterministic (bad URL, missing artifact) and won't succeed
+        // on retry, except 408/429, which are the server asking for exactly
+        // that. Loop on those, 5xx, and network errors.
+        permanent = res.status >= 400 && res.status < 500 && res.status !== 408 && res.status !== 429;
         continue;
       }
 

--- a/scripts/build/error.ts
+++ b/scripts/build/error.ts
@@ -31,11 +31,38 @@ export class BuildError extends Error {
       out += `  hint: ${this.hint}\n`;
     }
     if (this.cause !== undefined) {
-      const cause = this.cause instanceof Error ? this.cause.message : String(this.cause);
-      out += `  cause: ${cause}\n`;
+      out += `  cause: ${describeError(this.cause)}\n`;
     }
     return out;
   }
+}
+
+/**
+ * One line naming an error and everything it wraps, outermost first:
+ * `fetch failed: getaddrinfo EAI_AGAIN github.com`. The outer message alone
+ * is often content-free: node's fetch reports every network failure as
+ * "fetch failed" and puts the reason (DNS, connect timeout, reset) in
+ * `cause`, and a connect that failed on every resolved address is an
+ * AggregateError whose own message is empty.
+ */
+export function describeError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const parts: string[] = [];
+  const seen = new Set<Error>();
+  let e: unknown = err;
+  while (e instanceof Error && !seen.has(e)) {
+    seen.add(e);
+    if (e instanceof AggregateError && e.errors.length > 0) {
+      const inner = e.errors.map(describeError).join("; ");
+      parts.push(e.message ? `${e.message} (${inner})` : inner);
+    } else {
+      parts.push(e.message || e.name);
+    }
+    e = e.cause;
+  }
+  // A non-Error cause (`{ cause: "ECONNRESET" }`) still carries the reason.
+  if (e !== undefined && e !== null && !(e instanceof Error)) parts.push(String(e));
+  return parts.join(": ");
 }
 
 /**

--- a/test/internal/build-download-retry.test.ts
+++ b/test/internal/build-download-retry.test.ts
@@ -1,0 +1,194 @@
+/**
+ * downloadWithRetry() (scripts/build/download.ts) is all that stands between
+ * a CI build lane and github.com: every dep whose pin moved after the CI
+ * images (and the prefetch cache baked into them) were published downloads
+ * live on every lane of every build, WebKit included, so a build makes on the
+ * order of a hundred github.com round-trips through this one loop. The
+ * outages CI actually hits are agent-wide and last from 30s to a few minutes;
+ * a 5 attempt / ~30s schedule gave up inside them and failed the lane with
+ * nothing but "cause: fetch failed" in the log.
+ *
+ * The fake server below scripts one outcome per request. The production
+ * schedule is driven with its backoff zeroed, so the full attempt count runs
+ * in milliseconds; the schedule's real timing is asserted separately.
+ */
+import { expect, spyOn, test } from "bun:test";
+import { tempDir } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import { createServer, type AddressInfo } from "node:net";
+import { join } from "node:path";
+
+import { downloadRetry, downloadWithRetry, type RetryPolicy } from "../../scripts/build/download.ts";
+import { BuildError, describeError } from "../../scripts/build/error.ts";
+
+const BODY = "tarball bytes";
+
+/** The production attempt count with no waiting between attempts. */
+const noBackoff: RetryPolicy = { ...downloadRetry, backoffMs: () => 0 };
+
+/** "drop" closes the connection without answering; a string is a status line. */
+type Outcome = "drop" | string;
+
+/**
+ * Answers each request with the next scripted outcome, then with BODY once
+ * the script runs out (or drops forever when asked to). "drop" is what an
+ * unreachable or resetting github.com looks like to fetch(). Every response
+ * is Connection: close, so one attempt is exactly one request here.
+ */
+async function fakeServer(script: Outcome[], { dropForever = false } = {}) {
+  let requests = 0;
+  const server = createServer(socket => {
+    socket.once("data", () => {
+      requests++;
+      const outcome = dropForever ? "drop" : script.shift();
+      if (outcome === "drop") {
+        socket.destroy();
+      } else if (outcome === undefined) {
+        socket.end(`HTTP/1.1 200 OK\r\nContent-Length: ${BODY.length}\r\nConnection: close\r\n\r\n${BODY}`);
+      } else {
+        socket.end(`HTTP/1.1 ${outcome}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n`);
+      }
+    });
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}/dep.tar.gz`,
+    get requests() {
+      return requests;
+    },
+    [Symbol.asyncDispose]: () => new Promise<void>(resolve => server.close(() => resolve())),
+  };
+}
+
+async function rejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  throw new Error("expected the download to fail");
+}
+
+/** downloadWithRetry narrates each retry through console.log; collect those lines instead of printing them. */
+async function withLogCaptured<T>(fn: () => Promise<T>): Promise<{ result: T; lines: string[] }> {
+  const lines: string[] = [];
+  const log = spyOn(console, "log").mockImplementation((...args: unknown[]) => {
+    lines.push(args.join(" "));
+  });
+  try {
+    return { result: await fn(), lines };
+  } finally {
+    log.mockRestore();
+  }
+}
+
+test("the schedule waits out at least two minutes of github.com being unreachable", () => {
+  let totalBackoffMs = 0;
+  for (let attempt = 2; attempt <= downloadRetry.attempts; attempt++) {
+    const backoffMs = downloadRetry.backoffMs(attempt);
+    // Capped so a recovered network is noticed within half a minute.
+    expect(backoffMs).toBeLessThanOrEqual(30_000);
+    totalBackoffMs += backoffMs;
+  }
+  expect(totalBackoffMs).toBeGreaterThanOrEqual(120_000);
+});
+
+test("a download that fails on every attempt but the last still succeeds", async () => {
+  using dir = tempDir("build-download-retry", {});
+  await using server = await fakeServer(Array(downloadRetry.attempts - 1).fill("drop"));
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { lines } = await withLogCaptured(() => downloadWithRetry(server.url, dest, "dep", noBackoff));
+
+  expect(readFileSync(dest, "utf8")).toBe(BODY);
+  expect(server.requests).toBe(downloadRetry.attempts);
+  expect(lines.filter(line => line.startsWith("retry "))).toHaveLength(downloadRetry.attempts - 1);
+});
+
+test("429 is retried, and the retry line says what failed", async () => {
+  using dir = tempDir("build-download-retry", {});
+  await using server = await fakeServer(["429 Too Many Requests"]);
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { lines } = await withLogCaptured(() => downloadWithRetry(server.url, dest, "dep", noBackoff));
+
+  expect(readFileSync(dest, "utf8")).toBe(BODY);
+  expect(server.requests).toBe(2);
+  expect(lines).toEqual([`retry 2/${downloadRetry.attempts} in 0ms (HTTP 429 Too Many Requests for ${server.url})`]);
+});
+
+test("404 is not retried and is thrown as-is (prefetch-deps.ts matches on the message)", async () => {
+  using dir = tempDir("build-download-retry", {});
+  await using server = await fakeServer(["404 Not Found"]);
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { result: err, lines } = await withLogCaptured(() =>
+    rejection(downloadWithRetry(server.url, dest, "dep", noBackoff)),
+  );
+
+  expect(err).toBeInstanceOf(BuildError);
+  expect((err as BuildError).message).toBe(`HTTP 404 Not Found for ${server.url}`);
+  expect(lines).toEqual([]);
+  expect(server.requests).toBe(1);
+  expect(existsSync(dest)).toBe(false);
+});
+
+test("giving up reports the attempt count and the failure that ended it", async () => {
+  using dir = tempDir("build-download-retry", {});
+  await using server = await fakeServer([], { dropForever: true });
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { result, lines } = await withLogCaptured(() =>
+    rejection(downloadWithRetry(server.url, dest, "dep", noBackoff)),
+  );
+  const err = result as BuildError;
+
+  expect(err).toBeInstanceOf(BuildError);
+  expect(err.message).toBe(`Failed to download after ${downloadRetry.attempts} attempts: ${server.url}`);
+  // The dropped connection is what fetch() threw; it must be named both in
+  // the final report and on every retry line. (The exact wording is the
+  // runtime's, so only its gist is pinned.)
+  const droppedConnection = /closed|reset/i;
+  const reason = describeError(err.cause);
+  expect(reason).toMatch(droppedConnection);
+  expect(err.format()).toContain(`cause: ${reason}`);
+  expect(lines.map(line => line.replace(/ \(.*\)$/, ""))).toEqual(
+    Array.from({ length: downloadRetry.attempts - 1 }, (_, i) => `retry ${i + 2}/${downloadRetry.attempts} in 0ms`),
+  );
+  for (const line of lines) expect(line).toMatch(droppedConnection);
+  expect(server.requests).toBe(downloadRetry.attempts);
+  expect(existsSync(dest)).toBe(false);
+});
+
+test("BuildError.format() shows what is behind node's 'fetch failed'", () => {
+  const err = new BuildError("Failed to download after 10 attempts: https://github.com/o/r/archive/abc.tar.gz", {
+    hint: "Check network connectivity",
+    cause: new TypeError("fetch failed", { cause: new Error("getaddrinfo EAI_AGAIN github.com") }),
+  });
+
+  expect(err.format()).toBe(
+    "error: Failed to download after 10 attempts: https://github.com/o/r/archive/abc.tar.gz\n" +
+      "  hint: Check network connectivity\n" +
+      "  cause: fetch failed: getaddrinfo EAI_AGAIN github.com\n",
+  );
+});
+
+test("describeError() flattens cause chains, AggregateErrors, and non-Error causes", () => {
+  expect(describeError("just a string")).toBe("just a string");
+  expect(describeError(new Error("write failed", { cause: "ENOSPC" }))).toBe("write failed: ENOSPC");
+
+  // node's shape for a connect that failed on every resolved address: the
+  // AggregateError's own message is empty, the reasons are in .errors.
+  const connect = new AggregateError([
+    new Error("connect ETIMEDOUT 140.82.112.3:443"),
+    new Error("connect ENETUNREACH 140.82.112.4:443"),
+  ]);
+  expect(describeError(new TypeError("fetch failed", { cause: connect }))).toBe(
+    "fetch failed: connect ETIMEDOUT 140.82.112.3:443; connect ENETUNREACH 140.82.112.4:443",
+  );
+
+  const loop = new Error("loops");
+  loop.cause = loop;
+  expect(describeError(loop)).toBe("loops");
+});


### PR DESCRIPTION
### Problem
- Build lanes die in a dep fetch: `error: Failed to download after 5 attempts: https://github.com/oven-sh/lol-html/archive/725ce499....tar.gz`, `cause: fetch failed`. Build 93382 lost linux x64-asan on lolhtml. Build 93392 (a one-file PR) lost four lanes: x64-musl and x64-android on cares, mimalloc and the WebKit tarball, freebsd aarch64 on lolhtml, windows aarch64 on cares, libuv, mimalloc and WebKit.
- Those are the downloads that miss the image's prefetch cache (everything else in the same logs says `using prefetch cache`): the deps whose pins moved after the images were baked in #34782 (lolhtml #36733, mimalloc #36431, c-ares #34007, libuv #36839, WebKit several times a week), plus WebKit on every lane other than linux arm64, because `prefetch-deps.ts` only enumerates the bake host's own target (handed off separately). Each build makes on the order of a hundred live github.com downloads.
- `downloadWithRetry` (`scripts/build/download.ts:156`) made 5 attempts with 2+4+8+16s of backoff, about 30s in total. The logs show agent-wide outages longer than that: on the x64-musl lane three downloads that started together failed on all five attempts over roughly two minutes, after lolhtml had succeeded on the same agent seconds earlier; on the freebsd lane lolhtml failed five times in a row while cares and mimalloc went through and WebKit succeeded on its second try.
- `BuildError.format()` (`scripts/build/error.ts:33`) prints one level of cause. node's fetch throws `TypeError: fetch failed` and keeps the real error (DNS, connect timeout, reset) in `.cause`, so every one of these logs says only `cause: fetch failed`, and the retry lines say nothing about what failed.

### Fix
- `downloadRetry`: 10 attempts, backoff doubling from 2s and capped at 30s, 180s of backoff in total instead of 30s. Exported as a `RetryPolicy` (optional last parameter of `downloadWithRetry`) so the test can run the production attempt count with the backoff zeroed.
- 408 and 429 are retried along with 5xx and network errors. Other 4xx still fail on the first attempt and are still thrown unwrapped, which `prefetch-deps.ts` relies on to tell a 404 (variant not published) from a transient failure.
- Each retry line names the failure it is retrying, e.g. `retry 2/10 in 2000ms (fetch failed: other side closed)`, and `format()` prints the whole cause chain through the new `describeError()`, so the next one of these says what the network did.
- Why here: the prefetch cache goes stale by design as soon as a pin moves, and WebKit moves faster than images get rebaked (the images were rebaked on July 21 and this came back within two weeks; #30095 was an earlier rebake for the same symptom), so the live path is permanently on every build's critical path and has to outlast the outages CI actually sees. The wider window only costs time while github.com is actually down, when the lane would otherwise have failed; build-bun's step timeout is 60 minutes.
- Verified with `test/internal/build-download-retry.test.ts` (`bun bd test`, 7 pass). It drives the real `downloadWithRetry` against a local server that drops connections or returns scripted statuses, checks the retry lines and `format()` output, and pins the schedule's total backoff at two minutes or more. Against the previous `download.ts`/`error.ts` the file fails at import (`downloadRetry` and `describeError` did not exist); each behavioral case is something the old loop did not do (10 attempts, 429 retried, reason on the retry line, cause chain in `format()`).
- Also ran the loop under node, the runtime CI builds with, against a dropping server: retry lines read `(fetch failed: other side closed)` and the final report prints `cause: fetch failed: other side closed`. `bunx tsc -p scripts/build/tsconfig.json` reports nothing for these files.

### Background
- Dep fetching: configure emits one ninja `dep_fetch` edge per vendored dep, which runs `scripts/build/fetch-cli.ts`; that calls `downloadWithRetry` on `https://github.com/<repo>/archive/<commit>.tar.gz`, and `fetchPrebuilt` uses the same function for release tarballs such as WebKit. Both URL kinds start with a 302 from github.com (to codeload.github.com and objects.githubusercontent.com respectively), which is why one github.com problem takes out both kinds at once.
- Prefetch cache: CI images run `scripts/prefetch-deps.ts` at bake time, storing each tarball under `/opt/bun-prefetch/by-url/<sha256(url)>`. `downloadWithRetry` looks there before touching the network, so a dep is served from the image only while its pinned URL is the one that was current at bake time; anything bumped later downloads live until the next `[publish images]` rebake.
- `BuildError` is the build system's error type; `fetch-cli.ts` and `build.ts` print failures through its `format()`, which produces the `error:` / `hint:` / `cause:` lines seen in the build log.
