### PR TITLE
Bun.serve: answer requests to a failed HTML route with 500 instead of an empty 200

### DIFF
--- a/src/runtime/server/HTMLBundle.rs
+++ b/src/runtime/server/HTMLBundle.rs
@@ -362,8 +362,7 @@ impl Route {
                             bstr::BStr::new(req.url())
                         );
                     }
-                    // TODO: use the code from DevServer.rs to render the error
-                    resp.end_without_body(true);
+                    Self::end_build_failed(resp);
                 }
                 State::Html(html) => {
                     if bun_core::Environment::ENABLE_LOGS {
@@ -750,32 +749,28 @@ impl Route {
                         unsafe { StaticRoute::on(*html, resp) };
                     }
                 }
-                State::Err(_log) => {
-                    if self
-                        .server
-                        .get()
-                        .expect("server set")
-                        .config()
-                        .is_development()
-                    {
-                        // TODO: use the code from DevServer.rs to render the error
-                    } else {
-                        // To protect privacy, do not show errors to end users in production.
-                        // TODO: Show a generic error page.
-                    }
-                    // This runs from a JS event-loop task, not a uWS handler,
-                    // so `end_without_body(true)` alone cannot close the
-                    // socket; write Content-Length so the client has framing.
-                    resp.write_status(b"500 Build Failed");
-                    resp.write_header_int(b"Content-Length", 0);
-                    resp.end_without_body(true);
-                }
+                State::Err(_log) => Self::end_build_failed(resp),
                 _ => {
                     resp.write_header_int(b"Content-Length", 0);
                     resp.end_without_body(true);
                 }
             }
         }
+    }
+
+    /// The response for a route in `State::Err`, both for the requests that were
+    /// waiting on the build that failed and for every request arriving while
+    /// the route stays in that state (outside of development: until the server
+    /// is restarted). The build log is never rendered into the response so
+    /// error details do not reach end users.
+    ///
+    /// `resume_pending_responses` runs from a JS event-loop task, not a uWS
+    /// handler, so `end_without_body(true)` alone cannot close the socket
+    /// there; the Content-Length gives the client framing either way.
+    fn end_build_failed(resp: AnyResponse) {
+        resp.write_status(b"500 Build Failed");
+        resp.write_header_int(b"Content-Length", 0);
+        resp.end_without_body(true);
     }
 }
 

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -20,6 +20,17 @@ function extractHash(html: string, file_kind: "css" | "js") {
   return html.match(re)?.[1];
 }
 
+/**
+ * What an HTML route whose bundle could not be built answers with: the first
+ * request (which waited for the build) and every request after it.
+ */
+const buildFailedResponses = ["GET", "GET", "HEAD"].map(method => ({
+  method,
+  status: 500,
+  contentLength: "0",
+  body: "",
+}));
+
 test("serve html", async () => {
   await using dir = tempDir("html-css-js", {
     "dashboard.html": /*html*/ `
@@ -416,6 +427,67 @@ export default p;
     expect(response2.status).toBe(500);
   });
 
+  // A failed plugin load is remembered for the lifetime of the server. The first
+  // request is answered when the load rejects; later requests hit the remembered
+  // failure right away, both in production (the route stays failed) and in
+  // development without HMR (the route is retried per request and fails again).
+  test("requests after a failed plugin load keep getting 500", async () => {
+    await using dir = tempDir("html-failed-plugin-load", {
+      "bunfig.toml": /* toml */ `
+[serve.static]
+plugins = ["./plugin.ts"]
+`,
+      "index.html": /*html*/ `<!DOCTYPE html><html><head><title>Plugin load failure</title></head><body></body></html>`,
+      "plugin.ts": /*ts*/ `
+export default {
+  name: "throws-in-setup",
+  setup() {
+    throw new Error("setup failed on purpose");
+  },
+};
+`,
+      "serve-fixture.ts": /*ts*/ `
+import html from "./index.html";
+
+const server = Bun.serve({
+  port: 0,
+  development: process.argv[2] === "development" ? { hmr: false } : false,
+  routes: { "/": html },
+  fetch: () => new Response("fallback", { status: 404 }),
+});
+const results = [];
+for (const method of ["GET", "GET", "HEAD"]) {
+  const response = await fetch(server.url, { method });
+  results.push({
+    method,
+    status: response.status,
+    contentLength: response.headers.get("content-length"),
+    body: await response.text(),
+  });
+}
+server.stop(true);
+console.log(JSON.stringify(results));
+`,
+    });
+
+    await Promise.all(
+      ["production", "development"].map(async mode => {
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "serve-fixture.ts", mode],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toContain("Failed to load plugins for Bun.serve");
+        expect(stderr).toContain("setup failed on purpose");
+        expect(JSON.parse(stdout)).toEqual(buildFailedResponses);
+        expect(exitCode).toBe(0);
+      }),
+    );
+  });
+
   test("empty plugin array", async () => {
     await using dir = tempDir("html-css-js-empty-plugins", {
       "index.html": /*html*/ `
@@ -717,6 +789,46 @@ test("wildcard static routes", async () => {
       expect(text).toContain("<title>Error Page</title>");
     }
   }
+});
+
+// In production the route is built once; when that build fails the route stays
+// failed, so the requests served from the failed state must report it the same
+// way as the request that waited for the build.
+test("production html route whose build failed keeps answering 500", async () => {
+  await using dir = tempDir("bun-serve-html-build-failed", {
+    "index.html": /*html*/ `
+      <!DOCTYPE html>
+      <html>
+        <head>
+          <title>Build failure</title>
+          <script type="module" src="./does-not-exist.js"></script>
+        </head>
+        <body></body>
+      </html>
+    `,
+  });
+  const { default: html } = await import(join(String(dir), "index.html"));
+
+  using server = Bun.serve({
+    port: 0,
+    development: false,
+    routes: { "/": html },
+    fetch() {
+      return new Response("fallback", { status: 404 });
+    },
+  });
+
+  const results = [];
+  for (const method of ["GET", "GET", "HEAD"]) {
+    const response = await fetch(server.url, { method });
+    results.push({
+      method,
+      status: response.status,
+      contentLength: response.headers.get("content-length"),
+      body: await response.text(),
+    });
+  }
+  expect(results).toEqual(buildFailedResponses);
 });
 
 test("serve html with JSX runtime in development mode", async () => {


### PR DESCRIPTION
### Problem
- An HTML route whose bundle failed to build, served with `development: false`, answers the request that triggered the build with `500 Build Failed` and every request after it with `HTTP 200` and an empty body.
- Same for a route whose `[serve.static]` plugin load failed: the failure is remembered per server, so the second request onwards (in production and in `development: { hmr: false }`), and the first request when the load rejects before the route is registered (plugin module already in the module cache), get the empty 200.
- Cause: `Route::on_any_request`'s `State::Err` arm (src/runtime/server/HTMLBundle.rs:357) only called `resp.end_without_body(true)`. Nothing had written a status line, and uWS's `writeHeader` (reached through the `Connection: close` header) fills in `200 OK` when none was written. The 500 only existed in `resume_pending_responses` (HTMLBundle.rs:753), which answers the requests queued during the build.

### Fix
- Both `State::Err` sites now go through one `Route::end_build_failed`, which writes `500 Build Failed`, `Content-Length: 0` and ends the response (what the pending-response path already sent).
- Correct because the two sites report the same condition: the route has no page to serve, and outside of development the state is kept until the server is restarted (`get_or_load_plugins` documents the plugin failure as requiring a restart). Whether a request arrived during the failed build or after it should not change the answer, and a 200 tells clients and caches the page exists and is empty. The 200 was never chosen; it was uWS's default for a status-less response.
- Error details are still not rendered into the body (the previous code's privacy note for production), and development without HMR still prints the log to the console, so the only visible change is the status line and the Content-Length.
- Tests, both in test/js/bun/http/bun-serve-html.test.ts:
  - `production html route whose build failed keeps answering 500`: in-process server, HTML referencing a missing script, GET, GET, HEAD all expected to be `500` / `Content-Length: 0` / empty body. Before the fix the second and third are `200` with no Content-Length.
  - `serve plugins > requests after a failed plugin load keep getting 500`: spawned fixture with a bunfig plugin whose `setup()` throws, run once with `development: false` and once with `{ hmr: false }`, same three requests, plus the "Failed to load plugins for Bun.serve" report on stderr and exit code 0. Fails the same way before the fix in both modes.
- The first request in each test still goes through `resume_pending_responses`, so the refactored path is covered too. The rest of bun-serve-html.test.ts and bun-serve-html-405.test.ts pass on the debug build; `cargo fmt --check` and `cargo clippy -p bun_runtime` are clean.
- While writing the plugin fixture I hit a separate, already tracked bug: when the plugin load rejects during the microtask drain (second `Bun.serve` in one process), the rejection is also reported as unhandled and the process exits 1. The fixture therefore runs one server per process; the state that request reaches is the same `State::Err` arm the second request exercises.

### Background
- An HTML route (`Route` in HTMLBundle.rs) is built lazily on the first request: `Pending` -> `Building` -> `Html` (serves a `StaticRoute`) or `Err` (holds the build log). Requests that arrive while building are parked as `PendingResponse`s and answered from `resume_pending_responses` once the build settles; requests that arrive in a settled state are answered directly from `on_any_request`. These are the two response sites this PR unifies.
- `development` without HMR resets `Html`/`Err` back to `Pending` on every request, so build failures are retried there. Plugin loading is separate: `ServePlugins` is per server and a failed load stays `Err`, so `schedule_bundle` puts the route straight back into `State::Err` on each retry.
- uWS `end_without_body` terminates the header section and writes no framing of its own. From inside a uWS request handler the `close_connection` flag closes the socket after the handler returns; from an event-loop task (the pending-response path) it does not, which is why the explicit `Content-Length: 0` was already there and is kept in the shared helper.

<details>
<summary>Repro on the release binary (1.4.0-canary da3851e57)</summary>

`index.html` referencing `./missing.js`, served with `development: false`:

```
request 0 -> 500 "" content-length: 0 connection: close
request 1 -> 200 "" content-length: null connection: close
request 2 -> 200 "" content-length: null connection: close
```

bunfig `[serve.static] plugins = ["./plugin.ts"]` whose `setup()` throws, two servers in one process, `development: false` (identical with `{ hmr: false }`):

```
server 0 request 0 -> 500 ""
server 0 request 1 -> 200 ""
server 1 request 0 -> 200 ""
server 1 request 1 -> 200 ""
```

</details>
