### PR TITLE
test(napi): cover worker.terminate() with napi_async_work execute in flight

### DIFF
--- a/test/napi/napi-app/binding.gyp
+++ b/test/napi/napi-app/binding.gyp
@@ -319,5 +319,16 @@
                 "NAPI_VERSION=8",
             ],
         },
+        {
+            "target_name": "test_async_work_worker_terminate",
+            "sources": ["test_async_work_worker_terminate.c"],
+            "include_dirs": ["<!@(node -p \"require('node-addon-api').include\")"],
+            "libraries": [],
+            "dependencies": ["<!(node -p \"require('node-addon-api').gyp\")"],
+            "defines": [
+                "NAPI_DISABLE_CPP_EXCEPTIONS",
+                "NODE_API_EXPERIMENTAL_NOGC_ENV_OPT_OUT=1",
+            ],
+        },
     ]
 }

--- a/test/napi/napi-app/test_async_work_worker_terminate.c
+++ b/test/napi/napi-app/test_async_work_worker_terminate.c
@@ -1,0 +1,111 @@
+#include <node_api.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+static void sleep_ms(unsigned ms) { Sleep(ms); }
+#else
+#include <unistd.h>
+static void sleep_ms(unsigned ms) { usleep(ms * 1000); }
+#endif
+
+#define CHECK(env, call)                                                       \
+  do {                                                                         \
+    napi_status s_ = (call);                                                   \
+    if (s_ != napi_ok) {                                                       \
+      napi_throw_error((env), NULL, #call " failed");                          \
+      return NULL;                                                             \
+    }                                                                          \
+  } while (0)
+
+typedef struct {
+  napi_async_work work;
+  napi_ref buf_ref;
+  napi_ref cb_ref;
+  unsigned char *data;
+  size_t len;
+  unsigned sleep_ms;
+} work_t;
+
+static void exec_cb(napi_env env, void *arg) {
+  work_t *w = (work_t *)arg;
+  sleep_ms(w->sleep_ms);
+  // Touch the ArrayBuffer backing store. Before the fix, worker.terminate()
+  // could free it (via JSC VM teardown running the ArrayBuffer finalizer)
+  // while this callback is still running on the pool thread.
+  if (w->len > 0) {
+    volatile unsigned char first = w->data[0];
+    (void)first;
+    memset(w->data, 0xab, w->len);
+  }
+}
+
+static void done_cb(napi_env env, napi_status status, void *arg) {
+  work_t *w = (work_t *)arg;
+  napi_value cb = NULL, undef = NULL, argv[1];
+  if (w->cb_ref != NULL) {
+    napi_get_reference_value(env, w->cb_ref, &cb);
+  }
+  napi_get_undefined(env, &undef);
+  napi_create_int32(env, (int)status, &argv[0]);
+  if (cb != NULL) {
+    napi_call_function(env, undef, cb, 1, argv, NULL);
+  }
+  napi_delete_reference(env, w->buf_ref);
+  if (w->cb_ref != NULL) napi_delete_reference(env, w->cb_ref);
+  napi_delete_async_work(env, w->work);
+  free(w);
+}
+
+// queueWork(arrayBuffer, ms[, cb]) -> undefined
+static napi_value queue_work(napi_env env, napi_callback_info info) {
+  size_t argc = 3;
+  napi_value argv[3];
+  CHECK(env, napi_get_cb_info(env, info, &argc, argv, NULL, NULL));
+  if (argc < 2) {
+    napi_throw_error(env, NULL, "expected (arrayBuffer, ms[, cb])");
+    return NULL;
+  }
+
+  work_t *w = (work_t *)calloc(1, sizeof(*w));
+
+  void *data = NULL;
+  size_t len = 0;
+  CHECK(env, napi_get_arraybuffer_info(env, argv[0], &data, &len));
+  w->data = (unsigned char *)data;
+  w->len = len;
+
+  int32_t ms = 0;
+  CHECK(env, napi_get_value_int32(env, argv[1], &ms));
+  w->sleep_ms = (unsigned)(ms < 0 ? 0 : ms);
+
+  CHECK(env, napi_create_reference(env, argv[0], 1, &w->buf_ref));
+  if (argc >= 3) {
+    napi_valuetype t;
+    CHECK(env, napi_typeof(env, argv[2], &t));
+    if (t == napi_function) {
+      CHECK(env, napi_create_reference(env, argv[2], 1, &w->cb_ref));
+    }
+  }
+
+  napi_value name;
+  CHECK(env, napi_create_string_utf8(env, "test_async_work_worker_terminate",
+                                     NAPI_AUTO_LENGTH, &name));
+  CHECK(env, napi_create_async_work(env, NULL, name, exec_cb, done_cb, w,
+                                    &w->work));
+  CHECK(env, napi_queue_async_work(env, w->work));
+
+  napi_value undef;
+  CHECK(env, napi_get_undefined(env, &undef));
+  return undef;
+}
+
+NAPI_MODULE_INIT() {
+  napi_value fn;
+  CHECK(env, napi_create_function(env, "queueWork", NAPI_AUTO_LENGTH,
+                                  queue_work, NULL, &fn));
+  CHECK(env, napi_set_named_property(env, exports, "queueWork", fn));
+  return exports;
+}

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -672,15 +672,7 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       `;
       await using proc = spawn({
         cmd: [bunExe(), "-e", script],
-        // LSan is off in the subprocess: a `-e` script that creates eval
-        // workers reports their source Blobs at exit regardless of the addon,
-        // and this test is about the crash.
-        env: {
-          ...bunEnv,
-          ADDON: addon,
-          WORKER_SRC: workerSrc,
-          ASAN_OPTIONS: "detect_leaks=0:allow_user_segv_handler=1",
-        },
+        env: { ...bunEnv, ADDON: addon, WORKER_SRC: workerSrc },
         stdout: "pipe",
         stderr: "pipe",
       });

--- a/test/napi/napi.test.ts
+++ b/test/napi/napi.test.ts
@@ -627,6 +627,66 @@ describe.concurrent.skipIf(!canBuildNodeAddons())("napi", () => {
       expect(output).toContain("success!");
       expect(output).not.toContain("failure!");
     });
+    // worker.terminate() while execute callbacks are still running on the
+    // thread pool must not free the worker's VirtualMachine (the pool-thread
+    // completion would post into a freed event loop) or its JSC heap (the
+    // ArrayBuffer backing store would be finalized while the addon is still
+    // writing it). VM teardown counts queued napi_async_work and waits for the
+    // pool to hand each one back before destroying the VM. Before that the
+    // subprocess died with a heap-use-after-free in the pool thread's
+    // completion post instead of printing PASS.
+    it("worker.terminate() with execute callbacks in flight waits for them and does not UAF", async () => {
+      const addon = join(__dirname, "napi-app/build/Debug/test_async_work_worker_terminate.node");
+      const workerSrc = /* js */ `
+        const { parentPort, workerData } = require("node:worker_threads");
+        const addon = require(workerData.addon);
+        const keep = [];
+        for (let i = 0; i < 4; i++) {
+          const ab = new ArrayBuffer(16 << 20);
+          keep.push(ab);
+          addon.queueWork(ab, 300 + i * 50, () => {});
+        }
+        parentPort.postMessage("up");
+        setInterval(() => {}, 1000);
+      `;
+      const script = /* js */ `
+        const { Worker } = require("node:worker_threads");
+        (async () => {
+          for (let r = 0; r < ${isASAN ? 3 : 5}; r++) {
+            const w = new Worker(process.env.WORKER_SRC, {
+              eval: true,
+              workerData: { addon: process.env.ADDON },
+            });
+            await new Promise((resolve, reject) => {
+              w.once("message", resolve);
+              w.once("error", reject);
+              w.once("exit", code => reject(new Error("worker exited before queueing work, code " + code)));
+            });
+            await w.terminate();
+          }
+          console.log("PASS");
+        })().catch(e => {
+          console.error(String(e));
+          process.exit(1);
+        });
+      `;
+      await using proc = spawn({
+        cmd: [bunExe(), "-e", script],
+        // LSan is off in the subprocess: a `-e` script that creates eval
+        // workers reports their source Blobs at exit regardless of the addon,
+        // and this test is about the crash.
+        env: {
+          ...bunEnv,
+          ADDON: addon,
+          WORKER_SRC: workerSrc,
+          ASAN_OPTIONS: "detect_leaks=0:allow_user_segv_handler=1",
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({ stdout: "PASS", stderr: "", exitCode: 0 });
+    }, 30_000);
   });
 
   describe("napi_threadsafe_function", () => {


### PR DESCRIPTION
### Problem
- `worker.terminate()` while a `napi_async_work` `execute` callback was still running on the thread pool freed the worker's VM under it.
- The pool thread then posted into the freed VM: heap-use-after-free in `EventLoop::vm_ref` (freed by `WebWorker::shutdown`). `execute` also kept writing an `ArrayBuffer` teardown had released.
- #37075 fixed this but added no napi test. This carries over the test from #36855, which #37075 superseded. No runtime changes.

### Fix
- Adds a small addon whose `execute` sleeps, then memsets a JS-owned `ArrayBuffer` on the pool thread.
- Adds a test that terminates a worker only after it reports four such works queued, so terminate always lands while `execute` is asleep.
- Verified: at 52bf09cb1c (parent of the #37075 merge) it fails 3/3 under ASAN with the UAF above; on current main it passes 3/3.
- The subprocess inherits the runner's LSan env (`BUN_DESTRUCT_VM_ON_EXIT=1`, `detect_leaks=1`) and is clean with it, 4/4 runs, so the `stderr: ""` assertion also covers leaks on this path. An earlier revision disabled LSan here over a `Blob` report that turned out to be GC timing in a bare `-e` run, not a leak.

### Background
- node-api (napi) is the C ABI native Node addons compile against; bun implements it. The addons under `test/napi/napi-app` are built by node-gyp and driven from `napi.test.ts`.
- `napi_async_work` runs `execute` on a thread pool, then posts to the owning event loop so `complete` runs on the JS thread.
- Each `worker_threads` worker owns a VM and event loop; `terminate()` frees both and finalizes heap objects such as `ArrayBuffer` stores.
- ASAN aborts as soon as freed memory is touched, which makes this race a deterministic failure.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 9 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->

<details>
<summary>Original description</summary>

### Problem
- `worker.terminate()` while a `napi_async_work` `execute` callback was still running on the thread pool freed the worker's VM under it; the pool thread's completion post then hit a heap-use-after-free (`EventLoop::vm_ref` <- `enqueue_task_concurrent` <- `napi_async_work::run`, freed by `WebWorker::shutdown`), and the addon's `execute` kept writing an `ArrayBuffer` store that VM teardown had already released.
- #37075 fixed this class (napi async work now reaches the VM through the per-VM handle that teardown counts and closes). It did not add a napi-specific test; this PR carries over the one from #36855, which that PR superseded.

### Test
- `test/napi/napi.test.ts`, `napi_async_work > worker.terminate() with execute callbacks in flight ...`: a subprocess repeatedly starts a worker that queues four works (300-450 ms `execute`, each memsetting a 16 MiB `ArrayBuffer` on the pool thread) and terminates it while they are in flight.
- Addon: `test/napi/napi-app/test_async_work_worker_terminate.c`, public node-api only (`napi_get_arraybuffer_info` + `napi_ref` pin + `napi_create/queue_async_work`).
- At 52bf09cb1c (parent of the #37075 merge) with only this test applied: fails 3/3 under `bun bd` (ASAN), `heap-use-after-free` in `EventLoop::vm_ref` as above.
- On current main (9a543cc18f): passes 3/3.
- LSan is disabled for the subprocess: on main a `-e` script that creates eval workers reports their source `Blob`s at exit with or without the addon, so the test asserts on the crash only (the napi-side state is freed at teardown; nothing napi-related shows up with LSan on).

<details>
<summary>fail-before at 52bf09cb1c</summary>

```
+ ==15816==ERROR: AddressSanitizer: heap-use-after-free on address 0x716f37f4a628
+ SUMMARY: AddressSanitizer: heap-use-after-free src/jsc/event_loop.rs:1072:18 in <bun_jsc::event_loop::EventLoop>::vm_ref
(fail) napi > napi_async_work > worker.terminate() with execute callbacks in flight waits for them and does not UAF
```
(3/3 runs)
</details>

</details>

