### PR TITLE
test(install): serve URL tarball dependencies locally in bun-install.test.ts

### DIFF
--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -119,6 +119,33 @@ function serveDirectory(root: string) {
   });
 }
 
+/**
+ * Serves URL dependencies (`http://github.com/<user>/<repo>/tarball/<ref>`, `http://some.url/path?stuff`) without
+ * the network. `bun install` downloads such URLs as-is (there is no `GITHUB_API_URL` equivalent to point at a test
+ * server), so the returned `env` instead points the install's `http_proxy` at this server. A proxied plain-http
+ * request arrives in absolute form, so `request.url` is the dependency URL itself and the specifiers keep the real
+ * hosts bun classifies them by. The dependencies must use `http://`: `https://` would be tunneled (CONNECT) to the
+ * real host. Every URL seen is pushed to `urls`; registered ones are answered with a gzipped tarball of their files,
+ * anything else with a 404. The context's registry bypasses the proxy, so its `urls`/`requested` are unaffected.
+ */
+function urlTarballProxy(ctx: TestContext, urls: string[], tarballs: Record<string, Record<string, string>>) {
+  const server = Bun.serve({
+    port: 0,
+    async fetch(request) {
+      urls.push(request.url);
+      const files = tarballs[request.url];
+      if (!files) return new Response(`no tarball registered for ${request.url}`, { status: 404 });
+      return new Response(await new Bun.Archive(files, { compress: "gzip" }).bytes());
+    },
+  });
+  const proxy_url = server.url.href.replace(/\/+$/, "");
+  const registry_host = new URL(ctx.registry_url).hostname;
+  return {
+    env: { ...env, http_proxy: proxy_url, HTTP_PROXY: proxy_url, no_proxy: registry_host, NO_PROXY: registry_host },
+    [Symbol.asyncDispose]: () => server.stop(true),
+  };
+}
+
 describe.concurrent("bun-install", () => {
   for (let input of ["abcdef", "65537", "-1"]) {
     it(`bun install --network-concurrency=${input} fails`, async () => {
@@ -4356,126 +4383,92 @@ describe.concurrent("bun-install", () => {
     });
   });
 
-  it("should handle GitHub tarball URL in dependencies (https://github.com/user/repo/tarball/ref)", async () => {
-    await withContext(defaultOpts, async ctx => {
-      const urls: string[] = [];
-      setContextHandler(ctx, dummyRegistryForContext(ctx, urls));
-      await writeFile(
-        join(ctx.package_dir, "package.json"),
-        JSON.stringify({
-          name: "Foo",
-          version: "0.0.1",
-          dependencies: {
-            when: "https://github.com/cujojs/when/tarball/1.0.2",
-          },
-        }),
-      );
-      const { stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: ctx.package_dir,
-        stdout: "pipe",
-        stdin: "pipe",
-        stderr: "pipe",
-        env,
-      });
-      const err = await stderr.text();
-      expect(err).toContain("Saved lockfile");
-      let out = await stdout.text();
-      out = out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "");
-      out = out.replace(/(github:[^#]+)#[a-f0-9]+/, "$1");
-      expect(out.split(/\r?\n/)).toEqual([
-        expect.stringContaining("bun install v1."),
-        "",
-        "+ when@https://github.com/cujojs/when/tarball/1.0.2",
-        "",
-        "1 package installed",
-      ]);
-      expect(await exited).toBe(0);
-      expect(urls.sort()).toBeEmpty();
-      expect(ctx.requested).toBe(0);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "when"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "when"))).toEqual([
-        ".gitignore",
-        ".gitmodules",
-        "LICENSE.txt",
-        "README.md",
-        "apply.js",
-        "cancelable.js",
-        "delay.js",
-        "package.json",
-        "test",
-        "timed.js",
-        "timeout.js",
-        "when.js",
-      ]);
-      const package_json = await file(join(ctx.package_dir, "node_modules", "when", "package.json")).json();
-      expect(package_json.name).toBe("when");
-      await access(join(ctx.package_dir, "bun.lockb"));
-    });
-  });
+  // The second variant also sets GITHUB_API_URL: it only applies to `github:` dependencies, so the tarball URL
+  // must still be fetched verbatim (any request reaching the local stand-in would show up in `urls`).
+  for (const with_github_api_url of [false, true]) {
+    it(
+      "should handle GitHub tarball URL in dependencies (http://github.com/user/repo/tarball/ref)" +
+        (with_github_api_url ? " with custom GITHUB_API_URL" : ""),
+      async () => {
+        await withContext(defaultOpts, async ctx => {
+          const urls: string[] = [];
+          setContextHandler(ctx, dummyRegistryForContext(ctx, urls));
+          const proxied_urls: string[] = [];
+          await using proxy = urlTarballProxy(ctx, proxied_urls, {
+            // GitHub's tarballs have a single `<user>-<repo>-<short commit>` root directory.
+            "http://github.com/cujojs/when/tarball/1.0.2": {
+              "cujojs-when-1a2b3c4/.gitignore": "",
+              "cujojs-when-1a2b3c4/.gitmodules": "",
+              "cujojs-when-1a2b3c4/LICENSE.txt": "",
+              "cujojs-when-1a2b3c4/README.md": "",
+              "cujojs-when-1a2b3c4/apply.js": "",
+              "cujojs-when-1a2b3c4/cancelable.js": "",
+              "cujojs-when-1a2b3c4/delay.js": "",
+              "cujojs-when-1a2b3c4/package.json": JSON.stringify({ name: "when", version: "1.0.2" }),
+              "cujojs-when-1a2b3c4/test/when-test.js": "",
+              "cujojs-when-1a2b3c4/timed.js": "",
+              "cujojs-when-1a2b3c4/timeout.js": "",
+              "cujojs-when-1a2b3c4/when.js": "",
+            },
+          });
+          await writeFile(
+            join(ctx.package_dir, "package.json"),
+            JSON.stringify({
+              name: "Foo",
+              version: "0.0.1",
+              dependencies: {
+                when: "http://github.com/cujojs/when/tarball/1.0.2",
+              },
+            }),
+          );
+          const { stdout, stderr, exited } = spawn({
+            cmd: [bunExe(), "install"],
+            cwd: ctx.package_dir,
+            stdout: "pipe",
+            stdin: "pipe",
+            stderr: "pipe",
+            env: with_github_api_url ? { ...proxy.env, GITHUB_API_URL: `${ctx.registry_url}github/api` } : proxy.env,
+          });
+          const err = await stderr.text();
+          expect(err).toContain("Saved lockfile");
+          let out = await stdout.text();
+          out = out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "");
+          out = out.replace(/(github:[^#]+)#[a-f0-9]+/, "$1");
+          expect(out.split(/\r?\n/)).toEqual([
+            expect.stringContaining("bun install v1."),
+            "",
+            "+ when@http://github.com/cujojs/when/tarball/1.0.2",
+            "",
+            "1 package installed",
+          ]);
+          expect(await exited).toBe(0);
+          expect(proxied_urls).toEqual(["http://github.com/cujojs/when/tarball/1.0.2"]);
+          expect(urls.sort()).toBeEmpty();
+          expect(ctx.requested).toBe(0);
+          expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "when"]);
+          expect(await readdirSorted(join(ctx.package_dir, "node_modules", "when"))).toEqual([
+            ".gitignore",
+            ".gitmodules",
+            "LICENSE.txt",
+            "README.md",
+            "apply.js",
+            "cancelable.js",
+            "delay.js",
+            "package.json",
+            "test",
+            "timed.js",
+            "timeout.js",
+            "when.js",
+          ]);
+          const package_json = await file(join(ctx.package_dir, "node_modules", "when", "package.json")).json();
+          expect(package_json.name).toBe("when");
+          await access(join(ctx.package_dir, "bun.lockb"));
+        });
+      },
+    );
+  }
 
-  it("should handle GitHub tarball URL in dependencies (https://github.com/user/repo/tarball/ref) with custom GITHUB_API_URL", async () => {
-    await withContext(defaultOpts, async ctx => {
-      const urls: string[] = [];
-      setContextHandler(ctx, dummyRegistryForContext(ctx, urls));
-      await writeFile(
-        join(ctx.package_dir, "package.json"),
-        JSON.stringify({
-          name: "Foo",
-          version: "0.0.1",
-          dependencies: {
-            when: "https://github.com/cujojs/when/tarball/1.0.2",
-          },
-        }),
-      );
-      const { stdout, stderr, exited } = spawn({
-        cmd: [bunExe(), "install"],
-        cwd: ctx.package_dir,
-        stdout: "pipe",
-        stdin: "pipe",
-        stderr: "pipe",
-        env: {
-          ...env,
-          GITHUB_API_URL: "https://example.com/github/api",
-        },
-      });
-      const err = await stderr.text();
-      expect(err).toContain("Saved lockfile");
-      let out = await stdout.text();
-      out = out.replace(/\s*\[[0-9\.]+m?s\]\s*$/, "");
-      out = out.replace(/(github:[^#]+)#[a-f0-9]+/, "$1");
-      expect(out.split(/\r?\n/)).toEqual([
-        expect.stringContaining("bun install v1."),
-        "",
-        "+ when@https://github.com/cujojs/when/tarball/1.0.2",
-        "",
-        "1 package installed",
-      ]);
-      expect(await exited).toBe(0);
-      expect(urls.sort()).toBeEmpty();
-      expect(ctx.requested).toBe(0);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "when"]);
-      expect(await readdirSorted(join(ctx.package_dir, "node_modules", "when"))).toEqual([
-        ".gitignore",
-        ".gitmodules",
-        "LICENSE.txt",
-        "README.md",
-        "apply.js",
-        "cancelable.js",
-        "delay.js",
-        "package.json",
-        "test",
-        "timed.js",
-        "timeout.js",
-        "when.js",
-      ]);
-      const package_json = await file(join(ctx.package_dir, "node_modules", "when", "package.json")).json();
-      expect(package_json.name).toBe("when");
-      await access(join(ctx.package_dir, "bun.lockb"));
-    });
-  });
-
-  it("should treat non-GitHub http(s) URLs as tarballs (https://some.url/path?stuff)", async () => {
+  it("should treat non-GitHub http(s) URLs as tarballs (http://some.url/path?stuff)", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];
       setContextHandler(
@@ -4484,14 +4477,26 @@ describe.concurrent("bun-install", () => {
           "4.3.0": { as: "4.3.0" },
         }),
       );
+      const tarball_url = "http://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230922.2";
+      const proxied_urls: string[] = [];
+      await using proxy = urlTarballProxy(ctx, proxied_urls, {
+        [tarball_url]: {
+          "package/package.json": JSON.stringify({
+            name: "@vercel/turbopack-node",
+            version: "0.0.0",
+            dependencies: { "loader-runner": "^4.3.0" },
+          }),
+          "package/src/index.ts": "",
+          "package/tsconfig.json": "{}",
+        },
+      });
       await writeFile(
         join(ctx.package_dir, "package.json"),
         JSON.stringify({
           name: "Foo",
           version: "0.0.1",
           dependencies: {
-            "@vercel/turbopack-node":
-              "https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230922.2",
+            "@vercel/turbopack-node": tarball_url,
           },
         }),
       );
@@ -4501,7 +4506,7 @@ describe.concurrent("bun-install", () => {
         stdout: "pipe",
         stdin: "pipe",
         stderr: "pipe",
-        env,
+        env: proxy.env,
       });
       const err = await stderr.text();
       expect(err).toContain("Saved lockfile");
@@ -4511,12 +4516,13 @@ describe.concurrent("bun-install", () => {
       expect(out.split(/\r?\n/)).toEqual([
         expect.stringContaining("bun install v1."),
         "",
-        "+ @vercel/turbopack-node@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230922.2",
+        `+ @vercel/turbopack-node@${tarball_url}`,
         "",
         "2 packages installed",
       ]);
       expect(await exited).toBe(0);
-      expect(urls.sort()).toHaveLength(2);
+      expect(proxied_urls).toEqual([tarball_url]);
+      expect(urls.sort()).toEqual([`${ctx.registry_url}loader-runner`, `${ctx.registry_url}loader-runner-4.3.0.tgz`]);
       expect(ctx.requested).toBe(2);
       expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([
         ".cache",

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -125,17 +125,23 @@ function serveDirectory(root: string) {
  * server), so the returned `env` instead points the install's `http_proxy` at this server. A proxied plain-http
  * request arrives in absolute form, so `request.url` is the dependency URL itself and the specifiers keep the real
  * hosts bun classifies them by. The dependencies must use `http://`: `https://` would be tunneled (CONNECT) to the
- * real host. Every URL seen is pushed to `urls`; registered ones are answered with a gzipped tarball of their files,
- * anything else with a 404. The context's registry bypasses the proxy, so its `urls`/`requested` are unaffected.
+ * real host. Every URL seen is pushed to `urls`. A URL registered with a file map is answered with a gzipped tarball of
+ * those files, one registered with a `Response` (e.g. a redirect) with that response, anything else with a 404. The
+ * context's registry bypasses the proxy, so its `urls`/`requested` are unaffected.
  */
-function urlTarballProxy(ctx: TestContext, urls: string[], tarballs: Record<string, Record<string, string>>) {
+function urlTarballProxy(
+  ctx: TestContext,
+  urls: string[],
+  responses: Record<string, Record<string, string> | Response>,
+) {
   const server = Bun.serve({
     port: 0,
     async fetch(request) {
       urls.push(request.url);
-      const files = tarballs[request.url];
-      if (!files) return new Response(`no tarball registered for ${request.url}`, { status: 404 });
-      return new Response(await new Bun.Archive(files, { compress: "gzip" }).bytes());
+      const registered = responses[request.url];
+      if (!registered) return new Response(`nothing registered for ${request.url}`, { status: 404 });
+      if (registered instanceof Response) return registered.clone();
+      return new Response(await new Bun.Archive(registered, { compress: "gzip" }).bytes());
     },
   });
   const proxy_url = server.url.href.replace(/\/+$/, "");
@@ -4393,10 +4399,14 @@ describe.concurrent("bun-install", () => {
         await withContext(defaultOpts, async ctx => {
           const urls: string[] = [];
           setContextHandler(ctx, dummyRegistryForContext(ctx, urls));
+          const tarball_url = "http://github.com/cujojs/when/tarball/1.0.2";
+          // github.com answers /tarball/ URLs with a redirect to codeload.github.com, whose tarballs have a single
+          // `<user>-<repo>-<short commit>` root directory.
+          const codeload_url = "http://codeload.github.com/cujojs/when/legacy.tar.gz/refs/tags/1.0.2";
           const proxied_urls: string[] = [];
           await using proxy = urlTarballProxy(ctx, proxied_urls, {
-            // GitHub's tarballs have a single `<user>-<repo>-<short commit>` root directory.
-            "http://github.com/cujojs/when/tarball/1.0.2": {
+            [tarball_url]: new Response(null, { status: 302, headers: { Location: codeload_url } }),
+            [codeload_url]: {
               "cujojs-when-1a2b3c4/.gitignore": "",
               "cujojs-when-1a2b3c4/.gitmodules": "",
               "cujojs-when-1a2b3c4/LICENSE.txt": "",
@@ -4417,7 +4427,7 @@ describe.concurrent("bun-install", () => {
               name: "Foo",
               version: "0.0.1",
               dependencies: {
-                when: "http://github.com/cujojs/when/tarball/1.0.2",
+                when: tarball_url,
               },
             }),
           );
@@ -4437,12 +4447,12 @@ describe.concurrent("bun-install", () => {
           expect(out.split(/\r?\n/)).toEqual([
             expect.stringContaining("bun install v1."),
             "",
-            "+ when@http://github.com/cujojs/when/tarball/1.0.2",
+            `+ when@${tarball_url}`,
             "",
             "1 package installed",
           ]);
           expect(await exited).toBe(0);
-          expect(proxied_urls).toEqual(["http://github.com/cujojs/when/tarball/1.0.2"]);
+          expect(proxied_urls).toEqual([tarball_url, codeload_url]);
           expect(urls.sort()).toBeEmpty();
           expect(ctx.requested).toBe(0);
           expect(await readdirSorted(join(ctx.package_dir, "node_modules"))).toEqual([".cache", "when"]);


### PR DESCRIPTION
### Problem
- `test/cli/install/bun-install.test.ts` went red on every retry in CI build 93264 (darwin aarch64), and again in 93273 on an unrelated branch:
  ```
  error: GET https://github.com/cujojs/when/tarball/1.0.2 - 503
  error: when@https://github.com/cujojs/when/tarball/1.0.2 failed to resolve
  ```
  in `should handle GitHub tarball URL in dependencies (https://github.com/user/repo/tarball/ref)` and its `with custom GITHUB_API_URL` variant.
- Both tests install a URL dependency that bun downloads verbatim from github.com, so the file fails whenever github.com has a 5xx window. `should treat non-GitHub http(s) URLs as tarballs` two tests further down does the same against `gitpkg-fork.vercel.sh` and fails the same way when that host is unavailable (all three fail identically with the outside world unreachable, see the probe below).
- There is no culprit commit: the tests have fetched from these hosts since they were added in #6122 and #6247 (2023). The break is the tests depending on third-party hosts; this PR removes that dependency.

### Fix
- Adds `urlTarballProxy()` to `bun-install.test.ts`: a per-test `Bun.serve` on port 0 that answers each registered URL either with a gzipped tarball built in memory with `Bun.Archive` or with a given `Response` (404 for anything else), and records every URL it is asked for. The three tests run `bun install` with `http_proxy` pointed at it (`no_proxy` set to the dummy registry's host, so registry traffic is unchanged) and their dependencies switched from `https://` to `http://`.
- The GitHub fixture mirrors what github.com really does for `/tarball/` URLs: a 302 to `codeload.github.com/<user>/<repo>/legacy.tar.gz/refs/tags/<ref>` (checked with `curl -I` against the real URL), with the tarball served at the codeload URL. The old tests therefore also covered following a cross-host redirect while keeping the original URL as the resolution, and the new ones still do: they assert the proxy saw exactly `[tarball_url, codeload_url]` and that stdout/lockfile still name the original URL. The gitpkg fixture answers directly, covering the no-redirect path.
- Why a proxy rather than a localhost URL: these tests exist to cover the host-specific classification in `src/install/dependency.rs` (`https?://github.com/<user>/<repo>/tarball/<ref>` is a tarball, not a `github:` dependency, at `dependency.rs:959-974`; an unknown host with a query string falls through to tarball at `:969-974`). A proxied plain-http request reaches the proxy in absolute form, so the specifiers keep `github.com` / `gitpkg-fork.vercel.sh` and that code runs unchanged. Confirmed with a temporary `eprintln!` in the `is_github_tarball_path` branch: it fires for the new `http://github.com/...` specifier.
- Why `http://`: the scheme-stripping at `dependency.rs:946-957` treats `http://` and `https://` identically, while an `https://` dependency would make the install CONNECT-tunnel to the real host (`src/http/HTTPContext.rs:930`), which is exactly the network dependency being removed. Everything after classification is the same `RemoteTarball` download/extract/lockfile path as before; only the proxy hop is added, using bun's regular `http_proxy` support (`src/install/NetworkTask.rs:650`; the only other thing `http_proxy` changes in an install is skipping the registry DNS prefetch in `install_with_manager.rs:55`). What these tests no longer exercise is the TLS client path, which was never their subject and is covered by the registry/TLS install tests (e.g. `bun-install-stalled-tls.test.ts`).
- The `GITHUB_API_URL` variant keeps its purpose (that setting must not affect a tarball URL) but now points at a URL under the test's dummy registry instead of `example.com`; a request there would fail the existing `urls`/`ctx.requested` assertions instead of going to the network.
- Fixtures reproduce the directory listings the tests already assert (GitHub's `<user>-<repo>-<sha>/` root, gitpkg's `package/` root with the `loader-runner` dependency that the dummy registry serves), so every existing assertion is kept; the tests additionally assert the exact list of URLs fetched through the proxy and, for the gitpkg test, the exact registry URLs (previously just `toHaveLength(2)`).
- Verified: `bun bd test test/cli/install/bun-install.test.ts -t "tarball URL in dependencies|non-GitHub http"`: 3 pass, also with `HTTP_PROXY`/`HTTPS_PROXY` in the environment pointing at a dead port (no outside network). Same 3 pass with the release build on Linux and on Windows x64 (release build, with and without the dead ambient proxy; the ambient-proxy run also exercises the env override on Windows' case-insensitive environment). On main, the same three tests fail under that environment on both platforms (`ConnectionRefused downloading tarball ...`). Full file with the debug build: 181 pass, 2 todo; the 13 failures are the bitbucket/gitlab clone tests (blocked by this container's egress) and `should support --registry CLI flag` (fails identically on clean main here, IPv6 loopback ordering, reported separately), none of them touched by this change.
- Out of scope: the `github:`-shorthand tests (api.github.com) and the git-clone tests in this file still use the network. #35149 makes the bun-add.test.ts equivalents hermetic via `GITHUB_API_URL`, which is the right base for those; this PR deliberately does not touch `dummy.registry.ts` so the two do not conflict.

### Background
- URL dependencies: a `dependencies` value that is an `http(s)://` URL is downloaded as-is and extracted as a tarball (`ResolutionTag::RemoteTarball`, `src/install/extract_tarball.rs:405-420`). `github.com/<user>/<repo>/tarball/<ref>` is GitHub's legacy tarball endpoint (it redirects to codeload.github.com) and is one such URL; it is classified explicitly so it is not mistaken for the `github:user/repo` form.
- `github:` dependencies, by contrast, are resolved by building an API URL from `GITHUB_API_URL` (default `https://api.github.com`, `src/install/PackageManager/runTasks.rs:1693`), which is why those tests can be made hermetic with an environment variable and URL dependencies cannot.
- `http_proxy`: for a plain-http URL bun's HTTP client connects to the proxy and sends the full URL on the request line (`GET http://github.com/... HTTP/1.1`), so `Bun.serve` sees `request.url === "http://github.com/..."`. For an https URL it instead sends `CONNECT host:443` and speaks TLS to the real host through the tunnel. `no_proxy` lists hosts that bypass the proxy.

<details>
<summary>Probe: old vs new tests with the outside network unreachable</summary>

Parent environment: `HTTP_PROXY=HTTPS_PROXY=http_proxy=https_proxy=http://127.0.0.1:1` (inherited by the spawned installs through `bunEnv`).

main:

```
error: ConnectionRefused downloading tarball when@https://github.com/cujojs/when/tarball/1.0.2
error: when@https://github.com/cujojs/when/tarball/1.0.2 failed to resolve
(fail) bun-install > should handle GitHub tarball URL in dependencies (https://github.com/user/repo/tarball/ref)
(fail) bun-install > should handle GitHub tarball URL in dependencies (https://github.com/user/repo/tarball/ref) with custom GITHUB_API_URL
error: ConnectionRefused downloading tarball @vercel/turbopack-node@https://gitpkg-fork.vercel.sh/vercel/turbo/crates/turbopack-node/js?turbopack-230922.2
(fail) bun-install > should treat non-GitHub http(s) URLs as tarballs (https://some.url/path?stuff)
 0 pass
 3 fail
```

this branch (debug build):

```
(pass) bun-install > should handle GitHub tarball URL in dependencies (http://github.com/user/repo/tarball/ref) [721.42ms]
(pass) bun-install > should handle GitHub tarball URL in dependencies (http://github.com/user/repo/tarball/ref) with custom GITHUB_API_URL [543.59ms]
(pass) bun-install > should treat non-GitHub http(s) URLs as tarballs (http://some.url/path?stuff) [586.24ms]
 3 pass
 0 fail
```

Windows x64, release build, same dead ambient proxy: this branch 3 pass (about 33ms each); main 3 fail with the same `ConnectionRefused downloading tarball` errors.

What github.com returns for the URL the old tests used:

```
$ curl -sI https://github.com/cujojs/when/tarball/1.0.2
HTTP/2 302
location: https://codeload.github.com/cujojs/when/legacy.tar.gz/refs/tags/1.0.2
```

Classification probe (temporary `eprintln!` in the `is_github_tarball_path` branch of `dependency.rs`, installing `http://github.com/cujojs/when/tarball/1.0.2` through the proxy, reverted before committing):

```
TEMP_PROBE github tarball path classified as Tarball
TEMP_PROBE github tarball path classified as Tarball
Resolving dependencies
Resolved, downloaded and extracted [2]
Saved lockfile
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->