### PR TITLE
usockets: close half-open sockets on EPOLLHUP instead of spinning on it

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -712,6 +712,12 @@ void us_poll_change(struct us_poll_t *p, struct us_loop_t *loop, int events) {
         do {
             rc = epoll_ctl(loop->fd, EPOLL_CTL_MOD, p->state.fd, &event);
         } while (IS_EINTR(rc));
+        /* A paused socket that hung up was taken out of epoll by the dispatcher; put it back. */
+        if (rc == -1 && errno == ENOENT) {
+            do {
+                rc = epoll_ctl(loop->fd, EPOLL_CTL_ADD, p->state.fd, &event);
+            } while (IS_EINTR(rc));
+        }
 #else
         kqueue_change(loop->fd, p->state.fd, old_events, events, p);
 #endif

--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -263,7 +263,9 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
              * forwarded as a libus close code, and a raw EPOLLERR (8) would
              * read as errno 8 (ENOEXEC) in the JS error path. */
             const int error = !!(events & EPOLLERR);
-            const int eof = events & EPOLLHUP;
+            /* A read-side FIN is EPOLLIN + recv()==0; EPOLLHUP means both directions
+             * are down and is level-triggered, so tag it for the dispatch to close. */
+            const int eof = (events & EPOLLHUP) ? LIBUS_POLL_HANGUP : 0;
             events &= us_poll_events(poll);
             if (events || error || eof) {
                 us_internal_dispatch_ready_poll(poll, error, eof, events);

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -147,6 +147,10 @@ extern struct addrinfo_result *Bun__addrinfo_getRequestResult(struct addrinfo_re
 
 
 /* Loop related */
+/* `eof` values for us_internal_dispatch_ready_poll: nonzero = read-side EOF hint (half-open honored);
+ * LIBUS_POLL_HANGUP = epoll EPOLLHUP, both directions down, re-reported until the fd is closed. */
+#define LIBUS_POLL_EOF 1
+#define LIBUS_POLL_HANGUP 2
 void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, int events);
 void us_internal_timer_sweep(us_loop_r loop);
 void us_internal_enable_sweep_timer(struct us_loop_t *loop);

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -838,7 +838,11 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
 #ifdef LIBUS_USE_EPOLL
                 /* EPOLLHUP is unmaskable: leave epoll while paused so it cannot re-fire; the unread tail stays in
                  * the kernel until resume() re-adds the fd via us_poll_change (end() while paused keeps it parked). */
-                if (hangup) us_poll_stop(&s->p, loop);
+                if (hangup) {
+                    us_poll_stop(&s->p, loop);
+                    /* Sync the recorded mask with the DEL (a pause from on_data leaves WRITABLE) so end() is a no-op. */
+                    s->p.state.poll_type = us_internal_poll_type(&s->p);
+                }
 #endif
                 eof = 0;
             }

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -834,7 +834,12 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
              * are exempt (their peer's FIN must still close them promptly below),
              * as are error-flagged events. */
             if (eof && s && !error && s->flags.is_paused && !us_socket_is_shut_down(s) &&
-                !us_socket_is_closed(s)) {
+                !us_socket_is_closed(s) && !(hangup && s->read_eof)) {
+#ifdef LIBUS_USE_EPOLL
+                /* EPOLLHUP is unmaskable: leave epoll while paused so it cannot re-fire; the unread tail
+                 * stays in the kernel and us_poll_change re-adds the fd on resume()/shutdown(). */
+                if (hangup) us_poll_stop(&s->p, loop);
+#endif
                 eof = 0;
             }
             if(eof && s) {

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -584,6 +584,8 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             s = us_internal_socket_follow_adopted(s);
             /* The group can change after calling a callback but the loop is always the same */
             struct us_loop_t* loop = s->group->loop;
+            /* Captured before the read loop folds recv()==0 into `eof`; error events keep the error path. */
+            const int hangup = (eof & LIBUS_POLL_HANGUP) && !error;
             if (events & LIBUS_SOCKET_WRITABLE && !error) {
                 s->flags.last_write_failed = 0;
                 #ifdef LIBUS_USE_KQUEUE
@@ -790,7 +792,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         }
                         #endif
                     } else if (!length) {
-                        eof = 1; // lets handle EOF in the same place
+                        eof = LIBUS_POLL_EOF; // lets handle EOF in the same place
                         break;
                     } else if (length == LIBUS_SOCKET_ERROR && !bsd_would_block()) {
                         if (eof && read_any) {
@@ -845,10 +847,10 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     s = us_internal_socket_close_raw(s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, NULL);
                     return;
                 }
-                if (s->flags.allow_half_open && s->read_eof) {
+                if (s->flags.allow_half_open && !hangup && s->read_eof) {
                     /* on_end already delivered (libuv UV_HANDLE_READ_EOF): just drop the readable interest that re-surfaced it. */
                     us_poll_change(&s->p, loop, us_poll_events(&s->p) & LIBUS_SOCKET_WRITABLE);
-                } else if(s->flags.allow_half_open) {
+                } else if(s->flags.allow_half_open && !hangup) {
                     s->read_eof = 1;
                     /* EOF with half-open allowed: stop polling readable but KEEP
                      * polling writable. Masking with the current events dropped
@@ -869,8 +871,11 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
 #endif
                     s = s->ssl ? us_internal_ssl_on_end(s) : us_dispatch_end(s);
                 } else {
-                    /* We dont allow half open just emit end and close the socket */
-                    s = s->ssl ? us_internal_ssl_on_end(s) : us_dispatch_end(s);
+                    /* Half-open not allowed, or a hangup (both directions down, level-triggered):
+                     * emit end unless a FIN already did, then close so EPOLLHUP stops re-firing. */
+                    if (!s->read_eof) {
+                        s = s->ssl ? us_internal_ssl_on_end(s) : us_dispatch_end(s);
+                    }
                     s = us_internal_socket_close_raw(s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, NULL);
                     return;
                 }

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -836,8 +836,8 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             if (eof && s && !error && s->flags.is_paused && !us_socket_is_shut_down(s) &&
                 !us_socket_is_closed(s) && !(hangup && s->read_eof)) {
 #ifdef LIBUS_USE_EPOLL
-                /* EPOLLHUP is unmaskable: leave epoll while paused so it cannot re-fire; the unread tail
-                 * stays in the kernel and us_poll_change re-adds the fd on resume()/shutdown(). */
+                /* EPOLLHUP is unmaskable: leave epoll while paused so it cannot re-fire; the unread tail stays in
+                 * the kernel until resume() re-adds the fd via us_poll_change (end() while paused keeps it parked). */
                 if (hangup) us_poll_stop(&s->p, loop);
 #endif
                 eof = 0;

--- a/test/js/node/http/node-http-connect-unix-hangup-fixture.js
+++ b/test/js/node/http/node-http-connect-unix-hangup-fixture.js
@@ -1,0 +1,32 @@
+// N CONNECT clients over an AF_UNIX listener each destroy() once the server holds the handed-off
+// socket; the server never ends its side. Prints {ends, closes} once every server socket has closed.
+const http = require("node:http");
+const net = require("node:net");
+
+const N = 8;
+const clients = new Map();
+let ends = 0;
+let closes = 0;
+
+const server = http.createServer();
+server.on("connect", (req, socket) => {
+  socket.on("error", () => {});
+  socket.on("end", () => ends++);
+  socket.on("close", () => {
+    if (++closes === N) {
+      console.log(JSON.stringify({ ends, closes }));
+      server.close();
+    }
+  });
+  clients.get(req.url).destroy();
+});
+server.listen(process.env.SOCK, () => {
+  for (let i = 0; i < N; i++) {
+    const target = "peer-" + i + ":443";
+    const client = net.connect(process.env.SOCK, () => {
+      client.write("CONNECT " + target + " HTTP/1.1\r\nHost: " + target + "\r\n\r\n");
+    });
+    client.on("error", () => {});
+    clients.set(target, client);
+  }
+});

--- a/test/js/node/http/node-http-connect-unix-hangup-fixture.js
+++ b/test/js/node/http/node-http-connect-unix-hangup-fixture.js
@@ -1,12 +1,37 @@
-// N CONNECT clients over an AF_UNIX listener each destroy() once the server holds the handed-off
-// socket; the server never ends its side. Prints per-target {ends, closes} once every server socket has closed.
+// N CONNECT clients over an AF_UNIX listener each destroy() once the server holds the handed-off socket. The
+// server keeps its side open for an idle window after every peer is gone (this is where an unhandled EPOLLHUP
+// spins), reports whether the loop stayed idle, then ends its side and expects one end + one close per socket.
 const http = require("node:http");
 const net = require("node:net");
 
 const N = 8;
+const WINDOW_MS = 1000;
 const clients = new Map();
+const held = [];
 const counts = {};
+let peersGone = 0;
 let closed = 0;
+let verdict;
+
+function report() {
+  if (closed !== N || verdict === undefined) return;
+  const sorted = Object.fromEntries(Object.keys(counts).sort().map(k => [k, counts[k]]));
+  console.log(JSON.stringify(sorted));
+  console.log(verdict);
+  server.close();
+}
+
+function maybeMeasure() {
+  if (peersGone !== N || held.length !== N) return;
+  const cpu0 = process.cpuUsage();
+  setTimeout(() => {
+    const cpu = process.cpuUsage(cpu0);
+    const cpuMs = (cpu.user + cpu.system) / 1000;
+    verdict = cpuMs < WINDOW_MS / 4 ? "idle" : "spun " + Math.round(cpuMs) + "ms cpu in " + WINDOW_MS + "ms";
+    for (const socket of held) if (!socket.destroyed) socket.end();
+    report();
+  }, WINDOW_MS);
+}
 
 const server = http.createServer();
 server.on("connect", (req, socket) => {
@@ -15,13 +40,12 @@ server.on("connect", (req, socket) => {
   socket.on("end", () => c.ends++);
   socket.on("close", () => {
     c.closes++;
-    if (++closed === N) {
-      const sorted = Object.fromEntries(Object.keys(counts).sort().map(k => [k, counts[k]]));
-      console.log(JSON.stringify(sorted));
-      server.close();
-    }
+    closed++;
+    report();
   });
+  held.push(socket);
   clients.get(req.url).destroy();
+  maybeMeasure();
 });
 server.listen(process.env.SOCK, () => {
   for (let i = 0; i < N; i++) {
@@ -32,6 +56,10 @@ server.listen(process.env.SOCK, () => {
     client.on("error", err => {
       console.error("client " + target + " error: " + (err.code || err));
       process.exitCode = 1;
+    });
+    client.on("close", () => {
+      peersGone++;
+      maybeMeasure();
     });
     clients.set(target, client);
   }

--- a/test/js/node/http/node-http-connect-unix-hangup-fixture.js
+++ b/test/js/node/http/node-http-connect-unix-hangup-fixture.js
@@ -1,20 +1,23 @@
 // N CONNECT clients over an AF_UNIX listener each destroy() once the server holds the handed-off
-// socket; the server never ends its side. Prints {ends, closes} once every server socket has closed.
+// socket; the server never ends its side. Prints per-target {ends, closes} once every server socket has closed.
 const http = require("node:http");
 const net = require("node:net");
 
 const N = 8;
 const clients = new Map();
-let ends = 0;
-let closes = 0;
+const counts = {};
+let closed = 0;
 
 const server = http.createServer();
 server.on("connect", (req, socket) => {
+  const c = (counts[req.url] = { ends: 0, closes: 0 });
   socket.on("error", () => {});
-  socket.on("end", () => ends++);
+  socket.on("end", () => c.ends++);
   socket.on("close", () => {
-    if (++closes === N) {
-      console.log(JSON.stringify({ ends, closes }));
+    c.closes++;
+    if (++closed === N) {
+      const sorted = Object.fromEntries(Object.keys(counts).sort().map(k => [k, counts[k]]));
+      console.log(JSON.stringify(sorted));
       server.close();
     }
   });

--- a/test/js/node/http/node-http-connect-unix-hangup-fixture.js
+++ b/test/js/node/http/node-http-connect-unix-hangup-fixture.js
@@ -27,7 +27,8 @@ function maybeMeasure() {
   setTimeout(() => {
     const cpu = process.cpuUsage(cpu0);
     const cpuMs = (cpu.user + cpu.system) / 1000;
-    verdict = cpuMs < WINDOW_MS / 4 ? "idle" : "spun " + Math.round(cpuMs) + "ms cpu in " + WINDOW_MS + "ms";
+    // A spin burns >= the whole window; half leaves room for teardown + GC on debug/ASAN builds.
+    verdict = cpuMs < WINDOW_MS / 2 ? "idle" : "spun " + Math.round(cpuMs) + "ms cpu in " + WINDOW_MS + "ms";
     for (const socket of held) if (!socket.destroyed) socket.end();
     report();
   }, WINDOW_MS);

--- a/test/js/node/http/node-http-connect-unix-hangup-fixture.js
+++ b/test/js/node/http/node-http-connect-unix-hangup-fixture.js
@@ -11,7 +11,7 @@ let closed = 0;
 const server = http.createServer();
 server.on("connect", (req, socket) => {
   const c = (counts[req.url] = { ends: 0, closes: 0 });
-  socket.on("error", () => {});
+  socket.on("error", err => (c.error = err.code || String(err)));
   socket.on("end", () => c.ends++);
   socket.on("close", () => {
     c.closes++;
@@ -29,7 +29,10 @@ server.listen(process.env.SOCK, () => {
     const client = net.connect(process.env.SOCK, () => {
       client.write("CONNECT " + target + " HTTP/1.1\r\nHost: " + target + "\r\n\r\n");
     });
-    client.on("error", () => {});
+    client.on("error", err => {
+      console.error("client " + target + " error: " + (err.code || err));
+      process.exitCode = 1;
+    });
     clients.set(target, client);
   }
 });

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -633,8 +633,11 @@ describe("HTTP server CONNECT", () => {
       const result = await bunRun(join(import.meta.dir, "node-http-connect-unix-hangup-fixture.js"), {
         SOCK: join(String(dir), "proxy.sock"),
       });
+      const perTarget = Object.fromEntries(
+        Array.from({ length: 8 }, (_, i) => [`peer-${i}:443`, { ends: 1, closes: 1 }]),
+      );
       expect(result).toEqual({
-        stdout: JSON.stringify({ ends: 8, closes: 8 }),
+        stdout: JSON.stringify(perTarget),
         stderr: "",
         exitCode: 0,
         signalCode: null,

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, nodeExe, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, isLinux, nodeExe, tempDir, tls as tlsCert } from "harness";
 import http from "http";
 
 import { once } from "node:events";
@@ -618,6 +618,59 @@ describe("HTTP server CONNECT", () => {
       }).toEqual({
         server: ["server:end", "server:finish", "server:close"],
         hasClientClose: true,
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
+
+  test.skipIf(!isLinux)(
+    "AF_UNIX CONNECT sockets whose peer closes first are closed, not spun on EPOLLHUP forever",
+    async () => {
+      // An AF_UNIX peer close() on a half-open (CONNECT hand-off) socket is EPOLLHUP, which is level-triggered:
+      // it must end+close the socket rather than re-dispatch forever. The server never ends its own side.
+      const fixture = /* js */ `
+        const http = require("node:http");
+        const net = require("node:net");
+        const N = 8;
+        const clients = new Map();
+        let ends = 0;
+        let closes = 0;
+        const server = http.createServer();
+        server.on("connect", (req, socket) => {
+          socket.on("error", () => {});
+          socket.on("end", () => ends++);
+          socket.on("close", () => {
+            if (++closes === N) {
+              console.log(JSON.stringify({ ends, closes }));
+              server.close();
+            }
+          });
+          // Now that the server holds the handed-off socket, hang up this
+          // request's client without it ever seeing a response.
+          clients.get(req.url).destroy();
+        });
+        server.listen(process.env.SOCK, () => {
+          for (let i = 0; i < N; i++) {
+            const target = "peer-" + i + ":443";
+            const client = net.connect(process.env.SOCK, () => {
+              client.write("CONNECT " + target + " HTTP/1.1\\r\\nHost: " + target + "\\r\\n\\r\\n");
+            });
+            client.on("error", () => {});
+            clients.set(target, client);
+          }
+        });
+      `;
+      using dir = tempDir("connect-unix-hangup", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, SOCK: join(String(dir), "proxy.sock") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: JSON.stringify({ ends: 8, closes: 8 }),
         stderr: "",
         exitCode: 0,
       });

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, nodeExe, tempDir, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, bunRun, isLinux, nodeExe, tempDir, tls as tlsCert } from "harness";
 import http from "http";
 
 import { once } from "node:events";
@@ -629,50 +629,15 @@ describe("HTTP server CONNECT", () => {
     async () => {
       // An AF_UNIX peer close() on a half-open (CONNECT hand-off) socket is EPOLLHUP, which is level-triggered:
       // it must end+close the socket rather than re-dispatch forever. The server never ends its own side.
-      const fixture = /* js */ `
-        const http = require("node:http");
-        const net = require("node:net");
-        const N = 8;
-        const clients = new Map();
-        let ends = 0;
-        let closes = 0;
-        const server = http.createServer();
-        server.on("connect", (req, socket) => {
-          socket.on("error", () => {});
-          socket.on("end", () => ends++);
-          socket.on("close", () => {
-            if (++closes === N) {
-              console.log(JSON.stringify({ ends, closes }));
-              server.close();
-            }
-          });
-          // Now that the server holds the handed-off socket, hang up this
-          // request's client without it ever seeing a response.
-          clients.get(req.url).destroy();
-        });
-        server.listen(process.env.SOCK, () => {
-          for (let i = 0; i < N; i++) {
-            const target = "peer-" + i + ":443";
-            const client = net.connect(process.env.SOCK, () => {
-              client.write("CONNECT " + target + " HTTP/1.1\\r\\nHost: " + target + "\\r\\n\\r\\n");
-            });
-            client.on("error", () => {});
-            clients.set(target, client);
-          }
-        });
-      `;
       using dir = tempDir("connect-unix-hangup", {});
-      await using proc = Bun.spawn({
-        cmd: [bunExe(), "-e", fixture],
-        env: { ...bunEnv, SOCK: join(String(dir), "proxy.sock") },
-        stdout: "pipe",
-        stderr: "pipe",
+      const result = await bunRun(join(import.meta.dir, "node-http-connect-unix-hangup-fixture.js"), {
+        SOCK: join(String(dir), "proxy.sock"),
       });
-      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+      expect(result).toEqual({
         stdout: JSON.stringify({ ends: 8, closes: 8 }),
         stderr: "",
         exitCode: 0,
+        signalCode: null,
       });
     },
   );

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, bunRun, isLinux, nodeExe, tempDir, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, bunRun, isLinux, isWindows, nodeExe, tempDir, tls as tlsCert } from "harness";
 import http from "http";
 
 import { once } from "node:events";
@@ -624,11 +624,11 @@ describe("HTTP server CONNECT", () => {
     },
   );
 
-  test.skipIf(!isLinux)(
-    "AF_UNIX CONNECT sockets whose peer closes first are closed, not spun on EPOLLHUP forever",
+  test.skipIf(isWindows)(
+    "AF_UNIX CONNECT sockets whose peer closes first do not spin the loop on EPOLLHUP",
     async () => {
       // An AF_UNIX peer close() on a half-open (CONNECT hand-off) socket is EPOLLHUP, which is level-triggered:
-      // it must end+close the socket rather than re-dispatch forever. The server never ends its own side.
+      // the loop must stay idle while the server still holds its side, and each socket ends and closes once.
       using dir = tempDir("connect-unix-hangup", {});
       const result = await bunRun(join(import.meta.dir, "node-http-connect-unix-hangup-fixture.js"), {
         SOCK: join(String(dir), "proxy.sock"),
@@ -637,7 +637,7 @@ describe("HTTP server CONNECT", () => {
         Array.from({ length: 8 }, (_, i) => [`peer-${i}:443`, { ends: 1, closes: 1 }]),
       );
       expect(result).toEqual({
-        stdout: JSON.stringify(perTarget),
+        stdout: JSON.stringify(perTarget) + "\nidle",
         stderr: "",
         exitCode: 0,
         signalCode: null,

--- a/test/js/node/net/node-net-allowHalfOpen.test.js
+++ b/test/js/node/net/node-net-allowHalfOpen.test.js
@@ -125,5 +125,5 @@ test.skipIf(isWindows)("allowHalfOpen: paused socket whose unix peer closed deli
   const expected = Object.fromEntries(
     Array.from({ length: 4 }, (_, i) => [`tail-${i}`, { data: `tail-${i}\n`, ends: 1, closes: 1 }]),
   );
-  expect(result).toEqual({ stdout: JSON.stringify(expected), stderr: "", exitCode: 0, signalCode: null });
+  expect(result).toEqual({ stdout: JSON.stringify(expected) + "\nidle", stderr: "", exitCode: 0, signalCode: null });
 });

--- a/test/js/node/net/node-net-allowHalfOpen.test.js
+++ b/test/js/node/net/node-net-allowHalfOpen.test.js
@@ -1,6 +1,7 @@
 import { expect, test } from "bun:test";
-import { nodeExe, tempDirWithFiles } from "harness";
+import { bunRun, isWindows, nodeExe, tempDir, tempDirWithFiles } from "harness";
 import net from "node:net";
+import { join } from "node:path";
 
 async function nodeRun(callback, clients = 1) {
   const cwd = tempDirWithFiles("server", {
@@ -112,4 +113,17 @@ test("allowHalfOpen: false should work on client-side", async () => {
       .map(s => s.trim())
       .filter(s => s),
   ).toEqual(["Hello, World", "Received FIN"]);
+});
+
+// A paused allowHalfOpen socket whose AF_UNIX peer writes a tail and closes (EPOLLHUP while paused) must keep
+// the tail for resume() and then deliver data, end and close once each; the paused window must not spin the loop.
+test.skipIf(isWindows)("allowHalfOpen: paused socket whose unix peer closed delivers its tail on resume", async () => {
+  using dir = tempDir("net-paused-unix-hangup", {});
+  const result = await bunRun(join(import.meta.dir, "node-net-paused-unix-hangup-fixture.js"), {
+    SOCK: join(String(dir), "p.sock"),
+  });
+  const expected = Object.fromEntries(
+    Array.from({ length: 4 }, (_, i) => [`tail-${i}`, { data: `tail-${i}\n`, ends: 1, closes: 1 }]),
+  );
+  expect(result).toEqual({ stdout: JSON.stringify(expected), stderr: "", exitCode: 0, signalCode: null });
 });

--- a/test/js/node/net/node-net-paused-unix-hangup-fixture.js
+++ b/test/js/node/net/node-net-paused-unix-hangup-fixture.js
@@ -1,0 +1,54 @@
+// N clients over an AF_UNIX allowHalfOpen server each write a tail and close while the accepted socket is
+// still paused (pauseOnConnect); the server resumes only after the peer is gone. Prints per-client results.
+const net = require("node:net");
+
+const N = 4;
+const results = {};
+let closed = 0;
+let accepted = 0;
+let peersGone = 0;
+const sockets = [];
+
+function maybeResume() {
+  // Every peer has fully closed and every accepted socket is in hand: the hangup is pending on all of them.
+  if (peersGone === N && accepted === N) setImmediate(() => sockets.forEach(s => s.resume()));
+}
+
+const server = net.createServer({ allowHalfOpen: true, pauseOnConnect: true }, socket => {
+  const r = { data: "", ends: 0, closes: 0 };
+  sockets.push(socket);
+  socket.setEncoding("utf8");
+  socket.on("data", chunk => (r.data += chunk));
+  socket.on("error", err => (r.error = err.code || String(err)));
+  socket.on("end", () => {
+    r.ends++;
+    socket.end();
+  });
+  socket.on("close", () => {
+    r.closes++;
+    results[r.data.trim() || "socket-" + closed] = r;
+    if (++closed === N) {
+      const sorted = Object.fromEntries(Object.keys(results).sort().map(k => [k, results[k]]));
+      console.log(JSON.stringify(sorted));
+      server.close();
+    }
+  });
+  accepted++;
+  maybeResume();
+});
+
+server.listen(process.env.SOCK, () => {
+  for (let i = 0; i < N; i++) {
+    const client = net.connect(process.env.SOCK, () => {
+      client.end("tail-" + i + "\n", () => client.destroy());
+    });
+    client.on("error", err => {
+      console.error("client " + i + " error: " + (err.code || err));
+      process.exitCode = 1;
+    });
+    client.on("close", () => {
+      peersGone++;
+      maybeResume();
+    });
+  }
+});

--- a/test/js/node/net/node-net-paused-unix-hangup-fixture.js
+++ b/test/js/node/net/node-net-paused-unix-hangup-fixture.js
@@ -25,7 +25,8 @@ function maybeMeasure() {
   setTimeout(() => {
     const cpu = process.cpuUsage(cpu0);
     const cpuMs = (cpu.user + cpu.system) / 1000;
-    verdict = cpuMs < WINDOW_MS / 4 ? "idle" : "spun " + Math.round(cpuMs) + "ms cpu in " + WINDOW_MS + "ms";
+    // A spin burns >= the whole window; half leaves room for GC on debug/ASAN builds.
+    verdict = cpuMs < WINDOW_MS / 2 ? "idle" : "spun " + Math.round(cpuMs) + "ms cpu in " + WINDOW_MS + "ms";
     for (const socket of sockets) socket.resume();
     report();
   }, WINDOW_MS);

--- a/test/js/node/net/node-net-paused-unix-hangup-fixture.js
+++ b/test/js/node/net/node-net-paused-unix-hangup-fixture.js
@@ -1,22 +1,38 @@
-// N clients over an AF_UNIX allowHalfOpen server each write a tail and close while the accepted socket is
-// still paused (pauseOnConnect); the server resumes only after the peer is gone. Prints per-client results.
+// N clients over an AF_UNIX allowHalfOpen server each write a tail and close while the accepted socket is still
+// paused (pauseOnConnect). The server stays paused for an idle window after every peer is gone (this is where an
+// unhandled EPOLLHUP spins), reports whether the loop stayed idle, then resumes and expects tail+end+close each.
 const net = require("node:net");
 
 const N = 4;
+const WINDOW_MS = 1000;
 const results = {};
-let closed = 0;
-let accepted = 0;
-let peersGone = 0;
 const sockets = [];
+let peersGone = 0;
+let closed = 0;
+let verdict;
 
-function maybeResume() {
-  // Every peer has fully closed and every accepted socket is in hand: the hangup is pending on all of them.
-  if (peersGone === N && accepted === N) setImmediate(() => sockets.forEach(s => s.resume()));
+function report() {
+  if (closed !== N || verdict === undefined) return;
+  const sorted = Object.fromEntries(Object.keys(results).sort().map(k => [k, results[k]]));
+  console.log(JSON.stringify(sorted));
+  console.log(verdict);
+  server.close();
+}
+
+function maybeMeasure() {
+  if (peersGone !== N || sockets.length !== N) return;
+  const cpu0 = process.cpuUsage();
+  setTimeout(() => {
+    const cpu = process.cpuUsage(cpu0);
+    const cpuMs = (cpu.user + cpu.system) / 1000;
+    verdict = cpuMs < WINDOW_MS / 4 ? "idle" : "spun " + Math.round(cpuMs) + "ms cpu in " + WINDOW_MS + "ms";
+    for (const socket of sockets) socket.resume();
+    report();
+  }, WINDOW_MS);
 }
 
 const server = net.createServer({ allowHalfOpen: true, pauseOnConnect: true }, socket => {
   const r = { data: "", ends: 0, closes: 0 };
-  sockets.push(socket);
   socket.setEncoding("utf8");
   socket.on("data", chunk => (r.data += chunk));
   socket.on("error", err => (r.error = err.code || String(err)));
@@ -27,14 +43,11 @@ const server = net.createServer({ allowHalfOpen: true, pauseOnConnect: true }, s
   socket.on("close", () => {
     r.closes++;
     results[r.data.trim() || "socket-" + closed] = r;
-    if (++closed === N) {
-      const sorted = Object.fromEntries(Object.keys(results).sort().map(k => [k, results[k]]));
-      console.log(JSON.stringify(sorted));
-      server.close();
-    }
+    closed++;
+    report();
   });
-  accepted++;
-  maybeResume();
+  sockets.push(socket);
+  maybeMeasure();
 });
 
 server.listen(process.env.SOCK, () => {
@@ -48,7 +61,7 @@ server.listen(process.env.SOCK, () => {
     });
     client.on("close", () => {
       peersGone++;
-      maybeResume();
+      maybeMeasure();
     });
   }
 });


### PR DESCRIPTION
### What does this PR do?

Stops the epoll loop from spinning forever on an `allow_half_open` socket whose peer hung up while our side was still open.

Every node:http server socket is `allow_half_open` (including one handed to a `'connect'` listener). When the peer of an AF_UNIX socket `close()`s, Linux reports `EPOLLHUP` rather than a plain FIN. `EPOLLHUP` is level-triggered and cannot be masked off, but the dispatcher only mapped it to the generic eof hint: the half-open branch dropped readable interest, delivered `on_end`, and then got the same `EPOLLHUP` on the next `epoll_wait` — and on every wait after that, for as long as the application kept its side open. Each such socket cost a full core. Any AF_UNIX server whose clients go away first (e.g. a CONNECT proxy whose client is killed mid-request) accumulates them.

Two cases, two commits:

- **Not paused** — `EPOLLHUP` is tagged as `LIBUS_POLL_HANGUP` on the way into `us_internal_dispatch_ready_poll`, and the eof branch treats a hangup like the not-half-open case: emit end (unless a FIN already did) and close. The read loop has already drained the receive queue on the same event, so nothing unread is discarded; events that also carry `EPOLLERR` keep the error path and their close codes. kqueue already closes in this situation, so epoll now matches it.
- **Paused** — the `is_paused` deferral runs first and must keep the unread tail for `resume()`, so closing is not an option there. Instead the fd is taken out of epoll (`EPOLL_CTL_DEL`) for the duration of the pause — what libuv does for a stream with no active interest — and `us_poll_change` falls back to `EPOLL_CTL_ADD` on `ENOENT`, so `resume()` transparently re-registers it and the normal drain → end → close runs. An `end()` while still paused leaves it parked (the poll mask is already 0, so nothing is re-added) and the tail survives until `resume()`/`destroy()`, as on node. If `on_end` was already delivered there is no tail to keep and the hangup closes immediately.

kqueue and libuv still pass a plain 0/1 eof and are unaffected. Credit to @chrislloyd for the diagnosis and the original fix.

### How did you verify your code works?

Two fixture-based tests, both of which produce identical output under node v26.3.0:

- `node-http-connect.test.ts`: 8 CONNECT clients over an AF_UNIX listener `destroy()` once the server holds the handed-off socket; the server keeps its side for a 1 s window, then ends it. Asserts one `end` + one `close` per socket and that the process burned < 250 ms CPU in the window.
- `node-net-allowHalfOpen.test.js`: `pauseOnConnect` AF_UNIX server; each peer writes a tail and closes while the accepted socket is paused; after a 1 s paused window the server resumes. Asserts tail + `end` + `close` once per socket and an idle window.

Same test files, Linux aarch64, in Docker:

| runtime | CONNECT | paused |
|---|---|---|
| node v26.3.0 | pass (idle) | pass (idle) |
| main `1.4.0-canary.1+9a543cc18` | **fail** — `spun 1303ms cpu in 1000ms` | **fail** — `spun 1315ms cpu in 1000ms` |
| this branch (CI `bun-linux-aarch64`, `f6d9e33ca`) | pass (idle) | pass (idle, 2 ms CPU in a 3 s paused window vs 3930 ms before) |

macOS (kqueue) passes both before and after; `socket.test.ts`, `node-net.test.ts` and the rest of `node-http-connect.test.ts` are green locally on a debug build.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/http/node-http-connect.test.ts test/js/node/net/node-net-allowHalfOpen.test.js

<!-- robobun:evidence:end -->