### PR TITLE
shell: widen the brace expansion output slot counter

### DIFF
--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -540,8 +540,6 @@ pub fn expand(
     contains_nested: bool,
 ) -> Result<(), ExpandError> {
     check_brace_group_count(tokens)?;
-    // Next unclaimed `out` slot; ends at `out.len()` once every slot is
-    // claimed, so it must hold one more than the largest key.
     let mut out_key_counter: usize = 1;
     if !contains_nested {
         let expansions_table = build_expansion_table_alloc(tokens)?;

--- a/src/shell_parser/braces.rs
+++ b/src/shell_parser/braces.rs
@@ -540,7 +540,9 @@ pub fn expand(
     contains_nested: bool,
 ) -> Result<(), ExpandError> {
     check_brace_group_count(tokens)?;
-    let mut out_key_counter: u16 = 1;
+    // Next unclaimed `out` slot; ends at `out.len()` once every slot is
+    // claimed, so it must hold one more than the largest key.
+    let mut out_key_counter: usize = 1;
     if !contains_nested {
         let expansions_table = build_expansion_table_alloc(tokens)?;
 
@@ -582,8 +584,8 @@ pub fn expand(
 unsafe fn expand_nested(
     root: *mut ast::Group,
     out: &mut [Vec<u8>],
-    out_key: u16,
-    out_key_counter: &mut u16,
+    out_key: usize,
+    out_key_counter: &mut usize,
     start: u32,
 ) -> Result<(), ExpandError> {
     // SAFETY: see fn doc comment —
@@ -607,7 +609,7 @@ unsafe fn expand_nested(
 
             match &(*root).atoms {
                 ast::GroupAtoms::Single(ast::Atom::Text(txt)) => {
-                    out[usize::from(out_key)].extend_from_slice(txt.slice());
+                    out[out_key].extend_from_slice(txt.slice());
                     if !(*root).bubble_up.is_null() {
                         let bubble_up = (*root).bubble_up;
                         let next = (*root).bubble_up_next.unwrap();
@@ -622,7 +624,7 @@ unsafe fn expand_nested(
                     return Ok(());
                 }
                 ast::GroupAtoms::Single(ast::Atom::Expansion(expansion)) => {
-                    let length = out[usize::from(out_key)].len();
+                    let length = out[out_key].len();
                     let variants = expansion.variants;
                     let variants_len = variants.len();
                     for j in 0..variants_len {
@@ -636,8 +638,8 @@ unsafe fn expand_nested(
                             // new_key > out_key always (counter is bumped past out_key before
                             // any recursion into it), and the j==0 recursion only appends to
                             // out[out_key], so its [..length] prefix is stable.
-                            let (lo, hi) = out.split_at_mut(usize::from(new_key));
-                            hi[0].extend_from_slice(&lo[usize::from(out_key)][..length]);
+                            let (lo, hi) = out.split_at_mut(new_key);
+                            hi[0].extend_from_slice(&lo[out_key][..length]);
                             *out_key_counter += 1;
                             new_key
                         };
@@ -670,10 +672,10 @@ unsafe fn expand_nested(
             let atom: &ast::Atom = &(*many)[i_];
             match atom {
                 ast::Atom::Text(txt) => {
-                    out[usize::from(out_key)].extend_from_slice(txt.slice());
+                    out[out_key].extend_from_slice(txt.slice());
                 }
                 ast::Atom::Expansion(expansion) => {
-                    let length = out[usize::from(out_key)].len();
+                    let length = out[out_key].len();
                     let variants = expansion.variants;
                     let variants_len = variants.len();
                     for j in 0..variants_len {
@@ -684,8 +686,8 @@ unsafe fn expand_nested(
                             out_key
                         } else {
                             let new_key = *out_key_counter;
-                            let (lo, hi) = out.split_at_mut(usize::from(new_key));
-                            hi[0].extend_from_slice(&lo[usize::from(out_key)][..length]);
+                            let (lo, hi) = out.split_at_mut(new_key);
+                            hi[0].extend_from_slice(&lo[out_key][..length]);
                             *out_key_counter += 1;
                             new_key
                         };
@@ -713,8 +715,8 @@ fn expand_flat(
     tokens: &[Token],
     expansion_table: &[ExpansionVariant],
     out: &mut [Vec<u8>],
-    out_key: u16,
-    out_key_counter: &mut u16,
+    out_key: usize,
+    out_key_counter: &mut usize,
     depth_: u8,
     start: usize,
     end: usize,
@@ -728,7 +730,7 @@ fn expand_flat(
     for atom in tokens[start..end].iter() {
         match atom {
             Token::Text(txt) => {
-                out[usize::from(out_key)].extend_from_slice(txt.slice());
+                out[out_key].extend_from_slice(txt.slice());
             }
             Token::Close => {
                 depth -= 1;
@@ -741,7 +743,7 @@ fn expand_flat(
                     [usize::from(expansion_variants.idx)..usize::from(expansion_variants.end)];
                 let skip_over_idx = variants[variants.len() - 1].end();
 
-                let starting_len = out[usize::from(out_key)].len();
+                let starting_len = out[out_key].len();
                 for (i, variant) in variants.iter().enumerate() {
                     let new_key = if i == 0 {
                         out_key
@@ -749,8 +751,8 @@ fn expand_flat(
                         let new_key = *out_key_counter;
                         // new_key > out_key always; the i==0 recursion only appends to
                         // out[out_key], so its [..starting_len] prefix is stable.
-                        let (lo, hi) = out.split_at_mut(usize::from(new_key));
-                        hi[0].extend_from_slice(&lo[usize::from(out_key)][..starting_len]);
+                        let (lo, hi) = out.split_at_mut(new_key);
+                        hi[0].extend_from_slice(&lo[out_key][..starting_len]);
                         *out_key_counter += 1;
                         new_key
                     };

--- a/test/js/bun/shell/brace.test.ts
+++ b/test/js/bun/shell/brace.test.ts
@@ -217,6 +217,52 @@ console.log(JSON.stringify(Bun.$.braces("echo {a,b}")));`,
     `);
     expect(exitCode).toBe(0);
   });
+
+  // The expander hands out output slots from a counter that is bumped once per
+  // slot, so after the last of N slots it holds N. The expansion cap admits
+  // N = 65536, one more than the old u16 counter could hold, so a word with
+  // exactly 65536 variants tripped the overflow check in debug builds.
+  // Each case runs in a subprocess because that check aborts the process. The
+  // child prints [count, first, last]; the last variant lives in the slot whose
+  // claim used to overflow.
+  describe("exactly 65536 variants", () => {
+    async function expandInChild(script: string) {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", script],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.trim(), stderr, exitCode };
+    }
+
+    test.concurrent("shell word with 16 flat groups (2^16)", async () => {
+      const result = await expandInChild(`
+        const word = Buffer.alloc(16 * "{a,b}".length, "{a,b}").toString();
+        const words = (await Bun.$\`echo \${{ raw: word }}\`.text()).trimEnd().split(" ");
+        console.log(JSON.stringify([words.length, words[0], words.at(-1)]));
+      `);
+      expect(result).toEqual({
+        stdout: JSON.stringify([65536, "aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbb"]),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent("$.braces() with 8 nested groups (4^8)", async () => {
+      const result = await expandInChild(`
+        const word = Buffer.alloc(8 * "{{a,b},{c,d}}".length, "{{a,b},{c,d}}").toString();
+        const out = Bun.$.braces(word);
+        console.log(JSON.stringify([out.length, out[0], out.at(-1)]));
+      `);
+      expect(result).toEqual({
+        stdout: JSON.stringify([65536, "aaaaaaaa", "dddddddd"]),
+        stderr: "",
+        exitCode: 0,
+      });
+    });
+  });
 });
 
 // A `{...}` group with no top-level comma is literal text in bash. The brace


### PR DESCRIPTION
### Problem
- A shell word (or `$.braces()` input) that expands to exactly 65536 variants, e.g. `{a,b}` repeated 16 times, aborts debug/assert builds with `panic: attempt to add with overflow` at `bun_shell_parser::braces::expand_flat` (src/shell_parser/braces.rs:754, `*out_key_counter += 1`). `expand_nested` has the same arithmetic.
- `out_key_counter` (a `u16`, src/shell_parser/braces.rs:543) is the index of the next unclaimed output slot. It starts at 1 and is bumped once per slot claimed, so after the last of N slots it holds N. The callers' cap (`MAX_BRACE_EXPANSIONS = 65536` in src/runtime/shell/states/Expansion.rs and src/runtime/api/BunObject.rs) admits N = 65536, which is one more than a `u16` holds.
- Release builds wrap on that final bump and nothing reads the counter afterwards, so their output is correct; 65537 and above are already rejected by the cap. Only the N = 65536 case is affected, and only on builds with overflow checks.

### Fix
- `out_key` and `out_key_counter` in `expand`, `expand_flat` and `expand_nested` are now `usize`, the type they are used as (they index `out`). The counter's final value is `out.len()`, which always fits. The 65536 cap and release output are unchanged.
- Tests in test/js/bun/shell/brace.test.ts: one word with 16 flat groups run through the shell (`expand_flat`, the reported repro) and one with 8 nested 4-way groups through `$.braces()` (`expand_nested`). Each runs in a subprocess and checks the count plus the first and last variant; the last variant is written into the slot whose claim used to overflow.
- Verified: both tests fail on a debug build of main without the src change (child aborts with the panic above) and pass with it; test/js/bun/shell/brace.test.ts and bunshell.test.ts pass on the debug build; `cargo test -p bun_shell_parser` passes.

### Background
- Brace expansion preallocates `out`, one `Vec<u8>` per result, sized by `calculate_expanded_amount` (a `u32`, capped by the callers). The expander then walks the word: the first variant of a group keeps writing into the current slot, and every other variant claims a fresh slot from the counter and copies the prefix built so far into it before continuing. Every slot after the first is claimed exactly once, which is why the counter ends at `out.len()` rather than at the largest slot index.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 6 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/brace.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [2.51ms]
(pass) $.braces > 2 [2.07ms]
(pass) $.braces > 3 [1.88ms]
(pass) $.braces > nested [1.63ms]
(pass) $.braces > nested 2 [1.99ms]
(pass) $.braces > nested sibling product [2.00ms]
(pass) $.braces > nested sibling product with surrounding text [1.39ms]
(pass) $.braces > nested sibling product mixed with variants [3.13ms]
(pass) $.braces > nested sibling product triple [2.15ms]
(pass) $.braces > nested with empty variant > {x,a{,}b} [1.48ms]
(pass) $.braces > nested with empty variant > {x,{a,}}z [0.63ms]
(pass) $.braces > nested with empty variant > {x,{,a}}z [0.46ms]
(pass) $.braces > nested with empty variant > {x,{,}}z [0.47ms]
(pass) $.braces > nested with empty variant > a{b,c{d,}}e [0.44ms]
(pass) $.braces > nested with empty variant > a{b,c{,d}}e [0.48ms]
(pass) $.braces > nested with empty variant > {x,{a,,b}} [0.79ms]
(pass) $.braces > nested with empty variant > {x,{a,b,}} [0.44ms]
(pass) $.braces > nest
... (truncated)

release without fix: all passed
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [0.05ms]
(pass) $.braces > 2 [0.02ms]
(pass) $.braces > 3 [0.01ms]
(pass) $.braces > nested [0.05ms]
(pass) $.braces > nested 2 [0.02ms]
(pass) $.braces > nested sibling product [0.02ms]
(pass) $.braces > nested sibling product with surrounding text [0.01ms]
(pass) $.braces > nested sibling product mixed with variants [0.04ms]
(pass) $.braces > nested sibling product triple [0.03ms]
(pass) $.braces > nested with empty variant > {x,a{,}b} [0.02ms]
(pass) $.braces > nested with empty variant > {x,{a,}}z [0.01ms]
(pass) $.braces > nested with empty variant > {x,{,a}}z
(pass) $.braces > nested with empty variant > {x,{,}}z
(pass) $.braces > nested with empty variant > a{b,c{d,}}e
(pass) $.braces > nested with empty variant > a{b,c{,d}}e
(pass) $.braces > nested with empty variant > {x,{a,,b}}
(pass) $.braces > nested with empty variant > {x,{a,b,}}
(pass) $.braces > nested with empty variant > {{a,},x}
(pass) $.braces > nested with empty variant > p{q,{r,}{s,}}t
(pass) $.braces > very deeply nested [0.07ms]
(pass) $.braces > literal outer group around hundreds of nested groups
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/shell/brace.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/shell/brace.test.ts:
(pass) $.braces > no-op [1.90ms]
(pass) $.braces > 2 [1.97ms]
(pass) $.braces > 3 [1.90ms]
(pass) $.braces > nested [1.60ms]
(pass) $.braces > nested 2 [2.01ms]
(pass) $.braces > nested sibling product [1.57ms]
(pass) $.braces > nested sibling product with surrounding text [1.77ms]
(pass) $.braces > nested sibling product mixed with variants [3.16ms]
(pass) $.braces > nested sibling product triple [1.81ms]
(pass) $.braces > nested with empty variant > {x,a{,}b} [1.76ms]
(pass) $.braces > nested with empty variant > {x,{a,}}z [0.61ms]
(pass) $.braces > nested with empty variant > {x,{,a}}z [0.46ms]
(pass) $.braces > nested with empty variant > {x,{,}}z [0.48ms]
(pass) $.braces > nested with empty variant > a{b,c{d,}}e [0.45ms]
(pass) $.braces > nested with empty variant > a{b,c{,d}}e [0.46ms]
(pass) $.braces > nested with empty variant > {x,{a,,b}} [0.45ms]
(pass) $.braces > nested with empty variant > {x,{a,b,}} [0.78ms]
(pass) $.braces > nest
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 631ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/740] cc obj/vendor/tinycc/tccdbg.c.o
[2/740] cc obj/vendor/tinycc/tccelf.c.o
[3/740] cc obj/vendor/tinycc/x86_64-link.c.o
[4/740] cc obj/vendor/tinycc/x86_64-gen.c.o
[5/740] cc obj/vendor/tinycc/tccpp.c.o
[6/740] cc obj/vendor/tinycc/tccrun.c.o
[7/740] cc obj/vendor/tinycc/i386-asm.c.o
[8/740] cc obj/vendor/tinycc/tccgen.c.o
[9/740] cc obj/vendor/tinycc/tccasm.c.o
[10/740] fetch lshpack
[lshpack] up to date
[11/738] fetch lsquic
[lsquic] up to date
[12/669] fetch cares
[cares] up to date
[13/578] fetch boringssl
[boringssl] up to date
[14/156] fetch WebKit (prebuilt)
[WebKit] up to date
[15/156] fetch lolhtml
[lolhtml] up to date
[16/156] cc obj/codegen/InternalModuleRegistryConstants.S.o
[17/156] cc obj/packages/bun-usockets/src/fault_inject.c.o
[18/156] cc obj/packages/bun-usockets/src/context.c.o
[19/156] cc obj/packages/bun-usockets/src/bsd.c.o
[20/156] cc obj/packages/bun-usockets/src/loop.c.o
[21/156] cc obj/packages/bun-usockets/src/quic.c.o
[22/156] cc obj/packages/bun-usockets/src/udp.c.o
[23/1
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/shell_parser/braces.rs      | 34 +++++++++++++++---------------
 test/js/bun/shell/brace.test.ts | 46 +++++++++++++++++++++++++++++++++++++++++
 2 files changed, 63 insertions(+), 17 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 6

<details><summary>evidence per changed file</summary>

```
file                             reads  edits  tests
src/shell_parser/braces.rs           6     10      0
test/js/bun/shell/brace.test.ts      3      5      0
```

</details>

**root cause** · written by the author bot

The brace expansion output slot counter in braces.rs was a u16 that starts at 1 and is incremented once per output slot, so it reaches N after the last slot, while the callers' cap admits exactly 65,536 expansions, one more than u16::MAX, causing the final increment to overflow (a panic in overflow-checked builds, a harmless wrap in release since nothing reads it afterwards). The fix widens the out_key and out_key_counter values in expand, expand_flat, and expand_nested to usize, which is the natural type since they are only used to index the output slice, leaving the expansion limit and ou…

<!-- robobun:evidence:end -->