### PR TITLE
shell: make the seq builtin count in f64 at the operands' decimal precision

### DIFF
--- a/src/bun_core/fmt.rs
+++ b/src/bun_core/fmt.rs
@@ -1055,12 +1055,6 @@ pub fn parse_f64(s: &[u8]) -> Option<f64> {
     None // partial match → trailing garbage
 }
 
-/// `parse_f64` truncated to `f32`.
-#[inline]
-pub fn parse_f32(s: &[u8]) -> Option<f32> {
-    parse_f64(s).map(|v| v as f32)
-}
-
 /// Parse `s` as `T` for grammars whose alphabet is pure ASCII (IP addresses,
 /// booleans). Any non-ASCII byte short-circuits to `None`, so the `&str` view
 /// is always valid without a UTF-8 walk. **Do not** use for integers/floats —

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -15,9 +15,13 @@ enum State {
 
 pub struct Seq {
     state: State,
-    start: f32,
-    end: f32,
-    increment: f32,
+    start: f64,
+    end: f64,
+    increment: f64,
+    /// Most decimal places any positional argument was written with
+    /// (`seq 0 0.25 1` → 2). The sequence is generated in units of
+    /// 10^-decimals so fractional steps stay exact.
+    decimals: u32,
     /// Borrowed from argv (NUL-terminated arena strings) or `'static` literals;
     /// argv outlives the builtin — `RawSlice` invariant.
     separator: bun_ptr::RawSlice<u8>,
@@ -31,6 +35,7 @@ impl Default for Seq {
             start: 1.0,
             end: 1.0,
             increment: 1.0,
+            decimals: 0,
             separator: bun_ptr::RawSlice::new(b"\n"),
             terminator: bun_ptr::RawSlice::EMPTY,
         }
@@ -91,10 +96,14 @@ impl Seq {
         macro_rules! parse_num {
             ($i:expr) => {{
                 let s = Builtin::of(interp, cmd).arg_bytes($i);
-                match parse_f32(s) {
+                let n = match bun_core::fmt::parse_f64(s) {
                     Some(n) if n.is_finite() => n,
                     _ => return Self::fail(interp, cmd, b"seq: invalid argument\n"),
-                }
+                };
+                let decimals = decimal_places(s);
+                let me = Self::state_mut(interp, cmd);
+                me.decimals = me.decimals.max(decimals);
+                n
             }};
         }
 
@@ -159,9 +168,11 @@ impl Seq {
         let needs_io = Builtin::of(interp, cmd).stdout.needs_io().is_some();
         // Render entirely into a local Vec, then either enqueue it or
         // write_no_io it; we buffer once for simplicity.
-        let (start, end, incr, sep, term) = {
+        let (start, end, incr, scale, sep, term) = {
             let me = Self::state_mut(interp, cmd);
-            (me.start, me.end, me.increment, me.separator, me.terminator)
+            let (start, end, incr, scale) =
+                scale_to_decimals(me.start, me.end, me.increment, me.decimals);
+            (start, end, incr, scale, me.separator, me.terminator)
         };
         let mut out = Vec::new();
         let mut current = start;
@@ -170,16 +181,18 @@ impl Seq {
         } else {
             current >= end
         } {
-            // Rust `{}` for f32 prints the shortest decimal that round-trips
-            // (no exponent, no trailing ".0").
-            let _ = write!(&mut out, "{}", current);
+            // Rust `{}` for f64 prints the shortest decimal that round-trips
+            // (no exponent, no trailing ".0"), so an integer divided by an
+            // exact power of ten prints as the plain decimal (`13 / 10` → `1.3`).
+            let _ = write!(&mut out, "{}", current / scale);
             out.extend_from_slice(sep.slice());
             let next = current + incr;
             if next == current {
-                // f32 rounding can make `current + incr` equal `current`
-                // (e.g. `seq 1 99999999` saturates at 2^24, or a tiny
-                // increment relative to `current`). Without this check the
-                // loop never terminates and `out` grows without bound.
+                // Reached only when `scale_to_decimals` had to leave the
+                // operands unscaled and `incr` is below f64 resolution at this
+                // magnitude (`seq 1 1e-17 2`, integers past 2^53): the
+                // sequence cannot advance, and without this check the loop
+                // never terminates and `out` grows without bound.
                 break;
             }
             current = next;
@@ -218,7 +231,51 @@ impl Seq {
     }
 }
 
-#[inline]
-fn parse_f32(bytes: &[u8]) -> Option<f32> {
-    bun_core::fmt::parse_f32(bytes)
+/// Decimal places a positional argument was written with: `0.25` → 2,
+/// `1e-3` → 3, `2.50e1` → 1. `arg` has already been accepted by `parse_f64`,
+/// so it has the shape `[sign]digits[.digits][e[sign]digits]`.
+fn decimal_places(arg: &[u8]) -> u32 {
+    let (mantissa, exponent) = match bun_core::strings::index_of_any(arg, b"eE") {
+        Some(e) => {
+            // An exponent outside i32 either overflowed to inf (rejected by
+            // the caller) or underflowed to 0, which needs no decimal places.
+            let exponent = bun_core::fmt::parse_decimal::<i32>(&arg[e + 1..]).unwrap_or(0);
+            (&arg[..e], i64::from(exponent))
+        }
+        None => (arg, 0),
+    };
+    let fraction = match bun_core::strings::index_of_char_usize(mantissa, b'.') {
+        Some(dot) => (mantissa.len() - dot - 1) as i64,
+        None => 0,
+    };
+    (fraction - exponent).clamp(0, i64::from(u32::MAX)) as u32
+}
+
+/// Rescales the operands so the sequence is counted in whole units of the
+/// finest decimal place any operand was written with: `seq 0 0.1 1` counts
+/// 0..=10 by 1 and divides by 10 when printing. Integer-valued f64s below 2^53
+/// add exactly, which avoids both the drift of summing fractions (ten 0.1s
+/// make 0.9999999999999999) and the noise of multiplying them (3 * 0.1 prints
+/// as 0.30000000000000004). Returns `(start, end, increment, scale)`; operands
+/// that cannot be scaled exactly are returned as they are with scale 1.
+fn scale_to_decimals(start: f64, end: f64, incr: f64, decimals: u32) -> (f64, f64, f64, f64) {
+    const POW10: [f64; 23] = [
+        1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16,
+        1e17, 1e18, 1e19, 1e20, 1e21, 1e22,
+    ];
+    const MAX_EXACT_INTEGER: f64 = 9007199254740992.0; // 2^53
+
+    if decimals == 0 {
+        return (start, end, incr, 1.0);
+    }
+    // 1e22 is the largest power of ten f64 represents exactly.
+    let Some(&scale) = POW10.get(decimals as usize) else {
+        return (start, end, incr, 1.0);
+    };
+    let scaled = [start, end, incr].map(|v| (v * scale).round());
+    if scaled.iter().any(|v| v.abs() >= MAX_EXACT_INTEGER) {
+        return (start, end, incr, 1.0);
+    }
+    let [start, end, incr] = scaled;
+    (start, end, incr, scale)
 }

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -18,9 +18,7 @@ pub struct Seq {
     start: f64,
     end: f64,
     increment: f64,
-    /// Most decimal places any positional argument was written with
-    /// (`seq 0 0.25 1` → 2). The sequence is generated in units of
-    /// 10^-decimals so fractional steps stay exact.
+    /// Most decimal places any positional argument was written with (`seq 0 0.25 1` → 2).
     decimals: u32,
     /// Borrowed from argv (NUL-terminated arena strings) or `'static` literals;
     /// argv outlives the builtin — `RawSlice` invariant.
@@ -181,18 +179,12 @@ impl Seq {
         } else {
             current >= end
         } {
-            // Rust `{}` for f64 prints the shortest decimal that round-trips
-            // (no exponent, no trailing ".0"), so an integer divided by an
-            // exact power of ten prints as the plain decimal (`13 / 10` → `1.3`).
+            // f64 `{}` is the shortest round-trip decimal: no exponent, no trailing ".0".
             let _ = write!(&mut out, "{}", current / scale);
             out.extend_from_slice(sep.slice());
             let next = current + incr;
             if next == current {
-                // Reached only when `scale_to_decimals` had to leave the
-                // operands unscaled and `incr` is below f64 resolution at this
-                // magnitude (`seq 1 1e-17 2`, integers past 2^53): the
-                // sequence cannot advance, and without this check the loop
-                // never terminates and `out` grows without bound.
+                // Unscaled operands with `incr` below f64 resolution (`seq 1 1e-17 2`) would loop forever.
                 break;
             }
             current = next;
@@ -231,17 +223,13 @@ impl Seq {
     }
 }
 
-/// Decimal places a positional argument was written with: `0.25` → 2,
-/// `1e-3` → 3, `2.50e1` → 1. `arg` has already been accepted by `parse_f64`,
-/// so it has the shape `[sign]digits[.digits][e[sign]digits]`.
+/// Decimal places an operand was written with: `0.25` → 2, `1e-3` → 3, `2.50e1` → 1.
 fn decimal_places(arg: &[u8]) -> u32 {
     let (mantissa, exponent) = match bun_core::strings::index_of_any(arg, b"eE") {
-        Some(e) => {
-            // An exponent outside i32 either overflowed to inf (rejected by
-            // the caller) or underflowed to 0, which needs no decimal places.
-            let exponent = bun_core::fmt::parse_decimal::<i32>(&arg[e + 1..]).unwrap_or(0);
-            (&arg[..e], i64::from(exponent))
-        }
+        Some(e) => match bun_core::fmt::parse_decimal::<i32>(&arg[e + 1..]) {
+            Some(exponent) => (&arg[..e], i64::from(exponent)),
+            None => return u32::MAX,
+        },
         None => (arg, 0),
     };
     let fraction = match bun_core::strings::index_of_char_usize(mantissa, b'.') {
@@ -251,13 +239,7 @@ fn decimal_places(arg: &[u8]) -> u32 {
     (fraction - exponent).clamp(0, i64::from(u32::MAX)) as u32
 }
 
-/// Rescales the operands so the sequence is counted in whole units of the
-/// finest decimal place any operand was written with: `seq 0 0.1 1` counts
-/// 0..=10 by 1 and divides by 10 when printing. Integer-valued f64s below 2^53
-/// add exactly, which avoids both the drift of summing fractions (ten 0.1s
-/// make 0.9999999999999999) and the noise of multiplying them (3 * 0.1 prints
-/// as 0.30000000000000004). Returns `(start, end, increment, scale)`; operands
-/// that cannot be scaled exactly are returned as they are with scale 1.
+/// Counts in whole units of the operands' finest decimal place so the steps add exactly; scale 1 if that is not exact.
 fn scale_to_decimals(start: f64, end: f64, incr: f64, decimals: u32) -> (f64, f64, f64, f64) {
     const POW10: [f64; 23] = [
         1e0, 1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12, 1e13, 1e14, 1e15, 1e16,

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -214,6 +214,12 @@ describe("seq", async () => {
     .stderr("")
     .runAsTest("decimals implied by exponent notation");
 
+  TestBuilder.command`seq 1e-9999999999 0.5 1`
+    .exitCode(0)
+    .stdout("0\n0.5\n1\n")
+    .stderr("")
+    .runAsTest("exponent too large to count decimals for");
+
   // 2251799813685248 is 2^51; halves are still representable there, but the
   // values are too large to be counted in tenths, so they are used as written.
   TestBuilder.command`seq 2251799813685248.5 2251799813685249.5`

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -110,17 +110,123 @@ describe("seq", async () => {
     .stderr("seq: needs negative decrement\n")
     .runAsTest("needs negative decrement");
 
-  TestBuilder.command`seq 16777216 16777218`
+  // 16777216 is 2^24, where f32 stops being able to represent consecutive integers.
+  TestBuilder.command`seq 16777216 16777219`
     .exitCode(0)
-    .stdout("16777216\n")
+    .stdout("16777216\n16777217\n16777218\n16777219\n")
     .stderr("")
-    .runAsTest("terminates when adding the increment no longer changes the value");
+    .runAsTest("counts past 2^24");
 
-  TestBuilder.command`seq 1 0.00000001 2`
+  TestBuilder.command`seq 100000001 100000003`
+    .exitCode(0)
+    .stdout("100000001\n100000002\n100000003\n")
+    .stderr("")
+    .runAsTest("keeps every digit of nine-digit bounds");
+
+  TestBuilder.command`seq 100000003 100000001`
+    .exitCode(0)
+    .stdout("100000003\n100000002\n100000001\n")
+    .stderr("")
+    .runAsTest("counts down past 2^24");
+
+  TestBuilder.command`seq 4294967295 4294967297`
+    .exitCode(0)
+    .stdout("4294967295\n4294967296\n4294967297\n")
+    .stderr("")
+    .runAsTest("counts past 2^32");
+
+  TestBuilder.command`seq 16777217 2 16777221`
+    .exitCode(0)
+    .stdout("16777217\n16777219\n16777221\n")
+    .stderr("")
+    .runAsTest("explicit increment past 2^24");
+
+  // 9007199254740992 is 2^53, the last integer f64 can count to one by one.
+  TestBuilder.command`seq 9007199254740991 9007199254740992`
+    .exitCode(0)
+    .stdout("9007199254740991\n9007199254740992\n")
+    .stderr("")
+    .runAsTest("counts up to 2^53");
+
+  TestBuilder.command`seq 9007199254740992 9007199254740994`
+    .exitCode(0)
+    .stdout("9007199254740992\n")
+    .stderr("")
+    .runAsTest("terminates once the increment can no longer advance the value (past 2^53)");
+
+  TestBuilder.command`seq 1 1e-17 2`
     .exitCode(0)
     .stdout("1\n")
     .stderr("")
-    .runAsTest("terminates when the increment is too small to advance the accumulator");
+    .runAsTest("terminates when the increment is below the resolution of the start value");
+
+  TestBuilder.command`seq 0 0.1 1`
+    .exitCode(0)
+    .stdout("0\n0.1\n0.2\n0.3\n0.4\n0.5\n0.6\n0.7\n0.8\n0.9\n1\n")
+    .stderr("")
+    .runAsTest("fractional increment prints exact decimals and reaches the end value");
+
+  TestBuilder.command`seq 0.1 0.1 0.5`
+    .exitCode(0)
+    .stdout("0.1\n0.2\n0.3\n0.4\n0.5\n")
+    .stderr("")
+    .runAsTest("fractional start and increment");
+
+  TestBuilder.command`seq 1 0.3 2`
+    .exitCode(0)
+    .stdout("1\n1.3\n1.6\n1.9\n")
+    .stderr("")
+    .runAsTest("fractional increment does not accumulate rounding error");
+
+  TestBuilder.command`seq -0.9 0.3 0.9`
+    .exitCode(0)
+    .stdout("-0.9\n-0.6\n-0.3\n0\n0.3\n0.6\n0.9\n")
+    .stderr("")
+    .runAsTest("fractional sequence through zero");
+
+  TestBuilder.command`seq 2 -0.5 0`
+    .exitCode(0)
+    .stdout("2\n1.5\n1\n0.5\n0\n")
+    .stderr("")
+    .runAsTest("fractional decrement");
+
+  TestBuilder.command`seq 0.5 0.01 0.53`
+    .exitCode(0)
+    .stdout("0.5\n0.51\n0.52\n0.53\n")
+    .stderr("")
+    .runAsTest("uses the most precise operand's number of decimals");
+
+  TestBuilder.command`seq 0.5 3`
+    .exitCode(0)
+    .stdout("0.5\n1.5\n2.5\n")
+    .stderr("")
+    .runAsTest("implicit increment from a fractional start");
+
+  TestBuilder.command`seq 3 0.5`
+    .exitCode(0)
+    .stdout("3\n2\n1\n")
+    .stderr("")
+    .runAsTest("implicit decrement to a fractional end");
+
+  TestBuilder.command`seq 0 1e-1 3e-1`
+    .exitCode(0)
+    .stdout("0\n0.1\n0.2\n0.3\n")
+    .stderr("")
+    .runAsTest("decimals implied by exponent notation");
+
+  // 2251799813685248 is 2^51; halves are still representable there, but the
+  // values are too large to be counted in tenths, so they are used as written.
+  TestBuilder.command`seq 2251799813685248.5 2251799813685249.5`
+    .exitCode(0)
+    .stdout("2251799813685248.5\n2251799813685249.5\n")
+    .stderr("")
+    .runAsTest("large fractional values");
+
+  TestBuilder.command`seq 0 0.00000000000000000000001 0.00000000000000000000002`
+    .exitCode(0)
+    .stdout("0\n0.00000000000000000000001\n0.00000000000000000000002\n")
+    .stderr("")
+    .runAsTest("more than 22 decimals");
 });
 
 describe("seq without stdout", async () => {


### PR DESCRIPTION
### Problem
- The `seq` shell builtin stores `start`/`end`/`increment` as `f32` (`src/runtime/shell/builtin/seq.rs`), so every bound above 2^24 (16777216) is rounded when parsed.
- The guard that stops the loop when `current + incr == current` then turns the rounded sequence into a single wrong line with exit code 0: `seq 100000001 100000003` prints `100000000`, `seq 4294967295 4294967297` prints `4294967300`, `seq 16777216 16777219` prints `16777216`.
- Anything iterating `$(seq $START $END)` over ids, byte offsets or epoch seconds runs once with a wrong value and reports success.
- Fractional sequences were also drifting because the loop is a running sum: `seq 1 0.3 2` printed `1.5999999`, `seq 0 0.1 1` printed `0.70000005` and stopped at `0.9000001`.

### Fix
- Operands are parsed and stored as `f64`.
- `start()` records the most decimal places any operand was written with (`0.25` -> 2, `1e-3` -> 3), and `do_()` scales the operands by that power of ten before counting, dividing back only when printing. The loop therefore adds integer-valued doubles, which is exact below 2^53, and every printed value is `n / 10^decimals`, whose shortest round-trip form is the plain decimal. Integer operands take the same path with scale 1, so their output is unchanged apart from being correct past 2^24.
- Operands with more than 22 decimals (1e22 is the last exactly representable power of ten) or whose scaled values reach 2^53 are used as written; there the existing `next == current` guard still terminates the loop (`seq 1 1e-17 2`, integers past 2^53), as it did before, just at f64 resolution instead of f32.
- Output format is unchanged (shortest round-trip, BSD-style trailing separator); only the values differ.
- `bun_core::fmt::parse_f32` had no other caller and is removed.
- Verified with `test/js/bun/shell/commands/seq.test.ts`: the two tests that asserted the 2^24 collapse are replaced, and the new cases (bounds past 2^24 / 2^32 / up to 2^53, fractional steps, exponent spellings, the two unscaled fallbacks) fail 11 tests on the released build and pass 50/50 with this change.
- `test/js/bun/shell/{bunshell,exec,pipeline_stack,yield,file-io,shell-seq-condexpr,assignments-in-pipeline}.test.ts` and `commands/echo.test.ts` still pass; `cargo clippy -p bun_core -p bun_runtime` and `cargo fmt --check` are clean.

### Background
- `seq` is always a builtin in `Bun.$` (there is no flag to fall through to the system binary), following the BSD variant: `seq 5 1` counts down, `-s` is emitted after every value.
- f32 has a 24-bit significand, so consecutive integers are only representable up to 2^24; f64 has 53 bits, so up to 2^53 (9007199254740992), which covers ids, offsets and epoch values in seconds or milliseconds.
- Decimal fractions such as 0.1 have no exact binary representation, so both a running sum (`0.1` added ten times is `0.9999999999999999`) and a multiplied step (`3 * 0.1` is `0.30000000000000004`) produce visible noise under shortest round-trip printing. Counting in scaled integers is the same idea as GNU seq printing at the operands' precision, without changing Bun's output shape (`1`, not `1.0`).
- The scaled values stay below 2^53, and the rounding interval of a double there is narrower than one unit of the last decimal place, so `n / 10^decimals` always prints back as exactly that decimal.
- Related open PR touching the same file: #32323 (hex float operands); it mentions `parse_f32` only in a comment.

<details>
<summary>Before / after</summary>

```
$ bun -e 'for (const c of ["seq 16777216 16777219","seq 100000001 100000003","seq 4294967295 4294967297","seq 1 0.3 2","seq 0 0.1 1"]) { const r = await Bun.$`${{raw: c}}`.quiet(); console.log(c, JSON.stringify(r.text())); }'

# bun 1.4.0
seq 16777216 16777219      "16777216\n"
seq 100000001 100000003    "100000000\n"
seq 4294967295 4294967297  "4294967300\n"
seq 1 0.3 2                "1\n1.3\n1.5999999\n1.8999999\n"
seq 0 0.1 1                "0\n0.1\n0.2\n0.3\n0.4\n0.5\n0.6\n0.70000005\n0.8000001\n0.9000001\n"

# this branch
seq 16777216 16777219      "16777216\n16777217\n16777218\n16777219\n"
seq 100000001 100000003    "100000001\n100000002\n100000003\n"
seq 4294967295 4294967297  "4294967295\n4294967296\n4294967297\n"
seq 1 0.3 2                "1\n1.3\n1.6\n1.9\n"
seq 0 0.1 1                "0\n0.1\n0.2\n0.3\n0.4\n0.5\n0.6\n0.7\n0.8\n0.9\n1\n"
```
</details>
