### PR TITLE
node:module: implement findPackageJSON

### DIFF
--- a/src/jsc/NodeModuleModule.rs
+++ b/src/jsc/NodeModuleModule.rs
@@ -114,6 +114,56 @@ fn find_path_inner(
     errorable.unwrap().ok()
 }
 
+#[unsafe(no_mangle)]
+extern "C" fn NodeModuleModule__findPackageJSON(
+    global: &JSGlobalObject,
+    specifier: BunString,
+    source: BunString,
+) -> JSValue {
+    jsc::host_fn::to_js_host_call(global, || find_package_json(global, specifier, source))
+}
+
+fn find_package_json(
+    global: &JSGlobalObject,
+    specifier: BunString,
+    source: BunString,
+) -> JsResult<JSValue> {
+    let specifier = if specifier.has_prefix_comptime(b"file://") {
+        OwnedString::new(jsc::URL::path_from_file_url(specifier))
+    } else {
+        OwnedString::new(specifier.dupe_ref())
+    };
+
+    let source = if source.has_prefix_comptime(b"file://") {
+        OwnedString::new(jsc::URL::path_from_file_url(source))
+    } else {
+        OwnedString::new(source.dupe_ref())
+    };
+
+    let mut resolved = ErrorableString::ok(BunString::empty());
+    VirtualMachine::resolve(
+        &mut resolved,
+        global,
+        specifier.get(),
+        source.get(),
+        None,
+        crate::virtual_machine::ResolveMode::PackageJson,
+    )?;
+
+    if !resolved.success {
+        // SAFETY: !success activates the error arm of ErrorableString.
+        return Err(global.throw_value(unsafe { resolved.result.err }.value));
+    }
+
+    // SAFETY: success activates the value arm of ErrorableString.
+    let mut resolved = OwnedString::new(unsafe { resolved.result.value });
+    if resolved.get().is_empty() {
+        Ok(JSValue::UNDEFINED)
+    } else {
+        resolved.transfer_to_js(global)
+    }
+}
+
 pub fn stat(path: &[u8]) -> i32 {
     // PERF: `exists_at_type`
     // takes a `&ZStr`, so we copy into a NUL-terminated heap buffer here.

--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -3145,18 +3145,19 @@ pub enum ResolveMode {
     Require,
     /// `require.resolve()`: returns the bare specifier for Node builtins.
     RequireResolve,
+    PackageJson,
 }
 
 impl ResolveMode {
     #[inline]
     pub fn is_esm(self) -> bool {
-        matches!(self, Self::Esm)
+        matches!(self, Self::Esm | Self::PackageJson)
     }
 
     #[inline]
     pub fn import_kind(self) -> bun_ast::ImportKind {
         match self {
-            Self::Esm => bun_ast::ImportKind::Stmt,
+            Self::Esm | Self::PackageJson => bun_ast::ImportKind::Stmt,
             Self::Require => bun_ast::ImportKind::Require,
             Self::RequireResolve => bun_ast::ImportKind::RequireResolve,
         }
@@ -4541,7 +4542,11 @@ impl VirtualMachine {
                     source,
                     crate::BunPluginTarget::Bun,
                 )? {
-                    *res = resolved_path;
+                    *res = if mode == ResolveMode::PackageJson {
+                        ErrorableString::ok(bun_core::String::empty())
+                    } else {
+                        resolved_path
+                    };
                     return Ok(());
                 }
             }
@@ -4553,7 +4558,9 @@ impl VirtualMachine {
             Default::default(),
         ) {
             *res = ErrorableString::ok(
-                if mode == ResolveMode::RequireResolve && hardcoded.node_builtin {
+                if mode == ResolveMode::PackageJson {
+                    bun_core::String::empty()
+                } else if mode == ResolveMode::RequireResolve && hardcoded.node_builtin {
                     specifier.dupe_ref()
                 } else {
                     bun_core::String::init(hardcoded.path.as_bytes())
@@ -4564,7 +4571,11 @@ impl VirtualMachine {
 
         // Node's `--expose-internals`.
         if ModuleLoader::exposed_internal_tag(specifier_utf8.slice()).is_some() {
-            *res = ErrorableString::ok(specifier.dupe_ref());
+            *res = ErrorableString::ok(if mode == ResolveMode::PackageJson {
+                bun_core::String::empty()
+            } else {
+                specifier.dupe_ref()
+            });
             return Ok(());
         }
 
@@ -4674,7 +4685,17 @@ impl VirtualMachine {
             };
         }
 
-        *res = ErrorableString::ok(bun_core::String::clone_utf8(result.path));
+        let path = if mode == ResolveMode::PackageJson {
+            result
+                .result
+                .as_ref()
+                .and_then(bun_resolver::Result::package_json_path)
+                .map(bun_core::String::clone_utf8)
+                .unwrap_or_default()
+        } else {
+            bun_core::String::clone_utf8(result.path)
+        };
+        *res = ErrorableString::ok(path);
         Ok(())
     }
     /// Worker-thread teardown.

--- a/src/jsc/modules/NodeModuleModule.cpp
+++ b/src/jsc/modules/NodeModuleModule.cpp
@@ -12,6 +12,7 @@
 #include <JavaScriptCore/CallData.h>
 #include <JavaScriptCore/JSPromise.h>
 #include <JavaScriptCore/IteratorOperations.h>
+#include <wtf/URL.h>
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/JSNativeStdFunction.h"
 #include "JSCommonJSExtensions.h"
@@ -33,6 +34,7 @@ BUN_DECLARE_HOST_FUNCTION(Bun__JSSourceMap__find);
 BUN_DECLARE_HOST_FUNCTION(Resolver__nodeModulePathsForJS);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionDebugNoop);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionFindPath);
+JSC_DECLARE_HOST_FUNCTION(jsFunctionFindPackageJSON);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionIsBuiltinModule);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeModuleCreateRequire);
 JSC_DECLARE_HOST_FUNCTION(jsFunctionNodeModuleModuleConstructor);
@@ -572,6 +574,31 @@ JSC::JSValue resolveLookupPaths(JSC::JSGlobalObject* globalObject, String reques
 extern "C" JSC::EncodedJSValue NodeModuleModule__findPath(JSGlobalObject*,
     BunString, JSArray*);
 
+extern "C" JSC::EncodedJSValue NodeModuleModule__findPackageJSON(JSGlobalObject*,
+    BunString, BunString);
+
+JSC_DEFINE_HOST_FUNCTION(jsFunctionFindPackageJSON, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (callFrame->argumentCount() < 1)
+        return Bun::ERR::MISSING_ARGS(scope, globalObject, "The \"specifier\" argument must be specified"_s);
+
+    auto specifier = callFrame->argument(0).toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+    auto baseValue = callFrame->argument(1);
+    String base = baseValue.isUndefined()
+        ? "data:"_s
+        : baseValue.toWTFString(globalObject);
+    RETURN_IF_EXCEPTION(scope, {});
+
+    WTF::URL baseURL(base);
+    if (baseURL.isValid() && baseURL.protocolIsFile())
+        base = baseURL.fileSystemPath();
+
+    return NodeModuleModule__findPackageJSON(globalObject, Bun::toString(specifier), Bun::toString(base));
+}
+
 JSC_DEFINE_HOST_FUNCTION(jsFunctionFindPath, (JSGlobalObject * globalObject, JSC::CallFrame* callFrame))
 {
     auto& vm = JSC::getVM(globalObject);
@@ -976,6 +1003,7 @@ constants               getConstantsObject                PropertyCallback
 createRequire           jsFunctionNodeModuleCreateRequire Function 1
 enableCompileCache      jsFunctionEnableCompileCache      Function 1
 findSourceMap           Bun__JSSourceMap__find           Function 1
+findPackageJSON         jsFunctionFindPackageJSON        Function 2
 flushCompileCache       jsFunctionFlushCompileCache       Function 0
 getCompileCacheDir      jsFunctionGetCompileCacheDir      Function 0
 globalPaths             getGlobalPathsObject              PropertyCallback

--- a/src/resolver/result.rs
+++ b/src/resolver/result.rs
@@ -235,6 +235,10 @@ impl Result {
         Self::deref_package_json(self.package_json)
     }
 
+    pub fn package_json_path(&self) -> Option<&'static [u8]> {
+        self.package_json_ref().map(|package_json| package_json.source.path.text)
+    }
+
     /// Field-value form of [`package_json_ref`] for sites where `self` is
     /// already mutably borrowed (e.g. while iterating `path_pair`). Takes the
     /// `Copy` field directly so the borrow checker only sees a field read.

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import fs from "fs";
-import { bunEnv, bunExe, isWindows, ospath, tempDir } from "harness";
-import Module, { _nodeModulePaths, builtinModules, createRequire, isBuiltin, wrap } from "module";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, ospath, tempDir } from "harness";
+import Module, { _nodeModulePaths, builtinModules, createRequire, findPackageJSON, isBuiltin, wrap } from "module";
 import path from "path";
 
 describe.concurrent("node-module-module", () => {
@@ -23,6 +23,29 @@ describe.concurrent("node-module-module", () => {
     expect(isBuiltin("node:bacon")).toBe(false);
     expect(isBuiltin("node:test")).toBe(true);
     expect(isBuiltin("test")).toBe(false); // "test" does not alias to "node:test"
+  });
+
+  test("findPackageJSON resolves an ESM package import", async () => {
+    using dir = tempDir("find-package-json", {
+      "entry.mjs": `import { findPackageJSON } from "node:module";
+console.log(findPackageJSON("pkg", import.meta.url));
+console.log(findPackageJSON(import.meta.resolve("pkg")));`,
+      "node_modules/pkg/package.json": JSON.stringify({ name: "pkg", exports: "./index.js" }),
+      "node_modules/pkg/index.js": "export {};",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "entry.mjs"],
+      cwd: String(dir),
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(normalizeBunSnapshot(stdout, dir)).toMatchInlineSnapshot(`
+      "<dir>/node_modules/pkg/package.json
+      <dir>/node_modules/pkg/package.json"
+    `);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
   });
 
   test("module.globalPaths exists", () => {


### PR DESCRIPTION
Fixes #23898.

## Root cause

`node:module` did not export or implement `findPackageJSON`, so a named ESM import failed before the call could run.

## Change

Expose a native `findPackageJSON` binding and resolve through Bun’s existing ESM resolver, returning the selected package’s `package.json`. This preserves ESM package resolution for bare specifiers and resolved file URLs.

## Validation

The added regression test runs both `findPackageJSON("pkg", import.meta.url)` and the issue-shaped `findPackageJSON(import.meta.resolve("pkg"))`. It fails on the unfixed system Bun with `Export named 'findPackageJSON' not found in module 'node:module'`.\n\nValidated in Docker:\n\n```sh\nbun bd test test/js/node/module/node-module-module.test.js\n```\n\nResult: 38 passed, 1 pre-existing skip.