### PR TITLE
shell: implement seq -w and report -f as unsupported

### DIFF
--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -13,11 +13,9 @@ enum State {
     Done,
 }
 
-/// Upper bound on the number of decimals `-w` prints. The smallest f64 is
-/// 2^-1074, so no float value has more fractional digits than this and every
-/// digit past it would be a zero; it also keeps the precision and width handed
-/// to `core::fmt` below the `u16::MAX` it panics above (an operand written as
-/// `1e-70000` asks for 70000 decimals).
+/// `core::fmt` panics on a precision or width above `u16::MAX`, which an
+/// operand like `1e-70000` would request; no float has more than 1074
+/// fractional digits (the smallest f64 is 2^-1074), so the rest would be zeros.
 const MAX_FIXED_WIDTH_DECIMALS: u32 = 1074;
 
 pub struct Seq {
@@ -26,7 +24,7 @@ pub struct Seq {
     end: f32,
     increment: f32,
     /// Most decimal places any positional argument was written with
-    /// (`seq 0 0.25 1` → 2). `-w` prints every value with this many decimals.
+    /// (`seq 0 0.25 1` → 2); `-w` prints every value with this many.
     decimals: u32,
     /// `-w` / `--fixed-width`: zero-pad every value to the same width.
     fixed_width: bool,
@@ -99,8 +97,6 @@ impl Seq {
                 idx += 1;
                 continue;
             }
-            // `-f format` is in the (BSD) usage string but not implemented;
-            // report that instead of parsing the format as a number.
             if arg.starts_with(b"-f") || arg == b"--format" {
                 let flag: &'static [u8] = if arg == b"--format" {
                     b"--format"
@@ -216,7 +212,6 @@ impl Seq {
             current >= end
         } {
             let _ = match fixed_width {
-                // `0` pads after the sign (`-05`), as BSD and GNU seq do.
                 Some(FixedWidth { width, decimals }) => {
                     write!(&mut out, "{current:0width$.decimals$}")
                 }
@@ -269,8 +264,8 @@ impl Seq {
     }
 }
 
-/// How `-w` lays out each value: `decimals` fraction digits, zero-padded to
-/// `width`.
+/// `-w` layout: `decimals` fraction digits, zero-padded after the sign
+/// (`-05`) to `width`, as in BSD and GNU seq.
 #[derive(Clone, Copy)]
 struct FixedWidth {
     width: usize,
@@ -278,10 +273,8 @@ struct FixedWidth {
 }
 
 impl FixedWidth {
-    /// Every value printed lies between `start` and `end`, and at a fixed
-    /// number of decimals a value never prints wider than the bound it lies
-    /// inside of, so the wider of the two bounds is the width of the widest
-    /// value.
+    /// Every value lies between `start` and `end`, and at a fixed number of
+    /// decimals it prints no wider than the bound on its side of zero.
     fn new(start: f32, end: f32, decimals: u32) -> Self {
         let decimals = decimals.min(MAX_FIXED_WIDTH_DECIMALS) as usize;
         let len = |n: f32| bun_core::fmt::count(format_args!("{n:.decimals$}"));

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -1,7 +1,7 @@
 use std::io::Write as _;
 
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
-use crate::shell::interpreter::{Interpreter, NodeId};
+use crate::shell::interpreter::{Interpreter, NodeId, ParseError, unsupported_flag};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
 
@@ -13,11 +13,23 @@ enum State {
     Done,
 }
 
+/// Upper bound on the number of decimals `-w` prints. The smallest f64 is
+/// 2^-1074, so no float value has more fractional digits than this and every
+/// digit past it would be a zero; it also keeps the precision and width handed
+/// to `core::fmt` below the `u16::MAX` it panics above (an operand written as
+/// `1e-70000` asks for 70000 decimals).
+const MAX_FIXED_WIDTH_DECIMALS: u32 = 1074;
+
 pub struct Seq {
     state: State,
     start: f32,
     end: f32,
     increment: f32,
+    /// Most decimal places any positional argument was written with
+    /// (`seq 0 0.25 1` → 2). `-w` prints every value with this many decimals.
+    decimals: u32,
+    /// `-w` / `--fixed-width`: zero-pad every value to the same width.
+    fixed_width: bool,
     /// Borrowed from argv (NUL-terminated arena strings) or `'static` literals;
     /// argv outlives the builtin — `RawSlice` invariant.
     separator: bun_ptr::RawSlice<u8>,
@@ -31,6 +43,8 @@ impl Default for Seq {
             start: 1.0,
             end: 1.0,
             increment: 1.0,
+            decimals: 0,
+            fixed_width: false,
             separator: bun_ptr::RawSlice::new(b"\n"),
             terminator: bun_ptr::RawSlice::EMPTY,
         }
@@ -81,8 +95,25 @@ impl Seq {
                 continue;
             }
             if arg == b"-w" || arg == b"--fixed-width" {
+                Self::state_mut(interp, cmd).fixed_width = true;
                 idx += 1;
                 continue;
+            }
+            // `-f format` is in the (BSD) usage string but not implemented;
+            // report that instead of parsing the format as a number.
+            if arg.starts_with(b"-f") || arg == b"--format" {
+                let flag: &'static [u8] = if arg == b"--format" {
+                    b"--format"
+                } else {
+                    b"-f"
+                };
+                return Builtin::fail_parse(
+                    interp,
+                    cmd,
+                    Kind::Seq,
+                    &ParseError::Unsupported(unsupported_flag(flag)),
+                    || Self::state_mut(interp, cmd).state = State::Err,
+                );
             }
             break;
         }
@@ -91,10 +122,14 @@ impl Seq {
         macro_rules! parse_num {
             ($i:expr) => {{
                 let s = Builtin::of(interp, cmd).arg_bytes($i);
-                match parse_f32(s) {
+                let n = match parse_f32(s) {
                     Some(n) if n.is_finite() => n,
                     _ => return Self::fail(interp, cmd, b"seq: invalid argument\n"),
-                }
+                };
+                let decimals = decimal_places(s);
+                let me = Self::state_mut(interp, cmd);
+                me.decimals = me.decimals.max(decimals);
+                n
             }};
         }
 
@@ -159,9 +194,19 @@ impl Seq {
         let needs_io = Builtin::of(interp, cmd).stdout.needs_io().is_some();
         // Render entirely into a local Vec, then either enqueue it or
         // write_no_io it; we buffer once for simplicity.
-        let (start, end, incr, sep, term) = {
+        let (start, end, incr, sep, term, fixed_width) = {
             let me = Self::state_mut(interp, cmd);
-            (me.start, me.end, me.increment, me.separator, me.terminator)
+            let fixed_width = me
+                .fixed_width
+                .then(|| FixedWidth::new(me.start, me.end, me.decimals));
+            (
+                me.start,
+                me.end,
+                me.increment,
+                me.separator,
+                me.terminator,
+                fixed_width,
+            )
         };
         let mut out = Vec::new();
         let mut current = start;
@@ -170,9 +215,15 @@ impl Seq {
         } else {
             current >= end
         } {
-            // Rust `{}` for f32 prints the shortest decimal that round-trips
-            // (no exponent, no trailing ".0").
-            let _ = write!(&mut out, "{}", current);
+            let _ = match fixed_width {
+                // `0` pads after the sign (`-05`), as BSD and GNU seq do.
+                Some(FixedWidth { width, decimals }) => {
+                    write!(&mut out, "{current:0width$.decimals$}")
+                }
+                // Rust `{}` for f32 prints the shortest decimal that round-trips
+                // (no exponent, no trailing ".0").
+                None => write!(&mut out, "{}", current),
+            };
             out.extend_from_slice(sep.slice());
             let next = current + incr;
             if next == current {
@@ -218,7 +269,50 @@ impl Seq {
     }
 }
 
+/// How `-w` lays out each value: `decimals` fraction digits, zero-padded to
+/// `width`.
+#[derive(Clone, Copy)]
+struct FixedWidth {
+    width: usize,
+    decimals: usize,
+}
+
+impl FixedWidth {
+    /// Every value printed lies between `start` and `end`, and at a fixed
+    /// number of decimals a value never prints wider than the bound it lies
+    /// inside of, so the wider of the two bounds is the width of the widest
+    /// value.
+    fn new(start: f32, end: f32, decimals: u32) -> Self {
+        let decimals = decimals.min(MAX_FIXED_WIDTH_DECIMALS) as usize;
+        let len = |n: f32| bun_core::fmt::count(format_args!("{n:.decimals$}"));
+        Self {
+            width: len(start).max(len(end)),
+            decimals,
+        }
+    }
+}
+
 #[inline]
 fn parse_f32(bytes: &[u8]) -> Option<f32> {
     bun_core::fmt::parse_f32(bytes)
+}
+
+/// Decimal places a positional argument was written with: `0.25` → 2,
+/// `1e-3` → 3, `2.50e1` → 1. `arg` has already been accepted by `parse_f32`,
+/// so it has the shape `[sign]digits[.digits][e[sign]digits]`.
+fn decimal_places(arg: &[u8]) -> u32 {
+    let (mantissa, exponent) = match bun_core::strings::index_of_any(arg, b"eE") {
+        Some(e) => {
+            // An exponent outside i32 either overflowed to inf (rejected by
+            // the caller) or underflowed to 0, which needs no decimal places.
+            let exponent = bun_core::fmt::parse_decimal::<i32>(&arg[e + 1..]).unwrap_or(0);
+            (&arg[..e], i64::from(exponent))
+        }
+        None => (arg, 0),
+    };
+    let fraction = match bun_core::strings::index_of_char_usize(mantissa, b'.') {
+        Some(dot) => (mantissa.len() - dot - 1) as i64,
+        None => 0,
+    };
+    (fraction - exponent).clamp(0, i64::from(u32::MAX)) as u32
 }

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -121,6 +121,154 @@ describe("seq", async () => {
     .stdout("1\n")
     .stderr("")
     .runAsTest("terminates when the increment is too small to advance the accumulator");
+
+  TestBuilder.command`seq 1 0.5 3`
+    .exitCode(0)
+    .stdout("1\n1.5\n2\n2.5\n3\n")
+    .stderr("")
+    .runAsTest("without -w, values print in their shortest form");
+
+  TestBuilder.command`seq -f %g 1 3`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: unsupported option, please open a GitHub issue -- -f\n")
+    .runAsTest("-f is reported as unsupported");
+
+  TestBuilder.command`seq -f%03g 1 3`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: unsupported option, please open a GitHub issue -- -f\n")
+    .runAsTest("-f with the format attached is reported as unsupported");
+
+  TestBuilder.command`seq -f`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: unsupported option, please open a GitHub issue -- -f\n")
+    .runAsTest("-f without a format is reported as unsupported");
+
+  TestBuilder.command`seq --format %g 1 3`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: unsupported option, please open a GitHub issue -- --format\n")
+    .runAsTest("--format is reported as unsupported");
+
+  TestBuilder.command`seq -s , -f %g 1 3`
+    .exitCode(1)
+    .stdout("")
+    .stderr("seq: unsupported option, please open a GitHub issue -- -f\n")
+    .runAsTest("-f after other flags is reported as unsupported");
+});
+
+describe("seq -w", async () => {
+  TestBuilder.command`seq -w 8 11`
+    .exitCode(0)
+    .stdout("08\n09\n10\n11\n")
+    .stderr("")
+    .runAsTest("pads to the width of the widest value");
+
+  TestBuilder.command`seq --fixed-width 8 11`
+    .exitCode(0)
+    .stdout("08\n09\n10\n11\n")
+    .stderr("")
+    .runAsTest("--fixed-width is the long form of -w");
+
+  TestBuilder.command`seq -w 11 8`
+    .exitCode(0)
+    .stdout("11\n10\n09\n08\n")
+    .stderr("")
+    .runAsTest("pads when counting down");
+
+  TestBuilder.command`seq -w 10`
+    .exitCode(0)
+    .stdout("01\n02\n03\n04\n05\n06\n07\n08\n09\n10\n")
+    .stderr("")
+    .runAsTest("pads with a single operand");
+
+  TestBuilder.command`seq -w 1 3`
+    .exitCode(0)
+    .stdout("1\n2\n3\n")
+    .stderr("")
+    .runAsTest("adds nothing when the values already share a width");
+
+  TestBuilder.command`seq -w 99 1 101`
+    .exitCode(0)
+    .stdout("099\n100\n101\n")
+    .stderr("")
+    .runAsTest("width comes from the widest bound");
+
+  TestBuilder.command`seq -w 1 4 10`
+    .exitCode(0)
+    .stdout("01\n05\n09\n")
+    .stderr("")
+    .runAsTest("width comes from the end bound even when it is not reached");
+
+  TestBuilder.command`seq -w -1 1`
+    .exitCode(0)
+    .stdout("-1\n00\n01\n")
+    .stderr("")
+    .runAsTest("the sign counts towards the width");
+
+  TestBuilder.command`seq -w -10 5 10`
+    .exitCode(0)
+    .stdout("-10\n-05\n000\n005\n010\n")
+    .stderr("")
+    .runAsTest("zeros go between the sign and the digits");
+
+  TestBuilder.command`seq -w 1 0.5 3`
+    .exitCode(0)
+    .stdout("1.0\n1.5\n2.0\n2.5\n3.0\n")
+    .stderr("")
+    .runAsTest("every value gets the increment's decimals");
+
+  TestBuilder.command`seq -w 0 0.25 1`
+    .exitCode(0)
+    .stdout("0.00\n0.25\n0.50\n0.75\n1.00\n")
+    .stderr("")
+    .runAsTest("every value gets the most decimals any operand has");
+
+  TestBuilder.command`seq -w -0.5 0.25 0.5`
+    .exitCode(0)
+    .stdout("-0.50\n-0.25\n00.00\n00.25\n00.50\n")
+    .stderr("")
+    .runAsTest("fractional values pad after the sign");
+
+  TestBuilder.command`seq -w 1.50 2`.exitCode(0).stdout("1.50\n").stderr("").runAsTest("keeps decimals as written");
+
+  TestBuilder.command`seq -w 0 2.5e-1 1`
+    .exitCode(0)
+    .stdout("0.00\n0.25\n0.50\n0.75\n1.00\n")
+    .stderr("")
+    .runAsTest("a negative exponent adds decimals");
+
+  TestBuilder.command`seq -w 1.5e1 16`
+    .exitCode(0)
+    .stdout("15\n16\n")
+    .stderr("")
+    .runAsTest("a positive exponent removes decimals");
+
+  TestBuilder.command`seq -w -s , 8 11`.exitCode(0).stdout("08,09,10,11,").stderr("").runAsTest("works with -s");
+
+  TestBuilder.command`seq -s, -t. -w 8 11`
+    .exitCode(0)
+    .stdout("08,09,10,11,.")
+    .stderr("")
+    .runAsTest("works after -s and -t");
+
+  TestBuilder.command`echo $(seq -w 8 11)`
+    .exitCode(0)
+    .stdout("08 09 10 11\n")
+    .stderr("")
+    .runAsTest("pads when stdout is captured");
+
+  // 1e-70000 parses as 0 but was written with 70000 implied decimals; more
+  // than core::fmt can print, so the precision is capped at 1074 (the most
+  // fractional digits any double has) instead of panicking.
+  const zeros = Buffer.alloc(1074, "0").toString();
+  TestBuilder.command`seq -w 1e-70000 1`
+    .exitCode(0)
+    .stdout(`0.${zeros}\n1.${zeros}\n`)
+    .stderr("")
+    .runAsTest("caps the number of decimals");
 });
 
 describe("seq without stdout", async () => {

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -260,6 +260,13 @@ describe("seq -w", async () => {
     .stderr("")
     .runAsTest("pads when stdout is captured");
 
+  TestBuilder.command`seq -w 8 11 > out.txt`
+    .exitCode(0)
+    .stdout("")
+    .stderr("")
+    .fileEquals("out.txt", "08\n09\n10\n11\n")
+    .runAsTest("pads when stdout is a file");
+
   // 1e-70000 parses as 0 but was written with 70000 implied decimals; more
   // than core::fmt can print, so the precision is capped at 1074 (the most
   // fractional digits any double has) instead of panicking.


### PR DESCRIPTION
### Problem
- The `seq` builtin's usage string advertises `-w` and `-f format` (`src/runtime/shell/Builtin.rs:193`), but neither does anything useful.
- `-w` / `--fixed-width` is consumed by the flag loop and then ignored (`src/runtime/shell/builtin/seq.rs:83`, the arm only did `idx += 1`), so `seq -w 8 11` prints `8 9 10 11` where BSD and GNU seq print `08 09 10 11`. The original Zig builtin stored a `fixed_width` bool it never read, so this has been the case since the builtin was added.
- `-f` is not parsed at all, so it falls through to the operand parser and `seq -f %g 1 3` fails with `seq: invalid argument`, which points at the wrong thing.

### Fix
- `-w` sets `fixed_width`; each operand's decimal places as written are tracked in `decimals` (`decimal_places`: `0.25` -> 2, `2.5e-1` -> 2, `1.5e1` -> 0); `do_` prints every value with `{current:0width$.decimals$}`, where `width` is the wider of `start` and `end` rendered at that precision (`FixedWidth::new`). Output without `-w` is unchanged (`seq 1 0.5 3` still prints `1 1.5 2 2.5 3`).
- Why this layout: every value of `start + k*incr` has at most as many decimals as the most precise operand, so rendering at that precision prints each value exactly and gives all of them the same fractional part; every value lies between `start` and `end`, and at a fixed precision a value never renders wider than the bound it lies inside of, so the wider bound is the width of the widest value. Rust's `0` flag pads after the sign, so `seq -w -10 5 10` gives `-10 -05 000 005 010`, which is what GNU seq prints; precision from the operands as written and width from the bounds is also how both BSD and GNU seq define `-w` (the only visible difference: GNU keeps leading zeros typed in an operand, `seq -w 008 11` pads to 3 there and to 2 here, as on BSD).
- `decimals` is capped at 1074 when printing (`MAX_FIXED_WIDTH_DECIMALS`): no float has more fractional digits than that, and `core::fmt` panics on a precision or width above `u16::MAX`, which an operand like `1e-70000` (parses to 0, 70000 implied decimals) would otherwise reach.
- `-f`, `-fFORMAT` and `--format` go through `Builtin::fail_parse` with `ParseError::Unsupported`, so they fail with `seq: unsupported option, please open a GitHub issue -- -f`. This is how `cat`, `cp`, `touch` and `mkdir` already treat the flags their usage strings list but they do not implement; a printf-style `-f` (`%e`/`%g`/`%a` with flags, width and precision) is a feature of its own and is not added here. The usage string is left as is, like theirs.
- Verified with `test/js/bun/shell/commands/seq.test.ts`: 23 new cases (padding up and down, one operand, width taken from an unreached end bound, negative values, decimals from the increment, exponent spellings, `-s`/`-t`, both output paths (captured stdout and a `>` redirect), the precision cap, and the four `-f` spellings) fail on the released build and pass with this change (58/58).
- `test/js/bun/shell/pipeline_stack.test.ts`, `test/js/bun/shell/shell-seq-condexpr.test.ts` and `test/internal/source-lints/byte-search.test.ts` still pass; `cargo clippy -p bun_runtime` and `cargo fmt` are clean.
- Overlaps with open seq PRs: #37923 adds the same `decimals` field and `decimal_places` helper (copied here as is, so whichever lands second only has to drop its duplicate; `FixedWidth::new` takes the unscaled operands, which that PR still has at that point), and #33995 adds a `--` arm next to the new `-f` arm. Both are mechanical to resolve in either order.

### Background
- `seq` in `Bun.$` is always the builtin; it follows the BSD variant (its usage string is BSD's, `seq 5 1` counts down, `-t` exists, `-s` is emitted after every value). Without `-w` it prints each value in its shortest round-trip form, so fractional sequences have values of varying width (`1`, `1.5`); `-w` in both BSD and GNU seq switches to a fixed number of decimals and zero-pads, which is the only way every line can have the same width.
- `Builtin::fail_parse` / `ParseError::Unsupported` (`src/runtime/shell/Builtin.rs`, `interpreter.rs`) is the shared path that renders `<cmd>: unsupported option, please open a GitHub issue -- <flag>` and exits 1; `seq` has a hand-rolled flag loop (options take arguments and operands may be negative numbers), so it calls that path directly instead of going through `parse_flags`.
- The builtin currently counts in `f32`; `-w` only changes how values are rendered, so it is independent of that (and of #37923, which changes it).

<details>
<summary>Before / after</summary>

```
$ bun -e 'console.log(JSON.stringify(await Bun.$`seq -w 8 11`.text())); const r = await Bun.$`seq -f %g 1 3`.nothrow().quiet(); console.log(r.exitCode, r.stderr.toString())'

# bun 1.4.0
"8\n9\n10\n11\n"
1 seq: invalid argument

# this branch
"08\n09\n10\n11\n"
1 seq: unsupported option, please open a GitHub issue -- -f
```

More `-w` output from this branch, each identical to GNU coreutils 9.7 (`seq 11 8` excepted, GNU prints nothing there):

```
seq -w 10             01 02 03 04 05 06 07 08 09 10
seq -w 11 8           11 10 09 08
seq -w 1 4 10         01 05 09
seq -w -1 1           -1 00 01
seq -w -10 5 10       -10 -05 000 005 010
seq -w 1 0.5 3        1.0 1.5 2.0 2.5 3.0
seq -w 0 0.25 1       0.00 0.25 0.50 0.75 1.00
seq -w -0.5 0.25 0.5  -0.50 -0.25 00.00 00.25 00.50
seq -w 1 -0.5 -1      01.0 00.5 00.0 -0.5 -1.0
seq -w -0.0 1         -0.0 01.0
seq -w 1.5e1 16       15 16
```
</details>
