### PR TITLE
shell(cp): refuse copying a directory into itself and walk trees without recursion

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1501,6 +1501,25 @@ mod _async_tasks {
         }
     }
 
+    /// One directory still being read by `NewAsyncCpTask::cp_async_directory`;
+    /// owns the directory's descriptor (inside `iter`) until dropped.
+    /// `src_len`/`dest_len` delimit this directory's paths inside the walk's
+    /// shared path buffers; its children's paths are built right behind them.
+    struct CpDirFrame {
+        #[cfg(windows)]
+        iter: DirIterator::WrappedIteratorW,
+        #[cfg(not(windows))]
+        iter: DirIterator::WrappedIterator,
+        src_len: PathInt,
+        dest_len: PathInt,
+    }
+
+    impl Drop for CpDirFrame {
+        fn drop(&mut self) {
+            self.iter.iter.dir.close();
+        }
+    }
+
     impl<const IS_SHELL: bool> bun_event_loop::Taskable for NewAsyncCpTask<IS_SHELL> {
         const TAG: bun_event_loop::TaskTag = if IS_SHELL {
             bun_event_loop::task_tag::ShellAsyncCpTask
@@ -1917,9 +1936,8 @@ mod _async_tasks {
             // are slices into `src_buf`/`dest_buf` and must end their borrow first.
             let src_len = PathInt::try_from(src.len()).expect("int cast");
             let dest_len = PathInt::try_from(dest.len()).expect("int cast");
-            let _ = Self::cp_async_directory(
+            if let Err(err) = Self::cp_async_directory(
                 nodefs,
-                args.flags,
                 // Pass the raw `*mut Self` (Box::leak provenance) so spawned
                 // `CpSingleTask`s store a pointer that may later be promoted to
                 // `&mut` in `on_subtask_done`.
@@ -1928,147 +1946,78 @@ mod _async_tasks {
                 src_len,
                 &mut dest_buf,
                 dest_len,
-            );
+            ) {
+                this.finish_concurrently(Err(err));
+            }
         }
 
-        // returns boolean `should_continue`
+        /// Copies the tree rooted at `src_buf[..src_dir_len]` (a directory) to
+        /// `dest_buf[..dest_dir_len]`: directories are created on this thread,
+        /// each file becomes a `CpSingleTask`. The directories being read are
+        /// kept on an explicit stack rather than the call stack so the depth of
+        /// the tree is bounded by the path buffers, not by the pool thread's
+        /// stack. The first error ends the walk.
         fn cp_async_directory(
             nodefs: &mut NodeFS,
-            args: args::CpFlags,
             this: *mut Self,
             src_buf: &mut OSPathBuffer,
             src_dir_len: PathInt,
             dest_buf: &mut OSPathBuffer,
             dest_dir_len: PathInt,
-        ) -> bool {
+        ) -> Maybe<()> {
             // SAFETY: `this` is the live Box-leaked task. Shared borrow only — spawned
             // `CpSingleTask`s on other workpool threads may concurrently hold `&Self`.
-            // The raw `*mut` is threaded through (instead of `&Self`) so that the
+            // The raw `*mut` is kept alongside (instead of only `&Self`) so that the
             // `cp_task` pointers stored in subtasks retain mutable provenance for
             // `on_subtask_done`'s eventual `&mut` promotion.
             let this_ref = unsafe { &*this };
-            // SAFETY: callers NUL-terminate at src_dir_len/dest_dir_len before calling.
-            // Platform-generic — `OSPathBuffer` is `[u16;N]` on Windows, `[u8;N]` on POSIX,
-            // so reconstruct as `&OSPathSliceZ`.
-            let src = unsafe { OSPathSliceZ::from_raw(src_buf.as_ptr(), src_dir_len as usize) };
-            // SAFETY: dest_buf[dest_dir_len] == 0 written by caller
-            let dest = unsafe { OSPathSliceZ::from_raw(dest_buf.as_ptr(), dest_dir_len as usize) };
 
-            #[cfg(target_os = "macos")]
-            {
-                // CLONE_NOFOLLOW: `src` was classified as a directory via lstat, so
-                // mirror the O_NOFOLLOW directory open below instead of dereferencing.
-                if let Some(err) = Maybe::<ret::Cp>::errno_sys_p(
-                    bun_sys::c::clonefile_rc(src, dest, CLONE_NOFOLLOW),
-                    sys::Tag::clonefile,
-                    src.as_bytes(),
-                ) {
-                    match err.get_errno() {
-                        E::EACCES | E::ENAMETOOLONG | E::EROFS | E::EPERM | E::EINVAL => {
-                            // `errno_sys_p`
-                            // already boxed `src.as_bytes()` into `err.path`, so just forward.
-                            this_ref.finish_concurrently(err);
-                            return false;
-                        }
-                        // Other errors may be due to clonefile() not being supported
-                        // We'll fall back to other implementations
-                        _ => {}
+            let mut stack: Vec<CpDirFrame> = Vec::new();
+            match Self::cp_async_enter_directory(
+                nodefs,
+                this_ref,
+                src_buf,
+                src_dir_len,
+                dest_buf,
+                dest_dir_len,
+            )? {
+                Some(frame) => stack.push(frame),
+                None => return Ok(()),
+            }
+
+            while let Some(frame) = stack.last_mut() {
+                let sd = frame.src_len as usize;
+                let dd = frame.dest_len as usize;
+                let current = match frame.iter.next() {
+                    Ok(Some(current)) => current,
+                    Ok(None) => {
+                        stack.pop();
+                        continue;
                     }
-                } else {
-                    return true;
-                }
-            }
-
-            let open_flags = sys::O::DIRECTORY | sys::O::RDONLY | sys::O::NOFOLLOW;
-            let fd = match openat_os_path(FD::cwd(), src, open_flags, 0) {
-                Err(err) => {
-                    this_ref.finish_concurrently(Err(
-                        err.with_path(nodefs.os_path_into_sync_error_buf(src))
-                    ));
-                    return false;
-                }
-                Ok(fd_) => fd_,
-            };
-            let _close = scopeguard::guard(fd, |fd| fd.close());
-
-            #[cfg(windows)]
-            let mut buf = OSPathBuffer::uninit();
-            #[cfg(windows)]
-            let normdest: &OSPathSliceZ = match sys::normalize_path_windows_opts(
-                FD::INVALID,
-                dest.as_slice(),
-                &mut buf[..],
-                // No NT prefix — `normdest` feeds
-                // `mkdirRecursiveOSPath` / `CopyFileW` which expect Win32 paths,
-                // not `\??\` NT object paths.
-                sys::NormalizePathWindowsOpts {
-                    add_nt_prefix: false,
-                },
-            ) {
-                Err(err) => {
-                    this_ref.finish_concurrently(Err(err));
-                    return false;
-                }
-                Ok(n) => n,
-            };
-            #[cfg(not(windows))]
-            let normdest: &OSPathSliceZ = dest;
-
-            let mkdir_ = nodefs.mkdir_recursive_os_path(normdest, args::Mkdir::DEFAULT_MODE, false);
-            match mkdir_ {
-                Err(err) => {
-                    this_ref.finish_concurrently(Err(err));
-                    return false;
-                }
-                Ok(_) => {
-                    this_ref.on_copy(src, normdest);
-                }
-            }
-
-            // On POSIX directory entries are always UTF-8, so monomorphise the
-            // const-generic path type on `U8` and let the Windows branch (gated
-            // above) handle the wide path.
-            #[cfg(windows)]
-            let mut iterator = DirIterator::iterate::<true>(fd);
-            #[cfg(not(windows))]
-            let mut iterator = DirIterator::iterate::<false>(fd);
-            let mut entry = iterator.next();
-            loop {
-                let current = match entry {
                     Err(err) => {
-                        this_ref.finish_concurrently(Err(
-                            err.with_path(nodefs.os_path_into_sync_error_buf(src))
-                        ));
-                        return false;
+                        return Err(
+                            err.with_path(nodefs.os_path_into_sync_error_buf(&src_buf[..sd]))
+                        );
                     }
-                    Ok(ent) => match ent {
-                        Some(e) => e,
-                        None => break,
-                    },
                 };
+                // Points into the top frame's readdir buffer: it has to be consumed
+                // before the next `next()` call or push below, which may move it.
                 let cname = current.name.slice();
 
                 // The accumulated path for deep directory trees can exceed the fixed
                 // OSPathBuffer. Bail out with ENAMETOOLONG instead of writing past the
                 // end of the buffer and corrupting the stack.
-                if (src_dir_len as usize) + 1 + cname.len() >= src_buf.len()
-                    || (dest_dir_len as usize) + 1 + cname.len() >= dest_buf.len()
-                {
-                    this_ref.finish_concurrently(Err(sys::Error {
+                if sd + 1 + cname.len() >= src_buf.len() || dd + 1 + cname.len() >= dest_buf.len() {
+                    return Err(sys::Error {
                         errno: E::ENAMETOOLONG as _,
                         syscall: sys::Tag::copyfile,
-                        path: nodefs
-                            .os_path_into_sync_error_buf(&src_buf[..src_dir_len as usize])
-                            .into(),
+                        path: nodefs.os_path_into_sync_error_buf(&src_buf[..sd]).into(),
                         ..Default::default()
-                    }));
-                    return false;
+                    });
                 }
 
                 match current.kind {
                     crate::node::dirent::Kind::Directory => {
-                        let sd = src_dir_len as usize;
-                        let dd = dest_dir_len as usize;
                         src_buf[sd + 1..sd + 1 + cname.len()].copy_from_slice(cname);
                         src_buf[sd] = paths::SEP as OSPathChar;
                         src_buf[sd + 1 + cname.len()] = 0;
@@ -2076,23 +2025,19 @@ mod _async_tasks {
                         dest_buf[dd] = paths::SEP as OSPathChar;
                         dest_buf[dd + 1 + cname.len()] = 0;
 
-                        let should_continue = Self::cp_async_directory(
+                        if let Some(child) = Self::cp_async_enter_directory(
                             nodefs,
-                            args,
-                            this,
+                            this_ref,
                             src_buf,
                             (sd + 1 + cname.len()) as PathInt,
                             dest_buf,
                             (dd + 1 + cname.len()) as PathInt,
-                        );
-                        if !should_continue {
-                            return false;
+                        )? {
+                            stack.push(child);
                         }
                     }
                     _ => {
                         this_ref.subtask_count.fetch_add(1, Ordering::Relaxed);
-                        let sd = src_dir_len as usize;
-                        let dd = dest_dir_len as usize;
                         let total = sd + 1 + cname.len() + 1 + dd + 1 + cname.len() + 1;
 
                         // Allocate a path buffer for the path data
@@ -2117,10 +2062,91 @@ mod _async_tasks {
                         );
                     }
                 }
-                entry = iterator.next();
             }
 
-            true
+            Ok(())
+        }
+
+        /// Creates the destination directory for the source directory
+        /// `src_buf[..src_len]` and opens the source for reading. `None` when
+        /// the whole subtree was copied here already (macOS `clonefile`), so
+        /// there is nothing left to walk.
+        fn cp_async_enter_directory(
+            nodefs: &mut NodeFS,
+            this: &Self,
+            src_buf: &OSPathBuffer,
+            src_len: PathInt,
+            dest_buf: &OSPathBuffer,
+            dest_len: PathInt,
+        ) -> Maybe<Option<CpDirFrame>> {
+            // SAFETY: callers NUL-terminate at src_len/dest_len before calling.
+            // Platform-generic — `OSPathBuffer` is `[u16;N]` on Windows, `[u8;N]` on POSIX,
+            // so reconstruct as `&OSPathSliceZ`.
+            let src = unsafe { OSPathSliceZ::from_raw(src_buf.as_ptr(), src_len as usize) };
+            // SAFETY: dest_buf[dest_len] == 0 written by caller
+            let dest = unsafe { OSPathSliceZ::from_raw(dest_buf.as_ptr(), dest_len as usize) };
+
+            #[cfg(target_os = "macos")]
+            {
+                // CLONE_NOFOLLOW: `src` was classified as a directory via lstat, so
+                // mirror the O_NOFOLLOW directory open below instead of dereferencing.
+                match Maybe::<ret::Cp>::errno_sys_p(
+                    bun_sys::c::clonefile_rc(src, dest, CLONE_NOFOLLOW),
+                    sys::Tag::clonefile,
+                    src.as_bytes(),
+                ) {
+                    None => return Ok(None),
+                    // `errno_sys_p` already boxed `src.as_bytes()` into `err.path`.
+                    Some(Err(err))
+                        if matches!(
+                            err.get_errno(),
+                            E::EACCES | E::ENAMETOOLONG | E::EROFS | E::EPERM | E::EINVAL
+                        ) =>
+                    {
+                        return Err(err);
+                    }
+                    // Other errors may be due to clonefile() not being supported
+                    // We'll fall back to other implementations
+                    Some(_) => {}
+                }
+            }
+
+            let open_flags = sys::O::DIRECTORY | sys::O::RDONLY | sys::O::NOFOLLOW;
+            let fd = openat_os_path(FD::cwd(), src, open_flags, 0)
+                .map_err(|err| err.with_path(nodefs.os_path_into_sync_error_buf(src)))?;
+            // Built before the fallible steps below so that dropping it on their
+            // errors closes `fd`. On POSIX directory entries are always UTF-8, so
+            // monomorphise the const-generic path type on `U8` and let the
+            // Windows branch handle the wide path.
+            let frame = CpDirFrame {
+                #[cfg(windows)]
+                iter: DirIterator::iterate::<true>(fd),
+                #[cfg(not(windows))]
+                iter: DirIterator::iterate::<false>(fd),
+                src_len,
+                dest_len,
+            };
+
+            #[cfg(windows)]
+            let mut buf = OSPathBuffer::uninit();
+            #[cfg(windows)]
+            let normdest: &OSPathSliceZ = sys::normalize_path_windows_opts(
+                FD::INVALID,
+                dest.as_slice(),
+                &mut buf[..],
+                // No NT prefix — `normdest` feeds
+                // `mkdirRecursiveOSPath` / `CopyFileW` which expect Win32 paths,
+                // not `\??\` NT object paths.
+                sys::NormalizePathWindowsOpts {
+                    add_nt_prefix: false,
+                },
+            )?;
+            #[cfg(not(windows))]
+            let normdest: &OSPathSliceZ = dest;
+
+            nodefs.mkdir_recursive_os_path(normdest, args::Mkdir::DEFAULT_MODE, false)?;
+            this.on_copy(src, normdest);
+            Ok(Some(frame))
         }
     }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1501,10 +1501,9 @@ mod _async_tasks {
         }
     }
 
-    /// One directory still being read by `NewAsyncCpTask::cp_async_directory`;
-    /// owns the directory's descriptor (inside `iter`) until dropped.
-    /// `src_len`/`dest_len` delimit this directory's paths inside the walk's
-    /// shared path buffers; its children's paths are built right behind them.
+    /// A directory `cp_async_directory` is still reading; owns its descriptor
+    /// (inside `iter`). `src_len`/`dest_len` are its paths' lengths in the
+    /// walk's shared path buffers.
     struct CpDirFrame {
         #[cfg(windows)]
         iter: DirIterator::WrappedIteratorW,
@@ -1951,12 +1950,9 @@ mod _async_tasks {
             }
         }
 
-        /// Copies the tree rooted at `src_buf[..src_dir_len]` (a directory) to
-        /// `dest_buf[..dest_dir_len]`: directories are created on this thread,
-        /// each file becomes a `CpSingleTask`. The directories being read are
-        /// kept on an explicit stack rather than the call stack so the depth of
-        /// the tree is bounded by the path buffers, not by the pool thread's
-        /// stack. The first error ends the walk.
+        /// Copies the directory tree at `src_buf[..src_dir_len]` to
+        /// `dest_buf[..dest_dir_len]`; files are fanned out as `CpSingleTask`s.
+        /// Iterative: one call frame per level overflowed the pool thread's stack.
         fn cp_async_directory(
             nodefs: &mut NodeFS,
             this: *mut Self,
@@ -2000,8 +1996,7 @@ mod _async_tasks {
                         );
                     }
                 };
-                // Points into the top frame's readdir buffer: it has to be consumed
-                // before the next `next()` call or push below, which may move it.
+                // Points into the top frame's buffer: dead before `stack` grows below.
                 let cname = current.name.slice();
 
                 // The accumulated path for deep directory trees can exceed the fixed
@@ -2067,10 +2062,8 @@ mod _async_tasks {
             Ok(())
         }
 
-        /// Creates the destination directory for the source directory
-        /// `src_buf[..src_len]` and opens the source for reading. `None` when
-        /// the whole subtree was copied here already (macOS `clonefile`), so
-        /// there is nothing left to walk.
+        /// Creates the destination of the directory `src_buf[..src_len]` and opens
+        /// it for reading; `None` once macOS `clonefile` copied the whole subtree.
         fn cp_async_enter_directory(
             nodefs: &mut NodeFS,
             this: &Self,
@@ -2114,10 +2107,7 @@ mod _async_tasks {
             let open_flags = sys::O::DIRECTORY | sys::O::RDONLY | sys::O::NOFOLLOW;
             let fd = openat_os_path(FD::cwd(), src, open_flags, 0)
                 .map_err(|err| err.with_path(nodefs.os_path_into_sync_error_buf(src)))?;
-            // Built before the fallible steps below so that dropping it on their
-            // errors closes `fd`. On POSIX directory entries are always UTF-8, so
-            // monomorphise the const-generic path type on `U8` and let the
-            // Windows branch handle the wide path.
+            // Built first so that the `?`s below close `fd`.
             let frame = CpDirFrame {
                 #[cfg(windows)]
                 iter: DirIterator::iterate::<true>(fd),

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1501,9 +1501,7 @@ mod _async_tasks {
         }
     }
 
-    /// A directory `cp_async_directory` is still reading; owns its descriptor
-    /// (inside `iter`). `src_len`/`dest_len` are its paths' lengths in the
-    /// walk's shared path buffers.
+    /// An open directory of the walk; its paths fill the shared buffers up to `src_len`/`dest_len`.
     struct CpDirFrame {
         #[cfg(windows)]
         iter: DirIterator::WrappedIteratorW,
@@ -1950,9 +1948,7 @@ mod _async_tasks {
             }
         }
 
-        /// Copies the directory tree at `src_buf[..src_dir_len]` to
-        /// `dest_buf[..dest_dir_len]`; files are fanned out as `CpSingleTask`s.
-        /// Iterative: one call frame per level overflowed the pool thread's stack.
+        /// Copies the directory tree; iterative, a call frame per level overflowed the stack.
         fn cp_async_directory(
             nodefs: &mut NodeFS,
             this: *mut Self,
@@ -2062,8 +2058,7 @@ mod _async_tasks {
             Ok(())
         }
 
-        /// Creates the destination of the directory `src_buf[..src_len]` and opens
-        /// it for reading; `None` once macOS `clonefile` copied the whole subtree.
+        /// Creates one directory's destination and opens it; `None` when clonefile copied it whole.
         fn cp_async_enter_directory(
             nodefs: &mut NodeFS,
             this: &Self,

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -581,6 +581,45 @@ impl ShellCpTask {
         }
     }
 
+    /// Whether `tgt`, the directory the copy of the directory `src` would be
+    /// written to, is `src` itself or lies somewhere below it. Copying there
+    /// would make the walk descend into the directories it is creating, so it
+    /// is refused up front like coreutils does.
+    ///
+    /// Compared by identity rather than by path so that a `tgt` reached
+    /// through a symlink to `src` (or to one of its parents) is caught too;
+    /// `tgt` and its nearest ancestors may not exist yet, those are skipped.
+    fn dir_copy_relation(src: &bun_core::ZStr, tgt: &bun_core::ZStr) -> resolve_path::ParentEqual {
+        use resolve_path::ParentEqual;
+
+        // lstat: on Windows `src` may be a directory symlink, which the copy
+        // treats as a file rather than descending into its target.
+        let Ok(src_stat) = bun_sys::lstat(src) else {
+            return ParentEqual::Unrelated;
+        };
+        let mut buf = bun_paths::path_buffer_pool::get();
+        let mut len = tgt.len();
+        buf[..len].copy_from_slice(tgt.as_bytes());
+        let mut relation = ParentEqual::Equal;
+        loop {
+            buf[len] = 0;
+            if let Ok(stat) = bun_sys::stat(bun_core::ZStr::from_buf(&buf[..], len)) {
+                // An inode number of 0 means the filesystem reports no identity.
+                if stat.st_ino != 0
+                    && stat.st_ino == src_stat.st_ino
+                    && stat.st_dev == src_stat.st_dev
+                {
+                    return relation;
+                }
+            }
+            let Some(parent) = bun_paths::dirname(&buf[..len]) else {
+                return ParentEqual::Unrelated;
+            };
+            len = parent.len();
+            relation = ParentEqual::Parent;
+        }
+    }
+
     /// Resolves src/tgt to absolute paths, classifies them per the three
     /// POSIX `cp` synopses
     /// (<https://man7.org/linux/man-pages/man1/cp.1p.html>), then hands off to
@@ -651,6 +690,9 @@ impl ShellCpTask {
         };
 
         let mut _copying_many = false;
+        // Set when `tgt` gains the source's basename below (`cp -R src
+        // existing_dir`), so errors can name the path the copy would land on.
+        let mut appended_basename: Option<&[u8]> = None;
 
         // The following logic is based on the POSIX spec.
         if !src_is_dir && !tgt_is_dir && self.operands == 2 {
@@ -663,6 +705,7 @@ impl ShellCpTask {
                     buf3.as_mut_slice(),
                     &[tgt.as_bytes(), basename],
                 );
+                appended_basename = Some(basename);
             } else if self.operands == 2 {
                 // source_dir -> new_target_dir.
             } else {
@@ -695,6 +738,28 @@ impl ShellCpTask {
                 &[tgt.as_bytes(), basename],
             );
             _copying_many = true;
+        }
+
+        if src_is_dir {
+            let relation = Self::dir_copy_relation(src, tgt);
+            if relation != resolve_path::ParentEqual::Unrelated {
+                let mut display_buf = bun_paths::path_buffer_pool::get();
+                let shown_tgt: &[u8] = match appended_basename {
+                    Some(basename) => resolve_path::join_string_buf::<platform::Auto>(
+                        &mut display_buf[..],
+                        &[self.tgt.as_slice(), basename],
+                    ),
+                    None => &self.tgt,
+                };
+                let (src_shown, tgt_shown) =
+                    (bstr::BStr::new(&self.src), bstr::BStr::new(shown_tgt));
+                let msg = if relation == resolve_path::ParentEqual::Equal {
+                    format!("{src_shown} and {tgt_shown} are identical (not copied)")
+                } else {
+                    format!("cannot copy directory {src_shown} into itself {tgt_shown}")
+                };
+                return Some(ShellErr::Custom(msg.into_bytes().into_boxed_slice()));
+            }
         }
 
         self.src_absolute = Some(src.as_bytes().to_vec());

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -581,19 +581,13 @@ impl ShellCpTask {
         }
     }
 
-    /// Whether `tgt`, the directory the copy of the directory `src` would be
-    /// written to, is `src` itself or lies somewhere below it. Copying there
-    /// would make the walk descend into the directories it is creating, so it
-    /// is refused up front like coreutils does.
-    ///
-    /// Compared by identity rather than by path so that a `tgt` reached
-    /// through a symlink to `src` (or to one of its parents) is caught too;
-    /// `tgt` and its nearest ancestors may not exist yet, those are skipped.
+    /// Is `tgt`, where the copy of the directory `src` would land, `src` itself or
+    /// below it? Compared by identity (so symlinked paths count), skipping the
+    /// parts of `tgt` that do not exist yet.
     fn dir_copy_relation(src: &bun_core::ZStr, tgt: &bun_core::ZStr) -> resolve_path::ParentEqual {
         use resolve_path::ParentEqual;
 
-        // lstat: on Windows `src` may be a directory symlink, which the copy
-        // treats as a file rather than descending into its target.
+        // lstat: a directory symlink `src` (possible on Windows) is copied as a file.
         let Ok(src_stat) = bun_sys::lstat(src) else {
             return ParentEqual::Unrelated;
         };
@@ -690,8 +684,7 @@ impl ShellCpTask {
         };
 
         let mut _copying_many = false;
-        // Set when `tgt` gains the source's basename below (`cp -R src
-        // existing_dir`), so errors can name the path the copy would land on.
+        // For error messages: names the path the copy would land on.
         let mut appended_basename: Option<&[u8]> = None;
 
         // The following logic is based on the POSIX spec.

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -581,9 +581,7 @@ impl ShellCpTask {
         }
     }
 
-    /// Is `tgt`, where the copy of the directory `src` would land, `src` itself or
-    /// below it? Compared by identity (so symlinked paths count), skipping the
-    /// parts of `tgt` that do not exist yet.
+    /// Is `tgt` (where the copy of directory `src` lands) `src` or below it? Compared by inode.
     fn dir_copy_relation(src: &bun_core::ZStr, tgt: &bun_core::ZStr) -> resolve_path::ParentEqual {
         use resolve_path::ParentEqual;
 

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -264,9 +264,11 @@ describe.concurrent("bunshell cp -R of a directory", () => {
   });
 
   // Deep enough that the directory walk overflowed the worker thread's stack
-  // while it still used one stack frame per directory. Skipped on macOS:
-  // PATH_MAX is 1024 there, so a tree this deep cannot be created.
-  test.skipIf(isMacOS)("a tree 1000 directories deep is copied", async () => {
+  // while it still used one stack frame per directory. A tree this deep cannot
+  // be copied on macOS (PATH_MAX is 1024) or on Windows, where the copy creates
+  // its destination paths through MAX_PATH (260 char) limited calls and stops
+  // with ENAMETOOLONG about 100 levels down.
+  test.skipIf(isMacOS || isWindows)("a tree 1000 directories deep is copied", async () => {
     const deepest = Array(1000).fill("a").join("/");
     using dir = setup("deep", work => {
       mkdirSync(join(work, "deep", deepest), { recursive: true });

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { mkdirSync, readdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,114 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// The builtin is the default only on Windows; on POSIX it is enabled by an env
+// var that is read once per process, so these run each `cp` in a child bun.
+describe.concurrent("bunshell cp -R of a directory", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  // Runs argv[2] as a shell command inside `work/` and prints cp's exit code
+  // followed by whatever it wrote to stderr.
+  const runCpScript = /* ts */ `
+    import { $ } from "bun";
+    import { join } from "node:path";
+    const result = await $\`\${{ raw: process.argv[2] }}\`.cwd(join(import.meta.dir, "work")).nothrow().quiet();
+    process.stdout.write(result.exitCode + "\\n" + result.stderr.toString());
+  `;
+
+  /** A temp dir holding the script and `work/d/{a,sub/}`, the directory the tests copy. */
+  function setup(name: string, extra: (work: string) => void = () => {}) {
+    const dir = tempDir(`shell-cp-${name}`, {
+      "run-cp.ts": runCpScript,
+      "work": { "d": { "a": "A\n", "sub": {} } },
+    });
+    extra(join(String(dir), "work"));
+    return dir;
+  }
+
+  async function cp(dir: string, command: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run-cp.ts", command],
+      cwd: dir,
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function refused(message: string) {
+    return { stdout: `1\ncp: ${message}\n`, stderr: "", exitCode: 0 };
+  }
+  const copied = { stdout: "0\n", stderr: "", exitCode: 0 };
+
+  test("into its own subdirectory is refused", async () => {
+    using dir = setup("into-sub");
+    expect(await cp(String(dir), "cp -R d d/sub")).toEqual(
+      refused(`cannot copy directory d into itself ${p("d/sub/d")}`),
+    );
+    expect(readdirSync(join(String(dir), "work/d/sub"))).toEqual([]);
+  });
+
+  test("into itself is refused", async () => {
+    using dir = setup("into-self");
+    expect(await cp(String(dir), "cp -R d d")).toEqual(refused(`cannot copy directory d into itself ${p("d/d")}`));
+    expect(readdirSync(join(String(dir), "work/d")).sort()).toEqual(["a", "sub"]);
+  });
+
+  test("to a new directory below itself is refused", async () => {
+    using dir = setup("new-dir-below-self");
+    expect(await cp(String(dir), "cp -R d d/copy")).toEqual(refused("cannot copy directory d into itself d/copy"));
+    expect(readdirSync(join(String(dir), "work/d")).sort()).toEqual(["a", "sub"]);
+  });
+
+  test("onto itself is refused", async () => {
+    using dir = setup("onto-self");
+    expect(await cp(String(dir), "cp -R d .")).toEqual(refused("d and d are identical (not copied)"));
+    expect(readdirSync(join(String(dir), "work"))).toEqual(["d"]);
+  });
+
+  // Creating directory symlinks needs extra privileges on Windows.
+  test.skipIf(isWindows)("into itself through a symlink is refused", async () => {
+    using dir = setup("through-symlink", work => symlinkSync("d", join(work, "link")));
+    expect(await cp(String(dir), "cp -R d link")).toEqual(refused("cannot copy directory d into itself link/d"));
+    expect(readdirSync(join(String(dir), "work/d")).sort()).toEqual(["a", "sub"]);
+  });
+
+  test("the other sources are still copied when one of them would go into itself", async () => {
+    using dir = setup("one-of-many", work => mkdirSync(join(work, "e")));
+    expect(await cp(String(dir), "cp -R e d d/sub")).toEqual(
+      refused(`cannot copy directory d into itself ${p("d/sub/d")}`),
+    );
+    expect(readdirSync(join(String(dir), "work/d/sub"))).toEqual(["e"]);
+  });
+
+  test("into a directory next to it is copied", async () => {
+    using dir = setup("into-sibling", work => mkdirSync(join(work, "sib")));
+    expect(await cp(String(dir), "cp -R d sib")).toEqual(copied);
+    expect(readdirSync(join(String(dir), "work/sib/d")).sort()).toEqual(["a", "sub"]);
+    expect(readFileSync(join(String(dir), "work/sib/d/a"), "utf8")).toBe("A\n");
+  });
+
+  // Deep enough that the directory walk overflowed the worker thread's stack
+  // while it still used one stack frame per directory. Skipped on macOS:
+  // PATH_MAX is 1024 there, so a tree this deep cannot be created.
+  test.skipIf(isMacOS)("a tree 1000 directories deep is copied", async () => {
+    const deepest = Array(1000).fill("a").join("/");
+    using dir = setup("deep", work => {
+      mkdirSync(join(work, "deep", deepest), { recursive: true });
+      writeFileSync(join(work, "deep", deepest, "leaf"), "leaf\n");
+    });
+    try {
+      expect(await cp(String(dir), "cp -R deep out")).toEqual(copied);
+      expect(readFileSync(join(String(dir), "work/out", deepest, "leaf"), "utf8")).toBe("leaf\n");
+    } finally {
+      // fs.rmSync, which disposing `dir` falls back to, re-walks a chain this
+      // deep from the top once per level and takes over 10s on it.
+      await $`rm -rf ${join(String(dir), "work")}`.quiet();
+    }
   });
 });
 


### PR DESCRIPTION
### Problem
- The shell `cp` builtin (default on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX) has no "into itself" check: `cp -R d d/sub` creates `d/sub/d/sub/d/...` for as long as it can. On Linux with bun 1.4.0 that is 243 levels, then the process dies with a bare SIGSEGV (exit 139); on Windows it is 32 levels, then `cp: File name too long` (MAX_PATH stops it before the stack does). coreutils refuses with `cannot copy a directory, 'd', into itself` and exit 1; bun's own `fs.cp` refuses with `ERR_FS_CP_EINVAL` because that check lives in the JS layer (`src/js/internal/fs/cp-sync.ts`), which the builtin bypasses.
- Cause 1: `ShellCpTask::run_from_thread_pool_impl` (`src/runtime/shell/builtin/cp.rs`) computes the final destination and hands it straight to the native copy.
- Cause 2 (the crash itself): `NewAsyncCpTask::cp_async_directory` (`src/runtime/node/node_fs.rs`) recursed once per directory level with an inline 8 KB readdir buffer in each frame, on a 4 MB work-pool thread stack. Any tree a few hundred levels deep crashed the same way, self-referential or not: `cp -R deep out` on a 1000-level tree also exits 139 on 1.4.0 (Linux; macOS and Windows cannot express a tree that deep, see the test).

### Fix
- `cp.rs`: when the source is a directory, `dir_copy_relation` compares the source's `dev`/`ino` against the final destination and each of its parents (non-existent ones are skipped, the walk ends at the filesystem root via `bun_paths::dirname`). A match refuses the copy before anything is written:
  - destination below the source: `cp: cannot copy directory d into itself d/sub/d`, exit 1
  - destination is the source: `cp: d and d are identical (not copied)`, exit 1 (the wording the builtin already uses for files)
  - Identity rather than path comparison so `cp -R d link` (`link -> d`) or a destination under a symlinked parent is caught too; `lstat` for the source so a Windows directory symlink, which the copy treats as a file, is not a false positive. Other sources on the same command line are still copied.
- `node_fs.rs`: `cp_async_directory` now keeps the directories being read in a `Vec<CpDirFrame>` (each frame owns the fd and the iterator and closes the fd on drop) instead of recursing; `cp_async_enter_directory` holds the per-directory part (clonefile on macOS, open, mkdir, `-v` callback) unchanged. Errors propagate as `Maybe<()>` and are reported once in `cp_async`, which is the same `finish_concurrently` the recursion called at each site. Traversal order, the ENAMETOOLONG guard and the file fan-out are unchanged. The `CpFlags` parameter only fed the recursion and is gone.
- `cp_sync_inner`, the sync twin, is left recursive on purpose: node:fs only reaches the native directory copy on macOS (`tryNativeFastPath`), where PATH_MAX is 1024 and a tree cannot get deep enough to overflow.
- Verified: `test/js/bun/shell/commands/cp.test.ts` ("bunshell cp -R of a directory"): 7 of the 8 new tests fail on the unfixed build on Linux (5 crash the child, `cp -R d .` exited 0, the 1000-level tree crashed); the sibling-copy test guards against false positives. All pass with the fix on Linux, including `test/js/node/fs/cp*.test.ts`. On Windows (debug build on a Windows box) the refusal tests and the pre-existing in-process cp suite pass; the 1000-level test is skipped there, like on macOS, because the native copy creates destinations through MAX_PATH-limited calls and stops with ENAMETOOLONG around 100 levels on both the old and the new code (macOS: PATH_MAX 1024). `cargo check` passes for the Windows and macOS targets.

### Background
- The shell's `cp` does its own operand classification (POSIX synopses) in `cp.rs` and then reuses node:fs's `NewAsyncCpTask` (`ShellAsyncCpTask`) to do the copy: the task walks directories on one work-pool thread, creating each destination directory as it goes, and spawns a `CpSingleTask` per file. node:fs itself only uses that directory walk on macOS; on every other platform the shell builtin is its only user, which is why the missing check only shows up there.
- The refusal is placed in the builtin rather than in the native task because that is where the final destination (with the source's basename appended when the target exists) is known and where the coreutils-style message belongs; `fs.cp` already performs the equivalent check in JS before calling native.

<details>
<summary>Probes against the fixed debug build (Linux)</summary>

```
cp -R d d/sub          -> 1  cp: cannot copy directory d into itself d/sub/d
cp -R d d              -> 1  cp: cannot copy directory d into itself d/d
cp -R d d/copy         -> 1  cp: cannot copy directory d into itself d/copy
cp -R d .              -> 1  cp: d and d are identical (not copied)
cp -R d d/sub/         -> 1  cp: cannot copy directory d into itself d/sub/d
cp -R d link           -> 1  cp: cannot copy directory d into itself link/d        (link -> d)
cp -R d d/up/d/sub     -> 1  cp: cannot copy directory d into itself d/up/d/sub/d  (d/up -> cwd)
cp -R /tmp $PWD/y      -> 1  cp: cannot copy directory /tmp into itself /tmp/x/y
cp -R / $PWD/rootcopy  -> 1  cp: cannot copy directory / into itself /tmp/x/rootcopy
cp -R d sib            -> 0  (sib/d/{a,sub} created)
cp -R d dcopy          -> 0
cp -R d olink          -> 0  (olink -> other; other/d created)
cp -R e d d/sub        -> 1  one error line, d/sub/e created
cp -R deep out         -> 0  1000 levels, leaf file copied (SIGSEGV on 1.4.0)
```

In every refused case the tree on disk was unchanged afterwards.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->