### PR TITLE
usockets: close half-open sockets on EPOLLHUP instead of spinning on it

### DIFF
--- a/packages/bun-usockets/src/eventing/epoll_kqueue.c
+++ b/packages/bun-usockets/src/eventing/epoll_kqueue.c
@@ -263,7 +263,11 @@ static void us_internal_dispatch_ready_polls(struct us_loop_t *loop) {
              * forwarded as a libus close code, and a raw EPOLLERR (8) would
              * read as errno 8 (ENOEXEC) in the JS error path. */
             const int error = !!(events & EPOLLERR);
-            const int eof = events & EPOLLHUP;
+            /* A read-side FIN arrives as EPOLLIN + recv()==0 (EPOLLRDHUP is never
+             * requested, see us_poll_start_rc); EPOLLHUP means both directions are
+             * down and is reported on every wait until the fd is closed. Tag it so
+             * the socket dispatch closes instead of treating it as another FIN. */
+            const int eof = (events & EPOLLHUP) ? LIBUS_POLL_HANGUP : 0;
             events &= us_poll_events(poll);
             if (events || error || eof) {
                 us_internal_dispatch_ready_poll(poll, error, eof, events);

--- a/packages/bun-usockets/src/internal/internal.h
+++ b/packages/bun-usockets/src/internal/internal.h
@@ -147,6 +147,15 @@ extern struct addrinfo_result *Bun__addrinfo_getRequestResult(struct addrinfo_re
 
 
 /* Loop related */
+/* Values a backend passes as the `eof` argument of us_internal_dispatch_ready_poll.
+ * Any nonzero value is an end-of-stream hint for the read side (kqueue's read-filter
+ * EV_EOF, libuv's UV_EOF / deferred DISCONNECT); the socket may still be writable and
+ * allow_half_open is honored. LIBUS_POLL_HANGUP is epoll's EPOLLHUP: the kernel has
+ * marked BOTH directions shut (AF_UNIX peer close(), TCP after FIN in each direction
+ * or RST), so nothing can ever be written, and unlike EPOLLIN it cannot be masked
+ * off - it is reported on every epoll_wait until the fd is closed. */
+#define LIBUS_POLL_EOF 1
+#define LIBUS_POLL_HANGUP 2
 void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, int events);
 void us_internal_timer_sweep(us_loop_r loop);
 void us_internal_enable_sweep_timer(struct us_loop_t *loop);

--- a/packages/bun-usockets/src/loop.c
+++ b/packages/bun-usockets/src/loop.c
@@ -584,6 +584,10 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
             s = us_internal_socket_follow_adopted(s);
             /* The group can change after calling a callback but the loop is always the same */
             struct us_loop_t* loop = s->group->loop;
+            /* Captured before the read loop below folds recv()==0 into `eof`. An
+             * event that also carries an error is left to the error path at the
+             * bottom, which closes with the error code exactly as before. */
+            const int hangup = (eof & LIBUS_POLL_HANGUP) && !error;
             if (events & LIBUS_SOCKET_WRITABLE && !error) {
                 s->flags.last_write_failed = 0;
                 #ifdef LIBUS_USE_KQUEUE
@@ -790,7 +794,7 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                         }
                         #endif
                     } else if (!length) {
-                        eof = 1; // lets handle EOF in the same place
+                        eof = LIBUS_POLL_EOF; // lets handle EOF in the same place
                         break;
                     } else if (length == LIBUS_SOCKET_ERROR && !bsd_would_block()) {
                         if (eof && read_any) {
@@ -845,10 +849,10 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
                     s = us_internal_socket_close_raw(s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, NULL);
                     return;
                 }
-                if (s->flags.allow_half_open && s->read_eof) {
+                if (s->flags.allow_half_open && !hangup && s->read_eof) {
                     /* on_end already delivered (libuv UV_HANDLE_READ_EOF): just drop the readable interest that re-surfaced it. */
                     us_poll_change(&s->p, loop, us_poll_events(&s->p) & LIBUS_SOCKET_WRITABLE);
-                } else if(s->flags.allow_half_open) {
+                } else if(s->flags.allow_half_open && !hangup) {
                     s->read_eof = 1;
                     /* EOF with half-open allowed: stop polling readable but KEEP
                      * polling writable. Masking with the current events dropped
@@ -869,8 +873,23 @@ void us_internal_dispatch_ready_poll(struct us_poll_t *p, int error, int eof, in
 #endif
                     s = s->ssl ? us_internal_ssl_on_end(s) : us_dispatch_end(s);
                 } else {
-                    /* We dont allow half open just emit end and close the socket */
-                    s = s->ssl ? us_internal_ssl_on_end(s) : us_dispatch_end(s);
+                    /* Either half-open is not allowed, or the kernel reported a
+                     * hangup (LIBUS_POLL_HANGUP): both directions are down, so
+                     * there is nothing half-open left to keep. Emit end (unless a
+                     * plain FIN already delivered it) and close. Closing here is
+                     * what us_poll_start_rc's implicit EPOLLHUP relies on: the
+                     * event is level-triggered and unmaskable, so a half-open
+                     * socket that merely re-dropped its readable interest on it
+                     * (an AF_UNIX peer close()d before we ended our side - e.g.
+                     * an http CONNECT client that went away) was re-dispatched
+                     * on every epoll_wait, pinning the loop at 100% CPU per
+                     * such socket for the life of the process, and the fd was
+                     * never released. The read loop above already drained the
+                     * receive queue on the hangup hint (or the paused check
+                     * above deferred it), so nothing unread is discarded. */
+                    if (!s->read_eof) {
+                        s = s->ssl ? us_internal_ssl_on_end(s) : us_dispatch_end(s);
+                    }
                     s = us_internal_socket_close_raw(s, LIBUS_SOCKET_CLOSE_CODE_CLEAN_SHUTDOWN, NULL);
                     return;
                 }

--- a/test/js/node/http/node-http-connect.test.ts
+++ b/test/js/node/http/node-http-connect.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, nodeExe, tls as tlsCert } from "harness";
+import { bunEnv, bunExe, isLinux, nodeExe, tempDir, tls as tlsCert } from "harness";
 import http from "http";
 
 import { once } from "node:events";
@@ -618,6 +618,76 @@ describe("HTTP server CONNECT", () => {
       }).toEqual({
         server: ["server:end", "server:finish", "server:close"],
         hasClientClose: true,
+        stderr: "",
+        exitCode: 0,
+      });
+    },
+  );
+
+  test.skipIf(!isLinux)(
+    "AF_UNIX CONNECT sockets whose peer closes first are closed, not spun on EPOLLHUP forever",
+    async () => {
+      // A CONNECT hand-off leaves the server socket allow_half_open. When the
+      // peer of an AF_UNIX socket close()s, Linux reports EPOLLHUP (not just a
+      // FIN), which is level-triggered and cannot be masked off. Before the fix
+      // the half-open path only dropped readable interest and got re-dispatched
+      // on every epoll_wait: 'close' never fired, the fd was never released,
+      // and each such socket pinned the event loop at 100% CPU for the life of
+      // the process. A long-lived HTTP proxy listening on a unix socket can
+      // accumulate tens of thousands of these. The handler deliberately never
+      // ends its own side: the peer's close() alone must release the socket.
+      // (TCP does not exercise this: a peer FIN is EPOLLIN + recv()==0, and
+      // once readable interest is dropped it is quiet.)
+      const fixture = /* js */ `
+        const http = require("node:http");
+        const net = require("node:net");
+        const N = 8;
+        const clients = new Map();
+        let ends = 0;
+        let closes = 0;
+        const server = http.createServer();
+        server.on("connect", (req, socket) => {
+          socket.on("error", () => {});
+          socket.on("end", () => ends++);
+          socket.on("close", () => {
+            if (++closes === N) {
+              console.log(JSON.stringify({ ends, closes }));
+              server.close();
+            }
+          });
+          // Now that the server holds the handed-off socket, hang up this
+          // request's client without it ever seeing a response.
+          clients.get(req.url).destroy();
+        });
+        server.listen(process.env.SOCK, () => {
+          for (let i = 0; i < N; i++) {
+            const target = "peer-" + i + ":443";
+            const client = net.connect(process.env.SOCK, () => {
+              client.write("CONNECT " + target + " HTTP/1.1\\r\\nHost: " + target + "\\r\\n\\r\\n");
+            });
+            client.on("error", () => {});
+            clients.set(target, client);
+          }
+        });
+        // Failure backstop only: with the bug the loop is busy forever and this
+        // process would otherwise never exit, so report the counts instead of
+        // timing out. unref() so it cannot delay the natural exit that follows
+        // server.close() once the sockets do close.
+        setTimeout(() => {
+          console.log(JSON.stringify({ ends, closes }));
+          process.exit(1);
+        }, 3_000).unref();
+      `;
+      using dir = tempDir("connect-unix-hangup", {});
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "-e", fixture],
+        env: { ...bunEnv, SOCK: join(String(dir), "proxy.sock") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout: stdout.trim(), stderr, exitCode }).toEqual({
+        stdout: JSON.stringify({ ends: 8, closes: 8 }),
         stderr: "",
         exitCode: 0,
       });


### PR DESCRIPTION
### What does this PR do?

Fixes an epoll-only leak + busy-loop: an `allow_half_open` socket (every `node:http` server socket, including one handed to a `'connect'` listener) whose peer hangs up while our side is still open is never closed and pins the event loop.

Linux reports a peer's `close()` of an **AF_UNIX** socket as `EPOLLHUP` rather than a FIN. `EPOLLHUP` is level-triggered and cannot be masked off, but `us_internal_dispatch_ready_polls` only mapped it to the generic `eof` hint, so the half-open branch in `loop.c` dropped readable interest, delivered `on_end`, and was then re-dispatched with the same `EPOLLHUP` on every subsequent `epoll_wait` for the life of the process. Result per socket: `'close'` never fires, the fd is never released, and one core is burned. (`us_poll_start_rc`'s comment already describes `EPOLLHUP` as the thing that closes a half-open socket "once both directions are down" — the dispatcher just never did it.)

**Why it matters:** this is what a long-lived HTTP proxy listening on a unix socket looks like after a while — any CONNECT client that went away before the server ended its side (killed, or gave up while the upstream dial was pending) becomes one of these sockets. I hit a process with tens of thousands of them: `strace` showed thousands of `sendto`→`EPIPE`/s, every fd registered `EPOLLOUT|ERR|HUP`, and with ~1000 ready fds per `epoll_wait` everything else on the loop (stdin, timers) was serviced once every few dozen iterations — 100% CPU and multi-second input latency. Same signature reported in anthropics/claude-code#85666, anthropics/claude-code#85731, anthropics/claude-code#80404.

**Fix:** tag `EPOLLHUP` as `LIBUS_POLL_HANGUP` on the way into the dispatcher; in the eof branch, a hangup takes the existing not-half-open path — emit end (unless a plain FIN already did) and close cleanly. The read loop has already drained the receive queue on the hint (or the `is_paused` check deferred it), so nothing unread is discarded. Events that also carry `EPOLLERR` still take the error path, so error close codes are unchanged. kqueue and libuv still pass a plain 0/1 `eof` and are unaffected — kqueue already maps the write filter's `EV_EOF` to a close and libuv already probes for this exact re-report, so epoll was the last backend with the spin.

Not addressed here (pre-existing, much narrower): a socket that is *paused* when the peer hangs up defers the hint (`loop.c` `is_paused` check) and will also be re-dispatched on every wait until it is resumed. That one is bounded by the pause; this PR is about the unbounded case.

### How did you verify your code works?

All on Linux x64.

- **Regression test** (`test/js/node/http/node-http-connect.test.ts`, Linux only, next to the existing EPOLLHUP-after-both-FINs case): 8 CONNECT clients over an AF_UNIX listener; the `'connect'` handler destroys the matching client (looked up by `req.url`, so the peer-closes-first ordering is deterministic) and never ends its own side. Asserts `end` + `close` on all 8 and a natural exit.
- **Fails on current canary, passes with the patch**: `1.4.0-canary.1+9a543cc18` prints `{"ends":8,"closes":0}`, sits at ~100% CPU, and only exits via the fixture's 3 s backstop (1.3.13 prints `{"ends":0,"closes":0}` and also hangs). A build with this patch passes in ~600 ms total. With the close emulated in JS the fixture completes in ~70 ms, so the good path is nowhere near the backstop even on debug/ASAN builds.
- **Original repro is gone**: a standalone matrix (`http.Server` on a unix path vs TCP × {`end()` 403-style, `write()` 200-style, actively reading, no write} with 200 clients hanging up first). Unpatched, all four unix rows are `closes: 0` at ~1000 ms CPU/s forever; patched they're `closes: 200` at ~2 ms/s. The four TCP rows are identical between the two builds — including the two half-open rows that legitimately stay open at ~0 CPU — so TCP half-open semantics are unchanged.
- **No regressions in the socket suites**: ran `js/node/net`, `js/node/http`, `js/node/tls`, `js/bun/net`, `js/bun/http` on patched and unpatched builds and diffed the failing sets. They differ only in the new test (unpatched-only failure) plus one load flake (`bun-serve-file` "memory usage stays reasonable", passes 3/3 on both in isolation); everything else that fails does so identically on both and is environmental (e.g. the AF_UNIX long-path tests, which pass on both once `TMPDIR` is short).
- `clang -fsyntax-only -Wall` on `loop.c` / `epoll_kqueue.c` clean; header `clang-format` clean; test `prettier` clean.
