### PR TITLE
bake: reuse an html file's route bundle when server.reload() re-registers it

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5206,12 +5206,9 @@ impl DevServer {
 
         let _g = self.graph_safety_lock.guard();
 
-        // `server.reload()` creates fresh `HTMLBundleRoute`s for html files this
-        // DevServer may already be serving. The client graph tracks one route
-        // bundle per html file (`File::html_route_bundle_index`, where
-        // `finalize_bundle` delivers the bundled html), so the new route adopts
-        // it; with a second bundle, requests deferred on the first would be
-        // replayed against a bundle that never receives any html.
+        // `server.reload()` creates a new `HTMLBundleRoute` for an html file that
+        // may already have a route bundle. The graph has one slot per file
+        // (`File::html_route_bundle_index`), so the new route adopts that bundle.
         if let route_bundle::UnresolvedIndex::Html(html) = route {
             // SAFETY: caller guarantees `html` is a live IntrusiveRc-managed
             // allocation; single-threaded (uws JS-thread callback).

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5206,9 +5206,7 @@ impl DevServer {
 
         let _g = self.graph_safety_lock.guard();
 
-        // `server.reload()` creates a new `HTMLBundleRoute` for an html file that
-        // may already have a route bundle. The graph has one slot per file
-        // (`File::html_route_bundle_index`), so the new route adopts that bundle.
+        // `server.reload()` re-registers known html files; reuse their bundles.
         if let route_bundle::UnresolvedIndex::Html(html) = route {
             // SAFETY: caller guarantees `html` is a live IntrusiveRc-managed
             // allocation; single-threaded (uws JS-thread callback).

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5206,6 +5206,27 @@ impl DevServer {
 
         let _g = self.graph_safety_lock.guard();
 
+        // `server.reload()` creates fresh `HTMLBundleRoute`s for html files this
+        // DevServer may already be serving. The client graph tracks one route
+        // bundle per html file (`File::html_route_bundle_index`, where
+        // `finalize_bundle` delivers the bundled html), so the new route adopts
+        // it; with a second bundle, requests deferred on the first would be
+        // replayed against a bundle that never receives any html.
+        if let route_bundle::UnresolvedIndex::Html(html) = route {
+            // SAFETY: caller guarantees `html` is a live IntrusiveRc-managed
+            // allocation; single-threaded (uws JS-thread callback).
+            let html_ref = unsafe { &*html };
+            if let Some(existing) = self
+                .client_graph
+                .bundled_files
+                .get(&html_ref.bundle.path)
+                .and_then(|file| file.html_route_bundle_index)
+            {
+                html_ref.dev_server_id.set(Some(existing));
+                return Ok(existing);
+            }
+        }
+
         let bundle_index =
             route_bundle::Index::init(u32::try_from(self.route_bundles.len()).expect("int cast"));
 

--- a/test/js/bun/http/bun-serve-html.test.ts
+++ b/test/js/bun/http/bun-serve-html.test.ts
@@ -1163,3 +1163,88 @@ describe("production headers and import.meta.env", () => {
     expect(results).toEqual(cases.map(([, , expected]) => expected));
   });
 });
+
+// server.reload() hands the dev server a new route object for the same html
+// file. The dev server used to give it a second route bundle and deliver the
+// bundled html there, so a request that was deferred on the original bundle
+// while it was still building crashed the process once the bundle finished.
+test("server.reload() while an html route's first bundle is still in flight", async () => {
+  using dir = tempDir("bun-serve-html-reload-during-bundle", {
+    "bunfig.toml": `[serve.static]\nplugins = ["./plugin.ts"]\n`,
+    "index.html": `<!DOCTYPE html><html><head><title>t</title></head><body><script type="module" src="./app.ts"></script></body></html>`,
+    "app.ts": `console.log("app");`,
+    // Holds the first bundle open until serve.ts has reloaded the server, so
+    // the request that started the bundle stays deferred on it meanwhile.
+    "plugin.ts": /*ts*/ `
+      export default {
+        name: "hold-bundle",
+        setup(build) {
+          build.onLoad({ filter: /app\\.ts$/ }, async () => {
+            globalThis.bundleStarted.resolve();
+            await globalThis.releaseBundle.promise;
+            return { loader: "ts", contents: "console.log('app');" };
+          });
+        },
+      };
+    `,
+    "serve.ts": /*ts*/ `
+      import html from "./index.html";
+
+      globalThis.bundleStarted = Promise.withResolvers();
+      globalThis.releaseBundle = Promise.withResolvers();
+
+      const options = { port: 0, development: true, routes: { "/": html } };
+      const server = Bun.serve(options);
+
+      // Asks the dev server over its HMR socket which route bundle currently
+      // backs "/": the client's "set url" message ('n' + route pattern) is
+      // answered with 'n' + the route bundle index as a u32.
+      async function routeBundleIndex() {
+        const url = new URL("/_bun/hmr", server.url);
+        url.protocol = "ws:";
+        const ws = new WebSocket(url);
+        ws.binaryType = "arraybuffer";
+        const { promise, resolve, reject } = Promise.withResolvers();
+        ws.onerror = reject;
+        ws.onclose = () => reject(new Error("hmr socket closed before answering"));
+        ws.onmessage = ({ data }) => {
+          const view = new DataView(data);
+          if (view.getUint8(0) === "n".charCodeAt(0)) resolve(view.getUint32(1, true));
+        };
+        ws.onopen = () => ws.send(new TextEncoder().encode("n/"));
+        try {
+          return await promise;
+        } finally {
+          ws.onclose = null;
+          ws.close();
+        }
+      }
+
+      const first = fetch(server.url).then(res => res.status);
+      await globalThis.bundleStarted.promise;
+      const before = await routeBundleIndex();
+
+      server.reload(options);
+      const after = await routeBundleIndex();
+
+      globalThis.releaseBundle.resolve();
+      const second = fetch(server.url).then(res => res.status);
+
+      console.log(JSON.stringify({ first: await first, second: await second, sameRouteBundle: before === after }));
+      server.stop(true);
+    `,
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "serve.ts"],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout: stdout.trim(), exitCode }, stderr).toEqual({
+    stdout: JSON.stringify({ first: 200, second: 200, sameRouteBundle: true }),
+    exitCode: 0,
+  });
+});


### PR DESCRIPTION
### Problem
- `server.reload()` while an HTML route's first bundle is still building aborts the process (release builds included): `panic: called Option::unwrap() on a None value` in `DevServer::generate_html_payload` (`src/runtime/bake/DevServer.rs:2762`, `html.script_injection_offset.unwrap()`), reached from `on_html_request_with_bundle` via the deferred request replay at the end of `finalize_bundle`.
- Reachable from ordinary dev server use: anything that calls `reload()` while a page is loading (route re-registration on file events, `--hot`), with a window equal to the bundle duration.
- Cause: `reload()` parses a new config, and the per-config dedupe map in `html_route_from_js` (`src/runtime/server/server_body.rs:727`) gives the same `HTMLBundle` a fresh `HTMLBundleRoute` whose `dev_server_id` is `None`. `get_or_put_route_bundle` (`DevServer.rs:5181`) then pushed a second `RouteBundle` for the same html file and repointed the graph file's `html_route_bundle_index` at it. `finalize_bundle` delivers the bundled html through that index (`DevServer.rs:4105-4129`), so the new bundle got the text and offset while the request deferred on the original bundle was replayed against a bundle that never received any.
- Same logic existed before the Rust port (`orelse unreachable` in DevServer.zig), so this is not a regression of a specific release.

### Fix
- `get_or_put_route_bundle` looks the html file up in the client graph first; if the file already has a route bundle, the new `HTMLBundleRoute` adopts it (its `dev_server_id` is set and the existing index is returned) instead of getting a second one.
- Correct because the graph already models exactly one route bundle per html file (`File::html_route_bundle_index` is a single slot and is carried across rebundles in `receive_chunk`), files are never removed from the graph, and the only things a route bundle reads from its `HTMLBundleRoute` are the file path (identical for every route of the file) and a debug assertion on `dev_server_id`, which still holds. Reload no longer re-marks the file stale, so an unchanged page is served from cache after `reload()`, and HMR clients stay attached to the same bundle. Fresh files still take the existing create path.
- Verified with the new test in `test/js/bun/http/bun-serve-html.test.ts` (`server.reload() while an html route's first bundle is still in flight`): fails with `USE_SYSTEM_BUN=1` and with the fix stashed (exit 134, the panic above), passes with the fix.
- The reporter's timing-based repro (3 fetch/reload rounds) now returns `[200, 200, 200]` on a debug build; it crashed 3/3 on 1.4.0.
- `bun-serve-html.test.ts`, `bun-serve-html-405.test.ts`, `test/bake/dev/{html,hot}.test.ts`, `test/bake/serve-plugins-dev-server.test.ts`, `test/bake/deinitialization.test.ts` and `test/cli/inspect/BunFrontendDevServer.test.ts` pass locally on a debug build.

### Background
- `Bun.serve({ development: true })` with imported html files runs the dev server (bake). Each html route is an `HTMLBundleRoute` (one per `HTMLBundle` per server config) and, once requested, a `RouteBundle` in the dev server holding the route's bundling state, the bundled html text, and the offset where the dev server injects its script and link tags.
- The incremental graph is the dev server's map of every bundled file; for an html file, `html_route_bundle_index` says which `RouteBundle` receives that file's output when a bundle finishes.
- Requests for a route that is still bundling are deferred and replayed by `finalize_bundle` once the bundle completes; replaying an html request renders the page from the route bundle's stored text and offset.
- The test holds the first bundle open with a `[serve.static]` plugin whose `onLoad` waits on a promise, then uses the HMR socket's "set url" message (`'n'` + route pattern, answered with `'n'` + route bundle index) to ask which bundle backs `/` before and after `reload()`. This makes the window deterministic and also checks directly that both routes share one bundle.

<details>
<summary>Reporter's repro (timing based)</summary>

```js
import html from "./index.html";
const srv = Bun.serve({ routes: { "/": html }, development: true, port: 0, hostname: "127.0.0.1" });
const base = "http://127.0.0.1:" + srv.port, ps = [];
for (let i = 0; i < 3; i++) {
  ps.push(fetch(base + "/").then(r => r.status));          // queues on the in-flight first bundle
  await new Promise(r => setTimeout(r, 0));                 // let the request reach the server
  srv.reload({ routes: { "/": html }, development: true }); // same html, same options
}
console.log("responses:", await Promise.all(ps)); srv.stop(true);
```

1.4.0: `panic: called Option::unwrap() on a None value`, SIGABRT. With this change: `responses: [ 200, 200, 200 ]`.

Debug build stack without the fix:

```
<bun_runtime::bake::dev_server_body::DevServer>::generate_html_payload        src/runtime/bake/DevServer.rs:2762
<bun_runtime::bake::dev_server_body::DevServer>::on_html_request_with_bundle  src/runtime/bake/DevServer.rs:2710
bun_runtime::bake::dev_server_body::finalize_bundle                           src/runtime/bake/DevServer.rs:4851
<bun_bundler::bundle_v2::BundleV2>::finish_from_bake_dev_server
<bun_bundler::bundle_v2::BundleV2>::on_parse_task_complete
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 5 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 1 failed, 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_viLj2Y {
  "/": "/tmp/html-css-js_viLj2Y/index.html",
  "/dashboard": "/tmp/html-css-js_viLj2Y/dashboard.html",
}
[0.10ms] bundle index.html 1.09 KB
[0.06ms] bundle dashboard.html 1.27 KB
(pass) serve html [679.68ms]
waitForServer /tmp/bun-serve-html-txt_l3ZJuO {
  "/": "/tmp/bun-serve-html-txt_l3ZJuO/index.html",
}
[0.17ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [652.25ms]
waitForServer /tmp/html-css-js-failing-plugin_ZjOjsP {
  "/": "/tmp/html-css-js-failing-plugin_ZjOjsP/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_ZjOjsP/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_ZjOjsP/styles.css:0
(pass) serve plugins > serve html with failing plugin [539.47ms]
waitForServer /tmp/html-css-js-empty-plugins_VcTsFQ {
  "/": "/tmp/html-css-js-empty-plugins_VcTsFQ/index.html",
}
[0.09ms] bu
... (truncated)

release without fix: 1 FAILED
bun test v1.4.0-canary.1 (8326d1bd3)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_wdLxf7 {
  "/": "/tmp/html-css-js_wdLxf7/index.html",
  "/dashboard": "/tmp/html-css-js_wdLxf7/dashboard.html",
}
[0.00ms] bundle index.html 1.09 KB
[0.00ms] bundle dashboard.html 1.27 KB
(pass) serve html [19.60ms]
waitForServer /tmp/bun-serve-html-txt_snZy9A {
  "/": "/tmp/bun-serve-html-txt_snZy9A/index.html",
}
[0.00ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [18.05ms]
waitForServer /tmp/html-css-js-failing-plugin_K3Y9G1 {
  "/": "/tmp/html-css-js-failing-plugin_K3Y9G1/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_K3Y9G1/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_K3Y9G1/styles.css:0
(pass) serve plugins > serve html with failing plugin [13.98ms]
waitForServer /tmp/html-css-js-empty-plugins_dRxtLP {
  "/": "/tmp/html-css-js-empty-plugins_dRxtLP/index.html",
}
[0.00ms] bundle index.html 0.71 KB
(pass) serve plugins > empty plugin array [11.31ms]
Waiting for server
waitForServer /tmp/html-css-js-concurrent-plugins_iSgBRv {
  "/": "/tmp/
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 2 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/http/bun-serve-html.test.ts
bun test v1.4.0 (8326d1bd3)

test/js/bun/http/bun-serve-html.test.ts:
waitForServer /tmp/html-css-js_6Am7cA {
  "/": "/tmp/html-css-js_6Am7cA/index.html",
  "/dashboard": "/tmp/html-css-js_6Am7cA/dashboard.html",
}
[0.13ms] bundle index.html 1.09 KB
[0.06ms] bundle dashboard.html 1.27 KB
(pass) serve html [739.33ms]
waitForServer /tmp/bun-serve-html-txt_hhjhN8 {
  "/": "/tmp/bun-serve-html-txt_hhjhN8/index.html",
}
[0.15ms] bundle index.html 0.40 KB
HASH efbnbska
(pass) serve plugins > basic plugin [602.59ms]
waitForServer /tmp/html-css-js-failing-plugin_GKeQTV {
  "/": "/tmp/html-css-js-failing-plugin_GKeQTV/index.html",
}
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_GKeQTV/styles.css:0
error: Plugin failed intentionally
    at /tmp/html-css-js-failing-plugin_GKeQTV/styles.css:0
(pass) serve plugins > serve html with failing plugin [563.42ms]
waitForServer /tmp/html-css-js-empty-plugins_jfMcf0 {
  "/": "/tmp/html-css-js-empty-plugins_jfMcf0/index.html",
}
[0.11ms] bu
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     c4429804e2
  features     baseline

22 deps, 120 codegen, 1175 objects in 686ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1236] install /workspace/bun
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 107 installs across 153 packages (no changes) [18.00ms]
[2/1236] gen bindgenv2
[3/1236] gen ErrorCode+*.h
[4/1236] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 1 install across 2 packages (no changes) [1.00ms]
[5/1236] fetch tinycc
[tinycc] up to date
[6/1235] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[7/1235] fetch zlib
[zlib] up to date
[8/1235] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (8326d1bd3)

Checked 129 installs across 147 packages (no changes) [19.00ms]
[9/1235] gen .bind.ts → GeneratedBindings.cpp
[10/1235] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/bake/DevServer.rs           | 16 +++++++
 test/js/bun/http/bun-serve-html.test.ts | 85 +++++++++++++++++++++++++++++++++
 2 files changed, 101 insertions(+)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/runtime/bake/DevServer.rs               12      6      0
test/js/bun/http/bun-serve-html.test.ts      5      1      0
```

</details>

<!-- robobun:evidence:end -->