### PR TITLE
build: say why a download failed, and keep retrying for ~2 minutes

### DIFF
--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -8,10 +8,9 @@
  *
  * ## Retry behavior
  *
- * Exponential backoff (1s → 2s → 4s → 8s → cap at 30s), 5 attempts. GitHub
- * releases (our main source) are usually reliable, but CI sees transient
- * CDN failures often enough that no-retry means flaky builds. The cap at
- * 30s means worst-case we spend ~60s total before giving up.
+ * Exponential backoff (2s → 4s → 8s → 16s → cap at 30s), 8 attempts, ~2 minutes
+ * in all. A bad github.com edge stays bad for tens of seconds at a time, so the
+ * window has to outlast that rather than paper over one dropped connection.
  *
  * ## Atomic writes
  *
@@ -37,7 +36,7 @@ import { basename, resolve } from "node:path";
 import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeWebReadable } from "node:stream/web";
-import { BuildError, assert } from "./error.ts";
+import { BuildError, assert, describeError } from "./error.ts";
 
 // On Windows, prefer the OS-shipped bsdtar. Git-for-Windows / MSYS put GNU tar
 // earlier in PATH, and GNU tar parses `C:\...` as an rsh `host:path` spec
@@ -153,22 +152,32 @@ export async function downloadWithRetry(url: string, dest: string, logPrefix: st
     return;
   }
 
-  const maxAttempts = 5;
+  const maxAttempts = 8;
   let lastError: unknown;
   let permanent = false;
 
   for (let attempt = 1; attempt <= maxAttempts && !permanent; attempt++) {
     if (attempt > 1) {
       const backoffMs = Math.min(1000 * Math.pow(2, attempt - 1), 30000);
+      console.log(`attempt ${attempt - 1} failed: ${describeError(lastError)}`);
       console.log(`retry ${attempt}/${maxAttempts} in ${backoffMs}ms`);
       await new Promise(r => setTimeout(r, backoffMs));
     }
 
     const tmpPath = `${dest}.${process.pid}.partial`;
+    // Redirects are followed by hand so a failure names the hop that failed (github.com vs codeload vs objects.*).
+    let hop = url;
     try {
-      const res = await fetch(url, { headers: { "User-Agent": "bun-build-system" } });
+      let res: Response;
+      for (let redirects = 0; ; redirects++) {
+        res = await fetch(hop, { headers: { "User-Agent": "bun-build-system" }, redirect: "manual" });
+        const location = res.headers.get("location");
+        if (res.status < 300 || res.status >= 400 || location === null || redirects >= 10) break;
+        await res.body?.cancel();
+        hop = new URL(location, hop).href;
+      }
       if (!res.ok || res.body === null) {
-        lastError = new BuildError(`HTTP ${res.status} ${res.statusText} for ${url}`);
+        lastError = new BuildError(`HTTP ${res.status} ${res.statusText} for ${hop}`);
         // 4xx is deterministic — a bad URL/missing artifact won't succeed on
         // retry. Only loop on 5xx/network where the CDN may recover.
         permanent = res.status >= 400 && res.status < 500;
@@ -181,7 +190,7 @@ export async function downloadWithRetry(url: string, dest: string, logPrefix: st
       await rename(tmpPath, dest);
       return;
     } catch (err) {
-      lastError = err;
+      lastError = hop === url ? err : new BuildError(`while fetching ${hop}`, { cause: err });
       // Swallow cleanup errors: on Windows, AV/indexer can briefly lock the
       // partial; a failed unlink must not abort the retry loop. Next attempt's
       // createWriteStream truncates anyway.

--- a/scripts/build/error.ts
+++ b/scripts/build/error.ts
@@ -31,11 +31,24 @@ export class BuildError extends Error {
       out += `  hint: ${this.hint}\n`;
     }
     if (this.cause !== undefined) {
-      const cause = this.cause instanceof Error ? this.cause.message : String(this.cause);
-      out += `  cause: ${cause}\n`;
+      out += `  cause: ${describeError(this.cause)}\n`;
     }
     return out;
   }
+}
+
+/** The whole cause chain on one line: fetch() rejects with a bare "fetch failed" and keeps the socket/DNS/TLS error in `.cause` (or `.cause.errors[]`). */
+export function describeError(err: unknown, depth = 0): string {
+  if (!(err instanceof Error)) return String(err);
+  let out = err.message;
+  const code = (err as NodeJS.ErrnoException).code;
+  if (code !== undefined && !out.includes(code)) out = `${code}: ${out}`;
+  if (depth >= 5) return out;
+  if (err instanceof AggregateError && err.errors.length > 0) {
+    out += ` [${err.errors.map(e => describeError(e, depth + 1)).join("; ")}]`;
+  }
+  if (err.cause !== undefined) out += ` <- ${describeError(err.cause, depth + 1)}`;
+  return out;
 }
 
 /**


### PR DESCRIPTION
### What does this PR do?

Since ~16:00 UTC today most builds across every lane have been dying in the first minute with a dep fetch (`lolhtml`, `cares`, `mimalloc`, the WebKit prebuilt — whichever pins are newer than the image's prefetch cache) failing 5/5 attempts, and the log only says `cause: fetch failed`. That is undici's outer `TypeError`; the real socket/DNS/TLS error is in its `.cause` and `BuildError.format()` never printed it.

Reproducing the same fetch from outside CI showed github.com itself closing the TLS connection with nothing read, then answering `503`, for about 30 seconds at a stretch before recovering — and 30 seconds is also the entire old retry window (5 attempts, 31s), which is why the fetches that survived in the logs all succeeded on attempt 5.

- `BuildError.format()` prints the whole cause chain, including `code`s and `AggregateError` members, so the next incident is diagnosable from the log.
- `downloadWithRetry` logs each failed attempt's reason before sleeping, follows redirects itself so the message names the hop that failed (github.com vs codeload vs objects.githubusercontent.com), and makes 8 attempts (~2 minutes total) instead of 5.

Not in this PR: fetching archives from codeload directly to skip the github.com hop — the prefetch cache is keyed by the github.com URL, so that needs the cache key decoupled from the download URL first.

### How did you verify your code works?

Drove `downloadWithRetry` under `node --experimental-strip-types`: a real `oven-sh/lol-html` archive (302 to codeload followed, 570 KB written); a bogus sha (`HTTP 404 Not Found for https://codeload.github.com/...`, thrown immediately, still matches prefetch-deps' `HTTP 404` test); a local server redirecting to a dead port (`while fetching http://127.0.0.1:9/x.tgz <- fetch failed <- bad port` on every attempt and in the final error). During the first run GitHub happened to misbehave and the new output read `fetch failed <- UND_ERR_SOCKET: other side closed` then `HTTP 503 Service Unavailable for https://github.com/...`, which is the diagnosis above. `tsc -p scripts/build` reports nothing in these two files.