### PR TITLE
Suspend the caller's AsyncLocalStorage context while a blocking wait runs the event loop

### DIFF
--- a/src/jsc/bindings/AsyncContextFrame.cpp
+++ b/src/jsc/bindings/AsyncContextFrame.cpp
@@ -96,6 +96,38 @@ extern "C" JSC::EncodedJSValue AsyncContextFrame__withAsyncContextIfNeeded(JSGlo
     return JSValue::encode(AsyncContextFrame::withAsyncContextIfNeeded(globalObject, JSValue::decode(callback)));
 }
 
+// Event loop work is dispatched assuming no async context is installed: a
+// callback scheduled while none was active is stored unwrapped
+// (withAsyncContextIfNeeded above) and AsyncContextSwapScope does nothing for
+// an undefined context, so such callbacks run in whatever the slot holds.
+// Native code that dispatches event loop work from inside a JS frame
+// (waitForPromise, a microtask checkpoint) clears the frame's context with
+// this pair around the dispatch. `needsCleanup` carries the enterWith()
+// cleanup arming (jsCleanupLater), which a microtask run during the dispatch
+// would otherwise consume, leaving the restored context with nothing to clear
+// it later.
+extern "C" JSC::EncodedJSValue AsyncContextFrame__suspend(JSGlobalObject* lexicalGlobalObject, bool* needsCleanup)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    auto* asyncContextData = globalObject->m_asyncContextData.get();
+    JSValue context = asyncContextData->getInternalField(0);
+    *needsCleanup = globalObject->asyncHooksNeedsCleanup;
+    if (!context.isUndefined()) {
+        asyncContextData->putInternalField(globalObject->vm(), 0, jsUndefined());
+    }
+    return JSValue::encode(context);
+}
+
+extern "C" void AsyncContextFrame__resume(JSGlobalObject* lexicalGlobalObject, JSC::EncodedJSValue encodedContext, bool needsCleanup)
+{
+    auto* globalObject = defaultGlobalObject(lexicalGlobalObject);
+    globalObject->m_asyncContextData.get()->putInternalField(globalObject->vm(), 0, JSValue::decode(encodedContext));
+    if (globalObject->asyncHooksNeedsCleanup != needsCleanup) {
+        globalObject->asyncHooksNeedsCleanup = needsCleanup;
+        globalObject->resetOnEachMicrotaskTick();
+    }
+}
+
 #define ASYNCCONTEXTFRAME_CALL_IMPL(...)                                            \
     if (!functionObject.isCell())                                                   \
         return jsUndefined();                                                       \

--- a/src/jsc/bindings/AsyncContextFrame.cpp
+++ b/src/jsc/bindings/AsyncContextFrame.cpp
@@ -96,16 +96,7 @@ extern "C" JSC::EncodedJSValue AsyncContextFrame__withAsyncContextIfNeeded(JSGlo
     return JSValue::encode(AsyncContextFrame::withAsyncContextIfNeeded(globalObject, JSValue::decode(callback)));
 }
 
-// Event loop work is dispatched assuming no async context is installed: a
-// callback scheduled while none was active is stored unwrapped
-// (withAsyncContextIfNeeded above) and AsyncContextSwapScope does nothing for
-// an undefined context, so such callbacks run in whatever the slot holds.
-// Native code that dispatches event loop work from inside a JS frame
-// (waitForPromise, a microtask checkpoint) clears the frame's context with
-// this pair around the dispatch. `needsCleanup` carries the enterWith()
-// cleanup arming (jsCleanupLater), which a microtask run during the dispatch
-// would otherwise consume, leaving the restored context with nothing to clear
-// it later.
+// Pair behind bun_jsc::event_loop::SuspendedAsyncContext. needsCleanup is the enterWith() cleanup arming (jsCleanupLater), which a microtask run while suspended would otherwise consume.
 extern "C" JSC::EncodedJSValue AsyncContextFrame__suspend(JSGlobalObject* lexicalGlobalObject, bool* needsCleanup)
 {
     auto* globalObject = defaultGlobalObject(lexicalGlobalObject);

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -156,8 +156,6 @@ mod drain_result {
 // the microtask queue through it is interior mutation invisible to Rust.
 unsafe extern "C" {
     safe fn JSC__JSGlobalObject__drainMicrotasks(global: &JSGlobalObject) -> u8;
-    // safe: `&mut bool` is ABI-identical to the non-null `bool*` out-param C++
-    // fills unconditionally.
     safe fn AsyncContextFrame__suspend(
         global: &JSGlobalObject,
         needs_cleanup: &mut bool,
@@ -169,22 +167,13 @@ unsafe extern "C" {
     );
 }
 
-/// The AsyncLocalStorage context of the JS frame that is synchronously
-/// dispatching event loop work ([`EventLoop::wait_for_promise`], a microtask
-/// checkpoint), taken out of the global's async context slot for the duration
-/// of the dispatch and reinstalled on drop.
-///
-/// Dispatch assumes the slot is empty, as it is when the event loop itself
-/// dispatches: a callback scheduled with no context active is stored unwrapped
-/// and installs nothing when run, so it would otherwise observe the dispatching
-/// frame's context. Callbacks that did capture a context install their own and
-/// are unaffected. Callers that did not have a context get `None` and pay
-/// nothing beyond the slot read.
+/// The calling JS frame's async context, cleared while native code dispatches
+/// event loop work from inside that frame and reinstalled on drop: work that
+/// was scheduled with no context runs unwrapped and would otherwise see it.
 #[must_use = "the context is reinstalled when this guard drops"]
 pub struct SuspendedAsyncContext<'a> {
     global: &'a JSGlobalObject,
-    // Protected: the dispatch can run GC, and the frame that installed the
-    // context does not necessarily hold the array anywhere a GC root can see.
+    // Protected because the dispatch can GC and nothing else necessarily roots the array.
     context: jsc::ProtectedJSValue,
     needs_cleanup: bool,
 }
@@ -215,9 +204,6 @@ impl JSGlobalObject {
     /// Run one microtask checkpoint: `process.nextTick` callbacks, then the
     /// JSC microtask queue, and nothing else. No timers, no I/O, no deferred
     /// tasks, so this cannot re-enter the event loop.
-    ///
-    /// This runs from inside the calling JS frame, so that frame's async
-    /// context is suspended for the drain (see [`SuspendedAsyncContext`]).
     ///
     /// `Err` means JS was terminated; a termination exception is left pending.
     pub fn drain_microtasks_and_next_ticks(&self) -> Result<(), JsTerminated> {
@@ -1030,11 +1016,6 @@ impl EventLoop {
     /// still pending because the VM can no longer run the script that would
     /// settle it (execution forbidden, or a stop was requested: a worker being
     /// terminated mid-wait) — a `JsError::Terminated` for the caller.
-    ///
-    /// When called from inside a JS frame (`expect().resolves`, a macro, a
-    /// plugin wait), everything dispatched while spinning runs with that
-    /// frame's async context suspended (see [`SuspendedAsyncContext`]); the
-    /// top-level drivers have no context installed and skip that.
     pub fn wait_for_promise(&mut self, promise: jsc::AnyPromise) -> Result<(), jsc::JsTerminated> {
         let jsc_vm = self.vm_ref().jsc_vm();
         if promise.status() != PromiseStatus::Pending {

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -156,6 +156,59 @@ mod drain_result {
 // the microtask queue through it is interior mutation invisible to Rust.
 unsafe extern "C" {
     safe fn JSC__JSGlobalObject__drainMicrotasks(global: &JSGlobalObject) -> u8;
+    // safe: `&mut bool` is ABI-identical to the non-null `bool*` out-param C++
+    // fills unconditionally.
+    safe fn AsyncContextFrame__suspend(
+        global: &JSGlobalObject,
+        needs_cleanup: &mut bool,
+    ) -> JSValue;
+    safe fn AsyncContextFrame__resume(
+        global: &JSGlobalObject,
+        context: JSValue,
+        needs_cleanup: bool,
+    );
+}
+
+/// The AsyncLocalStorage context of the JS frame that is synchronously
+/// dispatching event loop work ([`EventLoop::wait_for_promise`], a microtask
+/// checkpoint), taken out of the global's async context slot for the duration
+/// of the dispatch and reinstalled on drop.
+///
+/// Dispatch assumes the slot is empty, as it is when the event loop itself
+/// dispatches: a callback scheduled with no context active is stored unwrapped
+/// and installs nothing when run, so it would otherwise observe the dispatching
+/// frame's context. Callbacks that did capture a context install their own and
+/// are unaffected. Callers that did not have a context get `None` and pay
+/// nothing beyond the slot read.
+#[must_use = "the context is reinstalled when this guard drops"]
+pub struct SuspendedAsyncContext<'a> {
+    global: &'a JSGlobalObject,
+    // Protected: the dispatch can run GC, and the frame that installed the
+    // context does not necessarily hold the array anywhere a GC root can see.
+    context: jsc::ProtectedJSValue,
+    needs_cleanup: bool,
+}
+
+impl<'a> SuspendedAsyncContext<'a> {
+    pub fn take(global: &'a JSGlobalObject) -> Option<Self> {
+        jsc::mark_binding();
+        let mut needs_cleanup = false;
+        let context = AsyncContextFrame__suspend(global, &mut needs_cleanup);
+        if context.is_undefined() {
+            return None;
+        }
+        Some(Self {
+            global,
+            context: context.protected(),
+            needs_cleanup,
+        })
+    }
+}
+
+impl Drop for SuspendedAsyncContext<'_> {
+    fn drop(&mut self) {
+        AsyncContextFrame__resume(self.global, self.context.value(), self.needs_cleanup);
+    }
 }
 
 impl JSGlobalObject {
@@ -163,9 +216,13 @@ impl JSGlobalObject {
     /// JSC microtask queue, and nothing else. No timers, no I/O, no deferred
     /// tasks, so this cannot re-enter the event loop.
     ///
+    /// This runs from inside the calling JS frame, so that frame's async
+    /// context is suspended for the drain (see [`SuspendedAsyncContext`]).
+    ///
     /// `Err` means JS was terminated; a termination exception is left pending.
     pub fn drain_microtasks_and_next_ticks(&self) -> Result<(), JsTerminated> {
         jsc::mark_binding();
+        let _caller_context = SuspendedAsyncContext::take(self);
         match JSC__JSGlobalObject__drainMicrotasks(self) {
             drain_result::SUCCESS => Ok(()),
             drain_result::JS_TERMINATED => Err(JsTerminated::JSTerminated),
@@ -973,11 +1030,17 @@ impl EventLoop {
     /// still pending because the VM can no longer run the script that would
     /// settle it (execution forbidden, or a stop was requested: a worker being
     /// terminated mid-wait) — a `JsError::Terminated` for the caller.
+    ///
+    /// When called from inside a JS frame (`expect().resolves`, a macro, a
+    /// plugin wait), everything dispatched while spinning runs with that
+    /// frame's async context suspended (see [`SuspendedAsyncContext`]); the
+    /// top-level drivers have no context installed and skip that.
     pub fn wait_for_promise(&mut self, promise: jsc::AnyPromise) -> Result<(), jsc::JsTerminated> {
         let jsc_vm = self.vm_ref().jsc_vm();
         if promise.status() != PromiseStatus::Pending {
             return Ok(());
         }
+        let _caller_context = SuspendedAsyncContext::take(self.global_ref());
         while promise.status() == PromiseStatus::Pending {
             if jsc_vm.execution_forbidden() || !self.vm_ref().script_allowed() {
                 jsc_vm.ensure_termination_exception_pending();

--- a/src/jsc/modules/BunJSCModule.h
+++ b/src/jsc/modules/BunJSCModule.h
@@ -636,8 +636,6 @@ JSC_DEFINE_HOST_FUNCTION(functionDrainMicrotasks,
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    vm.drainMicrotasks();
-    RETURN_IF_EXCEPTION(scope, {});
     Bun__drainMicrotasks();
     RETURN_IF_EXCEPTION(scope, {});
     return JSValue::encode(jsUndefined());

--- a/src/jsc/virtual_machine_exports.rs
+++ b/src/jsc/virtual_machine_exports.rs
@@ -1,5 +1,6 @@
 use core::ffi::c_void;
 
+use crate::event_loop::SuspendedAsyncContext;
 use crate::plugin_runner::PluginRunner;
 use crate::{
     CallFrame, JSGlobalObject, JSPromise, JSValue, JsResult, Strong, Task,
@@ -35,10 +36,16 @@ pub fn get_vm() -> *mut VirtualMachine {
     VirtualMachine::get_mut_ptr()
 }
 
-/// Caller must check for termination exception
+/// `bun:jsc`'s `drainMicrotasks()`; the caller checks for an exception afterwards.
 // HOST_EXPORT(Bun__drainMicrotasks, c)
 pub fn drain_microtasks() {
-    VirtualMachine::get().event_loop_mut().tick();
+    let vm = VirtualMachine::get();
+    let _caller_context = SuspendedAsyncContext::take(vm.global());
+    vm.jsc_vm().drain_microtasks();
+    if vm.global().has_exception() {
+        return;
+    }
+    vm.event_loop_mut().tick();
 }
 
 // HOST_EXPORT(Bun__readOriginTimer, c)

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage, AsyncResource } from "async_hooks";
+import { drainMicrotasks } from "bun:jsc";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
 import http2 from "http2";
@@ -1255,7 +1256,8 @@ describe("async generators", () => {
 // expect.extend matchers and Bun.build() with a plugin whose setup() returns a
 // promise block the calling frame and run the event loop from inside it;
 // HTMLRewriter.transform() runs a microtask checkpoint from inside it when a
-// handler returns a pending promise. Work that was scheduled with no store is
+// handler returns a pending promise, and bun:jsc's drainMicrotasks() drains on
+// request. Work that was scheduled with no store is
 // stored unwrapped and runs in whatever context is installed at dispatch time,
 // which in these cases used to be the blocked caller's store.
 describe("event loop work dispatched from inside a blocked frame", () => {
@@ -1342,7 +1344,8 @@ describe("event loop work dispatched from inside a blocked frame", () => {
       callerAfterwards = als.getStore();
       return result;
     });
-    expect((await build).success).toBe(true);
+    const { success, logs } = await build;
+    expect({ success, logs }).toEqual({ success: true, logs: [] });
     expect({ ...seen, ...setup, callerAfterwards }).toEqual({
       timer: "none",
       immediate: "none",
@@ -1462,6 +1465,17 @@ describe("event loop work dispatched from inside a blocked frame", () => {
       callerAfterwards: "caller",
       ambientAfterwards: "none",
     });
+  });
+
+  test("bun:jsc drainMicrotasks() inside run()", () => {
+    const als = new AsyncLocalStorage<string>();
+    const seen = { microtask: "not run", callerAfterwards: "not run" };
+    Promise.resolve().then(() => (seen.microtask = als.getStore() ?? "none"));
+    als.run("caller", () => {
+      drainMicrotasks();
+      seen.callerAfterwards = als.getStore() ?? "none";
+    });
+    expect(seen).toEqual({ microtask: "none", callerAfterwards: "caller" });
   });
 
   test("HTMLRewriter.transform() draining microtasks for an async handler", () => {

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1383,6 +1383,42 @@ describe("event loop work dispatched from inside a blocked frame", () => {
     });
   });
 
+  test("a block inside dispatched work restores each frame's own store", () => {
+    const als = new AsyncLocalStorage<string>();
+    const seen: Record<string, string> = {};
+    const observe = (key: string) => {
+      seen[key] = als.getStore() ?? "none";
+    };
+    // Reaction registered with no store; it runs during the inner block below.
+    let release!: () => void;
+    const innerWork = new Promise<void>(resolve => (release = resolve)).then(() => observe("innerWork"));
+    const timer = als.run(
+      "timer",
+      () =>
+        new Promise<void>(resolve =>
+          setTimeout(() => {
+            observe("timerBefore");
+            release();
+            expect(innerWork).resolves.toBeUndefined();
+            observe("timerAfter");
+            resolve();
+          }, 1),
+        ),
+    );
+    als.run("caller", () => {
+      expect(timer).resolves.toBeUndefined();
+      observe("callerAfterwards");
+    });
+    observe("outside");
+    expect(seen).toEqual({
+      timerBefore: "timer",
+      innerWork: "none",
+      timerAfter: "timer",
+      callerAfterwards: "caller",
+      outside: "none",
+    });
+  });
+
   test("enterWith() inside dispatched work does not replace the blocked caller's store", () => {
     const als = new AsyncLocalStorage<string>();
     const entered = new Promise<void>(resolve =>

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1249,3 +1249,171 @@ describe("async generators", () => {
     expect(caughtStore).toBe("STORE_X");
   });
 });
+
+// expect(promise).resolves/.rejects, expect(asyncFn).toThrow() and async
+// expect.extend matchers block the calling frame and run the event loop from
+// inside it; HTMLRewriter.transform() runs a microtask checkpoint from inside
+// it when a handler returns a pending promise. Work that was scheduled with no
+// store is stored unwrapped and runs in whatever context is installed at
+// dispatch time, which in these cases used to be the blocked caller's store.
+describe("event loop work dispatched from inside a blocked frame", () => {
+  // Schedules a timer, an immediate and a microtask while no store is active
+  // and records the store each one observes. `settled` resolves once all
+  // three have run, so blocking on it forces them to run during the block.
+  function scheduleWithoutStore(als: AsyncLocalStorage<string>) {
+    const seen = { timer: "not run", immediate: "not run", microtask: "not run" };
+    const observe = (key: keyof typeof seen) => {
+      seen[key] = als.getStore() ?? "none";
+    };
+    const settled = Promise.all([
+      new Promise<void>(resolve => setTimeout(() => resolve(observe("timer")), 1)),
+      new Promise<void>(resolve => setImmediate(() => resolve(observe("immediate")))),
+      Promise.resolve().then(() => observe("microtask")),
+    ]);
+    return { seen, settled };
+  }
+
+  expect.extend({
+    _toSettle(received: Promise<unknown>) {
+      return received.then(() => ({ pass: true, message: () => "" }));
+    },
+  });
+
+  const blockUntilSettled = {
+    ".resolves": (settled: Promise<unknown>) => expect(settled).resolves.toBeArray(),
+    ".rejects": (settled: Promise<unknown>) =>
+      expect(
+        settled.then(() => {
+          throw new Error("settled");
+        }),
+      ).rejects.toThrow("settled"),
+    "async toThrow()": (settled: Promise<unknown>) =>
+      expect(async () => {
+        await settled;
+        throw new Error("settled");
+      }).toThrow("settled"),
+    // @ts-expect-error: _toSettle is registered above via expect.extend
+    "async expect.extend matcher": (settled: Promise<unknown>) => expect(settled)._toSettle(),
+  };
+
+  test.each(Object.entries(blockUntilSettled))(
+    "work scheduled without a store sees none while %s blocks inside run()",
+    async (_, block) => {
+      const als = new AsyncLocalStorage<string>();
+      const { seen, settled } = scheduleWithoutStore(als);
+      let callerAfterwards: string | undefined;
+      await als.run("caller", () => {
+        const blocked = block(settled);
+        callerAfterwards = als.getStore();
+        return blocked;
+      });
+      expect({ ...seen, callerAfterwards, outside: als.getStore() }).toEqual({
+        timer: "none",
+        immediate: "none",
+        microtask: "none",
+        callerAfterwards: "caller",
+        outside: undefined,
+      });
+    },
+  );
+
+  test("work that captured a store keeps it while the caller blocks", async () => {
+    const als = new AsyncLocalStorage<string>();
+    const seen: Record<string, string> = {};
+    const observe = (key: string) => {
+      seen[key] = als.getStore() ?? "none";
+    };
+    const scheduled = als.run("scheduled", () =>
+      Promise.all([
+        new Promise<void>(resolve => setTimeout(() => resolve(observe("timer")), 1)),
+        Promise.resolve().then(() => observe("microtask")),
+      ]),
+    );
+    als.run("caller", () => {
+      const own = Promise.all([
+        scheduled,
+        new Promise<void>(resolve => setTimeout(() => resolve(observe("callerTimer")), 1)),
+        Promise.resolve().then(() => observe("callerMicrotask")),
+      ]);
+      expect(own).resolves.toBeArray();
+      observe("callerAfterwards");
+    });
+    expect(seen).toEqual({
+      timer: "scheduled",
+      microtask: "scheduled",
+      callerTimer: "caller",
+      callerMicrotask: "caller",
+      callerAfterwards: "caller",
+    });
+  });
+
+  test("enterWith() inside dispatched work does not replace the blocked caller's store", () => {
+    const als = new AsyncLocalStorage<string>();
+    const entered = new Promise<void>(resolve =>
+      setTimeout(() => {
+        als.enterWith("timer");
+        resolve();
+      }, 1),
+    );
+    let callerAfterwards: string | undefined;
+    als.run("caller", () => {
+      expect(entered).resolves.toBeUndefined();
+      callerAfterwards = als.getStore();
+    });
+    expect({ callerAfterwards, outside: als.getStore() }).toEqual({ callerAfterwards: "caller", outside: undefined });
+  });
+
+  test("enterWith() in the blocked frame survives the block and is still cleared on the next tick", async () => {
+    const als = new AsyncLocalStorage<string>();
+    let unblocked = false;
+    // Started before enterWith(), so it carries no store and reports whatever
+    // context is installed when it finally runs.
+    const ambientAfterwards = new Promise<string>(resolve => {
+      (function poll() {
+        if (unblocked) resolve(als.getStore() ?? "none");
+        else setImmediate(poll);
+      })();
+    });
+    const { seen, settled } = scheduleWithoutStore(als);
+
+    als.enterWith("caller");
+    expect(settled).resolves.toBeArray();
+    const callerAfterwards = als.getStore();
+    unblocked = true;
+    // enterWith() is undone after the next microtask runs; this is that microtask.
+    await Promise.resolve();
+
+    expect({ ...seen, callerAfterwards, ambientAfterwards: await ambientAfterwards }).toEqual({
+      timer: "none",
+      immediate: "none",
+      microtask: "none",
+      callerAfterwards: "caller",
+      ambientAfterwards: "none",
+    });
+  });
+
+  test("HTMLRewriter.transform() draining microtasks for an async handler", () => {
+    const als = new AsyncLocalStorage<string>();
+    const seen = { unrelatedMicrotask: "not run", handlerAfterAwait: "not run" };
+    Promise.resolve().then(() => (seen.unrelatedMicrotask = als.getStore() ?? "none"));
+    const rewriter = new HTMLRewriter().on("p", {
+      async element(element) {
+        await null;
+        seen.handlerAfterAwait = als.getStore() ?? "none";
+        element.setInnerContent("rewritten");
+      },
+    });
+    let html: string | undefined;
+    let callerAfterwards: string | undefined;
+    als.run("caller", () => {
+      html = rewriter.transform("<p>original</p>");
+      callerAfterwards = als.getStore();
+    });
+    expect({ ...seen, html, callerAfterwards }).toEqual({
+      unrelatedMicrotask: "none",
+      handlerAfterAwait: "caller",
+      html: "<p>rewritten</p>",
+      callerAfterwards: "caller",
+    });
+  });
+});

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1,7 +1,8 @@
 import { AsyncLocalStorage, AsyncResource } from "async_hooks";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import http2 from "http2";
+import { join } from "node:path";
 
 describe("AsyncLocalStorage", () => {
   test("throw inside of AsyncLocalStorage.run() will be passed out", () => {
@@ -1250,12 +1251,13 @@ describe("async generators", () => {
   });
 });
 
-// expect(promise).resolves/.rejects, expect(asyncFn).toThrow() and async
-// expect.extend matchers block the calling frame and run the event loop from
-// inside it; HTMLRewriter.transform() runs a microtask checkpoint from inside
-// it when a handler returns a pending promise. Work that was scheduled with no
-// store is stored unwrapped and runs in whatever context is installed at
-// dispatch time, which in these cases used to be the blocked caller's store.
+// expect(promise).resolves/.rejects, expect(asyncFn).toThrow(), async
+// expect.extend matchers and Bun.build() with a plugin whose setup() returns a
+// promise block the calling frame and run the event loop from inside it;
+// HTMLRewriter.transform() runs a microtask checkpoint from inside it when a
+// handler returns a pending promise. Work that was scheduled with no store is
+// stored unwrapped and runs in whatever context is installed at dispatch time,
+// which in these cases used to be the blocked caller's store.
 describe("event loop work dispatched from inside a blocked frame", () => {
   // Schedules a timer, an immediate and a microtask while no store is active
   // and records the store each one observes. `settled` resolves once all
@@ -1316,6 +1318,40 @@ describe("event loop work dispatched from inside a blocked frame", () => {
       });
     },
   );
+
+  test("Bun.build() blocking on an async plugin setup()", async () => {
+    using dir = tempDir("als-build-plugin", { "entry.js": "export default 1;" });
+    const als = new AsyncLocalStorage<string>();
+    const { seen, settled } = scheduleWithoutStore(als);
+    const setup = { sync: "not run", afterAwait: "not run" };
+    let callerAfterwards: string | undefined;
+    const build = als.run("caller", () => {
+      const result = Bun.build({
+        entrypoints: [join(String(dir), "entry.js")],
+        plugins: [
+          {
+            name: "als",
+            async setup() {
+              setup.sync = als.getStore() ?? "none";
+              await settled;
+              setup.afterAwait = als.getStore() ?? "none";
+            },
+          },
+        ],
+      });
+      callerAfterwards = als.getStore();
+      return result;
+    });
+    expect((await build).success).toBe(true);
+    expect({ ...seen, ...setup, callerAfterwards }).toEqual({
+      timer: "none",
+      immediate: "none",
+      microtask: "none",
+      sync: "caller",
+      afterAwait: "caller",
+      callerAfterwards: "caller",
+    });
+  });
 
   test("work that captured a store keeps it while the caller blocks", async () => {
     const als = new AsyncLocalStorage<string>();


### PR DESCRIPTION
### Problem
- `expect(p).rejects.toThrow()` called inside `als.run("CALLER", ...)` makes a timer that was scheduled with no store observe `"CALLER"` from `als.getStore()`; the expected value is `undefined`. Same for `setImmediate`, a context-less promise reaction, module evaluation of an `import()` started earlier, and any other work the event loop runs while the matcher blocks.
- Cause: `EventLoop::wait_for_promise` (`src/jsc/event_loop.rs`) ticks the event loop while the calling JS frame, and therefore its async context, is still installed in the global's async context slot. Work scheduled with no store is stored unwrapped (`AsyncContextFrame::withAsyncContextIfNeeded` returns the bare callback, `AsyncContextSwapScope` is a no-op for `undefined`), so it runs in whatever the slot holds. At the top of the event loop that is `undefined`; inside a blocked frame it is the caller's store.
- Reached from `expect().resolves` / `.rejects` (`expect.rs:493`), async `toThrow()` (`expect.rs:896`), async `expect.extend` matchers (`expect.rs:1492`), macro evaluation and `Bun.build` plugin waits. `JSGlobalObject::drain_microtasks_and_next_ticks`, the single microtask checkpoint `HTMLRewriter.transform()` runs when a handler returns a pending promise, has the same problem for context-less microtasks, as does `bun:jsc`'s `drainMicrotasks()` (`Bun__drainMicrotasks`), which drains and ticks on request from whatever frame calls it.
- The same mechanism also works in the other direction: `als.enterWith()` in a callback dispatched during the block replaces the blocked caller's store, and a caller that used `enterWith()` itself has it cleared out from under it by the first microtask that runs during the block.

### Fix
- `SuspendedAsyncContext` (`src/jsc/event_loop.rs`): reads the slot, clears it for the duration of the dispatch, and reinstalls the saved value on drop. `wait_for_promise` takes one after its already-settled early return, so every caller is covered; `drain_microtasks_and_next_ticks` takes one around its drain; `Bun__drainMicrotasks` (`virtual_machine_exports.rs`) now performs both of the drains `bun:jsc`'s `drainMicrotasks()` used to make from C++ (JSC queue, then a tick, same order) under one guard. The node:http internal drain (`Bun__drainMicrotasksFromJS`) is left alone: it runs from the server's own dispatch, where the slot already holds whatever the event loop installed, not from a user frame. The top-level drivers (entry point, test runner, preloads) run with no context installed and get `None`, so nothing changes for them beyond one slot read per blocking wait.
- The saved value is `gcProtect`ed while the loop runs: the dispatch can GC, and the frame that installed the array does not necessarily keep it reachable.
- Correct because Bun's propagation is capture based: everything that should see a store captured it when it was scheduled and installs it itself when it runs, so clearing the slot changes nothing for that work (pinned by the "keeps it" test). The only work that reads the slot at dispatch time is work that captured nothing, and for it the slot is supposed to read `undefined`, which is what the event loop's own dispatch gives it. Restoring afterwards keeps the caller's own frame unaffected by the call it made, which is what Node gives a synchronous frame (Node never runs other work inside a frame, so both halves match Node's observable behaviour).
- `AsyncContextFrame__suspend` / `__resume` (`AsyncContextFrame.cpp`) also save and restore `asyncHooksNeedsCleanup`, the `enterWith()` deferred-cleanup arming. A microtask run during the dispatch fires `cleanupAsyncHooksData` and disarms it; without re-arming, a context installed by `enterWith()` in the blocked frame would be reinstalled with nothing left to clear it and would leak into later top-level work (pinned by the "still cleared on the next tick" test). Resume only calls `resetOnEachMicrotaskTick()` when the flag actually changed, and that hook slot has exactly three states, all derived from the flag plus whether the nextTick queue exists yet (`resetOnEachMicrotaskTick`, `cleanupAsyncHooksData` and the startup lambda in `ZigGlobalObject.cpp` are the only installers), so recomputing it cannot discard anything installed during the dispatch.
- Verified with `test/js/node/async_hooks/AsyncLocalStorage.test.ts`, new describe block "event loop work dispatched from inside a blocked frame": 11 tests, 10 fail before (`USE_SYSTEM_BUN=1`) and all pass with the fix (`bun bd test`). They cover all four `bun:test` entry points into `wait_for_promise`, `bun:jsc`'s `drainMicrotasks()`, a block nested inside work dispatched by an outer block (each frame gets its own store back), `Bun.build()` waiting on an async plugin `setup()` (a non-test caller; also pins that `setup()` and its continuation after `await` keep the store), the HTMLRewriter checkpoint, both `enterWith()` directions, and that work which captured a store still sees it.
- No dispatch path reads the slot at dispatch time on purpose. Every reader of `m_asyncContextData[0]` / `$asyncContext` in the tree is either a capture site that runs when the work is scheduled (`withAsyncContextIfNeeded`, `queueMicrotask`, `queueMicrotaskJob`, the streams `queueReactionJob`s, `process.nextTick`, JSC's `AsyncContextSwapScope::current` in promise reactions, the http/http2 frame captures, `eos()`'s `hasAsyncContext`), a swap scope saving the previous value so it can restore it, or `getStore()` itself.
- The other `wait_for_promise` callers that can have a context installed (`Bun.build` and bake plugin `setup()`, macros) all call the user function synchronously and then wait on the promise it returned; the function itself still runs with the caller's store and its `await` continuations captured it, so only context-less work changes, from leaking to `undefined`.
- `bun-jsc.test.ts`, `spawnsync-no-microtask-drain.test.ts` and `serve-direct-readable-stream.test.ts` (the other users of `bun:jsc`'s `drainMicrotasks()`) pass on the debug build.
- Full `AsyncLocalStorage.test.ts` (57 pass), `test/js/node/async_hooks/` (143 pass), the HTMLRewriter suites (142 pass) and `expect.test.js` + `expect-extend.test.js` (443 pass) pass on the debug build.
- Related: #32693 (dynamic `import()` evaluation losing the store is a separate fix; this bug made such module bodies appear to see the store when the test used `.rejects`), #33261 (removing the blocking waits altogether; this change covers the waits that remain and any carve-outs).

### Background
- Async context slot: `JSGlobalObject::m_asyncContextData` field 0 holds the current AsyncLocalStorage context (an array of `[storage, value, ...]` or `undefined`). `als.run()` writes it for the callback and puts the previous value back in a `finally`; `als.getStore()` reads it. `vm` contexts share the parent's tuple, so one slot per VM.
- Capture and install: every place native code or JSC accepts a callback snapshots the slot (`withAsyncContextIfNeeded`, `queueMicrotask`, `process.nextTick`, promise reactions via `AsyncContextSwapScope::wrapWithCurrent`) and installs the snapshot around the call. As an optimisation an `undefined` snapshot is not stored and not installed, which is what makes dispatch depend on the slot already holding `undefined`.
- Blocking waits: `wait_for_promise` runs the event loop (microtasks, tasks, immediates, timers, I/O) until a promise settles, from inside whatever host function called it. `bun:test` uses it so `expect(p).resolves...` can return synchronously.
- `enterWith()` cleanup: `enterWith()` installs a context with no `finally` to remove it, so it sets `asyncHooksNeedsCleanup` and a per-microtask hook (`cleanupAsyncHooksData`) clears the slot after the next microtask runs, then disarms itself.

<details>
<summary>Repro from the report</summary>

```ts
import { expect, test } from "bun:test";
import { AsyncLocalStorage } from "node:async_hooks";

test("leak", async () => {
  const als = new AsyncLocalStorage();
  let seenInTimer: unknown = "not-run";
  const p = new Promise((_, reject) =>
    setTimeout(() => { seenInTimer = als.getStore(); reject(new Error("x")); }, 1),
  );
  p.catch(() => {});
  als.run("CALLER", () => {
    expect(p).rejects.toThrow("x"); // runs the event loop until p settles
  });
  console.log("timer saw:", seenInTimer);
});
```

`USE_SYSTEM_BUN=1 bun test` (1.4.0-canary da3851e57) prints `timer saw: CALLER`; with this change it prints `timer saw: undefined`.

Output of the new tests on the unfixed build, `.resolves` case:

```
  {
    "callerAfterwards": "caller",
-   "immediate": "none",
-   "microtask": "none",
+   "immediate": "caller",
+   "microtask": "caller",
    "outside": undefined,
-   "timer": "none",
+   "timer": "caller",
  }
```

</details>
