### PR TITLE
AsyncLocalStorage: evaluate dynamically imported modules under the importer's store (WebKit pin bump)

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,11 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "ceb9f90fb774fdb1ebf1275ae1aaf136ec66c754";
+// Preview of oven-sh/WebKit#274, two commits on top of ceb9f90fb774 (the previous
+// pin): a dynamic import() evaluates its module graph under the AsyncLocalStorage
+// context that was active at the import() call site. Repoint at the merged main sha
+// once it lands.
+export const WEBKIT_VERSION = "autobuild-preview-pr-274-a919cd42";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/node/async_hooks/AsyncLocalStorage.test.ts
+++ b/test/js/node/async_hooks/AsyncLocalStorage.test.ts
@@ -1,7 +1,9 @@
 import { AsyncLocalStorage, AsyncResource } from "async_hooks";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
 import http2 from "http2";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 
 describe("AsyncLocalStorage", () => {
   test("throw inside of AsyncLocalStorage.run() will be passed out", () => {
@@ -1247,5 +1249,200 @@ describe("async generators", () => {
       }
     });
     expect(caughtStore).toBe("STORE_X");
+  });
+});
+
+// https://github.com/oven-sh/bun/issues/32693
+//
+// A dynamic import() links and evaluates its module graph from the module loader's
+// internal microtasks, several hops after the import() call. JSC carries the async
+// context captured at the import() call site through that pipeline (oven-sh/WebKit#274),
+// so module bodies evaluate under the importer's store, as they do in Node.
+describe("dynamic import() module evaluation", () => {
+  const storeModule = `
+    import { AsyncLocalStorage } from "node:async_hooks";
+    export const als = new AsyncLocalStorage();
+  `;
+
+  // Each test gets its own directory, so every module below is a fresh registry entry
+  // whose body runs when the test import()s it.
+  function load(dir: string, file: string): Promise<any> {
+    return import(pathToFileURL(join(dir, file)).href);
+  }
+
+  test("import() from an entry module's top level (issue repro)", async () => {
+    using dir = tempDir("als-dynamic-import-entry", {
+      "store.mjs": storeModule,
+      "imported.mjs": `
+        import { als } from "./store.mjs";
+        console.log("imported:" + als.getStore());
+      `,
+      "index.mjs": `
+        import { als } from "./store.mjs";
+        await als.run("CONTEXT", () => import("./imported.mjs"));
+        console.log("after:" + als.getStore());
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "index.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({
+      stdout: "imported:CONTEXT\nafter:undefined\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test("the imported module's top level sees the importer's store", async () => {
+    using dir = tempDir("als-dynamic-import", {
+      "store.mjs": storeModule,
+      "lazy.mjs": `
+        import { als } from "./store.mjs";
+        export const storeAtEvaluation = als.getStore();
+      `,
+    });
+    const { als } = await load(String(dir), "store.mjs");
+
+    const lazy = await als.run("CONTEXT", () => load(String(dir), "lazy.mjs"));
+
+    expect(lazy.storeAtEvaluation).toBe("CONTEXT");
+    expect(als.getStore()).toBeUndefined();
+  });
+
+  test("static dependencies evaluated by the import() see the store too", async () => {
+    using dir = tempDir("als-dynamic-import-deps", {
+      "store.mjs": storeModule,
+      "dep.mjs": `
+        import { als } from "./store.mjs";
+        export const depStore = als.getStore();
+      `,
+      "lazy.mjs": `
+        import { als } from "./store.mjs";
+        export { depStore } from "./dep.mjs";
+        export const store = als.getStore();
+      `,
+    });
+    const { als } = await load(String(dir), "store.mjs");
+
+    const { depStore, store } = await als.run("CONTEXT", () => load(String(dir), "lazy.mjs"));
+
+    expect({ depStore, store }).toEqual({ depStore: "CONTEXT", store: "CONTEXT" });
+  });
+
+  test("the store survives the imported module's own top-level await", async () => {
+    using dir = tempDir("als-dynamic-import-tla", {
+      "store.mjs": storeModule,
+      "lazy.mjs": `
+        import { als } from "./store.mjs";
+        export const before = als.getStore();
+        await 0;
+        export const after = als.getStore();
+      `,
+    });
+    const { als } = await load(String(dir), "store.mjs");
+
+    const { before, after } = await als.run("CONTEXT", () => load(String(dir), "lazy.mjs"));
+
+    expect({ before, after }).toEqual({ before: "CONTEXT", after: "CONTEXT" });
+  });
+
+  // The importing module's body is not run by the import()'s evaluate() call here: it is
+  // deferred until its top-level-await dependency settles, and executed from the
+  // dependency's completion microtask (AsyncModuleExecutionFulfilled).
+  test("a module waiting on a top-level-await dependency still sees the store", async () => {
+    using dir = tempDir("als-dynamic-import-tla-dep", {
+      "store.mjs": storeModule,
+      "dep.mjs": `
+        import { als } from "./store.mjs";
+        export const depBefore = als.getStore();
+        await 0;
+        export const depAfter = als.getStore();
+      `,
+      "lazy.mjs": `
+        import { als } from "./store.mjs";
+        export { depBefore, depAfter } from "./dep.mjs";
+        export const store = als.getStore();
+      `,
+    });
+    const { als } = await load(String(dir), "store.mjs");
+
+    const { depBefore, depAfter, store } = await als.run("CONTEXT", () => load(String(dir), "lazy.mjs"));
+
+    expect({ depBefore, depAfter, store }).toEqual({ depBefore: "CONTEXT", depAfter: "CONTEXT", store: "CONTEXT" });
+  });
+
+  test("concurrent import()s each evaluate under their own importer's store", async () => {
+    const moduleSource = `
+      import { als } from "./store.mjs";
+      export const store = als.getStore();
+    `;
+    using dir = tempDir("als-dynamic-import-concurrent", {
+      "store.mjs": storeModule,
+      "a.mjs": moduleSource,
+      "b.mjs": moduleSource,
+      "c.mjs": moduleSource,
+    });
+    const { als } = await load(String(dir), "store.mjs");
+
+    const [a, b, c] = await Promise.all([
+      als.run("A", () => load(String(dir), "a.mjs")),
+      als.run("B", () => load(String(dir), "b.mjs")),
+      als.run("C", () => load(String(dir), "c.mjs")),
+    ]);
+
+    expect([a.store, b.store, c.store]).toEqual(["A", "B", "C"]);
+  });
+
+  test("a module that throws while evaluating saw the store, and the importer's context is intact", async () => {
+    using dir = tempDir("als-dynamic-import-throws", {
+      "store.mjs": `${storeModule}
+        export const observed = [];
+      `,
+      "lazy.mjs": `
+        import { als, observed } from "./store.mjs";
+        observed.push(als.getStore());
+        throw new Error("boom");
+      `,
+    });
+    const { als, observed } = await load(String(dir), "store.mjs");
+
+    // Not expect().rejects: that matcher spins the event loop synchronously inside run(),
+    // which would evaluate the module while the store is still installed regardless of
+    // whether import() propagates it.
+    const outcome = await als.run("CONTEXT", async () => {
+      try {
+        await load(String(dir), "lazy.mjs");
+        return "resolved";
+      } catch (e) {
+        return { rejectedWith: (e as Error).message, storeAfterRejection: als.getStore() };
+      }
+    });
+
+    expect({ observed, outcome, storeAfterRun: als.getStore() }).toEqual({
+      observed: ["CONTEXT"],
+      outcome: { rejectedWith: "boom", storeAfterRejection: "CONTEXT" },
+      storeAfterRun: undefined,
+    });
+  });
+
+  test("an import() made with no active store evaluates with none, even after an earlier run()", async () => {
+    using dir = tempDir("als-dynamic-import-no-context", {
+      "store.mjs": storeModule,
+      "lazy.mjs": `
+        import { als } from "./store.mjs";
+        export const storeAtEvaluation = als.getStore();
+      `,
+    });
+    const { als } = await load(String(dir), "store.mjs");
+    als.run("CONTEXT", () => {});
+
+    const { storeAtEvaluation } = await load(String(dir), "lazy.mjs");
+
+    expect(storeAtEvaluation).toBeUndefined();
   });
 });


### PR DESCRIPTION
### Problem
- A module loaded with `import()` inside `AsyncLocalStorage.run()` sees no store: `getStore()` is `undefined` in its top-level code, where Node returns the active store. Fixes #32693.
- The cause is in JSC. `import()` links and evaluates the graph from internal microtasks (`ModuleLoadTopSettled`, `DynamicImportLoadSettled`, `module->evaluate()`). They carry no async context, so `m_asyncContextData` slot 0 is reset before the body runs.

### Fix
- oven-sh/WebKit#274 (head `a919cd42`, two commits on main's pin `ceb9f90f`). `loadModule` captures the context of a dynamic import on `ModuleLoadingContext` and `ModuleLoaderPayload`. `dynamicImportLoadSettled` reinstalls it with `AsyncContextSwapScope` around `module->evaluate()`. The second commit does the same for `AsyncModuleExecutionDone`, which runs modules that wait on a top-level-await dependency.
- This PR pins `WEBKIT_VERSION` to the preview build `autobuild-preview-pr-274-a919cd42` and adds `describe("dynamic import() module evaluation")` (8 cases) to `test/js/node/async_hooks/AsyncLocalStorage.test.ts`.
- **Before merging:** oven-sh/WebKit#274 must land first. Then `WEBKIT_VERSION` must point at the merged sha. The preview release is deleted when the WebKit PR merges.
- Verified: `test/js/node/async_hooks/AsyncLocalStorage.test.ts` (7 of 8 new cases fail on main's engine). Also `test/js/node/async_hooks/` and the `test/js/bun/resolve/` module-loading suites: 199 pass.

### Background
- Bun's `AsyncLocalStorage` is one slot on the global object (`m_asyncContextData`, field 0). `run()` sets it for the callback. Deferred work snapshots the slot when scheduled and reinstalls it when it runs, through the RAII helper `AsyncContextSwapScope`.
- Internal microtasks are JSC's C++ replacements for the spec's abstract closures. The module loader is built from them. They did not snapshot the slot.
- `ModuleLoaderPayload` is the host object JSC threads through a dynamic import's load steps. The captured context rides on it to evaluation.
- A module with top-level `await` starts with `ExecuteAsyncModule`. Its dependents run later from the `AsyncModuleExecutionDone` microtask.

<details><summary>Notes</summary>

**Why the engine, and no userland workaround.** `enterWith`, `snapshot()` and `bind()` all go through the same microtasks, so none of them can carry the store into the imported module. The engine delta in this PR is the two WebKit commits only (seven files, all under `USE(BUN_JSC_ADDITIONS)`): `JSModuleLoader.cpp`, `ModuleLoadingContext.{h,cpp}`, `ModuleLoaderPayload.{h,cpp}`, `JSMicrotask.cpp`, `CyclicModuleRecord.cpp`. The captured context travels next to the existing `referrerAsyncOrder` field. The first commit also wraps the eager async-dependency evaluation for `import.defer()`.

**The 8 test cases.** The issue's repro as a subprocess (`imported:CONTEXT` / `after:undefined`), the top-level store, a fresh static dependency, top-level `await` in the module itself, a top-level-await dependency, three concurrent `import()`s under stores A/B/C, a module that throws while evaluating (written with try/catch, because `expect().rejects` spins the event loop inside `run()` and masks the bug), and a control `import()` made with no store.

**Gate shape.** The fix lives in `scripts/build/deps/webkit.ts`, not `src/`, so a `src/`-stashing fail-before check builds the new engine in both arms. The fail-before evidence: the test file run with a debug+ASAN build of main's engine (`e2f13c6aa1`, one unrelated commit before the pin of that round): 7 fail, 1 pass (the control).

**Local verification of the engine branch** (`bun run build:local`, debug, ASAN, assertions on), repeated for the bases `eeab0404`, `cb61607f`, `f5deafe0`, `1817c3c3` (identical engine files to the current head `a919cd42`): the issue repro prints `CONTEXT`; `test/js/node/async_hooks/AsyncLocalStorage.test.ts` 55 pass, 0 fail; all of `test/js/node/async_hooks/` plus `test/js/bun/resolve/{concurrent-dynamic-import,dynamic-import-tla-cycle,import-defer,require-esm-transitive-tla,require-esm-microtask-order,require-esm-gc-roots,esModule,import-query}.test.ts` and regression tests 32178 / 27428 / 18595 / 26286: 199 pass, 0 fail. With only the first WebKit commit applied, the top-level-await-dependency case fails with `store: undefined`, which is what the second commit fixes. Stress: 60 concurrent `import()`s, each under its own store and each pulling in a top-level-await dependency plus a synchronous sibling, under `BUN_JSC_collectContinuously=1`: 0 mismatches, no assertion failures (60/60 mismatch on the unfixed engine).

**Full CI on earlier rounds of this PR** (same tests, same two engine commits on the pin main had at the time). 181/181 or 179/179: builds 99632 (`0cbb4a19`), 99675 (`c6cfe90c`), 100414 (`eeab0404`), 105882 (`1cb96a7b`), 106151 (`76882271`), 106416 (`2da33d53`). Rounds with only unrelated red lanes, each also red on main's own builds: 101299 and 102196 (`node-tls-server.test.ts` on darwin aarch64), 104083 (the Windows `--cpu-prof` segfault, main's build 104049), 104857 and 105580 (`require-cache.test.ts` ASAN timeout, plus a `bun-patch.test.ts` case on Windows aarch64), 106969 (a `require()` RSS check on Windows, R2 timeouts, an ASAN macro test, an IDNA check on darwin), 107118 and 107225 (the `require-cache.test.ts` ASAN timeout and the `url.test.ts` IDNA check on darwin). Build 107637 (the `1817c3c3` round) reached 179 passed with no failures before the current push superseded it.

**Rebase history.** Each time main bumps `WEBKIT_VERSION`, the WebKit branch is re-based onto the new pin (both commits cherry-pick clean, diff-of-diffs identical) and this PR's pin moves to the new preview tag. The current round is the base `ceb9f90f` (#40767). The round before it (`c4ddc0cf`, #40677) ran as build 107659: 179/181, with two unrelated darwin x64 lanes red (a `socket.test.ts` peer-reset timing case and the `url.test.ts` IDNA check that fails on every main build), both reported separately.

</details>

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 16 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/node/async_hooks/AsyncLocalStorage.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/node/async_hooks/AsyncLocalStorage.test.ts
bun test v1.4.1 (65362b53b)

test/js/node/async_hooks/AsyncLocalStorage.test.ts:
(pass) AsyncLocalStorage > throw inside of AsyncLocalStorage.run() will be passed out [93.61ms]
(pass) AsyncLocalStorage > run() works with a defaultValue and no prior context [30.52ms]
(pass) AsyncLocalStorage > NaN is usable as a store value and as defaultValue [18.68ms]
(pass) AsyncLocalStorage > run() is unaffected by a userland Object.is patch [784.23ms]
(pass) AsyncLocalStorage > run() on a disabled storage does not leak the store past the callback [14.83ms]
(pass) AsyncLocalStorage > run() inside a snapshot does not expose a disabled storage's frame value [29.95ms]
(pass) AsyncLocalStorage > run(undefined)/exit() on a disabled storage re-enables it [6.77ms]
(pass) AsyncLocalStorage > run() short-circuits when the store value is unchanged (Object.is) [21.09ms]
(pass) AsyncLocalStorage > disable() mid-run then finally restores the previous value [23.07ms]
(pass) AsyncResource [9.02ms]
(pass) async context passes through > syncronously [13.62ms]
(pass) async context passes through > promise.then [12.21ms]
(pass) async context passes through > nested promises [31.41ms]
(pass) async context passes through > await 1 [11.77ms]
(pass) async context passes through > await an actual promise [13.39ms]
(pass) async context passes through > setTimeout [12.30ms]
(pass) async context passes through > setInterval [25.22ms]
(pass) async context passes through > setImmediate [12.12ms]
(pass) async context passes through > process.nextTick [34.96ms]
(pass) async context passes through > queueMicrotask [11.40ms]
(pass) async context passes through > promise catch [10.78ms]
(pass) async context passes through > promise finally [9.91ms]
(pass) async context passes through > fetch [36.05ms]
(pass) async context passes through > Bun.spawn() onExit [114.28ms]
(pass
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |   6 +-
 test/js/node/async_hooks/AsyncLocalStorage.test.ts | 199 ++++++++++++++++++++-
 2 files changed, 203 insertions(+), 2 deletions(-)
```

</details>

**gate history** · 16 passed · 1 rejected · iteration 16

<details><summary>evidence per changed file</summary>

```
file                                                reads  edits  tests
scripts/build/deps/webkit.ts                           19     20      0
test/js/node/async_hooks/AsyncLocalStorage.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->

