### PR TITLE
bun:test: cover Bun.serve's Date header timer under fake timers

### DIFF
--- a/test/js/bun/test/test-timers-date-header-fixture.ts
+++ b/test/js/bun/test/test-timers-date-header-fixture.ts
@@ -1,0 +1,20 @@
+import { jest, test } from "bun:test";
+
+test("runAllTimers returns with a keep-alive connection open and no user timers", async () => {
+  using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("hi") });
+
+  jest.useFakeTimers();
+  try {
+    // Accepting the connection arms Bun.serve's internal 1s Date header timer,
+    // and the keep-alive connection makes it re-arm itself every time it fires.
+    // Before oven-sh/bun#37946 it was enrolled in the fake heap, so runAllTimers()
+    // popped it, it re-armed at mocked now + 1s, and the drain never ended.
+    const res = await fetch(`http://127.0.0.1:${server.port}/`);
+    await res.text();
+
+    jest.runAllTimers();
+  } finally {
+    jest.useRealTimers();
+  }
+  console.log("RUN_ALL_OK");
+});

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -166,3 +166,36 @@ describe.each([
     }
   });
 });
+
+test("Bun.serve's Date header timer is not enrolled in fake timers", async () => {
+  using server = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("hi") });
+
+  jest.useFakeTimers();
+  try {
+    // Accepting the connection arms the internal 1s Date header timer.
+    const res = await fetch(`http://127.0.0.1:${server.port}/`);
+    await res.text();
+
+    expect(jest.getTimerCount()).toBe(0);
+  } finally {
+    jest.useRealTimers();
+  }
+});
+
+test("runAllTimers returns while Bun.serve holds a keep-alive connection", async () => {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "test", path.join(import.meta.dir, "test-timers-date-header-fixture.ts")],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+    // On a regressed build runAllTimers() never returns (the Date header timer
+    // re-arms itself into the fake heap on every pop), so bound the child.
+    timeout: 20_000,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  if (exitCode !== 0) console.error(stderr);
+  expect(stdout).toContain("RUN_ALL_OK");
+  // null => exited on its own; non-null => killed by the spawn timeout (spun).
+  expect(proc.signalCode).toBeNull();
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem
- Up to `1.4.0-canary.1`, accepting one `Bun.serve` connection under `jest.useFakeTimers()` put the server's internal Date header timer into the fake timer heap: `jest.getTimerCount()` reported `1` with no user timers, and `jest.runAllTimers()` never returned (the timer re-armed itself at mocked now + 1s on every pop while a keep-alive connection was open; a synchronous loop, so the test timeout could not fire).
- #37946 fixed the cause by turning `Tag::allow_fake_timers()` (`src/event_loop/EventLoopTimer.rs`) into an allowlist and arming the Date header timer on the real clock, but its tests cover `Bun.spawn`, `spawnSync`, SQL, Valkey and `Bun.cron`; nothing exercises `Bun.serve` or the `runAllTimers()` livelock that was reported.

### Fix
- Tests only, in `test/js/bun/test/test-timers.test.ts`, next to the existing real-heap-under-fake-timers test:
  - `Bun.serve's Date header timer is not enrolled in fake timers`: serve, `useFakeTimers()`, one `fetch`, then `getTimerCount()` must be `0`.
  - `runAllTimers returns while Bun.serve holds a keep-alive connection`: runs `test-timers-date-header-fixture.ts` in a child with a spawn timeout and requires it to exit on its own with `RUN_ALL_OK`, the same shape as the neighbouring `test-timers-gc-spin-fixture.ts` test. The livelock case has to be a child process because a regressed build spins synchronously and would hang the test file.
- On the released `1.4.0-canary.1` both fail (`getTimerCount()` is `1`; the child spins until killed). On the current main debug build (`74c245744`, which includes #37946) the whole file passes; the child test takes about 2.6s there.

### Background
- `timer::All` keeps two heaps of `EventLoopTimer` nodes. While fake timers are active, `All::insert` diverts nodes whose tag passes `allow_fake_timers()` into the fake heap, which only the `jest.*` functions drain; each pop moves the mocked clock to that node's deadline and fires it, and `runAllTimers()` pops until the heap is empty, so any node that re-arms itself on every fire makes it loop forever.
- The Date header timer (`src/runtime/timer/DateHeaderTimer.rs`) refreshes the cached `Date:` string `Bun.serve` writes into responses. usockets arms it when the first socket with an idle timeout appears, and it re-arms itself once per second for as long as such sockets exist, which is why one idle keep-alive connection is enough to trigger the old behaviour.

<details>
<summary>Original version of this PR (superseded by #37946)</summary>

The first revision of this PR added `Tag::DateHeaderTimer` to what was then an opt-out list in `allow_fake_timers()` and switched the two clock reads in `DateHeaderTimer::run` and `All::update_date_header_timer_if_necessary` from `AllowMockedTime` to `ForceRealTime`, with the same two tests. #37946 landed the equivalent source changes for this timer and every other runtime-internal timer at once, so this PR was rebased down to the tests.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 5 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/test/test-timers.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/test/test-timers.test.ts
bun test v1.4.1 (4448a2e21)

test/js/bun/test/test-timers.test.ts:
(pass) we can go back in time [221.79ms]
(pass) advanceTimersByTime ticks from the setSystemTime value [6.87ms]
(pass) setSystemTime accepts pre-epoch and epoch times and resets with no argument [4.67ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 'x' [306.20ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is Symbol() [282.53ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 1n [280.30ms]
(pass) real timer heap is ticked against the real clock under useFakeTimers [1815.41ms]
(pass) net.Server#listen() while fake timers are active > emits 'listening' without fake time being advanced [181.43ms]
(pass) net.Server#listen() while fake timers are active > emits 'error' for a port that is in use without fake time being advanced [37.64ms]
(pass) http.Server#listen() while fake timers are active > emits 'listening' without fake time being advanced [63.58ms]
(pass) http.Server#listen() while fake timers are active > emits 'error' for a port that is in use without fake time being advanced [27.40ms]
(pass) Bun.serve's Date header timer is not enrolled in fake timers [35.77ms]
(pass) runAllTimers returns while Bun.serve holds a keep-alive connection [1804.07ms]

 13 pass
 0 fail
 43 expect() calls
Ran 13 tests across 1 file. [7.78s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../js/bun/test/test-timers-date-header-fixture.ts | 20 +++++++++++++
 test/js/bun/test/test-timers.test.ts               | 33 ++++++++++++++++++++++
 2 files changed, 53 insertions(+)
```

</details>

**gate history** · 4 passed · 0 rejected · iteration 5

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
test/js/bun/test/test-timers-date-header-fixture.ts      1      3      0
test/js/bun/test/test-timers.test.ts                     3      5      0
```

</details>

<!-- robobun:evidence:end -->