### PR TITLE
bake: re-arm the memory visualizer timer when it fires

### DIFF
--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -1090,10 +1090,7 @@ impl Drop for DevServer {
             debug_assert!(self.active_websocket_connections.is_empty());
         }
 
-        if self.memory_visualizer_timer.state == EventLoopTimerState::ACTIVE {
-            let timer_ptr: *mut EventLoopTimer = &raw mut self.memory_visualizer_timer;
-            self.timer_heap().remove(timer_ptr);
-        }
+        self.disarm_memory_visualizer_timer();
         self.graph_safety_lock.lock();
         // Hand ownership of the heap allocation to the watcher thread (which frees it in
         // `thread_main` once `running` flips false). Auto-dropping the `Box`
@@ -5451,13 +5448,53 @@ impl DevServer {
         crate::jsc_hooks::timer_all_mut()
     }
 
-    pub fn emit_memory_visualizer_message_timer(
-        _timer: &mut EventLoopTimer,
-        _: &bun_core::Timespec,
-    ) {
+    /// Interval between `MemoryVisualizer` frames while at least one HMR
+    /// socket is subscribed to the topic.
+    const MEMORY_VISUALIZER_TICK_MS: i64 = 1000;
+
+    /// (Re)schedules `memory_visualizer_timer` one tick from now. Called when
+    /// the first subscriber arrives and from every tick; `disarm` undoes it
+    /// when the last subscriber leaves.
+    pub(crate) fn arm_memory_visualizer_timer(&mut self) {
+        let next = bun_core::Timespec::ms_from_now(
+            bun_core::TimespecMockMode::ForceRealTime,
+            Self::MEMORY_VISUALIZER_TICK_MS,
+        );
+        let timer_ptr: *mut EventLoopTimer = &raw mut self.memory_visualizer_timer;
+        self.timer_heap().update(timer_ptr, &next);
     }
 
-    pub fn emit_memory_visualizer_message_if_needed(&mut self) {}
+    pub(crate) fn disarm_memory_visualizer_timer(&mut self) {
+        if self.memory_visualizer_timer.state != EventLoopTimerState::ACTIVE {
+            return;
+        }
+        let timer_ptr: *mut EventLoopTimer = &raw mut self.memory_visualizer_timer;
+        self.timer_heap().remove(timer_ptr);
+    }
+
+    /// `DevServerMemoryVisualizerTick` handler. The event loop has already
+    /// popped `timer` from the heap, so it must be marked fired before anything
+    /// else runs: a subscriber leaving while the node still reads `ACTIVE` would
+    /// `remove()` a node the heap no longer contains.
+    ///
+    /// # Safety
+    /// `timer` must point to the `memory_visualizer_timer` field of a live,
+    /// heap-allocated `DevServer`.
+    pub(crate) unsafe fn emit_memory_visualizer_message_timer(timer: *mut EventLoopTimer) {
+        // SAFETY: caller contract; `from_timer_ptr` recovers the owning DevServer.
+        let dev: &mut DevServer = unsafe { &mut *DevServer::from_timer_ptr(timer) };
+        debug_assert!(dev.magic == Magic::Valid);
+        dev.memory_visualizer_timer.state = EventLoopTimerState::FIRED;
+        dev.emit_memory_visualizer_message();
+        dev.arm_memory_visualizer_timer();
+    }
+
+    pub fn emit_memory_visualizer_message_if_needed(&mut self) {
+        if self.emit_memory_visualizer_events == 0 {
+            return;
+        }
+        self.emit_memory_visualizer_message();
+    }
 
     pub fn emit_memory_visualizer_message(&mut self) {
         debug_assert!(self.emit_memory_visualizer_events > 0);

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5467,8 +5467,7 @@ impl DevServer {
         self.timer_heap().remove(timer_ptr);
     }
 
-    /// # Safety
-    /// `timer` must be the `memory_visualizer_timer` field of a live, heap-allocated `DevServer`.
+    /// SAFETY: `timer` must be the `memory_visualizer_timer` field of a live, boxed `DevServer`.
     pub(crate) unsafe fn emit_memory_visualizer_message_timer(timer: *mut EventLoopTimer) {
         // SAFETY: caller contract; `from_timer_ptr` recovers the owning DevServer.
         let dev: &mut DevServer = unsafe { &mut *DevServer::from_timer_ptr(timer) };

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5448,13 +5448,8 @@ impl DevServer {
         crate::jsc_hooks::timer_all_mut()
     }
 
-    /// Interval between `MemoryVisualizer` frames while at least one HMR
-    /// socket is subscribed to the topic.
     const MEMORY_VISUALIZER_TICK_MS: i64 = 1000;
 
-    /// (Re)schedules `memory_visualizer_timer` one tick from now. Called when
-    /// the first subscriber arrives and from every tick; `disarm` undoes it
-    /// when the last subscriber leaves.
     pub(crate) fn arm_memory_visualizer_timer(&mut self) {
         let next = bun_core::Timespec::ms_from_now(
             bun_core::TimespecMockMode::ForceRealTime,
@@ -5472,18 +5467,13 @@ impl DevServer {
         self.timer_heap().remove(timer_ptr);
     }
 
-    /// `DevServerMemoryVisualizerTick` handler. The event loop has already
-    /// popped `timer` from the heap, so it must be marked fired before anything
-    /// else runs: a subscriber leaving while the node still reads `ACTIVE` would
-    /// `remove()` a node the heap no longer contains.
-    ///
     /// # Safety
-    /// `timer` must point to the `memory_visualizer_timer` field of a live,
-    /// heap-allocated `DevServer`.
+    /// `timer` must be the `memory_visualizer_timer` field of a live, heap-allocated `DevServer`.
     pub(crate) unsafe fn emit_memory_visualizer_message_timer(timer: *mut EventLoopTimer) {
         // SAFETY: caller contract; `from_timer_ptr` recovers the owning DevServer.
         let dev: &mut DevServer = unsafe { &mut *DevServer::from_timer_ptr(timer) };
         debug_assert!(dev.magic == Magic::Valid);
+        // Already popped by the event loop; left ACTIVE, `disarm` would remove() it again.
         dev.memory_visualizer_timer.state = EventLoopTimerState::FIRED;
         dev.emit_memory_visualizer_message();
         dev.arm_memory_visualizer_timer();

--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -124,23 +124,7 @@ impl HmrSocket {
                                             dev.memory_visualizer_timer.state
                                                 != EventLoopTimerState::ACTIVE
                                         );
-                                        // Note (jsc/runtime crate cycle): `vm.timer` is `()` on the
-                                        // low-tier `VirtualMachine`; the real `timer::All`
-                                        // lives in `RuntimeState` (see jsc_hooks.rs).
-                                        let state = crate::jsc_hooks::runtime_state();
-                                        let next = bun_core::Timespec::ms_from_now(
-                                            bun_core::TimespecMockMode::ForceRealTime,
-                                            1000,
-                                        );
-                                        // SAFETY: `runtime_state()` is non-null after
-                                        // `bun_runtime::init()`; JS-thread only, sole
-                                        // `&mut` to `timer` in this scope.
-                                        unsafe {
-                                            (*state).timer.update(
-                                                &raw mut dev.memory_visualizer_timer,
-                                                &next,
-                                            );
-                                        }
+                                        dev.arm_memory_visualizer_timer();
                                     }
                                 }
                                 _ => {}
@@ -309,17 +293,8 @@ impl HmrSocket {
             }
             if field.contains(HmrTopic::MemoryVisualizer.as_bit()) {
                 dev.emit_memory_visualizer_events -= 1;
-                if dev.emit_incremental_visualizer_events == 0
-                    && dev.memory_visualizer_timer.state == EventLoopTimerState::ACTIVE
-                {
-                    // Note (jsc/runtime crate cycle): `vm.timer` is `()` on the low-tier
-                    // `VirtualMachine`; the real `timer::All` lives in `RuntimeState`.
-                    let state = crate::jsc_hooks::runtime_state();
-                    // SAFETY: `runtime_state()` is non-null after `bun_runtime::init()`;
-                    // JS-thread only, sole `&mut` to `timer` in this scope.
-                    unsafe {
-                        (*state).timer.remove(&raw mut dev.memory_visualizer_timer);
-                    }
+                if dev.emit_memory_visualizer_events == 0 {
+                    dev.disarm_memory_visualizer_timer();
                 }
             }
         }

--- a/src/runtime/dispatch.rs
+++ b/src/runtime/dispatch.rs
@@ -1097,7 +1097,7 @@ pub(crate) unsafe fn __bun_fire_timer(
         EventLoopTimerTag::DevServerMemoryVisualizerTick => {
             // SAFETY: per fn contract; `t` is the `memory_visualizer_timer`
             // field of a live DevServer.
-            DevServer::emit_memory_visualizer_message_timer(unsafe { &mut *t }, unsafe { &*now });
+            unsafe { DevServer::emit_memory_visualizer_message_timer(t) };
             Ok(())
         }
         EventLoopTimerTag::BunTest => {

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -622,17 +622,19 @@ const memoryVisualizerApp = {
   "index.html": emptyHtmlFile({}),
   "bun.app.ts": `
     import html from "./index.html";
+    // Always armed in the dev server's timer heap; /tick answers on its next fire.
+    const waiters = [];
+    setInterval(() => {
+      for (const resolve of waiters.splice(0)) resolve();
+    }, 20);
     export default {
       static: {
         "/": html,
       },
       async fetch(req) {
-        if (new URL(req.url).pathname === "/sleep") {
-          console.log("sleep: timer armed");
-          // Long enough to still be pending when the subscriber's close frame
-          // reaches the server; the test waits on the response, not on time.
-          await Bun.sleep(500);
-          return new Response("slept");
+        if (new URL(req.url).pathname === "/tick") {
+          await new Promise(resolve => waiters.push(resolve));
+          return new Response("ticked");
         }
         return new Response("Not Found", { status: 404 });
       },
@@ -650,6 +652,9 @@ async function subscribeMemoryVisualizer(dev: Dev) {
   ws.binaryType = "arraybuffer";
   let open = false;
   let frames = 0;
+  // Set when the socket errors or closes unexpectedly; fails the step being
+  // awaited at that moment and every step started afterwards.
+  let failure: Error | null = null;
   // The step currently being awaited: socket progress resolves it, socket
   // failure or the deadline rejects it.
   let step: { what: string; done: () => boolean; resolve: () => void; reject: (err: Error) => void } | null = null;
@@ -660,17 +665,21 @@ async function subscribeMemoryVisualizer(dev: Dev) {
     resolve();
   };
   const fail = (reason: string) => {
+    const err = new Error(
+      `${reason}${step ? ` while ${step.what}` : ""} (received ${frames} memory visualizer frames)`,
+    );
+    failure ??= err;
     if (step === null) return;
-    const { what, reject } = step;
+    const { reject } = step;
     step = null;
-    reject(new Error(`${reason} while ${what} (received ${frames} memory visualizer frames)`));
+    reject(err);
   };
   ws.onopen = () => {
     open = true;
     check();
   };
   ws.onerror = () => fail("hmr socket errored");
-  ws.onclose = event => fail(`hmr socket closed with code ${event.code}`);
+  ws.onclose = event => fail(`hmr socket closed unexpectedly with code ${event.code}`);
   ws.onmessage = event => {
     if (new Uint8Array(event.data as ArrayBuffer)[0] !== "M".charCodeAt(0)) return;
     frames++;
@@ -678,6 +687,7 @@ async function subscribeMemoryVisualizer(dev: Dev) {
   };
   const waitUntil = (what: string, done: () => boolean) =>
     new Promise<void>((resolve, reject) => {
+      if (failure) return reject(failure);
       const deadline = setTimeout(() => fail("timed out"), 5_000 * WAIT_MULTIPLIER);
       step = {
         what,
@@ -702,8 +712,9 @@ async function subscribeMemoryVisualizer(dev: Dev) {
     waitForFrames: (count: number) => waitUntil(`waiting for memory visualizer frame #${count}`, () => frames >= count),
     /** Closes the socket, which unsubscribes it on the server, and waits for the close handshake. */
     close: () =>
-      new Promise<void>(resolve => {
-        if (ws.readyState === WebSocket.CLOSED) return resolve();
+      new Promise<void>((resolve, reject) => {
+        if (failure) return reject(failure);
+        ws.onerror = () => reject(new Error("hmr socket errored during the close handshake"));
         ws.onclose = () => resolve();
         ws.close();
       }),
@@ -731,14 +742,14 @@ if (hasBakeDebuggingFeatures) {
       // i.e. at roughly 1s; 1.5s keeps clear of both.
       expect(performance.now() - start).toBeGreaterThanOrEqual(1500);
 
-      // Arm an unrelated timer inside the dev server, then unsubscribe while it
-      // is pending. Unsubscribing removes the tick timer from the heap; if the
-      // tick left its node marked as still in the heap, that removal discarded
-      // whichever timer was at the root instead (debug builds assert).
-      const sleeping = dev.fetch("/sleep");
-      await dev.output.waitForLine(/sleep: timer armed/);
+      // The fixture's interval is pending in the same heap while the subscriber
+      // leaves. Unsubscribing removes the visualizer timer from the heap; when
+      // the tick had left that node marked as still in the heap, the removal
+      // discarded whichever timer was at the root instead (debug builds assert),
+      // and the interval never fired again.
+      await dev.fetch("/tick").equals("ticked");
       await subscriber.close();
-      await sleeping.equals("slept");
+      await dev.fetch("/tick").equals("ticked");
 
       // The timer can be re-armed after being disarmed. This socket is left
       // open on purpose: the harness's graceful exit closes it while the timer

--- a/test/bake/dev/hot.test.ts
+++ b/test/bake/dev/hot.test.ts
@@ -1,7 +1,8 @@
 // Hot tests ensure that the `import.meta.hot` interface is functional
 import { expect } from "bun:test";
+import { isDebug } from "harness";
 import { renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { devTest, emptyHtmlFile } from "../bake-harness";
+import { Dev, devTest, emptyHtmlFile, WAIT_MULTIPLIER } from "../bake-harness";
 
 devTest("import.meta.hot.accept basic", {
   files: {
@@ -611,6 +612,155 @@ devTest("hot update frames are not delivered to application websocket topics", {
     }
   },
 });
+
+// The `M` (memory visualizer) HMR topic only exists in builds with
+// `BAKE_DEBUGGING_FEATURES` (canary or debug). A stable release accepts the
+// subscription but never emits a frame, so there is nothing to observe there.
+const hasBakeDebuggingFeatures = isDebug || Bun.version_with_sha.includes("-canary.");
+
+const memoryVisualizerApp = {
+  "index.html": emptyHtmlFile({}),
+  "bun.app.ts": `
+    import html from "./index.html";
+    export default {
+      static: {
+        "/": html,
+      },
+      async fetch(req) {
+        if (new URL(req.url).pathname === "/sleep") {
+          console.log("sleep: timer armed");
+          // Long enough to still be pending when the subscriber's close frame
+          // reaches the server; the test waits on the response, not on time.
+          await Bun.sleep(500);
+          return new Response("slept");
+        }
+        return new Response("Not Found", { status: 404 });
+      },
+    };
+  `,
+};
+
+/**
+ * Opens an extra `/_bun/hmr` socket and subscribes it to the memory
+ * visualizer topic (`s` = subscribe, `M` = topic). The server answers the
+ * subscription with one `M` frame immediately and then one per timer tick.
+ */
+async function subscribeMemoryVisualizer(dev: Dev) {
+  const ws = new WebSocket(dev.baseUrl + "/_bun/hmr");
+  ws.binaryType = "arraybuffer";
+  let open = false;
+  let frames = 0;
+  // The step currently being awaited: socket progress resolves it, socket
+  // failure or the deadline rejects it.
+  let step: { what: string; done: () => boolean; resolve: () => void; reject: (err: Error) => void } | null = null;
+  const check = () => {
+    if (step === null || !step.done()) return;
+    const { resolve } = step;
+    step = null;
+    resolve();
+  };
+  const fail = (reason: string) => {
+    if (step === null) return;
+    const { what, reject } = step;
+    step = null;
+    reject(new Error(`${reason} while ${what} (received ${frames} memory visualizer frames)`));
+  };
+  ws.onopen = () => {
+    open = true;
+    check();
+  };
+  ws.onerror = () => fail("hmr socket errored");
+  ws.onclose = event => fail(`hmr socket closed with code ${event.code}`);
+  ws.onmessage = event => {
+    if (new Uint8Array(event.data as ArrayBuffer)[0] !== "M".charCodeAt(0)) return;
+    frames++;
+    check();
+  };
+  const waitUntil = (what: string, done: () => boolean) =>
+    new Promise<void>((resolve, reject) => {
+      const deadline = setTimeout(() => fail("timed out"), 5_000 * WAIT_MULTIPLIER);
+      step = {
+        what,
+        done,
+        resolve: () => {
+          clearTimeout(deadline);
+          resolve();
+        },
+        reject: err => {
+          clearTimeout(deadline);
+          reject(err);
+        },
+      };
+      check();
+    });
+
+  const handle = {
+    get frames() {
+      return frames;
+    },
+    /** Resolves once this socket has received `count` memory visualizer frames in total. */
+    waitForFrames: (count: number) => waitUntil(`waiting for memory visualizer frame #${count}`, () => frames >= count),
+    /** Closes the socket, which unsubscribes it on the server, and waits for the close handshake. */
+    close: () =>
+      new Promise<void>(resolve => {
+        if (ws.readyState === WebSocket.CLOSED) return resolve();
+        ws.onclose = () => resolve();
+        ws.close();
+      }),
+  };
+
+  await waitUntil("opening the hmr socket", () => open);
+  ws.send("sM");
+  await handle.waitForFrames(1);
+  return handle;
+}
+
+if (hasBakeDebuggingFeatures) {
+  devTest("memory visualizer topic ticks while subscribed and unsubscribes without disturbing other timers", {
+    files: memoryVisualizerApp,
+    htmlFiles: [],
+    async test(dev) {
+      const start = performance.now();
+      const subscriber = await subscribeMemoryVisualizer(dev);
+      // Frame 1 is sent synchronously on subscribe and frame 2 by the timer
+      // armed at that point; frame 3 only arrives if the tick handler
+      // re-armed the timer after firing.
+      await subscriber.waitForFrames(3);
+      // Two real ticks take at least 2s. A handler that re-inserted the timer
+      // without moving its deadline would deliver frame 3 right after frame 2,
+      // i.e. at roughly 1s; 1.5s keeps clear of both.
+      expect(performance.now() - start).toBeGreaterThanOrEqual(1500);
+
+      // Arm an unrelated timer inside the dev server, then unsubscribe while it
+      // is pending. Unsubscribing removes the tick timer from the heap; if the
+      // tick left its node marked as still in the heap, that removal discarded
+      // whichever timer was at the root instead (debug builds assert).
+      const sleeping = dev.fetch("/sleep");
+      await dev.output.waitForLine(/sleep: timer armed/);
+      await subscriber.close();
+      await sleeping.equals("slept");
+
+      // The timer can be re-armed after being disarmed. This socket is left
+      // open on purpose: the harness's graceful exit closes it while the timer
+      // is armed, covering the teardown path.
+      await subscribeMemoryVisualizer(dev);
+    },
+  });
+
+  devTest("memory visualizer timer stays armed while another subscriber remains", {
+    files: memoryVisualizerApp,
+    htmlFiles: [],
+    async test(dev) {
+      const first = await subscribeMemoryVisualizer(dev);
+      const second = await subscribeMemoryVisualizer(dev);
+      await first.close();
+      // A frame published by a tick just before the close can still be in
+      // flight, so only the second frame from here on proves the timer is
+      // still armed for the remaining subscriber.
+      await second.waitForFrames(second.frames + 2);
+    },
+  });
+}
 
 devTest("dev.write resolves only after the new module body has run", {
   files: {


### PR DESCRIPTION
### Problem
- Sending `sM` (subscribe to the memory visualizer topic) on `/_bun/hmr`, waiting about a second, then closing the socket corrupts the process-wide timer heap of a dev server on canary and debug builds.
- Debug builds abort with `panic: assertion failed: self.root == v` at `bun_io::heap::Intrusive::remove` (src/io/heap.rs:165), reached from `timer::All::remove` via `HmrSocket::on_close -> on_unsubscribe` (src/runtime/bake/dev_server/hmr_socket.rs:321 on main). The same call sits in `DevServer`'s `Drop` (src/runtime/bake/DevServer.rs:1090 on main).
- Release canary builds take the `prev == null` branch of `remove` instead and `delete_min()` the real root of the heap: an unrelated timer (a `Bun.sleep`, a `setTimeout`, ...) is silently dropped and stays marked as armed. The repro below wedges on `await Bun.sleep(300)` on 1.4.0-canary.
- Cause: `DevServer::emit_memory_visualizer_message_timer` (src/runtime/bake/DevServer.rs:5448 on main) is an empty function. `All::next()` pops a due node without touching `state`/`in_heap` (every fire handler is responsible for that), so after the first tick the node is out of the heap but still reads `ACTIVE`/`in_heap`, and the unsubscribe and `Drop` paths remove it again.
- History: the body was gated on a cargo feature that nothing enabled, while the subscribe hook in `hmr_socket.rs` is gated on the `BAKE_DEBUGGING_FEATURES` const (canary or debug). #36184 deleted the never-compiled body and left the stub; the hook that arms the timer stayed live. Since #36184 the `/_bun/memory_visualizer` page is gone too, but the wire topic still arms the timer.
- `on_unsubscribe` also disarmed on `emit_incremental_visualizer_events == 0` instead of the memory visualizer count (carried over from the Zig version). With the tick restored that would keep the timer ticking with zero subscribers when an incremental visualizer socket is open, and stop it early when a second memory visualizer socket is still connected.

### Fix
- `emit_memory_visualizer_message_timer` marks the node `FIRED` before doing anything else, publishes the `M` frame and re-arms one tick later, the same shape as `SourceMapStore::sweep_weak_refs` (the other DevServer timer). It takes the raw timer pointer and recovers the owner with `from_timer_ptr`, like the sibling handler, so the dispatch arm passes `t` through.
- Arming and disarming are `DevServer::arm_memory_visualizer_timer` / `disarm_memory_visualizer_timer`, used by the subscribe hook, the unsubscribe hook (now keyed on `emit_memory_visualizer_events == 0`), the tick, and `Drop`. The inline `runtime_state()` copies in `hmr_socket.rs` are gone.
- `emit_memory_visualizer_message_if_needed` (called after each source map sweep) gets its body back: publish when there are subscribers.
- Audited the other 23 arms of `__bun_fire_timer`: every other handler sets a terminal state or re-arms on every path, so the stale node was specific to this handler. I left `All::next()` as is rather than also clearing `in_heap` on pop; that would be a timer-subsystem change affecting all handlers and both heaps, and nothing else needs it today.
- Verification: `test/bake/dev/hot.test.ts`, two new tests, wrapped in a canary-or-debug check because stable builds never emit the topic.
  - "ticks while subscribed and unsubscribes without disturbing other timers": waits for three `M` frames (the third only exists if the tick re-armed), checks they took at least 1.5s (a handler that re-inserted without moving the deadline would deliver them at once), then uses a 20ms `setInterval` in the fixture as the unrelated timer: a `/tick` request answers on its next fire, one round trip before closing the subscriber and one after. Finally re-subscribes and leaves that socket open so the harness teardown closes it with the timer armed.
  - "stays armed while another subscriber remains": two subscribers, close one, the other must keep receiving frames (fails with the old counter condition).
  - `bun bd test test/bake/dev/hot.test.ts`: 13/13 pass with the fix; with src/ stashed both new tests fail after one frame (`received 1 memory visualizer frames`); `USE_SYSTEM_BUN=1` on 1.4.0-canary.1 fails the same way. The interval half on its own also distinguishes the builds: on the unfixed canary binary the interval stops firing after the close (3/3 runs), on the fixed build it keeps firing.
  - The repro below exits 0 on the fixed debug build (two `M` frames, sleep resolves) and aborts with the assertion above on an unfixed debug build.
  - `cargo clippy -p bun_runtime --no-deps` clean. CI on the rebased head (build 95709): all 13 build lanes and all 177 finished jobs green; the only non-green entries are darwin 14 test shards that expired in the queue before an agent picked them up, plus retried flakes in install/napi tests unrelated to bake.
- Rebased onto main after #37946 merged: it had changed the arm site's `ms_from_now` to `ForceRealTime`, and that line now lives in `arm_memory_visualizer_timer`, so the helper uses `ForceRealTime` (required, since #37946 moved the dev server timers into the real-clock heap). Remaining overlap: #37878 fixes the unreachable `else if` in the subscribe handler and changes the same counter line in `on_unsubscribe`; this PR's hunk subsumes that line, so whichever lands second has a small rebase.
- If the visualizers are not coming back after #36184, deleting the `M`/`v` hooks, the timer and the two orphaned `*_visualizer.html` files is the alternative; this PR takes the smaller route of making the code that is still live consistent.

### Background
- `EventLoopTimer` is an intrusive node embedded in its owner (here `DevServer.memory_visualizer_timer`) and linked into `timer::All.timers`, a pairing heap. `All::drain_timers` pops each due node with `delete_min()` and calls the owner's handler by tag; popping clears the node's links but not its `state`/`in_heap` fields, which each handler updates itself (set `FIRED`/`CANCELLED`, or re-insert through `All::update`).
- `All::remove` trusts `in_heap` and calls the heap's `remove`, which uses a null `prev` link to mean "this node is the root". A popped node has null links, so removing it removes whatever the real root is; debug builds assert first.
- The memory visualizer is a canary/debug-only HMR topic: the dev server publishes a memory breakdown frame (`M`) on subscribe and then once a second while any socket is subscribed. `BAKE_DEBUGGING_FEATURES` is `IS_CANARY || IS_DEBUG`, so this is reachable on published canaries from anything that can open a WebSocket to the dev server.

<details>
<summary>Repro (from the report)</summary>

`index.html` loading `app.ts`, plus:

```js
import html from "./index.html";
const srv = Bun.serve({ routes: { "/": html }, development: true, port: 0, hostname: "127.0.0.1" });
await (await fetch("http://127.0.0.1:" + srv.port + "/")).text();
const t0 = Date.now();
setTimeout(() => console.log("user setTimeout(2500) fired", Date.now() - t0), 2500);
const ws = new WebSocket("ws://127.0.0.1:" + srv.port + "/_bun/hmr");
await new Promise(r => (ws.onopen = r));
ws.send("sM");
await Bun.sleep(1500);
ws.close();
await Bun.sleep(300); // never resolves on 1.4.0-canary; assertion failure on a debug build
console.log("sleeping 4 s"); await Bun.sleep(4000); console.log("OK woke up");
srv.stop(true); process.exit(0);
```

1.4.0-canary.1+da3851e57: prints `user setTimeout(2500) fired 2501`, then hangs until killed.

Unfixed debug build:

```
panic: assertion failed: self.root == v
<bun_io::heap::Intrusive<...>>::remove            src/io/heap.rs:165
<bun_runtime::timer::TimerHeap>::remove           src/runtime/timer/mod.rs:319
<bun_runtime::timer::All>::remove                 src/runtime/timer/mod.rs:827
HmrSocket::on_unsubscribe                          src/runtime/bake/dev_server/hmr_socket.rs:321
HmrSocket::on_close                                src/runtime/bake/dev_server/hmr_socket.rs:338
```

Fixed debug build: `M message 1`, `M message 2` one second later, `sleep(300) resolved`, `OK woke up`, exit 0.

</details>

<details>
<summary>Earlier version of the test</summary>

The first revision armed the unrelated timer with a 500ms `Bun.sleep` behind a `/sleep` route. Review pointed out that on a slow worker the sleep could finish before the close frame arrived, at which point that half of the test proved nothing; the interval replaces it so a timer is pending for the whole unsubscribe by construction.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bake/dev/hot.test.ts

<!-- robobun:evidence:end -->
