### PR TITLE
shell(cp): refuse FIFO, socket and device sources instead of hanging in open()

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8489,11 +8489,7 @@ impl NodeFS {
         result
     }
 
-    /// Classifies the source from its lstat before `copy_single_file_sync`
-    /// opens it: `open(2)` on a FIFO blocks until a writer shows up, and
-    /// sockets and devices have no contents to copy either, so only regular
-    /// files and symlinks (recreated by [`Self::cp_symlink`]) get as far as the
-    /// open. The macOS arm makes the same decision from the stat it takes anyway.
+    /// `open(2)` blocks on a FIFO with no writer, so the source kind is checked from its lstat first.
     #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
     fn cp_check_source_kind(src: &ZStr, reuse_stat: Option<&sys::Stat>) -> Maybe<()> {
         let st_mode = match reuse_stat {
@@ -8562,8 +8558,7 @@ impl NodeFS {
         src: &OSPathSliceZ,
         dest: &OSPathSliceZ,
         mode: constants::Copyfile,
-        // The caller's `lstat` of `src` on posix (the symlink checks below rely
-        // on it not following links), file attributes on windows
+        // The caller's lstat on posix, file attributes on windows
         #[cfg(windows)] reuse_stat: Option<windows::DWORD>,
         #[cfg(not(windows))] reuse_stat: Option<&sys::Stat>,
         args: &args::Cp,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8562,7 +8562,8 @@ impl NodeFS {
         src: &OSPathSliceZ,
         dest: &OSPathSliceZ,
         mode: constants::Copyfile,
-        // Stat on posix, file attributes on windows
+        // The caller's `lstat` of `src` on posix (the symlink checks below rely
+        // on it not following links), file attributes on windows
         #[cfg(windows)] reuse_stat: Option<windows::DWORD>,
         #[cfg(not(windows))] reuse_stat: Option<&sys::Stat>,
         args: &args::Cp,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8489,6 +8489,23 @@ impl NodeFS {
         result
     }
 
+    /// Classifies the source from its lstat before `copy_single_file_sync`
+    /// opens it: `open(2)` on a FIFO blocks until a writer shows up, and
+    /// sockets and devices have no contents to copy either, so only regular
+    /// files and symlinks (recreated by [`Self::cp_symlink`]) get as far as the
+    /// open. The macOS arm makes the same decision from the stat it takes anyway.
+    #[cfg(any(target_os = "linux", target_os = "android", target_os = "freebsd"))]
+    fn cp_check_source_kind(src: &ZStr, reuse_stat: Option<&sys::Stat>) -> Maybe<()> {
+        let st_mode = match reuse_stat {
+            Some(stat_) => stat_.st_mode,
+            None => Syscall::lstat(src)?.st_mode,
+        };
+        if sys::S::ISREG(st_mode as Mode) || sys::S::ISLNK(st_mode as Mode) {
+            return Ok(());
+        }
+        Err(sys::Error::from_code(E::ENOTSUP, sys::Tag::copyfile).with_path(src.as_bytes()))
+    }
+
     #[cfg_attr(any(windows, target_os = "macos"), allow(dead_code))]
     fn cp_symlink(&mut self, src: &ZStr, dest: &ZStr) -> Maybe<ret::CopyFile> {
         let mut target_buf = PathBuffer::uninit();
@@ -8688,11 +8705,12 @@ impl NodeFS {
 
         #[cfg(any(target_os = "linux", target_os = "android"))]
         {
-            let _ = reuse_stat;
             // https://manpages.debian.org/testing/manpages-dev/ioctl_ficlone.2.en.html
             if mode.is_force_clone() {
                 return Maybe::<ret::CopyFile>::todo();
             }
+
+            Self::cp_check_source_kind(src, reuse_stat)?;
 
             let src_fd = match Syscall::open(src, sys::O::RDONLY | sys::O::NOFOLLOW, 0o644) {
                 Ok(result) => result,
@@ -8856,7 +8874,6 @@ impl NodeFS {
 
         #[cfg(target_os = "freebsd")]
         {
-            let _ = reuse_stat;
             if mode.is_force_clone() {
                 return Err(sys::Error {
                     errno: SystemErrno::EOPNOTSUPP as _,
@@ -8864,6 +8881,8 @@ impl NodeFS {
                     ..Default::default()
                 });
             }
+
+            Self::cp_check_source_kind(src, reuse_stat)?;
 
             let src_fd = match Syscall::open(src, sys::O::RDONLY | sys::O::NOFOLLOW, 0o644) {
                 Ok(result) => result,

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,10 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, DirectoryTree, isMacOS, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { mkfifo } from "mkfifo";
+import { lstatSync, readFileSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +173,90 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// On Linux the builtin used to copy a non-directory source by opening it
+// first, and opening a FIFO that has no writer blocks forever, so each of the
+// refused copies below hung instead of finishing. The builtin is the default
+// only on Windows (no FIFOs there); on POSIX it is enabled by an env var read
+// once per process, so each cp runs in a child bun.
+describe.concurrent.skipIf(isWindows)("bunshell cp of a FIFO", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  // Runs argv[2] as a shell command inside `work/` and prints cp's exit code
+  // followed by whatever it wrote to stderr.
+  const runCpScript = /* ts */ `
+    import { $ } from "bun";
+    import { join } from "node:path";
+    const result = await $\`\${{ raw: process.argv[2] }}\`.cwd(join(import.meta.dir, "work")).nothrow().quiet();
+    process.stdout.write(result.exitCode + "\\n" + result.stderr.toString());
+  `;
+
+  /** A temp dir holding the script and `work/`, which has the FIFO `fifo` and `extra` in it. */
+  function setup(name: string, extra: DirectoryTree = {}) {
+    const dir = tempDir(`shell-cp-fifo-${name}`, { "run-cp.ts": runCpScript, "work": extra });
+    mkfifo(join(String(dir), "work/fifo"));
+    return dir;
+  }
+
+  async function cp(dir: string, command: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run-cp.ts", command],
+      cwd: dir,
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function refused(fifo: string) {
+    return { stdout: `1\ncp: Operation not supported: ${fifo}\n`, stderr: "", exitCode: 0 };
+  }
+  const copied = { stdout: "0\n", stderr: "", exitCode: 0 };
+
+  test("as the source is refused", async () => {
+    using dir = setup("source");
+    const work = join(String(dir), "work");
+    expect(await cp(String(dir), "cp fifo out")).toEqual(refused(join(work, "fifo")));
+    expect(lstatSync(join(work, "out"), { throwIfNoEntry: false })).toBeUndefined();
+  });
+
+  test("as the source of cp -R is refused", async () => {
+    using dir = setup("source-recursive");
+    const work = join(String(dir), "work");
+    expect(await cp(String(dir), "cp -R fifo out")).toEqual(refused(join(work, "fifo")));
+    expect(lstatSync(join(work, "out"), { throwIfNoEntry: false })).toBeUndefined();
+  });
+
+  test("next to other sources is refused while they are copied", async () => {
+    using dir = setup("one-of-many", { "a.txt": "A\n", "dest": {} });
+    const work = join(String(dir), "work");
+    expect(await cp(String(dir), "cp fifo a.txt dest")).toEqual(refused(join(work, "fifo")));
+    expect(readFileSync(join(work, "dest/a.txt"), "utf8")).toBe("A\n");
+    expect(lstatSync(join(work, "dest/fifo"), { throwIfNoEntry: false })).toBeUndefined();
+  });
+
+  // On macOS a directory is copied with one clonefile() of the whole tree, so
+  // the per-entry copy this exercises is only reached on Linux.
+  test.skipIf(isMacOS)("inside a directory copied with -R is refused while the rest is copied", async () => {
+    using dir = setup("in-directory", { "d": { "b.txt": "B\n" } });
+    const work = join(String(dir), "work");
+    mkfifo(join(work, "d/pipe"));
+    expect(await cp(String(dir), "cp -R d out")).toEqual(refused(join(work, "d/pipe")));
+    expect(readFileSync(join(work, "out/b.txt"), "utf8")).toBe("B\n");
+    expect(lstatSync(join(work, "out/pipe"), { throwIfNoEntry: false })).toBeUndefined();
+  });
+
+  // The source is classified without following symlinks, so a symlink is
+  // recreated as one whatever it points at.
+  test("behind a symlink is copied as a symlink", async () => {
+    using dir = setup("symlink");
+    const work = join(String(dir), "work");
+    symlinkSync("fifo", join(work, "link"));
+    expect(await cp(String(dir), "cp link out")).toEqual(copied);
+    expect(lstatSync(join(work, "out")).isSymbolicLink()).toBe(true);
   });
 });
 

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -249,13 +249,13 @@ describe.concurrent.skipIf(isWindows)("bunshell cp of a FIFO", () => {
     expect(lstatSync(join(work, "out/pipe"), { throwIfNoEntry: false })).toBeUndefined();
   });
 
-  // The source is classified without following symlinks, so a symlink is
-  // recreated as one whatever it points at.
-  test("behind a symlink is copied as a symlink", async () => {
+  // With -R a symlink operand is copied as a link, so what it points at is
+  // never looked at.
+  test("behind a symlink is copied as a symlink by cp -R", async () => {
     using dir = setup("symlink");
     const work = join(String(dir), "work");
     symlinkSync("fifo", join(work, "link"));
-    expect(await cp(String(dir), "cp link out")).toEqual(copied);
+    expect(await cp(String(dir), "cp -R link out")).toEqual(copied);
     expect(lstatSync(join(work, "out")).isSymbolicLink()).toBe(true);
   });
 });


### PR DESCRIPTION
### Problem
- The shell `cp` builtin (default on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX) never returns when a source is a named pipe: with `mkfifo fifo`, `cp fifo x`, `cp -R fifo x` and `cp -R dir x` for a `dir` containing a FIFO all hang the script (Linux, bun 1.4.0). coreutils recreates the FIFO under `-R`; node's `fs.cp` fails with `ERR_FS_CP_FIFO_PIPE`; bun on macOS already fails with `ENOTSUP`. Only Linux (and by inspection FreeBSD) hangs.
- Cause: the Linux and FreeBSD arms of `NodeFS::copy_single_file_sync` (`src/runtime/node/node_fs.rs`) `open()` the source and only then `fstat()` it to reject non-regular files. `open(2)` of a FIFO with no writer blocks until one shows up, so the `ENOTSUP` check after it is never reached, the work-pool thread stays blocked and the builtin waits for it forever (and if a writer did show up, the `fstat` check would fail the copy anyway, so the wait could never produce a copy). Both arms ignored the `reuse_stat` the callers pass in (`let _ = reuse_stat;`); the macOS arm uses it to reject special files before opening anything.
- `node:fs` `cp`/`cpSync` are not affected: their JS layer (`src/js/internal/fs/cp.ts`) only hands regular files to this native copy. The shell builtin calls the native copy directly with whatever `lstat` says is not a directory.

### Fix
- New `cp_check_source_kind` (Linux, Android, FreeBSD) classifies the source from the `lstat` the caller already took, or a fresh one when a directory entry is being copied (`reuse_stat` is `None` there), and fails with `ENOTSUP` naming the source for anything that is neither a regular file nor a symlink. Both arms call it before `open()`.
- Why this is the right shape:
  - The decision has to be made from `lstat`, not from the open fd: for a FIFO there is no fd until a writer appears, so no check placed after `open()` can run. The pre-open check is the same one the macOS arm and the shell's `mv` cross-device fallback (`move_across_devices`) already make, so Linux now prints the same `cp: Operation not supported: /path/fifo` macOS does, and sockets and devices are refused the same way instead of being opened.
  - Symlinks are let through on purpose: they still take the existing `open(O_NOFOLLOW)` -> `ELOOP` -> `cp_symlink` route, so symlink copies are unchanged (`cp -R link x` with the link pointing at a FIFO is covered by a test). The `fstat` check after the open stays as the guard for the source changing between the two calls.
  - Failing rather than recreating the FIFO: for a FIFO given as a source it matches `fs.cp` and what this binary already does on macOS, and a recreated FIFO would have been new behaviour for `-R` only (coreutils' plain `cp fifo x` reads the pipe). A FIFO inside a tree copied with `-R` on macOS is still whatever the one `clonefile()` of the tree makes of it; that path is not touched here.
  - Relation to #37954 (which makes the builtin follow a symlink operand unless `-R` is given): that change classifies the followed operand before opening it too, so on its own it also stops plain `cp fifo x` from hanging, but not `cp -R fifo x` or a FIFO inside a tree, which go through the non-following path fixed here. The two changes are independent; they touch neighbouring lines in the two arms, so whichever lands second has a trivial rebase.
  - Cost: single-file copies reuse the stat the caller passes, so nothing changes for them or for `node:fs`. Recursive shell copies on Linux do one extra `lstat` per entry, which macOS already does.
- Verified:
  - `test/js/bun/shell/commands/cp.test.ts`, new "bunshell cp of a FIFO" block: 4 of the 5 tests time out on the unfixed build (the builtin hangs and `bun test` kills the child), all 5 pass with the fix. They cover the FIFO as the only source, as the source of `cp -R`, next to a regular file (which is still copied), inside a directory copied with `-R` (the other entries are still copied; Linux only, since macOS clones the tree with one `clonefile()`), and `cp -R` of a symlink to a FIFO still producing a symlink (`-R` rather than a plain `cp` so the test stays valid once #37954 makes plain `cp` follow the link). The block is skipped on Windows, which has no `mkfifo`. CI ran the block on Linux, Linux ASAN and macOS 14.
  - `bun bd test test/js/node/fs/cp.test.ts`: 47 pass, and the 79 ported `test-fs-cp-*` / `test-fs-copyfile*` node tests pass with the debug build.
  - `cargo check -p bun_runtime --target x86_64-unknown-freebsd` and `cargo clippy -p bun_runtime` are clean.

### Background
- A FIFO (named pipe, `mkfifo`) is a filesystem entry with no contents of its own; `open(2)` for reading blocks until some process opens it for writing (unless `O_NONBLOCK` is given), which is why a plain open of an idle FIFO never returns.
- The shell `cp` builtin resolves its operands in `src/runtime/shell/builtin/cp.rs` and then reuses the native `fs.cp` implementation: `NewAsyncCpTask::cp_async` copies a non-directory source on the spot through `copy_single_file_sync`, and for a directory it walks the tree and runs one `CpSingleTask` (again `copy_single_file_sync`) per entry on the work pool; the builtin finishes once every one of those has reported back, so one blocked entry blocks the whole command.
- `reuse_stat` is the `lstat` result the callers of `copy_single_file_sync` pass along so the function does not have to stat the source again; before this change only the macOS arm read it.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->