### PR TITLE
ci: run one unpinned darwin aarch64 test lane on PR builds, keep the per-tier lanes on main

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -186,14 +186,15 @@ const testPlatforms = [
   // boxes tagged with that `release-tier` (see getTestAgent); one without a
   // tier runs on any box of its arch.
   //
-  // arm64 is listed both ways and runsByDefault() picks per branch: main runs
-  // the two pinned lanes, `latest` (current macOS, 26 today) and `previous`
-  // (anything older, currently 13/14/15), so the canary gate covers both; every
-  // other build runs the one unpinned lane. The `latest` pool is two boxes,
-  // `previous` eight: on 2026-08-12 `latest` ran flat out all day and 145 of
-  // the 220 PR builds that reached it still had the lane expire unrun (main's
-  // jobs, at a higher priority, waited ~5 min). Pin PRs again once `latest`
-  // has enough boxes to keep up with PR volume on its own.
+  // arm64 is listed both ways and runsByDefault() picks per branch: main and
+  // the merge queue run the two pinned lanes, `latest` (current macOS, 26
+  // today) and `previous` (anything older, currently 13/14/15), so what lands
+  // is checked on both; every other build runs the one unpinned lane. The
+  // `latest` pool is two boxes, `previous` eight: on 2026-08-12 `latest` ran
+  // flat out all day and 145 of the 220 PR builds that reached it still had the
+  // lane expire unrun, while main's jobs, which getPriority() puts ahead of
+  // every PR job, waited ~5 min. Pin PRs again once `latest` has enough boxes
+  // to keep up with PR volume on its own.
   //
   // x64 is never pinned: Intel Macs can't run latest macOS and the split
   // bottlenecked that pool too. Its `release` only labels the step.
@@ -215,9 +216,10 @@ const testPlatforms = [
 
 /**
  * Whether a test lane runs on this branch when nothing picked lanes
- * explicitly. Only darwin arm64 varies (see testPlatforms): pinned lanes on
- * main, the unpinned one everywhere else. A manual build that picks a pinned
- * lane in the options form gets it on any branch.
+ * explicitly. Only darwin arm64 varies (see testPlatforms): pinned lanes where
+ * a commit lands (main, the merge queue), the unpinned one everywhere else. A
+ * manual build that picks a pinned lane in the options form gets it on any
+ * branch.
  * @param {Platform} platform
  * @returns {boolean}
  */
@@ -226,7 +228,8 @@ function runsByDefault(platform) {
   if (os !== "darwin" || arch !== "aarch64") {
     return true;
   }
-  return isMainBranch() ? tier !== undefined : tier === undefined;
+  const pinned = isMainBranch() || isMergeQueue();
+  return pinned ? tier !== undefined : tier === undefined;
 }
 
 /**

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -102,7 +102,10 @@ function getTargetLabel(target) {
  * @property {Profile} [profile]
  * @property {boolean} [crossCompile]
  * @property {Distro} [distro]
- * @property {string} release
+ * @property {string} [release]
+ *   Absent on a test lane that floats across every box of its os/arch
+ *   (currently darwin aarch64 off main, see testPlatforms): there is no
+ *   version to put in the step label or to assert on the agent.
  * @property {Tier} [tier]
  * @property {string[]} [features]
  */
@@ -177,19 +180,28 @@ const buildPlatforms = [
  * @type {Platform[]}
  */
 const testPlatforms = [
-  // Darwin arm64 is targeted by `release-tier` (see getTestAgent): one job on
-  // `latest` (current macOS, 26 today) and one on `previous` (anything older
-  // — currently 13/14/15). x64 is NOT tier-targeted: a single entry runs on
-  // whichever Intel box is free. Intel Macs can't run latest macOS and the
-  // tier split bottlenecked the smaller pool, so x64 trades guaranteed
-  // version coverage for throughput. The `release` field only labels the step.
   // The darwin test suite runs on real macOS agents against the Linux-built
   // artifacts from the `darwin-<arch>-build-bun` steps (the only darwin build
-  // lanes — see buildPlatforms).
+  // lanes — see buildPlatforms). A darwin lane with a `tier` only runs on the
+  // boxes tagged with that `release-tier` (see getTestAgent); one without a
+  // tier runs on any box of its arch.
+  //
+  // arm64 is listed both ways and runsByDefault() picks per branch: main runs
+  // the two pinned lanes, `latest` (current macOS, 26 today) and `previous`
+  // (anything older, currently 13/14/15), so the canary gate covers both; every
+  // other build runs the one unpinned lane. The `latest` pool is two boxes,
+  // `previous` eight: on 2026-08-12 `latest` ran flat out all day and 145 of
+  // the 220 PR builds that reached it still had the lane expire unrun (main's
+  // jobs, at a higher priority, waited ~5 min). Pin PRs again once `latest`
+  // has enough boxes to keep up with PR volume on its own.
+  //
+  // x64 is never pinned: Intel Macs can't run latest macOS and the split
+  // bottlenecked that pool too. Its `release` only labels the step.
   { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
   { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
+  { os: "darwin", arch: "aarch64" },
   // x64 is off until enough Intel test agents are back on the queue.
-  // { os: "darwin", arch: "x64", release: "14", tier: "latest" },
+  // { os: "darwin", arch: "x64", release: "14" },
   { os: "linux", arch: "aarch64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", distro: "debian", release: "13", tier: "latest" },
   { os: "linux", arch: "x64", profile: "asan", distro: "debian", release: "13", tier: "latest" },
@@ -202,17 +214,35 @@ const testPlatforms = [
 ];
 
 /**
+ * Whether a test lane runs on this branch when nothing picked lanes
+ * explicitly. Only darwin arm64 varies (see testPlatforms): pinned lanes on
+ * main, the unpinned one everywhere else. A manual build that picks a pinned
+ * lane in the options form gets it on any branch.
+ * @param {Platform} platform
+ * @returns {boolean}
+ */
+function runsByDefault(platform) {
+  const { os, arch, tier } = platform;
+  if (os !== "darwin" || arch !== "aarch64") {
+    return true;
+  }
+  return isMainBranch() ? tier !== undefined : tier === undefined;
+}
+
+/**
  * @param {Platform} platform
  * @returns {string}
  */
 function getPlatformKey(platform) {
   const { distro, release } = platform;
-  const target = getTargetKey(platform);
-  const version = release.replace(/\./g, "");
+  let key = getTargetKey(platform);
   if (distro) {
-    return `${target}-${distro}-${version}`;
+    key += `-${distro}`;
   }
-  return `${target}-${version}`;
+  if (release) {
+    key += `-${release.replace(/\./g, "")}`;
+  }
+  return key;
 }
 
 /**
@@ -221,7 +251,7 @@ function getPlatformKey(platform) {
  */
 function getPlatformLabel(platform) {
   const { os, arch, baseline, profile, distro, release } = platform;
-  let label = `${getBuildkiteEmoji(distro || os)} ${release} ${arch}`;
+  let label = `${getBuildkiteEmoji(distro || os)} ${release ? `${release} ` : ""}${arch}`;
   if (baseline) {
     label += "-baseline";
   }
@@ -241,8 +271,10 @@ function getImageKey(platform) {
   // host image — bootstrap.sh installs the NDK / base.txz sysroot on it (the
   // macOS SDK is fetched by the build itself). No separate image is baked.
   const hostOs = os === "freebsd" || crossCompile ? "linux" : os;
-  const version = release.replace(/\./g, "");
-  let key = `${hostOs}-${arch}-${version}`;
+  let key = `${hostOs}-${arch}`;
+  if (release) {
+    key += `-${release.replace(/\./g, "")}`;
+  }
   if (distro) {
     key += `-${distro}`;
   }
@@ -399,16 +431,15 @@ function getTestAgent(platform, options) {
   const { os, arch, profile, tier } = platform;
 
   if (os === "darwin") {
-    // `release-tier` is emitted by scripts/agent.mjs based on the box's macOS
-    // major version. arm64 splits into `latest` (current macOS) + `previous`
-    // (anything older). x64 is NOT tier-targeted — single entry, any Intel
-    // box — because the tier split bottlenecked the smaller pool and Intel
-    // can't run latest anyway.
+    // `release-tier` is emitted by scripts/agent.mjs (bare boxes) and
+    // scripts/darwin-ci (tart hosts) from the macOS major version the jobs run
+    // on. Which lanes pin a tier, and why the rest float, is decided in
+    // testPlatforms.
     return {
       queue: `test-${os}`,
       os,
       arch,
-      ...(arch === "aarch64" ? { "release-tier": tier } : {}),
+      ...(tier ? { "release-tier": tier } : {}),
     };
   }
 
@@ -820,10 +851,10 @@ function getTestBunStep(platform, options, testOptions = {}) {
       ASAN_OPTIONS: "allow_user_segv_handler=1:disable_coredump=0:detect_leaks=0",
       // Platform smoke check: runner.node.mjs asserts the agent matches what
       // this step targets before running any test (see assertExpectedPlatform).
-      // `release` is only asserted where the lane pins an exact version:
-      // darwin aarch64 "previous" and darwin x64 intentionally float across
-      // macOS versions, and the windows "2019" label doesn't match the
-      // kernel-style version the agent reports.
+      // `release` is only asserted where the lane pins an exact version: every
+      // darwin lane except aarch64 `latest` intentionally floats across macOS
+      // versions (see testPlatforms), and the windows "2019" label doesn't
+      // match the kernel-style version the agent reports.
       EXPECTED_PLATFORM_OS: platform.os,
       EXPECTED_PLATFORM_ARCH: platform.arch,
       ...(platform.abi ? { EXPECTED_PLATFORM_ABI: platform.abi } : {}),
@@ -1240,7 +1271,7 @@ function getOptionsStep() {
       {
         key: "test-platforms",
         select: "If testing, which platforms do you want to test?",
-        hint: "If this is left blank, all platforms are tested",
+        hint: "If this is left blank, the platforms a push to this branch would test are tested",
         required: false,
         multiple: true,
         default: [],
@@ -1328,6 +1359,7 @@ async function getPipelineOptions() {
   const canary = await getCanaryRevision();
   const buildPlatformsMap = new Map(filteredBuildPlatforms.map(platform => [getTargetKey(platform), platform]));
   const testPlatformsMap = new Map(testPlatforms.map(platform => [getPlatformKey(platform), platform]));
+  const defaultTestPlatforms = testPlatforms.filter(runsByDefault);
 
   if (isManual) {
     const { fields } = getOptionsStep();
@@ -1361,7 +1393,7 @@ async function getPipelineOptions() {
         : Array.from(buildPlatformsMap.values()),
       testPlatforms: testPlatformKeys?.length
         ? testPlatformKeys.flatMap(key => buildProfiles.map(profile => ({ ...testPlatformsMap.get(key), profile })))
-        : Array.from(testPlatformsMap.values()),
+        : defaultTestPlatforms,
       dryRun: parseBoolean(options["dry-run"]),
     };
   }
@@ -1416,7 +1448,7 @@ async function getPipelineOptions() {
     publishImages,
     imageFilter,
     buildPlatforms: Array.from(buildPlatformsMap.values()),
-    testPlatforms: Array.from(testPlatformsMap.values()),
+    testPlatforms: defaultTestPlatforms,
   };
 }
 


### PR DESCRIPTION
### Problem
- PR builds fail with only the two `:darwin: 26 aarch64 - test-bun` shards red, in state `expired`: no agent ever picked them up. #37739 hit this on both of its full builds today (92897, 93345); each time the shards expired, were retried, and expired again, four attempts over five hours, while main builds in the same hours (92941, 93041, 93528) got the lane in 2 to 14 minutes.
- The lane is pinned to `release-tier=latest` (`getTestAgent`, `.buildkite/ci.mjs:401`), and exactly two agents carry that tag: the bare macOS 26 boxes `darwin-arm64-breadstick` and `darwin-arm64-crouton` (both register as `darwin-aarch64-26.6.1-1`). The eight tart agents on the four M2 Ultra hosts are all `release-tier=previous`, so the `previous` lane has four times the capacity of `latest`.
- Both boxes ran back to back from 05:27Z with no idle gap, about 15 minutes per job, so the lane drains roughly four builds an hour. `getPriority()` gives main 2 and PRs 0, so main always goes first and PRs absorb the whole shortfall. Of the non-canceled builds created on 2026-08-12 (UTC, through about 21:40Z): 293 PR builds reached the darwin tests; the `latest` lane ran on 75 of them and expired for good on 145 (79 were still queued, 170 jobs for two agents); the `previous` lane expired for good on 0. Median queue wait for PR jobs that did run: 45 min on `latest` (p90 96 min), 29 min on `previous`; 5 min and 1 min for main.
- Not a darwin-26 regression: the lane has not run on most PRs since #37633 put darwin tests back on every PR, because the fleet came back from the reimage with the tiers split 2:8.

### Fix
- `testPlatforms` gains a third darwin aarch64 entry with no `tier`, and `runsByDefault()` picks per branch: main and merge-queue builds (`getPriority()` 2 and 1, so they are never the ones starving) keep the pinned `latest` and `previous` lanes and what lands is still checked on both macOS versions; every other build gets the one unpinned lane, whose agent rules are `queue=test-darwin, os=darwin, arch=aarch64`, so its two shards take whichever of the ten arm64 boxes frees up first. `getPipelineOptions()` uses it for webhook builds and for manual builds that leave the platform field blank; a manual build that picks a pinned lane in the form still gets it on any branch.
- `getTestAgent()` emits `release-tier` only when the lane declares a tier (x64 never did; its commented-out entry drops the now-meaningless `tier`). `EXPECTED_PLATFORM_RELEASE` was already only set for the `latest` lane, so the unpinned lane passes the platform smoke check on a 15 or a 26 box, same as `previous` does today.
- `Platform.release` becomes optional so the unpinned lane has a key and label without a version: step `darwin-aarch64-test-bun`, label `:darwin: aarch64 - test-bun`. Its group label matches the darwin aarch64 build group, so `getPipeline()`'s group merge puts the test shards next to `darwin-aarch64-build-bun` in the UI. `getPlatformKey` / `getPlatformLabel` / `getImageKey` produce the same strings as before for every platform that has a release.
- Arithmetic, at today's volume (about 14 PR builds an hour reaching the darwin tests, 15 min a job): pinned lanes need about 28 jobs an hour from each tier, against a capacity of 8 (`latest`) and 32 (`previous`); unpinned, the same PRs need about 28 jobs an hour from a pool that does about 40. Peak hours (74 and 84 builds created in the 13Z and 17Z hours) will still queue, and more boxes is the only fix for that. #37934 rebalances the tart hosts to one guest per tier, which helps main's `latest` redundancy but still leaves each pinned PR lane short on its own (5 agents, about 20 jobs an hour), and needs the four tart hosts upgraded first: they run macOS 15.7.9 today and a tart guest cannot be newer than its host. Both changes are independent; #37934 only touches a comment in `getTestAgent()` in this file.
- Verified by generating the pipeline locally (`node .buildkite/ci.mjs`, which writes `.buildkite/ci.yml` and uploads nothing outside Buildkite):
  - checked out on `main`, the generated pipeline is byte for byte identical before and after this change; on a local `gh-readonly-queue/...` branch it has `priority: 1` and both pinned lanes;
  - on this branch, the only difference is the `darwin-aarch64-26` and `darwin-aarch64-14` test groups (4 jobs, `release-tier` rules, `EXPECTED_PLATFORM_RELEASE: 26`) replaced by one `darwin-aarch64-test-bun` step (2 shards, no `release-tier` rule, no release assertion) inside the `:darwin: aarch64` group; no duplicate step keys;
  - the manual-build options form lists `darwin-aarch64-26`, `darwin-aarch64-14` and `darwin-aarch64`;
  - prettier clean. This PR's own build exercises the unpinned lane.

### Background
- `release-tier` is a tag the agents put on themselves from the macOS major version the jobs run on: `latest` is 26, `previous` is 14 and 15 (`scripts/agent.mjs` on bare boxes, `scripts/darwin-ci/lib/agent.ts` on tart hosts, where it is the guest image's version). A Buildkite job only goes to an agent whose tags satisfy every rule on the step; extra agent tags do not matter, which is why a step with no `release-tier` rule matches both tiers.
- tart hosts run each job in a fresh macOS VM cloned from a baked image; the four Ultra hosts each run two such agents. The two 16 GB M2 boxes run the tests directly on the host (`bare` mode in `scripts/darwin-ci/README.md`) and are the only macOS 26 agents.
- `expired` is the state Buildkite gives a scheduled job that no agent accepted within the configured window (about an hour here); it fails the build like a red job. Within a priority level the darwin boxes hand out jobs in build order (today's dispatch log on the tart boxes is a strictly ascending sequence of build numbers, retried jobs included), so a retry keeps its build's place in line; a build dies on a lane when its retries run out before the lane gets down to it. The `latest` lane was running about five hours behind, and builds get about four hours of attempts: 92897's last attempt expired at 11:05Z and the lane reached the builds on either side of it at 11:03Z and 11:08Z.
- `getPriority()` returns 2 on main, 1 in the merge queue, 0 on PRs, -1 on forks; higher priority is dispatched first regardless of age, so a saturated pool serves main first no matter how long PR jobs have waited.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · build/CI scripts only; test-proof not applicable

<!-- robobun:evidence:end -->
