### PR TITLE
node:fs: make recursive rm linear in directory depth

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9645,8 +9645,9 @@ pub(crate) unsafe extern "C" fn Bun__mkdirp(
 // Implemented on top of
 // `bun_sys` primitives (`openat` + `unlinkat`) and *errno* values, mapping the
 // errno back to the error-set name strings the callers'
-// `map_anyerror_to_errno*` tables expect. The structure: 16-slot stack,
-// treat_as_dir flip-flop, close-then-deleteDir, retry-on-DirNotEmpty.
+// `map_anyerror_to_errno*` tables expect. The structure: one open directory
+// per level of the path being walked, treat_as_dir flip-flop,
+// close-then-deleteDir, retry-on-DirNotEmpty.
 
 #[inline]
 fn dt_err(errno: E) -> crate::Error {
@@ -9774,10 +9775,11 @@ pub(crate) fn zig_delete_tree(
             None => return Ok(()),
         };
 
-    // PERF: a Vec
-    // pre-reserved to 16 caps the depth the same way a fixed array would,
-    // with the bonus that the iterator buffers (8 KB each)
-    // live on the heap instead of the stack.
+    // One frame (an open fd plus an 8 KB readdir buffer) per level of the
+    // path currently being walked. The Vec grows with the tree, so every
+    // directory is opened once and the walk is linear in the number of
+    // entries; capping the depth here and re-walking deeper subtrees from
+    // their top made deep chains O(depth^2).
     let mut stack: Vec<DeleteTreeStackItem> = Vec::with_capacity(16);
     let close_all = |stack: &mut Vec<DeleteTreeStackItem>| {
         for item in stack.drain(..) {
@@ -9803,64 +9805,51 @@ pub(crate) fn zig_delete_tree(
                 Ok(None) => break,
                 Err(err) => return Err(dt_err(err.get_errno())),
             };
-            // `entry.name` borrows the iterator's internal buffer and
-            // is invalidated by the next `next()` call. Copy it once here so
-            // it survives both the push-onto-stack and the deleteDir-after-close
-            // paths.
+            // `entry.name` points into the iterator's buffer, which lives inside
+            // the stack frame: the next `next()` call overwrites it and a `push`
+            // below may reallocate the stack and move it. Copy it once here.
             let entry_name: Vec<u8> = entry.name.slice().to_vec();
             let mut treat_as_dir = entry.kind == sys::FileKind::Directory;
             'handle_entry: loop {
                 if treat_as_dir {
-                    if stack.len() < stack.capacity() {
-                        let top_fd = stack[top_idx].iter.iter.dir;
-                        match dt_open_dir(sys::Dir::borrow(&top_fd), &entry_name) {
-                            Ok(iterable_dir) => {
-                                stack.push(DeleteTreeStackItem {
-                                    name: entry_name,
-                                    name_is_borrowed: false,
-                                    parent_dir: top_fd,
-                                    iter: DirIterator::WrappedIterator::init(
-                                        iterable_dir.into_raw(),
-                                    ),
-                                });
-                                continue 'process_stack;
-                            }
-                            Err(E::ENOTDIR) => {
-                                treat_as_dir = false;
-                                continue 'handle_entry;
-                            }
-                            #[cfg(target_os = "macos")]
-                            Err(e @ (E::EACCES | E::EPERM)) => {
-                                // Same as the pop-delete site below: node's rimraf
-                                // retries rmdir on the directory whose child could
-                                // not be opened and reports its ENOTEMPTY on macOS.
-                                let ancestor = &stack[top_idx];
-                                let ancestor_name: &[u8] = if ancestor.name_is_borrowed {
-                                    sub_path
-                                } else {
-                                    &ancestor.name
-                                };
-                                if matches!(
-                                    dt_delete_dir(
-                                        sys::Dir::borrow(&ancestor.parent_dir),
-                                        ancestor_name
-                                    ),
-                                    Err(E::ENOTEMPTY | E::EEXIST)
-                                ) {
-                                    return Err(dt_err(E::ENOTEMPTY));
-                                }
-                                return Err(dt_err(e));
-                            }
-                            Err(e) => return Err(dt_err(e)),
+                    let top_fd = stack[top_idx].iter.iter.dir;
+                    match dt_open_dir(sys::Dir::borrow(&top_fd), &entry_name) {
+                        Ok(iterable_dir) => {
+                            stack.push(DeleteTreeStackItem {
+                                name: entry_name,
+                                name_is_borrowed: false,
+                                parent_dir: top_fd,
+                                iter: DirIterator::WrappedIterator::init(iterable_dir.into_raw()),
+                            });
+                            continue 'process_stack;
                         }
-                    } else {
-                        let top_fd = stack[top_idx].iter.iter.dir;
-                        zig_delete_tree_min_stack_size_with_kind_hint(
-                            sys::Dir::borrow(&top_fd),
-                            &entry_name,
-                            entry.kind,
-                        )?;
-                        break 'handle_entry;
+                        Err(E::ENOTDIR) => {
+                            treat_as_dir = false;
+                            continue 'handle_entry;
+                        }
+                        #[cfg(target_os = "macos")]
+                        Err(e @ (E::EACCES | E::EPERM)) => {
+                            // Same as the pop-delete site below: node's rimraf
+                            // retries rmdir on the directory whose child could
+                            // not be opened and reports its ENOTEMPTY on macOS.
+                            let ancestor = &stack[top_idx];
+                            let ancestor_name: &[u8] = if ancestor.name_is_borrowed {
+                                sub_path
+                            } else {
+                                &ancestor.name
+                            };
+                            if matches!(
+                                dt_delete_dir(
+                                    sys::Dir::borrow(&ancestor.parent_dir),
+                                    ancestor_name
+                                ),
+                                Err(E::ENOTEMPTY | E::EEXIST)
+                            ) {
+                                return Err(dt_err(E::ENOTEMPTY));
+                            }
+                            return Err(dt_err(e));
+                        }
+                        Err(e) => return Err(dt_err(e)),
                     }
                 } else {
                     let top_fd = stack[top_idx].iter.iter.dir;
@@ -10029,115 +10018,6 @@ fn zig_delete_tree_open_initial_subpath(
                 Err(e) => return Err(dt_err(e)),
             }
         }
-    }
-}
-
-fn zig_delete_tree_min_stack_size_with_kind_hint(
-    self_: &sys::Dir,
-    sub_path: &[u8],
-    kind_hint: sys::FileKind,
-) -> crate::Result<()> {
-    'start_over: loop {
-        let mut dir = match zig_delete_tree_open_initial_subpath(self_, sub_path, kind_hint)? {
-            Some(d) => d,
-            None => return Ok(()),
-        };
-        let mut cleanup_dir_parent: Option<sys::Dir> = None;
-
-        // Valid use of MAX_PATH_BYTES because dir_name_buf will only
-        // ever store a single path component that was returned from the
-        // filesystem.
-        let mut dir_name_buf = PathBuffer::uninit();
-        let mut dir_name_len = sub_path.len().min(dir_name_buf.len());
-        dir_name_buf[..dir_name_len].copy_from_slice(&sub_path[..dir_name_len]);
-        // `dir_name` conceptually aliases either `sub_path` or `dir_name_buf`;
-        // the borrow checker won't let that alias survive the copy/reassignment
-        // below, so track `(is_sub_path, len)` and re-slice on each use.
-        let mut dir_name_is_sub_path = true;
-
-        // Here we must avoid recursion, in order to provide O(1) memory guarantee of this function.
-        // Go through each entry and if it is not a directory, delete it. If it is a directory,
-        // open it, and close the original directory. Repeat. Then start the entire operation over.
-        let result: crate::Result<()> = 'scan_dir: loop {
-            let mut dir_it = DirIterator::WrappedIterator::init(dir.fd);
-            'dir_it: loop {
-                let entry = match dir_it.next() {
-                    Ok(Some(e)) => e,
-                    Ok(None) => break 'dir_it,
-                    Err(err) => break 'scan_dir Err(dt_err(err.get_errno())),
-                };
-                let entry_name: Vec<u8> = entry.name.slice().to_vec();
-                let mut treat_as_dir = entry.kind == sys::FileKind::Directory;
-                'handle_entry: loop {
-                    if treat_as_dir {
-                        match dt_open_dir(&dir, &entry_name) {
-                            Ok(new_dir) => {
-                                cleanup_dir_parent = Some(dir);
-                                dir = new_dir;
-                                let n = entry_name.len().min(dir_name_buf.len());
-                                dir_name_buf[..n].copy_from_slice(&entry_name[..n]);
-                                dir_name_len = n;
-                                dir_name_is_sub_path = false;
-                                continue 'scan_dir;
-                            }
-                            Err(E::ENOTDIR) => {
-                                treat_as_dir = false;
-                                continue 'handle_entry;
-                            }
-                            Err(E::ENOENT) => {
-                                // That's fine, we were trying to remove this directory anyway.
-                                continue 'dir_it;
-                            }
-                            Err(e) => break 'scan_dir Err(dt_err(e)),
-                        }
-                    } else {
-                        match dt_delete_file(&dir, &entry_name) {
-                            Ok(()) => continue 'dir_it,
-                            Err(E::ENOENT) => continue 'dir_it,
-                            Err(E::EISDIR) => {
-                                treat_as_dir = true;
-                                continue 'handle_entry;
-                            }
-                            Err(E::ENOTDIR) => {
-                                #[cfg(debug_assertions)]
-                                unreachable!();
-                                // "Unexpected" → caller's fallthrough arm = EFAULT.
-                                #[cfg(not(debug_assertions))]
-                                break 'scan_dir Err(err_from_static("Unexpected"));
-                            }
-                            Err(e) => break 'scan_dir Err(dt_err(e)),
-                        }
-                    }
-                }
-            }
-            // Reached the end of the directory entries, which means we successfully deleted all of them.
-            // Now to remove the directory itself.
-            dir.close();
-
-            let dir_name: &[u8] = if dir_name_is_sub_path {
-                sub_path
-            } else {
-                &dir_name_buf[..dir_name_len]
-            };
-            if let Some(d) = cleanup_dir_parent {
-                match dt_delete_dir(&d, dir_name) {
-                    Ok(()) | Err(E::ENOENT) | Err(E::ENOTEMPTY) | Err(E::EEXIST) => {
-                        // These two things can happen due to file system race conditions.
-                        continue 'start_over;
-                    }
-                    Err(e) => {
-                        return Err(dt_err(e));
-                    }
-                }
-            } else {
-                match dt_delete_dir(self_, sub_path) {
-                    Ok(()) | Err(E::ENOENT) => return Ok(()),
-                    Err(E::ENOTEMPTY) | Err(E::EEXIST) => continue 'start_over,
-                    Err(e) => return Err(dt_err(e)),
-                }
-            }
-        };
-        return result;
     }
 }
 

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9970,8 +9970,6 @@ pub(crate) fn zig_delete_tree(
                     }
                 }
             };
-            // We know there is room on the stack since we are just re-adding
-            // the StackItem that we previously popped.
             stack.push(DeleteTreeStackItem {
                 name: top.name,
                 name_is_borrowed: top.name_is_borrowed,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9773,8 +9773,7 @@ pub(crate) fn zig_delete_tree(
             None => return Ok(()),
         };
 
-    // One open fd plus an 8 KB readdir buffer per level of the path being
-    // walked; a depth cap here would make deep trees O(depth^2) (#37939).
+    // Grows with the depth of the tree; a cap here would make deep trees O(depth^2) (#37939).
     let mut stack: Vec<DeleteTreeStackItem> = Vec::with_capacity(16);
     let close_all = |stack: &mut Vec<DeleteTreeStackItem>| {
         for item in stack.drain(..) {
@@ -9800,8 +9799,7 @@ pub(crate) fn zig_delete_tree(
                 Ok(None) => break,
                 Err(err) => return Err(dt_err(err.get_errno())),
             };
-            // `entry.name` points into the top frame's readdir buffer, which the
-            // next `next()` overwrites and the `push` below may move.
+            // Points into the top frame's buffer, which `next()` overwrites and `push` may move.
             let entry_name: Vec<u8> = entry.name.slice().to_vec();
             let mut treat_as_dir = entry.kind == sys::FileKind::Directory;
             'handle_entry: loop {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9645,9 +9645,7 @@ pub(crate) unsafe extern "C" fn Bun__mkdirp(
 // Implemented on top of
 // `bun_sys` primitives (`openat` + `unlinkat`) and *errno* values, mapping the
 // errno back to the error-set name strings the callers'
-// `map_anyerror_to_errno*` tables expect. The structure: one open directory
-// per level of the path being walked, treat_as_dir flip-flop,
-// close-then-deleteDir, retry-on-DirNotEmpty.
+// `map_anyerror_to_errno*` tables expect.
 
 #[inline]
 fn dt_err(errno: E) -> crate::Error {
@@ -9775,11 +9773,8 @@ pub(crate) fn zig_delete_tree(
             None => return Ok(()),
         };
 
-    // One frame (an open fd plus an 8 KB readdir buffer) per level of the
-    // path currently being walked. The Vec grows with the tree, so every
-    // directory is opened once and the walk is linear in the number of
-    // entries; capping the depth here and re-walking deeper subtrees from
-    // their top made deep chains O(depth^2).
+    // One open fd plus an 8 KB readdir buffer per level of the path being
+    // walked; a depth cap here would make deep trees O(depth^2) (#37939).
     let mut stack: Vec<DeleteTreeStackItem> = Vec::with_capacity(16);
     let close_all = |stack: &mut Vec<DeleteTreeStackItem>| {
         for item in stack.drain(..) {
@@ -9805,9 +9800,8 @@ pub(crate) fn zig_delete_tree(
                 Ok(None) => break,
                 Err(err) => return Err(dt_err(err.get_errno())),
             };
-            // `entry.name` points into the iterator's buffer, which lives inside
-            // the stack frame: the next `next()` call overwrites it and a `push`
-            // below may reallocate the stack and move it. Copy it once here.
+            // `entry.name` points into the top frame's readdir buffer, which the
+            // next `next()` overwrites and the `push` below may move.
             let entry_name: Vec<u8> = entry.name.slice().to_vec();
             let mut treat_as_dir = entry.kind == sys::FileKind::Directory;
             'handle_entry: loop {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3137,38 +3137,42 @@ describe("rm", () => {
     return { top: top!, seam: seam! };
   }
 
-  // The recursive walk keeps one directory open per level of nesting. It used
-  // to keep at most 16 open and handle anything deeper by re-walking that
-  // subtree from its top once per directory it removed, which is O(depth^2):
-  // removing this 2000-deep chain took 27 s in a release build and about 40 s
-  // in a debug build. The linear walk takes ~0.4 s in a debug+ASAN build.
+  // One directory stays open per level, so the walk visits each directory once:
+  // this 2000-deep chain costs ~0.4 s of CPU in a debug+ASAN build, against 27 s
+  // or more for a walk quadratic in the depth (#37939). That quadratic work is
+  // pure CPU (re-reading cached directories), so the bound is on CPU time, which
+  // process.cpuUsage() also counts for the fs thread pool; wall-clock time, and
+  // hence the test timeout, mostly tracks I/O contention on the machine.
   it.each([
     ["rmSync", (p: string) => rmSync(p, { recursive: true, force: true })],
     ["promises.rm", (p: string) => promises.rm(p, { recursive: true, force: true })],
-  ])("%s removes a directory chain nested 2000 levels deep in linear time", async (_, rm) => {
-    using dir = tempDir("rm-deep-chain", {});
-    const { top, seam } = makeDeepChain(String(dir), 2000);
-    expect(statSync(seam).isDirectory()).toBe(true);
+  ])(
+    "%s removes a directory chain nested 2000 levels deep in linear time",
+    async (_, rm) => {
+      using dir = tempDir("rm-deep-chain", {});
+      const { top, seam } = makeDeepChain(String(dir), 2000);
+      expect(statSync(seam).isDirectory()).toBe(true);
 
-    const maxFDBefore = getMaxFD();
-    const start = performance.now();
-    await rm(top);
-    const elapsedMs = performance.now() - start;
+      const maxFDBefore = getMaxFD();
+      const cpuBefore = process.cpuUsage();
+      await rm(top);
+      const cpu = process.cpuUsage(cpuBefore);
 
-    expect(existsSync(top)).toBe(false);
-    // Every level's directory handle must have been released again; the fs
-    // thread pool may have opened a handful of fds of its own.
-    expect(getMaxFD() - maxFDBefore).toBeLessThan(5);
-    expect(elapsedMs).toBeLessThan(5000);
-  });
+      expect(existsSync(top)).toBe(false);
+      // Every level's directory handle must have been released again; the fs
+      // thread pool may have opened a handful of fds of its own.
+      expect(getMaxFD() - maxFDBefore).toBeLessThan(5);
+      expect((cpu.user + cpu.system) / 1000).toBeLessThan(5000);
+    },
+    30_000,
+  );
 
   // Node's test-fs-rm.js pins what a recursive rm reports when a directory in
   // the tree is not writable: the EACCES from removing its child, except that
   // on macOS node reports the ENOTEMPTY of removing the unwritable directory
-  // itself. Every level now goes through the same walk, so a directory 40
-  // levels down gets the same answer as one directly under the root (the
-  // fallback that used to handle everything below 16 levels said EACCES on
-  // macOS too), and bailing out releases the directories the walk had open.
+  // itself. Every level goes through the same walk, so a directory 40 levels
+  // down gets the same answer as one directly under the root, and bailing out
+  // releases every directory the walk had open.
   it.skipIf(isWindows || process.getuid?.() === 0)(
     "recursive rm reports an unwritable directory 40 levels down the same way as one at the top",
     () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3138,19 +3138,25 @@ describe("rm", () => {
   }
 
   // One directory stays open per level, so the walk visits each directory once:
-  // this 2000-deep chain costs ~0.4 s of CPU in a debug+ASAN build, against 27 s
-  // or more for a walk quadratic in the depth (#37939). That quadratic work is
-  // pure CPU (re-reading cached directories), so the bound is on CPU time, which
-  // process.cpuUsage() also counts for the fs thread pool; wall-clock time, and
-  // hence the test timeout, mostly tracks I/O contention on the machine.
+  // a 2000-deep chain costs ~0.4 s of CPU in a Linux debug+ASAN build, against
+  // 27 s or more for a walk quadratic in the depth (#37939). That quadratic work
+  // is pure CPU (re-reading cached directories), so the bound is on CPU time,
+  // which process.cpuUsage() also counts for the fs thread pool; wall-clock time,
+  // and hence the test timeout, mostly tracks I/O contention on the machine.
+  // Windows machines differ ~60x in what removing one directory costs (0.05 ms
+  // of CPU on a fast box, 3 ms on CI), so no bound is both safe on CI and below
+  // what the quadratic walk costs on a fast box; Windows only checks that a
+  // chain far deeper than the walk's initial 16-slot stack reservation is
+  // removed and cleaned up after.
+  const deepChain = isWindows ? { depth: 200, cpuBudgetMs: undefined } : { depth: 2000, cpuBudgetMs: 5_000 };
   it.each([
     ["rmSync", (p: string) => rmSync(p, { recursive: true, force: true })],
     ["promises.rm", (p: string) => promises.rm(p, { recursive: true, force: true })],
   ])(
-    "%s removes a directory chain nested 2000 levels deep in linear time",
+    `%s removes a directory chain nested ${deepChain.depth} levels deep`,
     async (_, rm) => {
       using dir = tempDir("rm-deep-chain", {});
-      const { top, seam } = makeDeepChain(String(dir), 2000);
+      const { top, seam } = makeDeepChain(String(dir), deepChain.depth);
       expect(statSync(seam).isDirectory()).toBe(true);
 
       const maxFDBefore = getMaxFD();
@@ -3162,7 +3168,9 @@ describe("rm", () => {
       // Every level's directory handle must have been released again; the fs
       // thread pool may have opened a handful of fds of its own.
       expect(getMaxFD() - maxFDBefore).toBeLessThan(5);
-      expect((cpu.user + cpu.system) / 1000).toBeLessThan(5000);
+      if (deepChain.cpuBudgetMs !== undefined) {
+        expect((cpu.user + cpu.system) / 1000).toBeLessThan(deepChain.cpuBudgetMs);
+      }
     },
     30_000,
   );

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3114,12 +3114,14 @@ describe("rm", () => {
   });
 
   // Builds a single chain of at least `depth` nested directories under `parent`
-  // without handing the fs a path longer than ~100 bytes past `parent` (macOS
-  // PATH_MAX is 1024): every chunk of the chain is created on its own, and the
-  // part of the chain built so far is renamed to the bottom of the new chunk.
-  // Returns the top of the chain and the directory the last rename moved.
+  // in chunks, each created with one mkdir and the part of the chain built so
+  // far renamed to its bottom, so that no path handed to the fs is longer than
+  // ~400 bytes past `parent` (macOS PATH_MAX is 1024; ~100 bytes on Windows for
+  // MAX_PATH) and a 2000-deep chain needs only 9 renames, which are slow on a
+  // busy host. Returns the top of the chain and the directory the last rename
+  // moved.
   function makeDeepChain(parent: string, depth: number) {
-    const chunk = 50;
+    const chunk = isWindows ? 50 : 200;
     let top: string | undefined;
     let seam: string | undefined;
     for (let i = 0; depth > 0; i++) {
@@ -3137,16 +3139,15 @@ describe("rm", () => {
     return { top: top!, seam: seam! };
   }
 
-  // One directory stays open per level, so the walk visits each directory once:
-  // a 2000-deep chain costs ~0.4 s of CPU in a Linux debug+ASAN build, against
-  // 27 s or more for a walk quadratic in the depth (#37939). That quadratic work
-  // is pure CPU (re-reading cached directories), so the bound is on CPU time,
-  // which process.cpuUsage() also counts for the fs thread pool; wall-clock time,
-  // and hence the test timeout, mostly tracks I/O contention on the machine.
-  // Windows machines differ ~60x in what removing one directory costs (0.05 ms
-  // of CPU on a fast box, 3 ms on CI), so no bound is both safe on CI and below
-  // what the quadratic walk costs on a fast box; Windows only checks that a
-  // chain far deeper than the walk's initial 16-slot stack reservation is
+  // Removing the 2000-deep chain costs ~0.4 s of CPU in a debug+ASAN build and
+  // 27 s or more with a walk quadratic in the depth (#37939). The bound is on CPU
+  // time, which process.cpuUsage() also counts for the fs thread pool, because
+  // the quadratic work is pure CPU while the wall-clock time of building and
+  // removing 2000 directories is dominated by fs contention on a busy machine
+  // (hence also the test timeout). Windows gets no bound: removing a directory
+  // costs 0.05 ms of CPU on a fast box but 3 ms on CI, so no bound is both safe
+  // on CI and below the quadratic walk's cost on a fast box; it only checks that
+  // a chain far deeper than the walk's 16-slot initial stack reservation is
   // removed and cleaned up after.
   const deepChain = isWindows ? { depth: 200, cpuBudgetMs: undefined } : { depth: 2000, cpuBudgetMs: 5_000 };
   it.each([

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3111,6 +3111,55 @@ describe("rm", () => {
     fs.rmSync(dir, { recursive: true, force: true });
     expect(fs.existsSync(dir)).toBe(false);
   });
+
+  // Builds a single chain of at least `depth` nested directories under `parent`
+  // without handing the fs a path longer than ~100 bytes past `parent` (macOS
+  // PATH_MAX is 1024): every chunk of the chain is created on its own, and the
+  // part of the chain built so far is renamed to the bottom of the new chunk.
+  // Returns the top of the chain and the directory the last rename moved.
+  function makeDeepChain(parent: string, depth: number) {
+    const chunk = 50;
+    let top: string | undefined;
+    let seam: string | undefined;
+    for (let i = 0; depth > 0; i++) {
+      const levels = Math.min(chunk, depth);
+      const chunkTop = join(parent, `chunk${i}`);
+      const chunkBottom = join(chunkTop, Buffer.alloc(levels * 2 - 1, "a/").toString());
+      mkdirSync(chunkBottom, { recursive: true });
+      if (top !== undefined) {
+        seam = join(chunkBottom, "a");
+        renameSync(top, seam);
+      }
+      top = chunkTop;
+      depth -= levels;
+    }
+    return { top: top!, seam: seam! };
+  }
+
+  // The recursive walk keeps one directory open per level of nesting. It used
+  // to keep at most 16 open and handle anything deeper by re-walking that
+  // subtree from its top once per directory it removed, which is O(depth^2):
+  // removing this 2000-deep chain took 27 s in a release build and about 40 s
+  // in a debug build. The linear walk takes ~0.4 s in a debug+ASAN build.
+  it.each([
+    ["rmSync", (p: string) => rmSync(p, { recursive: true, force: true })],
+    ["promises.rm", (p: string) => promises.rm(p, { recursive: true, force: true })],
+  ])("%s removes a directory chain nested 2000 levels deep in linear time", async (_, rm) => {
+    using dir = tempDir("rm-deep-chain", {});
+    const { top, seam } = makeDeepChain(String(dir), 2000);
+    expect(statSync(seam).isDirectory()).toBe(true);
+
+    const maxFDBefore = getMaxFD();
+    const start = performance.now();
+    await rm(top);
+    const elapsedMs = performance.now() - start;
+
+    expect(existsSync(top)).toBe(false);
+    // Every level's directory handle must have been released again; the fs
+    // thread pool may have opened a handful of fds of its own.
+    expect(getMaxFD() - maxFDBefore).toBeLessThan(5);
+    expect(elapsedMs).toBeLessThan(5000);
+  });
 });
 
 describe("rmdir", () => {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -9,6 +9,7 @@ import {
   isGlibc,
   isIntelMacOS,
   isLinux,
+  isMacOS,
   isPosix,
   isWindows,
   tempDir,
@@ -3160,6 +3161,43 @@ describe("rm", () => {
     expect(getMaxFD() - maxFDBefore).toBeLessThan(5);
     expect(elapsedMs).toBeLessThan(5000);
   });
+
+  // Node's test-fs-rm.js pins what a recursive rm reports when a directory in
+  // the tree is not writable: the EACCES from removing its child, except that
+  // on macOS node reports the ENOTEMPTY of removing the unwritable directory
+  // itself. Every level now goes through the same walk, so a directory 40
+  // levels down gets the same answer as one directly under the root (the
+  // fallback that used to handle everything below 16 levels said EACCES on
+  // macOS too), and bailing out releases the directories the walk had open.
+  it.skipIf(isWindows || process.getuid?.() === 0)(
+    "recursive rm reports an unwritable directory 40 levels down the same way as one at the top",
+    () => {
+      using dir = tempDir("rm-deep-unwritable", {});
+      const rmErrorCode = (levels: number) => {
+        const root = join(String(dir), `root-${levels}`);
+        const unwritable = join(root, Buffer.alloc(Math.max(levels * 2 - 1, 0), "a/").toString(), "unwritable");
+        mkdirSync(join(unwritable, "leaf"), { recursive: true });
+        fs.chmodSync(unwritable, 0o555);
+        try {
+          const maxFDBefore = getMaxFD();
+          let code: string | undefined;
+          try {
+            rmSync(root, { recursive: true });
+          } catch (e: any) {
+            code = e.code;
+          }
+          expect(getMaxFD()).toBe(maxFDBefore);
+          return code;
+        } finally {
+          if (existsSync(unwritable)) fs.chmodSync(unwritable, 0o755);
+        }
+      };
+
+      const atTop = rmErrorCode(0);
+      expect(atTop).toBe(isMacOS ? "ENOTEMPTY" : "EACCES");
+      expect(rmErrorCode(40)).toBe(atTop);
+    },
+  );
 });
 
 describe("rmdir", () => {


### PR DESCRIPTION
### Problem

- `fs.rmSync(dir, { recursive: true })` (and `fs.promises.rm` / `fs.rm`) takes time quadratic in how deeply the tree is nested. Removing two chains of single-letter directories with bun 1.4.0 on Linux: depth 250 / 500 / 1000 takes 657 ms / 2273 ms / 8221 ms (a debug build: 565 ms / 2670 ms / 13315 ms). Node 26 removes the depth-1000 tree in 241 ms.
- Cause: `zig_delete_tree` (`src/runtime/node/node_fs.rs`) walks the tree with a stack of open directory iterators, but the stack is created with `Vec::with_capacity(16)` and a directory is only pushed while `stack.len() < stack.capacity()`. Every directory more than 16 levels down is handed to `zig_delete_tree_min_stack_size_with_kind_hint`, which holds O(1) directories open and, after removing each directory, starts over from the top of its subtree. A chain `d` levels below the cap therefore costs about `d^2 / 2` `openat` + `getdents` + `close` round trips, all of it CPU time spent re-reading directories the kernel already has cached. The cap is inherited from Zig's `std.fs.Dir.deleteTree`, which has no allocator and uses a fixed-size array.

### Fix

- Push onto the stack unconditionally, so it grows with the depth of the tree (the one-line change at the top of the `treat_as_dir` branch), and delete the fallback, whose only caller was the removed branch. The `Vec` keeps its initial 16-slot reservation, so trees up to 16 deep allocate exactly as before.
- This is what `bun_sys::Dir::delete_tree` (`src/sys/dir.rs`, used by `bun install`) already does.
- Every depth now goes through the code path that depths 1 to 16 always took, so the error mapping, the macOS ENOTEMPTY handling and the re-open-on-ENOTEMPTY retry are the same at every level instead of changing past 16 levels (before, an unwritable directory deeper than 16 levels was reported as EACCES on macOS while a shallow one was reported as ENOTEMPTY, which is what Node reports).
- Growing the `Vec` may move the frames. A frame is plain data (two fds, the iterator's indices and its inline 8 KB buffer, an owned name), and the only pointer into a frame that exists at a push, the entry name returned by the iterator, is copied out before the push (it already had to be, because the next `next()` call overwrites it).
- Cost: one fd and one frame (`8192` byte readdir buffer plus a few words, about 8.2 KB) per level of the path currently being walked, not per directory in the tree; the 2000-deep chain in the test peaks at about 2000 fds and 17 MB. Concurrent `promises.rm` calls each hold their own stack. A tree deeper than the available fd headroom now fails with EMFILE (verified under `ulimit -n 300`: a clean `EMFILE` error, every fd released, tree left in place) instead of finishing after O(depth^2) re-walks, which at such depths takes minutes to hours. bun raises the soft `RLIMIT_NOFILE` to the hard limit at startup (`adjust_ulimit` in `src/resolver/lib.rs`; CI machines use 1048576), and Node's path-based rimraf cannot remove trees deeper than PATH_MAX at all (about 500 levels of one-letter names on macOS, 2000 on Linux), so the supported envelope is still larger than Node's.
- Tests, all in the `rm` block of `test/js/node/fs/fs.test.ts`:
  - `rmSync` / `promises.rm` `removes a directory chain nested 2000 levels deep` (200 on Windows): builds the chain in chunks (200 levels per `mkdir` on POSIX, 50 on Windows, each chunk's predecessor moved under it with one `rename`, so no path handed to the fs is longer than ~400 bytes past the temp dir), removes it, and asserts that it is gone, that no directory fd is left open, and, on POSIX, that the removal used less than 5 s of CPU time. CPU time rather than wall-clock time because the quadratic work is pure CPU, while the wall-clock time of building and removing 2000 directories tracks fs contention on the machine: on a loaded overlayfs box the removal alone was observed at 15 to 27 s, and the cross-directory renames at 250 to 430 ms each, with the CPU time unchanged at about 0.4 s; hence the 200-level chunks (9 renames instead of 39, whole case about 2 s on that box) and the 30 s test timeout. On CI's root filesystem the cases take 1 to 2 s each. `process.cpuUsage()` is `getrusage(RUSAGE_SELF)`, so it covers the fs thread pool used by `promises.rm`.
    - bun 1.4.0 (`USE_SYSTEM_BUN=1`, Linux): `rmSync` uses 44 s of CPU, both cases fail.
    - debug build without the `src/` change: `rmSync` takes 41 s, both cases fail.
    - debug+ASAN build with the change: 0.35 to 0.5 s of CPU per case, including while the host was loaded enough to stretch the wall-clock time to 13 to 20 s.
    - Windows has no CPU bound: removing one directory costs about 3 ms of CPU on the CI VMs (the 2000-deep chain used 6.1 s on the windows-11-aarch64 lane) but 0.05 ms on a fast Windows box, where bun 1.4.0 removes a 400-deep chain with the quadratic walk in 0.8 s and an 800-deep one in 3.8 s, so no single bound is both safe on CI and below the quadratic walk's cost. Windows removes a 200-deep chain (far past the stack's initial 16-slot reservation, so the `Vec` reallocates several times) and checks removal and cleanup only; verified with bun 1.4.0 on a Windows x64 machine that this variant of the test runs as intended there.
  - `recursive rm reports an unwritable directory 40 levels down the same way as one at the top` (skipped on Windows and as root, like the corresponding block of Node's `test-fs-rm.js`): asserts the platform's error code (EACCES; ENOTEMPTY on macOS) for a `0o555` directory directly under the root and 40 levels down, and that the failed walk releases every fd. It fails on the unfixed build on macOS (EACCES 40 levels down); on Linux both builds report EACCES, so there it only covers the error unwind of the grown stack. Run locally as a non-root user.
  - Doubling the depth with the change (debug+ASAN, two chains, the repro from the report): depth 250 / 500 / 1000 / 2000 takes 90 / 179 / 247 / 490 ms.
  - `test/js/node/fs/fs.test.ts` (510 pass), `promises.test.js`, `dir.test.ts`, and Node's `test-fs-rm.js`, `test-fs-rmSync-special-char.js`, `test-fs-rmdir-*.js` pass with the debug build.
- #35800 edits the call into the removed fallback as well; whichever of the two lands second needs a trivial rebase (with this change the fallback no longer exists, so only its main-loop hunks remain relevant).

### Background

- `zig_delete_tree` is the native implementation behind `rm({ recursive: true })`. It never builds paths: each directory is opened with `openat` relative to its parent's fd and its entries are removed with `unlinkat` relative to its own fd, which is why depth is limited by fds rather than by PATH_MAX. A stack frame holds a directory's fd together with the `getdents` buffer used to iterate it, plus the name needed to `rmdir` it from its parent once it is empty.
- `rmdir({ recursive: true })` also reaches this function natively, but `src/js/node/fs.ts` rejects that option before it gets there (Node removed it), so `rmSync`, `rm` and `promises.rm` are the user-reachable entry points; `fs.rm` is implemented on top of `promises.rm`.

<details>
<summary>Earlier revisions of the test</summary>

The first revision bounded wall-clock time (`performance.now()`, 5 s, default test timeout) at depth 2000 everywhere. It passed on every CI lane that ran it (Linux, ASAN, Alpine, Windows x64 and aarch64) but on a heavily loaded host the 2000 removals alone took 5 to 27 s of wall-clock time at 0.4 s of CPU, so it was switched to a CPU-time bound. The CPU-time bound at depth 2000 then failed on the windows-11-aarch64 lane with 6.1 s, which led to the per-platform sizing above. A review pass then found that with 50-level chunks the 39 cross-directory renames of the setup, not the removal, dominated the wall-clock time on a contended host, hence the 200-level chunks.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->