### PR TITLE
test: cover the c-ares poll timer under jest.useFakeTimers()

### DIFF
--- a/test/js/bun/test/test-timers-dns-resolver-fixture.ts
+++ b/test/js/bun/test/test-timers-dns-resolver-fixture.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, jest, test } from "bun:test";
+import dgram from "node:dgram";
+import { promises as dnsPromises } from "node:dns";
+import { once } from "node:events";
+
+// c-ares expires queries on its own real clock; Bun's per-resolver poll timer
+// (EventLoopTimer tag DNSResolver) only exists to call back into c-ares so it
+// notices. Both tests run with fake timers installed and print one JSON line
+// each, which test-timers.test.ts asserts on.
+
+// Nothing answers on this port, so a query stays in flight until c-ares gives
+// up on it or it is cancelled.
+const server = dgram.createSocket("udp4");
+let nameserver: string;
+
+beforeAll(async () => {
+  server.bind(0, "127.0.0.1");
+  await once(server, "listening");
+  nameserver = `127.0.0.1:${server.address().port}`;
+});
+
+afterAll(() => server.close());
+
+test("runAllTimers() returns while a query is in flight", async () => {
+  // With the poll timer in the fake heap, every pop re-arms it one fake second
+  // later and runAllTimers() spins until c-ares gives the query up, so keep the
+  // query alive well past the parent's spawn timeout: c-ares caps a single try
+  // at 5s (MAX_TIMEOUT_MS in ares_metrics.c), hence the retries.
+  const resolver = new dnsPromises.Resolver({ timeout: 5_000, tries: 10 });
+  resolver.setServers([nameserver]);
+
+  jest.useFakeTimers();
+  try {
+    const outcome = resolver.resolve4("silent.test").then(
+      () => "resolved",
+      e => e.code,
+    );
+    const timerCount = jest.getTimerCount();
+    jest.runAllTimers();
+    resolver.cancel();
+    console.log(JSON.stringify({ test: "runAllTimers", timerCount, outcome: await outcome }));
+  } finally {
+    jest.useRealTimers();
+  }
+});
+
+test("the poll timer is armed against the real clock", async () => {
+  const resolver = new dnsPromises.Resolver({ timeout: 100, tries: 1 });
+  resolver.setServers([nameserver]);
+
+  jest.useFakeTimers();
+  try {
+    // Same trick as test-timers-gc-spin-fixture.ts: push the mocked monotonic
+    // clock past any plausible machine uptime. A deadline derived from it would
+    // sit years out in the real heap and the query would never be failed.
+    for (let i = 0; i < 100; i++) jest.advanceTimersByTime(40 * 24 * 3600 * 1000);
+
+    // Fake time stands still from here on, so the rejection has to come from
+    // the poll timer firing on the real clock.
+    const outcome = await resolver.resolve4("silent.test").then(
+      () => "resolved",
+      e => e.code,
+    );
+    console.log(JSON.stringify({ test: "realClock", outcome }));
+  } finally {
+    jest.useRealTimers();
+  }
+});

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -1,4 +1,7 @@
 import { bunEnv, bunExe } from "harness";
+import dgram from "node:dgram";
+import { promises as dnsPromises } from "node:dns";
+import { once } from "node:events";
 import path from "node:path";
 
 test("we can go back in time", () => {
@@ -113,4 +116,71 @@ test("real timer heap is ticked against the real clock under useFakeTimers", asy
   // null => exited on its own; non-null => killed by the spawn timeout (spun).
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
+});
+
+describe("c-ares poll timer under useFakeTimers", () => {
+  test("an in-flight dns.resolve*() query is not counted, and survives useRealTimers()", async () => {
+    // Nothing answers on this port, so the query stays in flight until c-ares
+    // times it out (c-ares floors the timeout at 250ms; the poll runs every 1s).
+    const server = dgram.createSocket("udp4");
+    server.bind(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const resolver = new dnsPromises.Resolver({ timeout: 100, tries: 1 });
+      resolver.setServers([`127.0.0.1:${server.address().port}`]);
+
+      let outcome: Promise<string>;
+      let timerCount: number;
+      jest.useFakeTimers();
+      try {
+        outcome = resolver.resolve4("silent.test").then(
+          () => "resolved",
+          e => e.code,
+        );
+        timerCount = jest.getTimerCount();
+      } finally {
+        jest.useRealTimers();
+      }
+      expect(timerCount).toBe(0);
+
+      // useRealTimers() discarded every node in the fake heap. Pre-fix the poll
+      // timer was one of them and this query stayed pending forever.
+      expect(await outcome).toBe("ETIMEOUT");
+    } finally {
+      server.close();
+    }
+  });
+
+  // A passing child spends about a second of real time waiting for ETIMEOUT on
+  // top of its startup; pre-fix it never gets out of runAllTimers() (100% CPU)
+  // and has to be reaped by the spawn timeout before the test's own timeout.
+  const childTimeout = 20_000;
+  const testTimeout = 30_000;
+
+  test(
+    "runAllTimers() returns, and the query still times out on the real clock",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [bunExe(), "test", path.join(import.meta.dir, "test-timers-dns-resolver-fixture.ts")],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        timeout: childTimeout,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      if (exitCode !== 0) console.error(stderr);
+      const results = stdout
+        .split("\n")
+        .filter(line => line.startsWith("{"))
+        .map(line => JSON.parse(line));
+      expect(results).toEqual([
+        { test: "runAllTimers", timerCount: 0, outcome: "ECANCELLED" },
+        { test: "realClock", outcome: "ETIMEOUT" },
+      ]);
+      // null => exited on its own; non-null => killed by the spawn timeout (spun).
+      expect(proc.signalCode).toBeNull();
+      expect(exitCode).toBe(0);
+    },
+    testTimeout,
+  );
 });


### PR DESCRIPTION
Re-scoped to tests only: #37946 landed while this was open and contains the two source lines this PR originally carried (`Tag::DNSResolver` no longer fakeable, `Resolver::add_timer` arming with `ForceRealTime`). It added no DNS coverage, so this PR now just pins that behavior for the resolver. The original description is in the details block at the bottom.

### Problem
- On bun 1.4.0, under `jest.useFakeTimers()`, the resolver's 1 s c-ares poll timer went into the fake heap: `jest.getTimerCount()` was `1` with a single `dns.resolve*()` (or, on Linux/macOS, `dns.lookup()`) in flight, `jest.runAllTimers()` spun at 100% CPU re-arming it, and a query started under fake timers never settled, even after `jest.useRealTimers()` (which discards the fake heap, poll timer included).
- Since #37946 (`allow_fake_timers()` is an allowlist, `add_timer` reads the real clock) this is fixed on main, but nothing in the tree exercises the DNS resolver under fake timers, so either half (the tag routing or the clock `add_timer` reads) could regress silently.

### Change
- `test/js/bun/test/test-timers.test.ts`, new `describe("c-ares poll timer under useFakeTimers")`, next to the existing real-heap-under-fake-timers test. Both tests use a `dns.promises.Resolver` pointed at a local UDP socket that never answers, so nothing leaves the machine:
  - In process: `getTimerCount()` stays `0` with a query in flight, and after `useRealTimers()` the query still rejects with `ETIMEOUT` about a second later (c-ares floors the timeout at 250 ms; the poll runs once a second).
  - `test-timers-dns-resolver-fixture.ts`, run as a `bun test` child: `runAllTimers()` returns immediately with a query kept alive for ~50 s (`tries: 10`, since c-ares caps a try at 5 s), and a second query started after the mocked clock was pushed years past uptime still rejects with `ETIMEOUT` in real time. The second case fails if `add_timer` ever reads the mocked clock again, even with the tag routing intact, because the deadline would land years out in the real heap. The child is bounded by a spawn timeout, and the test's own timeout is set above it so a spinning child is reaped rather than orphaned.
- Why `resolve4()` is enough: every request path except the Windows libuv lookup arms this one timer through `request_sent` -> `add_timer` (c-ares resolve/reverse/getaddrinfo/getnameinfo, the libc work-pool lookups, dns_sd on macOS), so one entry point covers the routing and the clock. A hermetic `lookup()` variant is not possible, since the libc and dns_sd backends always use the system resolver.
- Verified: both tests pass on main at b7a777e (debug build, no source changes); both fail on the released 1.4.0 binary (`Received: 1`; the child spins until the spawn timeout kills it, 19.5 s of CPU in 20 s), and failed the same way on the debug build of the parent of the original fix before #37946 landed. This is coverage for an already-merged fix, so there is no unfixed main build for these to fail against.

### Background
- `timer::All` keeps two heaps of `EventLoopTimer` nodes. The event loop drains `timers` against `CLOCK_MONOTONIC`; while fake timers are active, `All::insert` diverts nodes whose `Tag::allow_fake_timers()` is true into the fake heap, which only the `jest.*` functions drain (each pop moves the mocked clock to the popped deadline). `useRealTimers()` / `clearAllTimers()` pop that heap without firing anything.
- The c-ares poll timer: c-ares computes retransmit and timeout deadlines from its own monotonic clock; Bun calls `ares_process_fd(ARES_SOCKET_BAD, ARES_SOCKET_BAD)` once a second while anything is pending so c-ares gets to act on them. The node is armed by `request_sent` / `request_completed` (clock read in `add_timer`) and re-armed from `check_timeouts` with the `now` the heap drain passes in, so both the heap it lands in and the clock `add_timer` reads have to be the real ones.

<details><summary>Original description (source fix, superseded by #37946)</summary>

### Problem
- Under `jest.useFakeTimers()`, `jest.getTimerCount()` reports `1` as soon as a `node:dns` `resolve*()` query is in flight, with no user timers created. The same timer is armed by every other request the resolver sends (`request_sent` callers in `dns.rs`: c-ares `getaddrinfo`/`reverse`/`lookupService`, the libc work-pool lookups, and `dns_sd.rs` on macOS), so `dns.lookup()` on Linux and macOS shows the same count; only the Windows libuv lookup path does not use it.
- `jest.runAllTimers()` in that state does not return: the process sits at 100% CPU in a synchronous loop, so the per-test timeout cannot fire either. For a c-ares query it ends once c-ares gives the query up (5 s per try, times `tries`); for a libc or dns_sd lookup it cannot end on its own.
- Without a drain, a `dns.resolve*()` started under fake timers never settles at all, and a later `jest.useRealTimers()` does not help, since it discards the fake heap, poll timer included.
- Cause: `Tag::DNSResolver` was not on the `Tag::allow_fake_timers()` opt-out list in `src/event_loop/EventLoopTimer.rs`, so `All::insert` put the node in the fake heap; `FakeTimers::execute_all_timers` is `while execute_next() {}`, each pop ran `check_timeouts` -> `ares_process_fd`, c-ares judged the query by its own real clock, and `add_timer` re-armed at mocked now + 1 s. `add_timer` also read `Timespec::now(AllowMockedTime)` for the deadline.

### Fix (as originally proposed here; now on main via #37946)
- Add `Tag::DNSResolver` to the opt-out list and read the clock with `ForceRealTime` in `Resolver::add_timer`, because the real heap is drained against the real clock, so a mocked deadline there would be either already due or years away. Same treatment `DnsSdConnection` and `GcRepeating` already had; #37935 does the same for the Date header timer.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 2 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/test/test-timers.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/test/test-timers.test.ts
bun test v1.4.0 (81a19e17f)

test/js/bun/test/test-timers.test.ts:
(pass) we can go back in time [323.10ms]
(pass) advanceTimersByTime ticks from the setSystemTime value [9.40ms]
(pass) setSystemTime accepts pre-epoch and epoch times and resets with no argument [7.77ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 'x' [454.05ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is Symbol() [379.06ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 1n [364.99ms]
(pass) real timer heap is ticked against the real clock under useFakeTimers [3532.05ms]
(pass) c-ares poll timer under useFakeTimers > an in-flight dns.resolve*() query is not counted, and survives useRealTimers() [1485.01ms]
(pass) c-ares poll timer under useFakeTimers > runAllTimers() returns, and the query still times out on the real clock [4878.72ms]

 9 pass
 0 fail
 32 expect() calls
Ran 9 tests across 1 file. [16.84s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
.../bun/test/test-timers-dns-resolver-fixture.ts   | 68 +++++++++++++++++++++
 test/js/bun/test/test-timers.test.ts               | 70 ++++++++++++++++++++++
 2 files changed, 138 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                  reads  edits  tests
test/js/bun/test/test-timers-dns-resolver-fixture.ts      0      4      0
test/js/bun/test/test-timers.test.ts                      4      7      0
```

</details>

<!-- robobun:evidence:end -->