### PR TITLE
Bump WebKit: keep the locals of a using block's synthesized catch alive in optimized code

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "cf1b36ec8703d8e87436094d21d478d358c7d886";
+export const WEBKIT_VERSION = "autobuild-preview-pr-417-db6d1d70";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/test/js/bun/jsc-stress/fixtures/for-using-dispose-call-live-catch-locals-ftl-validation.js
+++ b/test/js/bun/jsc-stress/fixtures/for-using-dispose-call-live-catch-locals-ftl-validation.js
@@ -1,0 +1,18 @@
+// @bun
+//@ requireOptions("--useConcurrentJIT=0", "--validateGraph=1")
+
+// Found by fuzzing. The FTL compile of this eval code used to fail OSR
+// availability validation ("Live bytecode local not available") on the local
+// that the synthesized catch handler around the dispose call reads: the try
+// range of that handler ends at a block boundary inside the enclosing for-of
+// handler, and DFG's LiveCatchVariablePreservationPhase flushed the outer
+// handler's locals instead of the inner handler's when it crossed from one to
+// the other. --validateGraph=1 makes release builds run that validation too.
+
+(0, eval)(`
+    const resource = { [Symbol.dispose]() { } };
+    for (using r of [resource]) {
+        try { r(); } catch (e) { }
+    }
+    for (let i = 0; i < 2000000; ++i) { }
+`);

--- a/test/js/bun/jsc-stress/fixtures/using-dispose-throw-after-body-throw-in-jit.js
+++ b/test/js/bun/jsc-stress/fixtures/using-dispose-throw-after-body-throw-in-jit.js
@@ -1,0 +1,54 @@
+// @bun
+//@ requireOptions("--useConcurrentJIT=0")
+
+// The disposal code emitted for a `using` block keeps "did the body throw" in a
+// local that is only read by the synthesized catch handler wrapped around the
+// dispose call. That handler has never run by the time the function is
+// optimized, so nothing in the compiled code reads the local and it is only
+// kept alive for the exception exit of the dispose call. The try range of the
+// synthesized catch ends right at that call, inside the range of the enclosing
+// handler, and DFG's LiveCatchVariablePreservationPhase used to switch to the
+// outer handler's liveness before flushing for the inner one, dropping the
+// local. The exit then restored it as undefined and the body's error was lost
+// instead of being reported through a SuppressedError.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+const state = { throwOnDispose: false };
+
+// Distinct executables so the dispose call site becomes megamorphic and stays a
+// real call instead of being inlined (inlining splits the block and hides the bug).
+const resources = [];
+for (let i = 0; i < 16; ++i) {
+    resources.push({
+        state,
+        [Symbol.dispose]: new Function(`if (this.state.throwOnDispose) throw new Error("dispose ${i}");`),
+    });
+}
+
+function run(resource, bodyShouldThrow) {
+    try {
+        {
+            using r = resource;
+            if (bodyShouldThrow)
+                throw new Error("body");
+        }
+    } catch (e) {
+        return e;
+    }
+    return null;
+}
+
+for (let i = 0; i < 20000; ++i) {
+    const error = run(resources[i % resources.length], i & 1);
+    shouldBe(error === null, !(i & 1));
+}
+
+state.throwOnDispose = true;
+const error = run(resources[0], 1);
+shouldBe(error instanceof SuppressedError, true);
+shouldBe(error.error.message, "dispose 0");
+shouldBe(error.suppressed.message, "body");

--- a/test/js/bun/jsc-stress/fixtures/using-inlined-dispose-live-catch-locals-ftl-validation.js
+++ b/test/js/bun/jsc-stress/fixtures/using-inlined-dispose-live-catch-locals-ftl-validation.js
@@ -1,0 +1,28 @@
+// @bun
+//@ requireOptions("--useConcurrentJIT=0", "--validateGraph=1")
+
+// Second fuzzer-found shape of the same bug as
+// for-using-dispose-call-live-catch-locals-ftl-validation.js: here the dispose
+// method is a trivial closure that gets inlined into the dispose call, which
+// still leaves the synthesized catch's try range ending in the middle of the
+// block, so the "body threw" flag it reads was likewise not flushed when the
+// block crossed into the user's try/catch. The body has to throw on some calls
+// so that the "body threw" path is live in the compiled graph. The FTL compile
+// of run() used to fail OSR availability validation on that flag.
+
+function run(bodyShouldThrow) {
+    try {
+        using r = { [Symbol.dispose]() { } };
+        if (bodyShouldThrow)
+            throw 0;
+    } catch (e) {
+        return e;
+    }
+    return null;
+}
+
+for (let i = 0; i < 20000; ++i) {
+    const result = run(i & 1);
+    if (result !== ((i & 1) ? 0 : null))
+        throw new Error(`Unexpected result ${result} on iteration ${i}`);
+}

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -120,6 +120,7 @@ const jsFixtures = [
   // DFG/FTL - live-at-catch locals across nested handlers (`using` disposal)
   "using-dispose-throw-after-body-throw-in-jit.js",
   "for-using-dispose-call-live-catch-locals-ftl-validation.js",
+  "using-inlined-dispose-live-catch-locals-ftl-validation.js",
   // Allocation sinking / OSR / LICM
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",

--- a/test/js/bun/jsc-stress/jsc-stress.test.ts
+++ b/test/js/bun/jsc-stress/jsc-stress.test.ts
@@ -117,6 +117,9 @@ const jsFixtures = [
   "dfg-exception-try-catch-in-constructor-with-inlined-throw.js",
   "dfg-call-class-constructor.js",
   "dfg-osr-entry-should-not-use-callframe-argument.js",
+  // DFG/FTL - live-at-catch locals across nested handlers (`using` disposal)
+  "using-dispose-throw-after-body-throw-in-jit.js",
+  "for-using-dispose-call-live-catch-locals-ftl-validation.js",
   // Allocation sinking / OSR / LICM
   "varargs-inlined-simple-exit.js",
   "loop-unrolling.js",


### PR DESCRIPTION
Found by fuzzing. Fingerprint: `DFGOSRAvailabilityAnalysisPhase.cpp(198)`.

### Problem

Reduced fuzzer input, run through indirect eval (that is how the REPRL harness evaluates scripts; a plain function with a `using` block hits the same thing once it reaches the FTL, see the second fixture):

```js
const resource = { [Symbol.dispose]() {} };
for (using r of [resource]) {
  try { r(); } catch (e) {}
}
for (let i = 0; i < 2000000; ++i) {}
```

Debug/ASAN builds abort when the FTL compiles it:

```
DFG ASSERTION FAILED: Live bytecode local not available: operand = loc21, availabilityMap = {...}, origin = bc#188
vendor/WebKit/Source/JavaScriptCore/dfg/DFGOSRAvailabilityAnalysisPhase.cpp(198) : ...::validateNode(Node *, LocalOSRAvailabilityCalculator &)
```

`loc21` is the `hasError` ("the body threw") flag of the disposal code the bytecode generator emits for `using`. Release builds do not abort, they miscompile: once a function containing a `using` block is optimized (the DFG tier is enough; the dispose call just has to remain a real call instead of being inlined), a dispose method that throws after the body also threw comes out as the dispose method's plain `Error` instead of a `SuppressedError` holding both errors, so the body's exception is silently dropped. On a release build of the unfixed engine (the phase in question is identical from the build I used through main's current pin and WebKit main):

```
$ bun test/js/bun/jsc-stress/fixtures/using-dispose-throw-after-body-throw-in-jit.js
error: Expected true but got false          # error instanceof SuppressedError
$ BUN_JSC_useJIT=0 bun <same file>           # interpreter: passes
```

### Cause

DFG's `LiveCatchVariablePreservationPhase` keeps the locals a catch handler reads alive by inserting `Flush`es: in front of `SetLocal`s inside a try range, and whenever a block's nodes cross from one handler's range into a different one (plus at the end of the block). The handler lookup it uses to detect "the handler changed" also overwrote its cached live-at-catch set with the liveness of the handler it had just found, before the flush for the handler being left was emitted, so a transition straight from one handler into another flushed the wrong handler's locals. Plain `try/catch` never crosses handlers inside a block because `TryNode` emits its jump over the catch block inside the try range. The `using` disposal code ends the synthesized catch's range right after the dispose call, at a label, so the block ends there as well and its terminal carries the origin of the next bytecode, which belongs to the enclosing handler (the for-of's synthesized finally here, the user's `try/catch` in the function case). `hasError` is only read by that synthesized catch, so with the flush missing nothing keeps it alive across the merge where it is either `false` or `true`; it is unavailable at the dispose call's exception exit, the exit restores it as `undefined`, and the catch treats that as "no pending error".

### Fix

oven-sh/WebKit#417: flush for the handler being left first, then compute the liveness of the handler being entered. That PR is rebased onto WebKit `cf1b36ec`, which is exactly what main pins today (none of the upstream merges in #39371, #40276, #40681, #41332 and #42319 nor the fork commits in between touch this phase), so its preview build (`autobuild-preview-pr-417-db6d1d70`, the pin in this PR) is main's engine plus that one change. The pin should move to the final `autobuild-<sha>` once #417 lands.

Fixtures in `test/js/bun/jsc-stress`: `for-using-dispose-call-live-catch-locals-ftl-validation.js` is the first fuzzer shape (eval, dispose call not inlined) and `using-inlined-dispose-live-catch-locals-ftl-validation.js` is a small deterministic version of a second fuzzer input that hit the same assertion with the dispose method inlined into the call and the function reached through recursion; both run with `--validateGraph=1`, so they fail on release builds of the unfixed engine too. `using-dispose-throw-after-body-throw-in-jit.js` checks the `SuppressedError` behaviour once the function is optimized. The first and third of these are also in the WebKit PR as stress tests.

### Verification

- Fail before: all three fixtures hit the assertion above on the `jsc` shell shipped in the `0cbb4a19` debug-asan prebuilt (main pinned that when the evidence was gathered) and on the shell from today's pin `cf1b36ec` (`loc12` in the function shapes, `loc21` in the eval shape), the two validation fixtures also fail through the harness with `USE_SYSTEM_BUN=1`, and the behaviour fixture returns the wrong result on a release build of the unfixed engine. The second fuzzer input itself asserts on the unfixed engine within its first FTL compile.
- Pass after: `bun bd` against the preview tarball, on this branch rebased onto current main: all three fixtures pass, `jsc-stress.test.ts` is 117/117 before the third fixture was added, and both fuzzer inputs no longer assert (the second one completes the FTL compile that used to fail; the input itself then runs for minutes even on a release build because it recurses to stack overflow from every level of another recursion). The preview's own `jsc` shell passes the fixtures as well. (Before the rebase, the earlier preview also passed `test/js/web/explicit-resource-management.test.ts`, `test/js/bun/test/mock-disposable.test.ts`, `test/js/bun/resolve/lower-using-bun-target.test.ts`, `test/js/bun/jsc/bun-jsc.test.ts` and `test/js/node/async_hooks`.)
- The `SuppressedError` scenario matches the interpreter at both the DFG and FTL tiers with the fix.

Rebased onto main eighteen times as the WebKit pin moved underneath (the upstream merge in #39371, then #39614, #39829, #35343, #40201, the upstream merge in #40276, #40417, #40507, #40570, #40270, #40643, the upstream merge in #40681, #40767, #40816, the group #41297, #41324, the upstream merge in #41332, #41378 and #41407, and then #42002 with the upstream merge in #42319); each time the only conflict was the `WEBKIT_VERSION` line, resolved to the preview built on top of the new pin. Latest: preview `db6d1d70` on `cf1b36ec`, jsc-stress 119/119 with it, and the three fixtures still fail on the `cf1b36ec` shell.

<!-- robobun:evidence:begin -->

---

**[policy-decision:webkit]** gate passed · iteration 9 · 5 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc-stress/jsc-stress.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/bun/jsc-stress/jsc-stress.test.ts
bun test v1.4.3 (4ff919377)

test/js/bun/jsc-stress/jsc-stress.test.ts:
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsqrt.js [369.73ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithsin.js [438.09ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-equality.js [385.46ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithcos.js [429.01ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-arithtan.js [435.63ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-ident-equality.js [350.34ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-string-strict-equality.js [417.94ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-library-substring.js [434.36ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-exec.js [472.21ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-regexp-test.js [451.95ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength.js [368.62ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-getmyargumentslength-inline.js [327.79ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined.js [572.15ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val.js [641.68ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception.js [443.33ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-exception-no-catch.js [549.22ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-get-my-argument-by-val-inlined-and-not-inlined.js [848.85ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-call-varargs-exception.js [407.73ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) > ftl-try-catch-getter-throw.js [611.24ms]
(pass) JSC JIT Stress Tests > JS (Baseline/DFG/FTL) 
... (truncated)
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/deps/webkit.ts                       |  2 +-
 ...ispose-call-live-catch-locals-ftl-validation.js | 18 ++++++++
 .../using-dispose-throw-after-body-throw-in-jit.js | 54 ++++++++++++++++++++++
 ...ned-dispose-live-catch-locals-ftl-validation.js | 28 +++++++++++
 test/js/bun/jsc-stress/jsc-stress.test.ts          |  4 ++
 5 files changed, 105 insertions(+), 1 deletion(-)
```

</details>

**gate history** · 20 passed · 0 rejected · iteration 9

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/deps/webkit.ts                                 20     19     49
…-using-dispose-call-live-catch-locals-ftl-validation.js      0      1     41
…fixtures/using-dispose-throw-after-body-throw-in-jit.js      0      1     40
…ing-inlined-dispose-live-catch-locals-ftl-validation.js      1      1     41
test/js/bun/jsc-stress/jsc-stress.test.ts                     2      3     40
```

</details>

<!-- robobun:evidence:end -->














