### PR TITLE
shell(cp): copy symlinks with their targets as written

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8565,36 +8565,36 @@ impl NodeFS {
         let mut dest_buf = paths::path_buffer_pool::get();
         let dest = strings::from_wpath(&mut dest_buf[..], dest.as_slice());
 
-        let result = if !is_dir {
-            Syscall::symlink(target, dest)
-        } else if paths::is_absolute(target.as_bytes()) {
-            sys::symlink_or_junction(dest, target, None)
-        } else {
-            // A junction needs an absolute target; resolve the link from the copy's own directory.
-            let mut junction_buf = paths::path_buffer_pool::get();
-            let junction_buf_len = junction_buf.len();
-            let Some(junction_target) =
-                paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Windows>(
-                    paths::resolve_path::dirname::<paths::platform::Windows>(dest.as_bytes()),
-                    &mut junction_buf[..junction_buf_len - 1],
-                    &[target.as_bytes()],
+        let flags = if is_dir { uv::UV_FS_SYMLINK_DIR } else { 0 };
+        let result = match Syscall::symlink_uv(target, dest, flags) {
+            Err(err) if is_dir && err.get_errno() != E::EEXIST && err.get_errno() != E::ENOENT => {
+                // Junctions need an absolute target: the link resolved from the copy's directory.
+                let mut junction_buf = paths::path_buffer_pool::get();
+                let junction_buf_len = junction_buf.len();
+                let Some(junction_target) =
+                    paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Windows>(
+                        dest.as_bytes(),
+                        &mut junction_buf[..junction_buf_len - 1],
+                        &[b"..", target.as_bytes()],
+                    )
+                else {
+                    return Err(sys::Error {
+                        errno: E::ENAMETOOLONG as _,
+                        syscall: sys::Tag::symlink,
+                        path: dest.as_bytes().into(),
+                        ..Default::default()
+                    });
+                };
+                let junction_target_len = junction_target.len();
+                junction_buf[junction_target_len] = 0;
+                // SAFETY: NUL written at `junction_buf[junction_target_len]`.
+                Syscall::symlink_uv(
+                    ZStr::from_buf(&junction_buf[..], junction_target_len),
+                    dest,
+                    uv::UV_FS_SYMLINK_JUNCTION,
                 )
-            else {
-                return Err(sys::Error {
-                    errno: E::ENAMETOOLONG as _,
-                    syscall: sys::Tag::symlink,
-                    path: dest.as_bytes().into(),
-                    ..Default::default()
-                });
-            };
-            let junction_target_len = junction_target.len();
-            junction_buf[junction_target_len] = 0;
-            // SAFETY: NUL written at `junction_buf[junction_target_len]`.
-            sys::symlink_or_junction(
-                dest,
-                target,
-                Some(ZStr::from_buf(&junction_buf[..], junction_target_len)),
-            )
+            }
+            result => result,
         };
         result.map_err(|err| err.with_path(dest.as_bytes()))
     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4343,10 +4343,8 @@ pub mod args {
         pub(crate) recursive: bool,
         pub(crate) error_on_exist: bool,
         pub(crate) force: bool,
-        /// Recreate each symlink with the target string it has in the source
-        /// (`cp -R`). Otherwise a relative target is resolved against the
-        /// source link's directory first, which is `fs.cp`'s default
-        /// (`verbatimSymlinks: false`).
+        /// `cp -R`: keep each link's target as stored. Off (`fs.cp`'s default), a
+        /// relative target is resolved against the source link's directory.
         pub(crate) verbatim_symlinks: bool,
     }
 
@@ -8550,12 +8548,9 @@ impl NodeFS {
         Syscall::symlink(ZStr::from_buf(&resolved_buf[..], resolved_len), dest)
     }
 
-    /// `verbatim_symlinks` arm of the Windows reparse-point branch in
-    /// `copy_single_file_sync`: recreates the link with the target string
-    /// stored in `src`. A directory link falls back to a junction when
-    /// symlinks cannot be created; a junction only holds an absolute target,
-    /// so a relative one is anchored at the copied link's own directory, which
-    /// is where the relative link would have been resolved from.
+    /// The junction `symlink_or_junction` falls back to needs an absolute
+    /// target, so a relative one is resolved from the copied link's directory,
+    /// which is where the symlink would have resolved it from.
     #[cfg(windows)]
     fn cp_symlink_verbatim(
         src: &OSPathSliceZ,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4343,6 +4343,11 @@ pub mod args {
         pub(crate) recursive: bool,
         pub(crate) error_on_exist: bool,
         pub(crate) force: bool,
+        /// Recreate each symlink with the target string it has in the source
+        /// (`cp -R`). Otherwise a relative target is resolved against the
+        /// source link's directory first, which is `fs.cp`'s default
+        /// (`verbatimSymlinks: false`).
+        pub(crate) verbatim_symlinks: bool,
     }
 
     pub struct Cp {
@@ -4389,6 +4394,7 @@ pub mod args {
                     recursive,
                     error_on_exist,
                     force,
+                    verbatim_symlinks: false,
                 },
             })
         }
@@ -8490,7 +8496,12 @@ impl NodeFS {
     }
 
     #[cfg_attr(any(windows, target_os = "macos"), allow(dead_code))]
-    fn cp_symlink(&mut self, src: &ZStr, dest: &ZStr) -> Maybe<ret::CopyFile> {
+    fn cp_symlink(
+        &mut self,
+        src: &ZStr,
+        dest: &ZStr,
+        flags: &args::CpFlags,
+    ) -> Maybe<ret::CopyFile> {
         let mut target_buf = PathBuffer::uninit();
         // `bun_sys::readlink` returns the byte length on every
         // platform (the `Syscall` alias = `sys_uv` on Windows would return the
@@ -8505,7 +8516,7 @@ impl NodeFS {
         target_buf[link_len] = 0;
         // SAFETY: NUL written at `target_buf[link_len]`.
         let link_target = ZStr::from_buf(&target_buf[..], link_len);
-        if paths::is_absolute(link_target.as_bytes()) {
+        if flags.verbatim_symlinks || paths::is_absolute(link_target.as_bytes()) {
             return Syscall::symlink(link_target, dest);
         }
         let mut cwd_buf = PathBuffer::uninit();
@@ -8539,6 +8550,63 @@ impl NodeFS {
         Syscall::symlink(ZStr::from_buf(&resolved_buf[..], resolved_len), dest)
     }
 
+    /// `verbatim_symlinks` arm of the Windows reparse-point branch in
+    /// `copy_single_file_sync`: recreates the link with the target string
+    /// stored in `src`. A directory link falls back to a junction when
+    /// symlinks cannot be created; a junction only holds an absolute target,
+    /// so a relative one is anchored at the copied link's own directory, which
+    /// is where the relative link would have been resolved from.
+    #[cfg(windows)]
+    fn cp_symlink_verbatim(
+        src: &OSPathSliceZ,
+        dest: &OSPathSliceZ,
+        is_dir: bool,
+    ) -> Maybe<ret::CopyFile> {
+        let mut target_buf = paths::path_buffer_pool::get();
+        let target_len = {
+            let mut src_buf = paths::path_buffer_pool::get();
+            let src = strings::from_wpath(&mut src_buf[..], src.as_slice());
+            sys::readlink(src, &mut target_buf[..])?
+        };
+        target_buf[target_len] = 0;
+        // SAFETY: NUL written at `target_buf[target_len]`.
+        let target = ZStr::from_buf(&target_buf[..], target_len);
+        let mut dest_buf = paths::path_buffer_pool::get();
+        let dest = strings::from_wpath(&mut dest_buf[..], dest.as_slice());
+
+        let result = if !is_dir {
+            Syscall::symlink(target, dest)
+        } else if paths::is_absolute(target.as_bytes()) {
+            sys::symlink_or_junction(dest, target, None)
+        } else {
+            let mut junction_buf = paths::path_buffer_pool::get();
+            let junction_buf_len = junction_buf.len();
+            let Some(junction_target) =
+                paths::resolve_path::join_abs_string_buf_checked::<paths::platform::Windows>(
+                    paths::resolve_path::dirname::<paths::platform::Windows>(dest.as_bytes()),
+                    &mut junction_buf[..junction_buf_len - 1],
+                    &[target.as_bytes()],
+                )
+            else {
+                return Err(sys::Error {
+                    errno: E::ENAMETOOLONG as _,
+                    syscall: sys::Tag::symlink,
+                    path: dest.as_bytes().into(),
+                    ..Default::default()
+                });
+            };
+            let junction_target_len = junction_target.len();
+            junction_buf[junction_target_len] = 0;
+            // SAFETY: NUL written at `junction_buf[junction_target_len]`.
+            sys::symlink_or_junction(
+                dest,
+                target,
+                Some(ZStr::from_buf(&junction_buf[..], junction_target_len)),
+            )
+        };
+        result.map_err(|err| err.with_path(dest.as_bytes()))
+    }
+
     /// This is `copyFile`, but it copies symlinks as-is
     pub(crate) fn copy_single_file_sync(
         &mut self,
@@ -8550,7 +8618,7 @@ impl NodeFS {
         #[cfg(not(windows))] reuse_stat: Option<&sys::Stat>,
         args: &args::Cp,
     ) -> Maybe<ret::CopyFile> {
-        let _ = args; // only the Windows branch consults `args` (shouldIgnoreEbusy)
+        let _ = args; // the macOS branch (copyfile handles symlinks) does not consult `args`
 
         // TODO: do we need to fchown?
         #[cfg(target_os = "macos")]
@@ -8700,7 +8768,7 @@ impl NodeFS {
                     if err.get_errno() == E::ELOOP {
                         // ELOOP is returned when you open a symlink with NOFOLLOW.
                         // as in, it does not actually let you open it.
-                        return self.cp_symlink(src, dest);
+                        return self.cp_symlink(src, dest, &args.flags);
                     }
                     return Err(err);
                 }
@@ -8872,7 +8940,7 @@ impl NodeFS {
                     // open(2) returns EMLINK for this case, though POSIX
                     // specifies ELOOP; accept either.
                     if matches!(err.get_errno(), E::EMLINK | E::ELOOP) {
-                        return self.cp_symlink(src, dest);
+                        return self.cp_symlink(src, dest, &args.flags);
                     }
                     return Err(err);
                 }
@@ -9067,6 +9135,10 @@ impl NodeFS {
                 }
                 return Ok(());
             } else {
+                let is_dir = stat_ & windows::FILE_ATTRIBUTE_DIRECTORY != 0;
+                if args.flags.verbatim_symlinks {
+                    return Self::cp_symlink_verbatim(src, dest, is_dir);
+                }
                 let handle = match sys::openat_windows(FD::INVALID, src, sys::O::RDONLY, 0) {
                     Err(err) => return Err(err),
                     Ok(fd) => fd,
@@ -9098,7 +9170,6 @@ impl NodeFS {
                 } else {
                     bun_core::WStr::from_buf(&wbuf[..], len)
                 };
-                let is_dir = stat_ & windows::FILE_ATTRIBUTE_DIRECTORY != 0;
                 // `symlink_w`/`symlink_or_junction` (not raw `CreateSymbolicLinkW`)
                 // so unprivileged creation is requested. UNC targets skip the junction
                 // fallback: libuv's `fs__create_junction` only accepts drive-letter targets.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4343,8 +4343,7 @@ pub mod args {
         pub(crate) recursive: bool,
         pub(crate) error_on_exist: bool,
         pub(crate) force: bool,
-        /// `cp -R`: keep each link's target as stored. Off (`fs.cp`'s default), a
-        /// relative target is resolved against the source link's directory.
+        /// Keep link targets as stored (`cp -R`) instead of resolving relative ones (`fs.cp`).
         pub(crate) verbatim_symlinks: bool,
     }
 
@@ -8548,9 +8547,6 @@ impl NodeFS {
         Syscall::symlink(ZStr::from_buf(&resolved_buf[..], resolved_len), dest)
     }
 
-    /// The junction `symlink_or_junction` falls back to needs an absolute
-    /// target, so a relative one is resolved from the copied link's directory,
-    /// which is where the symlink would have resolved it from.
     #[cfg(windows)]
     fn cp_symlink_verbatim(
         src: &OSPathSliceZ,
@@ -8574,6 +8570,7 @@ impl NodeFS {
         } else if paths::is_absolute(target.as_bytes()) {
             sys::symlink_or_junction(dest, target, None)
         } else {
+            // A junction needs an absolute target; resolve the link from the copy's own directory.
             let mut junction_buf = paths::path_buffer_pool::get();
             let junction_buf_len = junction_buf.len();
             let Some(junction_target) =

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -8500,7 +8500,7 @@ impl NodeFS {
         &mut self,
         src: &ZStr,
         dest: &ZStr,
-        flags: &args::CpFlags,
+        flags: args::CpFlags,
     ) -> Maybe<ret::CopyFile> {
         let mut target_buf = PathBuffer::uninit();
         // `bun_sys::readlink` returns the byte length on every
@@ -8768,7 +8768,7 @@ impl NodeFS {
                     if err.get_errno() == E::ELOOP {
                         // ELOOP is returned when you open a symlink with NOFOLLOW.
                         // as in, it does not actually let you open it.
-                        return self.cp_symlink(src, dest, &args.flags);
+                        return self.cp_symlink(src, dest, args.flags);
                     }
                     return Err(err);
                 }
@@ -8940,7 +8940,7 @@ impl NodeFS {
                     // open(2) returns EMLINK for this case, though POSIX
                     // specifies ELOOP; accept either.
                     if matches!(err.get_errno(), E::EMLINK | E::ELOOP) {
-                        return self.cp_symlink(src, dest, &args.flags);
+                        return self.cp_symlink(src, dest, args.flags);
                     }
                     return Err(err);
                 }

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -713,6 +713,7 @@ impl ShellCpTask {
                 recursive: self.opts.recursive,
                 force: true,
                 error_on_exist: false,
+                verbatim_symlinks: true,
             },
         };
 

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { lstatSync, readdirSync, readFileSync, readlinkSync, realpathSync, rmSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,97 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// The builtin is only the default on Windows; on POSIX it is switched on by an
+// env var that is read once per process, so each cp runs in a child bun.
+describe.concurrent("bunshell cp -R copies symlinks as written", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  /** A directory holding `outside.txt` and `src/inner/target`; `addLinks` adds links to `src/`. */
+  function setup(name: string, addLinks: (src: string) => void) {
+    const dir = tempDir(`shell-cp-symlinks-${name}`, {
+      "outside.txt": "outside\n",
+      "src/inner/target": "target\n",
+    });
+    addLinks(join(String(dir), "src"));
+    return dir;
+  }
+
+  /** Runs `command` through the shell builtin inside `cwd`; returns cp's exit code and stderr. */
+  async function cp(cwd: string, command: string): Promise<{ exitCode: number; stderr: string }> {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "const r = await Bun.$`${{ raw: process.argv[1] }}`.nothrow().quiet();" +
+          "console.log(JSON.stringify({ exitCode: r.exitCode, stderr: r.stderr.toString() }));",
+        command,
+      ],
+      cwd,
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  const copied = { exitCode: 0, stderr: "" };
+
+  function links(dir: string, names: string[]) {
+    return Object.fromEntries(names.map(name => [name, readlinkSync(join(dir, name))]));
+  }
+
+  test("relative targets stay relative, so the copy does not point into the source tree", async () => {
+    using dir = setup("relative", src => {
+      symlinkSync("inner/target", join(src, "rel"));
+      symlinkSync("../outside.txt", join(src, "up"));
+      symlinkSync(join(src, "inner", "target"), join(src, "abs"));
+      symlinkSync("inner", join(src, "reldir"), "dir");
+    });
+    const out = join(String(dir), "out");
+
+    expect(await cp(String(dir), "cp -R src out")).toEqual(copied);
+    expect(links(out, ["rel", "up", "abs", "reldir"])).toEqual({
+      rel: p("inner/target"),
+      up: p("../outside.txt"),
+      abs: readlinkSync(join(String(dir), "src", "abs")),
+      reldir: "inner",
+    });
+    expect(realpathSync(join(out, "rel"))).toBe(realpathSync(join(out, "inner", "target")));
+    expect(readdirSync(join(out, "reldir"))).toEqual(["target"]);
+
+    // The copy stands on its own once the source is gone.
+    rmSync(join(String(dir), "src"), { recursive: true });
+    expect(readFileSync(join(out, "rel"), "utf8")).toBe("target\n");
+    expect(readFileSync(join(out, "up"), "utf8")).toBe("outside\n");
+    expect(readFileSync(join(out, "reldir", "target"), "utf8")).toBe("target\n");
+  });
+
+  test("a dangling link is copied as written", async () => {
+    using dir = setup("dangling", src => symlinkSync("missing", join(src, "dangling")));
+
+    expect(await cp(String(dir), "cp -R src out")).toEqual(copied);
+    expect(readlinkSync(join(String(dir), "out", "dangling"))).toBe("missing");
+  });
+
+  test("a link named as the source operand is copied as written", async () => {
+    using dir = setup("operand", src => symlinkSync("inner/target", join(src, "rel")));
+
+    expect(await cp(String(dir), "cp -R src/rel rel-copy")).toEqual(copied);
+    expect(readlinkSync(join(String(dir), "rel-copy"))).toBe(p("inner/target"));
+  });
+
+  test.skipIf(!isWindows)("a junction is copied as a link to the same directory", async () => {
+    using dir = setup("junction", src => symlinkSync(join(src, "inner"), join(src, "junction"), "junction"));
+    const out = join(String(dir), "out");
+
+    expect(await cp(String(dir), "cp -R src out")).toEqual(copied);
+    expect(lstatSync(join(out, "junction")).isSymbolicLink()).toBe(true);
+    expect(realpathSync(join(out, "junction"))).toBe(realpathSync(join(String(dir), "src", "inner")));
   });
 });
 

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -264,6 +264,19 @@ describe.concurrent("bunshell cp -R copies symlinks as written", () => {
     expect(lstatSync(join(out, "junction")).isSymbolicLink()).toBe(true);
     expect(realpathSync(join(out, "junction"))).toBe(realpathSync(join(String(dir), "src", "inner")));
   });
+
+  // `\\localhost\C$\...` is the administrative-share spelling of a local path, as in the node:fs cp tests.
+  test.skipIf(!isWindows)("a directory link to a UNC path is copied as written", async () => {
+    using dir = setup("unc", src => {
+      const inner = realpathSync(join(src, "inner"));
+      symlinkSync(`\\\\localhost\\${inner[0]}$\\${inner.slice(3)}`, join(src, "share"), "dir");
+    });
+    const out = join(String(dir), "out");
+
+    expect(await cp(String(dir), "cp -R src out")).toEqual(copied);
+    expect(readlinkSync(join(out, "share"))).toBe(readlinkSync(join(String(dir), "src", "share")));
+    expect(readFileSync(join(out, "share", "target"), "utf8")).toBe("target\n");
+  });
 });
 
 function expectSortedOutput(expected: string) {


### PR DESCRIPTION
### Problem
- The shell `cp` builtin (the default on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX) rewrites symlinks while copying a tree: a relative link inside the source becomes an absolute link back into the source tree, so the copy is not self-contained and breaks once the source is moved or removed. `cp -R` from coreutils recreates the link with the same target string.
  ```
  mkdir -p d/inner && echo hi > d/inner/target && ln -s inner/target d/rel
  BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e 'await Bun.$`cp -R d dcopy`; console.log(require("fs").readlinkSync("dcopy/rel"))'
  # bun 1.4.0: /tmp/x/d/inner/target        cp -R: inner/target
  ```
- On Windows the builtin also fails outright on a dangling link (`cp: No such file or directory`), because the copy opens the link's target to find out where it points.
- Cause: `ShellCpTask` (`src/runtime/shell/builtin/cp.rs`) hands the copy to the native `fs.cp` implementation, whose symlink handling implements node's `fs.cp` default of `verbatimSymlinks: false`: `NodeFS::cp_symlink` (`src/runtime/node/node_fs.rs`, Linux/FreeBSD) resolves a relative target against the source link's directory, and the Windows reparse-point branch of `copy_single_file_sync` opens the link and recreates it from `GetFinalPathNameByHandleW`. That is right for `fs.cp`, but the shell builtin wants `cp` semantics.

### Fix
- `args::CpFlags` gets `verbatim_symlinks`. The shell builtin sets it; `Cp::from_js` (the `fs.cp`/`fs.cpSync` binding) leaves it off, so node's behavior is untouched.
- Linux/FreeBSD: `cp_symlink` recreates the link with the `readlink` result as is when the flag is set; the resolving path below it is unchanged for the binding.
- Windows: a new `cp_symlink_verbatim` arm reads the reparse point with `readlink` and recreates it with `uv_fs_symlink` (the call `fs.symlink` uses), passing the stored target through untouched and `UV_FS_SYMLINK_DIR` for directory links; nothing is opened, so dangling links copy too. If creating a directory symlink fails for any reason other than EEXIST/ENOENT (in practice: no symlink privilege), it creates a junction instead, the link type unprivileged Windows allows. A junction needs an absolute target, so it gets the stored target resolved from the copied link's own directory (`join(dest, "..", target)`), which is what the symlink would have resolved to. libuv rejects junction targets that are not drive-letter paths (UNC, drive-less), so those surface as EINVAL in that fallback; before this change UNC targets also failed when symlinks were unavailable.
- Why this is the right behavior: the builtin never dereferences links (it `lstat`s and opens with `O_NOFOLLOW`, and rejects `-H`/`-L`), which is `cp -R`/`cp -P` mode, and in that mode cp copies the link contents byte for byte; that is what makes a copied tree independent of its source. The macOS arm already did this (`copyfile(COPYFILE_NOFOLLOW_SRC)` and `clonefile` both preserve links), so this also makes the builtin behave the same on every platform.
- Behavior changes to be aware of: `cp link dest` without `-R` used to produce a resolved absolute link and now produces the link as written, consistent with `-R`. (coreutils would dereference in that case; the builtin never has, which is a separate pre-existing gap.) On Windows the copy treats every reparse point as a link (`dir_iterator.rs`, `cp_async`), so for a reparse point that is not a link (a cloud placeholder file, for example) the old code produced a symlink pointing back at the source file and the new code reports `readlink`'s EINVAL for it; copying such files as files is a separate pre-existing problem in that classification.
- `fs.cp`/`fs.cpSync` are unaffected: besides the flag being off for them, `internal/fs/cp*.ts` only takes the native path for regular files and (on macOS) link-free trees.
- Verified with `test/js/bun/shell/commands/cp.test.ts`, new block "bunshell cp -R copies symlinks as written" (each test runs cp in a child bun with the builtin enabled): the three platform-independent tests fail on bun 1.4.0 on Linux and on the Windows canary (targets rewritten to absolute; on Windows the dangling link additionally aborts the copy) and pass with the fix on Linux, Windows, and the darwin 14 CI lane. Two Windows-only tests cover directory links with an absolute target (a junction source, and a directory symlink to a UNC path, whose target must come out byte for byte).
- `test/js/node/fs/cp.test.ts` and `cp-symlink-target.test.ts` pass with the fix (node's resolving behavior still in place).
- The junction fallback cannot run on CI (the runners can create symlinks), so it was checked by hand on Windows with a local build that made the symlink attempt fail: `reldir -> inner` and `deep/updir -> ..\inner` came out as junctions to `out\inner`, an absolute target kept its value, a relative file link stayed a relative symlink, a link copied to a drive root resolved against the root, and a UNC directory link failed cleanly with `cp: Invalid argument` and created nothing.
- `cargo check`/`clippy` for `x86_64-pc-windows-msvc` report no new findings in `node_fs.rs` compared to main.

### Background
- Shell `cp` builtin: `ShellCpTask::run_from_thread_pool_impl` builds an `args::Cp` and starts a `ShellAsyncCpTask` (`NewAsyncCpTask<IS_SHELL = true>`), the same task type `fs.promises.cp` uses. It walks directories and copies every non-directory entry through `copy_single_file_sync`, which detects a symlink via `open(O_NOFOLLOW)` failing with `ELOOP` (`EMLINK` on FreeBSD) or via `FILE_ATTRIBUTE_REPARSE_POINT` on Windows.
- `verbatimSymlinks` is node's `fs.cp` option. Its default (`false`) makes `fs.cp` resolve a relative link target against the source link's directory; `true` copies the target string unchanged, which is what `cp` does.
- Windows reparse points: a symlink can point at a file or a directory (the link itself carries the directory attribute) and creating one normally needs a privilege or developer mode; a junction is a directory-only link that anyone can create but that can only hold an absolute drive-letter path. `uv_fs_symlink` creates either kind depending on its flags and already retries without the unprivileged-create flag on older systems.
- The builtin is only enabled by default on Windows; on POSIX `cp` normally runs the system binary, and `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` (read once per process) switches the builtin on, which is why the tests spawn a child bun.

<details>
<summary>Earlier revision of the Windows arm</summary>

Up to 2ceee95 directory links went through `bun_sys::symlink_or_junction`, the helper the installer uses for its own links. Review pointed out that it prefixes absolute targets with `\\?\`, which turns a UNC target such as `\\server\share\x` into an invalid link; the old reparse branch had special-cased UNC for that reason. 1812459 replaced it with direct `uv_fs_symlink` calls as described above and added the UNC test.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->