### PR TITLE
shell(cp): exit 1 when a held-back Windows error turns out to be real

### DIFF
--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -56,8 +56,7 @@ pub struct ExecState {
 pub struct EbusyState {
     pub(crate) tasks: Vec<*mut ShellCpTask>,
     pub(crate) idx: usize,
-    /// Exit code of the exec phase (tasks that failed outright); raised to 1
-    /// by `print_shell_cp_task` for every deferred task that is not ignorable.
+    /// 1 once any task, deferred or not, has been reported as failed.
     pub(crate) main_exit_code: ExitCode,
     /// Absolute target paths that some task copied successfully — used to
     /// suppress a sibling task's EBUSY on the same target.
@@ -211,8 +210,7 @@ impl Cp {
     /// Windows-only post-processing of tasks that failed with EBUSY: if some
     /// other task already succeeded
     /// for the same absolute src/tgt, the EBUSY is benign and the task is
-    /// dropped; otherwise its error is surfaced via `print_shell_cp_task`,
-    /// which also fails the builtin.
+    /// dropped; otherwise its error is surfaced via `print_shell_cp_task`.
     #[cfg(windows)]
     fn ignore_ebusy_error_if_possible(interp: &Interpreter, cmd: NodeId) -> Yield {
         loop {
@@ -321,13 +319,11 @@ impl Cp {
             let s = Builtin::shell_err_to_string(interp, cmd, Kind::Cp, &e).to_vec();
             match &mut Self::state_mut(interp, cmd).state {
                 State::Exec(exec) => exec.err = Some(e),
-                // A deferred task that turned out not to be ignorable. The
-                // exit code was already derived from `ExecState::err` when
-                // this phase started, so the failure is recorded directly.
                 #[cfg(windows)]
                 State::Ebusy(eb) => eb.main_exit_code = 1,
                 _ => {}
             }
+            // `e` drops here when not stored.
             s
         });
         OutputTask::<Cp>::start(output_task, interp, errstr.as_deref())

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -56,6 +56,8 @@ pub struct ExecState {
 pub struct EbusyState {
     pub(crate) tasks: Vec<*mut ShellCpTask>,
     pub(crate) idx: usize,
+    /// Exit code of the exec phase (tasks that failed outright); raised to 1
+    /// by `print_shell_cp_task` for every deferred task that is not ignorable.
     pub(crate) main_exit_code: ExitCode,
     /// Absolute target paths that some task copied successfully — used to
     /// suppress a sibling task's EBUSY on the same target.
@@ -209,7 +211,8 @@ impl Cp {
     /// Windows-only post-processing of tasks that failed with EBUSY: if some
     /// other task already succeeded
     /// for the same absolute src/tgt, the EBUSY is benign and the task is
-    /// dropped; otherwise its error is surfaced via `print_shell_cp_task`.
+    /// dropped; otherwise its error is surfaced via `print_shell_cp_task`,
+    /// which also fails the builtin.
     #[cfg(windows)]
     fn ignore_ebusy_error_if_possible(interp: &Interpreter, cmd: NodeId) -> Yield {
         loop {
@@ -316,10 +319,15 @@ impl Cp {
 
         let errstr: Option<Vec<u8>> = task.err.take().map(|e| {
             let s = Builtin::shell_err_to_string(interp, cmd, Kind::Cp, &e).to_vec();
-            if let State::Exec(exec) = &mut Self::state_mut(interp, cmd).state {
-                exec.err = Some(e);
+            match &mut Self::state_mut(interp, cmd).state {
+                State::Exec(exec) => exec.err = Some(e),
+                // A deferred task that turned out not to be ignorable. The
+                // exit code was already derived from `ExecState::err` when
+                // this phase started, so the failure is recorded directly.
+                #[cfg(windows)]
+                State::Ebusy(eb) => eb.main_exit_code = 1,
+                _ => {}
             }
-            // `e` drops here when not stored.
             s
         });
         OutputTask::<Cp>::start(output_task, interp, errstr.as_deref())

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
+import { dlopen, ptr } from "bun:ffi";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { isWindows, tempDir, tempDirWithFiles } from "harness";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -70,6 +72,63 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .exitCode(0)
       .fileEquals("somedir/hello.txt", "hi!\n")
       .runAsTest("doesn't fail on EBUSY when copying multiple files that are the same");
+
+    // On Windows a task whose error names its own source (any errno) or its
+    // target (EBUSY) is held back until every operand has been copied, so a
+    // sibling task that succeeded on the same file can excuse it. A held-back
+    // error that nothing excuses still has to be reported AND fail the command.
+    describe.skipIf(!isWindows)("still fails on EBUSY that no other task excuses", () => {
+      const busy = (path: string) => p(`cp: Device or resource busy: $TEMP_DIR/${path}\n`);
+
+      test.concurrent("error names the target (file copy)", async () => {
+        using dir = tempDir("cp-ebusy", { "locked.txt": "locked\n", "out": {} });
+        await whileOpenedExclusively(join(String(dir), "locked.txt"), () =>
+          TestBuilder.command`cp locked.txt out/copy.txt`
+            .ensureTempDir(String(dir))
+            .stderr(busy("out/copy.txt"))
+            .exitCode(1)
+            .doesNotExist("out/copy.txt")
+            .run(),
+        );
+      });
+
+      test.concurrent("error names the source (cp -R cannot open the directory)", async () => {
+        using dir = tempDir("cp-ebusy", { "lockeddir": { "a.txt": "a\n" }, "out": {} });
+        await whileOpenedExclusively(join(String(dir), "lockeddir"), () =>
+          TestBuilder.command`cp -R lockeddir out/lockeddir`
+            .ensureTempDir(String(dir))
+            .stderr(busy("lockeddir"))
+            .exitCode(1)
+            .doesNotExist("out/lockeddir")
+            .run(),
+        );
+      });
+
+      test.concurrent("another operand succeeding does not excuse it", async () => {
+        using dir = tempDir("cp-ebusy", { "free.txt": "free\n", "locked.txt": "locked\n", "out": {} });
+        await whileOpenedExclusively(join(String(dir), "locked.txt"), () =>
+          TestBuilder.command`cp free.txt locked.txt out`
+            .ensureTempDir(String(dir))
+            .stderr(busy("out/locked.txt"))
+            .exitCode(1)
+            .fileEquals("out/free.txt", "free\n")
+            .doesNotExist("out/locked.txt")
+            .run(),
+        );
+      });
+
+      test.concurrent("every held-back failure is reported", async () => {
+        using dir = tempDir("cp-ebusy", { "locked.txt": "locked\n", "out": {} });
+        await whileOpenedExclusively(join(String(dir), "locked.txt"), () =>
+          TestBuilder.command`cp locked.txt locked.txt out`
+            .ensureTempDir(String(dir))
+            .stderr(busy("out/locked.txt") + busy("out/locked.txt"))
+            .exitCode(1)
+            .doesNotExist("out/locked.txt")
+            .run(),
+        );
+      });
+    });
   });
 
   describe("uutils ported", () => {
@@ -172,6 +231,42 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .runAsTest("cp_recurse");
   });
 });
+
+/**
+ * Holds a Win32 handle to `path` (a file or a directory) with `dwShareMode = 0`
+ * while `fn` runs, so every other attempt to open it, including the one
+ * `CopyFileW` or a directory walk makes, fails with a sharing violation (EBUSY).
+ */
+async function whileOpenedExclusively<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const k32 = dlopen("kernel32.dll", {
+    CreateFileW: { args: ["ptr", "u32", "u32", "ptr", "u32", "u32", "ptr"], returns: "u64" },
+    CloseHandle: { args: ["u64"], returns: "i32" },
+    GetLastError: { args: [], returns: "u32" },
+  });
+  const INVALID_HANDLE_VALUE = 0xffffffffffffffffn;
+  const GENERIC_READ = 0x80000000;
+  const OPEN_EXISTING = 3;
+  // Required to open a directory; has no effect on a file.
+  const FILE_FLAG_BACKUP_SEMANTICS = 0x02000000;
+
+  const wpath = Buffer.from(path + "\0", "utf16le");
+  const handle = k32.symbols.CreateFileW(
+    ptr(wpath),
+    GENERIC_READ,
+    0,
+    null,
+    OPEN_EXISTING,
+    FILE_FLAG_BACKUP_SEMANTICS,
+    null,
+  );
+  if (handle === INVALID_HANDLE_VALUE) throw new Error(`CreateFileW(${path}) failed: ${k32.symbols.GetLastError()}`);
+  try {
+    return await fn();
+  } finally {
+    k32.symbols.CloseHandle(handle);
+    k32.close();
+  }
+}
 
 function expectSortedOutput(expected: string) {
   return (stdout: string, tempdir: string) =>

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -74,13 +74,27 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .runAsTest("doesn't fail on EBUSY when copying multiple files that are the same");
 
     // On Windows a task whose error names its own source (any errno) or its
-    // target (EBUSY) is held back until every operand has been copied, so a
-    // sibling task that succeeded on the same file can excuse it. A held-back
-    // error that nothing excuses still has to be reported AND fail the command.
-    describe.skipIf(!isWindows)("still fails on EBUSY that no other task excuses", () => {
+    // target (EBUSY) is held back until every operand has been copied. It is
+    // excused if a sibling task succeeded on the same source or target; a
+    // held-back error that nothing excuses has to be reported AND fail the
+    // command. Holding a file open with dwShareMode = 0 makes every copy that
+    // involves it fail with EBUSY deterministically.
+    describe.skipIf(!isWindows)("held-back errors", () => {
       const busy = (path: string) => p(`cp: Device or resource busy: $TEMP_DIR/${path}\n`);
 
-      test.concurrent("error names the target (file copy)", async () => {
+      test.concurrent("excused because a sibling copied the same target: exits 0", async () => {
+        using dir = tempDir("cp-ebusy", { "sub": { "same.txt": "from sub\n" }, "same.txt": "locked\n", "out": {} });
+        await whileOpenedExclusively(join(String(dir), "same.txt"), () =>
+          TestBuilder.command`cp sub/same.txt same.txt out`
+            .ensureTempDir(String(dir))
+            .stderr("")
+            .exitCode(0)
+            .fileEquals("out/same.txt", "from sub\n")
+            .run(),
+        );
+      });
+
+      test.concurrent("not excused, error names the target (file copy): exits 1", async () => {
         using dir = tempDir("cp-ebusy", { "locked.txt": "locked\n", "out": {} });
         await whileOpenedExclusively(join(String(dir), "locked.txt"), () =>
           TestBuilder.command`cp locked.txt out/copy.txt`
@@ -92,7 +106,7 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
         );
       });
 
-      test.concurrent("error names the source (cp -R cannot open the directory)", async () => {
+      test.concurrent("not excused, error names the source (cp -R cannot open the directory): exits 1", async () => {
         using dir = tempDir("cp-ebusy", { "lockeddir": { "a.txt": "a\n" }, "out": {} });
         await whileOpenedExclusively(join(String(dir), "lockeddir"), () =>
           TestBuilder.command`cp -R lockeddir out/lockeddir`
@@ -104,7 +118,7 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
         );
       });
 
-      test.concurrent("another operand succeeding does not excuse it", async () => {
+      test.concurrent("not excused by an operand that copied a different file: exits 1", async () => {
         using dir = tempDir("cp-ebusy", { "free.txt": "free\n", "locked.txt": "locked\n", "out": {} });
         await whileOpenedExclusively(join(String(dir), "locked.txt"), () =>
           TestBuilder.command`cp free.txt locked.txt out`
@@ -117,7 +131,7 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
         );
       });
 
-      test.concurrent("every held-back failure is reported", async () => {
+      test.concurrent("every unexcused failure is reported: exits 1", async () => {
         using dir = tempDir("cp-ebusy", { "locked.txt": "locked\n", "out": {} });
         await whileOpenedExclusively(join(String(dir), "locked.txt"), () =>
           TestBuilder.command`cp locked.txt locked.txt out`


### PR DESCRIPTION
### Problem
- Windows only: the Bun shell `cp` builtin prints `cp: Device or resource busy: <path>` (or any other error naming the source path) to stderr, copies nothing, and still exits 0. `await $\`cp locked.txt out/copy.txt\`.nothrow()` reports `exitCode: 0`.
- Only errors raised by the native copy itself are affected. Errors the builtin raises before handing off (missing source, `cp dir x` without `-R`, ...) exit 1 as they should.
- Cause, in `src/runtime/shell/builtin/cp.rs`:
  - `on_shell_cp_task_done` holds back a failed task (pushes it to `ebusy.tasks` instead of reporting it) when its error is EBUSY naming the task's target, or any sys error naming the task's source.
  - `Cp::next` then derives the exit code from `ExecState::err`, which a held-back task never set, and stores it as `EbusyState::main_exit_code` (0).
  - `ignore_ebusy_error_if_possible` finds the task is not excused and routes it through `print_shell_cp_task`, but that function only recorded failures while the state was still `State::Exec`. In `State::Ebusy` the error was printed and dropped, and the builtin finished with `main_exit_code` = 0.

### Fix
- `print_shell_cp_task` now also records the failure when it is driven from `State::Ebusy`, by setting `main_exit_code = 1`. That is the one place a held-back task is reported, so every reported task now fails the command.
- Why this is the right place: `main_exit_code` is the exit code of the tasks that failed outright; a held-back task that no sibling excused is a failure of exactly the same kind, it was just classified later. Excused tasks are dropped before `print_shell_cp_task` and keep exiting 0. The hold-back predicate itself is unchanged.
- Linux and macOS are unaffected: the hold-back phase and `State::Ebusy` are `cfg(windows)`, so there the `match` compiles down to the previous `if let`. The `cp` builtin is also in `posix_disabled` (the shell runs the system `cp` unless `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS` is set), which is why `cp.test.ts` is skipped on POSIX.
- Tests: five new cases in `test/js/bun/shell/commands/cp.test.ts`, under the existing "EBUSY windows" describe. Each holds a `dwShareMode = 0` handle on a file or directory through `bun:ffi` (same approach as `test/js/bun/util/which.test.ts`) so the copy deterministically fails with a sharing violation (EBUSY):
  - `cp sub/same.txt same.txt out` with `same.txt` locked: excused because a sibling copied the same target, exits 0 with no stderr (passes before and after; pins the boundary of the fix)
  - `cp locked.txt out/copy.txt`: error names the target (the EBUSY arm of the predicate), exits 1
  - `cp -R lockeddir out/lockeddir`: opening the source directory fails, error names the source (the source arm), exits 1
  - `cp free.txt locked.txt out`: an operand that copied a different file does not excuse it, `free.txt` is still copied, exits 1
  - `cp locked.txt locked.txt out`: two unexcused failures are both reported, exits 1
- Verified on Windows x64 (the file is skipped on POSIX because the builtin is disabled there, so a Linux run of it cannot show the failure):
  - `bun test` with a stock 1.4.0 canary: the 4 "exits 1" tests fail with exit code 0, the excused test and the other 30 pass
  - `git stash push -- src/` + `bun bd test`: 4 fail, with `src/` restored: 35 pass; the held-back cases were repeated 5 times with no flakes
  - Linux `bun bd test test/js/bun/shell/commands/cp.test.ts`: compiles, 35 skipped, same as on main

### Background
- The shell `cp` builtin starts one `ShellCpTask` per source operand. Each task resolves its paths on a work-pool thread and then hands the copy to the `node:fs` cp implementation (`ShellAsyncCpTask` in `src/runtime/node/node_fs.rs`), which reports back with either success or one `bun_sys::Error` carrying an errno and a path.
- `cp a.txt a.txt dir/` runs two tasks on the same file at once. On Windows that races inside the filesystem and one of them can fail with a sharing violation, which Bun maps to EBUSY, even though the copy as a whole succeeded. To paper over that, the builtin does not report such a failure immediately: once every task is done (`State::Ebusy`), it drops the held-back tasks whose absolute source or target was copied successfully by a sibling ("excused" above), and reports the rest.
- `Builtin::done(exit_code)` is how a shell builtin finishes; the Windows phase passes it `EbusyState::main_exit_code`, so that field is the only thing that decides the exit status once the phase has started.

<details>
<summary>Repro against stock bun 1.4.0 on Windows (before the fix)</summary>

```
--- file -> file (src locked)
exitCode: 0
stderr: "cp: Device or resource busy: C:\\...\\cp-ebusy-1zmXAM\\out\\copy.txt\n"
--- file+file -> dir (one src locked)
exitCode: 0
stderr: "cp: Device or resource busy: C:\\...\\cp-ebusy-1zmXAM\\out\\locked.txt\n"
out/free.txt exists: true
out/locked.txt exists: false
--- cp -R (src dir locked)
exitCode: 0
stderr: "cp: Device or resource busy: C:\\...\\cp-ebusy-1zmXAM\\lockeddir\n"
--- control: missing src
exitCode: 1
stderr: "cp: No such file or directory: C:\\...\\cp-ebusy-1zmXAM\\does-not-exist.txt\n"
```
</details>
