### PR TITLE
node:http2: an empty array value is not an occurrence of a single-value header

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -4019,7 +4019,7 @@ function stripInvalidWhitespaceFields(rawheaders: string[]): string[] {
 // node validates header constraints in JS before anything reaches the native encoder, so a
 // throwing request leaves no partial state in the shared HPACK table. Mirror the single-value
 // rule here: duplicated single-value fields (across case variants) and multi-element arrays for
-// them throw before encoding starts.
+// them throw before encoding starts. The native encoders apply the same rule.
 function assertSingleValueHeaders(headers) {
   let seen = null;
   const keys = Object.keys(headers);
@@ -4027,7 +4027,9 @@ function assertSingleValueHeaders(headers) {
     const lower = keys[i].toLowerCase();
     if (!kSingleValueHeaders.has(lower)) continue;
     const value = headers[keys[i]];
-    if (($isArray(value) && value.length > 1) || (seen !== null && seen.has(lower))) {
+    const fieldCount = $isArray(value) ? value.length : 1;
+    if (fieldCount === 0) continue;
+    if (fieldCount > 1 || (seen !== null && seen.has(lower))) {
       throw $ERR_HTTP2_HEADER_SINGLE_VALUE(`Header field "${lower}" must only have a single value`);
     }
     if (seen === null) seen = new SafeSet();

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -8006,6 +8006,10 @@ impl H2FrameParser {
 
             if js_value.js_type().is_array() {
                 let mut value_iter = js_value.array_iterator(global_object)?;
+                // [] sends nothing, so (as in node) it is not an occurrence of the field.
+                if value_iter.len == 0 {
+                    continue;
+                }
 
                 if let Some(idx) = this.single_value_index_checked(validated_name) {
                     if value_iter.len > 1 || single_value_headers[idx] {
@@ -8484,6 +8488,10 @@ impl H2FrameParser {
                 };
                 if js_value.js_type().is_array() {
                     let mut value_iter = js_value.array_iterator(global_object)?;
+                    // [] sends nothing, so (as in node) it is not an occurrence of the field.
+                    if value_iter.len == 0 {
+                        continue;
+                    }
                     if let Some(idx) = this.single_value_index_checked(validated_name) {
                         if value_iter.len > 1 || single_value_headers[idx] {
                             return Err(global_object
@@ -9042,6 +9050,10 @@ impl H2FrameParser {
                 if js_value.js_type().is_array() {
                     bun_output::scoped_log!(H2FrameParser, "array header {}", BStr::new(name));
                     let mut value_iter = js_value.array_iterator(global_object)?;
+                    // [] sends nothing, so (as in node) it is not an occurrence of the field.
+                    if value_iter.len == 0 {
+                        continue;
+                    }
 
                     if let Some(idx) = this.single_value_index_checked(validated_name) {
                         if value_iter.len > 1 || single_value_headers[idx] {

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -3984,6 +3984,217 @@ it("http2 pushStream reports an unsendable array element through the callback", 
   expect(blocks).toEqual([]);
 });
 
+// In the object header form an array value is sent as one field per element, so an empty array
+// sends nothing, and node (buildNgHeaderString) does not count it as an occurrence of a single-value
+// field: { "content-type": [], "Content-Type": "text/plain" } sends one content-type field. bun
+// applies the single-value rule in a JS pre-check (request, respond, additionalHeaders, pushStream)
+// and again in each native encoder (the only check sendTrailers has), so every entry point gets the
+// same rows. Each outcome is the list of content-type values the peer decoded from the wire, or the
+// error the call threw; the expected values were checked against node v26.3.0.
+describe.concurrent("http2 object-form headers: an empty array is not an occurrence of a single-value field", () => {
+  const singleValue = {
+    name: "TypeError",
+    code: "ERR_HTTP2_HEADER_SINGLE_VALUE",
+    message: 'Header field "content-type" must only have a single value',
+  };
+  const rows = [
+    { headers: { "content-type": [], "Content-Type": "text/plain" }, outcome: ["text/plain"] },
+    { headers: { "Content-Type": "text/plain", "content-type": [] }, outcome: ["text/plain"] },
+    { headers: { "content-type": [], "Content-Type": ["text/plain"] }, outcome: ["text/plain"] },
+    { headers: { "content-type": [], "Content-Type": [] }, outcome: [] },
+    // A one-element array is an occurrence, and a multi-element array is still rejected.
+    { headers: { "content-type": ["text/plain"], "Content-Type": "text/html" }, outcome: singleValue },
+    { headers: { "content-type": [], "Content-Type": ["text/plain", "text/html"] }, outcome: singleValue },
+  ];
+  const expected = rows.map(row => row.outcome);
+
+  const describeError = err => ({ name: err.constructor.name, code: err.code, message: err.message });
+  function contentTypeValues(rawHeaders) {
+    const values = [];
+    for (let i = 0; i < rawHeaders.length; i += 2) {
+      if (rawHeaders[i] === "content-type") values.push(rawHeaders[i + 1]);
+    }
+    return values;
+  }
+
+  // A server and a client for one row: `onStream` serves the request `useClient` makes, and the
+  // result of `useClient` is the row's outcome. Every row gets fresh peers because a block the native
+  // encoder rejects part-way through (the sendTrailers rows that throw) leaves that session's HPACK
+  // encoder ahead of the peer.
+  async function withPeers(onStream, useClient) {
+    const { promise: failure, reject } = Promise.withResolvers();
+    const server = http2.createServer();
+    server.on("error", reject);
+    server.on("sessionError", reject);
+    server.on("stream", onStream);
+    await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+    const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
+    client.on("error", reject);
+    try {
+      return await Promise.race([failure, useClient(client)]);
+    } finally {
+      client.destroy();
+      server.close();
+    }
+  }
+
+  // Ends `req` and resolves, once it has closed, with the raw header lists the client received.
+  function exchange(req) {
+    return new Promise((resolve, reject) => {
+      const received = {};
+      req.on("headers", (_headers, _flags, rawHeaders) => (received.informational = rawHeaders));
+      req.on("response", (_headers, _flags, rawHeaders) => (received.response = rawHeaders));
+      req.on("trailers", (_headers, _flags, rawHeaders) => (received.trailers = rawHeaders));
+      req.on("error", reject);
+      req.on("close", () => resolve(received));
+      req.resume();
+      req.end();
+    });
+  }
+
+  it("request()", async () => {
+    const outcomes = [];
+    for (const { headers } of rows) {
+      let requestReceived;
+      outcomes.push(
+        await withPeers(
+          (stream, _headers, _flags, rawHeaders) => {
+            requestReceived = contentTypeValues(rawHeaders);
+            stream.respond({ ":status": 200 });
+            stream.end();
+          },
+          async client => {
+            let req;
+            try {
+              req = client.request({ ":path": "/", ...headers });
+            } catch (err) {
+              return describeError(err);
+            }
+            await exchange(req);
+            return requestReceived;
+          },
+        ),
+      );
+    }
+    expect(outcomes).toEqual(expected);
+  });
+
+  it("respond()", async () => {
+    const outcomes = [];
+    for (const { headers } of rows) {
+      let threw;
+      outcomes.push(
+        await withPeers(
+          stream => {
+            try {
+              stream.respond({ ":status": 200, ...headers });
+            } catch (err) {
+              threw = describeError(err);
+              stream.respond({ ":status": 200 });
+            }
+            stream.end();
+          },
+          async client => {
+            const { response } = await exchange(client.request({ ":path": "/" }));
+            return threw ?? contentTypeValues(response);
+          },
+        ),
+      );
+    }
+    expect(outcomes).toEqual(expected);
+  });
+
+  it("additionalHeaders()", async () => {
+    const outcomes = [];
+    for (const { headers } of rows) {
+      let threw;
+      outcomes.push(
+        await withPeers(
+          stream => {
+            try {
+              stream.additionalHeaders({ ":status": 102, ...headers });
+            } catch (err) {
+              threw = describeError(err);
+            }
+            stream.respond({ ":status": 200 });
+            stream.end();
+          },
+          async client => {
+            const { informational } = await exchange(client.request({ ":path": "/" }));
+            return threw ?? contentTypeValues(informational);
+          },
+        ),
+      );
+    }
+    expect(outcomes).toEqual(expected);
+  });
+
+  it("pushStream()", async () => {
+    const outcomes = [];
+    for (const { headers } of rows) {
+      let threw;
+      outcomes.push(
+        await withPeers(
+          stream => {
+            try {
+              stream.pushStream({ ":path": "/pushed", ...headers }, (err, pushed) => {
+                if (err) {
+                  stream.destroy(err);
+                  return;
+                }
+                pushed.respond({ ":status": 200 });
+                pushed.end();
+              });
+            } catch (err) {
+              threw = describeError(err);
+            }
+            stream.respond({ ":status": 200 });
+            stream.end();
+          },
+          async client => {
+            const { promise: promised, resolve } = Promise.withResolvers();
+            client.on("stream", (pushed, _headers, _flags, rawHeaders) => {
+              pushed.on("close", () => resolve(contentTypeValues(rawHeaders)));
+              pushed.resume();
+            });
+            await exchange(client.request({ ":path": "/" }));
+            return threw ?? (await promised);
+          },
+        ),
+      );
+    }
+    expect(outcomes).toEqual(expected);
+  });
+
+  it("sendTrailers()", async () => {
+    const outcomes = [];
+    for (const { headers } of rows) {
+      let threw;
+      outcomes.push(
+        await withPeers(
+          stream => {
+            stream.respond({ ":status": 200 }, { waitForTrailers: true });
+            stream.on("wantTrailers", () => {
+              try {
+                stream.sendTrailers(headers);
+              } catch (err) {
+                threw = describeError(err);
+                stream.sendTrailers({});
+              }
+            });
+            stream.end();
+          },
+          async client => {
+            const { trailers = [] } = await exchange(client.request({ ":path": "/" }));
+            return threw ?? contentTypeValues(trailers);
+          },
+        ),
+      );
+    }
+    expect(outcomes).toEqual(expected);
+  });
+});
+
 it("http2 option range error messages use the options. prefix", () => {
   for (const opt of ["maxSessionInvalidFrames", "maxSessionRejectedStreams", "unknownProtocolTimeout"]) {
     let error;


### PR DESCRIPTION
### Problem
- With headers given as an object, an empty array on a single-value field counts as an occurrence of the field, so a second key for the same name (necessarily a case variant) is rejected even though the empty array sends nothing: `client.request({ ":path": "/", "content-type": [], "Content-Type": "text/plain" })` throws `TypeError [ERR_HTTP2_HEADER_SINGLE_VALUE]: Header field "content-type" must only have a single value`. Node v26.3.0 sends one `content-type` field.
- Same result from `stream.respond()`, `stream.additionalHeaders()`, `stream.pushStream()` and `stream.sendTrailers()` with the same object, in either key order.
- Cause: `assertSingleValueHeaders()` in `src/js/node/http2.ts` adds the name to its seen set for any value that is not a multi-element array, and the array branches of the three native encoders in `src/runtime/api/bun/h2_frame_parser.rs` (`send_trailers()`, `push_promise()`, the object walk in `request()`) set the field's `single_value_headers` bit before looking at the array's length. Node's `buildNgHeaderString` returns for a zero-length array before it touches its singles set.

### Fix
- `assertSingleValueHeaders()` skips a property whose value is an empty array; the three native array branches `continue` on a zero-length array before the single-value bookkeeping. Nothing else about the rule changes: a one-element array is still one occurrence, a multi-element array or a repeated name still throws, and `strictSingleValueFields: false` still disables all of it.
- Why this is correct: the rule exists to keep a single-value field from going out more than once, and an empty array puts nothing on the wire, so counting it can only reject blocks that would have been valid. Skipping it is also exactly what node does, so the outcome of every row in the new test (including the error name, code and message of the rows that still throw) is the same as node v26.3.0's.
- Why both layers change together: the JS check is a pre-encode guard, and the native encoders encode field by field into the session's HPACK encoder. Relaxing only the JS side would turn today's clean throw into a native throw part-way through a block, leaving the encoder ahead of the peer for the rest of the session; relaxing only the native side would change nothing, since the JS check throws first. `sendTrailers()` has no JS check, so for it the native change is the whole fix.
- Not changed here: the raw `[name, value, ...]` form (it has no array handling on main; #37796 adds it together with this same skip), `undefined`/`null` property values (bun rejects them, node skips `undefined` and sends `null` as "null"; tracked separately), the zero-length trailer block a trailers object made only of empty arrays still produces (pre-existing, accepted by nghttp2; node sends an empty DATA frame instead; tracked separately), and the fact that bun still validates the name of an empty-array field while node's early return skips that too.
- Verification: `test/js/node/http2/node-http2.test.js`, describe `http2 object-form headers: an empty array is not an occurrence of a single-value field`. Six header objects (empty array first, empty array second, empty array plus a one-element array, two empty arrays, and two that must still throw) are run through each of the five entry points against a real peer, asserting on the content-type fields the peer decoded from the wire or the error thrown. All five tests fail on the current release (the first four rows throw on every entry point) and pass with this change; the same rows were run through node v26.3.0 and produce the listed outcomes.
- Also run with the change: the rest of `node-http2.test.js` (362 pass), `h2-conformance.test.ts` (61 pass), and the ported `test-http2-{multiheaders,multiheaders-raw,single-headers-validation,single-headers-validation-disabled,sent-headers,sensitive-headers,raw-headers,raw-headers-defaults,info-headers,trailers,cookies,server-push-stream,server-push-stream-head,compat-serverresponse-headers,misc-util}.js`, all passing.

### Background
- Single-value fields: node refuses to send certain header fields more than once in one block (`content-type`, `content-length`, every pseudo-header, ...; `kSingleValueHeaders` in http2.ts). The check is per lowercased name, so the only way to name the same field twice in an object is with two spellings of the key. `strictSingleValueFields: false` turns the rule off.
- Array values: in the object form an array value means one field per element, so `[]` means no field. (An empty array is what header-building code such as `{ "set-cookie": cookies }` naturally produces.)
- Where bun applies the rule: `request()`, `respond()`, `additionalHeaders()` and `pushStream()` run `assertSingleValueHeaders()` in JS before calling into native, so a violation is reported before anything is encoded; each native encoder then applies the rule again while it walks the block, and for `sendTrailers()` that native walk is the only check.
- HPACK: header blocks are compressed with a per-connection table that both ends update as each field is encoded or decoded. A block that is encoded partially and then dropped leaves the sender's table with entries the receiver never saw, which is why the JS pre-check exists and why it has to agree with the native walks.

<details>
<summary>Probe output, before and after (debug build) and node v26.3.0</summary>

Input: `{ "content-type": [], "Content-Type": "text/plain" }` (the reversed key order gives the same results).

| entry point | main | this PR | node v26.3.0 |
| --- | --- | --- | --- |
| `client.request()` | throws `ERR_HTTP2_HEADER_SINGLE_VALUE` | server receives `content-type: text/plain` once | same as PR |
| `stream.respond()` | throws | client receives it once | same |
| `stream.additionalHeaders()` (102) | throws | client's `'headers'` block has it once | same |
| `stream.pushStream()` | throws | PUSH_PROMISE has it once | same |
| `stream.sendTrailers()` | throws | trailers have it once | same |

`{ "content-type": ["text/plain"], "Content-Type": "text/html" }` still throws `ERR_HTTP2_HEADER_SINGLE_VALUE` from all five entry points on this PR, as on main and on node.

</details>

