### PR TITLE
bun:test: keep runtime-internal timeouts out of the fake timer heap

### DIFF
--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -205,19 +205,12 @@ pub enum Tag {
 }
 
 impl Tag {
-    /// Whether `jest.useFakeTimers()` captures this timer. Only the timers a
-    /// program schedules itself (`setTimeout`/`setInterval`,
-    /// `AbortSignal.timeout()`, and `Bun.cron`, which is documented as
-    /// mockable) go into the fake heap, where they fire on
-    /// `advanceTimersByTime()` and are dropped by `useRealTimers()` /
-    /// `clearAllTimers()`. Everything else is a runtime-internal timeout
-    /// (subprocess kill, connection timeouts, c-ares polling, ...) that keeps
-    /// running on the real clock, as in Jest.
-    ///
-    /// This also decides which clock an owner arms with: a fakeable owner
-    /// computes its deadline with `TimespecMockMode::AllowMockedTime`; every
-    /// other owner must use `ForceRealTime`, because the real heap is drained
-    /// against the real clock (`timer::All::next`).
+    /// Whether `jest.useFakeTimers()` captures this timer. Only timers a
+    /// program schedules itself are faked; runtime-internal timeouts stay on
+    /// the real clock, as in Jest. A fakeable owner arms with
+    /// `AllowMockedTime` and has a release arm in `FakeTimers::clear`; every
+    /// other owner arms with `ForceRealTime`, the clock the real heap is
+    /// drained against.
     pub fn allow_fake_timers(self) -> bool {
         matches!(
             self,

--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -219,7 +219,10 @@ impl Tag {
     /// other owner must use `ForceRealTime`, because the real heap is drained
     /// against the real clock (`timer::All::next`).
     pub fn allow_fake_timers(self) -> bool {
-        matches!(self, Tag::TimeoutObject | Tag::AbortSignalTimeout | Tag::CronJob)
+        matches!(
+            self,
+            Tag::TimeoutObject | Tag::AbortSignalTimeout | Tag::CronJob
+        )
     }
 }
 

--- a/src/event_loop/EventLoopTimer.rs
+++ b/src/event_loop/EventLoopTimer.rs
@@ -205,18 +205,21 @@ pub enum Tag {
 }
 
 impl Tag {
+    /// Whether `jest.useFakeTimers()` captures this timer. Only the timers a
+    /// program schedules itself (`setTimeout`/`setInterval`,
+    /// `AbortSignal.timeout()`, and `Bun.cron`, which is documented as
+    /// mockable) go into the fake heap, where they fire on
+    /// `advanceTimersByTime()` and are dropped by `useRealTimers()` /
+    /// `clearAllTimers()`. Everything else is a runtime-internal timeout
+    /// (subprocess kill, connection timeouts, c-ares polling, ...) that keeps
+    /// running on the real clock, as in Jest.
+    ///
+    /// This also decides which clock an owner arms with: a fakeable owner
+    /// computes its deadline with `TimespecMockMode::AllowMockedTime`; every
+    /// other owner must use `ForceRealTime`, because the real heap is drained
+    /// against the real clock (`timer::All::next`).
     pub fn allow_fake_timers(self) -> bool {
-        match self {
-            Tag::WTFTimer // internal
-            | Tag::BunTest // for test timeouts
-            | Tag::EventLoopDelayMonitor // probably important
-            | Tag::StatWatcherScheduler
-            | Tag::GcRepeating // internal GC pacing
-            | Tag::QuicEndpoint
-            | Tag::DnsSdConnection // internal lookup pacing
-            => false,
-            _ => true,
-        }
+        matches!(self, Tag::TimeoutObject | Tag::AbortSignalTimeout | Tag::CronJob)
     }
 }
 

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -381,9 +381,7 @@ impl SpawnSyncEventLoop {
     /// Tick the isolated event loop with an optional timeout
     /// This is similar to the main event loop's tick but completely isolated
     ///
-    /// `timeout` is an absolute deadline on the real monotonic clock. Fake
-    /// timers cannot advance while the caller blocks in here, so the mocked
-    /// clock is never consulted.
+    /// `timeout` is an absolute deadline on the real (never mocked) clock.
     pub fn tick_with_timeout(&mut self, timeout: Option<&Timespec>) -> TickState {
         let duration_storage: Option<Timespec>;
         let duration: Option<&Timespec> = match timeout {

--- a/src/event_loop/SpawnSyncEventLoop.rs
+++ b/src/event_loop/SpawnSyncEventLoop.rs
@@ -380,12 +380,16 @@ impl SpawnSyncEventLoop {
 
     /// Tick the isolated event loop with an optional timeout
     /// This is similar to the main event loop's tick but completely isolated
+    ///
+    /// `timeout` is an absolute deadline on the real monotonic clock. Fake
+    /// timers cannot advance while the caller blocks in here, so the mocked
+    /// clock is never consulted.
     pub fn tick_with_timeout(&mut self, timeout: Option<&Timespec>) -> TickState {
         let duration_storage: Option<Timespec>;
         let duration: Option<&Timespec> = match timeout {
             Some(ts) => {
                 duration_storage =
-                    Some(ts.duration(&Timespec::now(TimespecMockMode::AllowMockedTime)));
+                    Some(ts.duration(&Timespec::now(TimespecMockMode::ForceRealTime)));
                 duration_storage.as_ref()
             }
             None => None,
@@ -454,7 +458,7 @@ impl SpawnSyncEventLoop {
             #[cfg(not(windows))]
             {
                 self.did_timeout.set(
-                    Timespec::now(TimespecMockMode::AllowMockedTime).order(ts)
+                    Timespec::now(TimespecMockMode::ForceRealTime).order(ts)
                         != core::cmp::Ordering::Less,
                 );
             }

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1889,10 +1889,9 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
                 // Note: `AbortSignal::Timeout.event_loop_timer` uses the
                 // bun_event_loop-local `Timespec` stub; convert fieldwise.
                 //
-                // Under `jest.useFakeTimers()` the signal's timer sits in the
-                // fake heap with a deadline on the mocked clock, which cannot
-                // advance while this call blocks, so it can never fire here;
-                // only a real-heap deadline is comparable with `now`.
+                // A fake-heap deadline is on the mocked clock, which cannot
+                // advance while this call blocks; only a real-heap one is
+                // comparable with `now`.
                 if abort_signal_timeout.event_loop_timer.state
                     == crate::timer::EventLoopTimerState::ACTIVE
                     && abort_signal_timeout.event_loop_timer.in_heap

--- a/src/runtime/api/bun/js_bun_spawn_bindings.rs
+++ b/src/runtime/api/bun/js_bun_spawn_bindings.rs
@@ -1657,8 +1657,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
         // This must go before other things happen so that the exit handler is
         // registered before onProcessExit can potentially be called.
         if let Some(timeout_val) = timeout {
-            let ts =
-                Timespec::ms_from_now(TimespecMockMode::AllowMockedTime, i64::from(timeout_val));
+            let ts = Timespec::ms_from_now(TimespecMockMode::ForceRealTime, i64::from(timeout_val));
             // Note: `EventLoopTimer.next` is a local-stub Timespec until
             // `bun_event_loop` switches to `bun_core::Timespec`; copy fieldwise.
             subprocess.event_loop_timer.with_mut(|t| {
@@ -1875,7 +1874,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
     // This ensures JavaScript timers don't fire and stdin/stdout from the main process aren't affected
     {
         let mut absolute_timespec = Timespec::EPOCH;
-        let mut now = Timespec::now(TimespecMockMode::AllowMockedTime);
+        let mut now = Timespec::now(TimespecMockMode::ForceRealTime);
         let mut user_timespec: Timespec = if let Some(timeout_ms) = timeout {
             now.add_ms(i64::from(timeout_ms))
         } else {
@@ -1889,8 +1888,15 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             if let Some(abort_signal_timeout) = signal.get_timeout() {
                 // Note: `AbortSignal::Timeout.event_loop_timer` uses the
                 // bun_event_loop-local `Timespec` stub; convert fieldwise.
+                //
+                // Under `jest.useFakeTimers()` the signal's timer sits in the
+                // fake heap with a deadline on the mocked clock, which cannot
+                // advance while this call blocks, so it can never fire here;
+                // only a real-heap deadline is comparable with `now`.
                 if abort_signal_timeout.event_loop_timer.state
                     == crate::timer::EventLoopTimerState::ACTIVE
+                    && abort_signal_timeout.event_loop_timer.in_heap
+                        == crate::timer::InHeap::Regular
                 {
                     let next = &abort_signal_timeout.event_loop_timer.next;
                     let next_ts = Timespec {
@@ -1959,7 +1965,7 @@ fn spawn_maybe_sync<const IS_SYNC: bool>(
             }) {
                 TickState::Completed => {}
                 TickState::Timeout => {
-                    now = Timespec::now(TimespecMockMode::AllowMockedTime);
+                    now = Timespec::now(TimespecMockMode::ForceRealTime);
                     let did_user_timeout = has_user_timespec
                         && (absolute_timespec.eql(&user_timespec)
                             || user_timespec.order(&now) == core::cmp::Ordering::Less);

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1640,6 +1640,19 @@ impl CronJob {
         Self::remove_from_list(this, vm);
     }
 
+    /// The fake timer heap dropped this job's timer (`jest.useRealTimers()` /
+    /// `jest.clearAllTimers()`), so it can never fire again: finish stopping
+    /// it like `stop()` would, instead of leaving it holding the event loop
+    /// open. The node is already unlinked, which `stop_internal` tolerates.
+    ///
+    /// # Safety
+    /// `this` was recovered from a node just popped off the fake heap; a
+    /// scheduled job is kept alive by its JS wrapper, and no JS has run since
+    /// the pop.
+    pub(crate) unsafe fn stop_dropped_from_fake_heap(this: *mut Self) {
+        Self::self_stop(this, VirtualMachine::get());
+    }
+
     fn self_stop(this: *mut Self, vm: &VirtualMachine) {
         let this_ref = Self::from_ctx_ptr(this);
         // While the callback is on the stack or its promise is pending, defer

--- a/src/runtime/api/cron.rs
+++ b/src/runtime/api/cron.rs
@@ -1640,15 +1640,13 @@ impl CronJob {
         Self::remove_from_list(this, vm);
     }
 
-    /// The fake timer heap dropped this job's timer (`jest.useRealTimers()` /
-    /// `jest.clearAllTimers()`), so it can never fire again: finish stopping
-    /// it like `stop()` would, instead of leaving it holding the event loop
-    /// open. The node is already unlinked, which `stop_internal` tolerates.
+    /// The fake heap dropped this job's timer (`useRealTimers()` /
+    /// `clearAllTimers()`): stop the job as `stop()` would, so it does not
+    /// keep the event loop alive for a timer that can no longer fire.
     ///
     /// # Safety
-    /// `this` was recovered from a node just popped off the fake heap; a
-    /// scheduled job is kept alive by its JS wrapper, and no JS has run since
-    /// the pop.
+    /// `this` was recovered from a node just popped off the fake heap and no
+    /// JS has run since; a scheduled job's wrapper keeps it alive.
     pub(crate) unsafe fn stop_dropped_from_fake_heap(this: *mut Self) {
         Self::self_stop(this, VirtualMachine::get());
     }

--- a/src/runtime/bake/dev_server/hmr_socket.rs
+++ b/src/runtime/bake/dev_server/hmr_socket.rs
@@ -129,7 +129,7 @@ impl HmrSocket {
                                         // lives in `RuntimeState` (see jsc_hooks.rs).
                                         let state = crate::jsc_hooks::runtime_state();
                                         let next = bun_core::Timespec::ms_from_now(
-                                            bun_core::TimespecMockMode::AllowMockedTime,
+                                            bun_core::TimespecMockMode::ForceRealTime,
                                             1000,
                                         );
                                         // SAFETY: `runtime_state()` is non-null after

--- a/src/runtime/bake/dev_server/source_map_store.rs
+++ b/src/runtime/bake/dev_server/source_map_store.rs
@@ -541,7 +541,7 @@ impl SourceMapStore {
         }
 
         let expire = Timespec::ms_from_now(
-            TimespecMockMode::AllowMockedTime,
+            TimespecMockMode::ForceRealTime,
             WEAK_REF_EXPIRY_SECONDS * 1000,
         );
         self.weak_refs

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -4132,7 +4132,7 @@ impl Resolver {
         self.ref_();
         let now_ts = now
             .copied()
-            .unwrap_or_else(|| bun::timespec::now(bun::TimespecMockMode::AllowMockedTime));
+            .unwrap_or_else(|| bun::timespec::now(bun::TimespecMockMode::ForceRealTime));
         let next = now_ts.add_ms(1000);
         // `EventLoopTimer.next` uses the event-loop crate's local
         // `Timespec` (distinct from `bun_core::Timespec`); convert by field.

--- a/src/runtime/socket/UpgradedDuplex.rs
+++ b/src/runtime/socket/UpgradedDuplex.rs
@@ -607,7 +607,7 @@ impl UpgradedDuplex {
         // Note: `EventLoopTimer.next` is the lower-tier `ElTimespec` stub;
         // bridge from `bun_core::Timespec` until the lower tier switches.
         let next =
-            bun_core::Timespec::ms_from_now(bun_core::TimespecMockMode::AllowMockedTime, ms as i64);
+            bun_core::Timespec::ms_from_now(bun_core::TimespecMockMode::ForceRealTime, ms as i64);
         self.event_loop_timer.with_mut(|t| {
             t.next = ElTimespec {
                 sec: next.sec,

--- a/src/runtime/socket/WindowsNamedPipe.rs
+++ b/src/runtime/socket/WindowsNamedPipe.rs
@@ -1023,7 +1023,7 @@ impl WindowsNamedPipe {
         // reschedule the timer
         // `EventLoopTimer.next` is the lower-tier `ElTimespec` stub;
         // bridge from `bun_core::Timespec` until the lower tier switches.
-        let next = timespec::ms_from_now(bun_core::TimespecMockMode::AllowMockedTime, ms as i64);
+        let next = timespec::ms_from_now(bun_core::TimespecMockMode::ForceRealTime, ms as i64);
         self.event_loop_timer.with_mut(|t| {
             t.next = ElTimespec {
                 sec: next.sec,

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -5,6 +5,7 @@ use bun_threading::RwLock;
 use bun_core::Environment;
 use bun_core::Timespec;
 use bun_jsc::{CallFrame, JSFunction, JSGlobalObject, JSHostFn, JSValue, JsResult};
+use crate::api::cron::CronJob;
 use crate::jsc::virtual_machine::VirtualMachine;
 use crate::timer::{
     AbortSignalTimeout, ElTimespec, EventLoopTimer, EventLoopTimerState, EventLoopTimerTag,
@@ -116,9 +117,14 @@ fn from_el_timespec(t: &ElTimespec) -> Timespec {
 }
 
 /// Owners of the nodes [`FakeTimers::clear`] popped, still to be told their
-/// timer is gone. Released only once the `FakeTimers` borrow has ended: both
+/// timer is gone. Released only once the `FakeTimers` borrow has ended: these
 /// paths re-enter `timer::All` (`TimerObjectInternals::cancel` → `All::remove`,
 /// `Timeout` deinit → `timer_remove`).
+///
+/// Every tag that [`EventLoopTimerTag::allow_fake_timers`] admits to the fake
+/// heap needs an entry here: popping a node only unlinks it, and an owner that
+/// is not told keeps believing it is armed (holding its event-loop ref, never
+/// firing).
 #[derive(Default)]
 #[must_use]
 struct ClearedTimers {
@@ -132,6 +138,9 @@ struct ClearedTimers {
     /// pins an observed signal's wrapper for as long as that is set. Only the
     /// signal's `cancelTimer()` clears it (and frees the box).
     signal_timeouts: Vec<*mut AbortSignalTimeout>,
+    /// A `Bun.cron()` job holds the event loop open until it is stopped; with
+    /// its timer gone it would do so forever without ever firing.
+    cron_jobs: Vec<*mut CronJob>,
 }
 
 impl ClearedTimers {
@@ -144,6 +153,13 @@ impl ClearedTimers {
             // still owned by a live signal; JS thread; the `FakeTimers` borrow
             // ended before this call. `t` is freed by the call.
             unsafe { AbortSignalTimeout::discard(t) };
+        }
+        for job in self.cron_jobs {
+            // SAFETY: `clear` popped `job`'s node from the fake heap, so the
+            // job was scheduled and its JS wrapper (strong while scheduled)
+            // keeps it alive; no JS has run since; the `FakeTimers` borrow
+            // ended before this call.
+            unsafe { CronJob::stop_dropped_from_fake_heap(job) };
         }
     }
 }
@@ -197,7 +213,16 @@ impl FakeTimers {
                             .signal_timeouts
                             .push(AbortSignalTimeout::from_timer_ptr(timer));
                     }
-                    _ => {}
+                    EventLoopTimerTag::CronJob => {
+                        cleared.cron_jobs.push(CronJob::from_timer_ptr(timer));
+                    }
+                    // `All::insert` only routes `allow_fake_timers()` tags here,
+                    // and each of those has an arm above.
+                    tag => debug_assert!(
+                        false,
+                        "{} timer in the fake heap has no release path",
+                        <&'static str>::from(tag),
+                    ),
                 }
             }
         }

--- a/src/runtime/test_runner/timers/FakeTimers.rs
+++ b/src/runtime/test_runner/timers/FakeTimers.rs
@@ -120,11 +120,6 @@ fn from_el_timespec(t: &ElTimespec) -> Timespec {
 /// timer is gone. Released only once the `FakeTimers` borrow has ended: these
 /// paths re-enter `timer::All` (`TimerObjectInternals::cancel` → `All::remove`,
 /// `Timeout` deinit → `timer_remove`).
-///
-/// Every tag that [`EventLoopTimerTag::allow_fake_timers`] admits to the fake
-/// heap needs an entry here: popping a node only unlinks it, and an owner that
-/// is not told keeps believing it is armed (holding its event-loop ref, never
-/// firing).
 #[derive(Default)]
 #[must_use]
 struct ClearedTimers {
@@ -138,8 +133,7 @@ struct ClearedTimers {
     /// pins an observed signal's wrapper for as long as that is set. Only the
     /// signal's `cancelTimer()` clears it (and frees the box).
     signal_timeouts: Vec<*mut AbortSignalTimeout>,
-    /// A `Bun.cron()` job holds the event loop open until it is stopped; with
-    /// its timer gone it would do so forever without ever firing.
+    /// A `Bun.cron()` job keeps the event loop alive until it is stopped.
     cron_jobs: Vec<*mut CronJob>,
 }
 
@@ -216,8 +210,6 @@ impl FakeTimers {
                     EventLoopTimerTag::CronJob => {
                         cleared.cron_jobs.push(CronJob::from_timer_ptr(timer));
                     }
-                    // `All::insert` only routes `allow_fake_timers()` tags here,
-                    // and each of those has an arm above.
                     tag => debug_assert!(
                         false,
                         "{} timer in the fake heap has no release path",

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -60,7 +60,7 @@ impl All {
                         vm,
                         // Be careful to avoid adding extra calls to bun.timespec.now()
                         // when it's not needed.
-                        &Timespec::now(TimespecMockMode::AllowMockedTime),
+                        &Timespec::now(TimespecMockMode::ForceRealTime),
                     );
                 }
             }

--- a/src/runtime/timer/mod.rs
+++ b/src/runtime/timer/mod.rs
@@ -400,7 +400,7 @@ impl DateHeaderTimer {
         // separate allocation from `RuntimeState.timer` so no aliasing with
         // `&mut self`).
         let loop_ = vm.uws_loop_mut();
-        let now = Timespec::now(TimespecMockMode::AllowMockedTime);
+        let now = Timespec::now(TimespecMockMode::ForceRealTime);
 
         // Record when we last ran it.
         self.event_loop_timer.next = ElTimespec {

--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -410,7 +410,7 @@ impl RefCountedTimer {
             return;
         }
         let now = bun_core::Timespec::ms_from_now(
-            bun_core::TimespecMockMode::AllowMockedTime,
+            bun_core::TimespecMockMode::ForceRealTime,
             i64::from(ms),
         );
         self.event_loop_timer.with_mut(|t| {

--- a/src/sql_jsc/mysql/JSMySQLConnection.rs
+++ b/src/sql_jsc/mysql/JSMySQLConnection.rs
@@ -257,7 +257,7 @@ impl JSMySQLConnection {
         }
 
         self.timer.with_mut(|t| {
-            t.next = timespec::ms_from_now(TimespecMockMode::AllowMockedTime, interval.into());
+            t.next = timespec::ms_from_now(TimespecMockMode::ForceRealTime, interval.into());
         });
         // whole-struct provenance: the fire path recovers the container from this pointer.
         let t = core::ptr::addr_of!(self.timer)
@@ -339,7 +339,7 @@ impl JSMySQLConnection {
 
         self.max_lifetime_timer.with_mut(|t| {
             t.next = timespec::ms_from_now(
-                TimespecMockMode::AllowMockedTime,
+                TimespecMockMode::ForceRealTime,
                 self.max_lifetime_interval_ms.into(),
             );
         });

--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -390,7 +390,7 @@ impl PostgresSQLConnection {
                 return;
             }
             t.next = bun_core::Timespec::ms_from_now(
-                bun_core::TimespecMockMode::AllowMockedTime,
+                bun_core::TimespecMockMode::ForceRealTime,
                 i64::from(interval),
             );
         });
@@ -500,7 +500,7 @@ impl PostgresSQLConnection {
         }
         self.max_lifetime_timer.with_mut(|t| {
             t.next = bun_core::Timespec::ms_from_now(
-                bun_core::TimespecMockMode::AllowMockedTime,
+                bun_core::TimespecMockMode::ForceRealTime,
                 i64::from(self.max_lifetime_interval_ms),
             );
         });

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -283,7 +283,7 @@ describe("runtime timeouts are not fake timers", () => {
   // Outlives the 50ms timeout by a wide margin but still exits on its own, so a
   // timeout that never fires shows up as a normal exit instead of a hang.
   const sleepingChild = () => ({
-    cmd: [bunExe(), "exec", "sleep 3"],
+    cmd: [bunExe(), "-e", "await Bun.sleep(3000)"],
     env: bunEnv,
     stdout: "ignore" as const,
     stderr: "ignore" as const,

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -1,6 +1,7 @@
 import { RedisClient, SQL } from "bun";
 import { heapStats } from "bun:jsc";
 import { bunEnv, bunExe } from "harness";
+import { spawnSync as childProcessSpawnSync } from "node:child_process";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 afterEach(() => vi.useRealTimers());
@@ -282,8 +283,9 @@ describe("AbortSignal.timeout", () => {
 describe("runtime timeouts are not fake timers", () => {
   // Outlives the 50ms timeout by a wide margin but still exits on its own, so a
   // timeout that never fires shows up as a normal exit instead of a hang.
+  const sleepArgs = ["-e", "await Bun.sleep(3000)"];
   const sleepingChild = () => ({
-    cmd: [bunExe(), "-e", "await Bun.sleep(3000)"],
+    cmd: [bunExe(), ...sleepArgs],
     env: bunEnv,
     stdout: "ignore" as const,
     stderr: "ignore" as const,
@@ -314,6 +316,18 @@ describe("runtime timeouts are not fake timers", () => {
       exitedDueToTimeout: true,
       signalCode: "SIGKILL",
     });
+  });
+
+  // node:child_process's sync functions hand their timeout to Bun.spawnSync.
+  test("child_process.spawnSync({ timeout }) times out while fake timers are active", () => {
+    vi.useFakeTimers();
+    const result = childProcessSpawnSync(bunExe(), sleepArgs, {
+      env: bunEnv,
+      stdio: "ignore",
+      timeout: 50,
+      killSignal: "SIGKILL",
+    });
+    expect({ signal: result.signal, code: result.error?.code }).toEqual({ signal: "SIGKILL", code: "ETIMEDOUT" });
   });
 
   // Accepts connections and never answers, so only the client's own connection

--- a/test/js/bun/test/fake-timers/fake-timers.test.ts
+++ b/test/js/bun/test/fake-timers/fake-timers.test.ts
@@ -1,4 +1,6 @@
+import { RedisClient, SQL } from "bun";
 import { heapStats } from "bun:jsc";
+import { bunEnv, bunExe } from "harness";
 import { afterEach, describe, expect, test, vi } from "vitest";
 
 afterEach(() => vi.useRealTimers());
@@ -272,6 +274,150 @@ describe("AbortSignal.timeout", () => {
     vi.advanceTimersByTime(1);
     expect({ aborted: signal.aborted, reasons }).toEqual({ aborted: true, reasons: ["TimeoutError"] });
   });
+});
+// Only the timers a test schedules itself are faked. Timeouts the runtime arms
+// for its own purposes keep running on the real clock: getTimerCount() does not
+// count them, they fire while fake timers are active, and useRealTimers(), which
+// drops every fake timer, does not disarm them.
+describe("runtime timeouts are not fake timers", () => {
+  // Outlives the 50ms timeout by a wide margin but still exits on its own, so a
+  // timeout that never fires shows up as a normal exit instead of a hang.
+  const sleepingChild = () => ({
+    cmd: [bunExe(), "exec", "sleep 3"],
+    env: bunEnv,
+    stdout: "ignore" as const,
+    stderr: "ignore" as const,
+    timeout: 50,
+    killSignal: "SIGKILL" as const,
+  });
+
+  test("Bun.spawn({ timeout }) kills the child while fake timers are active", async () => {
+    vi.useFakeTimers();
+    await using proc = Bun.spawn(sleepingChild());
+    expect(vi.getTimerCount()).toBe(0);
+    await proc.exited;
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: null, signalCode: "SIGKILL" });
+  });
+
+  test("Bun.spawn({ timeout }) armed under fake timers survives useRealTimers()", async () => {
+    vi.useFakeTimers();
+    await using proc = Bun.spawn(sleepingChild());
+    vi.useRealTimers();
+    await proc.exited;
+    expect({ exitCode: proc.exitCode, signalCode: proc.signalCode }).toEqual({ exitCode: null, signalCode: "SIGKILL" });
+  });
+
+  test("Bun.spawnSync({ timeout }) times out while fake timers are active", () => {
+    vi.useFakeTimers();
+    const result = Bun.spawnSync(sleepingChild());
+    expect({ exitedDueToTimeout: result.exitedDueToTimeout, signalCode: result.signalCode }).toEqual({
+      exitedDueToTimeout: true,
+      signalCode: "SIGKILL",
+    });
+  });
+
+  // Accepts connections and never answers, so only the client's own connection
+  // timeout can end a connection attempt.
+  function silentServer() {
+    const accepted = Promise.withResolvers<void>();
+    const listener = Bun.listen({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: {
+        open() {
+          accepted.resolve();
+        },
+        data() {},
+        close() {},
+        error() {},
+      },
+    });
+    return {
+      port: listener.port,
+      accepted: accepted.promise,
+      [Symbol.dispose]() {
+        listener.stop(true);
+      },
+    };
+  }
+
+  test.each([
+    ["postgres", "ERR_POSTGRES_CONNECTION_TIMEOUT"],
+    ["mysql", "ERR_MYSQL_CONNECTION_TIMEOUT"],
+  ])("%s connectionTimeout armed under fake timers survives useRealTimers()", async (protocol, code) => {
+    using server = silentServer();
+    vi.useFakeTimers();
+    const db = new SQL({ url: `${protocol}://user:pass@127.0.0.1:${server.port}/db`, connectionTimeout: 0.1, max: 1 });
+    try {
+      const connecting = db.connect().then(
+        () => "connected",
+        error => error.code,
+      );
+      await server.accepted;
+      const fakeTimers = vi.getTimerCount();
+      vi.useRealTimers();
+      expect(fakeTimers).toBe(0);
+      expect(await connecting).toBe(code);
+    } finally {
+      await db.close({ timeout: 0 });
+    }
+  });
+
+  test("RedisClient connectionTimeout armed under fake timers survives useRealTimers()", async () => {
+    using server = silentServer();
+    vi.useFakeTimers();
+    const client = new RedisClient(`redis://127.0.0.1:${server.port}`, {
+      connectionTimeout: 100,
+      autoReconnect: false,
+    });
+    try {
+      const command = client.get("key").then(
+        () => "replied",
+        error => error.code,
+      );
+      await server.accepted;
+      const fakeTimers = vi.getTimerCount();
+      vi.useRealTimers();
+      expect(fakeTimers).toBe(0);
+      expect(await command).toBe("ERR_REDIS_CONNECTION_TIMEOUT");
+    } finally {
+      client.close();
+    }
+  });
+});
+// Bun.cron() is mockable, so a job created under fake timers lives in the fake
+// heap, and useRealTimers() / clearAllTimers() drop it with the rest. Like a
+// dropped setInterval it has to end up stopped, rather than holding the process
+// open for a timer that can never fire.
+describe("Bun.cron() job dropped from the fake heap", () => {
+  test.each(["jest.useRealTimers()", "jest.clearAllTimers(); jest.useRealTimers()"])(
+    "does not keep the process alive after %s",
+    async drop => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const { jest } = Bun.jest();
+           jest.useFakeTimers();
+           Bun.cron("* * * * *", () => {});
+           ${drop};
+           console.log("exiting");`,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+        // A child that hangs (the bug) is killed rather than left behind.
+        timeout: 10_000,
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ stdout, stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+        stdout: "exiting\n",
+        stderr: "",
+        exitCode: 0,
+        signalCode: null,
+      });
+    },
+  );
 });
 describe("isFakeTimers", () => {
   test("returns true when fake timers are active", () => {


### PR DESCRIPTION
### Problem
- `jest.useFakeTimers()` captures the runtime's own safety timeouts. With fake timers active, `Bun.spawn({ timeout })` never kills the child, `new SQL({ connectionTimeout })` / `new RedisClient(url, { connectionTimeout })` never time out, and `jest.getTimerCount()` counts these timers as if the test had created them.
- `jest.useRealTimers()` (and `jest.clearAllTimers()`) then drains the fake heap and disarms them permanently: a child spawned with `timeout: 200` under fake timers runs to completion after the test is back on real time, and a Postgres connection attempt stays pending forever. The owner still believes it is armed, so nothing re-arms it.
- `Bun.spawnSync({ timeout })` under fake timers has the same problem without the heap: its wait loop compared the deadline against the mocked clock, which cannot advance while the call blocks.
- Cause: `Tag::allow_fake_timers()` in `src/event_loop/EventLoopTimer.rs` was an opt-out list, so every owner not on it (`SubprocessTimeout`, the Postgres/MySQL/Valkey connection, idle, lifetime and reconnect timers, `UpgradedDuplex`, `WindowsNamedPipe`, `DNSResolver`, `DateHeaderTimer`, the dev server timers) was routed into the fake heap by `All::insert` (`src/runtime/timer/mod.rs`), and each of them computed its deadline with `AllowMockedTime` to match. The fake timers PR left this list as a TODO ("should subprocess timeout? probably not").
- `FakeTimers::clear()` (`src/runtime/test_runner/timers/FakeTimers.rs`) only told `TimeoutObject` and `AbortSignal.timeout()` owners that their timer was gone; every other popped node was just marked `CANCELLED`.

### Fix
- `allow_fake_timers()` becomes an allowlist of the timers a program schedules itself: `setTimeout`/`setInterval` (`TimeoutObject`), `AbortSignal.timeout()`, and `Bun.cron()` (documented as honoring fake timers). Everything else stays in the real heap and keeps running on the real clock, which is also what Jest does (its fake timers never reach Node's internal timeouts).
- Every owner that moves to the real heap now arms with `ForceRealTime` (subprocess, Postgres, MySQL, Valkey, `UpgradedDuplex`, `WindowsNamedPipe`, c-ares poll timer, Date header timer, dev server sweep / visualizer). This is required, not optional: the real heap is drained against the real clock (`All::next`), so a mocked deadline there would be due immediately. It is the same convention the existing opt-outs (`BunTest`, `GcRepeating`, `StatWatcherScheduler`, `QuicEndpoint`, `DnsSdConnection`) already follow.
- `spawnSync` compares its `timeout` against the real clock too (`js_bun_spawn_bindings.rs`, `SpawnSyncEventLoop.rs`), and only consults an `AbortSignal.timeout()` deadline that lives in the real heap; one in the fake heap is on the mocked clock and cannot fire during a blocking call anyway. Behavior without fake timers is unchanged.
- `Bun.cron` is now the only non-JS owner the fake heap can drop, so `FakeTimers::clear()` collects dropped jobs and stops them the way `stop()` would (`CronJob::stop_dropped_from_fake_heap`), matching what happens to a dropped `setInterval`. Before, a job created under fake timers and then `useRealTimers()` kept the process alive forever with a timer that could never fire. The fallback arm is now a `debug_assert!`, so adding a tag to the allowlist without a release path fails loudly in debug builds.
- Behavior change to be aware of: `advanceTimersByTime()` no longer fires runtime-internal timeouts (e.g. a SQL `connectionTimeout`); they elapse in real time. No test or doc relied on that; the cron tests that do rely on mocking are unaffected. Not changed here: the async `node:child_process` `timeout` option is implemented with a JS `setTimeout` in `src/js/node/child_process.ts`, so it is still faked like any other `setTimeout`.
- Verified with `test/js/bun/test/fake-timers/fake-timers.test.ts` (new `runtime timeouts are not fake timers` and `Bun.cron() job dropped from the fake heap` blocks, 9 tests, including `node:child_process.spawnSync({ timeout })`, which hands its timeout to `Bun.spawnSync`). All 9 fail on the unfixed build (`getTimerCount()` is 1 or 2, spawn/spawnSync children exit normally, the cron child hangs until killed) and pass with the fix.
- Also passing on the debug build: `test/js/bun/test/fake-timers/sinonjs`, `test-timers.test.ts`, `test/js/bun/cron/in-process-cron.test.ts` and `cron-local-time.test.ts`, `spawn-signal.test.ts` (covers `spawnSync` + `AbortSignal.timeout`), `spawnSync.test.ts`, `spawn-maxbuf.test.ts`, `spawnsync-isolated-event-loop.test.ts`, `spawnsync-no-microtask-drain.test.ts`, `test/js/sql/sql-connect-error-reporting.test.ts`, the fake-timer cases of `test/cli/test/isolation.test.ts`, `test/regression/issue/25869.test.ts`, `26284.test.ts`. `cargo clippy` on `bun_event_loop`, `bun_runtime`, `bun_sql_jsc` is clean, including `--target x86_64-pc-windows-msvc` for the `WindowsNamedPipe` change.
- Overlap: #37935 (Date header timer) and #37940 (c-ares poll timer) each add one of these owners to the old opt-out list and flip its clock; this PR contains both of those source changes as part of the allowlist. Their tests still apply on top of this and are worth keeping; whichever lands second needs a small rebase of `allow_fake_timers()`.

### Background
- `timer::All` keeps two intrusive heaps of `EventLoopTimer` nodes. The event loop drains `timers` against `CLOCK_MONOTONIC`. While `jest.useFakeTimers()` is active, `All::insert` diverts nodes whose `Tag` allows it into `fake_timers.timers`, which only the `jest.*` functions drain: each pop sets the mocked clock to the node's deadline and fires it; `useRealTimers()` / `clearAllTimers()` pop everything without firing.
- `Tag` says which struct embeds a node (a `Subprocess`, a `PostgresSQLConnection`, a `TimeoutObject`, ...); `__bun_fire_timer` in `src/runtime/dispatch.rs` recovers the owner from it. Owners detect their own cancellation by checking `state == ACTIVE` before removing, which is why a foreign cancellation is silent rather than a crash.
- `Timespec::now(AllowMockedTime)` returns the fake-timers clock when one is installed; `ForceRealTime` always reads the monotonic clock. A deadline must be computed with the clock of the heap it is inserted into.
- `FakeTimers::clear()` returns the owners of the popped nodes so they can be released after the heap borrow ends (`TimeoutObject` drops its heap ref, `AbortSignal.timeout()` is cancelled through its signal, and now a `CronJob` is stopped); a node that is only unlinked leaves its owner holding event-loop refs for a timer that will never fire.
- `spawnSync` runs the child on an isolated mini event loop and blocks the JS thread in a tick loop, so no `jest.advanceTimersByTime()` can run while it waits; the only clock that can make its timeout elapse is the real one.

<details>
<summary>Repro on the released binary (1.4.0)</summary>

```ts
import { expect, jest, test } from "bun:test";

test("Bun.spawn timeout armed under fake timers, then useRealTimers()", async () => {
  jest.useFakeTimers();
  const p = Bun.spawn(["sleep", "3"], { timeout: 200, killSignal: "SIGKILL" });
  jest.useRealTimers();
  await p.exited;
  expect(p.signalCode).toBe("SIGKILL"); // null: child ran for 3 s
});

test("spawnSync timeout under fake timers", () => {
  jest.useFakeTimers();
  const r = Bun.spawnSync(["sleep", "3"], { timeout: 200, killSignal: "SIGKILL" });
  expect(r.exitedDueToTimeout).toBe(true); // undefined, and the call blocked for 3 s
});

test("cron job dropped by useRealTimers", () => {
  // as a script: the process never exits, the job holds the loop open with a dead timer
  jest.useFakeTimers();
  Bun.cron("* * * * *", () => {});
  jest.useRealTimers();
});
```

The SQL variant from the report (a `Bun.listen` that accepts and never answers, `connectionTimeout: 1`, let the connection get established, then `useRealTimers()`) stays pending past 4 s; with the fix it rejects with `ERR_POSTGRES_CONNECTION_TIMEOUT` after ~1 s.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 16 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 9 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/fake-timers/fake-timers.test.ts
bun test v1.4.0 (ada0dd1be)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [34.23ms]
(pass) advanceTimersToNextTimer > one setTimeout [11.19ms]
(pass) advanceTimersToNextTimer > setInterval [10.59ms]
(pass) advanceTimersToNextTimer > sorted timeouts [18.70ms]
(pass) advanceTimersToNextTimer > alternating intervals [12.93ms]
(pass) advanceTimersByTime > setInterval [9.41ms]
(pass) runOnlyPendingTimers > two setIntervals [12.40ms]
(pass) runAllTimers > two setIntervals [12.89ms]
(pass) getTimerCount > returns correct count of pending timers [10.69ms]
(pass) getTimerCount > throws error if fake timers not active [5.09ms]
(pass) clearAllTimers > clears all pending timers [6.90ms]
(pass) clearAllTimers > throws error if fake timers not active [3.88ms]
(pass) AbortSignal.timeout > pending signals stay alive while the fake heap holds their timer [653.89ms]
(pass) AbortSignal.timeout > useRealTimers() releases the signals whose timers it dropped [696.70ms]
(pass) AbortSign
... (truncated)

release without fix: 11 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [10.73ms]
(pass) advanceTimersToNextTimer > one setTimeout [0.29ms]
(pass) advanceTimersToNextTimer > setInterval [0.17ms]
(pass) advanceTimersToNextTimer > sorted timeouts [0.22ms]
(pass) advanceTimersToNextTimer > alternating intervals [0.13ms]
(pass) advanceTimersByTime > setInterval [0.15ms]
(pass) runOnlyPendingTimers > two setIntervals [0.17ms]
(pass) runAllTimers > two setIntervals [0.15ms]
(pass) getTimerCount > returns correct count of pending timers [0.12ms]
(pass) getTimerCount > throws error if fake timers not active [0.11ms]
(pass) clearAllTimers > clears all pending timers [0.10ms]
(pass) clearAllTimers > throws error if fake timers not active [0.04ms]
(pass) AbortSignal.timeout > pending signals stay alive while the fake heap holds their timer [12.11ms]
238 |   test("useRealTimers() releases the signals whose timers it dropped", () => {
239 |     const before = liveAbortSignals();
240 |     vi.useFakeTimers();
241 |     leakObservedTimeouts();
242 |     vi.useRealTimers();
243 |     expect(liveAbortSignals() - before).toBeLessThan(N * 0.1);
     
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/fake-timers/fake-timers.test.ts
bun test v1.4.0 (ada0dd1be)

test/js/bun/test/fake-timers/fake-timers.test.ts:
(pass) fake timers [27.16ms]
(pass) advanceTimersToNextTimer > one setTimeout [7.74ms]
(pass) advanceTimersToNextTimer > setInterval [8.05ms]
(pass) advanceTimersToNextTimer > sorted timeouts [13.95ms]
(pass) advanceTimersToNextTimer > alternating intervals [8.95ms]
(pass) advanceTimersByTime > setInterval [7.16ms]
(pass) runOnlyPendingTimers > two setIntervals [7.82ms]
(pass) runAllTimers > two setIntervals [8.66ms]
(pass) getTimerCount > returns correct count of pending timers [7.35ms]
(pass) getTimerCount > throws error if fake timers not active [4.26ms]
(pass) clearAllTimers > clears all pending timers [4.93ms]
(pass) clearAllTimers > throws error if fake timers not active [2.71ms]
(pass) AbortSignal.timeout > pending signals stay alive while the fake heap holds their timer [619.24ms]
(pass) AbortSignal.timeout > useRealTimers() releases the signals whose timers it dropped [609.59ms]
(pass) AbortSignal.tim
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 827ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/1179] fetch hdrhistogram
[hdrhistogram] up to date
[2/1179] fetch lshpack
[lshpack] up to date
[3/1179] fetch lolhtml
[lolhtml] up to date
[4/1179] cc obj/vendor/zlib/deflate_slow.c.o
[5/1179] cc obj/vendor/zlib/insert_string_roll.c.o
[6/1179] cc obj/vendor/zlib/deflate_quick.c.o
[7/1179] cc obj/vendor/zlib/insert_string.c.o
[8/1179] cc obj/vendor/zlib/functable.c.o
[9/1179] cc obj/vendor/zlib/deflate_rle.c.o
[10/1179] cc obj/vendor/zlib/deflate_medium.c.o
[11/1179] cc obj/vendor/zlib/uncompr.c.o
[12/1179] cc obj/vendor/zlib/deflate_stored.c.o
[13/1179] cc obj/vendor/zlib/inftrees.c.o
[14/1179] cc obj/vendor/zlib/zutil.c.o
[15/1179] cc obj/vendor/zlib/cpu_features.c.o
[16/1179] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[16/1179] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Co
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/event_loop/EventLoopTimer.rs                 |  21 ++-
 src/event_loop/SpawnSyncEventLoop.rs             |   6 +-
 src/runtime/api/bun/js_bun_spawn_bindings.rs     |  13 +-
 src/runtime/api/cron.rs                          |  11 ++
 src/runtime/bake/dev_server/hmr_socket.rs        |   2 +-
 src/runtime/bake/dev_server/source_map_store.rs  |   2 +-
 src/runtime/dns_jsc/dns.rs                       |   2 +-
 src/runtime/socket/UpgradedDuplex.rs             |   2 +-
 src/runtime/socket/WindowsNamedPipe.rs           |   2 +-
 src/runtime/test_runner/timers/FakeTimers.rs     |  21 ++-
 src/runtime/timer/Timer.rs                       |   2 +-
 src/runtime/timer/mod.rs                         |   2 +-
 src/runtime/valkey_jsc/js_valkey.rs              |   2 +-
 src/sql_jsc/mysql/JSMySQLConnection.rs           |   4 +-
 src/sql_jsc/postgres/PostgresSQLConnection.rs    |   4 +-
 test/js/bun/test/fake-timers/fake-timers.test.ts | 160 +++++++++++++++++++++++
 16 files changed, 225 insertions(+), 31 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/event_loop/EventLoopTimer.rs                      1      4      0
src/event_loop/SpawnSyncEventLoop.rs                  1      4      0
src/runtime/api/bun/js_bun_spawn_bindings.rs          4      5      0
src/runtime/api/cron.rs                               3      2      0
src/runtime/bake/dev_server/hmr_socket.rs             1      1      0
src/runtime/bake/dev_server/source_map_store.rs       2      1      0
src/runtime/dns_jsc/dns.rs                            3      1      0
src/runtime/socket/UpgradedDuplex.rs                  1      1      0
src/runtime/socket/WindowsNamedPipe.rs                1      1      0
src/runtime/test_runner/timers/FakeTimers.rs          2      7      0
src/runtime/timer/Timer.rs                            3      1      0
src/runtime/timer/mod.rs                              6      1      0
src/runtime/valkey_jsc/js_valkey.rs                   1      1      0
src/sql_jsc/mysql/JSMySQLConnection.rs                1      2      0
src/sql_jsc/postgres/PostgresSQLConnection.rs         3      2      0
test/js/bun/test/fake-timers/fake-timers.test.ts      4      8      0
```

</details>

<!-- robobun:evidence:end -->