### PR TITLE
ci: comment-cop should accept one- and two-line comments

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -113,3 +113,7 @@ export LLVM_VERSION_MAJOR=19
 - The script defaults to **format** mode (modifies files)
 - Always test locally before pushing workflow changes
 - Keep the exclusion list updated as new third-party code is added
+
+## comment-cop.yml Workflow
+
+Runs on `pull_request_target` for PRs labeled `claude` and leaves a review comment on every comment block the PR adds under `src/` that has three or more lines of text (`MIN_TEXT_LINES`). Lines that are only comment structure (`/**`, ` *`, ` */`, a bare `//`) are not counted, blocks containing `SAFETY:` are skipped, and a block is flagged once: threads are keyed by a hash of the block's text, and threads whose block disappeared from the diff are resolved automatically. One- and two-line comments are never flagged; the matching rule for authors is item 13 of the root `CLAUDE.md`. To check a change to the grouping logic, paste `groupsFromPatch` into a scratch script and feed it small hand-written patches; the workflow has no other inputs than the PR's file patches.

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -113,7 +113,3 @@ export LLVM_VERSION_MAJOR=19
 - The script defaults to **format** mode (modifies files)
 - Always test locally before pushing workflow changes
 - Keep the exclusion list updated as new third-party code is added
-
-## comment-cop.yml Workflow
-
-Runs on `pull_request_target` for PRs labeled `claude` and leaves a review comment on every comment block the PR adds under `src/` that has three or more lines of text (`MIN_TEXT_LINES`). Lines that are only comment structure (`/**`, ` *`, ` */`, a bare `//`) are not counted, blocks containing `SAFETY:` are skipped, and a block is flagged once: threads are keyed by a hash of the block's text, and threads whose block disappeared from the diff are resolved automatically. One- and two-line comments are never flagged; the matching rule for authors is item 13 of the root `CLAUDE.md`. To check a change to the grouping logic, paste `groupsFromPatch` into a scratch script and feed it small hand-written patches; the workflow has no other inputs than the PR's file patches.

--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -39,8 +39,8 @@ jobs:
 
             const SRC_EXT = /\.(rs|c|cc|cpp|h|hpp|m|mm|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
             const MIN_TEXT_LINES = 3;
-            // "//", "/*", "/**", "*", "*/": structure, not text.
-            const DELIMITER_ONLY = /^(\/\/|\/\*+|\*+\/?)$/;
+            // "//", "///", "//!", "/*", "/**", "*", "*/": structure, not text.
+            const DELIMITER_ONLY = /^(\/\/+!?|\/\*+|\*+\/?)$/;
 
             function isCommentLine(line) {
               const t = line.trimStart();

--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -1,8 +1,10 @@
 name: Comment Cop
 
-# Flags multi-line code comments added in src/ by claude-labeled PRs and
-# asks for them to be deleted. Groups containing a SAFETY: marker are
-# skipped. Runs entirely against the GitHub API (no checkout of PR code).
+# Flags paragraph-sized code comments (three or more lines of text, not
+# counting bare delimiter lines such as "/**" or "*/") added in src/ by
+# claude-labeled PRs and asks for them to be deleted. One- and two-line
+# comments are fine. Groups containing a SAFETY: marker are skipped. Runs
+# entirely against the GitHub API (no checkout of PR code).
 
 on:
   pull_request_target:
@@ -24,7 +26,7 @@ jobs:
       group: comment-cop-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
-      - name: Scan diff for added multi-line comments
+      - name: Scan diff for added paragraph-sized comments
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
@@ -36,7 +38,9 @@ jobs:
             const headSha = context.payload.pull_request.head.sha;
 
             const SRC_EXT = /\.(rs|c|cc|cpp|h|hpp|m|mm|ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
-            const MIN_LINES = 2;
+            const MIN_TEXT_LINES = 3;
+            // "//", "/*", "/**", "*", "*/": structure, not text.
+            const DELIMITER_ONLY = /^(\/\/|\/\*+|\*+\/?)$/;
 
             function isCommentLine(line) {
               const t = line.trimStart();
@@ -51,7 +55,7 @@ jobs:
               let newLine = 0;
               let cur = null;
               const flush = () => {
-                if (cur && cur.lines.length >= MIN_LINES) {
+                if (cur && cur.lines.filter(l => !DELIMITER_ONLY.test(l.trim())).length >= MIN_TEXT_LINES) {
                   const text = cur.lines.join('\n');
                   if (!/SAFETY:/.test(text)) out.push({ path, start: cur.start, end: cur.end, text });
                 }

--- a/.github/workflows/comment-cop.yml
+++ b/.github/workflows/comment-cop.yml
@@ -1,10 +1,7 @@
 name: Comment Cop
 
-# Flags paragraph-sized code comments (three or more lines of text, not
-# counting bare delimiter lines such as "/**" or "*/") added in src/ by
-# claude-labeled PRs and asks for them to be deleted. One- and two-line
-# comments are fine. Groups containing a SAFETY: marker are skipped. Runs
-# entirely against the GitHub API (no checkout of PR code).
+# Flags comments of 3+ text lines added in src/ by claude-labeled PRs (SAFETY: blocks exempt).
+# Runs entirely against the GitHub API, no checkout of PR code.
 
 on:
   pull_request_target:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ Several situational sections live in `.claude/docs/landing-prs.md` — read the 
 10. **Debug builds** - Use `BUN_DEBUG_QUIET_LOGS=1` to disable debug logging, or `BUN_DEBUG_<SCOPE>=1` to enable a specific `bun_core::output` scoped logger
 11. **Be humble & honest** - NEVER overstate what you got done or what actually works in commits, PRs or in messages to the user.
 12. **Branch names must start with `claude/`** - This is a requirement for the CI to work.
-13. **If you need a paragraph-long comment to justify why the workaround is OK, the code is wrong — fix the code.**.
+13. **If you need a paragraph-long comment to justify why the workaround is OK, the code is wrong — fix the code.** Concretely: a comment in `src/` is one line, two at most. If it needs a third line, make the code say it (rename, restructure, assert) or put the explanation in the PR description. CI (`.github/workflows/comment-cop.yml`) flags every added comment block with three or more lines of text; lines that are only `/**`, ` *` or ` */` do not count, and `SAFETY:` comments are exempt.
 14. After every code comment you write, ask yourself, "Is this information the next Claude would spend multiple tool calls trying to understand?". If the answer isn't clearly yes, the code comment is noise - delete it.
 
 **ONLY** push up changes after running `bun bd test <file>` and ensuring your tests pass.


### PR DESCRIPTION
### What does this PR do?

Requested by @cirospaciari in oven-sh/bun#32089 (review): the comment-cop workflow flagged two-line comments, not just paragraphs.

- `.github/workflows/comment-cop.yml` now flags a block only when it has three or more lines of comment text (`MIN_TEXT_LINES = 3`; it was two physical lines).
- Lines that are only comment structure (`/**`, ` *`, ` */`, a bare `//`, `///` or `//!` between paragraphs) are not counted, so a one- or two-sentence JSDoc block is treated like a one- or two-line `//` comment instead of being flagged for its delimiters.
- Everything else (src/ only, claude-labeled PRs, the SAFETY: exemption, dedup and auto-resolve of stale threads) is unchanged.
- `CLAUDE.md` item 13 now states the rule the bot enforces (one line, two at most, what to do instead of a third, and the exemptions).

### How did you verify your code works?

Ran the workflow's `groupsFromPatch` against sample patches with the new constants: one- and two-line `//` comments, one- and two-line JSDoc blocks and two short paragraphs separated by a bare `//` are not flagged; three-line `//` comments, three-line JSDoc blocks and `/* ... */` blocks with three lines of text are; a SAFETY: block is still skipped. The workflow itself only runs on `pull_request_target`, so it takes effect on claude-labeled PRs once this is on main; nothing in this PR is exercised by the Buildkite build.
