### PR TITLE
node:fs: stop fs.cp(dir, "") on macOS copying to an uninitialized destination path

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1947,12 +1947,11 @@ mod _async_tasks {
             // `cp_task` pointers stored in subtasks retain mutable provenance for
             // `on_subtask_done`'s eventual `&mut` promotion.
             let this_ref = unsafe { &*this };
-            // SAFETY: callers NUL-terminate at src_dir_len/dest_dir_len before calling.
-            // Platform-generic — `OSPathBuffer` is `[u16;N]` on Windows, `[u8;N]` on POSIX,
-            // so reconstruct as `&OSPathSliceZ`.
-            let src = unsafe { OSPathSliceZ::from_raw(src_buf.as_ptr(), src_dir_len as usize) };
-            // SAFETY: dest_buf[dest_dir_len] == 0 written by caller
-            let dest = unsafe { OSPathSliceZ::from_raw(dest_buf.as_ptr(), dest_dir_len as usize) };
+            // The NUL at `[len]` was written by `PathLikeExt::os_path` (top-level call
+            // from `cp_async`) or by the `Directory` arm below (recursion); `from_buf`
+            // debug-asserts it.
+            let src = OSPathSliceZ::from_buf(&src_buf[..], src_dir_len as usize);
+            let dest = OSPathSliceZ::from_buf(&dest_buf[..], dest_dir_len as usize);
 
             #[cfg(target_os = "macos")]
             {
@@ -2036,9 +2035,9 @@ mod _async_tasks {
             loop {
                 let current = match entry {
                     Err(err) => {
-                        this_ref.finish_concurrently(Err(
-                            err.with_path(nodefs.os_path_into_sync_error_buf(src))
-                        ));
+                        this_ref.finish_concurrently(Err(err.with_path(
+                            nodefs.os_path_into_sync_error_buf(&src_buf[..src_dir_len as usize]),
+                        )));
                         return false;
                     }
                     Ok(ent) => match ent {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1947,9 +1947,7 @@ mod _async_tasks {
             // `cp_task` pointers stored in subtasks retain mutable provenance for
             // `on_subtask_done`'s eventual `&mut` promotion.
             let this_ref = unsafe { &*this };
-            // The NUL at `[len]` was written by `PathLikeExt::os_path` (top-level call
-            // from `cp_async`) or by the `Directory` arm below (recursion); `from_buf`
-            // debug-asserts it.
+            // NUL at `[len]` written by `os_path` (top level) or the `Directory` arm below.
             let src = OSPathSliceZ::from_buf(&src_buf[..], src_dir_len as usize);
             let dest = OSPathSliceZ::from_buf(&dest_buf[..], dest_dir_len as usize);
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -862,6 +862,10 @@ pub trait PathLikeExt {
     fn slice_w<'a>(&'a self, buf: &'a mut WPathBuffer) -> Result<&'a WStr, NameTooLong>
     where
         Self: Sized;
+    /// The returned path (NUL included) always lives in `buf`, unlike
+    /// [`slice_z`](Self::slice_z), which hands back a slice of the operand
+    /// itself when it can. `cp` / `cpSync` keep only the length and go on
+    /// appending directory entries to `buf` while they walk the tree.
     fn os_path<'a>(&'a self, buf: &'a mut OSPathBuffer) -> Result<&'a OSPathSliceZ, NameTooLong>
     where
         Self: Sized;
@@ -1038,7 +1042,10 @@ impl PathLikeExt for PathLike {
         }
         #[cfg(not(windows))]
         {
-            Ok(self.slice_z_with_force_copy::<false>(buf))
+            // `FORCE`: without it an empty operand (`fs.cp(dir, "")`) comes
+            // back as the static `ZStr::EMPTY` and `buf` is never written,
+            // yet the callers go on reading their path out of `buf`.
+            Ok(self.slice_z_with_force_copy::<true>(buf))
         }
     }
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -862,10 +862,8 @@ pub trait PathLikeExt {
     fn slice_w<'a>(&'a self, buf: &'a mut WPathBuffer) -> Result<&'a WStr, NameTooLong>
     where
         Self: Sized;
-    /// The returned path (NUL included) always lives in `buf`, unlike
-    /// [`slice_z`](Self::slice_z), which hands back a slice of the operand
-    /// itself when it can. `cp` / `cpSync` keep only the length and go on
-    /// appending directory entries to `buf` while they walk the tree.
+    /// Always writes the path (NUL included) into `buf`, unlike [`slice_z`](Self::slice_z):
+    /// the `cp` tree walks keep only the length and append entry names to `buf`.
     fn os_path<'a>(&'a self, buf: &'a mut OSPathBuffer) -> Result<&'a OSPathSliceZ, NameTooLong>
     where
         Self: Sized;
@@ -1042,9 +1040,8 @@ impl PathLikeExt for PathLike {
         }
         #[cfg(not(windows))]
         {
-            // `FORCE`: without it an empty operand (`fs.cp(dir, "")`) comes
-            // back as the static `ZStr::EMPTY` and `buf` is never written,
-            // yet the callers go on reading their path out of `buf`.
+            // Non-forced, an empty operand (`fs.cp(dir, "")`) returns `ZStr::EMPTY` and leaves
+            // `buf` unwritten.
             Ok(self.slice_z_with_force_copy::<true>(buf))
         }
     }

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -862,8 +862,7 @@ pub trait PathLikeExt {
     fn slice_w<'a>(&'a self, buf: &'a mut WPathBuffer) -> Result<&'a WStr, NameTooLong>
     where
         Self: Sized;
-    /// Always writes the path (NUL included) into `buf`, unlike [`slice_z`](Self::slice_z):
-    /// the `cp` tree walks keep only the length and append entry names to `buf`.
+    /// Always materialized in `buf` (the `cp` walks append entry names to it), unlike `slice_z`.
     fn os_path<'a>(&'a self, buf: &'a mut OSPathBuffer) -> Result<&'a OSPathSliceZ, NameTooLong>
     where
         Self: Sized;
@@ -1040,8 +1039,7 @@ impl PathLikeExt for PathLike {
         }
         #[cfg(not(windows))]
         {
-            // Non-forced, an empty operand (`fs.cp(dir, "")`) returns `ZStr::EMPTY` and leaves
-            // `buf` unwritten.
+            // Unforced, an empty operand (`fs.cp(dir, "")`) yields `ZStr::EMPTY` and skips `buf`.
             Ok(self.slice_z_with_force_copy::<true>(buf))
         }
     }

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -594,9 +594,10 @@ describe.skipIf(isWindows).each(["cp", "cpSync"] as const)(
 );
 
 // An empty destination has to fail the way node's walker fails it: mkdir("")
-// -> ENOENT, with nothing created. (node's cpSync alone reports EINVAL, and
-// only because its C++ copy starts with std::filesystem::create_directories("");
-// given a filter it walks in JS and reports ENOENT/mkdir like its async forms.)
+// -> ENOENT, with nothing created. (node's cpSync alone reports whatever
+// std::filesystem::create_directories("") says in its C++ copy, EINVAL on Linux
+// and ESRCH on Windows; given a filter it walks in JS and reports ENOENT/mkdir
+// like its async forms do everywhere.)
 // On macOS a directory source takes the native recursive copy, which rebuilds
 // its destination from a stack buffer; an empty operand used to be returned
 // without ever being copied into that buffer, so the tree was copied to
@@ -637,8 +638,9 @@ test("empty destination is rejected with ENOENT and creates nothing", async () =
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   expect(stderr).toBe("");
   const { results, cwd } = JSON.parse(stdout);
-  // Single-file copies report the syscall that hit "" (mkdir of its parent on
-  // Linux, copyfile on macOS), so only the code is pinned for them.
+  // Single-file copies report whichever syscall hit "" on that platform (mkdir
+  // of its parent on Linux, copyfile on Windows), so only the code is pinned
+  // for them.
   expect({ ...results, cwd: cwd.map((entry: string) => entry.replaceAll("\\", "/")).sort() }).toEqual({
     "cpSync(d)": { code: "ENOENT", syscall: "mkdir" },
     "promises.cp(d)": { code: "ENOENT", syscall: "mkdir" },

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -593,6 +593,64 @@ describe.skipIf(isWindows).each(["cp", "cpSync"] as const)(
   },
 );
 
+// An empty destination has to fail the way node's walker fails it: mkdir("")
+// -> ENOENT, with nothing created. (node's cpSync alone reports EINVAL, and
+// only because its C++ copy starts with std::filesystem::create_directories("");
+// given a filter it walks in JS and reports ENOENT/mkdir like its async forms.)
+// On macOS a directory source takes the native recursive copy, which rebuilds
+// its destination from a stack buffer; an empty operand used to be returned
+// without ever being copied into that buffer, so the tree was copied to
+// whatever bytes the buffer happened to hold. The copies run in a child so ""
+// resolves against a throwaway cwd, and the listing afterwards proves the cwd
+// is untouched.
+test("empty destination is rejected with ENOENT and creates nothing", async () => {
+  using dir = tempDir("cp-empty-dest", {
+    "d/f": "f",
+    "d/sub/g": "g",
+    "file": "file",
+  });
+  const script = `
+    const fs = require("fs");
+    const shape = e => ({ code: e.code, syscall: e.syscall });
+    const forms = {
+      cpSync: (src, opts) => { try { fs.cpSync(src, "", opts); } catch (e) { return shape(e); } },
+      "promises.cp": (src, opts) => fs.promises.cp(src, "", opts).then(() => undefined, shape),
+      cp: (src, opts) => new Promise(resolve => fs.cp(src, "", opts, e => resolve(e ? shape(e) : undefined))),
+    };
+    (async () => {
+      const results = {};
+      for (const src of ["d", "file"]) {
+        for (const name in forms) {
+          results[name + "(" + src + ")"] = (await forms[name](src, { recursive: true })) ?? "resolved";
+        }
+      }
+      console.log(JSON.stringify({ results, cwd: fs.readdirSync(".", { recursive: true }) }));
+    })();
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect(stderr).toBe("");
+  const { results, cwd } = JSON.parse(stdout);
+  // Single-file copies report the syscall that hit "" (mkdir of its parent on
+  // Linux, copyfile on macOS), so only the code is pinned for them.
+  expect({ ...results, cwd: cwd.map((entry: string) => entry.replaceAll("\\", "/")).sort() }).toEqual({
+    "cpSync(d)": { code: "ENOENT", syscall: "mkdir" },
+    "promises.cp(d)": { code: "ENOENT", syscall: "mkdir" },
+    "cp(d)": { code: "ENOENT", syscall: "mkdir" },
+    "cpSync(file)": { code: "ENOENT", syscall: expect.any(String) },
+    "promises.cp(file)": { code: "ENOENT", syscall: expect.any(String) },
+    "cp(file)": { code: "ENOENT", syscall: expect.any(String) },
+    cwd: ["d", "d/f", "d/sub", "d/sub/g", "file"],
+  });
+  expect(exitCode).toBe(0);
+});
+
 // fs.promises.cp recursive: when one SingleTask copy fails while siblings are
 // still in flight on the thread pool, the parent AsyncCpTask must not be
 // destroyed until every subtask has dropped its reference. Before the fix,


### PR DESCRIPTION
### Problem
- On macOS, `fs.promises.cp(dir, "", { recursive: true })` (and callback `fs.cp`) runs the recursive copy against a destination read out of an uninitialized stack buffer. Depending on what the bytes spell it fails with an arbitrary errno, or copies the tree to a path left over from an earlier fs call on that pool thread. node fails with `ENOENT: no such file or directory, mkdir ''`.
- `""` is a valid path argument (node's `validatePath` only rejects non-strings and NUL bytes), and `tryNativeFastPath` in `src/js/internal/fs/cp.ts` takes the native binding for a directory source on darwin when the destination does not exist, so the empty operand reaches native code.
- `PathLikeExt::os_path` (`src/runtime/node/types.rs`) went through `slice_z_with_force_copy::<false>`, whose empty-operand branch returns the static `ZStr::EMPTY` and never writes into the caller's `OSPathBuffer`.
- `cp_async` (`src/runtime/node/node_fs.rs`, `NewAsyncCpTask`) keeps only `dest.len()` (0) and passes `dest_buf` to `cp_async_directory`, which rebuilt `dest` with `OSPathSliceZ::from_raw(dest_buf.as_ptr(), 0)` and handed it to `clonefile()` and then `mkdir_recursive_os_path()`. Both read the unwritten buffer as a C string.
- `cpSync` takes the same route but `cp_sync_inner` happens to write `dest_buf[0] = 0` itself, so it already failed with ENOENT. Linux and Windows are not affected: `fs.cp` only takes the native directory walk on darwin, and the shell's `cp` builtin (the other user of `cp_async_directory`) is Windows-only and always passes absolute paths.

### Fix
- `os_path` now uses `slice_z_with_force_copy::<true>` on POSIX, so the operand and its NUL always land in the buffer; `slice_w` already works that way on Windows. This is the contract both `cp` and `cp_async` rely on, since they keep the buffer and the length and append directory entries to it while walking.
- No other input changes behavior: the binding rejects NUL bytes and over-long paths before `os_path` runs, so every non-empty operand already took the copying branch. The empty operand now lands in the buffer as `""`: `clonefile()` fails with ENOENT and falls through, then `mkdir("")` fails with ENOENT, which is the error the JS walker on the other platforms (and node) produce.
- `cp_async_directory` builds its paths with `OSPathSliceZ::from_buf`, which debug-asserts the terminator, instead of `from_raw`; the readdir error path takes its prefix straight from the buffer so the borrow ends before the walk mutates it.
- Test: `test/js/node/fs/cp.test.ts` "empty destination is rejected with ENOENT and creates nothing" runs `cpSync`, `promises.cp` and callback `cp` with a directory and a file source against `""` inside a throwaway cwd and checks the errors plus that the cwd is untouched. The directory forms hit the fixed native walk only on macOS; on Linux and Windows they hit the JS walker, so there the test passes before and after this change. I have no macOS machine here, so the macOS before-fix behavior is from reading the code; with the fix, CI's macOS 14 arm64 lane passes the file (47 pass, 0 fail), which is the native walk returning ENOENT from `mkdir("")` and leaving the cwd alone. The file forms cover the other `os_path` consumer (`copy_single_file_sync`) on every platform.
- Also run: `test/js/node/fs/cp.test.ts` and `cp-symlink-target.test.ts` on Linux (debug build); `test/js/bun/shell/commands/cp.test.ts` on a Windows debug build, which drives `cp_async_directory` and its new debug assertions (30 pass); `cargo check -p bun_runtime --target aarch64-apple-darwin` for the macOS-only `clonefile` block.

- Overlaps with #37952 (Windows paths past MAX_PATH in the same two entry points): that PR replaces `os_path` with a helper that also copies the operand into the buffer, so it closes this hole on POSIX as a side effect, but it has no test for it. Either order works: if it lands first, this PR rebases down to the test (plus the `from_buf` hunk if that survives); if this lands first, the `os_path` hunks here are deleted by its rebase.

### Background
- `OSPathBuffer` is the stack buffer (`[u8; PATH_MAX]`, `[u16; 32767]` on Windows) bun's fs code fills with a NUL-terminated path for a syscall. It is intentionally left uninitialized (`uninit()`), so whatever reads from it has to have written it first.
- `PathLike::slice_z` hands back a NUL-terminated view of the operand without copying whenever it can (an empty operand becomes the static `""`) and copies into the buffer only otherwise; the `FORCE` variant always copies. The non-copying form is fine for callers that use the returned slice and wrong for callers that go on to use the buffer, which is what the recursive copy does.
- The recursive copy (`cp_sync_inner`, `cp_async_directory`) takes the src and dest buffers plus the current lengths and appends `/<entry>` in place for each directory entry, which is why it reconstructs the paths from the buffers instead of taking slices.
- `fs.cp` / `fs.cpSync` only call the native binding when its result matches node's walker: any regular-file source, and on darwin a directory source whose tree has only files and directories and whose destination does not exist (one `clonefile()`). Everything else goes through the JS port of node's walker.

<details>
<summary>node v26.3.0 on Linux for the same inputs (<code>d/</code> is a directory, <code>file</code> a regular file, destination <code>""</code>)</summary>

```
cpSync(d)        EINVAL  syscall=cp       (std::filesystem::create_directories("") in node's C++ cpSync;
                                           with a filter, i.e. node's JS walker, it is ENOENT / mkdir)
promises.cp(d)   ENOENT  syscall=mkdir    "ENOENT: no such file or directory, mkdir ''"
cp(d, cb)        ENOENT  syscall=mkdir
cpSync(file)     ENOENT  syscall=copyfile
promises.cp(file) ENOENT syscall=copyfile
cp(file, cb)     ENOENT  syscall=copyfile
```

Same node build on Windows: `cpSync(d)` is `ESRCH` (the std::error_code from `create_directories("")` reported as an errno), while `promises.cp(d)` is again `ENOENT` / `mkdir ''`. The cpSync code is an artifact of node's C++ path that differs per platform; the walker's ENOENT / mkdir is the behavior node has on every platform and in every form that walks, so that is what the test pins.

bun (Linux and Windows before and after; macOS after): every form rejects with ENOENT; the directory forms report `mkdir`, the file forms report whichever syscall hit `""` inside `copy_single_file_sync` on that platform (`mkdir` of the parent on Linux, `copyfile` on Windows). The test pins the code for all six and the syscall for the directory forms.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->
