### PR TITLE
vm.Script: parse once and reuse the unlinked code in every context it runs in

### DIFF
--- a/scripts/build/deps/webkit.ts
+++ b/scripts/build/deps/webkit.ts
@@ -3,7 +3,7 @@
  * for local mode. Override via `--webkit-version=<hash>` to test a branch.
  * From https://github.com/oven-sh/WebKit releases.
  */
-export const WEBKIT_VERSION = "7b763944f0ecd0e18cb9ac89a04ef994e3ccb4ae";
+export const WEBKIT_VERSION = "autobuild-preview-pr-418-79de1898";
 
 /**
  * WebKit (JavaScriptCore) — the JS engine.

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -3,6 +3,7 @@
 
 #include "ErrorCode.h"
 
+#include "JavaScriptCore/CodeCache.h"
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/JIT.h"
 #include "JavaScriptCore/JSWeakMap.h"
@@ -131,39 +132,21 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
 
     RefPtr fetcher(NodeVMScriptFetcher::create(vm, importer, jsUndefined()));
 
-    SourceCode source = makeSource(sourceString, JSC::SourceOrigin(WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher), JSC::SourceTaintedOrigin::Untainted, options.filename, TextPosition(options.lineOffset, options.columnOffset));
+    TextPosition startPosition(options.lineOffset, options.columnOffset);
+    Ref provider = NodeVMScriptSourceProvider::create(sourceString, JSC::SourceOrigin(WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher), String(options.filename), startPosition);
+    SourceCode source(provider.copyRef(), startPosition.m_line.oneBasedInt(), startPosition.m_column.oneBasedInt());
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Node's vm.Script throws SyntaxError at construction; the REPL's
-    // recoverable-error flow (and user code) relies on that. This is a
-    // double-parse (checkSyntax discards its AST and runInThisContext reparses
-    // via JSC::evaluate); compile-once via m_cachedExecutable is the follow-up.
-    JSC::ParserError parseError;
-    if (!JSC::checkSyntax(vm, source, parseError)) {
-        auto exception = parseError.toErrorObject(globalObject, source, -1);
-        // Building the error materializes its stack, running a user
-        // Error.prepareStackTrace that may throw; Node throws the SyntaxError
-        // anyway. tryClearException leaves a termination for the check below.
-        if (exception)
-            (void)scope.tryClearException();
-        RETURN_IF_EXCEPTION(scope, {});
-        // Node always attaches the arrow header to compile-time SyntaxErrors
-        // (node_contextify.cc DecorateErrorStack), independent of displayErrors.
-        // An absent filename becomes evalmachine.<anonymous>; an explicitly
-        // provided one — including "" — is used verbatim.
-        String url = options.filenameProvided ? options.filename : "evalmachine.<anonymous>"_s;
-        decorateParseErrorStack(globalObject, vm, exception, sourceString, url, parseError, options.lineOffset);
-        throwException(globalObject, scope, exception);
-        return {};
-    }
-
     const bool produceCachedData = options.produceCachedData;
-    auto filename = options.filename;
+    const bool filenameProvided = options.filenameProvided;
+    const OrdinalNumber lineOffset = options.lineOffset;
+    String filename = options.filename;
 
     NodeVMScript* script = NodeVMScript::create(vm, globalObject, structure, WTF::move(source), WTF::move(options));
     RETURN_IF_EXCEPTION(scope, {});
 
     fetcher->owner(vm, script);
+    provider->setScript(script);
 
     WTF::Vector<uint8_t>& cachedData = script->cachedData();
 
@@ -194,17 +177,76 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
             if (compilationResult != JSC::CompilationResult::CompilationFailed) {
                 executable->installCode(codeBlock);
                 script->cachedDataRejected(TriState::False);
+                // Accepted cached data is what the runs link, so the source is never parsed.
+                provider->pinUnlinkedCode(key, unlinkedBlock);
             } else {
                 script->cachedDataRejected(TriState::True);
             }
         }
-    } else if (produceCachedData) {
+    }
+
+    if (!script->hasPinnedUnlinkedCode()) {
+        // Node's vm.Script throws SyntaxError at construction; the REPL's
+        // recoverable-error flow (and user code) relies on that. The same parse
+        // is pinned for every later run, see NodeVMScriptSourceProvider.
+        JSC::ParserError parseError;
+        if (!script->compile(globalObject, parseError)) {
+            auto exception = parseError.toErrorObject(globalObject, script->source(), -1);
+            // Building the error materializes its stack, running a user
+            // Error.prepareStackTrace that may throw; Node throws the SyntaxError
+            // anyway. tryClearException leaves a termination for the check below.
+            if (exception)
+                (void)scope.tryClearException();
+            RETURN_IF_EXCEPTION(scope, {});
+            // Node always attaches the arrow header to compile-time SyntaxErrors
+            // (node_contextify.cc DecorateErrorStack), independent of displayErrors.
+            // An absent filename becomes evalmachine.<anonymous>; an explicitly
+            // provided one — including "" — is used verbatim.
+            String url = filenameProvided ? filename : "evalmachine.<anonymous>"_s;
+            decorateParseErrorStack(globalObject, vm, exception, sourceString, url, parseError, lineOffset);
+            throwException(globalObject, scope, exception);
+            return {};
+        }
+    }
+
+    if (cachedData.isEmpty() && produceCachedData) {
         script->cacheBytecode();
         // TODO(@heimskr): is there ever a case where bytecode production fails?
         script->cachedDataProduced(true);
     }
 
     return JSValue::encode(script);
+}
+
+JSC::JSCell* NodeVMScriptSourceProvider::pinnedUnlinkedCode(const JSC::SourceCodeKey& key) const
+{
+    return m_script ? m_script->pinnedUnlinkedCode(key.hash()) : nullptr;
+}
+
+void NodeVMScriptSourceProvider::pinUnlinkedCode(const JSC::SourceCodeKey& key, JSC::JSCell* unlinkedCode) const
+{
+    if (m_script)
+        m_script->pinUnlinkedCode(key.hash(), uncheckedDowncast<JSC::UnlinkedProgramCodeBlock>(unlinkedCode));
+}
+
+NodeVMScript::~NodeVMScript()
+{
+    static_cast<NodeVMScriptSourceProvider*>(m_source.provider())->setScript(nullptr);
+}
+
+void NodeVMScript::pinUnlinkedCode(unsigned keyHash, JSC::UnlinkedProgramCodeBlock* unlinkedCode)
+{
+    m_pinnedKeyHash = keyHash;
+    m_pinnedUnlinkedCode.set(vm(), this, unlinkedCode);
+}
+
+bool NodeVMScript::compile(JSGlobalObject* globalObject, JSC::ParserError& error)
+{
+    VM& vm = JSC::getVM(globalObject);
+    JSC::ProgramExecutable* executable = m_cachedExecutable ? m_cachedExecutable.get() : createExecutable();
+    // A successful parse reaches NodeVMScriptSourceProvider::pinUnlinkedCode from inside the CodeCache.
+    vm.codeCache()->getUnlinkedProgramCodeBlock(vm, executable, m_source, globalObject->defaultCodeGenerationMode(), error);
+    return !error.isValid();
 }
 
 JSC_DEFINE_HOST_FUNCTION(scriptConstructorCall, (JSGlobalObject * globalObject, CallFrame* callFrame))
@@ -268,6 +310,7 @@ void NodeVMScript::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     Base::visitChildren(thisObject, visitor);
     visitor.append(thisObject->m_cachedExecutable);
     visitor.append(thisObject->m_cachedBytecodeBuffer);
+    visitor.append(thisObject->m_pinnedUnlinkedCode);
 }
 
 NodeVMScriptConstructor::NodeVMScriptConstructor(VM& vm, Structure* structure)

--- a/src/jsc/bindings/NodeVMScript.h
+++ b/src/jsc/bindings/NodeVMScript.h
@@ -4,6 +4,11 @@
 
 #include "../vm/SigintReceiver.h"
 
+namespace JSC {
+class SourceCodeKey;
+class UnlinkedProgramCodeBlock;
+}
+
 namespace Bun {
 
 class ScriptOptions : public BaseVMOptions {
@@ -38,11 +43,43 @@ private:
 
 STATIC_ASSERT_ISO_SUBSPACE_SHARABLE(NodeVMScriptConstructor, JSC::InternalFunction);
 
+class NodeVMScript;
+
+// The SourceProvider behind a vm.Script. JSC's CodeCache consults it before parsing the
+// script's source and hands it what it parses (SourceProvider::pinnedUnlinkedCode /
+// pinUnlinkedCode), so every runInContext / runInThisContext of one Script links the same
+// UnlinkedProgramCodeBlock, however many contexts it runs in and whatever else has gone
+// through the CodeCache since. The Script cell owns that code block (it is what keeps it
+// alive); the provider only knows which Script to ask. The provider can outlive the Script
+// through the executables and stack traces earlier runs created, so the Script unlinks
+// itself when it is destroyed.
+class NodeVMScriptSourceProvider final : public JSC::StringSourceProvider {
+public:
+    static Ref<NodeVMScriptSourceProvider> create(const WTF::String& source, const JSC::SourceOrigin& sourceOrigin, WTF::String&& sourceURL, const TextPosition& startPosition)
+    {
+        return adoptRef(*new NodeVMScriptSourceProvider(source, sourceOrigin, WTF::move(sourceURL), startPosition));
+    }
+
+    void setScript(NodeVMScript* script) { m_script = script; }
+
+    JSC::JSCell* pinnedUnlinkedCode(const JSC::SourceCodeKey&) const final;
+    void pinUnlinkedCode(const JSC::SourceCodeKey&, JSC::JSCell*) const final;
+
+private:
+    NodeVMScriptSourceProvider(const WTF::String& source, const JSC::SourceOrigin& sourceOrigin, WTF::String&& sourceURL, const TextPosition& startPosition)
+        : JSC::StringSourceProvider(source, sourceOrigin, JSC::SourceTaintedOrigin::Untainted, WTF::move(sourceURL), startPosition, JSC::SourceProviderSourceType::Program)
+    {
+    }
+
+    NodeVMScript* m_script = nullptr;
+};
+
 class NodeVMScript final : public JSC::JSDestructibleObject, public SigintReceiver {
 public:
     using Base = JSC::JSDestructibleObject;
 
     static NodeVMScript* create(JSC::VM& vm, JSC::JSGlobalObject* globalObject, JSC::Structure* structure, JSC::SourceCode source, ScriptOptions options);
+    ~NodeVMScript();
 
     DECLARE_EXPORT_INFO;
     template<typename, JSC::SubspaceAccess mode> static JSC::GCClient::IsoSubspace* subspaceFor(JSC::VM& vm)
@@ -66,8 +103,17 @@ public:
     static JSObject* createPrototype(VM& vm, JSGlobalObject* globalObject);
 
     JSC::ProgramExecutable* createExecutable();
+    // Parses the source once and pins the result; false (with `error` filled in) on a syntax error.
+    bool compile(JSC::JSGlobalObject*, JSC::ParserError& error);
     void cacheBytecode();
     JSC::JSUint8Array* getBytecodeBuffer();
+
+    // The hash is SourceCodeKey::hash(): the source plus the parse flags (code type, strictness,
+    // code generation mode) the block was produced under. A lookup under different flags is a
+    // miss, and the block JSC then produces replaces the pinned one.
+    JSC::UnlinkedProgramCodeBlock* pinnedUnlinkedCode(unsigned keyHash) const { return m_pinnedKeyHash == keyHash ? m_pinnedUnlinkedCode.get() : nullptr; }
+    void pinUnlinkedCode(unsigned keyHash, JSC::UnlinkedProgramCodeBlock*);
+    bool hasPinnedUnlinkedCode() const { return !!m_pinnedUnlinkedCode; }
 
     const JSC::SourceCode& source() const { return m_source; }
     WTF::Vector<uint8_t>& cachedData() { return m_options.cachedData; }
@@ -86,6 +132,8 @@ private:
     RefPtr<JSC::CachedBytecode> m_cachedBytecode;
     JSC::WriteBarrier<JSC::JSUint8Array> m_cachedBytecodeBuffer;
     JSC::WriteBarrier<JSC::ProgramExecutable> m_cachedExecutable;
+    JSC::WriteBarrier<JSC::UnlinkedProgramCodeBlock> m_pinnedUnlinkedCode;
+    unsigned m_pinnedKeyHash = 0;
     ScriptOptions m_options;
     bool m_cachedDataProduced = false;
     bool m_sourceMapURLParsed = false;

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -892,6 +892,93 @@ test("can't use bytecode from a different script", () => {
   expect(secondScript.runInThisContext()).toBe(4);
 });
 
+describe.concurrent("Script compiles its source once for every context it runs in", () => {
+  // Runs one Script in several fresh contexts, keeping everything each run produced alive, and
+  // reports how many UnlinkedProgramCodeBlock cells (one per parse of a program) appeared between
+  // the first run and the last. A Script that pins its parse adds none; a Script that goes back
+  // to JSC's CodeCache adds one per context as soon as the cache does not hold the entry, which
+  // BUN_JSC_useCodeCache=0 forces for every run.
+  const fixture = String.raw`
+    const { Script, createContext } = require("node:vm");
+    const { heapStats } = require("bun:jsc");
+    const runs = 6;
+    let body = "";
+    for (let i = 0; i < 50; i++) body += "function f" + i + "(a) { return a + " + i + "; }\n";
+    const source = "(function (exports) {\n" + body + "exports.sum = f0(1) + f49(1);\n})";
+    const programBlocks = () => {
+      Bun.gc(true);
+      return heapStats().objectTypeCounts.UnlinkedProgramCodeBlock ?? 0;
+    };
+    const options = process.env.VM_FIXTURE_CACHED_DATA ? { cachedData: new Script(source).createCachedData() } : {};
+    const script = new Script(source, options);
+    const keep = [];
+    let afterFirstRun = 0;
+    for (let i = 0; i < runs; i++) {
+      const wrapper = script.runInContext(createContext({}));
+      const exports = {};
+      wrapper(exports);
+      if (exports.sum !== 51) throw new Error("run " + i + " computed " + exports.sum);
+      keep.push(wrapper, exports);
+      if (i === 0) afterFirstRun = programBlocks();
+    }
+    console.log(JSON.stringify({
+      programBlocksAddedByLaterRuns: programBlocks() - afterFirstRun,
+      cachedDataRejected: script.cachedDataRejected,
+      cachedDataStillProducible: script.createCachedData().length > 0,
+    }));
+  `;
+
+  async function runFixture(extraEnv: Record<string, string>) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", fixture],
+      env: { ...bunEnv, ...extraEnv },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  test("with the CodeCache", async () => {
+    expect(await runFixture({})).toEqual({
+      programBlocksAddedByLaterRuns: 0,
+      cachedDataStillProducible: true,
+    });
+  });
+
+  test("without the CodeCache", async () => {
+    expect(await runFixture({ BUN_JSC_useCodeCache: "0" })).toEqual({
+      programBlocksAddedByLaterRuns: 0,
+      cachedDataStillProducible: true,
+    });
+  });
+
+  test("from accepted cachedData, without the CodeCache", async () => {
+    expect(await runFixture({ BUN_JSC_useCodeCache: "0", VM_FIXTURE_CACHED_DATA: "1" })).toEqual({
+      programBlocksAddedByLaterRuns: 0,
+      cachedDataRejected: false,
+      cachedDataStillProducible: true,
+    });
+  });
+
+  test("each context still gets its own global declarations", () => {
+    const script = new Script(
+      "var counter = (typeof counter === 'number' ? counter : 0) + 1; function id() { return tag; } counter;",
+    );
+    const first = createContext({ tag: "first" });
+    const second = createContext({ tag: "second" });
+    expect(script.runInContext(first)).toBe(1);
+    expect(script.runInContext(second)).toBe(1);
+    expect(script.runInContext(first)).toBe(2);
+    expect(runInContext("id()", first)).toBe("first");
+    expect(runInContext("id()", second)).toBe("second");
+    expect(first.counter).toBe(2);
+    expect(second.counter).toBe(1);
+  });
+});
+
 describe("codeGeneration options", () => {
   test("disabling codeGeneration.strings should block eval and Function constructor", () => {
     const context = createContext(


### PR DESCRIPTION
Depends on oven-sh/WebKit#418 (this PR points `WEBKIT_VERSION` at that PR's preview build; it should land together with the real bump once that is merged).

### Problem
- `const s = new vm.Script(src)` followed by `s.runInContext(vm.createContext({}))` for N contexts parses `src` more than once. Both run paths call `JSC::evaluate(globalObject, script->source(), ...)` (src/jsc/bindings/NodeVMScript.cpp, `runInContext` / `scriptRunInThisContext`), which creates a fresh `ProgramExecutable` per run and gets its code through JSC's `CodeCache`. That works while the cache holds the entry, but `CodeCacheMap` is sized for a 16 MB working set (`workingSetMaxBytes`, CodeCache.h) and prunes whenever more than that has been added since the last prune, so a ~20 MB bundle is re-parsed by whichever context comes after any other sizable compilation. Each re-parse also produces a fresh tree of `UnlinkedFunctionExecutable`s, so memory grows per context instead of being shared.
- On top of that the constructor parsed once more: it ran `JSC::checkSyntax` to throw `SyntaxError` eagerly, threw the result away, and the first run parsed again (the comment in the constructor already named compile-once as the follow-up).
- `cachedData` was accepted (decoded and linked once to compute `cachedDataRejected`) but the runs never used it; they still went to the CodeCache and parsed.
- Numbers on the unfixed build, release, a 20 MB `(function(exports, require, module){...})` source with 117,978 functions, parses counted with `BUN_JSC_reportParseTimes=1`:
  - construction: 1 parse (~420 ms); first run: parses again; a second context after a 16.5 MB script went through the cache: 1 full parse of the program (~370-600 ms, `evaluate` 514-790 ms) plus a re-parse of the wrapper body on invoke, and `UnlinkedFunctionExecutable` goes from 118k to 236k live cells (two copies of the bundle).
  - with `cachedData`: construction still parses once (`checkSyntax`), and the first run parses again.

### Fix
- oven-sh/WebKit#418 adds `SourceProvider::pinnedUnlinkedCode()` / `pinUnlinkedCode()`: on a CodeCache miss JSC asks the provider before parsing, and hands the provider whatever it parses. Base implementations are no-ops.
- `vm.Script` now creates its `SourceCode` over a `NodeVMScriptSourceProvider` (NodeVMScript.h) that forwards those two hooks to the owning `NodeVMScript`, which keeps the `UnlinkedProgramCodeBlock` in a `WriteBarrier` keyed by `SourceCodeKey::hash()` (source plus code type / strictness / code generation mode, so a lookup under different flags misses and gets replaced). The Script is the GC root; the provider only holds a back-pointer, cleared in `~NodeVMScript` because executables and stack traces from earlier runs can keep the provider alive longer than the Script.
- The constructor's `checkSyntax` is replaced by `NodeVMScript::compile()`, which goes through `CodeCache::getUnlinkedProgramCodeBlock` and therefore pins the parse it does; syntax errors come out of the same `ParserError` and are decorated exactly as before. Accepted `cachedData` pins the decoded block instead, so such a Script never parses its source. The run paths are unchanged: `JSC::evaluate` still creates a `ProgramExecutable` per run (global declaration instantiation has to happen per context), but `initializeGlobalProperties` now links the pinned block.
- Net effect: one parse per Script (zero with accepted cachedData), regardless of how many contexts it runs in, what else goes through the CodeCache, or `useCodeCache`; the nested unlinked function executables / code blocks are shared by every context, linked code stays per context as before.
- Equivalents for the other two entry points (not done here):
  - `ShadowRealm.prototype.evaluate(string)` builds a new `SourceCode` per call (`evalInRealm`, ShadowRealmPrototype.cpp) so there is nothing to pin to; the WebKit hook already covers eval code blocks, so a Bun-side handle (for example a `vm.Script` method that evaluates the pinned source in a given realm via `IndirectEvalExecutable` + the realm's `wrapRemoteValue`) would give ShadowRealms the same one-parse behavior.
  - `vm.compileFunction` returns a bare function per call and already goes through `getUnlinkedProgramCodeBlock` on a per-call `StringSourceProvider` (NodeVM.cpp `constructAnonymousFunction`), so it too would only need a handle object owning a pinning provider. Until then, `new vm.Script("(function (exports, require, module) {...})")` + `runInContext` is the way to instantiate one compiled function per context with a single parse.
- Verified:
  - `test/js/node/vm/vm.test.ts`, new `describe` "Script compiles its source once for every context it runs in": a fixture keeps everything 6 context runs produce alive and reports how many `UnlinkedProgramCodeBlock`s later runs added. With `BUN_JSC_useCodeCache=0` (which makes every run miss the cache, i.e. the big-source behavior in miniature) and with accepted `cachedData`, the unfixed build reports 5 and this build 0; the default-cache case and a per-context global declaration check pass on both.
  - Parse counts (`BUN_JSC_reportParseTimes=1`, debug builds of the same revision with and without this change, a 5 MB source with ~30k functions run in 3 contexts; the probe is in the details block):

    | phase | unfixed | this PR |
    | --- | --- | --- |
    | `new Script(src)` | 1 parse | 1 parse |
    | first `runInContext` (evaluate) | 1 re-parse of the program | 0 |
    | first invoke of the wrapper | body parsed once | body parsed once (inherent, once per Script) |
    | another 16.5 MB script compiled in between | that script parsed twice | parsed once |
    | next context (evaluate) | 1 full parse, 9.0 s | 0 |
    | next context (invoke) | body re-parsed, 1.5 s | 0 |
    | `new Script(src, { cachedData })` | 1 parse (8.4 s) | 0 parses (2 ms) |
  - `test/js/node/vm/` (231 pass) and all 97 node `test/parallel/test-vm-*` files pass against the preview WebKit. `script-leak.test.ts` times out on this (slow, ASAN) machine with and without the change; its 10,000-script loop measured directly ends at 34 MB RSS growth with this change versus 138 MB without, because the construction-time compile turns every run into a CodeCache hit and the cache prunes its now-dead entries sooner.

- Related: #32839 rewrites the `cachedData` decode block this change adds one line to (textual overlap only); #35778 is about CodeCache key collisions between different sources, which this per-Script pin does not interact with (a pin only ever answers lookups for its own provider).

### Background
- JSC compiles a script in two stages. Parsing produces realm-independent "unlinked" cells: an `UnlinkedProgramCodeBlock` for the top level, with an `UnlinkedFunctionExecutable` per function in it, each of which lazily gets an `UnlinkedFunctionCodeBlock` the first time it is called. Running the code in a particular global object "links" those into per-realm `CodeBlock`s / `FunctionExecutable`s. Only the unlinked half is what a second context can share, and sharing it is exactly what the `CodeCache` does when it hits; this change just makes the hit unconditional for a `vm.Script`.
- `ProgramExecutable::initializeGlobalProperties` is the only place program code enters execution: it fetches the unlinked block from the `CodeCache` and performs global declaration instantiation (hoisting `var`s and functions onto the context's global) against it. Since the executable is created inside `Interpreter::executeProgram`, there is no way to pass it a block directly, which is why the hook lives in the cache lookup and is expressed through the `SourceProvider` (the object JSC already consults there for disk-cached bytecode).
- `Bun.gc()` calls `Heap::deleteAllUnlinkedCodeBlocks`, which drops every function's cached bytecode; a probe that calls `Bun.gc(true)` between contexts therefore sees function bodies re-parsed on the next call even with this change (and even in the main realm). The test only collects after all runs, and counts program blocks, which that call does not touch.

<details>
<summary>Raw probe output (parse counts per phase; "sibling" = a 16.5 MB script compiled between context 0 and 1)</summary>

The probe constructs one `vm.Script`, runs it in N fresh contexts (calling the returned wrapper each time and keeping the results alive), and counts the `Parsed ...` lines JSC prints with `BUN_JSC_reportParseTimes=1` between markers it writes to stderr.

```
### release build, unfixed, 20 MB / 117,978 functions
## sibling 16.5MB compile between run0 and run1
run 0: evaluate 181 ms, invoke 423 ms
run 1: evaluate 514 ms, invoke 309 ms
run 2: evaluate 0 ms, invoke 19 ms
live after 3 runs: UnlinkedProgramCodeBlock=5 UnlinkedFunctionExecutable=236314 UnlinkedFunctionCodeBlock=40 FunctionExecutable=354459
parses per phase (count, total parse ms):
  construct                           1       422 ms
  run0-evaluate                       2         0 ms
  run0-invoke                         2       143 ms
  sibling                             2       631 ms
  run1-evaluate                       1       371 ms
  run1-invoke                         2        90 ms
  run2-evaluate                       0         0 ms
  run2-invoke                         0         0 ms


# BEFORE, debug binary (unfixed, 536251ca9), 5MB source

## mode: plain
construct: 6632 ms
run 0: evaluate 330 ms, invoke 3065 ms
run 1: evaluate 0 ms, invoke 765 ms
run 2: evaluate 0 ms, invoke 506 ms
live after 3 runs: UnlinkedProgramCodeBlock=3 UnlinkedFunctionExecutable=30531 UnlinkedFunctionCodeBlock=10 FunctionExecutable=91055
parses per phase (count, total parse ms):
  construct                           1      5525 ms
  run0-evaluate                       2         1 ms
  run0-invoke                         2      1332 ms
  run1-evaluate                       0         0 ms
  run1-invoke                         0         0 ms
  run2-evaluate                       0         0 ms
  run2-invoke                         0         0 ms

## mode: --sibling
construct: 6607 ms
run 0: evaluate 331 ms, invoke 3006 ms
run 1: evaluate 10385 ms, invoke 4172 ms
run 2: evaluate 0 ms, invoke 669 ms
live after 3 runs: UnlinkedProgramCodeBlock=4 UnlinkedFunctionExecutable=30532 UnlinkedFunctionCodeBlock=8 FunctionExecutable=60877
parses per phase (count, total parse ms):
  construct                           1      5505 ms
  run0-evaluate                       2         1 ms
  run0-invoke                         2      1335 ms
  sibling                             2     26695 ms
  run1-evaluate                       1      9011 ms
  run1-invoke                         2      1518 ms
  run2-evaluate                       0         0 ms
  run2-invoke                         0         0 ms

## mode: --cachedData
construct: 9564 ms (cachedDataRejected=false)
run 0: evaluate 311 ms, invoke 3507 ms
run 1: evaluate 0 ms, invoke 1001 ms
run 2: evaluate 0 ms, invoke 512 ms
live after 3 runs: UnlinkedProgramCodeBlock=4 UnlinkedFunctionExecutable=30575 UnlinkedFunctionCodeBlock=9 FunctionExecutable=91109
parses per phase (count, total parse ms):
  construct                          45      8465 ms
  construct-with-cachedData           1      8445 ms
  run0-evaluate                       2         1 ms
  run0-invoke                         2      1759 ms
  run1-evaluate                       0         0 ms
  run1-invoke                         0         0 ms
  run2-evaluate                       0         0 ms
  run2-invoke                         0         0 ms

# AFTER, debug binary (fixed, 99d435d50 + preview-pr-418), 5MB source

## mode: plain
construct: 9119 ms
run 0: evaluate 0 ms, invoke 4323 ms
run 1: evaluate 0 ms, invoke 998 ms
run 2: evaluate 0 ms, invoke 558 ms
live after 3 runs: UnlinkedProgramCodeBlock=3 UnlinkedFunctionExecutable=30531 UnlinkedFunctionCodeBlock=9 FunctionExecutable=91055
parses per phase (count, total parse ms):
  construct                           1      6865 ms
  run0-evaluate                       1         1 ms
  run0-invoke                         2      2397 ms
  run1-evaluate                       0         0 ms
  run1-invoke                         0         0 ms
  run2-evaluate                       0         0 ms
  run2-invoke                         0         0 ms

## mode: --sibling
construct: 13062 ms
run 0: evaluate 1 ms, invoke 4432 ms
run 1: evaluate 0 ms, invoke 553 ms
run 2: evaluate 0 ms, invoke 589 ms
live after 3 runs: UnlinkedProgramCodeBlock=3 UnlinkedFunctionExecutable=30531 UnlinkedFunctionCodeBlock=8 FunctionExecutable=60877
parses per phase (count, total parse ms):
  construct                           1     10606 ms
  run0-evaluate                       1         2 ms
  run0-invoke                         2      1998 ms
  sibling                             1     28453 ms
  run1-evaluate                       0         0 ms
  run1-invoke                         0         0 ms
  run2-evaluate                       0         0 ms
  run2-invoke                         0         0 ms

## mode: --cachedData
construct: 2 ms (cachedDataRejected=false)
run 0: evaluate 0 ms, invoke 13344 ms
run 1: evaluate 1 ms, invoke 1792 ms
run 2: evaluate 0 ms, invoke 833 ms
live after 3 runs: UnlinkedProgramCodeBlock=3 UnlinkedFunctionExecutable=30574 UnlinkedFunctionCodeBlock=10 FunctionExecutable=91108
parses per phase (count, total parse ms):
  construct                          44      9504 ms
  construct-with-cachedData           0         0 ms
  run0-evaluate                       1         1 ms
  run0-invoke                         2      9648 ms
  run1-evaluate                       0         0 ms
  run1-invoke                         0         0 ms
  run2-evaluate                       0         0 ms
  run2-invoke                         0         0 ms
```
</details>
