### PR TITLE
node:http2: end the stream with an empty DATA frame when sendTrailers() encodes no fields

### DIFF
--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2606,10 +2606,6 @@ class Http2Stream extends Duplex {
     // node keeps the never-index list visible on sentTrailers (symbol keys are not iterated by
     // the wire-encoding path, so re-attaching is safe).
     if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;
-    // Like node, a trailer block with no fields ends the stream with an empty END_STREAM DATA
-    // frame instead of a HEADERS frame. `{}` (what the compat Http2ServerResponse always sends)
-    // takes the direct path here; native sendTrailers() does the same once it has walked a block
-    // whose values all encode to nothing (empty arrays).
     // Mark before the native call so a re-entrant sendTrailers() from a header-value
     // coercion hits ERR_HTTP2_TRAILERS_ALREADY_SENT, but clear it if validation throws
     // (no frame is written then) so a corrected retry succeeds like node.

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -2606,12 +2606,10 @@ class Http2Stream extends Duplex {
     // node keeps the never-index list visible on sentTrailers (symbol keys are not iterated by
     // the wire-encoding path, so re-attaching is safe).
     if (sensitives !== undefined) headers[sensitiveHeaders] = sensitives;
-    // RFC 9113 §8.1 doesn't explicitly forbid an empty trailer HEADERS frame,
-    // but strict peer implementations (nghttp2, used by curl and Node) reject
-    // a zero-length HPACK block as a callback failure. When the user passes an
-    // empty trailer object (which the compat Http2ServerResponse does
-    // unconditionally from onStreamTrailersReady), emit an empty DATA frame
-    // with END_STREAM instead — this matches Node's wire output.
+    // Like node, a trailer block with no fields ends the stream with an empty END_STREAM DATA
+    // frame instead of a HEADERS frame. `{}` (what the compat Http2ServerResponse always sends)
+    // takes the direct path here; native sendTrailers() does the same once it has walked a block
+    // whose values all encode to nothing (empty arrays).
     // Mark before the native call so a re-entrant sendTrailers() from a header-value
     // coercion hits ERR_HTTP2_TRAILERS_ALREADY_SENT, but clear it if validation throws
     // (no frame is written then) so a corrected retry succeeds like node.

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7722,10 +7722,8 @@ impl H2FrameParser {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// Ends our side of a `waitForTrailers` stream with an empty END_STREAM DATA frame. Used when
-    /// there are no trailers, and by `send_trailers` when the block encodes to zero fields (only
-    /// empty-array values). node's `Http2Stream::SubmitTrailers` sends this frame in both cases,
-    /// so the peer gets no 'trailers' event rather than one with an empty header list.
+    /// Ends our side of the stream with an empty END_STREAM DATA frame, which is what node's
+    /// `Http2Stream::SubmitTrailers` sends for any trailer block that encodes to no fields.
     fn send_no_trailers(&self, stream: &mut Stream) {
         stream.wait_for_trailers = false;
         let _ = self.send_data(stream, b"", true, JSValue::UNDEFINED, false, false);

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7722,8 +7722,7 @@ impl H2FrameParser {
         Ok(JSValue::UNDEFINED)
     }
 
-    /// Ends our side of the stream with an empty END_STREAM DATA frame, which is what node's
-    /// `Http2Stream::SubmitTrailers` sends for any trailer block that encodes to no fields.
+    /// Empty END_STREAM DATA frame: what node sends in place of a trailer block with no fields.
     fn send_no_trailers(&self, stream: &mut Stream) {
         stream.wait_for_trailers = false;
         let _ = self.send_data(stream, b"", true, JSValue::UNDEFINED, false, false);

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -7718,11 +7718,17 @@ impl H2FrameParser {
             return Err(global_object.throw(format_args!("Invalid stream id")));
         };
         // SAFETY: stream is a *mut Stream from self.streams (heap::alloc); valid while the map entry exists
-        let stream = unsafe { &mut *stream };
-
-        stream.wait_for_trailers = false;
-        let _ = this.send_data(stream, b"", true, JSValue::UNDEFINED, false, false);
+        this.send_no_trailers(unsafe { &mut *stream });
         Ok(JSValue::UNDEFINED)
+    }
+
+    /// Ends our side of a `waitForTrailers` stream with an empty END_STREAM DATA frame. Used when
+    /// there are no trailers, and by `send_trailers` when the block encodes to zero fields (only
+    /// empty-array values). node's `Http2Stream::SubmitTrailers` sends this frame in both cases,
+    /// so the peer gets no 'trailers' event rather than one with an empty header list.
+    fn send_no_trailers(&self, stream: &mut Stream) {
+        stream.wait_for_trailers = false;
+        let _ = self.send_data(stream, b"", true, JSValue::UNDEFINED, false, false);
     }
 
     /// node's strictSingleValueFields option (default true): when disabled, duplicate
@@ -8093,6 +8099,10 @@ impl H2FrameParser {
                     return Ok(ret);
                 }
             }
+        }
+        if encoded_headers.is_empty() {
+            this.send_no_trailers(&mut stream);
+            return Ok(JSValue::UNDEFINED);
         }
         let encoded_data = encoded_headers.as_slice();
         let encoded_size = encoded_data.len();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1008,6 +1008,105 @@ describe("request header and body framing (RFC 9113 §8.1)", () => {
   });
 });
 
+describe("sendTrailers() with a block that encodes to no fields (RFC 9113 §8.1)", () => {
+  // An empty array value puts no field on the wire. When that leaves nothing at all, node
+  // (Http2Stream::SubmitTrailers) ends the stream with the empty END_STREAM DATA frame that
+  // sendTrailers({}) also produces, instead of a HEADERS frame carrying a zero-length block,
+  // which the peer reports as a 'trailers' event with no headers in it.
+  const END_STREAM = 0x1;
+  const END_HEADERS = 0x4;
+
+  /** The flags of every HEADERS frame on stream 1, and the frame that ended the stream. */
+  function stream1(frames: Frame[]) {
+    const onStream = frames.filter(f => f.streamId === 1);
+    return {
+      headersFlags: onStream.filter(f => f.type === FrameType.HEADERS).map(f => f.flags),
+      endStream: onStream
+        .filter(f => (f.flags & END_STREAM) !== 0)
+        .map(f => ({ type: f.type, flags: f.flags, length: f.length })),
+    };
+  }
+
+  /** Serves one request with waitForTrailers, answering 'wantTrailers' with `trailers`. Resolves
+   *  once the response stream has ended on the wire, with the server stream's sentTrailers. */
+  async function serverSends(trailers: Record<string, unknown>) {
+    const sent = Promise.withResolvers<unknown>();
+    const server = http2.createServer();
+    server.on("stream", (stream: any) => {
+      stream.on("error", (err: Error) => sent.reject(err));
+      stream.respond({ ":status": 200 }, { waitForTrailers: true });
+      stream.on("wantTrailers", () => {
+        stream.sendTrailers(trailers);
+        sent.resolve(stream.sentTrailers);
+      });
+      stream.end("body");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      c.sendFrame(FrameType.HEADERS, END_STREAM | END_HEADERS, 1, requestHeaderBlock("GET"));
+      await c.waitFor(f => f.streamId === 1 && (f.flags & END_STREAM) !== 0);
+      return { ...stream1(c.frames), sentTrailers: await sent.promise };
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  }
+
+  test.each([[{ "x-none": [] }], [{ "x-none": [], "content-type": [] }], [{}]])(
+    "server: %j ends the response with an empty DATA frame and no trailer HEADERS frame",
+    async trailers => {
+      expect(await serverSends(trailers)).toEqual({
+        headersFlags: [END_HEADERS], // the response block; it cannot carry END_STREAM with trailers pending
+        endStream: [{ type: FrameType.DATA, flags: END_STREAM, length: 0 }],
+        sentTrailers: trailers,
+      });
+    },
+  );
+
+  test("server: one field next to an empty array still goes out as a trailer HEADERS frame", async () => {
+    const result = await serverSends({ "x-none": [], "x-sent": "1" });
+    expect(result).toEqual({
+      headersFlags: [END_HEADERS, END_STREAM | END_HEADERS],
+      endStream: [{ type: FrameType.HEADERS, flags: END_STREAM | END_HEADERS, length: expect.any(Number) }],
+      sentTrailers: { "x-none": [], "x-sent": "1" },
+    });
+    expect(result.endStream[0].length).toBeGreaterThan(0);
+  });
+
+  test("client: the same block ends the request with an empty DATA frame and no trailer HEADERS frame", async () => {
+    const raw = await RawH2Server.listen();
+    const client = http2.connect(`http://127.0.0.1:${raw.port}`);
+    client.on("error", () => {});
+    try {
+      const req = client.request({ ":method": "POST", ":path": "/" }, { waitForTrailers: true });
+      req.on("error", () => {});
+      const sent = new Promise<unknown>(resolve => {
+        req.on("wantTrailers", () => {
+          req.sendTrailers({ "x-none": [] });
+          resolve(req.sentTrailers);
+        });
+      });
+      req.end();
+      await raw.waitFor(f => f.type === FrameType.HEADERS && f.streamId === 1);
+      raw.sendFrame(FrameType.SETTINGS, 0, 0); // server SETTINGS
+      raw.sendFrame(FrameType.SETTINGS, 0x1, 0); // ACK the client's
+      await raw.waitFor(f => f.streamId === 1 && (f.flags & END_STREAM) !== 0);
+      expect({ ...stream1(raw.frames), sentTrailers: await sent }).toEqual({
+        headersFlags: [END_HEADERS],
+        endStream: [{ type: FrameType.DATA, flags: END_STREAM, length: 0 }],
+        sentTrailers: { "x-none": [] },
+      });
+    } finally {
+      client.destroy();
+      raw.close();
+    }
+  });
+});
+
 describe("request pseudo-header requirements (RFC 9113 §8.3.1)", () => {
   // HPACK "literal never indexed, new name" (0x10) so the wire shape is exactly what is written
   // and no client library normalizes it away.

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1008,11 +1008,11 @@ describe("request header and body framing (RFC 9113 §8.1)", () => {
   });
 });
 
-describe("sendTrailers() with a block that encodes to no fields (RFC 9113 §8.1)", () => {
-  // An empty array value puts no field on the wire. When that leaves nothing at all, node
-  // (Http2Stream::SubmitTrailers) ends the stream with the empty END_STREAM DATA frame that
-  // sendTrailers({}) also produces, instead of a HEADERS frame carrying a zero-length block,
-  // which the peer reports as a 'trailers' event with no headers in it.
+describe.concurrent("sendTrailers() with a block that encodes to no fields (RFC 9113 §8.1)", () => {
+  // An empty array value puts no field on the wire (nor does an empty name). When that leaves
+  // nothing at all, node (Http2Stream::SubmitTrailers) ends the stream with the empty END_STREAM
+  // DATA frame that sendTrailers({}) also produces, instead of a HEADERS frame carrying a
+  // zero-length block, which the peer reports as a 'trailers' event with no headers in it.
   const END_STREAM = 0x1;
   const END_HEADERS = 0x4;
 
@@ -1056,16 +1056,22 @@ describe("sendTrailers() with a block that encodes to no fields (RFC 9113 §8.1)
     }
   }
 
-  test.each([[{ "x-none": [] }], [{ "x-none": [], "content-type": [] }], [{}]])(
-    "server: %j ends the response with an empty DATA frame and no trailer HEADERS frame",
-    async trailers => {
-      expect(await serverSends(trailers)).toEqual({
-        headersFlags: [END_HEADERS], // the response block; it cannot carry END_STREAM with trailers pending
-        endStream: [{ type: FrameType.DATA, flags: END_STREAM, length: 0 }],
-        sentTrailers: trailers,
-      });
-    },
-  );
+  test.each([
+    [{ "x-none": [] }],
+    // content-type is a single-value field: its bookkeeping runs for the empty array but must
+    // not count as a field either.
+    [{ "x-none": [], "content-type": [] }],
+    [{ "": "x" }],
+    // {} is short-circuited to noTrailers() in JS before the encoder runs; it pins that the two
+    // routes put the same frame on the wire.
+    [{}],
+  ])("server: %j ends the response with an empty DATA frame and no trailer HEADERS frame", async trailers => {
+    expect(await serverSends(trailers)).toEqual({
+      headersFlags: [END_HEADERS], // the response block; it cannot carry END_STREAM with trailers pending
+      endStream: [{ type: FrameType.DATA, flags: END_STREAM, length: 0 }],
+      sentTrailers: trailers,
+    });
+  });
 
   test("server: one field next to an empty array still goes out as a trailer HEADERS frame", async () => {
     const result = await serverSends({ "x-none": [], "x-sent": "1" });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4720,6 +4720,48 @@ it("end(chunk) on a HALF_CLOSED_REMOTE stream still emits 'finish'", async () =>
   }
 });
 
+it("sendTrailers() whose values are all empty arrays ends the stream without a 'trailers' event", async () => {
+  // Empty arrays put no fields on the wire, so the block encodes to nothing. Node then ends the
+  // stream with an empty DATA frame (as for sendTrailers({})) and the peer never sees trailers;
+  // bun used to send a HEADERS frame with an empty block, surfacing as a 'trailers' event with
+  // no headers. sentTrailers still records what was passed, as in node.
+  const trailers = { "x-none": [] };
+  const server = http2.createServer();
+  try {
+    const serverSide = Promise.withResolvers();
+    server.on("stream", stream => {
+      stream.on("error", serverSide.reject);
+      stream.respond({ ":status": 200 }, { waitForTrailers: true });
+      stream.on("wantTrailers", () => stream.sendTrailers(trailers));
+      stream.on("close", () => serverSide.resolve({ sentTrailers: stream.sentTrailers, rstCode: stream.rstCode }));
+      stream.end("body");
+    });
+    const port = await new Promise(resolve => server.listen(0, () => resolve(server.address().port)));
+
+    const clientSide = Promise.withResolvers();
+    const client = http2.connect(`http://localhost:${port}`);
+    client.on("error", clientSide.reject);
+    try {
+      const req = client.request({ ":path": "/" });
+      req.on("error", clientSide.reject);
+      const trailerEvents = [];
+      req.on("trailers", (headers, flags, rawHeaders) => trailerEvents.push(rawHeaders));
+      let body = "";
+      req.setEncoding("utf8");
+      req.on("data", chunk => (body += chunk));
+      req.on("close", () => clientSide.resolve({ body, trailerEvents, rstCode: req.rstCode }));
+      req.end();
+
+      expect(await clientSide.promise).toEqual({ body: "body", trailerEvents: [], rstCode: 0 });
+      expect(await serverSide.promise).toEqual({ sentTrailers: trailers, rstCode: 0 });
+    } finally {
+      client.close();
+    }
+  } finally {
+    server.close();
+  }
+});
+
 it("client connects over a user Duplex that already has a 'data' listener", async () => {
   // A 'data' listener attached before connect() puts the stream in flowing mode, so the
   // peer's first frames can arrive before the connect callback has run. The preface must


### PR DESCRIPTION
### Problem
- `stream.sendTrailers({ "x-none": [] })` (any block whose fields all encode to nothing: empty-array values, or an empty name) writes a trailer `HEADERS` frame with `END_STREAM | END_HEADERS` and a 0-byte header block. The peer decodes an empty block and emits `'trailers'` with no headers (`rawHeaders` is `[]`). Same from a client stream's `sendTrailers()`.
- Node v26.3.0 sends an empty `END_STREAM` `DATA` frame instead, so the peer gets no `'trailers'` event at all. A bun or node client talking to a bun server sees one `'trailers'` event; talking to a node server it sees none.
- Cause: `H2FrameParser::send_trailers()` in `src/runtime/api/bun/h2_frame_parser.rs` writes whatever it encoded as a `HEADERS` frame, even when that is nothing. The JS side (`Http2Stream#sendTrailers` in `src/js/node/http2.ts`) only routes to `noTrailers()` when the object has no keys, so a block with keys that encode to nothing reaches the native encoder. The comment there claimed strict peers reject a zero-length block; they do not (node's client accepts it and emits `'trailers'`), the difference is only the spurious event.
- Noticed while working on #37945, which left this rule alone. Reproduces on the 1.4.0 release and on main.

### Fix
- `send_trailers()` checks the encoded block after the walk: if it is empty, it ends the stream the way `no_trailers()` does (clear `wait_for_trailers`, send an empty `END_STREAM` `DATA` frame) instead of writing a `HEADERS` frame. The two sites share a new `send_no_trailers()` helper so they cannot drift. The stale JS comment is removed; the JS `{}` shortcut itself is unchanged.
- Matches node: `Http2Stream::SubmitTrailers` (src/node_http2.cc) submits `DATA` with `END_STREAM` when the header count is 0 and `nghttp2_submit_trailer` otherwise; the count comes from `buildNgHeaderString`, which emits no field for an empty array or an empty name. The check is on the encoded output, so a block with one real field next to an empty array still goes out as trailers, and the JS `{}` shortcut and the native path now produce the same frame.
- The new path is the existing `noTrailers()` path, so its stream-state transition, `onStreamEnd` dispatch and stream release are the ones `sendTrailers({})` has always used (the removed `HEADERS` tail did the same things); under backpressure the frame is queued like any other `END_STREAM` frame. `sentTrailers` is unchanged: it is set to the block before the native call and stays set, as node keeps `kSentTrailers` either way. Client and server streams share the native function, so one change covers both.
- Overlap: #37953 (skip `undefined`-valued properties), opened shortly after this PR, carries an inline copy of the same `encoded_headers.is_empty()` rule in `send_trailers()`, because skipping `undefined` adds another way to reach an empty block. The rules are the same; whichever lands second drops its copy (a few-line conflict at the same spot). This PR is the standalone fix with the wire-level tests.
- Verification: `test/js/node/http2/h2-conformance.test.ts`, describe `sendTrailers() with a block that encodes to no fields`. A raw peer records the frames. Server with `{ "x-none": [] }`, `{ "x-none": [], "content-type": [] }` (a single-value field, whose bookkeeping must not count the empty array as a field), `{ "": "x" }` and `{}`, and a client with `{ "x-none": [] }`, must end the stream with `DATA(END_STREAM, length 0)` and send exactly one `HEADERS` frame (the response/request block); `{ "x-none": [], "x-sent": "1" }` must still end with a non-empty trailer `HEADERS` frame. Four of the six fail on the release binary (they get `HEADERS(0x5, length 0)` and a second `HEADERS` frame; `{}` already took the JS shortcut and the control already passed), all pass with the fix. Every row was also run under node v26.3.0, which produces the asserted outcome.
- `test/js/node/http2/node-http2.test.js`, `sendTrailers() whose values are all empty arrays ends the stream without a 'trailers' event`: bun server to bun client; the client must reach `'close'` with `rstCode` 0 and no `'trailers'` event, and the server stream's `sentTrailers` must still be the block. Fails on the release binary (one `'trailers'` event with `[]`), passes with the fix.
- Also run with the fix: the rest of `h2-conformance.test.ts` (67 pass) and `node-http2.test.js` (356 pass; the two "DATA payload survives its ArrayBuffer being detached" cases only hit the 5 s default timeout when the whole file runs on this debug build, pass on their own, and do not involve trailers), `node-http2-continuation.test.ts`, and the 14 upstream `test-http2-*trailers*`, `*multiheaders*`, `*single-headers-validation*`, `sent-headers`, `misused-pseudoheaders`, `exceeds-server-trailer-size` and `no-wanttrailers-listener` files, all passing. The probes below (including the queued-frame path) were run against node v26.3.0 and the fixed build with the same output.

### Background
- Trailers: with `waitForTrailers`, `end()` does not finish the stream. The stream emits `'wantTrailers'` and the app calls `sendTrailers(block)`, which normally goes out as a final `HEADERS` frame carrying `END_STREAM`. A stream can equally be finished by a zero-length `DATA` frame carrying `END_STREAM`; that is what `sendTrailers({})` (and a stream with no `'wantTrailers'` listener) sends in both node and bun.
- Array values: in the object form of a header block an array means one field per element, so an empty array contributes no field. A block can therefore have keys and still encode to nothing.
- `sentTrailers`: the stream property holding the block passed to `sendTrailers()`; it also backs the `ERR_HTTP2_TRAILERS_ALREADY_SENT` guard, which is why it stays set even when the block sends no fields.
- Two layers: `Http2Stream#sendTrailers` in `http2.ts` validates the argument and calls either `noTrailers(id)` or `sendTrailers(id, block, sensitive)` on the native `H2FrameParser`; the native `send_trailers()` walks the object, HPACK-encodes each field into a buffer and writes the frame. The fix is in that native function because it is the only place that knows how many fields the walk produced.
- Outbound queue: when the socket has backpressure or earlier frames are waiting on flow control, `send_data()` queues the frame per stream and the drain path writes it later, completing the stream's close at that point. The `noTrailers()` path has always gone through this; the trailer `HEADERS` frame was written directly.

<details>
<summary>Probes: server sends each block, client reports what it observed (node v26.3.0 vs bun)</summary>

Server: `respond({":status": 200}, {waitForTrailers: true})`, `sendTrailers(block)` from `'wantTrailers'`, `end("body")`. Client: logs the `'trailers'` event (if any) and `rstCode` at `'close'`.

| block | bun 1.4.0 server | this PR / node v26.3.0 server |
| --- | --- | --- |
| `{ "x-none": [] }` | `'trailers'` with `{}` / `[]`, rstCode 0 | no `'trailers'` event, rstCode 0 |
| `{ "x-none": [], "x-other": [] }` | `'trailers'` with `{}` / `[]`, rstCode 0 | no `'trailers'` event, rstCode 0 |
| `{ "": "x" }` | `'trailers'` with `{}` / `[]`, rstCode 0 | no `'trailers'` event, rstCode 0 |
| `{}` | no `'trailers'` event | no `'trailers'` event |
| `{ "x-real": "1" }` | `'trailers'` with `{ "x-real": "1" }` | same |
| `{ "x-none": [], "x-real": "1" }` | `'trailers'` with `{ "x-real": "1" }` | same |

`stream.sentTrailers` on the server is the passed block in every row on all three. The client direction (`req.sendTrailers({ "x-none": [] })` against a same-runtime server) behaves the same way: the unfixed bun server logs a `'trailers'` event with `[]`, node and the fixed build log none.

Queued path: stream A's response exhausts the send windows while the client is not reading it, then stream B sends `{ "x-none": [] }` as trailers, so B's terminating frame goes through the outbound queue. Node and the fixed build: B closes on both ends with rstCode 0 and no `'trailers'` event, and A still delivers all 196605 bytes once the client reads it; bun 1.4.0: the same, except one `'trailers'` event on B.

</details>

<details>
<summary>Review notes</summary>

A self-review of the diff found no problem introduced by it. Two pre-existing things it turned up, neither changed here: streams whose final `END_STREAM` frame goes out through the outbound queue are never released until the session ends (this predates the PR and applies to `sendTrailers({})` today; reported separately), and a client `request()` with `endStream` plus `waitForTrailers` marks the stream half-closed up front (#37718 is changing that path). Review nits on test coverage and comments were applied in the follow-up commits.

</details>
