### PR TITLE
node:fs, shell(cp): handle paths longer than MAX_PATH on Windows

### DIFF
--- a/src/paths/string_paths.rs
+++ b/src/paths/string_paths.rs
@@ -372,10 +372,10 @@ fn to_w_path_maybe_dir<'a, const ADD_TRAILING_LASH: bool>(
     // buffer (32767 units for `WPathBuffer`, i.e. longer than any path NT
     // can address). The empty result makes the consuming syscall fail
     // cleanly; JS-facing paths are rejected with `false`/ENAMETOOLONG before
-    // they get here (`PathLikeExt::{slice_w, os_path, os_path_kernel32}` in
-    // `runtime/node/types.rs`, via `fits_in_wide_path_buffer`). Prefixing
-    // wrappers (`to_kernel32_path`, `to_nt_path`, …) may then yield just
-    // their prefix, which likewise fails at the syscall.
+    // they get here (`PathLikeExt::os_path_kernel32` in `runtime/node/types.rs`,
+    // via `fits_in_wide_path_buffer`). Prefixing wrappers (`to_kernel32_path`,
+    // `to_nt_path`, …) may then yield just their prefix, which likewise fails
+    // at the syscall.
     let Some(converted) =
         crate::strings::try_convert_utf8_to_utf16_in_buffer(&mut wbuf[..cap], utf8)
     else {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -452,11 +452,9 @@ fn directory_exists_at_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<bool> {
     }
 }
 
-/// Copies a `cp` operand, converted with `os_path_kernel32`, into the buffer
-/// the copy goes on appending entry names to; the result (NUL included) always
-/// lives in `buf`. Every path built from it is handed to `mkdir_os_path` /
-/// `copy_single_file_sync`, which on Windows are the kernel32 calls that need
-/// that conversion to accept paths longer than `MAX_PATH`.
+/// Copies a `cp` operand, in the `os_path_kernel32` form every path derived
+/// from it needs (`mkdir_os_path`, `copy_single_file_sync`), into the buffer
+/// the copy appends entry names to. The result, NUL included, lives in `buf`.
 fn cp_operand<'a>(path: &PathLike, buf: &'a mut OSPathBuffer) -> Maybe<&'a OSPathSliceZ> {
     let name_too_long = || sys::Error {
         errno: E::ENAMETOOLONG as _,
@@ -477,11 +475,9 @@ fn cp_operand<'a>(path: &PathLike, buf: &'a mut OSPathBuffer) -> Maybe<&'a OSPat
     Ok(OSPathSliceZ::from_buf(&buf[..], len))
 }
 
-/// Appends `name` as a child of the directory path in `buf[..dir_len]`,
-/// NUL-terminates the result and returns its length. No separator is inserted
-/// after a path that already ends in one (a filesystem root, or an operand
-/// given with a trailing separator): Windows passes `\\?\` paths to the kernel
-/// unnormalized, so a doubled separator would make every call on the path fail.
+/// Appends `name` to the directory path in `buf[..dir_len]`, NUL-terminated;
+/// returns the new length. A path already ending in a separator (a root, or an
+/// operand given with one) gets no second one: `\\?\` paths are not normalized.
 fn cp_append_entry(buf: &mut OSPathBuffer, dir_len: usize, name: &[OSPathChar]) -> usize {
     debug_assert!(dir_len + 1 + name.len() < buf.len());
     let mut len = dir_len;

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -452,37 +452,29 @@ fn directory_exists_at_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<bool> {
     }
 }
 
-/// Converts a `cp` operand into the buffer the copy appends entry names to. Every
-/// path built from it is handed to `mkdir_os_path` / `copy_single_file_sync`,
-/// which on Windows are kernel32 calls (`CreateDirectoryW`, `CopyFileW`,
-/// `GetFileAttributesW`) that reject paths longer than `MAX_PATH` unless they
-/// carry the `\\?\` prefix `os_path_kernel32` adds, the same form `mkdir` and
-/// `copyFile` use.
-fn cp_operand<'a>(path: &'a PathLike, buf: &'a mut OSPathBuffer) -> Maybe<&'a OSPathSliceZ> {
+/// Copies a `cp` operand, converted with `os_path_kernel32`, into the buffer
+/// the copy goes on appending entry names to; the result (NUL included) always
+/// lives in `buf`. Every path built from it is handed to `mkdir_os_path` /
+/// `copy_single_file_sync`, which on Windows are the kernel32 calls that need
+/// that conversion to accept paths longer than `MAX_PATH`.
+fn cp_operand<'a>(path: &PathLike, buf: &'a mut OSPathBuffer) -> Maybe<&'a OSPathSliceZ> {
     let name_too_long = || sys::Error {
         errno: E::ENAMETOOLONG as _,
         syscall: sys::Tag::copyfile,
         path: path.slice().into(),
         ..Default::default()
     };
-    #[cfg(windows)]
-    {
-        let mut kernel32_buf = paths::path_buffer_pool::get();
-        let converted = path
-            .os_path_kernel32(&mut *kernel32_buf)
-            .map_err(|NameTooLong| name_too_long())?;
-        let len = converted.len();
-        if len >= buf.len() {
-            return Err(name_too_long());
-        }
-        buf[..len].copy_from_slice(converted.as_slice());
-        buf[len] = 0;
-        Ok(OSPathSliceZ::from_buf(&buf[..], len))
+    let mut scratch = paths::path_buffer_pool::get();
+    let converted = path
+        .os_path_kernel32(&mut *scratch)
+        .map_err(|NameTooLong| name_too_long())?;
+    let len = converted.len();
+    if len >= buf.len() {
+        return Err(name_too_long());
     }
-    #[cfg(not(windows))]
-    {
-        path.os_path(buf).map_err(|NameTooLong| name_too_long())
-    }
+    buf[..len].copy_from_slice(&converted[..]);
+    buf[len] = 0;
+    Ok(OSPathSliceZ::from_buf(&buf[..], len))
 }
 
 /// Appends `name` as a child of the directory path in `buf[..dir_len]`,
@@ -1857,7 +1849,7 @@ mod _async_tasks {
 
             #[cfg(windows)]
             {
-                // SAFETY: src is NUL-terminated (os_path); GetFileAttributesW is the Win32 FFI
+                // SAFETY: src is NUL-terminated (cp_operand); GetFileAttributesW is the Win32 FFI
                 let attributes = unsafe { bun_sys::c::GetFileAttributesW(src.as_ptr()) };
                 if attributes == bun_sys::c::INVALID_FILE_ATTRIBUTES {
                     this.finish_concurrently(Err(sys::Error {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -452,6 +452,57 @@ fn directory_exists_at_os_path(dir: FD, path: &OSPathSliceZ) -> Maybe<bool> {
     }
 }
 
+/// Converts a `cp` operand into the buffer the copy appends entry names to. Every
+/// path built from it is handed to `mkdir_os_path` / `copy_single_file_sync`,
+/// which on Windows are kernel32 calls (`CreateDirectoryW`, `CopyFileW`,
+/// `GetFileAttributesW`) that reject paths longer than `MAX_PATH` unless they
+/// carry the `\\?\` prefix `os_path_kernel32` adds, the same form `mkdir` and
+/// `copyFile` use.
+fn cp_operand<'a>(path: &'a PathLike, buf: &'a mut OSPathBuffer) -> Maybe<&'a OSPathSliceZ> {
+    let name_too_long = || sys::Error {
+        errno: E::ENAMETOOLONG as _,
+        syscall: sys::Tag::copyfile,
+        path: path.slice().into(),
+        ..Default::default()
+    };
+    #[cfg(windows)]
+    {
+        let mut kernel32_buf = paths::path_buffer_pool::get();
+        let converted = path
+            .os_path_kernel32(&mut *kernel32_buf)
+            .map_err(|NameTooLong| name_too_long())?;
+        let len = converted.len();
+        if len >= buf.len() {
+            return Err(name_too_long());
+        }
+        buf[..len].copy_from_slice(converted.as_slice());
+        buf[len] = 0;
+        Ok(OSPathSliceZ::from_buf(&buf[..], len))
+    }
+    #[cfg(not(windows))]
+    {
+        path.os_path(buf).map_err(|NameTooLong| name_too_long())
+    }
+}
+
+/// Appends `name` as a child of the directory path in `buf[..dir_len]`,
+/// NUL-terminates the result and returns its length. No separator is inserted
+/// after a path that already ends in one (a filesystem root, or an operand
+/// given with a trailing separator): Windows passes `\\?\` paths to the kernel
+/// unnormalized, so a doubled separator would make every call on the path fail.
+fn cp_append_entry(buf: &mut OSPathBuffer, dir_len: usize, name: &[OSPathChar]) -> usize {
+    debug_assert!(dir_len + 1 + name.len() < buf.len());
+    let mut len = dir_len;
+    if len > 0 && !paths::is_sep_native_t::<OSPathChar>(buf[len - 1]) {
+        buf[len] = paths::SEP as OSPathChar;
+        len += 1;
+    }
+    buf[len..len + name.len()].copy_from_slice(name);
+    len += name.len();
+    buf[len] = 0;
+    len
+}
+
 type ReadPosition = i64;
 type Buffer = super::types::Buffer;
 type GidT = node::gid_t;
@@ -1789,23 +1840,17 @@ mod _async_tasks {
             let args = &this.args;
             let mut src_buf = OSPathBuffer::uninit();
             let mut dest_buf = OSPathBuffer::uninit();
-            let name_too_long = |path: &PathLike| sys::Error {
-                errno: E::ENAMETOOLONG as _,
-                syscall: sys::Tag::copyfile,
-                path: path.slice().into(),
-                ..Default::default()
-            };
-            let src = match args.src.os_path(&mut src_buf) {
+            let src = match cp_operand(&args.src, &mut src_buf) {
                 Ok(p) => p,
-                Err(NameTooLong) => {
-                    this.finish_concurrently(Err(name_too_long(&args.src)));
+                Err(err) => {
+                    this.finish_concurrently(Err(err));
                     return;
                 }
             };
-            let dest = match args.dest.os_path(&mut dest_buf) {
+            let dest = match cp_operand(&args.dest, &mut dest_buf) {
                 Ok(p) => p,
-                Err(NameTooLong) => {
-                    this.finish_concurrently(Err(name_too_long(&args.dest)));
+                Err(err) => {
+                    this.finish_concurrently(Err(err));
                     return;
                 }
             };
@@ -1991,37 +2036,14 @@ mod _async_tasks {
             };
             let _close = scopeguard::guard(fd, |fd| fd.close());
 
-            #[cfg(windows)]
-            let mut buf = OSPathBuffer::uninit();
-            #[cfg(windows)]
-            let normdest: &OSPathSliceZ = match sys::normalize_path_windows_opts(
-                FD::INVALID,
-                dest.as_slice(),
-                &mut buf[..],
-                // No NT prefix — `normdest` feeds
-                // `mkdirRecursiveOSPath` / `CopyFileW` which expect Win32 paths,
-                // not `\??\` NT object paths.
-                sys::NormalizePathWindowsOpts {
-                    add_nt_prefix: false,
-                },
-            ) {
-                Err(err) => {
-                    this_ref.finish_concurrently(Err(err));
-                    return false;
-                }
-                Ok(n) => n,
-            };
-            #[cfg(not(windows))]
-            let normdest: &OSPathSliceZ = dest;
-
-            let mkdir_ = nodefs.mkdir_recursive_os_path(normdest, args::Mkdir::DEFAULT_MODE, false);
+            let mkdir_ = nodefs.mkdir_recursive_os_path(dest, args::Mkdir::DEFAULT_MODE, false);
             match mkdir_ {
                 Err(err) => {
                     this_ref.finish_concurrently(Err(err));
                     return false;
                 }
                 Ok(_) => {
-                    this_ref.on_copy(src, normdest);
+                    this_ref.on_copy(src, dest);
                 }
             }
 
@@ -2065,25 +2087,19 @@ mod _async_tasks {
                     return false;
                 }
 
+                let src_len = cp_append_entry(src_buf, src_dir_len as usize, cname);
+                let dest_len = cp_append_entry(dest_buf, dest_dir_len as usize, cname);
+
                 match current.kind {
                     crate::node::dirent::Kind::Directory => {
-                        let sd = src_dir_len as usize;
-                        let dd = dest_dir_len as usize;
-                        src_buf[sd + 1..sd + 1 + cname.len()].copy_from_slice(cname);
-                        src_buf[sd] = paths::SEP as OSPathChar;
-                        src_buf[sd + 1 + cname.len()] = 0;
-                        dest_buf[dd + 1..dd + 1 + cname.len()].copy_from_slice(cname);
-                        dest_buf[dd] = paths::SEP as OSPathChar;
-                        dest_buf[dd + 1 + cname.len()] = 0;
-
                         let should_continue = Self::cp_async_directory(
                             nodefs,
                             args,
                             this,
                             src_buf,
-                            (sd + 1 + cname.len()) as PathInt,
+                            src_len as PathInt,
                             dest_buf,
-                            (dd + 1 + cname.len()) as PathInt,
+                            dest_len as PathInt,
                         );
                         if !should_continue {
                             return false;
@@ -2091,30 +2107,11 @@ mod _async_tasks {
                     }
                     _ => {
                         this_ref.subtask_count.fetch_add(1, Ordering::Relaxed);
-                        let sd = src_dir_len as usize;
-                        let dd = dest_dir_len as usize;
-                        let total = sd + 1 + cname.len() + 1 + dd + 1 + cname.len() + 1;
-
-                        // Allocate a path buffer for the path data
-                        let mut path_buf = vec![0 as OSPathChar; total].into_boxed_slice();
-
-                        path_buf[..sd].copy_from_slice(&src_buf[..sd]);
-                        path_buf[sd] = paths::SEP as OSPathChar;
-                        path_buf[sd + 1..sd + 1 + cname.len()].copy_from_slice(cname);
-                        path_buf[sd + 1 + cname.len()] = 0;
-                        let dest_off = sd + 1 + cname.len() + 1;
-                        path_buf[dest_off..dest_off + dd].copy_from_slice(&dest_buf[..dd]);
-                        path_buf[dest_off + dd] = paths::SEP as OSPathChar;
-                        path_buf[dest_off + dd + 1..dest_off + dd + 1 + cname.len()]
-                            .copy_from_slice(cname);
-                        path_buf[dest_off + dd + 1 + cname.len()] = 0;
-
-                        CpSingleTask::<IS_SHELL>::create(
-                            this,
-                            path_buf,
-                            sd + 1 + cname.len(),
-                            dd + 1 + cname.len(),
-                        );
+                        // `<src>\0<dest>\0`, the layout `CpSingleTask` reads back.
+                        let path_buf = [&src_buf[..=src_len], &dest_buf[..=dest_len]]
+                            .concat()
+                            .into_boxed_slice();
+                        CpSingleTask::<IS_SHELL>::create(this, path_buf, src_len, dest_len);
                     }
                 }
                 entry = iterator.next();
@@ -8207,20 +8204,8 @@ impl NodeFS {
     pub(crate) fn cp(&mut self, args: &args::Cp, _: Flavor) -> Maybe<ret::Cp> {
         let mut src_buf = OSPathBuffer::uninit();
         let mut dest_buf = OSPathBuffer::uninit();
-        let name_too_long = |path: &PathLike| sys::Error {
-            errno: E::ENAMETOOLONG as _,
-            syscall: sys::Tag::copyfile,
-            path: path.slice().into(),
-            ..Default::default()
-        };
-        let src_len = match args.src.os_path(&mut src_buf) {
-            Ok(p) => p.len(),
-            Err(NameTooLong) => return Err(name_too_long(&args.src)),
-        };
-        let dest_len = match args.dest.os_path(&mut dest_buf) {
-            Ok(p) => p.len(),
-            Err(NameTooLong) => return Err(name_too_long(&args.dest)),
-        };
+        let src_len = cp_operand(&args.src, &mut src_buf)?.len();
+        let dest_len = cp_operand(&args.dest, &mut dest_buf)?.len();
         self.cp_sync_inner(
             &mut src_buf,
             PathInt::try_from(src_len).expect("int cast"),
@@ -8415,29 +8400,24 @@ impl NodeFS {
                 });
             }
 
-            src_buf[sd + 1..sd + 1 + name_slice.len()].copy_from_slice(name_slice);
-            src_buf[sd] = paths::SEP as OSPathChar;
-            src_buf[sd + 1 + name_slice.len()] = 0;
-
-            dest_buf[dd + 1..dd + 1 + name_slice.len()].copy_from_slice(name_slice);
-            dest_buf[dd] = paths::SEP as OSPathChar;
-            dest_buf[dd + 1 + name_slice.len()] = 0;
+            let src_len = cp_append_entry(src_buf, sd, name_slice);
+            let dest_len = cp_append_entry(dest_buf, dd, name_slice);
 
             match current.kind {
                 sys::FileKind::Directory => {
                     let r = self.cp_sync_inner(
                         src_buf,
-                        (sd + 1 + name_slice.len()) as PathInt,
+                        src_len as PathInt,
                         dest_buf,
-                        (dd + 1 + name_slice.len()) as PathInt,
+                        dest_len as PathInt,
                         args,
                     );
                     r?;
                 }
                 _ => {
-                    // NUL written at [len] above; `from_buf` debug-asserts it.
-                    let src_z = OSPathSliceZ::from_buf(&src_buf[..], sd + 1 + name_slice.len());
-                    let dest_z = OSPathSliceZ::from_buf(&dest_buf[..], dd + 1 + name_slice.len());
+                    // NUL written at [len] by `cp_append_entry`; `from_buf` debug-asserts it.
+                    let src_z = OSPathSliceZ::from_buf(&src_buf[..], src_len);
+                    let dest_z = OSPathSliceZ::from_buf(&dest_buf[..], dest_len);
                     let r = self.copy_single_file_sync(
                         src_z,
                         dest_z,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -858,13 +858,10 @@ pub trait PathLikeExt {
     fn slice_z<'a>(&'a self, buf: &'a mut PathBuffer) -> &'a ZStr
     where
         Self: Sized;
-    /// The path in the form the platform's file calls take (`&ZStr` as given
-    /// on POSIX). On Windows this is the only conversion for a path that
-    /// reaches kernel32 (`CreateDirectoryW`, `CopyFileW`, `GetFileAttributesW`,
-    /// ...): normalized, rooted paths resolved against the current drive, and
-    /// drive-letter paths given the `\\?\` prefix, without which those calls
-    /// reject anything longer than `MAX_PATH`. Paths opened through `Nt*`
-    /// calls take the `bun_sys` NT-path helpers instead.
+    /// The path for the platform's file calls: as given on POSIX; on Windows
+    /// normalized and `\\?\`-prefixed, the only form the kernel32 calls
+    /// (`CreateDirectoryW`, `CopyFileW`, ...) accept past `MAX_PATH`. Paths for
+    /// `Nt*` calls use the `bun_sys` NT-path helpers instead.
     fn os_path_kernel32<'a>(
         &'a self,
         buf: &'a mut PathBuffer,

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -4,9 +4,9 @@ use core::ffi::c_int;
 use crate::jsc::{self, CallFrame, JSGlobalObject, JSValue, JsResult};
 use bun_core::zig_string::Slice as ZigStringSlice;
 use bun_core::{self, fmt as bun_fmt};
-use bun_core::{WStr, ZStr, ZigString};
+use bun_core::{ZStr, ZigString};
 use bun_jsc::{SliceWithUnderlyingStringJsc as _, StringJsc as _, ZigStringJsc as _};
-use bun_paths::{MAX_PATH_BYTES, OSPathBuffer, OSPathSliceZ, PathBuffer, WPathBuffer};
+use bun_paths::{MAX_PATH_BYTES, OSPathSliceZ, PathBuffer};
 use bun_sys::{self, Fd, Mode, O};
 
 use crate::node::util::validators;
@@ -834,12 +834,11 @@ unsafe extern "C" {
 // `PathLikeExt` / `PathOrFdExt` extension traits.
 pub use bun_jsc::node_path::{PathLike, PathOrFileDescriptor};
 
-/// Returned by [`PathLikeExt::slice_w`] / [`PathLikeExt::os_path`] /
-/// [`PathLikeExt::os_path_kernel32`] when the path's UTF-16 form would not
-/// fit a `WPathBuffer` (`strings::fits_in_wide_path_buffer`). NT caps paths
-/// at `PATH_MAX_WIDE` units, so such a path cannot exist on disk — callers
-/// map this to `false`/`ENAMETOOLONG` as appropriate instead of letting the
-/// conversion overflow (oven-sh/bun#27775).
+/// Returned by [`PathLikeExt::os_path_kernel32`] when the path's UTF-16 form
+/// would not fit a `WPathBuffer` (`strings::fits_in_wide_path_buffer`). NT
+/// caps paths at `PATH_MAX_WIDE` units, so such a path cannot exist on disk —
+/// callers map this to `false`/`ENAMETOOLONG` as appropriate instead of
+/// letting the conversion overflow (oven-sh/bun#27775).
 #[derive(Debug, Clone, Copy)]
 pub struct NameTooLong;
 
@@ -859,12 +858,13 @@ pub trait PathLikeExt {
     fn slice_z<'a>(&'a self, buf: &'a mut PathBuffer) -> &'a ZStr
     where
         Self: Sized;
-    fn slice_w<'a>(&'a self, buf: &'a mut WPathBuffer) -> Result<&'a WStr, NameTooLong>
-    where
-        Self: Sized;
-    fn os_path<'a>(&'a self, buf: &'a mut OSPathBuffer) -> Result<&'a OSPathSliceZ, NameTooLong>
-    where
-        Self: Sized;
+    /// The path in the form the platform's file calls take (`&ZStr` as given
+    /// on POSIX). On Windows this is the only conversion for a path that
+    /// reaches kernel32 (`CreateDirectoryW`, `CopyFileW`, `GetFileAttributesW`,
+    /// ...): normalized, rooted paths resolved against the current drive, and
+    /// drive-letter paths given the `\\?\` prefix, without which those calls
+    /// reject anything longer than `MAX_PATH`. Paths opened through `Nt*`
+    /// calls take the `bun_sys` NT-path helpers instead.
     fn os_path_kernel32<'a>(
         &'a self,
         buf: &'a mut PathBuffer,
@@ -1019,27 +1019,6 @@ impl PathLikeExt for PathLike {
     #[inline]
     fn slice_z<'a>(&'a self, buf: &'a mut PathBuffer) -> &'a ZStr {
         self.slice_z_with_force_copy::<false>(buf)
-    }
-
-    #[inline]
-    fn slice_w<'a>(&'a self, buf: &'a mut WPathBuffer) -> Result<&'a WStr, NameTooLong> {
-        let sliced = self.slice();
-        if !strings::fits_in_wide_path_buffer(sliced) {
-            return Err(NameTooLong);
-        }
-        Ok(strings::paths::to_w_path(buf, sliced))
-    }
-
-    #[inline]
-    fn os_path<'a>(&'a self, buf: &'a mut OSPathBuffer) -> Result<&'a OSPathSliceZ, NameTooLong> {
-        #[cfg(windows)]
-        {
-            return self.slice_w(buf);
-        }
-        #[cfg(not(windows))]
-        {
-            Ok(self.slice_z_with_force_copy::<false>(buf))
-        }
     }
 
     #[inline]

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -581,6 +581,36 @@ impl ShellCpTask {
         }
     }
 
+    /// The operand in the form the copy reports it in its errors. The copy
+    /// converts its operands with `os_path_kernel32`, which on Windows
+    /// normalizes them and gives a rooted `\dir\file` its drive letter, and
+    /// builds its error paths from the result. `on_shell_cp_task_done` compares
+    /// those error paths against `src_absolute` / `tgt_absolute`, so the
+    /// operands are stored, and handed to the copy, already in that form; a
+    /// drive-qualified file path comes back from the copy's conversion unchanged.
+    fn as_copied_operand(path: &[u8]) -> Vec<u8> {
+        #[cfg(windows)]
+        {
+            use crate::node::types::PathLikeExt as _;
+            let operand = bun_jsc::node::PathLike::String(
+                bun_ptr::cow_slice::CowSlice::init_unchecked(path, false),
+            );
+            let mut wide = bun_paths::path_buffer_pool::get();
+            let Ok(converted) = operand.os_path_kernel32(&mut *wide) else {
+                // The copy rejects it as ENAMETOOLONG, naming the operand as given.
+                return path.to_vec();
+            };
+            let mut utf8 = bun_paths::path_buffer_pool::get();
+            bun_paths::strings::from_wpath(&mut utf8[..], converted.as_slice())
+                .as_bytes()
+                .to_vec()
+        }
+        #[cfg(not(windows))]
+        {
+            path.to_vec()
+        }
+    }
+
     /// Resolves src/tgt to absolute paths, classifies them per the three
     /// POSIX `cp` synopses
     /// (<https://man7.org/linux/man-pages/man1/cp.1p.html>), then hands off to
@@ -697,8 +727,8 @@ impl ShellCpTask {
             _copying_many = true;
         }
 
-        self.src_absolute = Some(src.as_bytes().to_vec());
-        self.tgt_absolute = Some(tgt.as_bytes().to_vec());
+        self.src_absolute = Some(Self::as_copied_operand(src.as_bytes()));
+        self.tgt_absolute = Some(Self::as_copied_operand(tgt.as_bytes()));
 
         let args = crate::node::fs::args::Cp {
             src: bun_jsc::node::PathLike::String(bun_ptr::cow_slice::CowSlice::init_unchecked(

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -581,13 +581,9 @@ impl ShellCpTask {
         }
     }
 
-    /// The operand in the form the copy reports it in its errors. The copy
-    /// converts its operands with `os_path_kernel32`, which on Windows
-    /// normalizes them and gives a rooted `\dir\file` its drive letter, and
-    /// builds its error paths from the result. `on_shell_cp_task_done` compares
-    /// those error paths against `src_absolute` / `tgt_absolute`, so the
-    /// operands are stored, and handed to the copy, already in that form; a
-    /// drive-qualified file path comes back from the copy's conversion unchanged.
+    /// The operand as the copy's errors will spell it (`os_path_kernel32` form:
+    /// on Windows a rooted `\dir\file` gains its drive letter), which is what
+    /// `on_shell_cp_task_done` compares those errors against.
     fn as_copied_operand(path: &[u8]) -> Vec<u8> {
         #[cfg(windows)]
         {

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6472,24 +6472,6 @@ impl Default for NtCreateFileOptions {
     }
 }
 
-/// `normalizePathWindows` options.
-#[cfg(windows)]
-#[derive(Copy, Clone)]
-pub struct NormalizePathWindowsOpts {
-    /// `false` emits Win32-consumable paths for kernel32 APIs: plain (no
-    /// `\??\`) for absolute inputs, `\\?\GLOBALROOT\Device\…` for dotted or
-    /// multi-component relatives. Bare names still pass through verbatim.
-    pub add_nt_prefix: bool,
-}
-#[cfg(windows)]
-impl Default for NormalizePathWindowsOpts {
-    fn default() -> Self {
-        Self {
-            add_nt_prefix: true,
-        }
-    }
-}
-
 /// `..`-clamp boundary from the kernel's own two answers (full NT object name
 /// minus volume-relative name), plus whether the device is an allowlisted
 /// share-rooted redirector. `None` when the names don't compose (rename race).
@@ -6554,20 +6536,6 @@ pub fn normalize_path_windows<'a>(
     path: &[u16],
     buf: &'a mut [u16],
 ) -> Maybe<&'a bun_core::WStr> {
-    normalize_path_windows_opts(dir_fd, path, buf, NormalizePathWindowsOpts::default())
-}
-
-/// Like [`normalize_path_windows`]; `opts.add_nt_prefix = false` makes the
-/// output Win32-consumable: absolute inputs lose `\??\`, dotted or
-/// multi-component relatives become `\\?\GLOBALROOT\Device\…`, and bare names
-/// pass through verbatim (Win32 resolves those against the cwd).
-#[cfg(windows)]
-pub fn normalize_path_windows_opts<'a>(
-    dir_fd: Fd,
-    path: &[u16],
-    buf: &'a mut [u16],
-    opts: NormalizePathWindowsOpts,
-) -> Maybe<&'a bun_core::WStr> {
     use bun_core::WStr;
     let too_long = || Error::from_code(E::ENAMETOOLONG, Tag::open);
 
@@ -6621,37 +6589,17 @@ pub fn normalize_path_windows_opts<'a>(
                 }
             }
         }
-        if opts.add_nt_prefix {
-            // Absolute → add `\??\` (idempotent if already present), normalize
-            // separators/`.`/`..` and NUL-terminate.
-            // `nt_prefix_headroom = 8`: reject when `path.len >
-            // buf.len - nt_prefix_headroom`.
-            // `normalizeStringGenericTZ` performs no bounds checking of its
-            // own, so reserve room for `\??\` + trailing-`\` growth + NUL
-            // before calling it. NOTE: `to_nt_path16` is NOT a substitute here
-            // — it only normalizes slashes and leaves `.`/`..` segments in
-            // place, which `NtCreateFile` rejects (e.g. `\??\C:\dir\.` →
-            // OBJECT_NAME_NOT_FOUND).
-            if path.len() > buf.len().saturating_sub(8) {
-                return Err(too_long());
-            }
-            let norm = bun_paths::resolve_path::normalize_string_generic_tz::<
-                u16,
-                /*ALLOW_ABOVE_ROOT*/ false,
-                /*PRESERVE_TRAILING_SLASH*/ false,
-                /*ZERO_TERMINATE*/ true,
-                /*ADD_NT_PREFIX*/ true,
-            >(path, buf, b'\\' as u16, bun_paths::is_sep_any_t::<u16>);
-            let len = norm.len();
-            // SAFETY: ZERO_TERMINATE wrote NUL at buf[len].
-            return Ok(unsafe { WStr::from_raw(norm.as_ptr(), len) });
-        }
-        // `add_nt_prefix = false` — produce a Win32 path
-        // (no `\??\` object prefix) for callers that feed kernel32 APIs
-        // (CreateDirectoryW / CopyFileW). With .add_nt_prefix = false the
-        // normalizer can still grow the input by one u16 (trailing `\` after a
-        // bare UNC volume name) plus the NUL terminator.
-        if path.len() > buf.len().saturating_sub(2) {
+        // Absolute → add `\??\` (idempotent if already present), normalize
+        // separators/`.`/`..` and NUL-terminate.
+        // `nt_prefix_headroom = 8`: reject when `path.len >
+        // buf.len - nt_prefix_headroom`.
+        // `normalizeStringGenericTZ` performs no bounds checking of its
+        // own, so reserve room for `\??\` + trailing-`\` growth + NUL
+        // before calling it. NOTE: `to_nt_path16` is NOT a substitute here
+        // — it only normalizes slashes and leaves `.`/`..` segments in
+        // place, which `NtCreateFile` rejects (e.g. `\??\C:\dir\.` →
+        // OBJECT_NAME_NOT_FOUND).
+        if path.len() > buf.len().saturating_sub(8) {
             return Err(too_long());
         }
         let norm = bun_paths::resolve_path::normalize_string_generic_tz::<
@@ -6659,7 +6607,7 @@ pub fn normalize_path_windows_opts<'a>(
             /*ALLOW_ABOVE_ROOT*/ false,
             /*PRESERVE_TRAILING_SLASH*/ false,
             /*ZERO_TERMINATE*/ true,
-            /*ADD_NT_PREFIX*/ false,
+            /*ADD_NT_PREFIX*/ true,
         >(path, buf, b'\\' as u16, bun_paths::is_sep_any_t::<u16>);
         let len = norm.len();
         // SAFETY: ZERO_TERMINATE wrote NUL at buf[len].
@@ -6695,14 +6643,6 @@ pub fn normalize_path_windows_opts<'a>(
     }
 
     // Otherwise: resolve `dir_fd` to its NT device path, join, normalize.
-    // Win32 consumers (`add_nt_prefix = false`) get the `\\?\GLOBALROOT`
-    // spelling of the same object — no mount manager, valid for kernel32.
-    const GLOBALROOT: &[u16] = bun_core::w!("\\\\?\\GLOBALROOT");
-    let g = if opts.add_nt_prefix {
-        0
-    } else {
-        GLOBALROOT.len()
-    };
     let base_fd = if dir_fd.is_valid() {
         dir_fd.native()
     } else {
@@ -6794,16 +6734,14 @@ pub fn normalize_path_windows_opts<'a>(
 
     let mut joined = bun_paths::w_path_buffer_pool::get();
     let joined_len = rest.len() + 1 + rel.len();
-    // `buf` holds `\\?\GLOBALROOT` (Win32 output only) + the copied prefix +
-    // the normalized remainder (never longer than `joined_len`) + NUL; keep
-    // 8 u16 of headroom to stay conservative.
+    // `buf` holds the copied prefix + the normalized remainder (never longer
+    // than `joined_len`) + NUL; keep 8 u16 of headroom to stay conservative.
     if joined_len > joined.0.len().saturating_sub(8)
-        || g + prefix_len + joined_len > buf.len().saturating_sub(8)
+        || prefix_len + joined_len > buf.len().saturating_sub(8)
     {
         return Err(too_long());
     }
-    buf[..g].copy_from_slice(&GLOBALROOT[..g]);
-    buf[g..g + prefix_len].copy_from_slice(&base[..prefix_len]);
+    buf[..prefix_len].copy_from_slice(&base[..prefix_len]);
     joined.0[..rest.len()].copy_from_slice(rest);
     joined.0[rest.len()] = b'\\' as u16;
     joined.0[rest.len() + 1..joined_len].copy_from_slice(rel);
@@ -6818,7 +6756,7 @@ pub fn normalize_path_windows_opts<'a>(
         /*ADD_NT_PREFIX*/ false,
     >(
         &joined.0[..joined_len],
-        &mut buf[g + prefix_len..],
+        &mut buf[prefix_len..],
         b'\\' as u16,
         bun_paths::is_sep_any_t::<u16>,
     )
@@ -6827,11 +6765,11 @@ pub fn normalize_path_windows_opts<'a>(
     // directory-path prefix, keep it for a bare device name where it selects
     // the root directory over the volume device.
     if sub_len == 1 && whole_base {
-        buf[g + prefix_len] = 0;
-        return Ok(WStr::from_buf(&buf[..], g + prefix_len));
+        buf[prefix_len] = 0;
+        return Ok(WStr::from_buf(&buf[..], prefix_len));
     }
-    // ZERO_TERMINATE wrote NUL at buf[g + prefix_len + sub_len].
-    Ok(WStr::from_buf(&buf[..], g + prefix_len + sub_len))
+    // ZERO_TERMINATE wrote NUL at buf[prefix_len + sub_len].
+    Ok(WStr::from_buf(&buf[..], prefix_len + sub_len))
 }
 
 /// Open a `\\.\…` device path via kernel32 `CreateFileW`
@@ -9739,18 +9677,6 @@ mod normalize_path_windows_tests {
         String::from_utf16(norm.as_slice()).unwrap()
     }
 
-    fn normalize_opts(dir: Fd, path: &str, add_nt_prefix: bool) -> String {
-        let mut buf = bun_paths::w_path_buffer_pool::get();
-        let norm = normalize_path_windows_opts(
-            dir,
-            &wide(path),
-            &mut buf.0[..],
-            NormalizePathWindowsOpts { add_nt_prefix },
-        )
-        .expect(path);
-        String::from_utf16(norm.as_slice()).unwrap()
-    }
-
     fn normalize_err(dir: Fd, path: &str) -> Error {
         let mut buf = bun_paths::w_path_buffer_pool::get();
         match normalize_path_windows(dir, &wide(path), &mut buf.0[..]) {
@@ -10181,38 +10107,6 @@ mod normalize_path_windows_tests {
         split_at("\\Device\\Mupp\\x", "\\x", "\\Device\\Mupp", false);
     }
 
-    #[test]
-    fn win32_output_uses_globalroot() {
-        let _g = crate::file::tests::FD_TEST_LOCK.lock();
-        let tree = TempTree::new("nt_norm_gr");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let got = normalize_opts(*dir, "a\\b", false);
-        assert!(got.starts_with("\\\\?\\GLOBALROOT\\Device\\"), "{got}");
-        assert!(got.ends_with("\\a\\b"), "{got}");
-        // rel `.`: GLOBALROOT + base, no trailing separator.
-        assert_eq!(
-            normalize_opts(*dir, ".", false),
-            format!("\\\\?\\GLOBALROOT{}", normalize(*dir, "."))
-        );
-    }
-
-    #[test]
-    fn win32_globalroot_output_creates_directories() {
-        let _g = crate::file::tests::FD_TEST_LOCK.lock();
-        let tree = TempTree::new("nt_norm_gr_mkdir");
-        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
-            let _ = close(fd);
-        });
-        let name = normalize_opts(*dir, ".\\fresh", false);
-        let wname: Vec<u16> = wide(&name).into_iter().chain([0u16]).collect();
-        // SAFETY: `wname` is NUL-terminated.
-        let ok = unsafe { w::CreateDirectoryW(wname.as_ptr(), core::ptr::null_mut()) };
-        assert_ne!(ok, 0, "CreateDirectoryW({name})");
-        assert!(std::fs::metadata(tree.0.join("fresh")).unwrap().is_dir());
-    }
-
     // ── branch-review matrix ────────────────────────────────────────────
 
     #[test]
@@ -10289,19 +10183,5 @@ mod normalize_path_windows_tests {
         // The bypass copies the ORIGINAL path (drive prefix included); only
         // the post-strip remainder decides the routing.
         assert_eq!(normalize(Fd::INVALID, "C:foo"), "C:foo");
-    }
-
-    #[test]
-    fn win32_globalroot_dotdot_composes() {
-        let _g = crate::file::tests::FD_TEST_LOCK.lock();
-        let tree = TempTree::new("nt_norm_gr_dotdot");
-        std::fs::create_dir_all(tree.0.join("child")).unwrap();
-        let child = scopeguard::guard(open_dir_handle(&tree.0.join("child")), |fd| {
-            let _ = close(fd);
-        });
-        assert_eq!(
-            normalize_opts(*child, "..\\x", false),
-            format!("\\\\?\\GLOBALROOT{}", normalize(*child, "..\\x"))
-        );
     }
 }

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -230,14 +230,10 @@ describe.concurrent("bunshell cp operands the native copy has to convert", () =>
     expect(readFileSync(copy, "utf8")).toBe("a\n");
   });
 
-  // A rooted operand (`\dir`, no drive letter) is resolved against the current
-  // drive and keeps its trailing separator, like a volume root (`D:\`) always
-  // has one. The copy must append entry names to such a path without doubling
-  // the separator: the `\\?\` paths it works with are not normalized by
-  // Windows, so `\\?\C:\out\\a.txt` does not exist. The destination case
-  // worked before the copy used those paths too; a rooted source used to fail
-  // with "Invalid argument" because it was opened without being resolved.
-  describe.if(isWindows)("rooted operands with a trailing separator", () => {
+  // A rooted operand (`\dir`, no drive letter) is the one shape the copy's
+  // conversion changes: it is resolved against the current drive, keeping its
+  // trailing separator, like a volume root (`D:\`) always has one.
+  describe.if(isWindows)("rooted operands", () => {
     const tree = { "tree/a.txt": "a\n", "tree/sub/b.txt": "b\n" };
     /** `C:\x\y` -> `\x\y\` */
     function rooted(dir: string, name: string) {
@@ -250,16 +246,37 @@ describe.concurrent("bunshell cp operands the native copy has to convert", () =>
       expect(readFileSync(join(out, "sub", "b.txt"), "utf8")).toBe("b\n");
     }
 
-    test("cp -R into a rooted destination", async () => {
+    // The copy must append entry names to such a path without doubling the
+    // separator: the `\\?\` paths it works with are not normalized by Windows,
+    // so `\\?\C:\out\\a.txt` does not exist. The destination case also worked
+    // before the copy used those paths; a rooted source used to fail with
+    // "Invalid argument" because it was opened without being resolved.
+    test("cp -R into a rooted destination with a trailing separator", async () => {
       using dir = tempDir("shell-cp-rooted-dest", { "run-cp-fixture.ts": fixture, ...tree });
       expect(await cp(String(dir), "-R", "tree", rooted(String(dir), "out"))).toEqual(copied);
       expectTreeCopiedTo(join(String(dir), "out"));
     });
 
-    test("cp -R from a rooted source", async () => {
+    test("cp -R from a rooted source with a trailing separator", async () => {
       using dir = tempDir("shell-cp-rooted-src", { "run-cp-fixture.ts": fixture, ...tree });
       expect(await cp(String(dir), "-R", rooted(String(dir), "tree"), "out")).toEqual(copied);
       expectTreeCopiedTo(join(String(dir), "out"));
+    });
+
+    // cp suppresses the EBUSY of copies that lose the race for a destination
+    // another copy of the same command already wrote ("EBUSY windows" above)
+    // by comparing the path in the error with the operand it resolved, so the
+    // operand has to be kept in the drive-qualified form the copy reports.
+    // With 50 copies racing, some of them lose on nearly every run.
+    test("copies of one file racing into a rooted directory stay quiet", async () => {
+      using dir = tempDir("shell-cp-rooted-ebusy", {
+        "run-cp-fixture.ts": fixture,
+        "hello.txt": "hi!\n",
+        "somedir": {},
+      });
+      const sources = Array(50).fill("hello.txt");
+      expect(await cp(String(dir), ...sources, rooted(String(dir), "somedir"))).toEqual(copied);
+      expect(readFileSync(join(String(dir), "somedir", "hello.txt"), "utf8")).toBe("hi!\n");
     });
   });
 });

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,95 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// The builtin is the default only on Windows; on POSIX it is enabled by an env
+// var read once per process, so each of these runs its `cp` in a child bun.
+describe.concurrent("bunshell cp operands the native copy has to convert", () => {
+  // Runs `cp <argv>` in its own directory and prints cp's exit code followed by
+  // whatever cp wrote to stderr.
+  const fixture = /* ts */ `
+    import { $ } from "bun";
+    const result = await $\`cp \${process.argv.slice(2)}\`.nothrow().quiet();
+    process.stdout.write(result.exitCode + "\\n" + result.stderr.toString());
+  `;
+
+  async function cp(dir: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run-cp-fixture.ts", ...args],
+      cwd: dir,
+      env: { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" },
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+  const copied = { stdout: "0\n", stderr: "", exitCode: 0 };
+
+  // 30 components of 10 characters: longer than Windows' MAX_PATH (260) before
+  // the temp directory is even prepended, and well under macOS' PATH_MAX (1024)
+  // after it. On Windows the copy used to create the destination directories
+  // and copy the files through calls limited to MAX_PATH, so `cp -R` of a tree
+  // like this stopped with "File name too long" and a lone file this far down
+  // was not copied at all.
+  const deep = Array(30).fill("0123456789").join("/");
+
+  test("cp -R copies a tree whose destination paths are longer than MAX_PATH", async () => {
+    using dir = tempDir("shell-cp-long-tree", {
+      "run-cp-fixture.ts": fixture,
+      [`tree/${deep}/leaf`]: "leaf\n",
+    });
+    const leafCopy = join(String(dir), "out", deep, "leaf");
+    expect(leafCopy.length).toBeGreaterThan(260);
+
+    expect(await cp(String(dir), "-R", "tree", "out")).toEqual(copied);
+    expect(readFileSync(leafCopy, "utf8")).toBe("leaf\n");
+  });
+
+  test("cp copies a file whose paths are longer than MAX_PATH", async () => {
+    using dir = tempDir("shell-cp-long-file", {
+      "run-cp-fixture.ts": fixture,
+      [`${deep}/a.txt`]: "a\n",
+    });
+    const copy = join(String(dir), deep, "b.txt");
+    expect(copy.length).toBeGreaterThan(260);
+
+    expect(await cp(String(dir), `${deep}/a.txt`, `${deep}/b.txt`)).toEqual(copied);
+    expect(readFileSync(copy, "utf8")).toBe("a\n");
+  });
+
+  // A rooted operand (`\dir`, no drive letter) is resolved against the current
+  // drive and keeps its trailing separator, like a volume root (`D:\`) always
+  // has one. The copy must append entry names to such a path without doubling
+  // the separator: the `\\?\` paths it works with are not normalized by
+  // Windows, so `\\?\C:\out\\a.txt` does not exist. The destination case
+  // worked before the copy used those paths too; a rooted source used to fail
+  // with "Invalid argument" because it was opened without being resolved.
+  describe.if(isWindows)("rooted operands with a trailing separator", () => {
+    const tree = { "tree/a.txt": "a\n", "tree/sub/b.txt": "b\n" };
+    /** `C:\x\y` -> `\x\y\` */
+    function rooted(dir: string, name: string) {
+      const absolute = join(dir, name);
+      expect(absolute).toMatch(/^[A-Za-z]:\\/);
+      return absolute.slice(2) + "\\";
+    }
+    function expectTreeCopiedTo(out: string) {
+      expect(readFileSync(join(out, "a.txt"), "utf8")).toBe("a\n");
+      expect(readFileSync(join(out, "sub", "b.txt"), "utf8")).toBe("b\n");
+    }
+
+    test("cp -R into a rooted destination", async () => {
+      using dir = tempDir("shell-cp-rooted-dest", { "run-cp-fixture.ts": fixture, ...tree });
+      expect(await cp(String(dir), "-R", "tree", rooted(String(dir), "out"))).toEqual(copied);
+      expectTreeCopiedTo(join(String(dir), "out"));
+    });
+
+    test("cp -R from a rooted source", async () => {
+      using dir = tempDir("shell-cp-rooted-src", { "run-cp-fixture.ts": fixture, ...tree });
+      expect(await cp(String(dir), "-R", rooted(String(dir), "tree"), "out")).toEqual(copied);
+      expectTreeCopiedTo(join(String(dir), "out"));
+    });
   });
 });
 

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -37,6 +37,38 @@ for (const [name, copy] of impls) {
       expect(fs.readFileSync(basename + "/to.txt", "utf8")).toBe("a");
     });
 
+    // Longer than Windows' MAX_PATH (260) on its own, so the absolute paths
+    // exceed it whatever the temp directory is; each component stays under
+    // NAME_MAX (255). On Windows the native copy used to hand these paths to
+    // the Win32 file calls without the `\\?\` prefix that lifts the limit and
+    // threw ENOENT, while fs.copyFile on the same paths worked.
+    const longDir = Buffer.alloc(200, "d").toString() + "/" + Buffer.alloc(100, "e").toString();
+
+    test("single file with paths longer than MAX_PATH", async () => {
+      await using basename = tempDir("cp", {
+        [longDir + "/a.txt"]: "a",
+      });
+      const from = join(String(basename), longDir, "a.txt");
+      const to = join(String(basename), longDir, "to.txt");
+      expect(Math.min(from.length, to.length)).toBeGreaterThan(260);
+
+      await copy(from, to);
+
+      assertContent(to, "a");
+    });
+
+    test("single file into a missing directory, with paths longer than MAX_PATH", async () => {
+      await using basename = tempDir("cp", {
+        [longDir + "/a.txt"]: "a",
+      });
+      const from = join(String(basename), longDir, "a.txt");
+      const to = join(String(basename), longDir, "new", "to.txt");
+
+      await copy(from, to);
+
+      assertContent(to, "a");
+    });
+
     test("refuse to copy directory with 'recursive: false'", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",


### PR DESCRIPTION
### Problem
- On Windows the shell `cp` builtin cannot copy a tree whose destination paths get longer than about 250 characters: `cp -R deep out` stops with `cp: File name too long: C:\...\out\a\a\...` (bun 1.4.0, a 120-level tree; `fs.mkdirSync` had just created the same paths fine).
- `fs.cpSync(file, dest)` and `fs.promises.cp(file, dest)` fail the same way once the paths pass MAX_PATH, as `ENOENT: no such file or directory, copyfile '<src>'`. `fs.copyFileSync` on the same two paths works, and node v26.3.0 copies in both cases (output below).
- Cause: the two native entry points, `NodeFS::cp` and `NewAsyncCpTask::cp_async` (`src/runtime/node/node_fs.rs`), convert their operands with `PathLikeExt::os_path`, a plain UTF-16 conversion. Every path the copy then builds is handed to kernel32: `mkdir_os_path` (`CreateDirectoryW`) for each directory, `GetFileAttributesW` + `CopyFileW` in `copy_single_file_sync` for each file. Those calls only accept paths past MAX_PATH in the `\\?\` form, which is what `mkdir` (`os_path_kernel32`) and `copyFile` (`to_kernel32_path`) already pass them. The per-directory `normalize_path_windows_opts(.., add_nt_prefix: false)` in `cp_async_directory` produced a plain Win32 path as well, and the per-file paths were never normalized at all.

### Fix
- `cp_operand` converts both operands of both entry points with `os_path_kernel32` (the conversion `mkdir`, `exists`, ... already use) and copies the result into the walk buffer, so the operands and everything appended to them reach kernel32 as normalized `\\?\C:\...` paths; relative, UNC and device paths keep their existing forms. This is the fix proper; `ENAMETOOLONG` for operands that do not fit the wide buffers is reported as before. The copy is the same on every platform (on POSIX `os_path_kernel32` is the operand as given), which also makes the buffer hold the operand even when it is empty. `PathLikeExt::os_path`, whose only callers were these two sites, and `slice_w`, whose only caller was `os_path`, are deleted; `os_path_kernel32` gets a doc comment saying when it is the right conversion.
- The shell builtin (`cp.rs`) stores its resolved operands, and passes them to the copy, in that same form (`as_copied_operand`). Its EBUSY bookkeeping compares the paths in the copy's errors against the stored operands, and with the copy now reporting rooted operands drive-qualified, a rooted destination (`cp f f \dir`) lost the suppression of losing duplicate copies: 9 of 10 runs of 50 copies into a rooted directory printed `Device or resource busy` and exited 1 with the first revision of this PR, 0 of 10 with bun 1.4.0 and 0 of 10 now (drive-qualified and relative destinations: 0 of 10 throughout). Errors that name a source with a trailing separator no longer match it either, which only turns the pre-existing exit 0 into exit 1 for those.
- `cp_append_entry` replaces the three hand-rolled `dir + SEP + name` appends (async directory, async file, sync walk) and does not insert a separator after a path that already ends in one. Windows hands `\\?\` paths to the kernel without normalizing them, so without this `cp -R D:\ out` (a volume root) and rooted operands such as `cp -R src \tmp\out\`, which `os_path_kernel32` resolves to `\\?\C:\tmp\out\`, would have produced `\\?\C:\...\\name` and regressed; verified by building that variant, which fails the two rooted tests with `out\\sub`. The async file branch now builds the `CpSingleTask` buffer from the two appended paths instead of re-deriving the layout by hand.
- `cp_async_directory` no longer re-normalizes the destination per directory: the operands arrive normalized and entry names cannot contain separators or be `.`/`..`. That call was the only user of the Win32 output mode of `normalize_path_windows_opts`, so the option struct, the `_opts` function and its `\\?\GLOBALROOT` branch are folded back into `normalize_path_windows` (NT output unchanged) and the three unit tests of that mode (`win32_output_uses_globalroot`, `win32_globalroot_output_creates_directories`, `win32_globalroot_dotdot_composes`) are deleted with it.
- Nothing user-visible carries the prefix: error paths and `-v` output go through `from_w_path`/`without_nt_prefix`, which strip it (checked: `cp: Not a directory: C:\...` and `C:\...\f.txt -> C:\...\copied.txt` are unchanged). Two other single-file inputs change on Windows, both towards node, because `os_path_kernel32` normalizes the way node's `toNamespacedPath` does: `cpSync(file, "newdir/")` now creates the file `newdir` like node instead of throwing `ENOENT`, and an absolute destination ending in a dot is created verbatim like node (and like `copyFileSync` already did) instead of being silently stripped; matrix below. Rooted sources with a trailing separator, which used to fail with `Invalid argument` because the unresolved path went straight to the NT open, now work as a side effect of the resolution. POSIX is unchanged apart from a doubled separator no longer appearing in paths built from an operand given with a trailing slash.
- Conflicts with #37949 (empty operand on macOS): that PR fixes the same buffer gap by changing `os_path`, which this PR deletes; whichever lands second needs a small rebase, and its test holds with this PR's `cp_operand` as well.
- Not changed: UNC paths stay MAX_PATH-limited, as they are for `mkdir`/`copyFile` (no `\\?\UNC\` form anywhere yet). `copyFile` adds the same prefix through `to_kernel32_path` without normalizing, so it still differs from node (and now from `cp`) for a destination with a trailing separator; that is tracked separately. The shell printing an error but exiting 0 when the failure names the source (visible in the single-file fail-before output below) is a separate pre-existing bug in `cp.rs`'s EBUSY deferral and is not touched here.
- Tests, all of which fail on the unfixed build on Windows and pass with the fix (Windows box, debug build; the first two files also pass on Linux, where the new shell tests run the builtin in a child with `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`):
  - `test/js/bun/shell/commands/cp.test.ts`: `cp -R` of a tree with 330-character relative paths, `cp` of a single file that deep, and (Windows only) `cp -R` into a rooted destination with a trailing separator (passes before too, pins the separator rule), from a rooted source (fails before with `Invalid argument`), and 50 copies of one file into a rooted directory (passes before too; pins the operand form `cp.rs` stores, failing on about 9 runs in 10 without it).
  - `test/js/node/fs/cp.test.ts`: `cpSync` and `promises.cp` of a single file with 300+ character paths, into an existing and into a missing directory (the latter exercises the `PATH_NOT_FOUND` retry, which now receives a `\\?\` parent). Both threw `ENOENT` before.
  - Also run: the pre-existing in-process shell cp suite and `fs-path-length.test.ts` on Windows, `cp.test.ts`, `cp-symlink-target.test.ts`, `fs-path-length.test.ts` and the 77 ported `test-fs-cp-*` node tests on Linux; `cargo check` for the `x86_64-apple-darwin` and `x86_64-pc-windows-msvc` targets; `cargo clippy` on the touched crates (Linux) adds nothing; the `bun_sys` test module still compiles on Windows (`cargo test -p bun_sys` gets to the link step, which needs the C++ dependencies and is not runnable standalone).

### Background
- MAX_PATH: Win32 file APIs (`CreateDirectoryW`, `CopyFileW`, `GetFileAttributesW`, ...) limit a path given in the ordinary `C:\...` spelling to 260 UTF-16 units (248 for `CreateDirectoryW`) unless the process has opted into long paths. A path spelled `\\?\C:\...` bypasses the limit (up to ~32K units) but is passed to the kernel verbatim: no `.`/`..` resolution, no `/` conversion and no collapsing of repeated separators, so it has to be normalized by the caller. `os_path_kernel32` (`src/runtime/node/types.rs`) is bun's existing helper for exactly that: normalize, resolve rooted paths against the current drive, prefix drive-letter paths.
- NT object paths (`\??\C:\...`) are the third spelling, accepted only by the `Nt*` calls. The source side of the copy was already immune to MAX_PATH because it opens directories through `openat_windows`, which builds one of these via `normalize_path_windows`; `normalize_path_windows` strips an incoming `\\?\` before adding `\??\`, so the source buffer now carrying the prefix changes nothing there.
- The native copy is reached by `fs.cp`/`cpSync` for single files on every platform and for whole trees only on macOS (`tryNativeFastPath`), and by the shell `cp` builtin (the default `cp` on Windows) for both, which is why the tree case is only user-visible through the shell. The walk keeps the current source and destination in two fixed buffers, appends each entry name in place, recurses for directories and hands each file to a `CpSingleTask` holding its own `<src>\0<dest>\0` copy of the two paths.

<details>
<summary>Before/after on the Windows box</summary>

Stock bun 1.4.0 (handoff repro, destination lengths 175/296/456):

```
shell cp -R depth 60  exit 0 leaf copied: true
shell cp -R depth 120 exit 1 "cp: File name too long: C:\Users\...\out120\a\a\..." leaf copied: false
shell cp -R depth 200 exit 1 "cp: File name too long: ..."                          leaf copied: false
copyFileSync (364-char paths)  => ok
cpSync(file)                   => threw ENOENT
cpSync(file, missing parent)   => threw ENOENT
fsp.cp(file)                   => threw ENOENT
shell cp <364-char file> <dest> exit 0, stderr "cp: No such file or directory: ...", nothing copied
```

This branch (debug build): every line above succeeds; the leaf is copied at depth 200 and all four single-file variants copy.

`ref-fs-cp-long.mjs` (single-file cpSync/promises.cp matrix on 358-character paths) under `node v26.3.0` and under this branch print identical results: every copy succeeds, `errorOnExist` still throws `ERR_FS_CP_EEXIST`, `force: false` still keeps the old contents. Stock bun throws `ENOENT` on the five copying lines.

Edge matrix, identical before and after unless noted: `cp -R s/ out`, `cp -R s out/` (new and existing), `cp -R s /rooted/out/`, `cp -R Q:\ out` and `cp -R Q:/ out` on a `subst` drive, operands containing `..` and forward slashes, the `Not a directory` error text, `-v` output for a file. `cp -R /rooted/s/ out`: `Invalid argument` before, copies now.

Single-file destination forms, `node v26.3.0` / stock bun / this branch (same result in all three unless listed):

```
cpSync(src, "newdir/"), abs + "\newdir\", abs + "/newdir/"   node: file created | stock: ENOENT | branch: file created
cpSync(src, "")                                              ENOENT everywhere
cpSync(src, "b.")  (relative)                                node: "b." | stock: "b" | branch: "b"   (relative paths are not prefixed, as for mkdir/copyFile)
cpSync(src, abs + "\c.")                                     node: "c." | stock: "c" | branch: "c."  (copyFileSync already created "d.")
cpSync("./a.txt", "./sub/../e.txt"), cpSync(src, "C:f.txt")  file created everywhere
```

Fail-before of the new tests against stock bun (`USE_SYSTEM_BUN=1`):

```
cp -R tree out      -> "1\ncp: File name too long: C:\...\out\0123456789\...(17 levels)"
cp deep/a.txt deep/b.txt -> "0\ncp: No such file or directory: C:\...\a.txt"   (nothing copied)
cp -R \...\tree\ out -> "0\ncp: Invalid argument: \Users\...\tree\"
cp -R tree \...\out\ -> passes (regression guard)
fs.cpSync / fs.cp x 2 -> ENOENT: no such file or directory, copyfile '...'
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->