### PR TITLE
ci(verify-baseline): use the image's qemu-user instead of downloading one per job

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -579,25 +579,11 @@ function needsBaselineVerification(platform) {
   return false;
 }
 
-// Ubuntu 20.04's qemu 4.2 mis-emulates concurrent atomics in same-arch user mode; after #34009
-// (mimalloc per-thread heaps) the SIMD baseline test segfaults/deadlocks in `_mi_theap_init`
-// ~10-20% of x64 runs and ~5% of aarch64 runs. qemu 9.1 is 40/40 green. Static-pie binaries.
-const PINNED_QEMU = {
-  x64: {
-    url: "https://github.com/ziglang/qemu-static/releases/download/9.1.0/qemu-linux-x86_64-9.1.0.tar.xz",
-    sha256: "1ac92f632417d981810fda891e4a1b20f2d71f50f9ec705532afa8162b449c70",
-    binary: "qemu-linux-x86_64-9.1.0/bin/qemu-x86_64",
-  },
-  aarch64: {
-    url: "https://github.com/ziglang/qemu-static/releases/download/9.1.0/qemu-linux-aarch64-9.1.0.tar.xz",
-    sha256: "5a82a96ac74932a802fb5753673beff27359faea8736286477b0bf2c268fd06d",
-    binary: "qemu-linux-aarch64-9.1.0/bin/qemu-aarch64",
-  },
-};
-
 /**
- * Returns the emulator binary name for the given platform.
- * Linux uses QEMU user-mode; Windows uses Intel SDE.
+ * Returns the emulator for the given platform. Both emulators come baked into
+ * the image the step runs on (getVerifyBaselineHost); nothing is downloaded at
+ * job time, since a per-job download failed the step whenever its host was
+ * unreachable (the qemu tarball used to be fetched from github.com releases).
  * @param {Platform} platform
  * @returns {string}
  */
@@ -607,8 +593,13 @@ function getEmulatorBinary(platform) {
   // (Install-IntelSde): downloadmirror.intel.com sits behind a bot challenge
   // that blocks non-browser clients, so it cannot be downloaded at job time.
   if (os === "windows") return "C:\\intel-sde\\sde.exe";
-  // Fetched into the checkout root by the setup command below (see PINNED_QEMU).
-  return `./${PINNED_QEMU[arch].binary}`;
+  // The distro's qemu-user, installed by scripts/bootstrap.sh
+  // install_build_essentials() (apt `qemu-user`, apk `qemu-x86_64` /
+  // `qemu-aarch64`) and resolved on PATH by scripts/verify-baseline.ts. Debian 13
+  // and Alpine 3.23 ship qemu 10.x; a host image's qemu must stay well past 4.2,
+  // whose same-arch user mode mis-emulated concurrent atomics and made the SIMD
+  // baseline test crash or hang on 10-20% of x64 runs (#34164).
+  return arch === "aarch64" ? "qemu-aarch64" : "qemu-x86_64";
 }
 
 /**
@@ -628,8 +619,10 @@ function hasWebKitChanges(options) {
 
 /**
  * Host platform the verify-baseline step runs on — per-TARGET-arch, not the
- * shared arm64 build host. Reuses test-fleet images (debian-13 / win-2019) so
- * no extra bake is needed; getPipeline() keys its build-image depends_on on this.
+ * shared arm64 build host. Reuses test-fleet images (debian-13 / alpine-3.23 /
+ * win-2019) so no extra bake is needed; getPipeline() keys its build-image
+ * depends_on on this. The image also supplies the emulator (getEmulatorBinary),
+ * so a different host here must have it installed too.
  * @param {Platform} platform
  * @returns {Platform}
  */
@@ -677,20 +670,12 @@ function getVerifyBaselineStep(platform, options) {
           `buildkite-agent artifact download '${profileDir}.zip' . --step ${targetKey}-build-bun`,
           `unzip -o '${profileDir}.zip'`,
           `chmod +x ${profileDir}/${profileExe}`,
-          // Linux lanes pin a known-good qemu (see PINNED_QEMU). sha256 check makes a
-          // truncated/hijacked download a hard failure before anything runs under it.
-          ...(abi === "android"
-            ? [] // --skip-emulation: no emulator needed
-            : [
-                `curl -fsSL --retry 5 --connect-timeout 15 --max-time 120 -o ./qemu.tar.xz '${PINNED_QEMU[platform.arch].url}'`,
-                `echo '${PINNED_QEMU[platform.arch].sha256}  ./qemu.tar.xz' | sha256sum -c -`,
-                `tar -xJf ./qemu.tar.xz '${PINNED_QEMU[platform.arch].binary}'`,
-              ]),
         ];
 
-  // verify-baseline is not a build lane: it stays on a host whose arch matches
-  // the TARGET so PINNED_QEMU's host-arch-specific static binaries keep working
-  // (the link agent is now always arm64 and can't run the x86_64-host qemu).
+  // verify-baseline is not a build lane: it stays on a host whose arch and libc
+  // match the TARGET, because qemu-user loads the emulated bun-profile against
+  // the host's own dynamic loader and libc (the shared arm64 build host has
+  // neither for an x64 or musl binary).
   const host = getVerifyBaselineHost(platform);
   const agents =
     os === "windows"

--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -581,9 +581,9 @@ function needsBaselineVerification(platform) {
 
 /**
  * Returns the emulator for the given platform. Both emulators come baked into
- * the image the step runs on (getVerifyBaselineHost); nothing is downloaded at
- * job time, since a per-job download failed the step whenever its host was
- * unreachable (the qemu tarball used to be fetched from github.com releases).
+ * the image the step runs on (getVerifyBaselineHost); neither is downloaded at
+ * job time. The qemu tarball used to be fetched from github.com releases per
+ * job, which failed the step whenever github.com was unreachable.
  * @param {Platform} platform
  * @returns {string}
  */
@@ -672,10 +672,10 @@ function getVerifyBaselineStep(platform, options) {
           `chmod +x ${profileDir}/${profileExe}`,
         ];
 
-  // verify-baseline is not a build lane: it stays on a host whose arch and libc
-  // match the TARGET, because qemu-user loads the emulated bun-profile against
-  // the host's own dynamic loader and libc (the shared arm64 build host has
-  // neither for an x64 or musl binary).
+  // verify-baseline is not a build lane: it runs on a host whose arch and libc
+  // match the TARGET, because verify-baseline.ts runs qemu-user without -L, so
+  // the emulated bun-profile resolves its dynamic loader and libc from the
+  // host's own / rather than from a sysroot.
   const host = getVerifyBaselineHost(platform);
   const agents =
     os === "windows"


### PR DESCRIPTION
### Problem
- Every Linux `<target> - verify-baseline` step starts with `curl ... 'https://github.com/ziglang/qemu-static/releases/download/9.1.0/qemu-linux-<arch>-9.1.0.tar.xz'` (`.buildkite/ci.mjs` `getVerifyBaselineStep`, setup commands), so the step fails whenever github.com is unreachable from the agent, even though the `build-bun` lane it verifies passed. During the 2026-08-12 github.com outage: build 93603 `:linux: aarch64-musl - verify-baseline` and build 93539 `:linux: aarch64 - verify-baseline`, both ending in `curl: (56) Connection died, tried 5 times before giving up` / `Error: The command exited with status 56`.
- The tarball is a fixed, sha-pinned release, so nothing about it varies per job; it only needs to exist on the host.
- The hosts already have a qemu-user. `getVerifyBaselineHost()` puts these steps on the debian-13 and alpine-3.23 test images, and `scripts/bootstrap.sh` `install_build_essentials()` installs `qemu-user` (apt) and `qemu-x86_64` / `qemu-aarch64` (apk) into them; the live `v41` images were baked from the bootstrap revision that added the apt line (#34782). The download was only kept because #34164 added it while the step still ran on the Ubuntu 20.04 link image, whose qemu 4.2 was the problem; #34782 then moved the step to these images without revisiting it.

### Fix
- `getEmulatorBinary()` returns the image's `qemu-x86_64` / `qemu-aarch64`; `scripts/verify-baseline.ts` `resolveEmulator()` already looks a bare name up on PATH. The `PINNED_QEMU` table and the curl / sha256sum / tar setup lines are removed. Windows keeps using the SDE baked into its image by `bootstrap.ps1`, which is the same arrangement.
- Correct because the pin's only requirement was a qemu without the 4.2 atomics bug (#34164 measured 9.1.0 as the fix); Debian 13 ships qemu-user 10.0.x and Alpine 3.23 ships 10.x, both newer than the pin. The distro release in `getVerifyBaselineHost()` now also pins the emulator version, and a future host change there gets exercised by the verify lanes of the PR that makes it. The version floor is recorded in the `getEmulatorBinary()` comment so it is not lost.
- No image rebuild or `# Version:` bump: the packages are already in the images, and `bootstrap.sh` is untouched.
- Verified by generating the pipeline with and without the change (`node .buildkite/ci.mjs`): the only differences are the four emulated Linux lanes losing the three download lines and all five Linux lanes passing `--emulator qemu-<arch>` (the android lane never used the emulator; it runs `--skip-emulation`). The Windows step is unchanged; the generated YAML contains no `github.com` reference afterwards. Diff below.
- Verified on a Debian 13 x64 machine with the distro `qemu-user` 10.0.11 (the x64 lanes' configuration): `bun scripts/verify-baseline.ts --binary <release bun> --arch x64 --emulator qemu-x86_64` resolves to `/usr/bin/qemu-x86_64 -cpu Nehalem` and passes the 28 SIMD baseline tests; the same command against a small binary that executes `vzeroupper` reports `Instruction failures: 1` and exits 1. `qemu-aarch64 -cpu help` from the same package version lists `cortex-a53`, and `dpkg -L qemu-user` contains both `/usr/bin/qemu-x86_64` and `/usr/bin/qemu-aarch64`. Output below.
- Verified end to end by this PR's own build (93705): all four emulated Linux verify-baseline lanes passed on the unmodified `v41` images, with the step log reporting `Emulator: /usr/bin/qemu-aarch64 -cpu cortex-a53` on alpine aarch64 and `Emulator: /usr/bin/qemu-x86_64 -cpu Nehalem` on alpine x64 (`Passed: 2`, static scan plus SIMD test, on each); the android and Windows lanes passed unchanged. This is a pipeline-definition change with no runtime code, so those lanes are the test; there is no `bun test` proof.
- Scope: this removes the one github.com fetch that only these steps had, which is what failed in the builds above while the jobs' checkouts succeeded. The step's remaining network use is unchanged: the checkout, like every job, and the `cargo build` of the static checker, which rustup-installs the pinned nightly (about 35 s in build 93705's x64 lane) and pulls crates from crates.io on every run. That is a separate exposure in a different step line and is being tracked on its own.
- #35005 (content-addressed images) carries the same download over into `.buildkite/ci.ts` and keeps these distro packages in its image spec, so if it lands first this is the same two-line change there.

### Background
- verify-baseline: after `build-bun`, a step downloads the unstripped `bun-profile`, runs a static instruction scan, and runs the SIMD baseline test under an emulator configured as the oldest supported CPU (`qemu-x86_64 -cpu Nehalem`, `qemu-aarch64 -cpu cortex-a53`, Intel SDE `-nhm` on Windows). Any instruction above the baseline kills the process with SIGILL and fails the step.
- qemu-user: QEMU's process-level mode. It runs one ELF binary for a given target architecture and can hide CPU features via `-cpu`. Unless given `-L <sysroot>`, it resolves the guest's dynamic loader and libc from the host's own `/`; `verify-baseline.ts` passes no `-L`, which is why each lane runs on a host matching the target's arch and libc (debian for glibc targets, alpine for musl).
- CI images: Linux agents boot from AMIs baked by running `scripts/bootstrap.sh`; the image tag is `<key>-v<N>` where `N` is the script's `# Version:` line, so a change to what is installed needs a bump plus a bake. This PR relies only on packages the current `v41` images already contain.

<details>
<summary>Generated pipeline diff (<code>node .buildkite/ci.mjs</code> before vs after, one of the four identical lanes shown)</summary>

```diff
            - buildkite-agent artifact download 'bun-linux-aarch64-musl-profile.zip' . --step linux-aarch64-musl-build-bun
            - unzip -o 'bun-linux-aarch64-musl-profile.zip'
            - chmod +x bun-linux-aarch64-musl-profile/bun-profile
-           - curl -fsSL --retry 5 --connect-timeout 15 --max-time 120 -o ./qemu.tar.xz 'https://github.com/ziglang/qemu-static/releases/download/9.1.0/qemu-linux-aarch64-9.1.0.tar.xz'
-           - echo '5a82a96ac74932a802fb5753673beff27359faea8736286477b0bf2c268fd06d  ./qemu.tar.xz' | sha256sum -c -
-           - tar -xJf ./qemu.tar.xz 'qemu-linux-aarch64-9.1.0/bin/qemu-aarch64'
            - cargo build --release --manifest-path scripts/verify-baseline-static/Cargo.toml
-           - bun scripts/verify-baseline.ts --binary bun-linux-aarch64-musl-profile/bun-profile --arch aarch64 --emulator ./qemu-linux-aarch64-9.1.0/bin/qemu-aarch64
+           - bun scripts/verify-baseline.ts --binary bun-linux-aarch64-musl-profile/bun-profile --arch aarch64 --emulator qemu-aarch64
```

The linux-x64, linux-x64-musl and linux-aarch64 lanes differ in the same way; linux-aarch64-android only changes its (unused) `--emulator` argument; the `:windows: x64 - verify-baseline` step is byte-identical. `grep -c github.com` on the generated YAML: 4 before, 0 after.
</details>

<details>
<summary>Local runs with Debian 13's qemu-user 10.0.11</summary>

```
$ qemu-x86_64 --version | head -1
qemu-x86_64 version 10.0.11 (Debian 1:10.0.11+ds-0+deb13u1)
$ dpkg -L qemu-user | grep -E 'bin/qemu-(x86_64|aarch64)$'
/usr/bin/qemu-aarch64
/usr/bin/qemu-x86_64
$ qemu-aarch64 -cpu help | grep -w cortex-a53
  cortex-a53

$ bun scripts/verify-baseline.ts --binary build/release/bun --arch x64 --emulator qemu-x86_64
--- Verifying bun on Nehalem (SSE4.2, no AVX/AVX2/AVX512)
    Emulator: /usr/bin/qemu-x86_64 -cpu Nehalem
...
 28 pass
 0 fail
    PASS (3.6s)
--- Summary
    Passed: 1
    Instruction failures: 0
    Other failures: 0 (not CPU instruction issues)
    All baseline verification passed on Nehalem (SSE4.2, no AVX/AVX2/AVX512).

$ cat avx.c
#include <stdio.h>
int main(void){ __asm__ volatile("vzeroupper"); puts("vzeroupper executed (AVX available)"); return 0; }
$ ./avx                                # native host has AVX
vzeroupper executed (AVX available)
$ qemu-x86_64 -cpu Nehalem ./avx; echo $?
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
132
$ bun scripts/verify-baseline.ts --binary ./avx --arch x64 --emulator qemu-x86_64; echo $?
+++ SIMD baseline tests
qemu: uncaught target signal 4 (Illegal instruction) - core dumped
    FAIL: CPU instruction violation detected (0.2s)
--- Summary
    Instruction failures: 1
1
```
</details>

<details>
<summary>Failing job log tail (build 93603, <code>:linux: aarch64-musl - verify-baseline</code>)</summary>

```
$ curl -fsSL --retry 5 --connect-timeout 15 --max-time 120 -o ./qemu.tar.xz 'https://github.com/ziglang/qemu-static/releases/download/9.1.0/qemu-linux-aarch64-9.1.0.tar.xz'
curl: (56) Connection died, tried 5 times before giving up
Error: The command exited with status 56
```
The `linux-aarch64-musl-build-bun` step it depends on had passed; the other three Linux verify lanes in the same build happened to get through to github.com. In build 93539 it was `:linux: aarch64 - verify-baseline` that exited 56, while the android lane, the one Linux lane that downloads nothing, passed.
</details>
