### PR TITLE
shell(cp): classify the target operand through symlinks

### DIFF
--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -563,8 +563,6 @@ impl ShellCpTask {
             .is_some_and(|&c| resolve_path::Platform::AUTO.is_separator(c))
     }
 
-    /// Classifies a source operand without following symlinks; the copy
-    /// recreates links rather than following them.
     fn is_dir(path: &bun_core::ZStr) -> bun_sys::Maybe<bool> {
         #[cfg(windows)]
         {
@@ -583,9 +581,7 @@ impl ShellCpTask {
         }
     }
 
-    /// Classifies the target operand through symlinks, as cp(1) does:
-    /// `cp file linkdir` copies into the directory `linkdir` points at, and a
-    /// dangling link counts as not existing (ENOENT).
+    /// Follows symlinks, as cp(1) does for its target: `cp file linkdir` copies into the directory.
     fn target_is_dir(path: &bun_core::ZStr) -> bun_sys::Maybe<bool> {
         let st = bun_sys::stat(path)?;
         Ok(bun_sys::S::ISDIR(st.st_mode as _))

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -563,6 +563,8 @@ impl ShellCpTask {
             .is_some_and(|&c| resolve_path::Platform::AUTO.is_separator(c))
     }
 
+    /// Classifies a source operand without following symlinks; the copy
+    /// recreates links rather than following them.
     fn is_dir(path: &bun_core::ZStr) -> bun_sys::Maybe<bool> {
         #[cfg(windows)]
         {
@@ -579,6 +581,14 @@ impl ShellCpTask {
             let st = bun_sys::lstat(path)?;
             Ok(bun_sys::S::ISDIR(st.st_mode as _))
         }
+    }
+
+    /// Classifies the target operand through symlinks, as cp(1) does:
+    /// `cp file linkdir` copies into the directory `linkdir` points at, and a
+    /// dangling link counts as not existing (ENOENT).
+    fn target_is_dir(path: &bun_core::ZStr) -> bun_sys::Maybe<bool> {
+        let st = bun_sys::stat(path)?;
+        Ok(bun_sys::S::ISDIR(st.st_mode as _))
     }
 
     /// Resolves src/tgt to absolute paths, classifies them per the three
@@ -641,7 +651,7 @@ impl ShellCpTask {
             ));
         }
 
-        let (tgt_is_dir, tgt_exists) = match Self::is_dir(tgt) {
+        let (tgt_is_dir, tgt_exists) = match Self::target_is_dir(tgt) {
             Ok(is_dir) => (is_dir, true),
             Err(e) if e.get_errno() == bun_sys::E::ENOENT => {
                 // If it has a trailing directory separator, it's a directory.

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, DirectoryTree, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { existsSync, lstatSync, readdirSync, readFileSync, readlinkSync, symlinkSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,122 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// cp classifies the target operand with stat(), so a symlink to a directory is
+// a directory target: `cp file linkdir` lands in the directory the link points
+// at. The builtin used to lstat() it and copy onto the link itself (EISDIR).
+// The builtin is only the default on Windows; on POSIX it is switched on by an
+// env var that is read once per process, so each cp runs in a child bun.
+describe.concurrent("bunshell cp into a directory reached through a symlink", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  /** A working directory holding `realdir/`, `linkdir -> realdir` and `files`. */
+  function setup(name: string, files: DirectoryTree) {
+    const dir = tempDir(`shell-cp-linkdir-${name}`, { realdir: {}, ...files });
+    symlinkSync("realdir", join(String(dir), "linkdir"), "dir");
+    return dir;
+  }
+
+  /** Runs `command` through the shell builtin inside `cwd`; returns cp's exit code and output. */
+  async function cp(cwd: string, command: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "const r = await Bun.$`${{ raw: process.argv[1] }}`.nothrow().quiet();" +
+          "console.log(JSON.stringify({ exitCode: r.exitCode, stdout: r.stdout.toString(), stderr: r.stderr.toString() }));",
+        command,
+      ],
+      cwd,
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  const copied = { exitCode: 0, stdout: "", stderr: "" };
+
+  test("file -> linkdir", async () => {
+    using dir = setup("file", { "file.txt": "data\n" });
+    const cwd = String(dir);
+
+    expect(await cp(cwd, "cp -v file.txt linkdir")).toEqual({
+      ...copied,
+      stdout: `${join(cwd, "file.txt")} -> ${join(cwd, "linkdir", "file.txt")}\n`,
+    });
+    expect(readFileSync(join(cwd, "realdir", "file.txt"), "utf8")).toBe("data\n");
+    // The link itself is left alone.
+    expect(lstatSync(join(cwd, "linkdir")).isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(cwd, "linkdir"))).toBe("realdir");
+  });
+
+  test("file+ -> linkdir", async () => {
+    using dir = setup("files", { "a.txt": "A\n", "b.txt": "B\n" });
+    const cwd = String(dir);
+
+    expect(await cp(cwd, "cp a.txt b.txt linkdir")).toEqual(copied);
+    expect(readdirSync(join(cwd, "realdir")).sort()).toEqual(["a.txt", "b.txt"]);
+    expect(readFileSync(join(cwd, "realdir", "a.txt"), "utf8")).toBe("A\n");
+    expect(readFileSync(join(cwd, "realdir", "b.txt"), "utf8")).toBe("B\n");
+  });
+
+  test("-R file -> linkdir", async () => {
+    using dir = setup("recursive-file", { "file.txt": "data\n" });
+    const cwd = String(dir);
+
+    expect(await cp(cwd, "cp -R file.txt linkdir")).toEqual(copied);
+    expect(readFileSync(join(cwd, "realdir", "file.txt"), "utf8")).toBe("data\n");
+    expect(lstatSync(join(cwd, "linkdir")).isSymbolicLink()).toBe(true);
+  });
+
+  test("-R dir -> linkdir", async () => {
+    using dir = setup("recursive-dir", { srcdir: { "inner.txt": "inner\n" } });
+    const cwd = String(dir);
+
+    expect(await cp(cwd, "cp -R srcdir linkdir")).toEqual(copied);
+    expect(readFileSync(join(cwd, "realdir", "srcdir", "inner.txt"), "utf8")).toBe("inner\n");
+  });
+
+  test.skipIf(!isWindows)("file -> junction", async () => {
+    using dir = setup("junction", { "file.txt": "data\n" });
+    const cwd = String(dir);
+    symlinkSync(join(cwd, "realdir"), join(cwd, "junction"), "junction");
+
+    expect(await cp(cwd, "cp file.txt junction")).toEqual(copied);
+    expect(readFileSync(join(cwd, "realdir", "file.txt"), "utf8")).toBe("data\n");
+  });
+
+  // What the link points at decides; the link itself is never a directory.
+  test("file+ -> link to a file is rejected", async () => {
+    using dir = setup("link-to-file", { "a.txt": "A\n", "b.txt": "B\n", "target.txt": "untouched\n" });
+    const cwd = String(dir);
+    symlinkSync("target.txt", join(cwd, "linkfile"));
+
+    expect(await cp(cwd, "cp a.txt b.txt linkfile")).toEqual({
+      exitCode: 1,
+      stdout: "",
+      stderr: "cp: linkfile is not a directory\n".repeat(2),
+    });
+    expect(readFileSync(join(cwd, "target.txt"), "utf8")).toBe("untouched\n");
+  });
+
+  test("file+ -> dangling link is rejected", async () => {
+    using dir = setup("dangling", { "a.txt": "A\n", "b.txt": "B\n" });
+    const cwd = String(dir);
+    symlinkSync("missing", join(cwd, "dangling"));
+
+    expect(await cp(cwd, "cp a.txt b.txt dangling")).toEqual({
+      exitCode: 1,
+      stdout: "",
+      stderr: "cp: dangling is not a directory\n".repeat(2),
+    });
+    expect(existsSync(join(cwd, "missing"))).toBe(false);
+    expect(readlinkSync(join(cwd, "dangling"))).toBe("missing");
   });
 });
 

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -175,11 +175,12 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
   });
 });
 
-// cp classifies the target operand with stat(), so a symlink to a directory is
-// a directory target: `cp file linkdir` lands in the directory the link points
-// at. The builtin used to lstat() it and copy onto the link itself (EISDIR).
-// The builtin is only the default on Windows; on POSIX it is switched on by an
-// env var that is read once per process, so each cp runs in a child bun.
+// The target operand is classified with stat(), as cp(1) does, so a symlink to
+// a directory is a directory target and `cp file linkdir` lands in the directory
+// the link points at. The builtin used to lstat() it on POSIX and copy onto the
+// link itself. The builtin is only the default on Windows; on POSIX it is
+// switched on by an env var that is read once per process, so each cp runs in a
+// child bun.
 describe.concurrent("bunshell cp into a directory reached through a symlink", () => {
   const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
 
@@ -276,10 +277,12 @@ describe.concurrent("bunshell cp into a directory reached through a symlink", ()
     expect(readFileSync(join(cwd, "target.txt"), "utf8")).toBe("untouched\n");
   });
 
+  // A dangling link is a target that does not exist, even on Windows, where a
+  // directory-type link carries the directory attribute itself.
   test("file+ -> dangling link is rejected", async () => {
     using dir = setup("dangling", { "a.txt": "A\n", "b.txt": "B\n" });
     const cwd = String(dir);
-    symlinkSync("missing", join(cwd, "dangling"));
+    symlinkSync("missing", join(cwd, "dangling"), "dir");
 
     expect(await cp(cwd, "cp a.txt b.txt dangling")).toEqual({
       exitCode: 1,

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -175,18 +175,18 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
   });
 });
 
-// The target operand is classified with stat(), as cp(1) does, so a symlink to
-// a directory is a directory target and `cp file linkdir` lands in the directory
-// the link points at. The builtin used to lstat() it on POSIX and copy onto the
-// link itself. The builtin is only the default on Windows; on POSIX it is
-// switched on by an env var that is read once per process, so each cp runs in a
-// child bun.
-describe.concurrent("bunshell cp into a directory reached through a symlink", () => {
+// The target operand is classified with stat(), as cp(1) does: a symlink to a
+// directory is a directory target and `cp file linkdir` lands in the directory
+// the link points at, while a link that cannot be followed is a target that does
+// not exist (or a stat error). The builtin used to classify the link itself.
+// The builtin is only the default on Windows; on POSIX it is switched on by an
+// env var that is read once per process, so each cp runs in a child bun.
+describe.concurrent("bunshell cp with a symlink as the target", () => {
   const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
 
   /** A working directory holding `realdir/`, `linkdir -> realdir` and `files`. */
   function setup(name: string, files: DirectoryTree) {
-    const dir = tempDir(`shell-cp-linkdir-${name}`, { realdir: {}, ...files });
+    const dir = tempDir(`shell-cp-link-target-${name}`, { realdir: {}, ...files });
     symlinkSync("realdir", join(String(dir), "linkdir"), "dir");
     return dir;
   }
@@ -278,7 +278,9 @@ describe.concurrent("bunshell cp into a directory reached through a symlink", ()
   });
 
   // A dangling link is a target that does not exist, even on Windows, where a
-  // directory-type link carries the directory attribute itself.
+  // directory-type link carries the directory attribute itself. The three
+  // tests below each pin one synopsis; the Windows build used to take the link
+  // for a directory and create `missing` with the copies in it.
   test("file+ -> dangling link is rejected", async () => {
     using dir = setup("dangling", { "a.txt": "A\n", "b.txt": "B\n" });
     const cwd = String(dir);
@@ -291,6 +293,76 @@ describe.concurrent("bunshell cp into a directory reached through a symlink", ()
     });
     expect(existsSync(join(cwd, "missing"))).toBe(false);
     expect(readlinkSync(join(cwd, "dangling"))).toBe("missing");
+  });
+
+  // Used to exit 0 on every platform without copying anything: the link counted
+  // as an existing target, and the native copy swallowed the EEXIST it got
+  // creating `dangling/`.
+  test("-R file+ -> dangling link is rejected", async () => {
+    using dir = setup("dangling-recursive", { "a.txt": "A\n", "b.txt": "B\n" });
+    const cwd = String(dir);
+    symlinkSync("missing", join(cwd, "dangling"), "dir");
+
+    expect(await cp(cwd, "cp -R a.txt b.txt dangling")).toEqual({
+      exitCode: 1,
+      stdout: "",
+      stderr: "cp: directory dangling does not exist\n".repeat(2),
+    });
+    expect(existsSync(join(cwd, "missing"))).toBe(false);
+    expect(readlinkSync(join(cwd, "dangling"))).toBe("missing");
+  });
+
+  // With one source the target is the file to write, and the copy addresses the
+  // link itself: on POSIX the open() writes through it like BSD cp (unchanged by
+  // the classification), on Windows CopyFileW refuses a directory-type link.
+  test("file -> dangling link", async () => {
+    using dir = setup("dangling-file", { "a.txt": "A\n" });
+    const cwd = String(dir);
+    symlinkSync("missing", join(cwd, "dangling"), "dir");
+
+    if (isWindows) {
+      expect(await cp(cwd, "cp a.txt dangling")).toEqual({
+        exitCode: 1,
+        stdout: "",
+        stderr: `cp: Operation not permitted: ${join(cwd, "dangling")}\n`,
+      });
+      expect(existsSync(join(cwd, "missing"))).toBe(false);
+    } else {
+      expect(await cp(cwd, "cp a.txt dangling")).toEqual(copied);
+      expect(readFileSync(join(cwd, "missing"), "utf8")).toBe("A\n");
+    }
+    expect(readlinkSync(join(cwd, "dangling"))).toBe("missing");
+  });
+
+  // Following the target can fail with something other than ENOENT; that is
+  // reported as is (cp(1): "target 'loop': Too many levels of symbolic links").
+  test("file+ -> link to itself is rejected with the stat error", async () => {
+    using dir = setup("loop", { "a.txt": "A\n", "b.txt": "B\n" });
+    const cwd = String(dir);
+    symlinkSync("loop", join(cwd, "loop"));
+
+    expect(await cp(cwd, "cp a.txt b.txt loop")).toEqual({
+      exitCode: 1,
+      stdout: "",
+      stderr: `cp: Too many levels of symbolic links: ${join(cwd, "loop")}\n`.repeat(2),
+    });
+    expect(readdirSync(cwd).sort()).toEqual(["a.txt", "b.txt", "linkdir", "loop", "realdir"]);
+  });
+
+  // Windows distinguishes file and directory links; a file-type link to a
+  // directory cannot be followed (stat fails with EPERM), so it is neither a
+  // directory to copy into nor a file to copy onto.
+  test.skipIf(!isWindows)("file+ -> file-type link to a directory is rejected with the stat error", async () => {
+    using dir = setup("file-type-link", { "a.txt": "A\n", "b.txt": "B\n" });
+    const cwd = String(dir);
+    symlinkSync("realdir", join(cwd, "filelink"), "file");
+
+    expect(await cp(cwd, "cp a.txt b.txt filelink")).toEqual({
+      exitCode: 1,
+      stdout: "",
+      stderr: `cp: Operation not permitted: ${join(cwd, "filelink")}\n`.repeat(2),
+    });
+    expect(readdirSync(join(cwd, "realdir"))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
### Problem
- The shell `cp` builtin (the default `cp` on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX) cannot copy into a directory that is named through a symlink. With `linkdir -> realdir`, on Linux (bun 1.4.0 and main):
  ```
  cp file.txt linkdir         # cp: Is a directory: /.../linkdir        (cp(1): creates realdir/file.txt)
  cp -R file.txt linkdir      # same
  cp a.txt b.txt linkdir      # cp: linkdir is not a directory
  ```
  (`cp file.txt linkdir/` already worked: the trailing slash makes the kernel follow the link.)
- A link that points nowhere is mishandled the other way round, as an existing target: `cp -R a.txt b.txt dangling` exits 0 without copying anything on every platform (the native copy swallows the EEXIST it gets creating `dangling/`), and on Windows, where a directory-type link carries the directory attribute itself, `cp a.txt b.txt dangling` exits 0 and creates the missing directory with the copies in it. cp(1) fails both: the target is not a directory.
- Cause: `ShellCpTask::is_dir` (`src/runtime/shell/builtin/cp.rs`) classifies the target operand the same way as the source, with `lstat` (`GetFileAttributesW` on Windows), so it describes the link rather than what it points at. `run_from_thread_pool_impl` then picks the wrong synopsis: file -> file for a link to a directory (the native copy opens the directory for writing, EISDIR), and "existing target" for a dangling link. cp(1) classifies the target operand with `stat`.

### Fix
- `target_is_dir` classifies the target with `bun_sys::stat` (follows links) on every platform and replaces the `is_dir(tgt)` call. The source keeps `is_dir`: the builtin copies a link operand as a link, so it has to look at the link itself there (#37954 changes that separately for the non-`-R` case; the two compose, with a few-line conflict next to `is_dir`).
- Why this is right: POSIX picks the `cp` synopsis by whether the target names an existing directory, and coreutils and BSD `cp` both decide that with `stat()`, so a link to a directory is a directory target and a dangling link is a target that does not exist. The dangling case lands in the existing ENOENT arm (`tgt_exists = false`), which yields cp's answers: "is not a directory" for several sources, "directory X does not exist" for `-R` with several sources, and the file -> file synopsis for one source. The `mv` builtin already classifies its target by following links (`ShellMvCheckTargetTask`, `openat` with `O_DIRECTORY`), so `mv file linkdir` and `cp file linkdir` now agree.
- Every routing the swap changes, by platform:
  - link to a directory: copies into it (was EISDIR / "is not a directory" on POSIX; already worked on Windows).
  - `-R files... dangling`: exit 1 "directory dangling does not exist" everywhere (was exit 0 without copying; on Windows it created the directory).
  - `files... dangling`: unchanged on POSIX; on Windows exit 1 "is not a directory" instead of exit 0 plus creating the directory.
  - `file dangling`: the file -> file synopsis on both builds, so unchanged on POSIX, where the open() writes through the link as BSD cp does (coreutils refuses); on Windows `CopyFileW` now fails with "Operation not permitted" where the old classification created the directory.
  - a link `stat` cannot follow (a loop; on Windows also a file-type link that points at a directory) now fails with the stat error for every form, as coreutils does ("target 'loop': Too many levels of symbolic links"); before, the several-sources form said "is not a directory" and the one-source form hit the same error later in the copy.
  - `-R dir dangling` (one directory source) is now the "create the target directory" synopsis, as in cp. On POSIX it still exits 1 (mkdir fails with "File exists" on the link; before, ENOENT under it). On Windows the native directory copy accepts the existing link as the new directory and creates the link's target when it writes the entries, so this one input now exits 0 with the tree at the link's target where it used to fail with ENOENT; coreutils refuses it. That is the native copy's handling of a dangling link as a destination (the single-file form of which also produced the old exit 0 above), reported separately rather than special-cased in the shell, and it is not pinned by a test here.
- `bun_sys::stat` on Windows is libuv's `uv_fs_stat`, the same call `fs.statSync` and the shell's `[[ -d ]]` use; directory symlinks and junctions still classify as directories, and an exclusively locked target file still classifies (attribute-only open), so #37943's EBUSY handling is unaffected.
- Verified with `test/js/bun/shell/commands/cp.test.ts`, new block "bunshell cp with a symlink as the target" (each cp runs in a child bun with the builtin enabled): one file, several files and `-R file` into a link to a directory; `-R dir` into one; a junction (Windows); and, as targets that are not directories, a link to a file, a dangling link in all three forms, a link to itself, and a file-type link to a directory (Windows). Linux: 5 of the 9 fail on bun 1.4.0 (the three linkdir copies, `-R` into the dangling link, the loop) and all pass with `bun bd test`. Windows x64, debug build of this branch: all 41 tests in the file pass, including the TestBuilder block that is the builtin's default-platform coverage; against the current canary the three dangling-link tests, the loop and the file-type link fail with the old outputs listed above.
- Other runs: the file's TestBuilder block forced on under Linux gives the same results on main and on this branch apart from the fixed tests (the remaining differences from a Windows run are the `cat` builtin, #35337); `cargo fmt` and clippy are clean.

### Background
- Shell `cp` builtin: `Cp::next` schedules one `ShellCpTask` per source operand. Each task resolves its source and the shared target to absolute paths, picks one of the three POSIX `cp` synopses (file -> file; `-R` sources -> target; files -> existing directory) and hands the final pair to the node:fs async copy (`ShellAsyncCpTask`). Whether the target "is a directory" and whether it "exists" are the two answers that pick the synopsis, so they decide between copying onto the target path, copying to `target/<basename>` inside it, and refusing.
- `stat` vs `lstat`: `stat` follows a symlink and describes the file it points at, failing with ENOENT when it points nowhere (or ELOOP for a loop); `lstat` describes the link itself, so it succeeds for any link. `GetFileAttributesW` behaves like `lstat`, and a Windows directory-type link carries `FILE_ATTRIBUTE_DIRECTORY` whether or not its target exists, which is where the Windows "dangling link is a directory" behaviour came from. Windows links have a type: a file-type link whose target is a directory cannot be followed at all.
- Enabling the builtin: `cp` is on the shell's POSIX-disabled list, so on Linux and macOS it only runs as a builtin when `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` is set; the flag is read once per process, which is why the tests spawn a child bun per case and why the file's TestBuilder block is skipped on POSIX.

<details>
<summary>Repro on Linux (bun 1.4.0) and Windows canary output</summary>

```
mkdir -p t/realdir && cd t && echo data > file.txt && echo b > b.txt && ln -s realdir linkdir && ln -s missing dangling
BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e '
for (const c of ["cp file.txt linkdir", "cp file.txt b.txt linkdir", "cp -R file.txt b.txt dangling"]) {
  const r = await Bun.$`${{ raw: c }}`.nothrow().quiet();
  console.log(c, "->", r.exitCode, JSON.stringify(r.stderr.toString()));
}
console.log(require("fs").readdirSync("realdir"), require("fs").existsSync("missing"));'
# cp file.txt linkdir -> 1 "cp: Is a directory: /tmp/t/linkdir\n"
# cp file.txt b.txt linkdir -> 1 "cp: linkdir is not a directory\ncp: linkdir is not a directory\n"
# cp -R file.txt b.txt dangling -> 0 ""
# [] false
# /bin/cp: the first two create realdir/file.txt (and b.txt); the third fails with "target 'dangling': No such file or directory"
```

Windows canary (1.4.0-canary), `dangling` created with `fs.symlinkSync("missing", "dangling", "dir")`, each in a fresh directory:

```
cp a.txt b.txt dangling      exit 0, missing\ created containing a.txt and b.txt     (this branch: exit 1, "cp: dangling is not a directory" x2, nothing created)
cp -R a.txt b.txt dangling   exit 0, missing\ created                                (this branch: exit 1, "cp: directory dangling does not exist" x2, nothing created)
cp a.txt dangling            exit 0, missing\a.txt created                           (this branch: exit 1, "cp: Operation not permitted: ...\dangling", nothing created)
cp a.txt b.txt loop          "cp: loop is not a directory" x2                        (this branch: "cp: Too many levels of symbolic links: ...\loop" x2)
cp a.txt b.txt filelink      "cp: filelink is not a directory" x2                    (this branch: "cp: Operation not permitted: ...\filelink" x2)
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->