### PR TITLE
test: pin the JSON.stringify toJSON fast-path fixes from the 3722912ff800 WebKit sync

### DIFF
--- a/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
+++ b/test/js/bun/jsc/webkit-upgrade-3722912f.test.ts
@@ -26,6 +26,109 @@ describe.concurrent("WebKit 3722912ff800 upgrade", () => {
     expect(() => a.join()).toThrow(RangeError);
   });
 
+  test("JSON.stringify fast path honors a non-enumerable own toJSON (8b9071b24ead, 9f9370cc729f)", () => {
+    // SerializeJSONProperty looks toJSON up with GetV, so enumerability is
+    // irrelevant. FastStringifier used to skip DontEnum entries before looking
+    // for it and serialized the object's own properties instead.
+    function withToJSON<T extends object>(object: T, toJSON: unknown): T {
+      Object.defineProperty(object, "toJSON", {
+        value: toJSON,
+        enumerable: false,
+        writable: false,
+        configurable: false,
+      });
+      return object;
+    }
+    const frozen = Object.freeze(
+      withToJSON({ uri: "u", cid: "c", text: "t" }, function (this: { uri: string; cid: string }) {
+        return { uri: this.uri, cid: this.cid };
+      }),
+    );
+    const plain = withToJSON({ a: 1, b: 2 }, () => "via toJSON");
+
+    expect({
+      frozen: JSON.stringify(frozen),
+      frozenNested: JSON.stringify({ record: frozen }),
+      frozenInArray: JSON.stringify([frozen]),
+      frozenWithGap: JSON.stringify(frozen, null, 2),
+      plain: JSON.stringify(plain),
+      plainNested: JSON.stringify({ plain }),
+      plainWithGap: JSON.stringify({ plain }, null, 1),
+      receivesKey: JSON.stringify({ key: withToJSON({ a: 1 }, (key: string) => key) }),
+      returnsUndefined: JSON.stringify(withToJSON({ a: 1 }, () => undefined)),
+      notCallable: JSON.stringify(withToJSON({ a: 1 }, 42)),
+      enumerable: JSON.stringify({ a: 1, toJSON: () => "enumerable" }),
+      enumerableNotCallable: JSON.stringify({ a: 1, toJSON: 42 }),
+    }).toEqual({
+      frozen: '{"uri":"u","cid":"c"}',
+      frozenNested: '{"record":{"uri":"u","cid":"c"}}',
+      frozenInArray: '[{"uri":"u","cid":"c"}]',
+      frozenWithGap: '{\n  "uri": "u",\n  "cid": "c"\n}',
+      plain: '"via toJSON"',
+      plainNested: '{"plain":"via toJSON"}',
+      plainWithGap: '{\n "plain": "via toJSON"\n}',
+      receivesKey: '{"key":"key"}',
+      returnsUndefined: undefined,
+      notCallable: '{"a":1}',
+      enumerable: '"enumerable"',
+      enumerableNotCallable: '{"a":1,"toJSON":42}',
+    });
+
+    // Big enough to leave FastStringifier's static buffer for the dynamic one.
+    const many = Array.from({ length: 2000 }, (_, i) => withToJSON({ index: i, name: "name" + i }, () => i));
+    expect(JSON.stringify(many)).toBe("[" + many.map((_, i) => i).join(",") + "]");
+  });
+
+  test("JSON.stringify fast path honors toJSON on a replaced array prototype (8b9071b24ead)", () => {
+    // FastStringifier only checked the global Array.prototype for toJSON.
+    // Object.setPrototypeOf keeps the array on the fast path, so a toJSON on
+    // the replaced prototype was ignored.
+    const proto = { __proto__: Array.prototype, toJSON: () => "via prototype" };
+    const array = Object.setPrototypeOf([1, 2, 3], proto);
+    const nonEnumerableProto = Object.create(Array.prototype);
+    Object.defineProperty(nonEnumerableProto, "toJSON", {
+      value(this: unknown[]) {
+        return this.length;
+      },
+      enumerable: false,
+    });
+    const ownWins = Object.setPrototypeOf([1], proto);
+    Object.defineProperty(ownWins, "toJSON", { value: () => "own", enumerable: false });
+    const extra: number[] & { extra?: number } = [1];
+    extra.extra = 2;
+
+    expect({
+      replaced: JSON.stringify(array),
+      replacedNested: JSON.stringify({ array }),
+      replacedInArray: JSON.stringify([array]),
+      replacedWithGap: JSON.stringify(array, null, 2),
+      nonEnumerableOnProto: JSON.stringify(Object.setPrototypeOf([1, 2], nonEnumerableProto)),
+      ownWins: JSON.stringify(ownWins),
+      untouched: JSON.stringify([1, 2, 3]),
+      resetToOriginal: JSON.stringify(Object.setPrototypeOf([1, 2, 3], Array.prototype)),
+      nullPrototype: JSON.stringify(Object.setPrototypeOf([1, 2], null)),
+      namedProperty: JSON.stringify(extra),
+    }).toEqual({
+      replaced: '"via prototype"',
+      replacedNested: '{"array":"via prototype"}',
+      replacedInArray: '["via prototype"]',
+      replacedWithGap: '"via prototype"',
+      nonEnumerableOnProto: "2",
+      ownWins: '"own"',
+      untouched: "[1,2,3]",
+      resetToOriginal: "[1,2,3]",
+      nullPrototype: "[1,2]",
+      namedProperty: "[1]",
+    });
+  });
+
+  test("JSON.stringify reaches toJSON held in a non-reified static table (8b9071b24ead)", () => {
+    // Date.prototype.toJSON sits in a static hash table until first touched, and
+    // is non-enumerable once reified. Either way the fast path used to return
+    // "{}" for it instead of calling it (which throws, since it is not a Date).
+    expect(() => JSON.stringify(Date.prototype)).toThrow(TypeError);
+  });
+
   test("WebAssembly.Exception gains options.traceStack and stack getter (bf6512f84f7d)", () => {
     expect(WebAssembly.Exception.length).toBe(2);
     const desc = Object.getOwnPropertyDescriptor(WebAssembly.Exception.prototype, "stack");


### PR DESCRIPTION
### Problem
- `JSON.stringify` returned wrong JSON (no error, no crash) for three shapes, all in JavaScriptCore's `FastStringifier` (`Source/JavaScriptCore/runtime/JSONObject.cpp`, `FastStringifier::append`):
  - an object with an own non-enumerable `toJSON`: the fast path skipped `DontEnum` entries before looking for `toJSON`, so `{"uri":"u","cid":"c","text":"t"}` came out where the `toJSON` result `{"uri":"u","cid":"c"}` was expected
  - an array whose prototype was replaced with one carrying `toJSON`: the fast path only checked the global `Array.prototype`, so `[1,2,3]` came out instead of the `toJSON` result
  - `JSON.stringify(Date.prototype)`: `toJSON` was still in a non-reified static table, so `{}` came out instead of the `TypeError` the call produces
- The frozen-object variant is what was reported: on 1.3.14, `Object.freeze` happened to move the object off the fast path, so a frozen record with a non-enumerable `toJSON` serialized correctly there and stopped doing so on the canaries after the WebKit upgrade.
- The engine fixes already landed upstream (316941@main, then 318072@main, which moves the check off the enumerable-property path after it showed up in upstream's JSON benchmarks) and reached Bun in #36794 (WebKit sync 3722912ff800). Bun has no test pinning any of the three shapes, so a later WebKit bump could bring them back without CI noticing.

### Fix
- Test only. Adds three cases to `test/js/bun/jsc/webkit-upgrade-3722912f.test.ts`, the file that pins the behaviors that sync introduced, named after the upstream commits like the existing cases.
- Each case compares a set of shapes in one `toEqual`: the reported frozen record (plain, nested, inside an array, with a gap), an unfrozen object, `toJSON` receiving its key, returning `undefined`, a non-callable `toJSON`, an enumerable one, an output large enough to leave the stringifier's static buffer, the replaced array prototype (plain, nested, with a gap, non-enumerable on the prototype, shadowed by an own `toJSON`), and the negative contract (a plain array, an array reset to `Array.prototype`, a null prototype, an array with an extra named property still serialize as arrays).
- Verified:
  - `bun bd test test/js/bun/jsc/webkit-upgrade-3722912f.test.ts`: 8 pass (5 existing + 3 new)
  - the same three tests run with the bun 1.3.14 release binary: 3 fail (unfrozen object, replaced prototype, `Date.prototype`; the frozen shapes pass there by accident, as described above)
  - the frozen shapes fail on the jsc build from the WebKit revision the canaries used before #36794 (c9ad5813fd), which is where they were originally reproduced

### Background
- `SerializeJSONProperty` (the spec routine behind `JSON.stringify`) starts by reading `toJSON` from the value with an ordinary `[[Get]]`, which finds own and inherited properties regardless of enumerability, and calls it if callable. Only after that does it serialize the object's own enumerable properties.
- `FastStringifier` is JavaScriptCore's fast path for `JSON.stringify` when there is no replacer. It walks the object's structure directly instead of doing property lookups, so it has to decide up front whether anything in the value could have a `toJSON`; when it cannot rule that out it bails and the general stringifier runs. These bugs were cases where it ruled it out wrongly.
- A non-reified static table is how JavaScriptCore stores built-in prototype methods (like `Date.prototype.toJSON`) until one is first accessed; until then they are not in the object's property table, so a structure walk does not see them.

<!-- robobun:evidence:begin -->

---

**[decide:webkit]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/bun/jsc/webkit-upgrade-3722912f.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "test/js/bun/jsc/webkit-upgrade-3722912f.test.ts"
bun test v1.4.0 (513dc9960)

test/js/bun/jsc/webkit-upgrade-3722912f.test.ts:
(pass) WebKit 3722912ff800 upgrade > Iterator.prototype.includes is enabled by default (319f94b3db4a) [14.75ms]
(pass) WebKit 3722912ff800 upgrade > cyclic Array.prototype.join throws RangeError (f2f2c2ddf637) [11.89ms]
(pass) WebKit 3722912ff800 upgrade > JSON.stringify fast path honors a non-enumerable own toJSON (8b9071b24ead, 9f9370cc729f) [175.70ms]
(pass) WebKit 3722912ff800 upgrade > JSON.stringify fast path honors toJSON on a replaced array prototype (8b9071b24ead) [13.48ms]
(pass) WebKit 3722912ff800 upgrade > JSON.stringify reaches toJSON held in a non-reified static table (8b9071b24ead) [3.35ms]
(pass) WebKit 3722912ff800 upgrade > WebAssembly.Exception gains options.traceStack and stack getter (bf6512f84f7d) [3.51ms]
(pass) WebKit 3722912ff800 upgrade > typed import attributes resolve through BunTranspiledModule (--isolate) (90b2ecf79ae3) [361.44ms]
(pass) WebKit 3722912ff800 upgrade > indirect, namespace and star re-exports link on the JSC ModuleAnalyzer path (90b2ecf79ae3) [1621.26ms]

 8 pass
 0 fail
 16 expect() calls
Ran 8 tests across 1 file. [5.99s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/bun/jsc/webkit-upgrade-3722912f.test.ts | 103 ++++++++++++++++++++++++
 1 file changed, 103 insertions(+)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                             reads  edits  tests
test/js/bun/jsc/webkit-upgrade-3722912f.test.ts      3      2      0
```

</details>

<!-- robobun:evidence:end -->