### PR TITLE
node:net, node:http: emit listen() results on nextTick so fake timers do not freeze listen()

### DIFF
--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -280,12 +280,19 @@ function emitRequestCloseNT(self) {
   self.emit("close");
 }
 
+// Both listen() outcomes are deferred with process.nextTick like Node's
+// net.Server. A setTimeout here lands in the bun:test fake timer heap while
+// jest.useFakeTimers() is active and never fires on its own.
 function emitListeningNextTick(self, hostname, port) {
   if ((self.listening = !!self[serverSymbol])) {
     // TODO: remove the arguments
     // Note does not pass any arguments.
     self.emit("listening", null, hostname, port);
   }
+}
+
+function emitListenErrorNextTick(self, err) {
+  self.emit("error", err);
 }
 
 // Node.js only requests a client certificate when `requestCert: true`.
@@ -684,7 +691,7 @@ Server.prototype.listen = function () {
 
     server[kRealListen](tls, port, host, socketPath, true, onListen);
   } catch (err) {
-    setTimeout(() => server.emit("error", err), 1);
+    process.nextTick(emitListenErrorNextTick, server, err);
   }
 
   return this;
@@ -1144,7 +1151,7 @@ Server.prototype[kRealListen] = function (tls, port, host, socketPath, reusePort
       this.once("listening", onListen);
     }
 
-    setTimeout(emitListeningNextTick, 1, this, this[serverSymbol]?.hostname, this[serverSymbol]?.port);
+    process.nextTick(emitListeningNextTick, this, this[serverSymbol]?.hostname, this[serverSymbol]?.port);
   }
 };
 

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3848,7 +3848,11 @@ Server.prototype.listen = function listen(port, hostname, onListen) {
     );
   } catch (err) {
     const isUnix = path != null;
-    setTimeout(emitErrorNextTick, 1, this, formatListenError(err, isUnix ? path : hostname, isUnix ? undefined : port));
+    process.nextTick(
+      emitErrorNextTick,
+      this,
+      formatListenError(err, isUnix ? path : hostname, isUnix ? undefined : port),
+    );
   }
   return this;
 };
@@ -3952,14 +3956,11 @@ Server.prototype[kRealListen] = function (
   // Unref the handle if the server was unref'ed prior to listening
   if (this._unref) this.unref();
 
-  // We must schedule the emitListeningNextTick() only after the next run of
-  // the event loop's IO queue. Otherwise, the server may not actually be listening
-  // when the 'listening' event is emitted.
-  //
-  // That leads to all sorts of confusion.
-  //
-  // process.nextTick() is not sufficient because it will run before the IO queue.
-  setTimeout(emitListeningNextTick, 1, this);
+  // Bun.listen has already bound, listened and registered the socket with the
+  // event loop, so like Node this only needs to be deferred to the next tick.
+  // A setTimeout here lands in the bun:test fake timer heap while
+  // jest.useFakeTimers() is active and never fires on its own.
+  process.nextTick(emitListeningNextTick, this);
 };
 
 Server.prototype[EventEmitter.captureRejectionSymbol] = function (err, event, sock) {
@@ -4144,7 +4145,7 @@ function listenInCluster(
         server[kClusterUnixPath] = undefined;
         handle[kClusterOwner] = null;
         handle.close();
-        setTimeout(emitErrorNextTick, 1, server, err);
+        process.nextTick(emitErrorNextTick, server, err);
       }
       return;
     }
@@ -4168,7 +4169,7 @@ Server.prototype[kClusterFauxListen] = function (handle, backlog, path) {
   handle[kClusterOwner] = this;
   handle.listen(backlog || 511);
   if (this._unref) this.unref();
-  setTimeout(emitListeningNextTick, 1, this);
+  process.nextTick(emitListeningNextTick, this);
 };
 
 function onClusterConnection(err, clientHandle) {

--- a/test/js/bun/test/test-timers.test.ts
+++ b/test/js/bun/test/test-timers.test.ts
@@ -1,4 +1,7 @@
 import { bunEnv, bunExe } from "harness";
+import { once } from "node:events";
+import http from "node:http";
+import net from "node:net";
 import path from "node:path";
 
 test("we can go back in time", () => {
@@ -113,4 +116,53 @@ test("real timer heap is ticked against the real clock under useFakeTimers", asy
   // null => exited on its own; non-null => killed by the spawn timeout (spun).
   expect(proc.signalCode).toBeNull();
   expect(exitCode).toBe(0);
+});
+
+describe.each([
+  ["net", () => net.createServer()],
+  ["http", () => http.createServer()],
+])("%s.Server#listen() while fake timers are active", (_, createServer) => {
+  test("emits 'listening' without fake time being advanced", async () => {
+    jest.useFakeTimers();
+    try {
+      const server = createServer();
+      try {
+        const listening = once(server, "listening");
+        server.listen(0, "127.0.0.1");
+        // The deferred emit must not be a timer, or it would sit in the fake heap.
+        expect(jest.getTimerCount()).toBe(0);
+        await listening;
+        expect(server.listening).toBe(true);
+        expect(server.address()).toMatchObject({ address: "127.0.0.1", port: expect.any(Number) });
+      } finally {
+        server.close();
+      }
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test("emits 'error' for a port that is in use without fake time being advanced", async () => {
+    const holder = createServer();
+    try {
+      holder.listen(0, "127.0.0.1");
+      await once(holder, "listening");
+      const { port } = holder.address() as net.AddressInfo;
+
+      jest.useFakeTimers();
+      try {
+        const server = createServer();
+        const errored = once(server, "error");
+        server.listen(port, "127.0.0.1");
+        expect(jest.getTimerCount()).toBe(0);
+        const [err] = await errored;
+        expect(err).toMatchObject({ code: "EADDRINUSE" });
+        expect(server.listening).toBe(false);
+      } finally {
+        jest.useRealTimers();
+      }
+    } finally {
+      holder.close();
+    }
+  });
 });


### PR DESCRIPTION
### Problem
- With `jest.useFakeTimers()` active, `http.createServer().listen(0, cb)` never calls `cb` and `server.listening` stays `false` until the test advances fake time; `jest.getTimerCount()` reports `1` right after `listen()`. The usual `beforeAll(() => new Promise(r => server.listen(0, r)))` hangs until the hook timeout. `net.createServer()` / `tls.createServer()` behave the same way, and so does the listen `'error'` path (EADDRINUSE is never emitted).
- Cause: the listen results are deferred with a 1 ms timer: `setTimeout(emitListeningNextTick, 1, ...)` in `src/js/node/_http_server.ts` (`kRealListen`) and `src/js/node/net.ts` (`kRealListen`, `kClusterFauxListen`), and `setTimeout(..., 1)` for the `'error'` emit in both `listen()` catch blocks and the cluster adopt path. Fake timers work at the timer heap level, so a `setTimeout` made by a built-in module is captured like one made by the test.
- The `net.ts` comment justifying the timer ("the server may not actually be listening yet, nextTick runs before the IO queue") dates from 2023 and no longer holds: `Bun.listen()` and `Bun.serve()` create, bind, `listen(2)` and register the socket with epoll/kqueue/libuv before they return (`us_socket_group_listen` in `packages/bun-usockets/src/context.c`, `Server::listen` in `src/runtime/server/mod.rs`), and `address()`/`port` read the live socket synchronously. `net.ts` already relies on this a few lines earlier (the unix socket chmod after `Bun.listen`).

### Fix
- Defer both outcomes with `process.nextTick`, which is what Node's `setupListenHandle` does (`process.nextTick(emitListeningNT, this)` / `process.nextTick(emitErrorNT, this, ex)`) and what the helper functions here were already named after. `process.nextTick` is not a timer, so fake timers do not affect it.
- Semantics otherwise unchanged: both emitters still check that the server is still open (`listen(); close()` in the same tick still emits nothing, as in Node), listeners attached synchronously after `listen()` still see `'listening'` / `'error'`, and `listen()` no longer costs a 1 ms timer per server.
- Verified with the four new cases in `test/js/bun/test/test-timers.test.ts` (`net` and `http`, `'listening'` and EADDRINUSE `'error'`); each fails in a few ms on main (`getTimerCount()` is 1) and passes with the fix.
- Also run on the debug build: `test/js/node/net/node-net-server.test.ts`, `server.spec.ts`, `node-net.test.ts`, `test/js/node/http/node-http.test.ts`, `node-http-server-timeouts.test.ts`, `node-http-with-ws.test.ts`, `test/js/node/cluster.test.ts`, `test/js/node/tls/node-tls-server.test.ts`, `test/js/third_party/express`, and ~135 upstream `test-net-*` / `test-http*-server-*` / `test-cluster-*` / `test-*-bind-twice` / `test-*-eaddrinuse` files. The only failures are the same ones main has in this container (tests that listen on `localhost` while `/etc/hosts` lists `::1` first, tests that need the public internet, and a 500 ms fetch budget on a debug build).
- Related but not changed here: once `'listening'` fires under fake timers, `http.Server`'s `connectionsCheckingInterval` (a 30 s `setInterval` created in `setupConnectionsTracking`) now lands in the fake heap, so `getTimerCount()` is 1 while such a server is open. That is the same "built-in module uses a JS timer" shape as the `child_process` timeout noted in #37946 and needs a way for built-ins to schedule real timers; #37946 covers the native-side timers and does not touch these JS sites, so the two do not overlap.

### Background
- `bun:test` fake timers: `jest.useFakeTimers()` makes `timer::All::insert` route every new timer whose tag allows it (including every `setTimeout`/`setInterval`/`setImmediate`, `TimeoutObject`/`ImmediateObject`) into a separate heap that only `jest.advanceTimersByTime()` and friends drain. The built-in modules in `src/js/` run against the same globals as user code, so a `setTimeout` inside `node:net` is indistinguishable from one in the test. `process.nextTick` callbacks and promise jobs are run by the event loop directly and are never diverted.
- `kRealListen` is the step of `Server.listen()` that actually creates the native listener (`Bun.listen` for `node:net`, `Bun.serve` for `node:http`); `kClusterFauxListen` is the cluster worker variant that wraps a handle handed over by the primary instead of binding itself. Both end by announcing the result to JS, which is the part this PR changes.
- Node defers `'listening'` (and a failed bind's `'error'`) to the next tick rather than emitting synchronously so that callers can attach listeners after `listen()` returns; it has never waited for an event loop turn.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 4 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-timers.test.ts
bun test v1.4.0 (9af6c23c2)

test/js/bun/test/test-timers.test.ts:
(pass) we can go back in time [353.01ms]
(pass) advanceTimersByTime ticks from the setSystemTime value [6.50ms]
(pass) setSystemTime accepts pre-epoch and epoch times and resets with no argument [5.18ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 'x' [494.11ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is Symbol() [478.09ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 1n [518.02ms]
(pass) real timer heap is ticked against the real clock under useFakeTimers [3457.70ms]
128 |       const server = createServer();
129 |       try {
130 |         const listening = once(server, "listening");
131 |         server.listen(0, "127.0.0.1");
132 |         // The deferred emit must not be a timer, or it would sit in the fake heap.
133 |         expect(jest.getTimerCount()).toBe(0);
                                           ^
error: expect(received).toBe(expected)

Expected: 0
Rece
... (truncated)

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/bun/test/test-timers.test.ts:
(pass) we can go back in time [27.62ms]
(pass) advanceTimersByTime ticks from the setSystemTime value [0.23ms]
(pass) setSystemTime accepts pre-epoch and epoch times and resets with no argument [0.09ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 'x' [13.09ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is Symbol() [12.59ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 1n [11.61ms]
(pass) real timer heap is ticked against the real clock under useFakeTimers [63.01ms]
128 |       const server = createServer();
129 |       try {
130 |         const listening = once(server, "listening");
131 |         server.listen(0, "127.0.0.1");
132 |         // The deferred emit must not be a timer, or it would sit in the fake heap.
133 |         expect(jest.getTimerCount()).toBe(0);
                                           ^
error: expect(received).toBe(expected)

Expected: 0
Received: 1

      at <anonymous> (/workspace/bun/test/js/bun/test/test-timers.test.ts:133:38)
(fail) net.Server#listen() while fake timers are active > emits 'listening' 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/test/test-timers.test.ts
bun test v1.4.0 (9af6c23c2)

test/js/bun/test/test-timers.test.ts:
(pass) we can go back in time [344.73ms]
(pass) advanceTimersByTime ticks from the setSystemTime value [9.37ms]
(pass) setSystemTime accepts pre-epoch and epoch times and resets with no argument [7.40ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 'x' [470.63ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is Symbol() [470.23ms]
(pass) useFakeTimers does not crash when globalThis.setTimeout is 1n [434.57ms]
(pass) real timer heap is ticked against the real clock under useFakeTimers [3259.65ms]
(pass) net.Server#listen() while fake timers are active > emits 'listening' without fake time being advanced [230.46ms]
(pass) net.Server#listen() while fake timers are active > emits 'error' for a port that is in use without fake time being advanced [68.41ms]
(pass) http.Server#listen() while fake timers are active > emits 'listening' without fake time being advanced [120.29ms]
(pass) http.Server#listen(
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     9af6c23c2e
  features     baseline

22 deps, 107 codegen, 1176 objects in 2062ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[2/1238] gen ErrorCode+*.h
[3/1238] gen bindgenv2
[4/1238] fetch zlib
[zlib] up to date
[5/1238] gen .bind.ts → GeneratedBindings.cpp
[6/1238] gen JSBuffer.lut.h
Generating /workspace/bun/build/release/codegen/JSBuffer.lut.h from /workspace/bun/src/jsc/bindings/JSBuffer.cpp
[7/1238] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[8/1238] fetch picohttpparser
[picohttpparser] up to date
[9/1238] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[10/1238] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/_http_server.ts          | 11 ++++++--
 src/js/node/net.ts                   | 23 ++++++++--------
 test/js/bun/test/test-timers.test.ts | 52 ++++++++++++++++++++++++++++++++++++
 3 files changed, 73 insertions(+), 13 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                  reads  edits  tests
src/js/node/_http_server.ts               5      3      0
src/js/node/net.ts                        3      4      0
test/js/bun/test/test-timers.test.ts      1      1      0
```

</details>

<!-- robobun:evidence:end -->