### PR TITLE
shell(cp): refuse copying a source onto itself however the destination is spelled

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4700,6 +4700,14 @@ impl NodeFS {
             let dest = args.dest.slice_z(&mut dest_buf);
 
             if args.mode.is_force_clone() {
+                // A copy onto itself is a Node no-op; under EXCL, clonefile reports the EEXIST.
+                if !args.mode.shouldnt_overwrite() {
+                    if let Ok(src_stat) = Syscall::stat(src) {
+                        if Self::copy_file_onto_itself(&src_stat, &Syscall::stat(dest)) {
+                            return Ok(());
+                        }
+                    }
+                }
                 // https://www.manpagez.com/man/2/clonefile/
                 return Maybe::<ret::CopyFile>::errno_sys_p(
                     bun_sys::c::clonefile_rc(src, dest, 0),
@@ -4719,6 +4727,13 @@ impl NodeFS {
                         syscall: sys::Tag::copyfile,
                         ..Default::default()
                     });
+                }
+
+                // A copy onto itself is a Node no-op; the unlink below would delete it.
+                if !args.mode.shouldnt_overwrite()
+                    && Self::copy_file_onto_itself(&stat_, &Syscall::stat(dest))
+                {
+                    return Ok(());
                 }
 
                 // 64 KB is about the break-even point for clonefile() to be worth it
@@ -4835,18 +4850,9 @@ impl NodeFS {
             };
             let _close_dest = scopeguard::guard(dest_fd, |fd| fd.close());
 
-            // Don't O_TRUNC at open: if src and dest resolve to the same
-            // inode, that would zero the file before the first read. Match
-            // Node by checking inodes after both are open and refusing.
-            if let Ok(dst_stat) = Syscall::fstat(dest_fd) {
-                if stat_.st_ino == dst_stat.st_ino && stat_.st_dev == dst_stat.st_dev {
-                    return Err(sys::Error {
-                        errno: SystemErrno::EINVAL as _,
-                        syscall: sys::Tag::copyfile,
-                        path: args.src.slice().into(),
-                        ..Default::default()
-                    });
-                }
+            // No O_TRUNC at open: a copy onto itself is a Node no-op, not a zeroed file.
+            if Self::copy_file_onto_itself(&stat_, &Syscall::fstat(dest_fd)) {
+                return Ok(());
             }
             let _ = Syscall::ftruncate(dest_fd, 0);
 
@@ -4937,6 +4943,12 @@ impl NodeFS {
             }
 
             let dest_fd = Syscall::open(dest, flags, stat_.st_mode as Mode)?;
+
+            // A copy onto itself is a Node no-op; the force-clone arm would unlink it.
+            if Self::copy_file_onto_itself(&stat_, &Syscall::fstat(dest_fd)) {
+                dest_fd.close();
+                return Ok(());
+            }
 
             let mut size: usize = stat_.st_size.max(0) as usize;
 
@@ -8354,6 +8366,9 @@ impl NodeFS {
                 });
             }
 
+            // The unlink below would remove the only name of a file copied onto itself.
+            self.cp_refuse_onto_itself(src, &stat_, &Syscall::stat(dest))?;
+
             // 64 KB is about the break-even point for clonefile() to be worth it
             // at least, on an M1 with an NVME SSD.
             if stat_.st_size > 128 * 1024 {
@@ -8482,6 +8497,11 @@ impl NodeFS {
             }
 
             let dest_fd = Self::cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode)?;
+            // Opened without O_TRUNC, so nothing has happened to the file yet.
+            if let Err(err) = self.cp_refuse_onto_itself(src, &stat_, &Syscall::fstat(dest_fd)) {
+                dest_fd.close();
+                return Err(err);
+            }
 
             let mut size: usize = stat_.st_size.max(0) as usize;
 
@@ -8658,19 +8678,10 @@ impl NodeFS {
                     Err(e) => return Err(e),
                 };
 
-            // No O_TRUNC at open: if src and dest resolve to the same inode,
-            // that would zero the file before the first read.
-            if let Ok(dst_stat) = Syscall::fstat(dest_fd) {
-                if stat_.st_ino == dst_stat.st_ino && stat_.st_dev == dst_stat.st_dev {
-                    dest_fd.close();
-                    self.sync_error_buf[..src.len()].copy_from_slice(src.as_bytes());
-                    return Err(sys::Error {
-                        errno: SystemErrno::EINVAL as _,
-                        syscall: sys::Tag::copyfile,
-                        path: self.sync_error_buf[..src.len()].into(),
-                        ..Default::default()
-                    });
-                }
+            // Opened without O_TRUNC, so nothing has happened to the file yet.
+            if let Err(err) = self.cp_refuse_onto_itself(src, &stat_, &Syscall::fstat(dest_fd)) {
+                dest_fd.close();
+                return Err(err);
             }
 
             let _close_dest = scopeguard::guard(
@@ -8927,6 +8938,38 @@ impl NodeFS {
                 Err(err.with_path(&self.sync_error_buf[..dest.len()]))
             }
         }
+    }
+
+    /// The destination (`dest_stat`) exists and is the file `src_stat` describes.
+    #[cfg(not(windows))]
+    fn copy_file_onto_itself(src_stat: &sys::Stat, dest_stat: &Maybe<sys::Stat>) -> bool {
+        let Ok(dest_stat) = dest_stat else {
+            return false;
+        };
+        // An inode number of 0 means the filesystem reports no identity.
+        dest_stat.st_ino != 0
+            && dest_stat.st_ino == src_stat.st_ino
+            && dest_stat.st_dev == src_stat.st_dev
+    }
+
+    /// EINVAL when the destination exists (`dest_stat`) and is the file `src_stat` describes.
+    #[cfg(not(windows))]
+    fn cp_refuse_onto_itself(
+        &mut self,
+        src: &ZStr,
+        src_stat: &sys::Stat,
+        dest_stat: &Maybe<sys::Stat>,
+    ) -> Maybe<()> {
+        if !Self::copy_file_onto_itself(src_stat, dest_stat) {
+            return Ok(());
+        }
+        self.sync_error_buf[..src.len()].copy_from_slice(src.as_bytes());
+        Err(sys::Error {
+            errno: SystemErrno::EINVAL as _,
+            syscall: sys::Tag::copyfile,
+            path: self.sync_error_buf[..src.len()].into(),
+            ..Default::default()
+        })
     }
 
     /// Const-generic dispatch from `NodeFSFunctionEnum` to the matching

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -597,6 +597,32 @@ impl ShellCpTask {
         }
     }
 
+    /// One entry under two names (hard links too), or one file behind a symlink on either side.
+    fn is_same_file(src: &bun_core::ZStr, tgt: &bun_core::ZStr) -> bool {
+        fn same_inode(a: &bun_sys::Stat, b: &bun_sys::Stat) -> bool {
+            // An inode number of 0 means the filesystem reports no identity.
+            a.st_ino != 0 && a.st_ino == b.st_ino && a.st_dev == b.st_dev
+        }
+        if src.as_bytes() == tgt.as_bytes() {
+            return true;
+        }
+        // A `tgt` that does not exist is created by the copy.
+        let (Ok(src_stat), Ok(tgt_stat)) = (bun_sys::lstat(src), bun_sys::lstat(tgt)) else {
+            return false;
+        };
+        if same_inode(&src_stat, &tgt_stat) {
+            return true;
+        }
+        if !bun_sys::S::ISLNK(src_stat.st_mode as _) && !bun_sys::S::ISLNK(tgt_stat.st_mode as _) {
+            return false;
+        }
+        // `stat` fails on a dangling link: nothing behind it to compare.
+        let (Ok(src_file), Ok(tgt_file)) = (bun_sys::stat(src), bun_sys::stat(tgt)) else {
+            return false;
+        };
+        same_inode(&src_file, &tgt_file)
+    }
+
     /// Resolves src/tgt to absolute paths, classifies them per the three
     /// POSIX `cp` synopses
     /// (<https://man7.org/linux/man-pages/man1/cp.1p.html>), then hands off to
@@ -649,17 +675,6 @@ impl ShellCpTask {
             ));
         }
 
-        if !src_is_dir && src.as_bytes() == tgt.as_bytes() {
-            return Some(ShellErr::Custom(
-                format!(
-                    "{0} and {0} are identical (not copied)",
-                    bstr::BStr::new(&self.src)
-                )
-                .into_bytes()
-                .into_boxed_slice(),
-            ));
-        }
-
         let (tgt_is_dir, tgt_exists) = match Self::is_dir(tgt) {
             Ok(is_dir) => (is_dir, true),
             Err(e) if e.get_errno() == bun_sys::E::ENOENT => {
@@ -670,6 +685,8 @@ impl ShellCpTask {
         };
 
         let mut _copying_many = false;
+        // For error messages: names the path the copy would land on.
+        let mut appended_basename: Option<&[u8]> = None;
 
         // The following logic is based on the POSIX spec.
         if !src_is_dir && !tgt_is_dir && self.operands == 2 {
@@ -682,6 +699,7 @@ impl ShellCpTask {
                     buf3.as_mut_slice(),
                     &[tgt.as_bytes(), basename],
                 );
+                appended_basename = Some(basename);
             } else if self.operands == 2 {
                 // source_dir -> new_target_dir.
             } else {
@@ -713,7 +731,31 @@ impl ShellCpTask {
                 buf3.as_mut_slice(),
                 &[tgt.as_bytes(), basename],
             );
+            appended_basename = Some(basename);
             _copying_many = true;
+        }
+
+        if Self::is_same_file(src, tgt) {
+            // As cp(1) prints it: the operand as given, plus the appended basename.
+            let mut shown_tgt = self.tgt.clone();
+            if let Some(basename) = appended_basename {
+                while shown_tgt.len() > 1 && Self::has_trailing_sep(&shown_tgt) {
+                    shown_tgt.pop();
+                }
+                if !Self::has_trailing_sep(&shown_tgt) {
+                    shown_tgt.push(bun_paths::SEP);
+                }
+                shown_tgt.extend_from_slice(basename);
+            }
+            return Some(ShellErr::Custom(
+                format!(
+                    "{} and {} are identical (not copied)",
+                    bstr::BStr::new(&self.src),
+                    bstr::BStr::new(&shown_tgt)
+                )
+                .into_bytes()
+                .into_boxed_slice(),
+            ));
         }
 
         let args = crate::node::fs::args::Cp::owned(

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { linkSync, mkdirSync, readdirSync, readFileSync, readlinkSync, symlinkSync, writeFileSync } from "node:fs";
+import { join, parse, relative } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,248 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// Windows needs a privilege or developer mode for symlinks (CI has it); junctions never do.
+const canCreateSymlink = (() => {
+  using probe = tempDir("shell-cp-symlink-probe", { "target": "" });
+  try {
+    symlinkSync("target", join(String(probe), "link"));
+    return true;
+  } catch (err: any) {
+    if (err.code === "EPERM" || err.code === "EACCES") return false;
+    throw err;
+  }
+})();
+
+// The builtin is the default only on Windows; on POSIX it is enabled by an env
+// var that is read once per process, so each of these runs cp in a child bun.
+describe.concurrent("bunshell cp of a source onto itself", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  /** A temp dir holding `d/f`, the file the tests copy; `extra` adds to it. */
+  function setup(name: string, extra: (work: string) => void = () => {}) {
+    const dir = tempDir(`shell-cp-same-file-${name}`, { "d": { "f": "F\n" } });
+    extra(String(dir));
+    return dir;
+  }
+
+  /** Runs `command` through the shell in `work` and returns cp's exit code followed by its stderr. */
+  async function cp(work: string, command: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const result = await Bun.$\`${command}\`.nothrow().quiet();
+         process.stdout.write(result.exitCode + "\\n" + result.stderr.toString());`,
+      ],
+      cwd: work,
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function refused(src: string, tgt: string) {
+    return { stdout: `1\ncp: ${src} and ${tgt} are identical (not copied)\n`, stderr: "", exitCode: 0 };
+  }
+  const copied = { stdout: "0\n", stderr: "", exitCode: 0 };
+  /** What the builtin puts between a directory operand and the basename it appends to it. */
+  const sep = isWindows ? "\\" : "/";
+
+  // Larger than the 128 KB above which the macOS copy unlinks the destination
+  // before cloning the source into its place.
+  const big = Buffer.alloc(200 * 1024, "big file contents\n");
+
+  test("into its own directory is refused", async () => {
+    using dir = setup("into-own-dir", work => writeFileSync(join(work, "d/f"), big));
+    expect(await cp(String(dir), "cp d/f d")).toEqual(refused("d/f", `d${sep}f`));
+    expect(readFileSync(join(String(dir), "d/f")).equals(big)).toBeTrue();
+  });
+
+  test("into its own directory written with a trailing slash is refused", async () => {
+    using dir = setup("trailing-slash");
+    expect(await cp(String(dir), "cp d/f d/")).toEqual(refused("d/f", `d${sep}f`));
+    expect(readFileSync(join(String(dir), "d/f"), "utf8")).toBe("F\n");
+  });
+
+  // The destination operand is reported as written, as cp(1) does, not normalized.
+  test("into its own directory written as d/. is refused", async () => {
+    using dir = setup("dot-segment");
+    expect(await cp(String(dir), "cp d/f d/.")).toEqual(refused("d/f", `d/.${sep}f`));
+  });
+
+  test("into its own directory written with a very long operand is refused", async () => {
+    using dir = setup("long-operand");
+    // Climbs to the filesystem root and back down into the temp dir: resolves
+    // to a short absolute path, but as written it is longer than PATH_MAX (4096
+    // on Linux), so reporting it must not go through a path buffer.
+    const { root } = parse(String(dir));
+    const fromRoot = relative(root, String(dir)).replaceAll("\\", "/");
+    const operand = `${Buffer.alloc(1500 * 3, "../").toString()}${fromRoot}/d`;
+    expect(operand.length).toBeGreaterThan(4096);
+    expect(await cp(String(dir), `cp d/f ${operand}`)).toEqual(refused("d/f", `${operand}${sep}f`));
+  });
+
+  test("into its own directory with -R is refused", async () => {
+    using dir = setup("recursive");
+    expect(await cp(String(dir), "cp -R d/f d")).toEqual(refused("d/f", `d${sep}f`));
+    expect(readFileSync(join(String(dir), "d/f"), "utf8")).toBe("F\n");
+  });
+
+  test("onto its own path is refused", async () => {
+    using dir = setup("own-path");
+    expect(await cp(String(dir), "cp d/f d/f")).toEqual(refused("d/f", "d/f"));
+    expect(readFileSync(join(String(dir), "d/f"), "utf8")).toBe("F\n");
+  });
+
+  test("a file target with several sources is not a directory, also for the source it is", async () => {
+    using dir = setup("target-is-a-source", work => writeFileSync(join(work, "x"), "X\n"));
+    expect(await cp(String(dir), "cp d/f x d/f")).toEqual({
+      stdout: "1\ncp: d/f is not a directory\ncp: d/f is not a directory\n",
+      stderr: "",
+      exitCode: 0,
+    });
+    expect(readFileSync(join(String(dir), "d/f"), "utf8")).toBe("F\n");
+  });
+
+  test("a directory onto itself with -R is refused", async () => {
+    using dir = setup("dir-onto-itself", work => writeFileSync(join(work, "d/f"), big));
+    expect(await cp(String(dir), "cp -R d .")).toEqual(refused("d", `.${sep}d`));
+    expect(readdirSync(join(String(dir), "d"))).toEqual(["f"]);
+    expect(readFileSync(join(String(dir), "d/f")).equals(big)).toBeTrue();
+  });
+
+  // A junction on Windows (which classifies it as a directory), a symlink elsewhere.
+  test("a directory link into its own directory with -R is refused", async () => {
+    using dir = setup("dir-link-into-own-dir", work => {
+      mkdirSync(join(work, "d/sub"));
+      symlinkSync(join(work, "d/sub"), join(work, "d/sublink"), "junction");
+    });
+    expect(await cp(String(dir), "cp -R d/sublink d")).toEqual(refused("d/sublink", `d${sep}sublink`));
+    expect(readdirSync(join(String(dir), "d")).sort()).toEqual(["f", "sub", "sublink"]);
+  });
+
+  test("a directory into a directory that already holds a copy is merged", async () => {
+    using dir = setup("merge", work => {
+      mkdirSync(join(work, "e/d/old"), { recursive: true });
+    });
+    expect(await cp(String(dir), "cp -R d e")).toEqual(copied);
+    expect(readdirSync(join(String(dir), "e/d")).sort()).toEqual(["f", "old"]);
+    expect(readFileSync(join(String(dir), "e/d/f"), "utf8")).toBe("F\n");
+  });
+
+  test("a directory into a directory where its name is a link back to it is refused", async () => {
+    using dir = setup("dir-link-back", work => {
+      mkdirSync(join(work, "e"));
+      symlinkSync(join(work, "d"), join(work, "e/d"), "junction");
+    });
+    expect(await cp(String(dir), "cp -R d e")).toEqual(refused("d", `e${sep}d`));
+    expect(readdirSync(join(String(dir), "d"))).toEqual(["f"]);
+  });
+
+  // Inside a tree the per-file pairs are only seen by the copy itself.
+  test.skipIf(isWindows)(
+    "a tree whose destination leads back into it through a link is not copied onto itself",
+    async () => {
+      using dir = setup("tree-link-back", work => {
+        mkdirSync(join(work, "p/d"), { recursive: true });
+        writeFileSync(join(work, "p/d/f"), big);
+        mkdirSync(join(work, "e/p"), { recursive: true });
+        symlinkSync(join(work, "p/d"), join(work, "e/p/d"));
+      });
+      expect(await cp(String(dir), "cp -R p e")).toEqual({
+        stdout: expect.stringMatching(/^1\ncp: .*[\\/]p[\\/]d[\\/]f\n$/),
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(readFileSync(join(String(dir), "p/d/f")).equals(big)).toBeTrue();
+    },
+  );
+
+  test("onto a hard link to itself is refused", async () => {
+    using dir = setup("hard-link", work => {
+      writeFileSync(join(work, "d/f"), big);
+      linkSync(join(work, "d/f"), join(work, "d/g"));
+    });
+    expect(await cp(String(dir), "cp d/f d/g")).toEqual(refused("d/f", "d/g"));
+    expect(readFileSync(join(String(dir), "d/f")).equals(big)).toBeTrue();
+  });
+
+  test("a hard link from elsewhere into the directory of its file is refused", async () => {
+    using dir = setup("hard-link-elsewhere", work => {
+      writeFileSync(join(work, "d/f"), big);
+      mkdirSync(join(work, "e"));
+      linkSync(join(work, "d/f"), join(work, "e/f"));
+    });
+    expect(await cp(String(dir), "cp e/f d")).toEqual(refused("e/f", `d${sep}f`));
+    expect(readFileSync(join(String(dir), "d/f")).equals(big)).toBeTrue();
+  });
+
+  test("into a link to its own directory is refused", async () => {
+    using dir = setup("into-dir-link", work => {
+      writeFileSync(join(work, "d/f"), big);
+      symlinkSync(join(work, "d"), join(work, "dj"), "junction");
+    });
+    expect(await cp(String(dir), "cp d/f dj/")).toEqual(refused("d/f", `dj${sep}f`));
+    expect(readFileSync(join(String(dir), "d/f")).equals(big)).toBeTrue();
+  });
+
+  test.skipIf(!canCreateSymlink)("onto a symlink to itself is refused", async () => {
+    using dir = setup("onto-symlink", work => symlinkSync("f", join(work, "d/link")));
+    expect(await cp(String(dir), "cp d/f d/link")).toEqual(refused("d/f", "d/link"));
+    expect(readFileSync(join(String(dir), "d/f"), "utf8")).toBe("F\n");
+  });
+
+  test.skipIf(!canCreateSymlink)("a symlink onto the file it points to is refused", async () => {
+    using dir = setup("symlink-onto-target", work => symlinkSync("f", join(work, "d/link")));
+    expect(await cp(String(dir), "cp d/link d/f")).toEqual(refused("d/link", "d/f"));
+    expect(readFileSync(join(String(dir), "d/f"), "utf8")).toBe("F\n");
+    expect(readlinkSync(join(String(dir), "d/link"))).toBe("f");
+  });
+
+  test.skipIf(!canCreateSymlink)("a symlink into its own directory is refused", async () => {
+    using dir = setup("symlink-into-own-dir", work => symlinkSync("f", join(work, "d/link")));
+    expect(await cp(String(dir), "cp d/link d")).toEqual(refused("d/link", `d${sep}link`));
+    expect(readlinkSync(join(String(dir), "d/link"))).toBe("f");
+  });
+
+  test.skipIf(!canCreateSymlink)("a symlink onto another symlink to the same file is refused", async () => {
+    using dir = setup("two-symlinks", work => {
+      symlinkSync("f", join(work, "d/link"));
+      symlinkSync("f", join(work, "d/link2"));
+    });
+    expect(await cp(String(dir), "cp d/link d/link2")).toEqual(refused("d/link", "d/link2"));
+    expect(readFileSync(join(String(dir), "d/f"), "utf8")).toBe("F\n");
+  });
+
+  test.skipIf(!canCreateSymlink)("a dangling symlink into its own directory with -R is refused", async () => {
+    using dir = setup("dangling-symlink", work => symlinkSync("nowhere", join(work, "d/dangling")));
+    expect(await cp(String(dir), "cp -R d/dangling d")).toEqual(refused("d/dangling", `d${sep}dangling`));
+    expect(readlinkSync(join(String(dir), "d/dangling"))).toBe("nowhere");
+  });
+
+  // Not on Windows: there the copy itself fails on a dangling link (it opens the target to recreate it).
+  test.skipIf(isWindows)("a dangling symlink onto another dangling symlink is not refused", async () => {
+    using dir = setup("two-dangling-symlinks", work => {
+      symlinkSync("nowhere", join(work, "d/dangling"));
+      symlinkSync("elsewhere", join(work, "d/dangling2"));
+    });
+    expect(await cp(String(dir), "cp -R d/dangling d/dangling2")).toEqual(copied);
+  });
+
+  test("the other sources are still copied when one of them is refused", async () => {
+    using dir = setup("one-of-many", work => writeFileSync(join(work, "other"), "other\n"));
+    expect(await cp(String(dir), "cp d/f other d")).toEqual(refused("d/f", `d${sep}f`));
+    expect(readFileSync(join(String(dir), "d/other"), "utf8")).toBe("other\n");
+  });
+
+  test("into another directory is copied", async () => {
+    using dir = setup("other-dir", work => mkdirSync(join(work, "e")));
+    expect(await cp(String(dir), "cp d/f e")).toEqual(copied);
+    expect(readFileSync(join(String(dir), "e/f"), "utf8")).toBe("F\n");
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -9,6 +9,7 @@ import {
   isGlibc,
   isIntelMacOS,
   isLinux,
+  isMacOS,
   isPosix,
   isWindows,
   tempDir,
@@ -977,6 +978,45 @@ describe("copyFileSync", () => {
     expect(() => {
       copyFileSync(import.meta.path, tempdir + "/copyFileSync.js", fs.constants.COPYFILE_EXCL);
     }).toThrow();
+  });
+
+  // Node skips the copy when both names are one file; the >128 KiB size is
+  // what routes macOS through its unlink-before-clonefile path.
+  it("copying a file onto itself is a no-op", () => {
+    const tempdir = tmpdirTestMkdir();
+    const file = tempdir + "/self.blob";
+    const content = Buffer.alloc(256 * 1024, "A");
+    writeFileSync(file, content);
+
+    copyFileSync(file, file);
+    expect(readFileSync(file).equals(content)).toBe(true);
+
+    const link = tempdir + "/self.link";
+    fs.linkSync(file, link);
+    copyFileSync(file, link);
+    expect(readFileSync(file).equals(content)).toBe(true);
+
+    expect(() => copyFileSync(file, file, fs.constants.COPYFILE_EXCL)).toThrow(
+      expect.objectContaining({ code: "EEXIST" }),
+    );
+    expect(readFileSync(file).equals(content)).toBe(true);
+  });
+
+  // Linux and macOS implement the same-file no-op for the force-clone mode;
+  // FreeBSD refuses the mode itself and Windows ignores it.
+  it.skipIf(!isLinux && !isMacOS)("FICLONE_FORCE of a file onto itself is a no-op", () => {
+    const tempdir = tmpdirTestMkdir();
+    const file = tempdir + "/self-force.blob";
+    const content = Buffer.alloc(256 * 1024, "B");
+    writeFileSync(file, content);
+
+    copyFileSync(file, file, fs.constants.COPYFILE_FICLONE_FORCE);
+    expect(readFileSync(file).equals(content)).toBe(true);
+
+    expect(() => copyFileSync(file, file, fs.constants.COPYFILE_EXCL | fs.constants.COPYFILE_FICLONE_FORCE)).toThrow(
+      expect.objectContaining({ code: "EEXIST" }),
+    );
+    expect(readFileSync(file).equals(content)).toBe(true);
   });
 
   if (process.platform === "linux") {


### PR DESCRIPTION
### Problem
- The shell `cp` builtin (the default on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` on POSIX) copies a source onto itself whenever the destination is spelled differently from the source: `cp d/f d`, `cp d/f d/`, `cp -R d/f d`, `cp f hardlink-to-f`, `cp f symlink-to-f`, `cp link target-of-link`, and `cp -R d .` for a directory (every file in it is then copied onto itself). cp(1) refuses all of these (`'d/f' and 'd/f' are the same file`, exit 1).
  ```
  mkdir d && head -c 300000 /dev/urandom > d/big.bin
  BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun -e 'const r = await Bun.$`cp d/big.bin d`.nothrow().quiet(); console.log(r.exitCode, JSON.stringify(r.stderr.toString()))'
  # bun 1.4.0: 0 ""
  ```
- What the per-file copy then does depends on the platform (`NodeFS::copy_single_file_sync`, `src/runtime/node/node_fs.rs`):
  - Linux: the destination is opened without `O_TRUNC` and the file is rewritten with its own bytes, exit 0 (verified).
  - Windows: `CopyFileW` fails with a sharing violation and `should_ignore_ebusy` turns that into success because source and destination are the same file, exit 0 (verified with bun 1.4.0 on Windows for the file, hard link, symlink, junction and directory spellings).
  - macOS, regular file over 128 KiB: the destination is unlinked before `clonefile` (the `st_size > 128 * 1024` branch), which removes the file's only name; the clone and the `copyfile` fallback then fail with ENOENT and the file is gone. With `cp -R d .` this happens to every such file in `d`. By code reading, no macOS box here; the tests use 200 KiB files so CI exercises this branch.
- Cause: `ShellCpTask::run_from_thread_pool_impl` (`src/runtime/shell/builtin/cp.rs`) compared the two operands as path strings, and did so before the synopsis code appends the source's basename to a directory destination, so only the literal `cp a a` spelling was caught. `fs.cp` is protected from the same native code by `areIdentical` in `src/js/internal/fs/cp-sync.ts`; the builtin calls the native copy directly and had no equivalent.
- `fs.copyFile` is a third entry point into the same pattern (`copy_file_inner`), with no guard anywhere in its chain: `copyFileSync(f, f)` on macOS over 128 KiB unlinks the file's only name before `clonefile`, and on Linux the `COPYFILE_FICLONE_FORCE` mode unlinks the destination when the clone fails, which for a copy onto itself deletes the source (verified: the file is gone). Node treats that copy as a no-op (libuv skips it when both names are one inode).

### Fix
- `ShellCpTask::is_same_file` runs once the final destination path is known (after the basename is appended), for every source, with and without `-R`. Same path, same `st_dev`/`st_ino` of the two entries, or, when either entry is a symlink, of the files behind them, is refused with the builtin's existing wording, exit 1: `cp: d/f and d/f are identical (not copied)`. Other sources on the same command line are still copied. The path comparison is folded into the new check.
- It is not limited to file sources because the question is whether the destination entry is the source, whatever the source is: that covers `cp -R d .`, and on Windows a directory symlink or junction source, which the builtin's attribute check classifies as a directory (the copy then treats it as a single link), so a file-only check let `cp -R dirlink .` through there. Copying into a directory that already holds a copy still merges as before (the existing `e/d` is a different inode).
- The message prints both operands as given; when the copy would have landed inside the destination, the basename is appended to the operand the way cp(1) prints it (`d/.` becomes `d/./f`, `.` becomes `./d`, trailing separators are dropped first). It is built by concatenation, not by joining into a path buffer: an operand that resolves to a short path can itself be longer than PATH_MAX (`../` repeated 1500 times and back down), and a join panicked on that (`index out of bounds`, found by the long-operand test while reviewing the first revision of this PR). The same pre-existing panic in the operand-resolving joins a few lines earlier is reported separately.
- Following symlinks is right because the copy writes through a symlink destination (plain `open` on POSIX, `CopyFileW` on Windows), so `cp f link-to-f` overwrites f with itself, and cp(1) refuses a link and its target as the same file in either direction. The one command this refuses that `cp -R` would carry out is copying a link over a different link to the same file; on Linux and Windows the builtin's copy of a link over an existing entry did nothing and exited 0 before (`EEXIST` is treated as success), so the refusal only replaces a silent no-op with an explanation.
- A destination that does not exist is created by the copy and never matches; an inode number of 0 (a filesystem that reports no identity) disables the inode half of the check, the path half still applies.
- Behaviour change beyond the bug, pinned by a test: `cp d/f x d/f` reports `d/f is not a directory` for both sources instead of `d/f and d/f are identical` for the first; cp(1) gives the "not a directory" error for that command line as well.
- Verified with `test/js/bun/shell/commands/cp.test.ts`, new block "bunshell cp of a source onto itself"; each case runs `cp` in a child bun with the builtin enabled, since the env var is read once per process (the existing in-process suite in this file is skipped on POSIX). On bun 1.4.0 on Linux 15 of the 18 tests fail (exit 0 and no message, or the old message order); the other 3 pin what must keep working (`cp d/f d/f`, a dangling link over a different dangling link, a copy into another directory). All 18 pass with the fix. The symlink cases run wherever the test process can create a symlink (a probe, as in `test/js/bun/glob/scan.test.ts`), which includes Windows CI; the directory-link case uses a junction so it runs everywhere; only the dangling-over-dangling case is POSIX-only, because on Windows the copy of a dangling link fails on its own.
- Windows, debug build of this branch on a Windows box: the whole file passes (47 tests, 1 skipped), so the symlink, junction, hard-link and long-operand paths are exercised on the platform where the builtin is on by default. With bun 1.4.0 there, `cp -R d/sublink d` (junction), `cp -R d .`, and both symlink directions exit 0 silently.
- Inside a tree copied with `-R` the per-file pairs are only seen by `copy_single_file_sync`, and a link in an existing destination tree can lead one back to its source, so the Linux and macOS arms now refuse that pair with EINVAL before anything destructive, as the FreeBSD arm already did (`NodeFS::cp_refuse_onto_itself`); covered by the tree cases in the shell test file.
- `fs.copyFile`'s three POSIX arms (`copy_file_inner`) now return early when source and destination are one inode, matching Node's no-op; `COPYFILE_EXCL` still reports EEXIST. The FreeBSD arm refused with EINVAL before, which matched neither Node nor the other arms. Windows already no-ops via `should_ignore_ebusy`. Tests in `test/js/node/fs/fs.test.ts` (`copyFileSync` block): same name and hard link keep the content, EEXIST under EXCL, and the `FICLONE_FORCE` spelling on Linux, which deleted the file and threw on bun 1.4.0.
- `cargo check -p bun_runtime` passes for the windows-msvc, aarch64-darwin and freebsd targets; clippy and rustfmt are clean for the crate.
- Overlap with open PRs touching the same function: #37927 refuses directory sources copied into or onto themselves; its "onto itself" case is also caught here (same message; its test expects `d and d` where this prints `d and ./d` like cp(1), so the merged version keeps one display rule), while its into-itself walk is still needed (`cp -R d link-to-d` still recurses until it crashes, here as on main). #37954 adds a dev/ino check for the non-`-R` mode as part of dereferencing symlink operands, which this check covers too (plus `-R`, hard links and symlink destinations), so whichever lands second drops one of the two. Textual conflicts with both are expected.

### Background
- Shell `cp` builtin: every source operand becomes a `ShellCpTask` on the work pool. It resolves both operands to absolute paths, applies the POSIX synopses (file to file; `-R` sources into a target; files into a directory, the latter two appending the source's basename to the target), then hands the pair to node:fs's native copy (`ShellAsyncCpTask`), which calls `copy_single_file_sync` once for a non-directory and once per file while walking a directory. The final destination and the cp(1)-style messages only exist in the builtin, which is why the check lives there and not in the shared native copy; `fs.cp` makes the same check in its JS layer before reaching the native code.
- `st_dev`/`st_ino`: the device and inode numbers in a stat result; two names that produce the same pair are one file (hard links, or one path spelled two ways). `lstat` describes a symlink entry itself, `stat` the file behind it; for anything that is not a symlink they agree, so the second comparison is only made when one of the entries is a link. On Windows bun's `stat`/`lstat` go through libuv, which fills the pair from the volume serial number and the file index, so hard links compare equal there too.
- Junction: a Windows directory link that needs no privilege to create, unlike a symlink. The builtin classifies sources on Windows with `GetFileAttributes`, which reports both junctions and directory symlinks as directories.
- Rebased onto main as one commit. The only conflict: main moved the `src_absolute`/`tgt_absolute` bookkeeping from the pool-thread handoff into `cp_on_finish`, so the builtin no longer records them before the handoff and the same-file check sits alone there. Both test files and all four target checks (linux, windows-msvc, aarch64-darwin, freebsd) pass on the rebased head.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 3 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts, test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->


