### PR TITLE
crypto: fix generatePrime with safe and add/rem returning oversized values, wrong residues, or hanging

### DIFF
--- a/src/jsc/bindings/ncrypto.cpp
+++ b/src/jsc/bindings/ncrypto.cpp
@@ -13,6 +13,7 @@
 #include <openssl/rand.h>
 #include <openssl/x509v3.h>
 #include <algorithm>
+#include <array>
 #include <cstring>
 #if OPENSSL_VERSION_MAJOR >= 3
 #include <openssl/provider.h>
@@ -406,6 +407,102 @@ int BignumPointer::isPrime(int nchecks,
     return BN_is_prime_ex(get(), nchecks, ctx.get(), cb.get());
 }
 
+namespace {
+// The first 1024 odd primes: the depth of BoringSSL's own trial division, which
+// also uses only the first half for candidates of up to 1024 bits.
+constexpr std::array<uint16_t, 1024> makeSafePrimeSievePrimes()
+{
+    std::array<uint16_t, 1024> primes {};
+    size_t count = 0;
+    for (unsigned n = 3; count < primes.size(); n += 2) {
+        bool isPrime = true;
+        for (size_t i = 0; i < count; i++) {
+            unsigned divisor = primes[i];
+            if (divisor * divisor > n) break;
+            if (n % divisor == 0) {
+                isPrime = false;
+                break;
+            }
+        }
+        if (isPrime) primes[count++] = static_cast<uint16_t>(n);
+    }
+    return primes;
+}
+constexpr auto kSafePrimeSievePrimes = makeSafePrimeSievePrimes();
+
+// True when a sieve prime r divides p (p % r == 0) or (p - 1) / 2 (p % r == 1).
+// Stops once r * r > p so that a small p or (p - 1) / 2 that is itself in the
+// table is not rejected.
+bool safePrimeCandidateHasSmallFactor(const BIGNUM* p)
+{
+    std::optional<BN_ULONG> word = BignumPointer::GetWord(p);
+    size_t depth = BN_num_bits(p) > 1024 ? kSafePrimeSievePrimes.size() : kSafePrimeSievePrimes.size() / 2;
+    for (size_t i = 0; i < depth; i++) {
+        BN_ULONG r = kSafePrimeSievePrimes[i];
+        if (word && r * r > *word) return false;
+        if (BN_mod_word(p, r) <= 1) return true;
+    }
+    return false;
+}
+
+// Replaces BN_generate_prime_ex(safe = 1, add): BoringSSL's probable_prime_dh_safe
+// steps q by add / 2 (so p leaves the progression for odd add), never checks the
+// size it ends on, and trial-divides small candidates by themselves, returning
+// one fixed 13-bit value for every size below that. This is OpenSSL's
+// probable_prime_dh(safe = 1) search, which Node's results come from: a random
+// bits-bit start moved onto p == rem (mod add), then stepped by add. One
+// difference: a candidate that fails Miller-Rabin is stepped past, where OpenSSL
+// draws a new start. Every value Node can return remains reachable, and the
+// search also terminates when add is nearly as wide as bits, where every start
+// projects onto the same value and OpenSSL retests one candidate forever. As in
+// OpenSSL, the result has at least bits bits (more once that size's safe primes
+// run out) and a progression with no safe prime in it never terminates. The walk
+// uses a scratch value so that a failure (add == 0) leaves out untouched.
+bool generateSafePrimeInProgression(BIGNUM* out, int bits, const BIGNUM* add, const BIGNUM* rem, BN_GENCB* cb)
+{
+    BignumCtxPointer ctx(BN_CTX_new());
+    BignumPointer candidate = BignumPointer::New();
+    BignumPointer t = BignumPointer::New();
+    BignumPointer q = BignumPointer::New();
+    if (!ctx || !candidate || !t || !q) return false;
+    BIGNUM* p = candidate.get();
+
+    // OpenSSL's default residue for safe primes is 3: with 1, (p - 1) / 2 would
+    // be a multiple of add / 2.
+    if (!BN_rand(p, bits, BN_RAND_TOP_ONE, BN_RAND_BOTTOM_ODD)
+        || !BN_mod(t.get(), p, add, ctx.get())
+        || !BN_sub(p, p, t.get())
+        || !(rem != nullptr ? BN_add(p, p, rem) : BN_add_word(p, 3))) {
+        return false;
+    }
+    // Moving onto the progression can take p below 2^(bits - 1); one step puts
+    // it back above the random start.
+    if (BN_num_bits(p) < static_cast<unsigned>(bits) && !BN_add(p, p, add)) return false;
+
+    // Unsigned: on a never-terminating progression the per-step increment
+    // would overflow an int within minutes.
+    unsigned candidates = 0;
+    for (;;) {
+        // Every step, not only sieve survivors: on a progression the sieve
+        // always rejects (an odd prime dividing add with rem % r <= 1), this
+        // call is the walk's only cancellation point for whileScriptAllowed.
+        if (!BN_GENCB_call(cb, BN_GENCB_GENERATED, static_cast<int>(candidates++))) return false;
+        if (!safePrimeCandidateHasSmallFactor(p)) {
+            // do_trial_division = 0: the sieve above already covered p and q.
+            int result = BN_is_prime_fasttest_ex(p, BN_prime_checks_for_generation, ctx.get(), 0, cb);
+            if (result < 0) return false;
+            if (result == 1) {
+                if (!BN_rshift1(q.get(), p)) return false;
+                result = BN_is_prime_fasttest_ex(q.get(), BN_prime_checks_for_generation, ctx.get(), 0, cb);
+                if (result < 0) return false;
+                if (result == 1) return BN_copy(out, p) != nullptr;
+            }
+        }
+        if (!BN_add(p, p, add)) return false;
+    }
+}
+} // namespace
+
 bool BignumPointer::generate(const PrimeConfig& params,
     PrimeCheckCallback innerCb) const
 {
@@ -424,6 +521,10 @@ bool BignumPointer::generate(const PrimeConfig& params,
                 return ptr(a, b) ? 1 : 0;
             },
             &innerCb);
+    }
+    // bits < 2 falls through so that BN_generate_prime_ex reports BN_R_BITS_TOO_SMALL.
+    if (params.safe && params.add && params.bits >= 2) {
+        return generateSafePrimeInProgression(get(), params.bits, params.add.get(), params.rem.get(), cb.get());
     }
     if (BN_generate_prime_ex(get(),
             params.bits,

--- a/test/js/node/crypto/crypto-random.test.ts
+++ b/test/js/node/crypto/crypto-random.test.ts
@@ -1,5 +1,14 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { checkPrime, checkPrimeSync, randomBytes, randomFill, randomFillSync, randomInt } from "crypto";
+import {
+  checkPrime,
+  checkPrimeSync,
+  generatePrime,
+  generatePrimeSync,
+  randomBytes,
+  randomFill,
+  randomFillSync,
+  randomInt,
+} from "crypto";
 import { bunEnv, bunExe, isLinux, isMacOS, isMusl, tempDir } from "harness";
 import { join } from "path";
 
@@ -256,6 +265,224 @@ describe("checkPrime candidate handling", () => {
     const result = await promise;
     expect(checksReads).toBe(1);
     expect(result).toBe(true);
+  });
+});
+
+describe.concurrent("generatePrime with safe and add/rem", () => {
+  // BoringSSL's BN_generate_prime_ex search for safe primes on a progression
+  // (probable_prime_dh_safe) never checks the size of what it walks to and
+  // trial-divides small candidates by themselves, so every size below ~13 bits
+  // returned the same 13-bit value (7523 for the progressions below), and with
+  // an odd `add` it drifted off the progression and frequently never returned.
+  // BignumPointer::generate() now walks the progression itself the way
+  // OpenSSL's search (the one behind Node's results) does, except that it keeps
+  // stepping after a Miller-Rabin failure where OpenSSL restarts from a new
+  // random value; see the comment on generateSafePrimeInProgression. Generation
+  // happens in a subprocess with a kill guard so that the never-returning
+  // inputs fail instead of wedging the test runner (the async form would
+  // otherwise leave a threadpool thread spinning forever).
+  // Every case goes through generatePrimeSync and through generatePrime (the
+  // threadpool job) `runs` times each (default 1). Results are indexed
+  // [form][case][run].
+  type Case = { bits: number; add: bigint; rem?: bigint; runs?: number };
+  type Form = "generatePrimeSync" | "generatePrime";
+  const forms: Form[] = ["generatePrimeSync", "generatePrime"];
+  type Results = Record<Form, bigint[][]>;
+
+  const label = (c: Case) => `${c.bits} bits, add ${c.add}${c.rem === undefined ? "" : `, rem ${c.rem}`}`;
+
+  async function generateSafePrimes(cases: Case[]): Promise<Results> {
+    const serialized = JSON.stringify(cases, (_, v) => (typeof v === "bigint" ? String(v) : v));
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { generatePrime, generatePrimeSync } = require("crypto");
+         const cases = ${serialized};
+         const options = c => ({
+           safe: true,
+           bigint: true,
+           add: BigInt(c.add),
+           ...(c.rem === undefined ? {} : { rem: BigInt(c.rem) }),
+         });
+         const forms = {
+           generatePrimeSync: c => Promise.resolve(generatePrimeSync(c.bits, options(c))),
+           generatePrime: c => new Promise((resolve, reject) =>
+             generatePrime(c.bits, options(c), (err, p) => (err ? reject(err) : resolve(p)))),
+         };
+         (async () => {
+           const out = {};
+           for (const form in forms) {
+             out[form] = [];
+             for (const c of cases) {
+               const primes = [];
+               for (let i = 0; i < (c.runs ?? 1); i++) primes.push(String(await forms[form](c)));
+               out[form].push(primes);
+             }
+           }
+           process.stdout.write(JSON.stringify(out));
+         })();`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stderr, signalCode: proc.signalCode, exitCode }).toEqual({ stderr: "", signalCode: null, exitCode: 0 });
+    const out: Record<Form, string[][]> = JSON.parse(stdout);
+    const toBigInts = (form: string[][]) => form.map(primes => primes.map(BigInt));
+    return { generatePrimeSync: toBigInts(out.generatePrimeSync), generatePrime: toBigInts(out.generatePrime) };
+  }
+
+  // For sizes this small the set of possible results is fixed: the first safe
+  // prime on the progression at or after a random `bits`-bit start. As in
+  // OpenSSL, the result is one bit wider than requested when the start is past
+  // the last safe prime of that size (263 for 8 bits; 5 for 2 bits, where no
+  // safe prime exists). Node returns exactly these sets for the first five
+  // rows. The last row pins the two branches Node's output cannot: every 4-bit
+  // start lands on 17 (a start of 9 first projects to 7, below 4 bits, and has
+  // to be stepped up), 17 passes the sieve but (17 - 1) / 2 = 8 is not prime,
+  // and the walk has to step on through 27 and 37 to 47; Node restarts from a
+  // fresh 4-bit value here and never returns.
+  //
+  // `variesBetweenCalls` pools both forms' results. With these run counts the
+  // chance that a row with several allowed values returns the same one on every
+  // call is below 1e-8 per row (the likeliest 8-bit value has probability 3/8,
+  // the two 4-bit values 1/2 each). Runs are kept low because under a debug
+  // build every call pays the full Miller-Rabin confirmation of two primes.
+  const smallCases: Array<[Case, bigint[]]> = [
+    [{ bits: 8, add: 12n, rem: 11n, runs: 10 }, [167n, 179n, 227n, 263n]],
+    [{ bits: 8, add: 4n, rem: 3n, runs: 10 }, [167n, 179n, 227n, 263n]],
+    [{ bits: 4, add: 4n, rem: 3n, runs: 14 }, [11n, 23n]],
+    [{ bits: 3, add: 4n, rem: 3n, runs: 2 }, [7n]],
+    [{ bits: 2, add: 2n, rem: 1n, runs: 2 }, [5n]],
+    [{ bits: 4, add: 10n, rem: 7n, runs: 10 }, [47n]],
+  ];
+
+  it("small sizes return the next safe prime on the progression, not a fixed 13-bit value", async () => {
+    const results = await generateSafePrimes(smallCases.map(([c]) => c));
+    const summary = smallCases.map(([c, allowed], i) => ({
+      case: label(c),
+      unexpected: Object.fromEntries(
+        forms.map(form => [form, [...new Set(results[form][i].filter(p => !allowed.includes(p)))]]),
+      ),
+      variesBetweenCalls: new Set(forms.flatMap(form => results[form][i])).size > 1,
+    }));
+    expect(summary).toEqual(
+      smallCases.map(([c, allowed]) => ({
+        case: label(c),
+        unexpected: { generatePrimeSync: [], generatePrime: [] },
+        variesBetweenCalls: allowed.length > 1,
+      })),
+    );
+  });
+
+  // Inputs the old search never returned from or answered incorrectly: an odd
+  // `add` took it off the progression (and hung it whenever the random start
+  // shared a factor with `add`), `add` without `rem` must use OpenSSL's
+  // safe-prime default residue of 3, `add: 1n` divided by zero internally, and
+  // the only 3-bit safe prime that is 1 (mod 4) is 5, whose (p - 1) / 2 is 2.
+  //
+  // The last row has `add` as wide as the requested size, so every 16-bit start
+  // projects onto the same value (32771) and the search is deterministic. The
+  // progression's first safe prime from there is 1736759 (21 bits), which is
+  // what stepping past failed candidates returns; restarting from a new random
+  // start after a failure (OpenSSL, and BoringSSL's old search) retests the same
+  // first candidate forever, so Node and the old code both hang on this input.
+  // Third element: expected bit length when it is not the requested size.
+  const residueCases: Array<[Case, bigint, number?]> = [
+    [{ bits: 64, add: 5n }, 3n],
+    [{ bits: 64, add: 5n, rem: 3n }, 3n],
+    [{ bits: 64, add: 5n, rem: 2n }, 2n],
+    [{ bits: 64, add: 7n, rem: 2n }, 2n],
+    [{ bits: 64, add: 4n }, 3n],
+    [{ bits: 64, add: 4n, rem: 3n }, 3n],
+    [{ bits: 64, add: 12n, rem: 11n }, 11n],
+    [{ bits: 64, add: 1n, rem: 0n }, 0n],
+    [{ bits: 3, add: 4n, rem: 1n }, 1n],
+    [{ bits: 16, add: 32769n, rem: 2n }, 2n, 21],
+  ];
+
+  it("terminates and honors add/rem, including odd add and a missing rem", async () => {
+    const results = await generateSafePrimes(residueCases.map(([c]) => c));
+    const describePrime = (c: Case, [p]: bigint[]) => ({
+      bits: p.toString(2).length,
+      residue: p % c.add,
+      safePrime: checkPrimeSync(p) && checkPrimeSync((p - 1n) / 2n),
+    });
+    const summary = residueCases.map(([c], i) => ({
+      case: label(c),
+      ...Object.fromEntries(forms.map(form => [form, describePrime(c, results[form][i])])),
+    }));
+    expect(summary).toEqual(
+      residueCases.map(([c, rem, resultBits = c.bits]) => {
+        const expected = { bits: resultBits, residue: rem, safePrime: true };
+        return { case: label(c), generatePrimeSync: expected, generatePrime: expected };
+      }),
+    );
+  });
+
+  it("safe without add, and add without safe, still go through BN_generate_prime_ex", async () => {
+    const safe = generatePrimeSync(64, { safe: true, bigint: true });
+    expect([safe.toString(2).length, checkPrimeSync(safe), checkPrimeSync((safe - 1n) / 2n)]).toEqual([64, true, true]);
+
+    const { promise, resolve, reject } = Promise.withResolvers<bigint>();
+    generatePrime(64, { add: 12n, rem: 11n, bigint: true }, (err, p) => (err ? reject(err) : resolve(p)));
+    const onProgression = await promise;
+    expect([onProgression.toString(2).length, onProgression % 12n, checkPrimeSync(onProgression)]).toEqual([
+      64,
+      11n,
+      true,
+    ]);
+  });
+
+  it("a generation that fails (add 0) does not hand back the untested starting value", () => {
+    // The binding currently surfaces a failed generation as the untouched 0n
+    // output; propagating it as an exception would be fine too. What must not
+    // happen is the random value the walk was seeded with coming back as a prime.
+    let outcome: bigint | "threw";
+    try {
+      outcome = generatePrimeSync(64, { safe: true, add: 0n, bigint: true });
+    } catch {
+      outcome = "threw";
+    }
+    expect([0n, "threw"]).toContain(outcome);
+  });
+
+  it("worker.terminate() interrupts a search on a progression the sieve always rejects", async () => {
+    // p == 1 (mod 3) makes (p - 1) / 2 a multiple of 3, so no candidate ever
+    // reaches Miller-Rabin and the walk can only stop at its cancellation
+    // callback. The kill guard makes an uninterruptible build fail here.
+    using dir = tempDir("generate-prime-terminate", {
+      "main.js": `
+        const worker = new Worker(new URL("./worker.js", import.meta.url).href);
+        worker.onmessage = async () => {
+          await worker.terminate();
+          console.log("terminated");
+          process.exit(0);
+        };
+      `,
+      "worker.js": `
+        postMessage("started");
+        require("crypto").generatePrimeSync(512, { safe: true, add: 6n, rem: 1n });
+      `,
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: 20_000,
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, signalCode: proc.signalCode, exitCode }).toEqual({
+      stdout: "terminated\n",
+      stderr: "",
+      signalCode: null,
+      exitCode: 0,
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- `crypto.generatePrimeSync(8, { safe: true, add: 12n, rem: 11n, bigint: true })` returns `7523n` (13 bits) on every call, in every process. Every size below about 13 bits does the same; Node returns one of `167n`, `179n`, `227n`, `263n`.
- `generatePrimeSync(64, { safe: true, add: 5n })` (a case from Node's own `test-crypto-prime.js`) hangs about one call in five and otherwise usually returns a prime with the wrong residue mod 5. Same for any odd `add`. The sync form wedges the process; the async form pins a threadpool thread forever.
- `generatePrimeSync(64, { safe: true, add: 1n, rem: 0n })` returns `0n`.
- `generatePrimeSync(16, { safe: true, add: 32769n, rem: 2n })` (an `add` as wide as the size, which the API allows) hangs. Node hangs on this one too; see the second Fix bullet.
- Cause: with `safe` and `add`, `BignumPointer::generate()` (`src/jsc/bindings/ncrypto.cpp`) calls `BN_generate_prime_ex`, whose BoringSSL implementation of this case (`probable_prime_dh_safe` in `vendor/boringssl/crypto/fipsmodule/bn/prime.cc.inc`) steps `p` by `add` and `q` by `add / 2` (which only keeps `p == 2q + 1` for even `add`), never compares the value the walk ends on against the requested size, and trial-divides candidates by a table of primes up to 3671 without excluding the candidate itself. Below 13 bits every real safe prime on the progression has `q` in that table and is rejected as "divisible by q", so the walk only stops at the first safe prime with `q > 3671`, which is 7523 for both progressions above. `add: 1n` makes `add / 2` zero and `BN_mod` fail; the failure is not propagated (#33837), so the untouched `0` comes back.
- OpenSSL's `BN_generate_prime_ex`, which is what Node runs, has none of this: `probable_prime_dh(safe = 1)` moves `p` itself along `p == rem (mod add)` and stops sieving at `sqrt(p)`.

### Fix
- When `safe` and `add` are both set, `generate()` now searches the progression itself (`generateSafePrimeInProgression`): draw a random `bits`-bit value, move it onto `p == rem (mod add)` (`rem` absent means 3, OpenSSL's safe-prime default, which Node's test expects), step once more if that dropped it below `2^(bits - 1)`, sieve, and step by `add` until `p` and `(p - 1) / 2` both pass `BN_is_prime_fasttest_ex`. Everything else (`safe` without `add`, `add` without `safe`, no options) still goes through `BN_generate_prime_ex`. The non-safe `add` path has its own open fix in #33838; the two are independent apart from inserting a block at the same spot in `generate()`.
- Relationship to Node: the start, the progression, the default residue and the size rule are OpenSSL's, so the small-size value sets are now exactly Node's (`{167, 179, 227, 263}` for 8 bits, `{11, 23}` for 4 bits, `7` and `5` for the 3-bit progressions, `5` for size 2; about 22% of 8-bit calls return the 9-bit 263, as in Node) and odd `add` gets the requested residue. The one deliberate difference: when a sieve survivor fails Miller-Rabin, OpenSSL (and BoringSSL's old search) draw a fresh random start, while this keeps stepping. Node only ever returns a start's first sieve survivor, so every value Node can return is still reachable here. Restarting was not copied because it is what makes the large-`add` case above hang: when `add` is nearly as wide as the size, every random start projects onto the same value (32771 for 16 bits and 32769), so restarting retests the same first survivor (622613, not a safe prime) forever, in Node and in the old code alike; stepping returns the progression's first safe prime, 1736759 (21 bits, checked independently). The same thing at toy sizes: 4 bits, `add: 10n, rem: 7n` leads every start to 17, whose `(p - 1) / 2` is 8; Node loops, this continues to 47. The cost of stepping is the usual incremental-search weighting of the output (a safe prime preceded by a longer gap on the progression is proportionally likelier), the same property as every sieve-and-step generator and a negligible entropy loss at any real size; OpenSSL's sieve already steps the same way, it just restarts one level up.
- Size rule, as in OpenSSL: at least `bits` bits, one more when the random start is past the last safe prime of that size. Clamping to exactly `bits` was deliberately not added: it would turn every progression whose safe primes lie just above the range (large `add` relative to the size, tiny sizes) into an infinite loop where both Node and the current code return a value. Progressions containing no safe prime (an even `rem`, `gcd(rem, add) > 1`, `add` divisible by 3 without `rem`) never return, exactly as in Node; the old code hung on those too, except that for an even `rem` it used to return a prime with the wrong residue and now loops like Node. Validation stays what Node has (`add` wider than the size, `rem >= add`, both already in `CryptoPrimes.cpp`).
- Why in `ncrypto.cpp` rather than a BoringSSL patch: the behaviour is upstream BoringSSL's, not a fork regression; `generatePrime` is Bun's only caller of this mode of `BN_generate_prime_ex` (BoringSSL's own `DH_generate_parameters_ex` uses it too, with `add` 24/10/2, so only the sub-13-bit face applies there, and Node rejects DH sizes below 512 anyway); #33838 fixes the sibling mode at the same spot; and a patch to the FIPS module source would have to be carried across every BoringSSL bump, whereas this only uses public `BN_*` functions.
- Sieve: one `BN_mod_word` per small odd prime `r` covers both halves (`p % r == 0` means `r | p`, `p % r == 1` means `r | (p - 1) / 2`), stopping at the first `r` with `r * r > p`, which is what keeps small safe primes from rejecting themselves. The table is built at compile time and is as deep as BoringSSL's own trial division (1024 odd primes, the first half below 1025 bits), so statistically the same number of candidates reach Miller-Rabin as before (table below); the primality tests are then called with `do_trial_division = 0`, as `BN_generate_prime_ex` does after its own sieve. The confirmation is cheaper than before because each half is tested once rather than once per round. The walk runs in a scratch value copied out on success, so a failing input (`add: 0n`) leaves the output untouched, as `BN_generate_prime_ex` did, instead of surfacing the random start through the unchecked return.
- The walk checks the cancellation callback (`whileScriptAllowed`, the hook that lets `worker.terminate()` and `process.exit()` abort a long search) at the top of every step, not only on sieve survivors. On a progression the sieve always rejects (an odd prime `r` dividing `add` with `rem % r <= 1`), that call is the walk's only cancellation point.
- Verification: `test/js/node/crypto/crypto-random.test.ts`, new `generatePrime with safe and add/rem` block. Each of the two generation tests runs its cases through both `generatePrimeSync` and `generatePrime` in one subprocess with a kill guard (the unfixed build hangs on several inputs). Small-size rows pin the value sets above plus a check that repeated calls vary, and a `4 bits, add 10, rem 7 -> 47` row that exercises the step-back-into-range line (a start of 9 projects to 7) and the step-after-Miller-Rabin-failure behaviour; without the range line that row returns `7n` a quarter of the time. Residue rows cover odd `add`, missing `rem`, `add: 1n`, the 3-bit `1 (mod 4)` progression whose only answer is 5, and the 16-bit / `add: 32769n` input above (expected: a 21-bit safe prime with residue 2); controls cover the two paths still delegated to `BN_generate_prime_ex` and `add: 0n`. A worker-terminate row pins the cancellation point: `add: 6n, rem: 1n` sieve-rejects every candidate, and `worker.terminate()` must still end the search.
  - `USE_SYSTEM_BUN=1 bun test test/js/node/crypto/crypto-random.test.ts -t "generatePrime with safe"`: both generation tests fail (`7523n`, `7607n` and `0n` in the small-size diff; the residue test is killed after hanging), the two controls pass.
  - `bun bd test test/js/node/crypto/crypto-random.test.ts`: 27 pass.
  - `bun bd test/js/node/test/parallel/test-crypto-prime.js`: exit 0.
  - Standalone harness against Bun's release BoringSSL objects: every output of 9,000 generations at 3 to 16 bits and 2,300 at 64 and 256 bits passed `BN_prime_checks_for_validation` on both halves with the requested residue; the 4/10/7 row produced exactly 2 Miller-Rabin candidates per run (17, then 47) and the other small rows exactly 1.

### Background
- A safe prime is a prime `p` for which `q = (p - 1) / 2` is also prime; `generatePrime({ safe: true })` produces them for Diffie-Hellman style use. `add` / `rem` additionally require `p % add == rem`, so candidates come from one arithmetic progression.
- Sieving: before running Miller-Rabin (the expensive probabilistic primality test) on a candidate, OpenSSL and BoringSSL both divide it by a table of small primes, which rejects most candidates almost for free. For safe primes the sieve has to clear both `p` and `q`; the `p % r <= 1` test does both with one division because `r` is odd.
- `BN_GENCB` is BoringSSL's progress callback for prime generation; Bun's callers pass one that always continues. The new search reports the same `BN_GENCB_GENERATED` event per candidate that `BN_generate_prime_ex` does and stops if the callback asks it to.

<details>
<summary>Timings against Bun's release BoringSSL objects (standalone harness, same binary for both, add = 12, rem = 11)</summary>

Generation time is geometrically distributed, so means are noisy; the number of candidates reaching Miller-Rabin per run is the stable comparison and shows the sieves are equivalent.

| bits | old `BN_generate_prime_ex` | new walk | MR candidates per run, old / new |
| --- | --- | --- | --- |
| 64 (n=2000) | 12.4 ms | 1.7 ms | 9.1 / 8.7 |
| 256 (n=300) | 82 ms | 37 ms | 143 / 133 |
| 512 (n=16) | 197 ms | 156 ms | |
| 1024 (n=14) | 3.6 s | 2.5 s | |

The 512 and 1024-bit rows were measured before `do_trial_division` was turned off (at 1024 bits the per-candidate cost was 1.17 ms old vs 0.91 ms new); turning it off saved a further ~20% at 64 bits and nothing measurable at 256. At small sizes the old code's time is dominated by its confirmation loop, which runs BoringSSL's 16-iteration minimum once per round for each of `p` and `q`; the new code confirms each half once. A shallower sieve (128 primes) raised the 256-bit candidate count to 227, which is why the table matches BoringSSL's depth.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/crypto/crypto-random.test.ts

<!-- robobun:evidence:end -->
