### PR TITLE
node:http: honor the signal option of server.listen()

### DIFF
--- a/src/js/internal/net/server_abort_signal.ts
+++ b/src/js/internal/net/server_abort_signal.ts
@@ -1,0 +1,28 @@
+const { validateAbortSignal } = require("internal/validators");
+
+let addAbortListener;
+
+// listen({ signal }) for net.Server and http.Server (which does not inherit from
+// net.Server here, unlike Node).
+// https://github.com/nodejs/node/blob/v26.3.0/lib/net.js (addServerAbortSignalOption)
+function addServerAbortSignalOption(self, options) {
+  if (options?.signal === undefined) {
+    return;
+  }
+  validateAbortSignal(options.signal, "options.signal");
+  const { signal } = options;
+  const onAborted = () => {
+    self.close();
+  };
+  if (signal.aborted) {
+    process.nextTick(onAborted);
+  } else {
+    addAbortListener ??= require("internal/abort_listener").addAbortListener;
+    const disposable = addAbortListener(signal, onAborted);
+    self.once("close", disposable[Symbol.dispose]);
+  }
+}
+
+export default {
+  addServerAbortSignalOption,
+};

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -22,6 +22,7 @@ const { ConnResetException, hasObserver, startPerf, stopPerf, kInternalSendOptio
 const kServerResponseStatistics = Symbol("ServerResponseStatistics");
 
 const { isPrimary } = require("internal/cluster/isPrimary");
+const { addServerAbortSignalOption } = require("internal/net/server_abort_signal");
 const {
   throwOnInvalidTLSArray,
   tlsStringToProtocolVersion,
@@ -596,6 +597,7 @@ Server.prototype.listen = function () {
     const arg0 = arguments[0];
     if (($isObject(arg0) || $isCallable(arg0)) && arg0 !== null) {
       // (options[...][, cb])
+      addServerAbortSignalOption(this, arg0);
       port = arg0.port;
       host = arg0.host;
       socketPath = arg0.path;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -40,9 +40,10 @@ import type { Socket, SocketHandler, SocketListener } from "bun";
 import type { Server as NetServer, Socket as NetSocket, ServerOpts } from "node:net";
 import type { TLSSocket } from "node:tls";
 const { kTimeout, getTimerDuration } = require("internal/timers");
-const { validateFunction, validateNumber, validateAbortSignal, validatePort, validateBoolean, validateInt32, validateString } = require("internal/validators"); // prettier-ignore
+const { validateFunction, validateNumber, validatePort, validateBoolean, validateInt32, validateString } = require("internal/validators"); // prettier-ignore
 const { isIPv4, isIPv6, isIP } = require("internal/net/isIP");
 const { kArmHandshakeTimeout, kSecureConnectDone, kVerifyError } = require("internal/net/symbols");
+const { addServerAbortSignalOption } = require("internal/net/server_abort_signal");
 
 const ArrayPrototypeIncludes = Array.prototype.includes;
 const ArrayPrototypeJoin = Array.prototype.join;
@@ -3985,20 +3986,6 @@ function emitErrorNextTick(self, error) {
 function emitErrorAndCloseNextTick(self, error) {
   self.emit("error", error);
   self.emit("close", true);
-}
-
-function addServerAbortSignalOption(self, options) {
-  if (options?.signal === undefined) {
-    return;
-  }
-  validateAbortSignal(options.signal, "options.signal");
-  const { signal } = options;
-  const onAborted = () => self.close();
-  if (signal.aborted) {
-    process.nextTick(onAborted);
-  } else {
-    signal.addEventListener("abort", onAborted);
-  }
 }
 
 function emitListeningNextTick(self) {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -160,6 +160,61 @@ describe("node:http", () => {
       server.close();
     });
 
+    it("listen({ signal }) closes the server when the signal is aborted", async () => {
+      const server = createServer();
+      try {
+        const controller = new AbortController();
+        await new Promise<void>(resolve =>
+          server.listen({ port: 0, host: "127.0.0.1", signal: controller.signal }, resolve),
+        );
+        const { port } = server.address() as AddressInfo;
+        const closed = once(server, "close");
+
+        controller.abort();
+
+        expect(server.listening).toBe(false);
+        expect(server.address()).toBeNull();
+        await closed;
+
+        const socket = connect({ port, host: "127.0.0.1" });
+        const [err] = await once(socket, "error");
+        expect(err.code).toBe("ECONNREFUSED");
+      } finally {
+        server.close();
+      }
+    });
+
+    it("listen({ signal }) with an already aborted signal closes the server without emitting 'listening'", async () => {
+      const server = createServer();
+      try {
+        const onListening = mock(() => {});
+        server.on("listening", onListening);
+        const closed = once(server, "close");
+
+        server.listen({ port: 0, host: "127.0.0.1", signal: AbortSignal.abort() }, onListening);
+        await new Promise<void>(resolve => process.nextTick(resolve));
+
+        expect(server.listening).toBe(false);
+        expect(server.address()).toBeNull();
+        await closed;
+        expect(onListening).not.toHaveBeenCalled();
+      } finally {
+        server.close();
+      }
+    });
+
+    it("listen({ signal }) rejects a value that is not an AbortSignal", () => {
+      const server = createServer();
+      try {
+        expect(() => server.listen({ port: 0, host: "127.0.0.1", signal: "INVALID_SIGNAL" as any })).toThrow(
+          expect.objectContaining({ name: "TypeError", code: "ERR_INVALID_ARG_TYPE" }),
+        );
+        expect(server.address()).toBeNull();
+      } finally {
+        server.close();
+      }
+    });
+
     it("should use the provided port", async () => {
       while (true) {
         try {

--- a/test/js/node/net/node-net-server.test.ts
+++ b/test/js/node/net/node-net-server.test.ts
@@ -433,6 +433,22 @@ describe("net.createServer events", () => {
       });
   });
 
+  it("should stop listening to the signal once the server has closed", async () => {
+    const controller = new AbortController();
+    const server = createServer();
+    let closeEvents = 0;
+    server.on("close", () => closeEvents++);
+
+    await new Promise<void>(resolve => server.listen({ port: 0, signal: controller.signal }, resolve));
+    await new Promise<void>(resolve => server.close(() => resolve()));
+    expect(closeEvents).toBe(1);
+
+    // Aborting now must not call close() again, which would emit a second 'close'.
+    controller.abort();
+    await new Promise<void>(resolve => setImmediate(resolve));
+    expect(closeEvents).toBe(1);
+  });
+
   it("should echo data", done => {
     const { mustNotCall } = createCallCheckCtx(done);
     let timeout: Timer;


### PR DESCRIPTION
### Problem
- `http.createServer().listen({ port, signal })` (and the `https` equivalent) ignores `signal`: aborting it never closes the server, `server.listening` stays `true`, the port keeps accepting connections, and the listening socket keeps the process alive. Node closes the server and emits `'close'`.
- Cause: `Server.prototype.listen` in `src/js/node/_http_server.ts` reads only `port`/`host`/`path`/`tls` from the options object. The code that handles `signal` (`addServerAbortSignalOption`) was a private function in `src/js/node/net.ts`, and Bun's `http.Server` does not inherit from `net.Server`, so it never ran for http servers.
- The net.ts helper also differed from Node: it never removed its abort listener, so `server.close()` followed by `controller.abort()` called `close()` a second time and `net.Server` emitted `'close'` twice (Node emits it once). A long-lived signal also kept a reference to every server ever listened with it.

### Fix
- Move the helper to `src/js/internal/net/server_abort_signal.ts` and call it from both `net.Server.prototype.listen` and `http.Server.prototype.listen` when an options object is passed. Same semantics as Node's `addServerAbortSignalOption`: `ERR_INVALID_ARG_TYPE` for a value that is not an `AbortSignal`, an already aborted signal closes the server on the next tick (so `'listening'` is never emitted), an abort later calls `server.close()`.
- The listener is now registered with `addAbortListener` and disposed when the server emits `'close'`, matching Node, which fixes the double `'close'` on `net.Server` and drops the signal -> server reference once the server is gone.
- `https.Server` is `http.Server` in Bun, so it is covered by the same change.
- Verified:
  - `test/js/node/http/node-http.test.ts` (3 new `listen({ signal })` tests: abort after listen, already aborted signal, invalid signal); all three fail on the current release and pass with this change.
  - `test/js/node/net/node-net-server.test.ts` (new close-then-abort test; fails on the current release with 2 `'close'` events, passes with this change).
  - The same four scenarios were checked against Node v26.3.0 with a standalone script to confirm the asserted behavior is Node's.
  - Full `node-http.test.ts` and `node-net-server.test.ts` runs, plus 13 vendored Node tests around `listen()`/`close()` (`test-net-server-listen-options-signal.js`, `test-net-server-listen-options.js`, `test-http-server-close-*.js`, ...), pass with the debug build.

### Background
- Node's `net.Server.prototype.listen` accepts `{ signal }` and implements it in `addServerAbortSignalOption` (lib/net.js): validate, then either `process.nextTick(close)` if already aborted, or register an abort listener that calls `server.close()` and remove that listener on the server's `'close'` event. `http.Server` and `https.Server` get this for free in Node because they extend `net.Server`.
- In Bun, `http.Server` (`src/js/node/_http_server.ts`) is a separate `EventEmitter` subclass wrapping `Bun.serve`, with its own `listen()`/`close()`, so anything implemented on `net.Server.listen` has to be wired up there explicitly.
- `internal/abort_listener` is Bun's copy of Node's `events.addAbortListener`: it adds a `once` abort listener and returns a disposable whose `[Symbol.dispose]` removes it. The rest of `node:net` (socket `signal` option) and `node:dgram` already use it the same way.
