### PR TITLE
structured clone: re-check the transfer list after serializing so a failed transfer detaches nothing

### DIFF
--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -105,8 +105,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
     }
     RETURN_IF_EXCEPTION(warnScope, {});
 
-    // create() detached the buffers, so the listed ports are consumed too even when the message
-    // is dropped below (closed sender, or a port posted to its own peer), as in node.
+    // create() already detached the buffers, so (as in node) a message dropped below still consumes the listed ports.
     Vector<TransferredMessagePort> transferredPorts;
     bool targetsEntangledPeer = false;
     if (!ports.isEmpty()) {
@@ -128,8 +127,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
         return {};
 
     if (targetsEntangledPeer) {
-        // Node warns and loses the channel instead of throwing; close() so the dead
-        // channel stops reffing the loop.
+        // Node warns and loses the channel instead of throwing; close() stops the dead channel from reffing the loop.
         Bun__Process__emitWarning(defaultGlobalObject(&state),
             JSC::JSValue::encode(JSC::jsString(vm, String("The target port was posted to itself, and the communication channel was lost"_s))),
             JSC::JSValue::encode(JSC::jsString(vm, String("Warning"_s))),

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -105,41 +105,43 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
     }
     RETURN_IF_EXCEPTION(warnScope, {});
 
-    if (!isEntangled())
-        return {};
-
+    // create() already detached the listed ArrayBuffers, so the listed ports are detached too
+    // before either reason to drop the message below (this port is closed, possibly by a getter
+    // that ran during serialization, or it is being posted its own peer) is checked. Node does
+    // the same; a dropped message must not leave the buffers gone but the ports still usable.
     Vector<TransferredMessagePort> transferredPorts;
+    bool targetsEntangledPeer = false;
     if (!ports.isEmpty()) {
         // Posting a port's own entangled peer targets the message at itself.
         // (The source port itself was rejected before serialization above.)
-        bool targetsEntangledPeer = false;
         for (auto& port : ports) {
             if (port->pipe() == m_pipe.ptr()) {
                 targetsEntangledPeer = true;
                 break;
             }
         }
-        // Detach every transfer-list port up front: transfer is atomic in node, so a
-        // third-party port must not stay usable even when the message is dropped below.
         auto disentangled = MessagePort::disentanglePorts(WTF::move(ports));
         if (disentangled.hasException())
             return disentangled.releaseException();
         transferredPorts = disentangled.releaseReturnValue();
+    }
 
-        if (targetsEntangledPeer) {
-            // Posting the port's own entangled peer: node warns and loses the channel
-            // rather than throwing. Transferables were already detached above; drop the
-            // message and close so the dead channel stops reffing the loop.
-            Bun__Process__emitWarning(defaultGlobalObject(&state),
-                JSC::JSValue::encode(JSC::jsString(vm, String("The target port was posted to itself, and the communication channel was lost"_s))),
-                JSC::JSValue::encode(JSC::jsString(vm, String("Warning"_s))),
-                JSC::JSValue::encode(JSC::jsUndefined()),
-                JSC::JSValue::encode(JSC::jsUndefined()));
-            CLEAR_IF_EXCEPTION(warnScope);
-            close();
-            RETURN_IF_EXCEPTION(warnScope, Exception { ExistingExceptionError });
-            return {};
-        }
+    if (!isEntangled())
+        return {};
+
+    if (targetsEntangledPeer) {
+        // Posting the port's own entangled peer: node warns and loses the channel
+        // rather than throwing. Drop the message and close so the dead channel stops
+        // reffing the loop.
+        Bun__Process__emitWarning(defaultGlobalObject(&state),
+            JSC::JSValue::encode(JSC::jsString(vm, String("The target port was posted to itself, and the communication channel was lost"_s))),
+            JSC::JSValue::encode(JSC::jsString(vm, String("Warning"_s))),
+            JSC::JSValue::encode(JSC::jsUndefined()),
+            JSC::JSValue::encode(JSC::jsUndefined()));
+        CLEAR_IF_EXCEPTION(warnScope);
+        close();
+        RETURN_IF_EXCEPTION(warnScope, Exception { ExistingExceptionError });
+        return {};
     }
 
     m_pipe->send(m_side, MessageWithMessagePorts { messageData.releaseReturnValue(), WTF::move(transferredPorts) });

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -105,10 +105,8 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
     }
     RETURN_IF_EXCEPTION(warnScope, {});
 
-    // create() already detached the listed ArrayBuffers, so the listed ports are detached too
-    // before either reason to drop the message below (this port is closed, possibly by a getter
-    // that ran during serialization, or it is being posted its own peer) is checked. Node does
-    // the same; a dropped message must not leave the buffers gone but the ports still usable.
+    // create() detached the buffers, so the listed ports are consumed too even when the message
+    // is dropped below (closed sender, or a port posted to its own peer), as in node.
     Vector<TransferredMessagePort> transferredPorts;
     bool targetsEntangledPeer = false;
     if (!ports.isEmpty()) {
@@ -130,9 +128,8 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& state, JSC::JSVa
         return {};
 
     if (targetsEntangledPeer) {
-        // Posting the port's own entangled peer: node warns and loses the channel
-        // rather than throwing. Drop the message and close so the dead channel stops
-        // reffing the loop.
+        // Node warns and loses the channel instead of throwing; close() so the dead
+        // channel stops reffing the loop.
         Bun__Process__emitWarning(defaultGlobalObject(&state),
             JSC::JSValue::encode(JSC::jsString(vm, String("The target port was posted to itself, and the communication channel was lost"_s))),
             JSC::JSValue::encode(JSC::jsString(vm, String("Warning"_s))),

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4353,6 +4353,29 @@ void markAsUntransferable(VM& vm, JSObject& object)
     markObjectWithPrivateName(vm, object, builtinNames(vm).isUntransferablePrivateName());
 }
 
+// The transfer list is validated before serializing, but CloneSerializer::serialize runs user
+// code (getters, Proxy traps) that can close or transfer a listed port, detach a listed buffer,
+// or markAsUntransferable() an entry. Those conditions are checked again, for the whole list,
+// before anything is detached: a rejected transfer must leave every entry intact, whereas
+// leaving a closed port for MessagePort::disentanglePorts to reject would report the failure
+// after transferArrayBuffers() had already emptied the caller's buffers.
+static std::optional<Exception> transferListChangedDuringSerialization(VM& vm, const Vector<JSC::Strong<JSC::JSObject>>& transferList, const Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<MessagePort>>& messagePorts)
+{
+    for (auto& transferable : transferList) {
+        if (transferable->getDirect(vm, builtinNames(vm).isUntransferablePrivateName()))
+            return Exception { DataCloneError, "Cannot transfer object marked as untransferable"_s };
+    }
+    for (auto& arrayBuffer : arrayBuffers) {
+        if (arrayBuffer->isDetached())
+            return Exception { DataCloneError, "ArrayBuffer in transfer list was detached during serialization"_s };
+    }
+    for (auto& port : messagePorts) {
+        if (port->isDetached() || port->isClosing())
+            return Exception { DataCloneError, "MessagePort in transfer list is already detached"_s };
+    }
+    return std::nullopt;
+}
+
 static ExceptionOr<std::unique_ptr<ArrayBufferContentsArray>> transferArrayBuffers(VM& vm, const Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers)
 {
     if (arrayBuffers.isEmpty())
@@ -4711,6 +4734,8 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
 
     Vector<RefPtr<JSC::ArrayBuffer>> arrayBuffers;
     HashSet<JSC::JSObject*> uniqueTransferables;
+    // Anything user code can change while serializing is checked a second time in
+    // transferListChangedDuringSerialization() below.
     for (auto& transferable : transferList) {
         // markAsUntransferable marker: a DontEnum JSC private name (see markAsUncloneable).
         if (transferable->getDirect(vm, builtinNames(vm).isUntransferablePrivateName()))
@@ -4783,6 +4808,11 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
     if (scope.exception() || code != SerializationReturnCode::SuccessfullyCompleted) [[unlikely]] {
         releaseSerializedBlockListRefs();
         RELEASE_AND_RETURN(scope, exceptionForSerializationFailure(code));
+    }
+
+    if (auto exception = transferListChangedDuringSerialization(vm, transferList, arrayBuffers, messagePorts)) [[unlikely]] {
+        releaseSerializedBlockListRefs();
+        RELEASE_AND_RETURN(scope, WTF::move(*exception));
     }
 
     auto arrayBufferContentsArray = transferArrayBuffers(vm, arrayBuffers);

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4353,8 +4353,7 @@ void markAsUntransferable(VM& vm, JSObject& object)
     markObjectWithPrivateName(vm, object, builtinNames(vm).isUntransferablePrivateName());
 }
 
-// Serializing runs user code (getters, Proxy traps) that can invalidate entries the transfer list
-// loop in create() accepted. Runs before anything is detached, so a failure detaches nothing.
+// Serializing runs user code (getters, Proxy traps) that can invalidate entries create() accepted; runs before anything is detached.
 static std::optional<Exception> transferListChangedDuringSerialization(VM& vm, const Vector<JSC::Strong<JSC::JSObject>>& transferList, const Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<MessagePort>>& messagePorts)
 {
     for (auto& transferable : transferList) {

--- a/src/jsc/bindings/webcore/SerializedScriptValue.cpp
+++ b/src/jsc/bindings/webcore/SerializedScriptValue.cpp
@@ -4353,12 +4353,8 @@ void markAsUntransferable(VM& vm, JSObject& object)
     markObjectWithPrivateName(vm, object, builtinNames(vm).isUntransferablePrivateName());
 }
 
-// The transfer list is validated before serializing, but CloneSerializer::serialize runs user
-// code (getters, Proxy traps) that can close or transfer a listed port, detach a listed buffer,
-// or markAsUntransferable() an entry. Those conditions are checked again, for the whole list,
-// before anything is detached: a rejected transfer must leave every entry intact, whereas
-// leaving a closed port for MessagePort::disentanglePorts to reject would report the failure
-// after transferArrayBuffers() had already emptied the caller's buffers.
+// Serializing runs user code (getters, Proxy traps) that can invalidate entries the transfer list
+// loop in create() accepted. Runs before anything is detached, so a failure detaches nothing.
 static std::optional<Exception> transferListChangedDuringSerialization(VM& vm, const Vector<JSC::Strong<JSC::JSObject>>& transferList, const Vector<RefPtr<JSC::ArrayBuffer>>& arrayBuffers, const Vector<RefPtr<MessagePort>>& messagePorts)
 {
     for (auto& transferable : transferList) {
@@ -4734,8 +4730,6 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
 
     Vector<RefPtr<JSC::ArrayBuffer>> arrayBuffers;
     HashSet<JSC::JSObject*> uniqueTransferables;
-    // Anything user code can change while serializing is checked a second time in
-    // transferListChangedDuringSerialization() below.
     for (auto& transferable : transferList) {
         // markAsUntransferable marker: a DontEnum JSC private name (see markAsUncloneable).
         if (transferable->getDirect(vm, builtinNames(vm).isUntransferablePrivateName()))

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1438,6 +1438,164 @@ describe("postMessage transfer list", () => {
   });
 });
 
+// Serializing the message runs user code (the getters below), which can invalidate an entry
+// of the transfer list after the list was checked. The transfer must then fail as a whole:
+// node reports the DataCloneError with every listed ArrayBuffer still intact. Bun used to
+// detach the buffers first and reject the port afterwards, so the caller got an error and
+// lost its data.
+describe("transfer list invalidated while the message is serialized", () => {
+  const dataClone = expect.objectContaining({ name: "DataCloneError", code: 25 });
+
+  // `first` is serialized, then the getter closes `transferred`, then `last`.
+  function messageClosingListedPort(transferred: MessagePort) {
+    const first = new ArrayBuffer(8);
+    const last = new ArrayBuffer(8);
+    const message = {
+      first,
+      get closeIt() {
+        transferred.close();
+        return 1;
+      },
+      transferred,
+      last,
+    };
+    return { message, transfer: [first, transferred, last], buffers: [first, last] };
+  }
+
+  test("port.postMessage: a getter closing a listed port leaves the listed buffers intact", () => {
+    const { port1, port2 } = new MessageChannel();
+    const { port1: transferred, port2: peer } = new MessageChannel();
+    const { message, transfer, buffers } = messageClosingListedPort(transferred);
+    expect(() => port1.postMessage(message, transfer)).toThrow(dataClone);
+    expect(buffers.map(b => b.byteLength)).toEqual([8, 8]);
+    expect(receiveMessageOnPort(port2)).toBeUndefined();
+    port1.close();
+    port2.close();
+    peer.close();
+  });
+
+  test("worker.postMessage: a getter closing a listed port leaves the listed buffers intact", async () => {
+    const worker = new Worker("", { eval: true });
+    const { port1: transferred, port2: peer } = new MessageChannel();
+    try {
+      const { message, transfer, buffers } = messageClosingListedPort(transferred);
+      expect(() => worker.postMessage(message, transfer)).toThrow(dataClone);
+      expect(buffers.map(b => b.byteLength)).toEqual([8, 8]);
+    } finally {
+      await worker.terminate();
+      peer.close();
+    }
+  });
+
+  test("new Worker: a workerData getter closing a listed port leaves the listed buffers intact", async () => {
+    const { port1: transferred, port2: peer } = new MessageChannel();
+    let worker: Worker | undefined;
+    try {
+      const { message, transfer, buffers } = messageClosingListedPort(transferred);
+      expect(() => {
+        worker = new Worker("", { eval: true, workerData: message, transferList: transfer });
+      }).toThrow(dataClone);
+      expect(buffers.map(b => b.byteLength)).toEqual([8, 8]);
+    } finally {
+      await worker?.terminate();
+      peer.close();
+    }
+  });
+
+  // The invalidated port is only in the transfer list, not in the message, so only the
+  // post-serialization check can notice it.
+  test("port.postMessage: a getter transferring a listed port elsewhere leaves the listed buffers intact", () => {
+    const { port1, port2 } = new MessageChannel();
+    const { port1: transferred, port2: peer } = new MessageChannel();
+    const { port1: elsewhere, port2: elsewherePeer } = new MessageChannel();
+    const buffer = new ArrayBuffer(8);
+    const message = {
+      buffer,
+      get moveIt() {
+        elsewhere.postMessage(null, [transferred]);
+        return 1;
+      },
+    };
+    expect(() => port1.postMessage(message, [buffer, transferred])).toThrow(dataClone);
+    expect(buffer.byteLength).toBe(8);
+    expect(receiveMessageOnPort(port2)).toBeUndefined();
+    port1.close();
+    port2.close();
+    elsewhere.close();
+    elsewherePeer.close();
+    peer.close();
+  });
+
+  // A mark applied by a getter counts like one applied before the call: the buffer is not
+  // detached. (Node also refuses, as a TypeError raised by the detach itself.)
+  function expectMarkDuringSerializationToBeHonored(send: (message: object, transfer: ArrayBuffer[]) => unknown) {
+    const buffer = new ArrayBuffer(16);
+    const message = {
+      get markIt() {
+        markAsUntransferable(buffer);
+        return 1;
+      },
+      buffer,
+    };
+    expect(() => send(message, [buffer])).toThrow(dataClone);
+    expect(buffer.byteLength).toBe(16);
+  }
+
+  test("structuredClone honors markAsUntransferable applied during serialization", () => {
+    expectMarkDuringSerializationToBeHonored((message, transfer) => structuredClone(message, { transfer }));
+  });
+
+  test("port.postMessage honors markAsUntransferable applied during serialization", () => {
+    const { port1, port2 } = new MessageChannel();
+    expectMarkDuringSerializationToBeHonored((message, transfer) => port1.postMessage(message, transfer));
+    expect(receiveMessageOnPort(port2)).toBeUndefined();
+    port1.close();
+    port2.close();
+  });
+
+  test("worker.postMessage honors markAsUntransferable applied during serialization", async () => {
+    const worker = new Worker("", { eval: true });
+    try {
+      expectMarkDuringSerializationToBeHonored((message, transfer) => worker.postMessage(message, transfer));
+    } finally {
+      await worker.terminate();
+    }
+  });
+
+  // The other direction of the same rule: once the buffers are detached, the listed ports go
+  // with them even though the message itself is dropped because the sending port is closed.
+  // Node performs the transfer for a closed sender too; bun used to leave the port usable.
+  test.each([
+    ["before the call", true],
+    ["by a getter during serialization", false],
+  ])("port.postMessage on a port closed %s still detaches the listed port", async (_name, closeBeforeCall) => {
+    const { port1: sender, port2: senderPeer } = new MessageChannel();
+    const { port1: transferred, port2: peer } = new MessageChannel();
+    const { promise: peerSawClose, resolve } = Promise.withResolvers<void>();
+    peer.on("close", () => resolve());
+    const buffer = new ArrayBuffer(8);
+    if (closeBeforeCall) sender.close();
+    const message = {
+      buffer,
+      get closeSender() {
+        sender.close();
+        return 1;
+      },
+      transferred,
+    };
+    expect(() => sender.postMessage(message, [buffer, transferred])).not.toThrow();
+    expect(buffer.byteLength).toBe(0);
+    const { port1: other, port2: otherPeer } = new MessageChannel();
+    expect(() => other.postMessage(null, [transferred])).toThrow("MessagePort in transfer list is already detached");
+    // The transferred endpoint had no receiver, which closes the channel from the peer's view.
+    await peerSawClose;
+    peer.close();
+    senderPeer.close();
+    other.close();
+    otherPeer.close();
+  });
+});
+
 test("MessagePort NodeEventTarget methods", () => {
   const { port1 } = new MessageChannel();
   expect(typeof port1.listenerCount).toBe("function");

--- a/test/js/web/workers/structured-clone.test.ts
+++ b/test/js/web/workers/structured-clone.test.ts
@@ -450,6 +450,35 @@ for (const structuredCloneFn of [structuredClone, jscSerializeRoundtrip, jscSeri
             structuredCloneFn(buffer, { transfer: [buffer] });
           }).toThrow(DOMException);
         });
+        // https://html.spec.whatwg.org/multipage/structured-data.html#structuredserializewithtransfer
+        // The transfer list is checked again after serialization (step 5), which can run user
+        // code. A listed buffer detached by a getter is a DataCloneError, and nothing else in
+        // the list may be detached by the failed call (previously: TypeError, with `first`
+        // already detached). `second` is deliberately kept out of the value so the serializer
+        // itself never sees it.
+        test("a listed ArrayBuffer detached during serialization fails without detaching the others", () => {
+          const first = new ArrayBuffer(8);
+          const second = new ArrayBuffer(8);
+          const value = {
+            first,
+            get detachSecond() {
+              structuredCloneFn(second, { transfer: [second] });
+              return 1;
+            },
+          };
+          let error: unknown;
+          try {
+            structuredCloneFn(value, { transfer: [first, second] });
+          } catch (e) {
+            error = e;
+          }
+          expect(error).toBeInstanceOf(DOMException);
+          expect({
+            name: (error as DOMException).name,
+            first: first.byteLength,
+            second: second.byteLength,
+          }).toEqual({ name: "DataCloneError", first: 8, second: 0 });
+        });
         // Bun's native borrows call ArrayBuffer::pin(), which makes the buffer
         // non-detachable without setting the C-API lock flag. Transferring a
         // pinned buffer must copy via transferTo()'s copyTo() fallback, not

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -100,6 +100,36 @@ describe("self.postMessage transfer list", () => {
     expect(results[0]).toEqual(["TypeError", "TypeError", "TypeError", "TypeError"]);
   });
 
+  // Serializing the message runs the getter, which closes a port that is in the
+  // transfer list. The transfer then fails as a whole: DataCloneError, with the
+  // buffer listed ahead of the port still intact (it used to be detached before
+  // the port was rejected).
+  test("postMessage with a listed port closed during serialization detaches nothing", async () => {
+    const results = await roundtrip(
+      `
+        const { port1 } = new MessageChannel();
+        const buf = new ArrayBuffer(16);
+        const message = {
+          buf,
+          get closeIt() {
+            port1.close();
+            return 1;
+          },
+          port1,
+        };
+        let name = "no throw";
+        try {
+          self.postMessage(message, [buf, port1]);
+        } catch (err) {
+          name = err.name;
+        }
+        self.postMessage({ name, byteLength: buf.byteLength });
+      `,
+      1,
+    );
+    expect(results[0]).toEqual({ name: "DataCloneError", byteLength: 16 });
+  });
+
   test("postMessage(msg, [MessagePort]) transfers the port", async () => {
     // Don't reuse roundtrip() here: it terminates the worker as soon as the
     // first message lands, which can race the port-channel delivery. Keep the
@@ -134,6 +164,39 @@ describe("self.postMessage transfer list", () => {
     } finally {
       worker.terminate();
       URL.revokeObjectURL(url);
+    }
+  });
+});
+
+// Parent-side Worker#postMessage: same rule as above, observed directly on the caller's
+// buffer. The message is serialized (and the transfer list applied) whether or not the
+// worker has started, so the worker body can be empty.
+describe("Worker#postMessage transfer list", () => {
+  test("a listed port closed during serialization fails the transfer without detaching the buffer", () => {
+    const url = URL.createObjectURL(new Blob([""]));
+    const worker = new Worker(url);
+    const { port1, port2 } = new MessageChannel();
+    try {
+      const buf = new ArrayBuffer(16);
+      const message = {
+        buf,
+        get closeIt() {
+          port1.close();
+          return 1;
+        },
+        port1,
+      };
+      let name = "no throw";
+      try {
+        worker.postMessage(message, [buf, port1]);
+      } catch (err) {
+        name = (err as Error).name;
+      }
+      expect({ name, byteLength: buf.byteLength }).toEqual({ name: "DataCloneError", byteLength: 16 });
+    } finally {
+      worker.terminate();
+      URL.revokeObjectURL(url);
+      port2.close();
     }
   });
 });


### PR DESCRIPTION
### Problem

- `port.postMessage(msg, [ab1, port, ab2])`, `worker.postMessage(...)` and `new Worker(file, { workerData, transferList })` throw `DataCloneError` when a getter inside `msg` closes `port` while the message is being serialized, but `ab1` and `ab2` are already detached when the error reaches the caller: the send is reported as failed and the caller's data is gone. Node throws the same error with both buffers intact.
- `markAsUntransferable(ab)` applied by a getter during serialization is ignored on every entry point (`structuredClone`, `port.postMessage`, `worker.postMessage`): the clone succeeds and `ab` is detached. Node refuses (as a `TypeError` from the detach itself) and leaves `ab` intact.
- Same class, found while reproducing: a listed buffer detached by a getter during serialization gives `TypeError: Type error` after the buffers listed ahead of it were detached; a listed port that a getter transfers elsewhere gives `DataCloneError` after the listed buffers were detached.
- Cause: `SerializedScriptValue::create` (src/jsc/bindings/webcore/SerializedScriptValue.cpp) validates the transfer list only before `CloneSerializer::serialize`, which is where user code runs. It then calls `transferArrayBuffers()` unconditionally, and the port state is only looked at again by `MessagePort::disentanglePorts`, which every caller runs after `create()` has returned, i.e. after the buffers are detached. The untransferable mark is never looked at again at all.
- Related: `port.postMessage(msg, [ab, otherPort])` on a port that is closed (before the call, or by a getter during serialization) detached `ab` but returned from `MessagePort::postMessage` before `otherPort` was disentangled, leaving it usable and re-transferable. Node detaches it.

### Fix

- `SerializedScriptValue::create`: after serialization succeeds and before `transferArrayBuffers()`, re-check the whole transfer list for the three things user code can change while serializing: a port that is now detached or closing, a buffer that is now detached, an entry that now carries the untransferable mark. Any of them returns `DataCloneError` with nothing detached. Conditions that cannot change during serialization (duplicates, shared or wasm buffers, invalid entries) stay in the pre-serialization loop only.
- This covers every entry point in one place, since `structuredClone`, `MessagePort::postMessage`, `Worker::postMessage`, the worker-side `postMessage` and the `Worker` constructor all go through `create()`. The `disentanglePorts` checks remain, but nothing runs user code between `create()` returning and them, so they no longer fire after buffers have been detached.
- The detached-buffer re-check is what HTML StructuredSerializeWithTransfer step 5 specifies (Node instead silently sends an empty buffer there). The mid-serialization mark is reported as the same `DataCloneError` as a mark applied before the call, rather than Node's incidental `TypeError`.
- `MessagePort::postMessage`: disentangle the listed ports before the "sending port is closed" early return, so a dropped message still applies the whole transfer (buffers were already detached by `create()`). The "posted to itself" warn-and-close path is unchanged apart from the ordering.
- Verified with:
  - `test/js/node/worker_threads/worker_threads.test.ts`, new `describe("transfer list invalidated while the message is serialized")`: 9 tests, all fail on the current release and pass with this change; whole file 131 pass.
  - `test/js/web/workers/worker-postmessage-transfer.test.ts`: worker-side `self.postMessage` and parent-side `Worker#postMessage` cases, both fail before and pass after.
  - `test/js/web/workers/structured-clone.test.ts`: listed buffer detached during serialization, fails before and passes after.
  - `test/js/node/test/parallel/test-worker-message-port-transfer-{closed,target,self,duplicate,terminate}.js`, `test-worker-message-port-terminate-transfer-list.js`, `test-worker-message-transfer-port-mark-as-untransferable.js`, `test-worker-message-mark-as-uncloneable.js`, `test-buffer-pool-untransferable.js`: pass.
  - `test/js/web/workers/message-channel.test.ts`, `message-event.test.ts`, `message-port-closed-leak.test.ts`, `structuredClone-classes.test.ts`, `test/js/node/worker_threads/worker-transfer-list.test.ts`: pass. Two tests in `message-port-pipe.test.ts` hit their 5 s timeout under the debug/ASAN build in my environment; both involve no transfer list and their child scripts complete correctly when run directly (about 7 s).

### Background

- Structured clone with a transfer list has two phases: serialize the value into a byte buffer (`CloneSerializer::serialize`), then apply the transfer, which detaches each listed `ArrayBuffer` (its bytes move to the receiver and `byteLength` becomes 0) and disentangles each listed `MessagePort` (the sender's object becomes inert and the receiver gets a new port on the same channel). Serializing reads the value's properties, so getters and Proxy traps run in the middle of the operation.
- In bun the buffer half of the transfer happens inside `SerializedScriptValue::create`, and the port half is done by each caller via `MessagePort::disentanglePorts` once `create()` has returned; `create()` only reports the ports to the caller through the `messagePorts` out-parameter.
- `markAsUntransferable` (node:worker_threads) tags an object with a private name; a tagged object in a transfer list is rejected with `DataCloneError` instead of being detached. Before this change that tag was only read before serialization.
- `MessagePort::isClosing()` is set at the start of `close()` and `isDetached()` at its end (and by a transfer); the re-check uses both, the same predicate as the existing pre-serialization check and `disentanglePorts`.

<details>
<summary>Reproduction and output before / after</summary>

```js
import { MessageChannel, Worker, markAsUntransferable } from "node:worker_threads";

const { port2 } = new MessageChannel();
const ab1 = new ArrayBuffer(8), ab2 = new ArrayBuffer(8);
const v = { ab1, get g() { port2.close(); return 1; }, p: port2, ab2 };
try { new MessageChannel().port1.postMessage(v, [ab1, port2, ab2]); } catch (e) { console.log(e.name, ab1.byteLength, ab2.byteLength); }

const ab4 = new ArrayBuffer(16);
try {
  structuredClone({ get g() { markAsUntransferable(ab4); return 1; }, ab4 }, { transfer: [ab4] });
  console.log("no error", ab4.byteLength);
} catch (e) { console.log(e.name, ab4.byteLength); }

const { port1: sender } = new MessageChannel();
const other = new MessageChannel();
const ab5 = new ArrayBuffer(8);
sender.close();
sender.postMessage({ ab5, p: other.port1 }, [ab5, other.port1]);
try { new MessageChannel().port1.postMessage(null, [other.port1]); console.log("otherPort still transferable", ab5.byteLength); }
catch (e) { console.log(e.name, ab5.byteLength); }
```

Before (bun 1.4.0):

```
DataCloneError 0 0
no error 0
otherPort still transferable 0
```

After:

```
DataCloneError 8 8
DataCloneError 16
DataCloneError 0
```

Node v26.3.0 prints `DataCloneError 8 8`, `TypeError 16`, `DataCloneError 0`. (Node aborts with a `CHECK(data_)` failure on the variant where a getter transfers a listed port elsewhere; bun now throws `DataCloneError` with the buffers intact for it.)

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/structured-clone.test.ts test/js/web/workers/worker-postmessage-transfer.test.ts
bun test v1.4.1 (861e9ae04)

test/js/web/workers/worker-postmessage-transfer.test.ts:
(pass) self.postMessage transfer list > postMessage(msg, [ArrayBuffer]) transfers and detaches the buffer [190.14ms]
(pass) self.postMessage transfer list > postMessage(msg, { transfer: [ArrayBuffer] }) transfers and detaches the buffer [181.60ms]
(pass) self.postMessage transfer list > postMessage(msg, [ArrayBuffer, null]) throws TypeError and detaches nothing [190.26ms]
(pass) self.postMessage transfer list > postMessage(msg, invalidOptions) throws TypeError [139.17ms]
125 |         }
126 |         self.postMessage({ name, byteLength: buf.byteLength });
127 |       `,
128 |       1,
129 |     );
130 |     expect(results[0]).toEqual({ name: "DataCloneError", byteLength: 16 });
                             ^
error: expect(received).toEqual(expected)

  {
-   "byteLength": 16,
+   "byteLength": 0,
    "
... (truncated)

release without fix: 12 FAILED
bun test v1.4.1-canary.1 (861e9ae04)

test/js/web/workers/worker-postmessage-transfer.test.ts:
(pass) self.postMessage transfer list > postMessage(msg, [ArrayBuffer]) transfers and detaches the buffer [3.46ms]
(pass) self.postMessage transfer list > postMessage(msg, { transfer: [ArrayBuffer] }) transfers and detaches the buffer [2.08ms]
(pass) self.postMessage transfer list > postMessage(msg, [ArrayBuffer, null]) throws TypeError and detaches nothing [1.53ms]
(pass) self.postMessage transfer list > postMessage(msg, invalidOptions) throws TypeError [1.52ms]
125 |         }
126 |         self.postMessage({ name, byteLength: buf.byteLength });
127 |       `,
128 |       1,
129 |     );
130 |     expect(results[0]).toEqual({ name: "DataCloneError", byteLength: 16 });
                             ^
error: expect(received).toEqual(expected)

  {
-   "byteLength": 16,
+   "byteLength": 0,
    "name": "DataCloneError",
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/js/web/workers/worker-postmessage-transfer.test.ts:130:24)
(fail) self.postMessage transfer list > postMessage with a listed port closed during serialization detaches nothing [2.1
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/structured-clone.test.ts test/js/web/workers/worker-postmessage-transfer.test.ts
bun test v1.4.1 (861e9ae04)

test/js/web/workers/worker-postmessage-transfer.test.ts:
(pass) self.postMessage transfer list > postMessage(msg, [ArrayBuffer]) transfers and detaches the buffer [188.62ms]
(pass) self.postMessage transfer list > postMessage(msg, { transfer: [ArrayBuffer] }) transfers and detaches the buffer [197.72ms]
(pass) self.postMessage transfer list > postMessage(msg, [ArrayBuffer, null]) throws TypeError and detaches nothing [193.39ms]
(pass) self.postMessage transfer list > postMessage(msg, invalidOptions) throws TypeError [202.08ms]
(pass) self.postMessage transfer list > postMessage with a listed port closed during serialization detaches nothing [195.34ms]
(pass) self.postMessage transfer list > postMessage(msg, [MessagePort]) transfers the port [135.38ms]
(pass) Worker#postMessage transfer list > a listed port closed during serialization fails the transfer witho
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 896ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/53] cxx obj/unified/UnifiedSource-src_jsc_bindings-3.cpp.o
[2/53] cxx obj/unified/UnifiedSource-src_jsc_bindings-1.cpp.o
[3/53] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_http-0.cpp.o
[4/53] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-0.cpp.o
[5/53] cxx obj/unified/UnifiedSource-src_jsc_bindings_node_crypto-1.cpp.o
[6/53] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-1.cpp.o
[7/53] cxx obj/unified/UnifiedSource-src_jsc_bindings-2.cpp.o
[8/53] cxx obj/unified/UnifiedSource-src_jsc_bindings-5.cpp.o
[9/53] cxx obj/unified/UnifiedSource-src_jsc_bindings-0.cpp.o
[10/53] cxx obj/unified/UnifiedSource-src_jsc_bindings-4.cpp.o
[11/53] cxx obj/unified/UnifiedSource-src_runtime_webview-0.cpp.o
[12/53] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcrypto-0.cpp.o
[13/53] cxx obj/unified/UnifiedSource-src_jsc_modules-0.cpp.o
[14/53] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-2.cpp.o
[15/53] cxx obj/unified/UnifiedSource-src_jsc_bindings_webcore-3.cpp.o
[16/53] cxx obj
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/MessagePort.cpp           |  37 +++--
 src/jsc/bindings/webcore/SerializedScriptValue.cpp |  23 +++
 test/js/node/worker_threads/worker_threads.test.ts | 158 +++++++++++++++++++++
 test/js/web/workers/structured-clone.test.ts       |  29 ++++
 .../workers/worker-postmessage-transfer.test.ts    |  63 ++++++++
 5 files changed, 290 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 3 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/webcore/MessagePort.cpp                     3      7      0
src/jsc/bindings/webcore/SerializedScriptValue.cpp           6     11      0
test/js/node/worker_threads/worker_threads.test.ts           4      3      0
test/js/web/workers/structured-clone.test.ts                 2      1      0
test/js/web/workers/worker-postmessage-transfer.test.ts      1      3      0
```

</details>

<!-- robobun:evidence:end -->