### PR TITLE
shell(cp): print the -v line only for a single-file copy that succeeded

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1520,8 +1520,6 @@ mod _async_tasks {
                 .cp_on_copy(src.as_ref(), dest.as_ref());
         }
 
-        /// A tolerated `EEXIST` is neither a copy nor an error. Success is not
-        /// recorded: `on_subtask_done` resolves `Ok` unless an error was.
         fn record_copy_result(
             &self,
             src: &OSPathSliceZ,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1532,6 +1532,27 @@ mod _async_tasks {
                 .cp_on_copy(src.as_ref(), dest.as_ref());
         }
 
+        /// Delivers the result of a `cp` whose source is a single file. Like
+        /// `CpSingleTask` in the directory walk, `on_copy` is only recorded for
+        /// a copy that happened: not for a failed one, and not for a
+        /// destination left alone because it already existed.
+        fn finish_single_file(
+            &self,
+            src: &OSPathSliceZ,
+            dest: &OSPathSliceZ,
+            result: Maybe<ret::CopyFile>,
+        ) {
+            let result = match result {
+                Ok(()) => {
+                    self.on_copy(src, dest);
+                    Ok(())
+                }
+                Err(e) if e.get_errno() == E::EEXIST && !self.args.flags.error_on_exist => Ok(()),
+                Err(e) => Err(e),
+            };
+            self.finish_concurrently(result);
+        }
+
         /// `fs.cp` / `fs.promises.cp` (JS thread): a promise, an async-stack
         /// tracker, and this VM's loop.
         pub(crate) fn create(
@@ -1852,14 +1873,7 @@ mod _async_tasks {
                         Some(attributes),
                         &this.args,
                     );
-                    if let Err(e) = &r {
-                        if e.errno == E::EEXIST as _ && !args.flags.error_on_exist {
-                            this.finish_concurrently(Ok(()));
-                            return;
-                        }
-                    }
-                    this.on_copy(src, dest);
-                    this.finish_concurrently(r);
+                    this.finish_single_file(src, dest, r);
                     return;
                 }
             }
@@ -1891,15 +1905,7 @@ mod _async_tasks {
                         Some(&stat_),
                         &this.args,
                     );
-                    if let Err(e) = &r {
-                        if e.errno == E::EEXIST as _ && !args.flags.error_on_exist {
-                            this.on_copy(src, dest);
-                            this.finish_concurrently(Ok(()));
-                            return;
-                        }
-                    }
-                    this.on_copy(src, dest);
-                    this.finish_concurrently(r);
+                    this.finish_single_file(src, dest, r);
                     return;
                 }
             }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1520,12 +1520,8 @@ mod _async_tasks {
                 .cp_on_copy(src.as_ref(), dest.as_ref());
         }
 
-        /// Accounts for one file's `copy_single_file_sync` result, whether the
-        /// file is the whole `cp` or one entry of the directory walk. Only a
-        /// copy that happened is reported through `on_copy`; an `EEXIST` the
-        /// flags tolerate is neither a copy nor an error. Success needs no
-        /// record: `on_subtask_done` resolves with `Ok` unless an error was
-        /// recorded.
+        /// A tolerated `EEXIST` is neither a copy nor an error. Success is not
+        /// recorded: `on_subtask_done` resolves `Ok` unless an error was.
         fn record_copy_result(
             &self,
             src: &OSPathSliceZ,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -1479,19 +1479,7 @@ mod _async_tasks {
                 &parent.args,
             );
 
-            'brk: {
-                match result {
-                    Err(ref err) => {
-                        if err.errno == E::EEXIST as _ && !args.flags.error_on_exist {
-                            break 'brk;
-                        }
-                        parent.finish_concurrently(result);
-                    }
-                    Ok(_) => {
-                        parent.on_copy(self.src(), self.dest());
-                    }
-                }
-            }
+            parent.record_copy_result(self.src(), self.dest(), result);
 
             // `self: Box<Self>` drops here (frees the owned `path_buf`).
             drop(self);
@@ -1532,25 +1520,23 @@ mod _async_tasks {
                 .cp_on_copy(src.as_ref(), dest.as_ref());
         }
 
-        /// Delivers the result of a `cp` whose source is a single file. Like
-        /// `CpSingleTask` in the directory walk, `on_copy` is only recorded for
-        /// a copy that happened: not for a failed one, and not for a
-        /// destination left alone because it already existed.
-        fn finish_single_file(
+        /// Accounts for one file's `copy_single_file_sync` result, whether the
+        /// file is the whole `cp` or one entry of the directory walk. Only a
+        /// copy that happened is reported through `on_copy`; an `EEXIST` the
+        /// flags tolerate is neither a copy nor an error. Success needs no
+        /// record: `on_subtask_done` resolves with `Ok` unless an error was
+        /// recorded.
+        fn record_copy_result(
             &self,
             src: &OSPathSliceZ,
             dest: &OSPathSliceZ,
             result: Maybe<ret::CopyFile>,
         ) {
-            let result = match result {
-                Ok(()) => {
-                    self.on_copy(src, dest);
-                    Ok(())
-                }
-                Err(e) if e.get_errno() == E::EEXIST && !self.args.flags.error_on_exist => Ok(()),
-                Err(e) => Err(e),
-            };
-            self.finish_concurrently(result);
+            match result {
+                Ok(()) => self.on_copy(src, dest),
+                Err(e) if e.get_errno() == E::EEXIST && !self.args.flags.error_on_exist => {}
+                Err(e) => self.finish_concurrently(Err(e)),
+            }
         }
 
         /// `fs.cp` / `fs.promises.cp` (JS thread): a promise, an async-stack
@@ -1873,7 +1859,7 @@ mod _async_tasks {
                         Some(attributes),
                         &this.args,
                     );
-                    this.finish_single_file(src, dest, r);
+                    this.record_copy_result(src, dest, r);
                     return;
                 }
             }
@@ -1905,7 +1891,7 @@ mod _async_tasks {
                         Some(&stat_),
                         &this.args,
                     );
-                    this.finish_single_file(src, dest, r);
+                    this.record_copy_result(src, dest, r);
                     return;
                 }
             }

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -2,7 +2,7 @@ import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
 import { describe, expect, test } from "bun:test";
 import { bunEnv, tempDir, tempDirWithFiles } from "harness";
-import { chmodSync, readFileSync } from "node:fs";
+import { chmodSync, lstatSync, readFileSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
@@ -231,6 +231,41 @@ describe.concurrent("bunshell cp -v only reports copies that happened", () => {
     } finally {
       chmodSync(ro, 0o644);
     }
+  });
+
+  test("-R: lists the directories and files that were copied, not the file that failed", async () => {
+    using dir = tempDir("shell-cp-v-recursive", {
+      "src": { "ok.txt": "ok\n", "sub": { "bad.txt": "bad\n" } },
+      "dest": { "src": { "sub": { "bad.txt": {} } } },
+    });
+    const cwd = String(dir);
+    const src = (...parts: string[]) => join(cwd, "src", ...parts);
+    const dest = (...parts: string[]) => join(cwd, "dest", "src", ...parts);
+
+    const result = await cp(cwd, "cp -R -v src dest");
+    // Files inside the tree are copied concurrently, so their lines come out in any order.
+    expect({ ...result, stdout: sortedShellOutput(result.stdout) }).toEqual({
+      ...failed,
+      stdout: sortedShellOutput([
+        `${src()} -> ${dest()}`,
+        `${src("ok.txt")} -> ${dest("ok.txt")}`,
+        `${src("sub")} -> ${dest("sub")}`,
+      ]),
+    });
+    expect(readFileSync(dest("ok.txt"), "utf8")).toBe("ok\n");
+  });
+
+  test("symlink -> existing file is listed only if the destination is now the link", async () => {
+    using dir = tempDir("shell-cp-v-symlink", { "target.txt": "target\n", "existing.txt": "keep\n" });
+    const cwd = String(dir);
+    symlinkSync("target.txt", join(cwd, "lnk"));
+
+    const { stdout } = await cp(cwd, "cp -v lnk existing.txt");
+    // A link source is recreated with symlink(2), which on most platforms cannot
+    // replace an existing destination (cp tolerates that EEXIST and leaves the
+    // destination alone). Whatever happened to the destination, the line has to agree with it.
+    const replaced = lstatSync(join(cwd, "existing.txt")).isSymbolicLink();
+    expect(stdout).toBe(replaced ? `${join(cwd, "lnk")} -> ${join(cwd, "existing.txt")}\n` : "");
   });
 });
 

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, tempDir, tempDirWithFiles } from "harness";
+import { chmodSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -9,6 +11,7 @@ const { builtinDisabled } = shellInternals;
 const TestBuilder = createTestBuilder(import.meta.path);
 
 const p = process.platform === "win32" ? (s: string) => s.replaceAll("/", "\\") : (s: string) => s;
+const isRoot = process.getuid?.() === 0;
 
 $.nothrow();
 
@@ -170,6 +173,64 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// The builtin is only the default on Windows; on POSIX it is switched on by an
+// env var that is read once per process, so each cp runs in a child bun.
+describe.concurrent("bunshell cp -v only reports copies that happened", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  /** Runs `command` through the shell builtin with `cwd` as the shell's cwd; returns what cp exited with and printed. */
+  async function cp(cwd: string, command: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        "const r = await Bun.$`${{ raw: process.argv[1] }}`.cwd(process.argv[2]).nothrow().quiet();" +
+          "console.log(JSON.stringify({ exitCode: r.exitCode, stdout: r.stdout.toString(), stderr: r.stderr.toString() }));",
+        command,
+        cwd,
+      ],
+      cwd,
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  const failed = { exitCode: 1, stdout: "", stderr: expect.stringMatching(/^cp: /) };
+
+  test("file -> dir whose entry of that name is a directory", async () => {
+    using dir = tempDir("shell-cp-v-failed", { "b.txt": "b\n", "d": { "b.txt": {} } });
+
+    expect(await cp(String(dir), "cp -v b.txt d")).toEqual(failed);
+  });
+
+  test("file+ -> dir reports only the file that was copied", async () => {
+    using dir = tempDir("shell-cp-v-mixed", { "a.txt": "a\n", "b.txt": "b\n", "d": { "b.txt": {} } });
+    const cwd = String(dir);
+
+    expect(await cp(cwd, "cp -v a.txt b.txt d")).toEqual({
+      ...failed,
+      stdout: `${join(cwd, "a.txt")} -> ${join(cwd, "d", "a.txt")}\n`,
+    });
+    expect(readFileSync(join(cwd, "d", "a.txt"), "utf8")).toBe("a\n");
+  });
+
+  test.skipIf(isRoot)("file -> read-only file", async () => {
+    using dir = tempDir("shell-cp-v-readonly", { "a.txt": "a\n", "ro.txt": "keep\n" });
+    const ro = join(String(dir), "ro.txt");
+    chmodSync(ro, 0o444);
+    try {
+      expect(await cp(String(dir), "cp -v a.txt ro.txt")).toEqual(failed);
+      expect(readFileSync(ro, "utf8")).toBe("keep\n");
+    } finally {
+      chmodSync(ro, 0o644);
+    }
   });
 });
 


### PR DESCRIPTION
### Problem
- The Bun Shell `cp -v` builtin prints `src -> dest` on stdout for a single-file copy that did not happen. With `d/b.txt` being a directory, `cp -v b.txt d` exits 1 and prints `cp: Is a directory: .../d/b.txt` on stderr, but stdout still says `.../b.txt -> .../d/b.txt`. Same for any other failing copy (a read-only destination as a non-root user, for example), and on Linux/FreeBSD also for a symlink source whose destination already exists, where the copy is skipped but the line was printed anyway.
- Cause: the two single-file arms of `NewAsyncCpTask::cp_async` (`src/runtime/node/node_fs.rs`, one `#[cfg(windows)]`, one POSIX) called `this.on_copy(src, dest)` regardless of what `copy_single_file_sync` returned. `on_copy` is what appends the verbose line (`ShellCpTask::cp_on_copy` in `src/runtime/shell/builtin/cp.rs`).
- The directory walk had its own copy of the decision (`CpSingleTask::run_owned`) and got it right; the two single-file arms had also drifted from each other (only the POSIX one printed the line for a tolerated `EEXIST`).

### Fix
- One `NewAsyncCpTask::record_copy_result(src, dest, result)` now handles a file's result for all three sites (both single-file arms and the walk): `on_copy` on `Ok`, nothing for an `EEXIST` the flags tolerate, `finish_concurrently(Err)` otherwise. Success is not recorded explicitly; `on_subtask_done` already resolves with `Ok` when no error was recorded, which is how the walk (and the macOS `clonefile` path) completed before.
- Why this is right: coreutils and BSD `cp -v` print `a -> b` only for copies they made, `cp_on_copy` is documented as being called per successfully copied file, and the walk already behaved this way. The error on stderr and the exit code were already correct; this only removes the line. Net effect for the single-file arms is the same as before except that `on_copy` is no longer called on `Err`.
- `fs.cp` / `fs.promises.cp` are unaffected: `on_copy` is a no-op for them, and each result still resolves or rejects the same way (`Ok` and a tolerated `EEXIST` resolve, anything else rejects with that error).
- The tolerated-`EEXIST` case is reachable from the shell today only through a symlink source onto an existing destination (`cp_symlink` cannot replace the destination and the shell passes `force: true`, so the `EEXIST` is swallowed). This PR stops printing the line there; that the copy is skipped silently with exit 0 instead of replacing the destination like `cp(1)` is a separate, pre-existing bug and is tracked separately.
- Verified with `test/js/bun/shell/commands/cp.test.ts`. The new block runs `cp -v` through the builtin in a child bun (`BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`, so it is exercised on every platform): a failing copy, `file file dir` where one file fails (only the copied one is listed, and it was copied), a read-only destination (skipped as root), `cp -R -v` with one file in the tree failing (the directories and the other file are listed, the failed file is not), and a symlink source onto an existing file (listed only if the destination actually became the link).
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/shell/commands/cp.test.ts`: 3 fail (failing copy, mixed, symlink); the read-only one also fails when run as an unprivileged user; the `-R` one passes before and after, it pins the walk's behaviour now that it shares the helper.
  - `bun bd test test/js/bun/shell/commands/cp.test.ts`: all pass (the read-only one verified as an unprivileged user as well).
  - `bun bd test test/js/node/fs/cp.test.ts`, `cp-symlink-target.test.ts`, and the upstream `test-fs-cp-async-*` file-to-file / overwrite / nested-tree cases: pass.
  - `cargo check -p bun_runtime --target x86_64-pc-windows-msvc` is clean (one of the arms is Windows-only); the Windows lanes of the first CI run were green as well.

### Background
- The shell `cp` builtin (always used on Windows, opt-in via `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` elsewhere) does not copy files itself. For each source operand it creates a `ShellCpTask`, which resolves the operands and hands the copy to the native implementation behind `fs.cp`, `NewAsyncCpTask`, instantiated with `IS_SHELL = true`.
- `NewAsyncCpTask::cp_async` runs on a work-pool thread. A non-directory source is copied right there with `copy_single_file_sync`; a directory is walked, and each file inside becomes a `CpSingleTask` on the pool. The task holds a subtask count; when the last holder calls `on_subtask_done`, the result is delivered to the JS thread, as `Ok` unless some holder recorded an error with `finish_concurrently` (first error wins, later files still get copied).
- `on_copy(src, dest)` feeds `-v`: for `IS_SHELL` it appends `src -> dest` to a buffer the shell writes to stdout when the task completes; for `node:fs` it does nothing. The walk also calls it once per directory after creating it.
- Tolerated `EEXIST`: `fs.cp` with `force: false` copies with `COPYFILE_EXCL` and treats an existing destination as "skip", unless `errorOnExist` was requested. The shell never asks for that (`force: true`), so for it the case only comes up via `cp_symlink`, as described above.

<details>
<summary>Earlier version of this PR</summary>

The first push changed only the two single-file arms (a `finish_single_file` helper that still called `finish_concurrently` itself) and left the walk's own copy of the logic in place. Review pointed out that the walk could share the helper, that nothing exercised `-R -v`, and that the tolerated-`EEXIST` arm is in fact reachable from the shell (symlink source onto an existing destination), so the helper was moved to cover all three sites and the `-R` and symlink tests were added.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts

<!-- robobun:evidence:end -->