### PR TITLE
h2: test the StreamClosed header-block disposition and the CONTINUATION re-park

### DIFF
--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1622,4 +1622,63 @@ describe("inbound stream lifecycle", () => {
       server.close();
     }
   });
+
+  // §5.1: HEADERS for a stream the client itself just reset is a stream error (RST_STREAM with
+  // STREAM_CLOSED), not a connection error, and §4.3 still requires the whole block (CONTINUATION
+  // half included) to be decoded so the connection-scoped HPACK dynamic table stays in sync.
+  // The RST_STREAM and the HEADERS have to arrive in one read: closed streams are evicted between
+  // reads, after which a late HEADERS simply opens a fresh stream.
+  test("keeps HPACK state in sync when a header block for a stream the client reset spans HEADERS and CONTINUATION", async () => {
+    const seen: { path: string; sync?: string }[] = [];
+    const server = http2.createServer();
+    server.on("stream", (stream: any, headers: any) => {
+      stream.on("error", () => {});
+      // Whether stream 3's first (valid) HEADERS reaches JS before the RST_STREAM pipelined
+      // behind it is processed is not what this test pins down; only stream 5 is recorded.
+      if (stream.id !== 5) return;
+      seen.push({ path: headers[":path"], sync: headers["x-bun-sync"] });
+      stream.respond({ ":status": 200 });
+      stream.end("ok");
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const c = await RawH2.connect((server.address() as net.AddressInfo).port);
+    try {
+      c.sendPreface();
+      c.sendEmptySettings();
+      const cancel = Buffer.alloc(4);
+      cancel.writeUInt32BE(ErrorCode.CANCEL, 0);
+      // The closed stream's block inserts `x-bun-sync: 1` into the dynamic table (literal with
+      // incremental indexing) from its CONTINUATION half.
+      const insert = Buffer.concat([Buffer.from([0x40]), hpackLiteral("x-bun-sync"), hpackLiteral("1")]);
+      const ping = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]);
+      c.send(
+        Buffer.concat([
+          encodeFrame(FrameType.HEADERS, 0x4 /* END_HEADERS */, 3, requestHeaderBlock("POST")),
+          encodeFrame(FrameType.RST_STREAM, 0, 3, cancel),
+          encodeFrame(FrameType.HEADERS, 0x1 /* END_STREAM, no END_HEADERS */, 3, requestHeaderBlock("GET")),
+          encodeFrame(FrameType.CONTINUATION, 0x4 /* END_HEADERS */, 3, insert),
+          encodeFrame(FrameType.PING, 0, 0, ping),
+        ]),
+      );
+      const rst = await c.waitFor(f => f.type === FrameType.RST_STREAM && f.streamId === 3);
+      expect(rst.payload.readUInt32BE(0)).toBe(ErrorCode.STREAM_CLOSED);
+      // The PING behind the block is answered: the connection itself survived.
+      const ack = await c.waitFor(f => f.type === FrameType.PING && (f.flags & 0x1) !== 0);
+      expect(Buffer.compare(ack.payload, ping)).toBe(0);
+
+      // 0xbe: indexed field 62 = the entry the closed stream's block inserted. If that block had
+      // not been decoded this is a COMPRESSION_ERROR and stream 5 never reaches JS.
+      c.sendFrame(FrameType.HEADERS, 0x5, 5, Buffer.concat([requestHeaderBlock("GET"), Buffer.from([0xbe])]));
+      const resp = await c.waitFor(
+        f => (f.type === FrameType.HEADERS && f.streamId === 5) || f.type === FrameType.GOAWAY,
+      );
+      expect(resp.type).toBe(FrameType.HEADERS);
+      expect(c.frames.find(f => f.type === FrameType.GOAWAY)).toBeUndefined();
+      expect(seen).toEqual([{ path: "/", sync: "1" }]);
+    } finally {
+      c.destroy();
+      server.close();
+    }
+  });
 });

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -1491,6 +1491,58 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
           }
         });
 
+        it("reassembles a header block split across HEADERS + CONTINUATION + CONTINUATION", async () => {
+          const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
+          const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();
+          const block = http2utils.kFakeResponseHeaders;
+          const server = net.createServer(async socket => {
+            socket.on("error", () => {});
+            const settings = new http2utils.SettingsFrame(true);
+            socket.write(settings.data);
+            await waitToWrite;
+
+            // Split 2 bytes into the cache-control literal and again inside the date value, so
+            // every fragment is needed and none decodes on its own. The middle fragment is a raw
+            // CONTINUATION without END_HEADERS (the helper always sets it): the partially
+            // assembled block has to be kept across it and completed by the last frame only.
+            socket.write(new http2utils.HeadersFrame(1, block.subarray(0, 7), 0, /* EOH */ false, false).data);
+            const middle = block.subarray(7, 30);
+            socket.write(Buffer.concat([new http2utils.Frame(middle.byteLength, 9, 0, 1).data, middle]));
+            socket.write(new http2utils.ContinuationFrame(1, block.subarray(30), 0, false).data);
+          });
+          server.listen(0, "127.0.0.1", () => serverResolve());
+          await serverListening;
+
+          const url = `http://127.0.0.1:${server.address().port}`;
+          const client = http2.connect(url);
+          try {
+            const { promise, resolve, reject } = Promise.withResolvers();
+            client.on("error", reject);
+            let sawTrailers = false;
+            client.on("connect", () => {
+              const req = client.request({ ":path": "/" });
+              req.on("error", reject);
+              req.on("trailers", () => {
+                sawTrailers = true;
+              });
+              req.on("response", headers => {
+                queueMicrotask(() => resolve(headers));
+              });
+              req.end();
+              allowWrite();
+            });
+            const headers = await promise;
+            expect(headers[":status"]).toBe(302);
+            expect(headers["cache-control"]).toBe("private");
+            expect(headers["date"]).toBe("Mon, 21 Oct 2013 20:13:21 GMT");
+            expect(headers["location"]).toBe("https://www.example.com");
+            expect(sawTrailers).toBe(false);
+          } finally {
+            client.destroy();
+            server.close();
+          }
+        });
+
         it("treats an HPACK decode error in a complete header block as COMPRESSION_ERROR", async () => {
           const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
           const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();
@@ -1580,8 +1632,29 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
         it("rejects a header block whose compressed size exceeds maxHeaderListSize", async () => {
           const { promise: waitToWrite, resolve: allowWrite } = Promise.withResolvers();
           const { promise: serverListening, resolve: serverResolve } = Promise.withResolvers();
+          const { promise: goawayReceived, resolve: onGoaway, reject: noGoaway } = Promise.withResolvers();
+          // Walks the frames the client sent (after its 24-byte connection preface) and returns
+          // the payload of the first GOAWAY among them.
+          function findGoaway(fromClient) {
+            let offset = http2utils.kClientMagic.byteLength;
+            while (offset + 9 <= fromClient.byteLength) {
+              const length = fromClient.readUIntBE(offset, 3);
+              if (offset + 9 + length > fromClient.byteLength) break;
+              if (fromClient[offset + 3] === 7 /* GOAWAY */) {
+                return fromClient.subarray(offset + 9, offset + 9 + length);
+              }
+              offset += 9 + length;
+            }
+          }
           const server = net.createServer(async socket => {
-            socket.on("error", () => {});
+            socket.on("error", noGoaway);
+            socket.on("close", () => noGoaway(new Error("client closed the connection without sending GOAWAY")));
+            let fromClient = Buffer.alloc(0);
+            socket.on("data", chunk => {
+              fromClient = Buffer.concat([fromClient, chunk]);
+              const goaway = findGoaway(fromClient);
+              if (goaway) onGoaway(goaway);
+            });
             const settings = new http2utils.SettingsFrame(true);
             socket.write(settings.data);
             await waitToWrite;
@@ -1617,6 +1690,13 @@ for (const nodeExecutable of [nodeExe(), bunExe()]) {
             // node: a violation nghttp2 detects locally surfaces as NghttpError ("Protocol error"),
             // not as ERR_HTTP2_SESSION_ERROR (that one is reserved for a GOAWAY received from the peer).
             expect(result.message).toBe("Protocol error");
+            // Every locally detected violation surfaces as "Protocol error"; only the GOAWAY on the
+            // wire says which one. COMPRESSION_ERROR (the 65536-byte block cap) is reached on the
+            // fourth CONTINUATION, which requires the partial block to survive each CONTINUATION
+            // without END_HEADERS; had it been dropped after the first one, the second would be an
+            // unexpected CONTINUATION and the GOAWAY would carry PROTOCOL_ERROR.
+            const goaway = await goawayReceived;
+            expect(goaway.readUInt32BE(4)).toBe(http2.constants.NGHTTP2_COMPRESSION_ERROR);
           } finally {
             server.close();
           }


### PR DESCRIPTION
Follow-up to #37637, covering the two gaps pointed out in its review. Tests only; no runtime change.

### Problem
- `BlockDisposition::StreamClosed` in `src/runtime/api/bun/h2/connection.rs` (a header block arriving for a stream that was reset earlier in the same `receive()` batch) had no test: nothing checked that such a block is answered with `RST_STREAM(STREAM_CLOSED)` rather than a connection error, or that it is still HPACK-decoded.
- The re-park of a partially assembled block after a CONTINUATION without END_HEADERS (`header_block_in_flight = Some(inflight)` in `handle_continuation`) was not pinned by any test: the one existing raw sender of such frames only asserted "Protocol error", which a dropped block produces as well (on the second CONTINUATION, as PROTOCOL_ERROR, instead of on the fourth, as COMPRESSION_ERROR).

### Fix
- `test/js/node/http2/h2-conformance.test.ts`: next to the refused-block test, one write carrying `HEADERS(3)`, `RST_STREAM(3)`, a second `HEADERS(3)` without END_HEADERS plus its `CONTINUATION(3)` inserting `x-bun-sync: 1` into the dynamic table, then a `PING`. Asserts `RST_STREAM(3)` with code 5, the PING ack, no GOAWAY, and that a request on stream 5 referencing dynamic index 62 (`0xbe`) still reaches the handler with that header, which is only true if the closed stream's block was decoded. The handler records stream 5 only, so the test does not depend on whether the first `HEADERS(3)` reaches JS before the reset is processed.
- `test/js/node/http2/node-http2.test.js`: the maxHeaderListSize test's raw server now collects what the client sends and asserts the GOAWAY carries `COMPRESSION_ERROR` (0x9); with the default list size the cap is first exceeded by the fourth CONTINUATION, so this only holds if the block survived the three CONTINUATIONs without END_HEADERS before it. A second test splits a valid response block across `HEADERS` + a raw `CONTINUATION` without END_HEADERS + `CONTINUATION(END_HEADERS)` and checks the four headers arrive once and intact.
- Verified on a debug build: `bun bd test test/js/node/http2/h2-conformance.test.ts test/js/node/http2/node-http2.test.js`: 425 pass, 6 skip (pre-existing leak tests), 0 fail. Each test was also checked against a build with the path it covers broken: with the `StreamClosed` decode skipped, the new conformance test fails at `expect(resp.type).toBe(FrameType.HEADERS)` (received GOAWAY) while its RST_STREAM and PING assertions and the existing refused-block test still pass; with the re-park line deleted, the GOAWAY assertion fails with `Expected: 9, Received: 1` in all six matrix variants while the pre-existing "Protocol error" assertions still pass, and the three-fragment test fails with `Protocol error`. No other test in either file reacts to either breakage.

### Background
- An HTTP/2 header block may be split across a HEADERS frame and any number of CONTINUATION frames; the last one carries END_HEADERS. The receiver has to hold the partial block in between (the "re-park") and must decode every complete block it receives, even ones it is going to reject, because HPACK's dynamic table is shared by the whole connection and an undecoded block would leave it out of sync with the sender (RFC 9113 §4.3).
- Bun evicts closed stream entries between reads, so "HEADERS for a closed stream" is only observable when the RST_STREAM and the HEADERS arrive in the same read; that is why the first test sends everything in one write.
- In the client test, the client under test is always Bun's own `http2.connect` against a raw `net` server; the file's outer matrix only varies padding and the executable used by other tests' helper servers, which is why the new assertion runs six times.
