### PR TITLE
valkey: fold is_authenticated and needs_to_open_socket into Status

### DIFF
--- a/src/runtime/valkey_jsc/js_valkey.rs
+++ b/src/runtime/valkey_jsc/js_valkey.rs
@@ -796,7 +796,7 @@ impl JSValkeyClient {
                 password,
                 in_flight: command::promise_pair::Queue::init(),
                 queue: command::entry::Queue::init(),
-                status: valkey::Status::Disconnected,
+                status: valkey::Status::NeverConnected,
                 connection_strings,
                 socket: Socket::SocketTcp(uws::SocketTCP {
                     socket: uws::InternalSocket::Detached,
@@ -905,7 +905,7 @@ impl JSValkeyClient {
                 password,
                 in_flight: command::promise_pair::Queue::init(),
                 queue: command::entry::Queue::init(),
-                status: valkey::Status::Disconnected,
+                status: valkey::Status::NeverConnected,
                 connection_strings: connection_strings_copy,
                 socket: Socket::SocketTcp(uws::SocketTCP {
                     socket: uws::InternalSocket::Detached,
@@ -913,8 +913,6 @@ impl JSValkeyClient {
                 tls,
                 database: client.database,
                 flags: valkey::ConnectionFlags {
-                    // Because this starts in the disconnected state, we need to reset some flags.
-                    is_authenticated: false,
                     // If the user manually closed the connection, then duplicating a closed client
                     // means the new client remains finalized.
                     is_manually_closed: client.flags.is_manually_closed,
@@ -923,7 +921,6 @@ impl JSValkeyClient {
                     } else {
                         client.flags.enable_offline_queue
                     },
-                    needs_to_open_socket: true,
                     enable_auto_reconnect: client.flags.enable_auto_reconnect,
                     is_reconnecting: false,
                     enable_auto_pipelining: if sub_ctx.is_subscriber {
@@ -1061,12 +1058,12 @@ impl JSValkeyClient {
         let self_br = BackRef::new(self);
         let _update = scopeguard::guard(self_br, |p| p.update_poll_ref());
 
-        if self.client.get().flags.needs_to_open_socket {
+        if self.client.get().status == valkey::Status::NeverConnected {
             self.poll_ref.with_mut(|r| r.ref_(vm_event_loop_ctx()));
 
             if let Err(err) = self.connect() {
                 self.poll_ref.with_mut(|r| r.unref(vm_event_loop_ctx()));
-                self.client_mut().flags.needs_to_open_socket = true;
+                self.client_mut().status = valkey::Status::NeverConnected;
                 let err_value = global_object
                     .err(
                         jsc::ErrorCode::SOCKET_CLOSED_BEFORE_CONNECTION,
@@ -1113,7 +1110,10 @@ impl JSValkeyClient {
         // which derefs. Hold a ref so `&self` stays live across the call.
         let _guard = self.ref_scope();
 
-        if self.client.get().status == valkey::Status::Disconnected {
+        if matches!(
+            self.client.get().status,
+            valkey::Status::NeverConnected | valkey::Status::Disconnected
+        ) {
             return Ok(JSValue::UNDEFINED);
         }
         self.client_mut().disconnect();
@@ -1168,7 +1168,9 @@ impl JSValkeyClient {
                 let _ = self.client_fail(msg, protocol::RedisError::IdleTimeout);
                 // TODO: properly propagate exception upwards
             }
-            valkey::Status::Disconnected | valkey::Status::Connecting => {
+            valkey::Status::NeverConnected
+            | valkey::Status::Disconnected
+            | valkey::Status::Connecting => {
                 use std::io::Write;
                 let mut cur = &mut buf[..];
                 let start = cur.len();
@@ -1488,7 +1490,9 @@ impl JSValkeyClient {
     }
 
     fn connect(&self) -> Result<(), crate::Error> {
-        self.client_mut().flags.needs_to_open_socket = false;
+        if self.client.get().status == valkey::Status::NeverConnected {
+            self.client_mut().status = valkey::Status::Disconnected;
+        }
 
         let _guard = self.ref_scope();
 
@@ -1591,11 +1595,11 @@ impl JSValkeyClient {
         // the host-fn shim passes a bare `&self` with no ref of its own.
         let _guard = self.ref_scope();
 
-        if self.client.get().flags.needs_to_open_socket {
+        if self.client.get().status == valkey::Status::NeverConnected {
             bun_core::hint::cold();
 
             if let Err(err) = self.connect() {
-                self.client_mut().flags.needs_to_open_socket = true;
+                self.client_mut().status = valkey::Status::NeverConnected;
                 let err_value = global_this
                     .err(
                         jsc::ErrorCode::SOCKET_CLOSED_BEFORE_CONNECTION,
@@ -1727,7 +1731,7 @@ impl JSValkeyClient {
                 debug!("upgrading this_value since we are connected/connecting");
                 self.this_value.with_mut(|t| t.upgrade(&self.global_object));
             }
-            valkey::Status::Disconnected => {
+            valkey::Status::NeverConnected | valkey::Status::Disconnected => {
                 // If we're disconnected, we need to check if we have any pending activity.
                 if has_activity {
                     debug!("upgrading this_value since there is pending activity");
@@ -1891,7 +1895,6 @@ impl<const SSL: bool> SocketHandler<SSL> {
                     // through to the authenticated state after a rejected
                     // handshake.
                     this.global_object.clear_exception();
-                    this.client_mut().flags.is_authenticated = false;
                     this.client_mut().flags.is_manually_closed = true;
                     this.client_mut().close();
                     return Ok(());
@@ -1905,7 +1908,6 @@ impl<const SSL: bool> SocketHandler<SSL> {
         _vm: &VirtualMachine,
         err_value: JSValue,
     ) -> JsTerminatedResult<()> {
-        this.client_mut().flags.is_authenticated = false;
         let _exit = this.vm().enter_event_loop_scope();
         this.client_mut().flags.is_manually_closed = true;
         let this_br = BackRef::new(this);

--- a/src/runtime/valkey_jsc/valkey.rs
+++ b/src/runtime/valkey_jsc/valkey.rs
@@ -29,15 +29,16 @@ bun_output::define_scoped_log!(debug, Redis, visible);
 
 /// Connection flags to track Valkey client state
 pub struct ConnectionFlags {
-    // These flags could be refactored into an enumerated state machine, which
-    // would read more naturally than a bag of booleans.
-    pub(crate) is_authenticated: bool,
     pub(crate) is_manually_closed: bool,
     pub(crate) is_selecting_db_internal: bool,
     pub(crate) enable_offline_queue: bool,
-    pub(crate) needs_to_open_socket: bool,
     pub(crate) enable_auto_reconnect: bool,
+    /// Sticky until the next accepted HELLO, so it overlaps `Connecting`
+    /// (`reconnect()` reads it there) and `failed` (`update_poll_ref` reads it
+    /// there); that is why it is not a `Status` variant.
     pub(crate) is_reconnecting: bool,
+    /// Sticky until `on_open`/`connect()`, and orthogonal to `Status`: `fail()`
+    /// while `Connected` leaves the socket open and `status` unchanged.
     pub(crate) failed: bool,
     pub(crate) enable_auto_pipelining: bool,
     pub(crate) finalized: bool,
@@ -56,11 +57,9 @@ pub struct ConnectionFlags {
 impl Default for ConnectionFlags {
     fn default() -> Self {
         Self {
-            is_authenticated: false,
             is_manually_closed: false,
             is_selecting_db_internal: false,
             enable_offline_queue: true,
-            needs_to_open_socket: true,
             enable_auto_reconnect: true,
             is_reconnecting: false,
             failed: false,
@@ -74,8 +73,13 @@ impl Default for ConnectionFlags {
 /// Valkey connection status
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub enum Status {
+    /// No socket has been opened yet; the first `connect()`/`send()` opens one.
+    /// Every later disconnect lands in `Disconnected` and goes through
+    /// `reconnect()` instead.
+    NeverConnected,
     Disconnected,
     Connecting,
+    /// Socket open and HELLO accepted.
     Connected,
 }
 
@@ -685,7 +689,6 @@ impl ValkeyClient {
         );
 
         self.flags.is_reconnecting = true;
-        self.flags.is_authenticated = false;
         self.flags.is_selecting_db_internal = false;
 
         self.reject_in_flight_commands(b"Connection closed", RedisError::ConnectionClosed)?;
@@ -991,7 +994,6 @@ impl ValkeyClient {
             RESPValue::SimpleString(str_) => {
                 if str_.as_ref() == b"OK" {
                     self.status = Status::Connected;
-                    self.flags.is_authenticated = true;
                     self.flags.is_reconnecting = false;
                     self.retry_attempts = 0;
                     self.on_valkey_connect(value)?;
@@ -1031,7 +1033,6 @@ impl ValkeyClient {
 
                 // Authentication successful via HELLO
                 self.status = Status::Connected;
-                self.flags.is_authenticated = true;
                 self.flags.is_reconnecting = false;
                 self.retry_attempts = 0;
                 self.on_valkey_connect(value)?;
@@ -1050,7 +1051,7 @@ impl ValkeyClient {
     /// Handle Valkey protocol response
     fn handle_response(&mut self, value: &mut RESPValue) -> JsTerminated<()> {
         // Special handling for the initial HELLO response
-        if !self.flags.is_authenticated {
+        if self.status != Status::Connected {
             self.handle_hello_response(value)?;
 
             // We've handled the HELLO response without consuming anything from the command queue
@@ -1286,12 +1287,8 @@ impl ValkeyClient {
         self.reply_scanner.reset();
         // A fresh socket has opened, so reset per-connection state. Without
         // this, `send()` would permanently reject with "Connection has failed"
-        // after a previous connection exhausted retries (#29925), and the
-        // new HELLO response would be dropped because `is_authenticated` was
-        // still set from a prior successful handshake — blocking the client
-        // from ever transitioning back to `.connected`.
+        // after a previous connection exhausted retries (#29925).
         self.flags.failed = false;
-        self.flags.is_authenticated = false;
         self.flags.is_selecting_db_internal = false;
         if matches!(self.socket, AnySocket::SocketTcp(_)) {
             // if is tcp, we need to start the connection process
@@ -1311,7 +1308,7 @@ impl ValkeyClient {
     /// Test whether we are ready to run "normal" RESP commands, such as
     /// get/set, pub/sub, etc.
     fn connection_ready(&self) -> bool {
-        self.flags.is_authenticated && !self.flags.is_selecting_db_internal
+        self.status == Status::Connected && !self.flags.is_selecting_db_internal
     }
 
     /// Process queued commands in the offline queue
@@ -1473,7 +1470,7 @@ impl ValkeyClient {
                         self.register_auto_flusher(self.vm);
                     }
                 }
-                Status::Connecting | Status::Disconnected => {
+                Status::NeverConnected | Status::Connecting | Status::Disconnected => {
                     // Only queue if offline queue is enabled
                     if self.flags.enable_offline_queue {
                         self.enqueue(&checked_command, promise)?;


### PR DESCRIPTION
is_authenticated was set to true at exactly the two places status was set to Connected, and needs_to_open_socket is just the state before the first socket is opened. Both become Status: a new NeverConnected variant replaces needs_to_open_socket, and Connected replaces is_authenticated. Every site that flipped the two flags by hand goes away, including the is_authenticated reset in on_open that #29925 added.

failed and is_reconnecting stay as bools on purpose. fail() while connected leaves the socket open with status still Connected, and is_reconnecting stays set across Connecting and after a failed retry, so neither is a state of the same machine. Short comments on the two fields say so.

Only difference in behavior I know of: between a non-reconnect close of an authenticated client and the next on_open, connection_ready() used to still read true because is_authenticated was stale; it now reads false, so a command sent in that window is queued rather than written into the buffer on_open discards. That matches what a first connect does.

Ran test/js/valkey and test/regression/issue/29925.test.ts against a local redis-server on the debug build (only failures were redis 8.6 float formatting and one 1000x1MB pub/sub timeout on a loaded laptop, both unrelated), plus a connect error / connect / close / connect-again script that behaves the same as released Bun.

Two pre-existing issues turned up while doing this, not touched here: a fail() while connected (idle timeout) leaves connected true and connect() returns immediately without clearing failed, and after auto-reconnect exhausts its retries is_reconnecting keeps the event loop alive. Also connect() a second time after a failed first attempt with autoReconnect false never settles; that reproduces on 1.3.14 too.