### PR TITLE
node:http: measure the keep-alive idle period on the monotonic clock

### DIFF
--- a/src/js/internal/timers.ts
+++ b/src/js/internal/timers.ts
@@ -4,6 +4,14 @@ const NumberIsFinite = Number.isFinite;
 
 const TIMEOUT_MAX = 2 ** 31 - 1;
 
+/**
+ * Monotonic milliseconds for deadlines the runtime itself measures. Not
+ * `Date.now()` / `performance.now()`: bun:test's `setSystemTime()` and
+ * `useFakeTimers()` override both inside the engine (capturing the function
+ * does not help), which would freeze or skew an internal deadline.
+ */
+const monotonicNowMs = $newRustFunction("runtime/timer/Timer.rs", "internal_bindings.monotonicNowMs", 0);
+
 function getTimerDuration(msecs, name) {
   validateNumber(msecs, name);
   if (msecs < 0 || !NumberIsFinite(msecs)) {
@@ -29,4 +37,5 @@ export default {
   // tests that inspect socket[kTimeout].
   kTimeout: Symbol.for("::buntimeout::"),
   getTimerDuration,
+  monotonicNowMs,
 };

--- a/src/js/internal/timers.ts
+++ b/src/js/internal/timers.ts
@@ -5,10 +5,12 @@ const NumberIsFinite = Number.isFinite;
 const TIMEOUT_MAX = 2 ** 31 - 1;
 
 /**
- * Monotonic milliseconds for deadlines the runtime itself measures. Not
- * `Date.now()` / `performance.now()`: bun:test's `setSystemTime()` and
- * `useFakeTimers()` override both inside the engine (capturing the function
- * does not help), which would freeze or skew an internal deadline.
+ * The real monotonic clock in whole milliseconds, for deadlines the runtime's
+ * own JS keeps (a mark recorded now and compared against when a timer fires).
+ * No JS-visible clock will do: bun:test's `setSystemTime()` overrides
+ * `Date.now()` inside the engine, and `useFakeTimers()` also overrides
+ * `performance.now()` and `process.hrtime()`, so a deadline measured with any
+ * of them freezes or jumps along with the mock.
  */
 const monotonicNowMs = $newRustFunction("runtime/timer/Timer.rs", "internal_bindings.monotonicNowMs", 0);
 

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -2513,14 +2513,17 @@ function onResponseFinishHandleSocket(server, socket, res) {
     // kept-alive connection), leave it in place and only record when this
     // idle period started; onSocketTimeoutTimerExpired grants the remaining
     // budget if the timer fires early, so the socket still closes after
-    // exactly `total` ms of idle.
+    // exactly `total` ms of idle. The mark is taken before the timer is armed:
+    // both are whole milliseconds, so a timer armed after the mark measures at
+    // least `total` when it fires and closes instead of re-arming for a
+    // rounding millisecond.
+    socket[kKeepAliveIdleStart] = monotonicNowMs();
     const timer = socket[kSocketTimeoutTimer];
     if (timer !== undefined && timer._idleTimeout === total) {
       socket.timeout = total;
     } else {
       socket.setTimeout(total);
     }
-    socket[kKeepAliveIdleStart] = monotonicNowMs();
     socket[kKeepAliveTimeoutSet] = true;
   }
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -69,6 +69,7 @@ const {
   validateMsecs,
 } = require("internal/http");
 const { FakeSocket } = require("internal/http/FakeSocket");
+const { monotonicNowMs } = require("internal/timers");
 const NumberIsNaN = Number.isNaN;
 
 const { format } = require("internal/util/inspect");
@@ -120,7 +121,6 @@ const kEmptyBuffer = Buffer.alloc(0);
 const ObjectKeys = Object.keys;
 const MathMin = Math.min;
 const MathFloor = Math.floor;
-const DateNow = Date.now;
 
 let cluster;
 
@@ -1419,7 +1419,10 @@ const kKeepAliveTimeoutSet = Symbol("keepAliveTimeoutSet");
 // When the keep-alive idle period on a connection started (the last response
 // finish). onResponseFinishHandleSocket records this instead of rescheduling
 // the socket timer on every response; onSocketTimeoutTimerExpired reads it to
-// grant the remaining idle budget when the timer actually fires.
+// grant the remaining idle budget when the timer actually fires. Taken with
+// monotonicNowMs(), not Date.now(): bun:test's setSystemTime() / fake timers
+// move Date.now(), which would expire the connection early or re-arm it for
+// however far the clock was moved.
 const kKeepAliveIdleStart = Symbol("keepAliveIdleStart");
 // HTTP/1.1 pipelining (responses queued behind an in-flight response):
 // - on the socket: array of queued ServerResponses, in arrival order
@@ -1518,7 +1521,7 @@ function onSocketTimeoutTimerExpired(socket) {
   const idleStart = socket[kKeepAliveIdleStart];
   if (idleStart !== undefined && socket[kKeepAliveTimeoutSet]) {
     socket[kKeepAliveIdleStart] = undefined;
-    const remaining = socket.timeout - (DateNow() - idleStart);
+    const remaining = socket.timeout - (monotonicNowMs() - idleStart);
     if (remaining > 0) {
       const existingTimer = socket[kSocketTimeoutTimer];
       if (existingTimer !== undefined) clearTimeout(existingTimer);
@@ -2519,7 +2522,7 @@ function onResponseFinishHandleSocket(server, socket, res) {
     } else {
       socket.setTimeout(total);
     }
-    socket[kKeepAliveIdleStart] = DateNow();
+    socket[kKeepAliveIdleStart] = monotonicNowMs();
     socket[kKeepAliveTimeoutSet] = true;
   }
 }

--- a/src/js/node/_http_server.ts
+++ b/src/js/node/_http_server.ts
@@ -1419,10 +1419,8 @@ const kKeepAliveTimeoutSet = Symbol("keepAliveTimeoutSet");
 // When the keep-alive idle period on a connection started (the last response
 // finish). onResponseFinishHandleSocket records this instead of rescheduling
 // the socket timer on every response; onSocketTimeoutTimerExpired reads it to
-// grant the remaining idle budget when the timer actually fires. Taken with
-// monotonicNowMs(), not Date.now(): bun:test's setSystemTime() / fake timers
-// move Date.now(), which would expire the connection early or re-arm it for
-// however far the clock was moved.
+// grant the remaining idle budget when the timer actually fires. Read from
+// monotonicNowMs(), which setSystemTime() / fake timers cannot move.
 const kKeepAliveIdleStart = Symbol("keepAliveIdleStart");
 // HTTP/1.1 pipelining (responses queued behind an in-flight response):
 // - on the socket: array of queued ServerResponses, in arrival order

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -597,11 +597,9 @@ pub(crate) mod internal_bindings {
         Ok(JSValue::js_number(now as f64))
     }
 
-    /// Monotonic milliseconds for deadlines Bun's own JS measures (e.g. the SQL
-    /// connect-retry budget). bun:test's `setSystemTime()` / `useFakeTimers()`
-    /// override `Date.now()` and `performance.now()` inside the engine, so a
-    /// deadline measured with either freezes or jumps along with the mocked
-    /// clock. This is the real clock the timer heap is drained against.
+    /// `require("internal/timers").monotonicNowMs()`, documented there. Always
+    /// the real clock, i.e. the one the real timer heap is drained against,
+    /// whatever bun:test has mocked.
     #[bun_jsc::host_fn]
     pub(crate) fn monotonic_now_ms(
         _global_this: &JSGlobalObject,

--- a/src/runtime/timer/Timer.rs
+++ b/src/runtime/timer/Timer.rs
@@ -596,4 +596,18 @@ pub(crate) mod internal_bindings {
         // `js_number(f64)` (i64 → f64 is lossless for the millisecond range).
         Ok(JSValue::js_number(now as f64))
     }
+
+    /// Monotonic milliseconds for deadlines Bun's own JS measures (e.g. the SQL
+    /// connect-retry budget). bun:test's `setSystemTime()` / `useFakeTimers()`
+    /// override `Date.now()` and `performance.now()` inside the engine, so a
+    /// deadline measured with either freezes or jumps along with the mocked
+    /// clock. This is the real clock the timer heap is drained against.
+    #[bun_jsc::host_fn]
+    pub(crate) fn monotonic_now_ms(
+        _global_this: &JSGlobalObject,
+        _call_frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        let now = Timespec::now(TimespecMockMode::ForceRealTime).ms();
+        Ok(JSValue::js_number(now as f64))
+    }
 }

--- a/test/js/node/http/node-http-server-timeouts.test.ts
+++ b/test/js/node/http/node-http-server-timeouts.test.ts
@@ -235,8 +235,8 @@ describe("keepAliveTimeout idle expiry ignores setSystemTime()", () => {
   const KEEP_ALIVE_MS = 500;
   // How long the server sits on the second request before answering it. The
   // socket timer armed by the first response keeps counting down meanwhile,
-  // so it fires this much into the second response's idle period and the
-  // expiry has to be settled from the recorded mark.
+  // so it fires KEEP_ALIVE_MS - SLOW_RESPONSE_MS (200ms) into the second
+  // response's idle period and the expiry has to be settled from the mark.
   const SLOW_RESPONSE_MS = 300;
   const HOUR_MS = 60 * 60 * 1000;
 
@@ -255,8 +255,10 @@ describe("keepAliveTimeout idle expiry ignores setSystemTime()", () => {
     const socket = net.connect(port, "127.0.0.1");
     try {
       socket.setNoDelay(true);
-      socket.on("error", () => {});
-      const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+      // An idle keep-alive close is a clean FIN; a reset or any other error
+      // would make this probe fail instead of timing an unrelated close.
+      const { promise: closed, resolve: onClosed, reject: onSocketError } = Promise.withResolvers<void>();
+      socket.on("error", onSocketError);
       socket.on("close", () => onClosed());
 
       let received = "";

--- a/test/js/node/http/node-http-server-timeouts.test.ts
+++ b/test/js/node/http/node-http-server-timeouts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, setSystemTime, test } from "bun:test";
+import { describe, expect, jest, setSystemTime, test } from "bun:test";
 import { once } from "node:events";
 import http from "node:http";
 import net from "node:net";
@@ -221,17 +221,18 @@ describe("node:http server timeout enforcement", () => {
 
 // The server notes when a connection's last response finished and, when the
 // socket timer fires, grants whatever is left of the keep-alive budget from
-// that mark. The mark has to be taken on the clock the timer runs on
-// (monotonic), not on Date.now(): bun:test's setSystemTime() (and
-// jest.useFakeTimers(), which overrides Date.now too) would otherwise decide
-// when, or whether, an idle connection gets closed.
+// that mark. The mark has to be taken on the real monotonic clock: Date.now()
+// follows bun:test's setSystemTime() and useFakeTimers(), and the mocked
+// monotonic clock that useFakeTimers() installs starts over at zero, so a mark
+// taken on either would decide when, or whether, an idle connection is closed.
 //
-// Each probe moves Date.now() by an hour once the last response has arrived,
-// then waits for the server to close the connection, timing it with
-// performance.now(), which setSystemTime() leaves alone. Not concurrent:
-// setSystemTime() is process-wide and the tests above time themselves with
-// Date.now().
-describe("keepAliveTimeout idle expiry ignores setSystemTime()", () => {
+// Each probe mocks the clock at some point, waits for the server to close the
+// connection and reports how long after the last response that happened. It
+// is timed with performance.now(), which setSystemTime() leaves alone and
+// useFakeTimers() freezes, so the end is read only after the mocks are
+// undone. Not concurrent: the mocks are process-wide and the tests above time
+// themselves with Date.now().
+describe("keepAliveTimeout idle expiry ignores mocked clocks", () => {
   const KEEP_ALIVE_MS = 500;
   // How long the server sits on the second request before answering it. The
   // socket timer armed by the first response keeps counting down meanwhile,
@@ -240,14 +241,31 @@ describe("keepAliveTimeout idle expiry ignores setSystemTime()", () => {
   const SLOW_RESPONSE_MS = 300;
   const HOUR_MS = 60 * 60 * 1000;
 
-  async function probeIdleClose(options: { requests: 1 | 2; skewMs: number }) {
+  async function probeIdleClose(options: {
+    requests: 1 | 2;
+    beforeRequests?: () => void;
+    afterLastResponse?: () => void;
+  }) {
+    // A probe that fails by timing out never reaches its cleanup; do not let
+    // its mocks leak into the next one.
+    jest.useRealTimers();
+    setSystemTime();
     let requests = 0;
+    // Taken right before each res.end(), i.e. just before the server takes its
+    // own mark, so the idle time reported below can only be longer than what
+    // the server measured, never shorter because the response reached the
+    // client late.
+    let lastResponseEndedAt = 0;
+    const endResponse = (res: http.ServerResponse) => {
+      lastResponseEndedAt = performance.now();
+      res.end("response-body");
+    };
     const server = http.createServer({ keepAliveTimeoutBuffer: 0 }, (req, res) => {
       req.resume();
       if (++requests === 2) {
-        setTimeout(() => res.end("response-body"), SLOW_RESPONSE_MS);
+        setTimeout(endResponse, SLOW_RESPONSE_MS, res);
       } else {
-        res.end("response-body");
+        endResponse(res);
       }
     });
     server.keepAliveTimeout = KEEP_ALIVE_MS;
@@ -277,32 +295,65 @@ describe("keepAliveTimeout idle expiry ignores setSystemTime()", () => {
       };
 
       await once(socket, "connect");
+      options.beforeRequests?.();
       await request();
       if (options.requests === 2) await request();
-      const lastResponseAt = performance.now();
-      setSystemTime(new Date(Date.now() + options.skewMs));
+      options.afterLastResponse?.();
       await closed;
-      return performance.now() - lastResponseAt;
     } finally {
+      jest.useRealTimers();
       setSystemTime();
       socket.destroy();
       server.closeAllConnections();
       server.close();
     }
+    return performance.now() - lastResponseEndedAt;
   }
 
   test("a clock moved forwards does not close the connection before its idle budget is used up", async () => {
     // Settled against Date.now(), the timer fire 200ms into the second idle
     // period sees an hour of idle time and closes the connection right there.
-    const idleMs = await probeIdleClose({ requests: 2, skewMs: HOUR_MS });
+    const idleMs = await probeIdleClose({
+      requests: 2,
+      afterLastResponse: () => setSystemTime(new Date(Date.now() + HOUR_MS)),
+    });
     expect(idleMs).toBeGreaterThanOrEqual(KEEP_ALIVE_MS - 150);
+  });
+
+  test("a pinned clock does not double the idle budget", async () => {
+    // Settled against a Date.now() that never advances, the timer fire sees
+    // no idle time at all and re-arms for the whole budget once more, so the
+    // connection is closed after two budgets. That floor does not depend on
+    // machine speed, which is what makes the upper bound safe.
+    const idleMs = await probeIdleClose({
+      requests: 1,
+      beforeRequests: () => setSystemTime(new Date("2020-01-01T00:00:00Z")),
+    });
+    expect(idleMs).toBeGreaterThanOrEqual(KEEP_ALIVE_MS - 150);
+    expect(idleMs).toBeLessThan(2 * KEEP_ALIVE_MS);
   });
 
   test("a clock moved backwards does not keep the idle connection open", async () => {
     // Settled against Date.now(), the timer fire re-arms the connection for
     // the budget plus the hour the clock went back, and this probe only
     // returns once the test times out.
-    const idleMs = await probeIdleClose({ requests: 1, skewMs: -HOUR_MS });
+    const idleMs = await probeIdleClose({
+      requests: 1,
+      afterLastResponse: () => setSystemTime(new Date(Date.now() - HOUR_MS)),
+    });
+    expect(idleMs).toBeGreaterThanOrEqual(KEEP_ALIVE_MS - 150);
+  });
+
+  test("fake timers enabled after the response do not keep the idle connection open", async () => {
+    // The socket timer was armed on real timers, so it still fires on its
+    // own; what fake timers change is the clocks. A mark taken on Date.now()
+    // (pinned when the fake timers were enabled) or on the mocked monotonic
+    // clock (which restarts at zero) makes that fire re-arm the connection,
+    // and the new timer lands in the fake heap, where nothing ever fires it.
+    const idleMs = await probeIdleClose({
+      requests: 1,
+      afterLastResponse: () => jest.useFakeTimers(),
+    });
     expect(idleMs).toBeGreaterThanOrEqual(KEEP_ALIVE_MS - 150);
   });
 });

--- a/test/js/node/http/node-http-server-timeouts.test.ts
+++ b/test/js/node/http/node-http-server-timeouts.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, setSystemTime, test } from "bun:test";
 import { once } from "node:events";
 import http from "node:http";
 import net from "node:net";
@@ -216,5 +216,91 @@ describe("node:http server timeout enforcement", () => {
       server.closeAllConnections();
       server.close();
     }
+  });
+});
+
+// The server notes when a connection's last response finished and, when the
+// socket timer fires, grants whatever is left of the keep-alive budget from
+// that mark. The mark has to be taken on the clock the timer runs on
+// (monotonic), not on Date.now(): bun:test's setSystemTime() (and
+// jest.useFakeTimers(), which overrides Date.now too) would otherwise decide
+// when, or whether, an idle connection gets closed.
+//
+// Each probe moves Date.now() by an hour once the last response has arrived,
+// then waits for the server to close the connection, timing it with
+// performance.now(), which setSystemTime() leaves alone. Not concurrent:
+// setSystemTime() is process-wide and the tests above time themselves with
+// Date.now().
+describe("keepAliveTimeout idle expiry ignores setSystemTime()", () => {
+  const KEEP_ALIVE_MS = 500;
+  // How long the server sits on the second request before answering it. The
+  // socket timer armed by the first response keeps counting down meanwhile,
+  // so it fires this much into the second response's idle period and the
+  // expiry has to be settled from the recorded mark.
+  const SLOW_RESPONSE_MS = 300;
+  const HOUR_MS = 60 * 60 * 1000;
+
+  async function probeIdleClose(options: { requests: 1 | 2; skewMs: number }) {
+    let requests = 0;
+    const server = http.createServer({ keepAliveTimeoutBuffer: 0 }, (req, res) => {
+      req.resume();
+      if (++requests === 2) {
+        setTimeout(() => res.end("response-body"), SLOW_RESPONSE_MS);
+      } else {
+        res.end("response-body");
+      }
+    });
+    server.keepAliveTimeout = KEEP_ALIVE_MS;
+    const port = await listen(server);
+    const socket = net.connect(port, "127.0.0.1");
+    try {
+      socket.setNoDelay(true);
+      socket.on("error", () => {});
+      const { promise: closed, resolve: onClosed } = Promise.withResolvers<void>();
+      socket.on("close", () => onClosed());
+
+      let received = "";
+      let responsesWanted = 0;
+      let onResponse = () => {};
+      socket.on("data", chunk => {
+        received += chunk.toString("latin1");
+        if (received.split("response-body").length - 1 >= responsesWanted) onResponse();
+      });
+      const request = () => {
+        const { promise, resolve } = Promise.withResolvers<void>();
+        responsesWanted++;
+        onResponse = resolve;
+        socket.write("GET / HTTP/1.1\r\nHost: a\r\n\r\n");
+        return promise;
+      };
+
+      await once(socket, "connect");
+      await request();
+      if (options.requests === 2) await request();
+      const lastResponseAt = performance.now();
+      setSystemTime(new Date(Date.now() + options.skewMs));
+      await closed;
+      return performance.now() - lastResponseAt;
+    } finally {
+      setSystemTime();
+      socket.destroy();
+      server.closeAllConnections();
+      server.close();
+    }
+  }
+
+  test("a clock moved forwards does not close the connection before its idle budget is used up", async () => {
+    // Settled against Date.now(), the timer fire 200ms into the second idle
+    // period sees an hour of idle time and closes the connection right there.
+    const idleMs = await probeIdleClose({ requests: 2, skewMs: HOUR_MS });
+    expect(idleMs).toBeGreaterThanOrEqual(KEEP_ALIVE_MS - 150);
+  });
+
+  test("a clock moved backwards does not keep the idle connection open", async () => {
+    // Settled against Date.now(), the timer fire re-arms the connection for
+    // the budget plus the hour the clock went back, and this probe only
+    // returns once the test times out.
+    const idleMs = await probeIdleClose({ requests: 1, skewMs: -HOUR_MS });
+    expect(idleMs).toBeGreaterThanOrEqual(KEEP_ALIVE_MS - 150);
   });
 });


### PR DESCRIPTION
### Problem
- A `node:http` server's keep-alive idle expiry follows `Date.now()`, so bun:test's `setSystemTime()` and `useFakeTimers()` (which overrides `Date.now` as well) decide when, or whether, an idle kept-alive connection is closed. Reproduced on 1.4.0 with `keepAliveTimeout = 500`, `keepAliveTimeoutBuffer = 0`: clock moved back an hour after the response, the connection is still open when the test times out; clock pinned before the request (the usual `setSystemTime(new Date("2020-01-01"))`), it closes after 1000ms instead of 500; clock moved ahead an hour after a late second response, it closes ~200ms after that response instead of 500; `useFakeTimers()` called after the response, it is never closed.
- Cause: `src/js/node/_http_server.ts`. `onResponseFinishHandleSocket` leaves the socket timer armed across responses and only records `socket[kKeepAliveIdleStart] = DateNow()`; when the timer fires, `onSocketTimeoutTimerExpired` computes `remaining = socket.timeout - (DateNow() - idleStart)` and re-arms for `remaining` when it is positive. Clock moved back: `remaining` is the budget plus the jump. Pinned: the full budget once more. Moved ahead: negative, so a fire that predates the idle period closes the connection. Fake timers: the re-arm's `setTimeout` lands in the fake heap, where nothing fires it.
- Capturing `Date.now` at module load does not help: `setSystemTime()` sets `JSGlobalObject::overridenDateNow`, which `Date.now()` consults in every tier. `useFakeTimers()` also freezes `performance.now()`, `process.hrtime()` and `Bun.nanoseconds()`, so builtin JS had no clock to measure this with.

### Fix
- `src/runtime/timer/Timer.rs`: `internal_bindings.monotonicNowMs()`, returning `Timespec::now(ForceRealTime).ms()`, next to the existing `timerClockMs` binding (which reads the mockable clock on purpose, for ported Node timer tests). `src/js/internal/timers.ts` exports it as `monotonicNowMs`, with the rationale on the export.
- `_http_server.ts` takes the idle mark and the fire-time reading with it, and takes the mark before arming the timer. Both readings are whole milliseconds, so a timer armed after the mark always measures at least the full budget when it fires; before, a mark taken just after arming could round the other way and re-arm for one more millisecond (harmless on real timers, a stranded connection if fake timers were enabled in between). Per-response cost is still one native clock read.
- Why `ForceRealTime` rather than the timer subsystem's `AllowMockedTime` clock: `keepAliveTimeout` is a real-time budget, and the socket timer it is reconciled against is a real timer whenever it was armed before any mocking started, which is the case for every connection a test suite's earlier tests leave behind. `ForceRealTime` is the clock that real heap is drained against and nothing in bun:test can move it. `AllowMockedTime` would read as the fake clock (which starts at zero when `useFakeTimers()` is called) against a mark taken on the real one, and re-arm the connection for roughly the machine's uptime; the fourth test below fails with exactly that variant (verified by building it). The same property covers production: the wall clock can be stepped by NTP, the monotonic clock cannot. It also matches Node, whose keep-alive expiry runs on libuv's loop time, which neither `Date` mocking nor jest's fake timers touch.
- Not changed: under `useFakeTimers()` enabled before the response, the socket timer itself is a plain `setTimeout` and still lands in the fake heap (builtin JS has no real-time timer yet; #37946 did this for native timers). With a real-clock mark, a fake fire that comes before the budget has really elapsed re-arms once for the remainder, so such a connection may take two advances instead of one; nothing in the tree depends on either.
- Overlap: #37960 adds the same Rust binding for the SQL connect-retry budget and binds it from `sql/shared.ts` directly, so the `internal/timers` export is only added here. The binding code is identical in both; only its doc comment differs (each points at its own consumer), so the conflict for whichever lands second is that comment and nothing else. This branch merges cleanly into current main.
- Tests: four serial cases in `test/js/node/http/node-http-server-timeouts.test.ts`, each measuring the idle time from just before the server's own `res.end()` to the client's `close`, so the number can only over-report the server's measurement. Clock moved ahead after a second response answered 300ms late: unfixed ~140-200ms against a `>= 350` bound, fixed ~500. Clock pinned before the request: unfixed 1001-1004ms against a `< 1000` bound (the unfixed server re-arms for the full budget, so two budgets is a floor independent of machine speed), fixed ~500-530, and the `>= 350` bound as well. Clock moved back, and fake timers enabled after the response: unfixed never closes (test timeout), fixed ~500. Each probe resets the mocks before it starts and after it ends, so a timed-out probe cannot leak into the next one. All four fail on 1.4.0 individually and together; the file passes repeatedly on the debug build.
- Also passing on the debug build: the rest of that file, `node-http.test.ts`, `node-http-res-settimeout-unref.test.ts`, and the ported `test-http-keep-alive-timeout*`, `test-http-server-keep-alive-*`, `test-http-server-*-timeout-*`, `test-http-set-timeout*.js` suites (17 files). `cargo clippy -p bun_runtime`, `rustfmt`, `oxlint` and prettier are clean.

### Background
- Keep-alive idle bookkeeping (#33879): rescheduling the socket timer on every response was the largest per-request cost of the keep-alive path, so after the first response the timer is left armed and each response only records when its idle period started. A fire that comes before `idleStart + budget` re-arms once for the remainder; the next fire closes the connection.
- `setSystemTime(d)` pins `Date.now()` at `d` (it does not advance) until reset; it touches no other clock. `useFakeTimers()` pins `Date.now()`, `performance.now()`, `process.hrtime()` and `Bun.nanoseconds()`, installs a mocked monotonic clock starting at zero that only `jest.advanceTimersByTime()` and friends move, and diverts new `setTimeout`s into a heap that only those calls drain; timers armed before the call stay in the real heap and keep firing.
- `Timespec::now(mode)` is bun's monotonic clock (`CLOCK_MONOTONIC`, QPC on Windows). `AllowMockedTime` returns the mocked clock while fake timers are installed; `ForceRealTime` never does. The event loop drains the real timer heap against `ForceRealTime`.
- `$newRustFunction(file, symbol, argc)` is how builtin JS calls into Rust: codegen emits a thunk per call site that calls the named function directly, so a misnamed Rust function is a compile error.

<details>
<summary>Measured close times (ms after the last response)</summary>

```
clock moved ahead, second response answered late   bound: >= 350
  unfixed debug 138-169, unfixed release 199-201, fixed debug ~500-620
clock pinned before the request                    bounds: >= 350 and < 1000
  unfixed release 1001-1004, fixed debug ~500-530
clock moved back after the response                bound: >= 350
  unfixed: never closes (5s test timeout), fixed debug ~500-530
useFakeTimers() after the response                 bound: >= 350
  unfixed: never closes (5s test timeout), fixed debug ~500-530
  binding switched to AllowMockedTime: never closes (the other three cases pass)
```

</details>

<details>
<summary>Earlier revision of this PR</summary>

The first revision took the mark after arming the timer and shipped only the moved-ahead and moved-back cases. Review added the pinned and fake-timers cases, which is what surfaced the rounding re-arm and the `ForceRealTime` argument above.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 4 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-timeouts.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 4 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/node/http/node-http-server-timeouts.test.ts:
(pass) node:http server timeout enforcement > headersTimeout closes a connection that never completes its request headers [257.34ms]
(pass) node:http server timeout enforcement > requestTimeout closes a connection that stalls mid-body [355.14ms]
(pass) node:http server timeout enforcement > server.setTimeout() fires the 'timeout' event for an inactive connection [205.53ms]
(pass) node:http server timeout enforcement > keepAliveTimeout closes an idle keep-alive connection after the response [1206.05ms]
(pass) node:http server timeout enforcement > headersTimeout answers 408 when there is no 'clientError' listener [254.62ms]
(pass) node:http server timeout enforcement > requestTimeout does not fire while a slow handler streams a response [406.75ms]
315 |     // period sees an hour of idle time and closes the connection right there.
316 |     const idleMs = await probeIdleClose({
317 |       requests: 2,
318 |       afterLastResponse: () => setSystemTime(new Date(Date.now() + HOUR_MS)),
319 |     });
320 |     expect(idleMs).toBeGreaterThanOrEqual(KEEP_ALIVE_MS - 150);
          
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/http/node-http-server-timeouts.test.ts
bun test v1.4.0 (fb9cfb248)

test/js/node/http/node-http-server-timeouts.test.ts:
(pass) node:http server timeout enforcement > headersTimeout closes a connection that never completes its request headers [959.68ms]
(pass) node:http server timeout enforcement > requestTimeout closes a connection that stalls mid-body [506.96ms]
(pass) node:http server timeout enforcement > server.setTimeout() fires the 'timeout' event for an inactive connection [344.66ms]
(pass) node:http server timeout enforcement > keepAliveTimeout closes an idle keep-alive connection after the response [1430.95ms]
(pass) node:http server timeout enforcement > headersTimeout answers 408 when there is no 'clientError' listener [350.03ms]
(pass) node:http server timeout enforcement > requestTimeout does not fire while a slow handler streams a response [623.50ms]
(pass) keepAliveTimeout idle expiry ignores mocked clocks > a clock moved forwards does not close the connection before its idle budget is used up [984.55ms]
(p
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1059ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/45] gen bindgenv2
[2/40] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/40] gen cpp.rs (cppbind)
[4/40] gen JS modules (bundle-modules)
Preprocess modules (15644ms)
Bundle modules (213ms)
Postprocesss modules (590ms)
Bundle Functions (1451ms)
Generate Code (54ms)

[17.98s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/29] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_url v0.0.0 (/workspace/bun/src/url)
[1m[92m   Compiling[0m bun_http_types v0.0.0 (/workspace/bun/src/http_types)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/internal/timers.ts                          |  11 ++
 src/js/node/_http_server.ts                        |  14 +-
 src/runtime/timer/Timer.rs                         |  12 ++
 .../js/node/http/node-http-server-timeouts.test.ts | 141 ++++++++++++++++++++-
 4 files changed, 172 insertions(+), 6 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                                 reads  edits  tests
src/js/internal/timers.ts                                3      4      0
src/js/node/_http_server.ts                             12      8      0
src/runtime/timer/Timer.rs                               3      4      0
test/js/node/http/node-http-server-timeouts.test.ts      8     13      0
```

</details>

**root cause** · written by the author bot

The node:http server measured keep-alive idle time with Date.now(), both when recording the idle start after each response and when the timer fired to compute the remaining budget, so bun:test's setSystemTime() or fake timers could delay, advance, or double the idle expiry of a kept-alive socket. The fix adds a monotonicNowMs binding backed by the real-time timer clock, exported from internal/timers, and uses it at both sites so the idle measurement is immune to wall-clock mocking. The idle start is also recorded before the timer is armed, so a timer that fires measures at least the full bu…

<!-- robobun:evidence:end -->