### PR TITLE
shell(cp): fail instead of creating the destination's missing parent directories

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -4342,8 +4342,7 @@ pub mod args {
         pub(crate) recursive: bool,
         pub(crate) error_on_exist: bool,
         pub(crate) force: bool,
-        /// Create the missing parent directories of `dest` (`fs.cp` does;
-        /// the shell's `cp`, like cp(1), fails with ENOENT instead).
+        /// `fs.cp` creates the missing parents of `dest`; cp(1), and so the shell builtin, does not.
         pub(crate) create_dest_parents: bool,
     }
 
@@ -9157,11 +9156,7 @@ impl NodeFS {
         }
     }
 
-    /// Creates `dest` for a directory being copied. It may already exist as a
-    /// directory (the copy then merges into it); with `create_parents`
-    /// (`CpFlags::create_dest_parents`) its missing parents are created too,
-    /// otherwise a missing parent fails with ENOENT and a parent that is not a
-    /// directory with ENOTDIR.
+    /// Creates the destination of a copied directory; an existing directory there is merged into.
     fn cp_mkdir_dest(&mut self, dest: &OSPathSliceZ, create_parents: bool) -> Maybe<()> {
         if create_parents {
             return self
@@ -9186,9 +9181,7 @@ impl NodeFS {
         Err(err.with_path(self.os_path_into_sync_error_buf(dest)))
     }
 
-    /// `CreateDirectoryW` reports a parent that is a file the same way as a
-    /// missing one (`PATH_NOT_FOUND`, so ENOENT), where POSIX `mkdir` reports
-    /// ENOTDIR.
+    /// `CreateDirectoryW` fails with `PATH_NOT_FOUND` (ENOENT) where POSIX `mkdir` would say ENOTDIR.
     #[cfg(windows)]
     fn cp_dest_parent_is_not_a_directory(dest: &OSPathSliceZ) -> bool {
         let parent = paths::dirname_w(dest.as_slice());
@@ -9200,10 +9193,7 @@ impl NodeFS {
 
     /// Shared `dest_fd:` block from the mac/linux/freebsd branches of
     /// `copy_single_file_sync`.
-    /// Tries `open(dest, flags, mode)`; on ENOENT with `create_parents`
-    /// (`CpFlags::create_dest_parents`) creates the parent directory and
-    /// retries once. Any other error is annotated with `dest` copied into
-    /// `sync_error_buf`.
+    /// Opens `dest`; with `create_parents`, an ENOENT is retried once after creating its parent.
     #[cfg_attr(windows, allow(dead_code))]
     fn cp_open_dest(
         &mut self,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -9157,26 +9157,45 @@ impl NodeFS {
         }
     }
 
-    /// Creates the directory a directory is being copied to. It may already
-    /// exist as a directory (the copy then merges into it); with
-    /// `create_parents` (`CpFlags::create_dest_parents`) its missing parents
-    /// are created too, otherwise a missing parent fails with ENOENT.
+    /// Creates `dest` for a directory being copied. It may already exist as a
+    /// directory (the copy then merges into it); with `create_parents`
+    /// (`CpFlags::create_dest_parents`) its missing parents are created too,
+    /// otherwise a missing parent fails with ENOENT and a parent that is not a
+    /// directory with ENOTDIR.
     fn cp_mkdir_dest(&mut self, dest: &OSPathSliceZ, create_parents: bool) -> Maybe<()> {
         if create_parents {
             return self
                 .mkdir_recursive_os_path(dest, args::Mkdir::DEFAULT_MODE, false)
                 .map(|_| ());
         }
-        match mkdir_os_path(dest, args::Mkdir::DEFAULT_MODE) {
-            Ok(()) => Ok(()),
-            Err(err)
-                if matches!(err.get_errno(), E::EEXIST | E::EISDIR)
-                    && directory_exists_at_os_path(FD::INVALID, dest).unwrap_or(false) =>
-            {
-                Ok(())
-            }
-            Err(err) => Err(err.with_path(self.os_path_into_sync_error_buf(dest))),
+        let err = match mkdir_os_path(dest, args::Mkdir::DEFAULT_MODE) {
+            Ok(()) => return Ok(()),
+            Err(err) => err,
+        };
+        if matches!(err.get_errno(), E::EEXIST | E::EISDIR)
+            && directory_exists_at_os_path(FD::INVALID, dest).unwrap_or(false)
+        {
+            return Ok(());
         }
+        #[cfg(windows)]
+        let err = if err.get_errno() == E::ENOENT && Self::cp_dest_parent_is_not_a_directory(dest) {
+            sys::Error::from_code(E::ENOTDIR, sys::Tag::mkdir)
+        } else {
+            err
+        };
+        Err(err.with_path(self.os_path_into_sync_error_buf(dest)))
+    }
+
+    /// `CreateDirectoryW` reports a parent that is a file the same way as a
+    /// missing one (`PATH_NOT_FOUND`, so ENOENT), where POSIX `mkdir` reports
+    /// ENOTDIR.
+    #[cfg(windows)]
+    fn cp_dest_parent_is_not_a_directory(dest: &OSPathSliceZ) -> bool {
+        let parent = paths::dirname_w(dest.as_slice());
+        let mut buf = paths::os_path_buffer_pool::get();
+        buf[..parent.len()].copy_from_slice(parent);
+        buf[parent.len()] = 0;
+        sys::exists_os_path(OSPathSliceZ::from_buf(&buf[..], parent.len()), true)
     }
 
     /// Shared `dest_fd:` block from the mac/linux/freebsd branches of

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2014,13 +2014,12 @@ mod _async_tasks {
             #[cfg(not(windows))]
             let normdest: &OSPathSliceZ = dest;
 
-            let mkdir_ = nodefs.mkdir_recursive_os_path(normdest, args::Mkdir::DEFAULT_MODE, false);
-            match mkdir_ {
+            match nodefs.cp_mkdir_dest(normdest, args.create_dest_parents) {
                 Err(err) => {
                     this_ref.finish_concurrently(Err(err));
                     return false;
                 }
-                Ok(_) => {
+                Ok(()) => {
                     this_ref.on_copy(src, normdest);
                 }
             }
@@ -4343,6 +4342,9 @@ pub mod args {
         pub(crate) recursive: bool,
         pub(crate) error_on_exist: bool,
         pub(crate) force: bool,
+        /// Create the missing parent directories of `dest` (`fs.cp` does;
+        /// the shell's `cp`, like cp(1), fails with ENOENT instead).
+        pub(crate) create_dest_parents: bool,
     }
 
     pub struct Cp {
@@ -4389,6 +4391,7 @@ pub mod args {
                     recursive,
                     error_on_exist,
                     force,
+                    create_dest_parents: true,
                 },
             })
         }
@@ -8371,10 +8374,7 @@ impl NodeFS {
         };
         let _close = scopeguard::guard(fd, |fd| fd.close());
 
-        match self.mkdir_recursive_os_path(dest, args::Mkdir::DEFAULT_MODE, false) {
-            Err(err) => return Err(err),
-            Ok(_) => {}
-        }
+        self.cp_mkdir_dest(dest, cp_flags.create_dest_parents)?;
 
         // The OSPathBuffer copy below is generic over `OSPathChar`, so on Windows
         // this needs the wide (u16) iterator; the u8 path is correct for POSIX.
@@ -8550,8 +8550,6 @@ impl NodeFS {
         #[cfg(not(windows))] reuse_stat: Option<&sys::Stat>,
         args: &args::Cp,
     ) -> Maybe<ret::CopyFile> {
-        let _ = args; // only the Windows branch consults `args` (shouldIgnoreEbusy)
-
         // TODO: do we need to fchown?
         #[cfg(target_os = "macos")]
         {
@@ -8632,8 +8630,13 @@ impl NodeFS {
                     flags |= sys::O::EXCL;
                 }
 
-                let dest_fd =
-                    Self::cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode)?;
+                let dest_fd = Self::cp_open_dest(
+                    self,
+                    dest,
+                    flags,
+                    stat_.st_mode as Mode,
+                    args.flags.create_dest_parents,
+                )?;
                 let _close_dest =
                     scopeguard::guard((dest_fd, stat_.st_mode, &wrote), |(fd, m, wrote)| {
                         let _ = Syscall::ftruncate(fd, (wrote.get() & ((1u64 << 63) - 1)) as i64);
@@ -8672,6 +8675,14 @@ impl NodeFS {
             match first_try {
                 None => return Ok(()),
                 Some(err) if err.get_errno() == E::ENOENT => {
+                    if !args.flags.create_dest_parents {
+                        // `src` was stat'd above, so it is `dest`'s parent that is missing.
+                        return Maybe::<ret::CopyFile>::init_err_with_p(
+                            SystemErrno::ENOENT,
+                            sys::Tag::copyfile,
+                            dest.as_bytes(),
+                        );
+                    }
                     let _ = sys::Dir::cwd().make_path(paths::resolve_path::dirname::<
                         paths::platform::Auto,
                     >(dest.as_bytes()));
@@ -8726,7 +8737,13 @@ impl NodeFS {
                 flags |= sys::O::EXCL;
             }
 
-            let dest_fd = Self::cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode)?;
+            let dest_fd = Self::cp_open_dest(
+                self,
+                dest,
+                flags,
+                stat_.st_mode as Mode,
+                args.flags.create_dest_parents,
+            )?;
 
             let mut size: usize = stat_.st_size.max(0) as usize;
 
@@ -8897,11 +8914,13 @@ impl NodeFS {
                 flags |= sys::O::EXCL;
             }
 
-            let dest_fd =
-                match Self::cp_open_dest_with_mkdir(self, dest, flags, stat_.st_mode as Mode) {
-                    Ok(fd) => fd,
-                    Err(e) => return Err(e),
-                };
+            let dest_fd = Self::cp_open_dest(
+                self,
+                dest,
+                flags,
+                stat_.st_mode as Mode,
+                args.flags.create_dest_parents,
+            )?;
 
             // No O_TRUNC at open: if src and dest resolve to the same inode,
             // that would zero the file before the first read.
@@ -9040,7 +9059,7 @@ impl NodeFS {
                     let mut err = windows::Win32Error::get();
                     match err {
                         windows::Win32Error::FILE_EXISTS | windows::Win32Error::ALREADY_EXISTS => {}
-                        windows::Win32Error::PATH_NOT_FOUND => {
+                        windows::Win32Error::PATH_NOT_FOUND if args.flags.create_dest_parents => {
                             let _ = sys::make_path::make_path_u16(
                                 &sys::Dir::cwd(),
                                 paths::dirname_w(dest.as_slice()),
@@ -9133,25 +9152,54 @@ impl NodeFS {
             windows
         )))]
         {
-            let _ = (src, dest, mode, reuse_stat);
+            let _ = (src, dest, mode, reuse_stat, args);
             Maybe::<ret::CopyFile>::todo()
+        }
+    }
+
+    /// Creates the directory a directory is being copied to. It may already
+    /// exist as a directory (the copy then merges into it); with
+    /// `create_parents` (`CpFlags::create_dest_parents`) its missing parents
+    /// are created too, otherwise a missing parent fails with ENOENT.
+    fn cp_mkdir_dest(&mut self, dest: &OSPathSliceZ, create_parents: bool) -> Maybe<()> {
+        if create_parents {
+            return self
+                .mkdir_recursive_os_path(dest, args::Mkdir::DEFAULT_MODE, false)
+                .map(|_| ());
+        }
+        match mkdir_os_path(dest, args::Mkdir::DEFAULT_MODE) {
+            Ok(()) => Ok(()),
+            Err(err)
+                if matches!(err.get_errno(), E::EEXIST | E::EISDIR)
+                    && directory_exists_at_os_path(FD::INVALID, dest).unwrap_or(false) =>
+            {
+                Ok(())
+            }
+            Err(err) => Err(err.with_path(self.os_path_into_sync_error_buf(dest))),
         }
     }
 
     /// Shared `dest_fd:` block from the mac/linux/freebsd branches of
     /// `copy_single_file_sync`.
-    /// Tries `open(dest, flags, mode)`; on ENOENT creates the
-    /// parent directory and retries once. Any other error is annotated with
-    /// `dest` copied into `sync_error_buf`.
+    /// Tries `open(dest, flags, mode)`; on ENOENT with `create_parents`
+    /// (`CpFlags::create_dest_parents`) creates the parent directory and
+    /// retries once. Any other error is annotated with `dest` copied into
+    /// `sync_error_buf`.
     #[cfg_attr(windows, allow(dead_code))]
-    fn cp_open_dest_with_mkdir(&mut self, dest: &ZStr, flags: i32, mode: Mode) -> Maybe<FD> {
+    fn cp_open_dest(
+        &mut self,
+        dest: &ZStr,
+        flags: i32,
+        mode: Mode,
+        create_parents: bool,
+    ) -> Maybe<FD> {
         // PORT: extracted from the mac/linux/freebsd arms of `copy_single_file_sync`
         // only — there `OSPathSliceZ == ZStr`. Taking `&ZStr` keeps the body
         // monomorphic (and lets it type-check on Windows where it's dead code).
         match Syscall::open(dest, flags, mode) {
             Ok(result) => Ok(result),
             Err(err) => {
-                if err.get_errno() == E::ENOENT {
+                if create_parents && err.get_errno() == E::ENOENT {
                     // Create the parent directory if it doesn't exist
                     let bytes = dest.as_bytes();
                     let mut len = bytes.len();

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -713,6 +713,7 @@ impl ShellCpTask {
                 recursive: self.opts.recursive,
                 force: true,
                 error_on_exist: false,
+                create_dest_parents: false,
             },
         };
 

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -181,7 +181,7 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
 // was asked for). The builtin is the default only on Windows; on POSIX it is
 // enabled by an env var read once per process, so each cp runs in a child bun
 // whose cwd is the directory holding the operands.
-describe.concurrent("bunshell cp into a directory that does not exist", () => {
+describe.concurrent("bunshell cp and the destination's directory", () => {
   const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
 
   // Runs the last argv entry as a shell command and prints cp's exit code
@@ -202,15 +202,15 @@ describe.concurrent("bunshell cp into a directory that does not exist", () => {
     return { stdout, stderr, exitCode };
   }
 
-  function failedWithEnoent(dest: string) {
-    return { stdout: `1\ncp: No such file or directory: ${dest}\n`, stderr: "", exitCode: 0 };
+  function failedWith(message: string, path: string) {
+    return { stdout: `1\ncp: ${message}: ${path}\n`, stderr: "", exitCode: 0 };
   }
   const succeeded = { stdout: "0\n", stderr: "", exitCode: 0 };
 
-  test("file -> file fails", async () => {
+  test("file -> file in a missing directory fails", async () => {
     using dir = tempDir("shell-cp-missing-dir", { "a.txt": "A\n" });
     expect(await cp(String(dir), "cp a.txt missing/out.txt")).toEqual(
-      failedWithEnoent(join(String(dir), "missing", "out.txt")),
+      failedWith("No such file or directory", join(String(dir), "missing", "out.txt")),
     );
     expect(existsSync(join(String(dir), "missing"))).toBe(false);
   });
@@ -218,20 +218,41 @@ describe.concurrent("bunshell cp into a directory that does not exist", () => {
   // On macOS a file over 128 KB is copied with copyfile() instead of being
   // opened and written, which is a separate place the directory used to be
   // created from.
-  test("large file -> file fails", async () => {
+  test("large file -> file in a missing directory fails", async () => {
     using dir = tempDir("shell-cp-missing-dir-large", { "big.bin": Buffer.alloc(256 * 1024, "x") });
     expect(await cp(String(dir), "cp big.bin missing/out.bin")).toEqual(
-      failedWithEnoent(join(String(dir), "missing", "out.bin")),
+      failedWith("No such file or directory", join(String(dir), "missing", "out.bin")),
     );
     expect(existsSync(join(String(dir), "missing"))).toBe(false);
   });
 
-  test("-R dir -> dir fails", async () => {
+  test("-R dir -> dir in a missing directory fails", async () => {
     using dir = tempDir("shell-cp-missing-dir-recursive", { "d": { "b.txt": "B\n" } });
     expect(await cp(String(dir), "cp -R d missing/copy")).toEqual(
-      failedWithEnoent(join(String(dir), "missing", "copy")),
+      failedWith("No such file or directory", join(String(dir), "missing", "copy")),
     );
     expect(existsSync(join(String(dir), "missing"))).toBe(false);
+  });
+
+  // Windows reports a file in the parent's position the same way as a missing
+  // parent, so this message comes from the builtin telling the two apart.
+  test("-R dir -> file fails as not a directory", async () => {
+    using dir = tempDir("shell-cp-dir-onto-file", { "d": { "b.txt": "B\n" }, "plain.txt": "P\n" });
+    expect(await cp(String(dir), "cp -R d plain.txt")).toEqual(
+      failedWith("Not a directory", join(String(dir), "plain.txt", "d")),
+    );
+    expect(readFileSync(join(String(dir), "plain.txt"), "utf8")).toBe("P\n");
+  });
+
+  test("-R dir -> existing dir holding a file of the same name fails", async () => {
+    using dir = tempDir("shell-cp-dir-onto-file-in-dir", {
+      "d": { "b.txt": "B\n" },
+      "existing": { "d": "not a dir\n" },
+    });
+    expect(await cp(String(dir), "cp -R d existing")).toEqual(
+      failedWith("File exists", join(String(dir), "existing", "d")),
+    );
+    expect(readFileSync(join(String(dir), "existing", "d"), "utf8")).toBe("not a dir\n");
   });
 
   test("-R dir -> new dir inside an existing directory still creates it", async () => {

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, tempDir, tempDirWithFiles } from "harness";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,82 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// The builtin used to hand the copy to the node:fs cp engine as-is, and fs.cp
+// creates the missing parent directories of its destination. cp(1) does not:
+// it fails with ENOENT (only `cp -R dir new_dir` creates the one directory it
+// was asked for). The builtin is the default only on Windows; on POSIX it is
+// enabled by an env var read once per process, so each cp runs in a child bun
+// whose cwd is the directory holding the operands.
+describe.concurrent("bunshell cp into a directory that does not exist", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  // Runs the last argv entry as a shell command and prints cp's exit code
+  // followed by whatever it wrote to stderr.
+  const runCp = [
+    `const result = await Bun.$\`\${{ raw: process.argv.at(-1) }}\`.nothrow().quiet();`,
+    `process.stdout.write(result.exitCode + "\\n" + result.stderr.toString());`,
+  ].join("\n");
+
+  async function cp(cwd: string, command: string) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", runCp, command],
+      cwd,
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  function failedWithEnoent(dest: string) {
+    return { stdout: `1\ncp: No such file or directory: ${dest}\n`, stderr: "", exitCode: 0 };
+  }
+  const succeeded = { stdout: "0\n", stderr: "", exitCode: 0 };
+
+  test("file -> file fails", async () => {
+    using dir = tempDir("shell-cp-missing-dir", { "a.txt": "A\n" });
+    expect(await cp(String(dir), "cp a.txt missing/out.txt")).toEqual(
+      failedWithEnoent(join(String(dir), "missing", "out.txt")),
+    );
+    expect(existsSync(join(String(dir), "missing"))).toBe(false);
+  });
+
+  // On macOS a file over 128 KB is copied with copyfile() instead of being
+  // opened and written, which is a separate place the directory used to be
+  // created from.
+  test("large file -> file fails", async () => {
+    using dir = tempDir("shell-cp-missing-dir-large", { "big.bin": Buffer.alloc(256 * 1024, "x") });
+    expect(await cp(String(dir), "cp big.bin missing/out.bin")).toEqual(
+      failedWithEnoent(join(String(dir), "missing", "out.bin")),
+    );
+    expect(existsSync(join(String(dir), "missing"))).toBe(false);
+  });
+
+  test("-R dir -> dir fails", async () => {
+    using dir = tempDir("shell-cp-missing-dir-recursive", { "d": { "b.txt": "B\n" } });
+    expect(await cp(String(dir), "cp -R d missing/copy")).toEqual(
+      failedWithEnoent(join(String(dir), "missing", "copy")),
+    );
+    expect(existsSync(join(String(dir), "missing"))).toBe(false);
+  });
+
+  test("-R dir -> new dir inside an existing directory still creates it", async () => {
+    using dir = tempDir("shell-cp-new-dir", { "d": { "b.txt": "B\n" }, "existing": {} });
+    expect(await cp(String(dir), "cp -R d existing/copy")).toEqual(succeeded);
+    expect(readFileSync(join(String(dir), "existing", "copy", "b.txt"), "utf8")).toBe("B\n");
+  });
+
+  test("-R dir -> existing dir still copies into it", async () => {
+    using dir = tempDir("shell-cp-into-existing-dir", {
+      "d": { "b.txt": "B\n" },
+      "existing": { "d": { "keep.txt": "K\n" } },
+    });
+    expect(await cp(String(dir), "cp -R d existing")).toEqual(succeeded);
+    expect(readFileSync(join(String(dir), "existing", "d", "b.txt"), "utf8")).toBe("B\n");
+    expect(readFileSync(join(String(dir), "existing", "d", "keep.txt"), "utf8")).toBe("K\n");
   });
 });
 

--- a/test/js/node/fs/cp.test.ts
+++ b/test/js/node/fs/cp.test.ts
@@ -37,6 +37,29 @@ for (const [name, copy] of impls) {
       expect(fs.readFileSync(basename + "/to.txt", "utf8")).toBe("a");
     });
 
+    // Unlike cp(1), fs.cp creates the missing parents of its destination.
+    test("single file into a directory that does not exist yet", async () => {
+      await using basename = tempDir("cp", {
+        "from/a.txt": "a",
+      });
+
+      await copy(basename + "/from/a.txt", basename + "/to/deeper/a.txt");
+
+      assertContent(basename + "/to/deeper/a.txt", "a");
+    });
+
+    // Over 128 KB, macOS copies with copyfile() instead of open()+write().
+    test("large single file into a directory that does not exist yet", async () => {
+      const content = Buffer.alloc(256 * 1024, "x").toString();
+      await using basename = tempDir("cp", {
+        "from/big.txt": content,
+      });
+
+      await copy(basename + "/from/big.txt", basename + "/to/deeper/big.txt");
+
+      assertContent(basename + "/to/deeper/big.txt", content);
+    });
+
     test("refuse to copy directory with 'recursive: false'", async () => {
       await using basename = tempDir("cp", {
         "from/a.txt": "a",


### PR DESCRIPTION
### Problem
- The shell's `cp` builtin silently creates the missing parent directories of its destination. `cp a.txt missing/out.txt` exits 0 and leaves `missing/out.txt` behind, and `cp -R d missing/copy` exits 0 and creates `missing/copy`. cp(1) fails both with `No such file or directory` and creates nothing (it only creates the one directory `cp -R d new_dir` asks for).
- Reproduces with the current canary (1.4.0-canary.1+da3851e57) on Linux (`BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1`, where the builtin is opt-in) and on Windows (where the builtin is the default `cp`).
- Cause: `src/runtime/shell/builtin/cp.rs:703` hands the copy to the engine behind `fs.cp`, which creates the destination's parents on purpose because `fs.cp` does. The creating code is `cp_open_dest_with_mkdir` (`src/runtime/node/node_fs.rs:9147`, used by the Linux, FreeBSD and macOS-under-128 KB file copies), the `copyfile()` ENOENT retry (`node_fs.rs:8674`, macOS files over 128 KB), the `CopyFileW` `PATH_NOT_FOUND` retry (`node_fs.rs:9043`, Windows) and the `mkdir -p` of a copied directory's destination (`node_fs.rs:2017`, with its sync twin at `:8374`). None of it knew which caller it was serving.

### Fix
- Adds `create_dest_parents` to `args::CpFlags`. `args::Cp::from_js` (every `fs.cp` / `fs.cpSync` call) sets it; the shell builtin clears it. The four fallbacks above run only when it is set.
- With it clear, a copied directory's destination is created with a single `mkdir` that tolerates an existing directory (`cp_mkdir_dest`), so `cp -R d new_dir` and `cp -R d existing_dir` still work and `cp -R d missing/new_dir` fails with ENOENT naming `missing/new_dir`, as cp(1) does. The file paths report ENOENT naming the destination; on the macOS `copyfile()` path the error is attributed to the destination explicitly, since the source was stat'd just before and `copyfile()` does not say which path was missing.
- The single `mkdir` reports the same errors the recursive one did: a file where the directory should go is still EEXIST, and `cp -R d some_file` (destination `some_file/d`) is still ENOTDIR. The latter needs one Windows-only check (`cp_dest_parent_is_not_a_directory`): `CreateDirectoryW` answers `PATH_NOT_FOUND` for a file in the parent's position, the same as for a missing parent, and the recursive mkdir used to tell the two apart while walking up. POSIX `mkdir` returns ENOTDIR by itself.
- Why this is the right layer: the engine is shared by `fs.cp` and the builtin, and the two callers want different things, so the engine has to be told. Checking for the parent in the builtin before handing off would leave the engine creating directories behind the shell's back (and would race with the copy). `fs.cp` keeps creating parents, which is what Node does (its `checkParentDir` step is `mkdir -p dirname(dest)` for files and directories alike); the existing `fs.cp` tests plus the new ones below pin that.
- Verified with `test/js/bun/shell/commands/cp.test.ts` (new `describe` block, runs each `cp` in a child bun with the builtin enabled): the three "missing directory" cases fail against the canary and pass with a debug build of this branch, on Linux and on Windows; the other four (new directory one level down, merge into an existing directory, file in the directory's place, `cp -R d some_file`) pass against both, pinning what must not change. The `cp -R d some_file` case is the one the first revision of this branch got wrong on Windows (ENOENT instead of ENOTDIR). On Windows the 30 pre-existing builtin tests also pass.
- `test/js/node/fs/cp.test.ts`: new single-file and over-128 KB copies into a missing directory for `cpSync` and `promises.cp`; they pass before and after (the existing "copy directory will ensure directory exists" covers the recursive side). Whole file passes on Linux and Windows debug builds.
- `cargo check -p bun_runtime` for `x86_64-apple-darwin`, `x86_64-pc-windows-msvc` and `x86_64-unknown-freebsd` (the arms a Linux build does not compile), `cargo clippy -p bun_runtime` and `cargo fmt` are clean.

### Background
- `NewAsyncCpTask<IS_SHELL>` (`node_fs.rs`) is the thread-pool implementation of `fs.promises.cp`; `IS_SHELL = true` is the same code driven by the shell builtin, which only differs in how completion is reported. Both callers describe the copy with an `args::Cp`, whose `flags: CpFlags` was `recursive` / `force` / `error_on_exist` until now.
- Node's `fs.cp` creates `dirname(dest)` recursively before copying anything, for single files and directories alike. Bun's engine gets the same result lazily: it tries the copy and creates the parents when the destination open fails with ENOENT.
- cp(1) has three forms: `cp file target_file`, `cp -R source... target` and `cp source... target_dir`. The builtin picks the form in `ShellCpTask::run_from_thread_pool_impl` (`cp.rs`) and then asks the engine to copy one source to one resolved destination. The only directory cp(1) ever creates is the target of `cp -R source target` when it does not exist, one level deep.
- On macOS the engine copies a regular file under 128 KB with `open()` + a write loop and a larger one with `clonefile()`, falling back to `copyfile()`; each route had its own parent-creating retry, which is why there is a large-file test.
- On POSIX the builtin is disabled unless `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` is in the environment when the process starts (`cp` spawns the system binary otherwise), which is why the new tests run each command in a child bun. On Windows it is always the builtin.

<details>
<summary>Repro output before and after (Linux, builtin enabled)</summary>

```
$ mkdir t && cd t && echo a > a.txt && mkdir -p d/sub && echo b > d/sub/b.txt
$ cat run.js
import { $ } from "bun"; import { existsSync } from "fs";
$.nothrow();
let r = await $`cp a.txt missing/out.txt`.quiet();
console.log(r.exitCode, JSON.stringify(r.stderr.toString()), existsSync("missing"));
r = await $`cp -R d missing3/newdir`.quiet();
console.log(r.exitCode, JSON.stringify(r.stderr.toString()), existsSync("missing3"));
r = await $`cp -R d newdir`.quiet();
console.log(r.exitCode, JSON.stringify(r.stderr.toString()), existsSync("newdir/sub/b.txt"));

# canary 1.4.0-canary.1+da3851e57
$ BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun run.js
0 "" true
0 "" true
0 "" true

# this branch
$ BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1 bun-debug run.js
1 "cp: No such file or directory: /tmp/t/missing/out.txt\n" false
1 "cp: No such file or directory: /tmp/t/missing3/newdir\n" false
0 "" true

# coreutils, for comparison
$ cp a.txt missing/out.txt
cp: cannot create regular file 'missing/out.txt': No such file or directory
$ cp -R d missing3/newdir
cp: cannot create directory 'missing3/newdir': No such file or directory
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts test/js/node/fs/cp.test.ts

<!-- robobun:evidence:end -->