### PR TITLE
node:http: pause the socket on Windows too when the request body is paused

### DIFF
--- a/src/runtime/server/NodeHTTPResponse.rs
+++ b/src/runtime/server/NodeHTTPResponse.rs
@@ -473,7 +473,6 @@ impl NodeHTTPResponse {
         self.request_trailers.with_mut(|v| v.append_slice(bytes));
     }
 
-    #[allow(dead_code)]
     pub(crate) fn pause_socket(&self) {
         scoped_log!(NodeHTTPResponse, "pauseSocket");
         let flags = self.flags.get();
@@ -1404,11 +1403,7 @@ impl NodeHTTPResponse {
             raw.on_data(on_buffer_paused_shim, self.as_ctx_ptr());
         }
 
-        // TODO: figure out why windows is not emitting EOF with UV_DISCONNECT
-        #[cfg(not(windows))]
-        {
-            self.pause_socket();
-        }
+        self.pause_socket();
         Ok(JSValue::TRUE)
     }
 

--- a/test/js/node/http/node-http-backpressure.test.ts
+++ b/test/js/node/http/node-http-backpressure.test.ts
@@ -309,6 +309,187 @@ describe("backpressure", () => {
     });
   });
 
+  // Request-body direction: once the handler stops reading the body (req.pause(),
+  // or nobody consuming the IncomingMessage), the connection's kernel reads must
+  // stop too, so the upload stalls on TCP backpressure instead of the unread
+  // body piling up in server memory (https://github.com/oven-sh/bun/issues/26332).
+  // Node does this with readStop(socket); Bun pauses the underlying uWS socket.
+  describe("request body", () => {
+    const TOTAL = 32 * 1024 * 1024;
+    const BLOCK = Buffer.alloc(256 * 1024, "b");
+
+    const keysDir = path.join(import.meta.dirname, "..", "test", "fixtures", "keys");
+    const tlsOptions = {
+      cert: readFileSync(path.join(keysDir, "agent1-cert.pem")),
+      key: readFileSync(path.join(keysDir, "agent1-key.pem")),
+    };
+    type RequestListener = (req: http.IncomingMessage, res: http.ServerResponse) => void;
+    const transports = {
+      http: {
+        createServer: (listener: RequestListener) => http.createServer(listener),
+        async connect(port: number) {
+          const sock = net.connect(port, "127.0.0.1");
+          sock.on("error", () => {});
+          await once(sock, "connect");
+          return sock;
+        },
+      },
+      https: {
+        createServer: (listener: RequestListener) => https.createServer(tlsOptions, listener),
+        async connect(port: number) {
+          const sock = nodeTls.connect({ port, host: "127.0.0.1", rejectUnauthorized: false });
+          sock.on("error", () => {});
+          await once(sock, "secureConnect");
+          return sock;
+        },
+      },
+    };
+    type Transport = (typeof transports)[keyof typeof transports];
+
+    // Raw client: sends the request head, then pumps TOTAL body bytes, parking
+    // on 'drain' whenever the kernel send buffer is full, and FINs after the
+    // last byte. Resolves once `sent` has stopped moving for 12 consecutive
+    // 25 ms polls (the upload is stalled) or the whole body has been handed to
+    // the kernel (nothing ever pushed back). The response is collected so the
+    // caller can check the server still answered after draining the body.
+    async function uploadUntilStalled(transport: Transport, port: number) {
+      const sock = await transport.connect(port);
+      let response = "";
+      sock.on("data", chunk => (response += chunk.toString("latin1")));
+      const closed = once(sock, "close");
+      sock.write(`POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: ${TOTAL}\r\nConnection: close\r\n\r\n`);
+
+      let sent = 0;
+      const pump = () => {
+        while (sent < TOTAL) {
+          const n = Math.min(BLOCK.byteLength, TOTAL - sent);
+          sent += n;
+          if (!sock.write(n === BLOCK.byteLength ? BLOCK : BLOCK.subarray(0, n))) {
+            sock.once("drain", pump);
+            return;
+          }
+        }
+        sock.end();
+      };
+      pump();
+
+      let last = -1;
+      let stable = 0;
+      while (sent < TOTAL && stable < 12) {
+        await new Promise(resolve => setTimeout(resolve, 25));
+        if (sent === last) stable++;
+        else {
+          stable = 0;
+          last = sent;
+        }
+      }
+      return {
+        sock,
+        sentWhileStalled: sent,
+        async finish() {
+          await closed;
+          return response;
+        },
+      };
+    }
+
+    function countBody(req: http.IncomingMessage, res: http.ServerResponse) {
+      const { promise, resolve, reject } = Promise.withResolvers<number>();
+      let received = 0;
+      req.on("data", (chunk: Buffer) => (received += chunk.byteLength));
+      req.on("end", () => {
+        res.end("ok");
+        resolve(received);
+      });
+      req.on("aborted", () => reject(new Error(`request aborted after ${received} body bytes`)));
+      // The callers await this only after their backpressure assertions; an
+      // abort before that must surface there, not as an unhandled rejection.
+      promise.catch(() => {});
+      return promise;
+    }
+
+    describe.each(Object.keys(transports) as (keyof typeof transports)[])("%s", name => {
+      const transport = transports[name];
+
+      it("stalls the client while the handler has req.pause()d, and delivers the rest after req.resume()", async () => {
+        const arrived = Promise.withResolvers<{ req: http.IncomingMessage; received: Promise<number> }>();
+        await using server = transport.createServer((req, res) => {
+          const received = countBody(req, res);
+          req.pause();
+          arrived.resolve({ req, received });
+        });
+        await once(server.listen(0, "127.0.0.1"), "listening");
+
+        const upload = await uploadUntilStalled(transport, (server.address() as AddressInfo).port);
+        try {
+          const { req, received } = await arrived.promise;
+          // Without TCP backpressure the client hands the kernel the whole body
+          // while the request is paused (and the server buffers all of it).
+          expect(upload.sentWhileStalled).toBeLessThan(TOTAL);
+
+          req.resume();
+          expect(await received).toBe(TOTAL);
+          expect(await upload.finish()).toStartWith("HTTP/1.1 200 ");
+        } finally {
+          upload.sock.destroy();
+        }
+      });
+
+      it("stalls the client once an unread body fills the IncomingMessage buffer, and delivers the rest once it is read", async () => {
+        // Nobody reads req here: the body push() returns false at the
+        // highWaterMark and the socket must be read-stopped from there (Node's
+        // readStop in parserOnBody), not only when user code pauses explicitly.
+        const arrived = Promise.withResolvers<{ req: http.IncomingMessage; res: http.ServerResponse }>();
+        await using server = transport.createServer((req, res) => arrived.resolve({ req, res }));
+        await once(server.listen(0, "127.0.0.1"), "listening");
+
+        const upload = await uploadUntilStalled(transport, (server.address() as AddressInfo).port);
+        try {
+          const { req, res } = await arrived.promise;
+          expect(upload.sentWhileStalled).toBeLessThan(TOTAL);
+          expect(req.readableLength).toBeGreaterThan(0);
+          expect(req.readableLength).toBeLessThan(TOTAL);
+
+          expect(await countBody(req, res)).toBe(TOTAL);
+          expect(await upload.finish()).toStartWith("HTTP/1.1 200 ");
+        } finally {
+          upload.sock.destroy();
+        }
+      });
+    });
+
+    it("delivers a body and FIN that arrived while the request was paused once it resumes", async () => {
+      // The whole body and the client's FIN land on the paused connection; the
+      // EOF has to stay parked until the handler resumes and then still be
+      // delivered as 'end' (paused sockets defer EOF rather than dropping it).
+      const BODY = 64 * 1024;
+      const arrived = Promise.withResolvers<{ req: http.IncomingMessage; received: Promise<number> }>();
+      await using server = http.createServer((req, res) => {
+        req.pause();
+        arrived.resolve({ req, received: countBody(req, res) });
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+
+      const sock = await transports.http.connect((server.address() as AddressInfo).port);
+      let response = "";
+      sock.on("data", chunk => (response += chunk.toString("latin1")));
+      const closed = once(sock, "close");
+      try {
+        sock.write(`POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: ${BODY}\r\nConnection: close\r\n\r\n`);
+        const { req, received } = await arrived.promise;
+        sock.end(Buffer.alloc(BODY, "c"));
+        await once(sock, "finish");
+
+        req.resume();
+        expect(await received).toBe(BODY);
+        await closed;
+        expect(response).toStartWith("HTTP/1.1 200 ");
+      } finally {
+        sock.destroy();
+      }
+    });
+  });
+
   it("should handle backpressure with INT_MAX bytes", async () => {
     const totalSize = 1024 * 1024 * 1024 * 2; // 2^31, one past INT_MAX
     const chunk = Buffer.alloc(64 * 1024 * 1024, "a");


### PR DESCRIPTION
### Problem
- On Windows, a `node:http` server whose handler stops reading the request body (`req.pause()`, or simply not consuming `req`) keeps accepting the upload at full speed; the bytes pile up in native memory until the request is resumed. Same scenario as #26332, which was filed from Windows: #34740 bounded the JS-side `IncomingMessage` buffer on every platform, but on Windows that only moved the growth into the native pause buffer.
- Repro below, 2.5 s after `req.pause()` (loopback upload of 256 KiB chunks): Windows x64 canary `9a543cc18` has pulled 8195 chunks (2 GB) and RSS is 2.1 GB and climbing; Linux stays at 12 chunks and 37 MB; Node v26 on Windows stays at 15 chunks.
- A client that finishes its upload and half-closes while the request is paused also gets its request aborted on Windows (the body was parked natively, so `'end'` never fired before the FIN arrived); Node and Bun on Linux deliver the body and the response.
- Cause: `NodeHTTPResponse::do_pause` (`src/runtime/server/NodeHTTPResponse.rs`) re-arms uWS `onData` with `on_buffer_paused_shim`, which appends every chunk to `buffered_request_body_data_during_pause` with no bound, but the `self.pause_socket()` call that stops the kernel reads was under `#[cfg(not(windows))]` (`// TODO: figure out why windows is not emitting EOF with UV_DISCONNECT`). Every pause path (`req.pause()`, the `push() === false` -> `readStop(socket)` path from #34740, `req.socket.pause()`) ends in `do_pause`, so none of them reached TCP on Windows.

### Fix
- Remove the cfg guard: `do_pause` calls `pause_socket()` on every platform (and `pause_socket` loses the `#[allow(dead_code)]` that existed only because it was dead on Windows). No other code changes.
- Why the guard is obsolete: it was added in #18599 (March 2025), which taught the epoll and kqueue backends to still see a peer FIN/RST on a socket that is polling for nothing (`EPOLLRDHUP|EPOLLHUP|EPOLLERR`, a kept `EVFILT_WRITE`) but had no equivalent for the libuv backend. #32488 added that equivalent: `us_poll_start`/`us_poll_change` in `packages/bun-usockets/src/eventing/libuv.c` always arm `UV_DISCONNECT`, `poll_cb` probes a paused socket with `MSG_PEEK` to tell a graceful FIN (deferred until resume) from a reset (closed immediately), and the shared dispatch in `loop.c` defers EOF for a paused socket until it resumes. The symptom the TODO names is exactly what #32488 fixed.
- Why a paused `node:http` socket always gets resumed: `do_resume` calls `resume_socket()` before any flag checks, and `end()`, `writeHeadAndEnd` and `abort()` resume the socket first as well, so a response ending with an unread body (`req._dump()` after `res.end()`) or a teardown re-arms the poll and any deferred FIN is delivered. This is the behavior Linux and macOS have had all along; this change gives Windows the same one.
- Same primitive, already live on Windows: `Bun.serve` request-body backpressure (#36006, `RequestContext::pause_request_body_socket`) and the node:http pipelining flood guard (`pause_socket_reads`) call the same `uws_res_pause` -> `us_socket_pause` on every platform.
- Verification: `test/js/node/http/node-http-backpressure.test.ts`, new `request body` group. Each stall test uploads a 32 MiB body into a request that is paused (explicitly, or implicitly by never being read) and requires the client's upload to stall short of the total, then resumes and requires all 32 MiB plus a 200 response; run over both http and https. A fifth test sends a small body plus FIN while the request is paused and requires them to be delivered on resume.
  - Windows x64, debug build without the fix: the 4 stall tests fail (`Expected: < 33554432, Received: 33554432`); with the fix the whole file passes (19/19). The FIN test passes on both and is coverage for the newly enabled deferred-EOF path, not the fail-before proof.
  - Linux, debug build: the file passes before and after (the compiled code is unchanged there), so the fail-before half of this proof exists only on Windows.
  - The standalone version of the stall scenario, same script under Node v26.3.0 and Bun on Linux: stalls at 2.75 MB; Bun on Windows with the fix: 3.25 MB (http), 3 MB (https); without the fix: all 32 MB sent, no stall.
  - Windows x64, all 498 upstream `test-http-*` / `test-https-*` files from `test/js/node/test/parallel` with the debug build: 497 pass both before and after. The one failure (`test-http-set-timeout-server.js`, a 1 ms `server.setTimeout` firing twice) is identical before and after and passes on the release canary.
  - Windows x64, `test/js/node/http` directory with the fix: 756 pass, 23 skip, 4 todo, 0 fail.

### Background
- `us_socket_pause` drops the socket's readable interest in the event backend (epoll/kqueue on POSIX, libuv `uv_poll` on Windows); the kernel receive buffer then fills, the peer's send window closes, and its writes block. That is how read-side backpressure reaches a TCP peer. `us_socket_resume` re-adds the interest.
- The pause contract in usockets: a FIN that arrives while a socket is paused is not acted on; it is re-discovered and delivered as `on_end` after the socket resumes. A reset closes the socket right away. The libuv backend needs extra machinery for this because Windows AFD only reports a FIN to a poll without read interest through the one-shot `UV_DISCONNECT` event; that machinery is what #32488 added.
- `on_buffer_paused_shim` / `buffered_request_body_data_during_pause`: while a node:http request is paused, body chunks that uWS has already read are parked in this `Vec` and handed to JS as one `Buffer` on resume. With the socket actually paused it holds at most what was already in flight (one recv buffer); without the pause it held the rest of the upload.
- Adjacent: #34761 (pipelined POST bodies) has context lines in this hunk but keeps the guard; it is a different bug.

<details>
<summary>Repro script and measurements</summary>

```js
import http from "node:http"; import { once } from "node:events";
const got = Promise.withResolvers();
const server = http.createServer(req => { req.on("data", () => {}); req.pause(); got.resolve(req); });
await once(server.listen(0, "127.0.0.1"), "listening");
let pulls = 0; const CHUNK = 256 * 1024;
const body = new ReadableStream({ pull(c) { pulls++; c.enqueue(new Uint8Array(CHUNK)); } }, { highWaterMark: 1 });
const ac = new AbortController();
fetch(`http://127.0.0.1:${server.address().port}/`, { method: "POST", body, duplex: "half", signal: ac.signal }).catch(() => {});
const req = await got.promise;
for (let t = 500; t <= 2500; t += 500) { await new Promise(r => setTimeout(r, 500)); console.log({ ms: t, pulls, readableLength: req.readableLength, rssMB: Math.round(process.memoryUsage().rss / 1048576) }); }
ac.abort(); req.destroy(); server.closeAllConnections(); server.close(); process.exit(0);
```

Windows x64, release canary `1.4.0-canary.1+9a543cc18` (unfixed):

```
{"ms":500,"pulls":1242,"readableLength":262144,"rssMB":368}
{"ms":1000,"pulls":2527,"readableLength":262144,"rssMB":679}
{"ms":1500,"pulls":4099,"readableLength":262144,"rssMB":2098}
{"ms":2000,"pulls":6553,"readableLength":262144,"rssMB":1694}
{"ms":2500,"pulls":8195,"readableLength":262144,"rssMB":2104}
```

Windows x64, debug build of this branch's parent (unfixed):

```
{"ms":500,"pulls":131,"readableLength":262144,"rssMB":215}
{"ms":2500,"pulls":2051,"readableLength":262144,"rssMB":1652}
```

Windows x64, debug build with this change:

```
{"ms":500,"pulls":14,"readableLength":262144,"rssMB":101}
{"ms":2500,"pulls":15,"readableLength":262144,"rssMB":101}
```

Linux, canary `da3851e57` (unchanged by this PR): `pulls` stays at 12, RSS 37 MB.

</details>
