### PR TITLE
bun:ffi: fix cc() integer argument decoding and the int32 boundary in FFI.h

### DIFF
--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -249,23 +249,18 @@ static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
    return res;
 }
 
-// ECMAScript ToInt32 (truncate, then wrap modulo 2^32), the conversion the
-// engine applies to every char/i8/u8/i16/u16/i32/u32 argument. ToUint32 is the
-// same bit pattern, so unsigned parameters take this value through C's
-// integer conversion. Ported from JSC's toIntImpl<int32_t> (runtime/MathCommon.h).
+// ECMAScript ToInt32, ported from JSC's toIntImpl<int32_t> (MathCommon.h); ToUint32 is the same bits.
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
   if (JSVALUE_IS_INT32(val)) {
     return (int32_t)val.asInt64;
   }
-  // Whether an integral number is int32-tagged or double-encoded is the
-  // engine's choice (out of int32 range, fractional, JIT double speculation,
-  // Math.* provenance), so the double encoding has to be decoded here.
+  if (val.asInt64 == TagValueTrue) {
+    return 1;
+  }
   val.asInt64 -= DoubleEncodeOffset;
   uint64_t bits = (uint64_t)val.asInt64;
   int32_t exp = (int32_t)((bits >> 52) & 0x7ff) - 0x3ff;
-  // exp < 0: |value| < 1. exp > 83: no mantissa bit reaches the low 32 bits.
-  // Zero, NaN, +-Infinity, and the decoded bits of undefined/null/booleans/cells
-  // (NaN patterns) all land here and become 0.
+  // Also 0, NaN, +-Infinity, and false/undefined/null/cells, whose decoded bits are NaNs.
   if (exp < 0 || exp > 83) {
     return 0;
   }

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -82,7 +82,8 @@ BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 #define TagValueNull             (OtherTag)
 #define NotCellMask  (int64_t)(NumberTag | OtherTag)
 
-#define MAX_INT32 2147483648
+#define MAX_INT32 2147483647
+#define MIN_INT32 (-MAX_INT32 - 1)
 #define MAX_INT52 9007199254740991
 
 // If all bits in the mask are set, this indicates an integer number,
@@ -248,16 +249,37 @@ static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
    return res;
 }
 
+// ECMAScript ToInt32 (truncate, then wrap modulo 2^32), the conversion the
+// engine applies to every char/i8/u8/i16/u16/i32/u32 argument. ToUint32 is the
+// same bit pattern, so unsigned parameters take this value through C's
+// integer conversion. Ported from JSC's toIntImpl<int32_t> (runtime/MathCommon.h).
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
   if (JSVALUE_IS_INT32(val)) {
     return (int32_t)val.asInt64;
   }
-  // Decode a double-encoded integer (JIT tier-up, Math.* provenance, etc.);
-  // int64_t intermediate keeps u32 callers (uint32_t)JSVALUE_TO_INT32(...) defined.
+  // Whether an integral number is int32-tagged or double-encoded is the
+  // engine's choice (out of int32 range, fractional, JIT double speculation,
+  // Math.* provenance), so the double encoding has to be decoded here.
   val.asInt64 -= DoubleEncodeOffset;
-  // NaN check also catches undefined/null/bool, whose decoded bits are all NaNs.
-  if (val.asDouble != val.asDouble) return 0;
-  return (int32_t)(int64_t)val.asDouble;
+  uint64_t bits = (uint64_t)val.asInt64;
+  int32_t exp = (int32_t)((bits >> 52) & 0x7ff) - 0x3ff;
+  // exp < 0: |value| < 1. exp > 83: no mantissa bit reaches the low 32 bits.
+  // Zero, NaN, +-Infinity, and the decoded bits of undefined/null/booleans/cells
+  // (NaN patterns) all land here and become 0.
+  if (exp < 0 || exp > 83) {
+    return 0;
+  }
+  uint32_t result = exp > 52 ? (uint32_t)(bits << (exp - 52)) : (uint32_t)(bits >> (52 - exp));
+  if (exp < 32) {
+    // Reinsert the implicit leading 1; mask off the shifted-in sign/exponent bits.
+    uint32_t implicit_one = (uint32_t)1 << exp;
+    result &= implicit_one - 1;
+    result += implicit_one;
+  }
+  if (bits >> 63) {
+    result = -result;
+  }
+  return (int32_t)result;
 }
 
 static EncodedJSValue INT32_TO_JSVALUE(int32_t val) {
@@ -339,7 +361,7 @@ static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
-  if (val < MAX_INT32) {
+  if (val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
@@ -351,7 +373,7 @@ static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
 }
 
 static EncodedJSValue INT64_TO_JSVALUE(void* jsGlobalObject, int64_t val) {
-  if (val >= -MAX_INT32 && val <= MAX_INT32) {
+  if (val >= MIN_INT32 && val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -191,20 +191,6 @@ impl ABIType {
         })
     }
 
-    /// Types that we can directly pass through as an `int64_t`
-    pub(crate) fn needs_a_cast_in_c(self) -> bool {
-        !matches!(
-            self,
-            ABIType::Char
-                | ABIType::Int8T
-                | ABIType::Uint8T
-                | ABIType::Int16T
-                | ABIType::Uint16T
-                | ABIType::Int32T
-                | ABIType::Uint32T
-        )
-    }
-
     pub(crate) fn is_floating_point(self) -> bool {
         matches!(self, ABIType::Double | ABIType::Float)
     }

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2171,7 +2171,11 @@ impl Function {
                     } else {
                         "*argsPtr"
                     };
-                    writeln!(writer, "  EncodedJSValue arg{i} = {{ .asInt64 = {slot} }};")?;
+                    // Not an initializer: TinyCC zero-fills an initialized aggregate with a memset() call.
+                    writeln!(
+                        writer,
+                        "  EncodedJSValue arg{i};\n  arg{i}.asInt64 = {slot};"
+                    )?;
                 }
             }
         }

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2165,32 +2165,13 @@ impl Function {
                         "  napi_env arg{} = (napi_env)&Bun__thisFFIModuleNapiEnv;\n  argsPtr++;\n",
                         i
                     )?;
-                } else if *arg == ABIType::NapiValue {
-                    writeln!(
-                        writer,
-                        "  EncodedJSValue arg{} = {{ .asInt64 = *argsPtr++ }};",
-                        i
-                    )?;
-                } else if arg.needs_a_cast_in_c() {
-                    if i < self.arg_types.len() - 1 {
-                        writeln!(
-                            writer,
-                            "  EncodedJSValue arg{} = {{ .asInt64 = *argsPtr++ }};",
-                            i
-                        )?;
-                    } else {
-                        write!(
-                            writer,
-                            "  EncodedJSValue arg{};\n  arg{}.asInt64 = *argsPtr;\n",
-                            i, i
-                        )?;
-                    }
                 } else {
-                    if i < self.arg_types.len() - 1 {
-                        writeln!(writer, "  int64_t arg{} = *argsPtr++;", i)?;
+                    let slot = if i + 1 < self.arg_types.len() {
+                        "*argsPtr++"
                     } else {
-                        writeln!(writer, "  int64_t arg{} = *argsPtr;", i)?;
-                    }
+                        "*argsPtr"
+                    };
+                    writeln!(writer, "  EncodedJSValue arg{i} = {{ .asInt64 = {slot} }};")?;
                 }
             }
         }
@@ -2222,11 +2203,7 @@ impl Function {
 
             let length_buf = bun_core::fmt::print_int(&mut arg_buf[3..], i);
             let arg_name = &arg_buf[0..3 + length_buf];
-            if arg.needs_a_cast_in_c() {
-                write!(writer, "{}", arg.to_c(arg_name))?;
-            } else {
-                writer.write_all(arg_name)?;
-            }
+            write!(writer, "{}", arg.to_c(arg_name))?;
         }
         writer.write_all(b");\n")?;
 

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1087,6 +1087,212 @@ describe("double <-> JSValue conversions", () => {
   });
 });
 
+// cc() symbols are called through the TinyCC-compiled trampoline (FFI.h), not
+// the engine's FFI that dlopen()/linkSymbols() use, so it has to apply the same
+// integer conversions itself. The C side reports every received integer as a
+// double so a return-boxing bug cannot mask or mimic an argument-decoding bug.
+describe("integer <-> JSValue conversions", () => {
+  it.concurrent("integer arguments are decoded with ToInt32 semantics, including double-encoded values", async () => {
+    using dir = tempDir("bun-ffi-int-args", {
+      "intargs.c": /* c */ `
+        double u32_arg(unsigned int x) { return x; }
+        double i32_arg(int x) { return x; }
+        double u16_arg(unsigned short x) { return x; }
+        double i16_arg(short x) { return x; }
+        double u8_arg(unsigned char x) { return x; }
+        double i8_arg(signed char x) { return x; }
+        double char_arg(char x) { return x; }
+      `,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "intargs.c"),
+          symbols: {
+            u32_arg: { args: ["u32"], returns: "f64" },
+            i32_arg: { args: ["i32"], returns: "f64" },
+            u16_arg: { args: ["u16"], returns: "f64" },
+            i16_arg: { args: ["i16"], returns: "f64" },
+            u8_arg: { args: ["u8"], returns: "f64" },
+            i8_arg: { args: ["i8"], returns: "f64" },
+            char_arg: { args: ["char"], returns: "f64" },
+          },
+        });
+
+        // Integer-valued, but the +0.5 intermediate pins a double-encoded
+        // JSValue regardless of JIT tier, as JIT-compiled arithmetic does.
+        const asDouble = x => {
+          const v = x + 0.5;
+          return v - 0.5;
+        };
+
+        const results = {
+          u32: {
+            max: symbols.u32_arg(0xffffffff),
+            two_pow_31: symbols.u32_arg(0x80000000),
+            int32_max: symbols.u32_arg(0x7fffffff),
+            minus_one: symbols.u32_arg(-1),
+            wraps_above_2_pow_32: symbols.u32_arg(2 ** 32 + 5),
+            wraps_below_int32_min: symbols.u32_arg(-(2 ** 31) - 1),
+            truncates_fraction: symbols.u32_arg(2147483648.5),
+            double_encoded: symbols.u32_arg(asDouble(7)),
+            huge: symbols.u32_arg(1e19),
+            infinity: symbols.u32_arg(Infinity),
+            nan: symbols.u32_arg(NaN),
+            undefined: symbols.u32_arg(undefined),
+          },
+          i32: {
+            two_pow_31: symbols.i32_arg(2 ** 31),
+            int32_min: symbols.i32_arg(-(2 ** 31)),
+            wraps_above_2_pow_32: symbols.i32_arg(2 ** 32 + 7),
+            truncates_fraction: symbols.i32_arg(5.7),
+            truncates_negative_fraction: symbols.i32_arg(-5.7),
+            double_encoded: symbols.i32_arg(asDouble(-938)),
+            huge_negative: symbols.i32_arg(-1e19),
+          },
+          narrow: {
+            u16_double_encoded: symbols.u16_arg(2 ** 31 + 3),
+            u16_wraps: symbols.u16_arg(70000),
+            i16_double_encoded: symbols.i16_arg(40000.5),
+            u8_double_encoded: symbols.u8_arg(2 ** 32 + 300),
+            u8_wraps: symbols.u8_arg(300),
+            i8_double_encoded: symbols.i8_arg(200.5),
+            char_double_encoded: symbols.char_arg(65.5),
+          },
+        };
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        u32: {
+          max: 4294967295,
+          two_pow_31: 2147483648,
+          int32_max: 2147483647,
+          minus_one: 4294967295,
+          wraps_above_2_pow_32: 5,
+          wraps_below_int32_min: 2147483647,
+          truncates_fraction: 2147483648,
+          double_encoded: 7,
+          huge: 2313682944, // 1e19 mod 2 ** 32
+          infinity: 0,
+          nan: 0,
+          undefined: 0,
+        },
+        i32: {
+          two_pow_31: -2147483648,
+          int32_min: -2147483648,
+          wraps_above_2_pow_32: 7,
+          truncates_fraction: 5,
+          truncates_negative_fraction: -5,
+          double_encoded: -938,
+          huge_negative: 1981284352, // -1e19 mod 2 ** 32, as int32
+        },
+        narrow: {
+          u16_double_encoded: 3,
+          u16_wraps: 4464, // 70000 - 65536
+          i16_double_encoded: -25536, // 40000 - 65536
+          u8_double_encoded: 44, // 300 - 256
+          u8_wraps: 44,
+          i8_double_encoded: -56, // 200 - 256
+          char_double_encoded: 65,
+        },
+      },
+      exitCode: 0,
+    });
+  });
+
+  // MAX_INT32 in FFI.h decides whether a u32 / i64_fast / u64_fast return is
+  // boxed as an int32 or as a double; 2 ** 31 does not fit an int32.
+  it.concurrent("u32 and 64-bit fast returns at the int32 boundary box as the right number", async () => {
+    using dir = tempDir("bun-ffi-int-returns", {
+      "intreturns.c": /* c */ `
+        unsigned int u32_identity(unsigned int x) { return x; }
+        unsigned int u32_two_pow_31(void) { return 2147483648u; }
+        unsigned int u32_int32_max(void) { return 2147483647u; }
+        unsigned int u32_max(void) { return 4294967295u; }
+        long long i64_two_pow_31(void) { return 2147483648LL; }
+        long long i64_int32_min(void) { return -2147483647LL - 1; }
+        long long i64_below_int32_min(void) { return -2147483649LL; }
+        unsigned long long u64_two_pow_31(void) { return 2147483648ull; }
+        unsigned long long u64_int32_max(void) { return 2147483647ull; }
+      `,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "intreturns.c"),
+          symbols: {
+            u32_identity: { args: ["u32"], returns: "u32" },
+            u32_two_pow_31: { args: [], returns: "u32" },
+            u32_int32_max: { args: [], returns: "u32" },
+            u32_max: { args: [], returns: "u32" },
+            i64_two_pow_31: { args: [], returns: "i64_fast" },
+            i64_int32_min: { args: [], returns: "i64_fast" },
+            i64_below_int32_min: { args: [], returns: "i64_fast" },
+            u64_two_pow_31: { args: [], returns: "u64_fast" },
+            u64_int32_max: { args: [], returns: "u64_fast" },
+          },
+        });
+
+        const show = value => [typeof value, String(value)];
+        const results = {
+          u32_identity_max: show(symbols.u32_identity(0xffffffff)),
+          u32_identity_two_pow_31: show(symbols.u32_identity(0x80000000)),
+          u32_two_pow_31: show(symbols.u32_two_pow_31()),
+          u32_int32_max: show(symbols.u32_int32_max()),
+          u32_max: show(symbols.u32_max()),
+          i64_two_pow_31: show(symbols.i64_two_pow_31()),
+          i64_int32_min: show(symbols.i64_int32_min()),
+          i64_below_int32_min: show(symbols.i64_below_int32_min()),
+          u64_two_pow_31: show(symbols.u64_two_pow_31()),
+          u64_int32_max: show(symbols.u64_int32_max()),
+        };
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        u32_identity_max: ["number", "4294967295"],
+        u32_identity_two_pow_31: ["number", "2147483648"],
+        u32_two_pow_31: ["number", "2147483648"],
+        u32_int32_max: ["number", "2147483647"],
+        u32_max: ["number", "4294967295"],
+        i64_two_pow_31: ["number", "2147483648"],
+        i64_int32_min: ["number", "-2147483648"],
+        i64_below_int32_min: ["number", "-2147483649"],
+        u64_two_pow_31: ["number", "2147483648"],
+        u64_int32_max: ["number", "2147483647"],
+      },
+      exitCode: 0,
+    });
+  });
+});
+
 describe.skipIf(isASAN)("compiler runtime header directory under BUN_TMPDIR", () => {
   const plantedHeader = "#define bool int\n#define true 100\n#define false 0\n";
   const files = {

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1088,21 +1088,33 @@ describe("double <-> JSValue conversions", () => {
 });
 
 // cc() symbols are called through the TinyCC-compiled trampoline (FFI.h), not
-// the engine's FFI that dlopen()/linkSymbols() use, so it has to apply the same
-// integer conversions itself. The C side reports every received integer as a
-// double so a return-boxing bug cannot mask or mimic an argument-decoding bug.
+// the engine's FFI that dlopen()/linkSymbols()/CFunction use, so it has to apply
+// the same integer conversions itself.
 describe("integer <-> JSValue conversions", () => {
+  // Every function reports the integer C received as a double, so a
+  // return-boxing bug cannot mask or mimic an argument-decoding bug. The addr_*
+  // functions let the same C code be called through CFunction (the engine's FFI)
+  // as the oracle for what the trampoline must hand to C.
+  const intArgsSource = /* c */ `
+    double u32_arg(unsigned int x) { return x; }
+    double i32_arg(int x) { return x; }
+    double u16_arg(unsigned short x) { return x; }
+    double i16_arg(short x) { return x; }
+    double u8_arg(unsigned char x) { return x; }
+    double i8_arg(signed char x) { return x; }
+    double char_arg(char x) { return x; }
+    void* addr_u32_arg(void) { return (void*)u32_arg; }
+    void* addr_i32_arg(void) { return (void*)i32_arg; }
+    void* addr_u16_arg(void) { return (void*)u16_arg; }
+    void* addr_i16_arg(void) { return (void*)i16_arg; }
+    void* addr_u8_arg(void) { return (void*)u8_arg; }
+    void* addr_i8_arg(void) { return (void*)i8_arg; }
+    void* addr_char_arg(void) { return (void*)char_arg; }
+  `;
+
   it.concurrent("integer arguments are decoded with ToInt32 semantics, including double-encoded values", async () => {
     using dir = tempDir("bun-ffi-int-args", {
-      "intargs.c": /* c */ `
-        double u32_arg(unsigned int x) { return x; }
-        double i32_arg(int x) { return x; }
-        double u16_arg(unsigned short x) { return x; }
-        double i16_arg(short x) { return x; }
-        double u8_arg(unsigned char x) { return x; }
-        double i8_arg(signed char x) { return x; }
-        double char_arg(char x) { return x; }
-      `,
+      "intargs.c": intArgsSource,
       "fixture.js": /* js */ `
         import { cc } from "bun:ffi";
         import path from "path";
@@ -1136,11 +1148,16 @@ describe("integer <-> JSValue conversions", () => {
             wraps_above_2_pow_32: symbols.u32_arg(2 ** 32 + 5),
             wraps_below_int32_min: symbols.u32_arg(-(2 ** 31) - 1),
             truncates_fraction: symbols.u32_arg(2147483648.5),
+            truncates_below_one: symbols.u32_arg(0.9),
             double_encoded: symbols.u32_arg(asDouble(7)),
             huge: symbols.u32_arg(1e19),
+            two_pow_84: symbols.u32_arg(2 ** 84),
             infinity: symbols.u32_arg(Infinity),
             nan: symbols.u32_arg(NaN),
             undefined: symbols.u32_arg(undefined),
+            null: symbols.u32_arg(null),
+            true: symbols.u32_arg(true),
+            false: symbols.u32_arg(false),
           },
           i32: {
             two_pow_31: symbols.i32_arg(2 ** 31),
@@ -1148,8 +1165,10 @@ describe("integer <-> JSValue conversions", () => {
             wraps_above_2_pow_32: symbols.i32_arg(2 ** 32 + 7),
             truncates_fraction: symbols.i32_arg(5.7),
             truncates_negative_fraction: symbols.i32_arg(-5.7),
+            truncates_above_minus_one: symbols.i32_arg(-0.9),
             double_encoded: symbols.i32_arg(asDouble(-938)),
             huge_negative: symbols.i32_arg(-1e19),
+            true: symbols.i32_arg(true),
           },
           narrow: {
             u16_double_encoded: symbols.u16_arg(2 ** 31 + 3),
@@ -1157,6 +1176,7 @@ describe("integer <-> JSValue conversions", () => {
             i16_double_encoded: symbols.i16_arg(40000.5),
             u8_double_encoded: symbols.u8_arg(2 ** 32 + 300),
             u8_wraps: symbols.u8_arg(300),
+            u8_true: symbols.u8_arg(true),
             i8_double_encoded: symbols.i8_arg(200.5),
             char_double_encoded: symbols.char_arg(65.5),
           },
@@ -1185,11 +1205,16 @@ describe("integer <-> JSValue conversions", () => {
           wraps_above_2_pow_32: 5,
           wraps_below_int32_min: 2147483647,
           truncates_fraction: 2147483648,
+          truncates_below_one: 0,
           double_encoded: 7,
           huge: 2313682944, // 1e19 mod 2 ** 32
+          two_pow_84: 0,
           infinity: 0,
           nan: 0,
           undefined: 0,
+          null: 0,
+          true: 1,
+          false: 0,
         },
         i32: {
           two_pow_31: -2147483648,
@@ -1197,8 +1222,10 @@ describe("integer <-> JSValue conversions", () => {
           wraps_above_2_pow_32: 7,
           truncates_fraction: 5,
           truncates_negative_fraction: -5,
+          truncates_above_minus_one: 0,
           double_encoded: -938,
           huge_negative: 1981284352, // -1e19 mod 2 ** 32, as int32
+          true: 1,
         },
         narrow: {
           u16_double_encoded: 3,
@@ -1206,10 +1233,80 @@ describe("integer <-> JSValue conversions", () => {
           i16_double_encoded: -25536, // 40000 - 65536
           u8_double_encoded: 44, // 300 - 256
           u8_wraps: 44,
+          u8_true: 1,
           i8_double_encoded: -56, // 200 - 256
           char_double_encoded: 65,
         },
       },
+      exitCode: 0,
+    });
+  });
+
+  // The same C functions, called once through the trampoline and once through
+  // CFunction, must hand C the same value for every input. The corpus hits each
+  // branch of the ToInt32 decode: |x| < 1, the implicit leading 1 (exponent
+  // below 32), exponents 32..52 and 53..83, exponents past 83, non-finite
+  // values, and the non-number immediates.
+  it.concurrent("integer argument decoding agrees with the engine's FFI for the same C functions", async () => {
+    using dir = tempDir("bun-ffi-int-args-parity", {
+      "intargs.c": intArgsSource,
+      "fixture.js": /* js */ `
+        import { cc, CFunction } from "bun:ffi";
+        import path from "path";
+
+        const types = ["u32", "i32", "u16", "i16", "u8", "i8", "char"];
+        const symbols = {};
+        for (const type of types) {
+          symbols[type + "_arg"] = { args: [type], returns: "f64" };
+          symbols["addr_" + type + "_arg"] = { args: [], returns: "ptr" };
+        }
+        const { symbols: trampoline } = cc({ source: path.join(import.meta.dir, "intargs.c"), symbols });
+
+        const asDouble = x => {
+          const v = x + 0.5;
+          return v - 0.5;
+        };
+        const corpus = [
+          0, -0, 1, -1, 0.9, -0.9, 5.7, -5.7, Number.MIN_VALUE,
+          127, 128, 200.5, 255, 256, 300, 32767, 32768, 40000.5, 65535, 65536, 70000,
+          2 ** 31 - 1, 2 ** 31, 2 ** 31 + 0.5, 2 ** 32 - 1, 2 ** 32, 2 ** 32 + 5,
+          -(2 ** 31), -(2 ** 31) - 1, -(2 ** 32), -(2 ** 32) - 3,
+          2 ** 52 + 1, 2 ** 53, 2 ** 62, 2 ** 63, 2 ** 63 + 2 ** 12, -(2 ** 63) - 2 ** 12,
+          2 ** 83 + 2 ** 31, 2 ** 84, 2 ** 100, 1e19, -1e19, Number.MAX_VALUE, -Number.MAX_VALUE,
+          Infinity, -Infinity, NaN, undefined, null, true, false,
+          ...[0, 1, -1, 7, 200, 40000, -938, 2 ** 31 - 1, -(2 ** 31)].map(asDouble),
+        ];
+
+        let calls = 0;
+        const mismatches = [];
+        for (const type of types) {
+          const viaTrampoline = trampoline[type + "_arg"];
+          const viaEngine = new CFunction({ ptr: trampoline["addr_" + type + "_arg"](), args: [type], returns: "f64" });
+          for (const value of corpus) {
+            calls++;
+            const fromTrampoline = viaTrampoline(value);
+            const fromEngine = viaEngine(value);
+            if (!Object.is(fromTrampoline, fromEngine)) {
+              mismatches.push({ type, value: String(value), fromTrampoline, fromEngine });
+            }
+          }
+        }
+        console.log(JSON.stringify({ calls, mismatches }));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: { calls: 7 * 60, mismatches: [] },
       exitCode: 0,
     });
   });

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -84,7 +84,8 @@ BUN_FFI_IMPORT extern struct NapiEnv Bun__thisFFIModuleNapiEnv;
 #define TagValueNull             (OtherTag)
 #define NotCellMask  (int64_t)(NumberTag | OtherTag)
 
-#define MAX_INT32 2147483648
+#define MAX_INT32 2147483647
+#define MIN_INT32 (-MAX_INT32 - 1)
 #define MAX_INT52 9007199254740991
 
 // If all bits in the mask are set, this indicates an integer number,
@@ -250,16 +251,37 @@ static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
    return res;
 }
 
+// ECMAScript ToInt32 (truncate, then wrap modulo 2^32), the conversion the
+// engine applies to every char/i8/u8/i16/u16/i32/u32 argument. ToUint32 is the
+// same bit pattern, so unsigned parameters take this value through C's
+// integer conversion. Ported from JSC's toIntImpl<int32_t> (runtime/MathCommon.h).
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
   if (JSVALUE_IS_INT32(val)) {
     return (int32_t)val.asInt64;
   }
-  // Decode a double-encoded integer (JIT tier-up, Math.* provenance, etc.);
-  // int64_t intermediate keeps u32 callers (uint32_t)JSVALUE_TO_INT32(...) defined.
+  // Whether an integral number is int32-tagged or double-encoded is the
+  // engine's choice (out of int32 range, fractional, JIT double speculation,
+  // Math.* provenance), so the double encoding has to be decoded here.
   val.asInt64 -= DoubleEncodeOffset;
-  // NaN check also catches undefined/null/bool, whose decoded bits are all NaNs.
-  if (val.asDouble != val.asDouble) return 0;
-  return (int32_t)(int64_t)val.asDouble;
+  uint64_t bits = (uint64_t)val.asInt64;
+  int32_t exp = (int32_t)((bits >> 52) & 0x7ff) - 0x3ff;
+  // exp < 0: |value| < 1. exp > 83: no mantissa bit reaches the low 32 bits.
+  // Zero, NaN, +-Infinity, and the decoded bits of undefined/null/booleans/cells
+  // (NaN patterns) all land here and become 0.
+  if (exp < 0 || exp > 83) {
+    return 0;
+  }
+  uint32_t result = exp > 52 ? (uint32_t)(bits << (exp - 52)) : (uint32_t)(bits >> (52 - exp));
+  if (exp < 32) {
+    // Reinsert the implicit leading 1; mask off the shifted-in sign/exponent bits.
+    uint32_t implicit_one = (uint32_t)1 << exp;
+    result &= implicit_one - 1;
+    result += implicit_one;
+  }
+  if (bits >> 63) {
+    result = -result;
+  }
+  return (int32_t)result;
 }
 
 static EncodedJSValue INT32_TO_JSVALUE(int32_t val) {
@@ -341,7 +363,7 @@ static int64_t JSVALUE_TO_INT64(EncodedJSValue value) {
 }
 
 static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
-  if (val < MAX_INT32) {
+  if (val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
@@ -353,7 +375,7 @@ static EncodedJSValue UINT64_TO_JSVALUE(void* jsGlobalObject, uint64_t val) {
 }
 
 static EncodedJSValue INT64_TO_JSVALUE(void* jsGlobalObject, int64_t val) {
-  if (val >= -MAX_INT32 && val <= MAX_INT32) {
+  if (val >= MIN_INT32 && val <= MAX_INT32) {
     return INT32_TO_JSVALUE((int32_t)val);
   }
 
@@ -374,8 +396,7 @@ float not_a_callback(float arg0);
 /* ---- Your Wrapper Function ---- */
 ZIG_REPR_TYPE JSFunctionCall(void* JS_GLOBAL_OBJECT, void* callFrame) {
   LOAD_ARGUMENTS_FROM_CALL_FRAME;
-  EncodedJSValue arg0;
-  arg0.asInt64 = *argsPtr;
+  EncodedJSValue arg0 = { .asInt64 = *argsPtr };
     float return_value = not_a_callback(    JSVALUE_TO_FLOAT(arg0));
 
     return FLOAT_TO_JSVALUE(return_value).asZigRepr;

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -251,23 +251,18 @@ static EncodedJSValue DOUBLE_TO_JSVALUE(double val) {
    return res;
 }
 
-// ECMAScript ToInt32 (truncate, then wrap modulo 2^32), the conversion the
-// engine applies to every char/i8/u8/i16/u16/i32/u32 argument. ToUint32 is the
-// same bit pattern, so unsigned parameters take this value through C's
-// integer conversion. Ported from JSC's toIntImpl<int32_t> (runtime/MathCommon.h).
+// ECMAScript ToInt32, ported from JSC's toIntImpl<int32_t> (MathCommon.h); ToUint32 is the same bits.
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) {
   if (JSVALUE_IS_INT32(val)) {
     return (int32_t)val.asInt64;
   }
-  // Whether an integral number is int32-tagged or double-encoded is the
-  // engine's choice (out of int32 range, fractional, JIT double speculation,
-  // Math.* provenance), so the double encoding has to be decoded here.
+  if (val.asInt64 == TagValueTrue) {
+    return 1;
+  }
   val.asInt64 -= DoubleEncodeOffset;
   uint64_t bits = (uint64_t)val.asInt64;
   int32_t exp = (int32_t)((bits >> 52) & 0x7ff) - 0x3ff;
-  // exp < 0: |value| < 1. exp > 83: no mantissa bit reaches the low 32 bits.
-  // Zero, NaN, +-Infinity, and the decoded bits of undefined/null/booleans/cells
-  // (NaN patterns) all land here and become 0.
+  // Also 0, NaN, +-Infinity, and false/undefined/null/cells, whose decoded bits are NaNs.
   if (exp < 0 || exp > 83) {
     return 0;
   }
@@ -396,7 +391,8 @@ float not_a_callback(float arg0);
 /* ---- Your Wrapper Function ---- */
 ZIG_REPR_TYPE JSFunctionCall(void* JS_GLOBAL_OBJECT, void* callFrame) {
   LOAD_ARGUMENTS_FROM_CALL_FRAME;
-  EncodedJSValue arg0 = { .asInt64 = *argsPtr };
+  EncodedJSValue arg0;
+  arg0.asInt64 = *argsPtr;
     float return_value = not_a_callback(    JSVALUE_TO_FLOAT(arg0));
 
     return FLOAT_TO_JSVALUE(return_value).asZigRepr;


### PR DESCRIPTION
### Problem

- `cc()` mis-converts integers at and above the int32 boundary. With `uint32_t identity_u32(uint32_t x) { return x; }` compiled through `cc()`: `identity_u32(0xFFFFFFFF)` returns `4292870144`, `identity_u32(0x80000000)` returns `0`, and a function returning `0x80000000u` yields `-2147483648`. The same definitions through `dlopen()` return the right values (repro in the details block).
- Argument side: `src/runtime/ffi/abi_type.rs` `needs_a_cast_in_c()` excluded `char`/`i8`/`u8`/`i16`/`u16`/`i32`/`u32`, so `print_source_code` (`src/runtime/ffi/ffi_body.rs`) emitted `int64_t arg0 = *argsPtr;` and passed the raw NaN-boxed JSValue bits to the C parameter, which truncated them. That is only right when the engine int32-tagged the number. Any double-encoded argument (outside int32 range, fractional, or produced by JIT-compiled arithmetic: `identity_u32(x + 0.5 - 0.5)` returns `0`) reached C as the low 32 bits of a double encoding, and `undefined`/`null`/`true` reached C as their tag bits (`10`/`2`/`7`). The `JSVALUE_TO_INT32(` entries in the ABI table for these types were never emitted.
- Return side: `src/runtime/ffi/FFI.h` had `#define MAX_INT32 2147483648` (2^31, one past `INT32_MAX`), so `UINT32_TO_JSVALUE` and `INT64_TO_JSVALUE` (`u32` and `i64_fast` returns) boxed exactly 2^31 as the int32 `-2147483648`.
- Only `cc()` is affected. Since #35246, `dlopen()`/`linkSymbols()`/`CFunction`/`JSCallback` use the engine's FFI and convert correctly; `cc()` still calls through the TinyCC-compiled trampoline built from `FFI.h`. #33340 and #32075 described the same symptoms and were closed as superseded by #35246, which did not reach this path.

### Fix

- `print_source_code` loads every argument as an `EncodedJSValue` and passes it through the type's `FFI.h` conversion; `needs_a_cast_in_c()` and the raw `int64_t` passthrough are deleted. This is the shape every other argument type already used (`JSVALUE_TO_DOUBLE`, `JSVALUE_TO_INT64`, `JSVALUE_TO_PTR` all branch on the encoding); the passthrough only worked because the JS wrapper layer removed in #35246 forced `val | 0` before the call. The exact fixing lines are the now unconditional `write!(writer, "{}", arg.to_c(arg_name))` and `#define MAX_INT32 2147483647`.
- `JSVALUE_TO_INT32`'s non-int32 branch is ECMAScript ToInt32, ported from JSC's `toIntImpl<int32_t>` (`runtime/MathCommon.h`), plus `true -> 1`. The engine path converts these seven types with `JSValue::toInt32()`/`toUInt32()`, so `cc()` now hands C the same value as `dlopen()` for every number, `undefined`, `null` and both booleans. The `(int32_t)(int64_t)double` cast it replaces is undefined in C for |x| >= 2^63 and differs between x64 and arm64 there.
- One helper covers the unsigned and narrow types because ToUint32 is the same 32-bit pattern as ToInt32 (JSC's `toUInt32` is literally `toInt32`); the generated prototype's `uint32_t`/`uint8_t`/... parameter performs the narrowing, exactly as the engine's `static_cast<uint8_t>(truncated)` does.
- The argument slot is emitted as `EncodedJSValue argN; argN.asInt64 = ...;` (the form the old code used for its last argument) rather than an initializer, because TinyCC compiles a local aggregate initializer into a `memset()` call (`vendor/tinycc/tccgen.c`, `init_putz`). Disassembling the JIT'd trampoline for `(u32, f64) -> u32` shows 4 calls with this PR versus 3 before: the added one is `JSVALUE_TO_INT32`, which is the cost of the fix; it is the same out-of-line decode `f64` and `ptr` arguments already pay.
- `MAX_INT32` is now `INT32_MAX` and `MIN_INT32` is added, so the int32 box is used for exactly `[INT32_MIN, INT32_MAX]` in `UINT32_TO_JSVALUE`, `UINT64_TO_JSVALUE` and `INT64_TO_JSVALUE`.
- Not changed: `u64_fast` returns exactly `2**53 - 1` as a BigInt in both paths (the engine has the same `<` comparison); strings, objects and BigInts passed to int parameters, which the engine path rejects or converts by calling into the VM, reach C as `0` (previously truncated pointer bits). The trampoline has no way to call back into the VM for those.
- Verification, `test/js/bun/ffi/cc.test.ts`, new `integer <-> JSValue conversions` block (runs under ASAN; all three tests fail on the released build and pass with `bun bd test`):
  - hand table of argument cases per type, reported back from C as `double`s so a return-boxing bug cannot mask or mimic an argument bug; includes the int32 boundaries, wraparound, fractions, a JIT double-encoded value, `1e19` (exercises the exponent > 52 branch; the old cast gets it wrong too), `2**84`, NaN/Infinity, `undefined`/`null`/`true`/`false`.
  - parity test: the same C functions called once through the `cc()` trampoline and once through `CFunction` (the engine's FFI, pointed at the addresses the C code returns) over a 60-value corpus covering every branch of the decode, 420 calls, must agree exactly. On the released build this reports the double-encoded and immediate cases as mismatches.
  - return cases for `u32`, `i64_fast` and `u64_fast` on both sides of the int32 boundary.
  - `test/js/bun/ffi/ffi.test.fixture.receiver.c` is the `viewSource()` output that `ffi.test.js` ("ffi print") rewrites; regenerated by running it. Its generated body is unchanged from main; only the embedded header differs.
  - `bun bd test test/js/bun/ffi/`: everything passes except the pre-existing `integer identities work for all possible values` 64-bit cases in `ffi.test.js`, which are `dlopen()` tests that take 4 to 6 seconds against a 5 second timeout under debug ASAN in this container and are unrelated to this change.

### Background

- JSC NaN-boxes values in 64 bits. A JS number is either int32-tagged (the value sits in the low 32 bits under a tag) or double-encoded (the IEEE bits plus a constant offset). Which one a given integer-valued number uses is the engine's choice: anything outside int32 range or fractional is always a double, and JIT-compiled arithmetic commonly leaves integral results as doubles too. Reading the low 32 bits is only meaningful for the int32-tagged form. `true`, `false`, `undefined` and `null` are small tag constants (7, 6, 10, 2).
- `bun:ffi` has two call paths. `dlopen()`/`linkSymbols()`/`CFunction` hand the signature to JavaScriptCore's FFI, which converts arguments and returns in C++ (`FFIConversions.cpp`). `cc()` instead generates a small C wrapper per symbol (`FFI.h` plus a few lines from `print_source_code`), compiles it with the bundled TinyCC, and installs it as the host function; `viewSource()` prints that wrapper. The conversions in `FFI.h` are the only conversions a `cc()` call gets, and TinyCC does not inline or optimize them.
- ECMAScript ToInt32 truncates a number toward zero and reduces it modulo 2^32; NaN and +-Infinity become 0, `true` becomes 1. ToUint32 is the same operation with the result read as unsigned. It is what `Int32Array`/`Uint32Array` stores, `x | 0`, and JSC's `JSValue::toInt32()` all compute.

<details>
<summary>Repro</summary>

```c
// t2.c
#include <stdint.h>
uint32_t identity_u32(uint32_t x) { return x; }
uint32_t mid_u32(void) { return 0x80000000u; }
```

```ts
import { cc, dlopen } from "bun:ffi";
const defs = {
  identity_u32: { args: ["u32"], returns: "u32" },
  mid_u32: { args: [], returns: "u32" },
} as const;
const viaCC = cc({ source: "./t2.c", symbols: defs }).symbols;
const viaDlopen = dlopen("./libt2.so", defs).symbols; // cc -O2 -shared -fPIC -o libt2.so t2.c
for (const [name, s] of [["cc", viaCC], ["dlopen", viaDlopen]] as const)
  console.log(name, s.identity_u32(0xffffffff), s.identity_u32(0x80000000), s.identity_u32(7 + 0.5 - 0.5), s.identity_u32(undefined), s.mid_u32());
```

Before (1.4.0 canary):

```
cc 4292870144 0 0 10 -2147483648
dlopen 4294967295 2147483648 7 0 2147483648
```

After, both lines read `4294967295 2147483648 7 0 2147483648`.

</details>

<details>
<summary>Changes made during review</summary>

The first revision returned 0 for `true` (the engine returns 1), emitted the argument slot as an aggregate initializer (a `memset()` call per argument under TinyCC), and only had the hand-written table as coverage. d5a4a8d8be adds the `TagValueTrue` check, switches to assignment, adds the `cc()`-vs-`CFunction` parity test, and trims the `FFI.h` comments to one line each. A local 18,335-call comparison against `dlopen()` on the same shared library also had 0 mismatches (18,173 before the fix); the committed parity test is the in-tree version of that check.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->