### PR TITLE
Print @font-face format() keywords as strings

### DIFF
--- a/src/css/rules/font_face.rs
+++ b/src/css/rules/font_face.rs
@@ -429,9 +429,6 @@ impl FontFormat {
     }
 
     fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // Browser support for keywords rather than strings is very limited,
-        // so every format is printed in its string form.
-        // https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src
         let format: &[u8] = match self {
             FontFormat::Woff => b"woff",
             FontFormat::Woff2 => b"woff2",
@@ -442,6 +439,8 @@ impl FontFormat {
             FontFormat::Svg => b"svg",
             FontFormat::String(s) => s,
         };
+        // Browser support for keywords rather than strings is very limited.
+        // https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src
         dest.serialize_string(format)
     }
 

--- a/src/css/rules/font_face.rs
+++ b/src/css/rules/font_face.rs
@@ -429,18 +429,20 @@ impl FontFormat {
     }
 
     fn to_css(&self, dest: &mut Printer) -> Result<(), PrintErr> {
-        // Browser support for keywords rather than strings is very limited.
+        // Browser support for keywords rather than strings is very limited,
+        // so every format is printed in its string form.
         // https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/src
-        match self {
-            FontFormat::Woff => dest.write_str("woff"),
-            FontFormat::Woff2 => dest.write_str("woff2"),
-            FontFormat::Truetype => dest.write_str("truetype"),
-            FontFormat::Opentype => dest.write_str("opentype"),
-            FontFormat::EmbeddedOpentype => dest.write_str("embedded-opentype"),
-            FontFormat::Collection => dest.write_str("collection"),
-            FontFormat::Svg => dest.write_str("svg"),
-            FontFormat::String(s) => dest.serialize_string(*s),
-        }
+        let format: &[u8] = match self {
+            FontFormat::Woff => b"woff",
+            FontFormat::Woff2 => b"woff2",
+            FontFormat::Truetype => b"truetype",
+            FontFormat::Opentype => b"opentype",
+            FontFormat::EmbeddedOpentype => b"embedded-opentype",
+            FontFormat::Collection => b"collection",
+            FontFormat::Svg => b"svg",
+            FontFormat::String(s) => s,
+        };
+        dest.serialize_string(format)
     }
 
     fn deep_clone(&self, _arena: &bun_alloc::Arena) -> Self {

--- a/test/js/bun/css/css.test.ts
+++ b/test/js/bun/css/css.test.ts
@@ -7627,6 +7627,66 @@ describe("css tests", () => {
     );
   });
 
+  describe("font-face", () => {
+    // format() is always printed in its string form. The bare keyword form is
+    // css-fonts-4 syntax that older browsers reject (they drop the whole src
+    // entry), so it is never emitted, matching lightningcss.
+    for (const format of ["woff", "woff2", "truetype", "opentype", "embedded-opentype", "collection", "svg"]) {
+      const expected = `@font-face{src:url(test.font)format("${format}")}`;
+      minify_test(`@font-face { src: url("test.font") format(${format}) }`, expected);
+      minify_test(`@font-face { src: url("test.font") format("${format}") }`, expected);
+      minify_test(`@font-face { src: url("test.font") format('${format}') }`, expected);
+      // Known formats are matched case-insensitively and printed in their canonical spelling.
+      minify_test(`@font-face { src: url("test.font") format(${format.toUpperCase()}) }`, expected);
+    }
+
+    // Unknown formats are printed as strings too, preserving their spelling.
+    minify_test(
+      '@font-face { src: url(test.woff2) format("woff2-variations") }',
+      '@font-face{src:url(test.woff2)format("woff2-variations")}',
+    );
+    minify_test(
+      "@font-face { src: url(test.woff2) format(woff2-variations) }",
+      '@font-face{src:url(test.woff2)format("woff2-variations")}',
+    );
+
+    minify_test(
+      '@font-face { src: url("test.otf") format(opentype) tech(features-aat) }',
+      '@font-face{src:url(test.otf)format("opentype")tech(features-aat)}',
+    );
+    minify_test(
+      '@font-face { src: url("test.woff2") format("woff2") tech(variations) }',
+      '@font-face{src:url(test.woff2)format("woff2")tech(variations)}',
+    );
+    minify_test(
+      `@font-face {
+        font-family: "Test";
+        src: local("Test"), url("test.woff2") format("woff2"), url("test.woff") format(woff);
+      }`,
+      '@font-face{font-family:Test;src:local(Test),url(test.woff2)format("woff2"),url(test.woff)format("woff")}',
+    );
+    // The minified output parses back to itself.
+    minify_test(
+      '@font-face{src:url(test.woff2)format("woff2"),url(test.woff)format("woff")}',
+      '@font-face{src:url(test.woff2)format("woff2"),url(test.woff)format("woff")}',
+    );
+
+    cssTest(
+      `
+      @font-face {
+        font-family: "Test";
+        src: url("test.woff2") format(woff2), url("test.woff") format("woff"), url("test.eot") format(embedded-opentype);
+      }
+    `,
+      indoc`
+      @font-face {
+        font-family: Test;
+        src: url("test.woff2") format("woff2"), url("test.woff") format("woff"), url("test.eot") format("embedded-opentype");
+      }
+`,
+    );
+  });
+
   describe("font-palette-values", () => {
     minify_test(
       "@font-palette-values --x{font-family:Foo;base-palette:2}",


### PR DESCRIPTION
### Problem

- `bun build` (and the CSS minifier) rewrites `src: url(a.woff2) format("woff2")` inside `@font-face` to `format(woff2)`. The same happens for all seven formats the parser recognizes (`woff`, `woff2`, `truetype`, `opentype`, `embedded-opentype`, `collection`, `svg`), whether or not the input was quoted.
- The bare keyword form is css-fonts-4 syntax and only recent browsers parse it (Chrome 108, Firefox 106, Safari 17 per MDN). A browser that does not parse the `format()` of a `src` entry skips that entry, so input written in the universally supported string form loads in fewer browsers after bundling than before.
- Cause: `FontFormat::to_css` in `src/css/rules/font_face.rs` writes the keyword arms with `dest.write_str("woff")` and so on. The upstream lightningcss implementation writes the quoted strings here; the quotes were dropped in the port. #36165 switched the unknown `String` arm to `serialize_string`, so `format("woff2-variations")` was already quoted again; the recognized keywords were still bare.

### Fix

- `FontFormat::to_css` maps every variant to its canonical name and prints it through `dest.serialize_string`, so `format()` always contains a string: `format("woff2")`.
- This is what lightningcss emits for the same input (checked against lightningcss 1.30.2: `format(woff2)` and `format("woff2")` both print as `format("woff2")`), and the comment above this code ("browser support for keywords rather than strings is very limited") is the reason it does so. The string form is accepted by every browser that accepts the keyword form, so the output is never less compatible than the input.
- Unknown formats are unaffected; they were already printed as strings.
- Test: `test/js/bun/css/css.test.ts`, new `font-face` block. Every recognized keyword in bare, double quoted, single quoted and upper case spelling, plus `tech()`, multiple sources, the unknown-format case and the non-minified printer. 33 of the new cases fail on the current binary (`format(woff2)` printed), the whole file passes with this change.
- Also ran `test/js/bun/css/custom-pseudo-ident-escape.test.ts`, `test/js/bun/css/doesnt_crash.test.ts`, `test/regression/issue/27598.test.ts` and `test/bundler/esbuild/css.test.ts` with the debug build, and `cargo clippy -p bun_css`.
- Related: #36961 takes a different route for the same output (remember whether the input was quoted, and also quote `font-family`). With this change the `format()` half of that PR is no longer needed, since the string form is emitted regardless of how the input was written; issue #17264 has the original report.

### Background

- `@font-face { src: url(...) format(...) }`: `src` is a comma separated list of font sources. `format()` tells the browser the file format of a source so it can skip formats it does not support. css-fonts-3 defined the argument as a string (`format("woff2")`); css-fonts-4 added bare keywords (`format(woff2)`) and says the string form stays supported. A `src` entry whose `format()` the browser cannot parse is dropped; the other entries in the list are still tried.
- `FontFormat`: the parsed value of `format()`. Recognized names become one of seven keyword variants (matched case-insensitively), anything else is kept as `FontFormat::String`. Printing is the only place where the distinction is visible.
- `Printer::serialize_string`: writes a double quoted CSS string token, escaping the contents where needed (a no-op for these keywords).

<details>
<summary>Before / after with <code>bun build</code></summary>

Input:

```css
@font-face{font-family:"My Font";src:url(https://x.invalid/a.woff2) format("woff2"), url(https://x.invalid/b.woff2) format("woff2-variations"), url(https://x.invalid/c.ttf) format(truetype) tech(variations)}
```

Before:

```css
src: url("https://x.invalid/a.woff2") format(woff2), url("https://x.invalid/b.woff2") format("woff2-variations"), url("https://x.invalid/c.ttf") format(truetype) tech(variations);
```

After (same as lightningcss):

```css
src: url("https://x.invalid/a.woff2") format("woff2"), url("https://x.invalid/b.woff2") format("woff2-variations"), url("https://x.invalid/c.ttf") format("truetype") tech(variations);
```

</details>
