### PR TITLE
ci: run the darwin macOS 26 lane on main only until the Studios host 26 guests

### DIFF
--- a/.buildkite/ci.mjs
+++ b/.buildkite/ci.mjs
@@ -186,6 +186,10 @@ const testPlatforms = [
   // The darwin test suite runs on real macOS agents against the Linux-built
   // artifacts from the `darwin-<arch>-build-bun` steps (the only darwin build
   // lanes — see buildPlatforms).
+  // The `latest` lane only has two agents behind it right now (the Studios
+  // came back on macOS 15 and can only host 15 guests), so until they are on
+  // 26 it runs on main and on opt-in (see darwinLatestLaneEnabled), not on
+  // every PR push.
   { os: "darwin", arch: "aarch64", release: "26", tier: "latest" },
   { os: "darwin", arch: "aarch64", release: "14", tier: "previous" },
   // x64 is off until enough Intel test agents are back on the queue.
@@ -1542,7 +1546,11 @@ async function getPipeline(options = {}) {
   // Tests run on main too so the canary release step below can gate on them.
   // ASAN is PR-only (see includeASAN above), so the asan test lane is dropped
   // on main along with its build.
-  const relevantTestPlatforms = includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan");
+  const darwinLatestLaneEnabled =
+    isMainBranch() || isBuildManual() || /\[(macos|darwin) tests?\]/i.test(getCommitMessage());
+  const relevantTestPlatforms = (
+    includeASAN ? testPlatforms : testPlatforms.filter(({ profile }) => profile !== "asan")
+  ).filter(({ os, tier }) => os !== "darwin" || tier !== "latest" || darwinLatestLaneEnabled);
   /** @type {string[]} */
   const testStepKeys = [];
   {


### PR DESCRIPTION
### What does this PR do?

Only two agents serve the darwin aarch64 `latest` (macOS 26) lane right now: the two Dublin minis. The Studios were reimaged onto macOS 15, so their Tart guests are 15 and can only take the `previous` lane. With darwin tests back on every PR (#37633) the 26 lane has ~130 jobs queued against 2 slots, so every PR build sits waiting on it.

Until the Studios are on 26 and baking 26 guests, the 26 lane runs on main, on manual builds, or when the commit subject has `[macos tests]`. PRs keep the `previous` lane (8 slots) and the darwin build lanes. Revert this once the Studios serve 26.

### How did you verify your code works?

Generated the pipeline locally with Buildkite env set:

- main: `darwin-aarch64-26-test-bun`, `darwin-aarch64-14-test-bun`, trace-order
- PR, plain subject: `darwin-aarch64-14-test-bun` only
- PR with `[macos tests]`: both lanes
