### PR TITLE
event loop: report promise rejections left by the turn that let the loop go idle

### DIFF
--- a/src/jsc/VirtualMachine.rs
+++ b/src/jsc/VirtualMachine.rs
@@ -2015,9 +2015,9 @@ pub struct RuntimeHooks {
     pub auto_tick: unsafe fn(vm: *mut VirtualMachine),
     /// `eventLoop().autoTickActive()` — like `auto_tick` but only sleeps in
     /// the uSockets loop while it has active handles.
-    /// Separate slot because the body skips `runImminentGCTimer` /
-    /// `handleRejectedPromises` and falls through to `tickWithoutIdle` when
-    /// idle — folding it into `auto_tick` would change shutdown semantics.
+    /// Separate slot because the body skips `runImminentGCTimer` and falls
+    /// through to `tickWithoutIdle` when idle — folding it into `auto_tick`
+    /// would change shutdown semantics.
     pub auto_tick_active: unsafe fn(vm: *mut VirtualMachine),
     /// `printException` / `printErrorlikeObject` — formats `value` (or its
     /// wrapped `JSC::Exception`) to stderr via `ConsoleObject::Formatter`.

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -939,6 +939,17 @@ impl WebWorker {
             if self.has_requested_terminate() {
                 break;
             }
+            // `tick()` reports the promises its tasks left rejected;
+            // `auto_tick_active()` (immediates, timers, I/O callbacks) leaves
+            // them to the next `tick()`. If those callbacks were the last thing
+            // keeping the loop alive there is no next turn, and the rejection
+            // would go unreported (Node reports it after every macrotask). Same
+            // below for what `on_before_exit` runs, as run_command.rs does for
+            // the main thread before `on_exit`.
+            vm.global().handle_rejected_promises();
+            if self.has_requested_terminate() {
+                break;
+            }
             if let EntryOutcome::Stop = observe_entry(vm) {
                 stopped_by_entry = true;
             }
@@ -960,10 +971,16 @@ impl WebWorker {
             // Only emit 'beforeExit' on a natural drain, not on terminate().
             // TODO: is this able to allow the event loop to continue?
             vm.as_mut().on_before_exit();
+            if !self.has_requested_terminate() {
+                vm.global().handle_rejected_promises();
+            }
             // Drained with the entry still pending: an unsettled top-level await,
-            // Node's exit 13 (unless the user chose a nonzero exit code).
+            // Node's exit 13 (unless the user chose a nonzero exit code, or the
+            // worker stopped itself just now, by process.exit() or an uncaught
+            // error, whose exit handlers already ran with the code they keep).
             // SAFETY: rooted by `entry_promise`.
-            if unsafe { (*promise).status() } == jsc::js_promise::Status::Pending
+            if !self.has_requested_terminate()
+                && unsafe { (*promise).status() } == jsc::js_promise::Status::Pending
                 && vm.exit_handler.exit_code == 0
             {
                 vm.as_mut().exit_handler.exit_code = 13;

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -939,13 +939,7 @@ impl WebWorker {
             if self.has_requested_terminate() {
                 break;
             }
-            // `tick()` reports the promises its tasks left rejected;
-            // `auto_tick_active()` (immediates, timers, I/O callbacks) leaves
-            // them to the next `tick()`. If those callbacks were the last thing
-            // keeping the loop alive there is no next turn, and the rejection
-            // would go unreported (Node reports it after every macrotask). Same
-            // below for what `on_before_exit` runs, as run_command.rs does for
-            // the main thread before `on_exit`.
+            // auto_tick_active() leaves rejections to the next tick(); a final turn never gets one.
             vm.global().handle_rejected_promises();
             if self.has_requested_terminate() {
                 break;
@@ -974,13 +968,13 @@ impl WebWorker {
             if !self.has_requested_terminate() {
                 vm.global().handle_rejected_promises();
             }
-            // SAFETY: rooted by `entry_promise`.
-            let entry_pending = unsafe { (*promise).status() } == jsc::js_promise::Status::Pending;
             // Drained with the entry still pending: an unsettled top-level await,
-            // Node's exit 13 (unless the user chose a nonzero exit code, or the
-            // worker stopped itself just now, by process.exit() or an uncaught
-            // error, whose exit handlers already ran with the code they keep).
-            if entry_pending && !self.has_requested_terminate() && vm.exit_handler.exit_code == 0 {
+            // Node's exit 13, unless the user chose a code or stopped the worker from 'beforeExit'.
+            // SAFETY: rooted by `entry_promise`.
+            if unsafe { (*promise).status() } == jsc::js_promise::Status::Pending
+                && vm.exit_handler.exit_code == 0
+                && !self.has_requested_terminate()
+            {
                 vm.as_mut().exit_handler.exit_code = 13;
             }
         }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -939,11 +939,6 @@ impl WebWorker {
             if self.has_requested_terminate() {
                 break;
             }
-            // auto_tick_active() leaves rejections to the next tick(); a final turn never gets one.
-            vm.global().handle_rejected_promises();
-            if self.has_requested_terminate() {
-                break;
-            }
             if let EntryOutcome::Stop = observe_entry(vm) {
                 stopped_by_entry = true;
             }
@@ -965,6 +960,7 @@ impl WebWorker {
             // Only emit 'beforeExit' on a natural drain, not on terminate().
             // TODO: is this able to allow the event loop to continue?
             vm.as_mut().on_before_exit();
+            // Rejections left by the 'beforeExit' listeners themselves (run_command.rs: likewise).
             if !self.has_requested_terminate() {
                 vm.global().handle_rejected_promises();
             }

--- a/src/jsc/web_worker.rs
+++ b/src/jsc/web_worker.rs
@@ -974,15 +974,13 @@ impl WebWorker {
             if !self.has_requested_terminate() {
                 vm.global().handle_rejected_promises();
             }
+            // SAFETY: rooted by `entry_promise`.
+            let entry_pending = unsafe { (*promise).status() } == jsc::js_promise::Status::Pending;
             // Drained with the entry still pending: an unsettled top-level await,
             // Node's exit 13 (unless the user chose a nonzero exit code, or the
             // worker stopped itself just now, by process.exit() or an uncaught
             // error, whose exit handlers already ran with the code they keep).
-            // SAFETY: rooted by `entry_promise`.
-            if !self.has_requested_terminate()
-                && unsafe { (*promise).status() } == jsc::js_promise::Status::Pending
-                && vm.exit_handler.exit_code == 0
-            {
+            if entry_pending && !self.has_requested_terminate() && vm.exit_handler.exit_code == 0 {
                 vm.as_mut().exit_handler.exit_code = 13;
             }
         }

--- a/src/runtime/jsc_hooks.rs
+++ b/src/runtime/jsc_hooks.rs
@@ -1114,9 +1114,8 @@ unsafe fn auto_tick(vm: *mut VirtualMachine) {
     unsafe { (*(*vm).global).handle_rejected_promises() };
 }
 
-/// `eventLoop().autoTickActive()`. Same shape as
-/// [`auto_tick`] but: no `runImminentGCTimer`, no `handleRejectedPromises` at
-/// the tail, and no debug sleep-timer logging. Used by `bun_main` /
+/// `eventLoop().autoTickActive()`. Same shape as [`auto_tick`] but with no
+/// `runImminentGCTimer` and no debug sleep-timer logging. Used by `bun_main` /
 /// `on_before_exit` drain loops where blocking when the loop is idle would
 /// hang shutdown.
 ///
@@ -1169,6 +1168,8 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
         unsafe { (*loop_).tick_without_idle() };
         // SAFETY: per fn contract.
         unsafe { (*vm).on_after_event_loop() };
+        // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
+        unsafe { (*(*vm).global).handle_rejected_promises() };
         return;
     }
 
@@ -1232,6 +1233,10 @@ unsafe fn auto_tick_active(vm: *mut VirtualMachine) {
 
     // SAFETY: per fn contract.
     unsafe { (*vm).on_after_event_loop() };
+    // The callbacks above (immediates, I/O, timers) may have left promises rejected; a caller's
+    // next `tick()` would report them, but a loop that just went idle does not tick again.
+    // SAFETY: `vm.global` is set during `VirtualMachine::init` and outlives the VM.
+    unsafe { (*(*vm).global).handle_rejected_promises() };
 }
 
 /// `printException` / `printErrorlikeObject` — formats `value` to stderr via

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -885,6 +885,16 @@ describe.concurrent("Bun REPL", () => {
       expect(exitCode).toBe(0);
     });
 
+    test("-e reports a rejection left by the last timer callback", async () => {
+      const { stdout, exitCode } = await runReplWith([
+        "-e",
+        "process.on('unhandledRejection', e => console.log('unhandledRejection', e.message));" +
+          "setTimeout(() => Promise.reject(new Error('late')), 1)",
+      ]);
+      expect(stdout).toBe("unhandledRejection late\n");
+      expect(exitCode).toBe(0);
+    });
+
     test("-p drains event loop before printing", async () => {
       // Result should be printed after the timer output, since we drain
       // the event loop before printing the final result.

--- a/test/js/node/process/process.test.js
+++ b/test/js/node/process/process.test.js
@@ -932,6 +932,72 @@ describe.concurrent(() => {
       expect(exitCode).toBe(0);
     });
 
+    // A promise left rejected by the callback that drained the loop (timer, immediate,
+    // I/O) used to be reported only after 'beforeExit' had been emitted, with
+    // whatever an 'unhandledRejection' listener scheduled never running; Node
+    // reports it as soon as that callback's turn is over.
+    it("is skipped after a fatal unhandled rejection from the last callback", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("beforeExit", () => console.log("beforeExit"));
+           process.on("exit", () => console.log("exit"));
+           setTimeout(() => Promise.reject(new Error("boom")), 1);`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("exit\n");
+      expect(stderr).toInclude("error: boom");
+      expect(exitCode).toBe(1);
+    });
+
+    it("fires after the work an unhandledRejection listener scheduled from the last callback", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("unhandledRejection", e => {
+             console.log("unhandledRejection", e.message);
+             setTimeout(() => console.log("late work"), 1);
+           });
+           process.on("beforeExit", () => console.log("beforeExit"));
+           setImmediate(() => Promise.reject(new Error("boom")));`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("unhandledRejection boom\nlate work\nbeforeExit\n");
+      expect(stderr).not.toInclude("error: boom");
+      expect(exitCode).toBe(0);
+    });
+
+    it("a rejection from work scheduled inside beforeExit is reported before beforeExit is re-emitted", async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `process.on("unhandledRejection", e => console.log("unhandledRejection", e.message));
+           let scheduled = false;
+           process.on("beforeExit", () => {
+             console.log("beforeExit");
+             if (scheduled) return;
+             scheduled = true;
+             setImmediate(() => Promise.reject(new Error("late")));
+           });`,
+        ],
+        env: bunEnv,
+        stdio: ["inherit", "pipe", "pipe"],
+      });
+      const [stderr, stdout, exitCode] = await Promise.all([proc.stderr.text(), proc.stdout.text(), proc.exited]);
+      expect(stdout).toBe("beforeExit\nunhandledRejection late\nbeforeExit\n");
+      expect(stderr).not.toInclude("error: late");
+      expect(exitCode).toBe(0);
+    });
+
     it("a throw from an exit listener after a fatal throw still stops subsequent exit listeners", async () => {
       // Skipping the beforeExit dispatch also skips the call that arms
       // exit_on_uncaught_exception; on_before_exit() arms it itself so a throw

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2020,6 +2020,122 @@ test("a top-level await rejecting while the loop is alive fails the worker then"
   expect(exitCode).toBe(0);
 });
 
+// A promise rejected by the last callback that kept the worker's loop alive (an
+// immediate, a timer, work a 'beforeExit' listener scheduled) used to be dropped
+// on the floor: no 'unhandledRejection' listener ran, the parent got no 'error',
+// and the worker exited 0 (13 with a top-level await pending), as if nothing had
+// happened. Node reports it like any other rejection.
+// (Subprocess: inside `bun test` a worker's rejection skips the worker's own
+// 'unhandledRejection' listeners.)
+describe.concurrent("a rejection from the worker's last turn is reported", () => {
+  // What the parent observed, printed once the worker is gone: every message
+  // the worker posted (its own handlers report through parentPort), every
+  // 'error', and the 'exit' code.
+  async function outcome(workerSource: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker } = require("worker_threads");
+         const w = new Worker(${JSON.stringify(workerSource)}, { eval: true });
+         const seen = { messages: [], errors: [] };
+         w.on("message", m => seen.messages.push(m));
+         w.on("error", e => seen.errors.push(e.message));
+         w.on("exit", code => console.log(JSON.stringify({ ...seen, code })));`,
+      ],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({ exitCode: 0 });
+    return JSON.parse(stdout) as { messages: string[]; errors: string[]; code: number };
+  }
+
+  test("setImmediate rejection while a top-level await is pending", async () => {
+    const { messages, errors, code } = await outcome(
+      `import { parentPort } from "worker_threads";
+       process.on("exit", c => parentPort.postMessage("exit handler: " + c));
+       setImmediate(() => Promise.reject(new Error("boom")));
+       await new Promise(() => {});`,
+    );
+    expect(errors).toEqual(["boom"]);
+    // The worker died from the rejection, not from the unsettled await: its
+    // 'exit' handlers ran and were told the code the parent then received.
+    expect(code).not.toBe(13);
+    expect(messages).toEqual([`exit handler: ${code}`]);
+  });
+
+  test("the worker's 'unhandledRejection' listener gets it (and the unsettled await still exits 13)", async () => {
+    expect(
+      await outcome(
+        `import { parentPort } from "worker_threads";
+         process.on("unhandledRejection", e => parentPort.postMessage("unhandledRejection: " + e.message));
+         setImmediate(() => Promise.reject(new Error("boom")));
+         await new Promise(() => {});`,
+      ),
+    ).toEqual({ messages: ["unhandledRejection: boom"], errors: [], code: 13 });
+  });
+
+  test("an 'unhandledRejection' listener that rethrows fails the worker with code 1", async () => {
+    expect(
+      await outcome(
+        `import { parentPort } from "worker_threads";
+         process.on("unhandledRejection", e => { parentPort.postMessage("unhandledRejection: " + e.message); throw e; });
+         process.on("exit", c => parentPort.postMessage("exit handler: " + c));
+         setImmediate(() => Promise.reject(new Error("boom")));
+         await new Promise(() => {});`,
+      ),
+    ).toEqual({ messages: ["unhandledRejection: boom", "exit handler: 1"], errors: ["boom"], code: 1 });
+  });
+
+  test("setTimeout rejection with nothing else keeping the worker alive", async () => {
+    const { messages, errors, code } = await outcome(
+      `const { parentPort } = require("worker_threads");
+       process.on("exit", c => parentPort.postMessage("exit handler: " + c));
+       setTimeout(() => Promise.reject(new Error("boom")), 1);`,
+    );
+    expect(errors).toEqual(["boom"]);
+    expect(messages).toEqual([`exit handler: ${code}`]);
+  });
+
+  test("rejection from work a 'beforeExit' listener scheduled", async () => {
+    const { messages, errors, code } = await outcome(
+      `const { parentPort } = require("worker_threads");
+       process.on("exit", c => parentPort.postMessage("exit handler: " + c));
+       let scheduled = false;
+       process.on("beforeExit", () => {
+         if (scheduled) return;
+         scheduled = true;
+         setImmediate(() => Promise.reject(new Error("late")));
+       });`,
+    );
+    expect(errors).toEqual(["late"]);
+    expect(messages).toEqual([`exit handler: ${code}`]);
+  });
+
+  test("process.exit(0) from a 'beforeExit' listener is not turned into 13 by a pending top-level await", async () => {
+    expect(
+      await outcome(
+        `process.on("beforeExit", () => process.exit(0));
+         await new Promise(() => {});`,
+      ),
+    ).toEqual({ messages: [], errors: [], code: 0 });
+  });
+
+  test("a rejection handled before the turn ends is not reported", async () => {
+    expect(
+      await outcome(
+        `const { parentPort } = require("worker_threads");
+         setImmediate(() => {
+           const p = Promise.reject(new Error("boom"));
+           queueMicrotask(() => p.catch(() => parentPort.postMessage("caught")));
+         });`,
+      ),
+    ).toEqual({ messages: ["caught"], errors: [], code: 0 });
+  });
+});
+
 // Static imports that are still being read/transpiled are loading, not a
 // top-level await: 'online' and message delivery wait for the graph to execute.
 test("a file worker's static imports load before it counts as started", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -2099,18 +2099,56 @@ describe.concurrent("a rejection from the worker's last turn is reported", () =>
     expect(messages).toEqual([`exit handler: ${code}`]);
   });
 
-  test("rejection from work a 'beforeExit' listener scheduled", async () => {
+  // Node reports the rejection as soon as the immediate's turn is over, so the
+  // worker dies of it before 'beforeExit' would have been emitted.
+  test("the rejection is reported before 'beforeExit', which then never fires", async () => {
+    const { messages, errors, code } = await outcome(
+      `const { parentPort } = require("worker_threads");
+       process.on("beforeExit", () => parentPort.postMessage("beforeExit"));
+       process.on("exit", c => parentPort.postMessage("exit handler: " + c));
+       setImmediate(() => Promise.reject(new Error("boom")));`,
+    );
+    expect(errors).toEqual(["boom"]);
+    expect(messages).toEqual([`exit handler: ${code}`]);
+  });
+
+  // Node: the rejection is reported right after the macrotask that left it,
+  // before anything that macrotask queued (here a MessagePort delivery) runs.
+  test("it is reported before tasks the same turn queued", async () => {
+    expect(
+      await outcome(
+        `const { parentPort } = require("worker_threads");
+         const { port1, port2 } = new MessageChannel();
+         port2.on("message", () => { parentPort.postMessage("task"); port2.close(); });
+         process.on("unhandledRejection", e => parentPort.postMessage("unhandledRejection: " + e.message));
+         setImmediate(() => { port1.postMessage(0); Promise.reject(new Error("boom")); });`,
+      ),
+    ).toEqual({ messages: ["unhandledRejection: boom", "task"], errors: [], code: 0 });
+  });
+
+  test("rejection from work a 'beforeExit' listener scheduled (and 'beforeExit' is not re-emitted)", async () => {
     const { messages, errors, code } = await outcome(
       `const { parentPort } = require("worker_threads");
        process.on("exit", c => parentPort.postMessage("exit handler: " + c));
        let scheduled = false;
        process.on("beforeExit", () => {
+         parentPort.postMessage("beforeExit");
          if (scheduled) return;
          scheduled = true;
          setImmediate(() => Promise.reject(new Error("late")));
        });`,
     );
     expect(errors).toEqual(["late"]);
+    expect(messages).toEqual(["beforeExit", `exit handler: ${code}`]);
+  });
+
+  test("rejection made by a 'beforeExit' listener itself", async () => {
+    const { messages, errors, code } = await outcome(
+      `const { parentPort } = require("worker_threads");
+       process.on("exit", c => parentPort.postMessage("exit handler: " + c));
+       process.on("beforeExit", () => { Promise.reject(new Error("in beforeExit")); });`,
+    );
+    expect(errors).toEqual(["in beforeExit"]);
     expect(messages).toEqual([`exit handler: ${code}`]);
   });
 

--- a/test/js/web/workers/worker.test.ts
+++ b/test/js/web/workers/worker.test.ts
@@ -369,6 +369,17 @@ describe("web worker", () => {
       expect(err.message).toBe("5");
       expect(err.error).toBe(null);
     });
+
+    // The immediate is the last thing keeping the worker alive, so the rejection
+    // it leaves behind has no later loop turn to be reported in; it used to be
+    // dropped and the worker closed as if nothing had happened.
+    test("is fired for a rejection left by the worker's last callback", async () => {
+      const worker = new Worker("data:text/javascript,setImmediate(() => Promise.reject(new Error('last turn')))");
+      const errors: string[] = [];
+      worker.addEventListener("error", e => errors.push(e.message));
+      await once(worker, "close");
+      expect(errors).toEqual([expect.stringContaining("error: last turn")]);
+    });
   });
 
   describe("terminate() races and lifecycle edges", () => {


### PR DESCRIPTION
### Problem
- A promise rejected by the callback that lets the event loop go idle (the last `setTimeout`/`setImmediate`/I/O callback, or work a `'beforeExit'` listener scheduled) is reported late or not at all:
  - `node:worker_threads` / Web `Worker`: never. The worker's `process.on('unhandledRejection')` listeners do not run, the parent gets no `'error'`, and the worker exits 0 (13 when a top-level `await` is pending). Repro (worker file, parent attaches `'error'`/`'exit'`): `setImmediate(() => Promise.reject(new Error("boom"))); await new Promise(() => {});` gives `exit 13` and nothing else on main; Node gives `error: boom`, `exit 1`.
  - main thread: only after `'beforeExit'` has been emitted, and what an `'unhandledRejection'` listener schedules (a timer, a write) never runs; Node reports it before `'beforeExit'` and runs that work. Work scheduled by a `'beforeExit'` listener that rejects gets `'beforeExit'` emitted a second time first.
  - `bun repl -e`: never (exit 0, nothing printed).
- Cause: `auto_tick()` ends by walking the rejected-promise list (`jsc_hooks.rs:1114`); `auto_tick_active()` did not, leaving that to the caller's next `tick()` (`event_loop.rs:699`). Every run loop is `tick(); auto_tick_active();` (`run_command.rs:1507`, `repl.rs:1539`, `VirtualMachine::on_before_exit` inner loop, `web_worker.rs:929`), so when the callbacks of the last `auto_tick_active()` are what let the loop go idle, no `tick()` follows. `run_command.rs:1568` papers over it for the main thread with one drain after `on_before_exit()`; the REPL and the worker loop have nothing, and the worker then reaches `shutdown()`, after which `unhandled_rejection` ignores everything.
- The worker's top-level-await case is new since #37075, which replaced the entry wait (it spun with `auto_tick()`, which drains) with this loop; the rest is older.

### Fix
- `auto_tick_active()` walks the rejected-promise list at its end, on both of its return paths, exactly as `auto_tick()` does (`src/runtime/jsc_hooks.rs`); the two doc comments that listed the omission are updated. The walk is a `[[likely]]` early return when the list is empty, so steady-state cost is one call per loop turn, which `tick()` already pays at least once.
- Why this is the right layer: it fixes every owner of a run loop at once (main thread, REPL, `on_before_exit()`'s inner loop, workers, watch mode) instead of adding a fourth per-caller drain, and it gives Node's timing: a rejection is processed right after the macrotask phase that produced it, before anything that phase queued, which is also when `auto_tick()` and `tick()` already process theirs. The omission in `auto_tick_active()` had no recorded reason (the no-runtime fallback for it, `VirtualMachine::auto_tick_active`, calls `tick()`, which drains). The main-thread drain at `run_command.rs:1568` and the test runner's at `test_command.rs:3381` are left in place; they still cover a `'beforeExit'` listener that rejects synchronously.
- `web_worker.rs`: the same post-`on_before_exit()` drain the main thread has (for rejections made by `'beforeExit'` listeners themselves), and exit code 13 is no longer stamped on a worker whose stop was requested during `'beforeExit'` (the rejection just reported, or `process.exit()` from the listener): its `'exit'` handlers already ran with their code. Before, `process.on('beforeExit', () => process.exit(0))` plus a pending top-level await exited 13; Node exits 0.
- Not changed here: a worker killed by a rejection still reports the hook's exit code (0) where Node reports 1; that pre-existing difference is #34193. The new tests assert the `'error'` event, that the worker's `'exit'` handler ran, and that its argument equals the code the parent received, so they hold either way; the rethrowing-listener case already exits 1 and is asserted exactly.
- Verified (debug/ASAN build; every new test fails on a build without the `src/` change and passes with it):
  - `test/js/node/worker_threads/worker_threads.test.ts`, new `describe` (10 subprocess tests: immediate and timer last turns, with and without a top-level await, listener handling / rethrowing, `'beforeExit'` suppressed, `'beforeExit'`-scheduled and `'beforeExit'`-made rejections, reported-before-queued-task ordering, `process.exit(0)` from `'beforeExit'`, and a same-turn `.catch` control that passes both ways); whole file 132 pass.
  - `test/js/web/workers/worker.test.ts` "error event" (Web Worker kind, in-process).
  - `test/js/node/process/process.test.js` `process.onBeforeExit`: three main-thread tests (no `'beforeExit'` after a fatal last-turn rejection; listener-scheduled work runs before `'beforeExit'`; `'beforeExit'`-scheduled rejection reported before any re-emit), each matching Node v26 output byte for byte.
  - `test/js/bun/repl/repl.test.ts` `-e` last-turn rejection.
  - Unchanged and passing: 68 upstream tests (`test-promise-unhandled-*`, `test-promises-*`, `test-process-beforeexit*`, `test-beforeexit-event-exit`, `test-process-exit-code*`, `test-process-exception-capture*`, `test-microtask-*`, `test-next-tick-*`, `test-worker-*` lifecycle), `repl.test.ts` (149), `cli/hot/hot.test.ts` and `watch.test.ts`, `node/process/` (the only failures there are local-environment ones, identical on a build without this change), `node-timers`, `setImmediate`, `microtask`, `bun:test` runner tests, `event-emitter`, and the worker suites.

### Background
- Rejected-promise list: JSC calls `promiseRejectionTracker` when a promise is rejected with no handler; Bun appends it to a per-global list. `handleRejectedPromises()` walks the list and, for each promise still unhandled, calls `VirtualMachine::unhandled_rejection`, which emits `process`'s `'unhandledRejection'` or, with no listener, calls the VM's `on_unhandled_rejection` hook (main thread: print and exit 1; worker: post `'error'` to the parent, run the worker's `'exit'` handlers, request the worker's stop). Attaching a handler before the walk takes the promise off the list, so a `.catch` added in the same turn's microtasks is never reported, as in Node.
- `tick()` runs the event loop's task queue and microtasks, then walks the list. `auto_tick()` / `auto_tick_active()` run immediates, poll I/O and fire timers; run loops alternate `tick()` with one of them. `auto_tick()` (used where the caller waits for something specific, e.g. the test runner) walked the list at its end; `auto_tick_active()` (the general run loops and the `'beforeExit'` drain) did not.
- Exit code 13: Node's code for "the entry module's top-level await never settled"; a worker applies it when its loop drains with the entry promise still pending and nothing chose another code.

<details>
<summary>Behaviour matrix (parent-observed for workers; stdout for the main thread)</summary>

| case | main before | this PR | node v26 |
|---|---|---|---|
| worker: immediate rejects, TLA pending | no error, exit 13 | error, exit handler ran, exit 0 | error, exit 1 |
| worker: same, `'unhandledRejection'` listener handles it | listener never runs, 13 | listener runs, 13 | same as PR |
| worker: same, listener rethrows | listener never runs, 13 | listener, error, exit 1 | same as PR |
| worker: timer rejects, no TLA | no error, exit 0 | error, exit 0 | error, exit 1 |
| worker: `'beforeExit'` listener present, immediate rejects | beforeExit, no error, 0 | error, no beforeExit, 0 | error, no beforeExit, 1 |
| worker: immediate posts a port message then rejects | task, then listener | listener, then task | same as PR |
| worker: `'beforeExit'` schedules a rejecting immediate | beforeExit x2, no error | beforeExit x1, error | beforeExit x1, error, 1 |
| worker: `'beforeExit'` listener rejects directly | no error, 0 | error, 0 | error, 1 |
| worker: `'beforeExit'` calls `process.exit(0)`, TLA pending | 13 | 0 | 0 |
| main: `'beforeExit'` listener present, timer rejects | `beforeExit`, `exit`, 1 | `exit`, 1 | same as PR |
| main: listener handles it and sets a timer | beforeExit, listener; timer never fires | listener, timer, beforeExit, 0 | same as PR |
| main: `'beforeExit'` schedules a rejecting immediate (listener) | beforeExit, beforeExit, listener | beforeExit, listener, beforeExit | same as PR |
| `bun repl -e`, timer rejects | nothing | listener runs | n/a |

The remaining exit-code difference on the default worker path (0 vs 1) is #34193's. A worker's own `process.stderr` writes from an `'exit'` handler can still be lost on these paths (#34340), so the tests report through `parentPort`.
</details>

<details>
<summary>Earlier revision of this PR</summary>

The first revision drained only inside the worker's loop (after each `auto_tick_active()`) and after its `on_before_exit()`. Review pointed out that this re-implemented the missing tail of `auto_tick_active()` in one of its callers while the same gap stayed in `repl -e`, watch mode, the main thread's `'beforeExit'` ordering and `on_before_exit()`'s own loop, and that no test distinguished the in-loop placement from a single drain after the loop. The current revision moves the drain into `auto_tick_active()` and adds the main-thread, REPL, ordering and `'beforeExit'` tests.
</details>
