### PR TITLE
Bun.serve: only treat a route segment as a parameter when it starts with ':'

### DIFF
--- a/docs/runtime/http/routing.mdx
+++ b/docs/runtime/http/routing.mdx
@@ -124,6 +124,8 @@ Bun.serve({
 });
 ```
 
+A path segment is a parameter only when it starts with `:`, and the parameter captures the whole segment. A `:` anywhere else in a segment is matched literally, so `/files:batchGet/:id` has a single parameter, `id`. A parameter segment cannot contain a second `:` (for example `/range/:from-:to`); `Bun.serve()` throws for such routes.
+
 Bun automatically decodes percent-encoded route parameter values, including Unicode characters. Bun replaces invalid Unicode with the Unicode replacement character (`\uFFFD`).
 
 ### Static responses

--- a/packages/bun-types/serve.d.ts
+++ b/packages/bun-types/serve.d.ts
@@ -520,15 +520,17 @@ declare module "bun" {
   }
 
   namespace Serve {
+    /**
+     * A path segment is a parameter only when it starts with `:`; a `:` anywhere
+     * else in a segment is literal text (`/files:batchGet/:id` has one parameter, `id`).
+     */
     type ExtractRouteParams<T> = string extends T
       ? Record<string, string>
-      : T extends `${string}:${infer Param}/${infer Rest}`
-        ? { [K in Param]: string } & ExtractRouteParams<Rest>
-        : T extends `${string}:${infer Param}`
+      : T extends `${string}/:${infer Param}/${infer Rest}`
+        ? { [K in Param]: string } & ExtractRouteParams<`/${Rest}`>
+        : T extends `${string}/:${infer Param}`
           ? { [K in Param]: string }
-          : T extends `${string}*`
-            ? {}
-            : {};
+          : {};
 
     /**
      * Development configuration for {@link Bun.serve}

--- a/src/jsc/bindings/ServerRouteList.cpp
+++ b/src/jsc/bindings/ServerRouteList.cpp
@@ -126,32 +126,24 @@ private:
             ZigString rawPath = paths[i];
             WTF::String path = Zig::toString(rawPath);
             uint32_t originalIdentifierIndex = m_pathIdentifiers.size();
-            size_t startOfIdentifier = 0;
             size_t identifierCount = 0;
-            for (size_t j = 0; j < path.length(); j++) {
-                switch (path[j]) {
-                case '/': {
-                    if (startOfIdentifier && startOfIdentifier < j) {
-                        WTF::String&& identifier = path.substring(startOfIdentifier, j - startOfIdentifier);
-                        m_pathIdentifiers.append(JSC::Identifier::fromString(vm, identifier));
-                        identifierCount++;
-                    }
-                    startOfIdentifier = 0;
-                    break;
+
+            // Same grammar as uWS::HttpRouter::add(): the path splits on '/', and a
+            // segment is a parameter only when it starts with ':'. paramsObjectForRoute
+            // pairs these identifiers positionally with req->getParameter(i), so a ':'
+            // inside a literal segment must not produce one.
+            size_t segmentStart = 0;
+            while (segmentStart < path.length()) {
+                size_t segmentEnd = path.find('/', segmentStart);
+                if (segmentEnd == WTF::notFound) {
+                    segmentEnd = path.length();
                 }
-                case ':': {
-                    startOfIdentifier = j + 1;
-                    break;
+                if (segmentEnd > segmentStart && path[segmentStart] == ':') {
+                    WTF::String identifier = path.substring(segmentStart + 1, segmentEnd - segmentStart - 1);
+                    m_pathIdentifiers.append(JSC::Identifier::fromString(vm, identifier));
+                    identifierCount++;
                 }
-                default: {
-                    break;
-                }
-                }
-            }
-            if (startOfIdentifier && startOfIdentifier < path.length()) {
-                WTF::String&& identifier = path.substring(startOfIdentifier, path.length() - startOfIdentifier);
-                m_pathIdentifiers.append(JSC::Identifier::fromString(vm, identifier));
-                identifierCount++;
+                segmentStart = segmentEnd + 1;
             }
 
             pathIdentifierRanges[0] = { static_cast<uint16_t>(originalIdentifierIndex), static_cast<uint16_t>(identifierCount) };

--- a/src/runtime/server/ServerConfig.rs
+++ b/src/runtime/server/ServerConfig.rs
@@ -641,21 +641,32 @@ fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
     // Already validated by the caller
     debug_assert!(!path.is_empty() && path[0] == b'/');
 
-    // For now, we don't support params that start with a number.
-    // Mostly because it makes the params object more complicated to implement and it's easier to cut scope this way for now.
-    let mut remaining = path;
+    // Same grammar as uWS::HttpRouter::add() and ServerRouteList.cpp: the path
+    // splits on '/', and a segment is a parameter only when it starts with ':'.
+    // A ':' anywhere else in a segment is literal text.
     let mut duped_route_names: StringHashMap<()> = StringHashMap::new();
-    while let Some(index) = strings::index_of_char(remaining, b':') {
-        remaining = &remaining[(index + 1) as usize..];
-        let end = strings::index_of_char(remaining, b'/')
-            .map(|i| i as usize)
-            .unwrap_or(remaining.len());
-        let route_name = &remaining[..end];
+    for segment in strings::split(&path[1..], b"/") {
+        let Some(route_name) = segment.strip_prefix(b":") else {
+            continue;
+        };
+
+        // For now, we don't support params that start with a number.
+        // Mostly because it makes the params object more complicated to implement and it's easier to cut scope this way for now.
         if !route_name.is_empty() && route_name[0].is_ascii_digit() {
             return Err(global.throw_todo(
                 b"Route parameter names cannot start with a number.\n\n\
                   If you run into this, please file an issue and we will add support for it.",
             ));
+        }
+
+        // The router captures the whole segment as the parameter's value, so
+        // ":id:verb" or ":from-:to" can neither be matched nor named.
+        if strings::contains_char(route_name, b':') {
+            return Err(global.throw_invalid_arguments(format_args!(
+                "Invalid route {}. A route parameter must span the whole path segment, so {} cannot contain another ':'",
+                bun_fmt::quote(path),
+                bun_fmt::quote(segment),
+            )));
         }
 
         let entry = bun_core::handle_oom(duped_route_names.get_or_put(route_name));
@@ -665,8 +676,6 @@ fn validate_route_name(global: &JSGlobalObject, path: &[u8]) -> JsResult<()> {
                   If you run into this, please file an issue and we will add support for it.",
             ));
         }
-
-        remaining = &remaining[end..];
     }
     Ok(())
 }

--- a/test/integration/bun-types/fixture/serve.ts
+++ b/test/integration/bun-types/fixture/serve.ts
@@ -7,6 +7,19 @@ Bun.serve({
     "/:id/:test": req => {
       expectType(req.params).is<{ id: string; test: string }>();
     },
+    "/orgs/:orgId/repos/:repoId/settings": req => {
+      expectType(req.params).is<{ orgId: string; repoId: string }>();
+    },
+    // A ':' that does not start a segment is literal text, not a parameter.
+    "/files:batchGet/:id": req => {
+      expectType(req.params).is<{ id: string }>();
+    },
+    "/v1:beta/:name/x": req => {
+      expectType(req.params).is<{ name: string }>();
+    },
+    "/static/*": req => {
+      expectType(req.params).is<{}>();
+    },
   },
   fetch: () => new Response("hello"),
   websocket: {

--- a/test/js/bun/http/bun-serve-routes.test.ts
+++ b/test/js/bun/http/bun-serve-routes.test.ts
@@ -721,6 +721,79 @@ describe("many route params", () => {
   });
 });
 
+describe("':' that does not start a segment is literal text", () => {
+  // uWS's router only treats a segment as a parameter when the segment starts with ':'.
+  // The params object has to use the same grammar, otherwise the identifiers it pairs
+  // with the router's captured values are shifted.
+  let server: Server;
+
+  beforeAll(() => {
+    server = Bun.serve({
+      port: 0,
+      fetch: () => new Response("fallback"),
+      routes: {
+        "/files:batchGet/:id": req => Response.json(req.params),
+        "/v1:beta/:name/x": req => Response.json(req.params),
+        "/users:search": req => Response.json(req.params),
+        "/:org/repos:list/:repo": req => Response.json(req.params),
+        "/docs:export/:id": {
+          GET: req => Response.json(req.params),
+        },
+      },
+    });
+    server.unref();
+  });
+
+  afterAll(() => {
+    server.stop(true);
+  });
+
+  it.each([
+    ["/files:batchGet/123", { id: "123" }],
+    ["/v1:beta/bob/x", { name: "bob" }],
+    ["/users:search", {}],
+    ["/oven-sh/repos:list/bun", { org: "oven-sh", repo: "bun" }],
+    ["/docs:export/7", { id: "7" }],
+  ])("%s only names the ':'-prefixed segments in req.params", async (path, params) => {
+    const res = await fetch(new URL(path, server.url));
+    expect(await res.json()).toEqual(params);
+    expect(res.status).toBe(200);
+  });
+
+  it.each(["/files/123", "/v1/bob/x", "/users", "/oven-sh/repos/bun"])("%s does not match", async path => {
+    const res = await fetch(new URL(path, server.url));
+    expect(await res.text()).toBe("fallback");
+  });
+});
+
+describe("route parameter validation uses the segment grammar", () => {
+  it.each(["/n/:id:undelete", "/range/:from-:to", "/:a:b/c"])(
+    "throws when a parameter segment contains another ':' (%s)",
+    path => {
+      expect(() => Bun.serve({ port: 0, routes: { [path]: () => new Response("test") } })).toThrow(
+        `Invalid route "${path}". A route parameter must span the whole path segment`,
+      );
+      expect(() => Bun.serve({ port: 0, routes: { [path]: { GET: () => new Response("test") } } })).toThrow(
+        `Invalid route "${path}". A route parameter must span the whole path segment`,
+      );
+    },
+  );
+
+  it("ignores the text after a ':' inside a literal segment", async () => {
+    // Neither the digit after "v1:" nor the "x" after "a:" is a parameter name.
+    await using server = Bun.serve({
+      port: 0,
+      routes: {
+        "/v1:2/:id": req => Response.json(req.params),
+        "/a:x/:x": req => Response.json(req.params),
+      },
+    });
+
+    expect(await fetch(new URL("/v1:2/5", server.url)).then(res => res.json())).toEqual({ id: "5" });
+    expect(await fetch(new URL("/a:x/1", server.url)).then(res => res.json())).toEqual({ x: "1" });
+  });
+});
+
 it("throws a validation error when a route parameter name starts with a number", () => {
   expect(() => {
     Bun.serve({


### PR DESCRIPTION
### Problem
- `Bun.serve({ routes })` builds `req.params` with shifted values when a route key has a `:` that is not the first byte of a segment:
  - `"/files:batchGet/:id"` served `/files:batchGet/123` gives `{ batchGet: "123", id: "" }` instead of `{ id: "123" }`
  - `"/v1:beta/:name/x"` gives `{ beta: "bob", name: "" }`
  - `"/n/:id:undelete"` gives `{ undelete: "42:undelete" }`, and also matches `/n/42`
- Cause: two grammars for the same route key.
  - The matcher (`packages/bun-uws/src/HttpRouter.h`, `add()` / `executeHandlers()`) splits on `/` and captures a segment only when its first byte is `:`. `files:batchGet` is a literal; `:id:undelete` is one whole-segment parameter.
  - The params builder (`src/jsc/bindings/ServerRouteList.cpp`, `finishCreation`) took every `:` in the key as the start of a name, so it produced more names than the router captures, and `paramsObjectForRoute` fills names positionally from `req->getParameter(i)` (out of range reads as `""`).
  - `validate_route_name` (`src/runtime/server/ServerConfig.rs`) used a third variant of the same scan, so it rejected `"/v1:2beta/:id"` (literal segment "starting with a digit") and `"/a:x/:x"` (as a "duplicate") while accepting the keys above.

### Fix
- `ServerRouteList.cpp`: build the identifier list per segment with the router's rule (segment starts with `:`), so there is exactly one name per captured value. This is the line that fixes the reported output.
- `ServerConfig.rs`: `validate_route_name` uses the same split. The leading-digit and duplicate checks now only look at real parameter names, and a parameter segment containing a second `:` (`":id:undelete"`, `":from-:to"`) throws `Invalid route "...". A route parameter must span the whole path segment, ...`, since the router can only capture the whole segment and there is no correct params object for such a key. This is the one behavior change for previously accepted keys; those keys never worked as written. The check stays in `validate_route_name` (handler routes), which is where the existing parameter-name rules live; static `Response`/HTML routes have no params object and are unchanged.
- Prior art for the throw (survey output below): Express 5 and @koa/router (path-to-regexp 8) also reject `/:id:undelete` at registration; Fastify and Hono accept it as one parameter literally named `"id:undelete"`; Express 4 splits it into `id: "4"`, `undelete: "2"`. Express and Fastify support `/:from-:to` as two parameters, which Bun's router cannot match, so throwing now keeps that spelling available for a later addition instead of giving it a different meaning. A `:` inside a literal segment is a parameter in Express/Fastify (they spell a literal colon `\:` / `::`) but a literal in Bun's router, Hono's TrieRouter and PatternRouter; this PR keeps it literal because static routes already match such paths today.
- `packages/bun-types/serve.d.ts`: `ExtractRouteParams` only extracts names preceded by `/`, matching the runtime (`BunRequest<"/files:batchGet/:id">["params"]` is `{ id: string }`, previously `{ batchGet: string; id: string }`). Checked with tsc and tsgo; existing fixtures are unaffected.
- `docs/runtime/http/routing.mdx`: one paragraph stating the rule.
- Verified:
  - `test/js/bun/http/bun-serve-routes.test.ts`: new `':' that does not start a segment is literal text` and `route parameter validation uses the segment grammar` blocks. 9 of the new tests fail on the released 1.4.0 (shifted params, missing throw, and the digit / duplicate false rejections); the whole file (68 tests) passes with this change.
  - `test/integration/bun-types/fixture/serve.ts`: added `expectType` cases for the literal-colon keys; `bun test test/integration/bun-types/bun-types.test.ts` type checks pass.
  - `cargo clippy -p bun_runtime`, `cargo fmt --check`, clang-format check, and the byte-search source lint are clean.

### Background
- A route key such as `"/users/:id"` is registered verbatim with uWS's `HttpRouter`, which stores it as a tree of path segments. While matching a request, each segment of the request path is compared against the tree; a `:` node matches any non-empty segment and pushes that segment onto a parameter stack. The handler only sees that stack, indexed by position, through `req->getParameter(i)`.
- `ServerRouteList` is the JS-side companion: for each route key it precomputes the list of parameter names and a JSC `Structure` for the params object, and on each request it fills that object by position from the router's stack. The two sides agree only if both derive the same number of parameters from the key, which is what this change makes true.

<details>
<summary>Repro before / after</summary>

```ts
const s = Bun.serve({
  port: 0,
  routes: {
    "/files:batchGet/:id": req => Response.json(req.params),
    "/v1:beta/:name/x": req => Response.json(req.params),
    "/anon/:/:id": req => Response.json(req.params),
  },
  fetch: () => new Response("fallback"),
});
```

| request | before | after |
| --- | --- | --- |
| `/files:batchGet/123` | `{"batchGet":"123","id":""}` | `{"id":"123"}` |
| `/v1:beta/bob/x` | `{"beta":"bob","name":""}` | `{"name":"bob"}` |
| `/anon/a/b` | `{"id":"a"}` | `{"":"a","id":"b"}` |

`"/n/:id:undelete"` and `"/range/:from-:to"` previously registered silently; they now throw a `TypeError` from `Bun.serve()`. `"/v1:2beta/:id"` and `"/a:x/:x"` previously threw (digit / duplicate) and now register with params `{ id }` / `{ x }`.

</details>

<details>
<summary>Survey of other routers (Express 4.22, Express 5.2, @koa/router 15.7, Fastify 5.11 / find-my-way 9.7, Hono 4.13); each route registered on its own, then probed</summary>

```
## route "/files:batchGet/:id"
- find-my-way (Fastify's router)
    /files:batchGet/123 -> {"batchGet":":batchGet","id":"123"}
    /filesXYZ/123 -> {"batchGet":"XYZ","id":"123"}
    /files/123 -> {"batchGet":"","id":"123"}
- fastify
    /files:batchGet/123 -> {"batchGet":":batchGet","id":"123"}
    /filesXYZ/123 -> {"batchGet":"XYZ","id":"123"}
    /files/123 -> {"batchGet":"","id":"123"}
- hono
    /files:batchGet/123 -> {"batchGet":":batchGet"}
    /filesXYZ/123 -> {"batchGet":"XYZ"}
    /files/123 -> no match
- express 4 (path-to-regexp 0.1)
    /files:batchGet/123 -> {"batchGet":":batchGet","id":"123"}
    /filesXYZ/123 -> {"batchGet":"XYZ","id":"123"}
    /files/123 -> no match
- express 5 (path-to-regexp 8)
    /files:batchGet/123 -> {"batchGet":":batchGet","id":"123"}
    /filesXYZ/123 -> {"batchGet":"XYZ","id":"123"}
    /files/123 -> no match
- @koa/router 15 (path-to-regexp 8)
    /files:batchGet/123 -> {"batchGet":":batchGet","id":"123"}
    /filesXYZ/123 -> {"batchGet":"XYZ","id":"123"}
    /files/123 -> no match

## route "/n/:id:undelete"
- find-my-way (Fastify's router)
    /n/42:undelete -> {"id:undelete":"42:undelete"}
    /n/42 -> {"id:undelete":"42"}
    /n/42undelete -> {"id:undelete":"42undelete"}
- fastify
    /n/42:undelete -> {"id:undelete":"42:undelete"}
    /n/42 -> {"id:undelete":"42"}
    /n/42undelete -> {"id:undelete":"42undelete"}
- hono
    /n/42:undelete -> {"id:undelete":"42:undelete"}
    /n/42 -> {"id:undelete":"42"}
    /n/42undelete -> {"id:undelete":"42undelete"}
- express 4 (path-to-regexp 0.1)
    /n/42:undelete -> {"id":"4","undelete":"2:undelete"}
    /n/42 -> {"id":"4","undelete":"2"}
    /n/42undelete -> {"id":"4","undelete":"2undelete"}
- express 5 (path-to-regexp 8)
    throws at registration: Missing text before "undelete" param: /n/:id:undelete; visit https://git.new/pathToRegexpError for info
- @koa/router 15 (path-to-regexp 8)
    throws at registration: Missing text before "undelete" param: /n/:id:undelete; visit https://git.new/pathToRegexpError for info

## route "/range/:from-:to"
- find-my-way (Fastify's router)
    /range/1-2 -> {"from":"1","to":"2"}
    /range/1 -> no match
- fastify
    /range/1-2 -> {"from":"1","to":"2"}
    /range/1 -> no match
- hono
    /range/1-2 -> {"from-:to":"1-2"}
    /range/1 -> {"from-:to":"1"}
- express 4 (path-to-regexp 0.1)
    /range/1-2 -> {"from":"1","to":"2"}
    /range/1 -> no match
- express 5 (path-to-regexp 8)
    /range/1-2 -> {"from":"1","to":"2"}
    /range/1 -> no match
- @koa/router 15 (path-to-regexp 8)
    /range/1-2 -> {"from":"1","to":"2"}
    /range/1 -> no match

## route "/files::batchGet/:id"
- find-my-way (Fastify's router)
    /files:batchGet/123 -> {"id":"123"}
    /filesXYZ/123 -> no match
- fastify
    /files:batchGet/123 -> {"id":"123"}
    /filesXYZ/123 -> no match
- hono
    /files:batchGet/123 -> {":batchGet":":batchGet"}
    /filesXYZ/123 -> {":batchGet":"XYZ"}
- express 4 (path-to-regexp 0.1)
    /files:batchGet/123 -> {"batchGet":"batchGet","id":"123"}
    /filesXYZ/123 -> no match
- express 5 (path-to-regexp 8)
    throws at registration: Missing parameter name at index 7: /files::batchGet/:id; visit https://git.new/pathToRegexpError for info
- @koa/router 15 (path-to-regexp 8)
    throws at registration: Missing parameter name at index 7: /files::batchGet/:id; visit https://git.new/pathToRegexpError for info

## route "/files\\:batchGet/:id"
- find-my-way (Fastify's router)
    /files:batchGet/123 -> no match
    /filesXYZ/123 -> no match
- fastify
    /files:batchGet/123 -> no match
    /filesXYZ/123 -> no match
- hono
    /files:batchGet/123 -> no match
    /filesXYZ/123 -> no match
- express 4 (path-to-regexp 0.1)
    /files:batchGet/123 -> {"id":"123"}
    /filesXYZ/123 -> no match
- express 5 (path-to-regexp 8)
    /files:batchGet/123 -> {"id":"123"}
    /filesXYZ/123 -> no match
- @koa/router 15 (path-to-regexp 8)
    /files:batchGet/123 -> {"id":"123"}
    /filesXYZ/123 -> no match
```

Hono per router (its default picks RegExpRouter here):

```
## hono default
  /files:batchGet/:id  /files:batchGet/123 -> {"params":{"batchGet":":batchGet"},"routePath":"/files:batchGet/:id"}
  /files:batchGet/:id  /filesXYZ/123 -> {"params":{"batchGet":"XYZ"},"routePath":"/files:batchGet/:id"}
  /files:batchGet/:id  /files/123 -> no match (404)
  /files:batchGet/:id  /files:batchGet -> no match (404)
  /n/:id:undelete  /n/42:undelete -> {"params":{"id:undelete":"42:undelete"},"routePath":"/n/:id:undelete"}
  /n/:id:undelete  /n/42 -> {"params":{"id:undelete":"42"},"routePath":"/n/:id:undelete"}
  /range/:from-:to  /range/1-2 -> {"params":{"from-:to":"1-2"},"routePath":"/range/:from-:to"}
  /range/:from-:to  /range/1 -> {"params":{"from-:to":"1"},"routePath":"/range/:from-:to"}

## hono RegExpRouter
  /files:batchGet/:id  /files:batchGet/123 -> {"params":{"batchGet":":batchGet"},"routePath":"/files:batchGet/:id"}
  /files:batchGet/:id  /filesXYZ/123 -> {"params":{"batchGet":"XYZ"},"routePath":"/files:batchGet/:id"}
  /files:batchGet/:id  /files/123 -> no match (404)
  /files:batchGet/:id  /files:batchGet -> no match (404)
  /n/:id:undelete  /n/42:undelete -> {"params":{"id:undelete":"42:undelete"},"routePath":"/n/:id:undelete"}
  /n/:id:undelete  /n/42 -> {"params":{"id:undelete":"42"},"routePath":"/n/:id:undelete"}
  /range/:from-:to  /range/1-2 -> {"params":{"from-:to":"1-2"},"routePath":"/range/:from-:to"}
  /range/:from-:to  /range/1 -> {"params":{"from-:to":"1"},"routePath":"/range/:from-:to"}

## hono TrieRouter
  /files:batchGet/:id  /files:batchGet/123 -> {"params":{"id":"123"},"routePath":"/files:batchGet/:id"}
  /files:batchGet/:id  /filesXYZ/123 -> no match (404)
  /files:batchGet/:id  /files/123 -> no match (404)
  /files:batchGet/:id  /files:batchGet -> no match (404)
  /n/:id:undelete  /n/42:undelete -> {"params":{"id:undelete":"42:undelete"},"routePath":"/n/:id:undelete"}
  /n/:id:undelete  /n/42 -> {"params":{"id:undelete":"42"},"routePath":"/n/:id:undelete"}
  /range/:from-:to  /range/1-2 -> {"params":{"from-:to":"1-2"},"routePath":"/range/:from-:to"}
  /range/:from-:to  /range/1 -> {"params":{"from-:to":"1"},"routePath":"/range/:from-:to"}

## hono PatternRouter
  /files:batchGet/:id  /files:batchGet/123 -> {"params":{"id":"123"},"routePath":"/files:batchGet/:id"}
  /files:batchGet/:id  /filesXYZ/123 -> no match (404)
  /files:batchGet/:id  /files/123 -> no match (404)
  /files:batchGet/:id  /files:batchGet -> no match (404)
  /n/:id:undelete  /n/42:undelete -> {"params":{"id":"42"},"routePath":"/n/:id:undelete"}
  /n/:id:undelete  /n/42 -> no match (404)
  /range/:from-:to  /range/1-2 -> no match (404)
  /range/:from-:to  /range/1 -> no match (404)
```

</details>
