### PR TITLE
test(ffi): stop addr32.test.ts from leaving libaddr32.so in the test directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,6 +206,9 @@ core.[0-9]*
 # them on disk; keep ignored so they don't show as untracked).
 src/jsc/bindings/GeneratedJS2Native.zig
 src/jsc/bindings/GeneratedBindings.zig
+# Legacy output of test/js/bun/ffi/addr32.test.ts, which used to compile its
+# fixture into the source tree; checkouts that ran the old test still have it.
+/test/js/bun/ffi/libaddr32.so
 
 # Web Streams rewrite working notes (design docs, spec transcription, review logs).
 # Kept locally for the ongoing work; not part of the source tree.

--- a/test/js/bun/ffi/addr32.test.ts
+++ b/test/js/bun/ffi/addr32.test.ts
@@ -1,18 +1,14 @@
 import { CString, dlopen, FFIType } from "bun:ffi";
 import { jscDescribe } from "bun:jsc";
 import { expect, test } from "bun:test";
+import { compileFixture, isLinux } from "harness";
 import { join } from "node:path";
-import { isLinux } from "../../../harness";
 
 // Only runs on Linux because that is where we can most reliably allocate a 32-bit pointer.
-test.skipIf(!isLinux)("can use addresses encoded as int32s", async () => {
-  const compiler = Bun.spawn(["cc", "-shared", "-o", "libaddr32.so", "addr32.c"], {
-    cwd: __dirname,
+test.skipIf(!isLinux)("can use addresses encoded as int32s", () => {
+  const { symbols } = dlopen(compileFixture(join(import.meta.dir, "addr32.c")), {
+    addr32: { args: [], returns: FFIType.pointer },
   });
-  await compiler.exited;
-  expect(compiler.exitCode).toBe(0);
-
-  const { symbols } = dlopen(join(__dirname, "libaddr32.so"), { addr32: { args: [], returns: FFIType.pointer } });
   const addr = symbols.addr32()!;
   expect(addr).toBeGreaterThan(0);
   expect(addr).toBeLessThan(2 ** 31);


### PR DESCRIPTION
### Problem
- Running `test/js/bun/ffi/addr32.test.ts` on Linux leaves an untracked file behind in the source tree: `git status` shows `?? test/js/bun/ffi/libaddr32.so` afterwards.
- The file is not gitignored, so `git add -A` picks up a ~15 KB binary by accident. This has happened on work branches in this repo before (one commit added the file, the follow-up commit had to remove it again), though it has never reached main.
- Cause: `test/js/bun/ffi/addr32.test.ts:9` ran `cc -shared -o libaddr32.so addr32.c` with `cwd: __dirname` (the checked-in test directory), dlopen'd the result from there, and never removed it.

### Fix
- The test now gets the library from `compileFixture(join(import.meta.dir, "addr32.c"))`, which compiles into a fresh directory under the OS temp dir. Nothing is written into the source tree.
- This is the same helper `ffi.test.js` in the same directory already uses for its two C fixtures, so the directory's tests now all build fixtures the same way. `compileFixture` also passes `-fPIC`, which the hand-rolled `cc` invocation relied on the toolchain defaulting to.
- The compile step no longer needs to be awaited, so the test body is synchronous; the assertions on the returned address are unchanged.
- `.gitignore` gains an entry for the exact path `/test/js/bun/ffi/libaddr32.so`. The test change only stops new copies from being created; every checkout that ran the old test still has the file on disk, and that is the copy `git add -A` sweeps in. It follows the existing "legacy codegen outputs" entries right above it, which exist for the same reason. The entry is the exact path rather than `*.so` so it cannot hide anything else (no `.so`, `.dylib` or `.dll` file is tracked today, but a blanket pattern would silently swallow a future fixture).
- Test and `.gitignore` only, no `src/` changes.
- Verified:
  - `USE_SYSTEM_BUN=1 bun test test/js/bun/ffi/addr32.test.ts` on main: passes, then `git status --short test/js/bun/ffi/` shows `?? libaddr32.so`.
  - Same command with this change: passes, `git status` is clean, and the library is in `$TMPDIR/ffi-fixture-*/addr32.so`.
  - `bun bd test test/js/bun/ffi/addr32.test.ts`: passes.
  - `bun bd test test/js/bun/ffi/` (whole directory): tree is clean afterwards. The only failures were the pre-existing `integer identities work for all possible values` cases in `ffi.test.js` hitting the 5 s per-test timeout under the local debug+ASAN build, which this PR does not touch.
  - Stale-file case: with a `libaddr32.so` built the old way sitting in `test/js/bun/ffi/`, `git check-ignore -v` matches the new entry, and neither `git status` nor `git add -A --dry-run` lists it.

### Background
- `compileFixture(sourcePath)` (`test/harness.ts`) finds a C compiler on `$PATH`, builds `sourcePath` as a shared library into a `tmpdirSync("ffi-fixture-")` directory, caches the output path per process, and throws with the compiler's stderr on failure.
- `addr32.c` is the fixture the test loads. It mmaps a page in the low 2 GiB of the address space (Linux-only `MAP_FIXED_NOREPLACE`) and returns a pointer to it, so the test can check that `bun:ffi` accepts a pointer that JSC stores as an int32. That is why the test is `skipIf(!isLinux)` and why the compile has to happen inside the test body rather than at module scope.
- A `.gitignore` entry only affects untracked files. It keeps the stale copy out of `git status` and `git add -A` in existing checkouts; a branch that has already committed the file still needs a `git rm` there.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->