### PR TITLE
node:fs: report async recursive readdir failures as scandir

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2444,8 +2444,6 @@ mod _async_tasks {
                                     } else {
                                         &self.root_path[..self.root_path.len() - 1]
                                     };
-                                    // Like `NodeFS::readdir` does for the sync walk: Node reports
-                                    // every readdir failure as `scandir`, whichever syscall tripped.
                                     self.pending_err = Some(
                                         err.with_path_and_syscall(err_path, sys::Tag::scandir),
                                     );

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -2444,7 +2444,11 @@ mod _async_tasks {
                                     } else {
                                         &self.root_path[..self.root_path.len() - 1]
                                     };
-                                    self.pending_err = Some(err.with_path(err_path));
+                                    // Like `NodeFS::readdir` does for the sync walk: Node reports
+                                    // every readdir failure as `scandir`, whichever syscall tripped.
+                                    self.pending_err = Some(
+                                        err.with_path_and_syscall(err_path, sys::Tag::scandir),
+                                    );
                                 }
                             }
                             if self.subtask_count.fetch_sub(1, Ordering::Relaxed) == 1 {

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1774,8 +1774,6 @@ it.skipIf(isWindows)("promises.readdir({recursive: true}) settles when multiple 
 });
 
 // Node reports every readdir failure, recursive or not, as syscall "scandir".
-// The async recursive walk used to hand out the raw openat() error, so the
-// callback and promises forms said "open" where readdirSync said "scandir".
 describe("readdir({recursive: true}) reports failures as scandir", () => {
   const resultKinds = {
     paths: {},

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1773,6 +1773,96 @@ it.skipIf(isWindows)("promises.readdir({recursive: true}) settles when multiple 
   });
 });
 
+// Node reports every readdir failure, recursive or not, as syscall "scandir".
+// The async recursive walk used to hand out the raw openat() error, so the
+// callback and promises forms said "open" where readdirSync said "scandir".
+describe("readdir({recursive: true}) reports failures as scandir", () => {
+  const resultKinds = {
+    paths: {},
+    withFileTypes: { withFileTypes: true },
+    buffer: { encoding: "buffer" },
+  } as const;
+
+  type ErrorShape = { code: string; syscall: string; path: string; message: string };
+  const shape = (err: any): ErrorShape | undefined =>
+    err && { code: err.code, syscall: err.syscall, path: err.path, message: err.message };
+
+  async function readdirErrors(target: string, kind: keyof typeof resultKinds) {
+    const options: any = { recursive: true, ...resultKinds[kind] };
+
+    let syncError: unknown;
+    try {
+      readdirSync(target, options);
+    } catch (err) {
+      syncError = err;
+    }
+
+    const { promise: callbackError, resolve } = Promise.withResolvers<unknown>();
+    fs.readdir(target, options, err => resolve(err));
+    const promisesError = promises.readdir(target, options).then(
+      () => undefined,
+      err => err,
+    );
+
+    return {
+      sync: shape(syncError),
+      callback: shape(await callbackError),
+      promises: shape(await promisesError),
+    };
+  }
+
+  describe.each(Object.keys(resultKinds) as (keyof typeof resultKinds)[])("%s", kind => {
+    it.concurrent("root does not exist", async () => {
+      using dir = tempDir("readdir-recursive-scandir-enoent", {});
+      const target = join(String(dir), "missing");
+      const expected: ErrorShape = {
+        code: "ENOENT",
+        syscall: "scandir",
+        path: target,
+        message: `ENOENT: no such file or directory, scandir '${target}'`,
+      };
+      expect(await readdirErrors(target, kind)).toEqual({ sync: expected, callback: expected, promises: expected });
+    });
+
+    it.concurrent("root is a file", async () => {
+      using dir = tempDir("readdir-recursive-scandir-enotdir", { "file.txt": "x" });
+      const target = join(String(dir), "file.txt");
+      const expected: ErrorShape = {
+        code: "ENOTDIR",
+        syscall: "scandir",
+        path: target,
+        message: `ENOTDIR: not a directory, scandir '${target}'`,
+      };
+      expect(await readdirErrors(target, kind)).toEqual({ sync: expected, callback: expected, promises: expected });
+    });
+
+    // Needs an unreadable directory: root bypasses mode bits and Windows has none.
+    it.skipIf(isWindows || process.getuid?.() === 0).concurrent("subdirectory is unreadable", async () => {
+      using dir = tempDir("readdir-recursive-scandir-eacces", { "keep.txt": "x", locked: {} });
+      const locked = join(String(dir), "locked");
+      fs.chmodSync(locked, 0o000);
+      try {
+        const errors = await readdirErrors(String(dir), kind);
+        // The async walk names the directory that failed, like Node does.
+        // (readdirSync names the root instead; its err.path is not asserted here.)
+        const expected: ErrorShape = {
+          code: "EACCES",
+          syscall: "scandir",
+          path: locked,
+          message: `EACCES: permission denied, scandir '${locked}'`,
+        };
+        expect({ callback: errors.callback, promises: errors.promises }).toEqual({
+          callback: expected,
+          promises: expected,
+        });
+        expect(errors.sync).toMatchObject({ code: "EACCES", syscall: "scandir" });
+      } finally {
+        fs.chmodSync(locked, 0o755);
+      }
+    });
+  });
+});
+
 describe("readSync", () => {
   it("rejects the read when the length argument detaches the destination buffer during coercion", () => {
     const fd = openSync(import.meta.dir + "/readFileSync.txt", "r");


### PR DESCRIPTION
### Problem
- `fs.readdir(path, { recursive: true }, cb)` and `fs.promises.readdir(path, { recursive: true })` report `err.syscall === "open"` (message `ENOENT: no such file or directory, open 'nope'`) when the root cannot be opened. `readdirSync` with the same arguments, and Node for all three forms, report `scandir`.
- Same for a root that is a regular file (`ENOTDIR`) and for a subdirectory that fails mid-walk (`EACCES`): Node says `scandir '<subdir>'`, Bun says `open '<subdir>'`.
- Cause: the sync path wraps whatever the walk returned into a `scandir` error (`NodeFS::readdir`, src/runtime/node/node_fs.rs:6316), but the async recursive task stores the walk's error as-is. `AsyncReaddirRecursiveTask::perform_work` (node_fs.rs:2447) only re-attaches the path, so the `openat` tag from `readdir_with_entries_recursive_async` (node_fs.rs:6503/6506; a `getdents64` / `NtQueryDirectoryFile` tag from the iterator on the other arms) reaches JS.

### Fix
- `perform_work` records the pending error with `with_path_and_syscall(err_path, sys::Tag::scandir)` instead of `with_path(err_path)`. Every error the async walk can produce goes through this one line, so the JS-visible syscall is `scandir` no matter which syscall failed, which is what the sync path already does and what Node does (`uv_fs_scandir` is the only syscall Node's readdir reports, for the root and for every subdirectory of a recursive listing).
- The path attached by the walk is unchanged: the root for root failures, the failing subdirectory for mid-walk failures, both as in Node.
- Verified with `test/js/node/fs/fs.test.ts` (`readdir({recursive: true}) reports failures as scandir`): 9 cases (paths / withFileTypes / buffer results, each for a missing root, a file as root, and an unreadable subdirectory), asserting `code`, `syscall`, `path` and `message` of the sync, callback and promises forms. The unreadable-subdirectory case is skipped as root (the gate and root CI lanes still run the other 6) and was run here as an unprivileged user: all 9 fail on bun 1.4.0, all 9 pass with this change.
- Expected values were taken from node v26.3.0 on the same fixtures (including the `EACCES` subdirectory case as an unprivileged user).
- Also ran the rest of the readdir tests in `fs.test.ts`, `test/js/node/test/parallel/test-fs-readdir*.js`, and `readdirSync-recursive-error-leak.test.ts` against the debug build.

### Background
- Node implements `readdir` (recursive or not) on top of libuv's `uv_fs_scandir`, so its errors always carry `syscall: "scandir"`; a recursive listing is a series of scandir calls, one per directory, and the error names the directory whose scandir failed.
- Bun's non-recursive and sync recursive readdir run inside `NodeFS::readdir`, which converts any failure into a `scandir` error before it reaches JS. The async recursive variant is a separate thread-pool task (`AsyncReaddirRecursiveTask`): each directory is a subtask that calls `readdir_with_entries_recursive_async`, and the first subtask to fail stores its error in `pending_err`, which `then` turns into the rejection. That store is the only place the async variant shapes its error, and it was skipping the syscall normalization.
- `bun_sys::Error::with_path_and_syscall` is the existing helper for "keep the errno, set the path and the JS-visible syscall name"; the sync truncate/utimes paths use it the same way.

<details>
<summary>Repro (bun 1.4.0 vs node v26.3.0)</summary>

```js
const fs = require("fs");
try { fs.readdirSync("nope", { recursive: true }); } catch (e) { console.log("sync", e.syscall, e.message); }
fs.readdir("nope", { recursive: true }, (e) => console.log("cb", e.syscall, e.message));
require("fs/promises").readdir("nope", { recursive: true }).catch((e) => console.log("promises", e.syscall, e.message));
```

bun 1.4.0:

```
sync scandir ENOENT: no such file or directory, scandir 'nope'
cb open ENOENT: no such file or directory, open 'nope'
promises open ENOENT: no such file or directory, open 'nope'
```

node v26.3.0 prints `scandir` / `..., scandir 'nope'` on all three lines. With this change bun does too.

Mid-walk failure as an unprivileged user (`root/locked` is mode 000), node:

```
cb  {"syscall":"scandir","code":"EACCES","path":".../root/locked","message":"EACCES: permission denied, scandir '.../root/locked'"}
```

bun 1.4.0 printed the same object with `open` in place of `scandir`; with this change it matches. (`readdirSync` reports the root instead of `locked` in `err.path` on both versions; that is a separate sync-walker issue and is not touched here.)
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->