### PR TITLE
bun:ffi: stop cc() from turning non-numeric pointer arguments into garbage pointers

### DIFF
--- a/src/jsc/bindings/JSCFFIBridge.cpp
+++ b/src/jsc/bindings/JSCFFIBridge.cpp
@@ -123,18 +123,15 @@ extern "C" void Bun__JSCFFICallbackClose(JSC::EncodedJSValue callbackValue)
         callback->close();
 }
 
-// JSVALUE_TO_PTR_SLOW for the wrappers cc() compiles (src/runtime/ffi/FFI.h). The wrapper converts
-// numbers, typed arrays and null inline; everything else (JSCallback, ArrayBuffer, BigInt, an object
-// with a numeric `ptr`, junk) gets the same conversion dlopen()'d symbols get, TypeErrors included.
-// No string arena is passed: nothing would free a transcoded `cstring` after the native call, so a
-// JavaScript string throws here instead.
+// JSVALUE_TO_PTR_SLOW in the wrappers cc() compiles (src/runtime/ffi/FFI.h).
 extern "C" void* Bun__FFI__jsValueToPointerSlow(JSC::JSGlobalObject* globalObject, int32_t abiType, bool* threw, JSC::EncodedJSValue encodedValue)
 {
     auto& vm = JSC::getVM(globalObject);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
     uint64_t slot = 0;
-    JSC::FFI::writeSlotFromJSValue(globalObject, globalObject->ffiContext(), static_cast<JSC::FFI::Type>(abiType), JSC::JSValue::decode(encodedValue), slot, nullptr);
+    // No string arena: nothing would free a transcoded cstring after the native call, so JS strings throw.
+    JSC::FFI::writeSlotFromJSValue(globalObject, globalObject->ffiContext(), static_cast<JSC::FFI::Type>(abiType), JSC::JSValue::decode(encodedValue), slot, /* arena */ nullptr);
     if (scope.exception()) [[unlikely]] {
         *threw = true;
         return nullptr;

--- a/src/jsc/bindings/JSCFFIBridge.cpp
+++ b/src/jsc/bindings/JSCFFIBridge.cpp
@@ -2,6 +2,7 @@
 #include "root.h"
 
 #include <JavaScriptCore/BunFFI.h>
+#include <JavaScriptCore/FFIConversions.h>
 #include <JavaScriptCore/FFISignature.h>
 #include <JavaScriptCore/FFIType.h>
 #include <JavaScriptCore/FFIContext.h>
@@ -17,6 +18,8 @@
 
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::Char) == 0, "FFI::Type tag drift");
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::Pointer) == 12, "FFI::Type tag drift");
+static_assert(static_cast<uint8_t>(JSC::FFI::Type::CString) == 14, "FFI::Type tag drift");
+static_assert(static_cast<uint8_t>(JSC::FFI::Type::Function) == 17, "FFI::Type tag drift");
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::JSValue) == 19, "FFI::Type tag drift");
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::Buffer) == 20, "FFI::Type tag drift");
 static_assert(static_cast<uint8_t>(JSC::FFI::Type::BufferLength) == 21, "FFI::Type tag drift");
@@ -118,4 +121,23 @@ extern "C" void Bun__JSCFFICallbackClose(JSC::EncodedJSValue callbackValue)
 {
     if (auto* callback = dynamicDowncast<JSC::JSFFICallback>(JSC::JSValue::decode(callbackValue)))
         callback->close();
+}
+
+// JSVALUE_TO_PTR_SLOW for the wrappers cc() compiles (src/runtime/ffi/FFI.h). The wrapper converts
+// numbers, typed arrays and null inline; everything else (JSCallback, ArrayBuffer, BigInt, an object
+// with a numeric `ptr`, junk) gets the same conversion dlopen()'d symbols get, TypeErrors included.
+// No string arena is passed: nothing would free a transcoded `cstring` after the native call, so a
+// JavaScript string throws here instead.
+extern "C" void* Bun__FFI__jsValueToPointerSlow(JSC::JSGlobalObject* globalObject, int32_t abiType, bool* threw, JSC::EncodedJSValue encodedValue)
+{
+    auto& vm = JSC::getVM(globalObject);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    uint64_t slot = 0;
+    JSC::FFI::writeSlotFromJSValue(globalObject, globalObject->ffiContext(), static_cast<JSC::FFI::Type>(abiType), JSC::JSValue::decode(encodedValue), slot, nullptr);
+    if (scope.exception()) [[unlikely]] {
+        *threw = true;
+        return nullptr;
+    }
+    return reinterpret_cast<void*>(static_cast<uintptr_t>(slot));
 }

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -125,6 +125,8 @@ napi_value asNapiValue;
 
 EncodedJSValue ValueUndefined = { TagValueUndefined };
 EncodedJSValue ValueTrue = { TagValueTrue };
+// What a host function returns after throwing; JSC unwinds to the pending exception and ignores it.
+EncodedJSValue ValueEmpty = { 0 };
 
 typedef void* JSContext;
 
@@ -159,7 +161,13 @@ static EncodedJSValue FLOAT_TO_JSVALUE(float val) __attribute__((__always_inline
 static EncodedJSValue BOOLEAN_TO_JSVALUE(bool val) __attribute__((__always_inline__));
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) __attribute__((__always_inline__));
 
-static void* JSVALUE_TO_PTR(EncodedJSValue val) __attribute__((__always_inline__));
+// The engine's pointer-argument conversion, shared with dlopen()'d symbols. `abiType` is one of
+// the ABI_TYPE_* tags the runtime defines when it compiles this file. Throws a TypeError for values
+// that cannot become a pointer and sets `*threw`, in which case the generated wrapper returns
+// without calling the native function.
+void* JSVALUE_TO_PTR_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t val);
+static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
+static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) __attribute__((__always_inline__));
 static float JSVALUE_TO_FLOAT(EncodedJSValue val) __attribute__((__always_inline__));
 static double JSVALUE_TO_DOUBLE(EncodedJSValue val) __attribute__((__always_inline__));
@@ -207,21 +215,35 @@ static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) {
 // Now, they're stored at the beginning of the 64-bit value
 // This behavior change enables the JIT to handle it better
 // It also is better readability when console.log(myPtr)
-static void* JSVALUE_TO_PTR(EncodedJSValue val) {
-  if (val.asInt64 == TagValueNull)
-    return 0;
+static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) {
+  if (JSVALUE_IS_INT32(val)) {
+    return (void*)(uintptr_t)JSVALUE_TO_INT32(val);
+  }
+
+  if (JSVALUE_IS_NUMBER(val)) {
+    val.asInt64 -= DoubleEncodeOffset;
+    return (void*)(uintptr_t)val.asDouble;
+  }
 
   if (JSCELL_IS_TYPED_ARRAY(val)) {
     return JSVALUE_TO_TYPED_ARRAY_VECTOR(val);
   }
 
-  if (JSVALUE_IS_INT32(val)) {
-    return (void*)(uintptr_t)JSVALUE_TO_INT32(val);
+  // A null callback is a TypeError (decided by the slow path), like it is for dlopen().
+  if (val.asInt64 == TagValueNull && abiType != ABI_TYPE_FUNCTION)
+    return 0;
+
+  // JSCallback, ArrayBuffer, BigInt, objects with a numeric `ptr`, undefined, strings, ...
+  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, abiType, threw, val.asInt64);
+}
+
+static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) {
+  if (JSCELL_IS_TYPED_ARRAY(val)) {
+    return JSVALUE_TO_TYPED_ARRAY_VECTOR(val);
   }
 
-  // Assume the JSValue is a double
-  val.asInt64 -= DoubleEncodeOffset;
-  return (void*)(uintptr_t)val.asDouble;
+  // Only views are accepted; the slow path throws for everything else.
+  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, ABI_TYPE_BUFFER, threw, val.asInt64);
 }
 
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -164,7 +164,6 @@ static EncodedJSValue PTR_TO_JSVALUE(void* ptr) __attribute__((__always_inline__
 // The engine's conversion (the one dlopen()'d symbols use); on a non-pointer it throws and sets *threw.
 void* JSVALUE_TO_PTR_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t val);
 static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
-static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) __attribute__((__always_inline__));
 static float JSVALUE_TO_FLOAT(EncodedJSValue val) __attribute__((__always_inline__));
 static double JSVALUE_TO_DOUBLE(EncodedJSValue val) __attribute__((__always_inline__));
@@ -213,34 +212,29 @@ static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) {
 // This behavior change enables the JIT to handle it better
 // It also is better readability when console.log(myPtr)
 static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) {
-  if (JSVALUE_IS_INT32(val)) {
-    return (void*)(uintptr_t)JSVALUE_TO_INT32(val);
+  // TinyCC does not inline, so the tag tests are spelled out instead of calling the helpers above.
+  int64_t bits = val.asInt64;
+
+  if (!(bits & NotCellMask)) {
+    uint8_t type = *(uint8_t*)((char*)val.asPtr + JSCell__offsetOfType);
+    if (type >= JSTypeArrayBufferViewMin && type <= JSTypeArrayBufferViewMax)
+      return *(void**)((char*)val.asPtr + JSArrayBufferView__offsetOfVector);
+  } else if (abiType != ABI_TYPE_BUFFER) {
+    if ((bits & NumberTag) == NumberTag)
+      return (void*)(uintptr_t)(int32_t)bits;
+
+    if (bits & NumberTag) {
+      val.asInt64 = bits - DoubleEncodeOffset;
+      return (void*)(uintptr_t)(int64_t)val.asDouble;
+    }
+
+    // null and undefined are NULL, except as a callback, where the slow path throws like dlopen() does.
+    if ((bits & ~UndefinedTag) == TagValueNull && abiType != ABI_TYPE_FUNCTION)
+      return 0;
   }
 
-  if (JSVALUE_IS_NUMBER(val)) {
-    val.asInt64 -= DoubleEncodeOffset;
-    return (void*)(uintptr_t)val.asDouble;
-  }
-
-  if (JSCELL_IS_TYPED_ARRAY(val)) {
-    return JSVALUE_TO_TYPED_ARRAY_VECTOR(val);
-  }
-
-  // A null callback is a TypeError (decided by the slow path), like it is for dlopen().
-  if (val.asInt64 == TagValueNull && abiType != ABI_TYPE_FUNCTION)
-    return 0;
-
-  // JSCallback, ArrayBuffer, BigInt, objects with a numeric `ptr`, undefined, strings, ...
-  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, abiType, threw, val.asInt64);
-}
-
-static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) {
-  if (JSCELL_IS_TYPED_ARRAY(val)) {
-    return JSVALUE_TO_TYPED_ARRAY_VECTOR(val);
-  }
-
-  // Only views are accepted; the slow path throws for everything else.
-  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, ABI_TYPE_BUFFER, threw, val.asInt64);
+  // Other cells (JSCallback, ArrayBuffer, BigInt, objects with a `ptr`, strings), non-views for 'buffer', junk.
+  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, abiType, threw, bits);
 }
 
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -161,10 +161,7 @@ static EncodedJSValue FLOAT_TO_JSVALUE(float val) __attribute__((__always_inline
 static EncodedJSValue BOOLEAN_TO_JSVALUE(bool val) __attribute__((__always_inline__));
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) __attribute__((__always_inline__));
 
-// The engine's pointer-argument conversion, shared with dlopen()'d symbols. `abiType` is one of
-// the ABI_TYPE_* tags the runtime defines when it compiles this file. Throws a TypeError for values
-// that cannot become a pointer and sets `*threw`, in which case the generated wrapper returns
-// without calling the native function.
+// The engine's conversion (the one dlopen()'d symbols use); on a non-pointer it throws and sets *threw.
 void* JSVALUE_TO_PTR_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t val);
 static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
 static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -143,7 +143,7 @@ static ABI_TABLE: [AbiRow; 22] = {
     /* Function  */ r(b"void*",      Some("JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_FUNCTION, &threw, "), Some(("PTR_TO_JSVALUE(", ")"))),
     /* NapiEnv   */ r(b"napi_env",   None,                                                                 None),
     /* NapiValue */ r(b"napi_value", None,                                                                 Some(("((EncodedJSValue) {.asNapiValue = ", " } )"))),
-    /* Buffer    */ r(b"void*",      Some("JSVALUE_TO_BUFFER(JS_GLOBAL_OBJECT, &threw, "),                 None),
+    /* Buffer    */ r(b"void*",      Some("JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_BUFFER, &threw, "),   None),
     /* BufferLen */ r(b"uint64_t",   None,                                                                 None),
     ]
 };

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -161,8 +161,7 @@ impl ABIType {
     /// See [`ABI_TYPE_LABEL`].
     pub(crate) const LABEL: &'static __ComptimeStringMap_ABI_TYPE_LABEL = &ABI_TYPE_LABEL;
 
-    /// Preprocessor definitions every generated wrapper is compiled with: the tags `FFI.h` and the
-    /// `to_c` conversions in [`ABI_TABLE`] hand to `JSVALUE_TO_PTR_SLOW`.
+    /// `#define`d into every generated wrapper; `FFI.h` passes them to `JSVALUE_TO_PTR_SLOW`.
     pub(crate) const POINTER_TAG_DEFINES: &'static [(&'static str, i64)] = &[
         ("ABI_TYPE_PTR", ABIType::Ptr as i64),
         ("ABI_TYPE_CSTRING", ABIType::CString as i64),
@@ -218,8 +217,7 @@ impl ABIType {
         matches!(self, ABIType::Double | ABIType::Float)
     }
 
-    /// Argument conversions that may throw (see `JSVALUE_TO_PTR_SLOW` in `FFI.h`). The generated
-    /// wrapper converts these into locals and stops before the native call if one of them threw.
+    /// Argument conversions that go through `JSVALUE_TO_PTR_SLOW` (`FFI.h`) and so can throw.
     pub(crate) fn arg_conversion_can_throw(self) -> bool {
         matches!(
             self,

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -123,28 +123,28 @@ static ABI_TABLE: [AbiRow; 22] = {
         AbiRow { c_type, to_c_macro, to_js }
     }
     [
-    /* Char      */ r(b"char",       Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Int8T     */ r(b"int8_t",     Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Uint8T    */ r(b"uint8_t",    Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Int16T    */ r(b"int16_t",    Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Uint16T   */ r(b"uint16_t",   Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Int32T    */ r(b"int32_t",    Some("JSVALUE_TO_INT32("),               Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
-    /* Uint32T   */ r(b"uint32_t",   Some("JSVALUE_TO_INT32("),               Some(("UINT32_TO_JSVALUE(", ")"))),
-    /* Int64T    */ r(b"int64_t",    Some("JSVALUE_TO_INT64("),               Some(("INT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
-    /* Uint64T   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64("),              Some(("UINT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
-    /* Double    */ r(b"double",     Some("JSVALUE_TO_DOUBLE("),              Some(("DOUBLE_TO_JSVALUE(", ")"))),
-    /* Float     */ r(b"float",      Some("JSVALUE_TO_FLOAT("),               Some(("FLOAT_TO_JSVALUE(", ")"))),
-    /* Bool      */ r(b"bool",       Some("JSVALUE_TO_BOOL("),                Some(("BOOLEAN_TO_JSVALUE(", ")"))),
-    /* Ptr       */ r(b"void*",      Some("JSVALUE_TO_PTR("),                 Some(("PTR_TO_JSVALUE(", ")"))),
-    /* Void      */ r(b"void",       None,                                    None),
-    /* CString   */ r(b"void*",      Some("JSVALUE_TO_PTR("),                 Some(("PTR_TO_JSVALUE(", ")"))),
-    /* I64Fast   */ r(b"int64_t",    Some("JSVALUE_TO_INT64("),               Some(("INT64_TO_JSVALUE(JS_GLOBAL_OBJECT, (int64_t)", ")"))),
-    /* U64Fast   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64("),              Some(("UINT64_TO_JSVALUE(JS_GLOBAL_OBJECT, ", ")"))),
-    /* Function  */ r(b"void*",      Some("JSVALUE_TO_PTR("),                 Some(("PTR_TO_JSVALUE(", ")"))),
-    /* NapiEnv   */ r(b"napi_env",   None,                                    None),
-    /* NapiValue */ r(b"napi_value", None,                                    Some(("((EncodedJSValue) {.asNapiValue = ", " } )"))),
-    /* Buffer    */ r(b"void*",      Some("JSVALUE_TO_TYPED_ARRAY_VECTOR("),  None),
-    /* BufferLen */ r(b"uint64_t",   None,                                    None),
+    /* Char      */ r(b"char",       Some("JSVALUE_TO_INT32("),                                            Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Int8T     */ r(b"int8_t",     Some("JSVALUE_TO_INT32("),                                            Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Uint8T    */ r(b"uint8_t",    Some("JSVALUE_TO_INT32("),                                            Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Int16T    */ r(b"int16_t",    Some("JSVALUE_TO_INT32("),                                            Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Uint16T   */ r(b"uint16_t",   Some("JSVALUE_TO_INT32("),                                            Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Int32T    */ r(b"int32_t",    Some("JSVALUE_TO_INT32("),                                            Some(("INT32_TO_JSVALUE((int32_t)", ")"))),
+    /* Uint32T   */ r(b"uint32_t",   Some("JSVALUE_TO_INT32("),                                            Some(("UINT32_TO_JSVALUE(", ")"))),
+    /* Int64T    */ r(b"int64_t",    Some("JSVALUE_TO_INT64("),                                            Some(("INT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
+    /* Uint64T   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64("),                                           Some(("UINT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ", ")"))),
+    /* Double    */ r(b"double",     Some("JSVALUE_TO_DOUBLE("),                                           Some(("DOUBLE_TO_JSVALUE(", ")"))),
+    /* Float     */ r(b"float",      Some("JSVALUE_TO_FLOAT("),                                            Some(("FLOAT_TO_JSVALUE(", ")"))),
+    /* Bool      */ r(b"bool",       Some("JSVALUE_TO_BOOL("),                                             Some(("BOOLEAN_TO_JSVALUE(", ")"))),
+    /* Ptr       */ r(b"void*",      Some("JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_PTR, &threw, "),      Some(("PTR_TO_JSVALUE(", ")"))),
+    /* Void      */ r(b"void",       None,                                                                 None),
+    /* CString   */ r(b"void*",      Some("JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_CSTRING, &threw, "),  Some(("PTR_TO_JSVALUE(", ")"))),
+    /* I64Fast   */ r(b"int64_t",    Some("JSVALUE_TO_INT64("),                                            Some(("INT64_TO_JSVALUE(JS_GLOBAL_OBJECT, (int64_t)", ")"))),
+    /* U64Fast   */ r(b"uint64_t",   Some("JSVALUE_TO_UINT64("),                                           Some(("UINT64_TO_JSVALUE(JS_GLOBAL_OBJECT, ", ")"))),
+    /* Function  */ r(b"void*",      Some("JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_FUNCTION, &threw, "), Some(("PTR_TO_JSVALUE(", ")"))),
+    /* NapiEnv   */ r(b"napi_env",   None,                                                                 None),
+    /* NapiValue */ r(b"napi_value", None,                                                                 Some(("((EncodedJSValue) {.asNapiValue = ", " } )"))),
+    /* Buffer    */ r(b"void*",      Some("JSVALUE_TO_BUFFER(JS_GLOBAL_OBJECT, &threw, "),                 None),
+    /* BufferLen */ r(b"uint64_t",   None,                                                                 None),
     ]
 };
 
@@ -160,6 +160,15 @@ impl ABIType {
 
     /// See [`ABI_TYPE_LABEL`].
     pub(crate) const LABEL: &'static __ComptimeStringMap_ABI_TYPE_LABEL = &ABI_TYPE_LABEL;
+
+    /// Preprocessor definitions every generated wrapper is compiled with: the tags `FFI.h` and the
+    /// `to_c` conversions in [`ABI_TABLE`] hand to `JSVALUE_TO_PTR_SLOW`.
+    pub(crate) const POINTER_TAG_DEFINES: &'static [(&'static str, i64)] = &[
+        ("ABI_TYPE_PTR", ABIType::Ptr as i64),
+        ("ABI_TYPE_CSTRING", ABIType::CString as i64),
+        ("ABI_TYPE_FUNCTION", ABIType::Function as i64),
+        ("ABI_TYPE_BUFFER", ABIType::Buffer as i64),
+    ];
 
     /// Returns `None` for out-of-range discriminants.
     #[inline]
@@ -207,6 +216,15 @@ impl ABIType {
 
     pub(crate) fn is_floating_point(self) -> bool {
         matches!(self, ABIType::Double | ABIType::Float)
+    }
+
+    /// Argument conversions that may throw (see `JSVALUE_TO_PTR_SLOW` in `FFI.h`). The generated
+    /// wrapper converts these into locals and stops before the native call if one of them threw.
+    pub(crate) fn arg_conversion_can_throw(self) -> bool {
+        matches!(
+            self,
+            ABIType::Ptr | ABIType::CString | ABIType::Function | ABIType::Buffer
+        )
     }
 
     pub(crate) fn to_c(self, symbol: &[u8]) -> ToCFormatter<'_> {

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2070,6 +2070,8 @@ impl Function {
         }
 
         CompilerRT::define(state);
+        // Only the wrapper uses these; `CompilerRT::define` is also run for the user's own C.
+        state.define_symbols(ABIType::POINTER_TAG_DEFINES);
 
         // SAFETY: source_code was NUL-terminated above
         if state
@@ -2595,7 +2597,6 @@ impl CompilerRT {
                 jsc::JSType::MAX_TYPED_ARRAY.0 as i64,
             ),
         ]);
-        state.define_symbols(ABIType::POINTER_TAG_DEFINES);
     }
 
     pub(crate) fn inject(state: &mut TCC::State) {

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -161,8 +161,7 @@ mod exposed_to_ffi {
         pub(super) fn INT64_TO_JSVALUE(global: *mut JSGlobalObject, i: i64) -> JSValue;
         #[link_name = "JSC__JSValue__fromUInt64NoTruncate"]
         pub(super) fn UINT64_TO_JSVALUE(global: *mut JSGlobalObject, i: u64) -> JSValue;
-        /// `JSCFFIBridge.cpp`: converts a `ptr`/`cstring`/`function`/`buffer` argument the inline
-        /// fast paths in `FFI.h` don't handle, using the same conversion as dlopen()'d symbols.
+        /// Slow path of `JSVALUE_TO_PTR`/`JSVALUE_TO_BUFFER` (`FFI.h`); defined in `JSCFFIBridge.cpp`.
         #[link_name = "Bun__FFI__jsValueToPointerSlow"]
         pub(super) fn JSVALUE_TO_PTR_SLOW(
             global: *mut JSGlobalObject,
@@ -2200,8 +2199,7 @@ impl Function {
         let mut arg_buf = [0u8; 512];
         arg_buf[0..3].copy_from_slice(b"arg");
 
-        // Pointer arguments are converted up front because the conversion can run JS (an object's
-        // `ptr` getter) and throw; the native function must not be called once something threw.
+        // Pointer conversions can run JS (a `ptr` getter) and throw, so they come before the call.
         let mut declared_threw = false;
         for (i, arg) in self.arg_types.iter().enumerate() {
             if !arg.arg_conversion_can_throw() {

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -151,7 +151,7 @@ fn create_jsc_ffi_function(
 
 /// Raw extern fn pointers fed to the TCC-JIT'd C trampolines via `add_symbol`.
 mod exposed_to_ffi {
-    use super::{JSGlobalObject, JSValue};
+    use super::{JSGlobalObject, JSValue, c_void};
     unsafe extern "C" {
         #[link_name = "JSC__JSValue__toInt64"]
         pub(super) fn JSVALUE_TO_INT64(value: JSValue) -> i64;
@@ -161,6 +161,15 @@ mod exposed_to_ffi {
         pub(super) fn INT64_TO_JSVALUE(global: *mut JSGlobalObject, i: i64) -> JSValue;
         #[link_name = "JSC__JSValue__fromUInt64NoTruncate"]
         pub(super) fn UINT64_TO_JSVALUE(global: *mut JSGlobalObject, i: u64) -> JSValue;
+        /// `JSCFFIBridge.cpp`: converts a `ptr`/`cstring`/`function`/`buffer` argument the inline
+        /// fast paths in `FFI.h` don't handle, using the same conversion as dlopen()'d symbols.
+        #[link_name = "Bun__FFI__jsValueToPointerSlow"]
+        pub(super) fn JSVALUE_TO_PTR_SLOW(
+            global: *mut JSGlobalObject,
+            abi_type: i32,
+            threw: *mut bool,
+            value: JSValue,
+        ) -> *mut c_void;
     }
 }
 
@@ -2145,12 +2154,6 @@ impl Function {
               ZIG_REPR_TYPE JSFunctionCall(void* JS_GLOBAL_OBJECT, void* callFrame) {\n",
         )?;
 
-        if self.needs_handle_scope() {
-            writer.write_all(
-                b"  void* handleScope = NapiHandleScope__open(&Bun__thisFFIModuleNapiEnv, false);\n",
-            )?;
-        }
-
         if !self.arg_types.is_empty() {
             writer.write_all(b"  LOAD_ARGUMENTS_FROM_CALL_FRAME;\n")?;
             for (i, arg) in self.arg_types.iter().enumerate() {
@@ -2195,6 +2198,34 @@ impl Function {
         // );
 
         let mut arg_buf = [0u8; 512];
+        arg_buf[0..3].copy_from_slice(b"arg");
+
+        // Pointer arguments are converted up front because the conversion can run JS (an object's
+        // `ptr` getter) and throw; the native function must not be called once something threw.
+        let mut declared_threw = false;
+        for (i, arg) in self.arg_types.iter().enumerate() {
+            if !arg.arg_conversion_can_throw() {
+                continue;
+            }
+            if !declared_threw {
+                declared_threw = true;
+                writer.write_all(b"  bool threw = false;\n")?;
+            }
+            let length_buf = bun_core::fmt::print_int(&mut arg_buf[3..], i);
+            let arg_name = &arg_buf[0..3 + length_buf];
+            write!(
+                writer,
+                "  void* ptr{} = {};\n  if (threw) return ValueEmpty.asZigRepr;\n",
+                i,
+                arg.to_c(arg_name)
+            )?;
+        }
+
+        if self.needs_handle_scope() {
+            writer.write_all(
+                b"  void* handleScope = NapiHandleScope__open(&Bun__thisFFIModuleNapiEnv, false);\n",
+            )?;
+        }
 
         writer.write_all(b"    ")?;
         if self.return_type != ABIType::Void {
@@ -2203,7 +2234,6 @@ impl Function {
         }
         write!(writer, "{}(", BStr::new(self.base_name.as_bytes()))?;
         first = true;
-        arg_buf[0..3].copy_from_slice(b"arg");
         for (i, arg) in self.arg_types.iter().enumerate() {
             if !first {
                 writer.write_all(b", ")?;
@@ -2213,7 +2243,9 @@ impl Function {
 
             let length_buf = bun_core::fmt::print_int(&mut arg_buf[3..], i);
             let arg_name = &arg_buf[0..3 + length_buf];
-            if arg.needs_a_cast_in_c() {
+            if arg.arg_conversion_can_throw() {
+                write!(writer, "ptr{}", i)?;
+            } else if arg.needs_a_cast_in_c() {
                 write!(writer, "{}", arg.to_c(arg_name))?;
             } else {
                 writer.write_all(arg_name)?;
@@ -2565,6 +2597,7 @@ impl CompilerRT {
                 jsc::JSType::MAX_TYPED_ARRAY.0 as i64,
             ),
         ]);
+        state.define_symbols(ABIType::POINTER_TAG_DEFINES);
     }
 
     pub(crate) fn inject(state: &mut TCC::State) {
@@ -2619,6 +2652,12 @@ impl CompilerRT {
             .add_symbol(
                 zstr!("UINT64_TO_JSVALUE_SLOW"),
                 WORKAROUND.uint64_to_jsvalue as *const c_void,
+            )
+            .expect("unreachable");
+        state
+            .add_symbol(
+                zstr!("JSVALUE_TO_PTR_SLOW"),
+                exposed_to_ffi::JSVALUE_TO_PTR_SLOW as *const c_void,
             )
             .expect("unreachable");
     }

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -161,7 +161,7 @@ mod exposed_to_ffi {
         pub(super) fn INT64_TO_JSVALUE(global: *mut JSGlobalObject, i: i64) -> JSValue;
         #[link_name = "JSC__JSValue__fromUInt64NoTruncate"]
         pub(super) fn UINT64_TO_JSVALUE(global: *mut JSGlobalObject, i: u64) -> JSValue;
-        /// Slow path of `JSVALUE_TO_PTR`/`JSVALUE_TO_BUFFER` (`FFI.h`); defined in `JSCFFIBridge.cpp`.
+        /// Slow path of `JSVALUE_TO_PTR` in `FFI.h`; defined in `JSCFFIBridge.cpp`.
         #[link_name = "Bun__FFI__jsValueToPointerSlow"]
         pub(super) fn JSVALUE_TO_PTR_SLOW(
             global: *mut JSGlobalObject,

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1124,7 +1124,7 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
         if (threw) return ValueEmpty.asZigRepr;
         void* ptr3 = JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_CSTRING, &threw, arg3);
         if (threw) return ValueEmpty.asZigRepr;
-        void* ptr4 = JSVALUE_TO_BUFFER(JS_GLOBAL_OBJECT, &threw, arg4);
+        void* ptr4 = JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_BUFFER, &threw, arg4);
         if (threw) return ValueEmpty.asZigRepr;
         void* ptr5 = JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_PTR, &threw, arg5);
         if (threw) return ValueEmpty.asZigRepr;
@@ -1208,6 +1208,7 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
           },
           echo_ptr: {
             number: address,
+            small_number: 8,
             view,
             array_buffer: buffer,
             bigint: BigInt(address),
@@ -1223,6 +1224,7 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
             number: address,
             view,
             null: null,
+            undefined: undefined,
             plain_object: {},
             string: "hello",
           },
@@ -1307,6 +1309,7 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
       },
       echo_ptr: {
         number: "address",
+        small_number: 8,
         view: "address",
         array_buffer: "address",
         bigint: "address",
@@ -1322,6 +1325,7 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
         number: "address",
         view: "address",
         null: null,
+        undefined: null,
         plain_object: cannotConvert("cstring"),
         // Only the engine path transcodes JS strings (it owns an arena to free the copy after the
         // call); cc() has nowhere to free it, so it refuses the string instead of passing garbage.

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1087,6 +1087,290 @@ describe("double <-> JSValue conversions", () => {
   });
 });
 
+describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", () => {
+  // The wrapper cc() compiles used to treat anything that was not a number, a view, or null as a
+  // double, so a JSCallback object (or any other object) became a garbage pointer and a `function`
+  // argument called address -1. Everything the inline paths don't handle now goes through the
+  // engine's conversion, the one dlopen()/CFunction symbols use, so the fixture runs one input
+  // matrix through a cc() wrapper and through a CFunction over the very same C function and the
+  // two tables must agree. Runs in a subprocess because the unfixed path is a segfault.
+  it("accepts what dlopen accepts and throws a TypeError for the rest", async () => {
+    using dir = tempDir("bun-ffi-cc-pointer-args", {
+      "pointers.c": /* c */ `
+        typedef int (*callback_t)(int);
+        int call_callback(callback_t callback) { return callback(21) * 2; }
+        void* echo_ptr(void* p) { return p; }
+        void* echo_cstring(const char* s) { return (void*)s; }
+        void* echo_buffer(void* p) { return p; }
+
+        static int native_calls = 0;
+        int two_pointers(void* a, void* b) { native_calls++; return a == b; }
+        int get_native_calls(void) { return native_calls; }
+
+        void* address_of_call_callback(void) { return (void*)&call_callback; }
+        void* address_of_echo_ptr(void) { return (void*)&echo_ptr; }
+        void* address_of_echo_cstring(void) { return (void*)&echo_cstring; }
+        void* address_of_echo_buffer(void) { return (void*)&echo_buffer; }
+        void* address_of_two_pointers(void) { return (void*)&two_pointers; }
+      `,
+      "fixture.js": /* js */ `
+        import { cc, CFunction, JSCallback, ptr } from "bun:ffi";
+        import path from "path";
+
+        const signatures = {
+          call_callback: { args: ["function"], returns: "i32" },
+          echo_ptr: { args: ["ptr"], returns: "ptr" },
+          echo_cstring: { args: ["cstring"], returns: "ptr" },
+          echo_buffer: { args: ["buffer"], returns: "ptr" },
+          two_pointers: { args: ["ptr", "ptr"], returns: "i32" },
+        };
+        const { symbols: compiled } = cc({
+          source: path.join(import.meta.dir, "pointers.c"),
+          symbols: {
+            ...signatures,
+            get_native_calls: { args: [], returns: "i32" },
+            ...Object.fromEntries(Object.keys(signatures).map(name => ["address_of_" + name, { args: [], returns: "ptr" }])),
+          },
+        });
+        // The same C functions behind the engine's (dlopen-style) argument conversion.
+        const engine = Object.fromEntries(
+          Object.entries(signatures).map(([name, signature]) => [
+            name,
+            new CFunction({ ...signature, ptr: compiled["address_of_" + name]() }),
+          ]),
+        );
+
+        const callback = new JSCallback(x => x + 1, { args: ["i32"], returns: "i32" });
+        // A view over an explicit ArrayBuffer keeps one stable address shared by the view, the
+        // buffer, and a DataView over it.
+        const buffer = new ArrayBuffer(8);
+        const view = new Uint8Array(buffer);
+        const address = ptr(view);
+
+        const inputs = {
+          call_callback: {
+            jscallback: callback,
+            jscallback_ptr: callback.ptr,
+            object_with_ptr: { ptr: callback.ptr },
+            null: null,
+            undefined: undefined,
+            plain_function: () => 1,
+            plain_object: {},
+            string: "callback",
+          },
+          echo_ptr: {
+            number: address,
+            view,
+            array_buffer: buffer,
+            bigint: BigInt(address),
+            object_with_ptr: { ptr: address },
+            jscallback: callback,
+            null: null,
+            undefined: undefined,
+            plain_object: {},
+            string: "hello",
+            boolean: true,
+          },
+          echo_cstring: {
+            number: address,
+            view,
+            null: null,
+            plain_object: {},
+            string: "hello",
+          },
+          echo_buffer: {
+            view,
+            data_view: new DataView(buffer),
+            array_buffer: buffer,
+            number: address,
+            null: null,
+            plain_object: {},
+          },
+        };
+
+        function outcome(fn, input) {
+          try {
+            const result = fn(input);
+            if (result === address) return "address";
+            if (result === callback.ptr) return "callback.ptr";
+            return result;
+          } catch (error) {
+            return error.name + ": " + error.message;
+          }
+        }
+
+        function run(symbols) {
+          const table = {};
+          for (const name in inputs) {
+            table[name] = {};
+            for (const label in inputs[name]) table[name][label] = outcome(symbols[name], inputs[name][label]);
+          }
+          table.two_pointers = {
+            both_valid: outcome(x => symbols.two_pointers(x, view), address),
+            second_invalid: outcome(x => symbols.two_pointers(x, {}), address),
+            throwing_ptr_getter: outcome(
+              x => symbols.two_pointers(x, { get ptr() { throw new Error("from the ptr getter"); } }),
+              address,
+            ),
+            native_calls: compiled.get_native_calls(),
+          };
+          return table;
+        }
+
+        const results = { cc: run(compiled) };
+        results.engine = run(engine);
+        callback.close();
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const cannotConvert = (type: string) => `TypeError: bun:ffi cannot convert argument to '${type}'`;
+    const noCallback =
+      "TypeError: bun:ffi: expected a callback (a JSCallback or an FFI function) but got undefined/null";
+    const stringIsNotAPointer = "TypeError: To convert a string to a pointer, encode it as a buffer";
+    const bufferNeedsAView = "TypeError: bun:ffi 'buffer' argument must be a TypedArray or DataView";
+    const expected = {
+      call_callback: {
+        jscallback: 44,
+        jscallback_ptr: 44,
+        object_with_ptr: 44,
+        null: noCallback,
+        undefined: noCallback,
+        plain_function: cannotConvert("function"),
+        plain_object: cannotConvert("function"),
+        string: stringIsNotAPointer,
+      },
+      echo_ptr: {
+        number: "address",
+        view: "address",
+        array_buffer: "address",
+        bigint: "address",
+        object_with_ptr: "address",
+        jscallback: "callback.ptr",
+        null: null,
+        undefined: null,
+        plain_object: cannotConvert("ptr"),
+        string: stringIsNotAPointer,
+        boolean: cannotConvert("ptr"),
+      },
+      echo_cstring: {
+        number: "address",
+        view: "address",
+        null: null,
+        plain_object: cannotConvert("cstring"),
+        // Only the engine path transcodes JS strings (it owns an arena to free the copy after the
+        // call); cc() has nowhere to free it, so it refuses the string instead of passing garbage.
+        string: expect.any(Number),
+      },
+      echo_buffer: {
+        view: "address",
+        data_view: "address",
+        array_buffer: bufferNeedsAView,
+        number: bufferNeedsAView,
+        null: bufferNeedsAView,
+        plain_object: bufferNeedsAView,
+      },
+      two_pointers: {
+        both_valid: 1,
+        second_invalid: cannotConvert("ptr"),
+        throwing_ptr_getter: "Error: from the ptr getter",
+        // Only both_valid reached C: a failed conversion stops the call before it happens. The
+        // engine table runs second, so it sees its own call on top of the cc() one.
+        native_calls: 1,
+      },
+    };
+
+    // On a crash there is no JSON; report the process output instead so the failure shows it.
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : { stdout, stderr };
+    expect({ results, exitCode }).toEqual({
+      results: {
+        cc: {
+          ...expected,
+          echo_cstring: {
+            ...expected.echo_cstring,
+            string:
+              "TypeError: bun:ffi: a JavaScript string is not valid here; return it from a 'cstring'-returning callback, or pass a pointer/TypedArray",
+          },
+        },
+        engine: {
+          ...expected,
+          two_pointers: { ...expected.two_pointers, native_calls: 2 },
+        },
+      },
+      exitCode: 0,
+    });
+  });
+
+  // napi_env wrappers open a handle scope around the native call; a rejected pointer argument
+  // has to bail out before that happens and leave later calls working. cc()-compiled C only
+  // exercises napi on POSIX today (see the napi_create_double test above).
+  it.skipIf(isWindows)("a rejected pointer argument bails out of a napi_env wrapper too", async () => {
+    using dir = tempDir("bun-ffi-cc-pointer-args-napi", {
+      "napi_ptr.c": /* c */ `
+        typedef struct napi_env_fake* napi_env_t;
+        static int native_calls = 0;
+        /* bit 0: the trampoline filled in env, bit 1: p is non-null */
+        int with_env(napi_env_t env, void* p) { native_calls++; return (env != 0 ? 1 : 0) | (p != 0 ? 2 : 0); }
+        int get_native_calls(void) { return native_calls; }
+      `,
+      "fixture.js": /* js */ `
+        import { cc } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "napi_ptr.c"),
+          symbols: {
+            with_env: { args: ["napi_env", "ptr"], returns: "i32" },
+            get_native_calls: { args: [], returns: "i32" },
+          },
+        });
+
+        const results = {};
+        try {
+          results.rejected = symbols.with_env(undefined, {});
+        } catch (error) {
+          results.rejected = error.name + ": " + error.message;
+        }
+        results.calls_after_rejection = symbols.get_native_calls();
+        results.view = symbols.with_env(undefined, new Uint8Array(4));
+        results.null = symbols.with_env(undefined, null);
+        results.calls_at_end = symbols.get_native_calls();
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : { stdout, stderr };
+    expect({ results, exitCode }).toEqual({
+      results: {
+        rejected: "TypeError: bun:ffi cannot convert argument to 'ptr'",
+        calls_after_rejection: 0,
+        view: 3,
+        null: 1,
+        calls_at_end: 2,
+      },
+      exitCode: 0,
+    });
+  });
+});
+
 describe.skipIf(isASAN)("compiler runtime header directory under BUN_TMPDIR", () => {
   const plantedHeader = "#define bool int\n#define true 100\n#define false 0\n";
   const files = {

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1,4 +1,4 @@
-import { cc, CString, JSCallback, ptr, type FFIFunction, type Library } from "bun:ffi";
+import { cc, CString, JSCallback, ptr, viewSource, type FFIFunction, type Library } from "bun:ffi";
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
 import {
   chmodSync,
@@ -1094,6 +1094,51 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
   // engine's conversion, the one dlopen()/CFunction symbols use, so the fixture runs one input
   // matrix through a cc() wrapper and through a CFunction over the very same C function and the
   // two tables must agree. Runs in a subprocess because the unfixed path is a segfault.
+  //
+  // The wrapper shape itself: pointer-typed arguments are converted into locals, tagged with
+  // their type for the engine, and each conversion is followed by a bail-out, since it can run JS
+  // (a `ptr` getter) and throw. Other arguments are still converted inline in the call, and a
+  // napi handle scope is only opened once every conversion has succeeded, so bailing out never
+  // leaves one open.
+  it("converts pointer-typed arguments before the call and bails out if one threw", () => {
+    const [source] = viewSource({
+      f: { args: ["napi_env", "function", "f64", "cstring", "buffer", "ptr"], returns: "i32" },
+    });
+    expect(source.slice(source.indexOf("/* --- The Function To Call */"))).toMatchInlineSnapshot(`
+      "/* --- The Function To Call */
+      int32_t f(napi_env arg0, void* arg1, double arg2, void* arg3, void* arg4, void* arg5);
+
+      /* ---- Your Wrapper Function ---- */
+      ZIG_REPR_TYPE JSFunctionCall(void* JS_GLOBAL_OBJECT, void* callFrame) {
+        LOAD_ARGUMENTS_FROM_CALL_FRAME;
+        napi_env arg0 = (napi_env)&Bun__thisFFIModuleNapiEnv;
+        argsPtr++;
+        EncodedJSValue arg1 = { .asInt64 = *argsPtr++ };
+        EncodedJSValue arg2 = { .asInt64 = *argsPtr++ };
+        EncodedJSValue arg3 = { .asInt64 = *argsPtr++ };
+        EncodedJSValue arg4 = { .asInt64 = *argsPtr++ };
+        EncodedJSValue arg5;
+        arg5.asInt64 = *argsPtr;
+        bool threw = false;
+        void* ptr1 = JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_FUNCTION, &threw, arg1);
+        if (threw) return ValueEmpty.asZigRepr;
+        void* ptr3 = JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_CSTRING, &threw, arg3);
+        if (threw) return ValueEmpty.asZigRepr;
+        void* ptr4 = JSVALUE_TO_BUFFER(JS_GLOBAL_OBJECT, &threw, arg4);
+        if (threw) return ValueEmpty.asZigRepr;
+        void* ptr5 = JSVALUE_TO_PTR(JS_GLOBAL_OBJECT, ABI_TYPE_PTR, &threw, arg5);
+        if (threw) return ValueEmpty.asZigRepr;
+        void* handleScope = NapiHandleScope__open(&Bun__thisFFIModuleNapiEnv, false);
+          int32_t return_value = f(    ((napi_env)&Bun__thisFFIModuleNapiEnv),     ptr1,     JSVALUE_TO_DOUBLE(arg2),     ptr3,     ptr4,     ptr5);
+
+            NapiHandleScope__close(&Bun__thisFFIModuleNapiEnv, handleScope);
+      return INT32_TO_JSVALUE((int32_t)return_value).asZigRepr;
+      }
+
+      "
+    `);
+  });
+
   it("accepts what dlopen accepts and throws a TypeError for the rest", async () => {
     using dir = tempDir("bun-ffi-cc-pointer-args", {
       "pointers.c": /* c */ `
@@ -1205,13 +1250,21 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
             table[name] = {};
             for (const label in inputs[name]) table[name][label] = outcome(symbols[name], inputs[name][label]);
           }
+
+          // Every read of .ptr is one conversion of this argument.
+          let ptrReads = 0;
+          const counted = { get ptr() { ptrReads++; return address; } };
+          const { two_pointers } = symbols;
           table.two_pointers = {
-            both_valid: outcome(x => symbols.two_pointers(x, view), address),
-            second_invalid: outcome(x => symbols.two_pointers(x, {}), address),
-            throwing_ptr_getter: outcome(
-              x => symbols.two_pointers(x, { get ptr() { throw new Error("from the ptr getter"); } }),
-              address,
+            both_valid: outcome(() => two_pointers(address, view)),
+            getter_as_first: outcome(() => two_pointers(counted, view)),
+            getter_reads_so_far: ptrReads,
+            second_invalid: outcome(() => two_pointers(address, {})),
+            throwing_getter_as_second: outcome(() =>
+              two_pointers(address, { get ptr() { throw new Error("from the ptr getter"); } }),
             ),
+            first_invalid_with_getter_as_second: outcome(() => two_pointers({}, counted)),
+            getter_reads_at_end: ptrReads,
             native_calls: compiled.get_native_calls(),
           };
           return table;
@@ -1281,11 +1334,17 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
       },
       two_pointers: {
         both_valid: 1,
+        getter_as_first: 1,
+        // Each argument is converted exactly once per call.
+        getter_reads_so_far: 1,
         second_invalid: cannotConvert("ptr"),
-        throwing_ptr_getter: "Error: from the ptr getter",
-        // Only both_valid reached C: a failed conversion stops the call before it happens. The
-        // engine table runs second, so it sees its own call on top of the cc() one.
-        native_calls: 1,
+        throwing_getter_as_second: "Error: from the ptr getter",
+        // Conversion stops at the first argument that fails: the getter behind it never runs.
+        first_invalid_with_getter_as_second: cannotConvert("ptr"),
+        getter_reads_at_end: 1,
+        // Only the two valid calls reached C. The engine table runs second, so its count includes
+        // the cc() table's calls.
+        native_calls: 2,
       },
     };
 
@@ -1303,7 +1362,7 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
         },
         engine: {
           ...expected,
-          two_pointers: { ...expected.two_pointers, native_calls: 2 },
+          two_pointers: { ...expected.two_pointers, native_calls: 4 },
         },
       },
       exitCode: 0,
@@ -1342,6 +1401,7 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
         }
         results.calls_after_rejection = symbols.get_native_calls();
         results.view = symbols.with_env(undefined, new Uint8Array(4));
+        results.object_with_ptr = symbols.with_env(undefined, { ptr: 8 });
         results.null = symbols.with_env(undefined, null);
         results.calls_at_end = symbols.get_native_calls();
         console.log(JSON.stringify(results));
@@ -1363,8 +1423,9 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
         rejected: "TypeError: bun:ffi cannot convert argument to 'ptr'",
         calls_after_rejection: 0,
         view: 3,
+        object_with_ptr: 3,
         null: 1,
-        calls_at_end: 2,
+        calls_at_end: 3,
       },
       exitCode: 0,
     });

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1142,6 +1142,9 @@ describe.concurrent("pointer-typed arguments (function, ptr, cstring, buffer)", 
   it("accepts what dlopen accepts and throws a TypeError for the rest", async () => {
     using dir = tempDir("bun-ffi-cc-pointer-args", {
       "pointers.c": /* c */ `
+        /* The tags the generated wrappers are compiled with must not be defined in the user's C. */
+        enum { ABI_TYPE_PTR, ABI_TYPE_CSTRING, ABI_TYPE_FUNCTION, ABI_TYPE_BUFFER };
+
         typedef int (*callback_t)(int);
         int call_callback(callback_t callback) { return callback(21) * 2; }
         void* echo_ptr(void* p) { return p; }

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -163,10 +163,7 @@ static EncodedJSValue FLOAT_TO_JSVALUE(float val) __attribute__((__always_inline
 static EncodedJSValue BOOLEAN_TO_JSVALUE(bool val) __attribute__((__always_inline__));
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) __attribute__((__always_inline__));
 
-// The engine's pointer-argument conversion, shared with dlopen()'d symbols. `abiType` is one of
-// the ABI_TYPE_* tags the runtime defines when it compiles this file. Throws a TypeError for values
-// that cannot become a pointer and sets `*threw`, in which case the generated wrapper returns
-// without calling the native function.
+// The engine's conversion (the one dlopen()'d symbols use); on a non-pointer it throws and sets *threw.
 void* JSVALUE_TO_PTR_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t val);
 static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
 static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -166,7 +166,6 @@ static EncodedJSValue PTR_TO_JSVALUE(void* ptr) __attribute__((__always_inline__
 // The engine's conversion (the one dlopen()'d symbols use); on a non-pointer it throws and sets *threw.
 void* JSVALUE_TO_PTR_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t val);
 static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
-static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) __attribute__((__always_inline__));
 static float JSVALUE_TO_FLOAT(EncodedJSValue val) __attribute__((__always_inline__));
 static double JSVALUE_TO_DOUBLE(EncodedJSValue val) __attribute__((__always_inline__));
@@ -215,34 +214,29 @@ static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) {
 // This behavior change enables the JIT to handle it better
 // It also is better readability when console.log(myPtr)
 static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) {
-  if (JSVALUE_IS_INT32(val)) {
-    return (void*)(uintptr_t)JSVALUE_TO_INT32(val);
+  // TinyCC does not inline, so the tag tests are spelled out instead of calling the helpers above.
+  int64_t bits = val.asInt64;
+
+  if (!(bits & NotCellMask)) {
+    uint8_t type = *(uint8_t*)((char*)val.asPtr + JSCell__offsetOfType);
+    if (type >= JSTypeArrayBufferViewMin && type <= JSTypeArrayBufferViewMax)
+      return *(void**)((char*)val.asPtr + JSArrayBufferView__offsetOfVector);
+  } else if (abiType != ABI_TYPE_BUFFER) {
+    if ((bits & NumberTag) == NumberTag)
+      return (void*)(uintptr_t)(int32_t)bits;
+
+    if (bits & NumberTag) {
+      val.asInt64 = bits - DoubleEncodeOffset;
+      return (void*)(uintptr_t)(int64_t)val.asDouble;
+    }
+
+    // null and undefined are NULL, except as a callback, where the slow path throws like dlopen() does.
+    if ((bits & ~UndefinedTag) == TagValueNull && abiType != ABI_TYPE_FUNCTION)
+      return 0;
   }
 
-  if (JSVALUE_IS_NUMBER(val)) {
-    val.asInt64 -= DoubleEncodeOffset;
-    return (void*)(uintptr_t)val.asDouble;
-  }
-
-  if (JSCELL_IS_TYPED_ARRAY(val)) {
-    return JSVALUE_TO_TYPED_ARRAY_VECTOR(val);
-  }
-
-  // A null callback is a TypeError (decided by the slow path), like it is for dlopen().
-  if (val.asInt64 == TagValueNull && abiType != ABI_TYPE_FUNCTION)
-    return 0;
-
-  // JSCallback, ArrayBuffer, BigInt, objects with a numeric `ptr`, undefined, strings, ...
-  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, abiType, threw, val.asInt64);
-}
-
-static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) {
-  if (JSCELL_IS_TYPED_ARRAY(val)) {
-    return JSVALUE_TO_TYPED_ARRAY_VECTOR(val);
-  }
-
-  // Only views are accepted; the slow path throws for everything else.
-  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, ABI_TYPE_BUFFER, threw, val.asInt64);
+  // Other cells (JSCallback, ArrayBuffer, BigInt, objects with a `ptr`, strings), non-views for 'buffer', junk.
+  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, abiType, threw, bits);
 }
 
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -127,6 +127,8 @@ napi_value asNapiValue;
 
 EncodedJSValue ValueUndefined = { TagValueUndefined };
 EncodedJSValue ValueTrue = { TagValueTrue };
+// What a host function returns after throwing; JSC unwinds to the pending exception and ignores it.
+EncodedJSValue ValueEmpty = { 0 };
 
 typedef void* JSContext;
 
@@ -161,7 +163,13 @@ static EncodedJSValue FLOAT_TO_JSVALUE(float val) __attribute__((__always_inline
 static EncodedJSValue BOOLEAN_TO_JSVALUE(bool val) __attribute__((__always_inline__));
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) __attribute__((__always_inline__));
 
-static void* JSVALUE_TO_PTR(EncodedJSValue val) __attribute__((__always_inline__));
+// The engine's pointer-argument conversion, shared with dlopen()'d symbols. `abiType` is one of
+// the ABI_TYPE_* tags the runtime defines when it compiles this file. Throws a TypeError for values
+// that cannot become a pointer and sets `*threw`, in which case the generated wrapper returns
+// without calling the native function.
+void* JSVALUE_TO_PTR_SLOW(void* jsGlobalObject, int32_t abiType, bool* threw, int64_t val);
+static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
+static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) __attribute__((__always_inline__));
 static int32_t JSVALUE_TO_INT32(EncodedJSValue val) __attribute__((__always_inline__));
 static float JSVALUE_TO_FLOAT(EncodedJSValue val) __attribute__((__always_inline__));
 static double JSVALUE_TO_DOUBLE(EncodedJSValue val) __attribute__((__always_inline__));
@@ -209,21 +217,35 @@ static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) {
 // Now, they're stored at the beginning of the 64-bit value
 // This behavior change enables the JIT to handle it better
 // It also is better readability when console.log(myPtr)
-static void* JSVALUE_TO_PTR(EncodedJSValue val) {
-  if (val.asInt64 == TagValueNull)
-    return 0;
+static void* JSVALUE_TO_PTR(void* jsGlobalObject, int32_t abiType, bool* threw, EncodedJSValue val) {
+  if (JSVALUE_IS_INT32(val)) {
+    return (void*)(uintptr_t)JSVALUE_TO_INT32(val);
+  }
+
+  if (JSVALUE_IS_NUMBER(val)) {
+    val.asInt64 -= DoubleEncodeOffset;
+    return (void*)(uintptr_t)val.asDouble;
+  }
 
   if (JSCELL_IS_TYPED_ARRAY(val)) {
     return JSVALUE_TO_TYPED_ARRAY_VECTOR(val);
   }
 
-  if (JSVALUE_IS_INT32(val)) {
-    return (void*)(uintptr_t)JSVALUE_TO_INT32(val);
+  // A null callback is a TypeError (decided by the slow path), like it is for dlopen().
+  if (val.asInt64 == TagValueNull && abiType != ABI_TYPE_FUNCTION)
+    return 0;
+
+  // JSCallback, ArrayBuffer, BigInt, objects with a numeric `ptr`, undefined, strings, ...
+  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, abiType, threw, val.asInt64);
+}
+
+static void* JSVALUE_TO_BUFFER(void* jsGlobalObject, bool* threw, EncodedJSValue val) {
+  if (JSCELL_IS_TYPED_ARRAY(val)) {
+    return JSVALUE_TO_TYPED_ARRAY_VECTOR(val);
   }
 
-  // Assume the JSValue is a double
-  val.asInt64 -= DoubleEncodeOffset;
-  return (void*)(uintptr_t)val.asDouble;
+  // Only views are accepted; the slow path throws for everything else.
+  return JSVALUE_TO_PTR_SLOW(jsGlobalObject, ABI_TYPE_BUFFER, threw, val.asInt64);
 }
 
 static EncodedJSValue PTR_TO_JSVALUE(void* ptr) {


### PR DESCRIPTION
### Problem

- A symbol compiled with `cc()` that declares a `"function"` argument crashes the process when it is given a `JSCallback` object instead of `callback.ptr`: `panic(main thread): Segmentation fault at address 0xFFFFFFFFFFFFFFFF`. The same declaration through `dlopen()` accepts either form, and the docs present passing the object as the normal form (`.ptr` is described as a performance tip).
- Cause: the C wrapper `cc()` compiles converts `ptr`, `cstring` and `function` arguments with `JSVALUE_TO_PTR` (src/runtime/ffi/FFI.h:210 on main), which handles null, typed arrays and int32 and then treats every other value as a NaN-boxed double. A JSCallback, an ArrayBuffer, a BigInt, an object with a `ptr` property, `undefined`, a plain object or a string all decode to the pointer `-1`. For a `function` argument the C code calls it; for `ptr`/`cstring` it is handed to C as a valid-looking pointer.
- The `buffer` row (src/runtime/ffi/abi_type.rs:146 on main) has the same shape of bug: it reads the typed-array vector slot out of whatever it is given, so a number or `null` segfaults and an `ArrayBuffer` or plain object passes a garbage pointer.
- Only `cc()` is affected. Since #35246, `dlopen()`/`linkSymbols()`/`CFunction` convert arguments in the engine (`JSC::FFI::writeSlotFromJSValue`), which handles all of these values and throws a TypeError for the rest. `cc()` still calls through the TinyCC-compiled wrapper built from `FFI.h`. #31776 addressed this crash in the JS wrapper layer and was closed when #35246 removed that layer; the wrapper path it did not cover is the one fixed here.

### Fix

- `FFI.h`: `JSVALUE_TO_PTR` now takes the argument's type tag and decides the unambiguous inputs itself: typed arrays and DataViews for all four types; int32, double, and null/undefined (as NULL) for `ptr`/`cstring`; int32 and double for `function`. Everything else goes to a new `JSVALUE_TO_PTR_SLOW`, which is `Bun__FFI__jsValueToPointerSlow` (JSCFFIBridge.cpp) calling the engine's `writeSlotFromJSValue` for that type: that is where a JSCallback, ArrayBuffer, BigInt or `{ ptr }` object is converted, where a null/undefined callback and a non-view `buffer` get the engine's TypeErrors, and where junk is rejected.
- TinyCC ignores `always_inline`, so the existing `JSVALUE_IS_*` / `JSCELL_IS_TYPED_ARRAY` helpers are real calls in the compiled wrapper. The tag tests in `JSVALUE_TO_PTR` are therefore written out on the raw bits, and every accepted input costs the one `JSVALUE_TO_PTR` call. On main the same inputs cost 1 call for null, 5 or 6 for a number and 6 for a view, and a `buffer` argument was one unchecked vector read; only values the engine has to look at leave the wrapper now. The double path converts through `int64` like the engine's `doubleToInt64` (the old unsigned conversion was a libtcc1 helper call, and undefined for negative values).
- The slow path can throw, so `print_source_code` now converts these arguments into locals before the call and returns the empty JSValue (the host-function convention after a throw) as soon as one of them threw; the native function is never entered with an exception pending. Every napi wrapper now opens its handle scope after the argument loads and these conversions instead of before them, so the bail-out has nothing to unwind (the only change to wrappers without pointer-typed arguments; the argument loads need no scope). Wrappers with neither pointer-typed nor napi arguments generate the same C as before, which is why the regenerated `ffi.test.fixture.receiver.c` only changes in its `FFI.h` half.
- The argument type tags (`ABI_TYPE_PTR` etc.) reach the C side through `define_symbols`, the mechanism `FFI.h` already uses for the JSC offsets, so the values come from the `ABIType` enum rather than being repeated in the header. They are defined only when the wrapper is compiled (`Function::compile`), not for the user's own C file, which the matrix fixture checks by declaring an enum with those names.
- Why this is correct: the engine converter is the definition of what bun:ffi accepts for a pointer-typed argument (it is what `dlopen()` has run since #35246), so delegating to it makes `cc()` accept the same values (JSCallback, ArrayBuffer, BigInt, objects with a numeric `ptr`, `undefined` as NULL for `ptr`/`cstring`) and reject the same values with the same TypeErrors, including `null`/`undefined` for a `function` argument, which `dlopen()` rejects and which `cc()` previously passed on as NULL (a fall-out of the untyped routine; `0` still passes NULL explicitly on both paths). Every input that worked before is still converted inside the wrapper to the same pointer, so the engine only ever sees inputs that previously produced a garbage pointer.
- One deliberate difference remains: a JavaScript string for a `cstring` argument throws in `cc()` (the engine's "a JavaScript string is not valid here" TypeError) where `dlopen()` transcodes it. The engine frees the copy through an arena bracketed around the call, which the cc() wrapper does not have; `cc()` never accepted strings here (they became `-1`), so this turns a garbage pointer into an error rather than removing anything. The test pins the difference.
- Verified with `test/js/bun/ffi/cc.test.ts` ("pointer-typed arguments"), three tests that all fail on the unfixed binary:
  - an inline snapshot of `viewSource()` for a `napi_env`/`function`/`f64`/`cstring`/`buffer`/`ptr` signature pins the wrapper shape: the tagged conversions into locals, the bail-out after each one, the inline conversion of the `f64`, and the handle scope opened only after the conversions (on the unfixed binary it shows the old inline `JSVALUE_TO_PTR(argN)` calls);
  - a fixture runs an input matrix through a `cc()` wrapper and through a `CFunction` over the same C functions and requires the two result tables to be equal (on the unfixed binary the process segfaults at the first row). A counting `ptr` getter shows each argument is converted exactly once and that conversion stops at the first argument that fails (the getter behind it never runs); a C-side counter shows the rejected calls never reached C; a throwing getter's exception propagates as-is;
  - a second fixture covers a `napi_env` wrapper: a rejected argument does not reach C, and the inline (view, null) and slow-path (`{ ptr }`) inputs still work afterwards (on the unfixed binary the rejected argument reaches C as `-1`).
  - `bun bd test test/js/bun/ffi/` (debug ASAN): everything passes except the pre-existing 5s timeouts of the dlopen "integer identities" tests on this container, which my change does not touch.
  - The same tests pass with `BUN_JSC_validateExceptionChecks=1`.
  - Cost check: since debug builds read `FFI.h` at runtime, one debug binary was timed calling a one-argument `cc()` symbol in a loop with three headers swapped in (the call structure of main, the first version of this PR, and the final one); numbers are in the details block. The final header is at or below main's structure for every input class; the first version of this PR was slower than main for null, views and `buffer` and sent `undefined` through the engine, which is what prompted the rewrite.
  - `test/js/bun/ffi/ffi.test.fixture.receiver.c` is the checked-in copy of the generated source and is regenerated by the `ffi print` test, as in #34653 and #32787.
- Overlaps textually with #37978 (integer argument decoding in the same generator loop); the two changes are independent and either can be rebased on the other.

### Background

- `cc()` compiles the user's C with TinyCC and, per symbol, also compiles a small C wrapper generated by `Function::print_source_code` (src/runtime/ffi/ffi_body.rs) with `FFI.h` prepended. JSC calls that wrapper directly as a host function with `(globalObject, callFrame)`; the wrapper reads the raw NaN-boxed argument slots, converts them, calls the user's function and boxes the result. `FFI.h` is therefore C compiled at runtime, and the conversion helpers in it have to be given any runtime symbols (`add_symbol`) and constants (`define_symbols`) they use; `CompilerRT::inject`/`define` in ffi_body.rs do that.
- `ABI_TABLE` in abi_type.rs holds, per argument type, the prefix of the C expression the generator emits to convert an argument; `INT64_TO_JSVALUE_SLOW(JS_GLOBAL_OBJECT, ` is an existing example of a prefix that names the wrapper's own parameter, which the new pointer prefixes also do (`JS_GLOBAL_OBJECT`, `&threw`).
- A host function signals a throw in JSC by leaving the exception on the VM and returning; the caller checks the VM's exception slot after the call and ignores the returned value, which by convention is the empty JSValue (`ValueEmpty` here, encoded as 0). Running further JS (such as another argument's `ptr` getter) with an exception pending is not allowed, which is why the wrapper checks after each conversion rather than once at the end.
- `JSC::FFI::writeSlotFromJSValue` is the engine-side converter added for #35246; for pointer types it accepts null/undefined (NULL, except for `function`), int32/double, BigInt, typed arrays and DataViews, ArrayBuffers, `JSFFICallback` cells (what a `JSCallback` is) and objects whose `ptr` property is a number or BigInt, and throws a TypeError otherwise. Its `cstring` string transcoding needs the caller to pass a string arena; passing none makes a JS string throw.
- TinyCC has no inliner: the `static ... __attribute__((always_inline))` helpers in `FFI.h` are compiled as ordinary functions and every use is a call, which is why the hot checks in `JSVALUE_TO_PTR` test the NaN-boxing tag bits directly. The constants it uses (`NumberTag`, `NotCellMask`, `UndefinedTag`, the JSC type byte and vector offsets) are the same ones the helpers use.

<details>
<summary>Cost check of the three headers (debug build, loaded shared host)</summary>

One-argument `cc()` symbols called in a loop from JS, best of 5 x 1M calls per run, ns per call including the JS-to-host call itself; minimum over 4 runs for the first and last columns, a single run for the middle one (taken on the binary built at that commit, before the header swap setup existed). The host had a load average above 200, so only the ordering is meaningful; the structural difference (number of calls made per argument, listed in the Fix section) is deterministic.

| input | main's check structure | first version of this PR | final |
| --- | --- | --- | --- |
| `ptr`, number | 62 | 62 | 48 |
| `ptr`, Uint8Array | 62 | 64 | 47 |
| `ptr`, null | 50 | 55 | 46 |
| `ptr`, undefined | 66 (garbage pointer) | 858 (engine round trip) | 55 |
| `buffer`, Uint8Array | 60 (unchecked) | 108 | 54 |
| `function`, number | 69 | 73 | 54 |

"main's check structure" is main's `JSVALUE_TO_PTR` body behind this PR's signature (plus main's unchecked vector read for `buffer`), swapped into the source tree for the current debug binary, which reads `FFI.h` from there at startup; the final column is the same binary with the real header.

</details>

<details>
<summary>Before/after on the repro from the report</summary>

```c
// t2.c
#include <stdint.h>
int32_t call_cb(int32_t (*cb)(int32_t)) { return cb ? cb(21) * 2 : -1; }
```

```ts
import { cc, dlopen, JSCallback } from "bun:ffi";
const def = { call_cb: { args: ["function"], returns: "i32" } } as const;
const cb = new JSCallback((x: number) => x + 1, { args: ["i32"], returns: "i32" });
const c = cc({ source: "./t2.c", symbols: def }).symbols;
console.log(c.call_cb(cb.ptr)); // 44 before and after
console.log(c.call_cb(cb));     // before: panic(main thread): Segmentation fault at address 0xFFFFFFFFFFFFFFFF
                                // after: 44
```

Other inputs on the unfixed binary, `ptr` argument echoed back by C: `undefined`, `{}`, `"hello"`, `true`, an ArrayBuffer, a BigInt, `{ ptr }` and a JSCallback all arrive in C as `-1`. `buffer` argument: a number or `null` segfaults, an ArrayBuffer arrives as an unrelated pointer read out of the JSArrayBuffer cell. After the fix each of these behaves as it does through `dlopen()`.

</details>



