### PR TITLE
test(bun-types): build and pack from a temp copy instead of inside packages/bun-types; raise the file's timeout

### DIFF
--- a/packages/bun-types/scripts/build.ts
+++ b/packages/bun-types/scripts/build.ts
@@ -1,10 +1,18 @@
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 import pkg from "../package.json";
 
 const BUN_VERSION = (process.env.BUN_VERSION || Bun.version || process.versions.bun).replace(/^.*v/, "");
 
-await Bun.write(join(import.meta.dir, "../package.json"), JSON.stringify({ ...pkg, version: BUN_VERSION }, null, 2));
+// Usage: bun scripts/build.ts [outDir]
+//
+// The generated files (package.json with the version filled in, CLAUDE.md, docs/)
+// are written to outDir, by default this package's own directory, which is what the
+// release workflow publishes. test/integration/bun-types builds into a scratch copy
+// of the package instead so that running the test never modifies the checkout.
+const outDir = process.argv[2] ? resolve(process.argv[2]) : join(import.meta.dir, "..");
+
+await Bun.write(join(outDir, "package.json"), JSON.stringify({ ...pkg, version: BUN_VERSION }, null, 2));
 
 // copy CLAUDE.md
 let claude = Bun.file(join(import.meta.dir, "../../../src/cli/init/rule.md"));
@@ -16,11 +24,11 @@ if (await claude.exists()) {
     original = original.slice(endOfFrontMatter + "---\n".length).trim() + "\n";
   }
 
-  await Bun.write(join(import.meta.dir, "../CLAUDE.md"), original);
+  await Bun.write(join(outDir, "CLAUDE.md"), original);
 }
 
 // Copy docs
-const docsDir = join(import.meta.dir, "../docs");
+const docsDir = join(outDir, "docs");
 const sourceDocsDir = join(import.meta.dir, "../../../docs");
 await Bun.$`rm -rf ${docsDir}`;
 

--- a/test/integration/bun-types/bun-types.test.ts
+++ b/test/integration/bun-types/bun-types.test.ts
@@ -1,18 +1,24 @@
 import { $ as Shell, fileURLToPath } from "bun";
-import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { afterAll, beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
 import { bunEnv, bunExe, isDebug, makeTree } from "harness";
-import { readFileSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { cp, mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { dirname, join, relative } from "node:path";
+import { basename, dirname, join, relative } from "node:path";
 
 import ts from "typescript";
+
+// beforeAll packs bun-types and installs it from the registry, and each case below copies
+// a fixture and type-checks it for several seconds, so everything here outlives the 5s
+// default that a plain `bun test <this file>` (CLAUDE.md, .github/workflows/bun-types.yml)
+// runs with; only the CI runner passes a larger --timeout. This call has to precede the
+// registrations: each hook/test captures the default when it is declared.
+setDefaultTimeout(1000 * 60 * 2);
 
 const BUN_REPO_ROOT = fileURLToPath(import.meta.resolve("../../../"));
 const BUN_TYPES_PACKAGE_ROOT = join(BUN_REPO_ROOT, "packages", "bun-types");
 const FIXTURE_SOURCE_DIR = fileURLToPath(import.meta.resolve("./fixture"));
 const TSCONFIG_SOURCE_PATH = join(BUN_REPO_ROOT, "src/cli/init/tsconfig.default.json");
-const BUN_TYPES_PACKAGE_JSON_PATH = join(BUN_TYPES_PACKAGE_ROOT, "package.json");
 const BUN_VERSION = (process.env.BUN_VERSION ?? Bun.version ?? process.versions.bun).replace(/^.*v/, "");
 const BUN_TYPES_TARBALL_NAME = `bun-types-${BUN_VERSION}.tgz`;
 
@@ -26,39 +32,38 @@ const DEFAULT_COMPILER_OPTIONS = ts.parseJsonConfigFileContent(
 
 const $ = Shell.cwd(BUN_REPO_ROOT);
 
+// What `bun run build` generates. beforeAll builds into a copy of the package under
+// TEMP_DIR, so none of this may change in the checkout (it used to be built in place,
+// with package.json restored afterwards, which left the tree dirty whenever beforeAll
+// was interrupted).
+function snapshotBunTypesCheckout() {
+  return {
+    "package.json": readFileSync(join(BUN_TYPES_PACKAGE_ROOT, "package.json"), "utf8"),
+    "CLAUDE.md": existsSync(join(BUN_TYPES_PACKAGE_ROOT, "CLAUDE.md")),
+    "docs": existsSync(join(BUN_TYPES_PACKAGE_ROOT, "docs")),
+  };
+}
+
+const bunTypesCheckoutBeforeSetup = snapshotBunTypesCheckout();
+
 let TEMP_DIR: string;
 let BASE_FIXTURE_DIR: string;
 
 beforeAll(async () => {
   TEMP_DIR = await mkdtemp(join(tmpdir(), "bun-types-test-"));
   BASE_FIXTURE_DIR = join(TEMP_DIR, "base-fixture");
+  const bunTypesBuildDir = join(TEMP_DIR, "bun-types");
 
   try {
-    await $`mkdir -p ${BASE_FIXTURE_DIR}`.quiet();
-
     await cp(FIXTURE_SOURCE_DIR, BASE_FIXTURE_DIR, { recursive: true });
+    await cp(BUN_TYPES_PACKAGE_ROOT, bunTypesBuildDir, {
+      recursive: true,
+      filter: source => basename(source) !== "node_modules",
+    });
 
-    await $`
-      cd ${BUN_TYPES_PACKAGE_ROOT}
-      bun install --no-cache
-      cp package.json package.json.backup
-    `.quiet();
-
-    const pkg = await Bun.file(BUN_TYPES_PACKAGE_JSON_PATH).json();
-
-    await Bun.write(BUN_TYPES_PACKAGE_JSON_PATH, JSON.stringify({ ...pkg, version: BUN_VERSION }, null, 2));
-
-    await $`
-      cd ${BUN_TYPES_PACKAGE_ROOT}
-      BUN_VERSION=${BUN_VERSION} bun run build
-      bun pm pack --destination ${BASE_FIXTURE_DIR}
-      rm -f CLAUDE.md
-      mv package.json.backup package.json
-
-      cd ${BASE_FIXTURE_DIR}
-      bun add bun-types@${BUN_TYPES_TARBALL_NAME}
-      rm ${BUN_TYPES_TARBALL_NAME}
-    `.quiet();
+    await $`cd ${BUN_TYPES_PACKAGE_ROOT} && BUN_VERSION=${BUN_VERSION} bun run build ${bunTypesBuildDir}`.quiet();
+    await $`cd ${bunTypesBuildDir} && bun pm pack --destination ${BASE_FIXTURE_DIR}`.quiet();
+    await $`cd ${BASE_FIXTURE_DIR} && bun add bun-types@${BUN_TYPES_TARBALL_NAME} && rm ${BUN_TYPES_TARBALL_NAME}`.quiet();
 
     const atTypesBunDir = join(BASE_FIXTURE_DIR, "node_modules", "@types", "bun");
 
@@ -311,6 +316,10 @@ afterAll(async () => {
 });
 
 describe("@types/bun integration test", () => {
+  test("building and packing bun-types leaves packages/bun-types untouched", () => {
+    expect(snapshotBunTypesCheckout()).toEqual(bunTypesCheckoutBeforeSetup);
+  });
+
   test("packed bun-types includes CLAUDE.md", async () => {
     const claude = Bun.file(join(BASE_FIXTURE_DIR, "node_modules", "bun-types", "CLAUDE.md"));
     expect(await claude.exists()).toBe(true);


### PR DESCRIPTION
### Problem
- `bun test test/integration/bun-types/bun-types.test.ts` (the invocation CLAUDE.md documents, and the one `.github/workflows/bun-types.yml` uses) runs the file under bun's 5s default timeout. On a slow or busy machine `beforeAll` is cut off with `a beforeEach/afterEach hook timed out for this test.` and nothing runs. Buildkite never sees this because `scripts/runner.node.mjs` passes `--timeout=150000` for integration files.
- The hook does not fit in 5s: `bun install --no-cache` inside `packages/bun-types` is a full workspace install that re-fetches manifests (0.7s to 6.2s in this container depending on the registry), then `bun run build`, `bun pm pack` and a `bun add` from the registry. The type-checking cases are in the same situation: a plain run here had the tsgo case at 5.1s and several LanguageService cases at 5 to 7s (those only pass today because the check is synchronous, so the timer cannot fire before the test resolves).
- `beforeAll` built the package in place (`bun-types.test.ts:41-61` on main): it rewrote the tracked `packages/bun-types/package.json`, and `bun run build` writes `CLAUDE.md` and `docs/` next to it. The restore was the `mv package.json.backup package.json` at the end of a shell chain, so a timed out hook (bun abandons the hook's promise and moves on to `afterAll`) or a failing `bun pm pack` left the checkout with a modified `package.json` plus `package.json.backup`. That residue has already been committed by accident once (#36505, caught in review and reverted there).

### Fix
- `packages/bun-types/scripts/build.ts` takes an optional output directory for the files it generates (`package.json` with the version filled in, `CLAUDE.md`, `docs/`). With no argument it still writes into the package itself, which is what `release.yml` runs and publishes, so the release flow is unchanged.
- The test copies `packages/bun-types` (minus `node_modules`) into its temp dir, runs `bun run build <copy>` and `bun pm pack` inside the copy, and installs the tarball from there. Nothing under `packages/` is written anymore, so there is no restore step that an interrupted hook can skip. `bun pm pack` only needs a lockfile for `workspace:`/`catalog:` specifiers and `build.ts` imports nothing, so the `bun install --no-cache` step is dropped rather than moved.
- The setup commands are now separate `&&` chains: a newline-separated Bun Shell script keeps going after a failing command and only throws if the last one fails, so a `build`/`pack` failure used to surface as a cascade of four errors instead of the first one.
- The file calls `setDefaultTimeout(2 minutes)` before registering anything (the runner captures the default when each hook/test is declared). Every entry in the file installs from the registry or type-checks for several seconds, so a per-test override would just repeat the value 15 times. 2 minutes is 15 to 25x the slowest entry measured here (the whole hook is 1 to 5s on a release build, about 4s under the debug build) and stays under the 150s the CI runner gives integration files, so a hang in CI is still attributed to a specific test rather than to the file.
- A new case, `building and packing bun-types leaves packages/bun-types untouched`, compares `package.json`'s text and the presence of `CLAUDE.md`/`docs/` in the checkout before the module's setup and after it. With the old `build.ts` the run fails earlier, in `beforeAll` (`bun pm pack` on the versionless copy reports `package.json must have name and version fields`), so this case is skipped on that path and the residue it leaves (`package.json` modified plus `CLAUDE.md` and `docs/`) is only visible in `git status`; #38115 moves the assertion into `afterAll` so it is reported on that path too. With the new `build.ts` the tree stays clean.
- Verified: `bun test test/integration/bun-types/bun-types.test.ts` (release, no `--timeout`): 15 pass, `git status` clean afterwards. `bun bd test test/integration/bun-types/bun-types.test.ts`: 3 pass, 12 skip (the LanguageService cases are `skipIf(isDebug)` already), tree clean. `bun run build` with no argument in `packages/bun-types` still builds in place. The tarball packed from the copy has the same 367 files as one packed in place (`files` in package.json selects them either way).

### Background
- `beforeAll` / test timeouts in `bun:test`: each hook and test gets a deadline when it starts, resolved at declaration time as explicit argument, then `setDefaultTimeout()`, then `--timeout` (default 5000ms). A `setDefaultTimeout()` call therefore has to come before the declarations it should apply to, and it overrides the CLI value. When a `beforeAll` times out its promise is abandoned (nothing is cancelled), the tests in its scope are skipped and `afterAll` still runs.
- `packages/bun-types/scripts/build.ts` is the `bun run build` script the release workflow runs before `npm publish` from inside `packages/bun-types`: it stamps the Bun version into `package.json`, copies `src/cli/init/rule.md` to `CLAUDE.md` and copies `docs/**/*.md(x)` in. `package.json` is tracked; `CLAUDE.md` and `docs/` are gitignored in that directory.
- This integration test packs the package with `bun pm pack`, installs the tarball into a fixture project together with a stub `@types/bun`, and type-checks the fixture with TypeScript's compiler API, so it needs the real build output (it is how the missing `CLAUDE.md` in #33940 was caught), just not inside the checkout.

