### PR TITLE
MessagePort: fire 'close' on a port that is transferred away

### DIFF
--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -249,7 +249,6 @@ void MessagePort::queueCloseEvent()
     // Defer 'close' to a task (node fires it at uv close-callback timing, i.e.
     // after sync code and microtasks), so a listener added after close() or the
     // transfer still observes it and close(cb) interleaves with other listeners.
-    // Listeners stay registered until then; the task drops them once it has fired.
     if (isContextStopped()) {
         removeAllEventListeners();
         return;
@@ -301,15 +300,11 @@ TransferredMessagePort MessagePort::disentangle()
 {
     ASSERT(isEntangled());
 
-    // Nothing is dispatched to this object after the transfer except the 'close'
-    // queued below; its listeners are dropped by that task.
+    // The listeners themselves are dropped by the close task queued below.
     m_hasMessageEventListener = false;
 
-    // Release the self-reference taken by jsRef() on the sending side. After
-    // transfer this object is inert (the receiving side gets a fresh
-    // MessagePort for the same pipe endpoint) and close() no-ops on it once
-    // m_isDetached is set, so nothing else will ever release a ref taken here.
-    // The caller (disentanglePorts) holds a RefPtr, so deref() is safe.
+    // Release the self-reference taken by jsRef(): close() no-ops on a detached port,
+    // so nothing else would. The caller (disentanglePorts) holds a RefPtr, so deref() is safe.
     if (m_hasRef) {
         m_hasRef = false;
         if (auto* context = scriptExecutionContext())
@@ -333,11 +328,10 @@ TransferredMessagePort MessagePort::disentangle()
     m_isDetached = true;
     m_started = false;
 
-    // Node closes the transferred-away object's handle, so it fires 'close' like a
-    // close()d port while the channel lives on in the receiver's new port (the peer
-    // is not told): https://github.com/nodejs/node/blob/v26.3.0/src/node_messaging.cc#L921-L924
-    // The task dispatches through our context, and only pins the wrapper while we are
-    // attached to one, so this object stays attached until collected, like a closed port.
+    // Node closes the transferred-away object (the channel itself lives on in the receiver's
+    // port): https://github.com/nodejs/node/blob/v26.3.0/src/node_messaging.cc#L921-L924
+    // Like a close()d port, stay attached to the context: the task dispatches through it,
+    // and a pending activity only pins the wrapper of an object that still has one.
     queueCloseEvent();
 
     return TransferredMessagePort { m_pipe.copyRef(), m_side };

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -241,9 +241,15 @@ void MessagePort::close()
         updateListenerEventLoopRef();
     }
 
+    queueCloseEvent();
+}
+
+void MessagePort::queueCloseEvent()
+{
     // Defer 'close' to a task (node fires it at uv close-callback timing, i.e.
-    // after sync code and microtasks), so a listener added after close() still
-    // observes it and close(cb) interleaves with other listeners.
+    // after sync code and microtasks), so a listener added after close() or the
+    // transfer still observes it and close(cb) interleaves with other listeners.
+    // Listeners stay registered until then; the task drops them once it has fired.
     if (isContextStopped()) {
         removeAllEventListeners();
         return;
@@ -295,16 +301,14 @@ TransferredMessagePort MessagePort::disentangle()
 {
     ASSERT(isEntangled());
 
-    // Drop any message listeners (and the event-loop ref they carry) while
-    // this port is still attached to its context; after observeContext(null)
-    // there would be nothing to unref.
-    removeAllEventListeners();
+    // Nothing is dispatched to this object after the transfer except the 'close'
+    // queued below; its listeners are dropped by that task.
     m_hasMessageEventListener = false;
 
     // Release the self-reference taken by jsRef() on the sending side. After
     // transfer this object is inert (the receiving side gets a fresh
-    // MessagePort for the same pipe endpoint) and is no longer a destruction
-    // observer, so nothing else will ever release a ref taken here.
+    // MessagePort for the same pipe endpoint) and close() no-ops on it once
+    // m_isDetached is set, so nothing else will ever release a ref taken here.
     // The caller (disentanglePorts) holds a RefPtr, so deref() is safe.
     if (m_hasRef) {
         m_hasRef = false;
@@ -329,12 +333,12 @@ TransferredMessagePort MessagePort::disentangle()
     m_isDetached = true;
     m_started = false;
 
-    // We can't receive any messages or generate any events after this, so remove ourselves from the list of active ports.
-    if (auto* context = scriptExecutionContext()) {
-        context->willDestroyActiveDOMObject(*this);
-        context->willDestroyDestructionObserver(*this);
-    }
-    observeContext(nullptr);
+    // Node closes the transferred-away object's handle, so it fires 'close' like a
+    // close()d port while the channel lives on in the receiver's new port (the peer
+    // is not told): https://github.com/nodejs/node/blob/v26.3.0/src/node_messaging.cc#L921-L924
+    // The task dispatches through our context, and only pins the wrapper while we are
+    // attached to one, so this object stays attached until collected, like a closed port.
+    queueCloseEvent();
 
     return TransferredMessagePort { m_pipe.copyRef(), m_side };
 }

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -365,6 +365,7 @@ void MessagePort::dispatchOneMessage(ScriptExecutionContext& context, MessageWit
 JSValue MessagePort::tryTakeMessage(JSGlobalObject* lexicalGlobalObject, bool& hadMessage)
 {
     hadMessage = false;
+    // Also what stops a transferred-away object, which keeps its context, from taking from the pipe side its receiver now owns.
     if (!isEntangled())
         return jsUndefined();
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -246,9 +246,7 @@ void MessagePort::close()
 
 void MessagePort::queueCloseEvent()
 {
-    // Defer 'close' to a task (node fires it at uv close-callback timing, i.e.
-    // after sync code and microtasks), so a listener added after close() or the
-    // transfer still observes it and close(cb) interleaves with other listeners.
+    // A task rather than synchronous: node fires it from the uv close callback, so a listener added right after close() or the transfer still sees it.
     if (isContextStopped()) {
         removeAllEventListeners();
         return;
@@ -303,8 +301,7 @@ TransferredMessagePort MessagePort::disentangle()
     // The listeners themselves are dropped by the close task queued below.
     m_hasMessageEventListener = false;
 
-    // Release the self-reference taken by jsRef(): close() no-ops on a detached port,
-    // so nothing else would. The caller (disentanglePorts) holds a RefPtr, so deref() is safe.
+    // Release jsRef()'s self-reference here, since close() no-ops on a detached port; the caller's RefPtr keeps us alive across deref().
     if (m_hasRef) {
         m_hasRef = false;
         if (auto* context = scriptExecutionContext())
@@ -328,10 +325,7 @@ TransferredMessagePort MessagePort::disentangle()
     m_isDetached = true;
     m_started = false;
 
-    // Node closes the transferred-away object (the channel itself lives on in the receiver's
-    // port): https://github.com/nodejs/node/blob/v26.3.0/src/node_messaging.cc#L921-L924
-    // Like a close()d port, stay attached to the context: the task dispatches through it,
-    // and a pending activity only pins the wrapper of an object that still has one.
+    // Stays attached to the context like a close()d port: the task dispatches through it, and only pins the wrapper while we have one.
     queueCloseEvent();
 
     return TransferredMessagePort { m_pipe.copyRef(), m_side };

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -84,8 +84,7 @@ public:
     void peerClosed();
     void dispatchCloseEvent();
 
-    // Transfer machinery. Like node, disentangle() closes the local object: it
-    // fires 'close' on it (its pipe side is not closed, the receiver takes it over).
+    // Transfer machinery. disentangle() also queues 'close' on the transferred-away object, as node does.
     static ExceptionOr<Vector<TransferredMessagePort>> disentanglePorts(Vector<RefPtr<MessagePort>>&&);
     static Vector<RefPtr<MessagePort>> entanglePorts(ScriptExecutionContext&, Vector<TransferredMessagePort>&&);
     static Ref<MessagePort> entangle(ScriptExecutionContext&, TransferredMessagePort&&);

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -84,7 +84,8 @@ public:
     void peerClosed();
     void dispatchCloseEvent();
 
-    // Transfer machinery.
+    // Transfer machinery. Like node, disentangle() closes the local object: it
+    // fires 'close' on it (its pipe side is not closed, the receiver takes it over).
     static ExceptionOr<Vector<TransferredMessagePort>> disentanglePorts(Vector<RefPtr<MessagePort>>&&);
     static Vector<RefPtr<MessagePort>> entanglePorts(ScriptExecutionContext&, Vector<TransferredMessagePort>&&);
     static Ref<MessagePort> entangle(ScriptExecutionContext&, TransferredMessagePort&&);
@@ -131,6 +132,8 @@ private:
 
     // Deliver messages already queued when close() is called, before teardown.
     void flushQueuedMessagesBeforeClose();
+    // Shared tail of close() and disentangle(): fires 'close' from a task, then drops the listeners.
+    void queueCloseEvent();
 
     bool isEntangled() const { return !m_isDetached; }
 

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -84,7 +84,7 @@ public:
     void peerClosed();
     void dispatchCloseEvent();
 
-    // Transfer machinery. disentangle() also queues 'close' on the transferred-away object, as node does.
+    // Transfer machinery. disentangle() also queues 'close' on the transferred-away object, like node's TransferForMessaging(): https://github.com/nodejs/node/blob/v26.3.0/src/node_messaging.cc#L921-L924
     static ExceptionOr<Vector<TransferredMessagePort>> disentanglePorts(Vector<RefPtr<MessagePort>>&&);
     static Vector<RefPtr<MessagePort>> entanglePorts(ScriptExecutionContext&, Vector<TransferredMessagePort>&&);
     static Ref<MessagePort> entangle(ScriptExecutionContext&, TransferredMessagePort&&);

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1246,10 +1246,16 @@ describe("a port transferred away fires 'close' on the sender's object", () => {
       "port1 close (listener added after the transfer)",
     ]);
 
-    // The channel is intact: the received port is entangled with port2.
+    // The channel is intact and belongs to the received port: the transferred-away object
+    // shares the pipe side with it (and, like a closed port, still has a context), so it
+    // must not be able to take the receiver's messages. (Node returns undefined here too,
+    // once the port's 'close' has fired.)
+    port2.postMessage("to the received port");
+    expect(receiveMessageOnPort(port1)).toBeUndefined();
     const received = await new Promise<MessagePort>(resolve => carrier.port2.once("message", resolve));
-    received.postMessage("via the received port");
-    expect(await new Promise(resolve => port2.once("message", resolve))).toBe("via the received port");
+    expect(await new Promise(resolve => received.once("message", resolve))).toBe("to the received port");
+    received.postMessage("from the received port");
+    expect(await new Promise(resolve => port2.once("message", resolve))).toBe("from the received port");
 
     // Closing the channel now closes port2 and the received port; the object that was
     // transferred away does not fire a second time.

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1236,6 +1236,9 @@ describe("a port transferred away fires 'close' on the sender's object", () => {
     carrier.port1.postMessage(port1, [port1]);
     port1.on("close", () => events.push("port1 close (listener added after the transfer)"));
     events.push("postMessage returned");
+    // The event is queued as a task, which runs before the first setImmediate. A fixed
+    // window instead of awaiting it keeps the exact lists below meaningful: they also
+    // assert what must not fire (port2 now, port1 again at the end).
     for (let i = 0; i < 2; i++) await new Promise(r => setImmediate(r));
     expect(events).toEqual([
       "postMessage returned",
@@ -1291,7 +1294,10 @@ describe("a port transferred away fires 'close' on the sender's object", () => {
   });
 
   // Ports transferred through the Worker constructor's transferList, through
-  // worker.postMessage(), and from the worker through parentPort.postMessage().
+  // worker.postMessage(), and from the worker through parentPort.postMessage(). Each
+  // route also passes a message through the port the other side received, so the
+  // sender's 'close' is shown to leave the channel itself intact. The process exits on
+  // its own once the worker has finished, so every line is in before it does.
   test("transfers to and from a Worker", async () => {
     await using proc = Bun.spawn({
       cmd: [
@@ -1302,27 +1308,40 @@ describe("a port transferred away fires 'close' on the sender's object", () => {
          const viaPostMessage = new MessageChannel();
          viaConstructor.port2.on("close", () => console.log("transferList: close"));
          viaPostMessage.port2.on("close", () => console.log("worker.postMessage: close"));
+         viaConstructor.port1.once("message", m => console.log("transferList: " + m));
+         viaPostMessage.port1.once("message", m => console.log("worker.postMessage: " + m));
          const w = new Worker(
            \`const { parentPort, workerData, MessageChannel } = require("worker_threads");
-            const { port1 } = new MessageChannel();
-            port1.on("close", () => parentPort.postMessage("parentPort.postMessage: close"));
-            parentPort.postMessage(port1, [port1]);\`,
+            workerData.postMessage("received port works");
+            parentPort.once("message", received => {
+              received.postMessage("received port works");
+              const { port1, port2 } = new MessageChannel();
+              port2.postMessage("received port works");
+              port1.on("close", () => parentPort.postMessage("parentPort.postMessage: close"));
+              parentPort.postMessage(port1, [port1]);
+            });\`,
            { eval: true, workerData: viaConstructor.port2, transferList: [viaConstructor.port2] },
          );
          w.postMessage(viaPostMessage.port2, [viaPostMessage.port2]);
          w.on("message", m => {
-           if (typeof m === "string") {
-             console.log(m);
-             w.unref();
-           }
+           if (typeof m === "string") console.log(m);
+           else m.once("message", x => console.log("parentPort.postMessage: " + x));
          });`,
       ],
       env: bunEnv,
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    // The routes complete independently of each other, so the order of the lines varies.
     expect({ lines: stdout.trim().split("\n").sort(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
-      lines: ["parentPort.postMessage: close", "transferList: close", "worker.postMessage: close"],
+      lines: [
+        "parentPort.postMessage: close",
+        "parentPort.postMessage: received port works",
+        "transferList: close",
+        "transferList: received port works",
+        "worker.postMessage: close",
+        "worker.postMessage: received port works",
+      ],
       stderr: "",
       exitCode: 0,
       signalCode: null,

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1223,6 +1223,113 @@ test("dropping a transferred port notifies its peer", async () => {
   port1.close();
 });
 
+// Transferring a port closes the sender's object (node closes its handle), so that object
+// fires 'close' once, asynchronously. The channel itself moves to the receiver: the peer
+// sees nothing, and the channel's eventual close goes to the received port.
+describe("a port transferred away fires 'close' on the sender's object", () => {
+  test("postMessage to a local port", async () => {
+    const { port1, port2 } = new MessageChannel();
+    const carrier = new MessageChannel();
+    const events: string[] = [];
+    port1.on("close", () => events.push("port1 close (listener added before the transfer)"));
+    port2.on("close", () => events.push("port2 close"));
+    carrier.port1.postMessage(port1, [port1]);
+    port1.on("close", () => events.push("port1 close (listener added after the transfer)"));
+    events.push("postMessage returned");
+    for (let i = 0; i < 2; i++) await new Promise(r => setImmediate(r));
+    expect(events).toEqual([
+      "postMessage returned",
+      "port1 close (listener added before the transfer)",
+      "port1 close (listener added after the transfer)",
+    ]);
+
+    // The channel is intact: the received port is entangled with port2.
+    const received = await new Promise<MessagePort>(resolve => carrier.port2.once("message", resolve));
+    received.postMessage("via the received port");
+    expect(await new Promise(resolve => port2.once("message", resolve))).toBe("via the received port");
+
+    // Closing the channel now closes port2 and the received port; the object that was
+    // transferred away does not fire a second time.
+    received.on("message", () => {});
+    const receivedClosed = new Promise<void>(resolve => received.once("close", () => resolve()));
+    port2.close();
+    await receivedClosed;
+    for (let i = 0; i < 2; i++) await new Promise(r => setImmediate(r));
+    expect(events).toEqual([
+      "postMessage returned",
+      "port1 close (listener added before the transfer)",
+      "port1 close (listener added after the transfer)",
+      "port2 close",
+    ]);
+    carrier.port1.close();
+    carrier.port2.close();
+  });
+
+  // The transfer is the last thing the script does: the event still fires, and the
+  // pending event does not keep the process alive afterwards.
+  test("the event fires before the process exits and does not keep it alive", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { MessageChannel } = require("worker_threads");
+         const { port1 } = new MessageChannel();
+         const carrier = new MessageChannel();
+         port1.on("close", () => console.log("port1 close"));
+         carrier.port1.postMessage(port1, [port1]);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      stdout: "port1 close",
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+
+  // Ports transferred through the Worker constructor's transferList, through
+  // worker.postMessage(), and from the worker through parentPort.postMessage().
+  test("transfers to and from a Worker", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { Worker, MessageChannel } = require("worker_threads");
+         const viaConstructor = new MessageChannel();
+         const viaPostMessage = new MessageChannel();
+         viaConstructor.port2.on("close", () => console.log("transferList: close"));
+         viaPostMessage.port2.on("close", () => console.log("worker.postMessage: close"));
+         const w = new Worker(
+           \`const { parentPort, workerData, MessageChannel } = require("worker_threads");
+            const { port1 } = new MessageChannel();
+            port1.on("close", () => parentPort.postMessage("parentPort.postMessage: close"));
+            parentPort.postMessage(port1, [port1]);\`,
+           { eval: true, workerData: viaConstructor.port2, transferList: [viaConstructor.port2] },
+         );
+         w.postMessage(viaPostMessage.port2, [viaPostMessage.port2]);
+         w.on("message", m => {
+           if (typeof m === "string") {
+             console.log(m);
+             w.unref();
+           }
+         });`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ lines: stdout.trim().split("\n").sort(), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+      lines: ["parentPort.postMessage: close", "transferList: close", "worker.postMessage: close"],
+      stderr: "",
+      exitCode: 0,
+      signalCode: null,
+    });
+  });
+});
+
 // close() outside a dispatch drops whatever is queued; close() from inside a
 // 'message' handler lets the in-flight drain finish. Both are node's behaviour.
 test("close() drops queued messages unless it runs inside a dispatch", async () => {

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -352,6 +352,36 @@ test("a pending close event survives GC after the port becomes unreachable", asy
   expect(fired).toBe(50);
 });
 
+// A transfer closes the sender's port object the same way (node fires 'close' on it), so
+// disentangle() queues the same task, and that object must stay attached to its context
+// until the task runs: the pending activity only pins the wrapper while it has a context.
+test("a transferred-away port's pending close event survives GC after the port becomes unreachable", async () => {
+  const { heapStats } = require("bun:jsc");
+  const count = () => heapStats().objectTypeCounts.MessagePort ?? 0;
+  Bun.gc(true);
+  const base = count();
+  let fired = 0;
+  const carrier = new MessageChannel();
+  for (let i = 0; i < 50; i++) {
+    (() => {
+      const { port1 } = new MessageChannel();
+      port1.addEventListener("close", () => fired++);
+      carrier.port1.postMessage(port1, [port1]);
+    })();
+    if (i % 10 === 0) Bun.gc(true);
+  }
+  Bun.gc(true);
+  for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
+  expect(fired).toBe(50);
+  // Once the event has fired nothing pins the transferred-away objects (or their
+  // unreferenced peers) any more; only the carrier pair is still reachable.
+  Bun.gc(true);
+  Bun.gc(true);
+  expect(count() - base).toBeLessThanOrEqual(2 + 10);
+  carrier.port1.close();
+  carrier.port2.close();
+});
+
 // The peer's notifyPeerClosed() task only holds a weak ref back to this port, so a
 // port whose only listener is 'close' must survive GC until the event is delivered.
 test("a close event from the peer survives GC of the unreachable port", async () => {

--- a/test/js/web/workers/message-channel.test.ts
+++ b/test/js/web/workers/message-channel.test.ts
@@ -1,3 +1,5 @@
+import { heapStats } from "bun:jsc";
+
 test("simple usage", done => {
   const channel = new MessageChannel();
   const port1 = channel.port1;
@@ -356,7 +358,6 @@ test("a pending close event survives GC after the port becomes unreachable", asy
 // disentangle() queues the same task, and that object must stay attached to its context
 // until the task runs: the pending activity only pins the wrapper while it has a context.
 test("a transferred-away port's pending close event survives GC after the port becomes unreachable", async () => {
-  const { heapStats } = require("bun:jsc");
   const count = () => heapStats().objectTypeCounts.MessagePort ?? 0;
   Bun.gc(true);
   const base = count();
@@ -371,6 +372,9 @@ test("a transferred-away port's pending close event survives GC after the port b
     if (i % 10 === 0) Bun.gc(true);
   }
   Bun.gc(true);
+  // The events are queued as tasks, which run before the first setImmediate; the fixed
+  // window (rather than awaiting the 50th event) is what lets the exact count below also
+  // catch a port firing twice.
   for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
   expect(fired).toBe(50);
   // Once the event has fired nothing pins the transferred-away objects (or their
@@ -405,7 +409,6 @@ test("a close event from the peer survives GC of the unreachable port", async ()
 // which never collects an entangled port). Bound the retention: explicitly-closed pairs
 // must still be swept, so a regression that leaks closed ports too would show as growth.
 test("explicitly-closed close-listener ports are collected; open ones are pinned like Node", async () => {
-  const { heapStats } = require("bun:jsc");
   const count = () => heapStats().objectTypeCounts.MessagePort ?? 0;
   for (let i = 0; i < 4; i++) await new Promise(r => setImmediate(r));
   Bun.gc(true);

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -136,4 +136,47 @@ describe("self.postMessage transfer list", () => {
       URL.revokeObjectURL(url);
     }
   });
+
+  // Transferring a port closes the sender's object (node fires 'close' on it, asynchronously).
+  // Worker#postMessage and the worker-side self.postMessage each disentangle the port
+  // themselves, so both directions are checked.
+  test("a port transferred with postMessage fires 'close' on the sender's object, in both directions", async () => {
+    const url = URL.createObjectURL(
+      new Blob([
+        `
+          const { port1 } = new MessageChannel();
+          const events = [];
+          port1.addEventListener("close", () => events.push("close"));
+          self.postMessage(port1, [port1]);
+          events.push("postMessage returned");
+          setImmediate(() => setImmediate(() => self.postMessage(events)));
+        `,
+      ]),
+    );
+    const worker = new Worker(url);
+    try {
+      const messages: any[] = [];
+      const workerEvents = new Promise<string[]>((resolve, reject) => {
+        worker.onerror = e => reject(e.error ?? e.message ?? e);
+        worker.onmessage = e => {
+          messages.push(e.data);
+          if (Array.isArray(e.data)) resolve(e.data);
+        };
+      });
+
+      const { port1 } = new MessageChannel();
+      const events: string[] = [];
+      port1.addEventListener("close", () => events.push("close"));
+      worker.postMessage(port1, [port1]);
+      events.push("postMessage returned");
+      await new Promise(r => setImmediate(() => setImmediate(r)));
+      expect(events).toEqual(["postMessage returned", "close"]);
+
+      expect(await workerEvents).toEqual(["postMessage returned", "close"]);
+      expect(messages[0]).toBeInstanceOf(MessagePort);
+    } finally {
+      worker.terminate();
+      URL.revokeObjectURL(url);
+    }
+  });
 });

--- a/test/js/web/workers/worker-postmessage-transfer.test.ts
+++ b/test/js/web/workers/worker-postmessage-transfer.test.ts
@@ -137,43 +137,57 @@ describe("self.postMessage transfer list", () => {
     }
   });
 
-  // Transferring a port closes the sender's object (node fires 'close' on it, asynchronously).
-  // Worker#postMessage and the worker-side self.postMessage each disentangle the port
-  // themselves, so both directions are checked.
+  // Transferring a port closes the sender's object (node fires 'close' on it, asynchronously)
+  // and nothing else: the peer stays open and the receiver's port talks to it. Worker#postMessage
+  // and the worker-side self.postMessage each disentangle the port themselves, so both
+  // directions are checked. The event is a task, which runs before the first setImmediate;
+  // both sides record for two of them rather than awaiting the event so that the recorded
+  // lists also show anything that fired when it should not have.
   test("a port transferred with postMessage fires 'close' on the sender's object, in both directions", async () => {
     const url = URL.createObjectURL(
       new Blob([
         `
-          const { port1 } = new MessageChannel();
+          const { port1, port2 } = new MessageChannel();
+          port2.postMessage("queued before the transfer"); // travels with port1
           const events = [];
           port1.addEventListener("close", () => events.push("close"));
+          port2.addEventListener("close", () => events.push("peer close"));
           self.postMessage(port1, [port1]);
           events.push("postMessage returned");
           setImmediate(() => setImmediate(() => self.postMessage(events)));
+          self.onmessage = e => e.data.postMessage("sent through the received port");
         `,
       ]),
     );
     const worker = new Worker(url);
     try {
-      const messages: any[] = [];
+      const fromWorker: any[] = [];
       const workerEvents = new Promise<string[]>((resolve, reject) => {
         worker.onerror = e => reject(e.error ?? e.message ?? e);
         worker.onmessage = e => {
-          messages.push(e.data);
+          fromWorker.push(e.data);
           if (Array.isArray(e.data)) resolve(e.data);
         };
       });
 
-      const { port1 } = new MessageChannel();
+      const { port1, port2 } = new MessageChannel();
       const events: string[] = [];
       port1.addEventListener("close", () => events.push("close"));
+      port2.addEventListener("close", () => events.push("peer close"));
+      const throughPort2 = new Promise<string>(resolve => (port2.onmessage = e => resolve(e.data)));
       worker.postMessage(port1, [port1]);
       events.push("postMessage returned");
       await new Promise(r => setImmediate(() => setImmediate(r)));
       expect(events).toEqual(["postMessage returned", "close"]);
+      expect(await throughPort2).toBe("sent through the received port");
 
       expect(await workerEvents).toEqual(["postMessage returned", "close"]);
-      expect(messages[0]).toBeInstanceOf(MessagePort);
+      const received = fromWorker[0];
+      expect(received).toBeInstanceOf(MessagePort);
+      const throughReceived = new Promise<string>(resolve => (received.onmessage = e => resolve(e.data)));
+      expect(await throughReceived).toBe("queued before the transfer");
+      received.close();
+      port2.close();
     } finally {
       worker.terminate();
       URL.revokeObjectURL(url);


### PR DESCRIPTION
### Problem

- A `MessagePort` listed in a transfer list never emits `'close'` on the sender's side. Node emits it: `port.on("close", ...)` followed by `other.postMessage(port, [port])` prints in node and prints nothing in bun. Same for `worker.postMessage(port, [port])`, `new Worker(file, { workerData, transferList: [port] })` and `parentPort.postMessage(port, [port])` inside a worker. This is the `port1 closed` line of #19862 that is still missing on main.
- Cause: `MessagePort::disentangle()` (src/jsc/bindings/webcore/MessagePort.cpp), which every transfer path ends in, called `removeAllEventListeners()` and `observeContext(nullptr)` synchronously. The deferred close task that `close()` queues was never queued for a transfer, and after those two calls nothing could have been dispatched on the object anyway.

### Fix

- The tail of `close()` (queue a task that dispatches `'close'` and then removes the listeners) becomes `queueCloseEvent()`; `disentangle()` calls it instead of removing the listeners and leaving the context. The pipe side is still handed to the receiver, so the peer is not notified and the channel keeps working through the received port; only the transferred-away object fires, once (`m_closeEventDispatched`).
- `disentangle()` no longer detaches the object from its `ScriptExecutionContext`: the task dispatches through that context (`EventTarget` dispatch asserts one), and `JSMessagePortOwner::isReachableFromOpaqueRoots` only honors the task's pending activity while `isContextStopped()` is false, so leaving early would let a GC collect the wrapper and the listeners before the event fires. A closed port already stays attached until it is collected; a transferred one now does the same. Nothing else pins it afterwards (heap count of `MessagePort` returns to baseline in the new test).
- Consequence of that: "transferred away" can no longer be recognized by a null context, only by `m_isDetached`. Everything that tells a dead object from a live one already keys on it (`tryTakeMessage`, `peerClosed`, `dispatchOneMessage`, `dispatchEvent`, `virtualHasPendingActivity`, `jsRef`, `disentanglePorts`, the transfer-list checks in `SerializedScriptValue.cpp` and `Worker.cpp`; `stop()`/`contextDestroyed()` go through `close()`, which returns early on it). The one place where the context used to be a second guard is `tryTakeMessage` (`receiveMessageOnPort`): the transferred-away object still refers to the pipe side its receiver now owns, so its `isEntangled()` check is what keeps it from taking the receiver's messages. That check gets a comment and is pinned by the local test (a message queued for the received port, `receiveMessageOnPort(transferredAway)` is `undefined`, the received port gets the message). Node returns `undefined` there as well once the port's `'close'` has fired (v26.3.0 segfaults if it is called in the same tick as the transfer, so the test asserts it after the event).
- Matches node: transferring a port is `MessagePort::TransferForMessaging()`, which is `Close(); return Detach();` ([node_messaging.cc#L921-L924](https://github.com/nodejs/node/blob/v26.3.0/src/node_messaging.cc#L921-L924)); the handle's close callback then dispatches the `close` event on the JS object ([io.js#L171-L174](https://github.com/nodejs/node/blob/v26.3.0/lib/internal/worker/io.js#L171-L174)). So node's event is asynchronous, reaches listeners added right after the `postMessage` call, and does not touch the peer. Bun fires it at the same point it already fires `close()`'s event (a task: after the calling code and its microtasks, before `setImmediate`, whereas node fires both in the uv close phase, after `setImmediate`); the tests wait two `setImmediate` turns so the same scripts pass under node.
- Every transfer entry point goes through `disentangle()` (`MessagePort::postMessage`, `Worker::postMessage`, the worker-global `postMessage`, the `Worker` constructor's `transferList`), so they are all covered by the one change. The ports bun transfers internally when constructing a `node:worker_threads` worker have no listeners; they now each queue one no-op task.
- Verified with:
  - `test/js/node/worker_threads/worker_threads.test.ts`, new `describe("a port transferred away fires 'close' on the sender's object")`: local `postMessage` (listener order, listener added after the transfer, peer untouched, `receiveMessageOnPort` on the transferred-away object, channel still works in both directions, no second event when the channel really closes), a process whose last statement is the transfer (event fires, process exits on its own), and the three `Worker` paths (constructor `transferList`, `worker.postMessage`, worker-side `parentPort.postMessage`), each also passing a message through the port the other side received. 3 fail on the release build, pass with the fix; whole file 125 pass.
  - `test/js/web/workers/message-channel.test.ts`: 50 transferred ports made unreachable and GC'd while the event is pending all fire, and are collected afterwards. Fails before (0 fired), passes after.
  - `test/js/web/workers/worker-postmessage-transfer.test.ts`: `Worker#postMessage` and worker-side `self.postMessage`, with `addEventListener("close")`; the peers stay open and both received ports carry a message. Fails before, passes after.
  - `message-port-pipe`, `message-port-closed-leak`, `message-port-context-destroy-leak`, `message-event`, `structured-clone`, `worker-transfer-list`, `worker-transfer-terminate-stress` test files and the 26 upstream `test-worker-message-*` / `test-messagechannel` files in `test/js/node/test/parallel` pass. Node's own suite has no case for this event, so no previously failing upstream test is enabled by this.
- Related open PRs touching `MessagePort.cpp`: #37966 (transfer-list re-validation) only edits `postMessage()` and is unaffected by this. #33638 (`receiveMessageOnPort` after `close()`) already conflicts with main on its own, and both of its `MessagePort.cpp` hunks need rework on top of this one: its `m_pipe->close()` has to stay specific to `close()` rather than go into `queueCloseEvent()`, which `disentangle()` also queues (the channel-intact tests here fail if it is put there), and it can no longer drop `tryTakeMessage`'s `isEntangled()` check on the grounds that a transferred-away port has no context (the `receiveMessageOnPort` assertion here fails if it does).

### Background

- A `MessageChannel` in bun is one `MessagePortPipe` with two sides; each JS `MessagePort` object owns one side. Transferring a port (`disentangle()`) detaches the object from its side and ships the side to the receiver, which wraps it in a new `MessagePort` object. The old object is inert from then on; the peer is still entangled, now with the new object.
- The same native `MessagePort` backs both `globalThis.MessageChannel` and `node:worker_threads` (the module adds `on()`/`once()` over `addEventListener`), and its `'close'` event already follows node (the closing port fires it too, #31216). The HTML spec has no event for the transferred-away object; in bun it is the same object either way, so it fires for both APIs.
- `ActiveDOMObject::queueTaskKeepingObjectAlive` posts a task on the object's `ScriptExecutionContext` and holds a pending activity on the object until it runs. `hasPendingActivity()` is what keeps a wrapper (and therefore the JS listener functions reachable only through it) alive across GC, but the wrapper's GC hook ignores it once the object has no context.

<details>
<summary>Repro scripts and output (node v26.3.0, bun 1.4.0 release, this branch)</summary>

Local channel, the scenario of the new `postMessage to a local port` test:

```js
import { MessageChannel, receiveMessageOnPort } from "node:worker_threads";
const tick = () => new Promise(r => setImmediate(r));
const { port1, port2 } = new MessageChannel();
const carrier = new MessageChannel();
const events = [];
port1.on("close", () => events.push("port1 close (listener added before the transfer)"));
port2.on("close", () => events.push("port2 close"));
carrier.port1.postMessage(port1, [port1]);
port1.on("close", () => events.push("port1 close (listener added after the transfer)"));
events.push("postMessage returned");
await tick(); await tick();
port2.postMessage("hello");
events.push("receiveMessageOnPort(port1): " + receiveMessageOnPort(port1));
const received = await new Promise(resolve => carrier.port2.once("message", resolve));
events.push("received port got: " + await new Promise(resolve => received.once("message", resolve)));
received.postMessage("hi back");
events.push("port2 got: " + await new Promise(resolve => port2.once("message", resolve)));
received.on("message", () => {});
const receivedClosed = new Promise(resolve => received.once("close", resolve));
port2.close();
await receivedClosed;
await tick(); await tick();
console.log(events.join("\n"));
carrier.port1.close(); carrier.port2.close();
```

node v26.3.0 and this branch print the same thing:

```
postMessage returned
port1 close (listener added before the transfer)
port1 close (listener added after the transfer)
receiveMessageOnPort(port1): undefined
received port got: hello
port2 got: hi back
port2 close
```

bun 1.4.0:

```
postMessage returned
receiveMessageOnPort(port1): undefined
received port got: hello
port2 got: hi back
port2 close
```

Worker paths (the script from the `transfers to and from a Worker` test; lines sorted, since the routes complete independently and node orders the two parent-side close lines the other way round from bun). node v26.3.0 and this branch print all six and exit 0:

```
parentPort.postMessage: close
parentPort.postMessage: received port works
transferList: close
transferList: received port works
worker.postMessage: close
worker.postMessage: received port works
```

bun 1.4.0 prints only the three `received port works` lines and exits 0.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/message-channel.test.ts test/js/web/workers/worker-postmessage-transfer.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (fe7dabcc9)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [0.25ms]
(pass) transfer message port [0.41ms]
(pass) transfer array buffer [0.12ms]
(node:108433) Warning: The target port was posted to itself, and the communication channel was lost
(Use `bun --trace-warnings ...` to show where the warning was created)
(pass) non-transferable [1.84ms]
(pass) transfer message ports and post messages [0.40ms]
(pass) message channel created on main thread [6.38ms]
(pass) message channel created on other thread [5.59ms]
(node:108433) Warning: The target port was posted to itself, and the communication channel was lost
(pass) many message channels [1.42ms]
(pass) gc [1.82ms]
(pass) cloneable and transferable equals [3.11ms]
(pass) cloneable and non-transferable equals (BunFile) [0.43ms]
(pass) cloneable and non-transferable equals (net.BlockList) [4.86ms]
(pass) a pending close event survives GC after the port becomes unreachable [18.70ms]
(pass) a transferred-away port's pending close event survives GC after the port becomes unreachable [33.34ms]
(pass) a close event from the peer survives GC of the unreachable port [6.44ms]
(pass) 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/worker_threads/worker_threads.test.ts test/js/web/workers/message-channel.test.ts test/js/web/workers/worker-postmessage-transfer.test.ts
bun test v1.4.0 (0b5c0bf11)

test/js/web/workers/message-channel.test.ts:
(pass) simple usage [19.04ms]
(pass) transfer message port [19.13ms]
(pass) transfer array buffer [9.64ms]
(node:117918) Warning: The target port was posted to itself, and the communication channel was lost
(Use `bun-debug --trace-warnings ...` to show where the warning was created)
(pass) non-transferable [76.53ms]
(pass) transfer message ports and post messages [28.51ms]
(pass) message channel created on main thread [195.29ms]
(pass) message channel created on other thread [261.14ms]
(node:117918) Warning: The target port was posted to itself, and the communication channel was lost
(pass) many message channels [68.15ms]
(pass) gc [129.00ms]
(pass) cloneable and transferable equals [195.92ms]
(pass) cloneable and non-transferable equals (BunFile) [20.11ms]
(pass) cloneable and non-transferable equals (net.BlockLis
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1358ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/41] gen bindgenv2
[2/36] gen cpp.rs (cppbind)
[3/36] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[4/36] gen JS modules (bundle-modules)
Preprocess modules (15232ms)
Bundle modules (118ms)
Postprocesss modules (203ms)
Bundle Functions (1367ms)
Generate Code (41ms)

[17.00s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/27] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspac
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/jsc/bindings/webcore/MessagePort.cpp           |  29 ++---
 src/jsc/bindings/webcore/MessagePort.h             |   4 +-
 test/js/node/worker_threads/worker_threads.test.ts | 132 +++++++++++++++++++++
 test/js/web/workers/message-channel.test.ts        |  35 +++++-
 .../workers/worker-postmessage-transfer.test.ts    |  57 +++++++++
 5 files changed, 237 insertions(+), 20 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                     reads  edits  tests
src/jsc/bindings/webcore/MessagePort.cpp                     6     13      0
src/jsc/bindings/webcore/MessagePort.h                       1      4      0
test/js/node/worker_threads/worker_threads.test.ts           7      5      0
test/js/web/workers/message-channel.test.ts                  4      6      0
test/js/web/workers/worker-postmessage-transfer.test.ts      2      2      0
```

</details>

<!-- robobun:evidence:end -->