### PR TITLE
test: drop NodeHTTPResponse.rs from the dead-code escape inventory

### DIFF
--- a/test/internal/source-lints/dead-code-escape-limits.json
+++ b/test/internal/source-lints/dead-code-escape-limits.json
@@ -22,7 +22,6 @@
   "src/runtime/image/codecs.rs": 1,
   "src/runtime/node/fs_events.rs": 3,
   "src/runtime/node/node_fs.rs": 2,
-  "src/runtime/server/NodeHTTPResponse.rs": 1,
   "src/runtime/shell/subproc.rs": 1,
   "src/spawn_sys/posix_spawn.rs": 4
 }


### PR DESCRIPTION
#37977 removed the last #[allow(dead_code)] in NodeHTTPResponse.rs but left the inventory at 1, so the source-lints job has been failing on main since a28fcc4704. Regenerated with bun ./test/internal/source-lints/dead-code-escapes.test.ts.