### PR TITLE
Report an empty path operand in err.path/err.dest and the error message instead of dropping it

### DIFF
--- a/src/CLAUDE.md
+++ b/src/CLAUDE.md
@@ -61,8 +61,9 @@ Key types and functions:
 - `bun_sys::open`, `read`, `write`, `pread`, `pwrite`, `stat`, `fstat`, `lstat`, `mkdir`, `unlink`, `rename`, `symlink`, `chmod` — free fns over `Fd`
 - Open flags: `bun_sys::O::RDONLY`, `O::WRONLY | O::CREAT | O::TRUNC`, etc.
 
-`bun_sys::Error` carries `errno`, `syscall: Tag`, `path: Box<[u8]>`. Convert
-to a JS exception via `bun_sys_jsc::ErrorJsc::to_js`:
+`bun_sys::Error` carries `errno`, `syscall: Tag`, `path: Option<Box<[u8]>>`
+(`None` when the operation had no path operand; an empty operand is `Some`).
+Convert to a JS exception via `bun_sys_jsc::ErrorJsc::to_js`:
 
 ```rust
 use bun_sys_jsc::ErrorJsc;

--- a/src/jsc/SystemError.rs
+++ b/src/jsc/SystemError.rs
@@ -13,11 +13,13 @@ pub struct SystemError {
     pub code: OwnedString,
     /// it is illegal to have an empty message
     pub message: OwnedString,
+    /// `Empty` tag = no `path` property; see `operand_to_c` for an operand of "".
     pub path: OwnedString,
     pub syscall: OwnedString,
     pub hostname: OwnedString,
     /// MinInt = no file descriptor
     pub fd: c_int,
+    /// Same convention as `path`.
     pub dest: OwnedString,
 }
 
@@ -55,12 +57,22 @@ impl From<bun_sys::SystemError> for SystemError {
             errno: errno as c_int,
             code,
             message,
-            path,
+            path: operand_to_c(path),
             syscall,
             hostname,
             fd: fd.unwrap_or(c_int::MIN),
-            dest,
+            dest: operand_to_c(dest),
         }
+    }
+}
+
+/// `SystemError__toErrorInstance` only defines the property for a string whose tag
+/// is not `Empty`, so an operand of "" crosses as a zero-length string of another tag.
+fn operand_to_c(operand: Option<OwnedString>) -> OwnedString {
+    match operand {
+        None => OwnedString::default(),
+        Some(operand) if operand.is_empty() => String::static_(b"").into(),
+        Some(operand) => operand,
     }
 }
 

--- a/src/jsc/SystemError.rs
+++ b/src/jsc/SystemError.rs
@@ -66,8 +66,7 @@ impl From<bun_sys::SystemError> for SystemError {
     }
 }
 
-/// `SystemError__toErrorInstance` only defines the property for a string whose tag
-/// is not `Empty`, so an operand of "" crosses as a zero-length string of another tag.
+/// C++ takes the `Empty` tag as "no property", so a present "" has to cross under another tag.
 fn operand_to_c(operand: Option<OwnedString>) -> OwnedString {
     match operand {
         None => OwnedString::default(),

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5783,9 +5783,8 @@ impl DevServer {
     }
 
     pub(crate) fn on_watch_error(&self, err: sys::Error) {
-        if !err.path.is_empty() {
-            // Note: split out path before moving `err` into `Output::err`.
-            let path = err.path.clone();
+        // Note: split out path before moving `err` into `Output::err`.
+        if let Some(path) = err.path.clone() {
             Output::err(
                 err,
                 "failed to watch {} for hot-reloading",

--- a/src/runtime/cli/build_command.rs
+++ b/src/runtime/cli/build_command.rs
@@ -1250,7 +1250,7 @@ pub(crate) fn collect_compile_assets(
     let fail = |err: bun_sys::Error| -> Result<(), String> {
         Err(format!(
             "failed to read asset {}: {}",
-            bun_fmt::quote(&err.path),
+            bun_fmt::quote(err.path.as_deref().unwrap_or_default()),
             err,
         ))
     };

--- a/src/runtime/image/Image.rs
+++ b/src/runtime/image/Image.rs
@@ -1598,12 +1598,9 @@ impl PipelineTask {
                 }
             };
             if !sys::S::ISREG(st.st_mode as _) {
-                self.result = TaskResult::IoErr(sys::Error {
-                    errno: sys::E::ENODEV as _,
-                    syscall: sys::Tag::read,
-                    path: p.as_bytes().to_vec().into_boxed_slice(),
-                    ..Default::default()
-                });
+                self.result = TaskResult::IoErr(
+                    sys::Error::from_code(sys::E::ENODEV, sys::Tag::read).with_path(p.as_bytes()),
+                );
                 return;
             }
             if u64::try_from(st.st_size.max(0)).expect("int cast") > MAX_INPUT_FILE_BYTES {

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -5981,7 +5981,7 @@ impl NodeFS {
         if rc < 0 {
             return Err(sys::Error {
                 errno: (-rc) as _,
-                syscall: sys::Tag::open,
+                syscall: sys::Tag::statfs,
                 path: Some(args.path.slice().into()),
                 #[cfg(windows)]
                 from_libuv: true,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -58,7 +58,7 @@ impl<R> MaybeSysResultExt<R> for Maybe<R> {
         Err(sys::Error {
             errno: (e as u16),
             syscall,
-            path: path.as_ref().into(),
+            path: Some(path.as_ref().into()),
             ..Default::default()
         })
     }
@@ -96,7 +96,7 @@ impl<R> MaybeSysResultExt<R> for Maybe<R> {
             e => Some(Err(sys::Error {
                 errno: (e as u16),
                 syscall,
-                path: path.as_ref().into(),
+                path: Some(path.as_ref().into()),
                 ..Default::default()
             })),
         }
@@ -113,8 +113,8 @@ impl<R> MaybeSysResultExt<R> for Maybe<R> {
             e => Some(Err(sys::Error {
                 errno: (e as u16),
                 syscall,
-                path: path.as_ref().into(),
-                dest: dest.as_ref().into(),
+                path: Some(path.as_ref().into()),
+                dest: Some(dest.as_ref().into()),
                 ..Default::default()
             })),
         }
@@ -600,17 +600,9 @@ mod _async_tasks {
                     ..Default::default()
                 });
                 match result {
-                    Err(err) => {
-                        (self.completion)(
-                            self.completion_ctx,
-                            // `with_path` already clones into a fresh `Box<[u8]>`; pass the
-                            // existing path slice.
-                            Err(err.with_path(&err.path)),
-                        );
-                    }
-                    Ok(_) => {
-                        (self.completion)(self.completion_ctx, Ok(()));
-                    }
+                    // `err.path` is an owned `Box<[u8]>`, so it outlives `node_fs`.
+                    Err(err) => (self.completion)(self.completion_ctx, Err(err)),
+                    Ok(_) => (self.completion)(self.completion_ctx, Ok(())),
                 }
             }
         }
@@ -1792,7 +1784,7 @@ mod _async_tasks {
             let name_too_long = |path: &PathLike| sys::Error {
                 errno: E::ENAMETOOLONG as _,
                 syscall: sys::Tag::copyfile,
-                path: path.slice().into(),
+                path: Some(path.slice().into()),
                 ..Default::default()
             };
             let src = match args.src.os_path(&mut src_buf) {
@@ -1818,7 +1810,7 @@ mod _async_tasks {
                     this.finish_concurrently(Err(sys::Error {
                         errno: SystemErrno::ENOENT as _,
                         syscall: sys::Tag::copyfile,
-                        path: nodefs.os_path_into_sync_error_buf(src).into(),
+                        path: Some(nodefs.os_path_into_sync_error_buf(src).into()),
                         ..Default::default()
                     }));
                     return;
@@ -1907,7 +1899,7 @@ mod _async_tasks {
                 this.finish_concurrently(Err(sys::Error {
                     errno: E::EISDIR as _,
                     syscall: sys::Tag::copyfile,
-                    path: nodefs.os_path_into_sync_error_buf(src).into(),
+                    path: Some(nodefs.os_path_into_sync_error_buf(src).into()),
                     ..Default::default()
                 }));
                 return;
@@ -2057,9 +2049,11 @@ mod _async_tasks {
                     this_ref.finish_concurrently(Err(sys::Error {
                         errno: E::ENAMETOOLONG as _,
                         syscall: sys::Tag::copyfile,
-                        path: nodefs
-                            .os_path_into_sync_error_buf(&src_buf[..src_dir_len as usize])
-                            .into(),
+                        path: Some(
+                            nodefs
+                                .os_path_into_sync_error_buf(&src_buf[..src_dir_len as usize])
+                                .into(),
+                        ),
                         ..Default::default()
                     }));
                     return false;
@@ -2439,10 +2433,9 @@ mod _async_tasks {
                             {
                                 let _lock = self.pending_err_mutex.lock_guard();
                                 if self.pending_err.is_none() {
-                                    let err_path: &[u8] = if !err.path.is_empty() {
-                                        &err.path[..]
-                                    } else {
-                                        &self.root_path[..self.root_path.len() - 1]
+                                    let err_path: &[u8] = match err.path.as_deref() {
+                                        Some(path) => path,
+                                        None => &self.root_path[..self.root_path.len() - 1],
                                     };
                                     self.pending_err = Some(err.with_path(err_path));
                                 }
@@ -4876,8 +4869,8 @@ impl NodeFS {
             Err(err) => Err(sys::Error {
                 errno: err.errno,
                 syscall: sys::Tag::copyfile,
-                path: args.src.slice().into(),
-                dest: args.dest.slice().into(),
+                path: Some(args.src.slice().into()),
+                dest: Some(args.dest.slice().into()),
                 ..Default::default()
             }),
         }
@@ -5040,7 +5033,7 @@ impl NodeFS {
                     return Err(sys::Error {
                         errno: SystemErrno::EINVAL as _,
                         syscall: sys::Tag::copyfile,
-                        path: args.src.slice().into(),
+                        path: Some(args.src.slice().into()),
                         ..Default::default()
                     });
                 }
@@ -5281,7 +5274,7 @@ impl NodeFS {
                     return Err(sys::Error {
                         errno: E::ENAMETOOLONG as _,
                         syscall: sys::Tag::copyfile,
-                        path: path.slice().into(),
+                        path: Some(path.slice().into()),
                         ..Default::default()
                     });
                 }
@@ -5500,7 +5493,7 @@ impl NodeFS {
             return Err(sys::Error {
                 errno: E::EOPNOTSUPP as _,
                 syscall: sys::Tag::lchmod,
-                path: args.path.slice().into(),
+                path: Some(args.path.slice().into()),
                 ..Default::default()
             });
         }
@@ -5587,12 +5580,7 @@ impl NodeFS {
 
     pub(crate) fn mkdir(&mut self, args: &args::Mkdir, _: Flavor) -> Maybe<ret::Mkdir> {
         if args.path.slice().is_empty() {
-            return Err(sys::Error {
-                errno: E::ENOENT as _,
-                syscall: sys::Tag::mkdir,
-                path: b"".as_slice().into(),
-                ..Default::default()
-            });
+            return Err(sys::Error::from_code(E::ENOENT, sys::Tag::mkdir).with_path(b""));
         }
         if args.recursive {
             self.mkdir_recursive(args)
@@ -5626,7 +5614,7 @@ impl NodeFS {
                 return Err(sys::Error {
                     errno: E::ENAMETOOLONG as _,
                     syscall: sys::Tag::mkdir,
-                    path: args.path.slice().into(),
+                    path: Some(args.path.slice().into()),
                     ..Default::default()
                 });
             }
@@ -5671,9 +5659,10 @@ impl NodeFS {
                         Err(_) => Err(sys::Error {
                             errno: err.errno,
                             syscall: sys::Tag::mkdir,
-                            path: self
-                                .os_path_into_sync_error_buf(without_nt_prefix(&path[..]))
-                                .into(),
+                            path: Some(
+                                self.os_path_into_sync_error_buf(without_nt_prefix(&path[..]))
+                                    .into(),
+                            ),
                             ..Default::default()
                         }),
                         // if is a directory, OK. otherwise failure
@@ -5684,9 +5673,12 @@ impl NodeFS {
                                 Err(sys::Error {
                                     errno: err.errno,
                                     syscall: sys::Tag::mkdir,
-                                    path: self
-                                        .os_path_into_sync_error_buf(without_nt_prefix(&path[..]))
+                                    path: Some(
+                                        self.os_path_into_sync_error_buf(without_nt_prefix(
+                                            &path[..],
+                                        ))
                                         .into(),
+                                    ),
                                     ..Default::default()
                                 })
                             }
@@ -5769,11 +5761,15 @@ impl NodeFS {
                                             return Err(sys::Error {
                                                 errno: E::ENOTDIR as _,
                                                 syscall: sys::Tag::mkdir,
-                                                path: Self::os_path_into_buf(
-                                                    unsafe { &mut *sync_error_buf_ptr },
-                                                    without_nt_prefix(&(&path[..])[..len as usize]),
-                                                )
-                                                .into(),
+                                                path: Some(
+                                                    Self::os_path_into_buf(
+                                                        unsafe { &mut *sync_error_buf_ptr },
+                                                        without_nt_prefix(
+                                                            &(&path[..])[..len as usize],
+                                                        ),
+                                                    )
+                                                    .into(),
+                                                ),
                                                 ..Default::default()
                                             });
                                         }
@@ -5915,7 +5911,7 @@ impl NodeFS {
                 return Err(sys::Error {
                     errno,
                     syscall: sys::Tag::mkdtemp,
-                    path: prefix_buf[..len + 6].into(),
+                    path: Some(prefix_buf[..len + 6].into()),
                     ..Default::default()
                 });
             }
@@ -5942,7 +5938,7 @@ impl NodeFS {
             Err(sys::Error {
                 errno: errno as _,
                 syscall: sys::Tag::mkdtemp,
-                path: prefix_buf[..len + 6].into(),
+                path: Some(prefix_buf[..len + 6].into()),
                 ..Default::default()
             })
         }
@@ -5967,7 +5963,7 @@ impl NodeFS {
             return Err(sys::Error {
                 errno: (-rc) as _,
                 syscall: sys::Tag::open,
-                path: args.path.slice().into(),
+                path: Some(args.path.slice().into()),
                 from_libuv: true,
                 ..Default::default()
             });
@@ -5986,7 +5982,7 @@ impl NodeFS {
             return Err(sys::Error {
                 errno: (-rc) as _,
                 syscall: sys::Tag::open,
-                path: args.path.slice().into(),
+                path: Some(args.path.slice().into()),
                 #[cfg(windows)]
                 from_libuv: true,
                 ..Default::default()
@@ -6316,7 +6312,7 @@ impl NodeFS {
             Err(err) => Err(sys::Error {
                 syscall: sys::Tag::scandir,
                 errno: err.errno,
-                path: args.path.slice().into(),
+                path: Some(args.path.slice().into()),
                 ..Default::default()
             }),
             Ok(result) => Ok(result),
@@ -7573,7 +7569,7 @@ impl NodeFS {
             Err(err) => Err(sys::Error {
                 errno: err.errno,
                 syscall: sys::Tag::lstat,
-                path: args.path.slice().into(),
+                path: Some(args.path.slice().into()),
                 ..Default::default()
             }),
         }
@@ -7585,7 +7581,7 @@ impl NodeFS {
             Err(err) => Err(sys::Error {
                 errno: err.errno,
                 syscall: sys::Tag::realpath,
-                path: args.path.slice().into(),
+                path: Some(args.path.slice().into()),
                 ..Default::default()
             }),
         }
@@ -7615,7 +7611,7 @@ impl NodeFS {
                 return Err(sys::Error {
                     errno,
                     syscall: sys::Tag::realpath,
-                    path: args.path.slice().into(),
+                    path: Some(args.path.slice().into()),
                     ..Default::default()
                 });
             }
@@ -7628,7 +7624,7 @@ impl NodeFS {
                 return Err(sys::Error {
                     errno: E::ENOENT as _,
                     syscall: sys::Tag::realpath,
-                    path: args.path.slice().into(),
+                    path: Some(args.path.slice().into()),
                     ..Default::default()
                 });
             }
@@ -7671,7 +7667,7 @@ impl NodeFS {
                 return Err(sys::Error {
                     errno: E::ENAMETOOLONG as _,
                     syscall: sys::Tag::realpath,
-                    path: args.path.slice().into(),
+                    path: Some(args.path.slice().into()),
                     ..Default::default()
                 });
             };
@@ -8010,7 +8006,7 @@ impl NodeFS {
                 let Err(e) = file else { unreachable!() };
                 return Err(sys::Error {
                     errno: e.errno,
-                    path: path.slice().into(),
+                    path: Some(path.slice().into()),
                     syscall: sys::Tag::truncate,
                     ..Default::default()
                 });
@@ -8128,7 +8124,7 @@ impl NodeFS {
                 Err(sys::Error {
                     errno,
                     syscall: sys::Tag::utime,
-                    path: args.path.slice().into(),
+                    path: Some(args.path.slice().into()),
                     ..Default::default()
                 })
             } else {
@@ -8165,7 +8161,7 @@ impl NodeFS {
                 Err(sys::Error {
                     errno,
                     syscall: sys::Tag::lutime,
-                    path: args.path.slice().into(),
+                    path: Some(args.path.slice().into()),
                     ..Default::default()
                 })
             } else {
@@ -8202,7 +8198,7 @@ impl NodeFS {
         let name_too_long = |path: &PathLike| sys::Error {
             errno: E::ENAMETOOLONG as _,
             syscall: sys::Tag::copyfile,
-            path: path.slice().into(),
+            path: Some(path.slice().into()),
             ..Default::default()
         };
         let src_len = match args.src.os_path(&mut src_buf) {
@@ -8268,7 +8264,7 @@ impl NodeFS {
                 return Err(sys::Error {
                     errno: SystemErrno::ENOENT as _,
                     syscall: sys::Tag::copyfile,
-                    path: self.os_path_into_sync_error_buf(src.as_slice()).into(),
+                    path: Some(self.os_path_into_sync_error_buf(src.as_slice()).into()),
                     ..Default::default()
                 });
             }
@@ -8328,7 +8324,7 @@ impl NodeFS {
             return Err(sys::Error {
                 errno: E::EISDIR as _,
                 syscall: sys::Tag::copyfile,
-                path: self.os_path_into_sync_error_buf(&src_buf[..sd]).into(),
+                path: Some(self.os_path_into_sync_error_buf(&src_buf[..sd]).into()),
                 ..Default::default()
             });
         }
@@ -8402,7 +8398,7 @@ impl NodeFS {
                 return Err(sys::Error {
                     errno: E::ENAMETOOLONG as _,
                     syscall: sys::Tag::copyfile,
-                    path: self.os_path_into_sync_error_buf(&src_buf[..sd]).into(),
+                    path: Some(self.os_path_into_sync_error_buf(&src_buf[..sd]).into()),
                     ..Default::default()
                 });
             }
@@ -8529,7 +8525,7 @@ impl NodeFS {
             return Err(sys::Error {
                 errno: E::ENAMETOOLONG as _,
                 syscall: sys::Tag::symlink,
-                path: self.sync_error_buf[..src.len()].into(),
+                path: Some(self.sync_error_buf[..src.len()].into()),
                 ..Default::default()
             });
         };
@@ -8593,7 +8589,7 @@ impl NodeFS {
                 self.sync_error_buf[..src.len()].copy_from_slice(src.as_bytes());
                 return Err(sys::Error {
                     errno: SystemErrno::ENOTSUP as _,
-                    path: self.sync_error_buf[..src.len()].into(),
+                    path: Some(self.sync_error_buf[..src.len()].into()),
                     syscall: sys::Tag::copyfile,
                     ..Default::default()
                 });
@@ -8912,7 +8908,7 @@ impl NodeFS {
                     return Err(sys::Error {
                         errno: SystemErrno::EINVAL as _,
                         syscall: sys::Tag::copyfile,
-                        path: self.sync_error_buf[..src.len()].into(),
+                        path: Some(self.sync_error_buf[..src.len()].into()),
                         ..Default::default()
                     });
                 }
@@ -8966,7 +8962,7 @@ impl NodeFS {
                         return Err(sys::Error {
                             errno: e as _,
                             syscall: sys::Tag::copyfile,
-                            path: self.sync_error_buf[..dest.len()].into(),
+                            path: Some(self.sync_error_buf[..dest.len()].into()),
                             ..Default::default()
                         });
                     }

--- a/src/runtime/node/node_fs_watcher.rs
+++ b/src/runtime/node/node_fs_watcher.rs
@@ -1115,7 +1115,7 @@ impl FSWatcher {
             return Err(bun_sys::Error {
                 errno: SystemErrno::ENAMETOOLONG as _,
                 syscall: bun_sys::Tag::watch,
-                path: args.path.slice().into(),
+                path: Some(args.path.slice().into()),
                 ..Default::default()
             });
         };
@@ -1187,7 +1187,7 @@ impl FSWatcher {
                         return Err(bun_sys::Error {
                             errno: err.errno,
                             syscall: bun_sys::Tag::watch,
-                            path: args.path.slice().into(),
+                            path: Some(args.path.slice().into()),
                             ..Default::default()
                         });
                     }

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -1041,12 +1041,13 @@ impl Builtin {
     ) -> &'a [u8] {
         if let Some((_code, sys_errno)) = err.get_error_code_tag_name() {
             if let Some(message) = bun_sys::coreutils_error_map::get(sys_errno) {
-                if !err.path.is_empty() {
+                // `"{path}: {message}"`, or just the message for an empty operand.
+                if let Some(path) = err.path.as_deref().filter(|path| !path.is_empty()) {
                     return Self::fmt_error_arena(
                         interp,
                         cmd,
                         Some(kind),
-                        format_args!("{}: {}\n", bstr::BStr::new(&err.path[..]), message),
+                        format_args!("{}: {}\n", bstr::BStr::new(path), message),
                     );
                 }
                 return Self::fmt_error_arena(

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -987,25 +987,20 @@ impl Builtin {
         use crate::shell::ShellErr;
         match err {
             ShellErr::Sys(sys) => {
-                // `"{message}\n"` or `"{message}: {path}\n"`.
-                if sys.path.is_empty() {
-                    Self::fmt_error_arena(
+                // `"{message}: {path}\n"`, or just the message for an empty operand.
+                match sys.path.as_deref().filter(|path| !path.is_empty()) {
+                    Some(path) => Self::fmt_error_arena(
+                        interp,
+                        cmd,
+                        Some(kind),
+                        format_args!("{}: {}\n", bstr::BStr::new(sys.message.byte_slice()), path),
+                    ),
+                    None => Self::fmt_error_arena(
                         interp,
                         cmd,
                         Some(kind),
                         format_args!("{}\n", bstr::BStr::new(sys.message.byte_slice())),
-                    )
-                } else {
-                    Self::fmt_error_arena(
-                        interp,
-                        cmd,
-                        Some(kind),
-                        format_args!(
-                            "{}: {}\n",
-                            bstr::BStr::new(sys.message.byte_slice()),
-                            sys.path,
-                        ),
-                    )
+                    ),
                 }
             }
             ShellErr::Custom(s) => Self::fmt_error_arena(

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -279,12 +279,16 @@ impl Cp {
                     // i.e. ANY sys error whose `path` equals `src_absolute` is
                     // deferred regardless of errno; preserved deliberately for
                     // compatibility.
-                    let is_ebusy = matches!(err, ShellErr::Sys(sys)
-                        if (sys.get_errno() == bun_sys::E::EBUSY
-                                && task.tgt_absolute.as_deref()
-                                    .map_or(false, |p| sys.path.eql_utf8(p)))
-                            || task.src_absolute.as_deref()
-                                    .map_or(false, |p| sys.path.eql_utf8(p)));
+                    let is_ebusy = match err {
+                        ShellErr::Sys(sys) => {
+                            let path_is =
+                                |p: &[u8]| sys.path.as_deref().is_some_and(|path| path.eql_utf8(p));
+                            (sys.get_errno() == bun_sys::E::EBUSY
+                                && task.tgt_absolute.as_deref().is_some_and(path_is))
+                                || task.src_absolute.as_deref().is_some_and(path_is)
+                        }
+                        _ => false,
+                    };
                     if is_ebusy {
                         exec.ebusy.tasks.push(bun_core::heap::into_raw(task));
                         return Self::next(interp, cmd).run(interp);

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -487,7 +487,7 @@ impl ShellMvBatchedTask {
         match bun_sys::renameat(src_dir, src, dst_dir, dst) {
             Err(e) if e.get_errno() == bun_sys::E::EXDEV => {
                 Self::move_across_devices(src_dir, src, dst_dir, dst).map_err(|e| {
-                    if e.path.is_empty() {
+                    if e.path.is_none() {
                         e.with_path(src.as_bytes())
                     } else {
                         e

--- a/src/runtime/shell/shell_body.rs
+++ b/src/runtime/shell/shell_body.rs
@@ -86,7 +86,7 @@ impl ShellErr {
                 bun_core::pretty_errorln!(
                     "<r><red>error<r>: Failed due to error: <b>bunsh: {}: {}<r>",
                     err.message,
-                    err.path
+                    err.path.as_deref().unwrap_or(&BunString::EMPTY)
                 );
             }
             ShellErr::Custom(custom) => {
@@ -115,7 +115,12 @@ impl ShellErr {
 impl fmt::Display for ShellErr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            ShellErr::Sys(e) => write!(f, "bun: {}: {}", e.message, e.path),
+            ShellErr::Sys(e) => write!(
+                f,
+                "bun: {}: {}",
+                e.message,
+                e.path.as_deref().unwrap_or(&BunString::EMPTY)
+            ),
             ShellErr::Custom(msg) => write!(f, "bun: {}", bstr::BStr::new(msg)),
             ShellErr::InvalidArguments { val } => {
                 write!(f, "bun: invalid arguments: {}", bstr::BStr::new(val))

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -137,10 +137,11 @@ impl CopyFile {
         if matches!(
             self.source_file_store.pathlike,
             PathOrFileDescriptor::Path(_)
-        ) && system_error.path.is_empty()
+        ) && system_error.path.is_none()
         {
-            system_error.path =
-                bun_core::String::clone_utf8(self.source_file_store.pathlike.path().slice()).into();
+            system_error.path = Some(
+                bun_core::String::clone_utf8(self.source_file_store.pathlike.path().slice()).into(),
+            );
         }
 
         if system_error.message.is_empty() {

--- a/src/runtime/webcore/blob/copy_file.rs
+++ b/src/runtime/webcore/blob/copy_file.rs
@@ -1421,7 +1421,7 @@ impl<'a> CopyFileWindows<'a> {
                         return bun_sys::Result::Err(bun_sys::Error {
                             errno: bun_sys::SystemErrno::EMFILE as u16,
                             syscall: bun_sys::Tag::open,
-                            path: path.slice().into(),
+                            path: Some(path.slice().into()),
                             ..Default::default()
                         });
                     }
@@ -1627,7 +1627,7 @@ impl<'a> CopyFileWindows<'a> {
                     errno
                 },
                 syscall: bun_sys::Tag::copyfile,
-                path: old_path.as_bytes().into(),
+                path: Some(old_path.as_bytes().into()),
                 ..Default::default()
             });
             return;

--- a/src/runtime/webcore/blob/read_file.rs
+++ b/src/runtime/webcore/blob/read_file.rs
@@ -529,18 +529,14 @@ impl ReadFile {
                         }
                         _ => {
                             self.errno = Some(bun_errno::from_errno(err.errno as i32).into());
-                            self.system_error = Some(err.to_system_error().into());
-                            if self.system_error.as_ref().unwrap().path.is_empty() {
-                                self.system_error.as_mut().unwrap().path =
-                                    if self.file_store.pathlike.is_path() {
-                                        BunString::clone_utf8(
-                                            self.file_store.pathlike.path().slice(),
-                                        )
-                                        .into()
-                                    } else {
-                                        BunString::EMPTY.into()
-                                    };
+                            let mut system_error = err.to_system_error();
+                            if system_error.path.is_none() && self.file_store.pathlike.is_path() {
+                                system_error.path = Some(
+                                    BunString::clone_utf8(self.file_store.pathlike.path().slice())
+                                        .into(),
+                                );
                             }
+                            self.system_error = Some(system_error.into());
                             return false;
                         }
                     }

--- a/src/runtime/webcore/blob/write_file.rs
+++ b/src/runtime/webcore/blob/write_file.rs
@@ -793,7 +793,7 @@ mod windows_impl {
                         this,
                         sys::Error {
                             errno: err as _,
-                            path,
+                            path: Some(path),
                             syscall: sys::Tag::open,
                             ..Default::default()
                         },
@@ -871,7 +871,7 @@ mod windows_impl {
                         this,
                         sys::Error {
                             errno: err as _,
-                            path,
+                            path: Some(path),
                             syscall: sys::Tag::open,
                             ..Default::default()
                         },

--- a/src/spawn_sys/posix_spawn.rs
+++ b/src/spawn_sys/posix_spawn.rs
@@ -529,16 +529,16 @@ pub mod posix_spawn {
         let arg0 = unsafe {
             let p = *argv;
             if p.is_null() {
-                &b""[..]
+                None
             } else {
-                bun_core::ffi::cstr(p).to_bytes()
+                Some(bun_core::ffi::cstr(p).to_bytes())
             }
         };
         sys::Result::Err(sys::Error {
             // posix_spawn* returns the errno value directly.
             errno: rc as sys::ErrorInt,
             syscall: SYSCALL_POSIX_SPAWN,
-            path: arg0.into(),
+            path: arg0.map(Box::from),
             ..Default::default()
         })
     }
@@ -708,7 +708,7 @@ pub mod posix_spawn {
             return sys::Result::Err(sys::Error {
                 errno: rc as sys::ErrorInt,
                 syscall: SYSCALL_POSIX_SPAWN,
-                path: path.to_bytes().into(),
+                path: Some(path.to_bytes().into()),
                 ..Default::default()
             });
         }
@@ -756,7 +756,7 @@ pub mod posix_spawn {
             sys::Result::Err(sys::Error {
                 errno: rc as sys::ErrorInt,
                 syscall: SYSCALL_POSIX_SPAWN,
-                path: path.to_bytes().into(),
+                path: Some(path.to_bytes().into()),
                 ..Default::default()
             })
         }

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -14,14 +14,6 @@ fn fd_unwrap_valid(fd: Fd) -> Option<Fd> {
     if fd == Fd::INVALID { None } else { Some(fd) }
 }
 
-/// `String::EMPTY` is "no operand" to `SystemError__toErrorInstance`; a real "" needs another tag.
-fn operand_string(operand: &[u8]) -> BunString {
-    if operand.is_empty() {
-        return BunString::static_(b"");
-    }
-    BunString::clone_utf8(operand)
-}
-
 #[cfg(windows)]
 const RETRY_ERRNO: Int = E::EINTR as Int;
 #[cfg(not(windows))]
@@ -376,6 +368,14 @@ impl Error {
         let mut err = SystemError {
             errno: js_errno,
             syscall: BunString::static_(<&'static str>::from(self.syscall).as_bytes()).into(),
+            path: self
+                .path
+                .as_deref()
+                .map(|path| BunString::clone_utf8(path).into()),
+            dest: self
+                .dest
+                .as_deref()
+                .map(|dest| BunString::clone_utf8(dest).into()),
             ..Default::default()
         };
 
@@ -384,14 +384,6 @@ impl Error {
             err.code = BunString::static_(code.as_bytes()).into();
             (code, map[system_errno])
         });
-
-        if let Some(path) = self.path.as_deref() {
-            err.path = operand_string(path).into();
-        }
-
-        if let Some(dest) = self.dest.as_deref() {
-            err.dest = operand_string(dest).into();
-        }
 
         if let Some(valid) = fd_unwrap_valid(self.fd) {
             // When the FD is a windows handle, there is no sane way to report this.
@@ -502,12 +494,15 @@ impl fmt::Display for Error {
         // because we're intending to pass them to writer.print()
         // which will convert them back into UTF*.
         let mut that = self.without_path().to_shell_system_error();
-        debug_assert!(that.path.tag() != bun_core::Tag::WTFStringImpl);
-        debug_assert!(that.dest.tag() != bun_core::Tag::WTFStringImpl);
-        that.path = BunString::borrow_utf8(self.path.as_deref().unwrap_or_default()).into();
-        that.dest = BunString::borrow_utf8(self.dest.as_deref().unwrap_or_default()).into();
-        debug_assert!(that.path.tag() != bun_core::Tag::WTFStringImpl);
-        debug_assert!(that.dest.tag() != bun_core::Tag::WTFStringImpl);
+        debug_assert!(that.path.is_none() && that.dest.is_none());
+        that.path = self
+            .path
+            .as_deref()
+            .map(|path| BunString::borrow_utf8(path).into());
+        that.dest = self
+            .dest
+            .as_deref()
+            .map(|dest| BunString::borrow_utf8(dest).into());
 
         fmt::Display::fmt(&that, f)
     }

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -14,6 +14,16 @@ fn fd_unwrap_valid(fd: Fd) -> Option<Fd> {
     if fd == Fd::INVALID { None } else { Some(fd) }
 }
 
+/// `SystemError__toErrorInstance` skips `path`/`dest` strings tagged `Empty`,
+/// which is what `clone_utf8` returns for zero bytes; an operand that really is
+/// "" goes over as a zero-length static string so the property still lands.
+fn operand_string(operand: &[u8]) -> BunString {
+    if operand.is_empty() {
+        return BunString::static_(b"");
+    }
+    BunString::clone_utf8(operand)
+}
+
 #[cfg(windows)]
 const RETRY_ERRNO: Int = E::EINTR as Int;
 #[cfg(not(windows))]
@@ -29,11 +39,11 @@ pub struct Error {
     pub fd: Fd,
     #[cfg(windows)]
     pub from_libuv: bool,
-    // Box<[u8]> per PORTING.md; `with_path*` eagerly clones. Revisit if
-    // profiling shows regressions.
-    pub path: Box<[u8]>,
+    // `None`: the operation had no path operand. `Some("")` is a real (empty)
+    // operand and is reported like any other, as Node does.
+    pub path: Option<Box<[u8]>>,
     pub syscall: Tag,
-    pub dest: Box<[u8]>,
+    pub dest: Option<Box<[u8]>>,
 }
 
 impl Default for Error {
@@ -43,9 +53,9 @@ impl Default for Error {
             fd: Fd::INVALID,
             #[cfg(windows)]
             from_libuv: false,
-            path: Box::default(),
+            path: None,
             syscall: Tag::TODO,
-            dest: Box::default(),
+            dest: None,
         }
     }
 }
@@ -222,7 +232,7 @@ impl Error {
             errno: self.errno,
             syscall: self.syscall,
             // PERF: clones the slice into a Box — profile if hot.
-            path: Box::from(path),
+            path: Some(Box::from(path)),
             ..Default::default()
         }
     }
@@ -233,7 +243,7 @@ impl Error {
             errno: self.errno,
             syscall: syscall_,
             // PERF: clones the slice into a Box — profile if hot.
-            path: Box::from(path),
+            path: Some(Box::from(path)),
             ..Default::default()
         }
     }
@@ -253,7 +263,7 @@ impl Error {
             #[cfg(windows)]
             from_libuv: self.from_libuv,
             path: self.path.clone(),
-            dest: Box::from(dest),
+            dest: Some(Box::from(dest)),
         }
     }
 
@@ -263,8 +273,8 @@ impl Error {
             errno: self.errno,
             syscall: self.syscall,
             // PERF: clones the slices into Boxes — profile if hot.
-            path: Box::from(path),
-            dest: Box::from(dest),
+            path: Some(Box::from(path)),
+            dest: Some(Box::from(dest)),
             ..Default::default()
         }
     }
@@ -280,8 +290,8 @@ impl Error {
             #[cfg(windows)]
             from_libuv: self.from_libuv,
             syscall: self.syscall,
-            path: Box::default(),
-            dest: Box::default(),
+            path: None,
+            dest: None,
         }
     }
 
@@ -378,12 +388,12 @@ impl Error {
             (code, map[system_errno])
         });
 
-        if !self.path.is_empty() {
-            err.path = BunString::clone_utf8(&self.path).into();
+        if let Some(path) = self.path.as_deref() {
+            err.path = operand_string(path).into();
         }
 
-        if !self.dest.is_empty() {
-            err.dest = BunString::clone_utf8(&self.dest).into();
+        if let Some(dest) = self.dest.as_deref() {
+            err.dest = operand_string(dest).into();
         }
 
         if let Some(valid) = fd_unwrap_valid(self.fd) {
@@ -444,22 +454,22 @@ impl Error {
                 {
                     break 'brk;
                 }
-                if !self.path.is_empty() {
+                if let Some(path) = self.path.as_deref() {
                     if cursor.write_all(b" '").is_err() {
                         break 'brk;
                     }
-                    if cursor.write_all(&self.path).is_err() {
+                    if cursor.write_all(path).is_err() {
                         break 'brk;
                     }
                     if cursor.write_all(b"'").is_err() {
                         break 'brk;
                     }
 
-                    if !self.dest.is_empty() {
+                    if let Some(dest) = self.dest.as_deref() {
                         if cursor.write_all(b" -> '").is_err() {
                             break 'brk;
                         }
-                        if cursor.write_all(&self.dest).is_err() {
+                        if cursor.write_all(dest).is_err() {
                             break 'brk;
                         }
                         if cursor.write_all(b"'").is_err() {
@@ -497,8 +507,8 @@ impl fmt::Display for Error {
         let mut that = self.without_path().to_shell_system_error();
         debug_assert!(that.path.tag() != bun_core::Tag::WTFStringImpl);
         debug_assert!(that.dest.tag() != bun_core::Tag::WTFStringImpl);
-        that.path = BunString::borrow_utf8(&self.path).into();
-        that.dest = BunString::borrow_utf8(&self.dest).into();
+        that.path = BunString::borrow_utf8(self.path.as_deref().unwrap_or_default()).into();
+        that.dest = BunString::borrow_utf8(self.dest.as_deref().unwrap_or_default()).into();
         debug_assert!(that.path.tag() != bun_core::Tag::WTFStringImpl);
         debug_assert!(that.dest.tag() != bun_core::Tag::WTFStringImpl);
 

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -14,8 +14,7 @@ fn fd_unwrap_valid(fd: Fd) -> Option<Fd> {
     if fd == Fd::INVALID { None } else { Some(fd) }
 }
 
-/// `String::EMPTY` means "no operand" to `SystemError__toErrorInstance`, so an
-/// operand that is itself "" is sent as a zero-length string of another tag.
+/// `String::EMPTY` is "no operand" to `SystemError__toErrorInstance`; a real "" needs another tag.
 fn operand_string(operand: &[u8]) -> BunString {
     if operand.is_empty() {
         return BunString::static_(b"");

--- a/src/sys/Error.rs
+++ b/src/sys/Error.rs
@@ -14,9 +14,8 @@ fn fd_unwrap_valid(fd: Fd) -> Option<Fd> {
     if fd == Fd::INVALID { None } else { Some(fd) }
 }
 
-/// `SystemError__toErrorInstance` skips `path`/`dest` strings tagged `Empty`,
-/// which is what `clone_utf8` returns for zero bytes; an operand that really is
-/// "" goes over as a zero-length static string so the property still lands.
+/// `String::EMPTY` means "no operand" to `SystemError__toErrorInstance`, so an
+/// operand that is itself "" is sent as a zero-length string of another tag.
 fn operand_string(operand: &[u8]) -> BunString {
     if operand.is_empty() {
         return BunString::static_(b"");
@@ -39,8 +38,7 @@ pub struct Error {
     pub fd: Fd,
     #[cfg(windows)]
     pub from_libuv: bool,
-    // `None`: the operation had no path operand. `Some("")` is a real (empty)
-    // operand and is reported like any other, as Node does.
+    /// `None` when the operation had no path operand; an operand of "" is `Some`.
     pub path: Option<Box<[u8]>>,
     pub syscall: Tag,
     pub dest: Option<Box<[u8]>>,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -1337,7 +1337,7 @@ impl Tag {
     pub const readlink: Tag = Tag(39);
     pub const rename: Tag = Tag(40);
     pub(crate) const stat: Tag = Tag(41);
-    pub(crate) const statfs: Tag = Tag(42);
+    pub const statfs: Tag = Tag(42);
     pub const symlink: Tag = Tag(43);
     #[cfg(not(windows))]
     pub(crate) const symlinkat: Tag = Tag(44);

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -41,11 +41,12 @@ pub struct SystemError {
     pub code: bun_core::OwnedString,
     /// it is illegal to have an empty message
     pub message: bun_core::OwnedString,
-    pub path: bun_core::OwnedString,
+    /// `None` when the operation had no path operand; an operand of "" is `Some`.
+    pub path: Option<bun_core::OwnedString>,
     pub syscall: bun_core::OwnedString,
     pub hostname: bun_core::OwnedString,
     pub fd: Option<core::ffi::c_int>,
-    pub dest: bun_core::OwnedString,
+    pub dest: Option<bun_core::OwnedString>,
 }
 impl SystemError {
     /// (`Error::to_system_error` stores `errno` negated to match Node.)
@@ -69,16 +70,15 @@ impl core::fmt::Display for SystemError {
     /// `Display` stays side-effect-free. The colored path is handled by
     /// `bun_core::Output::pretty*` at the call site that prints the error.
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        if !self.path.is_empty() {
+        match self.path.as_deref().filter(|path| !path.is_empty()) {
             // "<code>: <path>: <message> (<syscall>())"
-            write!(
+            Some(path) => write!(
                 f,
                 "{}: {}: {} ({}())",
-                self.code, self.path, self.message, self.syscall,
-            )
-        } else {
+                self.code, path, self.message, self.syscall,
+            ),
             // "<code>: <message> (<syscall>())"
-            write!(f, "{}: {} ({}())", self.code, self.message, self.syscall)
+            None => write!(f, "{}: {} ({}())", self.code, self.message, self.syscall),
         }
     }
 }

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -7,6 +7,7 @@ import {
   exampleSite,
   gcTick,
   isASAN,
+  isMacOS,
   isWindows,
   tempDir,
   withoutAggressiveGC,
@@ -146,23 +147,23 @@ const IS_UV_FS_COPYFILE_DISABLED =
         err => err,
       );
     const shapeOf = err => err && { code: err.code, syscall: err.syscall, message: err.message, path: err.path };
-    const enoentOpen = {
+    const enoent = syscall => ({
       code: "ENOENT",
-      syscall: "open",
-      message: "ENOENT: no such file or directory, open ''",
+      syscall,
+      message: `ENOENT: no such file or directory, ${syscall} ''`,
       path: "",
-    };
+    });
 
     it("Bun.file('').text()", async () => {
-      expect(shapeOf(await rejectionOf(Bun.file("").text()))).toEqual(enoentOpen);
+      expect(shapeOf(await rejectionOf(Bun.file("").text()))).toEqual(enoent("open"));
     });
 
     it("Bun.write('', string)", async () => {
-      expect(shapeOf(await rejectionOf(Bun.write("", "data")))).toEqual(enoentOpen);
+      expect(shapeOf(await rejectionOf(Bun.write("", "data")))).toEqual(enoent("open"));
     });
 
     it("Bun.write(Bun.file(''), string)", async () => {
-      expect(shapeOf(await rejectionOf(Bun.write(Bun.file(""), "data")))).toEqual(enoentOpen);
+      expect(shapeOf(await rejectionOf(Bun.write(Bun.file(""), "data")))).toEqual(enoent("open"));
     });
 
     // File to file copies take a different route on Windows (uv_fs_copyfile),
@@ -171,13 +172,14 @@ const IS_UV_FS_COPYFILE_DISABLED =
       it("empty destination is reported, not the source", async () => {
         using dir = tempDir("bun-write-empty-dest", { "src.txt": "data" });
         const err = await rejectionOf(Bun.write("", Bun.file(join(String(dir), "src.txt"))));
-        expect(shapeOf(err)).toEqual(enoentOpen);
+        expect(shapeOf(err)).toEqual(enoent("open"));
       });
 
       it("empty source", async () => {
         using dir = tempDir("bun-write-empty-src", {});
         const err = await rejectionOf(Bun.write(join(String(dir), "out.txt"), Bun.file("")));
-        expect(shapeOf(err)).toEqual(enoentOpen);
+        // macOS stats the source before trying clonefile(2); the others go straight to open(2).
+        expect(shapeOf(err)).toEqual(enoent(isMacOS ? "stat" : "open"));
       });
     });
   });

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -137,6 +137,51 @@ const IS_UV_FS_COPYFILE_DISABLED =
     }
   });
 
+  // Like node:fs, an operand that is the empty string is still an operand: it is
+  // quoted in the message and set as err.path.
+  describe("an empty path operand is reported in the error", () => {
+    const rejectionOf = promise =>
+      promise.then(
+        () => undefined,
+        err => err,
+      );
+    const shapeOf = err => err && { code: err.code, syscall: err.syscall, message: err.message, path: err.path };
+    const enoentOpen = {
+      code: "ENOENT",
+      syscall: "open",
+      message: "ENOENT: no such file or directory, open ''",
+      path: "",
+    };
+
+    it("Bun.file('').text()", async () => {
+      expect(shapeOf(await rejectionOf(Bun.file("").text()))).toEqual(enoentOpen);
+    });
+
+    it("Bun.write('', string)", async () => {
+      expect(shapeOf(await rejectionOf(Bun.write("", "data")))).toEqual(enoentOpen);
+    });
+
+    it("Bun.write(Bun.file(''), string)", async () => {
+      expect(shapeOf(await rejectionOf(Bun.write(Bun.file(""), "data")))).toEqual(enoentOpen);
+    });
+
+    // File to file copies take a different route on Windows (uv_fs_copyfile),
+    // whose errors name the source; these are the shapes of the POSIX copy.
+    describe.skipIf(isWindows)("Bun.write(file, Bun.file(file))", () => {
+      it("empty destination is reported, not the source", async () => {
+        using dir = tempDir("bun-write-empty-dest", { "src.txt": "data" });
+        const err = await rejectionOf(Bun.write("", Bun.file(join(String(dir), "src.txt"))));
+        expect(shapeOf(err)).toEqual(enoentOpen);
+      });
+
+      it("empty source", async () => {
+        using dir = tempDir("bun-write-empty-src", {});
+        const err = await rejectionOf(Bun.write(join(String(dir), "out.txt"), Bun.file("")));
+        expect(shapeOf(err)).toEqual(enoentOpen);
+      });
+    });
+  });
+
   describe.each(["plain-ascii-missing.txt", "surro-\ud800-gate.txt"])(
     "Bun.write(dest, Bun.file(missing source)) rejects with ENOENT (%s)",
     basename => {

--- a/test/js/bun/io/bun-write.test.js
+++ b/test/js/bun/io/bun-write.test.js
@@ -158,12 +158,16 @@ const IS_UV_FS_COPYFILE_DISABLED =
       expect(shapeOf(await rejectionOf(Bun.file("").text()))).toEqual(enoent("open"));
     });
 
+    // After open("") fails, Bun.write tries to create the parent directory. POSIX
+    // then reports the open again; Windows reports the failed mkdir instead.
+    const enoentWrite = enoent(isWindows ? "mkdir" : "open");
+
     it("Bun.write('', string)", async () => {
-      expect(shapeOf(await rejectionOf(Bun.write("", "data")))).toEqual(enoent("open"));
+      expect(shapeOf(await rejectionOf(Bun.write("", "data")))).toEqual(enoentWrite);
     });
 
     it("Bun.write(Bun.file(''), string)", async () => {
-      expect(shapeOf(await rejectionOf(Bun.write(Bun.file(""), "data")))).toEqual(enoent("open"));
+      expect(shapeOf(await rejectionOf(Bun.write(Bun.file(""), "data")))).toEqual(enoentWrite);
     });
 
     // File to file copies take a different route on Windows (uv_fs_copyfile),

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6401,3 +6401,100 @@ describe("fs.Utf8Stream", () => {
     await done;
   });
 });
+
+// Node reports an operand that happens to be the empty string like any other
+// operand: it is quoted in the message and set as `err.path` / `err.dest`.
+describe("an empty string operand is reported like any other path", () => {
+  type Form = "sync" | "callback" | "promises";
+  const tmp = tempDirWithFiles("fs-empty-operand", { "existing.txt": "" });
+  const existing = join(tmp, "existing.txt");
+
+  // Resolves with the error the operation failed with, or undefined if it succeeded.
+  function failureOf(form: Form, op: string, ...args: unknown[]): Promise<unknown> {
+    switch (form) {
+      case "sync":
+        try {
+          (fs as any)[`${op}Sync`](...args);
+          return Promise.resolve(undefined);
+        } catch (err) {
+          return Promise.resolve(err);
+        }
+      case "callback": {
+        const { promise, resolve } = Promise.withResolvers<unknown>();
+        (fs as any)[op](...args, (err: unknown) => resolve(err ?? undefined));
+        return promise;
+      }
+      case "promises":
+        return (fs.promises as any)[op](...args).then(
+          () => undefined,
+          (err: unknown) => err,
+        );
+    }
+  }
+
+  // `dest` is always picked so one-operand errors are also checked for not having one.
+  const shapeOf = (err: any) =>
+    err && { code: err.code, syscall: err.syscall, message: err.message, path: err.path, dest: err.dest };
+
+  const oneOperand: [label: string, op: string, syscall: string, args: unknown[]][] = [
+    ["stat", "stat", "stat", []],
+    ["lstat", "lstat", "lstat", []],
+    ["statfs", "statfs", "statfs", []],
+    ["access", "access", "access", []],
+    ["open", "open", "open", ["r"]],
+    ["readFile", "readFile", "open", []],
+    ["mkdir", "mkdir", "mkdir", []],
+    ["mkdir recursive", "mkdir", "mkdir", [{ recursive: true }]],
+    ["rmdir", "rmdir", "rmdir", []],
+    ["unlink", "unlink", "unlink", []],
+    ["rm", "rm", "lstat", []],
+    ["readlink", "readlink", "readlink", []],
+    ["chmod", "chmod", "chmod", [0o644]],
+    ["utimes", "utimes", "utime", [0, 0]],
+    ["opendir", "opendir", "opendir", []],
+  ];
+  // On Windows readdir("") currently lists the cwd instead of failing (tracked separately).
+  if (!isWindows) oneOperand.push(["readdir", "readdir", "scandir", []]);
+
+  const twoOperand: [op: string, syscall: string][] = [
+    ["copyFile", "copyfile"],
+    ["rename", "rename"],
+    ["link", "link"],
+    ["symlink", "symlink"],
+  ];
+  // On Windows the async copyFile(src, "") currently segfaults (tracked separately).
+  const twoOperandEmptyDest = twoOperand.filter(([op]) => !(isWindows && op === "copyFile"));
+
+  describe.each(["sync", "callback", "promises"] as Form[])("%s", form => {
+    it.each(oneOperand)("%s('')", async (_label, op, syscall, args) => {
+      expect(shapeOf(await failureOf(form, op, "", ...args))).toEqual({
+        code: "ENOENT",
+        syscall,
+        message: `ENOENT: no such file or directory, ${syscall} ''`,
+        path: "",
+        dest: undefined,
+      });
+    });
+
+    it.each(twoOperand)("%s('', other)", async (op, syscall) => {
+      const other = join(tmp, `${op}-${form}-other`);
+      expect(shapeOf(await failureOf(form, op, "", other))).toEqual({
+        code: "ENOENT",
+        syscall,
+        message: `ENOENT: no such file or directory, ${syscall} '' -> '${other}'`,
+        path: "",
+        dest: other,
+      });
+    });
+
+    it.each(twoOperandEmptyDest)("%s(existing, '')", async (op, syscall) => {
+      expect(shapeOf(await failureOf(form, op, existing, ""))).toEqual({
+        code: "ENOENT",
+        syscall,
+        message: `ENOENT: no such file or directory, ${syscall} '${existing}' -> ''`,
+        path: existing,
+        dest: "",
+      });
+    });
+  });
+});

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -6462,6 +6462,9 @@ describe("an empty string operand is reported like any other path", () => {
     ["link", "link"],
     ["symlink", "symlink"],
   ];
+  // Only Linux and Windows reject an empty symlink target; Darwin and the other
+  // BSDs create the link, so there is no error to look at there.
+  const twoOperandEmptyFirst = twoOperand.filter(([op]) => op !== "symlink" || isLinux || isWindows);
   // On Windows the async copyFile(src, "") currently segfaults (tracked separately).
   const twoOperandEmptyDest = twoOperand.filter(([op]) => !(isWindows && op === "copyFile"));
 
@@ -6476,7 +6479,7 @@ describe("an empty string operand is reported like any other path", () => {
       });
     });
 
-    it.each(twoOperand)("%s('', other)", async (op, syscall) => {
+    it.each(twoOperandEmptyFirst)("%s('', other)", async (op, syscall) => {
       const other = join(tmp, `${op}-${form}-other`);
       expect(shapeOf(await failureOf(form, op, "", other))).toEqual({
         code: "ENOENT",


### PR DESCRIPTION
### Problem

- `fs.statSync("")` throws `ENOENT: no such file or directory, stat` with `err.path === undefined`. Node throws `ENOENT: no such file or directory, stat ''` with `err.path === ""`.
- Same for every `node:fs` function that takes a path (`lstat`, `mkdir`, `readdir`, `open`, `readFile`, `unlink`, `rm`, `opendir`, ...) in the sync, callback and `fs.promises` forms, and for the Bun APIs that report errors the same way: `Bun.file("").text()`, `Bun.write("", ...)`, `Bun.file("").stat()` / `.delete()`.
- `fs.copyFileSync("f", "")` throws `... copyfile 'f'` with no `err.dest`; Node throws `... copyfile 'f' -> ''` with `err.dest === ""`. Same for `rename`, `link` and `symlink`, and for an empty first operand (`copyfile '' -> 'g'`).
- Cause: `bun_sys::Error` stored `path`/`dest` as `Box<[u8]>` and used the empty slice as the "no operand" marker, and `bun_sys::SystemError` did the same with `String::EMPTY`. `to_system_error` (`src/sys/Error.rs`) therefore could not tell an operand of `""` from no operand and dropped it from both the property and the message. `NodeFS::mkdir` even had an explicit `path: b""` early return for this case that the marker swallowed.

### Fix

- `bun_sys::Error::path` / `::dest` become `Option<Box<[u8]>>` and `bun_sys::SystemError::path` / `::dest` become `Option<OwnedString>` (the shape `SystemError::fd` already has). `with_path*` store `Some`, `Default` / `without_path` store `None`, and `to_system_error` copies the `Option` across and quotes a `Some` operand in the message whatever its length.
- The C++ layout is unchanged: `SystemError__toErrorInstance` defines `err.path` / `err.dest` for a string whose tag is not `Empty`, so the `From<bun_sys::SystemError>` impl that builds the `#[repr(C)]` struct (`src/jsc/SystemError.rs`, `operand_to_c`) maps `None` to `String::EMPTY` and a `Some` that is empty to a zero-length static string. That impl is the only place the Rust `Option` meets the C++ convention; every `bun_sys::Error` reaches JS through it (`ErrorJsc`, `SysErrorJsc`, `SystemErrorJsc`).
- Why `Option` at both layers: whether an operand was supplied is only known where the error is built, so the type has to carry it, and making it an `Option` lets the compiler find every producer and reader. The readers it found are the ones an encoding alone would have got wrong: Blob's copy and read error paths (`blob/copy_file.rs` `reject`, `blob/read_file.rs`) fill in their own path only when the error has none, and with a length-based check they would have replaced an empty destination with the source path. With this change `Bun.write("", Bun.file(src))` reports `open ''` with `err.path === ""`, and `Bun.write(dst, Bun.file(""))` keeps `err.path === ""`.
- Producers the compiler found wrap their operand in `Some` (`node_fs.rs`, `node_fs_watcher.rs`, `posix_spawn.rs`, which now maps a null `argv[0]` to `None`, `blob/copy_file.rs`, `blob/write_file.rs`, `Image.rs`). Readers that used emptiness as "no path" now test for `None` (`DevServer::on_watch_error`, `build_command`, readdir's `pending_err`, shell `mv`, shell `cp`'s EBUSY matching). The shell and CLI formatters (`task_error_to_string`, `shell_err_to_string`, the `Display` impls) print the bare message for both a missing and an empty operand, so their output is unchanged.
- `uv_statfs` (Windows, the callback and promises forms of `fs.statfs`) built its error with `Tag::open`, copied from `uv_open` above it; it now uses `Tag::statfs` like the sync form and Node, which the new Windows `statfs` cells check. `Tag::statfs` becomes `pub` for that.
- Matches Node, whose `UVException` tests the path pointer for null rather than for emptiness.
- Tests:
  - `test/js/node/fs/fs.test.ts`, "an empty string operand is reported like any other path": 16 one-operand cases (15 functions, `mkdir` with and without `recursive`) and the 4 two-operand functions in both directions, each in the sync, callback and promises forms. 72 cases on Linux, all failing on the release and passing here. `symlink("", link)` succeeds on Darwin and the other BSDs, so that direction runs only on Linux and Windows.
  - `test/js/bun/io/bun-write.test.js`, "an empty path operand is reported in the error": `Bun.file("").text()`, `Bun.write("", ...)`, `Bun.write(Bun.file(""), ...)`, and (POSIX, where the copy goes through Blob's own open) both `Bun.write` copy directions; the empty-destination case is the one that needs the `reject` reader change. All fail on the release.
  - `cargo check` on the linux, windows, macOS, android and freebsd targets, since many of the touched sites are cfg-gated; the rest of `test/js/node/fs/`, `bun-write.test.js` and the shell `ls`/`rm`/`mv`/`cp` suites pass apart from tests that time out on this debug build regardless of the change.
- Found while probing and tracked separately, not changed here: `fs.cp*(file, "")` reports `mkdir ''` where Node says `copyfile`; the async recursive `readdir` reports syscall `open`; `realpath.native("")` resolves to the cwd (#33421); on Windows `readdir("")` lists the cwd and the async `copyFile(src, "")` crashes, which is why those two cells of the matrix are skipped there.

### Background

- `bun_sys::Error` (`src/sys/Error.rs`) is the errno + syscall tag + operands value every syscall wrapper returns. `node:fs` and Blob attach the user's operands with `with_path` / `with_path_dest` and convert with `to_system_error()`, which builds the Node-style message (`CODE: description, syscall 'path' -> 'dest'`) and a `bun_sys::SystemError`.
- `bun_sys::SystemError` (`src/sys/lib.rs`) is the Rust-side data struct for that; `bun_jsc::SystemError` (`src/jsc/SystemError.rs`) is the `#[repr(C)]` copy of it that `SystemError__toErrorInstance` in bindings.cpp turns into the JS error object, built by a `From` impl. A few Bun APIs post-process the Rust struct before converting it, which is where the readers above live.
- `bun_core::String` is the tagged string shared with C++. `String::EMPTY` (tag `Empty`) is the canonical empty string and is what `clone_utf8` returns for zero bytes; a `StaticZigString` of length zero is also a valid empty string, which `Bun::toJS` converts to `""`.

<details>
<summary>Before / after on Linux (release 1.4.0 vs this branch; Node 26.3.0 matches the "after" column for the fs rows)</summary>

```
                               before                                                  after
statSync("")                   "ENOENT: ..., stat"             path undefined          "ENOENT: ..., stat ''"             path ""
mkdirSync("")                  "ENOENT: ..., mkdir"            path undefined          "ENOENT: ..., mkdir ''"            path ""
opendirSync("")                "ENOENT: ..., stat, opendir ''" path undefined          "ENOENT: ..., opendir ''"          path ""
copyFileSync("f", "")          "ENOENT: ..., copyfile 'f'"     dest undefined          "ENOENT: ..., copyfile 'f' -> ''"  dest ""
copyFileSync("", "g")          "ENOENT: ..., copyfile"         path undefined          "ENOENT: ..., copyfile '' -> 'g'"  path "", dest "g"
Bun.file("").text()            "ENOENT: ..., open"             path undefined          "ENOENT: ..., open ''"             path ""
Bun.write("", Bun.file("f"))   "ENOENT: ..., open"             path "f"                "ENOENT: ..., open ''"             path ""
Bun.write("out", Bun.file("")) "ENOENT: ..., open"             path undefined          "ENOENT: ..., open ''"             path ""
```

The `opendirSync` row changes because `opendirStatError` in `src/js/node/fs.ts` strips `, stat '<path>'` from the stat message; with no quoted path it left `stat` in the message.

</details>

<details>
<summary>Earlier revision of this PR</summary>

Up to 7b08b02 only `bun_sys::Error` carried the `Option`; `to_system_error` encoded an empty operand as a zero-length static string directly into the unchanged `bun_sys::SystemError`, on the assumption that no producer outside `node:fs` could see an empty operand. Review showed that assumption was wrong: Blob can (`Bun.file("")`, `Bun.write("")`), and its `is_empty()` readers turned the encoded operand back into "no path", so `Bun.write("", Bun.file(src))` would have said `open ''` in the message but `src` in `err.path`. fa81997 moved the `Option` into `bun_sys::SystemError` as well and fixed those readers.

</details>
