### PR TITLE
vm.Script: compile through the CodeCache in the constructor instead of checkSyntax

### DIFF
--- a/bench/snippets/node-vm-script-contexts.mjs
+++ b/bench/snippets/node-vm-script-contexts.mjs
@@ -1,0 +1,110 @@
+// @runtime bun
+//
+// How much does one vm.Script cost per context it runs in?
+//
+//   bun bench/snippets/node-vm-script-contexts.mjs [sourceMegabytes=5] [contexts=3] [--cached-data] [--evict]
+//
+// Generates a `(function (exports, require, module) { ...many functions... })` source of the
+// requested size (the shape of a `bun build --format=cjs` bundle), constructs one Script from it
+// and runs it in N fresh contexts, invoking the returned wrapper each time. For every phase it
+// prints the wall time, and how many times JSC's parser ran (counted from the lines JSC
+// writes to stderr under BUN_JSC_reportParseTimes=1, in a child process running the same
+// phases), followed by the unlinked code cells left alive at the end.
+//
+//   --cached-data   construct the measured Script from another Script's cachedData
+//   --evict         compile an unrelated 16.5 MB script between the first and second context,
+//                   which is enough to make JSC's CodeCache drop the measured Script's entry
+import { Script, createContext } from "node:vm";
+import { heapStats } from "bun:jsc";
+
+const args = process.argv.slice(2);
+const flags = new Set(args.filter(a => a.startsWith("--")));
+const [megabytes = "5", contexts = "3"] = args.filter(a => !a.startsWith("--"));
+const CHILD = "--child";
+
+function makeSource(bytes) {
+  const parts = ["(function (exports, require, module) {\n"];
+  let size = parts[0].length;
+  for (let i = 0; size < bytes; i++) {
+    const fn = `function f${i}(a, b) { var x = a + ${i}; if (x > b) return "s${i}" + x; for (var j = 0; j < ${i % 7}; j++) x += j; return x - b; }\n`;
+    parts.push(fn);
+    size += fn.length;
+  }
+  parts.push("module.exports = f0(1, 2);\n})");
+  return parts.join("");
+}
+
+function runPhases(report) {
+  // Compile node:vm's own lazily compiled helpers first so they don't show up in the phases.
+  new Script("1;", { produceCachedData: true }).runInContext(createContext({}));
+  const source = makeSource(Number(megabytes) * 1e6);
+  let start = performance.now();
+  const options = flags.has("--cached-data") ? { cachedData: new Script(source).createCachedData() } : {};
+  report.mark("construct");
+  start = performance.now();
+  const script = new Script(source, options);
+  report.done("construct", start);
+
+  const keep = [];
+  for (let i = 0; i < Number(contexts); i++) {
+    if (flags.has("--evict") && i === 1) {
+      report.mark("evict");
+      start = performance.now();
+      new Script(makeSource(16.5e6) + "// unrelated").runInContext(createContext({}));
+      report.done("evict", start);
+    }
+    const context = createContext({});
+    report.mark(`context ${i}: evaluate`);
+    start = performance.now();
+    const wrapper = script.runInContext(context);
+    report.done(`context ${i}: evaluate`, start);
+    report.mark(`context ${i}: invoke`);
+    start = performance.now();
+    const module = { exports: {} };
+    wrapper(module.exports, () => {}, module);
+    report.done(`context ${i}: invoke`, start);
+    keep.push(wrapper, module);
+  }
+  report.mark("end");
+  return keep;
+}
+
+if (args.includes(CHILD)) {
+  // Only the phase markers go to stderr from us; everything else on stderr is JSC's parse log.
+  runPhases({ mark: name => console.error(`@@${name}`), done() {} });
+} else {
+  const times = new Map();
+  const keep = runPhases({
+    mark() {},
+    done: (name, start) => times.set(name, performance.now() - start),
+  });
+
+  const child = Bun.spawnSync({
+    cmd: [process.execPath, import.meta.path, ...args, CHILD],
+    env: { ...process.env, BUN_JSC_reportParseTimes: "1" },
+    stdout: "ignore",
+    stderr: "pipe",
+  });
+  const parses = new Map();
+  let phase = "startup";
+  for (const line of child.stderr.toString().split("\n")) {
+    if (line.startsWith("@@")) phase = line.slice(2);
+    else if (line.startsWith("Parsed ")) parses.set(phase, (parses.get(phase) ?? 0) + 1);
+  }
+
+  console.log(
+    `${megabytes} MB source, ${contexts} contexts${[...flags].length ? ", " + [...flags].join(" ") : ""} (${process.versions.bun})`,
+  );
+  console.log("phase".padEnd(24) + "wall ms".padStart(10) + "parses".padStart(9));
+  for (const [name, ms] of times) {
+    console.log(name.padEnd(24) + ms.toFixed(1).padStart(10) + String(parses.get(name) ?? 0).padStart(9));
+  }
+
+  Bun.gc(true);
+  const counts = heapStats().objectTypeCounts;
+  console.log(
+    `live at end: UnlinkedProgramCodeBlock=${counts.UnlinkedProgramCodeBlock ?? 0} ` +
+      `UnlinkedFunctionExecutable=${counts.UnlinkedFunctionExecutable ?? 0} ` +
+      `FunctionExecutable=${counts.FunctionExecutable ?? 0} (keeping ${keep.length} results alive)`,
+  );
+}

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -135,10 +135,8 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
     SourceCode source = makeSource(sourceString, JSC::SourceOrigin(WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher), JSC::SourceTaintedOrigin::Untainted, options.filename, TextPosition(options.lineOffset, options.columnOffset));
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Node's vm.Script throws SyntaxError at construction; the REPL's
-    // recoverable-error flow (and user code) relies on that. Compiling through the
-    // CodeCache instead of checkSyntax() leaves the result where the first run
-    // (JSC::evaluate) and produceCachedData look for it, so the source is parsed once.
+    // Node throws SyntaxError from the constructor (the REPL relies on it). Unlike checkSyntax(),
+    // compiling through the CodeCache lets the first run and produceCachedData reuse this parse.
     JSC::ParserError parseError;
     vm.codeCache()->getUnlinkedProgramCodeBlock(vm, JSC::ProgramExecutable::create(globalObject, source), source, globalObject->defaultCodeGenerationMode(), parseError);
     if (parseError.isValid()) {

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -135,8 +135,7 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
     SourceCode source = makeSource(sourceString, JSC::SourceOrigin(WTF::URL::fileURLWithFileSystemPath(options.filename), *fetcher), JSC::SourceTaintedOrigin::Untainted, options.filename, TextPosition(options.lineOffset, options.columnOffset));
     RETURN_IF_EXCEPTION(scope, {});
 
-    // Node throws SyntaxError from the constructor (the REPL relies on it). Unlike checkSyntax(),
-    // compiling through the CodeCache lets the first run and produceCachedData reuse this parse.
+    // Compiled eagerly (Node throws SyntaxError here), via the CodeCache so the first run reuses it.
     JSC::ParserError parseError;
     vm.codeCache()->getUnlinkedProgramCodeBlock(vm, JSC::ProgramExecutable::create(globalObject, source), source, globalObject->defaultCodeGenerationMode(), parseError);
     if (parseError.isValid()) {

--- a/src/jsc/bindings/NodeVMScript.cpp
+++ b/src/jsc/bindings/NodeVMScript.cpp
@@ -3,6 +3,7 @@
 
 #include "ErrorCode.h"
 
+#include "JavaScriptCore/CodeCache.h"
 #include "JavaScriptCore/Completion.h"
 #include "JavaScriptCore/JIT.h"
 #include "JavaScriptCore/JSWeakMap.h"
@@ -135,11 +136,12 @@ constructScript(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue newT
     RETURN_IF_EXCEPTION(scope, {});
 
     // Node's vm.Script throws SyntaxError at construction; the REPL's
-    // recoverable-error flow (and user code) relies on that. This is a
-    // double-parse (checkSyntax discards its AST and runInThisContext reparses
-    // via JSC::evaluate); compile-once via m_cachedExecutable is the follow-up.
+    // recoverable-error flow (and user code) relies on that. Compiling through the
+    // CodeCache instead of checkSyntax() leaves the result where the first run
+    // (JSC::evaluate) and produceCachedData look for it, so the source is parsed once.
     JSC::ParserError parseError;
-    if (!JSC::checkSyntax(vm, source, parseError)) {
+    vm.codeCache()->getUnlinkedProgramCodeBlock(vm, JSC::ProgramExecutable::create(globalObject, source), source, globalObject->defaultCodeGenerationMode(), parseError);
+    if (parseError.isValid()) {
         auto exception = parseError.toErrorObject(globalObject, source, -1);
         // Building the error materializes its stack, running a user
         // Error.prepareStackTrace that may throw; Node throws the SyntaxError

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -892,6 +892,76 @@ test("can't use bytecode from a different script", () => {
   expect(secondScript.runInThisContext()).toBe(4);
 });
 
+describe.concurrent("Script parses its source once", () => {
+  // JSC prints one "Parsed ..." line to stderr per parse under reportParseTimes. The
+  // fixture warms up node:vm first so that only the Script under test parses between
+  // the markers; the constructor used to checkSyntax() and then parse again on the
+  // first run (or when producing cached data).
+  async function parsesDuring(body: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `
+          const { Script, createContext } = require("node:vm");
+          const warmup = new Script("warmup;", { produceCachedData: true });
+          warmup.runInContext(createContext({ warmup: 1 }));
+          if (warmup.cachedData.length === 0) throw new Error("warmup produced no cached data");
+          console.error("@@begin");
+          ${body}
+          console.error("@@end");
+        `,
+      ],
+      env: { ...bunEnv, BUN_JSC_reportParseTimes: "1" },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(exitCode).toBe(0);
+    const begin = stderr.indexOf("@@begin");
+    const end = stderr.indexOf("@@end");
+    expect(begin).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(begin);
+    return stderr
+      .slice(begin, end)
+      .split("\n")
+      .filter(line => line.startsWith("Parsed ")).length;
+  }
+
+  test("constructing and running it in a context", async () => {
+    expect(
+      await parsesDuring(`
+        const script = new Script("var answer = 6 * 7; answer;");
+        if (script.runInContext(createContext({})) !== 42) throw new Error("wrong result");
+      `),
+    ).toBe(1);
+  });
+
+  test("constructing it with produceCachedData", async () => {
+    expect(
+      await parsesDuring(`
+        const script = new Script("var answer = 6 * 7; answer;", { produceCachedData: true });
+        if (!script.cachedDataProduced || script.cachedData.length === 0) throw new Error("no cached data");
+      `),
+    ).toBe(1);
+  });
+
+  test("each context still gets its own global declarations", () => {
+    const script = new Script(
+      "var counter = (typeof counter === 'number' ? counter : 0) + 1; function id() { return tag; } counter;",
+    );
+    const first = createContext({ tag: "first" });
+    const second = createContext({ tag: "second" });
+    expect(script.runInContext(first)).toBe(1);
+    expect(script.runInContext(second)).toBe(1);
+    expect(script.runInContext(first)).toBe(2);
+    expect(runInContext("id()", first)).toBe("first");
+    expect(runInContext("id()", second)).toBe("second");
+    expect(first.counter).toBe(2);
+    expect(second.counter).toBe(1);
+  });
+});
+
 describe("codeGeneration options", () => {
   test("disabling codeGeneration.strings should block eval and Function constructor", () => {
     const context = createContext(

--- a/test/js/node/vm/vm.test.ts
+++ b/test/js/node/vm/vm.test.ts
@@ -913,15 +913,14 @@ describe.concurrent("Script parses its source once", () => {
         `,
       ],
       env: { ...bunEnv, BUN_JSC_reportParseTimes: "1" },
-      stdout: "pipe",
+      stdout: "ignore",
       stderr: "pipe",
     });
     const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    expect(exitCode).toBe(0);
     const begin = stderr.indexOf("@@begin");
     const end = stderr.indexOf("@@end");
-    expect(begin).toBeGreaterThanOrEqual(0);
-    expect(end).toBeGreaterThan(begin);
+    // The fixture's own error, if it threw, is in stderr too; show it rather than just the exit code.
+    if (exitCode !== 0 || begin < 0 || end < begin) throw new Error(`fixture exited with ${exitCode}:\n${stderr}`);
     return stderr
       .slice(begin, end)
       .split("\n")


### PR DESCRIPTION
Split out of #37950 (on hold until the replacement JSC API lands); this part needs no WebKit change.

### Problem
- `new vm.Script(src)` parsed `src` twice: the constructor ran `JSC::checkSyntax` to throw `SyntaxError` eagerly and discarded the result (src/jsc/bindings/NodeVMScript.cpp, `constructScript`), then the first `runInContext` / `runInThisContext` (`JSC::evaluate`) or `produceCachedData` (`getBytecode`) parsed it again, because neither finds anything in JSC's `CodeCache`. For a 20 MB bundle that is ~0.4 s (release) of duplicated work per Script; the constructor comment already described compile-once as the follow-up.

### Fix
- The constructor compiles through `vm.codeCache()->getUnlinkedProgramCodeBlock()` instead of `checkSyntax()`. Syntax errors come out of the same `ParserError` and are decorated exactly as before; the difference is that the parsed code is now in the `CodeCache` under the key the first run and `getBytecode` look up (same provider, same code generation mode, and the key is built before parsing so the strictness bit matches too), so both hit instead of parsing.
- Scripts that are constructed and never run leave a cache entry behind, which the cache's normal pruning handles; a run used to create the same entry anyway. Measured side effect: the 10,000-script loop from `script-leak.test.ts` ends at 34 MB RSS growth instead of 139 MB, because a lookup that hits lets the cache shrink and prune the dead entries sooner.
- Verified:
  - `test/js/node/vm/vm.test.ts`, new `describe` "Script parses its source once": counts JSC's `Parsed` lines (`BUN_JSC_reportParseTimes=1`) around construct+run and around construct with `produceCachedData`; both report 2 on the unfixed build (release and debug) and 1 here. A per-context global declaration check guards that runs still instantiate globals per context.
  - `test/js/node/vm/` (230 pass; `script-leak.test.ts` hits its 5 s timeout on this slow ASAN machine with and without the change) and all 97 node `test/parallel/test-vm-*` files pass.
  - `bench/snippets/node-vm-script-contexts.mjs` is the measurement script used for #37950 (per-phase wall time and parser runs for one Script across N contexts, with `--evict` and `--cached-data` variants); on a 1 MB source it shows the first context's evaluate going from 1 parser run to 0 with this change, everything else unchanged.

### Background
- `CodeCache` is JSC's in-memory map from source text (plus parse flags) to the parsed, realm-independent `UnlinkedProgramCodeBlock`. `ProgramExecutable::initializeGlobalProperties`, which every `JSC::evaluate` goes through, asks it first and only parses on a miss; `checkSyntax` never touches it, which is why the old constructor's work could not be reused. What the still-parked #37950 adds on top is keeping the block alive per Script so later contexts do not depend on the cache keeping the entry.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 2 failed, 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (1edc535e4)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [27.78ms]
(pass) vm > runInContext() > can return a value [17.44ms]
(pass) vm > runInContext() > can return a complex value [17.96ms]
(pass) vm > runInContext() > can return the last value [17.96ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [16.83ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [14.29ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [15.82ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [18.84ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [16.15ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [16.06ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.43ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [15.96ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release without fix: 2 failed, 62 skipped
bun test v1.4.0-canary.1 (da3851e57)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [0.65ms]
(pass) vm > runInContext() > can return a value [0.41ms]
(pass) vm > runInContext() > can return a complex value [0.34ms]
(pass) vm > runInContext() > can return the last value [0.29ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [0.39ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [0.27ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [0.34ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [0.35ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [0.33ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [0.29ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [0.30ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [0.35ms]
(pass) vm > runInContext() > new Float32Array() in VM context doesn't crash [0.27ms]
(pass) vm > runInContext() > new Float64Array() in VM context doesn't crash [0.30ms]
(pass) vm > runInContext() > new Big
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 62 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/vm/vm.test.ts
bun test v1.4.0 (1edc535e4)

test/js/node/vm/vm.test.ts:
(pass) vm > runInContext() > can do nothing [22.43ms]
(pass) vm > runInContext() > can return a value [22.74ms]
(pass) vm > runInContext() > can return a complex value [25.84ms]
(pass) vm > runInContext() > can return the last value [24.60ms]
(pass) vm > runInContext() > new ArrayBuffer() in VM context doesn't crash [26.23ms]
(pass) vm > runInContext() > new SharedArrayBuffer() in VM context doesn't crash [23.77ms]
(pass) vm > runInContext() > new Uint8Array() in VM context doesn't crash [26.42ms]
(pass) vm > runInContext() > new Int8Array() in VM context doesn't crash [17.20ms]
(pass) vm > runInContext() > new Uint16Array() in VM context doesn't crash [18.36ms]
(pass) vm > runInContext() > new Int16Array() in VM context doesn't crash [16.78ms]
(pass) vm > runInContext() > new Uint32Array() in VM context doesn't crash [15.32ms]
(pass) vm > runInContext() > new Int32Array() in VM context doesn't crash [22.23ms]
(pass) vm > runInContext() > new Float32Arr
... (truncated)

release with fix: 62 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1402ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/16] cc obj/packages/bun-usockets/src/crypto/openssl.c.o
[2/16] gen cpp.rs (cppbind)
[2/16] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/workspace/bun/src/boringssl_sys)
[1m[92m   Compiling[0m bun_safety v0.0.0 (/workspace/bun/src/safety)
[1m[92m   Compiling[0m bun_zlib_sys v0.0.0 (/workspace/bun/src/zlib_sys)
[1m[92m   Compiling[0m bun_cares_sys v0.0.0 (/workspace/bun/src/cares_sys)
[1m[92m   Compiling[0m bun_zstd v0.0.0 (/workspace/bun/src/zstd)
[1m[92m   Compiling[0m bun_picohttp v0.0.0 (/workspace/bun/src/picohttp)
[1m[92m   Compiling[0m bun_brotli v0.0.0 (/workspace/bun/src/brotli)
[1m[92m   Compil
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
bench/snippets/node-vm-script-contexts.mjs | 110 +++++++++++++++++++++++++++++
 src/jsc/bindings/NodeVMScript.cpp          |   9 ++-
 test/js/node/vm/vm.test.ts                 |  69 ++++++++++++++++++
 3 files changed, 183 insertions(+), 5 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                        reads  edits  tests
bench/snippets/node-vm-script-contexts.mjs      0      2      0
src/jsc/bindings/NodeVMScript.cpp               6     14      0
test/js/node/vm/vm.test.ts                      5     10      0
```

</details>

<!-- robobun:evidence:end -->