### PR TITLE
run: report a bin that failed to exec even when --silent is set (bunx exited silently)

### DIFF
--- a/src/runtime/cli/bunx_command.rs
+++ b/src/runtime/cli/bunx_command.rs
@@ -1356,6 +1356,15 @@ impl BunxCommand {
 
         let envp = env_loader.map.create_null_delimited_env_map()?;
 
+        fn install_failed(install_param: &[u8], err: &bun_sys::Error) -> ! {
+            bun_core::pretty_errorln!(
+                "<r><red>error<r>: bunx failed to install <b>{}<r> due to error:\n{}",
+                BStr::new(install_param),
+                err,
+            );
+            Global::exit(1);
+        }
+
         let spawn_result = match proc_sync::spawn(&proc_sync::Options {
             argv: argv_to_use.iter().map(|s| Box::<[u8]>::from(*s)).collect(),
 
@@ -1400,9 +1409,7 @@ impl BunxCommand {
                 Global::exit(1);
             }
             Ok(maybe) => match maybe {
-                bun_sys::Result::Err(_err) => {
-                    Global::exit(1);
-                }
+                bun_sys::Result::Err(err) => install_failed(&install_param, &err),
                 bun_sys::Result::Ok(result) => result,
             },
         };
@@ -1439,14 +1446,7 @@ impl BunxCommand {
                 // diverges with the *actual* signal.
                 Global::raise_ignoring_panic_handler_raw(core::ffi::c_int::from(*sig));
             }
-            SpawnStatus::Err(err) => {
-                bun_core::pretty_errorln!(
-                    "<r><red>error<r>: bunx failed to install <b>{}<r> due to error:\n{}",
-                    BStr::new(&install_param),
-                    err,
-                );
-                Global::exit(1);
-            }
+            SpawnStatus::Err(err) => install_failed(&install_param, err),
             _ => {}
         }
 

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2048,8 +2048,10 @@ impl RunCommand {
         )
     }
 
-    /// Not gated on `--silent` (which bunx also sets): unlike the exit code and
-    /// signal messages below, nothing else reports a binary that never ran.
+    /// Exits 1 because the spawn failed or the exit status could not be
+    /// collected. Not gated on `--silent` (which bunx also sets): that only
+    /// suppresses the messages below about a status we did collect, whereas
+    /// nothing else explains this exit code.
     fn run_binary_generic_error(executable: &[u8], err: &sys::Error) -> ! {
         pretty_errorln!(
             "<r><red>error<r>: Failed to run \"<b>{}<r>\" due to:\n{}",

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2048,14 +2048,14 @@ impl RunCommand {
         )
     }
 
-    fn run_binary_generic_error(executable: &[u8], silent: bool, err: &sys::Error) -> ! {
-        if !silent {
-            pretty_errorln!(
-                "<r><red>error<r>: Failed to run \"<b>{}<r>\" due to:\n{}",
-                bstr::BStr::new(Self::basename_or_bun(executable)),
-                err.with_path(executable),
-            );
-        }
+    /// Not gated on `--silent` (which bunx also sets): unlike the exit code and
+    /// signal messages below, nothing else reports a binary that never ran.
+    fn run_binary_generic_error(executable: &[u8], err: &sys::Error) -> ! {
+        pretty_errorln!(
+            "<r><red>error<r>: Failed to run \"<b>{}<r>\" due to:\n{}",
+            bstr::BStr::new(Self::basename_or_bun(executable)),
+            err.with_path(executable),
+        );
         Global::exit(1);
     }
 
@@ -2109,42 +2109,42 @@ impl RunCommand {
             Err(err) => {
                 bun_core::handle_error_return_trace(&err);
 
-                // an error occurred before the process was spawned
+                // an error occurred before the process was spawned; printed
+                // regardless of `silent` for the same reason as
+                // `run_binary_generic_error`.
                 #[allow(unused_labels)]
                 'print_error: {
-                    if !silent {
-                        #[cfg(unix)]
-                        {
-                            match sys::stat(executable_z) {
-                                Ok(stat) => {
-                                    if sys::S::ISDIR(stat.st_mode as _) {
-                                        pretty_errorln!(
-                                            "<r><red>error<r>: Failed to run directory \"<b>{}<r>\"\n",
-                                            bstr::BStr::new(Self::basename_or_bun(executable)),
-                                        );
-                                        break 'print_error;
-                                    }
+                    #[cfg(unix)]
+                    {
+                        match sys::stat(executable_z) {
+                            Ok(stat) => {
+                                if sys::S::ISDIR(stat.st_mode as _) {
+                                    pretty_errorln!(
+                                        "<r><red>error<r>: Failed to run directory \"<b>{}<r>\"\n",
+                                        bstr::BStr::new(Self::basename_or_bun(executable)),
+                                    );
+                                    break 'print_error;
                                 }
-                                Err(err2) => match err2.get_errno() {
-                                    sys::E::ENOENT | sys::E::EPERM | sys::E::ENOTDIR => {
-                                        pretty_errorln!(
-                                            "<r><red>error<r>: Failed to run \"<b>{}<r>\" due to error:\n{}",
-                                            bstr::BStr::new(Self::basename_or_bun(executable)),
-                                            err2,
-                                        );
-                                        break 'print_error;
-                                    }
-                                    _ => {}
-                                },
                             }
+                            Err(err2) => match err2.get_errno() {
+                                sys::E::ENOENT | sys::E::EPERM | sys::E::ENOTDIR => {
+                                    pretty_errorln!(
+                                        "<r><red>error<r>: Failed to run \"<b>{}<r>\" due to error:\n{}",
+                                        bstr::BStr::new(Self::basename_or_bun(executable)),
+                                        err2,
+                                    );
+                                    break 'print_error;
+                                }
+                                _ => {}
+                            },
                         }
-
-                        pretty_errorln!(
-                            "<r><red>error<r>: Failed to run \"<b>{}<r>\" due to <r><red>{}<r>",
-                            bstr::BStr::new(Self::basename_or_bun(executable)),
-                            bstr::BStr::new(err.name()),
-                        );
                     }
+
+                    pretty_errorln!(
+                        "<r><red>error<r>: Failed to run \"<b>{}<r>\" due to <r><red>{}<r>",
+                        bstr::BStr::new(Self::basename_or_bun(executable)),
+                        bstr::BStr::new(err.name()),
+                    );
                 }
                 Global::exit(1);
             }
@@ -2153,14 +2153,14 @@ impl RunCommand {
         match spawn_result {
             Err(err) => {
                 // an error occurred while spawning the process
-                Self::run_binary_generic_error(executable, silent, &err);
+                Self::run_binary_generic_error(executable, &err);
             }
             Ok(result) => {
                 let signal_code = result.status.signal_code();
                 match result.status {
                     // An error occurred after the process was spawned.
                     SpawnStatus::Err(err) => {
-                        Self::run_binary_generic_error(executable, silent, &err);
+                        Self::run_binary_generic_error(executable, &err);
                     }
 
                     SpawnStatus::Signaled(signal) => {

--- a/src/runtime/cli/run_command.rs
+++ b/src/runtime/cli/run_command.rs
@@ -2048,10 +2048,7 @@ impl RunCommand {
         )
     }
 
-    /// Exits 1 because the spawn failed or the exit status could not be
-    /// collected. Not gated on `--silent` (which bunx also sets): that only
-    /// suppresses the messages below about a status we did collect, whereas
-    /// nothing else explains this exit code.
+    /// Not gated on `silent` (bunx sets it): nothing else explains this exit code.
     fn run_binary_generic_error(executable: &[u8], err: &sys::Error) -> ! {
         pretty_errorln!(
             "<r><red>error<r>: Failed to run \"<b>{}<r>\" due to:\n{}",
@@ -2111,9 +2108,7 @@ impl RunCommand {
             Err(err) => {
                 bun_core::handle_error_return_trace(&err);
 
-                // an error occurred before the process was spawned; printed
-                // regardless of `silent` for the same reason as
-                // `run_binary_generic_error`.
+                // an error occurred before the process was spawned
                 #[allow(unused_labels)]
                 'print_error: {
                     #[cfg(unix)]

--- a/test/cli/install/bun-run.test.ts
+++ b/test/cli/install/bun-run.test.ts
@@ -1,7 +1,7 @@
 import { $ } from "bun";
 import { describe, expect, it } from "bun:test";
-import { chmodSync } from "fs";
-import { bunEnv as bunEnv_, bunExe, isWindows, tempDir, tempDirWithFiles } from "harness";
+import { chmodSync, mkdirSync, writeFileSync } from "fs";
+import { bunEnv as bunEnv_, bunExe, isWindows, normalizeBunSnapshot, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 
 const bunEnv = {
@@ -125,6 +125,40 @@ describe.concurrent("bun run", () => {
 
           expect(stderr).toEndWith(`error: "${exe}" exited with code 1\n`);
           expect(exitCode).toBe(1);
+        });
+
+        // Unlike the exit code message above, a bin that could not be exec'd is
+        // reported even with --silent (which bunx forces on): nothing else says why it did not run.
+        describe.each(["--silent", "not silent"])("%s", silentOption => {
+          const silent = silentOption === "--silent";
+          it.skipIf(isWindows)("reports a bin in node_modules/.bin that fails to exec", async () => {
+            using dir = tempDir("bun-run-unexecutable-bin", {
+              "package.json": JSON.stringify({ name: "test", version: "0.0.0" }),
+            });
+            const binDir = join(String(dir), "node_modules", ".bin");
+            mkdirSync(binDir, { recursive: true });
+            // execve() of a script whose interpreter does not exist fails with ENOENT.
+            writeFileSync(join(binDir, "unexecutable-bin-fixture"), `#!${join(String(dir), "missing-interpreter")}\n`, {
+              mode: 0o755,
+            });
+
+            await using proc = Bun.spawn({
+              cmd: [bunExe(), ...(silent ? ["--silent"] : []), ...(withRun ? ["run"] : []), "unexecutable-bin-fixture"],
+              cwd: String(dir),
+              env: bunEnv,
+              stdout: "pipe",
+              stderr: "pipe",
+            });
+
+            const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+            expect(normalizeBunSnapshot(stderr, String(dir))).toMatchInlineSnapshot(`
+              "error: Failed to run "unexecutable-bin-fixture" due to:
+              ENOENT: <dir>/node_modules/.bin/unexecutable-bin-fixture: No such file or directory (posix_spawn())"
+            `);
+            expect(stdout).toBe("");
+            expect(exitCode).toBe(1);
+          });
         });
 
         it.skipIf(isWindows)("exit code message works above 128", async () => {

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, isWindows, readdirSorted, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, readdirSorted, tmpdirSync } from "harness";
 import { chmodSync, copyFileSync, readdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "os";
 import { delimiter, join, resolve } from "path";
@@ -482,6 +482,49 @@ describe("bunx --no-install", () => {
       expect(out).not.toBeEmpty();
       expect(code).toBe(0);
     }
+  });
+
+  // What `bun install` leaves behind for a dependency with a `bin`. The shebang
+  // in `script` decides whether exec'ing it succeeds, so these are POSIX-only.
+  async function installLocalBin(x_dir: string, name: string, script: string) {
+    const packageDir = join(x_dir, "node_modules", name);
+    const binDir = join(x_dir, "node_modules", ".bin");
+    await mkdir(packageDir, { recursive: true });
+    await mkdir(binDir, { recursive: true });
+    await writeFile(
+      join(packageDir, "package.json"),
+      JSON.stringify({ name, version: "1.0.0", bin: { [name]: "cli" } }),
+    );
+    await writeFile(join(packageDir, "cli"), script, { mode: 0o755 });
+    symlinkSync(join("..", name, "cli"), join(binDir, name));
+  }
+
+  it.concurrent.skipIf(isWindows)("reports a bin that fails to exec instead of exiting silently", async () => {
+    const ctx = setup();
+    const name = "bunx-unexecutable-bin-fixture";
+    // execve() of a script whose interpreter does not exist fails with ENOENT.
+    await installLocalBin(ctx.x_dir, name, `#!${join(ctx.x_dir, "missing-interpreter")}\n`);
+
+    const [err, out, exited] = await run(ctx, "--no-install", name);
+
+    expect(normalizeBunSnapshot(err, ctx.x_dir)).toMatchInlineSnapshot(`
+      "error: Failed to run "bunx-unexecutable-bin-fixture" due to:
+      ENOENT: <dir>/node_modules/.bin/bunx-unexecutable-bin-fixture: No such file or directory (posix_spawn())"
+    `);
+    expect(out).toBe("");
+    expect(exited).toBe(1);
+  });
+
+  it.concurrent.skipIf(isWindows)("passes through a bin's exit code without reporting it", async () => {
+    const ctx = setup();
+    const name = "bunx-failing-bin-fixture";
+    await installLocalBin(ctx.x_dir, name, "#!/bin/sh\necho ran; exit 3\n");
+
+    const [err, out, exited] = await run(ctx, "--no-install", name);
+
+    expect(err).toBe("");
+    expect(out).toBe("ran\n");
+    expect(exited).toBe(3);
   });
 });
 

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -541,7 +541,9 @@ describe("bunx --no-install", () => {
     const subprocess = spawn({
       cmd: ["perl", "-e", '$SIG{CHLD} = "IGNORE"; exec @ARGV or die $!', "--", bunExe(), "x", "--no-install", name],
       cwd: x_dir,
-      env,
+      // The ASAN CI lanes set this; the no-orphans wait loop never notices a
+      // child the kernel already reaped and hangs (tracked separately).
+      env: { ...env, BUN_FEATURE_FLAG_NO_ORPHANS: undefined },
       stdout: "pipe",
       stderr: "pipe",
     });

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -1,7 +1,7 @@
 import { spawn } from "bun";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, setDefaultTimeout } from "bun:test";
 import { mkdir, rm, writeFile } from "fs/promises";
-import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, readdirSorted, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isLinux, isWindows, normalizeBunSnapshot, readdirSorted, tmpdirSync } from "harness";
 import { chmodSync, copyFileSync, readdirSync, symlinkSync } from "node:fs";
 import { tmpdir } from "os";
 import { delimiter, join, resolve } from "path";
@@ -532,7 +532,8 @@ describe("bunx --no-install", () => {
   // with SIGCHLD ignored (inherited from the launcher; bun's own spawn resets
   // it in children, hence perl) the kernel reaps the bin and waitpid() fails
   // with ECHILD. bunx exits 1 either way; the point is that it says why.
-  it.concurrent.skipIf(isWindows || !hasPerl)("reports a bin whose exit status could not be collected", async () => {
+  // Linux only: on macOS bunx execs the bin in place and never waits for it.
+  it.concurrent.skipIf(!isLinux || !hasPerl)("reports a bin whose exit status could not be collected", async () => {
     const { x_dir, env } = setup();
     const name = "bunx-unwaitable-bin-fixture";
     await installLocalBin(x_dir, name, "#!/bin/sh\necho ran\n");

--- a/test/cli/install/bunx.test.ts
+++ b/test/cli/install/bunx.test.ts
@@ -11,6 +11,7 @@ setDefaultTimeout(1000 * 60 * 5);
 
 let x_dir: string;
 let env: Record<string, string> = { ...bunEnv };
+const hasPerl = Bun.which("perl") != null;
 
 // Each test that hits the network gets its own isolated tmpdir + install cache
 // so the network-heavy tests can run concurrently without sharing bunx cache state.
@@ -525,6 +526,36 @@ describe("bunx --no-install", () => {
     expect(err).toBe("");
     expect(out).toBe("ran\n");
     expect(exited).toBe(3);
+  });
+
+  // Same report when the bin ran but its exit status could not be collected:
+  // with SIGCHLD ignored (inherited from the launcher; bun's own spawn resets
+  // it in children, hence perl) the kernel reaps the bin and waitpid() fails
+  // with ECHILD. bunx exits 1 either way; the point is that it says why.
+  it.concurrent.skipIf(isWindows || !hasPerl)("reports a bin whose exit status could not be collected", async () => {
+    const { x_dir, env } = setup();
+    const name = "bunx-unwaitable-bin-fixture";
+    await installLocalBin(x_dir, name, "#!/bin/sh\necho ran\n");
+
+    const subprocess = spawn({
+      cmd: ["perl", "-e", '$SIG{CHLD} = "IGNORE"; exec @ARGV or die $!', "--", bunExe(), "x", "--no-install", name],
+      cwd: x_dir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [err, out, exited] = await Promise.all([
+      subprocess.stderr.text(),
+      subprocess.stdout.text(),
+      subprocess.exited,
+    ]);
+
+    expect(normalizeBunSnapshot(err, x_dir)).toMatchInlineSnapshot(`
+      "error: Failed to run "bunx-unwaitable-bin-fixture" due to:
+      ECHILD: <dir>/node_modules/.bin/bunx-unwaitable-bin-fixture: No child processes (waitpid())"
+    `);
+    expect(out).toBe("ran\n");
+    expect(exited).toBe(1);
   });
 });
 


### PR DESCRIPTION
### Problem

- When the bin that `bunx` resolved cannot be exec'd (interpreter named by its shebang is missing, wrong-arch native binary, no shebang on current releases, ...), `bunx <pkg>` exits 1 and prints nothing at all. `bun run <bin>` prints `error: Failed to run "<bin>" due to:` followed by the errno; `bun --silent <bin>` / `bun run --silent <bin>` (and `[run] silent = true` in bunfig.toml) print nothing either.
- The same happens (on Linux; see Background for why not on macOS) when the bin ran but bun could not collect its exit status (`waitpid()` fails, e.g. with `ECHILD` when bunx inherited an ignored SIGCHLD): the bin's output appears, then `bunx` exits 1 with no explanation.
- `bunx` has a second silent exit of its own: if spawning the `bun add` that installs the package fails, `bunx_command.rs` discarded the error and exited 1.
- This is the silent `bunx` exit reported alongside #5386. The ENOEXEC retry through `/bin/sh` from that issue is a separate change (#31717); this PR only covers the missing error report, which applies to every spawn failure, not just ENOEXEC.
- Same symptom in #23906: `inngest-cli@1.12.1` (current when that issue was filed) ships its bin as an empty placeholder that `postinstall` replaces, so with the untrusted postinstall skipped `bunx inngest-cli` exec'd an empty file, got ENOEXEC, and exited 1 with no output. With this PR it prints `Failed to run "inngest-cli" due to: ENOEXEC ...` (verified with an empty `.bin` placeholder locally). Actually running that package still requires its postinstall, so this PR does not close that issue.
- Cause: `bunx` sets `ctx.debug.silent = true` (`src/runtime/cli/bunx_command.rs:673`) so that it does not echo the bin's exit code or signal. `RunCommand::run_binary_without_bunx_path` (`src/runtime/cli/run_command.rs`) used that same flag to also suppress `run_binary_generic_error` and the pre-spawn error branch, i.e. the only report of a spawn or `waitpid()` failure.

Repro on a release build (the `.bin` entry is a script whose shebang points at a path that does not exist, so `execve` fails with `ENOENT`):

```
$ bun run badinterp
error: Failed to run "badinterp" due to:
ENOENT: /tmp/r/node_modules/.bin/badinterp: No such file or directory (posix_spawn())
$ bun x badinterp; echo $?
1
$ bun run --silent badinterp; echo $?
1
```

### Fix

- `run_binary_generic_error` and the pre-spawn error branch in `run_binary_without_bunx_path` print regardless of `silent`. The exit code and signal messages keep honoring it, so `bunx tool` and `bun run --silent tool` are as quiet as before when the tool runs and exits non-zero.
- Why this is the right line to draw: `silent` exists to drop bun's commentary on an exit status it did collect (the bin already produced its own output, and `--silent` is documented as "Don't print the script command"). The two ungated sites are the cases where bun exits 1 without such a status, either because the spawn failed or because `waitpid()` did; nothing else explains that exit code, and `npx` prints an error in the same situation (`sh: 1: badinterp: not found`). The exit code is 1 in all of these cases before and after.
- `bunx_command.rs`: the `Ok(Err(err))` arm of the `bun add` spawn now prints the same `bunx failed to install <pkg> due to error:` message the post-spawn error arm already printed (shared through a small `install_failed` helper) instead of exiting 1 silently.
- `bun run <bin>` and `bunx` share `run_binary_without_bunx_path` (`bunx` reaches it through `Run::run_binary`), so both entry points are covered. On Windows, bins installed by bun are launched through the `.bunx` shim, which reports its own launch failures and was never silent; this function is only reached there for plain `.exe`/`.cmd` binaries found on `PATH` or when the shim metadata is unreadable, and it behaves the same way as on POSIX.
- Intentionally left alone: the package.json script path (`run_package_script_foreground_with_shell_path`) has its own `silent` checks, and when the system shell fails to spawn it also exits 0, which is a separate bug to be fixed on its own.
- Verification:
  - `test/cli/install/bunx.test.ts`: `bunx --no-install` on a locally installed bin whose interpreter is missing must print the `Failed to run` / `ENOENT (posix_spawn())` message; a second test (Linux only) execs bunx from `perl` with `$SIG{CHLD} = "IGNORE"` (bun's own spawn resets signal dispositions in its children, so a non-bun launcher is needed) and expects the bin's output plus the `ECHILD (waitpid())` message; both fail on the release build with empty stderr. The ECHILD test unsets `BUN_FEATURE_FLAG_NO_ORPHANS`, which the ASAN CI lanes export: the no-orphans wait loop in `src/spawn/process.rs` never returns once the kernel has auto-reaped the child (reproducible on the release build with plain `bun run <bin>` too), so the test timed out on that lane in the first CI run. That hang is a separate pre-existing bug, reported on its own; this PR only keeps the test on the ordinary wait path it is meant to exercise. A companion test pins that a bin exiting 3 still passes its exit code through with empty stderr (passes before and after).
  - `test/cli/install/bun-run.test.ts`: the missing-interpreter bin via `bun <bin>` and `bun run <bin>`, with and without `--silent`; the `--silent` variants fail on the release build. The existing `--silent omits error messages` and `exit signal works` tests in that file still pass and cover the messages that remain suppressed.
  - The `bun add` spawn failure in `bunx_command.rs` has no automated test: making bun's own executable fail to spawn requires unlinking it after bunx has started and before it reaches the install step, which is a race in either direction (it lost one of three runs in my probe). Exercised manually by hard-linking the binary, starting `<link> x <uninstalled pkg>` and unlinking it: the release build exits 1 with no output, this branch prints `bunx failed to install <pkg>@latest due to error:` / `ENOENT: <link> (deleted): No such file or directory (posix_spawn())`.
  - Both test files pass with `bun bd test` (one pre-existing `npm_config_user_agent` test in `bunx.test.ts` only fails locally because `bun bd` inherits the release wrapper's user agent; it passes when the debug binary runs the file directly). The fixtures are POSIX-only because they rely on shebangs and signal dispositions.

### Background

- `bun run <name>` falls back to running `node_modules/.bin/<name>` (or a `$PATH` binary) when `<name>` is neither a package.json script nor a file; `bunx <pkg>` runs the package's bin the same way. Both end in `RunCommand::run_binary_without_bunx_path`, which spawns the bin with stdio inherited, waits for it, and exits with its exit code.
- `ctx.debug.silent` is set by `--silent` / `[run] silent` and forced on by `bunx`. In this function it controls the `"x" exited with code N` and `Failed to run "x" due to signal` messages printed after the bin exits. On macOS it also selects `POSIX_SPAWN_SETEXEC`, which replaces the bun process with the bin once the spawn succeeds: a failed spawn still returns and is reported, but there is no bun process left to wait, so the `waitpid()` failure arm is unreachable for silent callers there (hence the Linux-only test).
- That function has three failure arms: setup failed before anything was spawned (the first `Err` arm), `posix_spawn` / `uv_spawn` itself failed (`ENOENT` for a missing interpreter, `ENOEXEC` for an unrecognized file format, `EACCES`, ...), or the child was spawned but `waitpid()` failed (`SpawnStatus::Err`, e.g. `ECHILD` when SIGCHLD is ignored, since the kernel then reaps the child itself). The last two share `run_binary_generic_error`; all three exit 1.
- `bunx` installs a package it does not find locally or in its cache by spawning `bun add <pkg>` into the cache directory and then running the bin from there; the `bunx_command.rs` change is in the error handling of that spawn.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-run.test.ts test/cli/install/bunx.test.ts

<!-- robobun:evidence:end -->