### PR TITLE
postgres: record which connection counter a request bumped as one enum

### DIFF
--- a/src/sql_jsc/postgres/PostgresSQLConnection.rs
+++ b/src/sql_jsc/postgres/PostgresSQLConnection.rs
@@ -27,7 +27,7 @@ use crate::postgres::data_cell as DataCell;
 use crate::postgres::error_jsc::{create_postgres_error, postgres_error_to_js};
 use crate::postgres::postgres_request as PostgresRequest;
 use crate::postgres::postgres_request::MessageType;
-use crate::postgres::postgres_sql_query::{self, Status as QueryStatus};
+use crate::postgres::postgres_sql_query::{self, RequestCounter, Status as QueryStatus};
 use crate::postgres::postgres_sql_statement::{Error as StatementError, Status as StatementStatus};
 use crate::postgres::sasl::SASLStatus;
 use crate::shared::CachedStructure as PostgresCachedStructure;
@@ -1763,19 +1763,20 @@ impl PostgresSQLConnection {
     fn finish_request(&self, item: &PostgresSQLQuery) {
         match item.status.get() {
             QueryStatus::Running | QueryStatus::Binding | QueryStatus::PartialResponse => {
-                let flags = item.flags.get();
-                if !flags.counted {
-                    return;
-                }
-                item.update_flags(|f| f.counted = false);
-                if flags.simple {
-                    let n = self.nonpipelinable_requests.get();
-                    debug_assert!(n > 0, "nonpipelinable_requests underflow");
-                    self.nonpipelinable_requests.set(n.saturating_sub(1));
-                } else if flags.pipelined {
-                    let n = self.pipelined_requests.get();
-                    debug_assert!(n > 0, "pipelined_requests underflow");
-                    self.pipelined_requests.set(n.saturating_sub(1));
+                let counter = item.flags.get().counter;
+                item.update_flags(|f| f.counter = RequestCounter::None);
+                match counter {
+                    RequestCounter::None => {}
+                    RequestCounter::Nonpipelinable => {
+                        let n = self.nonpipelinable_requests.get();
+                        debug_assert!(n > 0, "nonpipelinable_requests underflow");
+                        self.nonpipelinable_requests.set(n.saturating_sub(1));
+                    }
+                    RequestCounter::Pipelined => {
+                        let n = self.pipelined_requests.get();
+                        debug_assert!(n > 0, "pipelined_requests underflow");
+                        self.pipelined_requests.set(n.saturating_sub(1));
+                    }
                 }
             }
             QueryStatus::Pending => {
@@ -1895,7 +1896,7 @@ impl PostgresSQLConnection {
                         }
                         self.nonpipelinable_requests
                             .set(self.nonpipelinable_requests.get() + 1);
-                        req.update_flags(|f| f.counted = true);
+                        req.update_flags(|f| f.counter = RequestCounter::Nonpipelinable);
                         self.update_flags(|f| f.remove(ConnectionFlags::IS_READY_FOR_QUERY));
                         req.status.set(QueryStatus::Running);
                         defer_cleanup!(self);
@@ -2028,10 +2029,7 @@ impl PostgresSQLConnection {
                                         f.remove(ConnectionFlags::IS_READY_FOR_QUERY)
                                     });
                                     req.status.set(QueryStatus::Binding);
-                                    req.update_flags(|f| {
-                                        f.pipelined = true;
-                                        f.counted = true;
-                                    });
+                                    req.update_flags(|f| f.counter = RequestCounter::Pipelined);
                                     self.pipelined_requests
                                         .set(self.pipelined_requests.get() + 1);
 
@@ -2194,10 +2192,7 @@ impl PostgresSQLConnection {
                                         });
                                         req.status.set(QueryStatus::Binding);
                                         statement.status = StatementStatus::Parsing;
-                                        req.update_flags(|f| {
-                                            f.pipelined = true;
-                                            f.counted = true;
-                                        });
+                                        req.update_flags(|f| f.counter = RequestCounter::Pipelined);
                                         self.pipelined_requests
                                             .set(self.pipelined_requests.get() + 1);
                                         self.flush_data_and_reset_timeout();

--- a/src/sql_jsc/postgres/PostgresSQLQuery.rs
+++ b/src/sql_jsc/postgres/PostgresSQLQuery.rs
@@ -90,13 +90,20 @@ pub struct Flags {
     pub(crate) binary: bool,
     pub(crate) bigint: bool,
     pub(crate) simple: bool,
-    pub(crate) pipelined: bool,
-    /// Set when this request's dispatch incremented the connection's
-    /// `pipelined_requests` / `nonpipelinable_requests` counter; cleared when
-    /// `finish_request` consumes that contribution. Makes the decrement
-    /// idempotent across the three `finish_request` call sites.
-    pub(crate) counted: bool,
+    /// Which connection counter this request's dispatch incremented; reset to
+    /// `None` when `finish_request` consumes that contribution, so the
+    /// decrement is idempotent across its call sites.
+    pub(crate) counter: RequestCounter,
     pub(crate) result_mode: PostgresSQLQueryResultMode,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum RequestCounter {
+    None,
+    /// `PostgresSQLConnection::nonpipelinable_requests`
+    Nonpipelinable,
+    /// `PostgresSQLConnection::pipelined_requests`
+    Pipelined,
 }
 
 impl Default for Flags {
@@ -106,8 +113,7 @@ impl Default for Flags {
             binary: false,
             bigint: false,
             simple: false,
-            pipelined: false,
-            counted: false,
+            counter: RequestCounter::None,
             result_mode: PostgresSQLQueryResultMode::Objects,
         }
     }
@@ -547,7 +553,7 @@ impl PostgresSQLQuery {
                 connection
                     .nonpipelinable_requests
                     .set(connection.nonpipelinable_requests.get() + 1);
-                this.update_flags(|f| f.counted = true);
+                this.update_flags(|f| f.counter = RequestCounter::Nonpipelinable);
                 this.status.set(Status::Running);
             } else {
                 this.status.set(Status::Pending);
@@ -681,10 +687,7 @@ impl PostgresSQLQuery {
                                     connection.flags.set(f);
                                 }
                                 this.status.set(Status::Binding);
-                                this.update_flags(|f| {
-                                    f.pipelined = true;
-                                    f.counted = true;
-                                });
+                                this.update_flags(|f| f.counter = RequestCounter::Pipelined);
                                 connection
                                     .pipelined_requests
                                     .set(connection.pipelined_requests.get() + 1);


### PR DESCRIPTION
A request's dispatch bumps either nonpipelinable_requests or pipelined_requests, and finish_request has to undo the same one. That was tracked with counted plus pipelined, and finish_request picked the counter by re-reading the query's simple flag, which only works because the nonpipelinable increments happen to sit inside the simple branches. This replaces the two bools with a RequestCounter enum (None / Nonpipelinable / Pipelined) written at the five increment sites and matched in finish_request, so the decrement follows what was actually incremented and the counted-but-neither state cannot be expressed. simple stays a bool because it also selects the wire protocol.

No behavior change. Ran the mock-server postgres tests around request accounting (finish-request-underflow, split-prepare-reorder, failed-connection-resurrection, frame-boundary, multi-statement-fields, datarow-overrun) and simple-query-pipeline, prepared-pipeline-reorder and sql.test.ts against a local postgres on the debug build, plus a script mixing simple, pipelined and failing queries on one connection.