### PR TITLE
install: keep registry credentials across redirects to the same hostname

### DIFF
--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -106,16 +106,14 @@ pub enum Protocol {
     Http3,
 }
 
-/// Which redirects the request's credential headers (`Authorization`,
-/// `Proxy-Authorization`, `Cookie`) survive.
+/// Which redirects the request's credential headers survive.
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub enum RedirectCredentialsPolicy {
     /// fetch(): https://fetch.spec.whatwg.org/#concept-http-redirect-fetch
     #[default]
     SameOrigin,
-    /// npm's rule (make-fetch-happen), used by `bun install`: a port or scheme
-    /// change alone keeps them, except an https -> http downgrade.
+    /// npm's rule, used by `bun install`: port and scheme changes keep them, except https -> http.
     SameHostname,
 }
 
@@ -1090,8 +1088,7 @@ bun_core::comptime_string_map! {
 enum StrippedOnRedirect {
     /// Per `Flags::redirect_credentials`.
     Credential,
-    /// Names the previous origin and would suppress the default Host header
-    /// derived from the new URL.
+    /// Would suppress the default Host header derived from the new URL.
     Host,
 }
 

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -106,22 +106,16 @@ pub enum Protocol {
     Http3,
 }
 
-/// How far a followed redirect may move the request before its credential
-/// headers (`Authorization`, `Proxy-Authorization`, `Cookie`) are dropped. A
-/// caller-supplied `Host` header is dropped on any origin change regardless of
-/// this setting.
+/// Which redirects the request's credential headers (`Authorization`,
+/// `Proxy-Authorization`, `Cookie`) survive.
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub enum RedirectCredentialsPolicy {
-    /// WHATWG fetch (https://fetch.spec.whatwg.org/#concept-http-redirect-fetch):
-    /// dropped as soon as the origin (scheme, hostname or port) changes.
+    /// fetch(): https://fetch.spec.whatwg.org/#concept-http-redirect-fetch
     #[default]
     SameOrigin,
-    /// npm's registry client (make-fetch-happen): kept while the hostname is
-    /// unchanged, so a registry may redirect to itself on another port or
-    /// from http to https. Unlike npm, a redirect from https down to http
-    /// still drops them. `bun install` uses this for manifest and tarball
-    /// requests.
+    /// npm's rule (make-fetch-happen), used by `bun install`: a port or scheme
+    /// change alone keeps them, except an https -> http downgrade.
     SameHostname,
 }
 
@@ -1094,10 +1088,10 @@ bun_core::comptime_string_map! {
 
 #[derive(Copy, Clone)]
 enum StrippedOnRedirect {
-    /// Dropped according to `Flags::redirect_credentials`.
+    /// Per `Flags::redirect_credentials`.
     Credential,
-    /// A user-supplied Host header names the previous origin; keeping it would
-    /// also suppress the default Host header derived from the new URL.
+    /// Names the previous origin and would suppress the default Host header
+    /// derived from the new URL.
     Host,
 }
 
@@ -1112,14 +1106,11 @@ bun_core::comptime_string_map! {
     };
 }
 
-/// How far a redirect moved the request away from the URL it was just sent
-/// to. Decides which request headers the next hop keeps.
 #[derive(Copy, Clone)]
 struct RedirectHop {
     same_origin: bool,
     same_hostname: bool,
-    /// https -> http. Credentials never follow this hop: they would be
-    /// replayed in cleartext.
+    /// https -> http; credentials never follow this hop (cleartext replay).
     downgrades_to_http: bool,
 }
 
@@ -5269,9 +5260,7 @@ impl<'a> HTTPClient<'a> {
                 // locationURL's origin, then for each headerName of CORS
                 // non-wildcard request-header name, delete headerName from
                 // request's header list.
-                //
-                // The credential headers follow `Flags::redirect_credentials`
-                // instead (`bun install` uses `RedirectCredentialsPolicy::SameHostname`).
+                // The credential headers follow `Flags::redirect_credentials`.
                 if !hop.same_origin && self.header_entries.len() > 0 {
                     let strip_credentials = hop.strips_credentials(self.flags.redirect_credentials);
                     let mut i = 0;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -106,22 +106,23 @@ pub enum Protocol {
     Http3,
 }
 
-/// When a redirect is followed, which change of destination drops the
-/// request's credential headers (`Authorization`, `Proxy-Authorization`,
-/// `Cookie`). A caller-supplied `Host` header is dropped on any origin change
-/// regardless of this setting.
+/// How far a followed redirect may move the request before its credential
+/// headers (`Authorization`, `Proxy-Authorization`, `Cookie`) are dropped. A
+/// caller-supplied `Host` header is dropped on any origin change regardless of
+/// this setting.
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
 pub enum RedirectCredentialsPolicy {
     /// WHATWG fetch (https://fetch.spec.whatwg.org/#concept-http-redirect-fetch):
     /// dropped as soon as the origin (scheme, hostname or port) changes.
     #[default]
-    StripOnOriginChange,
-    /// npm's registry client (make-fetch-happen): dropped only when the
-    /// hostname changes, so a registry may redirect to itself on another
-    /// scheme or port. `bun install` uses this for manifest and tarball
+    SameOrigin,
+    /// npm's registry client (make-fetch-happen): kept while the hostname is
+    /// unchanged, so a registry may redirect to itself on another port or
+    /// from http to https. Unlike npm, a redirect from https down to http
+    /// still drops them. `bun install` uses this for manifest and tarball
     /// requests.
-    StripOnHostnameChange,
+    SameHostname,
 }
 
 pub use bun_http_types::Encoding::Encoding;
@@ -254,7 +255,7 @@ impl Default for Flags {
             forced_protocol: None,
             h3_retried: false,
             is_node_http_client: false,
-            redirect_credentials: RedirectCredentialsPolicy::StripOnOriginChange,
+            redirect_credentials: RedirectCredentialsPolicy::SameOrigin,
         }
     }
 }
@@ -1117,6 +1118,9 @@ bun_core::comptime_string_map! {
 struct RedirectHop {
     same_origin: bool,
     same_hostname: bool,
+    /// https -> http. Credentials never follow this hop: they would be
+    /// replayed in cleartext.
+    downgrades_to_http: bool,
 }
 
 impl RedirectHop {
@@ -1128,13 +1132,16 @@ impl RedirectHop {
                 true,
             ),
             same_hostname: strings::eql_case_insensitive_ascii(to.hostname, from.hostname, true),
+            downgrades_to_http: from.is_https() && !to.is_https(),
         }
     }
 
     fn strips_credentials(self, policy: RedirectCredentialsPolicy) -> bool {
         match policy {
-            RedirectCredentialsPolicy::StripOnOriginChange => !self.same_origin,
-            RedirectCredentialsPolicy::StripOnHostnameChange => !self.same_hostname,
+            RedirectCredentialsPolicy::SameOrigin => !self.same_origin,
+            RedirectCredentialsPolicy::SameHostname => {
+                !self.same_hostname || self.downgrades_to_http
+            }
         }
     }
 }
@@ -5263,8 +5270,8 @@ impl<'a> HTTPClient<'a> {
                 // non-wildcard request-header name, delete headerName from
                 // request's header list.
                 //
-                // `Flags::redirect_credentials` lets `bun install` keep the
-                // credential headers while the hostname is unchanged.
+                // The credential headers follow `Flags::redirect_credentials`
+                // instead (`bun install` uses `RedirectCredentialsPolicy::SameHostname`).
                 if !hop.same_origin && self.header_entries.len() > 0 {
                     let strip_credentials = hop.strips_credentials(self.flags.redirect_credentials);
                     let mut i = 0;

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -106,6 +106,24 @@ pub enum Protocol {
     Http3,
 }
 
+/// When a redirect is followed, which change of destination drops the
+/// request's credential headers (`Authorization`, `Proxy-Authorization`,
+/// `Cookie`). A caller-supplied `Host` header is dropped on any origin change
+/// regardless of this setting.
+#[repr(u8)]
+#[derive(Copy, Clone, PartialEq, Eq, Default)]
+pub enum RedirectCredentialsPolicy {
+    /// WHATWG fetch (https://fetch.spec.whatwg.org/#concept-http-redirect-fetch):
+    /// dropped as soon as the origin (scheme, hostname or port) changes.
+    #[default]
+    StripOnOriginChange,
+    /// npm's registry client (make-fetch-happen): dropped only when the
+    /// hostname changes, so a registry may redirect to itself on another
+    /// scheme or port. `bun install` uses this for manifest and tarball
+    /// requests.
+    StripOnHostnameChange,
+}
+
 pub use bun_http_types::Encoding::Encoding;
 pub use header_value_iterator::{
     HeaderValueIterator, connection_header_keep_alive, upgrade_header_is_not_h2,
@@ -214,6 +232,7 @@ pub struct Flags {
     pub forced_protocol: Option<Protocol>,
     pub(crate) h3_retried: bool,
     pub is_node_http_client: bool,
+    pub redirect_credentials: RedirectCredentialsPolicy,
 }
 
 impl Default for Flags {
@@ -235,6 +254,7 @@ impl Default for Flags {
             forced_protocol: None,
             h3_retried: false,
             is_node_http_client: false,
+            redirect_credentials: RedirectCredentialsPolicy::StripOnOriginChange,
         }
     }
 }
@@ -1071,18 +1091,52 @@ bun_core::comptime_string_map! {
     };
 }
 
+#[derive(Copy, Clone)]
+enum StrippedOnRedirect {
+    /// Dropped according to `Flags::redirect_credentials`.
+    Credential,
+    /// A user-supplied Host header names the previous origin; keeping it would
+    /// also suppress the default Host header derived from the new URL.
+    Host,
+}
+
 bun_core::comptime_string_map! {
     /// Headers deleted from the request on a cross-origin redirect.
-    /// `host` is included because a user-supplied Host header names the
-    /// previous origin; keeping it would also suppress the default Host
-    /// header derived from the new URL.
     /// Keys are lowercase: looked up via `get_ascii_case_insensitive`.
-    static CROSS_ORIGIN_STRIPPED_REQUEST_HEADERS: () = {
-        b"authorization" => (),
-        b"proxy-authorization" => (),
-        b"cookie" => (),
-        b"host" => (),
+    static CROSS_ORIGIN_STRIPPED_REQUEST_HEADERS: StrippedOnRedirect = {
+        b"authorization" => StrippedOnRedirect::Credential,
+        b"proxy-authorization" => StrippedOnRedirect::Credential,
+        b"cookie" => StrippedOnRedirect::Credential,
+        b"host" => StrippedOnRedirect::Host,
     };
+}
+
+/// How far a redirect moved the request away from the URL it was just sent
+/// to. Decides which request headers the next hop keeps.
+#[derive(Copy, Clone)]
+struct RedirectHop {
+    same_origin: bool,
+    same_hostname: bool,
+}
+
+impl RedirectHop {
+    fn between(from: &URL<'_>, to: &URL<'_>) -> Self {
+        Self {
+            same_origin: strings::eql_case_insensitive_ascii(
+                strings::without_trailing_slash(to.origin),
+                strings::without_trailing_slash(from.origin),
+                true,
+            ),
+            same_hostname: strings::eql_case_insensitive_ascii(to.hostname, from.hostname, true),
+        }
+    }
+
+    fn strips_credentials(self, policy: RedirectCredentialsPolicy) -> bool {
+        match policy {
+            RedirectCredentialsPolicy::StripOnOriginChange => !self.same_origin,
+            RedirectCredentialsPolicy::StripOnHostnameChange => !self.same_hostname,
+        }
+    }
 }
 
 // ── shared per-thread buffers ───────────────────────────────────────────
@@ -5020,7 +5074,7 @@ impl<'a> HTTPClient<'a> {
                 {
                     return Err(crate::Error::RequestBodyNotReusable);
                 }
-                let is_same_origin;
+                let hop: RedirectHop;
 
                 {
                     if let Some(i) = strings::index_of(location, b"://") {
@@ -5084,11 +5138,7 @@ impl<'a> HTTPClient<'a> {
                         // `self.redirect` below, which lives as long as `self` (≥ `'a`).
                         let new_url: URL<'a> =
                             unsafe { URL::parse(&normalized_url_str).erase_lifetime() };
-                        is_same_origin = strings::eql_case_insensitive_ascii(
-                            strings::without_trailing_slash(new_url.origin),
-                            strings::without_trailing_slash(self.url.origin),
-                            true,
-                        );
+                        hop = RedirectHop::between(&self.url, &new_url);
                         self.url = new_url;
                         // connected_url still borrows from the previous hop's buffer
                         // until doRedirect releases the socket, so park it in
@@ -5139,11 +5189,7 @@ impl<'a> HTTPClient<'a> {
                         // `self.redirect` below, which lives as long as `self` (≥ `'a`).
                         let new_url: URL<'a> =
                             unsafe { URL::parse(&normalized_url_str).erase_lifetime() };
-                        is_same_origin = strings::eql_case_insensitive_ascii(
-                            strings::without_trailing_slash(new_url.origin),
-                            strings::without_trailing_slash(self.url.origin),
-                            true,
-                        );
+                        hop = RedirectHop::between(&self.url, &new_url);
                         self.url = new_url;
                         debug_assert!(self.prev_redirect.is_empty());
                         self.prev_redirect =
@@ -5167,11 +5213,7 @@ impl<'a> HTTPClient<'a> {
                         // SAFETY: self-borrow — `new_url` is moved into `self.redirect`
                         // below, which lives as long as `self` (≥ `'a`).
                         self.url = unsafe { parsed_url.erase_lifetime() };
-                        is_same_origin = strings::eql_case_insensitive_ascii(
-                            strings::without_trailing_slash(self.url.origin),
-                            strings::without_trailing_slash(original_url.origin),
-                            true,
-                        );
+                        hop = RedirectHop::between(&original_url, &self.url);
                         debug_assert!(self.prev_redirect.is_empty());
                         self.prev_redirect = core::mem::replace(&mut self.redirect, new_url);
                     }
@@ -5211,7 +5253,7 @@ impl<'a> HTTPClient<'a> {
                 // Cross-origin redirect: re-derive SNI / cert
                 // verification / Host from the redirect target. See
                 // `InternalStateFlags::clear_hostname_on_redirect`.
-                if !is_same_origin {
+                if !hop.same_origin {
                     self.state.flags.clear_hostname_on_redirect = true;
                 }
 
@@ -5220,14 +5262,22 @@ impl<'a> HTTPClient<'a> {
                 // locationURL's origin, then for each headerName of CORS
                 // non-wildcard request-header name, delete headerName from
                 // request's header list.
-                if !is_same_origin && self.header_entries.len() > 0 {
+                //
+                // `Flags::redirect_credentials` lets `bun install` keep the
+                // credential headers while the hostname is unchanged.
+                if !hop.same_origin && self.header_entries.len() > 0 {
+                    let strip_credentials = hop.strips_credentials(self.flags.redirect_credentials);
                     let mut i = 0;
                     while i < self.header_entries.len() {
                         let name = self.header_str(self.header_entries.items_name()[i]);
-                        if CROSS_ORIGIN_STRIPPED_REQUEST_HEADERS
+                        let strip = match CROSS_ORIGIN_STRIPPED_REQUEST_HEADERS
                             .get_ascii_case_insensitive(name)
-                            .is_some()
                         {
+                            Some(StrippedOnRedirect::Host) => true,
+                            Some(StrippedOnRedirect::Credential) => strip_credentials,
+                            None => false,
+                        };
+                        if strip {
                             let _ = self.header_entries.ordered_remove(i);
                         } else {
                             i += 1;

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -677,7 +677,7 @@ impl NetworkTask {
         ));
         self.http_mut().client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
         self.http_mut().client.flags.redirect_credentials =
-            http::RedirectCredentialsPolicy::StripOnHostnameChange;
+            http::RedirectCredentialsPolicy::SameHostname;
 
         if PackageManager::verbose_install() {
             self.http_mut().client.verbose = HTTPVerboseLevel::Headers;
@@ -912,7 +912,7 @@ impl NetworkTask {
         ));
         self.http_mut().client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
         self.http_mut().client.flags.redirect_credentials =
-            http::RedirectCredentialsPolicy::StripOnHostnameChange;
+            http::RedirectCredentialsPolicy::SameHostname;
         if PackageManager::verbose_install() {
             self.http_mut().client.verbose = HTTPVerboseLevel::Headers;
         }

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -676,6 +676,8 @@ impl NetworkTask {
             },
         ));
         self.http_mut().client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
+        self.http_mut().client.flags.redirect_credentials =
+            http::RedirectCredentialsPolicy::StripOnHostnameChange;
 
         if PackageManager::verbose_install() {
             self.http_mut().client.verbose = HTTPVerboseLevel::Headers;
@@ -909,6 +911,8 @@ impl NetworkTask {
             http_options,
         ));
         self.http_mut().client.flags.reject_unauthorized = pm.tls_reject_unauthorized();
+        self.http_mut().client.flags.redirect_credentials =
+            http::RedirectCredentialsPolicy::StripOnHostnameChange;
         if PackageManager::verbose_install() {
             self.http_mut().client.verbose = HTTPVerboseLevel::Headers;
         }

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -95,11 +95,11 @@ it("retries a manifest whose redirect target 500s once", async () => {
 });
 
 // The registry (reached as `localhost`) redirects the manifest to a second
-// server standing in for a CDN. Whether that hop keeps the token depends only
-// on the hostname: bun install, like npm, keeps it when just the port (or
-// scheme) changes and drops it when the hostname changes. Either way the
-// install retry restarts from the original registry URL and must carry the
-// original headers, including Authorization, again.
+// server standing in for a CDN, and the retry restarts from the registry URL.
+// 127.0.0.1 is a different hostname, so that hop strips the token and the
+// retry must carry the original headers again; localhost:<other port> keeps
+// it, and the retry must apply the same rule. Which redirects keep the token
+// is covered by "registry token across redirects" in bun-install.test.ts.
 const token = "test-registry-token";
 it.each([
   { cdnHost: "localhost", expectedCdnAuth: [`Bearer ${token}`, `Bearer ${token}`] },

--- a/test/cli/install/bun-install-retry.test.ts
+++ b/test/cli/install/bun-install-retry.test.ts
@@ -94,16 +94,20 @@ it("retries a manifest whose redirect target 500s once", async () => {
   });
 });
 
-// A cross-origin redirect strips Authorization from the request (per the fetch
-// spec). The install retry restarts from the original registry URL and must
-// carry the original headers, including Authorization, again.
-it("retries an authorized manifest whose cross-origin redirect target 500s once", async () => {
-  const token = "test-registry-token";
+// The registry (reached as `localhost`) redirects the manifest to a second
+// server standing in for a CDN. Whether that hop keeps the token depends only
+// on the hostname: bun install, like npm, keeps it when just the port (or
+// scheme) changes and drops it when the hostname changes. Either way the
+// install retry restarts from the original registry URL and must carry the
+// original headers, including Authorization, again.
+const token = "test-registry-token";
+it.each([
+  { cdnHost: "localhost", expectedCdnAuth: [`Bearer ${token}`, `Bearer ${token}`] },
+  { cdnHost: "127.0.0.1", expectedCdnAuth: [null, null] },
+])("retries an authorized manifest redirected to $cdnHost when it 500s once", async ({ cdnHost, expectedCdnAuth }) => {
   const registryUrls: string[] = [];
   const cdnAuth: (string | null)[] = [];
   let cdnHits = 0;
-  // A second server on its own port stands in for the CDN the registry
-  // redirects to; a different port makes the redirect cross-origin.
   await using cdn = Bun.serve({
     port: 0,
     fetch(request) {
@@ -133,7 +137,7 @@ it("retries an authorized manifest whose cross-origin redirect target 500s once"
       }
       return new Response(null, {
         status: 302,
-        headers: { Location: `http://localhost:${cdn.port}/cdn/BaR` },
+        headers: { Location: `http://${cdnHost}:${cdn.port}/cdn/BaR` },
       });
     }
     if (pathname === "/BaR-0.0.2.tgz") {
@@ -168,10 +172,9 @@ it("retries an authorized manifest whose cross-origin redirect target 500s once"
   expect(err).toContain("Saved lockfile");
   expect(out).toContain("1 package installed");
   expect(exitCode).toBe(0);
-  // Both registry hits carried the token (the handler 401s otherwise); the
-  // cross-origin CDN hops must NOT have (the spec strips it for that hop).
+  // Both registry hits carried the token (the handler 401s otherwise).
   expect(registryUrls).toEqual(["/BaR", "/BaR", "/BaR-0.0.2.tgz"]);
-  expect(cdnAuth).toEqual([null, null]);
+  expect(cdnAuth).toEqual(expectedCdnAuth);
 });
 
 // Sibling retry site (tarball downloads in runTasks): the tarball URL

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -857,8 +857,8 @@ describe.concurrent("bun-install", () => {
   // Registries such as Nexus and Artifactory answer manifest and tarball
   // requests with a redirect to the same host on another scheme or port
   // (https://github.com/oven-sh/bun/issues/15516). Like npm, bun keeps the
-  // token across such a redirect and drops it only once the redirect leaves
-  // the registry's hostname.
+  // token across such a redirect; it drops it once the redirect leaves the
+  // registry's hostname, and (unlike npm) when it downgrades https to http.
   describe("registry token across redirects", () => {
     const token = "secret-registry-token";
     const tgz = join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
@@ -866,23 +866,44 @@ describe.concurrent("bun-install", () => {
     const manifestPath = "/no-deps";
     const tarballPath = "/no-deps/-/no-deps-1.0.0.tgz";
 
+    // The registry lives on `registry`://127.0.0.1; `target` is the scheme and
+    // hostname it redirects to (the port always differs). https servers use
+    // the harness certificate, which the install trusts via --cafile.
     it.each([
       {
         name: "keeps the token when only the port changes",
+        registry: "http",
         target: "http://127.0.0.1",
         authorization: `Bearer ${token}`,
       },
       {
-        name: "keeps the token when the scheme and the port change",
+        name: "keeps the token when only the port changes (https registry)",
+        registry: "https",
         target: "https://127.0.0.1",
         authorization: `Bearer ${token}`,
       },
-      // The same machine, but a different hostname than the registry's.
-      { name: "drops the token when the hostname changes", target: "http://localhost", authorization: null },
-    ])("$name", async ({ target, authorization }) => {
-      // `target` (scheme and hostname; the port is whatever it gets) serves
-      // the manifest and the tarball unconditionally and records the
-      // Authorization header each hop arrived with.
+      {
+        name: "keeps the token when the redirect upgrades http to https",
+        registry: "http",
+        target: "https://127.0.0.1",
+        authorization: `Bearer ${token}`,
+      },
+      {
+        name: "drops the token when the redirect downgrades https to http",
+        registry: "https",
+        target: "http://127.0.0.1",
+        authorization: null,
+      },
+      {
+        // The same machine, but a different hostname than the registry's.
+        name: "drops the token when the hostname changes",
+        registry: "http",
+        target: "http://localhost",
+        authorization: null,
+      },
+    ])("$name", async ({ registry: registryScheme, target, authorization }) => {
+      // `target` serves the manifest and the tarball unconditionally and
+      // records the Authorization header each hop arrived with.
       const received: { pathname: string; authorization: string | null }[] = [];
       await using targetServer = Bun.serve({
         port: 0,
@@ -901,7 +922,7 @@ describe.concurrent("bun-install", () => {
                 "1.0.0": {
                   name: "no-deps",
                   version: "1.0.0",
-                  dist: { integrity, tarball: `http://127.0.0.1:${registry.port}${tarballPath}` },
+                  dist: { integrity, tarball: `${registryScheme}://127.0.0.1:${registry.port}${tarballPath}` },
                 },
               },
             });
@@ -915,6 +936,7 @@ describe.concurrent("bun-install", () => {
       await using registry = Bun.serve({
         port: 0,
         hostname: "127.0.0.1",
+        ...(registryScheme === "https" ? tls : {}),
         fetch(req) {
           if (req.headers.get("authorization") !== `Bearer ${token}`) {
             return new Response("unauthorized", { status: 401 });
@@ -926,7 +948,7 @@ describe.concurrent("bun-install", () => {
       using dir = tempDir("token-across-redirects", {
         "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } }),
         ".npmrc": [
-          `registry=http://127.0.0.1:${registry.port}/`,
+          `registry=${registryScheme}://127.0.0.1:${registry.port}/`,
           `//127.0.0.1:${registry.port}/:_authToken=${token}`,
           ``,
         ].join("\n"),

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -12,6 +12,7 @@ import {
   runBunInstall,
   tempDir,
   textLockfile,
+  tls,
   toBeValidBin,
   toBeWorkspaceLink,
   toHaveBins,
@@ -851,6 +852,105 @@ describe.concurrent("bun-install", () => {
     });
     expect(stdout).toContain("2 packages installed");
     expect(exitCode).toBe(0);
+  });
+
+  // Registries such as Nexus and Artifactory answer manifest and tarball
+  // requests with a redirect to the same host on another scheme or port
+  // (https://github.com/oven-sh/bun/issues/15516). Like npm, bun keeps the
+  // token across such a redirect and drops it only once the redirect leaves
+  // the registry's hostname.
+  describe("registry token across redirects", () => {
+    const token = "secret-registry-token";
+    const tgz = join(import.meta.dir, "registry", "packages", "no-deps", "no-deps-1.0.0.tgz");
+    const integrity = "sha512-v4w12JRjUGvfHDUP8vFDwu0gUWu04j0cv9hLb1Abf9VdaXu4XcrddYFTMVBVvmldKViGWH7jrb6xPJRF0wq6gw==";
+    const manifestPath = "/no-deps";
+    const tarballPath = "/no-deps/-/no-deps-1.0.0.tgz";
+
+    it.each([
+      {
+        name: "keeps the token when only the port changes",
+        target: "http://127.0.0.1",
+        authorization: `Bearer ${token}`,
+      },
+      {
+        name: "keeps the token when the scheme and the port change",
+        target: "https://127.0.0.1",
+        authorization: `Bearer ${token}`,
+      },
+      // The same machine, but a different hostname than the registry's.
+      { name: "drops the token when the hostname changes", target: "http://localhost", authorization: null },
+    ])("$name", async ({ target, authorization }) => {
+      // `target` (scheme and hostname; the port is whatever it gets) serves
+      // the manifest and the tarball unconditionally and records the
+      // Authorization header each hop arrived with.
+      const received: { pathname: string; authorization: string | null }[] = [];
+      await using targetServer = Bun.serve({
+        port: 0,
+        ...(target.startsWith("https:") ? tls : {}),
+        fetch(req) {
+          const { pathname } = new URL(req.url);
+          received.push({ pathname, authorization: req.headers.get("authorization") });
+          if (pathname === manifestPath) {
+            // `dist.tarball` points at the registry origin so the tarball
+            // request carries the token in the first place (see the test
+            // above); the registry then redirects it as well.
+            return Response.json({
+              name: "no-deps",
+              "dist-tags": { latest: "1.0.0" },
+              versions: {
+                "1.0.0": {
+                  name: "no-deps",
+                  version: "1.0.0",
+                  dist: { integrity, tarball: `http://127.0.0.1:${registry.port}${tarballPath}` },
+                },
+              },
+            });
+          }
+          if (pathname === tarballPath) return new Response(file(tgz));
+          return new Response("not found", { status: 404 });
+        },
+      });
+      // The registry requires the token and answers every request with a
+      // redirect to the same path on `target`.
+      await using registry = Bun.serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        fetch(req) {
+          if (req.headers.get("authorization") !== `Bearer ${token}`) {
+            return new Response("unauthorized", { status: 401 });
+          }
+          return Response.redirect(`${target}:${targetServer.port}${new URL(req.url).pathname}`, 302);
+        },
+      });
+
+      using dir = tempDir("token-across-redirects", {
+        "package.json": JSON.stringify({ name: "app", version: "1.0.0", dependencies: { "no-deps": "1.0.0" } }),
+        ".npmrc": [
+          `registry=http://127.0.0.1:${registry.port}/`,
+          `//127.0.0.1:${registry.port}/:_authToken=${token}`,
+          ``,
+        ].join("\n"),
+        "cafile": tls.cert,
+      });
+      await using proc = spawn({
+        cmd: [bunExe(), "install", "--cafile", "cafile"],
+        cwd: String(dir),
+        env: { ...env, BUN_INSTALL_CACHE_DIR: join(String(dir), ".cache") },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+      expect({ stderr, received }).toEqual({
+        stderr: expect.stringContaining("Saved lockfile"),
+        received: [
+          { pathname: manifestPath, authorization },
+          { pathname: tarballPath, authorization },
+        ],
+      });
+      expect(stdout).toContain("1 package installed");
+      expect(exitCode).toBe(0);
+    });
   });
 
   it("--silent suppresses verbose output even when RUNNER_DEBUG is set", async () => {


### PR DESCRIPTION
### Problem
- `bun install` against a registry whose manifest or tarball URLs answer with a redirect to the same host on another scheme or port (Nexus in #15516: `http://host/...` 302s to `https://host/...`) fails with `error: GET https://host/.../pkg-1.0.0.tgz - 401`: the second request arrives without `Authorization`.
- `HTTPClient::handle_response_metadata` (src/http/lib.rs, the `CROSS_ORIGIN_STRIPPED_REQUEST_HEADERS` loop) deletes `Authorization`, `Proxy-Authorization`, `Cookie` and `Host` whenever the redirect target's origin differs from the current URL's, and origin includes scheme and port. That is the fetch() rule; the package manager's requests went through it unchanged.
- #15521 implemented this policy switch in the Zig client but was closed untested, so the issue is still reproducible on `main`.

Fixes #15516

### Fix
- Adds `Flags::redirect_credentials: RedirectCredentialsPolicy` to the HTTP client. The default, `SameOrigin`, is the existing behavior, so `fetch()`, S3, `node:http` and everything else are unchanged.
- `NetworkTask::for_manifest` and `NetworkTask::for_tarball` (src/install/NetworkTask.rs) set `SameHostname`: on a redirect the credential headers are kept while the hostname is unchanged, and dropped when the hostname changes or when the hop downgrades https to http. A user-supplied `Host` header is still dropped on any origin change, and the SNI / certificate re-derivation (`clear_hostname_on_redirect`) still keys off the origin; only the credential rule is policy dependent.
- Why this is the right rule: the hostname part is npm's. make-fetch-happen deletes `authorization` and `cookie` on a redirect only when `hostname` changes ("but not if just changing ports or protocols"), and registries like Nexus and Artifactory are built against that client. The token only ever follows a redirect issued by the host that already holds it; a redirect to any other hostname still strips it, and the existing first-hop guards (manifest URL and `dist.tarball` must be on the registry origin) are untouched.
- The https -> http exception is stricter than npm: that hop would replay the token in cleartext, and #15516 (an upgrade) and the port-change setups do not need it, so it fails closed (REVIEW.md, security section).
- Scope: only the package manager's manifest and tarball requests opt in (the requests #15516 is about). `bun publish` / `audit` / `info` keep the fetch() rule.
- Verified:
  - test/cli/install/bun-install.test.ts, "registry token across redirects": a registry on `127.0.0.1` requires the token and 302s both the manifest and the tarball to a second server. Five rows: http -> http on another port, https -> https on another port, and http -> https (the issue's case) must see the token on both hops; https -> http and http -> `localhost` (same machine, different hostname) must not. https servers use the harness certificate and the install passes `--cafile`. On `main` the three keep rows fail (both hops arrive with `authorization: null`) and the two drop rows pass; with the hostname rule alone the downgrade row fails (token arrives over http); with this change all five pass.
  - test/cli/install/bun-install-retry.test.ts: the existing authorized-redirect retry test now runs for both a same-host (`localhost` -> `localhost:<other port>`, token kept on both attempts) and a cross-host (`localhost` -> `127.0.0.1`, token stripped) redirect, so the flag is also shown to survive the install retry path, which re-schedules the same request. The same-host case fails on `main`.
  - Existing redirect coverage passes with the change: test/js/web/fetch/fetch.test.ts "cross-origin status code 302" (same host, different port, still stripped for fetch()), "same-origin status code 302 should not strip headers", "drops a custom Host header when following a cross-origin redirect", fetch-redirect.test.ts, fetch-url-after-redirect.test.ts, and the fetch.tls.test.ts cross-origin redirect test.

### Background
- Origin: scheme + hostname + port. The WHATWG fetch redirect algorithm (https://fetch.spec.whatwg.org/#concept-http-redirect-fetch) removes the credential-bearing request headers when the redirect target is not same-origin with the current URL, so `fetch()` must keep comparing origins.
- make-fetch-happen: the HTTP layer under npm's registry client (npm-registry-fetch, pacote), and therefore the behavior every npm-compatible registry is tested against. Its redirect handling compares hostnames only (quoted in #15521).
- Registry credentials in `bun install` are attached per request in `NetworkTask` (the `count_auth` / `append_auth` helpers) from the registry scope's token; the HTTP client then follows redirects on its own, which is where the headers were being removed.
- On retry, `bun install` re-schedules the same `AsyncHTTP`; the HTTP thread works on a bitwise copy whose `client.flags` (including the new field) is copied back afterwards, which is what the retry test exercises.

<details>
<summary>Earlier revision</summary>

The first push implemented the hostname rule without the https -> http exception (variants were named `StripOnOriginChange` / `StripOnHostnameChange`); review pointed out the cleartext replay, which the second commit closes and covers with the https registry rows.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts

<!-- robobun:evidence:end -->