### PR TITLE
shell: fail an empty operand with ENOENT instead of acting on the cwd

### DIFF
--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -588,6 +588,15 @@ impl ShellCpTask {
     fn run_from_thread_pool_impl(&mut self) -> Option<ShellErr> {
         use resolve_path::{Platform, platform};
 
+        // Joining an empty operand onto the cwd yields the cwd itself, so it
+        // would copy the cwd (or into it) instead of failing like `stat("")`.
+        if self.src.is_empty() || self.tgt.is_empty() {
+            return Some(ShellErr::new_sys(&bun_sys::Error::from_code(
+                bun_sys::E::ENOENT,
+                bun_sys::Tag::copyfile,
+            )));
+        }
+
         let mut buf2 = bun_paths::PathBuffer::uninit();
         let mut buf3 = bun_paths::PathBuffer::uninit();
         // We have to give an absolute path to our cp implementation for it to

--- a/src/runtime/shell/builtin/cp.rs
+++ b/src/runtime/shell/builtin/cp.rs
@@ -3,7 +3,7 @@ use bun_paths::resolve_path;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, reject_empty_path, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -588,13 +588,10 @@ impl ShellCpTask {
     fn run_from_thread_pool_impl(&mut self) -> Option<ShellErr> {
         use resolve_path::{Platform, platform};
 
-        // Joining an empty operand onto the cwd yields the cwd itself, so it
-        // would copy the cwd (or into it) instead of failing like `stat("")`.
-        if self.src.is_empty() || self.tgt.is_empty() {
-            return Some(ShellErr::new_sys(&bun_sys::Error::from_code(
-                bun_sys::E::ENOENT,
-                bun_sys::Tag::copyfile,
-            )));
+        if let Err(e) = reject_empty_path(&self.src, bun_sys::Tag::copyfile)
+            .and_then(|()| reject_empty_path(&self.tgt, bun_sys::Tag::copyfile))
+        {
+            return Some(ShellErr::new_sys(&e));
         }
 
         let mut buf2 = bun_paths::PathBuffer::uninit();

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -4,7 +4,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, reject_empty_path, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -296,13 +296,8 @@ impl ShellMkdirTask {
 
     fn run_from_thread_pool(this: &mut ShellMkdirTask) {
         use bun_paths::{Platform, platform, resolve_path};
-        // Joining an empty operand onto the cwd yields the cwd itself, so it
-        // would mkdir the cwd (a no-op under -p) instead of failing like `mkdir("")`.
-        if this.filepath.is_empty() {
-            this.err = Some(bun_sys::Error::from_code(
-                bun_sys::E::ENOENT,
-                bun_sys::Tag::mkdir,
-            ));
+        if let Err(e) = reject_empty_path(&this.filepath, bun_sys::Tag::mkdir) {
+            this.err = Some(e);
             return;
         }
         // We have to give an absolute path to our mkdir implementation for it

--- a/src/runtime/shell/builtin/mkdir.rs
+++ b/src/runtime/shell/builtin/mkdir.rs
@@ -296,6 +296,15 @@ impl ShellMkdirTask {
 
     fn run_from_thread_pool(this: &mut ShellMkdirTask) {
         use bun_paths::{Platform, platform, resolve_path};
+        // Joining an empty operand onto the cwd yields the cwd itself, so it
+        // would mkdir the cwd (a no-op under -p) instead of failing like `mkdir("")`.
+        if this.filepath.is_empty() {
+            this.err = Some(bun_sys::Error::from_code(
+                bun_sys::E::ENOENT,
+                bun_sys::Tag::mkdir,
+            ));
+            return;
+        }
         // We have to give an absolute path to our mkdir implementation for it
         // to work with cwd.
         let filepath: &bun_core::ZStr = if Platform::AUTO.is_absolute(&this.filepath) {

--- a/src/runtime/shell/builtin/mv.rs
+++ b/src/runtime/shell/builtin/mv.rs
@@ -6,7 +6,9 @@ use bun_ptr::BackRef;
 
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
-use crate::shell::interpreter::{Interpreter, NodeId, ShellTask, closefd, shell_openat};
+use crate::shell::interpreter::{
+    Interpreter, NodeId, ShellTask, closefd, reject_empty_path, shell_openat,
+};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
 
@@ -484,6 +486,8 @@ impl ShellMvBatchedTask {
         dst_dir: bun_sys::Fd,
         dst: &ZStr,
     ) -> Result<(), bun_sys::Error> {
+        reject_empty_path(src.as_bytes(), bun_sys::Tag::rename)?;
+        reject_empty_path(dst.as_bytes(), bun_sys::Tag::rename)?;
         match bun_sys::renameat(src_dir, src, dst_dir, dst) {
             Err(e) if e.get_errno() == bun_sys::E::EXDEV => {
                 Self::move_across_devices(src_dir, src, dst_dir, dst).map_err(|e| {

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -174,8 +174,7 @@ impl Rm {
 
                                 for i in args_start..argc {
                                     let path = Builtin::of(interp, cmd).arg_bytes(i);
-                                    // Joined onto the cwd, `""` would look like the cwd
-                                    // here; its task fails it with ENOENT instead.
+                                    // Joined below, `""` would resolve to the cwd itself.
                                     if path.is_empty() {
                                         continue;
                                     }
@@ -1203,8 +1202,6 @@ impl ShellRmTask {
         vtable: &mut V,
     ) -> bun_sys::Maybe<()> {
         let dirfd = self.cwd;
-        // Every operand is classified here first, so this is where an empty one
-        // gets the ENOENT (and `-f`) treatment of any other missing operand.
         match reject_empty_path(path.as_bytes(), bun_sys::Tag::unlink)
             .and_then(|()| bun_sys::unlinkat_with_flags(dirfd, path, 0))
         {

--- a/src/runtime/shell/builtin/rm.rs
+++ b/src/runtime/shell/builtin/rm.rs
@@ -7,7 +7,7 @@ use bun_sys::{E, FdExt, dir_iterator};
 use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, IoKind, Kind};
 use crate::shell::interpreter::{
-    EventLoopHandle, Interpreter, NodeId, ShellTask, WorkPoolTask, shell_openat,
+    EventLoopHandle, Interpreter, NodeId, ShellTask, WorkPoolTask, reject_empty_path, shell_openat,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -174,6 +174,11 @@ impl Rm {
 
                                 for i in args_start..argc {
                                     let path = Builtin::of(interp, cmd).arg_bytes(i);
+                                    // Joined onto the cwd, `""` would look like the cwd
+                                    // here; its task fails it with ENOENT instead.
+                                    if path.is_empty() {
+                                        continue;
+                                    }
                                     let resolved: &[u8] = if Platform::AUTO.is_absolute(path) {
                                         path
                                     } else {
@@ -1198,7 +1203,11 @@ impl ShellRmTask {
         vtable: &mut V,
     ) -> bun_sys::Maybe<()> {
         let dirfd = self.cwd;
-        match bun_sys::unlinkat_with_flags(dirfd, path, 0) {
+        // Every operand is classified here first, so this is where an empty one
+        // gets the ENOENT (and `-f`) treatment of any other missing operand.
+        match reject_empty_path(path.as_bytes(), bun_sys::Tag::unlink)
+            .and_then(|()| bun_sys::unlinkat_with_flags(dirfd, path, 0))
+        {
             Ok(()) => self.verbose_deleted(parent_dir_task, path.as_bytes()),
             Err(e) => match e.get_errno() {
                 E::ENOENT => {

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -2,7 +2,7 @@ use crate::shell::ExitCode;
 use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
 use crate::shell::interpreter::{
     EventLoopHandle, FlagParser, Interpreter, NodeId, OutputSrc, OutputTask, OutputTaskVTable,
-    ParseFlagResult, ShellTask, parse_flags, unsupported_flag,
+    ParseFlagResult, ShellTask, parse_flags, reject_empty_path, unsupported_flag,
 };
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
@@ -265,13 +265,8 @@ impl ShellTouchTask {
     pub(crate) fn run_from_thread_pool(this: &mut ShellTouchTask) {
         use bun_paths::resolve_path::{self, Platform, platform};
         use bun_sys::FdExt as _;
-        // Joining an empty operand onto the cwd yields the cwd itself, so it
-        // would touch the directory instead of failing like `utimensat("")`.
-        if this.filepath.is_empty() {
-            this.err = Some(bun_sys::Error::from_code(
-                bun_sys::E::ENOENT,
-                bun_sys::Tag::utime,
-            ));
+        if let Err(e) = reject_empty_path(&this.filepath, bun_sys::Tag::utime) {
+            this.err = Some(e);
             return;
         }
         // We have to give an absolute path.

--- a/src/runtime/shell/builtin/touch.rs
+++ b/src/runtime/shell/builtin/touch.rs
@@ -265,6 +265,15 @@ impl ShellTouchTask {
     pub(crate) fn run_from_thread_pool(this: &mut ShellTouchTask) {
         use bun_paths::resolve_path::{self, Platform, platform};
         use bun_sys::FdExt as _;
+        // Joining an empty operand onto the cwd yields the cwd itself, so it
+        // would touch the directory instead of failing like `utimensat("")`.
+        if this.filepath.is_empty() {
+            this.err = Some(bun_sys::Error::from_code(
+                bun_sys::E::ENOENT,
+                bun_sys::Tag::utime,
+            ));
+            return;
+        }
         // We have to give an absolute path.
         let mut buf = bun_paths::PathBuffer::uninit();
         let filepath: &bun_core::ZStr = if Platform::AUTO.is_absolute(&this.filepath) {

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2224,6 +2224,18 @@ pub(crate) fn shell_statat(dir: Fd, path_: &bun_core::ZStr) -> bun_sys::Result<b
     }
 }
 
+/// Fails an empty path operand with ENOENT, which is what every POSIX syscall
+/// returns for `""`. The shell's own path handling does not: joining `""` onto
+/// the cwd yields the cwd, and the Windows `*at()` emulation opens the
+/// directory handle itself for an empty name, so without this `touch ""`,
+/// `rm -r ""`, `cp -R "" x`, ... operate on the current directory.
+pub(crate) fn reject_empty_path(path: &[u8], syscall: bun_sys::Tag) -> bun_sys::Result<()> {
+    if path.is_empty() {
+        return Err(bun_sys::Error::from_code(bun_sys::E::ENOENT, syscall));
+    }
+    Ok(())
+}
+
 /// POSIX: `bun_sys::openat` with the error tagged `.with_path(path)`.
 /// Windows: for `O_DIRECTORY` opens, rewrite POSIX-absolute paths via
 /// `shell_get_path` and use `openDirAtWindowsA(.iterable=true)` +
@@ -2235,6 +2247,7 @@ pub(crate) fn shell_openat(
     flags: i32,
     perm: bun_sys::Mode,
 ) -> bun_sys::Result<Fd> {
+    reject_empty_path(path.as_bytes(), bun_sys::Tag::open)?;
     #[cfg(windows)]
     {
         use bun_sys::FdExt;

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2224,11 +2224,9 @@ pub(crate) fn shell_statat(dir: Fd, path_: &bun_core::ZStr) -> bun_sys::Result<b
     }
 }
 
-/// Fails an empty path operand with ENOENT, which is what every POSIX syscall
-/// returns for `""`. The shell's own path handling does not: joining `""` onto
-/// the cwd yields the cwd, and the Windows `*at()` emulation opens the
-/// directory handle itself for an empty name, so without this `touch ""`,
-/// `rm -r ""`, `cp -R "" x`, ... operate on the current directory.
+/// Syscalls fail on `""` with ENOENT, but the shell's own resolution would turn
+/// it into the cwd: joining it onto the cwd string, or the Windows `*at()`
+/// emulation, for which an empty name is the directory handle itself.
 pub(crate) fn reject_empty_path(path: &[u8], syscall: bun_sys::Tag) -> bun_sys::Result<()> {
     if path.is_empty() {
         return Err(bun_sys::Error::from_code(bun_sys::E::ENOENT, syscall));

--- a/src/runtime/shell/interpreter.rs
+++ b/src/runtime/shell/interpreter.rs
@@ -2224,9 +2224,7 @@ pub(crate) fn shell_statat(dir: Fd, path_: &bun_core::ZStr) -> bun_sys::Result<b
     }
 }
 
-/// Syscalls fail on `""` with ENOENT, but the shell's own resolution would turn
-/// it into the cwd: joining it onto the cwd string, or the Windows `*at()`
-/// emulation, for which an empty name is the directory handle itself.
+/// Resolved by the shell (cwd join, or the Windows `*at()` emulation), `""` would name the cwd.
 pub(crate) fn reject_empty_path(path: &[u8], syscall: bun_sys::Tag) -> bun_sys::Result<()> {
     if path.is_empty() {
         return Err(bun_sys::Error::from_code(bun_sys::E::ENOENT, syscall));

--- a/test/js/bun/shell/commands/cp.test.ts
+++ b/test/js/bun/shell/commands/cp.test.ts
@@ -1,7 +1,9 @@
 import { $ } from "bun";
 import { shellInternals } from "bun:internal-for-testing";
-import { describe, expect } from "bun:test";
-import { tempDirWithFiles } from "harness";
+import { describe, expect, test } from "bun:test";
+import { bunEnv, tempDir, tempDirWithFiles } from "harness";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
 import { bunExe, createTestBuilder } from "../test_builder";
 import { sortedShellOutput } from "../util";
 const { builtinDisabled } = shellInternals;
@@ -170,6 +172,55 @@ describe.if(!builtinDisabled("cp"))("bunshell cp", async () => {
       .fileEquals(TEST_COPY_TO_FOLDER_NEW_FILE, "Hello, World!")
       .testMini({ cwd: mini_tmpdir })
       .runAsTest("cp_recurse");
+  });
+});
+
+// The builtin is the default only on Windows; on POSIX it is enabled by an env
+// var that is read once per process, so each of these runs cp in a child bun.
+describe.concurrent("bunshell cp with an empty operand", () => {
+  const builtinEnv = { ...bunEnv, BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS: "1" };
+
+  /** Runs `command` through the shell in `cwd`; the child prints cp's exit code, then its stderr. */
+  async function cp(cwd: string, command: string) {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const result = await Bun.$\`\${{ raw: ${JSON.stringify(command)} }}\`.nothrow().quiet();
+         process.stdout.write(result.exitCode + "\\n" + result.stderr.toString() + result.stdout.toString());`,
+      ],
+      cwd,
+      env: builtinEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  const ENOENT = "cp: No such file or directory\n";
+
+  // An empty operand used to be joined onto the shell's cwd, which resolved to
+  // the cwd itself: `cp "" out` complained that "" is a directory, `cp -R "" out`
+  // copied the cwd into itself, and `cp f ""` copied f onto itself and exited 0.
+  test.each([
+    ['cp "" out', ENOENT],
+    ['cp -R "" out', ENOENT],
+    ['cp f ""', ENOENT],
+    ['cp -R f ""', ENOENT],
+    ['cp f g ""', ENOENT + ENOENT],
+  ])("%s fails with ENOENT and copies nothing", async (command, stderr) => {
+    using dir = tempDir("shell-cp-empty-operand", { f: "F\n", g: "G\n" });
+
+    expect(await cp(String(dir), command)).toEqual({ stdout: `1\n${stderr}`, stderr: "", exitCode: 0 });
+    expect(readdirSync(String(dir)).sort()).toEqual(["f", "g"]);
+    expect(readFileSync(join(String(dir), "f"), "utf8")).toBe("F\n");
+  });
+
+  test("the other sources are still copied when one of them is empty", async () => {
+    using dir = tempDir("shell-cp-empty-operand-one-of-many", { f: "F\n", out: {} });
+
+    expect(await cp(String(dir), 'cp "" f out')).toEqual({ stdout: `1\n${ENOENT}`, stderr: "", exitCode: 0 });
+    expect(readFileSync(join(String(dir), "out", "f"), "utf8")).toBe("F\n");
   });
 });
 

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -287,6 +287,26 @@ describe.concurrent("bunshell ls", () => {
         .run();
     });
 
+    // On Windows the shell's openat emulation used to resolve an empty operand
+    // to the cwd itself, so `ls ""` listed the cwd and exited 0.
+    test.each(['ls ""', 'ls -R ""'])("%s fails with ENOENT", async cmd => {
+      await TestBuilder.command`${{ raw: cmd }}`
+        .file("a", "")
+        .exitCode(1)
+        .stdout("")
+        .stderr("ls: No such file or directory\n")
+        .run();
+    });
+
+    test("the other operands are still listed when one is empty", async () => {
+      await TestBuilder.command`ls a ""`
+        .file("a", "")
+        .exitCode(1)
+        .stdout("a\n")
+        .stderr("ls: No such file or directory\n")
+        .run();
+    });
+
     test("invalid flag", async () => {
       await TestBuilder.command`ls -z`
         .exitCode(1)

--- a/test/js/bun/shell/commands/mkdir.test.ts
+++ b/test/js/bun/shell/commands/mkdir.test.ts
@@ -1,0 +1,45 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { readdirSync } from "node:fs";
+import { join } from "node:path";
+
+$.nothrow();
+
+const ENOENT = "mkdir: No such file or directory\n";
+
+describe.concurrent("bunshell mkdir", () => {
+  // An empty operand used to be joined onto the shell's cwd, which resolved to
+  // the cwd itself: `mkdir ""` reported the cwd as existing and `mkdir -p ""`
+  // exited 0.
+  test.each([
+    ['mkdir ""', () => $`mkdir ""`],
+    ['mkdir ${""}', () => $`mkdir ${""}`],
+    ['mkdir -p ""', () => $`mkdir -p ""`],
+    ['mkdir -pv ""', () => $`mkdir -pv ""`],
+    ['mkdir -v ""', () => $`mkdir -v ""`],
+  ])("%s fails with ENOENT", async (_name, command) => {
+    using dir = tempDir("mkdir-empty", {});
+    const cwd = String(dir);
+
+    const { stdout, stderr, exitCode } = await command().cwd(cwd).quiet();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toBe(ENOENT);
+    expect(exitCode).toBe(1);
+    expect(readdirSync(cwd)).toEqual([]);
+  });
+
+  test("the other operands are still created when one is empty", async () => {
+    using dir = tempDir("mkdir-empty-multi", {});
+    const cwd = String(dir);
+
+    const { stdout, stderr, exitCode } = await $`mkdir -p a "" b/c`.cwd(cwd).quiet();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toBe(ENOENT);
+    expect(exitCode).toBe(1);
+    expect(readdirSync(cwd).sort()).toEqual(["a", "b"]);
+    expect(readdirSync(join(cwd, "b"))).toEqual(["c"]);
+  });
+});

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -67,6 +67,46 @@ describe("mv", async () => {
     .stderr("mv: a: Not a directory\n")
     .runAsTest("move dir -> file fails");
 
+  // On Windows the shell's fd-relative open/rename emulation used to resolve an
+  // empty operand to the cwd itself: `mv a ""` moved a into the cwd (a no-op
+  // that exited 0) and `mv "" b` tried to rename the cwd.
+  describe("empty operand", () => {
+    TestBuilder.command`mv a ""`
+      .ensureTempDir()
+      .file("a", "A\n")
+      .exitCode(2 /* ENOENT */)
+      .stderr("mv: No such file or directory\n")
+      .fileEquals("a", "A\n")
+      .runAsTest("as the destination fails");
+
+    TestBuilder.command`mv "" b`
+      .ensureTempDir()
+      .file("a", "A\n")
+      .exitCode(2 /* ENOENT */)
+      .stderr("mv: No such file or directory\n")
+      .fileEquals("a", "A\n")
+      .doesNotExist("b")
+      .runAsTest("as the source fails");
+
+    TestBuilder.command`mkdir d; mv "" d`
+      .ensureTempDir()
+      .file("a", "A\n")
+      .exitCode(2 /* ENOENT */)
+      .stderr("mv: d: No such file or directory\n")
+      .fileEquals("a", "A\n")
+      .runAsTest("as a source moved into a directory fails");
+
+    TestBuilder.command`mv a b ""`
+      .ensureTempDir()
+      .file("a", "A\n")
+      .file("b", "B\n")
+      .exitCode(1)
+      .stderr("mv: : No such file or directory\n")
+      .fileEquals("a", "A\n")
+      .fileEquals("b", "B\n")
+      .runAsTest("as the directory for several sources fails");
+  });
+
   // POSIX `mv` must fall back to copy+unlink when `rename()` returns EXDEV
   // (source and destination on different filesystems). Requires a writable
   // mount on a different device from the harness temp dir.

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -6,8 +6,8 @@
  */
 import { $ } from "bun";
 import { beforeAll, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, tempDir } from "harness";
-import { existsSync, mkdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
+import { bunEnv, bunExe, isPosix, tempDir } from "harness";
+import { existsSync, mkdirSync, readdirSync, renameSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "path";
 import { createTestBuilder, sortedShellOutput } from "../util";
 const TestBuilder = createTestBuilder(import.meta.path);
@@ -329,3 +329,59 @@ test.skipIf(process.platform === "win32")(
     expect(exitCode).toBe(0);
   },
 );
+
+// An empty operand used to stand for the cwd twice over: the refuse-to-remove-
+// the-root check joined it onto the cwd (so in a top-level directory `rm ""`
+// refused to remove the cwd), and on Windows the fd-relative unlink/open
+// emulation resolved it to the cwd itself, so `rm -r ""` emptied the cwd.
+describe.concurrent("rm with an empty operand", () => {
+  const files = { f: "F\n", "sub/inner": "I\n" };
+  const ENOENT = "rm: No such file or directory\n";
+
+  test.each([
+    ['rm ""', { stdout: "", stderr: ENOENT, exitCode: 1 }],
+    ['rm -r ""', { stdout: "", stderr: ENOENT, exitCode: 1 }],
+    ['rm -d ""', { stdout: "", stderr: ENOENT, exitCode: 1 }],
+    ['rm -f ""', { stdout: "", stderr: "", exitCode: 0 }],
+    ['rm -rf ""', { stdout: "", stderr: "", exitCode: 0 }],
+  ])("%s removes nothing", async (command, expected) => {
+    using dir = tempDir("rm-empty-operand", files);
+
+    const { stdout, stderr, exitCode } = await $`${{ raw: command }}`.cwd(String(dir)).quiet();
+
+    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual(expected);
+    expect(readdirSync(String(dir)).sort()).toEqual(["f", "sub"]);
+    expect(existsSync(path.join(String(dir), "sub", "inner"))).toBeTrue();
+  });
+
+  test("the other operands are still removed when one is empty", async () => {
+    using dir = tempDir("rm-empty-operand-multi", files);
+
+    const { stdout, stderr, exitCode } = await $`rm "" f`.cwd(String(dir)).quiet();
+
+    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
+      stdout: "",
+      stderr: ENOENT,
+      exitCode: 1,
+    });
+    expect(readdirSync(String(dir))).toEqual(["sub"]);
+  });
+
+  // /tmp is a top-level directory, which is where the root check used to trip
+  // on "". Nothing can be removed here: "" names nothing and is the only operand.
+  test.if(isPosix)("is not mistaken for the cwd by the root check in a top-level directory", async () => {
+    const forced = await $`rm -f ""`.cwd("/tmp").quiet();
+    expect({ stdout: forced.stdout.toString(), stderr: forced.stderr.toString(), exitCode: forced.exitCode }).toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+
+    const plain = await $`rm ""`.cwd("/tmp").quiet();
+    expect({ stdout: plain.stdout.toString(), stderr: plain.stderr.toString(), exitCode: plain.exitCode }).toEqual({
+      stdout: "",
+      stderr: ENOENT,
+      exitCode: 1,
+    });
+  });
+});

--- a/test/js/bun/shell/commands/touch.test.ts
+++ b/test/js/bun/shell/commands/touch.test.ts
@@ -1,0 +1,54 @@
+import { $ } from "bun";
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { existsSync, statSync, utimesSync } from "node:fs";
+import { join } from "node:path";
+
+$.nothrow();
+
+const ENOENT = "touch: No such file or directory\n";
+const past = new Date("2000-01-01T00:00:00Z");
+
+describe.concurrent("bunshell touch", () => {
+  // An empty operand used to be joined onto the shell's cwd, which resolved to
+  // the cwd itself: `touch ""` exited 0 and bumped the cwd's timestamps.
+  test('touch "" fails and leaves the cwd untouched', async () => {
+    using dir = tempDir("touch-empty", {});
+    const cwd = String(dir);
+    utimesSync(cwd, past, past);
+
+    const { stdout, stderr, exitCode } = await $`touch ""`.cwd(cwd).quiet();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toBe(ENOENT);
+    expect(exitCode).toBe(1);
+    expect(statSync(cwd).mtimeMs).toBe(past.getTime());
+  });
+
+  test('touch ${""} fails and leaves the cwd untouched', async () => {
+    using dir = tempDir("touch-empty-interp", {});
+    const cwd = String(dir);
+    utimesSync(cwd, past, past);
+
+    const { stdout, stderr, exitCode } = await $`touch ${""}`.cwd(cwd).quiet();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toBe(ENOENT);
+    expect(exitCode).toBe(1);
+    expect(statSync(cwd).mtimeMs).toBe(past.getTime());
+  });
+
+  test("the other operands are still touched when one is empty", async () => {
+    using dir = tempDir("touch-empty-multi", { existing: "" });
+    const cwd = String(dir);
+    utimesSync(join(cwd, "existing"), past, past);
+
+    const { stdout, stderr, exitCode } = await $`touch created "" existing`.cwd(cwd).quiet();
+
+    expect(stdout.toString()).toBe("");
+    expect(stderr.toString()).toBe(ENOENT);
+    expect(exitCode).toBe(1);
+    expect(existsSync(join(cwd, "created"))).toBeTrue();
+    expect(statSync(join(cwd, "existing")).mtimeMs).toBeGreaterThan(past.getTime());
+  });
+});


### PR DESCRIPTION
### Problem

- An empty operand makes the shell builtins act on the current directory instead of failing. On every platform: `touch ""` exits 0 and sets the cwd's mtime to now; `mkdir ""` prints `mkdir: /path/to/cwd: File exists` and `mkdir -p ""` exits 0; with the `cp` builtin (the default on Windows, `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` elsewhere) `cp "" out` prints `cp:  is a directory (not copied)`, `cp f ""` exits 0 and `cp -R "" out` copies the cwd into itself until the worker thread overflows its stack (SIGSEGV); and when the cwd is a top-level directory such as `/tmp`, `rm -f ""` exits 1 with `rm: "/tmp" may not be removed`.
- On Windows the fd-relative builtins do it too: `ls ""` lists the cwd and exits 0, `rm -r ""` (and `rm -rf ""`) deletes the files in the cwd, `rm -d ""` tries to remove the cwd, `mv f ""` and `mv f g ""` exit 0 without moving anything, `mv "" h` tries to rename the cwd (EBUSY, exit 16), `cat ""` exits 21 silently.
- coreutils fails all of these with exit 1 (`touch: cannot touch '': No such file or directory`, `rm -f ''` exits 0), as does every syscall given `""`.
- Cause, first group: `touch`, `mkdir` and `cp` build an absolute path string by joining the operand onto the shell cwd (`touch.rs`, `mkdir.rs`, `cp.rs`, each task's `run_from_thread_pool`), and rm's refuse-to-remove-the-root check does the same (`rm.rs`, `Rm::next`); `join(cwd, "")` is `cwd`.
- Cause, second group: `ls`, `cat`, `rm -r` and mv's target check open their operand through `shell_openat`, and `rm`/`mv` unlink and rename it through `bun_sys`'s `*at()` wrappers. On POSIX the kernel returns ENOENT for an empty name, but the Windows emulation of these passes the name to `NtCreateFile` relative to the cwd handle, and an empty NT name means the handle's own directory. `bun_sys` relies on that itself (`DeleteFileBun` rewrites `.` to an empty name), so it cannot be changed there.

### Fix

- One helper, `reject_empty_path` (`src/runtime/shell/interpreter.rs`), returns ENOENT for an empty operand. It is applied at the lowest point the shell owns on each path: `shell_openat` (covers `ls`, `cat`, `rm -r`, mv's target check), rm's operand classification in `remove_entry_file` (the single entry point for every `rm` operand, so the existing ENOENT handling and `-f` apply to it unchanged), mv's `do_rename` (the single rename point of all three move modes), and the three builtins that resolve operands as strings. rm's root check skips an empty operand and leaves it to the task.
- Why this is the right result: ENOENT is what the syscall returns for `""`, so each builtin now behaves as if it had not rewritten the operand, and exit codes match coreutils. Every guard is keyed on the operand being empty, so no non-empty operand changes behavior; the existing per-operand error paths produce the messages, which are the ones the POSIX builds already printed for `ls ""` / `rm ""`. The one message that changes on POSIX is `mv f ""`, which used to blame `f` (`mv: f: No such file or directory`) and now prints `mv: No such file or directory`.
- Not changed, on purpose: `cd ""` joins onto the cwd and stays there, which is what bash does; the `[[ -f "" ]]` / `-d` tests already check for an empty operand before calling `shell_statat`; redirections to `""` are rejected earlier as an ambiguous redirect; the three string-resolving builtins keep their own resolution code (they differ in buffers and in whether absolute operands are normalized, and unifying that would change `mkdir`'s handling of absolute paths, which this bug does not need). The `cp -R` crash itself is the self-copy recursion tracked in #37927; an empty operand no longer reaches it.
- Tests: new `commands/touch.test.ts` and `commands/mkdir.test.ts` (`commands/` has one file per builtin and these had none), and new cases in `commands/cp.test.ts` (runs cp in a child bun with the env var), `commands/ls.test.ts`, `commands/rm.test.ts` and `commands/mv.test.ts`. They cover the literal and interpolated empty word, `-p`/`-v`/`-R`/`-r`/`-d`/`-f`, both operand positions of `cp` and `mv`, the top-level-cwd case for `rm`, and that the non-empty operands of the same command are still processed while nothing else in the directory changes (the touch test pins the cwd's mtime first).
- Verified: on Linux the touch, mkdir and cp cases (15), the `rm` top-level-cwd case and the `mv a ""` case fail on main and pass with this change; the remaining ls/rm/mv cases pass on Linux either way and pin what Windows now matches. On a Windows x64 machine, every new ls, rm, mv, touch and mkdir case (22) fails on the released build and all six files pass with this change (91 tests, including the existing cp builtin suite, which only runs on Windows). Also ran `bunshell.test.ts`, `exec.test.ts`, `leak.test.ts` and `commands/*` on Linux: the only failures need the network or a non-root user, or are stress tests that exceed their timeout on this debug build, identically without this change.

### Background

- A builtin such as `touch a b` runs one task per operand on the worker pool; a task records either its output or a `bun_sys::Error`, the builtin formats it as `<cmd>: <path>: <message>` (leaving the path out when it is empty) and exits 1 once every task is done if any failed. `mv` uses the failing errno as its exit code, hence exit 2 for ENOENT.
- The shell has its own cwd (`$.cwd()`, `cd`), which can differ from the process cwd. Builtins therefore either pass operands to fd-relative calls (`openat`, `unlinkat`, `renameat`) against the shell's cwd fd, or, where the underlying implementation wants a path string (`utimes`, the node:fs mkdir and cp implementations), join the operand onto the cwd string with `bun_paths::resolve_path::join`, which, like `path.join`, returns the base unchanged when a component is empty.
- `shell_openat` is the shell's wrapper around `openat`; on Windows it emulates the fd-relative open either by resolving the operand against the directory's path (also a join) or by calling `NtCreateFile` with the directory handle as `RootDirectory`.
- `cp` and `cat` are the two builtins the shell enables by default only on Windows; on POSIX they fall through to the system binaries unless `BUN_ENABLE_EXPERIMENTAL_SHELL_BUILTINS=1` is set, which is why a Linux reproduction only shows the touch and mkdir symptoms.

<details>
<summary>Reproduction</summary>

Linux, bun 1.4.0, in an empty directory:

```ts
import { $ } from "bun";
import { statSync, utimesSync } from "node:fs";
$.nothrow();
const past = new Date("2000-01-01T00:00:00Z");
utimesSync(".", past, past);
const t = await $`touch ""`.quiet();
console.log("touch", t.exitCode, JSON.stringify(t.stderr.toString()), statSync(".").mtime.toISOString());
const m = await $`mkdir ""`.quiet();
console.log("mkdir", m.exitCode, JSON.stringify(m.stderr.toString()));
const p = await $`mkdir -p ""`.quiet();
console.log("mkdir -p", p.exitCode, JSON.stringify(p.stderr.toString()));
const r = await $`rm -f ""`.cwd("/tmp").quiet();
console.log("rm -f (cwd /tmp)", r.exitCode, JSON.stringify(r.stderr.toString()));
```

```
touch 0 "" 2026-08-13T01:28:52.087Z
mkdir 1 "mkdir: /tmp/t5: File exists\n"
mkdir -p 0 ""
rm -f (cwd /tmp) 1 "rm: \"/tmp\" may not be removed\n"
```

Windows x64, bun 1.4.0, in a directory containing `f`, `g` and `sub/inner` (each line is one fresh directory):

```
ls ""        -> 0   prints f g sub
ls -R ""     -> 0   prints f g sub sub: inner
rm ""        -> 1   rm: Is a directory
rm -r ""     -> 1   rm: \sub: Invalid argument      f and g are gone
rm -rf ""    -> 1   same                            f and g are gone
rm -d ""     -> 1   rm: Directory not empty
mv f ""      -> 0
mv f g ""    -> 0
mv "" h      -> 16  mv: Device or resource busy
cat ""       -> 21
touch ""     -> 0   cwd mtime updated
mkdir ""     -> 1   mkdir: C:\...\cwd: File exists
mkdir -p ""  -> 0
cp "" out    -> 1   cp:  is a directory (not copied)
cp f ""      -> 0
```

With this change every line above exits 1 (mv: 2) with `<cmd>: No such file or directory` (`mv f g ""`: `mv: : No such file or directory`) and the directory is untouched, on both platforms.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/cp.test.ts test/js/bun/shell/commands/ls.test.ts test/js/bun/shell/commands/rm.test.ts

<!-- robobun:evidence:end -->