### PR TITLE
ByteStream: do not report a stored producer error as a clean empty body

### DIFF
--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -3206,7 +3206,10 @@ where
                             let resp = this.resp.get().expect("infallible: resp bound");
                             // If we've received the complete body by the time this function is called
                             // we can avoid streaming it and just send it all at once.
-                            if byte_stream.has_received_last_chunk.get() {
+                            // (A stored error goes through the attach path below instead.)
+                            if byte_stream.has_received_last_chunk.get()
+                                && !byte_stream.has_pending_error()
+                            {
                                 let mut byte_list = byte_stream.drain();
                                 this.blob.set(AnyBlob::from_array_list(
                                     byte_list.move_to_list_managed(),
@@ -3249,10 +3252,12 @@ where
                                     Self::drain_response_buffer_and_metadata_corked,
                                     this.as_ctx_ptr(),
                                 );
-                            } else if matches!(
-                                byte_stream.parent_const().producer.get(),
-                                WebCore::streams::SourceHandle::HTMLRewriter(_)
-                            ) {
+                            } else if byte_stream.has_pending_error()
+                                || matches!(
+                                    byte_stream.parent_const().producer.get(),
+                                    WebCore::streams::SourceHandle::HTMLRewriter(_)
+                                )
+                            {
                                 // Defer status/headers to the first chunk/end
                                 // so a pre-first-byte handler failure can
                                 // still reach `error()`.
@@ -3262,6 +3267,10 @@ where
                                     Self::render_metadata_corked,
                                     this.as_ctx_ptr(),
                                 );
+                            }
+                            // Runs `end_chunk`, which adopts the ref taken above and may free `this`.
+                            if byte_stream.end_sink_with_pending_error() {
+                                return;
                             }
                             // Wake the producer after the older bytes are queued.
                             byte_stream.signal_drained();

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -1663,6 +1663,8 @@ impl BlobExt for Blob {
                         ));
                     }
                     jsc::js_promise::Status::Rejected => {
+                        // Forwarded below; otherwise it is also reported as unhandled.
+                        promise.set_handled(global_this.vm());
                         // SAFETY: release our +1 ref on the sink.
                         unsafe { webcore::FileSink::deref(file_sink) };
                         readable_stream.cancel(global_this);

--- a/src/runtime/webcore/ByteStream.rs
+++ b/src/runtime/webcore/ByteStream.rs
@@ -124,11 +124,14 @@ impl ByteStream {
     }
 
     fn on_start(&self) -> streams::Start {
-        if self.has_received_last_chunk.get() && self.buffer.get().is_empty() {
-            return streams::Start::Empty;
-        }
-
         if self.has_received_last_chunk.get() {
+            // `Empty` would close the stream without the pull that returns the stored error.
+            if self.has_pending_error() {
+                return streams::Start::Ready;
+            }
+            if self.buffer.get().is_empty() {
+                return streams::Start::Empty;
+            }
             let buffer = self.buffer.replace(Vec::new());
             return streams::Start::OwnedAndDone(Vec::<u8>::move_from_list(buffer));
         }
@@ -262,9 +265,7 @@ impl ByteStream {
         if sink.is_some() {
             // Upstream error must reach the sink even while back-pressured.
             if let streams::Result::Err(err) = stream {
-                self.sink.set(SinkHandle::None);
-                self.sink_paused.set(false);
-                sink.end(Some(err));
+                self.end_sink(sink, err);
                 return Ok(());
             }
 
@@ -587,7 +588,7 @@ impl ByteStream {
         if self.has_received_last_chunk.get() {
             // Surface a stored terminal error (set by `append(Err)` when no
             // reader was waiting) instead of silently reporting `Done`.
-            if matches!(self.pending.get().result, streams::Result::Err(_)) {
+            if self.has_pending_error() {
                 return self
                     .pending
                     .with_mut(|p| core::mem::replace(&mut p.result, streams::Result::Done));
@@ -694,6 +695,11 @@ impl ByteStream {
         Vec::<u8>::default()
     }
 
+    /// The producer failed before anything attached and [`Self::append`] stored its error.
+    pub(crate) fn has_pending_error(&self) -> bool {
+        matches!(self.pending.get().result, streams::Result::Err(_))
+    }
+
     /// Take a pre-attach `StreamResult::Err` stashed by [`Self::append`].
     pub fn take_pending_error(&self) -> Option<streams::StreamError> {
         self.pending.with_mut(|p| {
@@ -708,8 +714,25 @@ impl ByteStream {
         })
     }
 
+    /// Delivers a stored error to the sink just installed as [`Self::on_data`] would; false if none.
+    pub(crate) fn end_sink_with_pending_error(&self) -> bool {
+        let sink = *self.sink.get();
+        debug_assert!(sink.is_some());
+        let Some(err) = self.take_pending_error() else {
+            return false;
+        };
+        self.end_sink(sink, err);
+        true
+    }
+
+    fn end_sink(&self, sink: SinkHandle, err: streams::StreamError) {
+        self.sink.set(SinkHandle::None);
+        self.sink_paused.set(false);
+        sink.end(Some(err));
+    }
+
     pub(crate) fn to_any_blob(&self) -> Option<blob::Any> {
-        if self.has_received_last_chunk.get() {
+        if self.has_received_last_chunk.get() && !self.has_pending_error() {
             let buffer = self.buffer.replace(Vec::new());
             self.done.set(true);
             self.pending.with_mut(|p| {

--- a/test/js/bun/http/bun-server.test.ts
+++ b/test/js/bun/http/bun-server.test.ts
@@ -2043,6 +2043,62 @@ test("should be able to abrubtly close a upload request", async () => {
   expect().pass();
 });
 
+// Same failure, but delivered while nothing is reading: the handler takes
+// req.body (which creates the native stream) and only starts reading after the
+// client has gone away. The stored abort must surface from the first read; it
+// used to come out as a clean `{ done: true }`, indistinguishable from a
+// complete upload.
+test("reading an upload whose client went away before the first read rejects", async () => {
+  const bodyTaken = Promise.withResolvers<void>();
+  const clientClosed = Promise.withResolvers<void>();
+  const outcome = Promise.withResolvers<string>();
+  using server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const body = req.body!;
+      bodyTaken.resolve();
+      await clientClosed.promise;
+      try {
+        // The abort reaches the body on a later event-loop turn. Bun.inspect(req)
+        // lists the body stream while the body is still pending and stops listing
+        // it once the body holds the error; reading it to find out is the very
+        // thing under test.
+        const deadline = Date.now() + 10_000;
+        while (Bun.inspect(req).includes("ReadableStream")) {
+          if (Date.now() > deadline) throw new Error("the abort never reached the idle body");
+          await Bun.sleep(1);
+        }
+        outcome.resolve(
+          await body
+            .getReader()
+            .read()
+            .then(
+              result => `resolved: ${JSON.stringify(result)}`,
+              error => `rejected: ${(error as Error).name}`,
+            ),
+        );
+      } catch (error) {
+        outcome.reject(error);
+      }
+      return new Response("unreachable by the client");
+    },
+  });
+  const socket = await Bun.connect({
+    hostname: server.hostname,
+    port: server.port,
+    socket: {
+      open(socket) {
+        socket.write("POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 100\r\n\r\npartial");
+      },
+      data() {},
+      close: () => clientClosed.resolve(),
+    },
+  });
+  await bodyTaken.promise;
+  socket.end();
+  expect(await outcome.promise).toBe("rejected: AbortError");
+});
+
 // This test is disabled because it can OOM the CI
 test.skip("should be able to stream huge amounts of data", async () => {
   const buf = Buffer.alloc(1024 * 1024 * 256);

--- a/test/js/bun/http/serve-stream-body-error-fixture.ts
+++ b/test/js/bun/http/serve-stream-body-error-fixture.ts
@@ -3,19 +3,28 @@
 // policy exits the process, so before the fix a single bad request took the
 // entire server down.
 //
-// argv[2]: variant name (see `sources` below)
-// argv[3]: "development" to run the server with development: true
+// argv[2]: variant name (see `sources` and `nativeSources` below)
+// argv[3..]: "development" to run the server with development: true,
+//            "no-error-handler" to run it without an error() callback
 //
-// Prints a single JSON object on stdout and exits 0.
+// Prints a single JSON object on stdout. Exits 0, except that a run without
+// error() reports the failures as unhandled, which makes Bun exit 1.
 import net from "node:net";
 
 const variant = process.argv[2];
-const development = process.argv[3] === "development";
+const flags = process.argv.slice(3);
+const development = flags.includes("development");
+const withErrorHandler = !flags.includes("no-error-handler");
 
 // Set by the mid-stream variant so it only errors once its chunk has provably
 // reached the client socket, i.e. after the 200 response is committed on the
 // wire. Called from the raw request's data handler below.
 let midStreamResolve: (() => void) | undefined;
+
+// Set by the native after-attach variant: called once the response's status
+// line has reached the client, i.e. after Bun.serve attached to the body and
+// committed the status.
+let statusOnWire: (() => void) | undefined;
 
 // Set by the cancel variants: resolved once the source's cancel() has run, so
 // the test observes any resulting rejection before declaring success.
@@ -112,8 +121,95 @@ const sources: Record<string, () => ReadableStream> = {
     }),
 };
 
+// Native counterparts: bodies backed by Bun's own ByteStream (a fetch()
+// response body, directly or through an HTMLRewriter) whose upstream
+// connection fails. The upstream is a raw socket so the failure is
+// deterministic: it announces a 100-byte body and closes when the variant
+// says so.
+//
+// Returns the fetch() Response; `fail()` closes the upstream connection.
+async function fetchFromFailingUpstream(firstWrite: string) {
+  const sockets: net.Socket[] = [];
+  const upstream = net.createServer(socket => {
+    sockets.push(socket);
+    socket.resume();
+    socket.on("error", () => {});
+    socket.write(firstWrite);
+  });
+  await new Promise<void>(resolve => upstream.listen(0, "127.0.0.1", resolve));
+  // Scratch server for one request: it must never be what keeps this process
+  // alive if something below goes wrong.
+  upstream.unref();
+  const { port } = upstream.address() as net.AddressInfo;
+  let res: Response;
+  try {
+    res = await fetch(`http://127.0.0.1:${port}/`);
+  } catch (error) {
+    for (const socket of sockets) socket.destroy();
+    upstream.close();
+    throw error;
+  }
+  return {
+    res,
+    fail() {
+      for (const socket of sockets) socket.end();
+      upstream.close();
+    },
+  };
+}
+
+// The failure reaches the fetch() Response on a later event-loop turn.
+// Bun.inspect(res) lists the body stream while the body is still pending and
+// stops listing it once the body holds the error; reading the stream to find
+// out would consume the very state under test. By then the error has also
+// been pushed into the already-materialized native stream.
+async function untilBodyFailed(res: Response) {
+  const deadline = Date.now() + 10_000;
+  while (Bun.inspect(res).includes("ReadableStream")) {
+    if (Date.now() > deadline) throw new Error("the upstream failure never reached the idle body");
+    await Bun.sleep(1);
+  }
+}
+
+const PARTIAL_BODY = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial";
+const HEADERS_ONLY = "HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\n";
+
+const nativeSources: Record<string, () => Promise<ReadableStream>> = {
+  // The stream exists (res.body was taken) but nothing reads it when the
+  // failure arrives, so the error is held inside the native stream with no
+  // JS-visible rejection anywhere by the time Bun.serve renders the Response
+  // wrapping it.
+  "native-errored-before-render": async () => {
+    const { res, fail } = await fetchFromFailingUpstream(PARTIAL_BODY);
+    const body = res.body!;
+    fail();
+    await untilBodyFailed(res);
+    return body;
+  },
+  // Same, one producer further away: the failing fetch() body feeds an
+  // HTMLRewriter and it is the rewriter's output stream that holds the error.
+  // (The rewriter is given a wrapper so `res` itself still tracks the failure.)
+  "native-rewriter-errored-before-render": async () => {
+    const { res, fail } = await fetchFromFailingUpstream(PARTIAL_BODY);
+    const input = new Response(res.body, { headers: { "content-type": "text/html" } });
+    const body = new HTMLRewriter().on("p", {}).transform(input).body!;
+    fail();
+    await untilBodyFailed(res);
+    return body;
+  },
+  // Control: the same upstream fails only after Bun.serve has attached to the
+  // healthy stream and committed the status line, so the error can only
+  // terminate the body.
+  "native-errored-after-attach": async () => {
+    const { res, fail } = await fetchFromFailingUpstream(HEADERS_ONLY);
+    statusOnWire = fail;
+    return res.body!;
+  },
+};
+
 const source = sources[variant];
-if (!source) {
+const nativeSource = nativeSources[variant];
+if (!source && !nativeSource) {
   console.error(`unknown variant: ${variant}`);
   process.exit(3);
 }
@@ -131,12 +227,17 @@ let errorCb = 0;
 await using server = Bun.serve({
   port: 0,
   development,
-  error() {
-    errorCb++;
-    return new Response("err-body", { status: 500 });
-  },
+  // The body names the error that reached error(), so the wire pins both the
+  // channel and the error's identity.
+  error: withErrorHandler
+    ? (error: Error & { code?: string }) => {
+        errorCb++;
+        return new Response(`err-body:${error.code ?? error.message}`, { status: 500 });
+      }
+    : undefined,
   fetch() {
-    return new Response(source());
+    if (nativeSource) return nativeSource().then(body => new Response(body));
+    return new Response(source!());
   },
 });
 
@@ -152,6 +253,9 @@ function rawRequest(abort: boolean): Promise<string> {
     });
     sock.on("data", d => {
       chunks.push(d);
+      // Anything at all on the wire means the status line went out.
+      statusOnWire?.();
+      statusOnWire = undefined;
       if (Buffer.concat(chunks).includes("chunk-a")) {
         midStreamResolve?.();
         // The cancel variants tear down the socket once a body chunk has

--- a/test/js/bun/http/serve-stream-body-error.test.ts
+++ b/test/js/bun/http/serve-stream-body-error.test.ts
@@ -72,6 +72,84 @@ test.concurrent("pull-throw in development mode: the rejection is handled", asyn
   expect(stderr).toContain("boom");
 });
 
+// Natively-backed bodies (a fetch() response stream, directly or through an
+// HTMLRewriter) whose producer failed while nothing was reading them: the error
+// is held inside the native stream, with no JS rejection anywhere, when
+// Bun.serve renders the Response wrapping it. Nothing has been committed to
+// the client at that point, so the failure goes to error() exactly as it does
+// when the handler returns the failed fetch() Response itself, or when such a
+// producer fails right after Bun.serve attaches (see end_chunk). This used to
+// be sent as a complete `200` with `Content-Length: 0`, with the error
+// reported nowhere in either mode.
+test.concurrent.each([
+  ["native-errored-before-render", "production"],
+  ["native-errored-before-render", "development"],
+  ["native-rewriter-errored-before-render", "production"],
+  ["native-rewriter-errored-before-render", "development"],
+])("%s (%s): error() receives the stored error and answers the request", async (variant, mode) => {
+  const { stdout, stderr, exitCode } = await runFixture(variant, mode);
+  expect({ result: JSON.parse(stdout), stderr, exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 500 Internal Server Error",
+      cleanChunkedTerminator: false,
+      body: "err-body:ECONNRESET",
+      errorCb: 2,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 500 Internal Server Error",
+    },
+    // error() handled it, so nothing is reported behind its back.
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
+// Without an error() callback it is treated like any other unhandled handler
+// failure: the default 500 goes out, the error is reported to stderr once per
+// request in both modes, and (as for a throwing handler) the process exit
+// status becomes 1. The default body is mode-specific and not pinned.
+test.concurrent.each(["production", "development"])(
+  "native stream errored before render, no error() (%s): default 500 and the error is reported",
+  async mode => {
+    const { stdout, stderr, exitCode } = await runFixture("native-errored-before-render", mode, "no-error-handler");
+    const { statusLine, secondStatusLine, errorCb, unhandled } = JSON.parse(stdout);
+    expect({
+      statusLine,
+      secondStatusLine,
+      errorCb,
+      unhandled,
+      reports: stderr.match(/ECONNRESET/g),
+      exitCode,
+    }).toEqual({
+      statusLine: "HTTP/1.1 500 Internal Server Error",
+      secondStatusLine: "HTTP/1.1 500 Internal Server Error",
+      errorCb: 0,
+      unhandled: 0,
+      reports: ["ECONNRESET", "ECONNRESET"],
+      exitCode: 1,
+    });
+  },
+);
+
+// Control for the above: the same upstream failure arriving just after
+// Bun.serve attached to the (then healthy) stream finds the status line
+// already committed, so all it can do is end the body; error() is not an
+// option any more. The before-render cases above must not be confused with
+// this one, and this path is unchanged.
+test.concurrent("native stream errored after attach: the committed 200 is ended with an empty body", async () => {
+  const { stdout, exitCode } = await runFixture("native-errored-after-attach");
+  expect({ result: JSON.parse(stdout), exitCode }).toEqual({
+    result: {
+      statusLine: "HTTP/1.1 200 OK",
+      cleanChunkedTerminator: true,
+      body: "0\r\n\r\n",
+      errorCb: 0,
+      unhandled: 0,
+      secondStatusLine: "HTTP/1.1 200 OK",
+    },
+    exitCode: 0,
+  });
+});
+
 // The body errors after a chunk has already been flushed to the client. The
 // 200 is irrevocable at that point, but the connection must be closed without
 // the terminating `0\r\n\r\n` chunk (RFC 9112 section 7) so the client can

--- a/test/js/bun/s3/s3-write-to-file-sync-close.test.ts
+++ b/test/js/bun/s3/s3-write-to-file-sync-close.test.ts
@@ -8,10 +8,11 @@ import path from "node:path";
 // controller before assignToStream returns. This used to trip a debug
 // assertion that the signal was still live.
 //
-// Today the credential error is swallowed by ByteStream::on_start() returning
-// Start::Empty without checking pending.result, so write() resolves to 0.
-// Accept either outcome here so a future fix that surfaces the error does not
-// trip this test.
+// The credential error is stored in the ByteStream before anything reads it.
+// It used to be swallowed (ByteStream::on_start() answered Start::Empty without
+// checking for it, so write() resolved to 0); now write() rejects with it, and
+// the pump's own already-rejected promise must not also be reported as an
+// unhandled rejection on stderr.
 test("Bun.file().write(S3 file) when the S3 stream closes synchronously", async () => {
   using dir = tempDir("s3-write-sync-close", {});
   const dest = path.join(String(dir), "out.bin");
@@ -54,7 +55,7 @@ test("Bun.file().write(S3 file) when the S3 stream closes synchronously", async 
     stderr: normalizeBunSnapshot(stderr),
     signalCode: proc.signalCode,
   }).toEqual({
-    stdout: expect.stringMatching(/^(resolved|rejected:ERR_S3_MISSING_CREDENTIALS)$/),
+    stdout: "rejected:ERR_S3_MISSING_CREDENTIALS",
     stderr: "",
     signalCode: null,
   });

--- a/test/js/web/fetch/body-mixin-errors.test.ts
+++ b/test/js/web/fetch/body-mixin-errors.test.ts
@@ -131,6 +131,80 @@ describe("body-mixin-errors", () => {
     },
   );
 
+  // The failure is delivered while `res.body` already exists but nothing is
+  // reading it, so it is held inside the native ByteStream behind the stream
+  // rather than on the Response. The server announces 100 bytes, sends part of
+  // them, and closes only after the test has materialized `res.body`, so the
+  // ordering does not depend on timing. Before the fix every consumer below
+  // saw a clean, empty body instead of the error.
+  async function withIdleErroredBody<T>(fn: (body: ReadableStream<Uint8Array>) => Promise<T>): Promise<T> {
+    const sockets: net.Socket[] = [];
+    const server = net.createServer(socket => {
+      sockets.push(socket);
+      socket.resume();
+      socket.on("error", () => {});
+      socket.write("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\npartial");
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      const body = res.body!;
+      for (const socket of sockets) socket.end();
+      // The failure reaches the body on a later event-loop turn. Bun.inspect(res)
+      // lists the body stream while the body is still pending and stops listing
+      // it once the body holds the error; reading the stream to find out would
+      // consume the very state under test.
+      const deadline = Date.now() + 10_000;
+      while (Bun.inspect(res).includes("ReadableStream")) {
+        if (Date.now() > deadline) throw new Error("the truncation never reached the idle body");
+        await Bun.sleep(1);
+      }
+      return await fn(body);
+    } finally {
+      for (const socket of sockets) socket.destroy();
+      await new Promise<void>(r => server.close(() => r()));
+    }
+  }
+
+  function expectTruncationError(err: unknown) {
+    expect(err).toBeInstanceOf(TypeError);
+    expect((err as any).code).toBe("ECONNRESET");
+  }
+
+  it.concurrent("fetch: reading a stream that errored while idle rejects instead of ending cleanly", async () => {
+    await withIdleErroredBody(async body => {
+      let err: unknown;
+      await body
+        .getReader()
+        .read()
+        .catch(e => (err = e));
+      expectTruncationError(err);
+    });
+  });
+
+  // text() never took the blob fast path and already rejected; it is listed so
+  // the whole family is pinned to one behaviour.
+  it.concurrent.each(["text", "arrayBuffer", "bytes", "blob", "json"] as const)(
+    "fetch: Response wrapping a stream that errored while idle rejects %s()",
+    async method => {
+      await withIdleErroredBody(async body => {
+        let err: unknown;
+        await new Response(body)[method]().catch((e: unknown) => (err = e));
+        expectTruncationError(err);
+      });
+    },
+  );
+
+  it.concurrent("fetch: Request wrapping a stream that errored while idle rejects arrayBuffer()", async () => {
+    await withIdleErroredBody(async body => {
+      let err: unknown;
+      await new Request("http://example.com/", { method: "POST", body }).arrayBuffer().catch((e: unknown) => (err = e));
+      expectTruncationError(err);
+    });
+  });
+
   // Counts inbound TCP connections on a server that answers a chunked POST
   // once it sees the 0\r\n\r\n terminator. `expectConnections(n)` first sends
   // a probe request so every accept queued before it has been delivered by the


### PR DESCRIPTION
### Problem

- A `Bun.serve` handler that returns `new Response(body)`, where `body` is a `fetch()` response stream whose connection failed while the handler was still running, sends `HTTP/1.1 200 OK` + `Content-Length: 0`. The failure is reported nowhere (not on stderr, not with `development: true`) and `error()` is not invoked. Returning the failed fetch `Response` itself does reach `error()`; only the materialized stream loses the error. An `HTMLRewriter` output stream whose input failed behaves the same way.
- The same stream misreports itself to every other consumer: `body.getReader().read()` resolves `{ done: true }`, `new Response(body).arrayBuffer()` / `bytes()` / `blob()` / `json()` (and the `Request` equivalents) resolve with an empty body, and a `Bun.serve` request body whose client went away before the handler started reading reads as a cleanly completed upload. `Bun.file().write(s3file)` with no credentials resolved to 0 bytes (`test/js/bun/s3/s3-write-to-file-sync-close.test.ts` documented that as a known gap).
- Cause: when the producer's error arrives while nothing is attached, `ByteStream::append` (`src/runtime/webcore/ByteStream.rs`) drops the buffered bytes and stores the error in `pending.result`, leaving `has_received_last_chunk` set with an empty buffer. Three places then read that state as "complete and empty":
  - `ByteStream::to_any_blob` released the stored error and returned an empty blob. `Body::Value::to_blob_if_possible` reaches it from `Bun.serve` before rendering and from the body mixin methods, static routes, spawn stdio and `fs.writeFile`.
  - `ByteStream::on_start` answered `Start::Empty`, so `materializeNativeSource` (BunStreamSource.cpp) built a closed stream without ever calling `on_pull`, the only place that returned the stored error to a reader.
  - The `Source::Bytes` fast path in `RequestContext::do_render_with_body` rendered the (already emptied) buffer as a blob. Unlike the two other native attach sites (`ReadableStream::wire_native_sink`, `s3/client.rs`) it never looked at the stored error.

### Fix

- `ByteStream::to_any_blob` returns `None` and `on_start` starts the stream normally (`Start::Ready`) while an error is stored; `has_pending_error()` is the shared check. Consumers then take the path they already use for a still-streaming body, and the first `on_pull` (or `take_pending_error()`) delivers the error.
- `Bun.serve` attaches to such a stream like a live one and then hands the stored error to its sink with the new `ByteStream::end_sink_with_pending_error`, which is the same detach-and-`sink.end(err)` step `on_data` performs for an error arriving after the attach. Both timings therefore end in the existing `end_chunk`, whose policy decides the outcome: nothing committed yet, so the error goes to `error()` (or the default 500 plus a stderr report without one). The attach skips the eager status/header write in this case for the same reason it already does for `HTMLRewriter` bodies, so "nothing committed" holds.
- Why `error()` is the right channel: it is what the native path already does everywhere the failure is known before anything is committed, so the result no longer depends on whether the handler touched `res.body` (`return res` reaches `error()` today) or on whether the producer failed one tick before or after `Bun.serve` attached (`end_chunk` routes an `HTMLRewriter` that fails before its first byte to `error()`, #36733). The control case, a producer failing right after the status line went out, is unchanged: the committed 200 is ended with an empty body. JS-sourced streams keep their separately pinned contract (`do_render_stream` commits the status before pumping); changing that is out of scope here.
- Why `None` / `Ready` rather than surfacing the error from `to_any_blob` or `on_start` themselves: every consumer of a `Locked` body already has a path for a body that is not trivially convertible and already handles errors on it. `Start::Err` only carries a syscall error, and throwing from `start` would surface as a synchronous exception from `getReader()` rather than as an errored stream.
- `Blob::pipe_readable_stream_to_blob` (the `Bun.file().write(s3file)` path, which deliberately uses the JS pump) now marks the pump's already-rejected promise handled before forwarding the rejection, as `s3/client.rs`, `html_rewriter.rs` and `FetchTasklet.rs` do. Without it the newly surfaced error was also printed as an unhandled rejection (caught by CI on the first revision of this PR).
- Consumers checked by hand under the debug build, before -> after: `for await`, `pipeTo`, `tee()` and `Response.clone()` on such a stream completed empty -> reject; `HTMLRewriter.transform()` and `Bun.readableStreamToArrayBuffer` already rejected -> unchanged; a static route built from such a Response served an empty 200 -> throws the existing "Body must be fully buffered" error; `HEAD` -> renders the usual stream-body framing; `Bun.spawn({ stdin })` -> unchanged (child sees EOF, as for a mid-stream failure).
- Verified (each new test fails on the unfixed build and passes with the fix):
  - `test/js/bun/http/serve-stream-body-error.test.ts`: three new fixture variants. `native-errored-before-render` and `native-rewriter-errored-before-render` (both modes) pin `error()` receiving the stored error (`err-body:ECONNRESET`, empty stderr); a `no-error-handler` run pins the default 500 plus one stderr report per request; `native-errored-after-attach` pins the unchanged committed-status control. The upstream is a raw socket that closes only after the handler has materialized the stream, so the error is stored deterministically; the after-attach variant closes it once the status line reaches the client.
  - `test/js/web/fetch/body-mixin-errors.test.ts`: `getReader().read()`, `Response` `text()`/`arrayBuffer()`/`bytes()`/`blob()`/`json()` and `Request.arrayBuffer()` on a stream that errored while idle reject with the truncation error.
  - `test/js/bun/http/bun-server.test.ts`: reading an upload whose client went away before the first read rejects with `AbortError` (second producer of stored errors).
  - `test/js/bun/s3/s3-write-to-file-sync-close.test.ts`: tightened to the now deterministic rejection, still with empty stderr.
  - Regression sweep with the debug build: the rest of the files above plus `body.test.ts`, `body-stream.test.ts`, `body-clone.test.ts`, `response.test.ts`, `fetch.stream.test.ts`, `streams.test.js`, `serve.test.ts`, `serve-direct-readable-stream`, `serve-error-handler-stream`, `serve-stream-reject-flush-leak`, `async-iterator-stream`, the `html-rewriter` and `workerd/html-rewriter` tests, `spawn-stdin-readable-stream`, `blob-write`, the `s3` directory and the source lints.

### Background

- `ByteStream` is the native source behind `ReadableStream`s that Bun fills itself (fetch response bodies, request bodies, HTMLRewriter output). The producer pushes chunks with `on_data`; a consumer is either a JS reader (pulling through `on_start` / `on_pull`), a buffered read (`to_buffered_value`, what `.text()` on the stream uses), or a native sink attached directly through a `SinkHandle` (what `Bun.serve` and `FileSink` do). `sink.end(Some(err))` is how a producer's failure reaches an attached sink; for `Bun.serve` that lands in `RequestContext::end_chunk`.
- The JS wrapper around a ByteStream is lazy: `res.body` creates it, but the source's `on_start` only runs when something first reads. Until then chunks, and a terminal error, are simply stored in the ByteStream; the error lives in `pending.result`, the slot normally used to answer an outstanding pull, and `take_pending_error()` moves it out.
- `Body::Value::to_blob_if_possible` is the fast path consumers call first on a `Locked` (stream-backed) body: if the stream already finished, the body is swapped for the buffered bytes. For a ByteStream it ends in the `to_any_blob` changed here.
- `end_chunk` is the server's end-of-body hook for natively attached streams. With an error it either hands the error to `error()` when no status has been written, or terminates the body (empty chunked end, or a connection close without the terminating chunk if body bytes were already sent) when one has.

<details>
<summary>Behaviour table, released bun 1.4.0 (same on main) vs this PR</summary>

The idle-errored stream is `res.body` of a fetch whose upstream sent part of the body and then closed.

| consumer | before | after |
| --- | --- | --- |
| `Bun.serve`: `return new Response(body)` | `200`, `Content-Length: 0`, nothing reported, `error()` not called | `error()` called with the error; its Response is sent (default 500 + stderr report without one) |
| `Bun.serve`: same through `HTMLRewriter.transform()` | same | same as above |
| `Bun.serve`: `return res` (the fetch Response itself) | `error()` called | unchanged |
| `Bun.serve`: upstream fails just after the attach | committed `200`, empty chunked body | unchanged |
| `body.getReader().read()`, `for await`, `pipeTo`, `tee()` | complete cleanly with nothing | reject `ECONNRESET` |
| `new Response(body).arrayBuffer()` / `bytes()` / `blob()` / `json()`, `new Request(..., { body }).arrayBuffer()` | resolve with an empty body | reject `ECONNRESET` |
| `new Response(body).text()`, `HTMLRewriter.transform(...).text()`, `Bun.readableStreamToArrayBuffer(body)` | reject | unchanged |
| `req.body` read after the uploading client went away | `{ done: true }` | rejects `AbortError` |
| `Bun.file(path).write(s3file)` without credentials | resolves 0 | rejects `ERR_S3_MISSING_CREDENTIALS`, nothing else printed |
| static route from such a Response | serves an empty 200 | throws "Body must be fully buffered..." at construction |

</details>

<details>
<summary>First revision of this PR</summary>

The first revision routed the stored error through `handle_reject_stream`, i.e. it copied the JS-stream outcome (the Response's own status, empty chunked body, error printed, `error()` not invoked). Review pointed out that this gave the same native failure a different channel depending on whether it landed one tick before or after the attach, and a different one from `return res`; it also bypassed the `HTMLRewriter` metadata deferral, sending a 200 where the rewriter's post-attach failure reaches `error()`. The current revision delivers the error through the attach path instead so one policy (`end_chunk`) covers both timings. CI on that revision also caught the `pipe_readable_stream_to_blob` unhandled-rejection report fixed here.

</details>
