### PR TITLE
bundler: free the ServerComponentParseTask after it generates its file

### DIFF
--- a/src/bundler/ServerComponentParseTask.rs
+++ b/src/bundler/ServerComponentParseTask.rs
@@ -24,10 +24,7 @@ use crate::cache::ExternalFreeFunction;
 use crate::options::{Loader, Target};
 use crate::parse_task::{self, ResultValue, Success, WatcherData, on_complete};
 
-/// Boxed by `BundleV2::enqueue_server_component_generated_file`, which hands
-/// it to the worker pool; [`task_callback_wrap`] takes the box back and frees
-/// it once the file has been generated. Everything the generated AST may
-/// point at (`Data`) lives in the bundle arena, never in the task itself.
+/// One box per generated file; [`task_callback_wrap`] takes it back and frees it.
 pub(crate) struct ServerComponentParseTask {
     pub task: ThreadPoolTask,
     pub data: Data,
@@ -48,13 +45,10 @@ pub enum Data {
 }
 
 pub struct ReferenceProxy {
-    /// Path of the "use client" module the proxy stands in for.
+    /// The "use client" module the proxy stands in for.
     pub(crate) client_path: FsPath<'static>,
-    /// Source index of that module; production builds refer to its chunk
-    /// through a `UniqueKey` built from it.
     pub(crate) client_source_index: Index,
-    /// That module's export names, in export order. Bundle-arena copies made
-    /// by `BundleV2::copy_export_names_for_reference_proxy`.
+    /// In export order; bundle-arena copies (`BundleV2::copy_export_names_for_reference_proxy`).
     pub(crate) export_names: &'static [&'static [u8]],
 }
 
@@ -63,18 +57,14 @@ pub struct ClientEntryWrapper {
     pub(crate) path: &'static [u8],
 }
 
-/// Raw thread-pool callback. Takes back the `Box<ServerComponentParseTask>`
-/// that `BundleV2::enqueue_server_component_generated_file` handed to the
-/// pool, generates the file, frees the task, then posts the result back to the
-/// owning event loop.
+/// Thread-pool callback: takes the task box back, generates the file, frees it, posts the result.
 // CONCURRENCY: thread-pool callback — runs on worker threads, one task per
 // `ServerComponentParseTask` (heap-allocated, scheduled exactly once). Writes:
 // own fields + `Log` (local) + result is posted via
 // `ctx.loop_.enqueue_task_concurrent` (MPSC). Reads `ctx: &BundleV2` shared.
-// `ServerComponentParseTask` is `Send` (built on the bundle thread, used and
-// freed here) because `ctx: *mut BundleV2` is a backref to a `Send` type,
-// `Data` is `Copy` data plus bundle-arena slices, and `Source` owns at most
-// global-heap buffers.
+// `ServerComponentParseTask` is `Send` because `ctx: *mut BundleV2` is a
+// backref to a `Send` type and `Source`/`Data` payloads are bundle-arena
+// slices.
 fn task_callback_wrap(thread_pool_task: *mut ThreadPoolTask) {
     // SAFETY: `thread_pool_task` is the `task` field of the
     // `ServerComponentParseTask` that `enqueue_server_component_generated_file`
@@ -106,8 +96,7 @@ fn task_callback_wrap(thread_pool_task: *mut ThreadPoolTask) {
         // Only possible error is OOM; abort like `bun.outOfMemory()`.
         Err(_oom) => bun_core::out_of_memory(),
     };
-    // `task_callback` moved `source` into `value` and nothing else in the
-    // result refers to the task, so it is gone before the result is posted.
+    // Nothing in `value` refers to the task, so it is freed before the result is posted.
     drop(task);
 
     let result = Box::new(parse_task::Result {

--- a/src/bundler/ServerComponentParseTask.rs
+++ b/src/bundler/ServerComponentParseTask.rs
@@ -8,10 +8,10 @@ use std::fmt::Write as _;
 use bun_alloc::{AllocError as OOM, Arena}; // bumpalo::Bump re-export
 use bun_collections::VecExt;
 
-use bun_ast::{Loc, Log, Source};
+use bun_ast::{Index, Loc, Log, Source};
+use bun_paths::fs::Path as FsPath;
 use bun_threading::thread_pool::Task as ThreadPoolTask;
 
-use bun_ast::ast_result::NamedExports;
 use bun_ast::{B, Binding, E, G, S, Stmt, symbol};
 use bun_ast::{ExprNodeList, LocRef, StmtOrExpr, UseDirective};
 use bun_ast::{ImportKind, ImportRecordFlags};
@@ -24,6 +24,10 @@ use crate::cache::ExternalFreeFunction;
 use crate::options::{Loader, Target};
 use crate::parse_task::{self, ResultValue, Success, WatcherData, on_complete};
 
+/// Boxed by `BundleV2::enqueue_server_component_generated_file`, which hands
+/// it to the worker pool; [`task_callback_wrap`] takes the box back and frees
+/// it once the file has been generated. Everything the generated AST may
+/// point at (`Data`) lives in the bundle arena, never in the task itself.
 pub(crate) struct ServerComponentParseTask {
     pub task: ThreadPoolTask,
     pub data: Data,
@@ -31,13 +35,10 @@ pub(crate) struct ServerComponentParseTask {
     // `ParentRef` (write-provenance via `NonNull::from(&mut self)` at construction)
     // so deref sites are safe; `None` only for the FRU `Default` placeholder.
     pub ctx: Option<bun_ptr::ParentRef<BundleV2<'static>, bun_ptr::Mut>>,
+    /// The generated file's own source record; moved into the result.
     pub source: Source,
 }
 
-// One heap allocation per generated file, freed as soon as the file has been
-// generated (`task_callback_wrap`); boxing the large arm would only add a
-// second allocation with the same lifetime.
-#[allow(clippy::large_enum_variant)]
 pub enum Data {
     /// Generate server-side code for a "use client" module. Given the
     /// client ast, a "reference proxy" is created with identical exports.
@@ -47,13 +48,19 @@ pub enum Data {
 }
 
 pub struct ReferenceProxy {
-    pub(crate) other_source: Source,
-    pub(crate) named_exports: NamedExports,
+    /// Path of the "use client" module the proxy stands in for.
+    pub(crate) client_path: FsPath<'static>,
+    /// Source index of that module; production builds refer to its chunk
+    /// through a `UniqueKey` built from it.
+    pub(crate) client_source_index: Index,
+    /// That module's export names, in export order. Bundle-arena copies made
+    /// by `BundleV2::copy_export_names_for_reference_proxy`.
+    pub(crate) export_names: &'static [&'static [u8]],
 }
 
 pub struct ClientEntryWrapper {
-    // Owned copy.
-    pub(crate) path: Box<[u8]>,
+    /// Bundle-arena or `'static` bytes; stored as-is in the `ImportRecord`.
+    pub(crate) path: &'static [u8],
 }
 
 /// Raw thread-pool callback. Takes back the `Box<ServerComponentParseTask>`
@@ -64,12 +71,10 @@ pub struct ClientEntryWrapper {
 // `ServerComponentParseTask` (heap-allocated, scheduled exactly once). Writes:
 // own fields + `Log` (local) + result is posted via
 // `ctx.loop_.enqueue_task_concurrent` (MPSC). Reads `ctx: &BundleV2` shared.
-// `ServerComponentParseTask` is `Send` because `ctx: *mut BundleV2` is a
-// backref to a `Send` type and `Source`/`Data` payloads are bundle-arena
-// slices. Dropping it here (off the bundle thread that built it) is fine for
-// the same reason: the only heap-owning payloads are global-heap `Cow`/`Box`
-// buffers and the `NamedExports` clone, whose `AstAlloc` storage is reclaimed
-// by its arena, not by `Drop` (`AstAlloc::deallocate` is a no-op).
+// `ServerComponentParseTask` is `Send` (built on the bundle thread, used and
+// freed here) because `ctx: *mut BundleV2` is a backref to a `Send` type,
+// `Data` is `Copy` data plus bundle-arena slices, and `Source` owns at most
+// global-heap buffers.
 fn task_callback_wrap(thread_pool_task: *mut ThreadPoolTask) {
     // SAFETY: `thread_pool_task` is the `task` field of the
     // `ServerComponentParseTask` that `enqueue_server_component_generated_file`
@@ -101,10 +106,8 @@ fn task_callback_wrap(thread_pool_task: *mut ThreadPoolTask) {
         // Only possible error is OOM; abort like `bun.outOfMemory()`.
         Err(_oom) => bun_core::out_of_memory(),
     };
-    // Everything the generated AST refers to was copied into the worker arena
-    // by `task_callback`, and `source` was moved into `value`; nothing points
-    // back into the task, so it is freed before the result becomes visible to
-    // the bundle thread.
+    // `task_callback` moved `source` into `value` and nothing else in the
+    // result refers to the task, so it is gone before the result is posted.
     drop(task);
 
     let result = Box::new(parse_task::Result {
@@ -232,9 +235,7 @@ impl Default for ServerComponentParseTask {
                 node: Default::default(),
                 callback: task_callback_wrap,
             },
-            data: Data::ClientEntryWrapper(ClientEntryWrapper {
-                path: Box::default(),
-            }),
+            data: Data::ClientEntryWrapper(ClientEntryWrapper { path: b"" }),
             ctx: None,
             source: Source::default(),
         }
@@ -242,12 +243,7 @@ impl Default for ServerComponentParseTask {
 }
 
 fn generate_client_entry_wrapper(data: &ClientEntryWrapper, b: &mut AstBuilder) -> Result<(), OOM> {
-    // `add_import_record` stores the slice raw in the `ImportRecord`, and
-    // `data.path` dies with the task as soon as this file is generated, so the
-    // record gets a copy in the AST arena. Route through `StoreStr` so the
-    // lifetime erasure goes through one audited unsafe.
-    let path = bun_ast::StoreStr::new(b.bump.alloc_slice_copy(&data.path));
-    let record = b.add_import_record(path.slice(), ImportKind::Stmt)?;
+    let record = b.add_import_record(data.path, ImportKind::Stmt)?;
     let namespace_ref = b.new_symbol(symbol::Kind::Other, b"main")?;
     b.append_stmt(S::Import {
         namespace_ref,
@@ -275,8 +271,6 @@ fn generate_client_reference_proxy(
         // config must be non-null to enter this function
         .unwrap_or_else(|| unreachable!());
 
-    let client_named_exports = &data.named_exports;
-
     // `add_import_stmt` stores the slices raw in `ImportRecord`/`ClauseItem`s;
     // the framework config outlives the bundle pass. Route through `StoreStr`
     // so the lifetime erasure goes through one audited unsafe.
@@ -293,7 +287,7 @@ fn generate_client_reference_proxy(
         // that information is not yet available since chunks are not
         // computed. The unique_key replacement system is used here.
         if ctx.transpiler().options.has_dev_server() {
-            b.bump.alloc_slice_copy(data.other_source.path.pretty)
+            b.bump.alloc_slice_copy(data.client_path.pretty)
         } else {
             let mut buf = bun_alloc::ArenaString::new_in(b.bump);
             write!(
@@ -302,7 +296,7 @@ fn generate_client_reference_proxy(
                 crate::chunk::UniqueKey {
                     prefix: ctx.unique_key,
                     kind: crate::chunk::QueryKind::Scb,
-                    index: data.other_source.index.0,
+                    index: data.client_source_index.0,
                 },
             )
             .map_err(|_| OOM)?;
@@ -310,11 +304,7 @@ fn generate_client_reference_proxy(
         },
     ));
 
-    for key in client_named_exports.keys() {
-        // `new_symbol` stores the name raw, and `client_named_exports` dies with
-        // the task as soon as this file is generated, so the symbol (and the
-        // string literal below) gets a copy in the AST arena.
-        let key: &[u8] = b.bump.alloc_slice_copy(key.as_ref());
+    for &key in data.export_names {
         let is_default = key == b"default";
 
         // This error message is taken from
@@ -330,7 +320,7 @@ fn generate_client_reference_proxy(
                         "client function from the server, it can only be rendered as a ",
                         "Component or passed to props of a Client Component.",
                     ),
-                    module_path = bstr::BStr::new(data.other_source.path.pretty),
+                    module_path = bstr::BStr::new(data.client_path.pretty),
                 )
             } else {
                 write!(

--- a/src/bundler/ServerComponentParseTask.rs
+++ b/src/bundler/ServerComponentParseTask.rs
@@ -34,8 +34,9 @@ pub(crate) struct ServerComponentParseTask {
     pub source: Source,
 }
 
-// `ServerComponentParseTask` is bump-arena-allocated; boxing the large arm
-// would leak. The size diff is acceptable.
+// One heap allocation per generated file, freed as soon as the file has been
+// generated (`task_callback_wrap`); boxing the large arm would only add a
+// second allocation with the same lifetime.
 #[allow(clippy::large_enum_variant)]
 pub enum Data {
     /// Generate server-side code for a "use client" module. Given the
@@ -55,21 +56,32 @@ pub struct ClientEntryWrapper {
     pub(crate) path: Box<[u8]>,
 }
 
-/// Raw thread-pool callback. Recovers `&mut ServerComponentParseTask` from the
-/// intrusive `task` field and dispatches the parse, then posts the result back
-/// to the owning event loop.
+/// Raw thread-pool callback. Takes back the `Box<ServerComponentParseTask>`
+/// that `BundleV2::enqueue_server_component_generated_file` handed to the
+/// pool, generates the file, frees the task, then posts the result back to the
+/// owning event loop.
 // CONCURRENCY: thread-pool callback — runs on worker threads, one task per
 // `ServerComponentParseTask` (heap-allocated, scheduled exactly once). Writes:
 // own fields + `Log` (local) + result is posted via
 // `ctx.loop_.enqueue_task_concurrent` (MPSC). Reads `ctx: &BundleV2` shared.
 // `ServerComponentParseTask` is `Send` because `ctx: *mut BundleV2` is a
 // backref to a `Send` type and `Source`/`Data` payloads are bundle-arena
-// slices.
+// slices. Dropping it here (off the bundle thread that built it) is fine for
+// the same reason: the only heap-owning payloads are global-heap `Cow`/`Box`
+// buffers and the `NamedExports` clone, whose `AstAlloc` storage is reclaimed
+// by its arena, not by `Drop` (`AstAlloc::deallocate` is a no-op).
 fn task_callback_wrap(thread_pool_task: *mut ThreadPoolTask) {
-    // SAFETY: `thread_pool_task` points to the `task` field of a heap-allocated
-    // `ServerComponentParseTask` enqueued by BundleV2; offset_of recovers the parent.
-    let task: &mut ServerComponentParseTask = unsafe {
-        &mut *(bun_core::from_field_ptr!(ServerComponentParseTask, task, thread_pool_task))
+    // SAFETY: `thread_pool_task` is the `task` field of the
+    // `ServerComponentParseTask` that `enqueue_server_component_generated_file`
+    // leaked with `heap::into_raw` and scheduled; the pool runs a task exactly
+    // once and never touches it after this callback, so ownership of the box
+    // is ours to reclaim.
+    let mut task: Box<ServerComponentParseTask> = unsafe {
+        bun_core::heap::take(bun_core::from_field_ptr!(
+            ServerComponentParseTask,
+            task,
+            thread_pool_task
+        ))
     };
 
     // `ctx` is a `ParentRef` BACKREF to the owning BundleV2 (set at enqueue).
@@ -84,11 +96,16 @@ fn task_callback_wrap(thread_pool_task: *mut ThreadPoolTask) {
     // worker-owned bump arena; lives for the worker's lifetime.
     let arena: &Arena = worker.arena();
 
-    let value = match task_callback(task, &mut log, arena) {
+    let value = match task_callback(&mut task, &mut log, arena) {
         Ok(success) => ResultValue::Success(success),
         // Only possible error is OOM; abort like `bun.outOfMemory()`.
         Err(_oom) => bun_core::out_of_memory(),
     };
+    // Everything the generated AST refers to was copied into the worker arena
+    // by `task_callback`, and `source` was moved into `value`; nothing points
+    // back into the task, so it is freed before the result becomes visible to
+    // the bundle thread.
+    drop(task);
 
     let result = Box::new(parse_task::Result {
         // `ctx` already a `ParentRef<BundleV2>` with write provenance
@@ -225,10 +242,11 @@ impl Default for ServerComponentParseTask {
 }
 
 fn generate_client_entry_wrapper(data: &ClientEntryWrapper, b: &mut AstBuilder) -> Result<(), OOM> {
-    // `add_import_record` stores the slice raw in the `ImportRecord`; `data.path`
-    // outlives the bundle pass (owned by the heap-allocated task). Route through
-    // `StoreStr` so the lifetime erasure goes through one audited unsafe.
-    let path = bun_ast::StoreStr::new(&data.path[..]);
+    // `add_import_record` stores the slice raw in the `ImportRecord`, and
+    // `data.path` dies with the task as soon as this file is generated, so the
+    // record gets a copy in the AST arena. Route through `StoreStr` so the
+    // lifetime erasure goes through one audited unsafe.
+    let path = bun_ast::StoreStr::new(b.bump.alloc_slice_copy(&data.path));
     let record = b.add_import_record(path.slice(), ImportKind::Stmt)?;
     let namespace_ref = b.new_symbol(symbol::Kind::Other, b"main")?;
     b.append_stmt(S::Import {
@@ -293,7 +311,10 @@ fn generate_client_reference_proxy(
     ));
 
     for key in client_named_exports.keys() {
-        let key: &[u8] = key.as_ref();
+        // `new_symbol` stores the name raw, and `client_named_exports` dies with
+        // the task as soon as this file is generated, so the symbol (and the
+        // string literal below) gets a copy in the AST arena.
+        let key: &[u8] = b.bump.alloc_slice_copy(key.as_ref());
         let is_default = key == b"default";
 
         // This error message is taken from
@@ -359,7 +380,7 @@ fn generate_client_reference_proxy(
                     ..Default::default()
                 }),
                 module_path,
-                b.new_expr(E::String::init(b.bump.alloc_slice_copy(key))),
+                b.new_expr(E::String::init(key)),
             ]),
             ..Default::default()
         });

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3728,6 +3728,27 @@ pub mod bv2_impl {
             Ok(source_index.get())
         }
 
+        /// Copies a "use client" module's export names into the bundle arena
+        /// for the `ReferenceProxy` generated in its place. The proxy is built
+        /// on a worker thread, so it cannot read the module's `named_exports`
+        /// out of `graph.ast`, which this thread keeps appending to.
+        fn copy_export_names_for_reference_proxy(
+            &self,
+            named_exports: &crate::bundled_ast::NamedExports,
+        ) -> &'static [&'static [u8]] {
+            // SAFETY: same contract as `interned_slice` — the arena outlives the
+            // bundle pass, and the proxy task (and the AST it produces, which
+            // stores these slices) is consumed within it.
+            let arena: &'static bun_alloc::Arena =
+                unsafe { bun_ptr::detach_lifetime_ref::<bun_alloc::Arena>(self.arena()) };
+            arena.alloc_slice_fill_iter(
+                named_exports
+                    .keys()
+                    .iter()
+                    .map(|name| -> &'static [u8] { arena.alloc_slice_copy(&name[..]) }),
+            )
+        }
+
         /// Enqueue a ServerComponentParseTask.
         /// `source_without_index` is copied and assigned a new source index. That index is returned.
         pub(crate) fn enqueue_server_component_generated_file(
@@ -7178,11 +7199,8 @@ pub mod bv2_impl {
                     }
                     result.ast.import_records = import_records;
 
-                    // `result.ast` is moved into `graph.ast` and `result.source` was
-                    // swapped earlier, so snapshot the data the use-directive block
-                    // needs *before* the move. Only paid for files that hit the SCB gate.
-                    let named_exports_for_scb = if result.use_directive != crate::UseDirective::None
-                        && {
+                    let is_server_component_boundary =
+                        result.use_directive != crate::UseDirective::None && {
                             let separate = this
                                 .framework
                                 .as_ref()
@@ -7198,11 +7216,7 @@ pub mod bv2_impl {
                             } else {
                                 is_client != is_browser
                             }
-                        } {
-                        Some(result.ast.named_exports.clone().expect("oom"))
-                    } else {
-                        None
-                    };
+                        };
 
                     let result_heap = *result.ast.parts.allocator();
                     this.graph.ast.set(
@@ -7221,7 +7235,8 @@ pub mod bv2_impl {
                         .expect("oom");
                     }
 
-                    if let Some(named_exports) = named_exports_for_scb {
+                    // Index the boundary and enqueue the files for its other side.
+                    if is_server_component_boundary {
                         if result.use_directive == crate::UseDirective::Server {
                             bun_core::todo_panic!("\"use server\"");
                         }
@@ -7243,17 +7258,21 @@ pub mod bv2_impl {
 
                         let (reference_source_index, ssr_index) = if separate_ssr_graph {
                             // Enqueue two files, one in server graph, one in ssr graph.
-                            let other_source =
-                                this.graph.input_files.items_source()[result_source_index].clone();
-                            let scb_source =
-                                this.graph.input_files.items_source()[result_source_index].clone();
+                            let export_names = this.copy_export_names_for_reference_proxy(
+                                &this.graph.ast.items_named_exports()[result_source_index],
+                            );
+                            let client_source =
+                                &this.graph.input_files.items_source()[result_source_index];
+                            let proxy = crate::ServerComponentParseTask::ReferenceProxy {
+                                client_path: client_source.path,
+                                client_source_index: client_source.index,
+                                export_names,
+                            };
+                            let scb_source = client_source.clone();
                             let reference_source_index = this
                                 .enqueue_server_component_generated_file(
                                     crate::ServerComponentParseTask::Data::ClientReferenceProxy(
-                                        crate::ServerComponentParseTask::ReferenceProxy {
-                                            other_source,
-                                            named_exports,
-                                        },
+                                        proxy,
                                     ),
                                     scb_source,
                                 )

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3728,10 +3728,7 @@ pub mod bv2_impl {
             Ok(source_index.get())
         }
 
-        /// Copies a "use client" module's export names into the bundle arena
-        /// for the `ReferenceProxy` generated in its place. The proxy is built
-        /// on a worker thread, so it cannot read the module's `named_exports`
-        /// out of `graph.ast`, which this thread keeps appending to.
+        /// Workers may not read `graph.ast` while this thread appends to it, hence the copies.
         fn copy_export_names_for_reference_proxy(
             &self,
             named_exports: &crate::bundled_ast::NamedExports,
@@ -3775,9 +3772,7 @@ pub mod bv2_impl {
             })?;
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: fire-and-forget
 
-            // Handed to the worker pool; `ServerComponentParseTask`'s pool
-            // callback takes the box back and frees it once the file has been
-            // generated.
+            // Freed by the pool callback (`task_callback_wrap`).
             let task = bun_core::heap::into_raw(Box::new(ServerComponentParseTask {
                 data,
                 // SAFETY: `from_mut(self)` is the live bundle (write provenance for

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3754,9 +3754,9 @@ pub mod bv2_impl {
             })?;
             let _ = self.graph.ast.append(JSAst::empty_in(self.graph.heap)); // OOM/capacity: fire-and-forget
 
-            // `bun.new(ServerComponentParseTask, …)` — heap-owned by the
-            // worker pool; freed via `bun.destroy` in `on_complete` after the
-            // result posts back to the bundle thread.
+            // Handed to the worker pool; `ServerComponentParseTask`'s pool
+            // callback takes the box back and frees it once the file has been
+            // generated.
             let task = bun_core::heap::into_raw(Box::new(ServerComponentParseTask {
                 data,
                 // SAFETY: `from_mut(self)` is the live bundle (write provenance for
@@ -3774,7 +3774,9 @@ pub mod bv2_impl {
 
             self.increment_scan_counter();
 
-            // SAFETY: `task` is the just-allocated arena box; sole reference here.
+            // SAFETY: `task` is the just-allocated box and this is its only
+            // pointer; projecting through it (not through a `&mut` to the field)
+            // keeps whole-allocation provenance for the callback's `heap::take`.
             self.graph
                 .pool()
                 .worker_pool()

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -1,4 +1,5 @@
-import { bunEnv, bunExe } from "harness";
+import { expect, test } from "bun:test";
+import { bunEnv, bunExe, isASAN, tempDir } from "harness";
 import path from "node:path";
 
 test("dev server deinitializes itself", () => {
@@ -13,3 +14,86 @@ test("dev server deinitializes itself", () => {
   // The child runs a whole `bun test` suite (nine GC-heavy cases plus leak
   // reporting at exit), which takes longer than the 5s default under ASAN.
 }, 60_000);
+
+// With separateSSRGraph, every "use client" module the server graph imports
+// makes the bundler generate a "reference proxy" module in its place. The
+// proxy is built on the thread pool from a heap-allocated
+// ServerComponentParseTask, which used to be scheduled and never freed (one
+// allocation per client module per bundle). LeakSanitizer reports that
+// allocation at exit, so this needs the ASAN build. The proxy's exports must
+// still come out right after the task is freed: their names are printed from
+// the generated module long after the task is gone.
+test.skipIf(!isASAN)(
+  'bundling a "use client" reference proxy does not leak its ServerComponentParseTask',
+  async () => {
+    using dir = tempDir("bake-reference-proxy-leak", {
+      "main.ts": `
+        using server = Bun.serve({
+          port: 0,
+          development: true,
+          app: {
+            framework: {
+              serverComponents: {
+                separateSSRGraph: true,
+                serverRuntimeImportSource: "./framework/server.ts",
+                serverRegisterClientReferenceExport: "registerClientReference",
+              },
+              fileSystemRouterTypes: [
+                {
+                  root: "routes",
+                  serverEntryPoint: "./framework/server.ts",
+                  style: "nextjs-pages",
+                },
+              ],
+            },
+          },
+        });
+        const response = await fetch(server.url);
+        console.log(response.status, await response.text());
+      `,
+      "framework/server.ts": `
+        export function render(request, meta) {
+          return new Response(meta.pageModule.default());
+        }
+        // Called once per export of the client module by the generated proxy.
+        export function registerClientReference(value, file, exportName) {
+          return () => exportName;
+        }
+      `,
+      // The server graph imports the client module, so it gets the proxy.
+      "routes/index.ts": `
+        import Widget, { Alpha, Beta } from "../components/Widget";
+        export default () => [Widget(), Alpha(), Beta()].join(" ");
+      `,
+      "components/Widget.ts": `
+        "use client";
+        export function Alpha() {}
+        export function Beta() {}
+        export default function Widget() {}
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "main.ts"],
+      cwd: String(dir),
+      env: {
+        ...bunEnv,
+        BUN_DESTRUCT_VM_ON_EXIT: "1",
+        ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+        LSAN_OPTIONS: `print_suppressions=0:suppressions=${path.join(import.meta.dir, "../leaksan.supp")}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toBe("200 default Alpha Beta\n");
+    // The dev server logs its bundle timing here; a leak report would follow it.
+    expect(stderr).not.toContain("LeakSanitizer");
+    expect(exitCode).toBe(0);
+  },
+  // Starting a dev server and bundling the route takes a few seconds under
+  // ASAN, and when LSan does find something, symbolizing the report against
+  // the debug binary takes longer still.
+  90_000,
+);

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -60,16 +60,24 @@ test.skipIf(!isASAN)(
           return () => file + "#" + exportName;
         }
       `,
-      // The server graph imports the client module, so it gets the proxy.
+      // The server graph imports both client modules, so it gets a proxy for
+      // each: the proxies, not the modules, run on the server, which is why
+      // Empty's side effect must not be visible to the route.
       "routes/index.ts": `
         import Widget, { Alpha, Beta } from "../components/Widget";
-        export default () => [Widget(), Alpha(), Beta()].join(" ");
+        import "../components/Empty";
+        export default () => [Widget(), Alpha(), Beta(), String(globalThis.emptyRanOnServer)].join(" ");
       `,
       "components/Widget.ts": `
         "use client";
         export function Alpha() {}
         export function Beta() {}
         export default function Widget() {}
+      `,
+      // A client module with no exports gets a proxy with no exports.
+      "components/Empty.ts": `
+        "use client";
+        globalThis.emptyRanOnServer = true;
       `,
     });
 
@@ -87,7 +95,9 @@ test.skipIf(!isASAN)(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toBe("200 components/Widget.ts#default components/Widget.ts#Alpha components/Widget.ts#Beta\n");
+    expect(stdout).toBe(
+      "200 components/Widget.ts#default components/Widget.ts#Alpha components/Widget.ts#Beta undefined\n",
+    );
     // The dev server logs its bundle timing here; a leak report would follow it.
     expect(stderr).not.toContain("LeakSanitizer");
     expect(exitCode).toBe(0);

--- a/test/bake/deinitialization.test.ts
+++ b/test/bake/deinitialization.test.ts
@@ -19,10 +19,10 @@ test("dev server deinitializes itself", () => {
 // makes the bundler generate a "reference proxy" module in its place. The
 // proxy is built on the thread pool from a heap-allocated
 // ServerComponentParseTask, which used to be scheduled and never freed (one
-// allocation per client module per bundle). LeakSanitizer reports that
-// allocation at exit, so this needs the ASAN build. The proxy's exports must
-// still come out right after the task is freed: their names are printed from
-// the generated module long after the task is gone.
+// per client module per bundle). LeakSanitizer reports the task at exit, so
+// this needs the ASAN build. The rendered output checks what the task hands
+// to the generator: the client module's path and its export names, which the
+// proxy passes to registerClientReference.
 test.skipIf(!isASAN)(
   'bundling a "use client" reference proxy does not leak its ServerComponentParseTask',
   async () => {
@@ -57,7 +57,7 @@ test.skipIf(!isASAN)(
         }
         // Called once per export of the client module by the generated proxy.
         export function registerClientReference(value, file, exportName) {
-          return () => exportName;
+          return () => file + "#" + exportName;
         }
       `,
       // The server graph imports the client module, so it gets the proxy.
@@ -87,7 +87,7 @@ test.skipIf(!isASAN)(
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-    expect(stdout).toBe("200 default Alpha Beta\n");
+    expect(stdout).toBe("200 components/Widget.ts#default components/Widget.ts#Alpha components/Widget.ts#Beta\n");
     // The dev server logs its bundle timing here; a leak report would follow it.
     expect(stderr).not.toContain("LeakSanitizer");
     expect(exitCode).toBe(0);


### PR DESCRIPTION
### Problem
- Every server-component file the bundler generates (the "reference proxy" it substitutes for a `"use client"` module when the framework uses a separate SSR graph, in dev and in `bun build --app`) leaks its `ServerComponentParseTask`. LeakSanitizer on a bake dev server that bundles one client module:
  ```
  Direct leak of 336 byte(s) in 1 object(s) allocated from:
      <alloc::boxed::Box<bun_bundler::ServerComponentParseTask::ServerComponentParseTask>>::new
      <bun_bundler::bundle_v2::BundleV2>::enqueue_server_component_generated_file  src/bundler/bundle_v2.rs:3760
      <bun_bundler::bundle_v2::BundleV2>::on_parse_task_complete
  ```
- Cause: `BundleV2::enqueue_server_component_generated_file` boxes the task with `heap::into_raw` and schedules it, and nothing ever takes the box back. `task_callback_wrap` (src/bundler/ServerComponentParseTask.rs) only borrowed it through the intrusive `task` field, and `parse_worker::on_complete` frees the `parse_task::Result`, not the task. The comment at the enqueue site claimed `on_complete` frees it.
- The task's payload leaked too, and freeing the box alone would not have fixed that: `ReferenceProxy` held a clone of the client module's `Source` and of its `NamedExports` map (bundle_v2.rs, `named_exports.clone()` in `on_parse_task_complete`). The map clone is `AstAlloc`-backed, and on both paths that produce these tasks no AST allocation state is installed when `on_parse_task_complete` runs, so it went to `AstAlloc`'s never-freed global fallback (invisible to LSan, one more per `"use client"` module on every dev-server rebuild). The Zig original shared the AST's map by value; the port deep-cloned it.

### Fix
- `task_callback_wrap` reclaims the `Box<ServerComponentParseTask>` with `heap::take` and drops it once the generated AST has been built, before the `Result` is posted. The pool runs a task exactly once and does not touch it after the callback returns (`ThreadPool.rs` worker loop), the same contract `OwnedTask::__callback` and `WorkPool::go` rely on to free their tasks inside the callback.
- `ReferenceProxy` now carries exactly what the generator reads: the client module's `Path` and source index by value, and its export names copied into the bundle arena by the bundle thread (`copy_export_names_for_reference_proxy`, read from `graph.ast` after the AST is moved in, so the pre-move snapshot and the clones are gone). The arena is freed with the bundle, so a dev server reclaims them on every rebuild; `ClientEntryWrapper::path` becomes a bundle-lifetime slice for the same reason.
- With that, the task owns nothing the generated AST can point at, so it is correct to free as soon as the file is generated, the generator stores the arena slices directly (`StoreStr`'s documented "arena-owned" contract; previously the export-name symbols pointed at key boxes inside the task's map and only survived because the task leaked), and the `large_enum_variant` allowance is unnecessary.
- `Data::ClientEntryWrapper` has no producer in the tree, so it is covered but not exercised; `client_source_index` is only read by production builds, which a dependency-free fixture cannot currently run (custom frameworks panic later in `bun build --app`, reported separately).
- Verified:
  - `test/bake/deinitialization.test.ts`, new case: bake dev server with a `separateSSRGraph` framework and two `"use client"` modules (one with three exports, one with none) under `detect_leaks=1`; asserts the proxy passed the module's path and every export name to `registerClientReference`, that the export-less module's side effect did not run on the server (its proxy did), no LeakSanitizer report, exit 0. Fails on main with the report above, passes here. `skipIf(!isASAN)`.
  - `bun bd test test/bake/dev/bundle.test.ts` (includes the `separateSSRGraph` client-component demotion test, which regenerates proxies across HMR rebuilds): 21 pass.

### Background
- Server components with `separateSSRGraph`: when the server graph imports a `"use client"` module, the module itself is bundled for the browser and SSR graphs, and the server graph gets a generated "reference proxy" whose exports are `registerClientReference(...)` calls, one per export of the client module. The proxy is built with `AstBuilder` on the bundler's thread pool by a `ServerComponentParseTask`, which posts a regular `parse_task::Result` back like a `ParseTask` would.
- Unlike `ParseTask`, which lives in the bundle arena and is bulk-freed with it, `ServerComponentParseTask` is an individual `Box` whose only owner is the pool task it embeds, so something has to take it back after it runs.
- Bundle arena (`BundleV2::arena()`, `graph.heap`): a per-bundle mimalloc heap, allocated from only on the bundle thread and destroyed when the bundle finishes (per rebuild in the dev server). Slices in it are stored with an erased `'static` lifetime throughout bundle_v2.rs (`interned_slice`, `path_as_static`); `copy_export_names_for_reference_proxy` uses the same convention.
- `AstAlloc`: the allocator behind `NamedExports`. It allocates from the thread's installed AST allocation state, or from global mimalloc when none is installed, and its `deallocate` is a no-op, so dropping an `AstAlloc`-backed container frees nothing; only an installed state's owner can reclaim it. `Bun.build()` installs one for the whole bundle; the bake dev server and `bun build --app`, the only producers of these tasks, do not have one installed during `on_parse_task_complete`.
- `StoreStr` (`Symbol::original_name`, `EString`) stores a raw `(ptr, len)` and documents that the bytes must be arena-owned or `'static`; the bundle arena satisfies that.

<details>
<summary>Earlier revision</summary>

The first revision only reclaimed the box in the callback and copied the export names and entry-wrapper path into the worker arena inside the generators, leaving the `Source` and `NamedExports` clones in the task. Review pointed out that the map clone's storage is never reclaimed on the bake paths, so the task's payload was still leaking (just not where LSan looks); the second commit replaces the payload instead.
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/deinitialization.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 1 skipped
bun test v1.4.0-canary.1 (da3851e57)

test/bake/deinitialization.test.ts:
bun test v1.4.0-canary.1 (da3851e57)

test.ts:
(pass) baseline: stopped server wrapper collects [0.07ms]
(pass) flags:  [71.55ms]
WebSocket opened
(pass) flags: websocket=1 [18.86ms]
WebSocket closed
WebSocket opened
WebSocket closed
(pass) flags: closeActiveConnections websocket=1 [255.35ms]
Bundled page in 259ms: index.html
(pass) flags: sendAnyRequests [265.62ms]
WebSocket opened
Bundled page in 253ms: index.html
WebSocket closed
(pass) flags: sendAnyRequests websocket=1 [257.32ms]
Bundled page in 254ms: index.html
(pass) flags: closeActiveConnections sendAnyRequests [505.77ms]
WebSocket opened
WebSocket closed
Bundled page in 254ms: index.html
(pass) flags: closeActiveConnections sendAnyRequests websocket=1 [508.49ms]
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
(pass) flags: websocket=8 [3.77ms]
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket closed
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
Web
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/deinitialization.test.ts
bun test v1.4.0 (ec7b26792)

test/bake/deinitialization.test.ts:
bun test v1.4.0 (ec7b26792)

test.ts:
(pass) baseline: stopped server wrapper collects [2.51ms]
(pass) flags:  [77.68ms]
WebSocket opened
(pass) flags: websocket=1 [77.39ms]
WebSocket closed
WebSocket opened
WebSocket closed
(pass) flags: closeActiveConnections websocket=1 [305.50ms]
Bundled page in 586ms: index.html
(pass) flags: sendAnyRequests [716.43ms]
WebSocket opened
Bundled page in 340ms: index.html
WebSocket closed
(pass) flags: sendAnyRequests websocket=1 [434.21ms]
Bundled page in 302ms: index.html
(pass) flags: closeActiveConnections sendAnyRequests [602.76ms]
WebSocket opened
WebSocket closed
Bundled page in 358ms: index.html
(pass) flags: closeActiveConnections sendAnyRequests websocket=1 [619.46ms]
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
WebSocket opened
(pass) flags: websocket=8 [56.35ms]
WebSocket closed
WebSocket closed
WebSocket closed
WebSo
... (truncated)

release with fix: 1 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1209ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/34] gen bindgenv2
[2/29] gen cpp.rs (cppbind)
[3/29] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[4/29] gen JS modules (bundle-modules)
Preprocess modules (17098ms)
Bundle modules (246ms)
Postprocesss modules (575ms)
Bundle Functions (1657ms)
Generate Code (40ms)

[19.64s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[4/18] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_paths v0.0.0 (/workspace/bun/src/paths)
[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_url v0.0.0 (/workspace/bun/src/url)
[1m[92m   Compiling[0m bun_http_types v0.0.0 (/workspace/bun/src/http_types)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/ServerComponentParseTask.rs | 66 +++++++++++------------
 src/bundler/bundle_v2.rs                | 62 +++++++++++++--------
 test/bake/deinitialization.test.ts      | 96 ++++++++++++++++++++++++++++++++-
 3 files changed, 167 insertions(+), 57 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                     reads  edits  tests
src/bundler/ServerComponentParseTask.rs      6     21      0
src/bundler/bundle_v2.rs                     8     12      0
test/bake/deinitialization.test.ts           4     10      0
```

</details>

<!-- robobun:evidence:end -->