### PR TITLE
Bun.color: return null when input continues past the color

### DIFF
--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -6058,11 +6058,12 @@ pub mod serializer {
 pub mod parse_utility {
     use super::*;
 
-    /// Parse a value from a string.
+    /// Parse a value from a string. Anything left over after the value, other
+    /// than whitespace and comments, is a parse error.
     ///
     /// NOTE: `input` should live as long as the returned value. Otherwise,
     /// strings in the returned parsed value will point to undefined memory.
-    pub(crate) fn parse_string<T>(
+    pub fn parse_string<T>(
         arena: &Bump,
         input: &[u8],
         parse_one: fn(&mut Parser) -> CssResult<T>,

--- a/src/css/css_parser.rs
+++ b/src/css/css_parser.rs
@@ -6058,8 +6058,7 @@ pub mod serializer {
 pub mod parse_utility {
     use super::*;
 
-    /// Parse a value from a string. Anything left over after the value, other
-    /// than whitespace and comments, is a parse error.
+    /// Parse a whole string as one value; anything left after it is a parse error.
     ///
     /// NOTE: `input` should live as long as the returned value. Otherwise,
     /// strings in the returned parsed value will point to undefined memory.

--- a/src/css_jsc/color_js.rs
+++ b/src/css_jsc/color_js.rs
@@ -329,14 +329,10 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
         // MimallocArena::new() calls mi_heap_new(), so defer creation to the
         // paths that actually allocate.
         let arena = Arena::new();
-        let mut parser_input = css::ParserInput::new(input.slice(), &arena);
-        let mut parser = css::Parser::new(
-            &mut parser_input,
-            None,
-            css::css_parser::ParserOpts::default(),
-            None,
-        );
-        break 'brk CssColor::parse(&mut parser);
+        // `CssColor::parse` stops after the first <color> it finds, so on its
+        // own it accepts "red;background:url(x)" as red. parse_string also
+        // requires the rest of the input to be empty.
+        break 'brk css::parse_utility::parse_string(&arena, input.slice(), CssColor::parse);
     };
 
     match parsed_color {

--- a/src/css_jsc/color_js.rs
+++ b/src/css_jsc/color_js.rs
@@ -329,9 +329,7 @@ pub fn js_function_color(global: &JSGlobalObject, frame: &CallFrame) -> JsResult
         // MimallocArena::new() calls mi_heap_new(), so defer creation to the
         // paths that actually allocate.
         let arena = Arena::new();
-        // `CssColor::parse` stops after the first <color> it finds, so on its
-        // own it accepts "red;background:url(x)" as red. parse_string also
-        // requires the rest of the input to be empty.
+        // Unlike CssColor::parse alone, this rejects "red;background:url(x)".
         break 'brk css::parse_utility::parse_string(&arena, input.slice(), CssColor::parse);
     };
 

--- a/test/js/bun/css/color.test.ts
+++ b/test/js/bun/css/color.test.ts
@@ -604,6 +604,50 @@ describe("input forms", () => {
   });
 });
 
+// The docs promise null for anything that does not parse as a single color, so
+// a color followed by more input is not a color either. It used to return the
+// leading color, which let "red;background:url(...)" through anything that
+// used color() to validate a string before putting it in a stylesheet.
+describe("the whole string must be one color", () => {
+  test.each([
+    "red;background:url(//evil.example/x)",
+    "red}body{display:none",
+    "#ff0000;color:blue",
+    "rgb(255,0,0)}*{x:y",
+    "rgb(255, 0, 0) x",
+    "red blue",
+    "red, blue",
+    "red red",
+    "hsl(0 100% 50%);;",
+    "red!",
+    "red !important",
+    "#fff;",
+    "red)",
+    "red]",
+    "red{",
+    "red;",
+  ])("color(%j) is null", input => {
+    expect([
+      color(input),
+      color(input, "css"),
+      color(input, "hex"),
+      color(input, "{rgba}"),
+      color(input, "number"),
+    ]).toEqual([null, null, null, null, null]);
+  });
+
+  test.each([
+    "  red  ",
+    "\tred\n",
+    "/* leading */ red",
+    "red /* trailing */",
+    " rgb(255, 0, 0) ",
+    "rgb(255, 0, 0)/**/",
+  ])("color(%j) ignores surrounding whitespace and comments", input => {
+    expect(color(input, "css")).toBe("red");
+  });
+});
+
 // https://drafts.csswg.org/css-color-5/#color-mix — the grammar is
 // <percentage [0,100]>, so a value outside that range is a parse error.
 describe("color-mix() percentage range", () => {


### PR DESCRIPTION
### Problem
- `Bun.color()` returns the leading color of a string that keeps going after it: `Bun.color("red;background:url(//evil.example/x)")` is `"red"`, `Bun.color("red}body{display:none", "hex")` is `"#ff0000"`, `"red blue"`, `"hsl(0 100% 50%);;"` and `"red!"` all resolve to red. Only an identifier continuation (`"redx"`) was rejected.
- The docs say `Bun.color` returns `null` when the input fails to parse and list validation as a use case, so code using `Bun.color(x) !== null` as a validator passes these strings through and interpolates the whole thing into a stylesheet.
- Cause: `src/css_jsc/color_js.rs:339` called `CssColor::parse` on a fresh parser and used the result as-is. `CssColor::parse` is the `<color>` grammar production: it consumes one color and leaves whatever follows for its caller, and nothing here checked that the input was exhausted.
- Same behavior since the original implementation, so this is not a regression.

### Fix
- String input now goes through `bun_css::parse_utility::parse_string` (made `pub`; it was `pub(crate)`), which runs the production and then `expect_exhausted()`, so leftover tokens turn into a parse error and `Bun.color` returns `null` like any other unparseable string.
- `expect_exhausted` skips whitespace and comments, so `"  red  "`, `"\tred\n"` and `"red /* c */"` still parse. A stray `;`, `!`, `,`, `)`, `]`, `}`, `{` or a second value after the color is rejected.
- This is the same helper bun_css uses internally when it needs to parse a single value out of a string (`page.rs`, `animation.rs`, `font.rs`); `CssColor::parse` itself is unchanged because property parsers legitimately call it with more input following.
- Verified with `test/js/bun/css/color.test.ts` ("the whole string must be one color"): 16 rejection cases fail on the unfixed build (each returns the leading color in every output format) and pass with the fix; 6 whitespace/comment cases pass on both and guard against over-rejecting.
- The rest of `color.test.ts` (1015 tests, snapshots included) is unchanged.

### Background
- `Bun.color` is implemented by feeding the string to Bun's CSS parser (`bun_css`, a port of lightningcss) and reformatting the parsed `CssColor`.
- In that parser each grammar production (`CssColor::parse`, `Length::parse`, ...) consumes only its own tokens from a shared cursor, so that productions can be chained when parsing a declaration such as `border: 1px solid red`. Requiring end of input is a separate step, `Parser::expect_exhausted()`, that the outermost caller performs; `parse_string` bundles a production with that step for the "this whole string should be one value" case.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 2 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 16 failed, 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
bun test v1.4.0 (cd0dcdf19)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [4.52ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [2.36ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [2.35ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.57ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [23.62ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.28ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [2.67ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.39ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.39ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.34ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.75ms]
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit") [0.6
... (truncated)

release without fix: 16 FAILED
bun test v1.4.0-canary.1 (b7a043103)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [0.11ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [0.03ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [0.02ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [0.06ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [0.85ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [0.04ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [0.02ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit"))
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256"))
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16"))
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.01ms]
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit")
(pass) color({"r":0,"g":255,"b":0}, "ansi-16")
(pass) color({"r":0,"g":255,"b":0}, "ansi256")
[38;2;0;0;255m[object Object]
(pass) console.log(color({"r":0,"g":0,"b":255}, "ansi-24bit")
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 1 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/css/color.test.ts
bun test v1.4.0 (cd0dcdf19)

test/js/bun/css/color.test.ts:
[38;2;255;0;0m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-24bit")) [2.93ms]
[38;5;196m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-256")) [1.51ms]
[91m[object Object]
(pass) console.log(color({"r":255,"g":0,"b":0}, "ansi-16")) [1.21ms]
(pass) color({"r":255,"g":0,"b":0}, "{rgb}") = {"r":255,"g":0,"b":0} [2.04ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-24bit") [13.83ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi-16") [2.16ms]
(pass) color({"r":255,"g":0,"b":0}, "ansi256") [1.78ms]
[38;2;0;255;0m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-24bit")) [0.30ms]
[38;5;46m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-256")) [0.27ms]
[92m[object Object]
(pass) console.log(color({"r":0,"g":255,"b":0}, "ansi-16")) [0.23ms]
(pass) color({"r":0,"g":255,"b":0}, "{rgb}") = {"r":0,"g":255,"b":0} [0.50ms]
(pass) color({"r":0,"g":255,"b":0}, "ansi-24bit") [0.4
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     cd0dcdf199
  features     baseline

22 deps, 123 codegen, 1176 objects in 784ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] install /workspace/bun
bun install v1.4.0-canary.1 (b7a043103)

Checked 107 installs across 153 packages (no changes) [21.00ms]
[2/1238] gen ErrorCode+*.h
[3/1238] gen bindgenv2
[4/1238] fetch tinycc
[tinycc] up to date
[5/1237] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (b7a043103)

Checked 1 install across 2 packages (no changes) [3.00ms]
[6/1237] fetch zlib
[zlib] up to date
[7/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
[8/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (b7a043103)

Checked 129 installs across 147 packages (no changes) [14.00ms]
[9/1237] gen .bind.ts → GeneratedBindings.cpp
[10/1237] subst deps/zlib/zlib.h
[11/1237] gen JSEvent.lut.h
Generating /workspace/bun/build/release/codegen/JSEvent.lut.h from /workspace/bun/src/jsc/bindings/webcore/JSEvent.cpp
[12/12
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/css/css_parser.rs         |  4 ++--
 src/css_jsc/color_js.rs       | 10 ++--------
 test/js/bun/css/color.test.ts | 44 +++++++++++++++++++++++++++++++++++++++++++
 3 files changed, 48 insertions(+), 10 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 2

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/css/css_parser.rs              7      2      0
src/css_jsc/color_js.rs            2      3      0
test/js/bun/css/color.test.ts      1      1      0
```

</details>

**root cause** · written by the author bot

`Bun.color()` built its own parser and returned whatever `CssColor::parse` produced, and that function stops as soon as it has consumed one complete `<color>`, so input such as `"red;background:url(...)"` was accepted as red with the trailing content silently ignored, contradicting the documented null-on-invalid behavior. The fix routes the call through the existing `parse_string` helper, which runs the same parse and then calls `expect_exhausted()`, so any leftover tokens other than whitespace and comments make the parse fail and `Bun.color()` return `null`. Tests cover the trailing-conten…

<!-- robobun:evidence:end -->