### PR TITLE
node:tls: attach the onConnectEnd 'end' listener once per connect()

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3042,6 +3042,27 @@ function lookupAndConnectMultiple(self, lookup, host, options, dnsopts, port, lo
   });
 }
 
+// Per connection attempt (autoSelectFamily dials several): rebuilds the native
+// tls options now that lookupAndConnect has assigned self._host (the SNI
+// default). The socket's handshake state and its onConnectEnd 'end' listener
+// are set up once per connect() call in Socket.prototype.connect, matching the
+// single removeListener in onClientHandshakeComplete.
+function clientTLSOptionsForAttempt(self, options, port) {
+  const bunTLS = self[bunTlsSymbol];
+  if (typeof bunTLS !== "function") return undefined;
+  const tls = bunTLS.$call(self, port, self._host, true);
+  if (tls) {
+    const { rejectUnauthorized, session, checkServerIdentity } = options;
+    applyRejectUnauthorized(self, tls, rejectUnauthorized);
+    tls.requestCert = true;
+    tls.session = session || tls.session;
+    self.servername = tls.servername;
+    tls.checkServerIdentity = checkServerIdentity || tls.checkServerIdentity;
+    self[bunTLSConnectOptions] = tls;
+  }
+  return tls;
+}
+
 function internalConnect(self, options, path);
 function internalConnect(self, options, address, port, addressType, localAddress, localPort, _flags?) {
   $assert(self.connecting);
@@ -3074,38 +3095,7 @@ function internalConnect(self, options, address, port, addressType, localAddress
     }
   }
 
-  //TLS
-  let connection = self[ksocket];
-  const optionsSocket = options.socket;
-  if (optionsSocket) {
-    connection = optionsSocket;
-  }
-  let tls = undefined;
-  const bunTLS = self[bunTlsSymbol];
-  if (typeof bunTLS === "function") {
-    tls = bunTLS.$call(self, port, self._host, true);
-    self._requestCert = true; // Client always request Cert
-    if (tls) {
-      const { rejectUnauthorized, session, checkServerIdentity } = options;
-      applyRejectUnauthorized(self, tls, rejectUnauthorized);
-      tls.requestCert = true;
-      tls.session = session || tls.session;
-      self.servername = tls.servername;
-      tls.checkServerIdentity = checkServerIdentity || tls.checkServerIdentity;
-      self[bunTLSConnectOptions] = tls;
-      let tlsSocket;
-      if (!connection && (tlsSocket = tls.socket)) {
-        connection = tlsSocket;
-      }
-    }
-    self.authorized = false;
-    self.secureConnecting = true;
-    self._secureEstablished = false;
-    self._securePending = true;
-    self[kConnectOptions] = options;
-    self.prependListener("end", onConnectEnd);
-  }
-  //TLS
+  const tls = clientTLSOptionsForAttempt(self, options, port);
 
   $debug("connect: attempting to connect to %s:%d (addressType: %d)", address, port, addressType);
   self.emit("connectionAttempt", address, port, addressType);
@@ -3222,38 +3212,7 @@ function internalConnectMultiple(context, canceled?) {
     return;
   }
 
-  //TLS
-  let connection = self[ksocket];
-  const contextOptionsSocket = context.options.socket;
-  if (contextOptionsSocket) {
-    connection = contextOptionsSocket;
-  }
-  let tls = undefined;
-  const bunTLS = self[bunTlsSymbol];
-  if (typeof bunTLS === "function") {
-    tls = bunTLS.$call(self, port, self._host, true);
-    self._requestCert = true; // Client always request Cert
-    if (tls) {
-      const { rejectUnauthorized, session, checkServerIdentity } = context.options;
-      applyRejectUnauthorized(self, tls, rejectUnauthorized);
-      tls.requestCert = true;
-      tls.session = session || tls.session;
-      self.servername = tls.servername;
-      tls.checkServerIdentity = checkServerIdentity || tls.checkServerIdentity;
-      self[bunTLSConnectOptions] = tls;
-      let tlsSocket;
-      if (!connection && (tlsSocket = tls.socket)) {
-        connection = tlsSocket;
-      }
-    }
-    self.authorized = false;
-    self.secureConnecting = true;
-    self._secureEstablished = false;
-    self._securePending = true;
-    self[kConnectOptions] = context.options;
-    self.prependListener("end", onConnectEnd);
-  }
-  //TLS
+  const tls = clientTLSOptionsForAttempt(self, context.options, port);
 
   $debug("connect/multiple: attempting to connect to %s:%d (addressType: %d)", address, port, addressType);
   self.emit("connectionAttempt", address, port, addressType);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3042,10 +3042,7 @@ function lookupAndConnectMultiple(self, lookup, host, options, dnsopts, port, lo
   });
 }
 
-// Built per dispatched attempt so a setServername()/setSession() made after
-// tls.connect() returned (even between autoSelectFamily attempts) is what gets
-// dialed. The per-connect() handshake state, onConnectEnd included, is set up
-// once in Socket.prototype.connect.
+// Per attempt, not per connect(): setServername()/setSession() calls made after tls.connect() must reach the dial.
 function clientTLSOptionsForAttempt(self, options, port) {
   const bunTLS = self[bunTlsSymbol];
   if (typeof bunTLS !== "function") return undefined;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3042,11 +3042,13 @@ function lookupAndConnectMultiple(self, lookup, host, options, dnsopts, port, lo
   });
 }
 
-// Per connection attempt (autoSelectFamily dials several): rebuilds the native
-// tls options now that lookupAndConnect has assigned self._host (the SNI
-// default). The socket's handshake state and its onConnectEnd 'end' listener
-// are set up once per connect() call in Socket.prototype.connect, matching the
-// single removeListener in onClientHandshakeComplete.
+// Rebuilt for every attempt dispatched (autoSelectFamily dials several) because
+// the native connect takes servername/session from this object, so a
+// setServername()/setSession() made after tls.connect() returned, even between
+// attempts, reaches the attempt that connects. self._host is the SNI default
+// lookupAndConnect stored (unset for { path }). The handshake state and the
+// onConnectEnd 'end' listener are per connect() call: Socket.prototype.connect
+// sets them up once, onClientHandshakeComplete removes the listener once.
 function clientTLSOptionsForAttempt(self, options, port) {
   const bunTLS = self[bunTlsSymbol];
   if (typeof bunTLS !== "function") return undefined;

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -3042,13 +3042,10 @@ function lookupAndConnectMultiple(self, lookup, host, options, dnsopts, port, lo
   });
 }
 
-// Rebuilt for every attempt dispatched (autoSelectFamily dials several) because
-// the native connect takes servername/session from this object, so a
-// setServername()/setSession() made after tls.connect() returned, even between
-// attempts, reaches the attempt that connects. self._host is the SNI default
-// lookupAndConnect stored (unset for { path }). The handshake state and the
-// onConnectEnd 'end' listener are per connect() call: Socket.prototype.connect
-// sets them up once, onClientHandshakeComplete removes the listener once.
+// Built per dispatched attempt so a setServername()/setSession() made after
+// tls.connect() returned (even between autoSelectFamily attempts) is what gets
+// dialed. The per-connect() handshake state, onConnectEnd included, is set up
+// once in Socket.prototype.connect.
 function clientTLSOptionsForAttempt(self, options, port) {
   const bunTLS = self[bunTlsSymbol];
   if (typeof bunTLS !== "function") return undefined;

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -158,6 +158,104 @@ it("should thow ECONNRESET if FIN is received before handshake", async () => {
   expect(error).toBeDefined();
   expect((error as Error).code as string).toBe("ECONNRESET");
 });
+
+// onConnectEnd is the 'end' listener that reports a peer FIN during the
+// handshake as ECONNRESET. Node attaches it once per tls.connect() and removes
+// it once the handshake completes, so the socket holds one copy until
+// 'secureConnect' has been emitted and none afterwards.
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1706 (removeListener)
+// https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L1811 (prependListener)
+describe("tls.connect() attaches onConnectEnd to 'end' exactly once", () => {
+  function onConnectEndCount(socket: tls.TLSSocket) {
+    return socket.listeners("end").filter(listener => listener.name === "onConnectEnd").length;
+  }
+
+  async function withTLSServer<T>(fn: (port: number) => Promise<T>): Promise<T> {
+    const server = tls.createServer(COMMON_CERT_, socket => socket.on("error", () => {}));
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    try {
+      return await fn((server.address() as AddressInfo).port);
+    } finally {
+      server.close();
+    }
+  }
+
+  // The count seen by a 'secureConnect' listener (the handshake is complete but
+  // the listener has not been removed yet) and the count once the emit returned.
+  async function countsThroughHandshake(socket: tls.TLSSocket) {
+    const secureConnect = Promise.withResolvers<number>();
+    socket.on("error", secureConnect.reject);
+    socket.on("secureConnect", () => secureConnect.resolve(onConnectEndCount(socket)));
+    try {
+      const duringSecureConnect = await secureConnect.promise;
+      return { duringSecureConnect, afterHandshake: onConnectEndCount(socket) };
+    } finally {
+      socket.destroy();
+    }
+  }
+
+  it("tls.connect({ host, port })", async () => {
+    await withTLSServer(async port => {
+      const socket = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false });
+      expect(await countsThroughHandshake(socket)).toEqual({ duringSecureConnect: 1, afterHandshake: 0 });
+    });
+  });
+
+  it("tls.connect({ host, port, autoSelectFamily }) with a refused first address", async () => {
+    await withTLSServer(async port => {
+      // The server only listens on IPv4, so listing ::1 first makes the first
+      // attempt fail and the connection go through the retry path.
+      const lookup = (_host: string, _options: unknown, callback: Function) =>
+        callback(null, [
+          { address: "::1", family: 6 },
+          { address: "127.0.0.1", family: 4 },
+        ]);
+      const socket = tls.connect({
+        host: "localhost",
+        port,
+        rejectUnauthorized: false,
+        autoSelectFamily: true,
+        lookup,
+      });
+      const counts = await countsThroughHandshake(socket);
+      expect({ ...counts, attempted: socket.autoSelectFamilyAttemptedAddresses }).toEqual({
+        duringSecureConnect: 1,
+        afterHandshake: 0,
+        attempted: [`::1:${port}`, `127.0.0.1:${port}`],
+      });
+    });
+  });
+
+  it("tls.connect({ socket }) over a connected net.Socket", async () => {
+    await withTLSServer(async port => {
+      const tcp = net.connect(port, "127.0.0.1");
+      try {
+        await once(tcp, "connect");
+        const socket = tls.connect({ socket: tcp, rejectUnauthorized: false });
+        expect(await countsThroughHandshake(socket)).toEqual({ duringSecureConnect: 1, afterHandshake: 0 });
+      } finally {
+        tcp.destroy();
+      }
+    });
+  });
+
+  it("a handshake the peer drops keeps the one copy that reported ECONNRESET", async () => {
+    await using server = net.createServer(c => {
+      c.resume();
+      c.end();
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { promise, resolve } = Promise.withResolvers<NodeJS.ErrnoException>();
+    const socket = tls.connect({ host: "127.0.0.1", port: (server.address() as AddressInfo).port });
+    socket.on("error", resolve);
+    const error = await promise;
+    expect({ code: error.code, onConnectEnd: onConnectEndCount(socket) }).toEqual({
+      code: "ECONNRESET",
+      onConnectEnd: 1,
+    });
+  });
+});
+
 it("initializes authorizationError to null in the TLSSocket constructor", () => {
   // https://github.com/nodejs/node/blob/v26.3.0/lib/internal/tls/wrap.js#L556
   // Node's onServerSocketSecure/onConnectSecure only assign on failure; a

--- a/test/js/node/tls/node-tls-connect.test.ts
+++ b/test/js/node/tls/node-tls-connect.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import { randomUUID } from "crypto";
 import { once } from "events";
-import { bunEnv, bunExe, tls as COMMON_CERT_, isASAN } from "harness";
+import { bunEnv, bunExe, tls as COMMON_CERT_, isASAN, isWindows, tempDir } from "harness";
 import https from "https";
 import net from "net";
 import { join } from "path";
@@ -159,6 +160,33 @@ it("should thow ECONNRESET if FIN is received before handshake", async () => {
   expect((error as Error).code as string).toBe("ECONNRESET");
 });
 
+async function withTLSServer<T>(listenOn: net.ListenOptions, fn: (server: tls.Server) => Promise<T>): Promise<T> {
+  const server = tls.createServer(COMMON_CERT_, socket => socket.on("error", () => {}));
+  await once(server.listen(listenOn), "listening");
+  try {
+    return await fn(server);
+  } finally {
+    server.close();
+  }
+}
+
+// IPv4 only: paired with lookupIPv6LoopbackFirst, an autoSelectFamily connect
+// has its first attempt (::1) refused and connects on the retry.
+function withIPv4TLSServer<T>(fn: (server: tls.Server) => Promise<T>): Promise<T> {
+  return withTLSServer({ port: 0, host: "127.0.0.1" }, fn);
+}
+
+function lookupIPv6LoopbackFirst(_host: string, _options: unknown, callback: Function) {
+  callback(null, [
+    { address: "::1", family: 6 },
+    { address: "127.0.0.1", family: 4 },
+  ]);
+}
+
+function portOf(server: tls.Server) {
+  return (server.address() as AddressInfo).port;
+}
+
 // onConnectEnd is the 'end' listener that reports a peer FIN during the
 // handshake as ECONNRESET. Node attaches it once per tls.connect() and removes
 // it once the handshake completes, so the socket holds one copy until
@@ -168,16 +196,6 @@ it("should thow ECONNRESET if FIN is received before handshake", async () => {
 describe("tls.connect() attaches onConnectEnd to 'end' exactly once", () => {
   function onConnectEndCount(socket: tls.TLSSocket) {
     return socket.listeners("end").filter(listener => listener.name === "onConnectEnd").length;
-  }
-
-  async function withTLSServer<T>(fn: (port: number) => Promise<T>): Promise<T> {
-    const server = tls.createServer(COMMON_CERT_, socket => socket.on("error", () => {}));
-    await once(server.listen(0, "127.0.0.1"), "listening");
-    try {
-      return await fn((server.address() as AddressInfo).port);
-    } finally {
-      server.close();
-    }
   }
 
   // The count seen by a 'secureConnect' listener (the handshake is complete but
@@ -195,27 +213,21 @@ describe("tls.connect() attaches onConnectEnd to 'end' exactly once", () => {
   }
 
   it("tls.connect({ host, port })", async () => {
-    await withTLSServer(async port => {
-      const socket = tls.connect({ host: "127.0.0.1", port, rejectUnauthorized: false });
+    await withIPv4TLSServer(async server => {
+      const socket = tls.connect({ host: "127.0.0.1", port: portOf(server), rejectUnauthorized: false });
       expect(await countsThroughHandshake(socket)).toEqual({ duringSecureConnect: 1, afterHandshake: 0 });
     });
   });
 
   it("tls.connect({ host, port, autoSelectFamily }) with a refused first address", async () => {
-    await withTLSServer(async port => {
-      // The server only listens on IPv4, so listing ::1 first makes the first
-      // attempt fail and the connection go through the retry path.
-      const lookup = (_host: string, _options: unknown, callback: Function) =>
-        callback(null, [
-          { address: "::1", family: 6 },
-          { address: "127.0.0.1", family: 4 },
-        ]);
+    await withIPv4TLSServer(async server => {
+      const port = portOf(server);
       const socket = tls.connect({
         host: "localhost",
         port,
         rejectUnauthorized: false,
         autoSelectFamily: true,
-        lookup,
+        lookup: lookupIPv6LoopbackFirst,
       });
       const counts = await countsThroughHandshake(socket);
       expect({ ...counts, attempted: socket.autoSelectFamilyAttemptedAddresses }).toEqual({
@@ -226,9 +238,18 @@ describe("tls.connect() attaches onConnectEnd to 'end' exactly once", () => {
     });
   });
 
+  it("tls.connect({ path })", async () => {
+    using dir = tempDir("tls-connect-path", {});
+    const path = isWindows ? `\\\\.\\pipe\\tls-connect-path-${randomUUID()}` : join(String(dir), "tls.sock");
+    await withTLSServer({ path }, async () => {
+      const socket = tls.connect({ path, rejectUnauthorized: false });
+      expect(await countsThroughHandshake(socket)).toEqual({ duringSecureConnect: 1, afterHandshake: 0 });
+    });
+  });
+
   it("tls.connect({ socket }) over a connected net.Socket", async () => {
-    await withTLSServer(async port => {
-      const tcp = net.connect(port, "127.0.0.1");
+    await withIPv4TLSServer(async server => {
+      const tcp = net.connect(portOf(server), "127.0.0.1");
       try {
         await once(tcp, "connect");
         const socket = tls.connect({ socket: tcp, rejectUnauthorized: false });
@@ -252,6 +273,51 @@ describe("tls.connect() attaches onConnectEnd to 'end' exactly once", () => {
     expect({ code: error.code, onConnectEnd: onConnectEndCount(socket) }).toEqual({
       code: "ECONNRESET",
       onConnectEnd: 1,
+    });
+  });
+});
+
+// tls.connect() returns before any attempt is dialed, so the tls options each
+// attempt hands to the native connect are built when that attempt is dispatched
+// (clientTLSOptionsForAttempt in net.ts), not once up front. Node behaves the
+// same: setServername() before the ClientHello goes out decides the SNI.
+describe("a setServername() made after tls.connect() returned is what the connecting attempt sends", () => {
+  function servernameReceivedBy(server: tls.Server, client: tls.TLSSocket) {
+    const received = Promise.withResolvers<string>();
+    server.once("secureConnection", serverSide => received.resolve(serverSide.servername));
+    client.on("error", received.reject);
+    return received.promise;
+  }
+
+  it("set synchronously after tls.connect({ host, port })", async () => {
+    await withIPv4TLSServer(async server => {
+      const socket = tls.connect({ host: "127.0.0.1", port: portOf(server), rejectUnauthorized: false });
+      try {
+        const received = servernameReceivedBy(server, socket);
+        socket.setServername("late.example");
+        expect(await received).toBe("late.example");
+      } finally {
+        socket.destroy();
+      }
+    });
+  });
+
+  it("set between autoSelectFamily attempts, from a 'connectionAttemptFailed' listener", async () => {
+    await withIPv4TLSServer(async server => {
+      const socket = tls.connect({
+        host: "localhost",
+        port: portOf(server),
+        rejectUnauthorized: false,
+        autoSelectFamily: true,
+        lookup: lookupIPv6LoopbackFirst,
+      });
+      try {
+        const received = servernameReceivedBy(server, socket);
+        socket.once("connectionAttemptFailed", () => socket.setServername("retry.example"));
+        expect(await received).toBe("retry.example");
+      } finally {
+        socket.destroy();
+      }
     });
   });
 });


### PR DESCRIPTION
### Problem
- `tls.connect({ host, port })` and `tls.connect({ path })` leave `socket.listeners("end")` holding `onConnectEnd` after the handshake: one stale copy for a single address, one per address with `autoSelectFamily`. Node holds it once until `secureConnect` has been emitted and not at all afterwards.
- During `secureConnect` bun reports 2 copies (3 with two `autoSelectFamily` attempts), and 2 copies remain after a handshake the peer drops; Node reports 1 in both cases.
- Cause: `Socket.prototype.connect` (src/js/node/net.ts:1929-1969) sets up the client handshake state and prepends `onConnectEnd` for every `connect()` call, then hands off to `internalConnect` (net.ts:3085-3107 on main) or `internalConnectMultiple` (net.ts:3233-3255 on main), each of which carried a copy of that block from the node:net rework (#18962) and prepended `onConnectEnd` again. `internalConnectMultiple` runs once per address attempt. `onClientHandshakeComplete` (net.ts:343) removes one copy, like Node's `onConnectSecure`.
- Not a leak (the copies live on the socket and go away with it) and no runtime effect (bun's `onConnectEnd` also checks `secureConnecting`), so this only shows up in `listeners("end")` / `listenerCount("end")`. Found while triaging #26564.

### Fix
- `internalConnect` and `internalConnectMultiple` now call a shared `clientTLSOptionsForAttempt`, which only builds the tls options the attempt hands to the native connect. The handshake state and the `'end'` listener stay owned by `Socket.prototype.connect`, so every `connect()` registers `onConnectEnd` exactly once, at the same place Node's `tls.connect()` does, and the single `removeListener` on handshake completion brings it to zero.
- Building the options stays per attempt (not hoisted into `connect()`): the native connect takes servername and session from that object when the attempt is dispatched, so a `setServername()` / `setSession()` made after `tls.connect()` returned, including from a `connectionAttemptFailed` listener between `autoSelectFamily` attempts, is what gets dialed. Node behaves the same way; two tests pin it.
- The removed lines in the two copies were either re-assigning state `connect()` had set a moment earlier on the same socket (`_requestCert`, `authorized`, `secureConnecting`, `_secureEstablished`, `_securePending`, `kConnectOptions`), or computing a `connection` local that nothing read (the `{ socket }` upgrade path returns from `connect()` before reaching these functions), so the only observable change is the listener count.
- `tls.connect({ socket })` is unaffected: it only ever went through the `connect()` registration and already matched Node; a test pins that.
- Unlike #26564 (closed), the removal side is untouched: `onConnectEnd` is still attached until the handshake completes, so a FIN during the handshake still reports ECONNRESET (`test-tls-wrap-econnreset*.js` still pass). This also composes with #35990, which invokes `onConnectEnd` directly and does not depend on how many copies are registered.
- Tests, all in test/js/node/tls/node-tls-connect.test.ts. `describe("tls.connect() attaches onConnectEnd to 'end' exactly once")`: host/port, host/port with an `autoSelectFamily` retry (asserts both addresses were attempted), `{ path }`, the `{ socket }` upgrade, and a handshake the peer drops. On the unfixed build the host/port, `autoSelectFamily`, `{ path }` and dropped-handshake cases fail with counts 2/1, 3/2, 2/1 and 2; `{ socket }` passes both ways on purpose. `describe("a setServername() made after tls.connect() returned ...")`: set synchronously after `tls.connect()`, and set from a `connectionAttemptFailed` listener; both pass before and after and exist to keep the options build per attempt. All seven scenarios were run under node v26.3.0 and produce the asserted values.
- Also run with the fix: the rest of test/js/node/tls (the two failures there, `node-tls-server.test.ts` "SNICallback runs even when the requested servername matches the bind hostname" and `node-tls-root-certs-concurrent-init.test.ts`, fail identically without this change in this environment: localhost resolving to `::1` for listen and `127.0.0.1` for connect, and a 5s timeout under the debug build), and test/js/node/test/parallel/test-tls-wrap-econnreset{,-socket,-pipe,-localaddress}.js, test-tls-connect-{given-socket,simple,pipe,address-family,no-host,secure-context,timeout-option}.js, test-tls-client-abort{,2}.js, test-http-autoselectfamily.js, test-https-autoselectfamily.js.

### Background
- `onConnectEnd` is a listener for the socket's `'end'` event. While a client handshake is in progress, a peer closing the connection arrives as `'end'`, and this listener converts it into the ECONNRESET error "Client network socket disconnected before secure TLS connection was established". Node attaches it with `prependListener` in `tls.connect()` (lib/internal/tls/wrap.js#L1811 at v26.3.0) and removes it in `onConnectSecure` after emitting `secureConnect` (wrap.js#L1706); in Node that removal is what stops a normal post-handshake FIN from being reported as an error. Bun's copy additionally checks `secureConnecting`, which is why the duplicates were inert.
- In bun, `tls.connect()` builds a `TLSSocket` and calls `net.Socket.prototype.connect` on it. `connect()` either upgrades an existing connection in place (`tls.connect({ socket })`, returns early), calls `internalConnect` directly for `{ path }`, or goes through `lookupAndConnect`, which resolves the host and calls `internalConnect` for a single address or `internalConnectMultiple` once per address when `autoSelectFamily` is on. Each attempt passes a tls options object to the native connect; the `TLSSocket` builds that object from its current `servername` and session (`TLSSocket.prototype[buntls]` in tls.ts), which is why it is built at dispatch time.

<details>
<summary>listeners('end') names, bun 1.4.0 release vs node v26.3.0, before the fix</summary>

```
                                        bun                                          node
host/port, after handshake              ["onConnectEnd","onSocketEnd"]               ["onReadableStreamEnd"]
autoSelectFamily (::1 refused, then     ["onConnectEnd","onConnectEnd","onSocketEnd"] ["onReadableStreamEnd"]
  127.0.0.1), after handshake
{ socket: tcp }, after handshake        ["onSocketEnd","<anon>"]                     ["onReadableStreamEnd"]
peer FIN after ClientHello, after error ["onConnectEnd","onConnectEnd","onSocketEnd"] ["onConnectEnd","onReadableStreamEnd"]
```

`onSocketEnd` is bun's name for Node's `onReadableStreamEnd`; `<anon>` is the `kCloseRawConnection` once-listener the upgrade path adds. Neither is affected by this change.

</details>

<details>
<summary>Observed while reviewing, deliberately left as is</summary>

The helper passes `self._host` to the options builder exactly as the two copies did. `_host` is assigned by `lookupAndConnect`, so for a `{ path }` connect it is `undefined` on a fresh socket (no SNI, which is also what Node sends for a pipe connect), and on a `TLSSocket` that is reused for a `{ path }` connect after a host/port one it still holds the previous host, which then becomes the SNI. That is pre-existing behavior on main and is not changed here.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/tls/node-tls-connect.test.ts

<!-- robobun:evidence:end -->