### PR TITLE
MessagePort: release an explicit ref() when the last 'message' listener is removed

### DIFF
--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -342,9 +342,7 @@ function makePortReadable(port, incrementsPortRef) {
   let startedReading = false;
   function onMessage(payload) {
     if (payload === null) {
-      // The listener stays on until 'close' (below): removing a port's last 'message'
-      // listener releases its refs, and data still buffered in the stream has to keep
-      // the thread alive until it is consumed (node's kWaitingStreams).
+      // The listener (and with it the port's ref) comes off in 'close', once the buffered data is consumed.
       if (ended === false) {
         ended = true;
         stream.push(null);

--- a/src/js/node/worker_threads.ts
+++ b/src/js/node/worker_threads.ts
@@ -342,11 +342,13 @@ function makePortReadable(port, incrementsPortRef) {
   let startedReading = false;
   function onMessage(payload) {
     if (payload === null) {
+      // The listener stays on until 'close' (below): removing a port's last 'message'
+      // listener releases its refs, and data still buffered in the stream has to keep
+      // the thread alive until it is consumed (node's kWaitingStreams).
       if (ended === false) {
         ended = true;
         stream.push(null);
       }
-      port.off("message", onMessage);
     } else if (ended === false) {
       for (let i = 0; i < payload.length; i++) {
         stream.push(Buffer.from(payload[i]));

--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -203,12 +203,12 @@ static inline bool setJSMessagePort_onmessageSetter(JSGlobalObject& lexicalGloba
     vm.writeBarrier(&thisObject, value);
     ensureStillAliveHere(value);
 
-    // node: a callable handler starts the port and keeps the loop alive; assigning anything else
-    // clears the handler and lets the loop exit again.
+    // node: a callable handler starts the port and keeps the loop alive. Assigning anything
+    // else just removes the handler; MessagePort::onDidChangeListenerImpl releases the refs
+    // only if that removed the last 'message' listener (so `onmessage = null` with nothing
+    // set, or with other listeners still attached, changes nothing, as in node).
     if (value.isCallable())
         thisObject.wrapped().jsRef(&lexicalGlobalObject);
-    else
-        thisObject.wrapped().jsUnref(&lexicalGlobalObject);
 
     return true;
 }
@@ -354,7 +354,7 @@ static inline JSC::EncodedJSValue jsMessagePortPrototypeFunction_closeBody(JSC::
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    impl.jsUnref(lexicalGlobalObject);
+    impl.jsUnref();
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.close(); })));
 }
 
@@ -385,7 +385,7 @@ static inline JSC::EncodedJSValue jsMessagePortPrototypeFunction_unrefBody(JSC::
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.jsUnref(lexicalGlobalObject); })));
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.jsUnref(); })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsMessagePortPrototypeFunction_unref, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -203,8 +203,7 @@ static inline bool setJSMessagePort_onmessageSetter(JSGlobalObject& lexicalGloba
     vm.writeBarrier(&thisObject, value);
     ensureStillAliveHere(value);
 
-    // node: a callable handler keeps the loop alive. Clearing one is a plain listener removal;
-    // MessagePort::onDidChangeListenerImpl releases the refs iff it was the last 'message' listener.
+    // node: a callable handler keeps the loop alive; clearing one is an ordinary listener removal (onDidChangeListenerImpl).
     if (value.isCallable())
         thisObject.wrapped().jsRef(&lexicalGlobalObject);
 

--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -203,10 +203,8 @@ static inline bool setJSMessagePort_onmessageSetter(JSGlobalObject& lexicalGloba
     vm.writeBarrier(&thisObject, value);
     ensureStillAliveHere(value);
 
-    // node: a callable handler starts the port and keeps the loop alive. Assigning anything
-    // else just removes the handler; MessagePort::onDidChangeListenerImpl releases the refs
-    // only if that removed the last 'message' listener (so `onmessage = null` with nothing
-    // set, or with other listeners still attached, changes nothing, as in node).
+    // node: a callable handler keeps the loop alive. Clearing one is a plain listener removal;
+    // MessagePort::onDidChangeListenerImpl releases the refs iff it was the last 'message' listener.
     if (value.isCallable())
         thisObject.wrapped().jsRef(&lexicalGlobalObject);
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -296,7 +296,8 @@ TransferredMessagePort MessagePort::disentangle()
     // After transfer this object is inert (the receiving side gets a fresh
     // MessagePort for the same pipe endpoint) and is no longer a destruction
     // observer, so nothing else would ever release a jsRef() taken on it.
-    // The caller (disentanglePorts) holds a RefPtr, so the deref() is safe.
+    // (Clearing the listeners above already did this if any 'message' listener
+    // was attached; this covers a ref()'d port that had none.)
     releaseJsRef();
 
     // A transferred port is inert; clear the listener keepalive too so hasRef()
@@ -386,6 +387,10 @@ void MessagePort::contextDestroyed()
 {
     ASSERT(scriptExecutionContext());
 
+    // A context torn down without a stop phase (a collected ShadowRealm global, a retired
+    // test-isolation global) gets here directly, and a port whose wrapper is already gone
+    // may be alive only through the self-ref that close() -> releaseJsRef() drops.
+    Ref protectedThis { *this };
     close();
     ActiveDOMObject::contextDestroyed();
 }
@@ -587,7 +592,10 @@ void MessagePort::releaseJsRef()
     // still attached here: contextDestroyed() reaches this via close() before detaching.
     if (auto* context = scriptExecutionContext())
         context->unrefEventLoop();
-    // Drops the self-ref, so `this` must not be touched afterwards.
+    // Every caller (and the EventTarget code under the listener hook) keeps using the port
+    // after this, so the self-ref being dropped must not be its last reference: callers
+    // hold one themselves (JS wrapper, protectedThis, disentanglePorts' RefPtr, ...).
+    ASSERT(!hasOneRef());
     deref();
 }
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -293,11 +293,8 @@ TransferredMessagePort MessagePort::disentangle()
     removeAllEventListeners();
     m_hasMessageEventListener = false;
 
-    // After transfer this object is inert (the receiving side gets a fresh
-    // MessagePort for the same pipe endpoint) and is no longer a destruction
-    // observer, so nothing else would ever release a jsRef() taken on it.
-    // (Clearing the listeners above already did this if any 'message' listener
-    // was attached; this covers a ref()'d port that had none.)
+    // The transferred-away object is inert and stops observing its context below, so nothing
+    // later would release a jsRef() taken on it (a port with no 'message' listener still has one).
     releaseJsRef();
 
     // A transferred port is inert; clear the listener keepalive too so hasRef()
@@ -387,9 +384,8 @@ void MessagePort::contextDestroyed()
 {
     ASSERT(scriptExecutionContext());
 
-    // A context torn down without a stop phase (a collected ShadowRealm global, a retired
-    // test-isolation global) gets here directly, and a port whose wrapper is already gone
-    // may be alive only through the self-ref that close() -> releaseJsRef() drops.
+    // Without a stop phase first (collected ShadowRealm / retired test-isolation global), the
+    // self-ref that close() drops may be this port's last reference.
     Ref protectedThis { *this };
     close();
     ActiveDOMObject::contextDestroyed();
@@ -502,8 +498,7 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
         break;
     }
     port.updateListenerEventLoopRef();
-    // node's setupPortReferencing unref()s the port outright when its last 'message'
-    // listener goes away, so an earlier .ref() (or onmessage=) does not outlive it.
+    // node (setupPortReferencing) unref()s outright when the last 'message' listener goes, .ref() or not.
     if (hadListeners && port.m_messageEventCount == 0)
         port.releaseJsRef();
 }
@@ -588,13 +583,10 @@ void MessagePort::releaseJsRef()
     if (!m_hasRef)
         return;
     m_hasRef = false;
-    // Same per-thread VM that jsRef() ref'd through the lexical global. The context is
-    // still attached here: contextDestroyed() reaches this via close() before detaching.
+    // The context's VM is the one jsRef() ref'd through the lexical global.
     if (auto* context = scriptExecutionContext())
         context->unrefEventLoop();
-    // Every caller (and the EventTarget code under the listener hook) keeps using the port
-    // after this, so the self-ref being dropped must not be its last reference: callers
-    // hold one themselves (JS wrapper, protectedThis, disentanglePorts' RefPtr, ...).
+    // Callers keep using the port afterwards, so this self-ref must not be its last reference.
     ASSERT(!hasOneRef());
     deref();
 }

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -293,8 +293,7 @@ TransferredMessagePort MessagePort::disentangle()
     removeAllEventListeners();
     m_hasMessageEventListener = false;
 
-    // The transferred-away object is inert and stops observing its context below, so nothing
-    // later would release a jsRef() taken on it (a port with no 'message' listener still has one).
+    // Inert from here on and about to stop observing its context: nothing later could release a jsRef().
     releaseJsRef();
 
     // A transferred port is inert; clear the listener keepalive too so hasRef()
@@ -384,8 +383,7 @@ void MessagePort::contextDestroyed()
 {
     ASSERT(scriptExecutionContext());
 
-    // Without a stop phase first (collected ShadowRealm / retired test-isolation global), the
-    // self-ref that close() drops may be this port's last reference.
+    // With no stop phase before this (ShadowRealm, retired test-isolation global), close() may drop the last reference.
     Ref protectedThis { *this };
     close();
     ActiveDOMObject::contextDestroyed();

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -224,15 +224,8 @@ void MessagePort::close()
     // it in hasPendingActivity()); marking our side Closed is sufficient.
     m_pipe->close(m_side, MessagePortPipe::CloseKind::Explicit);
 
-    // Release the self-reference taken by jsRef() (set when .onmessage is
-    // assigned or .ref() is called from JS). The JS .close() binding calls
-    // jsUnref() first; stop() and contextDestroyed() do not.
-    if (m_hasRef) {
-        m_hasRef = false;
-        if (auto* context = scriptExecutionContext())
-            context->unrefEventLoop();
-        deref();
-    }
+    // The JS .close() binding calls jsUnref() first; stop() and contextDestroyed() do not.
+    releaseJsRef();
 
     // close() can run without a prior jsUnref() (warn-and-close, contextDestroyed());
     // clear the listener keepalive so a later listener add can't re-ref the loop.
@@ -287,8 +280,7 @@ void MessagePort::peerClosed()
     dispatchCloseEvent();
     // jsUnref() clears both the listener loop-ref (m_isRefd) and the onmessage/ref()
     // keepalive (m_hasRef), so a listening transferred port stops pinning the loop.
-    auto* globalObject = defaultGlobalObject(context->globalObject());
-    jsUnref(globalObject);
+    jsUnref();
 }
 
 TransferredMessagePort MessagePort::disentangle()
@@ -301,17 +293,11 @@ TransferredMessagePort MessagePort::disentangle()
     removeAllEventListeners();
     m_hasMessageEventListener = false;
 
-    // Release the self-reference taken by jsRef() on the sending side. After
-    // transfer this object is inert (the receiving side gets a fresh
+    // After transfer this object is inert (the receiving side gets a fresh
     // MessagePort for the same pipe endpoint) and is no longer a destruction
-    // observer, so nothing else will ever release a ref taken here.
-    // The caller (disentanglePorts) holds a RefPtr, so deref() is safe.
-    if (m_hasRef) {
-        m_hasRef = false;
-        if (auto* context = scriptExecutionContext())
-            context->unrefEventLoop();
-        deref();
-    }
+    // observer, so nothing else would ever release a jsRef() taken on it.
+    // The caller (disentanglePorts) holds a RefPtr, so the deref() is safe.
+    releaseJsRef();
 
     // A transferred port is inert; clear the listener keepalive too so hasRef()
     // reports false (the disentangle analogue of the close() reset above).
@@ -497,6 +483,7 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
         return;
 
     auto& port = static_cast<MessagePort&>(self);
+    bool hadListeners = port.m_messageEventCount > 0;
     switch (kind) {
     case Add:
         port.m_messageEventCount++;
@@ -510,6 +497,10 @@ void MessagePort::onDidChangeListenerImpl(EventTarget& self, const AtomString& e
         break;
     }
     port.updateListenerEventLoopRef();
+    // node's setupPortReferencing unref()s the port outright when its last 'message'
+    // listener goes away, so an earlier .ref() (or onmessage=) does not outlive it.
+    if (hadListeners && port.m_messageEventCount == 0)
+        port.releaseJsRef();
 }
 
 bool MessagePort::addEventListener(const AtomString& eventType, Ref<EventListener>&& listener, const AddEventListenerOptions& options)
@@ -576,7 +567,7 @@ void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
     }
 }
 
-void MessagePort::jsUnref(JSGlobalObject* lexicalGlobalObject)
+void MessagePort::jsUnref()
 {
     // Also release the listener loop-ref; otherwise an always-listening transferred
     // port (a postMessageToThread control port) would pin the event loop forever.
@@ -584,11 +575,20 @@ void MessagePort::jsUnref(JSGlobalObject* lexicalGlobalObject)
         m_isRefd = false;
         updateListenerEventLoopRef();
     }
-    if (m_hasRef) {
-        m_hasRef = false;
-        deref();
-        Bun__eventLoop__refKeepAlive(WebCore::clientData(lexicalGlobalObject->vm())->bunVM, -1);
-    }
+    releaseJsRef();
+}
+
+void MessagePort::releaseJsRef()
+{
+    if (!m_hasRef)
+        return;
+    m_hasRef = false;
+    // Same per-thread VM that jsRef() ref'd through the lexical global. The context is
+    // still attached here: contextDestroyed() reaches this via close() before detaching.
+    if (auto* context = scriptExecutionContext())
+        context->unrefEventLoop();
+    // Drops the self-ref, so `this` must not be touched afterwards.
+    deref();
 }
 
 } // namespace WebCore

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -114,7 +114,7 @@ public:
     JSValue tryTakeMessage(JSGlobalObject*, bool& hadMessage);
 
     void jsRef(JSGlobalObject*);
-    void jsUnref(JSGlobalObject*);
+    void jsUnref();
     // Report the actual loop-ref state (matches Node's uv_has_ref), not the intent flag.
     bool jsHasRef() { return m_hasRef || m_listenerLoopRefActive; }
 
@@ -159,7 +159,11 @@ private:
     // Read from the GC thread: a port whose only listener is 'close' must survive
     // until that event is delivered, or the peer's close is lost to a collection.
     std::atomic<bool> m_hasCloseEventListener { false };
+    // jsRef() (.ref(), or a callable .onmessage=) took a self-ref plus an event-loop ref.
+    // Released by unref(), close(), the peer closing, a transfer, and (as node's
+    // setupPortReferencing does) the removal of the last 'message' listener.
     bool m_hasRef { false };
+    void releaseJsRef();
 
     // Whether .ref()/.unref() want this port to keep the loop alive (default refd);
     // independent of m_hasRef (the .onmessage=/.ref() keepalive).

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -159,9 +159,7 @@ private:
     // Read from the GC thread: a port whose only listener is 'close' must survive
     // until that event is delivered, or the peer's close is lost to a collection.
     std::atomic<bool> m_hasCloseEventListener { false };
-    // jsRef() (.ref(), or a callable .onmessage=) took a self-ref plus an event-loop ref.
-    // Released by unref(), close(), the peer closing, a transfer, and (as node's
-    // setupPortReferencing does) the removal of the last 'message' listener.
+    // jsRef() (.ref() or a callable .onmessage=) holds a self-ref plus an event-loop ref; releaseJsRef() drops both.
     bool m_hasRef { false };
     void releaseJsRef();
 

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1106,16 +1106,27 @@ test("removeAllListeners() releases an explicit ref() like off() does", async ()
   expect(results).toEqual({ byType: false, all: false, unrelatedType: true });
 });
 
-// node: assigning a non-function to onmessage removes the handler, and the port is
+// node: assigning a non-object to onmessage removes the handler, and the port is
 // unref()'d only if that removed its last 'message' listener. Clearing a handler that
 // was never set, or while on() listeners remain, leaves the ref state alone.
-test("onmessage = null releases the port only when it removed the last 'message' listener", async () => {
+//
+// A non-callable object is not a removal: the event handler attribute installs it (the
+// getter returns it, and it occupies the 'message' listener slot), so the ref state simply
+// follows the listener list: ref'd while it is installed, released when it is cleared.
+// node agrees on installing one over nothing; it differs on the two rarer transitions
+// (it only counts functions, so replacing a function with an object unrefs there and
+// clearing an object does not), where bun keeps hasRef() in step with the listener list.
+test("onmessage = <non-function> releases the port only when it removed the last 'message' listener", async () => {
   const f = () => {};
   const g = () => {};
   const results = {
     handlerCleared: await hasRefAfter(p => {
       p.onmessage = f;
       p.onmessage = null;
+    }),
+    handlerClearedByString: await hasRefAfter(p => {
+      p.onmessage = f;
+      p.onmessage = "not a handler" as any;
     }),
     refdHandlerCleared: await hasRefAfter(p => {
       p.ref();
@@ -1135,13 +1146,28 @@ test("onmessage = null releases the port only when it removed the last 'message'
       p.on("message", f);
       p.onmessage = null;
     }),
+    objectHandlerInstalled: await hasRefAfter(p => {
+      p.onmessage = {} as any;
+    }),
+    functionReplacedByObject: await hasRefAfter(p => {
+      p.onmessage = f;
+      p.onmessage = {} as any;
+    }),
+    objectHandlerCleared: await hasRefAfter(p => {
+      p.onmessage = {} as any;
+      p.onmessage = null;
+    }),
   };
   expect(results).toEqual({
     handlerCleared: false,
+    handlerClearedByString: false,
     refdHandlerCleared: false,
     nothingToClear: true,
     onListenerRemains: true,
     onListenerOnly: true,
+    objectHandlerInstalled: true,
+    functionReplacedByObject: true,
+    objectHandlerCleared: false,
   });
 });
 
@@ -1191,6 +1217,40 @@ test("a ref()'d parentPort whose last 'message' listener was removed lets the wo
   const hasRef = once(w, "message");
   const exited = once(w, "exit");
   expect({ hasRef: (await hasRef)[0], exitCode: (await exited)[0] }).toEqual({ hasRef: false, exitCode: 0 });
+});
+
+// The worker's process.stdin is fed by a port that is ref()'d once reading starts. Data
+// that is still buffered when EOF arrives has to keep the thread alive until it is
+// consumed (node's kWaitingStreams), so the stream may only drop its port listener (which
+// releases that ref) after it has been drained, not when the EOF message comes in.
+test("stdin data buffered behind a paused consumer is still delivered after EOF arrives", async () => {
+  const w = new Worker(
+    `const { parentPort } = require("worker_threads");
+     const seen = [];
+     process.stdin.on("data", chunk => {
+       seen.push(chunk.toString());
+       if (seen.length !== 1) return;
+       process.stdin.pause();
+       // Resume once EOF has been received, via unref'd timers only: the buffered data is
+       // then the one thing entitled to keep this thread alive. A thread that exits at EOF
+       // never gets here again and reports nothing.
+       const poll = () => {
+         if (process.stdin._readableState.ended) process.stdin.resume();
+         else setTimeout(poll, 1).unref();
+       };
+       setTimeout(poll, 1).unref();
+     });
+     process.stdin.on("end", () => parentPort.postMessage(seen));`,
+    { eval: true, stdin: true },
+  );
+  const reports: string[][] = [];
+  w.on("message", report => reports.push(report));
+  const exited = once(w, "exit");
+  w.stdin!.write("aaaaaaaaaa");
+  w.stdin!.write("bbbbbbbbbb");
+  w.stdin!.end();
+  const [exitCode] = await exited;
+  expect({ reports, exitCode }).toEqual({ reports: [["aaaaaaaaaa", "bbbbbbbbbb"]], exitCode: 0 });
 });
 
 // markAsUncloneable blocks *cloning*, not transfer: a marked port in the transfer

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -997,6 +997,202 @@ test("hasRef() survives collection of the unreferenced peer", () => {
   port1.close();
 });
 
+// port1.hasRef() after running `scenario` on a fresh channel. port2 stays reachable
+// until the end so that collecting it cannot close port1 underneath the scenario.
+async function hasRefAfter(scenario: (port1: MessagePort, port2: MessagePort) => void | Promise<void>) {
+  const { port1, port2 } = new MessageChannel();
+  try {
+    await scenario(port1, port2);
+    return port1.hasRef();
+  } finally {
+    port1.close();
+    port2.close();
+  }
+}
+
+// node's setupPortReferencing (lib/internal/worker/io.js) unref()s a port when its
+// last 'message' listener is removed, whether or not ref() was called on it before.
+test("removing the last 'message' listener releases an explicit ref() as well", async () => {
+  const f = () => {};
+  const g = () => {};
+  const results = {
+    refThenListenerRemoved: await hasRefAfter(p => {
+      p.ref();
+      p.on("message", f);
+      p.off("message", f);
+    }),
+    listenerThenRefThenRemoved: await hasRefAfter(p => {
+      p.on("message", f);
+      p.ref();
+      p.off("message", f);
+    }),
+    viaRemoveEventListener: await hasRefAfter(p => {
+      p.ref();
+      p.addEventListener("message", f);
+      p.removeEventListener("message", f);
+    }),
+    viaOnceListenerFiring: await hasRefAfter(async (p, peer) => {
+      p.ref();
+      const fired = new Promise<void>(resolve => p.once("message", () => resolve()));
+      peer.postMessage(1);
+      await fired;
+    }),
+    // None of these remove the last 'message' listener, so nothing is released.
+    oneOfTwoRemoved: await hasRefAfter(p => {
+      p.ref();
+      p.on("message", f);
+      p.on("message", g);
+      p.off("message", f);
+    }),
+    neverAddedListenerRemoved: await hasRefAfter(p => {
+      p.ref();
+      p.off("message", f);
+    }),
+    closeListenerRemoved: await hasRefAfter(p => {
+      p.ref();
+      p.on("close", f);
+      p.off("close", f);
+    }),
+    // The release is not sticky: a later listener or ref() refs the port again.
+    listenerAddedAgain: await hasRefAfter(p => {
+      p.ref();
+      p.on("message", f);
+      p.off("message", f);
+      p.on("message", g);
+    }),
+    refCalledAgain: await hasRefAfter(p => {
+      p.ref();
+      p.on("message", f);
+      p.off("message", f);
+      p.ref();
+    }),
+  };
+  expect(results).toEqual({
+    refThenListenerRemoved: false,
+    listenerThenRefThenRemoved: false,
+    viaRemoveEventListener: false,
+    viaOnceListenerFiring: false,
+    oneOfTwoRemoved: true,
+    neverAddedListenerRemoved: true,
+    closeListenerRemoved: true,
+    listenerAddedAgain: true,
+    refCalledAgain: true,
+  });
+});
+
+// bun's removeAllListeners() removes the listeners one by one, so it releases the port
+// exactly like off() on each of them would. (node's NodeEventTarget#removeAllListeners
+// bypasses its listener hooks and leaves a port with no listeners ref'd; bun does not
+// keep the listener-count ref there either, and the explicit ref follows the same rule.)
+test("removeAllListeners() releases an explicit ref() like off() does", async () => {
+  const f = () => {};
+  const results = {
+    byType: await hasRefAfter(p => {
+      p.ref();
+      p.on("message", f);
+      p.removeAllListeners("message");
+    }),
+    all: await hasRefAfter(p => {
+      p.ref();
+      p.on("message", f);
+      p.removeAllListeners();
+    }),
+    unrelatedType: await hasRefAfter(p => {
+      p.ref();
+      p.on("message", f);
+      p.removeAllListeners("close");
+    }),
+  };
+  expect(results).toEqual({ byType: false, all: false, unrelatedType: true });
+});
+
+// node: assigning a non-function to onmessage removes the handler, and the port is
+// unref()'d only if that removed its last 'message' listener. Clearing a handler that
+// was never set, or while on() listeners remain, leaves the ref state alone.
+test("onmessage = null releases the port only when it removed the last 'message' listener", async () => {
+  const f = () => {};
+  const g = () => {};
+  const results = {
+    handlerCleared: await hasRefAfter(p => {
+      p.onmessage = f;
+      p.onmessage = null;
+    }),
+    refdHandlerCleared: await hasRefAfter(p => {
+      p.ref();
+      p.onmessage = f;
+      p.onmessage = null;
+    }),
+    nothingToClear: await hasRefAfter(p => {
+      p.ref();
+      p.onmessage = null;
+    }),
+    onListenerRemains: await hasRefAfter(p => {
+      p.on("message", f);
+      p.onmessage = g;
+      p.onmessage = null;
+    }),
+    onListenerOnly: await hasRefAfter(p => {
+      p.on("message", f);
+      p.onmessage = null;
+    }),
+  };
+  expect(results).toEqual({
+    handlerCleared: false,
+    refdHandlerCleared: false,
+    nothingToClear: true,
+    onListenerRemains: true,
+    onListenerOnly: true,
+  });
+});
+
+// End to end: once the listener is gone nothing about the port may hold the process open.
+test.concurrent("a ref()'d port whose last 'message' listener was removed lets the process exit", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { MessageChannel } = require("worker_threads");
+       const { port1, port2 } = new MessageChannel();
+       // Keep the peer reachable: collecting it would close port1 (and release its refs) by itself.
+       globalThis.keep = port2;
+       const f = () => {};
+       port1.ref();
+       port1.on("message", f);
+       port1.off("message", f);
+       console.log("hasRef=" + port1.hasRef());
+       // Never fires when the port released the loop; bounds the failure mode (a process
+       // that stays alive) instead of letting the test run into its timeout.
+       setTimeout(() => { console.log("still alive"); process.exit(1); }, 2_000).unref();`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "inherit",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  expect(stdout).toBe("hasRef=false\n");
+  expect(exitCode).toBe(0);
+});
+
+// Same rule for parentPort: node's worker exits once the listeners are gone even if
+// the script ref()'d the port explicitly.
+test("a ref()'d parentPort whose last 'message' listener was removed lets the worker exit", async () => {
+  const w = new Worker(
+    `const { parentPort } = require("worker_threads");
+     const f = () => {};
+     parentPort.ref();
+     parentPort.on("message", f);
+     parentPort.off("message", f);
+     parentPort.postMessage(parentPort.hasRef());
+     // Never fires when the port released the loop; bounds the failure mode (a worker
+     // that stays alive) with a distinctive exit code.
+     setTimeout(() => process.exit(7), 2_000).unref();`,
+    { eval: true },
+  );
+  const hasRef = once(w, "message");
+  const exited = once(w, "exit");
+  expect({ hasRef: (await hasRef)[0], exitCode: (await exited)[0] }).toEqual({ hasRef: false, exitCode: 0 });
+});
+
 // markAsUncloneable blocks *cloning*, not transfer: a marked port in the transfer
 // list is moved, so node lets it through and it still works on the far side.
 test("markAsUncloneable blocks cloning a port but not transferring it", async () => {

--- a/test/js/web/workers/message-port-context-destroy-leak.test.ts
+++ b/test/js/web/workers/message-port-context-destroy-leak.test.ts
@@ -88,12 +88,14 @@ test.skipIf(isWindows)(
 //
 // ASAN only: the port lives in a bmalloc heap, which Malloc=1 routes to the system
 // allocator so ASAN can see a read of the freed port.
-test.skipIf(!isASAN)("closing a ref()'d port during context destruction does not free it mid-close", async () => {
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const { heapStats } = require("bun:jsc");
+test.skipIf(!isASAN)(
+  "closing a ref()'d port during context destruction does not free it mid-close",
+  async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const { heapStats } = require("bun:jsc");
        const globals = () => heapStats().objectTypeCounts.GlobalObject;
        const baseline = globals();
        let realm = new ShadowRealm();
@@ -111,15 +113,19 @@ test.skipIf(!isASAN)("closing a ref()'d port during context destruction does not
          collected = globals() === baseline;
        }
        console.log(collected ? "PASS" : "the realm's global was never collected");`,
-    ],
-    env: { ...bunEnv, ...(isWindows ? {} : { Malloc: "1" }) },
-    stdout: "pipe",
-    stderr: "pipe",
-  });
+      ],
+      env: { ...bunEnv, ...(isWindows ? {} : { Malloc: "1" }) },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
 
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
-  expect(stderr).toBe("");
-  expect(stdout).toBe("PASS\n");
-  expect(exitCode).toBe(0);
-});
+    expect(stderr).toBe("");
+    expect(stdout).toBe("PASS\n");
+    expect(exitCode).toBe(0);
+  },
+  // The passing run takes about a second; a failing one has to symbolize an ASAN report
+  // for the debug binary first, which takes longer than the default timeout.
+  30_000,
+);

--- a/test/js/web/workers/message-port-context-destroy-leak.test.ts
+++ b/test/js/web/workers/message-port-context-destroy-leak.test.ts
@@ -79,3 +79,47 @@ test.skipIf(isWindows)(
   },
   120_000,
 );
+
+// The other half of the contract above: once the wrapper and the peer are collected, the
+// self-ref taken by .ref() is the only thing keeping the native port alive. A context that
+// is torn down without a stop phase (a collected ShadowRealm global here) reaches
+// contextDestroyed() -> close() directly, and close() drops that self-ref part-way
+// through, so it has to hold its own reference for the rest of the teardown.
+//
+// ASAN only: the port lives in a bmalloc heap, which Malloc=1 routes to the system
+// allocator so ASAN can see a read of the freed port.
+test.skipIf(!isASAN)("closing a ref()'d port during context destruction does not free it mid-close", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { heapStats } = require("bun:jsc");
+       const globals = () => heapStats().objectTypeCounts.GlobalObject;
+       const baseline = globals();
+       let realm = new ShadowRealm();
+       realm.evaluate("(() => { const { port1 } = new MessageChannel(); port1.ref(); })()");
+       // Collect the wrapper and the peer while the realm is still alive: the ref()'d native
+       // port now survives on its self-ref alone.
+       for (let i = 0; i < 5; i++) Bun.gc(true);
+       // Drop the realm. Destroying its global destroys the context the port is registered on.
+       // A stale stack slot can keep the realm alive through a collection or two, so collect
+       // (with a different call in between each time) until its global is actually gone.
+       realm = null;
+       let collected = false;
+       for (let i = 0; i < 50 && !collected; i++) {
+         Bun.gc(true);
+         collected = globals() === baseline;
+       }
+       console.log(collected ? "PASS" : "the realm's global was never collected");`,
+    ],
+    env: { ...bunEnv, ...(isWindows ? {} : { Malloc: "1" }) },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+  expect(stderr).toBe("");
+  expect(stdout).toBe("PASS\n");
+  expect(exitCode).toBe(0);
+});


### PR DESCRIPTION
### Problem

- `port.ref(); port.on("message", f); port.off("message", f)` leaves `port.hasRef()` true and the process alive. Node prints `false` and exits. The same happens for a worker doing this on `parentPort` (the thread never exits), and for `removeEventListener()`, `removeAllListeners()` and a `once()` listener firing.
- Cause: the port has two independent loop refs (src/jsc/bindings/webcore/MessagePort.h): `m_hasRef`, taken by `jsRef()` (`.ref()` or a callable `onmessage =`), and the listener ref, held while `m_isRefd && m_messageEventCount > 0`. `onDidChangeListenerImpl()` (MessagePort.cpp) only reconciled the second one, so an explicit ref outlived the listeners. Node has one handle ref flag, and `setupPortReferencing` (lib/internal/worker/io.js) calls `port.unref()` unconditionally when the last `'message'` listener is removed.
- Same mechanism, other direction: the `onmessage` setter (JSMessagePort.cpp) called `jsUnref()` for every non-callable assignment as its own approximation of that release. `port.on("message", f); port.onmessage = null` therefore unref'd a port that is still listening, and `port.ref(); port.onmessage = null` dropped the explicit ref. Node changes nothing in either case.
- Found while fixing the above, pre-existing on main: `MessagePort::contextDestroyed()` -> `close()` released `m_hasRef` (a self-reference) and kept using the port. When the context dies without a stop phase (a collected `ShadowRealm` global, a retired test-isolation global) and the port's wrapper is already gone, that self-reference is the last one, and `close()` reads freed memory (`heap-use-after-free` in `MessagePort::close()` from `MessagePort::contextDestroyed()` <- `~ScriptExecutionContext` <- `Zig::GlobalObject::~GlobalObject`, reproduced on main under ASAN with `Malloc=1`).

### Fix

- `onDidChangeListenerImpl()` releases `m_hasRef` when the `'message'` listener count goes from non-zero to zero (`Remove` or `Clear`). Every removal path funnels through this hook: `off()`/`removeListener()`, `removeEventListener()`, `removeAllListeners()` (one removal per listener), `once()` listeners being removed before they fire, `AbortSignal` removal, and `onmessage = <non-object>` via `setAttributeEventListener`. `parentPort` is the same class, so workers are covered.
- `m_isRefd` is left alone on that transition: with no listeners it has no effect, and keeping it means `on(); off(); on()` refs the port again, as in node.
- The `onmessage` setter keeps `jsRef()` for a callable value and no longer calls `jsUnref()` otherwise; the removal itself (if there was one, and it was the last listener) now releases, which is node's rule. A non-callable object is installed as the handler by the attribute setter (and returned by the getter), so it counts as a listener and keeps the port ref'd until it is cleared; node agrees for `onmessage = {}` on an empty port and differs only on replacing a function with an object (it unrefs there) and on clearing an object (it stays ref'd there), because it only counts functions. Pinned by the test either way.
- The three copies of the `m_hasRef` release in `close()`, `disentangle()` and `jsUnref()` become `releaseJsRef()`, which the hook also uses. It unrefs through the port's `ScriptExecutionContext` as `close()` already did (the same per-thread VM `jsRef()` ref'd), so `jsUnref()` no longer needs a `JSGlobalObject` and loses the parameter. Every caller keeps using the port after the release, so the self-reference must never be the last one; `releaseJsRef()` now asserts that (`ASSERT(!hasOneRef())`), and the callers hold one: the JS wrapper for the bindings, `protectedThis` in `peerClosed()`, `disentanglePorts()`'s `RefPtr`, `forEachActiveDOMObject()`'s `RefPtr` for `stop()`, and for the hook `EventTarget::removeEventListener` (wrapper or the `Ref` taken by `innerInvokeEventListeners` / the abort algorithm), the close task (`queueTaskKeepingObjectAlive`) and `disentangle()`.
- `contextDestroyed()` was the one caller without such a reference; it now holds one across `close()` and `ActiveDOMObject::contextDestroyed()` (the wrapper-less port is then destroyed when that reference goes away, after its context pointer has been cleared, which is the order `~ActiveDOMObject` expects).
- src/js/node/worker_threads.ts `makePortReadable` (a worker's `process.stdin`, and captured `worker.stdout`/`stderr`) dropped its port listener as soon as the EOF message arrived. With the release above that also dropped the `ref()` it takes when reading starts, so a worker whose stdin consumer was paused exited before the buffered data and `'end'` were delivered (node and main deliver them). The EOF branch now only pushes `null`; the stream's `'close'` handler already removes the listener and unrefs once the data has been consumed, which is node's `kWaitingStreams` behavior. The other internal `ref()` users are unaffected: the `Worker` public port and the messaging hub port never remove their listener, and the stdio writable unrefs before it drops its ack listener.
- Why this is correct: it is node's rule (`setupPortReferencing` in v26.3.0: `removeListener(size) { if (size === 0) { stopMessagePort(port); port.unref(); } }`, called with the count left after an actual removal), and it leaves no way for an explicit ref to outlive the listeners except an explicit `ref()` taken afterwards. The stdio change keeps the one internal user that relied on the old timing at its previous (and node's) semantics, and the `contextDestroyed()` reference makes the lifetime rule the new hook relies on hold for every caller.
- Verification:
  - test/js/node/worker_threads/worker_threads.test.ts: a `hasRef()` matrix over the removal paths and the cases that must not release, the `removeAllListeners()` cases, the `onmessage` cases (null, string, object, nothing set, other listeners remaining), a spawned process and a worker that must exit on their own, and the paused-stdin delivery test. The first five fail on main (release and debug+ASAN builds); the stdin test passes on main, fails with the native change alone, and passes with the `makePortReadable` change.
  - test/js/web/workers/message-port-context-destroy-leak.test.ts: the `ShadowRealm` teardown under ASAN with `Malloc=1` (it collects until the realm's global is gone, checked through `heapStats()`, so the teardown path is known to have run). Against main's `MessagePort` files it fails on its `stderr` assertion with the ASAN report above; with the `contextDestroyed()` change it passes, 10/10 runs.
  - Unchanged and passing on this branch (debug+ASAN): the rest of worker_threads.test.ts (128 tests), message-channel, message-port-closed-leak, message-port-pipe (except its two sanitizer-gated burst tests, whose fixture takes 11 to 16 seconds on this machine with or without the change against a 5 second budget), worker-postmessage-transfer, the broadcastchannel suite, and 40 upstream tests: `test-messagechannel`, `test-worker-message-port*`, `test-worker-message-channel*`, `test-worker-workerdata-messageport`, `test-worker-ref*`, `test-worker-parent-port-ref`, `test-worker-terminate-ref-public-port`, `test-worker-unref-from-message-during-exit`, `test-worker-onmessage*`, `test-worker-stdio*`, `test-worker-no-stdin-stdout-interaction`, `test-worker-terminate-unrefed`, `test-worker-event`, `test-worker-message-event`, `test-worker-cleanexit*`, `test-worker-exit-code`. The new assertion did not fire anywhere in these.
- Remaining differences from node, both pre-existing and not changed here: `removeAllListeners()` in node bypasses its listener hooks and leaves a listener-less port ref'd (the process hangs); bun already released the listener ref there and now releases the explicit one the same way. `unref(); on("message", f)` re-refs the port in node and not in bun (the add side of the same hook; #36434 addresses it).

### Background

- A MessagePort "refs" its thread's event loop while something may still need it. Node keeps one boolean on the uv handle: `ref()`/`unref()` set it, and `setupPortReferencing` sets it when the first `'message'` listener is added and clears it when the last one is removed. `hasRef()` reads it.
- Bun models this with two contributions on the native `MessagePort`: `m_hasRef` (an event-loop ref plus a self-reference, so the native object outlives its JS wrapper while explicitly ref'd) and a listener-driven event-loop ref. `hasRef()` reports either being held.
- The native `MessagePort` is refcounted; its JS wrapper holds one reference, `m_hasRef` holds one, and code paths that run on a port take a temporary one (`Ref protectedThis`) when they may drop one of those. Dropping the last reference destroys the object immediately, so a method that drops a reference and continues needs the caller to hold another.
- `onDidChangeListener` is a hook `EventTarget` invokes after a listener was actually added (`Add`), actually removed (`Remove`), or the whole list was cleared (`Clear`); duplicates and removals of absent listeners do not invoke it. `MessagePort` uses it to count `'message'` listeners.
- A `ScriptExecutionContext` is the native per-global object that ports, channels and workers register on. Normal teardown (process exit, worker exit) runs a stop phase over those objects before the context goes away; a global collected on a live VM (`ShadowRealm`, a test-isolation global) skips that and only notifies them from the context's destructor (`contextDestroyed()`).
- node's `on()`/`off()`/`removeAllListeners()` on a port are a shim in src/js/node/worker_threads.ts over the native `addEventListener`/`removeEventListener`, which is why one native hook covers the node-style and web-style APIs. The worker stdio streams in the same file are `Readable`/`Writable` objects fed by internal MessagePorts; the readable refs its port while it has a consumer so unconsumed data keeps the thread alive.

<details>
<summary>hasRef() / exit probe: node v26.3.0, bun 1.4.0 (main), this branch</summary>

Each row is a fresh `MessageChannel` with the peer kept reachable; `f`/`g` are no-op functions. "exits" means the process exited on its own; "alive" means it was still running 400ms later.

| scenario on port1 | node | main | this PR |
| --- | --- | --- | --- |
| ref; on; off | false, exits | true, alive | false, exits |
| on; ref; off | false, exits | true, alive | false, exits |
| ref; addEventListener; removeEventListener | false, exits | true, alive | false, exits |
| ref; once; message delivered | false, exits | true, alive | false, exits |
| ref; onmessage=null (nothing set) | true, alive | false, exits | true, alive |
| on f; onmessage=null | true, alive | false, exits | true, alive |
| on f; onmessage=g; onmessage=null | true, alive | false, exits | true, alive |
| ref; on f; onmessage=null | true, alive | false, exits | true, alive |
| onmessage={} | true | false | true |
| onmessage=f; onmessage={} | false | false | true |
| onmessage={}; onmessage=null | true | false | false |
| ref; on; removeAllListeners('message') | true, alive | true, alive | false, exits |
| ref; on; removeAllListeners() | true, alive | true, alive | false, exits |
| unref; on | true, alive | false, exits | false, exits |
| ref; onmessage=f; onmessage=null | false, exits | false, exits | false, exits |
| onmessage=f; onmessage=null | false, exits | false, exits | false, exits |
| onmessage=f; onmessage='str' | false | false | false |
| onmessage=f; unref; onmessage=g | true, alive | true, alive | true, alive |
| ref; on f; on g; off f | true, alive | true, alive | true, alive |
| ref; off (never added) | true, alive | true, alive | true, alive |
| ref; removeEventListener (never added) | true, alive | true, alive | true, alive |
| ref; on close; off close | true, alive | true, alive | true, alive |
| ref; on messageerror; off messageerror | true, alive | true, alive | true, alive |
| on; off; on | true, alive | true, alive | true, alive |
| ref; on; off; on | true, alive | true, alive | true, alive |
| ref; on; off; ref | true, alive | true, alive | true, alive |
| ref / on / on; unref / on; unref; ref / unref; ref | as node | as node | as node |

Worker stdin probe (parent writes two chunks and ends; the worker pauses in the first `'data'` handler and resumes from an unref'd timer once EOF has been received): node and main report both chunks and `'end'` and exit 0; the native change alone made the worker exit 0 after the first chunk; with the `makePortReadable` change it matches node and main again.

</details>

<details>
<summary>Earlier revision of this description</summary>

The first revision of this PR contained only the hook release, the setter change and the `releaseJsRef()` consolidation. Review of that revision turned up the stdio readable's dependence on the old release timing, the unprotected `contextDestroyed()` path, and the unpinned non-callable-object `onmessage` behavior; the current revision adds the fixes and tests for all three. Its internal-caller analysis claimed the stdio readable was "done with the port" when it dropped its listener at EOF, which was wrong for a consumer that still has buffered data; that is the `makePortReadable` bullet above.

</details>
