### PR TITLE
HTMLRewriter: fail the transformed body when the input stream is already errored

### DIFF
--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -715,10 +715,13 @@ pub struct RewriterPipe {
     /// Input EOF arrived while a suspension or output backpressure kept us
     /// from calling `end_rewrite()`; run it once unblocked.
     input_ended: Cell<bool>,
-    /// `true` while a JS-pump `.then()` reaction (attached in
+    /// `true` while the JS pump's result (the `assign_to_stream` return value
+    /// or, if that is a pending promise, its `.then()` reaction attached in
     /// [`Self::wire_input`]) is still owed. The generated `${controller}__close`
     /// drops its error argument, so `end_from_stream` defers terminal work to
-    /// the reaction (which carries the real error) while this is set.
+    /// that result (which carries the real error) while this is set. Armed
+    /// before the pump is entered: a stream that is already errored or closed
+    /// settles the pump synchronously, inside `assign_to_stream`.
     js_pump_reaction_pending: Cell<bool>,
     /// Bytes accepted from the input while suspended or output-backpressured.
     pending_input: JsCell<Vec<u8>>,
@@ -1145,49 +1148,44 @@ impl RewriterPipe {
         // GC destructor), so it owns a ref until `release_pump_ref`.
         this.pump_controller_attached.set(true);
         this.ref_();
+        // A stream that is already errored (or closed) settles the pump inside
+        // `assign_to_stream`, calling `controller.close(error)` / `end()` (which
+        // reach `end_from_stream` without the error) before the pump promise
+        // settles. Arm the deferral first so the pump's result, handled below,
+        // is the terminal signal whether it settles now or later.
+        this.js_pump_reaction_pending.set(true);
         let assignment_result =
             JSSink::<RewriterPipe>::assign_to_stream(global, stream.value, pipe.into());
         assignment_result.ensure_still_alive();
 
-        if let Some(err) = assignment_result.to_error() {
-            this.end_from_stream(Some(StreamError::JSValue(jsc::strong::Optional::create(
-                err, global,
-            ))));
-            return;
-        }
-
-        if !assignment_result.is_empty_or_undefined_or_null() {
-            if let Some(promise) = assignment_result.as_any_promise() {
-                match promise.status() {
-                    jsc::js_promise::Status::Pending => {
-                        this.js_pump_reaction_pending.set(true);
-                        assignment_result.then_with_value(
-                            global,
-                            this.cell.get(),
-                            on_resolve_input_stream_shim,
-                            on_reject_input_stream_shim,
-                        );
-                        return;
-                    }
-                    jsc::js_promise::Status::Fulfilled => {
-                        this.end_from_stream(None);
-                        return;
-                    }
-                    jsc::js_promise::Status::Rejected => {
-                        promise.set_handled(global.vm());
-                        let result = promise.result(global.vm());
-                        this.end_from_stream(Some(StreamError::JSValue(
-                            jsc::strong::Optional::create(result, global),
-                        )));
-                        return;
-                    }
+        let err = if let Some(err) = assignment_result.to_error() {
+            Some(err)
+        } else if let Some(promise) = assignment_result.as_any_promise() {
+            match promise.status() {
+                jsc::js_promise::Status::Pending => {
+                    assignment_result.then_with_value(
+                        global,
+                        this.cell.get(),
+                        on_resolve_input_stream_shim,
+                        on_reject_input_stream_shim,
+                    );
+                    return;
+                }
+                jsc::js_promise::Status::Fulfilled => None,
+                jsc::js_promise::Status::Rejected => {
+                    promise.set_handled(global.vm());
+                    Some(promise.result(global.vm()))
                 }
             }
-        }
-
-        // undefined/null: the stream drained synchronously inside
-        // assignToStream.
-        this.end_from_stream(None);
+        } else {
+            // undefined/null: the stream drained synchronously inside
+            // assignToStream.
+            None
+        };
+        this.js_pump_reaction_pending.set(false);
+        this.end_from_stream(
+            err.map(|err| StreamError::JSValue(jsc::strong::Optional::create(err, global))),
+        );
     }
 
     /// `PendingValue::on_start_streaming` — the output Response's body is
@@ -1286,12 +1284,12 @@ impl RewriterPipe {
         self.detach_input_source(false);
 
         if self.js_pump_reaction_pending.get() {
-            // The pump-promise `.then()` reaction is the single terminal
-            // authority on the JS-pump path: `rsisAbrupt` calls
-            // `controller.close(error)` synchronously (the generated `__close`
-            // drops the argument) before rejecting the pump promise, so running
-            // `end_rewrite` here would resolve the body with truncated output
-            // and pre-empt the reject reaction.
+            // The pump's result (handled in `wire_input`, or by its `.then()`
+            // reaction) is the single terminal authority on the JS-pump path:
+            // `rsisAbrupt` calls `controller.close(error)` (the generated
+            // `__close` drops the argument) before rejecting the pump promise,
+            // so running `end_rewrite` here would resolve the body with
+            // truncated output and pre-empt the rejection.
             return;
         }
 

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -715,14 +715,6 @@ pub struct RewriterPipe {
     /// Input EOF arrived while a suspension or output backpressure kept us
     /// from calling `end_rewrite()`; run it once unblocked.
     input_ended: Cell<bool>,
-    /// `true` while the JS pump's result (the `assign_to_stream` return value
-    /// or, if that is a pending promise, its `.then()` reaction attached in
-    /// [`Self::wire_input`]) is still owed. The generated `${controller}__close`
-    /// drops its error argument, so `end_from_stream` defers terminal work to
-    /// that result (which carries the real error) while this is set. Armed
-    /// before the pump is entered: a stream that is already errored or closed
-    /// settles the pump synchronously, inside `assign_to_stream`.
-    js_pump_reaction_pending: Cell<bool>,
     /// Bytes accepted from the input while suspended or output-backpressured.
     pending_input: JsCell<Vec<u8>>,
     high_water_mark: Cell<BlobSizeType>,
@@ -929,7 +921,6 @@ impl RewriterPipe {
             context,
             input_source: Cell::new(SourceHandle::None),
             input_ended: Cell::new(false),
-            js_pump_reaction_pending: Cell::new(false),
             pending_input: JsCell::new(Vec::new()),
             high_water_mark: Cell::new(16384),
             output: Cell::new(None),
@@ -1148,44 +1139,52 @@ impl RewriterPipe {
         // GC destructor), so it owns a ref until `release_pump_ref`.
         this.pump_controller_attached.set(true);
         this.ref_();
-        // A stream that is already errored (or closed) settles the pump inside
-        // `assign_to_stream`, calling `controller.close(error)` / `end()` (which
-        // reach `end_from_stream` without the error) before the pump promise
-        // settles. Arm the deferral first so the pump's result, handled below,
-        // is the terminal signal whether it settles now or later.
-        this.js_pump_reaction_pending.set(true);
+        // The pump's result ends the rewrite on this path (the controller's
+        // `close()`/`end()` do not; see the `JsSinkType` impl). A stream that
+        // is already errored or closed settles it inside `assign_to_stream`,
+        // which is what the settled branches below are for.
         let assignment_result =
             JSSink::<RewriterPipe>::assign_to_stream(global, stream.value, pipe.into());
         assignment_result.ensure_still_alive();
 
-        let err = if let Some(err) = assignment_result.to_error() {
-            Some(err)
-        } else if let Some(promise) = assignment_result.as_any_promise() {
-            match promise.status() {
-                jsc::js_promise::Status::Pending => {
-                    assignment_result.then_with_value(
-                        global,
-                        this.cell.get(),
-                        on_resolve_input_stream_shim,
-                        on_reject_input_stream_shim,
-                    );
-                    return;
-                }
-                jsc::js_promise::Status::Fulfilled => None,
-                jsc::js_promise::Status::Rejected => {
-                    promise.set_handled(global.vm());
-                    Some(promise.result(global.vm()))
+        if let Some(err) = assignment_result.to_error() {
+            this.end_from_stream(Some(StreamError::JSValue(jsc::strong::Optional::create(
+                err, global,
+            ))));
+            return;
+        }
+
+        if !assignment_result.is_empty_or_undefined_or_null() {
+            if let Some(promise) = assignment_result.as_any_promise() {
+                match promise.status() {
+                    jsc::js_promise::Status::Pending => {
+                        assignment_result.then_with_value(
+                            global,
+                            this.cell.get(),
+                            on_resolve_input_stream_shim,
+                            on_reject_input_stream_shim,
+                        );
+                        return;
+                    }
+                    jsc::js_promise::Status::Fulfilled => {
+                        this.end_from_stream(None);
+                        return;
+                    }
+                    jsc::js_promise::Status::Rejected => {
+                        promise.set_handled(global.vm());
+                        let result = promise.result(global.vm());
+                        this.end_from_stream(Some(StreamError::JSValue(
+                            jsc::strong::Optional::create(result, global),
+                        )));
+                        return;
+                    }
                 }
             }
-        } else {
-            // undefined/null: the stream drained synchronously inside
-            // assignToStream.
-            None
-        };
-        this.js_pump_reaction_pending.set(false);
-        this.end_from_stream(
-            err.map(|err| StreamError::JSValue(jsc::strong::Optional::create(err, global))),
-        );
+        }
+
+        // undefined/null: the stream drained synchronously inside
+        // assignToStream.
+        this.end_from_stream(None);
     }
 
     /// `PendingValue::on_start_streaming` — the output Response's body is
@@ -1274,7 +1273,9 @@ impl RewriterPipe {
         Writable::Owned(len)
     }
 
-    /// `SinkHandle::end` entry — input EOF or terminal upstream error.
+    /// Input EOF or terminal upstream error. Entered from `SinkHandle::end`
+    /// (native sources) and from the JS pump's result ([`Self::wire_input`],
+    /// `on_resolve_input_stream` / `on_reject_input_stream`).
     pub fn end_from_stream(&self, err: Option<StreamError>) {
         // Detach via `detach_input_source` (not a bare `.set(None)`) so a
         // `JSController`'s `m_sinkPtr` is nulled before any path can free the
@@ -1282,16 +1283,6 @@ impl RewriterPipe {
         // `__controllerDetached`/`__finalize` on freed memory. The upstream
         // already ended, so there is nothing to cancel.
         self.detach_input_source(false);
-
-        if self.js_pump_reaction_pending.get() {
-            // The pump's result (handled in `wire_input`, or by its `.then()`
-            // reaction) is the single terminal authority on the JS-pump path:
-            // `rsisAbrupt` calls `controller.close(error)` (the generated
-            // `__close` drops the argument) before rejecting the pump promise,
-            // so running `end_rewrite` here would resolve the body with
-            // truncated output and pre-empt the rejection.
-            return;
-        }
 
         js_HTMLRewriterTransform::input_stream_set_cached(
             self.cell.get(),
@@ -1677,12 +1668,16 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
         let _ = buf.write_latin1(bytes);
         RewriterPipe::write(self, &StreamResult::Temporary(RawSlice::new(&buf)))
     }
-    fn end(&mut self, err: Option<SysError>) -> bun_sys::Result<()> {
-        self.end_from_stream(err.map(StreamError::Error));
+    // The pump controller's `close()`/`end()` are not terminal: `close(error)`
+    // arrives here without its error (the generated `__close` drops it), and
+    // `readStreamIntoSink` calls it before rejecting the pump promise. The
+    // pump's result ends the rewrite instead (`wire_input`,
+    // `on_resolve_input_stream` / `on_reject_input_stream`), as for
+    // `FetchRequestBodySink`; native sources end it via `SinkHandle::end`.
+    fn end(&mut self, _err: Option<SysError>) -> bun_sys::Result<()> {
         bun_sys::Result::Ok(())
     }
     fn end_from_js(&mut self, _global: &JSGlobalObject) -> bun_sys::Result<JSValue> {
-        self.end_from_stream(None);
         bun_sys::Result::Ok(JSValue::js_number(0.0))
     }
     fn flush(&mut self) -> bun_sys::Result<()> {
@@ -3140,8 +3135,6 @@ fn on_resolve_input_stream(
         return Ok(JSValue::UNDEFINED);
     };
     let this = BackRef::from(this);
-    let this = &*this;
-    this.js_pump_reaction_pending.set(false);
     this.end_from_stream(None);
     Ok(JSValue::UNDEFINED)
 }
@@ -3156,8 +3149,6 @@ fn on_reject_input_stream(
     };
     let err = args[0];
     let this = BackRef::from(this);
-    let this = &*this;
-    this.js_pump_reaction_pending.set(false);
     this.end_from_stream(Some(crate::webcore::streams::StreamError::JSValue(
         jsc::strong::Optional::create(err, global_this),
     )));

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1139,10 +1139,8 @@ impl RewriterPipe {
         // GC destructor), so it owns a ref until `release_pump_ref`.
         this.pump_controller_attached.set(true);
         this.ref_();
-        // The pump's result ends the rewrite on this path (the controller's
-        // `close()`/`end()` do not; see the `JsSinkType` impl). A stream that
-        // is already errored or closed settles it inside `assign_to_stream`,
-        // which is what the settled branches below are for.
+        // An already-errored or already-closed stream settles the pump inside
+        // `assign_to_stream`; the settled branches below are its terminal step.
         let assignment_result =
             JSSink::<RewriterPipe>::assign_to_stream(global, stream.value, pipe.into());
         assignment_result.ensure_still_alive();
@@ -1273,9 +1271,8 @@ impl RewriterPipe {
         Writable::Owned(len)
     }
 
-    /// Input EOF or terminal upstream error. Entered from `SinkHandle::end`
-    /// (native sources) and from the JS pump's result ([`Self::wire_input`],
-    /// `on_resolve_input_stream` / `on_reject_input_stream`).
+    /// Input EOF or terminal upstream error, from `SinkHandle::end` (native
+    /// sources) or from the JS pump's result.
     pub fn end_from_stream(&self, err: Option<StreamError>) {
         // Detach via `detach_input_source` (not a bare `.set(None)`) so a
         // `JSController`'s `m_sinkPtr` is nulled before any path can free the
@@ -1668,12 +1665,9 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
         let _ = buf.write_latin1(bytes);
         RewriterPipe::write(self, &StreamResult::Temporary(RawSlice::new(&buf)))
     }
-    // The pump controller's `close()`/`end()` are not terminal: `close(error)`
-    // arrives here without its error (the generated `__close` drops it), and
-    // `readStreamIntoSink` calls it before rejecting the pump promise. The
-    // pump's result ends the rewrite instead (`wire_input`,
-    // `on_resolve_input_stream` / `on_reject_input_stream`), as for
-    // `FetchRequestBodySink`; native sources end it via `SinkHandle::end`.
+    // Not terminal: the controller's `close(error)` arrives here without its
+    // error, so the pump's result (`wire_input` / the `.then()` reactions) ends
+    // the rewrite instead, as in `FetchRequestBodySink`.
     fn end(&mut self, _err: Option<SysError>) -> bun_sys::Result<()> {
         bun_sys::Result::Ok(())
     }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1139,8 +1139,6 @@ impl RewriterPipe {
         // GC destructor), so it owns a ref until `release_pump_ref`.
         this.pump_controller_attached.set(true);
         this.ref_();
-        // An already-errored or already-closed stream settles the pump inside
-        // `assign_to_stream`; the settled branches below are its terminal step.
         let assignment_result =
             JSSink::<RewriterPipe>::assign_to_stream(global, stream.value, pipe.into());
         assignment_result.ensure_still_alive();
@@ -1271,8 +1269,7 @@ impl RewriterPipe {
         Writable::Owned(len)
     }
 
-    /// Input EOF or terminal upstream error, from `SinkHandle::end` (native
-    /// sources) or from the JS pump's result.
+    /// Input EOF or terminal upstream error (`SinkHandle::end` or the JS pump's result).
     pub fn end_from_stream(&self, err: Option<StreamError>) {
         // Detach via `detach_input_source` (not a bare `.set(None)`) so a
         // `JSController`'s `m_sinkPtr` is nulled before any path can free the
@@ -1665,9 +1662,8 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
         let _ = buf.write_latin1(bytes);
         RewriterPipe::write(self, &StreamResult::Temporary(RawSlice::new(&buf)))
     }
-    // Not terminal: the controller's `close(error)` arrives here without its
-    // error, so the pump's result (`wire_input` / the `.then()` reactions) ends
-    // the rewrite instead, as in `FetchRequestBodySink`.
+    // Not terminal: the controller's `close(error)` arrives without its error,
+    // so the pump's result (`wire_input` / the `.then()` reactions) ends the rewrite.
     fn end(&mut self, _err: Option<SysError>) -> bun_sys::Result<()> {
         bun_sys::Result::Ok(())
     }

--- a/src/runtime/api/html_rewriter.rs
+++ b/src/runtime/api/html_rewriter.rs
@@ -1662,8 +1662,7 @@ impl crate::webcore::sink::JsSinkType for RewriterPipe {
         let _ = buf.write_latin1(bytes);
         RewriterPipe::write(self, &StreamResult::Temporary(RawSlice::new(&buf)))
     }
-    // Not terminal: the controller's `close(error)` arrives without its error,
-    // so the pump's result (`wire_input` / the `.then()` reactions) ends the rewrite.
+    // Not terminal: `close(error)` arrives without its error; the pump's result ends the rewrite.
     fn end(&mut self, _err: Option<SysError>) -> bun_sys::Result<()> {
         bun_sys::Result::Ok(())
     }

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -365,21 +365,32 @@ describe("HTMLRewriter", () => {
       }
     });
 
-    // On the JS-pump path the pump's own settlement decides how the body ends,
-    // because the sink's close() carries no error. So a direct pull() that
-    // closes the controller and then rejects fails the body, whether or not a
-    // handler suspended the rewrite in between (fetch() fails a request with
-    // this body the same way).
-    it.each(["synchronous", "suspending"])(
-      "a direct ReadableStream whose pull() rejects after close() rejects the body (%s handler)",
-      async kind => {
+    // On the JS-pump path the pump's own outcome decides how the body ends,
+    // because the controller's close() carries no error. So a direct pull()
+    // that closes the controller and then fails still fails the body: whether
+    // pull() throws synchronously (the pump reports the failure from inside
+    // transform()) or rejects later, and whether or not a handler suspended
+    // the rewrite in between. fetch() fails a request with this body the same
+    // way.
+    describe.each(["throws", "rejects"])("a direct ReadableStream whose pull() %s after close()", failure => {
+      it.each(["synchronous", "suspending"])("rejects the body (%s handler)", async kind => {
+        const fail = () => {
+          throw new Error("pull failed after close");
+        };
         const stream = new ReadableStream({
           type: "direct",
-          async pull(controller) {
-            controller.write("<p>x</p>");
-            controller.close();
-            throw new Error("pull rejected after close");
-          },
+          pull:
+            failure === "throws"
+              ? controller => {
+                  controller.write("<p>x</p>");
+                  controller.close();
+                  fail();
+                }
+              : async controller => {
+                  controller.write("<p>x</p>");
+                  controller.close();
+                  fail();
+                },
         });
         const handler =
           kind === "suspending"
@@ -390,9 +401,46 @@ describe("HTMLRewriter", () => {
               }
             : { element() {} };
         const res = new HTMLRewriter().on("p", handler).transform(new Response(stream));
-        await expect(res.text()).rejects.toThrow("pull rejected after close");
-      },
-    );
+        await expect(res.text()).rejects.toThrow("pull failed after close");
+      });
+    });
+
+    // The clean counterparts: a direct pull() that finishes the stream
+    // synchronously (or a direct source with no pull() at all) completes the
+    // pump inside transform() without a promise; the document must still be
+    // completed, exactly once.
+    it.each([
+      ["a synchronous pull() that writes and closes", "<p>hi</p>"],
+      ["no pull() at all", ""],
+    ])("control: a direct ReadableStream with %s completes the rewrite", async (_, html) => {
+      const stream = new ReadableStream(
+        html
+          ? {
+              type: "direct",
+              pull(controller) {
+                controller.write(html);
+                controller.close();
+              },
+            }
+          : { type: "direct" },
+      );
+      let endCalls = 0;
+      const res = new HTMLRewriter()
+        .on("p", {
+          element(element) {
+            element.setAttribute("seen", "1");
+          },
+        })
+        .onDocument({
+          end(end) {
+            endCalls++;
+            end.append("<!--end-->", { html: true });
+          },
+        })
+        .transform(new Response(stream));
+      expect(await res.text()).toBe(html ? '<p seen="1">hi</p><!--end-->' : "<!--end-->");
+      expect(endCalls).toBe(1);
+    });
 
     // `fail()` must settle the `WritablePending` slot so a direct `pull()`
     // parked on `await controller.flush(true)` resumes, letting the pump

--- a/test/js/workerd/html-rewriter.test.js
+++ b/test/js/workerd/html-rewriter.test.js
@@ -365,6 +365,35 @@ describe("HTMLRewriter", () => {
       }
     });
 
+    // On the JS-pump path the pump's own settlement decides how the body ends,
+    // because the sink's close() carries no error. So a direct pull() that
+    // closes the controller and then rejects fails the body, whether or not a
+    // handler suspended the rewrite in between (fetch() fails a request with
+    // this body the same way).
+    it.each(["synchronous", "suspending"])(
+      "a direct ReadableStream whose pull() rejects after close() rejects the body (%s handler)",
+      async kind => {
+        const stream = new ReadableStream({
+          type: "direct",
+          async pull(controller) {
+            controller.write("<p>x</p>");
+            controller.close();
+            throw new Error("pull rejected after close");
+          },
+        });
+        const handler =
+          kind === "suspending"
+            ? {
+                async element() {
+                  await setImmediatePromise();
+                },
+              }
+            : { element() {} };
+        const res = new HTMLRewriter().on("p", handler).transform(new Response(stream));
+        await expect(res.text()).rejects.toThrow("pull rejected after close");
+      },
+    );
+
     // `fail()` must settle the `WritablePending` slot so a direct `pull()`
     // parked on `await controller.flush(true)` resumes, letting the pump
     // promise settle and release the input `+1` (`cancel_from_output`
@@ -1066,6 +1095,124 @@ describe("HTMLRewriter", () => {
           threw: true,
         });
       });
+    });
+
+    // A JS ReadableStream body that is already errored when transform() runs
+    // fails the pump synchronously, inside transform() itself. The transformed
+    // body must reject with the stream's error like a direct read of the input
+    // does, instead of resolving as an empty document. (A stream that errors
+    // after transform() returned is covered under "async handlers suspend the
+    // rewrite".)
+    describe("input stream already errored when transform() is called", () => {
+      const erroredInputs = {
+        "error() in start() after enqueuing": () =>
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("<p>partial"));
+              controller.error(new Error("upstream boom"));
+            },
+          }),
+        "error() in start() with nothing enqueued": () =>
+          new ReadableStream({
+            start(controller) {
+              controller.error(new Error("upstream boom"));
+            },
+          }),
+        "error() between construction and transform()": () => {
+          let controller;
+          const stream = new ReadableStream({
+            start(c) {
+              controller = c;
+            },
+          });
+          controller.error(new Error("upstream boom"));
+          return stream;
+        },
+        "error() in start() of a byte stream": () =>
+          new ReadableStream({
+            type: "bytes",
+            start(controller) {
+              controller.error(new Error("upstream boom"));
+            },
+          }),
+      };
+      const shapes = Object.keys(erroredInputs);
+      const erroredInput = shape => new Response(erroredInputs[shape](), { headers: { "content-type": "text/html" } });
+      const rejectedWithUpstreamError = { rejected: true, name: "Error", message: "upstream boom" };
+
+      it.each(shapes)("%s: .text() rejects like a direct read of the input", async shape => {
+        expect(await settle(erroredInput(shape).text())).toEqual(rejectedWithUpstreamError);
+        expect(await settle(rewriter().transform(erroredInput(shape)).text())).toEqual(rejectedWithUpstreamError);
+      });
+
+      it(".arrayBuffer() rejects", async () => {
+        const transformed = rewriter().transform(erroredInput(shapes[0]));
+        expect(await settle(transformed.arrayBuffer())).toEqual(rejectedWithUpstreamError);
+      });
+
+      it("reading .body rejects", async () => {
+        const transformed = rewriter().transform(erroredInput(shapes[0]));
+        expect(await settle(transformed.body.getReader().read())).toEqual(rejectedWithUpstreamError);
+      });
+
+      it("does not invoke onDocument end", async () => {
+        let endCalls = 0;
+        const rw = rewriter().onDocument({
+          end() {
+            endCalls++;
+          },
+        });
+        expect(await settle(rw.transform(erroredInput(shapes[0])).text())).toEqual(rejectedWithUpstreamError);
+        expect(endCalls).toBe(0);
+      });
+
+      it("the transformed body is already failed when transform() returns", async () => {
+        const transformed = rewriter().transform(erroredInput(shapes[0]));
+        // Same rule as "transform() of a body that already failed" above: a
+        // second rewriter chained onto the failed body throws the upstream
+        // error instead of rewriting an empty document.
+        expect(() => rewriter().transform(transformed)).toThrow("upstream boom");
+      });
+
+      it("Bun.serve routes the error to error() instead of sending an empty 200", async () => {
+        const seen = Promise.withResolvers();
+        await using server = Bun.serve({
+          port: 0,
+          error(e) {
+            seen.resolve(e.message);
+            return new Response("handled", { status: 500 });
+          },
+          fetch: () => rewriter().transform(erroredInput(shapes[0])),
+        });
+        const res = await fetch(`http://localhost:${server.port}/`);
+        expect({ status: res.status, body: await res.text() }).toEqual({ status: 500, body: "handled" });
+        expect(await seen.promise).toBe("upstream boom");
+      });
+
+      // The clean counterpart settles the pump inside transform() too; it must
+      // still complete the document, exactly once.
+      it.each(["with a chunk", "empty"])(
+        "control: an input stream already closed (%s) still completes the rewrite",
+        async shape => {
+          const stream = new ReadableStream({
+            start(controller) {
+              if (shape === "with a chunk") controller.enqueue(new TextEncoder().encode("<p>hi</p>"));
+              controller.close();
+            },
+          });
+          let endCalls = 0;
+          const rw = rewriter().onDocument({
+            end(end) {
+              endCalls++;
+              end.append("<!--end-->", { html: true });
+            },
+          });
+          expect(await rw.transform(new Response(stream)).text()).toBe(
+            shape === "with a chunk" ? '<p seen="1">hi</p><!--end-->' : "<!--end-->",
+          );
+          expect(endCalls).toBe(1);
+        },
+      );
     });
   });
 


### PR DESCRIPTION
### Problem

- `HTMLRewriter.transform(response)` where `response` has a JS `ReadableStream` body that is already errored when `transform()` is called returns a Response with an empty, successful body: `.text()` resolves to `""`, and a `Bun.serve` handler returning it sends `200` with `Content-Length: 0`. Reading the same input directly (`response.text()`) rejects with the stream's error.
- Reproduces on 1.4.0 and main for every way of getting there: `controller.error()` inside `start()` (with or without an `enqueue()` first), `controller.error()` between construction and `transform()`, and a `type: "bytes"` stream erroring in `start()`. A stream that errors after `transform()` has returned already rejects correctly (#32927, #36733); this is the synchronous variant. A `type: "direct"` source whose `pull()` closes the controller and then throws synchronously has the same bug: the body resolves with the pre-close output while a direct read of the stream rejects.
- Cause, in `src/runtime/api/html_rewriter.rs`, on the JS-pump input path:
  - `RewriterPipe`'s `JsSinkType::end` / `end_from_js` impls (the targets of the pump controller's `close()` / `end()`) called `end_from_stream`, which ends the rewrite. The controller's `close(error)` loses its error on the way (the generated `__close` drops the argument), and `readStreamIntoSink` calls it before it rejects its promise.
  - The existing guard against that, `js_pump_reaction_pending`, was only armed in `wire_input` after `assign_to_stream` returned a pending promise. An already-errored stream fails the pump inside `assign_to_stream` (`readMany()` throws the stored error, `rsisAbrupt` calls `controller.close(error)` and rejects the pump promise), so the `close()` ran `end_rewrite()` and resolved the body as a complete empty document, and the rejected promise that `wire_input` then saw was ignored because the pipe was already `Done`.

### Fix

- `RewriterPipe`'s `JsSinkType::end` / `end_from_js` no longer end the rewrite, and `js_pump_reaction_pending` is deleted. `end_from_stream` is now only reached from native sources (`SinkHandle::end`, `EndedInline`) and from the pump's result, which `wire_input` already handled for every settled shape (setup threw, fulfilled, rejected, drained inline) and which the `.then()` reactions handle when it settles later.
- Why this is correct: those two impls are only ever entered from the pump controller (`RewriterPipe` creates no standalone sink object, and the native-transform fast path only calls `write()`), every pump path settles its result after calling them, and the result is the only signal on this path that carries the error. The flag was encoding exactly "the pump has been entered and its result is still owed"; making the impls non-terminal says the same thing structurally and closes the window inside `assign_to_stream`. `FetchRequestBodySink`, the other consumer of the same pump, already terminates this way. A pump that finishes cleanly still ends the rewrite through the same `end_from_stream(None)` call, from the result instead of from `end()`.
- Behaviour consequences, deliberate: the transformed body now follows the pump's outcome in every case, so for a `type: "direct"` source the returned `pull()` promise decides, not the `controller.close()` call inside it (`readDirectStream` resolves the pump from the `pull()` promise whenever one is returned). Two shapes change:
  - `pull()` closes the controller and then rejects: the body now fails with a non-suspending handler too (it already did with a suspending one; a synchronous throw after `close()` already rejected a direct read of the same stream; `fetch()` fails a request with that body the same way). Pinned by the new direct-stream tests.
  - `pull()` closes the controller and then returns a promise that never settles: the body now stays pending (it resolved before, only because the `close()` happened inside the window the old flag did not cover; a `close()` after an `await` already left it pending). `fetch()` with that body never finishes either; a plain reader resolves it. The pipe cannot tell this apart from close-then-reject without `readDirectStream` telling it, so it follows the same rule as the other sinks; not covered by a test since the only observable is a hang.
- Verified with `test/js/workerd/html-rewriter.test.js`:
  - new `describe("input stream already errored when transform() is called")` under the #32927 coverage: `.text()` rejects like a direct read for all four input shapes, `.arrayBuffer()` rejects, reading `.body` rejects, `onDocument.end` is not invoked, the body is already failed when `transform()` returns (chaining a second rewriter throws the upstream error), `Bun.serve` routes the error to `error()` instead of sending an empty 200, plus controls that an already-closed input (with a chunk / empty) still completes the document exactly once.
  - new direct-stream matrix next to the existing direct-stream tests: `pull()` that closes and then throws synchronously or rejects later, each with a synchronous and a suspending handler, rejects the body; controls that a synchronous `pull()` which writes and closes, and a direct source with no `pull()`, complete the document exactly once (the inline-drained pump outcome).
  - Unfixed binary (`USE_SYSTEM_BUN=1`): 11 of the 17 new tests fail (the controls and the suspending-handler variants pass); fixed: all 149 tests in the file pass.
  - `bun bd test` over `test/js/workerd/`, `test/js/web/html/`, the HTMLRewriter regression tests and the HTMLRewriter cases in `test/js/bun/io/bun-write.test.js`: 178 pass, 0 fail (1 pre-existing skip).

### Background

- `RewriterPipe` is the native object behind one `transform()` call: it receives the input body's bytes, feeds them through lol-html, and settles the output Response's body when the input ends. `end_from_stream(None)` completes the document; `end_from_stream(Some(err))` fails the body with `err`.
- Input wiring has two paths. Native sources (`fetch()` bodies, `Bun.file()`) are wired directly and report EOF or the real error through `SinkHandle::end`. A JS-created `ReadableStream` goes through the JS pump: `assign_to_stream` creates a sink controller whose `write()` / `close()` / `end()` forward to the pipe's `JsSinkType` impl, runs `readStreamIntoSink` (or `readDirectStream` for `type: "direct"`, which hands that controller to the user's `pull()`), and returns a promise that settles with the pump's outcome, or `undefined` / a thrown value when it finished inline.
- On the pump path the controller's `close(error)` is generated glue that discards the error, so the pump's returned result is the only place the pipe can learn why the input ended.

<details>
<summary>Earlier version of this PR</summary>

The first revision kept `js_pump_reaction_pending` and armed it before calling `assign_to_stream`, clearing it on each synchronously settled branch. Review pointed out that this left the flag meaning exactly "the pump has been entered", at which point the `JsSinkType` impls it was guarding could simply stop being terminal; this revision does that and removes the flag.

</details>
