### PR TITLE
resolver: keep sibling entries whose names differ only in case

### DIFF
--- a/src/collections/Cargo.toml
+++ b/src/collections/Cargo.toml
@@ -11,9 +11,10 @@ workspace = true
 
 [dependencies]
 strum.workspace = true
-# `raw-entry` powers `StringHashMap::{get_hashed, put_static_key_hashed}` — the
-# precomputed-hash probe/insert path the resolver's `DirEntry::add_entry` hot
-# loop uses so it hashes each basename once instead of on every lookup + insert.
+# `raw-entry` powers `StringHashMap::{get_hashed, get_mut_hashed,
+# get_or_put_static_key_hashed}` — the precomputed-hash probe/insert path the
+# resolver's `DirEntry::add_entry` hot loop uses so it hashes each basename once
+# instead of on every lookup + insert.
 hashbrown = { workspace = true, features = ["raw-entry"] }
 # Direct dep purely so its `nightly` feature unifies — makes hashbrown's
 # `Allocator` bound a re-export of `core::alloc::Allocator` instead of the

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -1788,10 +1788,11 @@ impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A>
     /// `get`/`insert`/&c. compute internally for a `[u8]` lookup. Exposed
     /// so a caller that already has the key bytes in hand (and will probe *and*
     /// then insert the same key) can hash once and feed the result to
-    /// [`get_hashed`] / [`put_static_key_hashed`] instead of re-deriving it on
-    /// each call. The resolver's `DirEntry::add_entry` does precisely this: one
-    /// case-insensitive probe against the previous-generation directory map,
-    /// one insert into the new one, same (lowercased) basename bytes.
+    /// [`get_hashed`] / [`get_mut_hashed`] / [`get_or_put_static_key_hashed`]
+    /// instead of re-deriving it on each call. The resolver's
+    /// `DirEntry::add_entry` does precisely this: one probe against the
+    /// previous-generation directory map, one insert into the new one, same
+    /// (lowercased) basename bytes.
     #[inline]
     pub fn hash_key(&self, key: &[u8]) -> u64 {
         use core::hash::BuildHasher;
@@ -1808,31 +1809,52 @@ impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A>
             .map(|(_, v)| v)
     }
 
-    /// [`put_static_key`] with a caller-supplied hash. `hash` MUST equal
-    /// `self.hash_key(key)` (see [`hash_key`]); the insert trusts it without
-    /// recomputing. Same zero-copy / `'static`-key contract as [`put_static_key`]:
-    /// overwrites the value if the key is already present.
+    /// [`get_hashed`] returning a mutable reference to the stored value.
     #[inline]
-    pub fn put_static_key_hashed(
-        &mut self,
-        hash: u64,
-        key: &'static [u8],
-        value: V,
-    ) -> Result<(), AllocError> {
+    pub fn get_mut_hashed(&mut self, hash: u64, key: &[u8]) -> Option<&mut V> {
         use hashbrown::hash_map::RawEntryMut;
         match self
             .inner
             .raw_entry_mut()
             .from_key_hashed_nocheck(hash, key)
         {
-            RawEntryMut::Occupied(mut e) => {
-                e.insert(value);
-            }
-            RawEntryMut::Vacant(e) => {
-                e.insert_hashed_nocheck(hash, StringHashMapKey::borrowed(key), value);
-            }
+            RawEntryMut::Occupied(e) => Some(e.into_mut()),
+            RawEntryMut::Vacant(_) => None,
         }
-        Ok(())
+    }
+
+    /// [`put_static_key`] with a caller-supplied hash, except that an existing
+    /// value is kept rather than overwritten: `value` is inserted only when
+    /// `key` is absent, and the result says which value is now stored. `hash`
+    /// MUST equal `self.hash_key(key)` (see [`hash_key`]); the single probe
+    /// trusts it without recomputing. Same zero-copy / `'static`-key contract
+    /// as [`put_static_key`].
+    #[inline]
+    pub fn get_or_put_static_key_hashed(
+        &mut self,
+        hash: u64,
+        key: &'static [u8],
+        value: V,
+    ) -> Result<StringHashMapGetOrPut<'_, V>, AllocError> {
+        use hashbrown::hash_map::RawEntryMut;
+        Ok(
+            match self
+                .inner
+                .raw_entry_mut()
+                .from_key_hashed_nocheck(hash, key)
+            {
+                RawEntryMut::Occupied(e) => StringHashMapGetOrPut {
+                    found_existing: true,
+                    value_ptr: e.into_mut(),
+                },
+                RawEntryMut::Vacant(e) => StringHashMapGetOrPut {
+                    found_existing: false,
+                    value_ptr: e
+                        .insert_hashed_nocheck(hash, StringHashMapKey::borrowed(key), value)
+                        .1,
+                },
+            },
+        )
     }
 
     /// Insert `value` under `key` **without copying the key bytes** — the

--- a/src/collections/array_hash_map.rs
+++ b/src/collections/array_hash_map.rs
@@ -1790,9 +1790,8 @@ impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A>
     /// then insert the same key) can hash once and feed the result to
     /// [`get_hashed`] / [`get_mut_hashed`] / [`get_or_put_static_key_hashed`]
     /// instead of re-deriving it on each call. The resolver's
-    /// `DirEntry::add_entry` does precisely this: one probe against the
-    /// previous-generation directory map, one insert into the new one, same
-    /// (lowercased) basename bytes.
+    /// `DirEntry::add_entry` does precisely this: one probe against the previous
+    /// listing, one insert into the new one, same lowercased basename bytes.
     #[inline]
     pub fn hash_key(&self, key: &[u8]) -> u64 {
         use core::hash::BuildHasher;
@@ -1823,12 +1822,9 @@ impl<V, A: Allocator + HashbrownAllocator + Clone + Default> StringHashMap<V, A>
         }
     }
 
-    /// [`put_static_key`] with a caller-supplied hash, except that an existing
-    /// value is kept rather than overwritten: `value` is inserted only when
-    /// `key` is absent, and the result says which value is now stored. `hash`
-    /// MUST equal `self.hash_key(key)` (see [`hash_key`]); the single probe
-    /// trusts it without recomputing. Same zero-copy / `'static`-key contract
-    /// as [`put_static_key`].
+    /// Single-probe get-or-insert with the zero-copy key contract of
+    /// [`put_static_key`]: an existing value is kept and returned, otherwise
+    /// `value` is inserted. `hash` MUST equal `self.hash_key(key)`.
     #[inline]
     pub fn get_or_put_static_key_hashed(
         &mut self,

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -1,4 +1,4 @@
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicPtr, Ordering};
 use std::borrow::Cow;
 use std::io::Write as _;
 
@@ -155,9 +155,105 @@ pub struct Entry {
     pub need_stat: AtomicBool,
 
     pub abs_path: Interned,
+
+    /// Next sibling whose basename ASCII-lowercases to the same `DirEntry::data`
+    /// key (`mod.js` and `Mod.js` in one directory, which only a case-sensitive
+    /// filesystem allows). The map holds the sibling listed first; the others
+    /// hang off it in listing order. Null for nearly every entry. Read and
+    /// written only under `entries_mutex`, like the map itself; the atomic
+    /// exists so the link can be rewritten through a shared reference.
+    next_case_variant: AtomicPtr<Entry>,
 }
 
 impl Entry {
+    /// Picks the entry a lookup for `name` returns out of the chain rooted at
+    /// `head_ptr`, the entry stored under `name`'s lowercased key.
+    ///
+    /// A lone entry satisfies any spelling of `name`: that is what the resolver
+    /// has always done, and what a case-insensitive filesystem does itself. Once
+    /// two siblings share the key the filesystem is known to be case-sensitive,
+    /// so only the sibling spelled byte-for-byte like `name` exists on disk.
+    fn select_case_variant(head_ptr: *mut Entry, name: &[u8]) -> Option<*mut Entry> {
+        // SAFETY: EntryStore slots are never freed (see `dir_entry::EntryStore`).
+        let head = unsafe { &*head_ptr };
+        let mut cur_ptr = head.next_case_variant.load(Ordering::Relaxed);
+        if cur_ptr.is_null() || head.base() == name {
+            return Some(head_ptr);
+        }
+        while !cur_ptr.is_null() {
+            // SAFETY: as above.
+            let cur = unsafe { &*cur_ptr };
+            if cur.base() == name {
+                return Some(cur_ptr);
+            }
+            cur_ptr = cur.next_case_variant.load(Ordering::Relaxed);
+        }
+        None
+    }
+
+    /// Detaches the entry spelled exactly `name` from the chain rooted in
+    /// `slot` (a value slot of the listing being replaced) and returns it, so
+    /// that a directory re-read reuses the entry for the same file instead of
+    /// one for a sibling that merely lowercases alike. Detaching keeps the
+    /// remaining variants findable by the re-read's later iterations; a head
+    /// without successors is left in place, as no other name can match it.
+    fn take_case_variant(slot: &mut *mut Entry, name: &[u8]) -> Option<*mut Entry> {
+        let head_ptr = *slot;
+        // SAFETY: EntryStore slots are never freed.
+        let head = unsafe { &*head_ptr };
+        let mut cur_ptr = head.next_case_variant.load(Ordering::Relaxed);
+        if head.base() == name {
+            if !cur_ptr.is_null() {
+                *slot = cur_ptr;
+                head.next_case_variant
+                    .store(core::ptr::null_mut(), Ordering::Relaxed);
+            }
+            return Some(head_ptr);
+        }
+        let mut prev = head;
+        while !cur_ptr.is_null() {
+            // SAFETY: as above.
+            let cur = unsafe { &*cur_ptr };
+            let after = cur.next_case_variant.load(Ordering::Relaxed);
+            if cur.base() == name {
+                prev.next_case_variant.store(after, Ordering::Relaxed);
+                cur.next_case_variant
+                    .store(core::ptr::null_mut(), Ordering::Relaxed);
+                return Some(cur_ptr);
+            }
+            prev = cur;
+            cur_ptr = after;
+        }
+        None
+    }
+
+    /// Appends `new_ptr` (whose own link must be null) to the chain rooted at
+    /// `head_ptr`. A no-op when it is already chained, which happens if the
+    /// listing reports the same name twice; appending it again would close a
+    /// cycle.
+    fn push_case_variant(head_ptr: *mut Entry, new_ptr: *mut Entry) {
+        let mut cur_ptr = head_ptr;
+        while cur_ptr != new_ptr {
+            // SAFETY: EntryStore slots are never freed.
+            let cur = unsafe { &*cur_ptr };
+            let next = cur.next_case_variant.load(Ordering::Relaxed);
+            if next.is_null() {
+                cur.next_case_variant.store(new_ptr, Ordering::Relaxed);
+                return;
+            }
+            cur_ptr = next;
+        }
+    }
+
+    /// `head_ptr` followed by every case variant chained behind it.
+    fn case_variants(head_ptr: *mut Entry) -> impl Iterator<Item = *mut Entry> {
+        core::iter::successors(Some(head_ptr), |&ptr| {
+            // SAFETY: EntryStore slots are never freed.
+            let next = unsafe { &*ptr }.next_case_variant.load(Ordering::Relaxed);
+            (!next.is_null()).then_some(next)
+        })
+    }
+
     /// Snapshot of the lazily-populated stat cache. `EntryCache` is `Copy`
     /// (3 word-sized fields), so by-value return is free and avoids the
     /// `&self → &interior` aliasing hazard the old `UnsafeCell` accessor had.
@@ -327,6 +423,9 @@ pub mod dir_entry {
     use super::{Entry, EntryStoreBacking};
 
     /// Lowercased-basename → entry-pointer map backing `DirEntry::data`.
+    /// Siblings whose names differ only in case share one key; the value is
+    /// the one listed first and the rest are chained through
+    /// `Entry::next_case_variant`.
     pub(crate) type EntryMap = bun_collections::StringHashMap<*mut Entry>;
 
     /// Process-wide append-only store that owns all `Entry` allocations.
@@ -474,10 +573,14 @@ impl DirEntry {
 
         let stored: *mut Entry = 'brk: {
             if let Some(map) = prev_map {
-                // `data` keys are the lowercased basenames, so an exact match on
-                // `name_lc` is the case-insensitive match — and reuses
-                // `name_hash` instead of re-hashing.
-                if let Some(&existing_ptr) = map.get_hashed(name_hash, name_lc) {
+                // `data` keys are the lowercased basenames (probed with
+                // `name_hash` instead of re-hashing); within the key's chain only
+                // the entry spelled exactly like this one may be reused, since a
+                // differently-cased sibling is a different file.
+                if let Some(existing_ptr) = map
+                    .get_mut_hashed(name_hash, name_lc)
+                    .and_then(|slot| Entry::take_case_variant(slot, name_slice))
+                {
                     // SAFETY: EntryStore-owned pointer, valid for lifetime of store
                     let existing = unsafe { &mut *existing_ptr };
                     // `MutexGuard` stores a `BackRef<Mutex>` (lifetime-erased), so
@@ -559,6 +662,7 @@ impl DirEntry {
                     fd: Fd::INVALID,
                 }));
                 addr_of_mut!((*p).abs_path).write(Interned::EMPTY);
+                addr_of_mut!((*p).next_case_variant).write(AtomicPtr::new(core::ptr::null_mut()));
                 p
             }
         };
@@ -578,9 +682,16 @@ impl DirEntry {
         let key: &'static [u8] =
             unsafe { &*core::ptr::from_ref::<[u8]>((*stored).base_lowercase()) };
         // `(*stored).base_lowercase()` equals `name_lc` byte-for-byte (a fresh
-        // entry interned `name_lc`; a recycled one matched it exactly above), so
-        // `name_hash` is its hash too — insert without re-hashing.
-        self.data.put_static_key_hashed(name_hash, key, stored)?;
+        // entry interned `name_lc`; a recycled one matched `name_slice` exactly
+        // above), so `name_hash` is its hash too — insert without re-hashing.
+        let slot = self
+            .data
+            .get_or_put_static_key_hashed(name_hash, key, stored)?;
+        if slot.found_existing {
+            // A sibling differing only in case was listed first and owns the
+            // key; keep this one reachable behind it instead of dropping it.
+            Entry::push_case_variant(*slot.value_ptr, stored);
+        }
 
         if !I::IS_VOID {
             iterator.next(stored_ref, self.fd);
@@ -617,10 +728,20 @@ impl DirEntry {
         );
     }
 
+    fn lookup<'a>(&'a self, key_lower: &[u8], name: &[u8]) -> Option<EntryLookup<'a>> {
+        let &head = self.data.get(key_lower)?;
+        Some(EntryLookup {
+            entry: Entry::select_case_variant(head, name)?,
+            _marker: core::marker::PhantomData,
+        })
+    }
+
     // `query_` borrow is detached from the returned `Entry` lifetime so callers
     // can pass a slice into the same threadlocal buffer they then mutate. The
-    // lookup key is the lowercased basename; a case-mismatched query still
-    // returns the stored entry.
+    // lookup key is the lowercased basename: a case-mismatched query still
+    // returns the directory's only entry with that key, but once siblings
+    // differing only in case coexist, only the exactly-spelled one is returned
+    // (see `Entry::select_case_variant`).
     pub fn get<'a>(&'a self, query_: &[u8]) -> Option<EntryLookup<'a>> {
         Self::debug_assert_entries_mutex_held();
         if query_.is_empty() || query_.len() > MAX_PATH_BYTES {
@@ -629,31 +750,32 @@ impl DirEntry {
         let mut scratch_lookup_buffer = PathBuffer::uninit();
 
         let query = strings::copy_lowercase_if_needed(query_, &mut scratch_lookup_buffer[..]);
-        let &result_ptr = self.data.get(query)?;
-        Some(EntryLookup {
-            entry: result_ptr,
-            _marker: core::marker::PhantomData,
-        })
+        self.lookup(query, query_)
     }
 
-    /// Looks up a cached entry by name. Takes a `&'static [u8]` that is
-    /// already lowercase, so no per-call lowercasing buffer is needed.
+    /// [`get`](Self::get) for a `&'static [u8]` that is already lowercase, so
+    /// no per-call lowercasing buffer is needed.
     pub(crate) fn get_comptime_query<'a>(
         &'a self,
         query_lower: &'static [u8],
     ) -> Option<EntryLookup<'a>> {
         Self::debug_assert_entries_mutex_held();
-        let &result_ptr = self.data.get(query_lower)?;
-        Some(EntryLookup {
-            entry: result_ptr,
-            _marker: core::marker::PhantomData,
-        })
+        self.lookup(query_lower, query_lower)
     }
 
-    /// True if a cached entry exists for the given already-lowercase name.
+    /// True if [`get_comptime_query`](Self::get_comptime_query) would find an
+    /// entry for the given already-lowercase name.
     pub fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool {
+        self.get_comptime_query(query_lower).is_some()
+    }
+
+    /// Every entry in the listing, including the case variants chained behind
+    /// a shared key, which `data.values()` alone does not reach.
+    pub fn iter_entries(&self) -> impl Iterator<Item = *mut Entry> + '_ {
         Self::debug_assert_entries_mutex_held();
-        self.data.contains_key(query_lower)
+        self.data
+            .values()
+            .flat_map(|&head| Entry::case_variants(head))
     }
 }
 

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -156,25 +156,21 @@ pub struct Entry {
 
     pub abs_path: Interned,
 
-    /// Next sibling whose basename ASCII-lowercases to the same `DirEntry::data`
-    /// key (`mod.js` and `Mod.js` in one directory, which only a case-sensitive
-    /// filesystem allows). The map holds the sibling listed first; the others
-    /// hang off it in listing order. Null for nearly every entry. Read and
-    /// written only under `entries_mutex`, like the map itself; the atomic
-    /// exists so the link can be rewritten through a shared reference.
+    /// Next sibling whose name differs from this one only in case (`mod.js`
+    /// and `Mod.js`, which only a case-sensitive filesystem can both hold).
+    /// `DirEntry::data` holds the first one listed; the rest chain behind it.
+    /// Accessed only under `entries_mutex`, like the map; atomic so it can be
+    /// set through a shared reference.
     next_case_variant: AtomicPtr<Entry>,
 }
 
 impl Entry {
-    /// Picks the entry a lookup for `name` returns out of the chain rooted at
-    /// `head_ptr`, the entry stored under `name`'s lowercased key.
-    ///
-    /// A lone entry satisfies any spelling of `name`: that is what the resolver
-    /// has always done, and what a case-insensitive filesystem does itself. Once
-    /// two siblings share the key the filesystem is known to be case-sensitive,
-    /// so only the sibling spelled byte-for-byte like `name` exists on disk.
-    /// Only the current listing counts: once a re-read finds the other
-    /// sibling gone, the survivor is a lone entry again.
+    /// Resolves a lookup for `name` against the chain rooted at `head_ptr`, the
+    /// entry stored under `name`'s lowercased key. A lone entry matches any
+    /// spelling of `name`, as it always has (and as a case-insensitive
+    /// filesystem itself would). Two or more entries prove the filesystem is
+    /// case-sensitive, so only the one spelled exactly like `name` exists.
+    /// This is decided per listing: the survivor of a re-read is lone again.
     fn select_case_variant(head_ptr: *mut Entry, name: &[u8]) -> Option<*mut Entry> {
         // SAFETY: EntryStore slots are never freed (see `dir_entry::EntryStore`).
         let head = unsafe { &*head_ptr };
@@ -193,12 +189,10 @@ impl Entry {
         None
     }
 
-    /// Detaches the entry spelled exactly `name` from the chain rooted in
-    /// `slot` (a value slot of the listing being replaced) and returns it, so
-    /// that a directory re-read reuses the entry for the same file instead of
-    /// one for a sibling that merely lowercases alike. Detaching keeps the
-    /// remaining variants findable by the re-read's later iterations; a head
-    /// without successors is left in place, as no other name can match it.
+    /// Unlinks and returns the entry spelled exactly `name` from the chain in
+    /// `slot`, a value slot of the listing being re-read, so the new listing
+    /// reuses it; the rest of the chain stays reachable for the names still to
+    /// come. A lone head is left in the slot: no other name can match it.
     fn take_case_variant(slot: &mut *mut Entry, name: &[u8]) -> Option<*mut Entry> {
         let head_ptr = *slot;
         // SAFETY: EntryStore slots are never freed.
@@ -229,10 +223,9 @@ impl Entry {
         None
     }
 
-    /// Appends `new_ptr` (whose own link must be null) to the chain rooted at
-    /// `head_ptr`. A no-op when it is already chained, which happens if the
-    /// listing reports the same name twice; appending it again would close a
-    /// cycle.
+    /// Appends unlinked `new_ptr` to the chain at `head_ptr`. No-op if it is
+    /// already in the chain (a listing that repeats a name), which would
+    /// otherwise close a cycle.
     fn push_case_variant(head_ptr: *mut Entry, new_ptr: *mut Entry) {
         let mut cur_ptr = head_ptr;
         while cur_ptr != new_ptr {
@@ -425,9 +418,7 @@ pub mod dir_entry {
     use super::{Entry, EntryStoreBacking};
 
     /// Lowercased-basename → entry-pointer map backing `DirEntry::data`.
-    /// Siblings whose names differ only in case share one key; the value is
-    /// the one listed first and the rest are chained through
-    /// `Entry::next_case_variant`.
+    /// Names differing only in case share a key; see `Entry::next_case_variant`.
     pub(crate) type EntryMap = bun_collections::StringHashMap<*mut Entry>;
 
     /// Process-wide append-only store that owns all `Entry` allocations.
@@ -575,10 +566,8 @@ impl DirEntry {
 
         let stored: *mut Entry = 'brk: {
             if let Some(map) = prev_map {
-                // `data` keys are the lowercased basenames (probed with
-                // `name_hash` instead of re-hashing); within the key's chain only
-                // the entry spelled exactly like this one may be reused, since a
-                // differently-cased sibling is a different file.
+                // Probe by the lowercased key (reusing `name_hash`), but only
+                // the entry spelled exactly like this one is the same file.
                 if let Some(existing_ptr) = map
                     .get_mut_hashed(name_hash, name_lc)
                     .and_then(|slot| Entry::take_case_variant(slot, name_slice))
@@ -690,8 +679,6 @@ impl DirEntry {
             .data
             .get_or_put_static_key_hashed(name_hash, key, stored)?;
         if slot.found_existing {
-            // A sibling differing only in case was listed first and owns the
-            // key; keep this one reachable behind it instead of dropping it.
             Entry::push_case_variant(*slot.value_ptr, stored);
         }
 
@@ -739,11 +726,8 @@ impl DirEntry {
     }
 
     // `query_` borrow is detached from the returned `Entry` lifetime so callers
-    // can pass a slice into the same threadlocal buffer they then mutate. The
-    // lookup key is the lowercased basename: a case-mismatched query still
-    // returns the directory's only entry with that key, but once siblings
-    // differing only in case coexist, only the exactly-spelled one is returned
-    // (see `Entry::select_case_variant`).
+    // can pass a slice into the same threadlocal buffer they then mutate.
+    // Case handling is `Entry::select_case_variant`'s.
     pub fn get<'a>(&'a self, query_: &[u8]) -> Option<EntryLookup<'a>> {
         Self::debug_assert_entries_mutex_held();
         if query_.is_empty() || query_.len() > MAX_PATH_BYTES {
@@ -755,8 +739,7 @@ impl DirEntry {
         self.lookup(query, query_)
     }
 
-    /// [`get`](Self::get) for a `&'static [u8]` that is already lowercase, so
-    /// no per-call lowercasing buffer is needed.
+    /// [`get`](Self::get) for a name that is already lowercase.
     pub(crate) fn get_comptime_query<'a>(
         &'a self,
         query_lower: &'static [u8],
@@ -765,14 +748,12 @@ impl DirEntry {
         self.lookup(query_lower, query_lower)
     }
 
-    /// True if [`get_comptime_query`](Self::get_comptime_query) would find an
-    /// entry for the given already-lowercase name.
+    /// True if a cached entry exists for the given already-lowercase name.
     pub fn has_comptime_query(&self, query_lower: &'static [u8]) -> bool {
         self.get_comptime_query(query_lower).is_some()
     }
 
-    /// Every entry in the listing, including the case variants chained behind
-    /// a shared key, which `data.values()` alone does not reach.
+    /// Every entry, including the case variants `data.values()` does not reach.
     pub fn iter_entries(&self) -> impl Iterator<Item = *mut Entry> + '_ {
         Self::debug_assert_entries_mutex_held();
         self.data

--- a/src/resolver/fs.rs
+++ b/src/resolver/fs.rs
@@ -173,6 +173,8 @@ impl Entry {
     /// has always done, and what a case-insensitive filesystem does itself. Once
     /// two siblings share the key the filesystem is known to be case-sensitive,
     /// so only the sibling spelled byte-for-byte like `name` exists on disk.
+    /// Only the current listing counts: once a re-read finds the other
+    /// sibling gone, the survivor is a lone entry again.
     fn select_case_variant(head_ptr: *mut Entry, name: &[u8]) -> Option<*mut Entry> {
         // SAFETY: EntryStore slots are never freed (see `dir_entry::EntryStore`).
         let head = unsafe { &*head_ptr };

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -171,16 +171,23 @@ impl<'a> Scanner<'a> {
                 // `path` cached (e.g. `run_env_loader`/`read_dir_info` read the
                 // cwd before the scanner runs), so `read_directory_with_iterator`
                 // returned the cached `EntryMap` without invoking `iterator.next`.
-                // Hash-map iteration order is not stable. Sort by (lowercased)
-                // base name so test-file discovery order is deterministic —
+                // Hash-map iteration order is not stable. Sort by base name so
+                // test-file discovery order is deterministic —
                 // regression/issue/26851 relies on `a_*.test` running before
                 // `b_*.test` under `--bail`.
-                let mut entry_ptrs: Vec<*mut fs::Entry> = entries.data.values().copied().collect();
+                let mut entry_ptrs: Vec<*mut fs::Entry> = {
+                    // The listing must be walked under `entries_mutex`
+                    // (uncontended: nothing else runs before the tests start).
+                    let _entries_lock = self.fs().fs.entries_mutex.lock_guard();
+                    entries.iter_entries().collect()
+                };
                 entry_ptrs.sort_by(|a, b| {
-                    // SAFETY: `EntryMap` stores `*mut Entry` into the
+                    // SAFETY: the listing holds `*mut Entry` into the
                     // process-static `EntryStore`; valid for `'static`.
-                    let (an, bn) = unsafe { ((**a).base_lowercase(), (**b).base_lowercase()) };
-                    an.cmp(bn)
+                    let (a, b) = unsafe { (&**a, &**b) };
+                    a.base_lowercase()
+                        .cmp(b.base_lowercase())
+                        .then_with(|| a.base().cmp(b.base()))
                 });
                 for entry_ptr in entry_ptrs {
                     // SAFETY: `EntryMap` stores `*mut Entry` into the

--- a/src/runtime/cli/test/Scanner.rs
+++ b/src/runtime/cli/test/Scanner.rs
@@ -171,18 +171,17 @@ impl<'a> Scanner<'a> {
                 // `path` cached (e.g. `run_env_loader`/`read_dir_info` read the
                 // cwd before the scanner runs), so `read_directory_with_iterator`
                 // returned the cached `EntryMap` without invoking `iterator.next`.
-                // Hash-map iteration order is not stable. Sort by base name so
-                // test-file discovery order is deterministic —
+                // Hash-map iteration order is not stable. Sort by (lowercased)
+                // base name so test-file discovery order is deterministic —
                 // regression/issue/26851 relies on `a_*.test` running before
                 // `b_*.test` under `--bail`.
                 let mut entry_ptrs: Vec<*mut fs::Entry> = {
-                    // The listing must be walked under `entries_mutex`
-                    // (uncontended: nothing else runs before the tests start).
+                    // `.data` iteration must hold `entries_mutex` (uncontended here).
                     let _entries_lock = self.fs().fs.entries_mutex.lock_guard();
                     entries.iter_entries().collect()
                 };
                 entry_ptrs.sort_by(|a, b| {
-                    // SAFETY: the listing holds `*mut Entry` into the
+                    // SAFETY: `EntryMap` stores `*mut Entry` into the
                     // process-static `EntryStore`; valid for `'static`.
                     let (a, b) = unsafe { (&**a, &**b) };
                     a.base_lowercase()

--- a/test/bundler/esbuild/extra.test.ts
+++ b/test/bundler/esbuild/extra.test.ts
@@ -1,4 +1,5 @@
 import { describe } from "bun:test";
+import { isCaseSensitiveFileSystem } from "harness";
 import { itBundled } from "../expectBundled";
 
 // Tests ported from:
@@ -1781,7 +1782,9 @@ describe("bundler", () => {
     run: true,
   });
   itBundled("extra/CaseSensitiveImport2", {
-    todo: true,
+    // file1.js and File1.js can only coexist on a case-sensitive filesystem;
+    // elsewhere the later fixture overwrites the earlier one.
+    todo: !isCaseSensitiveFileSystem(),
     files: {
       "in.js": `
         import x from "./File1.js"

--- a/test/cli/test/bun-test.test.ts
+++ b/test/cli/test/bun-test.test.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from "bun";
 import { beforeAll, describe, expect, it, test } from "bun:test";
-import { bunEnv, bunExe, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isCaseSensitiveFileSystem, tempDir, tempDirWithFiles, tmpdirSync } from "harness";
 import { mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 
@@ -1746,6 +1746,36 @@ describe.concurrent("test file discovery (scanner)", () => {
     expect(stdout).toContain("RAN solo");
     expect(stdout).not.toContain("RAN other");
     expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test.skipIf(!isCaseSensitiveFileSystem())("runs test files whose names differ only in case", async () => {
+    // Discovery walks the cwd from the directory cache (it is already cached
+    // by the time the scanner runs) and lists nested directories fresh; each
+    // file found is then loaded through the same cache, which keys entries by
+    // lowercased name. Every step has to keep the two spellings apart: before,
+    // this ran 2 tests across 3 files.
+    using dir = tempDir("scanner-case-variants", {
+      "a.test.ts": `import { test } from "bun:test"; test("root lower", () => { console.log("RAN root lower"); });`,
+      "A.test.ts": `import { test } from "bun:test"; test("root upper", () => { console.log("RAN root upper"); });`,
+      "nested/b.test.ts": `import { test } from "bun:test"; test("nested lower", () => { console.log("RAN nested lower"); });`,
+      "nested/B.test.ts": `import { test } from "bun:test"; test("nested upper", () => { console.log("RAN nested upper"); });`,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stdout).toContain("RAN root lower");
+    expect(stdout).toContain("RAN root upper");
+    expect(stdout).toContain("RAN nested lower");
+    expect(stdout).toContain("RAN nested upper");
+    expect(stderr).toContain(" 4 pass");
     expect(exitCode).toBe(0);
   });
 });

--- a/test/harness.ts
+++ b/test/harness.ts
@@ -1457,6 +1457,28 @@ export function tmpdirSync(pattern: string = "bun.test."): string {
   return fs.mkdtempSync(join(fs.realpathSync.native(os.tmpdir()), pattern));
 }
 
+let caseSensitiveFileSystem: boolean | undefined;
+
+/**
+ * Whether the filesystem holding the temporary directories (`tempDir`,
+ * `tempDirWithFiles`, the bundler test fixtures) treats names that differ only
+ * in case as different files. Usually true on Linux and false on macOS and
+ * Windows, but it depends on the mounted filesystem, so it is probed once on
+ * first use.
+ */
+export function isCaseSensitiveFileSystem(): boolean {
+  if (caseSensitiveFileSystem === undefined) {
+    const dir = tmpdirSync("bun.case-probe.");
+    try {
+      fs.writeFileSync(join(dir, "probe"), "");
+      caseSensitiveFileSystem = !fs.existsSync(join(dir, "PROBE"));
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+  return caseSensitiveFileSystem;
+}
+
 export async function runBunInstall(
   env: NodeJS.Dict<string>,
   cwd: string,

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   realpathSync,
+  renameSync,
   symlinkSync,
   unlinkSync,
   writeFileSync,
@@ -22,7 +23,7 @@ import {
   tempDir,
   tempDirWithFiles,
 } from "harness";
-import { join, resolve, sep } from "path";
+import { basename, join, resolve, sep } from "path";
 
 const fixture = (...segs: string[]) => resolve(import.meta.dir, "fixtures", ...segs);
 
@@ -1711,6 +1712,32 @@ describe.concurrent("dot specifiers resolve to the directory index, not a siblin
 });
 
 describe("sibling files whose names differ only in case", () => {
+  // Bundles `entry` in-process and returns the on-disk spelling of every
+  // module it pulled in (bun build prints a `// <path>` line above each module
+  // with content), or the build errors. In-process because later Bun.build
+  // calls in a process run at a higher resolver generation and therefore
+  // re-read the directories an earlier build cached, which is the path the
+  // re-read tests exercise.
+  async function bundledModules(dir: string, entry: string): Promise<string[]> {
+    const result = await Bun.build({ entrypoints: [join(dir, entry)], throw: false });
+    if (!result.success) return result.logs.map(log => log.message);
+    const bundle = await result.outputs[0].text();
+    return Array.from(bundle.matchAll(/^\/\/ (.+)$/gm), match => basename(match[1])).filter(name => name !== entry);
+  }
+
+  // The generation is bumped by the bundle thread once it has drained its
+  // queue, which can land after the previous build's promise has already
+  // resolved; a build enqueued before that still sees the old listing. Each
+  // attempt is itself a build, so a later attempt re-reads, provided no other
+  // test keeps the queue from draining: the tests using this are serial.
+  async function expectBundledModulesAfterChange(dir: string, entry: string, expected: string[]) {
+    let actual = await bundledModules(dir, entry);
+    for (let attempt = 0; attempt < 50 && !Bun.deepEquals(actual, expected); attempt++) {
+      actual = await bundledModules(dir, entry);
+    }
+    expect(actual).toEqual(expected);
+  }
+
   // The directory cache keys entries by lowercased name, so each of these
   // used to return whichever of the two files readdir listed last. Only a
   // case-sensitive filesystem can hold both files at once.
@@ -1820,59 +1847,84 @@ describe("sibling files whose names differ only in case", () => {
       });
     });
 
-    it.concurrent("re-reading a directory between Bun.build calls tracks added and removed variants", async () => {
-      // Later Bun.build calls in a process run at a higher resolver generation,
-      // so they re-read an already cached directory in place, carrying the
-      // entries of still-present files over. Runs in-process because that is
-      // what makes the later builds take the re-read path.
+    it.serial("re-reading a directory between Bun.build calls tracks added and removed variants", async () => {
       using dir = tempDir("resolve-case-reread", {
-        "mod.mjs": `export const who = "lower";`,
-        "Mod.mjs": `export const who = "UPPER";`,
+        "mod.mjs": `console.log("lower");`,
+        "Mod.mjs": `console.log("UPPER");`,
         "two.mjs": `
-          import { who as lower } from "./mod.mjs";
-          import { who as upper } from "./Mod.mjs";
-          console.log(lower, upper);
+          import "./mod.mjs";
+          import "./Mod.mjs";
         `,
         "three.mjs": `
-          import { who as lower } from "./mod.mjs";
-          import { who as upper } from "./Mod.mjs";
-          import { who as shout } from "./MOD.mjs";
-          console.log(lower, upper, shout);
+          import "./mod.mjs";
+          import "./Mod.mjs";
+          import "./MOD.mjs";
         `,
         "lower-shout.mjs": `
-          import { who as lower } from "./mod.mjs";
-          import { who as shout } from "./MOD.mjs";
-          console.log(lower, shout);
+          import "./mod.mjs";
+          import "./MOD.mjs";
         `,
-        "upper.mjs": `import { who } from "./Mod.mjs"; console.log(who);`,
+        "upper.mjs": `import "./Mod.mjs";`,
       });
-      const build = async (entry: string) => {
-        const result = await Bun.build({ entrypoints: [join(String(dir), entry)], throw: false });
-        if (!result.success) return result.logs.map(log => log.message);
-        const bundle = await result.outputs[0].text();
-        return Array.from(bundle.matchAll(/"(lower|UPPER|SHOUT)"/g), match => match[1]);
-      };
-      // The generation is bumped by the bundle thread once it has drained its
-      // queue, which can land after the previous build's promise has already
-      // resolved; a build enqueued before that still sees the old listing.
-      // Each attempt is itself a build, so a later attempt always re-reads.
-      const buildAfterChange = async (entry: string, expected: string[]) => {
-        let actual = await build(entry);
-        for (let attempt = 0; attempt < 50 && !Bun.deepEquals(actual, expected); attempt++) {
-          actual = await build(entry);
-        }
-        expect(actual).toEqual(expected);
-      };
 
-      expect(await build("two.mjs")).toEqual(["lower", "UPPER"]);
+      expect(await bundledModules(String(dir), "two.mjs")).toEqual(["mod.mjs", "Mod.mjs"]);
 
-      writeFileSync(join(String(dir), "MOD.mjs"), `export const who = "SHOUT";`);
-      await buildAfterChange("three.mjs", ["lower", "UPPER", "SHOUT"]);
+      writeFileSync(join(String(dir), "MOD.mjs"), `console.log("SHOUT");`);
+      await expectBundledModulesAfterChange(String(dir), "three.mjs", ["mod.mjs", "Mod.mjs", "MOD.mjs"]);
 
       unlinkSync(join(String(dir), "Mod.mjs"));
-      await buildAfterChange("lower-shout.mjs", ["lower", "SHOUT"]);
-      await buildAfterChange("upper.mjs", ['Could not resolve: "./Mod.mjs"']);
+      await expectBundledModulesAfterChange(String(dir), "lower-shout.mjs", ["mod.mjs", "MOD.mjs"]);
+      await expectBundledModulesAfterChange(String(dir), "upper.mjs", ['Could not resolve: "./Mod.mjs"']);
     });
+
+    // Exact spelling is only required while several spellings exist; once the
+    // other file is gone, the survivor is a lone entry again and any spelling
+    // resolves to it, as for any other lone file. Both orders are run because
+    // which of the two files readdir lists first (and so which one the re-read
+    // has to unhook from the other) depends on the filesystem.
+    it.serial.each([
+      ["mod.mjs", "Mod.mjs"],
+      ["Mod.mjs", "mod.mjs"],
+    ])("deleting %s between Bun.build calls makes other spellings resolve to %s again", async (removed, kept) => {
+      using dir = tempDir("resolve-case-shrink", {
+        "mod.mjs": `console.log("lower");`,
+        "Mod.mjs": `console.log("UPPER");`,
+        "both.mjs": `
+          import "./mod.mjs";
+          import "./Mod.mjs";
+        `,
+        "shout.mjs": `import "./MOD.mjs";`,
+        "removed.mjs": `import "./${removed}";`,
+      });
+
+      expect(await bundledModules(String(dir), "both.mjs")).toEqual(["mod.mjs", "Mod.mjs"]);
+      expect(await bundledModules(String(dir), "shout.mjs")).toEqual(['Could not resolve: "./MOD.mjs"']);
+
+      unlinkSync(join(String(dir), removed));
+      await expectBundledModulesAfterChange(String(dir), "removed.mjs", [kept]);
+      await expectBundledModulesAfterChange(String(dir), "shout.mjs", [kept]);
+    });
+  });
+
+  it.serial("re-reading a directory between Bun.build calls picks up a case-only rename", async () => {
+    // The re-read only reuses the previous entry for a name spelled exactly
+    // the same, so the renamed file gets an entry carrying its new spelling
+    // (the old one kept resolving to the old path, which on a case-sensitive
+    // filesystem no longer exists). Works on any filesystem: a case-only
+    // rename is allowed on case-insensitive ones too.
+    using dir = tempDir("resolve-case-rename", {
+      "x.mjs": `console.log("x");`,
+      "before.mjs": `import "./x.mjs";`,
+      "exact.mjs": `import "./X.mjs";`,
+      "old-spelling.mjs": `import "./x.mjs";`,
+    });
+
+    expect(await bundledModules(String(dir), "before.mjs")).toEqual(["x.mjs"]);
+
+    renameSync(join(String(dir), "x.mjs"), join(String(dir), "X.mjs"));
+    await expectBundledModulesAfterChange(String(dir), "exact.mjs", ["X.mjs"]);
+    // A lone file still resolves under any spelling, but to its current name.
+    await expectBundledModulesAfterChange(String(dir), "old-spelling.mjs", ["X.mjs"]);
   });
 
   it.concurrent("a specifier whose case differs from the only file of that name still resolves", async () => {

--- a/test/js/bun/resolve/resolve.test.ts
+++ b/test/js/bun/resolve/resolve.test.ts
@@ -1,7 +1,27 @@
 import { pathToFileURL } from "bun";
 import { describe, expect, it, test } from "bun:test";
-import { chmodSync, chownSync, mkdirSync, readFileSync, realpathSync, symlinkSync, writeFileSync } from "fs";
-import { bunEnv, bunExe, bunRun, isLinux, isMacOS, isWindows, joinP, tempDir, tempDirWithFiles } from "harness";
+import {
+  chmodSync,
+  chownSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import {
+  bunEnv,
+  bunExe,
+  bunRun,
+  isCaseSensitiveFileSystem,
+  isLinux,
+  isMacOS,
+  isWindows,
+  joinP,
+  tempDir,
+  tempDirWithFiles,
+} from "harness";
 import { join, resolve, sep } from "path";
 
 const fixture = (...segs: string[]) => resolve(import.meta.dir, "fixtures", ...segs);
@@ -1687,5 +1707,184 @@ describe.concurrent("dot specifiers resolve to the directory index, not a siblin
     expect(stderr).toBe("");
     expect(stdout).toBe("index\n");
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("sibling files whose names differ only in case", () => {
+  // The directory cache keys entries by lowercased name, so each of these
+  // used to return whichever of the two files readdir listed last. Only a
+  // case-sensitive filesystem can hold both files at once.
+  describe.skipIf(!isCaseSensitiveFileSystem())("on a case-sensitive filesystem", () => {
+    it.concurrent("import loads each file and Bun.resolveSync returns each path", async () => {
+      using dir = tempDir("resolve-case-esm", {
+        "mod.mjs": `export const who = "lower";`,
+        "Mod.mjs": `export const who = "UPPER";`,
+        "entry.mjs": `
+          import { who as lower } from "./mod.mjs";
+          import { who as upper } from "./Mod.mjs";
+          console.log(
+            JSON.stringify({
+              lower,
+              upper,
+              resolved: [Bun.resolveSync("./mod.mjs", import.meta.dir), Bun.resolveSync("./Mod.mjs", import.meta.dir)],
+            }),
+          );
+        `,
+      });
+      const result = await bunRun(join(String(dir), "entry.mjs"));
+      expect(result).toSpawn();
+      expect(JSON.parse(result.stdout)).toEqual({
+        lower: "lower",
+        upper: "UPPER",
+        resolved: [join(String(dir), "mod.mjs"), join(String(dir), "Mod.mjs")],
+      });
+    });
+
+    it.concurrent("require loads each file and require.resolve returns each path", async () => {
+      using dir = tempDir("resolve-case-cjs", {
+        "readme.js": `module.exports = "lower";`,
+        "README.js": `module.exports = "UPPER";`,
+        "entry.js": `
+          console.log(
+            JSON.stringify({
+              lower: require("./readme.js"),
+              upper: require("./README.js"),
+              resolved: [require.resolve("./readme.js"), require.resolve("./README.js")],
+            }),
+          );
+        `,
+      });
+      const result = await bunRun(join(String(dir), "entry.js"));
+      expect(result).toSpawn();
+      expect(JSON.parse(result.stdout)).toEqual({
+        lower: "lower",
+        upper: "UPPER",
+        resolved: [join(String(dir), "readme.js"), join(String(dir), "README.js")],
+      });
+    });
+
+    it.concurrent("an extensionless specifier picks the file spelled like the specifier", async () => {
+      using dir = tempDir("resolve-case-extensionless", {
+        "util.ts": `export const who = "lower";`,
+        "Util.ts": `export const who = "UPPER";`,
+        "entry.ts": `
+          import { who as lower } from "./util";
+          import { who as upper } from "./Util";
+          console.log(JSON.stringify({ lower, upper }));
+        `,
+      });
+      const result = await bunRun(join(String(dir), "entry.ts"));
+      expect(result).toSpawn();
+      expect(JSON.parse(result.stdout)).toEqual({ lower: "lower", upper: "UPPER" });
+    });
+
+    it.concurrent("a spelling that matches neither file does not resolve", () => {
+      using dir = tempDir("resolve-case-neither", {
+        "mod.mjs": "",
+        "Mod.mjs": "",
+      });
+      expect(Bun.resolveSync("./mod.mjs", String(dir))).toBe(join(String(dir), "mod.mjs"));
+      expect(Bun.resolveSync("./Mod.mjs", String(dir))).toBe(join(String(dir), "Mod.mjs"));
+      expect(() => Bun.resolveSync("./MOD.mjs", String(dir))).toThrow("Cannot find module './MOD.mjs'");
+      expect(() => Bun.resolveSync("./MOD", String(dir))).toThrow("Cannot find module './MOD'");
+    });
+
+    it.concurrent("directories reached through a symlink each resolve to their own real path", async () => {
+      // The real path of a directory below a symlink is cached on the parent
+      // listing's entry for it, so `lib` and `Lib` used to share one.
+      using dir = tempDir("resolve-case-dirs", {
+        "real/lib/x.mjs": `export const who = "lower";`,
+        "real/Lib/x.mjs": `export const who = "UPPER";`,
+        "entry.mjs": `
+          import { who as lower } from "./link/lib/x.mjs";
+          import { who as upper } from "./link/Lib/x.mjs";
+          console.log(
+            JSON.stringify({
+              lower,
+              upper,
+              resolved: [
+                Bun.resolveSync("./link/lib/x.mjs", import.meta.dir),
+                Bun.resolveSync("./link/Lib/x.mjs", import.meta.dir),
+              ],
+            }),
+          );
+        `,
+      });
+      symlinkSync("real", join(String(dir), "link"), "dir");
+      const result = await bunRun(join(String(dir), "entry.mjs"));
+      expect(result).toSpawn();
+      expect(JSON.parse(result.stdout)).toEqual({
+        lower: "lower",
+        upper: "UPPER",
+        resolved: [join(String(dir), "real", "lib", "x.mjs"), join(String(dir), "real", "Lib", "x.mjs")],
+      });
+    });
+
+    it.concurrent("re-reading a directory between Bun.build calls tracks added and removed variants", async () => {
+      // Later Bun.build calls in a process run at a higher resolver generation,
+      // so they re-read an already cached directory in place, carrying the
+      // entries of still-present files over. Runs in-process because that is
+      // what makes the later builds take the re-read path.
+      using dir = tempDir("resolve-case-reread", {
+        "mod.mjs": `export const who = "lower";`,
+        "Mod.mjs": `export const who = "UPPER";`,
+        "two.mjs": `
+          import { who as lower } from "./mod.mjs";
+          import { who as upper } from "./Mod.mjs";
+          console.log(lower, upper);
+        `,
+        "three.mjs": `
+          import { who as lower } from "./mod.mjs";
+          import { who as upper } from "./Mod.mjs";
+          import { who as shout } from "./MOD.mjs";
+          console.log(lower, upper, shout);
+        `,
+        "lower-shout.mjs": `
+          import { who as lower } from "./mod.mjs";
+          import { who as shout } from "./MOD.mjs";
+          console.log(lower, shout);
+        `,
+        "upper.mjs": `import { who } from "./Mod.mjs"; console.log(who);`,
+      });
+      const build = async (entry: string) => {
+        const result = await Bun.build({ entrypoints: [join(String(dir), entry)], throw: false });
+        if (!result.success) return result.logs.map(log => log.message);
+        const bundle = await result.outputs[0].text();
+        return Array.from(bundle.matchAll(/"(lower|UPPER|SHOUT)"/g), match => match[1]);
+      };
+      // The generation is bumped by the bundle thread once it has drained its
+      // queue, which can land after the previous build's promise has already
+      // resolved; a build enqueued before that still sees the old listing.
+      // Each attempt is itself a build, so a later attempt always re-reads.
+      const buildAfterChange = async (entry: string, expected: string[]) => {
+        let actual = await build(entry);
+        for (let attempt = 0; attempt < 50 && !Bun.deepEquals(actual, expected); attempt++) {
+          actual = await build(entry);
+        }
+        expect(actual).toEqual(expected);
+      };
+
+      expect(await build("two.mjs")).toEqual(["lower", "UPPER"]);
+
+      writeFileSync(join(String(dir), "MOD.mjs"), `export const who = "SHOUT";`);
+      await buildAfterChange("three.mjs", ["lower", "UPPER", "SHOUT"]);
+
+      unlinkSync(join(String(dir), "Mod.mjs"));
+      await buildAfterChange("lower-shout.mjs", ["lower", "SHOUT"]);
+      await buildAfterChange("upper.mjs", ['Could not resolve: "./Mod.mjs"']);
+    });
+  });
+
+  it.concurrent("a specifier whose case differs from the only file of that name still resolves", async () => {
+    // Deliberately more lenient than Node on a case-sensitive filesystem
+    // (see extra/CaseSensitiveImport in test/bundler/esbuild/extra.test.ts);
+    // a case-insensitive filesystem resolves it regardless.
+    using dir = tempDir("resolve-case-lone", {
+      "Mod.mjs": `export const who = "UPPER";`,
+      "entry.mjs": `import { who } from "./mod.mjs"; console.log(who);`,
+    });
+    const result = await bunRun(join(String(dir), "entry.mjs"));
+    expect(result).toSpawn();
+    expect(result.stdout).toBe("UPPER");
   });
 });


### PR DESCRIPTION
### Problem
- On a case-sensitive filesystem, a directory holding `mod.mjs` and `Mod.mjs` resolves both `import "./mod.mjs"` and `import "./Mod.mjs"` to the same file (whichever `readdir` listed last); `Bun.resolveSync` and `require.resolve` return that file for both spellings, and also for spellings that exist as neither (`./MOD.mjs`). Node loads the two files separately and rejects `./MOD.mjs`.
- Same for extensionless specifiers (`./util` with `util.ts` + `Util.ts`), for directories reached through a symlink (`link/lib/x.mjs` and `link/Lib/x.mjs` both resolve to `real/lib/x.mjs`, because the real path is cached on the shared entry in `dir_info_uncached`), and for `bun test`, which ran 2 tests across 3 files for `a.test.ts` + `A.test.ts` + `nested/b.test.ts` + `nested/B.test.ts` (the cwd listing is walked from the cache, and loading `nested/B.test.ts` resolved to `nested/b.test.ts`).
- Cause: `DirEntry::data` (`src/resolver/fs.rs`) is keyed by the ASCII-lowercased basename, and `add_entry_with_store` inserted with the overwriting `put_static_key_hashed`, so the second sibling replaced the first. `DirEntry::get` lowercases the query and returns whatever holds the key. The re-read path had the matching flaw: `prev_map` reuse matched on the lowercased key, so a re-read handed a renamed or differently-cased file the entry (and cached `abs_path`) of another spelling; after a case-only rename of a lone file, later `Bun.build` calls in the same process failed with `File not found ".../x.mjs"`.
- `extra/CaseSensitiveImport2` in `test/bundler/esbuild/extra.test.ts` has been `todo` for this; it only passed where the filesystem happened to list the files in a lucky order.

### Fix
- `Entry` gets a `next_case_variant` link. The map still holds one pointer per lowercased key; when a key is already taken, the new entry is chained behind the first (`push_case_variant`) instead of replacing it. Insertion uses a new single-probe `get_or_put_static_key_hashed` in place of the removed `put_static_key_hashed`, so the hot readdir loop still hashes and probes once per entry.
- `get` / `get_comptime_query` / `has_comptime_query` go through `select_case_variant`: a key with a single entry is returned for any spelling of the query, exactly as before; a key with several entries returns only the entry spelled byte-for-byte like the query, else none.
- Why this is the right rule: a lone entry carries no information about the filesystem, so the existing lenient behavior is kept for it (a Linux machine with a case-insensitive mount, or macOS, keeps resolving `./File1.js` to `file1.js`; `extra/CaseSensitiveImport` and `CaseSensitiveImport4` still pass unchanged). Two entries under one key can only exist on a filesystem that distinguishes them, so there the exact spelling is the only one that exists on disk and returning it, or nothing, is what the OS itself would do and what Node does. No platform constant or probing syscall is involved, so the behavior follows the actual mount rather than the build target.
- The rule is evaluated against the current listing only: when a re-read finds one of the siblings deleted, the survivor is a lone entry again and any spelling resolves to it (tested in both deletion orders). Keeping strictness after the fact would need state that outlives the listing and would make resolution depend on history.
- Re-reads (`prev_map`, used when a directory is listed again at a newer generation, e.g. a later `Bun.build` in the same process): `take_case_variant` reuses only the previous entry with the identical basename and unlinks it from the previous chain, so siblings keep their own entries across re-reads, a deleted variant drops out, and a case-only rename gets a fresh entry carrying the new spelling instead of inheriting the old `base()`. The rename half applies on case-insensitive filesystems as well and is tested on every platform.
- `DirEntry::iter_entries` walks the chains; the `bun test` scanner uses it for the already-cached cwd listing (with a `base()` tie-break so `A.test.ts` / `a.test.ts` order is stable). Other whole-listing readers (`bun run` bin listing, routers, the glob accessor) are unchanged and still see one entry per key as before; they can switch to `iter_entries` if wanted.
- `test/harness.ts` gains `isCaseSensitiveFileSystem()`, a one-time probe of the temp directory's filesystem, used to gate the case-sensitive-only tests and to un-`todo` `extra/CaseSensitiveImport2` where it can run.
- Verified with:
  - `test/js/bun/resolve/resolve.test.ts`, "sibling files whose names differ only in case": ESM import + `Bun.resolveSync`; `require` + `require.resolve`; extensionless specifiers; a spelling matching neither sibling, with and without extension; `lib`/`Lib` directories behind a symlink; `Bun.build` re-reads that add a third variant and then delete one; re-reads that delete either sibling and check the other spellings resolve to the survivor; a case-only rename of a lone file between builds (runs on every filesystem); and a control pinning the unchanged lone-file leniency. 9 of the 10 fail on the released bun (the control passes), all pass with this change. The re-read tests assert the on-disk spelling of each bundled module, run in-process because that is what triggers the re-read, and are `it.serial` because the bundle thread only advances the generation when its queue drains.
  - `test/cli/test/bun-test.test.ts`, "runs test files whose names differ only in case": released bun runs 2 tests across 3 files, this change 4 across 4.
  - `test/bundler/esbuild/extra.test.ts`: `CaseSensitiveImport2` now runs on case-sensitive filesystems; the whole file passes.
  - `test/js/bun/resolve/` (except the two count-bound timing tests in `load-same-js-file-a-lot.test.ts`, ~25 ms per import in this debug+ASAN container with or without this change), `test/cli/test/bun-test.test.ts`, `test/cli/hot/hot.test.ts`, `test/bake/framework-router.test.ts`, `test/js/bun/util/filesystem_router.test.ts` pass; `cargo clippy` on `bun_resolver`, `bun_collections`, `bun_runtime` is clean.
- Interaction: #36636 (open) makes the scanner collect every directory's entries from `.data`; whichever of the two lands second needs that collect to use `iter_entries()`, and the nested half of the new scanner test flags it otherwise.

### Background
- `DirEntry` is the resolver's cached listing of one directory: `data` maps a basename to an `Entry` (the per-file record holding the on-disk `base()`, the lazily stat'ed kind, the cached symlink target, and `abs_path`). All `Entry` values live in `EntryStore`, a process-lifetime append-only list, which is why raw pointers to them can be chained freely and never dangle.
- The key is lowercased on purpose: on case-insensitive filesystems (macOS, Windows) a specifier may legitimately differ in case from the on-disk name and must still hit the cached entry. A previous attempt (#36047) keyed by exact name on non-macOS/Windows builds, which breaks case-insensitive mounts on Linux; this change keeps the key and only changes what happens when two names actually share one.
- Generations and `prev_map`: the bundle thread runs each batch of builds at an increasing generation; a listing cached at an older generation is re-read in place, and `add_entry_with_store` is handed the old map so files that still exist keep their existing `Entry` (and pointers to it). `take_case_variant` is the case-aware version of that reuse.
- `entries_mutex` serializes every probe of `data` (and the in-place rewrite); the chain link is read and written only under it, so the `AtomicPtr` uses relaxed ordering and exists so the link can be updated through shared references.
- #36054 (open) is the separate fix for `todos.ts` + `Todos.tsx` (different extensions, so different keys); it does not touch the keying and this change does not touch the extension probes.

<details>
<summary>Repro on the released bun</summary>

```sh
mkdir /tmp/cc && cd /tmp/cc
printf 'export const who="lower";' > mod.mjs
printf 'export const who="UPPER";' > Mod.mjs
printf 'import {who as L} from "./mod.mjs"; import {who as U} from "./Mod.mjs"; console.log(L, U);
console.log(Bun.resolveSync("./mod.mjs", import.meta.dir));
console.log(Bun.resolveSync("./MOD.mjs", import.meta.dir));' > e.mjs
bun e.mjs
# UPPER UPPER
# /tmp/cc/Mod.mjs
# /tmp/cc/Mod.mjs          (node: "lower UPPER", and ./MOD.mjs does not resolve)
```

With this change: `lower UPPER`, `/tmp/cc/mod.mjs`, and `./MOD.mjs` throws `Cannot find module`.

`bun test` in a directory with `a.test.ts`, `A.test.ts`, `nested/b.test.ts`, `nested/B.test.ts`: released bun prints `Ran 2 tests across 3 files` (`nested/b.test.ts` is listed twice), this change prints `Ran 4 tests across 4 files`.

Case-only rename between two in-process `Bun.build` calls (`x.mjs` built once, renamed to `X.mjs`, then an entry importing `./X.mjs` built): released bun fails with `File not found ".../x.mjs"` on Linux and bundles the module as `x.mjs` on macOS/Windows; this change bundles `X.mjs` everywhere.
</details>

<details>
<summary>Earlier revision</summary>

The first push covered the same fix with the add/delete re-read test only; the self-review asked for the shrink-to-lone transition (both deletion orders) and the case-only rename to be asserted, and for the per-listing rule to be stated, which the current revision does. Comments were also trimmed after the comment lint.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/test/bun-test.test.ts test/js/bun/resolve/resolve.test.ts

<!-- robobun:evidence:end -->