### PR TITLE
Bind the JSX runtime and bun:wrap helpers with require() in CommonJS-wrapped modules

### DIFF
--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1973,7 +1973,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         // it "for side effects" pulls in React for code the user never asked
         // to run. See mark_file_live_step for the matching JsxImport skip.
         let is_jsx = tag == bun_ast::PartTag::JsxImport;
-        parts.push(js_ast::Part {
+        let part = js_ast::Part {
             stmts: stmts.into(),
             declared_symbols,
             import_record_indices: js_ast::PartImportRecordIndices::init_one(import_record_i),
@@ -1981,7 +1981,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
             can_be_removed_if_unused: is_jsx,
             force_tree_shaking: is_jsx,
             ..Default::default()
-        });
+        };
+        if as_require {
+            // Classes hoisted to the top of the module are already in `parts`; unlike an import, this binding is not hoisted above them.
+            parts.insert(0, part);
+        } else {
+            parts.push(part);
+        }
         Ok(())
     }
 

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1774,13 +1774,9 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    /// Binds generated helper symbols (runtime helpers, the JSX runtime) to
-    /// `import_path`. This is an `import` statement, except when the module is
-    /// about to be wrapped in Bun's CommonJS function wrapper
-    /// (`wrap_mode == BunCommonjs`): an `import` inside that function body is a
-    /// syntax error, so the helpers are bound with
-    /// `const { a, b } = require(import_path)` instead, like the `bun:test`
-    /// globals are.
+    /// Binds generated helper symbols to `import_path` with an `import`
+    /// statement, or with `const { .. } = require()` when the module body is
+    /// going into the CommonJS wrapper function, where an `import` cannot appear.
     pub(crate) fn generate_import_stmt<I, Sym>(
         &mut self,
         import_path: &'a [u8],

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1774,6 +1774,13 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
+    /// Binds generated helper symbols (runtime helpers, the JSX runtime) to
+    /// `import_path`. This is an `import` statement, except when the module is
+    /// about to be wrapped in Bun's CommonJS function wrapper
+    /// (`wrap_mode == BunCommonjs`): an `import` inside that function body is a
+    /// syntax error, so the helpers are bound with
+    /// `const { a, b } = require(import_path)` instead, like the `bun:test`
+    /// globals are.
     pub(crate) fn generate_import_stmt<I, Sym>(
         &mut self,
         import_path: &'a [u8],
@@ -1784,6 +1791,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         prefix: &'static [u8],
         is_internal: bool,
         tag: bun_ast::PartTag,
+        wrap_mode: WrapMode,
     ) -> Result<(), crate::Error>
     where
         I: AsRef<[<Sym as GenerateImportSymbols>::Key]>,
@@ -1791,8 +1799,16 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
     {
         let arena = self.arena;
         let imports = imports.as_ref();
-        let import_record_i =
-            self.add_import_record_by_range(ImportKind::Stmt, bun_ast::Range::NONE, import_path);
+        let as_require = wrap_mode == WrapMode::BunCommonjs;
+        let import_record_i = self.add_import_record_by_range(
+            if as_require {
+                ImportKind::Require
+            } else {
+                ImportKind::Stmt
+            },
+            bun_ast::Range::NONE,
+            import_path,
+        );
         {
             let import_record = &mut self.import_records.items_mut()[import_record_i as usize];
             if is_internal {
@@ -1802,100 +1818,148 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
                 .flags
                 .set(bun_ast::ImportRecordFlags::IS_INTERNAL, is_internal);
         }
-        // Render the sanitized-identifier formatter into the bump arena (same
-        // pattern as `transpose_require` above).
-        let import_path_identifier: &'a [u8] = {
-            use core::fmt::Write as _;
-            let base = self.import_records.items()[import_record_i as usize]
-                .path
-                .name()
-                .non_unique_name_string_base();
-            let mut buf = bun_alloc::ArenaString::new_in(arena);
-            write!(&mut buf, "{}", bun_core::fmt::fmt_identifier(base)).expect("unreachable");
-            buf.into_bump_str().as_bytes()
-        };
-        let mut namespace_identifier =
-            BumpVec::with_capacity_in(import_path_identifier.len() + prefix.len(), arena);
-        namespace_identifier.extend_from_slice(prefix);
-        namespace_identifier.extend_from_slice(import_path_identifier);
-        let namespace_identifier = namespace_identifier.into_bump_slice();
 
-        let clause_items =
-            arena.alloc_slice_fill_with::<js_ast::ClauseItem, _>(imports.len(), |_| {
-                js_ast::ClauseItem {
-                    alias: js_ast::StoreStr::new(b""),
-                    original_name: js_ast::StoreStr::new(b""),
-                    alias_loc: bun_ast::Loc::default(),
-                    name: LocRef::default(),
-                }
-            });
         let mut declared_symbols = bun_ast::DeclaredSymbolList::default();
         declared_symbols.ensure_total_capacity(imports.len() + 1)?;
 
-        let namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, namespace_identifier);
-        declared_symbols.append_assume_capacity(DeclaredSymbol {
-            ref_: namespace_ref,
-            is_top_level: true,
-        });
-        // SAFETY: arena-owned Scope pointer valid for parser 'a lifetime; no aliasing &mut outstanding
-        VecExt::append(&mut self.module_scope_mut().generated, namespace_ref);
-        for (alias, clause_item) in imports.iter().zip(clause_items.iter_mut()) {
-            let ref_ = symbols.get(alias).expect("unreachable");
-            let alias_name: &'static [u8] = symbols.alias_name(alias);
-            *clause_item = js_ast::ClauseItem {
-                alias: js_ast::StoreStr::new(alias_name),
-                original_name: js_ast::StoreStr::new(alias_name),
-                alias_loc: bun_ast::Loc::default(),
-                name: LocRef {
+        let import_stmt = if as_require {
+            let mut properties = BumpVec::<B::Property>::with_capacity_in(imports.len(), arena);
+            for alias in imports {
+                let ref_ = symbols.get(alias).expect("unreachable");
+                let alias_name: &'static [u8] = symbols.alias_name(alias);
+                let key = self.new_expr(E::String::init(alias_name), bun_ast::Loc::EMPTY);
+                let value = self.b(B::Identifier { r#ref: ref_ }, bun_ast::Loc::EMPTY);
+                properties.push(B::Property {
+                    flags: Default::default(),
+                    key,
+                    value,
+                    default_value: None,
+                });
+                declared_symbols.append_assume_capacity(DeclaredSymbol {
                     ref_,
-                    loc: bun_ast::Loc::default(),
-                },
-            };
-            declared_symbols.append_assume_capacity(DeclaredSymbol {
-                ref_,
-                is_top_level: true,
-            });
-
-            // ensure every e_import_identifier holds the namespace
-            if self.options.features.hot_module_reloading {
-                let symbol = &mut self.symbols[ref_.inner_index() as usize];
-                if symbol.namespace_alias.is_none() {
-                    symbol.namespace_alias = Some(bun_alloc::ast_box(js_ast::NamespaceAlias {
-                        namespace_ref,
-                        alias: js_ast::StoreStr::new(alias_name),
-                        import_record_index: import_record_i,
-                        was_originally_property_access: false,
-                    }));
-                }
+                    is_top_level: true,
+                });
             }
 
-            self.is_import_item.insert(ref_, ());
-            self.named_imports.put(
-                ref_,
-                js_ast::NamedImport {
-                    alias: Some(js_ast::StoreStr::new(alias_name)),
-                    alias_loc: bun_ast::Loc::default(),
-                    namespace_ref,
-                    import_record_index: import_record_i,
-                    local_parts_with_uses: bun_alloc::AstAlloc::vec(),
-                    alias_is_star: false,
-                    is_exported: false,
+            let binding = self.b(
+                B::Object {
+                    properties: bun_ast::StoreSlice::from_bump(properties),
+                    is_single_line: false,
                 },
-            )?;
-        }
+                bun_ast::Loc::EMPTY,
+            );
+            let value = self.new_expr(
+                E::RequireString {
+                    import_record_index: import_record_i,
+                    ..Default::default()
+                },
+                bun_ast::Loc::EMPTY,
+            );
+            self.s(
+                S::Local {
+                    kind: js_ast::s::Kind::KConst,
+                    decls: G::DeclList::from_slice(&[Decl {
+                        binding,
+                        value: Some(value),
+                    }]),
+                    ..Default::default()
+                },
+                bun_ast::Loc::EMPTY,
+            )
+        } else {
+            // Render the sanitized-identifier formatter into the bump arena (same
+            // pattern as `transpose_require` above).
+            let import_path_identifier: &'a [u8] = {
+                use core::fmt::Write as _;
+                let base = self.import_records.items()[import_record_i as usize]
+                    .path
+                    .name()
+                    .non_unique_name_string_base();
+                let mut buf = bun_alloc::ArenaString::new_in(arena);
+                write!(&mut buf, "{}", bun_core::fmt::fmt_identifier(base)).expect("unreachable");
+                buf.into_bump_str().as_bytes()
+            };
+            let mut namespace_identifier =
+                BumpVec::with_capacity_in(import_path_identifier.len() + prefix.len(), arena);
+            namespace_identifier.extend_from_slice(prefix);
+            namespace_identifier.extend_from_slice(import_path_identifier);
+            let namespace_identifier = namespace_identifier.into_bump_slice();
 
-        let import_stmt = self.s(
-            S::Import {
-                namespace_ref,
-                items: clause_items.into(),
-                import_record_index: import_record_i,
-                is_single_line: true,
-                default_name: None,
-                star_name_loc: bun_ast::Loc::EMPTY,
-                phase_defer: false,
-            },
-            bun_ast::Loc::default(),
-        );
+            let clause_items =
+                arena.alloc_slice_fill_with::<js_ast::ClauseItem, _>(imports.len(), |_| {
+                    js_ast::ClauseItem {
+                        alias: js_ast::StoreStr::new(b""),
+                        original_name: js_ast::StoreStr::new(b""),
+                        alias_loc: bun_ast::Loc::default(),
+                        name: LocRef::default(),
+                    }
+                });
+
+            let namespace_ref = self.new_symbol(js_ast::symbol::Kind::Other, namespace_identifier);
+            declared_symbols.append_assume_capacity(DeclaredSymbol {
+                ref_: namespace_ref,
+                is_top_level: true,
+            });
+            // SAFETY: arena-owned Scope pointer valid for parser 'a lifetime; no aliasing &mut outstanding
+            VecExt::append(&mut self.module_scope_mut().generated, namespace_ref);
+            for (alias, clause_item) in imports.iter().zip(clause_items.iter_mut()) {
+                let ref_ = symbols.get(alias).expect("unreachable");
+                let alias_name: &'static [u8] = symbols.alias_name(alias);
+                *clause_item = js_ast::ClauseItem {
+                    alias: js_ast::StoreStr::new(alias_name),
+                    original_name: js_ast::StoreStr::new(alias_name),
+                    alias_loc: bun_ast::Loc::default(),
+                    name: LocRef {
+                        ref_,
+                        loc: bun_ast::Loc::default(),
+                    },
+                };
+                declared_symbols.append_assume_capacity(DeclaredSymbol {
+                    ref_,
+                    is_top_level: true,
+                });
+
+                // ensure every e_import_identifier holds the namespace
+                if self.options.features.hot_module_reloading {
+                    let symbol = &mut self.symbols[ref_.inner_index() as usize];
+                    if symbol.namespace_alias.is_none() {
+                        symbol.namespace_alias = Some(bun_alloc::ast_box(js_ast::NamespaceAlias {
+                            namespace_ref,
+                            alias: js_ast::StoreStr::new(alias_name),
+                            import_record_index: import_record_i,
+                            was_originally_property_access: false,
+                        }));
+                    }
+                }
+
+                self.is_import_item.insert(ref_, ());
+                self.named_imports.put(
+                    ref_,
+                    js_ast::NamedImport {
+                        alias: Some(js_ast::StoreStr::new(alias_name)),
+                        alias_loc: bun_ast::Loc::default(),
+                        namespace_ref,
+                        import_record_index: import_record_i,
+                        local_parts_with_uses: bun_alloc::AstAlloc::vec(),
+                        alias_is_star: false,
+                        is_exported: false,
+                    },
+                )?;
+            }
+
+            self.s(
+                S::Import {
+                    namespace_ref,
+                    items: clause_items.into(),
+                    import_record_index: import_record_i,
+                    is_single_line: true,
+                    default_name: None,
+                    star_name_loc: bun_ast::Loc::EMPTY,
+                    phase_defer: false,
+                },
+                bun_ast::Loc::default(),
+            )
+        };
         let stmts = arena
             .alloc_slice_fill_with::<Stmt, _>(1 + usize::from(additional_stmt.is_some()), |_| {
                 import_stmt

--- a/src/js_parser/p.rs
+++ b/src/js_parser/p.rs
@@ -1774,9 +1774,7 @@ impl<'a, const TYPESCRIPT: bool, const SCAN_ONLY: bool> P<'a, TYPESCRIPT, SCAN_O
         Ok(())
     }
 
-    /// Binds generated helper symbols to `import_path` with an `import`
-    /// statement, or with `const { .. } = require()` when the module body is
-    /// going into the CommonJS wrapper function, where an `import` cannot appear.
+    /// Emits `import { .. } from path`, or `const { .. } = require(path)` when the module body is going into the CommonJS wrapper.
     pub(crate) fn generate_import_stmt<I, Sym>(
         &mut self,
         import_path: &'a [u8],

--- a/src/js_parser/parse/parse_entry.rs
+++ b/src/js_parser/parse/parse_entry.rs
@@ -1931,6 +1931,7 @@ impl<'a> Parser<'a> {
                     b"import_",
                     true,
                     js_ast::PartTag::Runtime,
+                    wrap_mode,
                 )
                 .expect("unreachable");
             }
@@ -1964,6 +1965,7 @@ impl<'a> Parser<'a> {
                     b"",
                     false,
                     js_ast::PartTag::JsxImport,
+                    wrap_mode,
                 )
                 .expect("unreachable");
             }
@@ -1979,6 +1981,7 @@ impl<'a> Parser<'a> {
                     b"",
                     false,
                     js_ast::PartTag::JsxImport,
+                    wrap_mode,
                 )
                 .expect("unreachable");
             }

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,9 +51,8 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: CommonJS-wrapped modules bind the JSX runtime and the `bun:wrap`
-/// helpers with `require()` instead of an `import` statement. Entries written
-/// before that carry the `import` inside the wrapper, which JSC rejects (#12812).
+/// Version 26: CommonJS-wrapped modules bind the JSX runtime and `bun:wrap`
+/// helpers with `require()`; older entries have an `import` inside the wrapper (#12812).
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,8 +51,7 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-/// Version 26: CommonJS-wrapped modules bind the JSX runtime and `bun:wrap`
-/// helpers with `require()`; older entries have an `import` inside the wrapper (#12812).
+/// Version 26: CommonJS-wrapped modules bind the JSX runtime and `bun:wrap` helpers with `require()`; older entries have an `import` inside the wrapper (#12812).
 const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk

--- a/src/jsc/RuntimeTranspilerCache.rs
+++ b/src/jsc/RuntimeTranspilerCache.rs
@@ -51,7 +51,10 @@ bun_core::declare_scope!(cache, visible);
 /// Version 25: Every ModuleInfo record carries a trailing FetchParameters slot
 /// so ImportEntry/ExportEntry/StarExportEntry moduleRequestType matches JSC's
 /// after WebKit 90b2ecf79ae3 keyed m_loadedModules on (specifier, type).
-const EXPECTED_VERSION: u32 = 25;
+/// Version 26: CommonJS-wrapped modules bind the JSX runtime and the `bun:wrap`
+/// helpers with `require()` instead of an `import` statement. Entries written
+/// before that carry the `import` inside the wrapper, which JSC rejects (#12812).
+const EXPECTED_VERSION: u32 = 26;
 
 /// Source files smaller than this are not written to / read from the on-disk
 /// transpiler cache. Originally 50 KiB, which excluded almost every file in a

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -3,10 +3,13 @@ import { mkdirSync } from "fs";
 import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
 
-// A stand-in for react's JSX runtime so the auto-imported `react/jsx-dev-runtime`
-// (or `react/jsx-runtime`) resolves without touching the network.
+// A stand-in for react so the JSX runtime bun auto-imports (`react/jsx-dev-runtime`,
+// `react/jsx-runtime`, or `react` itself for createElement) resolves without the network.
 const fakeReact = {
   "node_modules/react/package.json": JSON.stringify({ name: "react", version: "0.0.0" }),
+  "node_modules/react/index.js": `
+    exports.createElement = (type, props, ...children) => ({ type, props, children });
+  `,
   "node_modules/react/jsx-dev-runtime.js": `
     exports.Fragment = "fragment";
     exports.jsxDEV = (type, props) => ({ type, props });
@@ -18,11 +21,14 @@ const fakeReact = {
   `,
 };
 
-async function runFile(dir: string, file: string) {
+const requireAndJsx = `const { basename } = require("node:path"); console.log(JSON.stringify(<div title={basename("/a/b.txt")} />));`;
+
+async function runBun(dir: string, args: string[], stdin?: string) {
   await using proc = Bun.spawn({
-    cmd: [bunExe(), file],
+    cmd: [bunExe(), ...args],
     cwd: dir,
     env: bunEnv,
+    stdin: stdin === undefined ? "ignore" : Buffer.from(stdin),
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -45,8 +51,8 @@ describe.concurrent("run-cjs", () => {
   });
 
   // The JSX runtime and the helpers from "bun:wrap" are bound with generated
-  // statements. A module that uses require()/module.exports is evaluated inside
-  // the CommonJS function wrapper, where those bindings have to be require()
+  // statements. A module that bun treats as CommonJS is evaluated inside the
+  // CommonJS function wrapper, where those bindings have to be require()
   // calls: an `import` statement there is a SyntaxError.
   test("commonjs module using JSX", async () => {
     using dir = tempDir("run-cjs-jsx", {
@@ -64,7 +70,7 @@ describe.concurrent("run-cjs", () => {
       `,
     });
 
-    const [stdout, stderr, exitCode] = await runFile(String(dir), "entry.js");
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["entry.js"]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({ type: "div", props: { title: "b.txt", children: "hi" } });
     expect(exitCode).toBe(0);
@@ -87,12 +93,51 @@ describe.concurrent("run-cjs", () => {
       `,
     });
 
-    const [stdout, stderr, exitCode] = await runFile(String(dir), "app.tsx");
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["app.tsx"]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({
       type: "fragment",
       props: { children: { type: "h1", props: { children: "string" } } },
     });
+    expect(exitCode).toBe(0);
+  });
+
+  // `key` after a spread is the one JSX shape that is lowered to createElement
+  // from the package itself rather than to the jsx runtime.
+  test("commonjs module using JSX with a key after a spread", async () => {
+    using dir = tempDir("run-cjs-jsx-create-element", {
+      ...fakeReact,
+      "component.jsx": `
+        const { basename } = require("node:path");
+        const props = { title: basename("/a/b.txt") };
+        module.exports = <div {...props} key="k">hi</div>;
+      `,
+      "entry.js": `console.log(JSON.stringify(require("./component.jsx")));`,
+    });
+
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["entry.js"]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ type: "div", props: { title: "b.txt", key: "k" }, children: ["hi"] });
+    expect(exitCode).toBe(0);
+  });
+
+  // "use strict" and __dirname also make a file CommonJS. The generated binding
+  // is placed before the user's code, so the directive has to stay in effect.
+  test('commonjs module detected via "use strict" and __dirname using JSX', async () => {
+    using dir = tempDir("run-cjs-use-strict-jsx", {
+      ...fakeReact,
+      "component.jsx": `
+        "use strict";
+        function isStrict() {
+          return this === undefined;
+        }
+        console.log(JSON.stringify(<div title={typeof __dirname} strict={isStrict()} />));
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["component.jsx"]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ type: "div", props: { title: "string", strict: true } });
     expect(exitCode).toBe(0);
   });
 
@@ -110,14 +155,7 @@ describe.concurrent("run-cjs", () => {
       `,
     });
 
-    await using proc = Bun.spawn({
-      cmd: [bunExe(), "test", "./component.test.jsx"],
-      cwd: String(dir),
-      env: bunEnv,
-      stdout: "ignore",
-      stderr: "pipe",
-    });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    const [, stderr, exitCode] = await runBun(String(dir), ["test", "./component.test.jsx"]);
     expect(stderr).toContain(" 1 pass\n");
     expect(stderr).toContain(" 0 fail\n");
     expect(exitCode).toBe(0);
@@ -143,7 +181,7 @@ describe.concurrent("run-cjs", () => {
       `,
     });
 
-    const [stdout, stderr, exitCode] = await runFile(String(dir), "entry.js");
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["entry.js"]);
     expect(stderr).toBe("");
     expect(stdout).toBe("decorated.ts\n");
     expect(exitCode).toBe(0);
@@ -168,9 +206,88 @@ describe.concurrent("run-cjs", () => {
       `,
     });
 
-    const [stdout, stderr, exitCode] = await runFile(String(dir), "entry.js");
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["entry.js"]);
     expect(stderr).toBe("");
     expect(stdout).toBe("decorated.ts:Service\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // A .cts file is CommonJS because of its extension, not because of anything in its body.
+  test(".cts module using standard decorators", async () => {
+    using dir = tempDir("run-cjs-cts-decorators", {
+      "service.cts": `
+        function tag(value: string) {
+          return (target: any, context: ClassDecoratorContext) => {
+            target.tag = value + ":" + String(context.name);
+          };
+        }
+        @tag("cts")
+        class Service {}
+        exports.Service = Service;
+      `,
+      "entry.js": `console.log(require("./service.cts").Service.tag);`,
+    });
+
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["entry.js"]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("cts:Service\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // Top-level classes that can be hoisted are moved to the front of the module
+  // before the helper bindings are generated. Lowering `accessor` calls a
+  // "bun:wrap" helper while the class is being defined, so the binding has to
+  // end up ahead of the hoisted class.
+  test("commonjs module with a hoisted class that needs a bun:wrap helper", async () => {
+    using dir = tempDir("run-cjs-hoisted-class-helper", {
+      "box.ts": `
+        const { basename } = require("node:path");
+        class Box {
+          accessor value = basename("/a/b.txt");
+        }
+        module.exports = { Box };
+      `,
+      "entry.js": `
+        const { Box } = require("./box.ts");
+        console.log(new Box().value);
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["entry.js"]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe("b.txt\n");
+    expect(exitCode).toBe(0);
+  });
+
+  // `bun -e`, `bun -p` and `bun run -` evaluate their source as CommonJS too,
+  // but without the function wrapper.
+  test("bun -e using require() and JSX", async () => {
+    using dir = tempDir("run-cjs-eval-jsx", fakeReact);
+
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["-e", requireAndJsx]);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ type: "div", props: { title: "b.txt" } });
+    expect(exitCode).toBe(0);
+  });
+
+  test("bun -p prints the value of JSX that follows a require()", async () => {
+    using dir = tempDir("run-cjs-print-jsx", fakeReact);
+
+    const [stdout, stderr, exitCode] = await runBun(String(dir), [
+      "-p",
+      `const { basename } = require("node:path"); JSON.stringify(<div title={basename("/a/b.txt")} />)`,
+    ]);
+    expect(stderr).toBe("");
+    expect(stdout).toBe(`{"type":"div","props":{"title":"b.txt"}}\n`);
+    expect(exitCode).toBe(0);
+  });
+
+  test("stdin script using require() and JSX", async () => {
+    using dir = tempDir("run-cjs-stdin-jsx", fakeReact);
+
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["run", "-"], requireAndJsx);
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ type: "div", props: { title: "b.txt" } });
     expect(exitCode).toBe(0);
   });
 
@@ -189,7 +306,7 @@ describe.concurrent("run-cjs", () => {
       `,
     });
 
-    const [stdout, stderr, exitCode] = await runFile(String(dir), "entry.ts");
+    const [stdout, stderr, exitCode] = await runBun(String(dir), ["entry.ts"]);
     expect(stderr).toBe("");
     expect(JSON.parse(stdout)).toEqual({ type: "div", props: { title: "b.txt", children: "hi" } });
     expect(exitCode).toBe(0);

--- a/test/cli/run/run-cjs.test.ts
+++ b/test/cli/run/run-cjs.test.ts
@@ -1,7 +1,33 @@
 import { describe, expect, test } from "bun:test";
 import { mkdirSync } from "fs";
-import { bunEnv, bunExe, tmpdirSync } from "harness";
+import { bunEnv, bunExe, tempDir, tmpdirSync } from "harness";
 import { join } from "path";
+
+// A stand-in for react's JSX runtime so the auto-imported `react/jsx-dev-runtime`
+// (or `react/jsx-runtime`) resolves without touching the network.
+const fakeReact = {
+  "node_modules/react/package.json": JSON.stringify({ name: "react", version: "0.0.0" }),
+  "node_modules/react/jsx-dev-runtime.js": `
+    exports.Fragment = "fragment";
+    exports.jsxDEV = (type, props) => ({ type, props });
+  `,
+  "node_modules/react/jsx-runtime.js": `
+    exports.Fragment = "fragment";
+    exports.jsx = (type, props) => ({ type, props });
+    exports.jsxs = exports.jsx;
+  `,
+};
+
+async function runFile(dir: string, file: string) {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), file],
+    cwd: dir,
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+}
 
 describe.concurrent("run-cjs", () => {
   test("running a commonjs module works", async () => {
@@ -16,5 +42,156 @@ describe.concurrent("run-cjs", () => {
     });
     const stdout = await proc.stdout.text();
     expect(stdout).toEqual("hello world\n");
+  });
+
+  // The JSX runtime and the helpers from "bun:wrap" are bound with generated
+  // statements. A module that uses require()/module.exports is evaluated inside
+  // the CommonJS function wrapper, where those bindings have to be require()
+  // calls: an `import` statement there is a SyntaxError.
+  test("commonjs module using JSX", async () => {
+    using dir = tempDir("run-cjs-jsx", {
+      ...fakeReact,
+      "component.jsx": `
+        const { basename } = require("node:path");
+        function App() {
+          return <div title={basename("/a/b.txt")}>hi</div>;
+        }
+        module.exports = { App };
+      `,
+      "entry.js": `
+        const { App } = require("./component.jsx");
+        console.log(JSON.stringify(App()));
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await runFile(String(dir), "entry.js");
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ type: "div", props: { title: "b.txt", children: "hi" } });
+    expect(exitCode).toBe(0);
+  });
+
+  // https://github.com/oven-sh/bun/issues/12812
+  test("tsx entry point using `import x = require()` and JSX", async () => {
+    using dir = tempDir("run-cjs-import-equals-jsx", {
+      ...fakeReact,
+      "app.tsx": `
+        import process = require("node:process");
+        function App() {
+          return (
+            <>
+              <h1>{typeof process.platform}</h1>
+            </>
+          );
+        }
+        console.log(JSON.stringify(App()));
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await runFile(String(dir), "app.tsx");
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({
+      type: "fragment",
+      props: { children: { type: "h1", props: { children: "string" } } },
+    });
+    expect(exitCode).toBe(0);
+  });
+
+  test("commonjs test file using JSX under bun test", async () => {
+    using dir = tempDir("run-cjs-jsx-bun-test", {
+      ...fakeReact,
+      "component.test.jsx": `
+        const { basename } = require("node:path");
+        test("renders", () => {
+          expect(<div title={basename("/a/b.txt")}>hi</div>).toEqual({
+            type: "div",
+            props: { title: "b.txt", children: "hi" },
+          });
+        });
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", "./component.test.jsx"],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    expect(stderr).toContain(" 1 pass\n");
+    expect(stderr).toContain(" 0 fail\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("commonjs module using TypeScript experimental decorators", async () => {
+    using dir = tempDir("run-cjs-legacy-decorators", {
+      "tsconfig.json": JSON.stringify({ compilerOptions: { experimentalDecorators: true } }),
+      "service.ts": `
+        const { basename } = require("node:path");
+        function tag(value: string) {
+          return (target: any) => {
+            target.tag = value;
+          };
+        }
+        @tag(basename("/x/decorated.ts"))
+        class Service {}
+        module.exports = { Service };
+      `,
+      "entry.js": `
+        const { Service } = require("./service.ts");
+        console.log(Service.tag);
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await runFile(String(dir), "entry.js");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("decorated.ts\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("commonjs module using standard decorators", async () => {
+    using dir = tempDir("run-cjs-standard-decorators", {
+      "service.ts": `
+        const { basename } = require("node:path");
+        function tag(value: string) {
+          return (target: any, context: ClassDecoratorContext) => {
+            target.tag = value + ":" + String(context.name);
+          };
+        }
+        @tag(basename("/x/decorated.ts"))
+        class Service {}
+        module.exports = { Service };
+      `,
+      "entry.js": `
+        const { Service } = require("./service.ts");
+        console.log(Service.tag);
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await runFile(String(dir), "entry.js");
+    expect(stderr).toBe("");
+    expect(stdout).toBe("decorated.ts:Service\n");
+    expect(exitCode).toBe(0);
+  });
+
+  test("ES module using JSX works", async () => {
+    using dir = tempDir("run-esm-jsx", {
+      ...fakeReact,
+      "component.tsx": `
+        import { basename } from "node:path";
+        export function App() {
+          return <div title={basename("/a/b.txt")}>hi</div>;
+        }
+      `,
+      "entry.ts": `
+        import { App } from "./component.tsx";
+        console.log(JSON.stringify(App()));
+      `,
+    });
+
+    const [stdout, stderr, exitCode] = await runFile(String(dir), "entry.ts");
+    expect(stderr).toBe("");
+    expect(JSON.parse(stdout)).toEqual({ type: "div", props: { title: "b.txt", children: "hi" } });
+    expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- A CommonJS-style `.jsx`/`.tsx` file (uses `require()` or `module.exports`, no `import`/`export`) fails to load at runtime with `SyntaxError: Unexpected token '{'. import call expects one or two arguments.` The same happens for a CommonJS-style `.ts` file that uses decorators, and for `bun -e` / stdin code that mixes `require()` with JSX. This is the remaining failing case in #12812 (`import x = require("...")` itself works; it is the JSX in that repro that breaks). Bun 1.3.x failed on the same inputs with `TypeError: Expected CommonJS module to have a function wrapper`, so this is not a regression from the Rust port.
- Cause: `P::generate_import_stmt` (`src/js_parser/p.rs`) always emits an ESM `import { jsx as jsx_xxx } from "react/jsx-dev-runtime"` (and `import { __legacyDecorateClassTS, ... } from "bun:wrap"`) into a part that is prepended to the module. When the parser has decided the module is CommonJS (`wrap_mode == BunCommonjs`, `src/js_parser/parse/parse_entry.rs`), `to_ast` copies every statement into the `(function(exports, require, module, __filename, __dirname) { ... })` wrapper, so the generated `import` ends up inside a function body:
  ```js
  (function(exports, require, module, __filename, __dirname) {
    import { jsx as jsx_w77yafs4 } from "react/jsx-runtime";
    const process = require("node:process");
    ...
  ```
- The `bun:test` globals injected into test files already handle this case (they are emitted as `const { test, expect } = require("bun:test")` when `exports_kind` is CommonJS); the JSX and `bun:wrap` imports did not.

### Fix
- `generate_import_stmt` takes the module's `WrapMode`. For `BunCommonjs` it adds the import record as a `require` and emits `const { jsx: jsx_xxx, ... } = require(path)`; otherwise it emits the `import` statement exactly as before. The three callers (runtime helpers and the two JSX imports in `parse_entry.rs`) pass the `wrap_mode` computed a few lines earlier. Output now:
  ```js
  (function(exports, require, module, __filename, __dirname) {
    const { jsx: jsx_w77yafs4 } = require("react/jsx-runtime");
    const process = require("node:process");
    ...
  ```
- `EXPECTED_VERSION` of the runtime transpiler cache (`src/jsc/RuntimeTranspilerCache.rs`) goes from 25 to 26: the unfixed build writes the broken output to the cache before JSC rejects it, and a fixed build at version 25 restores that entry and fails the same way (verified with a 10 KB CommonJS `.jsx` file; at version 26 the entry is rejected as stale and the file runs).
- The `require()` binding is inserted at the front of the module's leading parts rather than pushed at the end. While the file is visited, top-level classes that can be hoisted are already moved into that list (`parse_entry.rs`, the `SClass` arm), so a binding pushed after them is still in its temporal dead zone when such a class is defined. The `import` form never cared because imports hoist; with a pushed `const`, a hoisted class whose lowering calls a `bun:wrap` helper during definition (an `accessor` member, for example) failed with `ReferenceError: Cannot access '__decoratorStart_...' before initialization`.
- Why this is correct: `wrap_mode` is only ever `BunCommonjs` when `commonjs_at_runtime` is set, which only the runtime module loader does (`allow_commonjs` in `src/runtime/jsc_hooks.rs` and `src/jsc/RuntimeTranspilerStore.rs`), so the bundler, `bun build --no-bundle` and `Bun.Transpiler` keep producing the `import` form. Inside the wrapper, `require` is the wrapper's own parameter (for `bun -e` / `-p` / stdin, which run the same output without the wrapper, it is the `require` that `JSCommonJSModule.cpp` installs on the global object before evaluating the eval entry point); the binding is the first statement of the module, so it exists before any user statement, hoisted or not, runs; and the helper symbols keep printing as plain identifiers because no namespace alias is attached to them. `require("bun:wrap")` resolves at runtime the same way the `import` did.
- Verified with `test/cli/run/run-cjs.test.ts`: twelve new cases fail on the current build (eleven with the SyntaxError above; the hoisted `accessor` class additionally fails with the ReferenceError on an earlier revision of this branch) and pass with this change. They cover all three generated bindings (jsx runtime, `createElement` via a key after a spread, `bun:wrap` for experimental and standard decorators), the ways a file becomes CommonJS (`require()`, `module.exports`, `import x = require()`, `"use strict"` plus `__dirname`, a `.cts` extension), a test file under `bun test`, and the `-e`, `-p` and stdin entry points. Two control cases (plain CommonJS, ES module with JSX) pass both ways.
- Also ran: `test/cli/run/transpiler-cache.test.ts`, `test/bundler/transpiler/`, `test/bundler/bundler_jsx.test.ts`, `bundler_cjs.test.ts`, `bundler_decorator_metadata.test.ts`, `test/regression/issue/11100.test.ts`, `test/js/bun/test/test-auto-import-jest-globals.test.js`, `test/js/bun/resolve/require.test.ts` and the CommonJS/JSX tests under `test/cli/run/`. The only failures were per-test timeouts in `jsx-production.test.ts` and `require-cache.test.ts` that re-transpile react-dom or a 200 KB fixture dozens of times; each of those runs produces the expected output on the debug build, it just takes longer than the test timeout there.

### Background
- CommonJS wrapper: Bun's runtime does not evaluate CommonJS modules directly. The transpiler wraps the module body in a function taking `(exports, require, module, __filename, __dirname)` and the module loader calls it. `import` declarations are only legal at the top level of a module, so any `import` inside that function is a parse error.
- `wrap_mode`: computed in `parse_entry.rs` after visiting the file. It is `BunCommonjs` when the module is CommonJS (uses `module`/`exports`, or has no ESM syntax and uses `require()`/`__dirname`/`"use strict"`, or is in a `"type": "commonjs"` package) and the parse is for the runtime (`commonjs_at_runtime`). The bundler never sets it.
- Generated imports: lowering JSX and decorators produces calls to helper functions the user never imported. The parser collects the helpers it used and, at the end of the parse, generates one binding statement for the JSX runtime package and one for `bun:wrap` (Bun's internal helper module), which is what `generate_import_stmt` builds.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/run/run-cjs.test.ts

<!-- robobun:evidence:end -->