### PR TITLE
bun:ffi: treat arguments not passed to a cc() symbol as undefined instead of reading past the call frame

### DIFF
--- a/src/jsc/bindings/ffi.cpp
+++ b/src/jsc/bindings/ffi.cpp
@@ -5,8 +5,13 @@ typedef struct FFIFields {
     uint32_t JSArrayBufferView__offsetOfByteOffset;
     uint32_t JSArrayBufferView__offsetOfVector;
     uint32_t JSCell__offsetOfType;
+    // Register (8-byte slot) indices into a CallFrame, not byte offsets.
+    uint32_t CallFrame__argumentCountIncludingThisSlot;
+    uint32_t CallFrame__firstArgumentSlot;
 } FFIFields;
 extern "C" FFIFields Bun__FFI__offsets = { 0 };
+
+static_assert(sizeof(JSC::Register) == sizeof(void*), "the cc() wrapper indexes the CallFrame as an array of pointer-sized slots");
 
 extern "C" void Bun__FFI__ensureOffsetsAreLoaded()
 {
@@ -14,4 +19,6 @@ extern "C" void Bun__FFI__ensureOffsetsAreLoaded()
     Bun__FFI__offsets.JSArrayBufferView__offsetOfByteOffset = JSC::JSArrayBufferView::offsetOfByteOffset();
     Bun__FFI__offsets.JSArrayBufferView__offsetOfVector = JSC::JSArrayBufferView::offsetOfVector();
     Bun__FFI__offsets.JSCell__offsetOfType = JSC::JSCell::typeInfoTypeOffset();
+    Bun__FFI__offsets.CallFrame__argumentCountIncludingThisSlot = static_cast<uint32_t>(JSC::CallFrameSlot::argumentCountIncludingThis);
+    Bun__FFI__offsets.CallFrame__firstArgumentSlot = static_cast<uint32_t>(JSC::CallFrame::argumentOffset(0));
 }

--- a/src/jsc/lib.rs
+++ b/src/jsc/lib.rs
@@ -76,8 +76,6 @@ pub mod marked_argument_buffer;
 pub mod regular_expression;
 #[path = "ScriptExecutionStatus.rs"]
 pub mod script_execution_status;
-#[path = "sizes.rs"]
-pub mod sizes;
 #[path = "SourceProvider.rs"]
 pub mod source_provider;
 #[path = "TextCodec.rs"]

--- a/src/jsc/sizes.rs
+++ b/src/jsc/sizes.rs
@@ -1,8 +1,0 @@
-//! This namespace contains JSC C++ type sizes/alignments exported from a code
-//! generator. Do not rely on any of these values in new code. If possible,
-//! rewrite old ones to use another approach.
-//!
-//! It is not reliable to interpret C++ classes as raw bytes, since the
-//! memory layout is not guaranteed by the compiler.
-
-pub const BUN_FFI_POINTER_OFFSET_TO_ARGUMENTS_LIST: usize = 6;

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -133,13 +133,16 @@ typedef void* JSContext;
 // slot indices are defined by the runtime from JSC::CallFrameSlot when it
 // compiles this file (src/jsc/bindings/ffi.cpp).
 #define LOAD_ARGUMENTS_FROM_CALL_FRAME \
-  EncodedJSValue *argsPtr = (EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
+  int64_t *argsPtr = (int64_t*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
   int32_t argsCount = ((EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentCountIncludingThis))->asBits.payload - 1
 
-// JSC::CallFrame::argument(i): slots past argsCount are not arguments (they are
-// whatever the caller's stack holds there), so a missing argument is undefined,
-// like it is for a JS function and for the dlopen()/linkSymbols() FFI.
-#define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : ValueUndefined)
+// JSC::CallFrame::argument(i) as encoded bits: slots past argsCount are not
+// arguments (they are whatever the caller's stack holds there), so a missing
+// argument is undefined, like it is for a JS function and for the
+// dlopen()/linkSymbols() FFI. Yields an int64_t rather than an EncodedJSValue
+// because this file is linked with -nostdlib and, on every target but x86_64,
+// TinyCC compiles a struct/union copy into a call to memmove.
+#define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : TagValueUndefined)
 
 
 

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -128,13 +128,18 @@ EncodedJSValue ValueTrue = { TagValueTrue };
 
 typedef void* JSContext;
 
-// Bun_FFI_PointerOffsetToArgumentsList is injected into the build 
-// The value is generated in `make sizegen`
-// The value is 6.
-// On ARM64_32, the value is something else but it really doesn't matter for our case
-// However, I don't want this to subtly break amidst future upgrades to JavaScriptCore
+// JSFunctionCall is installed as a JSC host function, so `callFrame` is a
+// JSC::CallFrame: an array of 8-byte slots. The two Bun_FFI_PointerOffsetTo*
+// slot indices are defined by the runtime from JSC::CallFrameSlot when it
+// compiles this file (src/jsc/bindings/ffi.cpp).
 #define LOAD_ARGUMENTS_FROM_CALL_FRAME \
-  int64_t *argsPtr = (int64_t*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList)
+  EncodedJSValue *argsPtr = (EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
+  int32_t argsCount = ((EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentCountIncludingThis))->asBits.payload - 1
+
+// JSC::CallFrame::argument(i): slots past argsCount are not arguments (they are
+// whatever the caller's stack holds there), so a missing argument is undefined,
+// like it is for a JS function and for the dlopen()/linkSymbols() FFI.
+#define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : ValueUndefined)
 
 
 
@@ -208,7 +213,9 @@ static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) {
 // This behavior change enables the JIT to handle it better
 // It also is better readability when console.log(myPtr)
 static void* JSVALUE_TO_PTR(EncodedJSValue val) {
-  if (val.asInt64 == TagValueNull)
+  // Same as the engine FFI (FFIConversions.cpp writePointerSlot): both null and
+  // undefined, including an argument that was not passed at all, are NULL.
+  if (val.asInt64 == TagValueNull || val.asInt64 == TagValueUndefined)
     return 0;
 
   if (JSCELL_IS_TYPED_ARRAY(val)) {

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -128,15 +128,12 @@ EncodedJSValue ValueTrue = { TagValueTrue };
 
 typedef void* JSContext;
 
-// callFrame is the JSC::CallFrame (an array of 8-byte slots); the two slot indices
-// are defined from JSC::CallFrameSlot by src/jsc/bindings/ffi.cpp.
+// The Bun_FFI_PointerOffsetTo* slot indices into the JSC::CallFrame are defined from JSC::CallFrameSlot by src/jsc/bindings/ffi.cpp.
 #define LOAD_ARGUMENTS_FROM_CALL_FRAME \
   int64_t *argsPtr = (int64_t*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
   int32_t argsCount = ((EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentCountIncludingThis))->asBits.payload - 1
 
-// Bits of JSC::CallFrame::argument(i): a slot past argsCount is stale stack, so an
-// argument that was not passed reads as undefined. int64_t rather than a union copy:
-// TinyCC emits a memmove call for those on non-x86_64 and this file is built -nostdlib.
+// JSC::CallFrame::argument(i) as encoded bits: an argument the caller did not pass reads as undefined, not as the stale slot.
 #define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : TagValueUndefined)
 
 

--- a/src/runtime/ffi/FFI.h
+++ b/src/runtime/ffi/FFI.h
@@ -128,20 +128,15 @@ EncodedJSValue ValueTrue = { TagValueTrue };
 
 typedef void* JSContext;
 
-// JSFunctionCall is installed as a JSC host function, so `callFrame` is a
-// JSC::CallFrame: an array of 8-byte slots. The two Bun_FFI_PointerOffsetTo*
-// slot indices are defined by the runtime from JSC::CallFrameSlot when it
-// compiles this file (src/jsc/bindings/ffi.cpp).
+// callFrame is the JSC::CallFrame (an array of 8-byte slots); the two slot indices
+// are defined from JSC::CallFrameSlot by src/jsc/bindings/ffi.cpp.
 #define LOAD_ARGUMENTS_FROM_CALL_FRAME \
   int64_t *argsPtr = (int64_t*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
   int32_t argsCount = ((EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentCountIncludingThis))->asBits.payload - 1
 
-// JSC::CallFrame::argument(i) as encoded bits: slots past argsCount are not
-// arguments (they are whatever the caller's stack holds there), so a missing
-// argument is undefined, like it is for a JS function and for the
-// dlopen()/linkSymbols() FFI. Yields an int64_t rather than an EncodedJSValue
-// because this file is linked with -nostdlib and, on every target but x86_64,
-// TinyCC compiles a struct/union copy into a call to memmove.
+// Bits of JSC::CallFrame::argument(i): a slot past argsCount is stale stack, so an
+// argument that was not passed reads as undefined. int64_t rather than a union copy:
+// TinyCC emits a memmove call for those on non-x86_64 and this file is built -nostdlib.
 #define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : TagValueUndefined)
 
 
@@ -216,8 +211,7 @@ static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) {
 // This behavior change enables the JIT to handle it better
 // It also is better readability when console.log(myPtr)
 static void* JSVALUE_TO_PTR(EncodedJSValue val) {
-  // Same as the engine FFI (FFIConversions.cpp writePointerSlot): both null and
-  // undefined, including an argument that was not passed at all, are NULL.
+  // undefined (e.g. an argument that was not passed) is NULL, as in the engine's writePointerSlot.
   if (val.asInt64 == TagValueNull || val.asInt64 == TagValueUndefined)
     return 0;
 

--- a/src/runtime/ffi/abi_type.rs
+++ b/src/runtime/ffi/abi_type.rs
@@ -191,20 +191,6 @@ impl ABIType {
         })
     }
 
-    /// Types that we can directly pass through as an `int64_t`
-    pub(crate) fn needs_a_cast_in_c(self) -> bool {
-        !matches!(
-            self,
-            ABIType::Char
-                | ABIType::Int8T
-                | ABIType::Uint8T
-                | ABIType::Int16T
-                | ABIType::Uint16T
-                | ABIType::Int32T
-                | ABIType::Uint32T
-        )
-    }
-
     pub(crate) fn is_floating_point(self) -> bool {
         matches!(self, ABIType::Double | ABIType::Float)
     }

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2154,8 +2154,7 @@ impl Function {
             )?;
         }
 
-        // A napi_env parameter is filled in by `to_c` below but still takes up
-        // its position in the JS argument list, so `i` is the JS index too.
+        // napi_env comes from `to_c` but still occupies its JS argument position, so `i` is the JS index.
         if self.arg_types.iter().any(|arg| *arg != ABIType::NapiEnv) {
             writer.write_all(b"  LOAD_ARGUMENTS_FROM_CALL_FRAME;\n")?;
             for (i, arg) in self.arg_types.iter().enumerate() {

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2159,10 +2159,10 @@ impl Function {
             writer.write_all(b"  LOAD_ARGUMENTS_FROM_CALL_FRAME;\n")?;
             for (i, arg) in self.arg_types.iter().enumerate() {
                 if *arg != ABIType::NapiEnv {
-                    // Initialized from the bits, never copied as a union: TinyCC lowers union copies to memmove on non-x86_64 and the wrapper is -nostdlib.
+                    // Member store: TinyCC emits a memset call for a brace-initialized local and a memmove call (unresolvable under -nostdlib) for a union copy.
                     writeln!(
                         writer,
-                        "  EncodedJSValue arg{i} = {{ .asInt64 = ARGUMENT({i}) }};"
+                        "  EncodedJSValue arg{i};\n  arg{i}.asInt64 = ARGUMENT({i});"
                     )?;
                 }
             }

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2160,7 +2160,10 @@ impl Function {
             writer.write_all(b"  LOAD_ARGUMENTS_FROM_CALL_FRAME;\n")?;
             for (i, arg) in self.arg_types.iter().enumerate() {
                 if *arg != ABIType::NapiEnv {
-                    writeln!(writer, "  EncodedJSValue arg{i} = ARGUMENT({i});")?;
+                    writeln!(
+                        writer,
+                        "  EncodedJSValue arg{i} = {{ .asInt64 = ARGUMENT({i}) }};"
+                    )?;
                 }
             }
         }

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -2159,6 +2159,7 @@ impl Function {
             writer.write_all(b"  LOAD_ARGUMENTS_FROM_CALL_FRAME;\n")?;
             for (i, arg) in self.arg_types.iter().enumerate() {
                 if *arg != ABIType::NapiEnv {
+                    // Initialized from the bits, never copied as a union: TinyCC lowers union copies to memmove on non-x86_64 and the wrapper is -nostdlib.
                     writeln!(
                         writer,
                         "  EncodedJSValue arg{i} = {{ .asInt64 = ARGUMENT({i}) }};"

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -72,12 +72,15 @@ fn dangerously_run_without_jit_protections<R>(func: impl FnOnce() -> R) -> R {
     func()
 }
 
+/// Mirrors `FFIFields` in `src/jsc/bindings/ffi.cpp`.
 #[repr(C)]
 struct Offsets {
     js_array_buffer_view_offset_of_length: u32,
     js_array_buffer_view_offset_of_byte_offset: u32,
     js_array_buffer_view_offset_of_vector: u32,
     js_cell_offset_of_type: u32,
+    call_frame_argument_count_including_this_slot: u32,
+    call_frame_first_argument_slot: u32,
 }
 
 unsafe extern "C" {
@@ -2151,41 +2154,13 @@ impl Function {
             )?;
         }
 
-        if !self.arg_types.is_empty() {
+        // A napi_env parameter is filled in by `to_c` below but still takes up
+        // its position in the JS argument list, so `i` is the JS index too.
+        if self.arg_types.iter().any(|arg| *arg != ABIType::NapiEnv) {
             writer.write_all(b"  LOAD_ARGUMENTS_FROM_CALL_FRAME;\n")?;
             for (i, arg) in self.arg_types.iter().enumerate() {
-                if *arg == ABIType::NapiEnv {
-                    write!(
-                        writer,
-                        "  napi_env arg{} = (napi_env)&Bun__thisFFIModuleNapiEnv;\n  argsPtr++;\n",
-                        i
-                    )?;
-                } else if *arg == ABIType::NapiValue {
-                    writeln!(
-                        writer,
-                        "  EncodedJSValue arg{} = {{ .asInt64 = *argsPtr++ }};",
-                        i
-                    )?;
-                } else if arg.needs_a_cast_in_c() {
-                    if i < self.arg_types.len() - 1 {
-                        writeln!(
-                            writer,
-                            "  EncodedJSValue arg{} = {{ .asInt64 = *argsPtr++ }};",
-                            i
-                        )?;
-                    } else {
-                        write!(
-                            writer,
-                            "  EncodedJSValue arg{};\n  arg{}.asInt64 = *argsPtr;\n",
-                            i, i
-                        )?;
-                    }
-                } else {
-                    if i < self.arg_types.len() - 1 {
-                        writeln!(writer, "  int64_t arg{} = *argsPtr++;", i)?;
-                    } else {
-                        writeln!(writer, "  int64_t arg{} = *argsPtr;", i)?;
-                    }
+                if *arg != ABIType::NapiEnv {
+                    writeln!(writer, "  EncodedJSValue arg{i} = ARGUMENT({i});")?;
                 }
             }
         }
@@ -2213,11 +2188,7 @@ impl Function {
 
             let length_buf = bun_core::fmt::print_int(&mut arg_buf[3..], i);
             let arg_name = &arg_buf[0..3 + length_buf];
-            if arg.needs_a_cast_in_c() {
-                write!(writer, "{}", arg.to_c(arg_name))?;
-            } else {
-                writer.write_all(arg_name)?;
-            }
+            write!(writer, "{}", arg.to_c(arg_name))?;
         }
         writer.write_all(b");\n")?;
 
@@ -2542,7 +2513,11 @@ impl CompilerRT {
         state.define_symbols(&[
             (
                 "Bun_FFI_PointerOffsetToArgumentsList",
-                bun_jsc::sizes::BUN_FFI_POINTER_OFFSET_TO_ARGUMENTS_LIST as i64,
+                offsets.call_frame_first_argument_slot as i64,
+            ),
+            (
+                "Bun_FFI_PointerOffsetToArgumentCountIncludingThis",
+                offsets.call_frame_argument_count_including_this_slot as i64,
             ),
             (
                 "JSArrayBufferView__offsetOfLength",

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -75,10 +75,13 @@ describe.skipIf(isASAN)("given an add(a, b) function", () => {
       expect(() => res.symbols.add("1", "2")).toThrow();
     });
 
-    // looks like `b` defaults to `0`, is this U.B. or expected?
-    it.skip("when passed too few arguments, throws an error", () => {
+    // A missing argument is undefined, which converts to 0, exactly as it does
+    // for a dlopen() symbol.
+    it("when passed too few arguments, the missing ones are 0", () => {
       // @ts-expect-error
-      expect(() => res.symbols.add(1)).toThrow();
+      expect(res.symbols.add(1)).toBe(1);
+      // @ts-expect-error
+      expect(res.symbols.add()).toBe(0);
     });
 
     it("when passed too many arguments, still works", () => {
@@ -100,6 +103,127 @@ describe.skipIf(isASAN)("given an add(a, b) function", () => {
     }).toThrow(/"subtract" is missing/);
   });
 }); // </given add(a, b) function>
+
+// The wrapper cc() compiles for a symbol used to load one call-frame slot per
+// declared parameter without looking at how many arguments were passed, so a
+// call with fewer arguments handed C whatever the caller's frame held past the
+// last one: garbage integers, and for pointer parameters a segfault while the
+// stale slot was being inspected as a JSValue. A missing argument is undefined,
+// which converts the way it does for dlopen() symbols: 0 for integers and
+// pointers, NaN for floating point, false for bool, undefined for napi_value.
+// Runs in a subprocess because the unfixed wrapper crashes.
+describe("calling a symbol with fewer arguments than it declares", () => {
+  it("converts the missing arguments as undefined instead of reading past the call frame", async () => {
+    using dir = tempDir("bun-ffi-cc-missing-args", {
+      // Every function reports what C received as an int, so a bad argument
+      // decode cannot be masked by the matching return conversion.
+      "arity.c": /* c */ `
+        int digits(int a, int b, int c) { return a * 100 + b * 10 + c; }
+        int u8_value(unsigned char x) { return x; }
+        int bool_value(_Bool x) { return x; }
+        int f64_is_nan(double x) { return x != x; }
+        int f32_is_nan(float x) { return x != x; }
+        int ptr_is_null(void* p) { return p == 0; }
+        int cstring_is_null(const char* s) { return s == 0; }
+        /* bit i is set when parameter i arrived as the value undefined converts to */
+        int missing_mask(int a, double b, void* c, _Bool d) {
+          return (a == 0) | ((b != b) << 1) | ((c == 0) << 2) | ((d == 0) << 3);
+        }
+        typedef struct bun_test_env* env_t;
+        typedef struct bun_test_value* value_t;
+        value_t echo_napi_value(env_t env, value_t value) { return value; }
+      `,
+      "fixture.js": /* js */ `
+        import { cc, ptr } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "arity.c"),
+          symbols: {
+            digits: { args: ["i32", "i32", "i32"], returns: "i32" },
+            u8_value: { args: ["u8"], returns: "i32" },
+            bool_value: { args: ["bool"], returns: "i32" },
+            f64_is_nan: { args: ["f64"], returns: "i32" },
+            f32_is_nan: { args: ["f32"], returns: "i32" },
+            ptr_is_null: { args: ["ptr"], returns: "i32" },
+            cstring_is_null: { args: ["cstring"], returns: "i32" },
+            missing_mask: { args: ["i32", "f64", "ptr", "bool"], returns: "i32" },
+            echo_napi_value: { args: ["napi_env", "napi_value"], returns: "napi_value" },
+          },
+        });
+
+        const bytes = new Uint8Array(8);
+
+        // Repeated calls from one call site walk through the JIT tiers, which
+        // is where the stale slot past the arguments tends to hold a pointer.
+        let nullPointers = 0;
+        for (let i = 0; i < 500; i++) nullPointers += symbols.ptr_is_null();
+
+        const results = {
+          digits: {
+            none: symbols.digits(),
+            one: symbols.digits(1),
+            two: symbols.digits(1, 2),
+            all: symbols.digits(1, 2, 3),
+            extra: symbols.digits(1, 2, 3, 4),
+          },
+          u8: { missing: symbols.u8_value(), passed: symbols.u8_value(200) },
+          bool: { missing: symbols.bool_value(), passed: symbols.bool_value(true) },
+          f64_is_nan: { missing: symbols.f64_is_nan(), passed: symbols.f64_is_nan(1.5) },
+          f32_is_nan: { missing: symbols.f32_is_nan(), passed: symbols.f32_is_nan(1.5) },
+          ptr_is_null: {
+            missing: symbols.ptr_is_null(),
+            missing_500_times: nullPointers,
+            undefined: symbols.ptr_is_null(undefined),
+            null: symbols.ptr_is_null(null),
+            typed_array: symbols.ptr_is_null(bytes),
+            address: symbols.ptr_is_null(ptr(bytes)),
+          },
+          cstring_is_null: { missing: symbols.cstring_is_null(), undefined: symbols.cstring_is_null(undefined) },
+          missing_mask: {
+            none: symbols.missing_mask(),
+            first_only: symbols.missing_mask(5),
+            all: symbols.missing_mask(5, 2.5, bytes, true),
+          },
+          // napi_env takes up position 0 of the JS argument list but is filled in by the wrapper.
+          echo_napi_value: {
+            none: typeof symbols.echo_napi_value(),
+            placeholder_only: typeof symbols.echo_napi_value(null),
+            passed: symbols.echo_napi_value(undefined, 42),
+          },
+        };
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    // stderr is included in the received object so failures show it, but is not
+    // asserted empty: debug builds emit benign startup warnings.
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        digits: { none: 0, one: 100, two: 120, all: 123, extra: 123 },
+        u8: { missing: 0, passed: 200 },
+        bool: { missing: 0, passed: 1 },
+        f64_is_nan: { missing: 1, passed: 0 },
+        f32_is_nan: { missing: 1, passed: 0 },
+        ptr_is_null: { missing: 1, missing_500_times: 500, undefined: 1, null: 1, typed_array: 0, address: 0 },
+        cstring_is_null: { missing: 1, undefined: 1 },
+        missing_mask: { none: 0b1111, first_only: 0b1110, all: 0 },
+        echo_napi_value: { none: "undefined", placeholder_only: "undefined", passed: 42 },
+      },
+      exitCode: 0,
+    });
+  });
+});
 
 describe("given a source file with syntax errors", () => {
   const source = /* c */ `

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -125,6 +125,7 @@ describe("calling a symbol with fewer arguments than it declares", () => {
         int f32_is_nan(float x) { return x != x; }
         int ptr_is_null(void* p) { return p == 0; }
         int cstring_is_null(const char* s) { return s == 0; }
+        int function_is_null(void (*f)(void)) { return f == 0; }
         /* bit i is set when parameter i arrived as the value undefined converts to */
         int missing_mask(int a, double b, void* c, _Bool d) {
           return (a == 0) | ((b != b) << 1) | ((c == 0) << 2) | ((d == 0) << 3);
@@ -147,6 +148,7 @@ describe("calling a symbol with fewer arguments than it declares", () => {
             f32_is_nan: { args: ["f32"], returns: "i32" },
             ptr_is_null: { args: ["ptr"], returns: "i32" },
             cstring_is_null: { args: ["cstring"], returns: "i32" },
+            function_is_null: { args: ["function"], returns: "i32" },
             missing_mask: { args: ["i32", "f64", "ptr", "bool"], returns: "i32" },
             echo_napi_value: { args: ["napi_env", "napi_value"], returns: "napi_value" },
           },
@@ -167,7 +169,8 @@ describe("calling a symbol with fewer arguments than it declares", () => {
             all: symbols.digits(1, 2, 3),
             extra: symbols.digits(1, 2, 3, 4),
           },
-          u8: { missing: symbols.u8_value(), passed: symbols.u8_value(200) },
+          // 200.5 is a double-encoded JSValue; integer parameters used to receive the raw slot bits.
+          u8: { missing: symbols.u8_value(), passed: symbols.u8_value(200), double_encoded: symbols.u8_value(200.5) },
           bool: { missing: symbols.bool_value(), passed: symbols.bool_value(true) },
           f64_is_nan: { missing: symbols.f64_is_nan(), passed: symbols.f64_is_nan(1.5) },
           f32_is_nan: { missing: symbols.f32_is_nan(), passed: symbols.f32_is_nan(1.5) },
@@ -180,6 +183,9 @@ describe("calling a symbol with fewer arguments than it declares", () => {
             address: symbols.ptr_is_null(ptr(bytes)),
           },
           cstring_is_null: { missing: symbols.cstring_is_null(), undefined: symbols.cstring_is_null(undefined) },
+          // The engine's FFI throws a TypeError for an undefined callback; the cc() wrapper
+          // has no throwing conversion yet (#37989 adds it), so C receives NULL until then.
+          function_is_null: { missing: symbols.function_is_null(), undefined: symbols.function_is_null(undefined) },
           missing_mask: {
             none: symbols.missing_mask(),
             first_only: symbols.missing_mask(5),
@@ -211,12 +217,13 @@ describe("calling a symbol with fewer arguments than it declares", () => {
     expect({ results, stderr, exitCode }).toMatchObject({
       results: {
         digits: { none: 0, one: 100, two: 120, all: 123, extra: 123 },
-        u8: { missing: 0, passed: 200 },
+        u8: { missing: 0, passed: 200, double_encoded: 200 },
         bool: { missing: 0, passed: 1 },
         f64_is_nan: { missing: 1, passed: 0 },
         f32_is_nan: { missing: 1, passed: 0 },
         ptr_is_null: { missing: 1, missing_500_times: 500, undefined: 1, null: 1, typed_array: 0, address: 0 },
         cstring_is_null: { missing: 1, undefined: 1 },
+        function_is_null: { missing: 1, undefined: 1 },
         missing_mask: { none: 0b1111, first_only: 0b1110, all: 0 },
         echo_napi_value: { none: "undefined", placeholder_only: "undefined", passed: 42 },
       },

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -130,20 +130,15 @@ EncodedJSValue ValueTrue = { TagValueTrue };
 
 typedef void* JSContext;
 
-// JSFunctionCall is installed as a JSC host function, so `callFrame` is a
-// JSC::CallFrame: an array of 8-byte slots. The two Bun_FFI_PointerOffsetTo*
-// slot indices are defined by the runtime from JSC::CallFrameSlot when it
-// compiles this file (src/jsc/bindings/ffi.cpp).
+// callFrame is the JSC::CallFrame (an array of 8-byte slots); the two slot indices
+// are defined from JSC::CallFrameSlot by src/jsc/bindings/ffi.cpp.
 #define LOAD_ARGUMENTS_FROM_CALL_FRAME \
   int64_t *argsPtr = (int64_t*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
   int32_t argsCount = ((EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentCountIncludingThis))->asBits.payload - 1
 
-// JSC::CallFrame::argument(i) as encoded bits: slots past argsCount are not
-// arguments (they are whatever the caller's stack holds there), so a missing
-// argument is undefined, like it is for a JS function and for the
-// dlopen()/linkSymbols() FFI. Yields an int64_t rather than an EncodedJSValue
-// because this file is linked with -nostdlib and, on every target but x86_64,
-// TinyCC compiles a struct/union copy into a call to memmove.
+// Bits of JSC::CallFrame::argument(i): a slot past argsCount is stale stack, so an
+// argument that was not passed reads as undefined. int64_t rather than a union copy:
+// TinyCC emits a memmove call for those on non-x86_64 and this file is built -nostdlib.
 #define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : TagValueUndefined)
 
 
@@ -218,8 +213,7 @@ static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) {
 // This behavior change enables the JIT to handle it better
 // It also is better readability when console.log(myPtr)
 static void* JSVALUE_TO_PTR(EncodedJSValue val) {
-  // Same as the engine FFI (FFIConversions.cpp writePointerSlot): both null and
-  // undefined, including an argument that was not passed at all, are NULL.
+  // undefined (e.g. an argument that was not passed) is NULL, as in the engine's writePointerSlot.
   if (val.asInt64 == TagValueNull || val.asInt64 == TagValueUndefined)
     return 0;
 

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -130,13 +130,18 @@ EncodedJSValue ValueTrue = { TagValueTrue };
 
 typedef void* JSContext;
 
-// Bun_FFI_PointerOffsetToArgumentsList is injected into the build 
-// The value is generated in `make sizegen`
-// The value is 6.
-// On ARM64_32, the value is something else but it really doesn't matter for our case
-// However, I don't want this to subtly break amidst future upgrades to JavaScriptCore
+// JSFunctionCall is installed as a JSC host function, so `callFrame` is a
+// JSC::CallFrame: an array of 8-byte slots. The two Bun_FFI_PointerOffsetTo*
+// slot indices are defined by the runtime from JSC::CallFrameSlot when it
+// compiles this file (src/jsc/bindings/ffi.cpp).
 #define LOAD_ARGUMENTS_FROM_CALL_FRAME \
-  int64_t *argsPtr = (int64_t*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList)
+  EncodedJSValue *argsPtr = (EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
+  int32_t argsCount = ((EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentCountIncludingThis))->asBits.payload - 1
+
+// JSC::CallFrame::argument(i): slots past argsCount are not arguments (they are
+// whatever the caller's stack holds there), so a missing argument is undefined,
+// like it is for a JS function and for the dlopen()/linkSymbols() FFI.
+#define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : ValueUndefined)
 
 
 
@@ -210,7 +215,9 @@ static uint64_t JSVALUE_TO_TYPED_ARRAY_LENGTH(EncodedJSValue val) {
 // This behavior change enables the JIT to handle it better
 // It also is better readability when console.log(myPtr)
 static void* JSVALUE_TO_PTR(EncodedJSValue val) {
-  if (val.asInt64 == TagValueNull)
+  // Same as the engine FFI (FFIConversions.cpp writePointerSlot): both null and
+  // undefined, including an argument that was not passed at all, are NULL.
+  if (val.asInt64 == TagValueNull || val.asInt64 == TagValueUndefined)
     return 0;
 
   if (JSCELL_IS_TYPED_ARRAY(val)) {
@@ -374,8 +381,7 @@ float not_a_callback(float arg0);
 /* ---- Your Wrapper Function ---- */
 ZIG_REPR_TYPE JSFunctionCall(void* JS_GLOBAL_OBJECT, void* callFrame) {
   LOAD_ARGUMENTS_FROM_CALL_FRAME;
-  EncodedJSValue arg0;
-  arg0.asInt64 = *argsPtr;
+  EncodedJSValue arg0 = ARGUMENT(0);
     float return_value = not_a_callback(    JSVALUE_TO_FLOAT(arg0));
 
     return FLOAT_TO_JSVALUE(return_value).asZigRepr;

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -375,7 +375,8 @@ float not_a_callback(float arg0);
 /* ---- Your Wrapper Function ---- */
 ZIG_REPR_TYPE JSFunctionCall(void* JS_GLOBAL_OBJECT, void* callFrame) {
   LOAD_ARGUMENTS_FROM_CALL_FRAME;
-  EncodedJSValue arg0 = { .asInt64 = ARGUMENT(0) };
+  EncodedJSValue arg0;
+  arg0.asInt64 = ARGUMENT(0);
     float return_value = not_a_callback(    JSVALUE_TO_FLOAT(arg0));
 
     return FLOAT_TO_JSVALUE(return_value).asZigRepr;

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -135,13 +135,16 @@ typedef void* JSContext;
 // slot indices are defined by the runtime from JSC::CallFrameSlot when it
 // compiles this file (src/jsc/bindings/ffi.cpp).
 #define LOAD_ARGUMENTS_FROM_CALL_FRAME \
-  EncodedJSValue *argsPtr = (EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
+  int64_t *argsPtr = (int64_t*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
   int32_t argsCount = ((EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentCountIncludingThis))->asBits.payload - 1
 
-// JSC::CallFrame::argument(i): slots past argsCount are not arguments (they are
-// whatever the caller's stack holds there), so a missing argument is undefined,
-// like it is for a JS function and for the dlopen()/linkSymbols() FFI.
-#define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : ValueUndefined)
+// JSC::CallFrame::argument(i) as encoded bits: slots past argsCount are not
+// arguments (they are whatever the caller's stack holds there), so a missing
+// argument is undefined, like it is for a JS function and for the
+// dlopen()/linkSymbols() FFI. Yields an int64_t rather than an EncodedJSValue
+// because this file is linked with -nostdlib and, on every target but x86_64,
+// TinyCC compiles a struct/union copy into a call to memmove.
+#define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : TagValueUndefined)
 
 
 
@@ -381,7 +384,7 @@ float not_a_callback(float arg0);
 /* ---- Your Wrapper Function ---- */
 ZIG_REPR_TYPE JSFunctionCall(void* JS_GLOBAL_OBJECT, void* callFrame) {
   LOAD_ARGUMENTS_FROM_CALL_FRAME;
-  EncodedJSValue arg0 = ARGUMENT(0);
+  EncodedJSValue arg0 = { .asInt64 = ARGUMENT(0) };
     float return_value = not_a_callback(    JSVALUE_TO_FLOAT(arg0));
 
     return FLOAT_TO_JSVALUE(return_value).asZigRepr;

--- a/test/js/bun/ffi/ffi.test.fixture.receiver.c
+++ b/test/js/bun/ffi/ffi.test.fixture.receiver.c
@@ -130,15 +130,12 @@ EncodedJSValue ValueTrue = { TagValueTrue };
 
 typedef void* JSContext;
 
-// callFrame is the JSC::CallFrame (an array of 8-byte slots); the two slot indices
-// are defined from JSC::CallFrameSlot by src/jsc/bindings/ffi.cpp.
+// The Bun_FFI_PointerOffsetTo* slot indices into the JSC::CallFrame are defined from JSC::CallFrameSlot by src/jsc/bindings/ffi.cpp.
 #define LOAD_ARGUMENTS_FROM_CALL_FRAME \
   int64_t *argsPtr = (int64_t*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentsList); \
   int32_t argsCount = ((EncodedJSValue*)((size_t*)callFrame + Bun_FFI_PointerOffsetToArgumentCountIncludingThis))->asBits.payload - 1
 
-// Bits of JSC::CallFrame::argument(i): a slot past argsCount is stale stack, so an
-// argument that was not passed reads as undefined. int64_t rather than a union copy:
-// TinyCC emits a memmove call for those on non-x86_64 and this file is built -nostdlib.
+// JSC::CallFrame::argument(i) as encoded bits: an argument the caller did not pass reads as undefined, not as the stale slot.
 #define ARGUMENT(i) ((i) < argsCount ? argsPtr[i] : TagValueUndefined)
 
 


### PR DESCRIPTION
### Problem

- Calling a `cc()` symbol with fewer arguments than its `args` declares reads past the arguments that were passed. Integer parameters receive garbage, and a pointer parameter crashes: `panic(main thread): Segmentation fault at address 0x5` (debug build: `AddressSanitizer: SEGV on unknown address 0x000000000005`), raised from `JSCELL_IS_TYPED_ARRAY` inside `JSVALUE_TO_PTR` while the stale slot is inspected as a JSValue.
- Cause: the C wrapper generated in `Function::print_source_code` (`src/runtime/ffi/ffi_body.rs`) emitted one `*argsPtr++` per declared parameter and never looked at the call frame's argument count (`LOAD_ARGUMENTS_FROM_CALL_FRAME` in `src/runtime/ffi/FFI.h` only computed the pointer to the first argument). A host function's frame holds exactly the arguments the caller passed, so slot `i >= argc` is whatever the caller's stack held there.
- The `int32` family (`char` through `u32`) was passed to C as the raw JSValue bits of the slot, which is only right for an int32-tagged value: `add(undefined, 1)` returned `11` (the `0xa` undefined tag truncated to an `int`), and a double-encoded number (anything JSC does not tag as int32) arrived as garbage. Substituting `undefined` for a missing argument is only meaningful if these parameters decode it.
- `test/js/bun/ffi/cc.test.ts` already carried an `it.skip` for this ("looks like `b` defaults to `0`, is this U.B.?"). It is: the value depends on what the frame happens to hold.

### Fix

- `FFI.h`: `LOAD_ARGUMENTS_FROM_CALL_FRAME` also reads `argumentCountIncludingThis` from the frame, and the new `ARGUMENT(i)` yields the slot's bits when `i < argsCount` and the bits of `undefined` otherwise. This is the fixing line; it is the C equivalent of `JSC::CallFrame::argument(i)`, which is what the engine-backed `dlopen()`/`linkSymbols()` FFI uses (`FFICallHost.cpp`), so a missing argument now means the same thing for both kinds of symbols: it is `undefined`, and converts exactly like an explicitly passed `undefined`.
- `ffi_body.rs`: every parameter is loaded as `EncodedJSValue argN; argN.asInt64 = ARGUMENT(N);` and passed through its type's `to_c` conversion, so the int32 family goes through `JSVALUE_TO_INT32` (0 for `undefined`, truncation for double-encoded numbers) like every other type; `ABIType::needs_a_cast_in_c` is deleted. #37978 makes this same routing change for its own reasons; whichever lands second drops the duplicate hunk. `napi_env` parameters still occupy their position in the JS argument list, as before; they just no longer declare an unused local.
- The load is a member store on purpose. TinyCC emits a `memset` call for every brace-initialized local (`tccgen.c` `init_putz`) and, on every target except x86_64, a `memmove` call for a struct/union copy (`tccgen.c` `vstore`; `TCC_TARGET_NATIVE_STRUCT_COPY` is x86_64-only). The wrapper is compiled with `-nostdlib` and `CompilerRT::inject` provides `memset` but not `memmove`, so a union copy fails to link on aarch64 and a brace initializer costs a call per argument. Compiling an `add(i32, i32)` wrapper with the vendored TinyCC confirms the three shapes: union copy references `memmove` on arm64, brace initializer references `memset` on both targets, member store references neither. `memmove` is deliberately still not injected: a union copy in the wrapper is a per-call `memmove` even where it links, and the aarch64 link failure is what catches it.
- `FFI.h`: `JSVALUE_TO_PTR` returns NULL for `undefined` as it already did for `null`. This helper is shared by the `ptr`, `cstring`, and `function` rows of the ABI table. For `ptr`/`cstring` that matches the engine's `writePointerSlot`; for `function` the engine throws a TypeError instead, and the wrapper has no throwing conversion yet (#37989 adds one and routes `undefined` through it), so until then a missing or `undefined` callback reaches C as NULL rather than as the `-1` pointer it decoded to before. The fixture pins the NULL so #37989 flips that expectation deliberately.
- `ffi.cpp` / `ffi_body.rs`: both slot indices (`argumentCountIncludingThis`, first argument) are taken from `JSC::CallFrameSlot` through the existing `Bun__FFI__offsets` struct. The old hardcoded `BUN_FFI_POINTER_OFFSET_TO_ARGUMENTS_LIST` in `src/jsc/sizes.rs` was that module's only content and this was its only user, so the module is deleted.
- Cost: one compare per argument, plus, for the int32 family only, the `JSVALUE_TO_INT32` call (TinyCC does not inline, so it is a real call, as the `JSVALUE_TO_*` call already is for every other type; previously these parameters cost nothing and decoded wrongly). Only the TinyCC-compiled `cc()` path is affected, not `dlopen()`.
- Verified:
  - `test/js/bun/ffi/cc.test.ts`: new spawned-fixture test covering `i32`/`u8`/`bool`/`f64`/`f32`/`ptr`/`cstring`/`function`/`napi_value` parameters with zero, some, all, and extra arguments, 500 repeated pointer calls from one call site, explicit `undefined` for the three pointer-like types, and one double-encoded integer argument; the previously skipped `add(1)` test now asserts the defined result. On the unfixed build the fixture reports garbage integers, non-NULL pointers, and a stale object/string coming back through `napi_value`; with the fix it passes under the debug ASAN build.
  - `test/js/bun/ffi/ffi.test.js` regenerates `ffi.test.fixture.receiver.c` (the checked-in copy of a generated wrapper); the regenerated file is included. The remaining suite passes except the pre-existing "all possible values" timeouts, which are `dlopen()` loops that exceed 5s under the debug ASAN build regardless of this change.
  - `test/js/bun/ffi/cc-fixture.js` (a `napi_env`-only signature, plus `ptr`/`u64`) still passes on the debug build.
  - `cc.test.ts`, `ffi.test.js` and `test/napi/napi-value-ffi.test.ts` pass on the Linux aarch64 lanes (glibc and musl), the targets where the linker enforces the union-copy constraint.

Not changed here: a missing `buffer` argument now takes the same path as an explicit `undefined`, which `JSVALUE_TO_TYPED_ARRAY_VECTOR` already dereferences today (the engine throws a TypeError; #37989 brings that to the wrapper), and `i64`/`u64` parameters given `undefined` still hit the slow path's non-number assertion (tracked separately). In both cases this PR converts the out-of-frame read into the existing explicit-`undefined` behavior and leaves that behavior to the PRs that own it.

### Background

- `cc()` compiles the user's C with TinyCC and, per symbol, also compiles a small C wrapper (`FFI.h` followed by generated code, visible via `viewSource()`) that JSC installs directly as the host function for `symbols.name`. The wrapper receives the raw `JSC::CallFrame*`, converts the arguments itself, calls the user's function, and boxes the result. `dlopen()`/`linkSymbols()` symbols do not use this wrapper; they go through JSC's own FFI conversions.
- A JSC call frame is an array of 8-byte registers: caller frame, return PC, code block, callee, `argumentCountIncludingThis` (count stored in the low 32 bits of its slot), `this`, then the arguments that were actually passed. Host functions are not padded to their declared `length`, so the frame has exactly `argc` argument slots; `CallFrame::argument(i)` is the accessor that substitutes `undefined` beyond that.
- `Bun__FFI__offsets` (`src/jsc/bindings/ffi.cpp`) is how the wrapper already learns JSC layout facts (typed array vector/length offsets, the JSCell type byte): C++ fills the struct from JSC headers, and the runtime turns the fields into preprocessor defines when it compiles `FFI.h`.
- The wrapper's TinyCC state is created with `-nostdlib`, which also disables TinyCC's fallback of resolving symbols against the host process, so `CompilerRT::inject` (`memset`, `memcpy`, the 64-bit slow paths, the NAPI handle scope hooks) is the complete set of symbols the wrapper can reference. The user's own C is compiled in a separate state without `-nostdlib`, which is why struct assignment in user code links on aarch64 while the same thing in the wrapper does not.

<details>
<summary>Earlier revisions of this PR</summary>

- The first push had `ARGUMENT(i)` return an `EncodedJSValue` and initialized each `argN` from it (a union copy). Every Linux aarch64 lane failed with `unresolved reference to 'memmove'`; x86_64 was unaffected because TinyCC open-codes struct copies there.
- The second revision used `EncodedJSValue argN = { .asInt64 = ARGUMENT(N) };`, which links everywhere but makes TinyCC zero the local through a `memset` call before the store, on every target and for every argument. The current revision uses the plain member store, which the generator already used for the last argument before this change.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->