### PR TITLE
build: give every dep download attempt a connection of its own

### DIFF
--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -9,8 +9,8 @@
  * ## Retry behavior
  *
  * `downloadRetry`: 10 attempts, backoff doubling from 2s and capped at 30s,
- * so a download keeps trying through ~3 minutes of backoff (plus whatever
- * the failing attempts themselves take).
+ * so a download keeps trying through ~3 minutes of backoff, plus whatever
+ * the failing attempts themselves take (each bounded by `idleTimeoutMs`).
  *
  * The window is sized for github.com being unreachable from a CI agent, not
  * for one bad request. Every download starts at github.com (archives and
@@ -18,15 +18,22 @@
  * the CI images were baked misses the prefetch cache below, so each build
  * makes on the order of a hundred live github.com downloads (several deps at
  * any given time, plus WebKit, which is bumped more often than the images
- * are rebaked). The outages CI actually hits are agent-wide: every
- * github.com connection from one agent failing for 30s to over two minutes
- * while the rest of the build is fine. The previous 5 attempts / ~30s gave
- * up inside those and took a random build lane with them.
+ * are rebaked). The outages CI actually hits last from 30s to a few minutes;
+ * 5 attempts / ~30s gave up inside them and took a random build lane along.
+ *
+ * Every attempt, and every redirect hop within one, goes out on a connection
+ * of its own (`get` below). When this went through fetch(), its pool handed
+ * each retry the very connection the previous attempt had failed on, and
+ * github.com keeps a connection open while answering 503 or refusing the
+ * stream on it (node's fetch speaks HTTP/2 to it), so a fetch-cli process
+ * that had landed on a bad front-end failed every one of its attempts in a
+ * row while the dep fetches next to it, on connections of their own, went
+ * through in the same second. A retry is only worth anything if it can land
+ * somewhere else.
  *
  * 408/429 are retried along with 5xx and network errors; the other 4xx are
  * deterministic and fail immediately. Retry lines and the final error name
- * the underlying failure (`describeError`), since `fetch` itself only says
- * "fetch failed".
+ * the underlying failure and the hop it happened on (`describeError`).
  *
  * ## Atomic writes
  *
@@ -37,21 +44,20 @@
  * ## Streaming to disk
  *
  * Response body is piped to the temp file via `pipeline()` rather than
- * buffered through `res.arrayBuffer()`. Under node on Windows arm64,
- * `arrayBuffer()` on multi-MB responses intermittently fastfails the
- * process (0xC0000409) — no exception, just gone. Streaming avoids the
- * large native allocation and keeps peak memory flat regardless of
- * tarball size (WebKit is ~200MB).
+ * buffered in memory first. Under node on Windows arm64, buffering multi-MB
+ * responses intermittently fastfailed the process (0xC0000409) — no
+ * exception, just gone. Streaming avoids the large native allocation and
+ * keeps peak memory flat regardless of tarball size (WebKit is ~200MB).
  */
 
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { createWriteStream, existsSync, readFileSync } from "node:fs";
 import { chmod, copyFile, cp, lstat, mkdir, readdir, rename, rm, writeFile } from "node:fs/promises";
+import * as http from "node:http";
+import * as https from "node:https";
 import { basename, resolve } from "node:path";
-import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
-import type { ReadableStream as NodeWebReadable } from "node:stream/web";
 import { BuildError, assert, describeError } from "./error.ts";
 
 // On Windows, prefer the OS-shipped bsdtar. Git-for-Windows / MSYS put GNU tar
@@ -153,12 +159,59 @@ export interface RetryPolicy {
   attempts: number;
   /** Delay before try number `attempt` (2..attempts). */
   backoffMs(attempt: number): number;
+  /**
+   * An attempt whose connection has carried nothing for this long (while
+   * connecting, waiting for headers, or mid-body) is failed and retried.
+   * Bounds each attempt; a healthy transfer of any size never goes idle.
+   */
+  idleTimeoutMs: number;
 }
 
 export const downloadRetry: RetryPolicy = {
   attempts: 10,
   backoffMs: attempt => Math.min(1000 * 2 ** (attempt - 1), 30_000),
+  idleTimeoutMs: 60_000,
 };
+
+/** Same cap as fetch(); github.com needs one hop (to codeload or objects.githubusercontent.com). */
+const maxRedirects = 20;
+
+/**
+ * One GET for `hop` on a connection of its own. The request gets a fresh
+ * non-keep-alive Agent, so it cannot inherit the connection an earlier
+ * attempt failed on ("Retry behavior" above), and the connection is closed
+ * behind the response. Resolves with the response headers in; the body is
+ * still to be read.
+ *
+ * `proxyEnv` keeps HTTPS_PROXY / NO_PROXY honored the way bun's fetch() did
+ * when this went through it (node's fetch never did); builds in proxied
+ * environments depend on that for every dep that misses the prefetch cache.
+ */
+function get(hop: string, idleTimeoutMs: number): Promise<http.IncomingMessage> {
+  const secure = new URL(hop).protocol === "https:";
+  const options: https.RequestOptions = {
+    agent: secure ? new https.Agent({ proxyEnv: process.env }) : new http.Agent({ proxyEnv: process.env }),
+    headers: { "User-Agent": "bun-build-system" },
+    timeout: idleTimeoutMs,
+  };
+  return new Promise((resolve, reject) => {
+    const req = secure ? https.request(hop, options) : http.request(hop, options);
+    let res: http.IncomingMessage | undefined;
+    req.on("response", response => {
+      res = response;
+      resolve(response);
+    });
+    // 'timeout' is advisory: the socket stays open until something destroys
+    // it. Once the response has started, its consumer (the pipeline in the
+    // caller) is the one waiting, so the error has to be delivered there.
+    req.on("timeout", () => (res ?? req).destroy(new BuildError(`no data from ${hop} for ${idleTimeoutMs}ms`)));
+    // Kept attached for the life of the socket: a mid-body failure is
+    // reported through `res`, but node emits it on the request as well, and
+    // an unhandled 'error' there would take the process down.
+    req.on("error", reject);
+    req.end();
+  });
+}
 
 /**
  * Download a URL to a file with retry. Atomic: temp file → rename on success.
@@ -201,24 +254,34 @@ export async function downloadWithRetry(
     }
 
     const tmpPath = `${dest}.${process.pid}.partial`;
+    // Redirects are followed by hand, each hop on its own connection, so a
+    // failure can say whether github.com or the host it redirected to failed.
+    let hop = url;
     try {
-      const res = await fetch(url, { headers: { "User-Agent": "bun-build-system" } });
-      if (!res.ok || res.body === null) {
-        lastError = new BuildError(`HTTP ${res.status} ${res.statusText} for ${url}`);
+      let res = await get(hop, retry.idleTimeoutMs);
+      for (let redirects = 0; res.statusCode! >= 300 && res.statusCode! < 400 && res.headers.location; redirects++) {
+        res.resume();
+        if (redirects === maxRedirects) throw new BuildError(`more than ${maxRedirects} redirects`);
+        hop = new URL(res.headers.location, hop).href;
+        res = await get(hop, retry.idleTimeoutMs);
+      }
+
+      const status = res.statusCode!;
+      if (status < 200 || status >= 300) {
+        res.resume();
+        lastError = new BuildError(`HTTP ${status} ${res.statusMessage ?? ""} for ${hop}`);
         // 4xx is deterministic (bad URL, missing artifact) and won't succeed
         // on retry, except 408/429, which are the server asking for exactly
         // that. Loop on those, 5xx, and network errors.
-        permanent = res.status >= 400 && res.status < 500 && res.status !== 408 && res.status !== 429;
+        permanent = status >= 400 && status < 500 && status !== 408 && status !== 429;
         continue;
       }
 
-      // Cast: DOM ReadableStream vs node:stream/web ReadableStream — same
-      // shape at runtime, different TS lib declarations.
-      await pipeline(Readable.fromWeb(res.body as unknown as NodeWebReadable), createWriteStream(tmpPath));
+      await pipeline(res, createWriteStream(tmpPath));
       await rename(tmpPath, dest);
       return;
     } catch (err) {
-      lastError = err;
+      lastError = hop === url ? err : new BuildError(`while fetching ${hop}`, { cause: err });
       // Swallow cleanup errors: on Windows, AV/indexer can briefly lock the
       // partial; a failed unlink must not abort the retry loop. Next attempt's
       // createWriteStream truncates anyway.

--- a/scripts/build/download.ts
+++ b/scripts/build/download.ts
@@ -22,10 +22,10 @@
  * 5 attempts / ~30s gave up inside them and took a random build lane along.
  *
  * Every attempt, and every redirect hop within one, goes out on a connection
- * of its own (`get` below). When this went through fetch(), its pool handed
- * each retry the very connection the previous attempt had failed on, and
- * github.com keeps a connection open while answering 503 or refusing the
- * stream on it (node's fetch speaks HTTP/2 to it), so a fetch-cli process
+ * of its own (`throwawayAgents` below). When this went through fetch(), its
+ * pool handed each retry the very connection the previous attempt had failed
+ * on, and github.com keeps a connection open while answering 503 or refusing
+ * the stream on it (node's fetch speaks HTTP/2 to it), so a fetch-cli process
  * that had landed on a bad front-end failed every one of its attempts in a
  * row while the dep fetches next to it, on connections of their own, went
  * through in the same second. A retry is only worth anything if it can land
@@ -160,9 +160,9 @@ export interface RetryPolicy {
   /** Delay before try number `attempt` (2..attempts). */
   backoffMs(attempt: number): number;
   /**
-   * An attempt whose connection has carried nothing for this long (while
-   * connecting, waiting for headers, or mid-body) is failed and retried.
-   * Bounds each attempt; a healthy transfer of any size never goes idle.
+   * An attempt that has gone this long without the response headers, or
+   * without a further chunk of body, is failed and retried. Bounds each
+   * attempt; a healthy transfer of any size never goes idle.
    */
   idleTimeoutMs: number;
 }
@@ -177,40 +177,116 @@ export const downloadRetry: RetryPolicy = {
 const maxRedirects = 20;
 
 /**
- * One GET for `hop` on a connection of its own. The request gets a fresh
- * non-keep-alive Agent, so it cannot inherit the connection an earlier
- * attempt failed on ("Retry behavior" above), and the connection is closed
- * behind the response. Resolves with the response headers in; the body is
- * still to be read.
+ * The proxy settings handed to the Agents, in the spelling their `proxyEnv`
+ * parser accepts. Builds behind a proxy used to be served by bun's fetch()
+ * honoring these variables itself (node's fetch never did), with curl's
+ * reading of them; the Agent's reading is stricter in two places that would
+ * otherwise silently change where a `bun bd` connects:
  *
- * `proxyEnv` keeps HTTPS_PROXY / NO_PROXY honored the way bun's fetch() did
- * when this went through it (node's fetch never did); builds in proxied
- * environments depend on that for every dep that misses the prefetch cache.
+ * - a proxy given without a scheme (`HTTPS_PROXY=proxy:3128`) is ignored by
+ *   the Agent, where curl and bun's fetch() take it as an http proxy;
+ * - a bare NO_PROXY host (`github.com`) only matches itself, where curl and
+ *   bun's fetch() also match its subdomains. Every download here is
+ *   redirected from github.com to a subdomain of github.com or
+ *   githubusercontent.com, so without the `.github.com` form the second hop
+ *   would take the other route from the first.
+ *
+ * Schemes the Agent does not support (socks5://) are left alone and the
+ * download goes direct, which is what node's fetch() did with any proxy.
  */
-function get(hop: string, idleTimeoutMs: number): Promise<http.IncomingMessage> {
+export function proxyEnvironment(env: NodeJS.ProcessEnv = process.env): http.ProxyEnv {
+  const out: http.ProxyEnv = {};
+  for (const name of ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY"] as const) {
+    const proxy = env[name]?.trim();
+    if (proxy) out[name] = /^[a-z][a-z0-9+.-]*:\/\//i.test(proxy) ? proxy : `http://${proxy}`;
+  }
+  for (const name of ["no_proxy", "NO_PROXY"] as const) {
+    const entries =
+      env[name]
+        ?.split(",")
+        .map(entry => entry.trim())
+        .filter(Boolean) ?? [];
+    if (entries.length === 0) continue;
+    // Only host names are widened: `*`, `.suffix`, `*.suffix`, `host:port`,
+    // addresses and address ranges already mean what they meant.
+    const isHostName = (entry: string) => /^[a-z0-9][a-z0-9.-]*$/i.test(entry) && /[a-z]/i.test(entry);
+    out[name] = entries.flatMap(entry => (isHostName(entry) ? [entry, `.${entry}`] : [entry])).join(",");
+  }
+  return out;
+}
+
+/**
+ * One Agent per scheme for the duration of a download. Neither keeps
+ * sockets alive, so every request made through them gets a connection of
+ * its own, closed behind the response; a retry therefore cannot inherit the
+ * connection the previous attempt failed on ("Retry behavior" above).
+ */
+interface Agents {
+  http: http.Agent;
+  https: https.Agent;
+}
+
+function throwawayAgents(): Agents {
+  const options: http.AgentOptions = { proxyEnv: proxyEnvironment() };
+  return { http: new http.Agent(options), https: new https.Agent(options) };
+}
+
+function idleError(hop: string, idleTimeoutMs: number): BuildError {
+  return new BuildError(`no data from ${hop} for ${idleTimeoutMs}ms`);
+}
+
+/**
+ * GET `hop`, resolving once the response headers are in (the body is still
+ * to be read) and failing if they have not arrived within `idleTimeoutMs`.
+ *
+ * The idle clock is our own timer, and it rejects directly rather than only
+ * destroying the request, because the bun releases that still run this
+ * through their older fetch-based node:http client (1.3.x, the version the
+ * CI images are baked with) neither fire the request's `timeout` option nor
+ * emit 'error' for a destroy() before the response; under them a stalled
+ * github.com would otherwise hang the build instead of being retried.
+ */
+function get(hop: string, agents: Agents, idleTimeoutMs: number): Promise<http.IncomingMessage> {
   const secure = new URL(hop).protocol === "https:";
   const options: https.RequestOptions = {
-    agent: secure ? new https.Agent({ proxyEnv: process.env }) : new http.Agent({ proxyEnv: process.env }),
+    agent: secure ? agents.https : agents.http,
     headers: { "User-Agent": "bun-build-system" },
-    timeout: idleTimeoutMs,
   };
   return new Promise((resolve, reject) => {
     const req = secure ? https.request(hop, options) : http.request(hop, options);
-    let res: http.IncomingMessage | undefined;
-    req.on("response", response => {
-      res = response;
-      resolve(response);
+    const idle = setTimeout(() => {
+      const err = idleError(hop, idleTimeoutMs);
+      reject(err);
+      req.destroy(err);
+    }, idleTimeoutMs);
+    req.on("response", res => {
+      clearTimeout(idle);
+      resolve(res);
     });
-    // 'timeout' is advisory: the socket stays open until something destroys
-    // it. Once the response has started, its consumer (the pipeline in the
-    // caller) is the one waiting, so the error has to be delivered there.
-    req.on("timeout", () => (res ?? req).destroy(new BuildError(`no data from ${hop} for ${idleTimeoutMs}ms`)));
-    // Kept attached for the life of the socket: a mid-body failure is
-    // reported through `res`, but node emits it on the request as well, and
-    // an unhandled 'error' there would take the process down.
-    req.on("error", reject);
+    // Stays attached for the life of the socket: a failure while the body is
+    // being read is reported through the response, but node emits it on the
+    // request as well, and unhandled there it would take the process down.
+    req.on("error", err => {
+      clearTimeout(idle);
+      reject(err);
+    });
     req.end();
   });
+}
+
+/** Stream the body to `file`, failing the attempt if it stops arriving for `idleTimeoutMs`. */
+async function saveBody(res: http.IncomingMessage, hop: string, file: string, idleTimeoutMs: number): Promise<void> {
+  const stalled = () => res.destroy(idleError(hop, idleTimeoutMs));
+  let idle = setTimeout(stalled, idleTimeoutMs);
+  res.on("data", () => {
+    clearTimeout(idle);
+    idle = setTimeout(stalled, idleTimeoutMs);
+  });
+  try {
+    await pipeline(res, createWriteStream(file));
+  } finally {
+    clearTimeout(idle);
+  }
 }
 
 /**
@@ -242,6 +318,10 @@ export async function downloadWithRetry(
     return;
   }
 
+  // Built once, outside the loop: a proxy setting the Agent rejects outright
+  // (ERR_PROXY_INVALID_CONFIG) is a configuration error, not something to
+  // retry ten times.
+  const agents = throwawayAgents();
   const maxAttempts = retry.attempts;
   let lastError: unknown;
   let permanent = false;
@@ -258,12 +338,12 @@ export async function downloadWithRetry(
     // failure can say whether github.com or the host it redirected to failed.
     let hop = url;
     try {
-      let res = await get(hop, retry.idleTimeoutMs);
+      let res = await get(hop, agents, retry.idleTimeoutMs);
       for (let redirects = 0; res.statusCode! >= 300 && res.statusCode! < 400 && res.headers.location; redirects++) {
         res.resume();
         if (redirects === maxRedirects) throw new BuildError(`more than ${maxRedirects} redirects`);
         hop = new URL(res.headers.location, hop).href;
-        res = await get(hop, retry.idleTimeoutMs);
+        res = await get(hop, agents, retry.idleTimeoutMs);
       }
 
       const status = res.statusCode!;
@@ -277,7 +357,7 @@ export async function downloadWithRetry(
         continue;
       }
 
-      await pipeline(res, createWriteStream(tmpPath));
+      await saveBody(res, hop, tmpPath, retry.idleTimeoutMs);
       await rename(tmpPath, dest);
       return;
     } catch (err) {

--- a/scripts/build/error.ts
+++ b/scripts/build/error.ts
@@ -39,11 +39,11 @@ export class BuildError extends Error {
 
 /**
  * One line naming an error and everything it wraps, outermost first:
- * `fetch failed: getaddrinfo EAI_AGAIN github.com`. The outer message alone
- * is often content-free: node's fetch reports every network failure as
- * "fetch failed" and puts the reason (DNS, connect timeout, reset) in
- * `cause`, and a connect that failed on every resolved address is an
- * AggregateError whose own message is empty.
+ * `while fetching https://codeload.github.com/...: ECONNRESET: socket hang up`.
+ * An error's own message is often content-free: node's socket errors say
+ * "socket hang up" and keep the reason in `code`, a connect that failed on
+ * every resolved address is an AggregateError whose own message is empty,
+ * and wrappers put the interesting part in `cause`.
  */
 export function describeError(err: unknown): string {
   if (!(err instanceof Error)) return String(err);
@@ -52,12 +52,15 @@ export function describeError(err: unknown): string {
   let e: unknown = err;
   while (e instanceof Error && !seen.has(e)) {
     seen.add(e);
+    let part = e.message || e.name;
     if (e instanceof AggregateError && e.errors.length > 0) {
       const inner = e.errors.map(describeError).join("; ");
-      parts.push(e.message ? `${e.message} (${inner})` : inner);
-    } else {
-      parts.push(e.message || e.name);
+      part = e.message ? `${e.message} (${inner})` : inner;
     }
+    // `getaddrinfo ENOTFOUND host` already names its code; "socket hang up" does not.
+    const { code } = e as NodeJS.ErrnoException;
+    if (typeof code === "string" && code !== "" && !part.includes(code)) part = `${code}: ${part}`;
+    parts.push(part);
     e = e.cause;
   }
   // A non-Error cause (`{ cause: "ECONNRESET" }`) still carries the reason.

--- a/test/internal/build-download-retry.test.ts
+++ b/test/internal/build-download-retry.test.ts
@@ -3,19 +3,28 @@
  * a CI build lane and github.com: every dep whose pin moved after the CI
  * images (and the prefetch cache baked into them) were published downloads
  * live on every lane of every build, WebKit included, so a build makes on the
- * order of a hundred github.com round-trips through this one loop. The
- * outages CI actually hits are agent-wide and last from 30s to a few minutes;
- * a 5 attempt / ~30s schedule gave up inside them and failed the lane with
- * nothing but "cause: fetch failed" in the log.
+ * order of a hundred github.com round-trips through this one loop.
  *
- * The fake server below scripts one outcome per request. The production
- * schedule is driven with its backoff zeroed, so the full attempt count runs
- * in milliseconds; the schedule's real timing is asserted separately.
+ * Two things have taken build lanes down through it. Outages long enough to
+ * outlast the retry schedule, and, once the schedule was long enough, retries
+ * that could not land anywhere new: fetch() handed every retry the pooled
+ * connection the previous attempt had just failed on, so a process that drew
+ * a bad github.com front-end on its first connection (503s, or HTTP/2
+ * REFUSED_STREAM) failed every attempt on it while the fetches next to it
+ * succeeded. Hence the shape of the fake server below: it is scripted per
+ * CONNECTION, and a plan applies to every request that connection carries,
+ * which is exactly what distinguishes "retried on a new connection" from
+ * "retried on the same one".
+ *
+ * The production schedule is driven with its backoff zeroed, so the full
+ * attempt count runs in milliseconds; the schedule's real timing is asserted
+ * separately.
  */
 import { expect, spyOn, test } from "bun:test";
 import { tempDir } from "harness";
-import { existsSync, readFileSync } from "node:fs";
-import { createServer, type AddressInfo } from "node:net";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo, Socket } from "node:net";
 import { join } from "node:path";
 
 import { downloadRetry, downloadWithRetry, type RetryPolicy } from "../../scripts/build/download.ts";
@@ -26,38 +35,79 @@ const BODY = "tarball bytes";
 /** The production attempt count with no waiting between attempts. */
 const noBackoff: RetryPolicy = { ...downloadRetry, backoffMs: () => 0 };
 
-/** "drop" closes the connection without answering; a string is a status line. */
-type Outcome = "drop" | string;
+/**
+ * For the stall tests: how long a stalled connection is waited on. Well above
+ * what a loopback exchange takes even on a debug build under load, since a
+ * healthy connection timing out would show up as an extra retry.
+ */
+const stallMs = 1000;
 
 /**
- * Answers each request with the next scripted outcome, then with BODY once
- * the script runs out (or drops forever when asked to). "drop" is what an
- * unreachable or resetting github.com looks like to fetch(). Every response
- * is Connection: close, so one attempt is exactly one request here.
+ * What a connection does with each request it carries.
+ *  - "body":      200 with BODY
+ *  - "drop":      close the connection without answering (a reset or an
+ *                 unreachable host, as far as the client can tell)
+ *  - "stall":     accept the request and never answer
+ *  - "stall-mid-body": send the headers and half the body, then nothing
+ *  - "NNN text":  that status line, keep-alive, empty body
+ *  - { redirect } 302 there, keep-alive
  */
-async function fakeServer(script: Outcome[], { dropForever = false } = {}) {
+type Plan = "body" | "drop" | "stall" | "stall-mid-body" | `${number} ${string}` | { redirect: string };
+
+/**
+ * Connection number i (0-based) follows `plans[i]`, every connection after the
+ * script follows `rest`. Responses deliberately keep the connection alive:
+ * a client that reuses it gets the same plan again, one that reconnects moves
+ * on to the next.
+ */
+async function fakeServer(plans: Plan[], rest: Plan = "body") {
+  const planOf = new WeakMap<Socket, Plan>();
+  let connections = 0;
   let requests = 0;
-  const server = createServer(socket => {
-    socket.once("data", () => {
-      requests++;
-      const outcome = dropForever ? "drop" : script.shift();
-      if (outcome === "drop") {
-        socket.destroy();
-      } else if (outcome === undefined) {
-        socket.end(`HTTP/1.1 200 OK\r\nContent-Length: ${BODY.length}\r\nConnection: close\r\n\r\n${BODY}`);
-      } else {
-        socket.end(`HTTP/1.1 ${outcome}\r\nContent-Length: 0\r\nConnection: close\r\n\r\n`);
-      }
-    });
+  const paths: string[] = [];
+  const sockets = new Set<Socket>();
+  const server = createServer((req, res) => {
+    requests++;
+    paths.push(req.url!);
+    const plan = planOf.get(req.socket)!;
+    if (plan === "drop") {
+      req.socket.destroy();
+    } else if (plan === "stall") {
+      // Nothing: the client has to give up on its own.
+    } else if (plan === "stall-mid-body") {
+      res.writeHead(200, { "Content-Length": String(BODY.length) });
+      res.write(BODY.slice(0, 4));
+    } else if (plan === "body") {
+      res.writeHead(200, { "Content-Length": String(BODY.length) });
+      res.end(BODY);
+    } else if (typeof plan === "object") {
+      res.writeHead(302, { Location: plan.redirect, "Content-Length": "0" });
+      res.end();
+    } else {
+      const space = plan.indexOf(" ");
+      res.writeHead(Number(plan.slice(0, space)), plan.slice(space + 1), { "Content-Length": "0" });
+      res.end();
+    }
+  });
+  server.on("connection", socket => {
+    planOf.set(socket, plans[connections++] ?? rest);
+    sockets.add(socket);
+    socket.once("close", () => sockets.delete(socket));
   });
   await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
   const { port } = server.address() as AddressInfo;
   return {
+    origin: `http://127.0.0.1:${port}`,
     url: `http://127.0.0.1:${port}/dep.tar.gz`,
-    get requests() {
-      return requests;
+    /** Connections accepted and requests served; with one request per connection the two are equal. */
+    get traffic() {
+      return { connections, requests };
     },
-    [Symbol.asyncDispose]: () => new Promise<void>(resolve => server.close(() => resolve())),
+    paths,
+    [Symbol.asyncDispose]: () => {
+      for (const socket of sockets) socket.destroy();
+      return new Promise<void>(resolve => server.close(() => resolve()));
+    },
   };
 }
 
@@ -83,6 +133,9 @@ async function withLogCaptured<T>(fn: () => Promise<T>): Promise<{ result: T; li
   }
 }
 
+/** What a closed-without-answering connection is reported as; the wording is the runtime's. */
+const droppedConnection = /reset|hang up|closed/i;
+
 test("the schedule waits out at least two minutes of github.com being unreachable", () => {
   let totalBackoffMs = 0;
   for (let attempt = 2; attempt <= downloadRetry.attempts; attempt++) {
@@ -92,6 +145,25 @@ test("the schedule waits out at least two minutes of github.com being unreachabl
     totalBackoffMs += backoffMs;
   }
   expect(totalBackoffMs).toBeGreaterThanOrEqual(120_000);
+  // A stalled connection is given up on rather than waited on, and even a
+  // download that stalls on every attempt ends well inside build-bun's
+  // step timeout (60 minutes).
+  expect(downloadRetry.idleTimeoutMs).toBeGreaterThanOrEqual(30_000);
+  expect(totalBackoffMs + downloadRetry.attempts * downloadRetry.idleTimeoutMs).toBeLessThanOrEqual(20 * 60_000);
+});
+
+test("a retry gets a new connection, not the one the failed attempt used", async () => {
+  using dir = tempDir("build-download-retry", {});
+  // The first connection is a bad front-end: it stays open and answers 503
+  // to anything sent on it. Anything that reconnects is served.
+  await using server = await fakeServer(["503 Service Unavailable"]);
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { lines } = await withLogCaptured(() => downloadWithRetry(server.url, dest, "dep", noBackoff));
+
+  expect(readFileSync(dest, "utf8")).toBe(BODY);
+  expect(lines).toEqual([`retry 2/${downloadRetry.attempts} in 0ms (HTTP 503 Service Unavailable for ${server.url})`]);
+  expect(server.traffic).toEqual({ connections: 2, requests: 2 });
 });
 
 test("a download that fails on every attempt but the last still succeeds", async () => {
@@ -102,7 +174,7 @@ test("a download that fails on every attempt but the last still succeeds", async
   const { lines } = await withLogCaptured(() => downloadWithRetry(server.url, dest, "dep", noBackoff));
 
   expect(readFileSync(dest, "utf8")).toBe(BODY);
-  expect(server.requests).toBe(downloadRetry.attempts);
+  expect(server.traffic).toEqual({ connections: downloadRetry.attempts, requests: downloadRetry.attempts });
   expect(lines.filter(line => line.startsWith("retry "))).toHaveLength(downloadRetry.attempts - 1);
 });
 
@@ -114,7 +186,7 @@ test("429 is retried, and the retry line says what failed", async () => {
   const { lines } = await withLogCaptured(() => downloadWithRetry(server.url, dest, "dep", noBackoff));
 
   expect(readFileSync(dest, "utf8")).toBe(BODY);
-  expect(server.requests).toBe(2);
+  expect(server.traffic).toEqual({ connections: 2, requests: 2 });
   expect(lines).toEqual([`retry 2/${downloadRetry.attempts} in 0ms (HTTP 429 Too Many Requests for ${server.url})`]);
 });
 
@@ -130,13 +202,85 @@ test("404 is not retried and is thrown as-is (prefetch-deps.ts matches on the me
   expect(err).toBeInstanceOf(BuildError);
   expect((err as BuildError).message).toBe(`HTTP 404 Not Found for ${server.url}`);
   expect(lines).toEqual([]);
-  expect(server.requests).toBe(1);
+  expect(server.traffic).toEqual({ connections: 1, requests: 1 });
   expect(existsSync(dest)).toBe(false);
+});
+
+test("redirects are followed, each hop on its own connection", async () => {
+  using dir = tempDir("build-download-retry", {});
+  // github.com answers every archive and release download with a 302 to
+  // codeload.github.com / objects.githubusercontent.com; here both hops are
+  // the same server, told apart by path.
+  await using server = await fakeServer([{ redirect: "/mirror/dep.tar.gz" }]);
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { lines } = await withLogCaptured(() => downloadWithRetry(server.url, dest, "dep", noBackoff));
+
+  expect(readFileSync(dest, "utf8")).toBe(BODY);
+  expect(lines).toEqual([]);
+  expect(server.paths).toEqual(["/dep.tar.gz", "/mirror/dep.tar.gz"]);
+  expect(server.traffic).toEqual({ connections: 2, requests: 2 });
+});
+
+test("a failure on the redirected-to hop is reported against that hop", async () => {
+  using dir = tempDir("build-download-retry", {});
+  await using server = await fakeServer([
+    { redirect: "/mirror/dep.tar.gz" },
+    "drop", // the mirror hop of attempt 1
+    { redirect: "/mirror/dep.tar.gz" },
+    "404 Not Found", // the mirror hop of attempt 2
+  ]);
+  const dest = join(String(dir), "dep.tar.gz");
+  const mirror = `${server.origin}/mirror/dep.tar.gz`;
+
+  const { result, lines } = await withLogCaptured(() =>
+    rejection(downloadWithRetry(server.url, dest, "dep", noBackoff)),
+  );
+  const err = result as BuildError;
+
+  expect(lines).toHaveLength(1);
+  expect(lines[0]).toStartWith(`retry 2/${downloadRetry.attempts} in 0ms (while fetching ${mirror}: `);
+  expect(lines[0]).toMatch(droppedConnection);
+  // The 404 is still thrown bare, naming the hop that produced it, so
+  // prefetch-deps.ts' /\bHTTP 404\b/ and prebuiltDownloadError's check work.
+  expect(err).toBeInstanceOf(BuildError);
+  expect(err.message).toBe(`HTTP 404 Not Found for ${mirror}`);
+  expect(server.traffic).toEqual({ connections: 4, requests: 4 });
+  expect(existsSync(dest)).toBe(false);
+});
+
+test("a connection that accepts the request and never answers is given up on and retried", async () => {
+  using dir = tempDir("build-download-retry", {});
+  await using server = await fakeServer(["stall"]);
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { lines } = await withLogCaptured(() =>
+    downloadWithRetry(server.url, dest, "dep", { ...noBackoff, idleTimeoutMs: stallMs }),
+  );
+
+  expect(readFileSync(dest, "utf8")).toBe(BODY);
+  expect(lines).toEqual([`retry 2/${downloadRetry.attempts} in 0ms (no data from ${server.url} for ${stallMs}ms)`]);
+  expect(server.traffic).toEqual({ connections: 2, requests: 2 });
+});
+
+test("a body that stops arriving is given up on and retried, leaving no partial file", async () => {
+  using dir = tempDir("build-download-retry", {});
+  await using server = await fakeServer(["stall-mid-body"]);
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { lines } = await withLogCaptured(() =>
+    downloadWithRetry(server.url, dest, "dep", { ...noBackoff, idleTimeoutMs: stallMs }),
+  );
+
+  expect(readFileSync(dest, "utf8")).toBe(BODY);
+  expect(lines).toEqual([`retry 2/${downloadRetry.attempts} in 0ms (no data from ${server.url} for ${stallMs}ms)`]);
+  expect(server.traffic).toEqual({ connections: 2, requests: 2 });
+  expect(readdirSync(String(dir))).toEqual(["dep.tar.gz"]);
 });
 
 test("giving up reports the attempt count and the failure that ended it", async () => {
   using dir = tempDir("build-download-retry", {});
-  await using server = await fakeServer([], { dropForever: true });
+  await using server = await fakeServer([], "drop");
   const dest = join(String(dir), "dep.tar.gz");
 
   const { result, lines } = await withLogCaptured(() =>
@@ -146,10 +290,8 @@ test("giving up reports the attempt count and the failure that ended it", async 
 
   expect(err).toBeInstanceOf(BuildError);
   expect(err.message).toBe(`Failed to download after ${downloadRetry.attempts} attempts: ${server.url}`);
-  // The dropped connection is what fetch() threw; it must be named both in
-  // the final report and on every retry line. (The exact wording is the
-  // runtime's, so only its gist is pinned.)
-  const droppedConnection = /closed|reset/i;
+  // The dropped connection is what the last attempt failed with; it must be
+  // named both in the final report and on every retry line.
   const reason = describeError(err.cause);
   expect(reason).toMatch(droppedConnection);
   expect(err.format()).toContain(`cause: ${reason}`);
@@ -157,24 +299,26 @@ test("giving up reports the attempt count and the failure that ended it", async 
     Array.from({ length: downloadRetry.attempts - 1 }, (_, i) => `retry ${i + 2}/${downloadRetry.attempts} in 0ms`),
   );
   for (const line of lines) expect(line).toMatch(droppedConnection);
-  expect(server.requests).toBe(downloadRetry.attempts);
+  expect(server.traffic).toEqual({ connections: downloadRetry.attempts, requests: downloadRetry.attempts });
   expect(existsSync(dest)).toBe(false);
 });
 
-test("BuildError.format() shows what is behind node's 'fetch failed'", () => {
+test("BuildError.format() prints the whole cause chain", () => {
   const err = new BuildError("Failed to download after 10 attempts: https://github.com/o/r/archive/abc.tar.gz", {
     hint: "Check network connectivity",
-    cause: new TypeError("fetch failed", { cause: new Error("getaddrinfo EAI_AGAIN github.com") }),
+    cause: new BuildError("while fetching https://codeload.github.com/o/r/tar.gz/abc", {
+      cause: Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }),
+    }),
   });
 
   expect(err.format()).toBe(
     "error: Failed to download after 10 attempts: https://github.com/o/r/archive/abc.tar.gz\n" +
       "  hint: Check network connectivity\n" +
-      "  cause: fetch failed: getaddrinfo EAI_AGAIN github.com\n",
+      "  cause: while fetching https://codeload.github.com/o/r/tar.gz/abc: ECONNRESET: socket hang up\n",
   );
 });
 
-test("describeError() flattens cause chains, AggregateErrors, and non-Error causes", () => {
+test("describeError() flattens cause chains, AggregateErrors, codes, and non-Error causes", () => {
   expect(describeError("just a string")).toBe("just a string");
   expect(describeError(new Error("write failed", { cause: "ENOSPC" }))).toBe("write failed: ENOSPC");
 
@@ -186,6 +330,14 @@ test("describeError() flattens cause chains, AggregateErrors, and non-Error caus
   ]);
   expect(describeError(new TypeError("fetch failed", { cause: connect }))).toBe(
     "fetch failed: connect ETIMEDOUT 140.82.112.3:443; connect ENETUNREACH 140.82.112.4:443",
+  );
+
+  // A code is added when the message does not already carry it.
+  expect(describeError(Object.assign(new Error("socket hang up"), { code: "ECONNRESET" }))).toBe(
+    "ECONNRESET: socket hang up",
+  );
+  expect(describeError(Object.assign(new Error("getaddrinfo ENOTFOUND github.com"), { code: "ENOTFOUND" }))).toBe(
+    "getaddrinfo ENOTFOUND github.com",
   );
 
   const loop = new Error("loops");

--- a/test/internal/build-download-retry.test.ts
+++ b/test/internal/build-download-retry.test.ts
@@ -16,21 +16,44 @@
  * which is exactly what distinguishes "retried on a new connection" from
  * "retried on the same one".
  *
+ * The same server doubles as an HTTP proxy for the proxy tests: builds behind
+ * a proxy only ever worked because the downloader honored HTTP(S)_PROXY, and
+ * the downloader now has to do that itself.
+ *
  * The production schedule is driven with its backoff zeroed, so the full
  * attempt count runs in milliseconds; the schedule's real timing is asserted
  * separately.
  */
-import { expect, spyOn, test } from "bun:test";
+import { afterEach, beforeEach, expect, spyOn, test } from "bun:test";
 import { tempDir } from "harness";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { createServer } from "node:http";
 import type { AddressInfo, Socket } from "node:net";
 import { join } from "node:path";
 
-import { downloadRetry, downloadWithRetry, type RetryPolicy } from "../../scripts/build/download.ts";
+import { downloadRetry, downloadWithRetry, proxyEnvironment, type RetryPolicy } from "../../scripts/build/download.ts";
 import { BuildError, describeError } from "../../scripts/build/error.ts";
 
 const BODY = "tarball bytes";
+
+/**
+ * downloadWithRetry reads the proxy variables from process.env. Each test
+ * starts with none of them set (whatever the machine running the tests has),
+ * and the proxy tests set exactly the ones they are about.
+ */
+const proxyVariables = ["http_proxy", "HTTP_PROXY", "https_proxy", "HTTPS_PROXY", "no_proxy", "NO_PROXY"] as const;
+let ambientProxyEnv: Partial<Record<(typeof proxyVariables)[number], string>>;
+beforeEach(() => {
+  ambientProxyEnv = {};
+  for (const name of proxyVariables) {
+    if (process.env[name] !== undefined) ambientProxyEnv[name] = process.env[name];
+    delete process.env[name];
+  }
+});
+afterEach(() => {
+  for (const name of proxyVariables) delete process.env[name];
+  Object.assign(process.env, ambientProxyEnv);
+});
 
 /** The production attempt count with no waiting between attempts. */
 const noBackoff: RetryPolicy = { ...downloadRetry, backoffMs: () => 0 };
@@ -276,6 +299,62 @@ test("a body that stops arriving is given up on and retried, leaving no partial 
   expect(lines).toEqual([`retry 2/${downloadRetry.attempts} in 0ms (no data from ${server.url} for ${stallMs}ms)`]);
   expect(server.traffic).toEqual({ connections: 2, requests: 2 });
   expect(readdirSync(String(dir))).toEqual(["dep.tar.gz"]);
+});
+
+test("http_proxy is honored, including the scheme-less form curl and bun's fetch() accept", async () => {
+  using dir = tempDir("build-download-retry", {});
+  // The fake server plays the proxy: a proxied request reaches it carrying
+  // the full URL as its request target. dep.invalid itself resolves nowhere,
+  // so a download that ignored the proxy could only fail.
+  await using proxy = await fakeServer([]);
+  process.env.http_proxy = proxy.origin.slice("http://".length);
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { lines } = await withLogCaptured(() =>
+    downloadWithRetry("http://dep.invalid/dep.tar.gz", dest, "dep", noBackoff),
+  );
+
+  expect(readFileSync(dest, "utf8")).toBe(BODY);
+  expect(lines).toEqual([]);
+  expect(proxy.paths).toEqual(["http://dep.invalid/dep.tar.gz"]);
+  expect(proxy.traffic).toEqual({ connections: 1, requests: 1 });
+});
+
+test("NO_PROXY sends a download past the proxy", async () => {
+  using dir = tempDir("build-download-retry", {});
+  await using proxy = await fakeServer([]);
+  await using server = await fakeServer([]);
+  process.env.HTTP_PROXY = proxy.origin;
+  process.env.NO_PROXY = "127.0.0.1";
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { lines } = await withLogCaptured(() => downloadWithRetry(server.url, dest, "dep", noBackoff));
+
+  expect(readFileSync(dest, "utf8")).toBe(BODY);
+  expect(lines).toEqual([]);
+  expect(server.paths).toEqual(["/dep.tar.gz"]);
+  expect(proxy.traffic).toEqual({ connections: 0, requests: 0 });
+});
+
+test("proxyEnvironment() rewrites the settings into the form the Agent's parser accepts", () => {
+  expect(
+    proxyEnvironment({
+      HTTPS_PROXY: "proxy.corp:3128",
+      https_proxy: " http://proxy.corp:3128/ ",
+      http_proxy: "socks5://proxy.corp:1080",
+      HTTP_PROXY: "",
+      NO_PROXY:
+        "github.com, build-cache.corp ,.example.org,*.example.net,registry.corp:5000,127.0.0.1,10.0.0.1-10.0.0.9,*",
+    }),
+  ).toEqual({
+    HTTPS_PROXY: "http://proxy.corp:3128",
+    https_proxy: "http://proxy.corp:3128/",
+    http_proxy: "socks5://proxy.corp:1080",
+    NO_PROXY:
+      "github.com,.github.com,build-cache.corp,.build-cache.corp,.example.org,*.example.net,registry.corp:5000,127.0.0.1,10.0.0.1-10.0.0.9,*",
+  });
+  expect(proxyEnvironment({ no_proxy: " , " })).toEqual({});
+  expect(proxyEnvironment({})).toEqual({});
 });
 
 test("giving up reports the attempt count and the failure that ended it", async () => {

--- a/test/internal/build-download-retry.test.ts
+++ b/test/internal/build-download-retry.test.ts
@@ -357,6 +357,22 @@ test("proxyEnvironment() rewrites the settings into the form the Agent's parser 
   expect(proxyEnvironment({})).toEqual({});
 });
 
+test("a proxy setting the Agent rejects fails the download once, before any attempt", async () => {
+  using dir = tempDir("build-download-retry", {});
+  await using server = await fakeServer([]);
+  process.env.http_proxy = "http://proxy with spaces:3128";
+  const dest = join(String(dir), "dep.tar.gz");
+
+  const { result: err, lines } = await withLogCaptured(() =>
+    rejection(downloadWithRetry(server.url, dest, "dep", noBackoff)),
+  );
+
+  expect((err as NodeJS.ErrnoException).code).toBe("ERR_PROXY_INVALID_CONFIG");
+  expect(lines).toEqual([]);
+  expect(server.traffic).toEqual({ connections: 0, requests: 0 });
+  expect(existsSync(dest)).toBe(false);
+});
+
 test("giving up reports the attempt count and the failure that ended it", async () => {
   using dir = tempDir("build-download-retry", {});
   await using server = await fakeServer([], "drop");


### PR DESCRIPTION
### Problem
- Build lanes still die in the dep download step after #37915 lengthened the retry schedule. On main, build 93726 lost linux x64-android and build 93595 lost darwin x64 to `error: Failed to download after 10 attempts: https://github.com/oven-sh/lol-html/archive/725ce499....tar.gz` / `cause: fetch failed: Stream closed with error code NGHTTP2_REFUSED_STREAM` (93595 also saw `HTTP 503` from github.com on the same connections). Every lost build lane takes its 20-50 test jobs with it.
- The retries never leave the connection the first attempt failed on. `downloadWithRetry` (`scripts/build/download.ts`) called `fetch()`, and the runtime's pool hands the next `fetch()` to the same origin the connection it already has. github.com keeps that connection open while it refuses streams or answers 503 on it, so the retry loop asks the same bad front-end ten times. Under node (what CI builds with) the pooled connection is an HTTP/2 session, which undici keeps open indefinitely: a probe against a local h2 server that refuses every stream shows node 26's `fetch()` making all of its attempts over one connection, with 5s and 31s between attempts; bun's `fetch()` does the same over HTTP/1.1 keep-alive after a 503. `fetch()` offers no way out of this: a `Connection: close` header is stripped as forbidden, and node does not expose undici's `Agent`, so there is nothing to pass as a per-attempt `dispatcher`.
- The logs have the matching shape: in 93726, `[lolhtml]` logged `retry 2/10` through `retry 10/10`, all `NGHTTP2_REFUSED_STREAM`, and gave up 181s after it started (the 180s of backoff plus ten instant refusals), while `[cares]`, `[mimalloc]` and `[WebKit]` downloaded from github.com on the same agent within the first seconds of that window. Of the 60 build-bun jobs since 21:00 UTC that failed this way, 45 have a dep failing every attempt while another live download in the same job succeeded; the failing dep differs from lane to lane of the same build, so it is the connection, not the URL.

### Fix
- `downloadWithRetry` builds one `http.Agent` and one `https.Agent` per download (`throwawayAgents`), neither keeping sockets alive, and every attempt and every redirect hop does its GET through them, so each request gets a connection of its own that is closed behind the response. The retry schedule from #37915 is unchanged; this is what lets a retry land on a different front-end, which is the only thing a retry can buy here. The common path makes the same two connections it made before (github.com, then the redirect target), so nothing gets slower.
- The Agents get `proxyEnv`, since builds behind a proxy previously worked only because bun's `fetch()` honors `HTTPS_PROXY` on its own (node's `fetch()` never did; `bun bd` in a proxied environment would otherwise stop being able to fetch any dep that misses the prefetch cache). `proxyEnvironment()` rewrites the variables into the form the Agent's parser accepts, because it is stricter than curl and bun's `fetch()` in two ways that would otherwise silently change where a build connects: a proxy given without a scheme (`HTTPS_PROXY=proxy:3128`) would be ignored, and a bare `NO_PROXY` host (`github.com`) would not cover the subdomain every download is redirected to, so the two hops would take different routes. The Agents are built outside the retry loop, so a proxy value the parser rejects is reported once rather than retried ten times.
- Redirects are followed by hand (github.com 302s archives to codeload.github.com and release assets to objects.githubusercontent.com), so a status error names the hop that produced it and a network error on a later hop is wrapped as `while fetching <hop>`. A 404 is still thrown bare with `HTTP 404` in the message, which `prefetch-deps.ts` and `prebuiltDownloadError` match on. This is the reporting half of #37930.
- `RetryPolicy.idleTimeoutMs` (60s): an attempt that goes that long without response headers, or without a further body chunk, is failed and retried. `fetch()` bounded these through undici's defaults; a bare `http.request` has no timeout, so without this a stalled front-end would hang the fetch edge until the step timeout. The clock is our own timer (reset by the body's `data` events) and it rejects the attempt directly as well as destroying the request: bun 1.3.x, which the CI images are baked with and which runs `prefetch-deps.ts`, still has the older fetch-based `node:http` client, and it neither fires the request's `timeout` option nor emits `error` for a `destroy()` before the response, so a stall would otherwise hang there.
- `describeError()` prepends the error `code` when the message does not already contain it, because node's socket errors put the reason there (`ECONNRESET: socket hang up`; `getaddrinfo ENOTFOUND github.com` is left alone).
- Verified with `test/internal/build-download-retry.test.ts` (`bun bd test`, 16 pass). Its server is scripted per connection: a plan applies to every request a connection carries, so a retry that reuses the connection is told apart from one that reconnects. Against the previous `download.ts`/`error.ts`, "a retry gets a new connection" fails the way CI does: connection 1 answers 503 to everything, anything that reconnects is served, and the old loop makes all 10 requests on connection 1. The other cases cover redirect hop naming, both idle-timeout paths (before headers and mid-body, including the `.partial` being removed), the same server acting as an HTTP proxy (a scheme-less `http_proxy` reaching it with the absolute URL, `NO_PROXY` going past it, an unparseable proxy URL failing once with `ERR_PROXY_INVALID_CONFIG` before any request), `proxyEnvironment()` itself, and the code in `describeError()`. The proxy variables are cleared before each test and restored after.
- Also run under node v26.3.0, the runtime CI builds with, and under bun 1.3.13 and 1.4.0, since the test file only runs under the bun being built: the sticky 503 server (2 connections, 2 requests, downloaded), a stall before headers and one mid-body (each retried once on a new connection, and the process exits on its own afterwards), a 302 whose body is cut off (no unhandled error, download completes), an https server whose root is supplied through `NODE_EXTRA_CA_CERTS` (which `stream.ts` sets for fetch-cli behind TLS-intercepting proxies; trusted on all three, rejected without it), and, through this machine's egress proxy, a real `oven-sh/lol-html` archive (570130 bytes, `tar -tzf` lists 3308 entries), a real release asset, a nuget package (the `winsysroot.ts` caller), and a bogus sha (`HTTP 404 Not Found for https://codeload.github.com/...` thrown bare); under node also with the proxy given without a scheme. `fetch-cli.ts dep picohttpparser ...` run directly under node and under bun downloads and extracts. `tsc -p scripts/build` reports nothing in the changed files.
- This PR's own CI runs (builds 94011 and 94533) built all 13 build-bun lanes through this code each time: 54 live downloads per build, all of them completed. github.com was still flaky during 94011: `[mimalloc]` logged `retry 2/10 in 2000ms (ECONNRESET: socket hang up)` on two lanes and went through on the next connection.

### Background
- Dep fetching: configure emits one ninja `dep_fetch` edge per vendored dep, which runs `scripts/build/fetch-cli.ts` in its own process (node in CI, bun for `bun bd`); it calls `downloadWithRetry` on the github archive URL, and `fetchPrebuilt` uses the same function for release tarballs such as WebKit. `prefetch-deps.ts` (image bake, run with the bun version pinned in `bootstrap.sh`, currently 1.3.13) and `winsysroot.ts` (Windows cross lanes) are the other callers; none of them changed.
- Prefetch cache: CI images carry the tarballs that were current when the image was baked, keyed by URL. A dep whose pin moved since (currently cares, mimalloc, libuv, lolhtml and WebKit) downloads live on every lane of every build, which is why these failures land on those deps and not on the others.
- Connection pooling: `fetch()` in both runtimes keeps the connection to an origin open after a response and reuses it for the next request to that origin; with HTTP/2 (node's fetch to github.com) all requests to the origin share one session. A non-keep-alive `http.Agent` does the opposite: it sends `Connection: close` and destroys the socket after the response, so every request gets a new TCP connection, and with github.com's load balancing, usually a different front-end.
- `REFUSED_STREAM` is the HTTP/2 reset code a server uses to decline a request before processing it (overload, or a connection it is draining); the connection itself stays up, so a client that retries on the same connection keeps getting it.
- `proxyEnv` is the `http.Agent` option (node 24.5+, and bun's `node:http` since 1.3.2) that makes an agent honor `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` from the given object; with none of them set it does nothing. Its parser only accepts `http://` and `https://` proxy URLs and matches `NO_PROXY` entries exactly unless they start with a dot (`.github.com` covers the subdomains); curl, and bun's `fetch()` following it, also accept a scheme-less proxy and match a bare host's subdomains.

Related: #37915 (merged, retry schedule and cause reporting), #37930 (open, redirect hop naming on the pre-#37915 code).

<details>
<summary>Per-job shape of the 60 failed build-bun jobs since 2026-08-12 21:00 UTC</summary>

Summary from the Buildkite job logs (times are when ninja printed the dep's output, relative to the first dep fetch in the job; deps served from the prefetch cache are omitted). Most of these branches predate #37915 and show the old 5-attempt loop; the two post-#37915 ones show the reasons.

```
build 93726 (main) linux x64-android
   cares      ok              +1s
   mimalloc   ok              +1s
   WebKit     ok              +18s
   lolhtml    FAILED          +182s   REFUSED_STREAM x9

build 93781 darwin aarch64
   mimalloc   ok              +2s
   lolhtml    ok              +2s
   cares      ok-after-retry  +151s   REFUSED_STREAM x8
   WebKit     FAILED          +182s   REFUSED_STREAM x9

build 93691, four lanes of one build, same URLs:
   linux aarch64:   cares FAILED,          mimalloc/lolhtml/WebKit ok
   linux x64:       mimalloc FAILED,       cares/lolhtml/WebKit ok
   linux x64-asan:  cares+mimalloc FAILED, lolhtml/WebKit ok
   windows x64:     WebKit FAILED,         cares/libuv/mimalloc/lolhtml ok

totals: 60 jobs; in 45 a dep failed every attempt while another live
download in the same job succeeded; in 15 every live download failed.
```

The remaining 15 (for example main build 93595, darwin x64: cares, mimalloc and WebKit all failing with a mix of `REFUSED_STREAM` and `HTTP 503` for over four minutes, lolhtml succeeding on its 10th attempt) look like genuine agent-wide outages. Reconnecting per attempt is the right behavior for those too, but it is the schedule, not this change, that decides whether they are survived.
</details>

<details>
<summary>Earlier revision</summary>

The first revision created a fresh Agent per request with `proxyEnv: process.env` and used the request's `timeout` option for the idle clock. Self-review found that the Agent's proxy parsing differs from what proxied `bun bd` builds previously got through bun's `fetch()` (scheme-less proxies ignored, bare `NO_PROXY` hosts not covering the redirect hop), that the proxy path had no test, and that the `timeout` option never fires on the `node:http` client in bun 1.3.x, so a stall would have hung there. The second commit addresses all three as described above.
</details>
