### PR TITLE
node:fs: name the failing subdirectory in recursive readdirSync errors

### DIFF
--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6313,12 +6313,17 @@ impl NodeFS {
             ),
         };
         match maybe {
-            Err(err) => Err(sys::Error {
-                syscall: sys::Tag::scandir,
-                errno: err.errno,
-                path: args.path.slice().into(),
-                ..Default::default()
-            }),
+            // Node reports every readdir failure as `scandir`, naming the directory
+            // whose listing failed: for a recursive walk that is the subdirectory
+            // the walker attached, not necessarily `args.path`.
+            Err(err) => {
+                let path: &[u8] = if err.path.is_empty() {
+                    args.path.slice()
+                } else {
+                    &err.path
+                };
+                Err(err.with_path_and_syscall(path, sys::Tag::scandir))
+            }
             Ok(result) => Ok(result),
         }
     }
@@ -6627,6 +6632,22 @@ impl NodeFS {
         Ok(())
     }
 
+    /// `err` failed the subdirectory at `relative` (the walker's path relative to
+    /// the root fd). Node reports that directory as `path.join(root, relative)`;
+    /// `readdir_with_entries_recursive_async` attaches the same path.
+    fn readdir_recursive_subdir_error(
+        err: &sys::Error,
+        args: &args::Readdir,
+        relative: &[u8],
+    ) -> sys::Error {
+        let mut spill: Vec<u8> = Vec::new();
+        let joined = paths::resolve_path::join_spill::<paths::platform::Auto>(
+            &mut spill,
+            &[args.path.slice(), relative],
+        );
+        err.with_path(joined)
+    }
+
     fn readdir_with_entries_recursive_sync<T: ReaddirEntry>(
         buf: &mut PathBuffer,
         args: &args::Readdir,
@@ -6698,8 +6719,11 @@ impl NodeFS {
                         // Node doesn't gracefully handle errors like these. It fails the entire operation.
                         E::ENOENT | E::ENOTDIR | E::EPERM => continue,
                         _ => {
-                            // TODO: propagate file path (removed previously because it leaked the path)
-                            return Err(err);
+                            return Err(Self::readdir_recursive_subdir_error(
+                                &err,
+                                args,
+                                basename_bytes,
+                            ));
                         }
                     }
                 }
@@ -6721,7 +6745,14 @@ impl NodeFS {
                 let current = match iterator.next() {
                     Err(err) => {
                         dirent_path_prev.deref();
-                        return Err(err.with_path(args.path.slice()));
+                        if is_root {
+                            return Err(err.with_path(args.path.slice()));
+                        }
+                        return Err(Self::readdir_recursive_subdir_error(
+                            &err,
+                            args,
+                            basename_bytes,
+                        ));
                     }
                     Ok(None) => break,
                     Ok(Some(ent)) => ent,

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6313,16 +6313,12 @@ impl NodeFS {
             ),
         };
         match maybe {
-            // Node reports every readdir failure as `scandir`, naming the directory
-            // whose listing failed: for a recursive walk that is the subdirectory
-            // the walker attached, not necessarily `args.path`.
-            Err(err) => {
-                let path: &[u8] = if err.path.is_empty() {
-                    args.path.slice()
-                } else {
-                    &err.path
-                };
-                Err(err.with_path_and_syscall(path, sys::Tag::scandir))
+            // Node reports every readdir failure as `scandir`. `err.path` already names
+            // the directory whose listing failed, which for a recursive walk is not
+            // necessarily `args.path`.
+            Err(mut err) => {
+                err.syscall = sys::Tag::scandir;
+                Err(err)
             }
             Ok(result) => Ok(result),
         }
@@ -6449,6 +6445,16 @@ impl NodeFS {
         Ok(())
     }
 
+    /// Both recursive walkers open subdirectories by `relative`, their path
+    /// relative to the root; Node reports a failing one as
+    /// `path.join(root argument, relative)`.
+    fn readdir_subdir_error(err: &sys::Error, root: &[u8], relative: &[u8]) -> sys::Error {
+        let mut spill: Vec<u8> = Vec::new();
+        let joined =
+            paths::resolve_path::join_spill::<paths::platform::Auto>(&mut spill, &[root, relative]);
+        err.with_path(joined)
+    }
+
     pub(crate) fn readdir_with_entries_recursive_async<T: ReaddirEntry>(
         buf: &mut PathBuffer,
         async_task: &mut AsyncReaddirRecursiveTask,
@@ -6498,15 +6504,11 @@ impl NodeFS {
                         E::ENOENT | E::ENOTDIR | E::EPERM => return Ok(()),
                         _ => {}
                     }
-                    if root_basename.len() + 1 + basename.as_bytes().len() + 1
-                        < paths::MAX_PATH_BYTES
-                    {
-                        let joined = paths::resolve_path::join_z_buf::<paths::platform::Auto>(
-                            &mut buf[..],
-                            &[root_basename, basename.as_bytes()],
-                        );
-                        return Err(err.with_path(joined.as_bytes()));
-                    }
+                    return Err(Self::readdir_subdir_error(
+                        &err,
+                        root_basename,
+                        basename.as_bytes(),
+                    ));
                 }
                 return Err(err.with_path(root_basename));
             }
@@ -6531,15 +6533,12 @@ impl NodeFS {
             let current = match iterator.next() {
                 Err(err) => {
                     dirent_path_prev.deref();
-                    if !is_root
-                        && root_basename.len() + 1 + basename.as_bytes().len() + 1
-                            < paths::MAX_PATH_BYTES
-                    {
-                        let joined = paths::resolve_path::join_z_buf::<paths::platform::Auto>(
-                            &mut buf[..],
-                            &[root_basename, basename.as_bytes()],
-                        );
-                        return Err(err.with_path(joined.as_bytes()));
+                    if !is_root {
+                        return Err(Self::readdir_subdir_error(
+                            &err,
+                            root_basename,
+                            basename.as_bytes(),
+                        ));
                     }
                     return Err(err.with_path(root_basename));
                 }
@@ -6632,22 +6631,6 @@ impl NodeFS {
         Ok(())
     }
 
-    /// `err` failed the subdirectory at `relative` (the walker's path relative to
-    /// the root fd). Node reports that directory as `path.join(root, relative)`;
-    /// `readdir_with_entries_recursive_async` attaches the same path.
-    fn readdir_recursive_subdir_error(
-        err: &sys::Error,
-        args: &args::Readdir,
-        relative: &[u8],
-    ) -> sys::Error {
-        let mut spill: Vec<u8> = Vec::new();
-        let joined = paths::resolve_path::join_spill::<paths::platform::Auto>(
-            &mut spill,
-            &[args.path.slice(), relative],
-        );
-        err.with_path(joined)
-    }
-
     fn readdir_with_entries_recursive_sync<T: ReaddirEntry>(
         buf: &mut PathBuffer,
         args: &args::Readdir,
@@ -6719,9 +6702,9 @@ impl NodeFS {
                         // Node doesn't gracefully handle errors like these. It fails the entire operation.
                         E::ENOENT | E::ENOTDIR | E::EPERM => continue,
                         _ => {
-                            return Err(Self::readdir_recursive_subdir_error(
+                            return Err(Self::readdir_subdir_error(
                                 &err,
-                                args,
+                                args.path.slice(),
                                 basename_bytes,
                             ));
                         }
@@ -6748,9 +6731,9 @@ impl NodeFS {
                         if is_root {
                             return Err(err.with_path(args.path.slice()));
                         }
-                        return Err(Self::readdir_recursive_subdir_error(
+                        return Err(Self::readdir_subdir_error(
                             &err,
-                            args,
+                            args.path.slice(),
                             basename_bytes,
                         ));
                     }

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6313,9 +6313,7 @@ impl NodeFS {
             ),
         };
         match maybe {
-            // Node reports every readdir failure as `scandir`. `err.path` already names
-            // the directory whose listing failed, which for a recursive walk is not
-            // necessarily `args.path`.
+            // Node's operation name; `err.path` already names the directory that failed.
             Err(mut err) => {
                 err.syscall = sys::Tag::scandir;
                 Err(err)
@@ -6445,9 +6443,7 @@ impl NodeFS {
         Ok(())
     }
 
-    /// Both recursive walkers open subdirectories by `relative`, their path
-    /// relative to the root; Node reports a failing one as
-    /// `path.join(root argument, relative)`.
+    /// Node names a failing subdirectory as `path.join(root argument, path relative to root)`.
     fn readdir_subdir_error(err: &sys::Error, root: &[u8], relative: &[u8]) -> sys::Error {
         let mut spill: Vec<u8> = Vec::new();
         let joined =

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1773,6 +1773,95 @@ it.skipIf(isWindows)("promises.readdir({recursive: true}) settles when multiple 
   });
 });
 
+// When a recursive readdirSync fails while descending, the error used to name the
+// root argument. Node names the directory whose listing failed, joined onto the
+// root the way path.join would, and so do fs.readdir / fs.promises.readdir.
+describe("readdirSync({recursive: true}) error names the directory that failed", () => {
+  const resultKinds = [{}, { withFileTypes: true }, { encoding: "buffer" }] as const;
+
+  function readdirSyncError(root: string, options: object = {}): any {
+    try {
+      readdirSync(root, { recursive: true, ...options });
+    } catch (err) {
+      return err;
+    }
+    throw new Error(`expected readdirSync(${root}, { recursive: true }) to throw`);
+  }
+
+  function expectSubdirectoryError(root: string, failed: string, code: string) {
+    for (const kind of resultKinds) {
+      const err = readdirSyncError(root, kind);
+      expect({ code: err.code, syscall: err.syscall, path: err.path, message: err.message }).toEqual({
+        code,
+        syscall: "scandir",
+        path: failed,
+        message: expect.stringContaining(`, scandir '${failed}'`),
+      });
+    }
+  }
+
+  // A self-referential symlink fails to open with ELOOP for any user, root included.
+  it.skipIf(isWindows)("subdirectory that fails to open", async () => {
+    using dir = tempDir("readdir-recursive-error-path", { "keep.txt": "x", sub: { "inner.txt": "x" } });
+    const root = String(dir);
+    const failed = join(root, "sub", "loop");
+    symlinkSync("loop", failed);
+
+    expectSubdirectoryError(root, failed, "ELOOP");
+    // Joined like path.join, not concatenated: a trailing separator on the root does not leak into the path.
+    expectSubdirectoryError(root + "/", failed, "ELOOP");
+
+    const asyncError = await promises.readdir(root, { recursive: true }).then(
+      () => null,
+      err => err,
+    );
+    expect({ code: asyncError.code, path: asyncError.path }).toEqual({ code: "ELOOP", path: failed });
+  });
+
+  // Root bypasses directory permissions and Windows has no mode bits, so this
+  // variant only runs as an unprivileged user. Expected values match node.
+  it.skipIf(isWindows || process.getuid?.() === 0)("subdirectory that is not readable", async () => {
+    using dir = tempDir("readdir-recursive-error-path-eacces", { "keep.txt": "x", sub: { locked: {} } });
+    const root = String(dir);
+    const failed = join(root, "sub", "locked");
+    fs.chmodSync(failed, 0o000);
+    try {
+      expectSubdirectoryError(root, failed, "EACCES");
+
+      const asyncError = await promises.readdir(root, { recursive: true }).then(
+        () => null,
+        err => err,
+      );
+      expect({ code: asyncError.code, path: asyncError.path }).toEqual({ code: "EACCES", path: failed });
+    } finally {
+      fs.chmodSync(failed, 0o755);
+    }
+  });
+
+  it("root that cannot be listed is still reported as given", () => {
+    using dir = tempDir("readdir-recursive-error-path-root", { "file.txt": "x" });
+    const missing = join(String(dir), "missing");
+    const file = join(String(dir), "file.txt");
+
+    const shape = (err: any) => ({ code: err.code, syscall: err.syscall, path: err.path });
+    expect(shape(readdirSyncError(missing))).toEqual({ code: "ENOENT", syscall: "scandir", path: missing });
+    expect(shape(readdirSyncError(file))).toEqual({ code: "ENOTDIR", syscall: "scandir", path: file });
+    expect(shape(readdirSyncError(missing, { withFileTypes: true }))).toEqual({
+      code: "ENOENT",
+      syscall: "scandir",
+      path: missing,
+    });
+
+    let nonRecursive: any;
+    try {
+      readdirSync(missing);
+    } catch (err) {
+      nonRecursive = err;
+    }
+    expect(shape(nonRecursive)).toEqual({ code: "ENOENT", syscall: "scandir", path: missing });
+  });
+});
+
 describe("readSync", () => {
   it("rejects the read when the length argument detaches the destination buffer during coercion", () => {
     const fd = openSync(import.meta.dir + "/readFileSync.txt", "r");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1773,11 +1773,12 @@ it.skipIf(isWindows)("promises.readdir({recursive: true}) settles when multiple 
   });
 });
 
-// When a recursive readdirSync fails while descending, the error used to name the
+// When a recursive readdirSync failed while descending, the error used to name the
 // root argument. Node names the directory whose listing failed, joined onto the
-// root the way path.join would, and so do fs.readdir / fs.promises.readdir.
-describe("readdirSync({recursive: true}) error names the directory that failed", () => {
+// root the way path.join would; fs.readdir / fs.promises.readdir already did.
+describe("recursive readdir error names the directory that failed", () => {
   const resultKinds = [{}, { withFileTypes: true }, { encoding: "buffer" }] as const;
+  const shape = (err: any) => ({ code: err?.code, syscall: err?.syscall, path: err?.path });
 
   function readdirSyncError(root: string, options: object = {}): any {
     try {
@@ -1788,16 +1789,26 @@ describe("readdirSync({recursive: true}) error names the directory that failed",
     throw new Error(`expected readdirSync(${root}, { recursive: true }) to throw`);
   }
 
-  function expectSubdirectoryError(root: string, failed: string, code: string) {
+  function expectSyncError(root: string, failed: string, code: string) {
     for (const kind of resultKinds) {
       const err = readdirSyncError(root, kind);
-      expect({ code: err.code, syscall: err.syscall, path: err.path, message: err.message }).toEqual({
+      expect({ ...shape(err), message: err.message }).toEqual({
         code,
         syscall: "scandir",
         path: failed,
         message: expect.stringContaining(`, scandir '${failed}'`),
       });
     }
+  }
+
+  // The async walk joins the path the same way. Only its path is compared here;
+  // the syscall name it reports is normalized separately.
+  async function expectAsyncPath(root: string, failed: string, code: string) {
+    const err = await promises.readdir(root, { recursive: true }).then(
+      () => null,
+      err => err,
+    );
+    expect({ code: err?.code, path: err?.path }).toEqual({ code, path: failed });
   }
 
   // A self-referential symlink fails to open with ELOOP for any user, root included.
@@ -1807,15 +1818,11 @@ describe("readdirSync({recursive: true}) error names the directory that failed",
     const failed = join(root, "sub", "loop");
     symlinkSync("loop", failed);
 
-    expectSubdirectoryError(root, failed, "ELOOP");
+    expectSyncError(root, failed, "ELOOP");
     // Joined like path.join, not concatenated: a trailing separator on the root does not leak into the path.
-    expectSubdirectoryError(root + "/", failed, "ELOOP");
-
-    const asyncError = await promises.readdir(root, { recursive: true }).then(
-      () => null,
-      err => err,
-    );
-    expect({ code: asyncError.code, path: asyncError.path }).toEqual({ code: "ELOOP", path: failed });
+    expectSyncError(root + "/", failed, "ELOOP");
+    await expectAsyncPath(root, failed, "ELOOP");
+    await expectAsyncPath(root + "/", failed, "ELOOP");
   });
 
   // Root bypasses directory permissions and Windows has no mode bits, so this
@@ -1826,16 +1833,85 @@ describe("readdirSync({recursive: true}) error names the directory that failed",
     const failed = join(root, "sub", "locked");
     fs.chmodSync(failed, 0o000);
     try {
-      expectSubdirectoryError(root, failed, "EACCES");
-
-      const asyncError = await promises.readdir(root, { recursive: true }).then(
-        () => null,
-        err => err,
-      );
-      expect({ code: asyncError.code, path: asyncError.path }).toEqual({ code: "EACCES", path: failed });
+      expectSyncError(root, failed, "EACCES");
+      await expectAsyncPath(root, failed, "EACCES");
     } finally {
       fs.chmodSync(failed, 0o755);
     }
+  });
+
+  // Linux: /proc/<pid>/net of a child that has exited but not been reaped still
+  // opens as a directory, but listing it fails with EINVAL because the exited
+  // task has no network namespace. That is the walker's other failure arm: the
+  // subdirectory opened and reading its entries failed. Bun reaps children from
+  // the event loop, so the child stays a zombie while the caller stays synchronous;
+  // it is reaped as soon as the test yields. The probe below skips the test where
+  // the environment does not behave this way (no procfs, children reaped by a thread).
+  function spawnZombie(): number {
+    const child = Bun.spawn({ cmd: ["/bin/true"], stdio: ["ignore", "ignore", "ignore"] });
+    const deadline = Date.now() + 10_000;
+    while (!readFileSync(`/proc/${child.pid}/stat`, "latin1").includes(") Z ")) {
+      if (Date.now() > deadline) throw new Error(`pid ${child.pid} did not become a zombie`);
+      Bun.sleepSync(1);
+    }
+    return child.pid;
+  }
+  const zombieNetDirFailsToList =
+    isLinux &&
+    (() => {
+      try {
+        readdirSync(`/proc/${spawnZombie()}/net`);
+      } catch (err: any) {
+        return err.code === "EINVAL";
+      }
+      return false;
+    })();
+
+  it.skipIf(!zombieNetDirFailsToList)("subdirectory that opens but cannot be listed", () => {
+    using dir = tempDir("readdir-recursive-error-path-einval", { "keep.txt": "x" });
+    const root = String(dir);
+    const failed = join(root, "sub");
+    const netDir = `/proc/${spawnZombie()}/net`;
+    symlinkSync(netDir, failed);
+
+    expectSyncError(root, failed, "EINVAL");
+    // The same failure on the root itself reports the root as given.
+    expect(shape(readdirSyncError(netDir))).toEqual({ code: "EINVAL", syscall: "scandir", path: netDir });
+  });
+
+  // Linux only: the tree is built through /proc/self/fd because the paths involved
+  // are longer than PATH_MAX. The walkers open subdirectories relative to the root,
+  // so they still reach the failing entry; the async walk used to report the root
+  // instead once root + relative path no longer fit in a path buffer.
+  it.skipIf(!isLinux)("subdirectory whose path is longer than PATH_MAX", async () => {
+    using dir = tempDir("readdir-recursive-error-path-long", {});
+    const segment = Buffer.alloc(255, "d").toString();
+    const root = join(String(dir), Buffer.alloc(255, "r").toString());
+    mkdirSync(root);
+    // 15 levels of NAME_MAX-sized names is the deepest the walkers descend
+    // (NAME_MAX + 1 + the 3839-byte relative path still fits PATH_MAX).
+    const levels = Array.from({ length: 15 }, () => segment);
+    let fd = openSync(root, "r");
+    try {
+      for (let depth = 0; depth < levels.length; depth++) {
+        mkdirSync(`/proc/self/fd/${fd}/${segment}`);
+        const next = openSync(`/proc/self/fd/${fd}/${segment}`, "r");
+        closeSync(fd);
+        fd = next;
+      }
+      symlinkSync("loop", `/proc/self/fd/${fd}/loop`);
+    } finally {
+      closeSync(fd);
+    }
+    const failed = join(root, ...levels, "loop");
+    expect(failed.length).toBeGreaterThan(4096);
+
+    // err.message is not checked here: it is formatted into a 4 KiB buffer and a
+    // path this long gets cut off in it, for every fs error (tracked separately).
+    for (const kind of resultKinds) {
+      expect(shape(readdirSyncError(root, kind))).toEqual({ code: "ELOOP", syscall: "scandir", path: failed });
+    }
+    await expectAsyncPath(root, failed, "ELOOP");
   });
 
   it("root that cannot be listed is still reported as given", () => {
@@ -1843,7 +1919,6 @@ describe("readdirSync({recursive: true}) error names the directory that failed",
     const missing = join(String(dir), "missing");
     const file = join(String(dir), "file.txt");
 
-    const shape = (err: any) => ({ code: err.code, syscall: err.syscall, path: err.path });
     expect(shape(readdirSyncError(missing))).toEqual({ code: "ENOENT", syscall: "scandir", path: missing });
     expect(shape(readdirSyncError(file))).toEqual({ code: "ENOTDIR", syscall: "scandir", path: file });
     expect(shape(readdirSyncError(missing, { withFileTypes: true }))).toEqual({


### PR DESCRIPTION
### Problem
- When `fs.readdirSync(root, { recursive: true })` fails while descending, the thrown error names the root: `EACCES: permission denied, scandir '/tmp/r'` with `err.path === "/tmp/r"`, although `/tmp/r` listed fine and `/tmp/r/sub` is what failed.
- Node reports the subdirectory (`scandir '/tmp/r/sub'`, `err.path === "/tmp/r/sub"`) for `readdirSync`, `fs.readdir` and `fs.promises.readdir` alike. Bun's two async forms already did, so `readdirSync` also disagreed with them.
- Cause, in `src/runtime/node/node_fs.rs` (line numbers on main):
  - `readdir_with_entries_recursive_sync` returned a subdirectory `openat` failure without any path (node_fs.rs:6702, the `TODO: propagate file path` arm) and attached the root to a directory-iteration failure (node_fs.rs:6724).
  - `NodeFS::readdir` (node_fs.rs:6316) then rebuilt every error as `{ scandir, errno, path: args.path }`, discarding whatever path the walk had attached.
- Smaller, same-class defect in the async walker: it joined root + subdirectory inline, twice, and reported the root instead once `root + relative path` did not fit a `PathBuffer` (4 KiB on Linux, 1 KiB on macOS), although the walk itself reaches such entries since it opens them relative to the root.

### Fix
- One helper, `readdir_subdir_error(err, root, relative)`, builds the failing directory's path for all four failure arms (open and iteration, sync and async) as `join(root argument, path relative to the root)`, through `join_spill`, which this code already uses for `Dirent.parentPath` and which has no length limit. The two inline async copies and their root fallback are deleted. Root failures keep reporting the root argument as given.
- `NodeFS::readdir` now only sets the syscall name to `scandir`. Every error it receives already carries a path: the non-recursive arms and the standalone-executable arm attach `args.path`, the recursive walk attaches the directory that failed. This is the same `Err(mut err) => { err.syscall = ...; Err(err) }` shape the `futimes` path in this file uses.
- Why this is correct: it matches Node, whose recursive readdir lists each directory with its own `scandir` on `path.join(root, entry)` and throws that call's error unchanged. The join normalizes like `path.join`, so `readdirSync("./r/", ...)` reports `r/sub`, exactly as node does. Non-recursive readdir and root failures are unaffected: those errors carried the root argument before and still do.
- Intentionally left alone: the first-error store in `AsyncReaddirRecursiveTask::perform_work` (its own keep-path-or-root line) is the line #37988 rewrites to fix the async forms' syscall name, so it is not touched here; the path it keeps is the one this helper attaches.
- Tests, in `test/js/node/fs/fs.test.ts` (`recursive readdir error names the directory that failed`); each subdirectory case checks `code`/`syscall`/`path`/`message` for the string, `withFileTypes` and `encoding: "buffer"` results of `readdirSync`, and that `fs.promises.readdir` reports the same path:
  - `subdirectory that fails to open`: self-referential symlink two levels down (`ELOOP`, works as root, which is how the neighbouring tests already make a subdirectory fail), also with a trailing slash on the root to pin join-not-concatenate.
  - `subdirectory that is not readable`: the `EACCES` case from the report; skipped as root and on Windows; expected values match node v26.3.0.
  - `subdirectory that opens but cannot be listed` (Linux): `/proc/<pid>/net` of an exited, not yet reaped child opens but fails to list with `EINVAL`, which is the only way to reach the iteration-failure arm deterministically; covers both its subdirectory branch and its root branch. A probe at collection time skips it where the environment does not behave this way.
  - `subdirectory whose path is longer than PATH_MAX` (Linux): 255-byte root name plus 15 levels of 255-byte names, built through `/proc/self/fd`; the failing entry's full path is over 4 KiB, which is where the async walk used to fall back to the root. This one checks `err.path` only: `err.message` is formatted into a fixed 4 KiB buffer and gets cut off for any fs error with operands this long (pre-existing, reported separately).
  - `root that cannot be listed is still reported as given`: `ENOENT`/`ENOTDIR` on the root, recursive and not, guard the wrapper change.
- Verified: on bun 1.4.0 the subdirectory tests fail (three as root, all four as an unprivileged user, where the `EACCES` one is not skipped) and the root test passes; with this branch everything passes both as root and as an unprivileged user. The over-long case was also run against the build of this branch's first revision (sync fixed, async not yet shared): `fs.promises.readdir` reported the root there (output in the details below), which is what the async assertion of that test pins. `readdirSync-recursive-error-leak.test.ts` (30k passes through the new open-failure arm), `dir.test.ts`, the readdir tests in `fs.test.ts` and `test/js/node/test/parallel/test-fs-readdir*.js` pass against the debug build.
- Related open PRs, all independent of this one: #37988 (async forms say `open` instead of `scandir`; their path was already right), #33432 / #31418 (which symlink failures abort the walk; they would switch the `ELOOP` fixtures here to `EACCES` as they already do for the neighbouring tests), #37995 (representation of `sys::Error.path`; touches the same wrapper lines, trivial rebase either way).

### Background
- Recursive readdir is a breadth-first walk (`readdir_with_entries_recursive_sync`, or `AsyncReaddirRecursiveTask` subtasks calling `readdir_with_entries_recursive_async` on the thread pool). It opens the root once, then opens every directory it finds with `openat(root_fd, relative_path)`, where `relative_path` (`sub`, `sub/deeper`, ...) is relative to the root. The failure arms therefore only have the relative path at hand and must join it back onto the root argument to name the directory the way the caller would; the async task keeps an owned copy of the root argument (`root_path`) because subtasks must not touch the JS-backed arguments, which is why the helper takes the root as bytes.
- Each walk has two failure arms: the `openat` of a subdirectory fails (`EACCES`, `ELOOP`, ...; `ENOENT`/`ENOTDIR`/`EPERM` are skipped), or the directory opened but reading its entries fails (`getdents64` returning an error, e.g. `EINVAL` from procfs above).
- `bun_sys::Error` is Bun's syscall error (errno, syscall tag, path); `err.path` becomes the JS error's `path` property and the `'...'` suffix of its message. `with_path` returns a copy with an owned copy of the path (the removed `TODO` dates from when the path was borrowed). `join_spill` joins and normalizes path parts into a thread-local buffer, spilling to a caller-provided `Vec` when the result exceeds 4 KiB.
- Node implements every form of readdir on top of libuv's `uv_fs_scandir`, so its errors always say `scandir`; `NodeFS::readdir` is where Bun applies that to the sync and non-recursive forms, `perform_work` is the async recursive equivalent (#37988).

<details>
<summary>Repro (Linux, as a non-root user)</summary>

```sh
mkdir -p /tmp/r/sub && touch /tmp/r/a.txt && chmod 000 /tmp/r/sub
bun -e '
const fs = require("fs");
try { fs.readdirSync("/tmp/r", { recursive: true }) } catch (e) { console.log("sync    ", e.path, "|", e.message) }
fs.readdir("/tmp/r", { recursive: true }, e => console.log("callback", e.path))
'
```

bun 1.4.0:

```
sync     /tmp/r | EACCES: permission denied, scandir '/tmp/r'
callback /tmp/r/sub
```

node v26.3.0 prints `/tmp/r/sub` and `EACCES: permission denied, scandir '/tmp/r/sub'` for the sync, callback and promises forms. With this change bun's sync line becomes `/tmp/r/sub | EACCES: permission denied, scandir '/tmp/r/sub'`. Relative roots follow `path.join` as in node: `readdirSync("./r", ...)` and `readdirSync("r/", ...)` both report `r/sub`.

Over-long case (300-byte root, 3804-byte relative path, self-referential symlink at the bottom): before this branch `readdirSync` reported the root; with only the sync arms fixed, `readdirSync` reported the 4105-byte joined path while `fs.readdir` / `fs.promises.readdir` still reported the 300-byte root; with the shared helper all three report the joined path.
</details>

<details>
<summary>Superseded first revision</summary>

The first push fixed only the sync walker (a helper taking `&args::Readdir`) and made `NodeFS::readdir` keep the inner path with a fall back to `args.path`. Review pointed out that the async walker could not share that helper and still had its own length-limited join, that the fallback was unreachable, and that the iteration-failure arm had no test; the current revision addresses all three.
</details>
