### PR TITLE
install(windows): store an absolute target in .bunx shims when the package dir is on another drive

### DIFF
--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1179,12 +1179,19 @@ impl<'a> Linker<'a> {
             resolve_path::dirname::<PlatformAuto>(abs_dest.as_bytes()),
             abs_target.as_bytes(),
         );
-        debug_assert!(strings::has_prefix(rel_target.as_bytes(), b"..\\"));
 
-        let rel_target_w = strings::to_w_path_normalized(
-            target_buf.as_mut_slice(),
-            &rel_target.as_bytes()[b"..\\".len()..],
-        );
+        // The shim resolves `bin_path` against the parent of its own directory,
+        // so the leading `..\` is implied. `relative` yields no `..\` when the
+        // target is on another drive (it returns the absolute path) or when the
+        // target is inside the bin directory itself, both of which happen with
+        // global installs; those shims store the absolute target.
+        let (bin_path, is_absolute_target): (&[u8], bool) =
+            match strings::without_prefix_if_possible_comptime(rel_target.as_bytes(), b"..\\") {
+                Some(rel_to_parent) => (rel_to_parent, false),
+                None => (abs_target.as_bytes(), true),
+            };
+
+        let bin_path_w = strings::to_w_path_normalized(target_buf.as_mut_slice(), bin_path);
 
         let shebang = 'shebang: {
             let first_content_chunk: Option<&[u8]> = 'contents: {
@@ -1201,7 +1208,7 @@ impl<'a> Linker<'a> {
             };
 
             if let Some(chunk) = first_content_chunk {
-                match WinShimShebang::parse(chunk, rel_target_w) {
+                match WinShimShebang::parse(chunk, bin_path_w) {
                     Ok(s) => break 'shebang s,
                     Err(_) => {
                         self.err = Some(crate::Error::InvalidBinCount);
@@ -1209,12 +1216,13 @@ impl<'a> Linker<'a> {
                     }
                 }
             } else {
-                break 'shebang WinShimShebang::parse_from_bin_path(rel_target_w);
+                break 'shebang WinShimShebang::parse_from_bin_path(bin_path_w);
             }
         };
 
         let shim = WinBinLinkingShim {
-            bin_path: rel_target_w,
+            bin_path: bin_path_w,
+            is_absolute_target,
             shebang,
         };
 

--- a/src/install/bin.rs
+++ b/src/install/bin.rs
@@ -1271,10 +1271,10 @@ impl<'a> Linker<'a> {
         // so each return path calls `Self::chmod_on_ok` explicitly instead.
 
         let abs_dest_dir = resolve_path::dirname::<PlatformAuto>(abs_dest.as_bytes());
+        // Usually starts with `..`, but a global install may nest the package
+        // directory inside the bin directory; any relative path works here.
         let rel_target =
             resolve_path::relative_buf_z(self.rel_buf, abs_dest_dir, abs_target.as_bytes());
-
-        debug_assert!(strings::has_prefix(rel_target.as_bytes(), b".."));
 
         match sys::symlink_running_executable(rel_target, abs_dest) {
             sys::Result::Err(err) => {

--- a/src/install/windows-shim/BinLinkingShim.rs
+++ b/src/install/windows-shim/BinLinkingShim.rs
@@ -9,6 +9,13 @@
 //! [WSTR:program][u16:0][WSTR:args][u32:bin_path_byte_len][u32:arg_byte_len]
 //! - args always ends with a trailing space
 //!
+//! `bin_path` is normally relative to the parent of the directory containing
+//! the shim (`node_modules` for `node_modules/.bin/foo.exe`), which is what
+//! keeps a `node_modules` tree relocatable. When no such relative path exists
+//! (a global install whose bin directory is on a different drive than the
+//! package directory, or whose package directory is inside the bin directory)
+//! `Flags::is_absolute_target` is set and `bin_path` is the absolute path.
+//!
 //! See `bun_shim_impl.rs` for more details on how this file is consumed.
 //!
 //! ## `shim_standalone` feature
@@ -22,7 +29,7 @@
 /// Random numbers are chosen for validation purposes
 /// These arbitrary numbers will probably not show up in the other fields.
 /// This will reveal off-by-one mistakes.
-// The encoding is an open-ended 13-bit value, so model it as a transparent u16
+// The encoding is an open-ended 12-bit value, so model it as a transparent u16
 // newtype rather than an exhaustive enum.
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -32,10 +39,18 @@ impl VersionFlag {
     const CURRENT: VersionFlag = VersionFlag::V5;
 
     /// Fixed bugs where passing arguments did not always work.
-    const V5: VersionFlag = VersionFlag(5478);
+    ///
+    /// Before `Flags::is_absolute_target` existed this was the 13-bit value
+    /// 5478 stored at bit 3 of `Flags`. It now occupies the 12 bits above the
+    /// flag and `2739 << 4 == 5478 << 3`, so a `.bunx` written before the flag
+    /// existed has exactly these bits (with the flag clear) and still
+    /// validates, while a `.bunx` with the flag set reads as version 5479 to a
+    /// launcher that predates it and is rejected instead of being resolved as
+    /// a relative path.
+    const V5: VersionFlag = VersionFlag(2739);
 
-    /// Maximum 13-bit value.
-    const MAX: VersionFlag = VersionFlag((1u16 << 13) - 1);
+    /// Maximum 12-bit value.
+    const MAX: VersionFlag = VersionFlag((1u16 << 12) - 1);
 
     #[inline]
     pub(crate) const fn bits(self) -> u16 {
@@ -43,7 +58,7 @@ impl VersionFlag {
     }
 }
 
-// Packed u16 bitfield (three bools + a 13-bit version tag): `#[repr(transparent)]`
+// Packed u16 bitfield (four bools + a 12-bit version tag): `#[repr(transparent)]`
 // newtype with manual shift accessors (LSB first).
 #[repr(transparent)]
 #[derive(Copy, Clone, Eq, PartialEq)]
@@ -55,13 +70,15 @@ impl Flags {
         is_node_or_bun: bool,
         is_node: bool,
         has_shebang: bool,
+        is_absolute_target: bool,
         version_tag: VersionFlag,
     ) -> Flags {
         Flags(
             (is_node_or_bun as u16)
                 | ((is_node as u16) << 1)
                 | ((has_shebang as u16) << 2)
-                | (version_tag.0 << 3),
+                | ((is_absolute_target as u16) << 3)
+                | (version_tag.0 << 4),
         )
     }
 
@@ -90,9 +107,15 @@ impl Flags {
     pub(crate) const fn has_shebang(self) -> bool {
         (self.0 & 0b100) != 0
     }
+    // indicates that bin_path is an absolute path instead of being relative to
+    // the parent of the directory containing the shim
+    #[inline]
+    pub(crate) const fn is_absolute_target(self) -> bool {
+        (self.0 & 0b1000) != 0
+    }
     #[inline]
     pub(crate) const fn version_tag(self) -> VersionFlag {
-        VersionFlag(self.0 >> 3)
+        VersionFlag(self.0 >> 4)
     }
 
     #[inline]
@@ -101,8 +124,8 @@ impl Flags {
     }
 
     pub(crate) fn is_valid(self) -> bool {
-        let mask: u16 = Flags::new(false, false, false, VersionFlag::MAX).bits();
-        let compare_to: u16 = Flags::new(false, false, false, VersionFlag::CURRENT).bits();
+        let mask: u16 = Flags::new(false, false, false, false, VersionFlag::MAX).bits();
+        let compare_to: u16 = Flags::new(false, false, false, false, VersionFlag::CURRENT).bits();
         (self.0 & mask) == compare_to
     }
 }
@@ -341,8 +364,10 @@ mod host {
     }
 
     pub(crate) struct BinLinkingShim<'a> {
-        /// Relative to node_modules. Do not include slash
+        /// Relative to the parent of the directory containing the shim (do not
+        /// include a leading slash), or absolute when `is_absolute_target` is set.
         pub(crate) bin_path: &'a [u16],
+        pub(crate) is_absolute_target: bool,
         /// Information found within the target file's shebang
         pub(crate) shebang: Option<Shebang<'a>>,
     }
@@ -392,6 +417,7 @@ mod host {
                 is_node_or_bun,
                 /* is_node */ false,
                 /* has_shebang */ self.shebang.is_some(),
+                self.is_absolute_target,
                 VersionFlag::CURRENT,
             );
 

--- a/src/install/windows-shim/BinLinkingShim.rs
+++ b/src/install/windows-shim/BinLinkingShim.rs
@@ -40,13 +40,9 @@ impl VersionFlag {
 
     /// Fixed bugs where passing arguments did not always work.
     ///
-    /// Before `Flags::is_absolute_target` existed this was the 13-bit value
-    /// 5478 stored at bit 3 of `Flags`. It now occupies the 12 bits above the
-    /// flag and `2739 << 4 == 5478 << 3`, so a `.bunx` written before the flag
-    /// existed has exactly these bits (with the flag clear) and still
-    /// validates, while a `.bunx` with the flag set reads as version 5479 to a
-    /// launcher that predates it and is rejected instead of being resolved as
-    /// a relative path.
+    /// Was the 13-bit value 5478 at bit 3 of `Flags` before
+    /// `Flags::is_absolute_target` took that bit; `2739 << 4` is the same bit
+    /// pattern. The assertions below `Flags` explain and pin this.
     const V5: VersionFlag = VersionFlag(2739);
 
     /// Maximum 12-bit value.
@@ -129,6 +125,13 @@ impl Flags {
         (self.0 & mask) == compare_to
     }
 }
+
+// Launchers that predate `is_absolute_target` validate `bits >> 3 == 5478`. A relative
+// shim must still satisfy that (they keep working on existing installs, and the bunx fast
+// path in a newer bun.exe keeps accepting the files they wrote), and an absolute shim must
+// not (they would otherwise resolve the absolute path as a relative one).
+const _: () = assert!(Flags::new(false, false, false, false, VersionFlag::V5).bits() == 5478 << 3);
+const _: () = assert!(Flags::new(false, false, false, true, VersionFlag::V5).bits() >> 3 != 5478);
 
 // ──────────────────────────────────────────────────────────────────────────
 // Host-side encoding / embedding. None of this is compiled into the

--- a/src/install/windows-shim/bun_shim_impl.rs
+++ b/src/install/windows-shim/bun_shim_impl.rs
@@ -43,7 +43,9 @@
 //! This file is compiled twice: into bun.exe (for the bunx fast paths below) and as
 //! the standalone `bun_shim_impl.exe` PE (see `main.rs` / the `shim_standalone`
 //! feature), which is then `include_bytes!`-embedded into Bun by `BinLinkingShim.rs`.
-//! When the encoding changes, `BinLinkingShim::VersionFlag::CURRENT` should be bumped.
+//! When the encoding changes, `BinLinkingShim::VersionFlag::CURRENT` should be bumped, unless
+//! the change only affects files carrying a new flag bit that older launchers already reject
+//! (see the assertions below `Flags` in `BinLinkingShim.rs`).
 //!
 //! Theorized and written by @paperclover during one of the most entranced all-nighters of her life.
 

--- a/src/install/windows-shim/bun_shim_impl.rs
+++ b/src/install/windows-shim/bun_shim_impl.rs
@@ -11,6 +11,12 @@
 //! launcher exe. We read that (see `BinLinkingShim.rs` for the creation of this file)
 //! and then we call NtCreateProcess to spawn the correct child process.
 //!
+//! The target path stored in the `.bunx` file is usually relative to the parent of the
+//! directory the launcher lives in, and is read into memory directly after that directory's
+//! path to form the absolute path without copying. When the `.bunx` file carries
+//! `Flags::is_absolute_target`, the stored path is already absolute and is used as-is from
+//! where it was read.
+//!
 //! Every attempt possible to make this file as minimal as possible has been made.
 //! Which has unfortunatly made is difficult to read. To make up for this, every
 //! part of this program is documented as much as possible, including links to
@@ -899,6 +905,8 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
         );
     }
 
+    let metadata_ptr: *mut u16 = read_ptr;
+
     // All three `read_len` outcomes land on initialized memory:
     //   - SUCCESS, read_len >= 2  → inside the bytes NtReadFile just wrote.
     //   - SUCCESS, read_len < 2   → moves *backward* into the image-path prefix we
@@ -925,6 +933,7 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
         debug!("    is_node_or_bun: {}", flags.is_node_or_bun());
         debug!("    is_node: {}", flags.is_node());
         debug!("    has_shebang: {}", flags.has_shebang());
+        debug!("    is_absolute_target: {}", flags.is_absolute_target());
         debug!("    version_tag: {}", flags.version_tag().bits());
     }
 
@@ -937,6 +946,26 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
 
         return LauncherMode::fail(MODE, FailReason::InvalidShimValidation);
     }
+
+    // Where the target's absolute path starts in buf1. A relative bin path was read in directly
+    // after the parent of the launcher's directory, so the absolute path starts right after the
+    // NT object prefix. An absolute bin path is complete on its own, so it starts where it was
+    // read and the directory left in front of it is never used:
+    //
+    //   relative: '\??\C:\Users\chloe\project\node_modules\my-cli\src\app.js"#...'
+    //                 ^ bin_path_start
+    //   absolute: '\??\C:\Users\chloe\.bun\E:\store\node_modules\my-cli\src\app.js"#...'
+    //                                     ^ bin_path_start (== metadata_ptr)
+    //
+    // Either way the u16 right before it is a `\` (the end of the NT prefix, or the separator
+    // the directory walk above stopped on) which the no-shebang path below may overwrite.
+    let bin_path_start: *mut u16 = if flags.is_absolute_target() {
+        metadata_ptr
+    } else {
+        // SAFETY: NT_OBJECT_PREFIX was written at the start of buf1 above.
+        unsafe { buf1_u16.add(NT_OBJECT_PREFIX.len()) }
+    };
+    debug_assert!(unsafe { *bin_path_start.sub(1) } == '\\' as u16);
 
     let mut spawn_command_line: *mut u16 = if !flags.has_shebang() {
         'spawn_command_line: {
@@ -951,12 +980,13 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
             //                                                                  ^^ flags
             //                                                         zero char|
 
-            // change the \ from '\??\' to '""
+            // change the \ before the path (the one from '\??\' here) to '"'
             // the ending quote is assumed to already exist as per the format
             // BUF1: '\??"C:\Users\chloe\project\node_modules\my-cli\src\app.js"##!!!!!!!!!!'
-            //           ^
-            // SAFETY: index 3 is within buf1.
-            unsafe { *buf1_u16.add(3) = '"' as u16 };
+            //           ^ opening_quote_ptr
+            // SAFETY: the u16 before bin_path_start is inside buf1 (see where it is computed).
+            let opening_quote_ptr: *mut u16 = unsafe { bin_path_start.sub(1) };
+            unsafe { *opening_quote_ptr = '"' as u16 };
 
             // Copy user arguments in, overwriting old data. Remember that we ensured the arguments
             // this started with a space.
@@ -996,12 +1026,7 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
                     .write_unaligned(0);
             }
 
-            // SAFETY: buf1_u8 + 2*(4-1) is 2-byte-aligned (buf1 is u16-aligned, offset is even).
-            break 'spawn_command_line unsafe {
-                buf1_u8
-                    .add(2 * (NT_OBJECT_PREFIX.len() - 1/* "\"".len */))
-                    .cast::<u16>()
-            };
+            break 'spawn_command_line opening_quote_ptr;
         }
     } else {
         'spawn_command_line: {
@@ -1080,17 +1105,15 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
                 }
                 // BUF1: '\??\C:\Users\chloe\project\node_modules\my-cli\src\app.js"#node #####!!!!!!!!!!'
                 //            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^  ^ read_ptr
-                let len = ((read_ptr as usize) - (buf1_u8 as usize) - shebang_arg_len_u8 as usize)
+                //            ^ bin_path_start
+                let len = ((read_ptr as usize)
+                    - shebang_arg_len_u8 as usize
+                    - (bin_path_start as usize))
                     / 2
-                    - NT_OBJECT_PREFIX.len()
                     - 2 /* "\"\x00".len */;
-                // SAFETY: buf1_u16 + 4 .. + 4 + len is within buf1; the next char is '"' (the metadata format places '"' after the bin path).
-                let launch_slice =
-                    unsafe { bun_core::ffi::slice_mut(buf1_u16.add(NT_OBJECT_PREFIX.len()), len) };
-                debug_assert_eq!(
-                    unsafe { *buf1_u16.add(NT_OBJECT_PREFIX.len() + len) },
-                    '"' as u16
-                );
+                // SAFETY: bin_path_start .. + len is within buf1; the next char is '"' (the metadata format places '"' after the bin path).
+                let launch_slice = unsafe { bun_core::ffi::slice_mut(bin_path_start, len) };
+                debug_assert_eq!(unsafe { *bin_path_start.add(len) }, '"' as u16);
                 bun_ctx.direct_launch_with_bun_js(launch_slice);
                 return LauncherMode::fail(MODE, FailReason::CouldNotDirectLaunch);
             }
@@ -1112,9 +1135,9 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
             //
             // BUF1: '\??\C:\Users\chloe\project\node_modules\my-cli\src\app.js"#node #####!!!!!!!!!!'
             //            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ ^ read_ptr
-            let length_of_filename_u8 = (read_ptr as usize)
-                - (buf1_u8 as usize)
-                - 2 * (NT_OBJECT_PREFIX.len() + 1/* "\x00".len */);
+            //            ^ bin_path_start
+            let length_of_filename_u8 =
+                (read_ptr as usize) - (bin_path_start as usize) - 2 * 1 /* "\x00".len */;
             if shebang_arg_len_u8 as usize
                 + 2 /* "\"".len */
                 + length_of_filename_u8
@@ -1147,18 +1170,15 @@ fn launcher<const MODE: LauncherMode, Ctx: BunCtx>(bun_ctx: Ctx) -> LauncherRet 
             // Copy the filename in. There is no leading " but there is a trailing "
             // BUF1: '\??\C:\Users\chloe\project\node_modules\my-cli\src\app.js"#node #####!!!!!!!!!!'
             //            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^ ^ read_ptr
+            //            ^ bin_path_start
             // BUF2: 'node "C:\Users\chloe\project\node_modules\my-cli\src\app.js"!!!!!!!!!!!!!!!!!!!!'
             // SAFETY: slice within buf1.
-            let filename: &[u8] = unsafe {
-                bun_core::ffi::slice(
-                    buf1_u8.add(2 * NT_OBJECT_PREFIX.len()),
-                    length_of_filename_u8,
-                )
-            };
-            // `filename` is a UTF-16 byte view: its base is `buf1_u8 + 2*NT_OBJECT_PREFIX.len()`
-            // (even offset from a `*mut u16`-derived pointer ⇒ 2-aligned) and its length is the
-            // difference of two `*mut u16`-derived addresses minus an even constant ⇒ even.
-            // `bytemuck::cast_slice` checks both invariants at runtime, so no `unsafe` needed.
+            let filename: &[u8] =
+                unsafe { bun_core::ffi::slice(bin_path_start.cast::<u8>(), length_of_filename_u8) };
+            // `filename` is a UTF-16 byte view: its base is a `*mut u16` into buf1 (⇒ 2-aligned)
+            // and its length is the difference of two `*mut u16`-derived addresses minus an even
+            // constant ⇒ even. `bytemuck::cast_slice` checks both invariants at runtime, so no
+            // `unsafe` needed.
             let filename_u16: &[u16] = bytemuck::cast_slice(filename);
             if DBG {
                 debug!("filename and quote: '{}'", fmt16(filename_u16));

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -8637,6 +8637,24 @@ describe("outdated", () => {
 // This test is to verify that BinLinkingShim.zig creates correct shim files as
 // well as bun_shim_impl.exe works in various edge cases. There are many fast
 // paths for many many cases.
+// The parts of a Windows `.bunx` file that the tests below look at (the layout
+// is documented in src/install/windows-shim/BinLinkingShim.rs): the UTF-16
+// target path, which ends at a `"`, and the flags word that ends the file. Bit 3
+// of the flags is `is_absolute_target`; the bits above it are the format
+// version. Launchers built before that bit existed check the version bits for
+// exactly this value, so it must stay the same for both kinds of shim.
+const BUNX_VERSION_BITS = 0xab30;
+function readBunxShim(path: string) {
+  const bytes = readFileSync(path);
+  const text = bytes.toString("utf16le");
+  const flags = bytes.readUInt16LE(bytes.length - 2);
+  return {
+    target: text.slice(0, text.indexOf('"')),
+    isAbsoluteTarget: (flags & 0b1000) !== 0,
+    versionBits: flags & 0xfff0,
+  };
+}
+
 describe("windows bin linking shim should work", async () => {
   if (!isWindows) return;
 
@@ -8714,6 +8732,20 @@ describe("windows bin linking shim should work", async () => {
     { bin: "native", name: "exe" },
     { bin: "uses-native", name: `exe ${packageDir}\\node_modules\\bunx-bins\\uses-native.ts` },
   ];
+
+  test("the .bunx files store the target relative to node_modules", () => {
+    const binDir = join(packageDir, "node_modules", ".bin");
+    expect(readBunxShim(join(binDir, "native.bunx"))).toEqual({
+      target: "bunx-bins\\native.exe",
+      isAbsoluteTarget: false,
+      versionBits: BUNX_VERSION_BITS,
+    });
+    expect(readBunxShim(join(binDir, "bin-bun.bunx"))).toEqual({
+      target: "bunx-bins\\bin-bun.ts",
+      isAbsoluteTarget: false,
+      versionBits: BUNX_VERSION_BITS,
+    });
+  });
 
   for (const { bin, name } of bins) {
     test(`bun run ${bin} arg1 arg2`, async () => {
@@ -8812,13 +8844,21 @@ describe("global bin links when the package dir is inside the bin dir", () => {
     root = tmpdirSync();
     binDir = join(root, "bin");
     globalDir = join(binDir, "global");
+    const tmp = join(root, "tmp");
+    await mkdir(tmp);
+    // `env` is shared with the file-level beforeEach, which points its cache and
+    // temp dirs at whichever test ran last; pin them so `bunx` below (which puts
+    // `<temp>/bunx-*/node_modules/.bin` ahead of PATH) sees the same thing in
+    // every run.
     globalEnv = mergeWindowEnvs([
       env,
       {
         BUN_INSTALL_BIN: binDir,
         BUN_INSTALL_GLOBAL_DIR: globalDir,
         BUN_INSTALL_CACHE_DIR: join(root, "cache"),
-        BUN_TMPDIR: join(root, "tmp"),
+        BUN_TMPDIR: tmp,
+        TMPDIR: tmp,
+        TEMP: tmp,
         PATH: binDir + delimiter + process.env.PATH,
       },
     ]);
@@ -8851,26 +8891,17 @@ describe("global bin links when the package dir is inside the bin dir", () => {
     expect(await exists(join(binDir, "bin-bun"))).toBe(true);
   });
 
-  // The `.bunx` layout is described in src/install/windows-shim/BinLinkingShim.rs:
-  // the target path in UTF-16 terminated by a `"`, and the flags as the last u16.
-  function readShim(bin: string) {
-    const bytes = readFileSync(join(binDir, `${bin}.bunx`));
-    const text = bytes.toString("utf16le");
-    return {
-      target: text.slice(0, text.indexOf('"')),
-      isAbsoluteTarget: (bytes.readUInt16LE(bytes.length - 2) & 0b1000) !== 0,
-    };
-  }
-
   test.skipIf(!isWindows)("the .bunx files store the absolute path of the target", () => {
     const packageDir = join(globalDir, "node_modules", "bunx-bins");
-    expect(readShim("native")).toEqual({
+    expect(readBunxShim(join(binDir, "native.bunx"))).toEqual({
       target: join(packageDir, "native.exe"),
       isAbsoluteTarget: true,
+      versionBits: BUNX_VERSION_BITS,
     });
-    expect(readShim("bin-bun")).toEqual({
+    expect(readBunxShim(join(binDir, "bin-bun.bunx"))).toEqual({
       target: join(packageDir, "bin-bun.ts"),
       isAbsoluteTarget: true,
+      versionBits: BUNX_VERSION_BITS,
     });
   });
 

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -1,7 +1,7 @@
 import { file, spawn, write } from "bun";
 import { install_test_helpers, npm_manifest_test_helpers } from "bun:internal-for-testing";
-import { afterAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
-import { copyFileSync, mkdirSync } from "fs";
+import { afterAll, beforeAll, beforeEach, describe, expect, setDefaultTimeout, test } from "bun:test";
+import { copyFileSync, mkdirSync, readFileSync } from "fs";
 import { cp, exists, lstat, mkdir, readlink, rm, writeFile } from "fs/promises";
 import {
   assertManifestsPopulated,
@@ -8787,6 +8787,113 @@ describe("windows bin linking shim should work", async () => {
       expect(err.trim()).toBe("");
       const out = await stdout.text();
       expect(out.trim()).toBe(`i am ${name} arg1 arg2`);
+      expect(await exited).toBe(0);
+    });
+  }
+});
+
+// A `.bunx` file normally stores the target relative to the parent of the
+// directory holding the shim. A global install can put the global bin dir and
+// the global package dir anywhere relative to each other, and when the target
+// is not reachable through a single `..` (most commonly because the two dirs
+// are on different drives, https://github.com/oven-sh/bun/issues/23414) the
+// shim has to store the absolute target instead. CI machines have a single
+// drive, so this uses the other layout that has no `..\` relative path: the
+// package dir nested inside the bin dir. Both layouts take the same path
+// through the linker and the shim.
+describe.skipIf(!isWindows)("windows global bin shims with an absolute target", () => {
+  let root: string;
+  let binDir: string;
+  let globalDir: string;
+  let globalEnv: Record<string, string | undefined>;
+
+  beforeAll(async () => {
+    root = tmpdirSync();
+    binDir = join(root, "bin");
+    globalDir = join(binDir, "global");
+    globalEnv = mergeWindowEnvs([
+      env,
+      {
+        BUN_INSTALL_BIN: binDir,
+        BUN_INSTALL_GLOBAL_DIR: globalDir,
+        BUN_INSTALL_CACHE_DIR: join(root, "cache"),
+        BUN_TMPDIR: join(root, "tmp"),
+        PATH: binDir + ";" + process.env.PATH,
+      },
+    ]);
+
+    await writeFile(
+      join(root, "bunfig.toml"),
+      Bun.TOML.stringify({
+        install: {
+          cache: false,
+          registry: `http://localhost:${port}/`,
+        },
+      }),
+    );
+
+    const { stdout, stderr, exited } = spawn({
+      cmd: [bunExe(), "install", "-g", "--linker=hoisted", `--config=${join(root, "bunfig.toml")}`, "bunx-bins"],
+      cwd: root,
+      stdout: "pipe",
+      stderr: "pipe",
+      env: globalEnv,
+    });
+    const err = await stderr.text();
+    expect(err).not.toContain("error:");
+    expect(await stdout.text()).toContain("bunx-bins@1.0.0");
+    expect(await exited).toBe(0);
+  });
+
+  // The `.bunx` layout is described in src/install/windows-shim/BinLinkingShim.rs:
+  // the target path in UTF-16 terminated by a `"`, and the flags as the last u16.
+  function readShim(bin: string) {
+    const bytes = readFileSync(join(binDir, `${bin}.bunx`));
+    const text = bytes.toString("utf16le");
+    return {
+      target: text.slice(0, text.indexOf('"')),
+      isAbsoluteTarget: (bytes.readUInt16LE(bytes.length - 2) & 0b1000) !== 0,
+    };
+  }
+
+  test("the .bunx files store the absolute path of the target", () => {
+    const packageDir = join(globalDir, "node_modules", "bunx-bins");
+    expect(readShim("native")).toEqual({
+      target: join(packageDir, "native.exe"),
+      isAbsoluteTarget: true,
+    });
+    expect(readShim("bin-bun")).toEqual({
+      target: join(packageDir, "bin-bun.ts"),
+      isAbsoluteTarget: true,
+    });
+  });
+
+  // `native` has no shebang, so the shim launches the target itself. `bin-bun`
+  // has a `#!/usr/bin/env bun` shebang, so the shim launches `bun <target>`.
+  // Running the `.exe` exercises the standalone shim; `bunx` finds the `.exe`
+  // in PATH and reads the `.bunx` file inside bun.exe instead; `bun --bun x`
+  // additionally runs the target in-process instead of spawning `bun`.
+  const runs: [name: string, cmd: () => string[], expected: string][] = [
+    ["native.exe", () => [join(binDir, "native.exe")], "i am exe arg1 arg2"],
+    ["bin-bun.exe", () => [join(binDir, "bin-bun.exe")], "i am bin-bun arg1 arg2"],
+    ["bun x native", () => [bunExe(), "x", "native"], "i am exe arg1 arg2"],
+    ["bun x bin-bun", () => [bunExe(), "x", "bin-bun"], "i am bin-bun arg1 arg2"],
+    ["bun --bun x bin-bun", () => [bunExe(), "--bun", "x", "bin-bun"], "i am bin-bun arg1 arg2"],
+  ];
+
+  for (const [name, cmd, expected] of runs) {
+    test(`${name} arg1 arg2`, async () => {
+      const { stdout, stderr, exited } = spawn({
+        cmd: [...cmd(), "arg1", "arg2"],
+        cwd: root,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: globalEnv,
+      });
+      const err = await stderr.text();
+      expect(err.trim()).toBe("");
+      const out = await stdout.text();
+      expect(out.trim()).toBe(expected);
       expect(await exited).toBe(0);
     });
   }

--- a/test/cli/install/bun-install-registry.test.ts
+++ b/test/cli/install/bun-install-registry.test.ts
@@ -23,7 +23,7 @@ import {
   VerdaccioRegistry,
   writeShebangScript,
 } from "harness";
-import { join, resolve } from "path";
+import { delimiter, join, resolve } from "path";
 const { parseLockfile } = install_test_helpers;
 
 expect.extend({
@@ -8792,16 +8792,17 @@ describe("windows bin linking shim should work", async () => {
   }
 });
 
-// A `.bunx` file normally stores the target relative to the parent of the
-// directory holding the shim. A global install can put the global bin dir and
-// the global package dir anywhere relative to each other, and when the target
-// is not reachable through a single `..` (most commonly because the two dirs
-// are on different drives, https://github.com/oven-sh/bun/issues/23414) the
+// Bin links are created relative to the bin dir, and a global install can put
+// the global bin dir and the global package dir anywhere relative to each
+// other. Bin linking used to assume that path always starts with `..`. On
+// Windows that matters: a `.bunx` file stores the target relative to the parent
+// of the directory holding the shim, which is impossible when the two dirs are
+// on different drives (https://github.com/oven-sh/bun/issues/23414), so the
 // shim has to store the absolute target instead. CI machines have a single
-// drive, so this uses the other layout that has no `..\` relative path: the
-// package dir nested inside the bin dir. Both layouts take the same path
-// through the linker and the shim.
-describe.skipIf(!isWindows)("windows global bin shims with an absolute target", () => {
+// drive, so this uses the other layout whose relative path does not start with
+// `..`: the package dir nested inside the bin dir. Both layouts take the same
+// path through the linker and the shim.
+describe("global bin links when the package dir is inside the bin dir", () => {
   let root: string;
   let binDir: string;
   let globalDir: string;
@@ -8818,7 +8819,7 @@ describe.skipIf(!isWindows)("windows global bin shims with an absolute target", 
         BUN_INSTALL_GLOBAL_DIR: globalDir,
         BUN_INSTALL_CACHE_DIR: join(root, "cache"),
         BUN_TMPDIR: join(root, "tmp"),
-        PATH: binDir + ";" + process.env.PATH,
+        PATH: binDir + delimiter + process.env.PATH,
       },
     ]);
 
@@ -8845,6 +8846,11 @@ describe.skipIf(!isWindows)("windows global bin shims with an absolute target", 
     expect(await exited).toBe(0);
   });
 
+  test.skipIf(isWindows)("the bins are symlinks relative to the bin dir", async () => {
+    expect(await readlink(join(binDir, "bin-bun"))).toBe(join("global", "node_modules", "bunx-bins", "bin-bun.ts"));
+    expect(await exists(join(binDir, "bin-bun"))).toBe(true);
+  });
+
   // The `.bunx` layout is described in src/install/windows-shim/BinLinkingShim.rs:
   // the target path in UTF-16 terminated by a `"`, and the flags as the last u16.
   function readShim(bin: string) {
@@ -8856,7 +8862,7 @@ describe.skipIf(!isWindows)("windows global bin shims with an absolute target", 
     };
   }
 
-  test("the .bunx files store the absolute path of the target", () => {
+  test.skipIf(!isWindows)("the .bunx files store the absolute path of the target", () => {
     const packageDir = join(globalDir, "node_modules", "bunx-bins");
     expect(readShim("native")).toEqual({
       target: join(packageDir, "native.exe"),
@@ -8882,7 +8888,7 @@ describe.skipIf(!isWindows)("windows global bin shims with an absolute target", 
   ];
 
   for (const [name, cmd, expected] of runs) {
-    test(`${name} arg1 arg2`, async () => {
+    test.skipIf(!isWindows)(`${name} arg1 arg2`, async () => {
       const { stdout, stderr, exited } = spawn({
         cmd: [...cmd(), "arg1", "arg2"],
         cwd: root,


### PR DESCRIPTION
### Problem
- On Windows, `bun install -g <pkg>` writes a broken `<bin>.bunx` whenever the global bin dir and the global package dir are on different drives (#23414, #30129, the Dev Drive layout). Running the bin then fails with `error: bin executable does not exist on disk` followed by `Bun failed to remap this bin to its proper location within node_modules` (or `Module not found` for script bins). The same happens when the package dir is nested inside the bin dir.
- Cause: `create_windows_shim` (src/install/bin.rs, `relative_buf_z` call) computes the path from the bin dir to the target and unconditionally drops its first three bytes, assuming it starts with `..\`. Across drives `relative()` returns the absolute target instead (src/paths/resolve_path.rs, `relative_to_common_path`), so `E:\store\node_modules\pkg\cli.js` is stored as `store\node_modules\pkg\cli.js`; in the nested layout `global\node_modules\...` becomes `bal\node_modules\...`. Release builds write the mangled path silently, debug builds hit the `debug_assert!`. The Zig version asserted in release builds too, which is the `Internal assertion failure at install/bin.zig:723:83` panic reported in #23414.
- `create_symlink` (POSIX) carried the same `debug_assert!`; the nested layout panics debug builds there, release builds already created a valid symlink.

### Fix
- The `.bunx` format gains an `is_absolute_target` flag (bit 3 of the trailing flags `u16`). `create_windows_shim` keeps the existing encoding when the relative path starts with `..\` and otherwise stores the absolute target with the flag set, so every target is representable and no error path is needed.
- The launcher (`bun_shim_impl.rs`, compiled both into `bun_shim_impl.exe` and into bun.exe for the `bunx` fast path) picks where the target path starts after validating the flags: at the position the metadata was read into for an absolute target, right after the NT prefix as before for a relative one. The no-shebang, shebang and `--bun` direct-launch paths all go through that one pointer.
- Compatibility: the version tag moves from 13 bits at bit 3 to 12 bits at bit 4 with its value halved (`2739 << 4 == 5478 << 3`), so every existing relative `.bunx` is bit-identical and still validates, and a new bun.exe keeps taking the fast path on existing installs. An absolute `.bunx` reads as version 5479 to a launcher that predates the flag, so an older bun.exe falls through to spawning the `.exe`, which is always written together with the `.bunx` and understands it. Both directions were checked against the released build (details below).
- Why this is the right fix: the relative encoding exists so a `node_modules` tree can be moved; the two layouts that have no `..\` path are both global installs, where the shim and the package dir are configured independently and nothing is relocated together, so an absolute path is the only representation and loses nothing. What reaches `CreateProcessW` (or the interpreter) is a quoted absolute path either way.
- POSIX: the assertion in `create_symlink` is removed; any relative path is a valid symlink target.
- Verified by `global bin links when the package dir is inside the bin dir` in test/cli/install/bun-install-registry.test.ts. CI has a single drive, so it installs globally into the nested layout, which takes the same path through the linker and the launcher as the cross-drive one. On Windows it checks the `.bunx` payload and flag and runs the bin through every launcher route: the standalone `.exe` with and without a shebang, `bunx` (in-process fast path) with and without a shebang, and `bun --bun x` (direct launch). All six fail on the released build (`bal\node_modules\...`, "failed to remap", `Module not found`) and pass with this change. On POSIX it checks the symlink; it fails on a debug build without the change (the assertion) and passes with it.
- Also run on a Windows x64 debug build of this branch: the existing `windows bin linking shim should work` suite (44 tests), `bin types (global)`, bunx.test.ts, bun-run.test.ts, bun-install-native-binlink.test.ts and regression/13316, all passing. `cargo check` of `bun_install` and the standalone `bun_shim_impl` crate for x86_64 and aarch64 Windows targets is clean.

### Background
- Windows bin links: `node_modules/.bin/<bin>.exe` is a copy of a small launcher (`bun_shim_impl.exe`) and `<bin>.bunx` next to it holds the metadata: the target path, the parsed shebang and a flags word. The launcher copies its own path into a buffer, walks back two separators (past `<bin>.exe` and `.bin`) and reads the `.bunx` file straight into the buffer at that point, so a stored `pkg\cli.js` turns into `...\node_modules\pkg\cli.js` without copying. That is why the stored path is relative to the parent of the directory holding the shim, and why the linker strips the `..\`.
- bunx fast path: bun.exe contains the same launcher code and uses it to run `.bin` entries in-process instead of spawning the `.exe`; when it does not recognise the metadata it falls back to spawning the `.exe`. This is what makes the flags/version layout a compatibility question between bun versions.
- Global bin dir vs global package dir: `bun install -g` links bins into `BUN_INSTALL_BIN` / `install.globalBinDir` (default `~/.bun/bin`) and installs packages under `BUN_INSTALL_GLOBAL_DIR` / `install.globalDir` (default `~/.bun/install/global`). They are configured independently, so they can end up on different drives or nested.
- `relative()` across drives: there is no relative path between two Windows drives, so bun's `relative()` (like Node's `path.relative`) returns the absolute destination in that case. It is the only case in which it does not return a relative path.

<details>
<summary>Manual verification of the real cross-drive layout and of the format compatibility</summary>

A second NTFS volume (`E:`) was created on the Windows machine's scratch disk. `bunx-bins-1.0.0.tgz` is the fixture package from test/cli/install/registry.

Released build (1.4.0 canary), bin dir on `C:`, packages on `E:`:

```
> bun add -g C:\repro\bunx-bins-1.0.0.tgz            (BUN_INSTALL_BIN=C:\repro\bin, BUN_INSTALL_GLOBAL_DIR=E:\repro\global)
... installed bunx-bins ... exit 0
bin-bun.bunx payload: repro\global\node_modules\bunx-bins\bin-bun.ts"
> C:\repro\bin\bin-bun.exe arg1 arg2
error: Module not found "C:\repro\repro\global\node_modules\bunx-bins\bin-bun.ts"
> C:\repro\bin\native.exe arg1 arg2
error: bin executable does not exist on disk
Bun failed to remap this bin to its proper location within node_modules.
```

This branch (debug build), same layout:

```
bin-bun.bunx payload: E:\xd\global\node_modules\bunx-bins\bin-bun.ts"   (flags 0xAB3D: absolute + shebang + bun)
C:\xd\bin\bin-bun.exe a b        -> i am bin-bun a b
C:\xd\bin\native.exe a b         -> i am exe a b
C:\xd\bin\no-shebang.exe a b     -> i am no-shebang a b
bun-debug x native a b           -> i am exe a b
bun-debug x bin-bun a b          -> i am bin-bun a b
bun-debug --bun x bin-bun a b    -> i am bin-bun a b
bun-debug --bun x bin-node a b   -> i am bin-node a b
```

Reverse layout (bin dir on `E:`, packages on `C:`, the #30129 shape) behaves the same (`native.bunx` payload `C:\xg\global\node_modules\bunx-bins\native.exe`, flags 0xAB38).

Compatibility:

- A normal local install of the same package with the released build and with this branch produces byte-identical `native.bunx` / `bin-bun.bunx` (same file hashes; flags `0xAB30` / `0xAB35` in both), so relative shims are unaffected by the flags repack.
- Released bun.exe running `bunx native` / `bunx bin-bun` against the shims written by this branch: its fast path rejects the absolute `.bunx` and spawns the new `.exe`, output is correct.
- This branch running `bunx native` / `bunx bin-bun` against a project whose `.bin` was written by the released build: `BUN_DEBUG_BUNX_FAST_PATH_LOG=1` shows the fast path loading the old `.bunx` and launching from it (no "did not start via shim"), so existing installs keep the fast path.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install-registry.test.ts

<!-- robobun:evidence:end -->