### PR TITLE
MessagePort: keep hasRef() true until the 'close' event fires, and false inside it

### DIFF
--- a/src/jsc/bindings/webcore/JSMessagePort.cpp
+++ b/src/jsc/bindings/webcore/JSMessagePort.cpp
@@ -208,7 +208,7 @@ static inline bool setJSMessagePort_onmessageSetter(JSGlobalObject& lexicalGloba
     if (value.isCallable())
         thisObject.wrapped().jsRef(&lexicalGlobalObject);
     else
-        thisObject.wrapped().jsUnref(&lexicalGlobalObject);
+        thisObject.wrapped().jsUnref();
 
     return true;
 }
@@ -354,7 +354,6 @@ static inline JSC::EncodedJSValue jsMessagePortPrototypeFunction_closeBody(JSC::
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    impl.jsUnref(lexicalGlobalObject);
     RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.close(); })));
 }
 
@@ -385,7 +384,7 @@ static inline JSC::EncodedJSValue jsMessagePortPrototypeFunction_unrefBody(JSC::
     UNUSED_PARAM(throwScope);
     UNUSED_PARAM(callFrame);
     auto& impl = castedThis->wrapped();
-    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.jsUnref(lexicalGlobalObject); })));
+    RELEASE_AND_RETURN(throwScope, JSValue::encode(toJS<IDLUndefined>(*lexicalGlobalObject, throwScope, [&]() -> decltype(auto) { return impl.jsUnref(); })));
 }
 
 JSC_DEFINE_HOST_FUNCTION(jsMessagePortPrototypeFunction_unref, (JSGlobalObject * lexicalGlobalObject, CallFrame* callFrame))

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -224,31 +224,20 @@ void MessagePort::close()
     // it in hasPendingActivity()); marking our side Closed is sufficient.
     m_pipe->close(m_side, MessagePortPipe::CloseKind::Explicit);
 
-    // Release the self-reference taken by jsRef() (set when .onmessage is
-    // assigned or .ref() is called from JS). The JS .close() binding calls
-    // jsUnref() first; stop() and contextDestroyed() do not.
-    if (m_hasRef) {
-        m_hasRef = false;
-        if (auto* context = scriptExecutionContext())
-            context->unrefEventLoop();
-        deref();
-    }
-
-    // close() can run without a prior jsUnref() (warn-and-close, contextDestroyed());
-    // clear the listener keepalive so a later listener add can't re-ref the loop.
-    if (m_isRefd) {
-        m_isRefd = false;
-        updateListenerEventLoopRef();
-    }
-
-    // Defer 'close' to a task (node fires it at uv close-callback timing, i.e.
-    // after sync code and microtasks), so a listener added after close() still
-    // observes it and close(cb) interleaves with other listeners.
     if (isContextStopped()) {
+        jsUnref();
         removeAllEventListeners();
         return;
     }
+    // Defer 'close' to a task (node fires it at uv close-callback timing, i.e.
+    // after sync code and microtasks), so a listener added after close() still
+    // observes it and close(cb) interleaves with other listeners. The loop refs
+    // are released by that task, not here: node's handle stays ref'd (hasRef()
+    // true) until its close callback, which marks it closed right before 'close'
+    // (https://github.com/nodejs/node/blob/v26.3.0/src/handle_wrap.cc#L135-L156).
+    // stop() drops them instead if teardown discards the task unrun.
     queueTaskKeepingObjectAlive(*this, TaskSource::PostedMessageQueue, [](MessagePort& port) {
+        port.jsUnref();
         port.dispatchCloseEvent();
         port.removeAllEventListeners();
     });
@@ -282,13 +271,12 @@ void MessagePort::peerClosed()
     // drain is scheduled -- e.g. on('close') registered before on('message').
     if (m_started && hasMessageEventListener())
         flushQueuedMessagesBeforeClose();
-    // Fire 'close' (guarded against a double dispatch) and release this side's loop refs
-    // so the loop can idle, matching node.
+    // Node closes this side's handle when the peer's close arrives, so its 'close'
+    // handler already sees hasRef() false: release this side's loop refs (both the
+    // listener one and the onmessage/ref() one, so a listening transferred port stops
+    // pinning the loop), then fire 'close' (guarded against a double dispatch).
+    jsUnref();
     dispatchCloseEvent();
-    // jsUnref() clears both the listener loop-ref (m_isRefd) and the onmessage/ref()
-    // keepalive (m_hasRef), so a listening transferred port stops pinning the loop.
-    auto* globalObject = defaultGlobalObject(context->globalObject());
-    jsUnref(globalObject);
 }
 
 TransferredMessagePort MessagePort::disentangle()
@@ -301,24 +289,12 @@ TransferredMessagePort MessagePort::disentangle()
     removeAllEventListeners();
     m_hasMessageEventListener = false;
 
-    // Release the self-reference taken by jsRef() on the sending side. After
-    // transfer this object is inert (the receiving side gets a fresh
+    // After transfer this object is inert (the receiving side gets a fresh
     // MessagePort for the same pipe endpoint) and is no longer a destruction
-    // observer, so nothing else will ever release a ref taken here.
-    // The caller (disentanglePorts) holds a RefPtr, so deref() is safe.
-    if (m_hasRef) {
-        m_hasRef = false;
-        if (auto* context = scriptExecutionContext())
-            context->unrefEventLoop();
-        deref();
-    }
-
-    // A transferred port is inert; clear the listener keepalive too so hasRef()
-    // reports false (the disentangle analogue of the close() reset above).
-    if (m_isRefd) {
-        m_isRefd = false;
-        updateListenerEventLoopRef();
-    }
+    // observer, so nothing else would ever release jsRef()'s self-ref and
+    // loop ref, or the listener keepalive. The caller (disentanglePorts)
+    // holds a RefPtr, so the deref() is safe.
+    jsUnref();
 
     // Hand the pipe endpoint to its next owner. Messages that arrive while
     // in transit buffer in the pipe; the receiving context's entangle()
@@ -396,11 +372,22 @@ void MessagePort::dispatchEvent(Event& event)
     EventTarget::dispatchEvent(event);
 }
 
+void MessagePort::stop()
+{
+    close();
+    // A close() that ran earlier left the refs for its 'close' task to release, and
+    // teardown discards queued tasks unrun.
+    jsUnref();
+}
+
 void MessagePort::contextDestroyed()
 {
     ASSERT(scriptExecutionContext());
 
-    close();
+    // A context destroyed without a stop phase still has to release the refs, and
+    // jsRef()'s self-ref may be the last reference to this port.
+    Ref protectedThis { *this };
+    stop();
     ActiveDOMObject::contextDestroyed();
 }
 
@@ -553,11 +540,13 @@ WebCoreOpaqueRoot root(MessagePort* port)
 void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
 {
     // A closed or transferred-away port can never receive messages again, so
-    // taking a self-ref (and an event-loop ref) here would only leak:
-    // close()/disentangle() have already run and nothing will ever release a
-    // ref taken afterwards. Same once the peer has closed: peerClosed() already
-    // ran jsUnref(), and nothing releases a ref re-taken after it, so `.ref()`
-    // or a late `onmessage =` would pin the loop forever. Node no-ops both.
+    // taking a self-ref (and an event-loop ref) here would only leak: once
+    // close()'s 'close' task (or disentangle()) has released the refs, nothing
+    // will ever release one taken afterwards. (Node still honours ref() in the
+    // window before its close callback; it is pointless there, so we don't.)
+    // Same once the peer has closed: peerClosed() already ran jsUnref(), and
+    // nothing releases a ref re-taken after it, so `.ref()` or a late
+    // `onmessage =` would pin the loop forever. Node no-ops both.
     // Only an explicit peer close counts: node never closes a channel because a
     // port was collected, so keying on Closed alone made this GC-dependent.
     if (!isEntangled() || m_pipe->isOtherSideClosedByRequest(m_side))
@@ -576,7 +565,7 @@ void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
     }
 }
 
-void MessagePort::jsUnref(JSGlobalObject* lexicalGlobalObject)
+void MessagePort::jsUnref()
 {
     // Also release the listener loop-ref; otherwise an always-listening transferred
     // port (a postMessageToThread control port) would pin the event loop forever.
@@ -584,10 +573,13 @@ void MessagePort::jsUnref(JSGlobalObject* lexicalGlobalObject)
         m_isRefd = false;
         updateListenerEventLoopRef();
     }
+    // The context's unrefEventLoop() balances jsRef()'s refKeepAlive: both address the
+    // thread's one bun VM. Every caller holds a reference across the deref().
     if (m_hasRef) {
         m_hasRef = false;
+        if (auto* context = scriptExecutionContext())
+            context->unrefEventLoop();
         deref();
-        Bun__eventLoop__refKeepAlive(WebCore::clientData(lexicalGlobalObject->vm())->bunVM, -1);
     }
 }
 

--- a/src/jsc/bindings/webcore/MessagePort.cpp
+++ b/src/jsc/bindings/webcore/MessagePort.cpp
@@ -229,13 +229,10 @@ void MessagePort::close()
         removeAllEventListeners();
         return;
     }
-    // Defer 'close' to a task (node fires it at uv close-callback timing, i.e.
-    // after sync code and microtasks), so a listener added after close() still
-    // observes it and close(cb) interleaves with other listeners. The loop refs
-    // are released by that task, not here: node's handle stays ref'd (hasRef()
-    // true) until its close callback, which marks it closed right before 'close'
-    // (https://github.com/nodejs/node/blob/v26.3.0/src/handle_wrap.cc#L135-L156).
-    // stop() drops them instead if teardown discards the task unrun.
+    // Defer 'close' to a task (node fires it at uv close-callback timing, after
+    // sync code and microtasks) and release the loop refs there, matching node's
+    // handle which stays ref'd until its close callback runs. stop() releases
+    // them instead if teardown discards the task unrun.
     queueTaskKeepingObjectAlive(*this, TaskSource::PostedMessageQueue, [](MessagePort& port) {
         port.jsUnref();
         port.dispatchCloseEvent();
@@ -271,10 +268,8 @@ void MessagePort::peerClosed()
     // drain is scheduled -- e.g. on('close') registered before on('message').
     if (m_started && hasMessageEventListener())
         flushQueuedMessagesBeforeClose();
-    // Node closes this side's handle when the peer's close arrives, so its 'close'
-    // handler already sees hasRef() false: release this side's loop refs (both the
-    // listener one and the onmessage/ref() one, so a listening transferred port stops
-    // pinning the loop), then fire 'close' (guarded against a double dispatch).
+    // Node's 'close' handler sees hasRef() false (its handle closes when the
+    // peer's close arrives): release this side's loop refs, then fire 'close'.
     jsUnref();
     dispatchCloseEvent();
 }
@@ -289,11 +284,9 @@ TransferredMessagePort MessagePort::disentangle()
     removeAllEventListeners();
     m_hasMessageEventListener = false;
 
-    // After transfer this object is inert (the receiving side gets a fresh
-    // MessagePort for the same pipe endpoint) and is no longer a destruction
-    // observer, so nothing else would ever release jsRef()'s self-ref and
-    // loop ref, or the listener keepalive. The caller (disentanglePorts)
-    // holds a RefPtr, so the deref() is safe.
+    // A transferred port is inert (the receiving side gets a fresh MessagePort
+    // for the same pipe endpoint), so nothing later would release jsRef()'s
+    // refs. The caller (disentanglePorts) holds a RefPtr across the deref().
     jsUnref();
 
     // Hand the pipe endpoint to its next owner. Messages that arrive while
@@ -375,8 +368,7 @@ void MessagePort::dispatchEvent(Event& event)
 void MessagePort::stop()
 {
     close();
-    // A close() that ran earlier left the refs for its 'close' task to release, and
-    // teardown discards queued tasks unrun.
+    // Teardown discards close()'s queued 'close' task unrun, so release the refs here.
     jsUnref();
 }
 
@@ -384,7 +376,6 @@ void MessagePort::contextDestroyed()
 {
     ASSERT(scriptExecutionContext());
 
-    // A context destroyed without a stop phase still has to release the refs, and
     // jsRef()'s self-ref may be the last reference to this port.
     Ref protectedThis { *this };
     stop();
@@ -539,17 +530,12 @@ WebCoreOpaqueRoot root(MessagePort* port)
 
 void MessagePort::jsRef(JSGlobalObject* lexicalGlobalObject)
 {
-    // A closed or transferred-away port can never receive messages again, so
-    // taking a self-ref (and an event-loop ref) here would only leak: once
-    // close()'s 'close' task (or disentangle()) has released the refs, nothing
-    // will ever release one taken afterwards. (Node still honours ref() in the
-    // window before its close callback; it is pointless there, so we don't.)
-    // Same once the peer has closed: peerClosed() already ran jsUnref(), and
-    // nothing releases a ref re-taken after it, so `.ref()` or a late
-    // `onmessage =` would pin the loop forever. Node no-ops both.
-    // Only an explicit peer close counts: node never closes a channel because a
-    // port was collected, so keying on Closed alone made this GC-dependent.
-    if (!isEntangled() || m_pipe->isOtherSideClosedByRequest(m_side))
+    // Once the port is closed, transferred away, explicitly closed by its peer,
+    // or its 'close' event has fired (the only signal when a collected peer
+    // closed the channel), nothing would ever release a ref taken here, so a
+    // late `.ref()` or `onmessage =` would pin the loop forever. Node no-ops
+    // ref() on a closed port too.
+    if (!isEntangled() || m_pipe->isOtherSideClosedByRequest(m_side) || m_closeEventDispatched)
         return;
 
     // Re-acquire the message-listener loop-ref (if a listener is present) that .unref() released.
@@ -573,8 +559,8 @@ void MessagePort::jsUnref()
         m_isRefd = false;
         updateListenerEventLoopRef();
     }
-    // The context's unrefEventLoop() balances jsRef()'s refKeepAlive: both address the
-    // thread's one bun VM. Every caller holds a reference across the deref().
+    // unrefEventLoop() balances jsRef()'s refKeepAlive; every caller holds a
+    // reference across the deref().
     if (m_hasRef) {
         m_hasRef = false;
         if (auto* context = scriptExecutionContext())

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -79,8 +79,8 @@ public:
     // The worker's entry module finished evaluating: a start() requested before that takes effect now.
     void entrySettled();
     void close();
-    // Called on the entangled peer when this side closes: dispatches a
-    // 'close' event and releases the event-loop ref so the loop can idle.
+    // Called on the entangled peer when this side closes: releases the peer's
+    // event-loop refs so the loop can idle, then dispatches its 'close' event.
     void peerClosed();
     void dispatchCloseEvent();
 
@@ -114,8 +114,12 @@ public:
     JSValue tryTakeMessage(JSGlobalObject*, bool& hadMessage);
 
     void jsRef(JSGlobalObject*);
-    void jsUnref(JSGlobalObject*);
-    // Report the actual loop-ref state (matches Node's uv_has_ref), not the intent flag.
+    // .unref(), and the step that drops every loop ref this port holds when it is
+    // closed, transferred away, or its context stops. Idempotent.
+    void jsUnref();
+    // Report the actual loop-ref state, not the intent flag: node's HandleWrap::HasRef()
+    // is uv_has_ref() until the handle is closed, so a closing port keeps its refs until
+    // its 'close' event fires (https://github.com/nodejs/node/blob/v26.3.0/src/handle_wrap.h#L64-L72).
     bool jsHasRef() { return m_hasRef || m_listenerLoopRefActive; }
 
 private:
@@ -126,7 +130,7 @@ private:
 
     // ActiveDOMObject.
     void contextDestroyed() final;
-    void stop() final { close(); }
+    void stop() final;
     bool virtualHasPendingActivity() const final;
 
     // Deliver messages already queued when close() is called, before teardown.

--- a/src/jsc/bindings/webcore/MessagePort.h
+++ b/src/jsc/bindings/webcore/MessagePort.h
@@ -79,8 +79,8 @@ public:
     // The worker's entry module finished evaluating: a start() requested before that takes effect now.
     void entrySettled();
     void close();
-    // Called on the entangled peer when this side closes: releases the peer's
-    // event-loop refs so the loop can idle, then dispatches its 'close' event.
+    // Called on the entangled peer when this side closes: drops the peer's
+    // loop refs, then fires its 'close' event.
     void peerClosed();
     void dispatchCloseEvent();
 
@@ -114,12 +114,10 @@ public:
     JSValue tryTakeMessage(JSGlobalObject*, bool& hadMessage);
 
     void jsRef(JSGlobalObject*);
-    // .unref(), and the step that drops every loop ref this port holds when it is
-    // closed, transferred away, or its context stops. Idempotent.
+    // .unref(); also drops every loop ref on close, transfer, or context stop. Idempotent.
     void jsUnref();
-    // Report the actual loop-ref state, not the intent flag: node's HandleWrap::HasRef()
-    // is uv_has_ref() until the handle is closed, so a closing port keeps its refs until
-    // its 'close' event fires (https://github.com/nodejs/node/blob/v26.3.0/src/handle_wrap.h#L64-L72).
+    // The actual loop-ref state, not the intent flag: node's hasRef() stays true
+    // until the handle closes, right before its 'close' event fires.
     bool jsHasRef() { return m_hasRef || m_listenerLoopRefActive; }
 
 private:

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1092,7 +1092,9 @@ test("a worker exiting right after closing ref'd ports shuts down cleanly", asyn
 // takes a self-ref on the native port that only its 'close' task or the teardown
 // releases, so a port closed right before exit leaks outright if teardown skips it.
 // Malloc=1 routes WebKit allocations through the system allocator so LSan can see the
-// port; LSan itself is only available on the (Linux-only) ASAN builds.
+// port. Linux is where that combination is verified clean (CI's ASAN lane); keep the
+// fixture on the main thread, since every exited worker thread leaves its thread_local
+// eventNames() table behind under Malloc=1, which LSan would report here.
 test.skipIf(!isASAN || !isLinux)("ports closed right before exit are released by the VM teardown", async () => {
   await using proc = Bun.spawn({
     cmd: [

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1174,6 +1174,41 @@ test("hasRef() survives collection of the unreferenced peer", () => {
   port1.close();
 });
 
+// A collected peer does close the channel (bun collects entangled ports; node
+// never does), and once this side's 'close' has fired, ref() must stay a no-op:
+// a re-taken loop ref is never released. Spawned: the symptom is "the process
+// never exits".
+test("ref() inside 'close' after the peer is collected does not pin the loop", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { MessageChannel } = require("worker_threads");
+       function setup() {
+         const { port1 } = new MessageChannel(); // port2 unreachable from birth
+         port1.on("message", () => {});
+         return port1;
+       }
+       const port1 = setup();
+       const pump = setInterval(() => Bun.gc(true), 10);
+       port1.on("close", () => {
+         clearInterval(pump);
+         port1.ref();
+         console.log("refInClose:" + port1.hasRef());
+       });`,
+    ],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  // signalCode null => it exited on its own rather than being killed.
+  expect({ stdout: stdout.trim(), exitCode, signalCode: proc.signalCode }).toEqual({
+    stdout: "refInClose:false",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
 // markAsUncloneable blocks *cloning*, not transfer: a marked port in the transfer
 // list is moved, so node lets it through and it still works on the far side.
 test("markAsUncloneable blocks cloning a port but not transferring it", async () => {

--- a/test/js/node/worker_threads/worker_threads.test.ts
+++ b/test/js/node/worker_threads/worker_threads.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, setDefaultTimeout, test } from "bun:test";
-import { bunEnv, bunExe, isDebug, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isASAN, isDebug, isLinux, tempDir, tmpdirSync } from "harness";
 import { once } from "node:events";
 import fs from "node:fs";
 import { join, relative, resolve } from "node:path";
@@ -945,6 +945,181 @@ test("MessagePort.hasRef() reports actual loop-ref state", () => {
   port1.ref();
   expect(port1.hasRef()).toBe(true);
   port1.close();
+});
+
+// node: close() only starts closing the handle. hasRef() keeps reporting the handle's
+// ref flag until the close callback fires 'close' (HandleWrap::OnClose marks the handle
+// closed before emitting), so it is still true right after close() and false inside
+// the handler. A port learns of its peer's close the same way, so it follows the same
+// timing. Both ways of holding a ref are covered: a 'message' listener and ref().
+describe.each([
+  ["a 'message' listener", (port: MessagePort) => port.on("message", () => {})],
+  ["ref()", (port: MessagePort) => port.ref()],
+])("hasRef() around close() on a port kept alive by %s", (_, keepAlive) => {
+  test("own close(): true until its 'close' event, false inside and after it", async () => {
+    const { port1 } = new MessageChannel();
+    keepAlive(port1);
+    const { promise, resolve } = Promise.withResolvers<boolean>();
+    port1.on("close", () => resolve(port1.hasRef()));
+    port1.close();
+    const afterClose = port1.hasRef();
+    const inCloseEvent = await promise;
+    expect({ afterClose, inCloseEvent, afterCloseEvent: port1.hasRef() }).toEqual({
+      afterClose: true,
+      inCloseEvent: false,
+      afterCloseEvent: false,
+    });
+  });
+
+  test("peer close(): true until this side's 'close' event, false inside and after it", async () => {
+    const { port1, port2 } = new MessageChannel();
+    keepAlive(port1);
+    const { promise, resolve } = Promise.withResolvers<boolean>();
+    port1.on("close", () => resolve(port1.hasRef()));
+    port2.close();
+    const afterPeerClose = port1.hasRef();
+    const inCloseEvent = await promise;
+    expect({ afterPeerClose, inCloseEvent, afterCloseEvent: port1.hasRef() }).toEqual({
+      afterPeerClose: true,
+      inCloseEvent: false,
+      afterCloseEvent: false,
+    });
+  });
+});
+
+// The closing half of node's test/parallel/test-messageport-hasref.js: closing one side
+// leaves both sides reporting true until their 'close' events; the closing side's own
+// 'close' fires first, so by the time the peer's handler runs both report false.
+test("closing one side: both ports report true until their 'close' events, then false", async () => {
+  const { port1, port2 } = new MessageChannel();
+  port1.on("message", () => {});
+  port2.on("message", () => {});
+  const events: string[] = [];
+  const { promise, resolve } = Promise.withResolvers<void>();
+  port2.on("close", () => events.push(`port2 close: ${port1.hasRef()} ${port2.hasRef()}`));
+  port1.on("close", () => {
+    events.push(`port1 close: ${port1.hasRef()} ${port2.hasRef()}`);
+    resolve();
+  });
+  port2.close();
+  const rightAfterClose = [port1.hasRef(), port2.hasRef()];
+  await promise;
+  expect({ rightAfterClose, events }).toEqual({
+    rightAfterClose: [true, true],
+    events: ["port2 close: true false", "port1 close: false false"],
+  });
+});
+
+// Between close() and 'close' the handle is still alive in node, so ref changes made
+// in that window show up in hasRef(), and 'close' still ends with it false.
+test("hasRef() tracks unref() and listener changes made between close() and 'close'", async () => {
+  const { port1: unrefd } = new MessageChannel();
+  unrefd.on("message", () => {});
+  const unrefdClosed = Promise.withResolvers<boolean>();
+  unrefd.on("close", () => unrefdClosed.resolve(unrefd.hasRef()));
+  unrefd.close();
+  unrefd.unref();
+  const afterUnref = unrefd.hasRef();
+
+  const { port1: listened } = new MessageChannel();
+  const listenedClosed = Promise.withResolvers<boolean>();
+  listened.on("close", () => listenedClosed.resolve(listened.hasRef()));
+  listened.close();
+  listened.on("message", () => {});
+  const afterListenerAdd = listened.hasRef();
+
+  expect({
+    afterUnref,
+    unrefdInCloseEvent: await unrefdClosed.promise,
+    afterListenerAdd,
+    listenedInCloseEvent: await listenedClosed.promise,
+  }).toEqual({
+    afterUnref: false,
+    unrefdInCloseEvent: false,
+    afterListenerAdd: true,
+    listenedInCloseEvent: false,
+  });
+});
+
+// The refs close() leaves in place for hasRef() are dropped when 'close' fires, so a
+// closed port cannot keep the process alive. Spawned: the failure mode is a hang.
+test("a closed port stops keeping the process alive once 'close' has fired", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { MessageChannel } = require("worker_threads");
+       const { port1 } = new MessageChannel();
+       port1.on("message", () => {});
+       port1.ref();
+       port1.on("close", () => console.log("in close event: " + port1.hasRef()));
+       port1.close();
+       console.log("after close(): " + port1.hasRef());`,
+    ],
+    env: bunEnv,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ lines: stdout.split(/\r?\n/).filter(Boolean), stderr, exitCode, signalCode: proc.signalCode }).toEqual({
+    lines: ["after close(): true", "in close event: false"],
+    stderr: "",
+    exitCode: 0,
+    signalCode: null,
+  });
+});
+
+// Teardown can start while a close() is still waiting for its 'close' task (which is
+// then never run): the worker's stop phase has to drop the refs that task would have.
+test("a worker exiting right after closing ref'd ports shuts down cleanly", async () => {
+  const w = new Worker(
+    `const { parentPort, MessageChannel } = require("worker_threads");
+     const { port1, port2 } = new MessageChannel();
+     port1.on("message", () => {});
+     port2.ref();
+     parentPort.on("message", () => {});
+     port1.close();
+     port2.close();
+     parentPort.close();
+     process.exit(parentPort.hasRef() && port1.hasRef() && port2.hasRef() ? 42 : 1);`,
+    { eval: true },
+  );
+  const exited = new Promise<number>(resolve => w.on("exit", resolve));
+  expect(await exited).toBe(42);
+});
+
+// The same close-then-exit sequence on the main thread, checked for leaks: onmessage=
+// takes a self-ref on the native port that only its 'close' task or the teardown
+// releases, so a port closed right before exit leaks outright if teardown skips it.
+// Malloc=1 routes WebKit allocations through the system allocator so LSan can see the
+// port; LSan itself is only available on the (Linux-only) ASAN builds.
+test.skipIf(!isASAN || !isLinux)("ports closed right before exit are released by the VM teardown", async () => {
+  await using proc = Bun.spawn({
+    cmd: [
+      bunExe(),
+      "-e",
+      `const { MessageChannel } = require("worker_threads");
+       for (let i = 0; i < 50; i++) {
+         const { port1, port2 } = new MessageChannel();
+         port1.onmessage = () => {};
+         port2.on("message", () => {});
+         port1.close();
+         port2.close();
+       }
+       process.exit(0);`,
+    ],
+    env: {
+      ...bunEnv,
+      BUN_DESTRUCT_VM_ON_EXIT: "1",
+      Malloc: "1",
+      ASAN_OPTIONS: [bunEnv.ASAN_OPTIONS, "detect_leaks=1"].filter(Boolean).join(":"),
+      LSAN_OPTIONS: `print_suppressions=0:suppressions=${join(import.meta.dirname, "../../../leaksan.supp")}`,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: "", stderr: "", exitCode: 0 });
 });
 
 // In a node worker only parentPort receives what the parent posts; the global
@@ -1926,6 +2101,30 @@ test("parentPort.unref() lets a listening worker exit", async () => {
   );
   const exited = new Promise<number>(resolve => w.on("exit", resolve));
   expect(await exited).toBe(0);
+});
+
+// Same close() timing as any other port (node): hasRef() is still true right after
+// parentPort.close() and false once its 'close' event runs. Results travel over a
+// separate port because parentPort itself is the one being closed.
+test("parentPort.hasRef() stays true after parentPort.close() until its 'close' event", async () => {
+  const { port1, port2 } = new MessageChannel();
+  const { promise, resolve } = Promise.withResolvers<unknown>();
+  port1.on("message", resolve);
+  const w = new Worker(
+    `const { parentPort, workerData } = require("worker_threads");
+     parentPort.on("message", () => {});
+     parentPort.on("close", () => {
+       workerData.report.postMessage({ afterClose, inCloseEvent: parentPort.hasRef() });
+       workerData.report.close();
+     });
+     parentPort.close();
+     const afterClose = parentPort.hasRef();`,
+    { eval: true, workerData: { report: port2 }, transferList: [port2] },
+  );
+  const exited = new Promise<number>(resolve => w.on("exit", resolve));
+  expect(await promise).toEqual({ afterClose: true, inCloseEvent: false });
+  expect(await exited).toBe(0);
+  port1.close();
 });
 
 test("receiveMessageOnPort distinguishes an undefined message from an empty queue", () => {


### PR DESCRIPTION
### Problem

- `port.close(); port.hasRef()` returns `false` in Bun; node returns `true` until the port's `'close'` event has fired (and `false` inside and after it). Same for a worker's `parentPort`.
- When the *peer* closes, Bun's `'close'` handler on the surviving port still sees `hasRef() === true`; node's sees `false`.
- Cause, own close: the `close()` binding called `jsUnref()` before `MessagePort::close()` (src/jsc/bindings/webcore/JSMessagePort.cpp:357), and `close()` itself dropped `m_hasRef` / `m_isRefd` synchronously (src/jsc/bindings/webcore/MessagePort.cpp:230-242), while the `'close'` event is dispatched from a queued task.
- Cause, peer close: `peerClosed()` called `dispatchCloseEvent()` first and `jsUnref()` after it (MessagePort.cpp:287-291).
- `hasRef()` reads the live ref state (`m_hasRef || m_listenerLoopRefActive`, MessagePort.h), so in both cases it reports the release at the wrong moment relative to the event. No user report; found while triaging worker_threads PRs against main after #37075 made `parentPort` a real MessagePort.

### Fix

- `MessagePort::close()` no longer releases the refs; the task it queues releases them (`jsUnref()`) and then dispatches `'close'`. The `close()` binding no longer calls `jsUnref()` first.
- `peerClosed()` releases, then dispatches.
- `stop()` is now `close(); jsUnref();` and `contextDestroyed()` goes through it, because a `close()` issued shortly before teardown leaves the refs to a task that teardown discards unrun (the stop phase is where ports are expected to drop their keep-alives; `jsRef()`'s self-ref would otherwise leak the native port). `close()` on an already stopped context releases immediately, as before. `contextDestroyed()` holds a `Ref` across the release since that self-ref can be the last reference.
- The release code that was duplicated in `close()`, `disentangle()` and `jsUnref()` is now just `jsUnref()`, which unrefs through the port's `ScriptExecutionContext` (the same per-thread VM `jsRef()` ref'd, and what `close()` already did) and so no longer takes a `JSGlobalObject`.
- Why this is right: it is node's model. A node MessagePort is a `HandleWrap`; `hasRef()` is `uv_has_ref()` for as long as the handle is not closed, `close()` only starts the uv close, and the close callback marks the handle closed immediately before emitting `'close'` ([handle_wrap.h#L64-L72](https://github.com/nodejs/node/blob/v26.3.0/src/handle_wrap.h#L64-L72), [handle_wrap.cc#L135-L156](https://github.com/nodejs/node/blob/v26.3.0/src/handle_wrap.cc#L135-L156)). A peer close reaches the other side as a close message that closes that side's handle the same way, so its `'close'` handler also runs after the refs are gone. Holding the refs until the task is also physically what a closing uv handle does: the loop stays alive until the close callback runs, which here is the next turn of the task queue. Because the refs are simply held rather than snapshotted, `unref()` and listener changes made between `close()` and `'close'` are reflected by `hasRef()` exactly as in node, with no extra state.
- Verified with the new tests in test/js/node/worker_threads/worker_threads.test.ts (own close and peer close, each with a `'message'` listener and with an explicit `ref()`; both sides of a channel; changes made during the closing window; a spawned process that must still exit after `close()`; `parentPort`; a worker that exits with closes pending; and an LSan check, gated to the ASAN build, that ports closed right before exit are released by the VM teardown). The 9 behavioural tests fail on main and pass with this change; the LSan test passes on both and was confirmed to report the 50 leaked ports when the `stop()` release is removed.
  - The whole file passes (133 tests), as do test/js/web/workers/message-channel.test.ts, message-port-pipe, message-port-closed-leak, message-port-context-destroy-leak, worker-postmessage-transfer and message-event, and the 21 upstream `test-worker-message-port*` / `test-worker-message-channel` / `test-worker-workerdata-messageport` tests plus `test-worker-ref*`, `test-worker-parent-port-ref`, `test-worker-terminate-ref-public-port`, `test-worker-terminate-unrefed`, `test-worker-unref-from-message-during-exit`, `test-worker-cleanexit-with-js`, `test-worker-exit-code`, `test-worker-on-process-exit`, `test-worker-terminate-nested`.
  - A 13-scenario `hasRef()` probe comparing node v26.3.0 with this branch is in the details below: every close-related scenario now matches.
- Deliberate remaining difference, noted in the `jsRef()` comment: node also honours a `ref()` issued between `close()` and `'close'` (`hasRef()` briefly true); a closed port still refuses new refs here, since there is nothing left for it to keep the loop alive for.
- The `peerClosed()` reordering needed one more guard, caught in review: Bun also fires `'close'` when the peer port was garbage collected rather than closed (node never collects an entangled port), and a collected peer never sets the `ClosedByRequest` bit that `jsRef()`'s guard keyed on, so a `ref()` or `onmessage =` inside or after that `'close'` handler re-took loop refs that nothing released, pinning the loop forever (before the reorder the post-dispatch release balanced the in-handler case). `jsRef()` now also keys on `m_closeEventDispatched`: once a port's `'close'` event has fired, `ref()` is a no-op whatever the close reason. Covered by a new spawned test (collected peer, `ref()` inside the `'close'` handler, the process must still exit).
- Not in this PR: node's own test/parallel/test-messageport-hasref.js asserts the same close ordering but locates the ports through `async_hooks` `MESSAGEPORT` init events, which Bun does not emit yet (#35366), and also asserts `unref(); on('message')` re-refs the port, which is a separate gap in how listener changes and `ref()`/`unref()` combine (#38009 covers the removal half; the add half was filed separately). #38009 edits the same functions (it also turns `jsUnref(JSGlobalObject*)` into `jsUnref()`), so the two will need a trivial textual rebase, but they fix different things and neither subsumes the other.

### Background

- A MessagePort "refs" its thread's event loop while something may still need the loop to stay alive, and `hasRef()` reports whether it currently does. Bun's native port holds up to two such refs: `m_hasRef`, taken by `.ref()` or a callable `onmessage =` (an event-loop ref plus a self-`ref()` so the native object outlives its JS wrapper), and a listener ref held while `m_isRefd` (not `.unref()`'d) and at least one `'message'` listener is registered. `jsUnref()` drops both.
- `'close'` is dispatched from a task queued on the event loop rather than synchronously from `close()`, so that listeners added after `close()` (and node's `close(cb)`) still observe it; the event therefore runs after the current script and its microtasks, which is also when node's uv close callback runs.
- `ActiveDOMObject::stop()` is called on every live port when its context is torn down (worker exit/terminate, `process.exit()` with `BUN_DESTRUCT_VM_ON_EXIT`, `bun test --isolate` retiring a file); after that phase the VM releases everything still queued without running it, which is why a release that lives in a queued task needs a teardown counterpart. `contextDestroyed()` is the later notification from the context's destructor and is the backstop for a context that was never stopped.

<details>
<summary>Repros from the report: node v26.3.0 vs Bun main vs this branch</summary>

```js
// own close
import { MessageChannel } from "node:worker_threads";
const { port1 } = new MessageChannel();
port1.on("message", () => {});
port1.on("close", () => console.log("in close event:", port1.hasRef()));
port1.close();
console.log("right after own close():", port1.hasRef());
```

| | node | main | this PR |
| --- | --- | --- | --- |
| right after own close() | true | false | true |
| in close event | false | false | false |

```js
// peer close
import { MessageChannel } from "node:worker_threads";
const { port1, port2 } = new MessageChannel();
port1.on("message", () => {});
port1.on("close", () => console.log("in close event:", port1.hasRef()));
port2.close();
console.log("right after peer close():", port1.hasRef());
```

| | node | main | this PR |
| --- | --- | --- | --- |
| right after peer close() | true | true | true |
| in close event | false | true | false |

`parentPort` inside a `Worker` (`parentPort.close(); parentPort.hasRef()`, then inside its `'close'` handler): node `true` / `false`, main `false` / `false`, this PR `true` / `false`.

</details>

<details>
<summary>hasRef() probe, 13 scenarios, node v26.3.0 vs this branch</summary>

Each scenario uses a fresh channel; "during" is read synchronously after the listed calls, "inClose" inside the port's `'close'` handler.

| scenario | node | this PR |
| --- | --- | --- |
| on; close; unref | false | false |
| on; unref; close; ref | during true, inClose false | during **false**, inClose false (deliberate, see above) |
| on; close; await 'close'; ref | false | false |
| on; peer close; await 'close'; ref | false | false |
| on; unref; close | false | false |
| close; on | during true, inClose false | during true, inClose false |
| on f; close; off f | false | false |
| ref; close | during true, inClose false | during true, inClose false |
| on; peer close; await 'close' | false | false |
| ref; on f; off f | false | true (pre-existing, #38009) |
| onmessage=f; unref; onmessage=g | true | true |
| on close only; peer close | before false, inClose false | before false, inClose false |
| ref; peer close | before true, inClose false | before true, inClose false |

On main, `close; on`, `ref; close` and `ref; peer close` (plus the two repros above) also differed from node; they match now. The two annotated rows are the only differences left.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/node/worker_threads/worker_threads.test.ts

<!-- robobun:evidence:end -->