### PR TITLE
node:fs: open() embedded /$bunfs/ files in compiled executables

### DIFF
--- a/docs/bundler/executables.mdx
+++ b/docs/bundler/executables.mdx
@@ -839,7 +839,7 @@ If you're using `@mapbox/node-pre-gyp` or similar tools, the `.node` file must b
 
 ### Embed directories
 
-Use `--asset` (or `compile.assets` in the JavaScript API) to embed a file or directory tree into the executable under its original relative path. The embedded files live under `import.meta.dir` at runtime and are reachable via `node:fs` (`existsSync`, `statSync`, `readdirSync`, `readFileSync`) and `Bun.file()`.
+Use `--asset` (or `compile.assets` in the JavaScript API) to embed a file or directory tree into the executable under its original relative path. The embedded files live under `import.meta.dir` at runtime and are reachable via `node:fs` (`existsSync`, `statSync`, `readdirSync`, `readFileSync`, `openSync`, `createReadStream`) and `Bun.file()`. They are read-only: opening one for writing fails with `EROFS`. On Linux, every descriptor `fs.open()` (and therefore `createReadStream`) returns for a given file shares one in-memory copy of it; on macOS and Windows each open copies the file into a temporary file that goes away when the descriptor is closed.
 
 <Tabs>
   <Tab title="CLI">

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -318,6 +318,46 @@ fn standalone_module_graph() -> Option<&'static bun_standalone_graph::Graph> {
     bun_standalone_graph::Graph::get_ref()
 }
 
+/// Backs `fs.open()` of an embedded file: copies `contents` into an anonymous
+/// file and returns a descriptor for it with the offset at 0, so `read`,
+/// `pread`, `fstat` and `close` behave as they would on a regular file holding
+/// those bytes. On Linux that is a memfd; elsewhere (or without memfd support) a
+/// temp file that is unlinked before the descriptor is handed out, so closing
+/// the descriptor is all the cleanup there is.
+fn embedded_file_fd(contents: &[u8]) -> Maybe<FD> {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    if sys::can_use_memfd() {
+        // `memfd_create` latches `can_use_memfd()` off when the kernel or a
+        // seccomp policy refuses it; the temp file below is the fallback.
+        if let Ok(fd) = sys::memfd_create(c"bunfs", sys::MemfdFlags::NonExecutable) {
+            let file = sys::File::from_fd(fd);
+            file.pwrite_all(contents, 0)?;
+            return Ok(file.into_raw());
+        }
+    }
+
+    let mut name_buf = [0u8; 64];
+    let name = paths::fs::FileSystem::tmpname(b"bunfs", &mut name_buf, bun_core::fast_random())
+        .map_err(|_| sys::Error::from_code(E::ENAMETOOLONG, sys::Tag::open))?;
+    let mut path_buf = paths::path_buffer_pool::get();
+    let path = paths::resolve_path::join_abs_string_buf_z::<paths::platform::Auto>(
+        bun_resolver::fs::RealFS::tmpdir_path(),
+        &mut path_buf[..],
+        &[name.as_bytes()],
+    );
+    let file = sys::File::open(
+        path,
+        sys::O::RDWR | sys::O::CREAT | sys::O::EXCL | sys::O::CLOEXEC,
+        0o600,
+    )?;
+    let written = file.pwrite_all(contents, 0);
+    // The name only existed to get a descriptor; if unlinking it fails the
+    // descriptor is still good and the stray temp file is the only casualty.
+    let _ = Syscall::unlink(path);
+    written?;
+    Ok(file.into_raw())
+}
+
 /// Local shim for `Maybe(void)::aborted` (node.rs:302). `bun_sys::Maybe` is
 /// `core::result::Result`, which has no `aborted()` constructor; inline the
 /// sentinel error directly.
@@ -529,6 +569,12 @@ mod _async_tasks {
         pub(crate) type Mkdtemp =
             AsyncFSTask<ret::Mkdtemp, args::MkdirTemp, { NodeFSFunctionEnum::Mkdtemp }>;
         pub(crate) type Open = UVFSRequest<ret::Open, args::Open, { NodeFSFunctionEnum::Open }>;
+        /// `fs.open()` of an embedded `/$bunfs/` path: `NodeFS::open` serves it
+        /// from the thread pool, since `uv_fs_open` cannot see those files.
+        /// On POSIX `Open` already is this type.
+        #[cfg(windows)]
+        pub(crate) type OpenStandalone =
+            AsyncFSTask<ret::Open, args::Open, { NodeFSFunctionEnum::Open }>;
         pub(crate) type Read = UVFSRequest<ret::Read, args::Read, { NodeFSFunctionEnum::Read }>;
         pub(crate) type Readdir =
             AsyncFSTask<ret::Readdir, args::Readdir, { NodeFSFunctionEnum::Readdir }>;
@@ -5957,6 +6003,9 @@ impl NodeFS {
     }
 
     pub(crate) fn open(&mut self, args: &args::Open, _: Flavor) -> Maybe<ret::Open> {
+        if let Some(result) = Self::open_standalone(args) {
+            return result;
+        }
         let path = if cfg!(windows) && args.path.slice() == b"/dev/null" {
             // SAFETY: literal is NUL-terminated; len excludes the sentinel.
             ZStr::from_static(b"\\\\.\\NUL\0")
@@ -5967,6 +6016,33 @@ impl NodeFS {
             Err(err) => Err(err.with_path(args.path.slice())),
             Ok(fd) => Ok(fd),
         }
+    }
+
+    /// `open()` of a path inside a compiled executable's `/$bunfs/` tree.
+    /// `None` when the path is not embedded, so the caller falls through to the
+    /// real filesystem (same as `readFile`/`stat`/`readdir` above).
+    ///
+    /// Embedded files are read-only; a descriptor for one is a private copy of
+    /// its bytes (see [`embedded_file_fd`]), so any flag asking for write access
+    /// is refused up front instead of handing out a copy whose writes vanish.
+    fn open_standalone(args: &args::Open) -> Option<Maybe<ret::Open>> {
+        let graph = standalone_module_graph()?;
+        let path = args.path.slice();
+        let Some(file) = graph.find_ref(path) else {
+            return graph
+                .find_dir(path)
+                .then(|| Err(sys::Error::from_code(E::EISDIR, sys::Tag::open).with_path(path)));
+        };
+        if args.flags.as_int() & (sys::O::WRONLY | sys::O::RDWR | sys::O::TRUNC) != 0 {
+            return Some(Err(
+                sys::Error::from_code(E::EROFS, sys::Tag::open).with_path(path)
+            ));
+        }
+        Some(
+            embedded_file_fd(file.contents.as_bytes()).map_err(|err| {
+                sys::Error::from_code(err.get_errno(), sys::Tag::open).with_path(path)
+            }),
+        )
     }
 
     #[cfg(windows)]

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -318,17 +318,12 @@ fn standalone_module_graph() -> Option<&'static bun_standalone_graph::Graph> {
     bun_standalone_graph::Graph::get_ref()
 }
 
-/// Backs `fs.open()` of an embedded file: copies `contents` into an anonymous
-/// file and returns a descriptor for it with the offset at 0, so `read`,
-/// `pread`, `fstat` and `close` behave as they would on a regular file holding
-/// those bytes. On Linux that is a memfd; elsewhere (or without memfd support) a
-/// temp file that is unlinked before the descriptor is handed out, so closing
-/// the descriptor is all the cleanup there is.
+/// `fs.open()` of an embedded file: a descriptor (memfd on Linux, otherwise an
+/// already-unlinked temp file) holding a copy of `contents`, positioned at 0.
+/// Closing it is the only cleanup.
 fn embedded_file_fd(contents: &[u8]) -> Maybe<FD> {
     #[cfg(any(target_os = "linux", target_os = "android"))]
     if sys::can_use_memfd() {
-        // `memfd_create` latches `can_use_memfd()` off when the kernel or a
-        // seccomp policy refuses it; the temp file below is the fallback.
         if let Ok(fd) = sys::memfd_create(c"bunfs", sys::MemfdFlags::NonExecutable) {
             let file = sys::File::from_fd(fd);
             file.pwrite_all(contents, 0)?;
@@ -351,8 +346,7 @@ fn embedded_file_fd(contents: &[u8]) -> Maybe<FD> {
         0o600,
     )?;
     let written = file.pwrite_all(contents, 0);
-    // The name only existed to get a descriptor; if unlinking it fails the
-    // descriptor is still good and the stray temp file is the only casualty.
+    // A failed unlink only leaves a stray temp file; the descriptor is still good.
     let _ = Syscall::unlink(path);
     written?;
     Ok(file.into_raw())
@@ -569,9 +563,7 @@ mod _async_tasks {
         pub(crate) type Mkdtemp =
             AsyncFSTask<ret::Mkdtemp, args::MkdirTemp, { NodeFSFunctionEnum::Mkdtemp }>;
         pub(crate) type Open = UVFSRequest<ret::Open, args::Open, { NodeFSFunctionEnum::Open }>;
-        /// `fs.open()` of an embedded `/$bunfs/` path: `NodeFS::open` serves it
-        /// from the thread pool, since `uv_fs_open` cannot see those files.
-        /// On POSIX `Open` already is this type.
+        /// Embedded `/$bunfs/` paths, which libuv cannot open; see `Binding::open`.
         #[cfg(windows)]
         pub(crate) type OpenStandalone =
             AsyncFSTask<ret::Open, args::Open, { NodeFSFunctionEnum::Open }>;
@@ -6018,13 +6010,9 @@ impl NodeFS {
         }
     }
 
-    /// `open()` of a path inside a compiled executable's `/$bunfs/` tree.
-    /// `None` when the path is not embedded, so the caller falls through to the
-    /// real filesystem (same as `readFile`/`stat`/`readdir` above).
-    ///
-    /// Embedded files are read-only; a descriptor for one is a private copy of
-    /// its bytes (see [`embedded_file_fd`]), so any flag asking for write access
-    /// is refused up front instead of handing out a copy whose writes vanish.
+    /// `None` unless `args.path` is embedded in this compiled executable.
+    /// Embedded files are read-only, so write access is refused with EROFS
+    /// rather than served by the private copy [`embedded_file_fd`] hands out.
     fn open_standalone(args: &args::Open) -> Option<Maybe<ret::Open>> {
         let graph = standalone_module_graph()?;
         let path = args.path.slice();

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -318,17 +318,17 @@ fn standalone_module_graph() -> Option<&'static bun_standalone_graph::Graph> {
     bun_standalone_graph::Graph::get_ref()
 }
 
-/// `fs.open()` of an embedded file: a descriptor (memfd on Linux, otherwise an
-/// already-unlinked temp file) holding a copy of `contents`, positioned at 0.
-/// Closing it is the only cleanup.
-fn embedded_file_fd(contents: &[u8]) -> Maybe<FD> {
+/// A read-only descriptor over an embedded file's bytes, positioned at 0.
+/// Linux reopens the file's shared memfd, so an open() costs no copy; anywhere
+/// else each open() copies the bytes into a temp file that is unlinked before
+/// its descriptor is returned, so closing the descriptor is the only cleanup.
+fn embedded_file_fd(file: &bun_standalone_graph::File) -> Maybe<FD> {
     #[cfg(any(target_os = "linux", target_os = "android"))]
-    if sys::can_use_memfd() {
-        if let Ok(fd) = sys::memfd_create(c"bunfs", sys::MemfdFlags::NonExecutable) {
-            let file = sys::File::from_fd(fd);
-            file.pwrite_all(contents, 0)?;
-            return Ok(file.into_raw());
-        }
+    if let Some(fd) = file
+        .shared_memfd()
+        .and_then(|memfd| sys::reopen_read_only(memfd).ok())
+    {
+        return Ok(fd);
     }
 
     let mut name_buf = [0u8; 64];
@@ -340,16 +340,17 @@ fn embedded_file_fd(contents: &[u8]) -> Maybe<FD> {
         &mut path_buf[..],
         &[name.as_bytes()],
     );
-    let file = sys::File::open(
+    let writer = sys::File::open(
         path,
-        sys::O::RDWR | sys::O::CREAT | sys::O::EXCL | sys::O::CLOEXEC,
+        sys::O::WRONLY | sys::O::CREAT | sys::O::EXCL | sys::O::CLOEXEC,
         0o600,
     )?;
-    let written = file.pwrite_all(contents, 0);
-    // A failed unlink only leaves a stray temp file; the descriptor is still good.
+    let reader = writer
+        .pwrite_all(file.contents.as_bytes(), 0)
+        .and_then(|()| sys::File::open(path, sys::O::RDONLY | sys::O::CLOEXEC, 0));
+    // A failed unlink only leaves a stray temp file behind.
     let _ = Syscall::unlink(path);
-    written?;
-    Ok(file.into_raw())
+    Ok(reader?.into_raw())
 }
 
 /// Local shim for `Maybe(void)::aborted` (node.rs:302). `bun_sys::Maybe` is
@@ -4671,10 +4672,15 @@ impl NodeFS {
             let is_dir = graph.find_dir(p);
             if is_dir || graph.contains_file(p) {
                 let mode = args.mode.as_int();
-                if (mode & sys::posix::W_OK) != 0 || ((mode & sys::posix::X_OK) != 0 && !is_dir) {
-                    return Err(sys::Error::from_code(E::EACCES, sys::Tag::access).with_path(p));
-                }
-                return Ok(Null);
+                // Same answers as a real read-only filesystem holding 0644 files.
+                let denied = if (mode & sys::posix::W_OK) != 0 {
+                    E::EROFS
+                } else if (mode & sys::posix::X_OK) != 0 && !is_dir {
+                    E::EACCES
+                } else {
+                    return Ok(Null);
+                };
+                return Err(sys::Error::from_code(denied, sys::Tag::access).with_path(p));
             }
         }
         // The `bun_sys::access` Windows
@@ -6010,9 +6016,8 @@ impl NodeFS {
         }
     }
 
-    /// `None` unless `args.path` is embedded in this compiled executable.
-    /// Embedded files are read-only, so write access is refused with EROFS
-    /// rather than served by the private copy [`embedded_file_fd`] hands out.
+    /// `None` unless `args.path` is embedded. Embedded files live on what
+    /// behaves as a read-only filesystem, hence EROFS for any write access.
     fn open_standalone(args: &args::Open) -> Option<Maybe<ret::Open>> {
         let graph = standalone_module_graph()?;
         let path = args.path.slice();
@@ -6027,7 +6032,7 @@ impl NodeFS {
             ));
         }
         Some(
-            embedded_file_fd(file.contents.as_bytes()).map_err(|err| {
+            embedded_file_fd(file).map_err(|err| {
                 sys::Error::from_code(err.get_errno(), sys::Tag::open).with_path(path)
             }),
         )

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -271,9 +271,8 @@ impl Binding {
         Ok(async_::Readdir::create(global, this, rd_args, vm))
     }
 
-    /// `callAsync(.open)`. On Windows `async_::Open` is a libuv request, which
-    /// cannot see embedded `/$bunfs/` files; those take the thread-pool task
-    /// (`NodeFS::open`) that POSIX uses for every open.
+    /// On Windows `async_::Open` is a libuv request, which cannot open embedded
+    /// `/$bunfs/` files; those use the thread-pool task POSIX uses for every open.
     pub(crate) fn open(
         this: &Self,
         global: &JSGlobalObject,

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -265,12 +265,28 @@ impl Binding {
         // SAFETY: re-borrow `vm` mutably; the `slice` borrow is no longer used.
         let vm: &mut VirtualMachine = global.bun_vm().as_mut();
         // /$bunfs/ is in-memory; readdir_inner handles it (recursive included).
-        let is_bunfs = bun_standalone_graph::Graph::get().is_some()
-            && bun_standalone_graph::is_bun_standalone_file_path(rd_args.path.slice());
-        if rd_args.recursive && !is_bunfs {
+        if rd_args.recursive && !is_standalone_path(rd_args.path.slice()) {
             return Ok(AsyncReaddirRecursiveTask::create(global, rd_args, vm));
         }
         Ok(async_::Readdir::create(global, this, rd_args, vm))
+    }
+
+    /// `callAsync(.open)`. On Windows `async_::Open` is a libuv request, and
+    /// libuv cannot see the embedded `/$bunfs/` files, so those go to the
+    /// thread pool where `NodeFS::open` serves them the same way `openSync`
+    /// does. On POSIX `async_::Open` already is the thread-pool task.
+    pub(crate) fn open(
+        this: &Self,
+        global: &JSGlobalObject,
+        frame: &CallFrame,
+    ) -> JsResult<JSValue> {
+        run_async::<args::Open>(this, global, frame, |global, binding, open_args, vm| {
+            #[cfg(windows)]
+            if is_standalone_path(open_args.path.slice()) {
+                return async_::OpenStandalone::create(global, binding, open_args, vm);
+            }
+            async_::Open::create(global, binding, open_args, vm)
+        })
     }
 
     /// `callSync(.watch)` — `args::Watch` borrows `globalThis` so it can't go
@@ -391,7 +407,6 @@ node_fs_bindings! {
     lstat_sync        / lstat             => Lstat,             args::Lstat,     ret::Lstat;
     mkdir_sync        / mkdir             => Mkdir,             args::Mkdir,     ret::Mkdir;
     mkdtemp_sync      / mkdtemp           => Mkdtemp,           args::MkdirTemp, ret::Mkdtemp;
-    open_sync         / open              => Open,              args::Open,      ret::Open;
     read_sync         / read              => Read,              args::Read,      ret::Read;
     write_sync        / write             => Write,             args::Write,     ret::Write;
     read_file_sync    / read_file         => ReadFile,          args::ReadFile,  ret::ReadFile;
@@ -414,13 +429,22 @@ node_fs_bindings! {
     fdatasync_sync    / fdatasync         => Fdatasync,         args::FdataSync, ret::Fdatasync;
 }
 
-// `readdirSync` goes through the generic sync path; only the async side is
-// special-cased above.
+// `readdirSync` / `openSync` go through the generic sync path; only their
+// async sides are special-cased above.
 impl Binding {
     pub(crate) const readdir_sync: NodeFSFunction =
         call_sync::<ret::Readdir, args::Readdir, { NodeFSFunctionEnum::Readdir }>();
+    pub(crate) const open_sync: NodeFSFunction =
+        call_sync::<ret::Open, args::Open, { NodeFSFunctionEnum::Open }>();
     // pub const statfs = callAsync(.statfs);
     // pub const statfsSync = callSync(.statfs);
+}
+
+/// Whether `path` is inside a compiled executable's embedded `/$bunfs/` tree,
+/// which `NodeFS` serves from memory instead of the real filesystem.
+fn is_standalone_path(path: &[u8]) -> bool {
+    bun_standalone_graph::Graph::get().is_some()
+        && bun_standalone_graph::is_bun_standalone_file_path(path)
 }
 
 pub(crate) fn create_binding(global: &JSGlobalObject) -> JSValue {

--- a/src/runtime/node/node_fs_binding.rs
+++ b/src/runtime/node/node_fs_binding.rs
@@ -271,10 +271,9 @@ impl Binding {
         Ok(async_::Readdir::create(global, this, rd_args, vm))
     }
 
-    /// `callAsync(.open)`. On Windows `async_::Open` is a libuv request, and
-    /// libuv cannot see the embedded `/$bunfs/` files, so those go to the
-    /// thread pool where `NodeFS::open` serves them the same way `openSync`
-    /// does. On POSIX `async_::Open` already is the thread-pool task.
+    /// `callAsync(.open)`. On Windows `async_::Open` is a libuv request, which
+    /// cannot see embedded `/$bunfs/` files; those take the thread-pool task
+    /// (`NodeFS::open`) that POSIX uses for every open.
     pub(crate) fn open(
         this: &Self,
         global: &JSGlobalObject,
@@ -440,8 +439,7 @@ impl Binding {
     // pub const statfsSync = callSync(.statfs);
 }
 
-/// Whether `path` is inside a compiled executable's embedded `/$bunfs/` tree,
-/// which `NodeFS` serves from memory instead of the real filesystem.
+/// `path` is under a compiled executable's embedded `/$bunfs/` tree.
 fn is_standalone_path(path: &[u8]) -> bool {
     bun_standalone_graph::Graph::get().is_some()
         && bun_standalone_graph::is_bun_standalone_file_path(path)

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -475,11 +475,31 @@ pub struct File {
     pub bytecode_origin_path: &'static [u8],
     pub module_format: ModuleFormat,
     pub side: FileSide,
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    shared_memfd: std::sync::OnceLock<Option<Fd>>,
 }
 
 impl File {
     pub fn appears_in_embedded_files_array(&self) -> bool {
         self.side == FileSide::Client || !self.loader.is_javascript_like()
+    }
+
+    /// A sealed memfd holding `contents`, created on first use and kept for the
+    /// rest of the process so every `fs.open()` of this file shares its pages.
+    /// `None` when memfds are unavailable or creating it failed.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn shared_memfd(&self) -> Option<Fd> {
+        *self.shared_memfd.get_or_init(|| {
+            if !Syscall::can_use_memfd() {
+                return None;
+            }
+            let fd = Syscall::memfd_create(c"bunfs", Syscall::MemfdFlags::NonExecutable).ok()?;
+            let file = Syscall::File::from_fd(fd);
+            file.pwrite_all(self.contents.as_bytes(), 0)
+                .and_then(|()| Syscall::memfd_seal(fd))
+                .ok()?;
+            Some(file.into_raw())
+        })
     }
 
     pub fn stat(&self) -> Stat {
@@ -729,6 +749,8 @@ impl StandaloneModuleGraph {
                     cached_blob: None,
                     encoding: module.encoding,
                     wtf_string: BunString::empty(),
+                    #[cfg(any(target_os = "linux", target_os = "android"))]
+                    shared_memfd: std::sync::OnceLock::new(),
                 },
             );
         }

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -3448,10 +3448,13 @@ mod posix_impl {
     }
     #[cfg(any(target_os = "linux", target_os = "android"))]
     impl MemfdFlags {
+        /// The same flags without `MFD_EXEC` / `MFD_NOEXEC_SEAL` (Linux 6.3+).
         #[inline]
         fn older_kernel_flag(self) -> u32 {
             match self {
-                MemfdFlags::NonExecutable | MemfdFlags::Executable => libc::MFD_CLOEXEC,
+                MemfdFlags::NonExecutable | MemfdFlags::Executable => {
+                    libc::MFD_ALLOW_SEALING | libc::MFD_CLOEXEC
+                }
                 MemfdFlags::CrossProcess => 0,
             }
         }
@@ -3519,6 +3522,32 @@ mod posix_impl {
             }
             return Ok(Fd::from_native(rc));
         }
+    }
+
+    /// Seals a memfd from [`memfd_create`] (`Executable` / `NonExecutable`
+    /// flags) against every later write, resize and writable shared mapping,
+    /// through any descriptor; those fail with EPERM from now on.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn memfd_seal(fd: Fd) -> Maybe<()> {
+        let seals =
+            libc::F_SEAL_SEAL | libc::F_SEAL_SHRINK | libc::F_SEAL_GROW | libc::F_SEAL_WRITE;
+        fcntl(fd, libc::F_ADD_SEALS, seals as isize)?;
+        Ok(())
+    }
+
+    /// Opens the file behind `fd` again, read-only, as a new open file
+    /// description with its own offset. Goes through `/proc/self/fd`, so it
+    /// works for memfds and unlinked files and fails where `/proc` is missing.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pub fn reopen_read_only(fd: Fd) -> Maybe<Fd> {
+        let mut proc = [0u8; 32];
+        let n = {
+            use std::io::Write as _;
+            let mut c = std::io::Cursor::new(&mut proc[..]);
+            let _ = write!(c, "/proc/self/fd/{}\0", fd.native());
+            c.position() as usize - 1
+        };
+        open(ZStr::from_buf(&proc[..], n), O::RDONLY | O::CLOEXEC, 0)
     }
 
     /// `sendfile(src, dest, len)`. Clamps `len` (avoid EINVAL on

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -63,6 +63,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           dirLstatIsDir: fs.lstatSync(assetDir).isDirectory(),
           accessOk: errcode(() => fs.accessSync(assetDir)) === "",
           accessWriteErr: errcode(() => fs.accessSync(asset, fs.constants.W_OK)),
+          accessExecErr: errcode(() => fs.accessSync(asset, fs.constants.X_OK)),
           readdir: fs.readdirSync(assetDir).sort(),
           readdirHasAsset: fs.readdirSync(assetDir).includes(path.basename(asset)),
         };
@@ -108,20 +109,31 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           readdirCode: errcode(() => fs.readdirSync(cfg)),
         };
 
-        // fs.open() hands out a real descriptor for an embedded file.
-        // createReadStream and FileHandle are built on open + read + close.
+        // fs.open() hands out a real, read-only descriptor for an embedded file;
+        // each one has its own offset. createReadStream and FileHandle are built
+        // on open + read + close.
         const buf = Buffer.alloc(64);
         const fd = fs.openSync(nestedCss, "r");
+        const fd2 = fs.openSync(nestedCss, "r");
         const empty = fs.openSync(path.join(import.meta.dir, "empty.txt"), "r");
+        const readAll = (d: number) => buf.subarray(0, fs.readSync(d, buf, 0, buf.length, null)).toString();
+        // highWaterMark: 4 forces several sequential reads through each descriptor
+        const streamAll = (p: string) => fs.createReadStream(p, { highWaterMark: 4 }).toArray();
         const open = {
-          firstRead: buf.subarray(0, fs.readSync(fd, buf, 0, buf.length, null)).toString(),
+          firstRead: readAll(fd),
           secondReadIsEof: fs.readSync(fd, buf, 0, buf.length, null),
+          secondDescriptorStartsAtZero: readAll(fd2),
           pread: buf.subarray(0, fs.readSync(fd, buf, 0, 6, 5)).toString(),
           fstat: { isFile: fs.fstatSync(fd).isFile(), size: fs.fstatSync(fd).size },
+          writeToFdCode: errcode(() => fs.writeSync(fd, "x")),
+          contentAfterWriteAttempt: fs.readFileSync(nestedCss, "utf8"),
+          preadAfterWriteAttempt: buf.subarray(0, fs.readSync(fd2, buf, 0, buf.length, 0)).toString(),
           emptyRead: fs.readSync(empty, buf, 0, buf.length, null),
           emptySize: fs.fstatSync(empty).size,
-          // highWaterMark: 4 forces several sequential reads through the descriptor
-          stream: Buffer.concat(await fs.createReadStream(indexHtml, { highWaterMark: 4 }).toArray()).toString(),
+          // two streams of the same file at once must not share an offset
+          streams: (await Promise.all([streamAll(indexHtml), streamAll(indexHtml)])).map(chunks =>
+            Buffer.concat(chunks).toString(),
+          ),
           streamRange: Buffer.concat(await fs.createReadStream(nestedCss, { start: 5, end: 10 }).toArray()).toString(),
           streamMissing: await new Promise<string>(resolve =>
             fs.createReadStream(missing).on("error", (e: any) => resolve(e.code)),
@@ -140,6 +152,7 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           missingCode: errcode(() => fs.openSync(missing)),
         };
         fs.closeSync(fd);
+        fs.closeSync(fd2);
         fs.closeSync(empty);
 
         console.log(JSON.stringify({ fileLoader, client, enoent, singleFile, open }));
@@ -166,10 +179,10 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         "index.html",
       ].sort();
 
-      // open() on an embedded file is served from a memfd on Linux and from a
-      // temp file everywhere else (and on Linux without memfd), so the Linux run
-      // is repeated with memfd disabled to cover both. The binary's temp dir is
-      // pointed at scratch-tmp so the temp-file variant can be checked for leftovers.
+      // open() on an embedded file reopens a shared memfd on Linux and copies the
+      // file into a temp file everywhere else (and on Linux without memfd), so the
+      // Linux run is repeated with memfd disabled to cover both. The binary's temp
+      // dir is pointed at scratch-tmp so the temp-file variant can be checked for leftovers.
       const scratch = join(String(dir), "scratch-tmp");
       const runs: Record<string, string>[] = [{}];
       if (process.platform === "linux") runs.push({ BUN_FEATURE_FLAG_DISABLE_MEMFD: "1" });
@@ -192,7 +205,9 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
             dirStatIsDir: true,
             dirLstatIsDir: true,
             accessOk: true,
-            accessWriteErr: "EACCES",
+            // embedded files behave like 0644 files on a read-only filesystem
+            accessWriteErr: "EROFS",
+            accessExecErr: "EACCES",
             // the hashed file-loader name is covered by readdirHasAsset
             readdir: expect.arrayContaining(["client", "config.json", "empty.txt"]),
             readdirHasAsset: true,
@@ -222,11 +237,15 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           open: {
             firstRead: "body{margin:0}",
             secondReadIsEof: 0,
+            secondDescriptorStartsAtZero: "body{margin:0}",
             pread: "margin",
             fstat: { isFile: true, size: "body{margin:0}".length },
+            writeToFdCode: "EBADF",
+            contentAfterWriteAttempt: "body{margin:0}",
+            preadAfterWriteAttempt: "body{margin:0}",
             emptyRead: 0,
             emptySize: 0,
-            stream: "<!doctype html><h1>hi</h1>",
+            streams: ["<!doctype html><h1>hi</h1>", "<!doctype html><h1>hi</h1>"],
             streamRange: "margin",
             streamMissing: "ENOENT",
             fileHandle: { content: `{"ok":true}`, size: `{"ok":true}`.length },

--- a/test/bundler/compile-asset-bunfs.test.ts
+++ b/test/bundler/compile-asset-bunfs.test.ts
@@ -1,5 +1,6 @@
 // https://github.com/oven-sh/bun/issues/15734
 import { describe, expect, test } from "bun:test";
+import { readdirSync } from "fs";
 import { bunEnv, bunExe, tempDir } from "harness";
 import { join, sep } from "path";
 
@@ -20,12 +21,12 @@ async function compile(dir: string, extraArgs: string[] = []) {
   if (code !== 0) throw new Error(`compile failed (exit ${code})\n${stdout}\n${stderr}`);
 }
 
-async function run(dir: string) {
+async function run(dir: string, env: Record<string, string> = {}) {
   // cwd outside the build dir so the binary cannot accidentally find real files on disk.
   await using proc = Bun.spawn({
     cmd: [join(dir, "app" + exe)],
     cwd: process.platform === "win32" ? process.env.TEMP || "C:\\Windows\\Temp" : "/tmp",
-    env: bunEnv,
+    env: { ...bunEnv, ...env },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -36,7 +37,8 @@ async function run(dir: string) {
 describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
   // One compiled binary exercises every CLI-side /$bunfs/ path we care about:
   // a file-loader asset's parent directory, an --asset directory tree, an
-  // --asset single file, and the ENOENT/ENOTDIR/EISDIR/EACCES error paths.
+  // --asset single file, fs.open()/createReadStream()/FileHandle on embedded
+  // files, and the ENOENT/ENOTDIR/EISDIR/EACCES/EROFS error paths.
   // These used to be four separate `bun build --compile` invocations.
   test(
     "CLI: file-loader asset, --asset dir + file, and /$bunfs/ fs semantics",
@@ -106,7 +108,41 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
           readdirCode: errcode(() => fs.readdirSync(cfg)),
         };
 
-        console.log(JSON.stringify({ fileLoader, client, enoent, singleFile }));
+        // fs.open() hands out a real descriptor for an embedded file.
+        // createReadStream and FileHandle are built on open + read + close.
+        const buf = Buffer.alloc(64);
+        const fd = fs.openSync(nestedCss, "r");
+        const empty = fs.openSync(path.join(import.meta.dir, "empty.txt"), "r");
+        const open = {
+          firstRead: buf.subarray(0, fs.readSync(fd, buf, 0, buf.length, null)).toString(),
+          secondReadIsEof: fs.readSync(fd, buf, 0, buf.length, null),
+          pread: buf.subarray(0, fs.readSync(fd, buf, 0, 6, 5)).toString(),
+          fstat: { isFile: fs.fstatSync(fd).isFile(), size: fs.fstatSync(fd).size },
+          emptyRead: fs.readSync(empty, buf, 0, buf.length, null),
+          emptySize: fs.fstatSync(empty).size,
+          // highWaterMark: 4 forces several sequential reads through the descriptor
+          stream: Buffer.concat(await fs.createReadStream(indexHtml, { highWaterMark: 4 }).toArray()).toString(),
+          streamRange: Buffer.concat(await fs.createReadStream(nestedCss, { start: 5, end: 10 }).toArray()).toString(),
+          streamMissing: await new Promise<string>(resolve =>
+            fs.createReadStream(missing).on("error", (e: any) => resolve(e.code)),
+          ),
+          fileHandle: await fs.promises.open(cfg, "r").then(async fh => {
+            try {
+              return { content: await fh.readFile("utf8"), size: (await fh.stat()).size };
+            } finally {
+              await fh.close();
+            }
+          }),
+          writeCode: errcode(() => fs.openSync(nestedCss, "w")),
+          readWriteCode: errcode(() => fs.openSync(nestedCss, "r+")),
+          asyncWriteCode: await fs.promises.open(nestedCss, "w").then(() => "", (e: any) => e.code),
+          dirCode: errcode(() => fs.openSync(root)),
+          missingCode: errcode(() => fs.openSync(missing)),
+        };
+        fs.closeSync(fd);
+        fs.closeSync(empty);
+
+        console.log(JSON.stringify({ fileLoader, client, enoent, singleFile, open }));
       `,
         "data.txt": "hello",
         "client/index.html": "<!doctype html><h1>hi</h1>",
@@ -114,12 +150,11 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         "client/_app/immutable/app.css": "body{margin:0}",
         "client/_app/immutable/chunks/entry.js": "export default 1;",
         "config.json": `{"ok":true}`,
+        "empty.txt": "",
+        "scratch-tmp/.keep": "",
       });
 
-      await compile(String(dir), ["--asset", "./client", "--asset", "./config.json"]);
-      const { stdout, stderr, code } = await run(String(dir));
-      expect(stderr.trim()).toBe("");
-      const r = JSON.parse(stdout.trim());
+      await compile(String(dir), ["--asset", "./client", "--asset", "./config.json", "--asset", "./empty.txt"]);
 
       const expectedRecursive = [
         "_app",
@@ -131,47 +166,85 @@ describe.concurrent("compile --asset and /$bunfs/ directory semantics", () => {
         "index.html",
       ].sort();
 
-      expect(r).toEqual({
-        fileLoader: {
-          assetExists: true,
-          dirExists: true,
-          dirExistsTrailingSlash: true,
-          dirStatIsDir: true,
-          dirLstatIsDir: true,
-          accessOk: true,
-          accessWriteErr: "EACCES",
-          // the hashed file-loader name is covered by readdirHasAsset
-          readdir: expect.arrayContaining(["client", "config.json"]),
-          readdirHasAsset: true,
-        },
-        client: {
-          root: expect.stringMatching(/[/\\]root[/\\]client$/),
-          entries: ["_app", "favicon.svg", "index.html"],
-          byName: {
-            _app: { isDir: true, isFile: false },
-            "favicon.svg": { isDir: false, isFile: true },
-            "index.html": { isDir: false, isFile: true },
+      // open() on an embedded file is served from a memfd on Linux and from a
+      // temp file everywhere else (and on Linux without memfd), so the Linux run
+      // is repeated with memfd disabled to cover both. The binary's temp dir is
+      // pointed at scratch-tmp so the temp-file variant can be checked for leftovers.
+      const scratch = join(String(dir), "scratch-tmp");
+      const runs: Record<string, string>[] = [{}];
+      if (process.platform === "linux") runs.push({ BUN_FEATURE_FLAG_DISABLE_MEMFD: "1" });
+      for (const extraEnv of runs) {
+        const { stdout, stderr, code } = await run(String(dir), {
+          TMPDIR: scratch,
+          TMP: scratch,
+          TEMP: scratch,
+          BUN_TMPDIR: scratch,
+          ...extraEnv,
+        });
+        expect(stderr.trim()).toBe("");
+        const r = JSON.parse(stdout.trim());
+
+        expect(r).toEqual({
+          fileLoader: {
+            assetExists: true,
+            dirExists: true,
+            dirExistsTrailingSlash: true,
+            dirStatIsDir: true,
+            dirLstatIsDir: true,
+            accessOk: true,
+            accessWriteErr: "EACCES",
+            // the hashed file-loader name is covered by readdirHasAsset
+            readdir: expect.arrayContaining(["client", "config.json", "empty.txt"]),
+            readdirHasAsset: true,
           },
-          indexHtmlExists: true,
-          indexHtmlSize: "<!doctype html><h1>hi</h1>".length,
-          indexHtmlContent: "<!doctype html><h1>hi</h1>",
-          nestedCssExists: true,
-          nestedCssContent: "body{margin:0}",
-          nestedCssViaReadFile: "body{margin:0}",
-          nestedDirIsDir: true,
-          readFileDirErr: "EISDIR",
-          recursive: expectedRecursive,
-          recursiveAsync: expectedRecursive,
-          embeddedFileCount: expect.any(Number),
-        },
-        enoent: { code: "ENOENT", exists: false },
-        singleFile: { exists: true, content: `{"ok":true}`, readdirCode: "ENOTDIR" },
-      });
-      // recursive uses the platform path separator (same as Node's real-fs recursive readdir)
-      expect(r.client.recursive.join("\n")).not.toContain(sep === "/" ? "\\" : "/");
-      // data.txt + config.json + 4 under client/
-      expect(r.client.embeddedFileCount).toBeGreaterThanOrEqual(6);
-      expect(code).toBe(0);
+          client: {
+            root: expect.stringMatching(/[/\\]root[/\\]client$/),
+            entries: ["_app", "favicon.svg", "index.html"],
+            byName: {
+              _app: { isDir: true, isFile: false },
+              "favicon.svg": { isDir: false, isFile: true },
+              "index.html": { isDir: false, isFile: true },
+            },
+            indexHtmlExists: true,
+            indexHtmlSize: "<!doctype html><h1>hi</h1>".length,
+            indexHtmlContent: "<!doctype html><h1>hi</h1>",
+            nestedCssExists: true,
+            nestedCssContent: "body{margin:0}",
+            nestedCssViaReadFile: "body{margin:0}",
+            nestedDirIsDir: true,
+            readFileDirErr: "EISDIR",
+            recursive: expectedRecursive,
+            recursiveAsync: expectedRecursive,
+            embeddedFileCount: expect.any(Number),
+          },
+          enoent: { code: "ENOENT", exists: false },
+          singleFile: { exists: true, content: `{"ok":true}`, readdirCode: "ENOTDIR" },
+          open: {
+            firstRead: "body{margin:0}",
+            secondReadIsEof: 0,
+            pread: "margin",
+            fstat: { isFile: true, size: "body{margin:0}".length },
+            emptyRead: 0,
+            emptySize: 0,
+            stream: "<!doctype html><h1>hi</h1>",
+            streamRange: "margin",
+            streamMissing: "ENOENT",
+            fileHandle: { content: `{"ok":true}`, size: `{"ok":true}`.length },
+            writeCode: "EROFS",
+            readWriteCode: "EROFS",
+            asyncWriteCode: "EROFS",
+            dirCode: "EISDIR",
+            missingCode: "ENOENT",
+          },
+        });
+        // recursive uses the platform path separator (same as Node's real-fs recursive readdir)
+        expect(r.client.recursive.join("\n")).not.toContain(sep === "/" ? "\\" : "/");
+        // data.txt + config.json + empty.txt + 4 under client/
+        expect(r.client.embeddedFileCount).toBeGreaterThanOrEqual(7);
+        expect(code).toBe(0);
+        // the temp file behind each open() was unlinked before its descriptor was handed out
+        expect(readdirSync(scratch).filter(name => name.endsWith(".bunfs"))).toEqual([]);
+      }
     },
     TIMEOUT,
   );


### PR DESCRIPTION
### Problem
- In a `bun build --compile` binary, `fs.openSync(p, "r")` on an embedded file throws `ENOENT: no such file or directory, open '/$bunfs/root/assets/a.txt'` (`B:\~BUN\root\...` on Windows), while `fs.readFileSync(p)` and `Bun.file(p)` on the same path work.
- `fs.open`, `fs.promises.open`, `fs.createReadStream` and `FileHandle` fail the same way: all of them are `open` + `read` + `close` underneath (`src/js/internal/fs/streams.ts`, `streamConstruct`).
- Cause: `NodeFS::open` (`src/runtime/node/node_fs.rs`) goes straight to the real filesystem. Only `access`, `exists`, `stat`, `lstat`, `readdir` and `readFile` consult the standalone module graph. #36302 added the directory semantics and left this as the follow-up.
- Remaining half of #22223 (the `readdir` half landed in #36302).

### Fix
- `NodeFS::open` consults the graph first and, for an embedded file, returns a real read-only descriptor positioned at 0 (`embedded_file_fd`). Everything that was broken consumes the fd through plain `read`/`pread`/`fstat`/`close`, so `readSync`, `createReadStream` (including `start`/`end`), `FileHandle.readFile()`/`stat()` and `readFileSync(fd)` work without changes of their own.
- Linux: each embedded file gets one memfd, filled once and sealed (`File::shared_memfd`, `bun_sys::memfd_seal`), kept for the rest of the process; every `open()` reopens it read-only through `/proc/self/fd` (`bun_sys::reopen_read_only`), so an open costs no copy, concurrent streams of one asset share its pages, and each descriptor has its own offset. `MemfdFlags::older_kernel_flag` now keeps `MFD_ALLOW_SEALING`, so sealing also works on kernels before 6.3 (previously the retry dropped it; no caller sealed, so nothing else changes).
- macOS, Windows, and Linux without memfd or `/proc`: each `open()` writes the bytes to a temp file under bun's temp dir through one descriptor, opens the file again `O_RDONLY`, unlinks the name, and returns the read-only descriptor. Closing it is the only cleanup. This is the approach `bun:ffi`'s `dlopen()` already uses for embedded libraries (#30720), minus leaving the file behind.
- Both routes hand out a descriptor that is read-only at the kernel level: `fs.writeSync(fd, ...)` fails with `EBADF` and `ftruncateSync` fails as well (`EINVAL` on Linux), the same as a descriptor from a real `"r"` open. `fstat` reports a regular file of the right size; mode and timestamps are those of the backing copy, not the synthetic values `stat(path)` reports.
- Opening an embedded file with write access (`O_WRONLY`, `O_RDWR` or `O_TRUNC`) fails with `EROFS`; opening an embedded directory fails with `EISDIR` (what `readFileSync` already reports for one); `/$bunfs/` paths that are not embedded still fall through to the real filesystem and get `ENOENT` as before. `accessSync(p, W_OK)`, which #36302 (unreleased) made return `EACCES`, now returns `EROFS` too, so the one question "can I write this embedded file" has one answer across `access`, `open` and (#34189, if it lands) the mutating calls; `X_OK` on a file still returns `EACCES`, as a 0644 file on a read-only filesystem would.
- Windows: the async `open` binding is a libuv `uv_fs_open` request, which cannot see embedded files, so `Binding::open` routes `/$bunfs/` paths to the thread-pool task (`async_::OpenStandalone`), the task POSIX already uses for every open. `openSync` and the libuv path for real paths are unchanged; the prefix check is shared with the existing `readdir` binding (`is_standalone_path`).
- Docs: the `--asset` section lists `openSync`/`createReadStream` and states the read-only rule and the per-open cost on each platform.
- Verified with `test/bundler/compile-asset-bunfs.test.ts` (CLI case extended; still 2 compiles in the file). The compiled program exercises `openSync` twice on the same file (sequential reads to EOF on one, the other still starts at 0), a positional read, `fstatSync`, a write through the descriptor (`EBADF`, content intact afterwards), an empty embedded file, two concurrent `createReadStream`s of one file with a 4-byte `highWaterMark`, `createReadStream` with `start`/`end` and on a missing path, `fs.promises.open` -> `FileHandle.readFile()`/`stat()`, and the `EROFS` (sync and async), `EISDIR`, `ENOENT`, `access(W_OK)` and `access(X_OK)` codes. The binary runs with every temp-dir variable pointed at a scratch directory that is checked for leftovers; on Linux it runs a second time with `BUN_FEATURE_FLAG_DISABLE_MEMFD=1`, so both routes are covered there.
  - `bun bd test test/bundler/compile-asset-bunfs.test.ts`: 9 pass; `USE_SYSTEM_BUN=1`: the CLI case fails at the first `openSync` with the `ENOENT` above (also checked on Windows Server 2019, where the canary fails with the `B:\~BUN\` path and a debug build of the first revision of this branch passed)
  - A probe binary confirmed the mechanics on Linux: two opens of one file share an inode and have independent offsets, 200 open/close cycles grow the fd table by exactly the per-file memfds, and with memfd disabled each open is an unlinked temp file under `BUN_TMPDIR` with nothing left behind
  - `test/js/node/fs/fs.test.ts`, `promises.test.js`, `test/js/bun/memfd-disabled.test.ts`, `spawn/spawnSync.test.ts`, `test/internal/source-lints`: pass (one pre-existing 10s-budget readdir timing test in `fs.test.ts` exceeds its budget under the local debug+ASAN build, unrelated)
  - `cargo check -p bun_runtime` for `x86_64-pc-windows-msvc`, `aarch64-apple-darwin` and `aarch64-linux-android`; `cargo clippy` on `bun_sys`, `bun_standalone_graph`, `bun_runtime`: clean

Closes #22223

### Background
- `/$bunfs/` (`B:\~BUN\` on Windows) is the virtual path prefix for files embedded in a compiled executable. The standalone module graph (`bun_standalone_graph::Graph`) is the in-memory table of those files; each entry's contents are a slice of the executable's own mapped image, so there is no file or descriptor behind them. A descriptor on the executable itself would not do: `read()` would run past the end of the asset into the next one and `fstat()` would report the executable's size, which is why a separate backing object is needed.
- A memfd (`memfd_create`) is a Linux anonymous file that behaves like a regular file descriptor and is freed when its last descriptor closes. Seals (`fcntl(F_ADD_SEALS)`) make its contents and size immutable through every descriptor; `MFD_ALLOW_SEALING` must be passed at creation for that. `bun_sys::can_use_memfd()` is latched off when the kernel or a seccomp policy refuses memfds, which is why the temp-file route exists on Linux as well.
- Opening `/proc/self/fd/N` creates a new open file description for the same file, with its own offset and its own access mode; it works for memfds and unlinked files. Each `fs.open()` needs its own offset because `createReadStream` reads sequentially.
- Unlinking a file while a descriptor to it is open keeps the data reachable through that descriptor until it is closed. On Windows, libuv opens files with delete sharing and its unlink uses POSIX delete semantics, so the same pattern holds there (verified on Windows Server 2019: the name is already gone while the descriptor is open).
- node:fs async operations run either as `AsyncFSTask` (the same `NodeFS` method as the sync call, on the thread pool; used for everything on POSIX) or, on Windows for a few fd-centric operations including `open`, as a `UVFSRequest` handed to libuv. The `async_::*` aliases in `node_fs.rs` pick the task type per operation.

<details>
<summary>Earlier revision</summary>

The first revision returned a private copy per open (a fresh memfd, or a temp file opened read-write), which review pointed out was writable through the returned descriptor and cost one full copy of the asset per open. The current revision replaces that with the shared sealed memfd plus read-only reopen described above; the temp-file route is the same idea with a separate `O_RDONLY` open.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/compile-asset-bunfs.test.ts

<!-- robobun:evidence:end -->