### PR TITLE
codegen: reject builtin macro calls with type arguments instead of silently skipping them

### DIFF
--- a/.github/workflows/source-lints.yml
+++ b/.github/workflows/source-lints.yml
@@ -13,6 +13,7 @@ on:
     branches: [main]
     paths:
       - "src/**/*.rs"
+      - "src/codegen/**"
       - "src/jsc/bindings/**"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"
@@ -25,6 +26,7 @@ on:
   pull_request:
     paths:
       - "src/**/*.rs"
+      - "src/codegen/**"
       - "src/jsc/bindings/**"
       - "scripts/build/**"
       - "scripts/glob-sources.ts"

--- a/src/codegen/builtin-parser.ts
+++ b/src/codegen/builtin-parser.ts
@@ -9,7 +9,8 @@ function createStopRegex(allow_comma: boolean) {
     "((?:[(,=;:{]|return|\\=\\>)\\s*)\\/[^\\/\\*]|\\/\\*|\\/\\/|['\"}`\\)" +
       (allow_comma ? "," : "") +
       "]|(?<!\\$)\\brequire\\(|(" +
-      function_replacements.map(x => escapeRegex(x) + "\\(").join("|") +
+      // `$macro(` is expanded by applyReplacements; `$macro<` (type arguments) is rejected there.
+      function_replacements.map(x => escapeRegex(x) + "[(<]").join("|") +
       ")",
   );
 }

--- a/src/codegen/replacements.ts
+++ b/src/codegen/replacements.ts
@@ -184,7 +184,8 @@ export const function_replacements = [
   "$isPromisePending",
   "$bindgenFn",
 ];
-const function_regexp = new RegExp(`__intrinsic__(${function_replacements.join("|").replaceAll("$", "")})`);
+// Anchored: builtin-parser.ts ends the chunk right after the macro being called; any earlier macro name is a plain reference.
+const function_regexp = new RegExp(`__intrinsic__(${function_replacements.join("|").replaceAll("$", "")})$`);
 
 /** Applies source code replacements as defined in `replacements` */
 export function applyReplacements(src: string, length: number) {
@@ -197,8 +198,14 @@ export function applyReplacements(src: string, length: number) {
       replacement.toRaw ?? replacement.to!.replaceAll("$", "__intrinsic__").replaceAll("%", "$"),
     );
   }
-  let match;
-  if ((match = slice.match(function_regexp)) && rest.startsWith("(")) {
+  const match = slice.match(function_regexp);
+  if (match && rest.startsWith("<")) {
+    throw new Error(
+      `$${match[1]} does not accept type arguments; only '$${match[1]}(' is expanded at bundle time. ` +
+        `Cast the result instead: '$${match[1]}(...) as T'. Found: '$${match[1]}${rest.slice(0, 80)}'`,
+    );
+  }
+  if (match && rest.startsWith("(")) {
     const name = match[1];
     if (name === "debug") {
       const innerSlice = sliceSourceCode(rest, true);

--- a/src/js/private.d.ts
+++ b/src/js/private.d.ts
@@ -212,7 +212,7 @@ interface JSCommonJSModule {
  *
  * @returns whatever the binding function returns.
  */
-declare function $cpp<T = any>(filename: NativeFilenameCPP, symbol: string): T;
+declare function $cpp(filename: NativeFilenameCPP, symbol: string): any;
 /**
  * Call a native Rust binding function, getting whatever it returns.
  *
@@ -230,17 +230,13 @@ declare function $cpp<T = any>(filename: NativeFilenameCPP, symbol: string): T;
  *
  * @returns whatever the binding function returns.
  */
-declare function $rust<T = any>(filename: NativeFilenameRust, symbol: string): T;
-declare function $newCppFunction<T = (...args: any) => any>(
-  filename: NativeFilenameCPP,
-  symbol: string,
-  argCount: number,
-): T;
-declare function $newRustFunction<T = (...args: any) => any>(
+declare function $rust(filename: NativeFilenameRust, symbol: string): any;
+declare function $newCppFunction(filename: NativeFilenameCPP, symbol: string, argCount: number): (...args: any) => any;
+declare function $newRustFunction(
   filename: NativeFilenameRust,
   symbol: string,
   argCount: number,
-): T;
+): (...args: any) => any;
 /**
  * Retrieves a handle to a function defined in native code, defined in a
  * `.bind.ts` file. For more information on how to define bindgen functions, see
@@ -248,7 +244,7 @@ declare function $newRustFunction<T = (...args: any) => any>(
  * @param filename - The basename of the `.bind.ts` file.
  * @param symbol - The name of the function to call.
  */
-declare function $bindgenFn<T = (...args: any) => any>(filename: string, symbol: string): T;
+declare function $bindgenFn(filename: string, symbol: string): (...args: any) => any;
 // NOTE: $debug, $assert, and $isPromiseFulfilled omitted
 
 declare module "node:net" {

--- a/test/internal/source-lints/codegen-builtin-macros.test.ts
+++ b/test/internal/source-lints/codegen-builtin-macros.test.ts
@@ -58,14 +58,32 @@ describe.each(macros)("%s", (macro, args, expansion) => {
   });
 });
 
-test("type arguments inside strings and comments are not code", () => {
-  const code = `{ const s = "$rust<T>(a, b)"; /* $cpp<T>(a, b) */ // $newRustFunction<T>(a, b, 0)\n}`;
+test("type arguments are rejected inside macro arguments and template substitutions too", () => {
+  // $assert's condition is sliced in end-on-comma mode, which uses the other
+  // stop regexp; template substitutions re-enter the slicer.
+  expect(() => expand(`$assert($rust<T>("node_util_binding.rs", "internalErrorName"))`)).toThrow(
+    "$rust does not accept type arguments",
+  );
+  expect(() => expand(`$debug("x", $newCppFunction<T>("NodeValidator.cpp", "validateInteger", 4))`)).toThrow(
+    "$newCppFunction does not accept type arguments",
+  );
+  expect(() => expand('`${$cpp<T>("NodeValidator.cpp", "validateInteger")}`')).toThrow(
+    "$cpp does not accept type arguments",
+  );
+});
+
+test("type arguments inside strings, comments and template text are not code", () => {
+  const code = `{ const s = "$rust<T>(a, b)" + \`$bindgenFn<T>(a, b) \${1}\`; /* $cpp<T>(a, b) */ // $newRustFunction<T>(a, b, 0)\n}`;
   expect(sliceSourceCode(code, true)).toEqual({ result: code, rest: "" });
 });
 
 test("a macro name that is not being called passes through as a plain intrinsic", () => {
   // `$debug` is also a value: bundle-modules defines `__intrinsic__debug` to the
   // debug-logging flag, so `if ($debug)` is a real pattern in src/js.
+  expect(sliceSourceCode(`{ if ($debug) { x(); } }`, true)).toEqual({
+    result: `{ if (__intrinsic__debug) { x(); } }`,
+    rest: "",
+  });
   expect(expand(`$debug && !handle`)).toBe(`__intrinsic__debug && !handle`);
 });
 

--- a/test/internal/source-lints/codegen-builtin-macros.test.ts
+++ b/test/internal/source-lints/codegen-builtin-macros.test.ts
@@ -1,0 +1,75 @@
+/** Unit tests for the `$macro(...)` expansion that bundle-modules.ts and
+ * bundle-functions.ts apply to the builtin JS in src/js
+ * (src/codegen/builtin-parser.ts + src/codegen/replacements.ts). Nothing here
+ * needs the built binary: the preprocessor is plain TypeScript run at build time. */
+import { describe, expect, test } from "bun:test";
+
+import { sliceSourceCode } from "../../../src/codegen/builtin-parser.ts";
+import { function_replacements } from "../../../src/codegen/replacements.ts";
+
+/** One well-formed call per macro and what it expands to. The native macros
+ * are resolved against the real tree (generate-js2native.ts), so their
+ * arguments name files that exist in src/. */
+const macros: [macro: string, args: string, expansion: string | RegExp][] = [
+  ["$debug", `("x")`, `(IS_BUN_DEVELOPMENT?$debug_log("x"):void 0)`],
+  ["$assert", `(ok, "x")`, `!(IS_BUN_DEVELOPMENT?$assert(ok,"ok", "x"):void 0)`],
+  ["$rust", `("node_util_binding.rs", "internalErrorName")`, /^__intrinsic__lazy\(\d+\)$/],
+  ["$newRustFunction", `("node_util_binding.rs", "internalErrorName", 1)`, /^__intrinsic__lazy\(\d+\)$/],
+  ["$cpp", `("NodeValidator.cpp", "validateInteger")`, /^__intrinsic__lazy\(\d+\)$/],
+  ["$newCppFunction", `("NodeValidator.cpp", "validateInteger", 4)`, /^__intrinsic__lazy\(\d+\)$/],
+  ["$bindgenFn", `("bindgen_test.bind.ts", "add")`, /^__intrinsic__lazy\(\d+\)$/],
+  ["$isPromisePending", `(p)`, `(__intrinsic__peekPromiseStatus(p) === 0)`],
+  ["$isPromiseFulfilled", `(p)`, `(__intrinsic__peekPromiseStatus(p) === 1)`],
+  ["$isPromiseRejected", `(p)`, `(__intrinsic__peekPromiseStatus(p) === 2)`],
+];
+
+function expand(code: string): string {
+  const { result, rest } = sliceSourceCode(`{ const v = ${code}; }`, true);
+  expect(rest).toBe("");
+  expect(result).toStartWith("{ const v = ");
+  expect(result).toEndWith("; }");
+  return result.slice("{ const v = ".length, -"; }".length);
+}
+
+test("every macro the preprocessor expands is covered below", () => {
+  expect(macros.map(([macro]) => macro).sort()).toEqual([...function_replacements].sort());
+});
+
+describe.each(macros)("%s", (macro, args, expansion) => {
+  test("a plain call is expanded", () => {
+    const expanded = expand(`${macro}${args}`);
+    if (typeof expansion === "string") {
+      expect(expanded).toBe(expansion);
+    } else {
+      expect(expanded).toMatch(expansion);
+    }
+  });
+
+  // private.d.ts used to declare the native macros as generic, so
+  // `$newRustFunction<() => number>(...)` type-checked, and the preprocessor
+  // only looked for `$name(`: the call went into the bundle unexpanded and the
+  // native side was never registered, which only surfaced later as a dead-code
+  // error in cargo or as a module that fails to load.
+  test("a call with type arguments is a bundle-time error", () => {
+    expect(() => expand(`${macro}<() => number>${args}`)).toThrow(
+      `${macro} does not accept type arguments; only '${macro}(' is expanded at bundle time. ` +
+        `Cast the result instead: '${macro}(...) as T'. Found: '${macro}<() => number>${args}`,
+    );
+  });
+});
+
+test("type arguments inside strings and comments are not code", () => {
+  const code = `{ const s = "$rust<T>(a, b)"; /* $cpp<T>(a, b) */ // $newRustFunction<T>(a, b, 0)\n}`;
+  expect(sliceSourceCode(code, true)).toEqual({ result: code, rest: "" });
+});
+
+test("a macro name that is not being called passes through as a plain intrinsic", () => {
+  // `$debug` is also a value: bundle-modules defines `__intrinsic__debug` to the
+  // debug-logging flag, so `if ($debug)` is a real pattern in src/js.
+  expect(expand(`$debug && !handle`)).toBe(`__intrinsic__debug && !handle`);
+});
+
+test("a bare reference earlier in the same chunk does not hijack the call being expanded", () => {
+  expect(expand(`$debug && $debug("x")`)).toBe(`__intrinsic__debug && (IS_BUN_DEVELOPMENT?$debug_log("x"):void 0)`);
+  expect(expand(`$assert && $debug("x")`)).toBe(`__intrinsic__assert && (IS_BUN_DEVELOPMENT?$debug_log("x"):void 0)`);
+});


### PR DESCRIPTION
### Problem
- A builtin-JS macro call written with TypeScript type arguments, e.g. `timerClockMs: $newRustFunction<() => number>("runtime/timer/Timer.rs", "internal_bindings.timerClockMs", 0)` in `src/js`, bundles without any error: the bundled module keeps a literal `@newRustFunction(...)` (a private name that does not exist) and the call is missing from `GeneratedJS2Native.h` / `generated_js2native.rs`.
- What does surface is far away: for a Rust target `bun bd` fails in cargo with ``error: function `timer_clock_ms` is never used`` because the thunk was never generated; if the symbol is used elsewhere, or for a C++ target, the build passes and the module fails when it is first loaded.
- Cause: `src/codegen/builtin-parser.ts:12` only ends a chunk at `$macro(`, and `src/codegen/replacements.ts` (`applyReplacements`) only expands when the rest of the source starts with `(`. `$macro<...>(` matches neither, so the call falls through the plain-text path. This applies to every macro in `function_replacements`.
- `src/js/private.d.ts` declared `$cpp`, `$rust`, `$newCppFunction`, `$newRustFunction` and `$bindgenFn` as generic, so tsc accepted exactly this form. The `$cpp`/`$rust` doc comments have said since #15742 that a type parameter "will break codegen"; nothing enforced it, and it was hit again while working on #37974.

### Fix
- `builtin-parser.ts` also ends a chunk at `$macro<`; `applyReplacements` throws there with the macro name, the source it found, and the supported spelling (`$macro(...) as T`). `bundle-modules` exits 1 and names the module (`While processing: internal-for-testing.ts`).
- The macro regexp in `replacements.ts` is anchored to the end of the chunk. The chunk ends right after the macro name whose `(`/`<` ended it, so that is the only name that can be the call being expanded; previously the first macro name anywhere in the chunk won, so `x = $debug && $debug("..")` spliced out the `$debug && ` prefix. `$debug` as a value (`if ($debug)`, defined by `--define`) still passes through unchanged.
- `private.d.ts` drops the type parameters from the five native macros, so tsc reports the form too (`TS2558: Expected 0 type arguments, but got 1`). The return types are the old defaults (`any` and `(...args: any) => any`), and no call site in `src/js` passes type arguments, so nothing else changes.
- Rejecting rather than stripping the type arguments is deliberate: it keeps the one call spelling the preprocessor, the `$rust()` registry comments in `generate-js2native.ts`, and greps for `$name(` all agree on, and `as T` already covers typing the result (it is what the existing call sites do).
- Why this is safe: `bundle-modules.ts` output for the current tree is byte-identical before and after (all 197 modules, the builtin functions, `GeneratedJS2Native.h`, `generated_js2native.rs`, and the module blob were diffed), and the `tsc -p src/js` error set is unchanged.
- Verified by `test/internal/source-lints/codegen-builtin-macros.test.ts`: for each of the 10 macros, the plain call still expands and the type-argument form throws; type arguments inside strings/comments are left alone; the bare-reference and anchoring cases above. 11 of 24 cases fail without the `src/` change. The file goes in `source-lints/` because it imports the build scripts directly and never needs the built binary; `src/codegen/**` is added to that workflow's path filter so it runs when the preprocessor changes.
- Also run: `bun bd test` on the new file plus `test/internal/internal-module-blob.test.ts` and `test/internal/bindgen.test.ts`, the whole `test/internal/source-lints/` directory, `bun run lint`, and the temporary repro above through `bundle-modules.ts` (fails at bundle time now, passed silently before).

### Background
- Builtin JS (`src/js/**`) is preprocessed by `bundle-modules.ts` / `bundle-functions.ts` before being bundled: `$name` becomes the JSC private name `@name`, and a few `$` names are macros expanded by `replacements.ts` (`$rust`, `$cpp`, `$newRustFunction`, `$newCppFunction`, `$bindgenFn`, `$debug`, `$assert`, `$isPromise*`).
- The native macros register their target with `generate-js2native.ts` and are replaced by `@lazy(id)`; that registry is what emits the C++ dispatch table and the Rust thunks. A call the preprocessor does not see is therefore missing from the native side as well, not just left as-is in the JS.
- `builtin-parser.ts` (`sliceSourceCode`) is regexp-based: it walks the source in chunks, ending a chunk at strings, comments, brackets or a macro call, and hands each code chunk to `applyReplacements(src, chunkLength)`, which sees the chunk plus everything after it.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 5 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: 12 FAILED
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/codegen-builtin-macros.test.ts
bun test v1.4.0 (22be79566)

test/internal/source-lints/codegen-builtin-macros.test.ts:
(pass) every macro the preprocessor expands is covered below [50.36ms]
(pass) $debug > a plain call is expanded [1019.69ms]
49 |   // `$newRustFunction<() => number>(...)` type-checked, and the preprocessor
50 |   // only looked for `$name(`: the call went into the bundle unexpanded and the
51 |   // native side was never registered, which only surfaced later as a dead-code
52 |   // error in cargo or as a module that fails to load.
53 |   test("a call with type arguments is a bundle-time error", () => {
54 |     expect(() => expand(`${macro}<() => number>${args}`)).toThrow(
                                                               ^
error: expect(received).toThrow(expected)

Expected substring: "$debug does not accept type arguments; only '$debug(' is expanded at bundle time. Cast the result instead: '$debug(...) as T'. Found: '$debug<() => number>(\"x\")"

Received function did not thr
... (truncated)

release without fix: 12 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/internal/source-lints/codegen-builtin-macros.test.ts:
(pass) every macro the preprocessor expands is covered below [0.11ms]
(pass) $debug > a plain call is expanded [3.70ms]
49 |   // `$newRustFunction<() => number>(...)` type-checked, and the preprocessor
50 |   // only looked for `$name(`: the call went into the bundle unexpanded and the
51 |   // native side was never registered, which only surfaced later as a dead-code
52 |   // error in cargo or as a module that fails to load.
53 |   test("a call with type arguments is a bundle-time error", () => {
54 |     expect(() => expand(`${macro}<() => number>${args}`)).toThrow(
                                                               ^
error: expect(received).toThrow(expected)

Expected substring: "$debug does not accept type arguments; only '$debug(' is expanded at bundle time. Cast the result instead: '$debug(...) as T'. Found: '$debug<() => number>(\"x\")"

Received function did not throw
Received value: "__intrinsic__debug<() => number>(\"x\")"

      at <anonymous> (/workspace/bun/test/internal/source-lints/codegen-builtin-macros.test.ts:54:59)
(fail) $debug > a call
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/internal/source-lints/codegen-builtin-macros.test.ts
bun test v1.4.0 (22be79566)

test/internal/source-lints/codegen-builtin-macros.test.ts:
(pass) every macro the preprocessor expands is covered below [48.55ms]
(pass) $debug > a plain call is expanded [647.51ms]
(pass) $debug > a call with type arguments is a bundle-time error [116.86ms]
(pass) $assert > a plain call is expanded [431.55ms]
(pass) $assert > a call with type arguments is a bundle-time error [86.62ms]
(pass) $rust > a plain call is expanded [540.91ms]
(pass) $rust > a call with type arguments is a bundle-time error [107.43ms]
(pass) $newRustFunction > a plain call is expanded [526.16ms]
(pass) $newRustFunction > a call with type arguments is a bundle-time error [104.76ms]
(pass) $cpp > a plain call is expanded [573.07ms]
(pass) $cpp > a call with type arguments is a bundle-time error [107.55ms]
(pass) $newCppFunction > a plain call is expanded [572.14ms]
(pass) $newCppFunction > a call with type arguments is a bundle-time error [105.63ms]
(pass) $bindgenFn > a plain
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     22be795666
  features     baseline

22 deps, 123 codegen, 1176 objects in 1083ms

ninja: Entering directory `/workspace/bun/build/release'
[1/735] cc obj/vendor/cares/src/lib/ares_library_init.c.o
[2/735] gen bindgenv2
[3/735] gen .bind.ts → GeneratedBindings.cpp
[4/735] cc obj/vendor/cares/src/lib/ares_metrics.c.o
[5/735] cc obj/vendor/cares/src/lib/ares_options.c.o
[6/735] cc obj/vendor/cares/src/lib/ares_parse_into_addrinfo.c.o
[7/735] fetch WebKit (prebuilt)
[WebKit] up to date
[8/735] cc obj/vendor/cares/src/lib/ares_process.c.o
[9/735] cc obj/vendor/cares/src/lib/ares_qcache.c.o
[10/735] cc obj/vendor/cares/src/lib/ares_query.c.o
[11/735] cc obj/vendor/cares/src/lib/ares_send.c.o
[12/735] cc obj/vendor/cares/src/lib/ares_search.c.o
[13/735] cc obj/vendor/cares/src/lib/ares_socket.c.o
[14/735] cc obj/vendor/cares/src/lib/ares_sortaddrinfo.c.o
[15/735] cc obj/vendor/cares/src/lib/ares_set_socket_functions.c.o
[16/735] cc obj/vendor/cares/src/lib/ares_strerror.c.o
[17/735] cc obj/v
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
.github/workflows/source-lints.yml                 |  2 +
 src/codegen/builtin-parser.ts                      |  3 +-
 src/codegen/replacements.ts                        | 13 ++-
 src/js/private.d.ts                                | 16 ++--
 .../source-lints/codegen-builtin-macros.test.ts    | 93 ++++++++++++++++++++++
 5 files changed, 113 insertions(+), 14 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
.github/workflows/source-lints.yml                            1      2      0
src/codegen/builtin-parser.ts                                 3      5      0
src/codegen/replacements.ts                                   4      4      0
src/js/private.d.ts                                           2      6      0
…st/internal/source-lints/codegen-builtin-macros.test.ts      3      4      0
```

</details>

<!-- robobun:evidence:end -->