### PR TITLE
repl: keep multi-line history entries on one line of the history file

### DIFF
--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -62,6 +62,10 @@ unsafe extern "C" {
 
 const MAX_HISTORY_SIZE: usize = 1000;
 const HISTORY_FILENAME: &[u8] = b".bun_repl_history";
+/// The history file holds one entry per line, so the newlines inside a
+/// multi-line entry are stored as this byte instead (as node's repl history
+/// does). Nothing else puts a CR in an entry: the line editor reads it as Enter.
+const HISTORY_STORED_NEWLINE: &[u8] = b"\r";
 
 // ANSI escape codes
 const CSI: &str = concat!("\x1b", "[");
@@ -204,14 +208,13 @@ impl History {
         };
 
         for line in strings::split(&content, b"\n") {
-            // Tolerate a file re-saved with CRLF line endings: that CR is not part
-            // of the entry, unlike the ones inside the line (see save()).
+            // A CRLF line ending; never entry content, since add() gets newline-trimmed input.
             let line = strings::trim_suffix(line, b"\r");
             if line.is_empty() {
                 continue;
             }
-            self.entries
-                .push(strings::replace_owned(line, b"\r", b"\n").into_boxed_slice());
+            let entry = strings::replace_owned(line, HISTORY_STORED_NEWLINE, b"\n");
+            self.entries.push(entry.into_boxed_slice());
         }
 
         // Trim to max size
@@ -240,11 +243,8 @@ impl History {
 
         let mut content: Vec<u8> = Vec::new();
         for entry in &self.entries[start..] {
-            // One entry per line: the newlines of a multi-line entry are stored as
-            // CR, as node's repl history does. This is lossless because an entry
-            // never contains a CR (Key::from_byte reads it as Enter) and never ends
-            // in a newline (handle_enter trims them), so load() can undo it exactly.
-            content.extend_from_slice(&strings::replace_owned(entry, b"\n", b"\r"));
+            let stored = strings::replace_owned(entry, b"\n", HISTORY_STORED_NEWLINE);
+            content.extend_from_slice(&stored);
             content.push(b'\n');
         }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -172,23 +172,6 @@ struct History {
     modified: bool,
 }
 
-/// Copies `entry` to `out`, replacing each `from` with `to`.
-///
-/// The history file holds one entry per line, so `save` stores the newlines of
-/// a multi-line entry as `\r` and `load` turns them back (the encoding node's
-/// repl history uses). `\r` is free for this because the line editor reads a
-/// typed `\r` as Enter, so no entry contains one.
-fn append_swapping_line_breaks(out: &mut Vec<u8>, entry: &[u8], from: &[u8], to: u8) {
-    let mut segments = strings::split(entry, from);
-    if let Some(first) = segments.next() {
-        out.extend_from_slice(first);
-    }
-    for segment in segments {
-        out.push(to);
-        out.extend_from_slice(segment);
-    }
-}
-
 impl History {
     fn init() -> History {
         History {
@@ -221,15 +204,14 @@ impl History {
         };
 
         for line in strings::split(&content, b"\n") {
-            // A CRLF line ending (file rewritten on Windows) is not part of the
-            // entry; drop it before the remaining CRs are decoded as newlines.
+            // Tolerate a file re-saved with CRLF line endings: that CR is not part
+            // of the entry, unlike the ones inside the line (see save()).
             let line = strings::trim_suffix(line, b"\r");
             if line.is_empty() {
                 continue;
             }
-            let mut entry: Vec<u8> = Vec::with_capacity(line.len());
-            append_swapping_line_breaks(&mut entry, line, b"\r", b'\n');
-            self.entries.push(entry.into_boxed_slice());
+            self.entries
+                .push(strings::replace_owned(line, b"\r", b"\n").into_boxed_slice());
         }
 
         // Trim to max size
@@ -258,7 +240,11 @@ impl History {
 
         let mut content: Vec<u8> = Vec::new();
         for entry in &self.entries[start..] {
-            append_swapping_line_breaks(&mut content, entry, b"\n", b'\r');
+            // One entry per line: the newlines of a multi-line entry are stored as
+            // CR, as node's repl history does. This is lossless because an entry
+            // never contains a CR (Key::from_byte reads it as Enter) and never ends
+            // in a newline (handle_enter trims them), so load() can undo it exactly.
+            content.extend_from_slice(&strings::replace_owned(entry, b"\n", b"\r"));
             content.push(b'\n');
         }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -172,6 +172,23 @@ struct History {
     modified: bool,
 }
 
+/// Copies `entry` to `out`, replacing each `from` with `to`.
+///
+/// The history file holds one entry per line, so `save` stores the newlines of
+/// a multi-line entry as `\r` and `load` turns them back (the encoding node's
+/// repl history uses). `\r` is free for this because the line editor reads a
+/// typed `\r` as Enter, so no entry contains one.
+fn append_swapping_line_breaks(out: &mut Vec<u8>, entry: &[u8], from: &[u8], to: u8) {
+    let mut segments = strings::split(entry, from);
+    if let Some(first) = segments.next() {
+        out.extend_from_slice(first);
+    }
+    for segment in segments {
+        out.push(to);
+        out.extend_from_slice(segment);
+    }
+}
+
 impl History {
     fn init() -> History {
         History {
@@ -204,9 +221,15 @@ impl History {
         };
 
         for line in strings::split(&content, b"\n") {
-            if !line.is_empty() {
-                self.entries.push(Box::<[u8]>::from(line));
+            // A CRLF line ending (file rewritten on Windows) is not part of the
+            // entry; drop it before the remaining CRs are decoded as newlines.
+            let line = strings::trim_suffix(line, b"\r");
+            if line.is_empty() {
+                continue;
             }
+            let mut entry: Vec<u8> = Vec::with_capacity(line.len());
+            append_swapping_line_breaks(&mut entry, line, b"\r", b'\n');
+            self.entries.push(entry.into_boxed_slice());
         }
 
         // Trim to max size
@@ -235,7 +258,7 @@ impl History {
 
         let mut content: Vec<u8> = Vec::new();
         for entry in &self.entries[start..] {
-            content.extend_from_slice(entry);
+            append_swapping_line_breaks(&mut content, entry, b"\n", b'\r');
             content.push(b'\n');
         }
 

--- a/src/runtime/cli/repl.rs
+++ b/src/runtime/cli/repl.rs
@@ -62,9 +62,7 @@ unsafe extern "C" {
 
 const MAX_HISTORY_SIZE: usize = 1000;
 const HISTORY_FILENAME: &[u8] = b".bun_repl_history";
-/// The history file holds one entry per line, so the newlines inside a
-/// multi-line entry are stored as this byte instead (as node's repl history
-/// does). Nothing else puts a CR in an entry: the line editor reads it as Enter.
+/// Replaces an entry's inner newlines in the one-entry-per-line file (entries never contain CR).
 const HISTORY_STORED_NEWLINE: &[u8] = b"\r";
 
 // ANSI escape codes

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1266,6 +1266,117 @@ describe.skipIf(isWindows)("REPL history file permissions", () => {
   });
 });
 
+describe.concurrent("REPL history file", () => {
+  // $HOME/.bun_repl_history holds one entry per line; the newlines inside a
+  // multi-line entry are written as '\r' so the entry survives a restart.
+  const ARROW_UP = "\x1b[A";
+
+  async function runReplWithHome(home: string, input: string[]) {
+    const { stdout, stderr, exitCode } = await runRepl(input, { env: { HOME: home, USERPROFILE: home } });
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    const out = stripAnsi(stdout);
+    // Everything after the banner. With piped stdin the input is not echoed;
+    // the output is a "> " prompt each time the REPL is back at top level
+    // plus whatever each input printed.
+    return out.slice(out.indexOf("> "));
+  }
+
+  // The physical lines of the history file (the last one is the "" after the
+  // final newline).
+  async function savedLines(home: string) {
+    const content = await Bun.file(path.join(home, ".bun_repl_history")).text();
+    return content.split("\n");
+  }
+
+  test("multi-line entry is saved on one line and reloads as one entry", async () => {
+    using dir = tempDir("repl-history-multiline", {});
+    const home = String(dir);
+
+    await runReplWithHome(home, ["function f() {", "  return 1", "}", ".exit"]);
+
+    expect(await savedLines(home)).toEqual(["function f() {\r  return 1\r}", ""]);
+
+    // Next session: recall the entry with the up arrow and run it, then list
+    // the history. The recalled entry defines f, and re-running it does not
+    // add a duplicate entry.
+    const session = await runReplWithHome(home, [ARROW_UP, "f()", ".history", ".exit"]);
+    expect(session).toMatchInlineSnapshot(`
+      "> 
+      undefined
+      > 
+      1
+      > 
+
+      Command History:
+           1  function f() {
+        return 1
+      }
+           2  f()
+
+      > 
+      "
+    `);
+  });
+
+  test("entries with blank lines round-trip in order", async () => {
+    using dir = tempDir("repl-history-mixed", {});
+    const home = String(dir);
+
+    await runReplWithHome(home, ["const a = 1", "function g() {", "", "  return 2", "}", "const b = 3", ".exit"]);
+
+    expect(await savedLines(home)).toEqual(["const a = 1", "function g() {\r\r  return 2\r}", "const b = 3", ""]);
+
+    const session = await runReplWithHome(home, [".history", ".exit"]);
+    expect(session).toMatchInlineSnapshot(`
+      "> 
+
+      Command History:
+           1  const a = 1
+           2  function g() {
+
+        return 2
+      }
+           3  const b = 3
+
+      > 
+      "
+    `);
+  });
+
+  test("loads a CRLF history file without keeping the line endings", async () => {
+    // A history file rewritten with CRLF line endings (Windows, or a CRLF
+    // editor): the '\r' before each '\n' is part of the line ending, while
+    // the ones inside the second entry are its stored newlines.
+    using dir = tempDir("repl-history-crlf", {
+      ".bun_repl_history": "1 + 1\r\nfunction h() {\r  return 3\r}\r\n",
+    });
+    const home = String(dir);
+
+    const session = await runReplWithHome(home, [".history", "2 + 2", ".exit"]);
+    // Snapshot matching tolerates CRLF, so check for a leaked '\r' explicitly.
+    expect(session).not.toContain("\r");
+    expect(session).toMatchInlineSnapshot(`
+      "> 
+
+      Command History:
+           1  1 + 1
+           2  function h() {
+        return 3
+      }
+
+      > 
+      4
+      > 
+      "
+    `);
+
+    // Re-saved with plain '\n' line endings; the stored newlines inside the
+    // multi-line entry are kept.
+    expect(await savedLines(home)).toEqual(["1 + 1", "function h() {\r  return 3\r}", "2 + 2", ""]);
+  });
+});
+
 // `bun --interactive` boots the full node:repl + readline + acorn stack; on a
 // debug+asan build that is ~4–5s per spawn, so the 5s default is too tight.
 const interactiveTimeout = 20_000;

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1345,9 +1345,9 @@ describe.concurrent("REPL history file", () => {
   });
 
   test("loads a CRLF history file without keeping the line endings", async () => {
-    // A history file rewritten with CRLF line endings (Windows, or a CRLF
-    // editor): the '\r' before each '\n' is part of the line ending, while
-    // the ones inside the second entry are its stored newlines.
+    // A history file re-saved by a CRLF editor: the '\r' before each '\n' is
+    // part of the line ending, while the ones inside the second entry are its
+    // stored newlines.
     using dir = tempDir("repl-history-crlf", {
       ".bun_repl_history": "1 + 1\r\nfunction h() {\r  return 3\r}\r\n",
     });

--- a/test/js/bun/repl/repl.test.ts
+++ b/test/js/bun/repl/repl.test.ts
@@ -1375,6 +1375,33 @@ describe.concurrent("REPL history file", () => {
     // multi-line entry are kept.
     expect(await savedLines(home)).toEqual(["1 + 1", "function h() {\r  return 3\r}", "2 + 2", ""]);
   });
+
+  test("a CRLF file of single-line entries loads and is re-saved without the CRs", async () => {
+    // A history file written on Windows, or edited in a CRLF editor: every '\r'
+    // is part of a line ending, so none of them may end up in an entry, where
+    // it would show in recall and .history and be written back on every save.
+    using dir = tempDir("repl-history-crlf-single-line", {
+      ".bun_repl_history": "old_one\r\nold_two\r\n",
+    });
+    const home = String(dir);
+
+    const session = await runReplWithHome(home, [".history", "2 + 2", ".exit"]);
+    expect(session).not.toContain("\r");
+    expect(session).toMatchInlineSnapshot(`
+      "> 
+
+      Command History:
+           1  old_one
+           2  old_two
+
+      > 
+      4
+      > 
+      "
+    `);
+
+    expect(await savedLines(home)).toEqual(["old_one", "old_two", "2 + 2", ""]);
+  });
 });
 
 // `bun --interactive` boots the full node:repl + readline + acorn stack; on a


### PR DESCRIPTION
### Problem
- `bun repl` keeps a multi-line input (a function typed over three lines, say) as one history entry, but `History::save` in `src/runtime/cli/repl.rs` writes every entry verbatim followed by `\n`, so that entry lands in `~/.bun_repl_history` as three physical lines.
- `History::load` splits the file on `\n`, so the next session gets three entries: `function f() {`, `  return 1`, `}`. Arrow-up recalls a fragment (a syntax error, or it drops into multi-line mode) and `.history` lists the fragments. Within the session that typed it, the same input is one entry, so only the file round trip is wrong.
- The same `\n`-only split keeps the `\r` of a CRLF line ending (a history file written on Windows or re-saved by a CRLF editor) on every loaded entry, so `.history` prints `old_one\r`, recall inserts the CR, and the next save writes it back (#30293, previously carried by #36510).
- Repro on bun 1.4.0: `printf 'function f() {\n  return 1\n}\n.exit\n' | HOME=/tmp/h bun repl`, then `.history` in a second `HOME=/tmp/h bun repl` lists 3 entries. For the CRLF case: `printf 'old_one\r\nold_two\r\n' > /tmp/h/.bun_repl_history`, then `.history` in `HOME=/tmp/h bun repl` prints `1  old_one\r`.

### Fix
- `save` writes the newlines inside an entry as `HISTORY_STORED_NEWLINE` (`\r`), so each entry is exactly one line of the file. `load` drops a CRLF line ending and turns the remaining `\r`s back into `\n`. Both directions are `strings::replace_owned`.
- A typed `\r` never reaches an entry: the line editor reads it as Enter (`Key::from_byte`), so using it as the stored form of a newline does not change the meaning of any typed entry. The one way a CR can get into an entry is tab-completing a property whose name contains one; that entry comes back with `\n` in its place, which JS treats as a line terminator just like CR, so it still evaluates the same. This is the encoding node's repl history uses, with the same edge (`internal/repl/history.js` swaps `\n` and `\r` when storing an entry and keeps one entry per line of `.node_repl_history`).
- Entries are added with their surrounding newlines trimmed (`handle_enter`), so a stored entry never ends in `\r`; stripping one trailing `\r` per line is therefore unambiguous. It is also what keeps a CRLF-converted file loading correctly, since otherwise the line ending would now decode into a trailing newline on every entry. Node's loader likewise splits its history file on `/\r?\n+/`.
- Files written by bun so far contain no `\r`, so they load exactly as before (an entry an older bun already split stays split); CRLF-converted files are the intended change above. A file written by this version still loads in an older bun as one entry per line, with the CRs of a multi-line entry shown raw; the entry still evaluates, since CR is a line terminator.
- In-memory entries keep real newlines, so `.history`, recall, the last-entry duplicate check and `.save` (which writes source code, where the newlines belong) are unchanged.
- Verified with the `REPL history file` block in `test/js/bun/repl/repl.test.ts`: the file holds the multi-line entry on one line and the next session lists it as one entry, recalls it with arrow-up and runs it; entry order and blank lines inside an entry survive the round trip; a CRLF file containing a stored multi-line entry loads without stray `\r`s and is re-saved with LF endings; a CRLF file of ordinary single-line entries (the #30293 case) does the same. All four fail on bun 1.4.0 and pass with this change.
- The whole file passes on a debug build (152 tests); `cargo fmt --check` and `cargo clippy -p bun_runtime` are clean.

### Relation to #36510 and #30293
- The trailing-CR strip in `load` is the fix @samuelpatro contributed in #30293 (against the Zig REPL); #36510 re-applied it to `repl.rs` and has been closed in favour of this PR, which needs the same strip for the decode. The commits here carry the `Co-authored-by` trailer from those PRs, and #36510's test case is the last test in the block.
- This PR's branch was verified against #36510's test and repro before #36510 was closed: #36510's test passes unchanged on a build of this branch, and the repro above prints the entries without `\r` and re-saves the file with LF endings.

### Background
- A history entry is the text of one evaluated input. In multi-line mode the REPL accumulates the typed lines in `multiline_buffer` and, once the code parses, adds the whole buffer (embedded newlines included) as a single entry.
- The history file is `$HOME/.bun_repl_history` (`USERPROFILE` on Windows). It is read once at startup and rewritten from the in-memory entries on exit (only if an entry was added during the session); its only structure is one entry per line, which is why an entry's own newlines need a different in-line byte. Bun itself always writes LF; CRLF endings only come from an external editor.
- Issue #27560 (the terminal redraw of a recalled multi-line entry) is a display bug in `refresh_line` and is not touched here; this change only affects what is written to and read from the file. Until it is fixed, recalling a multi-line entry from a previous session redraws the same way recalling one from the current session already does.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/repl/repl.test.ts

<!-- robobun:evidence:end -->

