### PR TITLE
dns: keep the c-ares uv_poll_t alive while its poll callback is on the stack (Windows)

### DIFF
--- a/patches/libuv/win-poll-no-reendgame-after-close.patch
+++ b/patches/libuv/win-poll-no-reendgame-after-close.patch
@@ -1,0 +1,29 @@
+--- a/src/win/poll.c
++++ b/src/win/poll.c
+@@ -217,8 +217,14 @@ static void uv__fast_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
+       handle->submitted_events_2)) != 0) {
+     uv__fast_poll_submit_poll_req(loop, handle);
+   } else if ((handle->flags & UV_HANDLE_CLOSING) &&
++             !(handle->flags & UV_HANDLE_CLOSED) &&
+              handle->submitted_events_1 == 0 &&
+              handle->submitted_events_2 == 0) {
++    /* A nested uv_run entered from inside poll_cb may have already run this
++     * handle's endgame: uv__process_endgames cleared ENDGAME_QUEUED and
++     * uv__handle_close set CLOSED. Re-queuing it here would run the endgame
++     * again, which uv__poll_endgame asserts against and which invokes
++     * close_cb a second time. */
+     uv__want_endgame(loop, (uv_handle_t*) handle);
+   }
+ }
+@@ -418,8 +424,11 @@ static void uv__slow_poll_process_poll_req(uv_loop_t* loop, uv_poll_t* handle,
+       handle->submitted_events_2)) != 0) {
+     uv__slow_poll_submit_poll_req(loop, handle);
+   } else if ((handle->flags & UV_HANDLE_CLOSING) &&
++             !(handle->flags & UV_HANDLE_CLOSED) &&
+              handle->submitted_events_1 == 0 &&
+              handle->submitted_events_2 == 0) {
++    /* Same as the fast path: never re-queue an endgame that a nested uv_run
++     * already ran for this handle. */
+     uv__want_endgame(loop, (uv_handle_t*) handle);
+   }
+ }

--- a/scripts/build/deps/libuv.ts
+++ b/scripts/build/deps/libuv.ts
@@ -53,7 +53,18 @@ export const libuv: Dependency = {
   // an in-process loopback fetch().abort() can fall into. To upstream:
   // send to libuv/libuv with the wepoll/ReactOS references in the patch
   // comment as the rationale.
-  patches: ["patches/libuv/win-poll-rearm-before-callback.patch", "patches/libuv/win-poll-abort-with-disconnect.patch"],
+  //
+  // win-poll-no-reendgame-after-close: the post-poll_cb endgame check in
+  // uv__fast_poll_process_poll_req (and its slow-poll sibling) re-queues a
+  // handle whose endgame a nested uv_run, entered from inside poll_cb,
+  // already ran, which double-invokes close_cb. Guard the check on
+  // !(flags & UV_HANDLE_CLOSED), which uv__poll_endgame already asserts.
+  // Nested uv_run is outside libuv's contract, so this is not upstreamable.
+  patches: [
+    "patches/libuv/win-poll-rearm-before-callback.patch",
+    "patches/libuv/win-poll-abort-with-disconnect.patch",
+    "patches/libuv/win-poll-no-reendgame-after-close.patch",
+  ],
 
   build: () => ({
     kind: "direct",

--- a/src/runtime/dns_jsc/dns.rs
+++ b/src/runtime/dns_jsc/dns.rs
@@ -3685,6 +3685,15 @@ pub(crate) struct UvDnsPoll {
     // `Resolver::deref`, which may write/free `*this`.
     pub parent: *mut Resolver,
     pub socket: c_ares::ares_socket_t,
+    /// `on_dns_poll_uv` frames for this handle currently on the stack. libuv
+    /// reads `poll` again after each one returns, so while this is non-zero
+    /// the allocation must stay alive even if libuv has already closed the
+    /// handle (a nested `uv_run` spun from JS inside the callback runs the
+    /// endgame phase, and with it `on_close_uv`, underneath the frame).
+    poll_cb_depth: u32,
+    /// `on_close_uv` ran while `poll_cb_depth` was non-zero; the outermost
+    /// frame frees the allocation once it unwinds instead.
+    closed: bool,
     pub poll: libuv::uv_poll_t,
 }
 
@@ -3694,12 +3703,28 @@ impl UvDnsPoll {
         bun_core::heap::into_raw(Box::new(Self {
             parent,
             socket,
+            poll_cb_depth: 0,
+            closed: false,
             poll: bun_core::ffi::zeroed(),
         }))
     }
 
     fn destroy(this: *mut Self) {
         unsafe { drop(bun_core::heap::take(this)) };
+    }
+
+    /// libuv's `uv__fast_poll_process_poll_req` (and its slow-poll sibling)
+    /// still reads `poll` after `on_dns_poll_uv` returns, so a handle whose
+    /// close callback already ran underneath that frame is freed from the task
+    /// queue, which the loop drains only after the libuv callback has returned.
+    fn destroy_after_poll_cb_returns(this: *mut Self, vm: &VirtualMachine) {
+        fn run(this: *mut UvDnsPoll) -> bun_event_loop::JsResult<()> {
+            UvDnsPoll::destroy(this);
+            Ok(())
+        }
+        // `new_owned` also frees `this` if the VM tears down before the task runs.
+        vm.event_loop_mut()
+            .enqueue_task(jsc::ManagedTask::ManagedTask::new_owned(this, run));
     }
 
     fn from_poll(poll: *mut libuv::uv_poll_t) -> *mut Self {
@@ -4730,44 +4755,67 @@ impl Resolver {
     ) {
         let poll = UvDnsPoll::from_poll(watcher);
         // SAFETY: `poll` is the live `UvDnsPoll` recovered from libuv's `watcher`
-        // via `from_poll` (libuv guarantees the handle outlives this callback).
+        // via `from_poll`; `on_close_uv` leaves it allocated while
+        // `poll_cb_depth` is non-zero, so it stays valid through this frame even
+        // if c-ares closes the socket below and JS then re-enters the loop.
         // `parent` is the heap-allocated Resolver back-ptr (set in
         // `on_dns_socket_state`); it is kept alive across `Channel::process` by the
         // `ref_()`/`_deref` bracket below. `channel` is non-null because c-ares
         // must have been initialized for this poll callback to fire.
         unsafe {
+            (*poll).poll_cb_depth += 1;
             let parent: *mut Resolver = (*poll).parent;
             let vm = (*parent).vm.get();
-            let _exit = vm.enter_event_loop_scope();
-            // SAFETY: `parent` is the live heap-allocated Resolver back-ptr.
-            let _deref = Self::ref_scope(parent);
-            // channel must be non-null here as c_ares must have been initialized if we're receiving callbacks
-            let channel = (*parent).channel.get().unwrap();
-            if status < 0 {
-                // an error occurred. just pretend that the socket is both readable and writable.
-                // https://github.com/nodejs/node/blob/8a41d9b636be86350cd32847c3f89d327c4f6ff7/src/cares_wrap.cc#L93
-                (*channel).process((*poll).socket, true, true);
-            } else {
-                (*channel).process(
-                    (*poll).socket,
-                    events & libuv::UV_READABLE != 0,
-                    events & libuv::UV_WRITABLE != 0,
-                );
-            }
+            {
+                let _exit = vm.enter_event_loop_scope();
+                // SAFETY: `parent` is the live heap-allocated Resolver back-ptr.
+                let _deref = Self::ref_scope(parent);
+                // channel must be non-null here as c_ares must have been initialized if we're receiving callbacks
+                let channel = (*parent).channel.get().unwrap();
+                if status < 0 {
+                    // an error occurred. just pretend that the socket is both readable and writable.
+                    // https://github.com/nodejs/node/blob/8a41d9b636be86350cd32847c3f89d327c4f6ff7/src/cares_wrap.cc#L93
+                    (*channel).process((*poll).socket, true, true);
+                } else {
+                    (*channel).process(
+                        (*poll).socket,
+                        events & libuv::UV_READABLE != 0,
+                        events & libuv::UV_WRITABLE != 0,
+                    );
+                }
 
-            // See `on_dns_poll` for why this re-check follows `ares_process_fd`.
-            if !(*parent).any_requests_pending() {
-                (*parent).remove_timer();
+                // See `on_dns_poll` for why this re-check follows `ares_process_fd`.
+                if !(*parent).any_requests_pending() {
+                    (*parent).remove_timer();
+                }
+                // `_deref` drops here (may free the resolver), then `_exit` drains
+                // microtasks: JS runs, and may spin a nested `uv_run` whose endgame
+                // phase calls `on_close_uv` for this very handle.
+            }
+            (*poll).poll_cb_depth -= 1;
+            if (*poll).poll_cb_depth == 0 && (*poll).closed {
+                UvDnsPoll::destroy_after_poll_cb_returns(poll, vm);
             }
         }
     }
 
     #[cfg(windows)]
     pub(crate) unsafe extern "C" fn on_close_uv(watcher: *mut libuv::uv_handle_t) {
+        let poll = UvDnsPoll::from_poll(watcher.cast());
         // SAFETY: libuv invokes the close cb with the same handle pointer passed
         // to `uv_close`, which was `&mut UvDnsPoll::poll` (a `uv_poll_t` whose
-        // header is `uv_handle_t`); `from_poll` recovers the containing struct.
-        let poll = UvDnsPoll::from_poll(watcher.cast());
+        // header is `uv_handle_t`), and exactly once per handle
+        // (patches/libuv/win-poll-no-reendgame-after-close.patch covers the
+        // nested case). `from_poll` recovers the containing struct, which is
+        // still allocated: it is freed only below or, after this function
+        // defers, by the `on_dns_poll_uv` frame that is still on the stack.
+        unsafe {
+            debug_assert!(!(*poll).closed);
+            if (*poll).poll_cb_depth > 0 {
+                (*poll).closed = true;
+                return;
+            }
+        }
         UvDnsPoll::destroy(poll);
     }
 

--- a/test/js/node/dns/node-dns.test.js
+++ b/test/js/node/dns/node-dns.test.js
@@ -491,6 +491,90 @@ test.skipIf(!isLinux)("dns.lookup uses getaddrinfo, not the c-ares resolver", as
   expect(exitCode).toBe(0);
 });
 
+// Windows drives each c-ares socket with a libuv uv_poll_t. c-ares closes the
+// UDP socket as soon as the answer arrives, i.e. from inside that handle's poll
+// callback, and the callback's microtask drain then runs the query's promise
+// reactions. A reaction that synchronously spins the event loop (a nested
+// uv_run) used to run libuv's close callback, which freed the uv_poll_t while
+// libuv's own poll-dispatch frame for it was still suspended underneath and
+// reads the handle again once the callback returns. The freed handle was then
+// closed a second time, and the release build crashed after a few rounds.
+// POSIX polls c-ares sockets with FilePoll, which is not involved.
+test.skipIf(!isWindows)("dns.Resolver: a query's promise reaction may re-enter the event loop", async () => {
+  const rounds = 20;
+  const fixture = `
+    const dns = require("node:dns");
+    // Echo the question back with one A record for it.
+    function answer(query) {
+      let off = 12;
+      while (off < query.length && query[off] !== 0) off += query[off] + 1;
+      off += 1 + 2 + 2;
+      const header = Buffer.alloc(12);
+      header[0] = query[0];
+      header[1] = query[1];
+      header[2] = 0x81; // QR=1, RD=1
+      header[3] = 0x80; // RA=1
+      header[5] = 1; // QDCOUNT
+      header[7] = 1; // ANCOUNT
+      const record = Buffer.from([
+        0xc0, 0x0c, // NAME: pointer to the question name
+        0x00, 0x01, // TYPE A
+        0x00, 0x01, // CLASS IN
+        0x00, 0x00, 0x00, 0x3c, // TTL 60
+        0x00, 0x04, // RDLENGTH
+        127, 0, 0, 1,
+      ]);
+      return Buffer.concat([header, query.subarray(12, off), record]);
+    }
+    const server = await Bun.udpSocket({
+      hostname: "127.0.0.1",
+      port: 0,
+      socket: { data(sock, buf, port, addr) { sock.send(answer(Buffer.from(buf)), port, addr); } },
+    });
+    const resolver = new dns.promises.Resolver({ timeout: 5000, tries: 1 });
+    resolver.setServers(["127.0.0.1:" + server.port]);
+
+    // Bun.build() runs a plugin's setup() while it parses its options and, if
+    // setup() returns a pending promise, spins the event loop until it settles.
+    // Called from a promise reaction, that is a nested event loop tick inside
+    // the I/O callback that settled the promise.
+    let reentries = 0;
+    const builds = [];
+    function reenterEventLoop() {
+      const before = reentries;
+      builds.push(Bun.build({
+        entrypoints: ["/entry.js"],
+        files: { "/entry.js": "" },
+        plugins: [{
+          name: "spin",
+          setup: () => new Promise(resolve => setImmediate(() => { reentries++; resolve(); })),
+        }],
+      }));
+      if (reentries !== before + 1) throw new Error("Bun.build() returned without spinning the event loop");
+    }
+
+    // A different name every round: c-ares answers a repeated name from its
+    // own cache without touching the network, and the socket is the point.
+    for (let i = 0; i < ${rounds}; i++) {
+      const addresses = await resolver.resolve4("round" + i + ".example.test").then(addresses => {
+        reenterEventLoop();
+        return addresses;
+      });
+      if (addresses[0] !== "127.0.0.1") throw new Error("unexpected answer: " + addresses);
+    }
+    await Promise.all(builds);
+    server.close();
+    console.log("reentries=" + reentries);
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", fixture],
+    env: bunEnv,
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  expect({ stdout, stderr, exitCode }).toEqual({ stdout: `reentries=${rounds}\n`, stderr: "", exitCode: 0 });
+});
+
 test("dns.getServers", () => {
   function parseResolvConf() {
     const servers = [];


### PR DESCRIPTION
### Problem

- Windows only. A `dns.promises.Resolver` (or `dns.Resolver`) query whose promise reaction synchronously spins the event loop crashes the release build after about ten queries: `panic(main thread): Segmentation fault at address 0x0` (also seen as `address 0x600000030`). Levers that spin the loop from a reaction include `Bun.build()` with a plugin whose `setup()` returns a pending promise, and `expect().resolves` in `bun:test`.
- Each c-ares socket is driven by a `uv_poll_t` embedded in a heap `UvDnsPoll` (`src/runtime/dns_jsc/dns.rs`). c-ares closes a UDP socket as soon as its answer has been processed, which happens inside `Channel::process` in `on_dns_poll_uv` (dns.rs:4726 on main), so `on_dns_socket_state` issues the `uv_close` (dns.rs:4830) from inside the handle's own poll callback.
- `on_dns_poll_uv` then drains microtasks (`EventLoopEnterGuard` drop). A reaction that re-enters the loop runs a nested `uv_run`; its endgame phase invoked `on_close_uv`, which freed the `UvDnsPoll` immediately (dns.rs:4771).
- libuv's `uv__fast_poll_process_poll_req` frame for that handle is still suspended underneath `on_dns_poll_uv` and reads `handle->events`, `submitted_events_*` and `flags` once the callback returns (vendor `src/win/poll.c`, the block after `poll_cb`). On the stale bytes it re-queues the endgame of the already closed handle, `on_close_uv` runs a second time, and the struct is freed twice; mimalloc then hands the block out twice and a later round crashes.
- Same shape as the uSockets bug in #33018, whose review (alii) pointed at this copy. The POSIX path polls c-ares sockets with `FilePoll`, whose dispatch does not touch the poll after the callback, and is not affected.

### Fix

- `UvDnsPoll` counts the `on_dns_poll_uv` frames currently active for it (`poll_cb_depth`). `on_close_uv` frees the struct only when that is zero; otherwise it just marks the handle `closed`.
- When the outermost frame finishes (after its microtask drain, so after any nested `uv_run`) and sees `closed`, it hands the struct to the event loop task queue (`ManagedTask::new_owned`, the same primitive `cares_jsc.rs` already uses; it also frees the struct if the VM tears down first). Bun drains that queue from its own tick, never from inside the libuv callback that enqueued the task, so by the time the task runs the frame that enqueued it has returned and libuv's tail behind it has finished reading the handle.
- Why this is the right boundary: after `on_dns_socket_state` removes the map entry, the only things still referring to a `UvDnsPoll` are the suspended `on_dns_poll_uv` frames for it and libuv's tail under each of them, which is exactly what the counter tracks. libuv does not invoke `poll_cb` for a closing handle, so the count can only go down once `uv_close` was issued, and the close callback reaching a handle with a zero count means no frame holds it, which is today's behavior unchanged. Re-entrant dispatch of the same handle (depth 2) works the same way: inner frames only decrement, the outermost one defers.
- `patches/libuv/win-poll-no-reendgame-after-close.patch` (and its entry in `deps/libuv.ts`) is a byte-identical copy of the patch in #33018: once the struct stays alive, unpatched libuv reads real flags in the tail and re-queues the endgame of the CLOSED handle, invoking `close_cb` twice (double free in release; in debug `uv__poll_endgame` asserts, trace below). The patch guards the re-queue on `!(flags & UV_HANDLE_CLOSED)`, which `uv__poll_endgame` already asserts. Whichever of the two PRs lands second drops the duplicate on rebase.
- The common path is unchanged: with no re-entry, the close callback arrives after the poll callback returned, the count is zero, and `on_close_uv` frees immediately as before (trace below shows 20/20 queries taking that branch).
- Test: `test/js/node/dns/node-dns.test.js`, "dns.Resolver: a query's promise reaction may re-enter the event loop". A child answers 20 `resolve4()` queries from a local UDP responder and re-enters the loop from each reaction via `Bun.build()`; it also checks the re-entry really was synchronous (`HTMLRewriter.transform()`, which #33018 uses, no longer spins the loop on main). Distinct names per query keep c-ares from answering later rounds from its own cache. Windows only (`skipIf(!isWindows)`).
- Verified on Windows x64:
  - `USE_SYSTEM_BUN=1 bun test ... -t "promise reaction may re-enter"` (canary 1.4.0, unfixed): fail, child exit 3 with the segfault above; the repro script crashed by round 9 or 10 in 10/10 runs.
  - `bun bd test test/js/node/dns/node-dns.test.js -t "promise reaction may re-enter"` on this branch: pass. Whole file: 133 pass, 0 fail (canary: 132 pass, only the new test failing).
  - `test/js/node/dns/` + `test/js/bun/dns/`: 222 pass, 0 fail on rerun (one `dns.getServers` failure in the first run; it compares against `node -e dns.getServers()` and passed alone and in the full-file reruns on the same build).
  - 10 node `test-dns-*` / `test-worker-dns-terminate-during-query` tests that use local servers: all exit 0.
  - Since the libuv patch affects every `uv_poll_t`: `socket.test.ts` 76 pass, `tcp-server`, `udp_socket`, `socket-retention`, `worker-terminate-lifetime` 228 pass, 0 fail.
- Fail-before is visible on release builds only, which is what the Windows CI lanes run: in a debug build mimalloc fills freed memory with `0xDF`, which makes libuv's stale read take its "both request slots busy" no-op branch, so the unfixed debug build reads freed memory silently. The instrumented traces below show the free inside the frame on the unfixed build regardless.

### Background

- A libuv handle is closed with `uv_close(handle, close_cb)`; libuv invokes `close_cb` later, from the endgame phase of a `uv_run` iteration, and the embedding struct may only be freed from `close_cb` or later. For a `uv_poll_t` the endgame is reached once its outstanding AFD poll requests have completed; bun's existing rearm patch means one is always outstanding during `poll_cb`, so `uv_close` from inside `poll_cb` cancels it and the endgame comes from whichever `uv_run` iteration dequeues that cancellation.
- `uv__fast_poll_process_poll_req` is the libuv function that calls `poll_cb`; after the callback it checks whether to resubmit a request or, for a closing handle, queue the endgame. libuv assumes `uv_run` is not re-entered from a callback, so it never expects the endgame to have run in between.
- bun does re-enter it: `EventLoop::wait_for_promise` (behind `Bun.build()` option parsing, `bun:test`'s `.resolves`/`.rejects`, and others) calls `auto_tick`, which on Windows is `us_loop_run`/`us_loop_pump`, i.e. a nested `uv_run`.
- `EventLoopEnterGuard` (`enter_event_loop_scope`) is how native callbacks drain microtasks when they return; that drain is where the promise reactions run, still inside the libuv callback.
- `ManagedTask` is the event loop's one-off heap task; a task enqueued during a libuv callback runs when bun drains its task queue after `uv_run` returns, or is released (here: freed) if the VM tears down before that.

<details>
<summary>Instrumented traces (Windows x64 debug builds, one query shown; eprintln added locally, not in this diff)</summary>

Unfixed (main). `close_cb` frees the struct between the reaction's start and end, i.e. while `poll_cb` for the same handle is still on the stack; the same sequence repeated for all 20 queries:

```
[uv] poll_cb enter poll=0x222807e0540 fd=840 status=0 events=1
[uv] uv_close poll=0x222807e0540 fd=840
[js] round 0: before re-entry
[uv] close_cb poll=0x222807e0540
[js] round 0: after re-entry
[uv] poll_cb exit poll=0x222807e0540
```

This branch, with re-entry (20/20 deferred, 0 freed early, 20 deferred frees ran):

```
[uv] poll_cb enter poll=0x1ef007e0540 fd=832 depth=0
[uv] uv_close poll=0x1ef007e0540 fd=832
[js] round 0: before re-entry
[uv] close_cb poll=0x1ef007e0540 depth=1
[uv] close_cb: poll_cb frame active, deferring free poll=0x1ef007e0540
[js] round 0: after re-entry
[uv] enqueue deferred destroy poll=0x1ef007e0540
[uv] poll_cb exit poll=0x1ef007e0540
[uv] deferred destroy task ran poll=0x1ef007e0540
```

This branch, without re-entry (20/20 freed directly in `close_cb`, no task enqueued):

```
[uv] poll_cb enter poll=0x1dc007e0540 fd=828 depth=0
[uv] uv_close poll=0x1dc007e0540 fd=828
[uv] poll_cb exit poll=0x1dc007e0540
[uv] close_cb poll=0x1dc007e0540 depth=0
[uv] close_cb: freeing now poll=0x1dc007e0540
```

This branch's dns.rs change with the libuv patch removed from `deps/libuv.ts`: the now-live handle makes libuv's post-callback check re-queue the endgame, and the first query aborts in libuv:

```
[uv] enqueue deferred destroy poll=0x2be007e0540
[uv] poll_cb exit poll=0x2be007e0540
Assertion failed: !(handle->flags & UV_HANDLE_CLOSED), file ..\..\vendor\libuv\src\win\poll.c, line 623
```

</details>
