### PR TITLE
pm pkg: support arrays in set and delete

### DIFF
--- a/docs/pm/cli/pm.mdx
+++ b/docs/pm/cli/pm.mdx
@@ -324,6 +324,8 @@ bun pm pkg get scripts.build                      # nested property
 bun pm pkg set name="my-package"                  # simple property
 bun pm pkg set scripts.test="jest" version=2.0.0  # multiple properties
 bun pm pkg set private=true --json                # JSON values with --json flag
+bun pm pkg set 'keywords[]=cli'                   # append to an array (created if missing)
+bun pm pkg set 'contributors[0].name=Jane'        # update an array element
 
 # delete
 bun pm pkg delete description                     # single property

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -624,14 +624,12 @@ impl PmPkgCommand {
                     Some(index) if index <= len => index,
                     Some(index) => {
                         Output::err_generic(
-                            "{s}: index {s} is out of range for {s} (length {s})\n<blue>note<r><d>:<r> {s}[] appends to the end of the array",
-                            (
-                                quote(key),
-                                index,
-                                quote(container_name),
-                                len,
-                                bstr::BStr::new(container_name),
-                            ),
+                            "{s}: index {s} is out of range for {s} (length {s})",
+                            (quote(key), index, quote(container_name), len),
+                        );
+                        bun_core::note!(
+                            "{}[] appends to the end of the array",
+                            bstr::BStr::new(container_name)
                         );
                         Global::exit(1);
                     }

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -51,7 +51,16 @@ struct PackageJson {
 
 /// One step of a key path such as `contributors[0].name` or `keywords[]`.
 #[derive(Clone, Copy)]
-enum Segment<'a> {
+struct Segment<'a> {
+    kind: SegmentKind<'a>,
+    /// Offset just past this segment in the key it was parsed from, so
+    /// `&key[..end]` is the path down to it (`contributors[0]` for the second
+    /// segment of `contributors[0].name`). Error messages name values this way.
+    end: usize,
+}
+
+#[derive(Clone, Copy)]
+enum SegmentKind<'a> {
     /// `b` in `a.b` or `a[b]`. Applied to an existing array it is an index,
     /// applied to an object it is a property name.
     Key { name: &'a [u8], bracketed: bool },
@@ -59,25 +68,18 @@ enum Segment<'a> {
     Append,
 }
 
-impl<'a> Segment<'a> {
+impl Segment<'_> {
     /// Whether `set` creates an array (rather than an object) for this segment
     /// to land in when nothing exists yet: `files[0]=x` and `files[]=x` create
     /// an array, `config.0=x` creates an object with the property `"0"`.
     fn creates_array(self) -> bool {
-        match self {
-            Segment::Key {
+        match self.kind {
+            SegmentKind::Key {
                 name,
                 bracketed: true,
             } => array_index(name).is_some(),
-            Segment::Key { .. } => false,
-            Segment::Append => true,
-        }
-    }
-
-    fn name(self) -> &'a [u8] {
-        match self {
-            Segment::Key { name, .. } => name,
-            Segment::Append => b"[]",
+            SegmentKind::Key { .. } => false,
+            SegmentKind::Append => true,
         }
     }
 }
@@ -532,7 +534,7 @@ impl PmPkgCommand {
     fn resolve_path(root: Expr, key: &[u8]) -> Result<Expr, Error> {
         let mut current = root;
         for segment in Self::parse_key_path(key)? {
-            let Segment::Key { name, .. } = segment else {
+            let SegmentKind::Key { name, .. } = segment.kind else {
                 return Err(crate::Error::InvalidPath);
             };
             current = match &current.data {
@@ -547,48 +549,49 @@ impl PmPkgCommand {
     }
 
     /// Splits `a.b[0][c][]` into `[Key("a"), Key("b"), Key("0"), Key("c"), Append]`.
-    /// Segments are sub-slices of `key`: `E::Object::put` stores keys by
+    /// Names are sub-slices of `key`: `E::Object::put` stores keys by
     /// reference (no copy into the AST arena), so they must outlive the `Expr`
     /// tree, which `key` (an argv slice) does. Returning owned buffers here
     /// would leave dangling keys.
     fn parse_key_path(key: &[u8]) -> Result<Vec<Segment<'_>>, Error> {
         let mut segments: Vec<Segment<'_>> = Vec::new();
 
-        for part in strings::tokenize(key, b".") {
-            let Some(first_bracket) = strings::index_of(part, b"[") else {
-                segments.push(Segment::Key {
-                    name: part,
-                    bracketed: false,
-                });
-                continue;
-            };
+        let mut part_start = 0;
+        for part in strings::split(key, b".") {
+            let start = part_start;
+            part_start += part.len() + b".".len();
 
-            if first_bracket > 0 {
-                segments.push(Segment::Key {
-                    name: &part[..first_bracket],
-                    bracketed: false,
+            let name_len = strings::index_of(part, b"[").unwrap_or(part.len());
+            if name_len > 0 {
+                segments.push(Segment {
+                    kind: SegmentKind::Key {
+                        name: &part[..name_len],
+                        bracketed: false,
+                    },
+                    end: start + name_len,
                 });
             }
 
-            let mut remaining_part = &part[first_bracket..];
-            while let Some(bracket_start) = strings::index_of(remaining_part, b"[") {
-                let Some(bracket_end) = strings::index_of(&remaining_part[bracket_start..], b"]")
-                else {
+            let mut cursor = name_len;
+            while let Some(open) = strings::index_of(&part[cursor..], b"[") {
+                let open = cursor + open;
+                let Some(close) = strings::index_of(&part[open..], b"]") else {
                     return Err(crate::Error::InvalidPath);
                 };
-                let actual_bracket_end = bracket_start + bracket_end;
-                let index_str = &remaining_part[bracket_start + 1..actual_bracket_end];
-
-                segments.push(if index_str.is_empty() {
-                    Segment::Append
-                } else {
-                    Segment::Key {
-                        name: index_str,
-                        bracketed: true,
-                    }
+                let close = open + close;
+                let name = &part[open + 1..close];
+                segments.push(Segment {
+                    kind: if name.is_empty() {
+                        SegmentKind::Append
+                    } else {
+                        SegmentKind::Key {
+                            name,
+                            bracketed: true,
+                        }
+                    },
+                    end: start + close + 1,
                 });
-
-                remaining_part = &remaining_part[actual_bracket_end + 1..];
+                cursor = close + 1;
             }
         }
 
@@ -609,8 +612,9 @@ impl PmPkgCommand {
         Self::set_in_container(root, b"package.json", key, &path, expr)
     }
 
-    /// `container` is the object or array that `container_name` refers to;
-    /// `path` is the remaining, non-empty key path below it.
+    /// `container` is the object or array that `container_name` (a prefix of
+    /// `key`, or `package.json` for the root) refers to; `path` is the
+    /// remaining, non-empty part of `key` below it.
     ///
     /// Like `npm pkg set`, only the final segment ever replaces a value: a
     /// scalar or an array standing in the way of an earlier segment is an
@@ -625,12 +629,13 @@ impl PmPkgCommand {
         let [segment, rest @ ..] = path else {
             return Ok(());
         };
+        let slot_name = &key[..segment.end];
 
         if let Some(array) = container.data.e_array_mut() {
             let len = array.items.len();
-            let index = match *segment {
-                Segment::Append => len,
-                Segment::Key { name, .. } => match array_index(name) {
+            let index = match segment.kind {
+                SegmentKind::Append => len,
+                SegmentKind::Key { name, .. } => match array_index(name) {
                     Some(index) if index <= len => index,
                     Some(index) => {
                         Output::err_generic(
@@ -661,13 +666,12 @@ impl PmPkgCommand {
                 array.items[index] = value;
                 return Ok(());
             };
-            let slot_name = segment.name();
             let mut child = Self::child_container(Some(array.items[index]), *next, key, slot_name);
             array.items[index] = child;
             return Self::set_in_container(&mut child, slot_name, key, rest, value);
         }
 
-        let Segment::Key { name, .. } = *segment else {
+        let SegmentKind::Key { name, .. } = segment.kind else {
             Output::err_generic(
                 "{s}: cannot append to {s} because it is not an array",
                 (quote(key), quote(container_name)),
@@ -682,9 +686,9 @@ impl PmPkgCommand {
             object.put(dummy_bump(), name, value)?;
             return Ok(());
         };
-        let mut child = Self::child_container(object.get(name), *next, key, name);
+        let mut child = Self::child_container(object.get(name), *next, key, slot_name);
         object.put(dummy_bump(), name, child)?;
-        Self::set_in_container(&mut child, name, key, rest, value)
+        Self::set_in_container(&mut child, slot_name, key, rest, value)
     }
 
     /// The object or array `set` descends into at a slot currently holding
@@ -759,7 +763,7 @@ impl PmPkgCommand {
         let [segment, rest @ ..] = path else {
             return Ok(false);
         };
-        let Segment::Key { name, .. } = *segment else {
+        let SegmentKind::Key { name, .. } = segment.kind else {
             Output::err_generic(
                 "Empty brackets are not valid syntax for deleting values.",
                 (),

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -5,6 +5,7 @@ use crate::cli::command::Context;
 use bun_ast::{E, Expr, ExprData, G};
 use bun_ast::{Loc, Log, Source};
 use bun_collections::{StringArrayHashMap, VecExt};
+use bun_core::fmt::quote;
 use bun_core::strings;
 use bun_core::{Global, Output};
 use bun_install::PackageManager;
@@ -46,6 +47,43 @@ struct PackageJson {
     contents: Box<[u8]>,
     source: Source,
     indentation: bun_ast::Indentation,
+}
+
+/// One step of a key path such as `contributors[0].name` or `keywords[]`.
+#[derive(Clone, Copy)]
+enum Segment<'a> {
+    /// `b` in `a.b` or `a[b]`. Applied to an existing array it is an index,
+    /// applied to an object it is a property name.
+    Key { name: &'a [u8], bracketed: bool },
+    /// `[]`: the slot after the last element of an array.
+    Append,
+}
+
+impl<'a> Segment<'a> {
+    /// Whether `set` creates an array (rather than an object) for this segment
+    /// to land in when nothing exists yet: `files[0]=x` and `files[]=x` create
+    /// an array, `config.0=x` creates an object with the property `"0"`.
+    fn creates_array(self) -> bool {
+        match self {
+            Segment::Key {
+                name,
+                bracketed: true,
+            } => array_index(name).is_some(),
+            Segment::Key { .. } => false,
+            Segment::Append => true,
+        }
+    }
+
+    fn name(self) -> &'a [u8] {
+        match self {
+            Segment::Key { name, .. } => name,
+            Segment::Append => b"[]",
+        }
+    }
+}
+
+fn array_index(name: &[u8]) -> Option<usize> {
+    bun_core::fmt::parse_decimal::<usize>(name)
 }
 
 impl PmPkgCommand {
@@ -106,7 +144,9 @@ impl PmPkgCommand {
   <d>$<r> <b><green>bun pm pkg<r> <cyan>set<r> <blue>config='{"port":3000,"debug":true}'<r> <cyan>--json<r>
   <d>$<r> <b><green>bun pm pkg<r> <cyan>set<r> <blue>scripts.test="bun test"<r>
   <d>$<r> <b><green>bun pm pkg<r> <cyan>set<r> <blue>bin.mycli=cli.js<r>
+  <d>$<r> <b><green>bun pm pkg<r> <cyan>set<r> <blue>'keywords[]=cli' 'files[0]=dist'<r>
   <d>$<r> <b><green>bun pm pkg<r> <cyan>delete<r> <blue>scripts.test devDependencies.webpack<r>
+  <d>$<r> <b><green>bun pm pkg<r> <cyan>delete<r> <blue>'keywords[0]'<r>
   <d>$<r> <b><green>bun pm pkg<r> <cyan>fix<r>
 
 <b>More info<r>: <magenta>https://bun.com/docs/cli/pm#pkg<r>
@@ -490,128 +530,69 @@ impl PmPkgCommand {
     }
 
     fn resolve_path(root: Expr, key: &[u8]) -> Result<Expr, Error> {
-        if !matches!(root.data, ExprData::EObject(_)) {
-            return Err(crate::Error::NotFound);
-        }
-
-        let mut parts = strings::tokenize(key, b".");
         let mut current = root;
-
-        while let Some(part) = parts.next() {
-            if let Some(first_bracket) = strings::index_of(part, b"[") {
-                let mut remaining_part = part;
-
-                if first_bracket > 0 {
-                    let prop_name = &part[..first_bracket];
-                    if !matches!(current.data, ExprData::EObject(_)) {
-                        return Err(crate::Error::NotFound);
-                    }
-                    current = current.get(prop_name).ok_or(crate::Error::NotFound)?;
-                    remaining_part = &part[first_bracket..];
-                }
-
-                while let Some(bracket_start) = strings::index_of(remaining_part, b"[") {
-                    let bracket_end = strings::index_of(&remaining_part[bracket_start..], b"]")
-                        .ok_or(crate::Error::InvalidPath)?;
-                    let actual_bracket_end = bracket_start + bracket_end;
-                    let index_str = &remaining_part[bracket_start + 1..actual_bracket_end];
-
-                    if index_str.is_empty() {
-                        return Err(crate::Error::InvalidPath);
-                    }
-
-                    if let Some(index) = bun_core::fmt::parse_decimal::<usize>(index_str) {
-                        let ExprData::EArray(arr) = &current.data else {
-                            return Err(crate::Error::NotFound);
-                        };
-
-                        if index >= arr.items.len_u32() as usize {
-                            return Err(crate::Error::NotFound);
-                        }
-
-                        current = arr.items.slice()[index];
-                    } else {
-                        if !matches!(current.data, ExprData::EObject(_)) {
-                            return Err(crate::Error::NotFound);
-                        }
-                        current = current.get(index_str).ok_or(crate::Error::NotFound)?;
-                    }
-
-                    remaining_part = &remaining_part[actual_bracket_end + 1..];
-                    if remaining_part.is_empty() {
-                        break;
-                    }
-                }
-            } else {
-                if let Some(index) = bun_core::fmt::parse_decimal::<usize>(part) {
-                    match &current.data {
-                        ExprData::EArray(arr) => {
-                            if index >= arr.items.len_u32() as usize {
-                                return Err(crate::Error::NotFound);
-                            }
-                            current = arr.items.slice()[index];
-                        }
-                        ExprData::EObject(_) => {
-                            current = current.get(part).ok_or(crate::Error::NotFound)?;
-                        }
-                        _ => return Err(crate::Error::NotFound),
-                    }
-                } else {
-                    if !matches!(current.data, ExprData::EObject(_)) {
-                        return Err(crate::Error::NotFound);
-                    }
-                    current = current.get(part).ok_or(crate::Error::NotFound)?;
-                }
-            }
+        for segment in Self::parse_key_path(key)? {
+            let Segment::Key { name, .. } = segment else {
+                return Err(crate::Error::InvalidPath);
+            };
+            current = match &current.data {
+                ExprData::EArray(array) => array_index(name)
+                    .and_then(|index| array.items.slice().get(index).copied())
+                    .ok_or(crate::Error::NotFound)?,
+                ExprData::EObject(_) => current.get(name).ok_or(crate::Error::NotFound)?,
+                _ => return Err(crate::Error::NotFound),
+            };
         }
-
         Ok(current)
     }
 
-    /// Splits `a.b[0][c]` into `["a", "b", "0", "c"]`. Segments are sub-slices
-    /// of `key`: `E::Object::put` stores keys by reference (no copy into the
-    /// AST arena), so they must outlive the `Expr` tree, which `key` (an argv
-    /// slice) does. Returning owned buffers here would leave dangling keys.
-    fn parse_key_path(key: &[u8]) -> Result<Vec<&[u8]>, Error> {
-        let mut path_parts: Vec<&[u8]> = Vec::new();
+    /// Splits `a.b[0][c][]` into `[Key("a"), Key("b"), Key("0"), Key("c"), Append]`.
+    /// Segments are sub-slices of `key`: `E::Object::put` stores keys by
+    /// reference (no copy into the AST arena), so they must outlive the `Expr`
+    /// tree, which `key` (an argv slice) does. Returning owned buffers here
+    /// would leave dangling keys.
+    fn parse_key_path(key: &[u8]) -> Result<Vec<Segment<'_>>, Error> {
+        let mut segments: Vec<Segment<'_>> = Vec::new();
 
-        let mut parts = strings::tokenize(key, b".");
+        for part in strings::tokenize(key, b".") {
+            let Some(first_bracket) = strings::index_of(part, b"[") else {
+                segments.push(Segment::Key {
+                    name: part,
+                    bracketed: false,
+                });
+                continue;
+            };
 
-        while let Some(part) = parts.next() {
-            if let Some(first_bracket) = strings::index_of(part, b"[") {
-                let mut remaining_part = part;
+            if first_bracket > 0 {
+                segments.push(Segment::Key {
+                    name: &part[..first_bracket],
+                    bracketed: false,
+                });
+            }
 
-                if first_bracket > 0 {
-                    path_parts.push(&part[..first_bracket]);
-                    remaining_part = &part[first_bracket..];
-                }
+            let mut remaining_part = &part[first_bracket..];
+            while let Some(bracket_start) = strings::index_of(remaining_part, b"[") {
+                let Some(bracket_end) = strings::index_of(&remaining_part[bracket_start..], b"]")
+                else {
+                    return Err(crate::Error::InvalidPath);
+                };
+                let actual_bracket_end = bracket_start + bracket_end;
+                let index_str = &remaining_part[bracket_start + 1..actual_bracket_end];
 
-                while let Some(bracket_start) = strings::index_of(remaining_part, b"[") {
-                    let Some(bracket_end) =
-                        strings::index_of(&remaining_part[bracket_start..], b"]")
-                    else {
-                        return Err(crate::Error::InvalidPath);
-                    };
-                    let actual_bracket_end = bracket_start + bracket_end;
-                    let index_str = &remaining_part[bracket_start + 1..actual_bracket_end];
-
-                    if index_str.is_empty() {
-                        return Err(crate::Error::InvalidPath);
+                segments.push(if index_str.is_empty() {
+                    Segment::Append
+                } else {
+                    Segment::Key {
+                        name: index_str,
+                        bracketed: true,
                     }
+                });
 
-                    path_parts.push(index_str);
-
-                    remaining_part = &remaining_part[actual_bracket_end + 1..];
-                    if remaining_part.is_empty() {
-                        break;
-                    }
-                }
-            } else {
-                path_parts.push(part);
+                remaining_part = &remaining_part[actual_bracket_end + 1..];
             }
         }
 
-        Ok(path_parts)
+        Ok(segments)
     }
 
     fn set_value(root: &mut Expr, key: &[u8], value: &[u8], parse_json: bool) -> Result<(), Error> {
@@ -619,70 +600,114 @@ impl PmPkgCommand {
             return Err(crate::Error::InvalidRoot);
         }
 
-        let path_parts = Self::parse_key_path(key)?;
-
-        if path_parts.is_empty() {
+        let path = Self::parse_key_path(key)?;
+        if path.is_empty() {
             return Err(crate::Error::EmptyKey);
         }
 
-        if path_parts.len() == 1 {
-            let expr = Self::parse_value(value, parse_json)?;
-
-            root.data
-                .e_object_mut()
-                .unwrap()
-                .put(dummy_bump(), path_parts[0], expr)?;
-
-            return Ok(());
-        }
-
-        Self::set_nested(root, &path_parts, value, parse_json)
+        let expr = Self::parse_value(value, parse_json)?;
+        Self::set_in_container(root, b"package.json", key, &path, expr)
     }
 
-    fn set_nested(
-        root: &mut Expr,
-        path: &[&[u8]],
-        value: &[u8],
-        parse_json: bool,
+    /// `container` is the object or array that `container_name` refers to;
+    /// `path` is the remaining, non-empty key path below it.
+    ///
+    /// Like `npm pkg set`, only the final segment ever replaces a value: a
+    /// scalar or an array standing in the way of an earlier segment is an
+    /// error, not something to overwrite.
+    fn set_in_container(
+        container: &mut Expr,
+        container_name: &[u8],
+        key: &[u8],
+        path: &[Segment<'_>],
+        value: Expr,
     ) -> Result<(), Error> {
-        if path.is_empty() {
+        let [segment, rest @ ..] = path else {
             return Ok(());
+        };
+
+        if let Some(array) = container.data.e_array_mut() {
+            let len = array.items.len();
+            let index = match *segment {
+                Segment::Append => len,
+                Segment::Key { name, .. } => match array_index(name) {
+                    Some(index) if index <= len => index,
+                    Some(index) => {
+                        Output::err_generic(
+                            "{s}: index {s} is out of range for {s} (length {s})\n<blue>note<r><d>:<r> {s}[] appends to the end of the array",
+                            (
+                                quote(key),
+                                index,
+                                quote(container_name),
+                                len,
+                                bstr::BStr::new(container_name),
+                            ),
+                        );
+                        Global::exit(1);
+                    }
+                    None => {
+                        Output::err_generic(
+                            "{s}: {s} is an array, so {s} must be an index or []",
+                            (quote(key), quote(container_name), quote(name)),
+                        );
+                        Global::exit(1);
+                    }
+                },
+            };
+            if index == len {
+                array.push(dummy_bump(), Expr::init(E::Null {}, Loc::EMPTY))?;
+            }
+            let Some(next) = rest.first() else {
+                array.items[index] = value;
+                return Ok(());
+            };
+            let slot_name = segment.name();
+            let mut child = Self::child_container(Some(array.items[index]), *next, key, slot_name);
+            array.items[index] = child;
+            return Self::set_in_container(&mut child, slot_name, key, rest, value);
         }
 
-        let current_key = path[0];
-        let remaining_path = &path[1..];
-
-        if remaining_path.is_empty() {
-            let expr = Self::parse_value(value, parse_json)?;
-
-            root.data
-                .e_object_mut()
-                .unwrap()
-                .put(dummy_bump(), current_key, expr)?;
-
+        let Segment::Key { name, .. } = *segment else {
+            Output::err_generic(
+                "{s}: cannot append to {s} because it is not an array",
+                (quote(key), quote(container_name)),
+            );
+            Global::exit(1);
+        };
+        let object = container
+            .data
+            .e_object_mut()
+            .expect("set_value checks the root and child_container only returns arrays or objects");
+        let Some(next) = rest.first() else {
+            object.put(dummy_bump(), name, value)?;
             return Ok(());
+        };
+        let mut child = Self::child_container(object.get(name), *next, key, name);
+        object.put(dummy_bump(), name, child)?;
+        Self::set_in_container(&mut child, name, key, rest, value)
+    }
+
+    /// The object or array `set` descends into at a slot currently holding
+    /// `existing`; an empty (missing or `null`) slot gets a new container
+    /// shaped for `next`.
+    fn child_container(
+        existing: Option<Expr>,
+        next: Segment<'_>,
+        key: &[u8],
+        slot_name: &[u8],
+    ) -> Expr {
+        match existing {
+            Some(expr) if matches!(expr.data, ExprData::EArray(_) | ExprData::EObject(_)) => expr,
+            Some(expr) if !matches!(expr.data, ExprData::ENull(_)) => {
+                Output::err_generic(
+                    "{s}: {s} already exists and is not an object or array",
+                    (quote(key), quote(slot_name)),
+                );
+                Global::exit(1);
+            }
+            _ if next.creates_array() => Expr::init(E::Array::default(), Loc::EMPTY),
+            _ => Expr::init(E::Object::default(), Loc::EMPTY),
         }
-
-        let mut nested_obj = root.get(current_key);
-        if nested_obj.is_none()
-            || !matches!(nested_obj.as_ref().unwrap().data, ExprData::EObject(_))
-        {
-            let new_obj = Expr::init(E::Object::default(), Loc::EMPTY);
-
-            root.data
-                .e_object_mut()
-                .unwrap()
-                .put(dummy_bump(), current_key, new_obj)?;
-
-            nested_obj = root.get(current_key);
-        }
-
-        if !matches!(nested_obj.as_ref().unwrap().data, ExprData::EObject(_)) {
-            return Err(crate::Error::ExpectedObject);
-        }
-
-        let mut nested = nested_obj.unwrap();
-        Self::set_nested(&mut nested, remaining_path, value, parse_json)
     }
 
     fn parse_value(value: &[u8], parse_json: bool) -> Result<Expr, Error> {
@@ -724,60 +749,43 @@ impl PmPkgCommand {
             return Ok(false);
         }
 
-        let mut path_parts: Vec<&[u8]> = Vec::new();
-        for part in strings::tokenize(key, b".") {
-            path_parts.push(part);
-        }
-
-        if path_parts.is_empty() {
-            return Ok(false);
-        }
-
-        if path_parts.len() == 1 {
-            let exists = root.get(path_parts[0]).is_some();
-            if exists {
-                return Self::remove_property(root, path_parts[0]);
-            }
-            return Ok(false);
-        }
-
-        Self::delete_nested(root, &path_parts)
+        Self::delete_in_container(root, &Self::parse_key_path(key)?)
     }
 
-    fn delete_nested(root: &mut Expr, path: &[&[u8]]) -> Result<bool, Error> {
-        if path.is_empty() {
+    /// Removes the value `path` addresses below `container` (an array element
+    /// is spliced out, an object property is dropped). Returns whether
+    /// anything was removed; a path that leads nowhere removes nothing.
+    fn delete_in_container(container: &mut Expr, path: &[Segment<'_>]) -> Result<bool, Error> {
+        let [segment, rest @ ..] = path else {
             return Ok(false);
-        }
+        };
+        let Segment::Key { name, .. } = *segment else {
+            Output::err_generic(
+                "Empty brackets are not valid syntax for deleting values.",
+                (),
+            );
+            Global::exit(1);
+        };
 
-        let current_key = path[0];
-        let remaining_path = &path[1..];
-
-        if remaining_path.is_empty() {
-            let exists = root.get(current_key).is_some();
-            if exists {
-                return Self::remove_property(root, current_key);
+        let mut child = if let Some(array) = container.data.e_array_mut() {
+            let Some(index) = array_index(name).filter(|&index| index < array.items.len()) else {
+                return Ok(false);
+            };
+            if rest.is_empty() {
+                array.items.remove(index);
+                return Ok(true);
             }
-            return Ok(false);
-        }
-
-        let nested_obj = root.get(current_key);
-        if nested_obj.is_none()
-            || !matches!(nested_obj.as_ref().unwrap().data, ExprData::EObject(_))
-        {
-            return Ok(false);
-        }
-
-        let mut nested = nested_obj.unwrap();
-        let deleted = Self::delete_nested(&mut nested, remaining_path)?;
-
-        if deleted {
-            root.data
-                .e_object_mut()
-                .unwrap()
-                .put(dummy_bump(), current_key, nested)?;
-        }
-
-        Ok(deleted)
+            array.items[index]
+        } else {
+            if rest.is_empty() {
+                return Self::remove_property(container, name);
+            }
+            let Some(child) = container.get(name) else {
+                return Ok(false);
+            };
+            child
+        };
+        Self::delete_in_container(&mut child, rest)
     }
 
     fn remove_property(obj: &mut Expr, key: &[u8]) -> Result<bool, Error> {

--- a/src/runtime/cli/pm_pkg_command.rs
+++ b/src/runtime/cli/pm_pkg_command.rs
@@ -53,25 +53,20 @@ struct PackageJson {
 #[derive(Clone, Copy)]
 struct Segment<'a> {
     kind: SegmentKind<'a>,
-    /// Offset just past this segment in the key it was parsed from, so
-    /// `&key[..end]` is the path down to it (`contributors[0]` for the second
-    /// segment of `contributors[0].name`). Error messages name values this way.
+    /// Offset just past this segment in the key; errors name a value by `&key[..end]`.
     end: usize,
 }
 
 #[derive(Clone, Copy)]
 enum SegmentKind<'a> {
-    /// `b` in `a.b` or `a[b]`. Applied to an existing array it is an index,
-    /// applied to an object it is a property name.
+    /// `b` in `a.b` or `a[b]`: an index when applied to an array, otherwise a property name.
     Key { name: &'a [u8], bracketed: bool },
     /// `[]`: the slot after the last element of an array.
     Append,
 }
 
 impl Segment<'_> {
-    /// Whether `set` creates an array (rather than an object) for this segment
-    /// to land in when nothing exists yet: `files[0]=x` and `files[]=x` create
-    /// an array, `config.0=x` creates an object with the property `"0"`.
+    /// `files[0]=x` and `files[]=x` create an array; `config.0=x` creates an object keyed `"0"`.
     fn creates_array(self) -> bool {
         match self.kind {
             SegmentKind::Key {
@@ -548,11 +543,7 @@ impl PmPkgCommand {
         Ok(current)
     }
 
-    /// Splits `a.b[0][c][]` into `[Key("a"), Key("b"), Key("0"), Key("c"), Append]`.
-    /// Names are sub-slices of `key`: `E::Object::put` stores keys by
-    /// reference (no copy into the AST arena), so they must outlive the `Expr`
-    /// tree, which `key` (an argv slice) does. Returning owned buffers here
-    /// would leave dangling keys.
+    /// Names are sub-slices of `key`; `E::Object::put` stores them by reference (#33186).
     fn parse_key_path(key: &[u8]) -> Result<Vec<Segment<'_>>, Error> {
         let mut segments: Vec<Segment<'_>> = Vec::new();
 
@@ -612,13 +603,7 @@ impl PmPkgCommand {
         Self::set_in_container(root, b"package.json", key, &path, expr)
     }
 
-    /// `container` is the object or array that `container_name` (a prefix of
-    /// `key`, or `package.json` for the root) refers to; `path` is the
-    /// remaining, non-empty part of `key` below it.
-    ///
-    /// Like `npm pkg set`, only the final segment ever replaces a value: a
-    /// scalar or an array standing in the way of an earlier segment is an
-    /// error, not something to overwrite.
+    /// As in npm, only the final segment may replace a value; anything else in the way is an error.
     fn set_in_container(
         container: &mut Expr,
         container_name: &[u8],
@@ -691,9 +676,7 @@ impl PmPkgCommand {
         Self::set_in_container(&mut child, slot_name, key, rest, value)
     }
 
-    /// The object or array `set` descends into at a slot currently holding
-    /// `existing`; an empty (missing or `null`) slot gets a new container
-    /// shaped for `next`.
+    /// A missing or `null` slot gets a new container shaped for `next`.
     fn child_container(
         existing: Option<Expr>,
         next: Segment<'_>,
@@ -756,9 +739,7 @@ impl PmPkgCommand {
         Self::delete_in_container(root, &Self::parse_key_path(key)?)
     }
 
-    /// Removes the value `path` addresses below `container` (an array element
-    /// is spliced out, an object property is dropped). Returns whether
-    /// anything was removed; a path that leads nowhere removes nothing.
+    /// Splices out an array element or removes a property; returns whether anything was removed.
     fn delete_in_container(container: &mut Expr, path: &[Segment<'_>]) -> Result<bool, Error> {
         let [segment, rest @ ..] = path else {
             return Ok(false);

--- a/src/runtime/error.rs
+++ b/src/runtime/error.rs
@@ -250,8 +250,6 @@ pub enum Error {
     InvalidRoot,
     #[error("EmptyKey")]
     EmptyKey,
-    #[error("ExpectedObject")]
-    ExpectedObject,
     #[error("FormatFailed")]
     FormatFailed,
     #[error("SelfExePathFailed")]
@@ -704,7 +702,6 @@ impl Error {
             Self::NotFound => "NotFound",
             Self::InvalidRoot => "InvalidRoot",
             Self::EmptyKey => "EmptyKey",
-            Self::ExpectedObject => "ExpectedObject",
             Self::FormatFailed => "FormatFailed",
             Self::SelfExePathFailed => "SelfExePathFailed",
             Self::SpawnFailed => "SpawnFailed",

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -431,10 +431,22 @@ describe.concurrent("bun pm pkg", () => {
           "contributors[0].name.first=x",
           'error: "contributors[0].name.first": "contributors[0].name" already exists and is not an object or array\n',
         ],
+        [
+          "nested.matrix[0][9]=x",
+          'error: "nested.matrix[0][9]": index 9 is out of range for "nested.matrix[0]" (length 1)\n' +
+            "note: nested.matrix[0][] appends to the end of the array\n",
+        ],
+        // an empty part between dots is skipped but still counts towards the name
+        [
+          "nested..matrix[0].foo=x",
+          'error: "nested..matrix[0].foo": "nested..matrix[0]" is an array, so "foo" must be an index or []\n',
+        ],
       ] as const;
 
       it.each(rejected)("should reject %s without touching package.json", async (arg, expectedError) => {
-        using dir = tempDir("pm-pkg-reject", { "package.json": createTestPackageJson({ matrix: [["a", "b"]] }) });
+        using dir = tempDir("pm-pkg-reject", {
+          "package.json": createTestPackageJson({ matrix: [["a", "b"]], nested: { matrix: [["a"]] } }),
+        });
         const before = await readRaw(dir);
         const { output, error, code } = await runPmPkg(["set", arg], dir, false);
         expect({ output, error, code }).toEqual({ output: "", error: expectedError, code: 1 });

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -850,20 +850,22 @@ describe.concurrent("bun pm pkg", () => {
     it("should handle numeric indices with different data types", async () => {
       using dir = makeTestDir();
 
-      const [arr0, arr1] = await Promise.all([
-        runPmPkg(["get", "keywords.0"], dir, false),
-        runPmPkg(["get", "keywords.1"], dir, false),
+      const setThenGet = async () => {
+        const { code } = await runPmPkg(["set", "config.0=zero-value"], dir);
+        expect(code).toBe(0);
+        return runPmPkg(["get", "config.0"], dir);
+      };
+      // The read-only gets use the shared fixture so they can overlap with the set/get round trip.
+      const [arr0, arr1, config0] = await Promise.all([
+        runPmPkg(["get", "keywords.0"], readonlyDir, false),
+        runPmPkg(["get", "keywords.1"], readonlyDir, false),
+        setThenGet(),
       ]);
       expect(arr0.output.trim()).toBe('"test"');
       expect(arr0.code).toBe(0);
       expect(arr1.output.trim()).toBe('"package"');
       expect(arr1.code).toBe(0);
-
-      const { code: setCode } = await runPmPkg(["set", "config.0=zero-value"], dir);
-      expect(setCode).toBe(0);
-
-      const { output } = await runPmPkg(["get", "config.0"], dir);
-      expect(output.trim()).toBe('"zero-value"');
+      expect(config0.output.trim()).toBe('"zero-value"');
     });
 
     it("should gracefully handle invalid notation patterns", async () => {
@@ -887,15 +889,15 @@ describe.concurrent("bun pm pkg", () => {
     it("should maintain consistency between set and get operations", async () => {
       using dir = makeTestDir();
 
-      const { code: setCode1 } = await runPmPkg(["set", "test.array.0=first"], dir);
-      expect(setCode1).toBe(0);
-      const { output: getOutput1 } = await runPmPkg(["get", "test.array.0"], dir);
-      expect(getOutput1.trim()).toBe('"first"');
+      const { code: setCode } = await runPmPkg(["set", "test.array.0=first", "test.bracket.access=success"], dir);
+      expect(setCode).toBe(0);
 
-      const { code: setCode2 } = await runPmPkg(["set", "test.bracket.access=success"], dir);
-      expect(setCode2).toBe(0);
-      const { output: getOutput2 } = await runPmPkg(["get", "test.bracket.access"], dir);
-      expect(getOutput2.trim()).toBe('"success"');
+      const [getOutput1, getOutput2] = await Promise.all([
+        runPmPkg(["get", "test.array.0"], dir),
+        runPmPkg(["get", "test.bracket.access"], dir),
+      ]);
+      expect(getOutput1.output.trim()).toBe('"first"');
+      expect(getOutput2.output.trim()).toBe('"success"');
     });
 
     it("should handle edge cases with special characters", async () => {

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -417,18 +417,24 @@ describe.concurrent("bun pm pkg", () => {
             "note: keywords[] appends to the end of the array\n",
         ],
         ["keywords.foo=x", 'error: "keywords.foo": "keywords" is an array, so "foo" must be an index or []\n'],
-        ["keywords[foo]=x", 'error: "keywords[foo]": "keywords" is an array, so "foo" must be an index or []\n'],
         ["scripts[]=x", 'error: "scripts[]": cannot append to "scripts" because it is not an array\n'],
         ["name[]=x", 'error: "name[]": "name" already exists and is not an object or array\n'],
         ["name.first=x", 'error: "name.first": "name" already exists and is not an object or array\n'],
+        // nested values are named by the part of the key that leads to them
+        [
+          "matrix[0][9]=x",
+          'error: "matrix[0][9]": index 9 is out of range for "matrix[0]" (length 2)\n' +
+            "note: matrix[0][] appends to the end of the array\n",
+        ],
+        ["matrix[0].foo=x", 'error: "matrix[0].foo": "matrix[0]" is an array, so "foo" must be an index or []\n'],
         [
           "contributors[0].name.first=x",
-          'error: "contributors[0].name.first": "name" already exists and is not an object or array\n',
+          'error: "contributors[0].name.first": "contributors[0].name" already exists and is not an object or array\n',
         ],
       ] as const;
 
       it.each(rejected)("should reject %s without touching package.json", async (arg, expectedError) => {
-        using dir = makeTestDir();
+        using dir = tempDir("pm-pkg-reject", { "package.json": createTestPackageJson({ matrix: [["a", "b"]] }) });
         const before = await readRaw(dir);
         const { output, error, code } = await runPmPkg(["set", arg], dir, false);
         expect({ output, error, code }).toEqual({ output: "", error: expectedError, code: 1 });

--- a/test/cli/install/bun-pm-pkg.test.ts
+++ b/test/cli/install/bun-pm-pkg.test.ts
@@ -23,6 +23,7 @@ async function runPmPkg(args: string[], cwd: string, expectSuccess = true) {
 }
 
 const readPkg = (dir: string) => Bun.file(join(dir, "package.json")).json();
+const readRaw = (dir: string) => Bun.file(join(dir, "package.json")).text();
 
 function createTestPackageJson(overrides = {}) {
   return JSON.stringify(
@@ -312,9 +313,135 @@ describe.concurrent("bun pm pkg", () => {
       expect(await readPkg(dir)).toEqual({
         name: "x",
         version: "1.0.0",
-        contributors: { "0": "alice" },
-        nested: { deep: { "0": "value" } },
+        contributors: ["alice"],
+        nested: { deep: ["value"] },
         scripts: { lint: "eslint ." },
+      });
+    });
+
+    describe("arrays", () => {
+      it("should append, index, and create arrays", async () => {
+        using dir = makeTestDir();
+        const { error, code } = await runPmPkg(
+          [
+            "set",
+            // existing array: append, then replace by bracket and dot index, then add at index == length
+            "keywords[]=cli",
+            "keywords[0]=first",
+            "keywords.1=second",
+            "keywords[3]=fourth",
+            // missing properties: [] and a bracketed index create arrays, a dotted number creates an object
+            "files[]=dist",
+            "files[]=README.md",
+            "os[0]=linux",
+            "config.0=zero",
+            // existing object: either notation is a property name
+            "scripts[0]=bracket",
+            "scripts.1=dot",
+            // null is treated as missing
+            "testNull[0]=x",
+            "matrix[0][0]=a",
+            "matrix[0][]=b",
+            "matrix[][0]=c",
+          ],
+          dir,
+        );
+        expect(error).toBe("");
+        expect(code).toBe(0);
+        expect(await readPkg(dir)).toEqual({
+          ...JSON.parse(createTestPackageJson()),
+          keywords: ["first", "second", "cli", "fourth"],
+          files: ["dist", "README.md"],
+          os: ["linux"],
+          config: { "0": "zero" },
+          scripts: { test: "echo 'test'", build: "echo 'build'", "0": "bracket", "1": "dot" },
+          testNull: ["x"],
+          matrix: [["a", "b"], ["c"]],
+        });
+
+        const { output } = await runPmPkg(["get", "scripts[0]", "scripts.1", "keywords[3]"], dir);
+        expect(JSON.parse(output)).toEqual({ "scripts[0]": "bracket", "scripts.1": "dot", "keywords[3]": "fourth" });
+      });
+
+      it("should set properties of objects inside an array, creating elements as needed", async () => {
+        using dir = makeTestDir();
+        const { error, code } = await runPmPkg(
+          [
+            "set",
+            "contributors[0].email=john@new.example",
+            "contributors[1].email=jane@example.com",
+            "contributors[2].name=Third",
+            "contributors[].name=Fourth",
+            "testNull.key=x",
+          ],
+          dir,
+        );
+        expect(error).toBe("");
+        expect(code).toBe(0);
+        expect(await readPkg(dir)).toEqual({
+          ...JSON.parse(createTestPackageJson()),
+          contributors: [
+            { name: "John Doe", email: "john@new.example" },
+            { name: "Jane Smith", email: "jane@example.com" },
+            { name: "Third" },
+            { name: "Fourth" },
+          ],
+          testNull: { key: "x" },
+        });
+      });
+
+      it("should append --json values", async () => {
+        using dir = makeTestDir();
+        const { code } = await runPmPkg(["set", "keywords[]=42", 'contributors[]={"name":"Obj"}', "--json"], dir);
+        expect(code).toBe(0);
+        expect(await readPkg(dir)).toMatchObject({
+          keywords: ["test", "package", 42],
+          contributors: [{ name: "John Doe", email: "john@example.com" }, { name: "Jane Smith" }, { name: "Obj" }],
+        });
+      });
+
+      it("should still replace a whole array or element when it is the final segment", async () => {
+        using dir = makeTestDir();
+        const { code } = await runPmPkg(["set", "keywords=none", "contributors[0]=alice"], dir);
+        expect(code).toBe(0);
+        expect(await readPkg(dir)).toMatchObject({
+          keywords: "none",
+          contributors: ["alice", { name: "Jane Smith" }],
+        });
+      });
+
+      const rejected = [
+        [
+          "keywords[3]=x",
+          'error: "keywords[3]": index 3 is out of range for "keywords" (length 2)\n' +
+            "note: keywords[] appends to the end of the array\n",
+        ],
+        ["keywords.foo=x", 'error: "keywords.foo": "keywords" is an array, so "foo" must be an index or []\n'],
+        ["keywords[foo]=x", 'error: "keywords[foo]": "keywords" is an array, so "foo" must be an index or []\n'],
+        ["scripts[]=x", 'error: "scripts[]": cannot append to "scripts" because it is not an array\n'],
+        ["name[]=x", 'error: "name[]": "name" already exists and is not an object or array\n'],
+        ["name.first=x", 'error: "name.first": "name" already exists and is not an object or array\n'],
+        [
+          "contributors[0].name.first=x",
+          'error: "contributors[0].name.first": "name" already exists and is not an object or array\n',
+        ],
+      ] as const;
+
+      it.each(rejected)("should reject %s without touching package.json", async (arg, expectedError) => {
+        using dir = makeTestDir();
+        const before = await readRaw(dir);
+        const { output, error, code } = await runPmPkg(["set", arg], dir, false);
+        expect({ output, error, code }).toEqual({ output: "", error: expectedError, code: 1 });
+        expect(await readRaw(dir)).toBe(before);
+      });
+
+      it("should not write earlier arguments when a later one is rejected", async () => {
+        using dir = makeTestDir();
+        const before = await readRaw(dir);
+        const { error, code } = await runPmPkg(["set", "description=changed", "keywords[9]=x"], dir, false);
+        expect(error).toStartWith('error: "keywords[9]": index 9 is out of range');
+        expect(code).toBe(1);
+        expect(await readRaw(dir)).toBe(before);
       });
     });
 
@@ -378,6 +505,43 @@ describe.concurrent("bun pm pkg", () => {
       const { error, code } = await runPmPkg(["delete"], dir, false);
       expect(error).toContain("delete expects key args");
       expect(code).toBe(1);
+    });
+
+    it("should delete array elements and bracketed properties", async () => {
+      using dir = makeTestDir();
+      const { error, code } = await runPmPkg(
+        ["delete", "keywords[0]", "contributors.1", "contributors[0].email", "scripts[test]"],
+        dir,
+      );
+      expect(error).toBe("");
+      expect(code).toBe(0);
+      expect(await readPkg(dir)).toEqual({
+        ...JSON.parse(createTestPackageJson()),
+        keywords: ["package"],
+        contributors: [{ name: "John Doe" }],
+        scripts: { build: "echo 'build'" },
+      });
+    });
+
+    it("should leave package.json alone when the path does not lead anywhere", async () => {
+      using dir = makeTestDir();
+      const before = await readRaw(dir);
+      const { error, code } = await runPmPkg(
+        ["delete", "keywords[2]", "keywords.foo", "contributors[0].missing", "name[0]", "missing[0]"],
+        dir,
+      );
+      expect(error).toBe("");
+      expect(code).toBe(0);
+      expect(await readRaw(dir)).toBe(before);
+    });
+
+    it("should reject empty brackets", async () => {
+      using dir = makeTestDir();
+      const before = await readRaw(dir);
+      const { error, code } = await runPmPkg(["delete", "keywords[]"], dir, false);
+      expect(error).toBe("error: Empty brackets are not valid syntax for deleting values.\n");
+      expect(code).toBe(1);
+      expect(await readRaw(dir)).toBe(before);
     });
   });
 


### PR DESCRIPTION
Fixes #22035

### Problem

- `bun pm pkg set 'array[]=abc'` exits with `error: An internal error occurred (InvalidPath)`; npm appends to the array.
- `bun pm pkg set 'array[1]=def'` writes `"array": { "1": "def" }`; npm writes an array.
- Worse, `set 'files[1]=x'` on an existing `"files": ["a", "b", "c"]` replaces the whole array with `{ "1": "x" }` (`set_nested` replaced anything that was not an object), so the existing entries are lost.
- `bun pm pkg delete 'contributors[0]'` and `delete 'scripts[test]'` silently delete nothing: `delete_value` only split the key on dots, although `docs/pm/cli/pm.mdx` lists `delete scripts.test contributors[0]` as an example and says all subcommands take bracket notation.
- Cause: `src/runtime/cli/pm_pkg_command.rs` had three separate key-path walkers. `set_nested` only knew how to create and descend into objects, `delete_value` did not parse brackets at all, and `resolve_path` (get) had its own copy of the bracket grammar. #33186 fixed the memory bug in this area and left the array behavior as is (it says so in its description).

### Fix

- `parse_key_path` now produces `Segment`s (`Key { name, bracketed }` or `Append` for `[]`) and is the single parser used by get, set and delete.
- `set` (`set_in_container` / `child_container`):
  - on an array, a segment is `[]` (index = length), an existing index (replaced), or index == length (added); anything else is an error that names the key, the array and the offending segment, and an index past the end gets a `note:` pointing at `[]`. Each segment records where it ends in the key, so a nested value is named by the part of the key that leads to it (`index 9 is out of range for "matrix[0]"`, `note: matrix[0][] appends ...`, `"contributors[0].name" already exists ...`).
  - a missing or `null` property gets an array when the next segment is `[]` or a bracketed index, and an object otherwise, so `files[0]=x` creates `["x"]` while `config.0=x` keeps creating `{ "0": "x" }` as before.
  - an existing object or array is descended into whatever the notation; an existing scalar in the middle of the path is an error instead of being replaced. Only the final segment ever overwrites a value (`set keywords=x` on an array still works).
  - errors exit before anything is written, so a failing argument leaves package.json untouched even when earlier arguments in the same invocation were fine (same as before for the errors that already existed).
- `delete` (`delete_in_container`) walks the same segments: array elements are spliced out, object properties removed, paths that lead nowhere are no-ops as before, and `[]` is rejected with the same wording get uses.
- `resolve_path` is the same walk in read-only form. One behavior change: `get 'scripts[0]'` on an object now reads the `"0"` property like `get scripts.0` already did, so what `set 'scripts[0]=x'` writes can be read back.
- Why this shape rather than copying npm exactly:
  - npm fills skipped indexes with `null` (`set 'e[2]=x'` on a missing `e` gives `[null, null, "x"]`) and turns `config.123=x` into a 124 element array. Both are artifacts of assigning into a sparse JS array; neither is useful in a package.json, and the unbounded one would let a typo allocate an arbitrarily large array. Refusing with a message (and keeping the dotted numeric key an object property, which `bun pm pkg` already supported and tests) covers every real use of the issue's examples.
  - refusing to replace a scalar or an array in the middle of a path is what npm does (`EOVERRIDEVALUE` / `ENOADDPROP`); it is also the only way to stop the silent array loss above.
- `Error::ExpectedObject` was only returned by the old `set_nested` and is deleted. Help text and `docs/pm/cli/pm.mdx` gain array examples.
- Verification: `test/cli/install/bun-pm-pkg.test.ts` gains a `set > arrays` group (append / index / create, objects inside arrays, `--json`, final-segment replacement, exact stderr for each rejected path with the file byte-for-byte unchanged, including nested values and an empty `..` part so the key-prefix offsets are pinned, and the nothing-written-on-a-later-failure case) and delete cases (elements and bracketed properties, no-op paths, `[]`). The pre-existing bracket test from #33186 is updated to the array result its inputs now produce. Two pre-existing tests in the notation group that chained three or four invocations back to back now set their values in one invocation and read them back concurrently (same assertions); with the extra cases in this file, the chained form ran past the per-test timeout on a loaded ASAN build, and nothing in the file is more than two invocations deep now. the new cases fail on the unfixed build (`USE_SYSTEM_BUN=1`), the file passes with `bun bd test` (95 tests), `cargo clippy -p bun_runtime` is clean and `test/internal/source-lints` passes.

### Background

- `bun pm pkg` edits package.json through the JSON AST (`bun_ast::Expr`). Containers are `E::Object` / `E::Array` nodes reached through `StoreRef` handles, so mutating a copied `Expr` mutates the node the parent points at; the code only has to store a child back into its parent when it just created it. Object keys are stored by reference, which is why the segments are slices of the argv key (the invariant #33186 established).
- A new `E::Array` prints multi-line; an array parsed from a single line keeps `is_single_line`, so appending to `["a", "b"]` prints `["a", "b", "c"]`. The uneven indentation you may notice when a file contains single-line objects is pre-existing (#35667), not changed here.


