### PR TITLE
yaml: only a plain or !!merge-tagged `<<` key is a merge key

### DIFF
--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4327,17 +4327,16 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         // (`foo: !custom` above `<<: *base`) is the block
                         // mapping's, not the key's. In a flow pair [150] the
                         // pair takes no properties, so the tag stays the key's.
-                        let key_tag = if matches!(
-                            self.context.get(),
-                            Context::BlockOut | Context::BlockIn
-                        ) && node_props
-                            .tag_line()
-                            .is_some_and(|line| line != scalar_line)
-                        {
-                            NodeTag::None
-                        } else {
-                            node_props.tag()
-                        };
+                        let key_tag =
+                            if matches!(self.context.get(), Context::BlockOut | Context::BlockIn)
+                                && node_props
+                                    .tag_line()
+                                    .is_some_and(|line| line != scalar_line)
+                            {
+                                NodeTag::None
+                            } else {
+                                node_props.tag()
+                            };
 
                         let anchors = node_props.take_implicit_key_anchors(scalar_line)?;
                         if let Some(key_anchor) = anchors.key_anchor {

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -4323,9 +4323,14 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
 
                         let implicit_key = scalar.data.to_expr(scalar_start, self.input, self.bump);
 
-                        // [200] a tag on an earlier line (`foo: !custom` above
-                        // `<<: *base`) is the block mapping's, not the key's.
-                        let key_tag = if node_props
+                        // [200] in block context a tag on an earlier line
+                        // (`foo: !custom` above `<<: *base`) is the block
+                        // mapping's, not the key's. In a flow pair [150] the
+                        // pair takes no properties, so the tag stays the key's.
+                        let key_tag = if matches!(
+                            self.context.get(),
+                            Context::BlockOut | Context::BlockIn
+                        ) && node_props
                             .tag_line()
                             .is_some_and(|line| line != scalar_line)
                         {

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -1557,10 +1557,8 @@ impl NodeTag {
         }
     }
 
-    /// Whether a `<<` scalar carrying this tag is a merge key
-    /// (yaml.org/type/merge.html). Untagged, only a plain `<<` resolves to
-    /// `!!merge`: a quoted `"<<"` (what `YAML.stringify` emits for that
-    /// property name) or a `!!str <<` is an ordinary string key.
+    /// Whether a `<<` scalar carrying this tag resolves to `!!merge`
+    /// (yaml.org/type/merge.html). A quoted `"<<"` or `!!str <<` does not.
     pub(crate) fn resolves_merge_key(self, style: ScalarStyle) -> bool {
         match self {
             NodeTag::None => matches!(style, ScalarStyle::Plain { .. }),
@@ -2128,12 +2126,9 @@ pub struct Parser<'i, Enc: Encoding> {
     pub(crate) tab_after_indent: bool,
     pub(crate) line: Line,
     pub(crate) token: Token<Enc>,
-    /// `NodeTag::resolves_merge_key` for the scalar `parse_node` most
-    /// recently produced. Style and tag are gone once the scalar is an
-    /// `Expr`, so a mapping parser reads this right after it obtains a key
-    /// (parsing the value overwrites it) and hands it to `append_entry`,
-    /// which only consults it for a key whose text is `<<`. A key that is not
-    /// a scalar leaves it describing some scalar inside the key.
+    /// `NodeTag::resolves_merge_key` of the scalar `parse_node` most recently
+    /// produced; mapping parsers read it right after parsing a key and pass
+    /// it to `append_entry` alongside that key.
     pub(crate) scalar_may_be_merge_key: bool,
 
     /// Growable buffers use the global
@@ -2863,6 +2858,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         &mut self,
         anchor: Option<PendingAnchor>,
         first_key: Expr,
+        first_key_may_merge: bool,
         mapping_start: Pos,
         mapping_indent: Indent,
         mapping_line: Line,
@@ -2871,6 +2867,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         self.parse_collection::<E::Object>(anchor, mapping_start.loc(), |p| {
             p.parse_block_mapping_entries(
                 first_key,
+                first_key_may_merge,
                 mapping_indent,
                 mapping_line,
                 flow_pair_allowed,
@@ -2878,17 +2875,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         })
     }
 
-    /// The current token is the one after `first_key`, which is the node
-    /// parsed most recently, so `scalar_may_be_merge_key` still describes it.
+    /// The current token is the one after `first_key`.
     fn parse_block_mapping_entries(
         &mut self,
         first_key: Expr,
+        first_key_may_merge: bool,
         mapping_indent: Indent,
         mapping_line: Line,
         flow_pair_allowed: bool,
     ) -> Result<E::Object, ParseError> {
-        let first_key_may_merge = self.scalar_may_be_merge_key;
-
         if let Some(explicit_document_start_line) = self.explicit_document_start_line {
             if mapping_line == explicit_document_start_line {
                 // TODO: more specific error
@@ -3207,10 +3202,9 @@ impl MappingProps {
 }
 
 impl<'i, Enc: Encoding> Parser<'i, Enc> {
-    /// Appends `key: value` to `props`, expanding a `<<` merge key;
-    /// `key_may_merge` is `scalar_may_be_merge_key` as read right after `key`
-    /// was parsed. A merge cannot pull in a collection that is still being
-    /// parsed (its properties are not there yet).
+    /// Appends `key: value` to `props`, expanding a `<<` merge key. A merge
+    /// cannot pull in a collection that is still being parsed (its properties
+    /// are not there yet).
     fn append_entry(
         &mut self,
         props: &mut MappingProps,
@@ -3987,6 +3981,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         let map = self.parse_block_mapping(
                             node_props.take_block_mapping_anchor(alias_line)?,
                             copy,
+                            false,
                             alias_start,
                             alias_indent,
                             alias_line,
@@ -4045,6 +4040,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         let map = self.parse_block_mapping(
                             node_props.take_block_mapping_anchor(sequence_line)?,
                             seq,
+                            false,
                             sequence_start,
                             sequence_indent,
                             sequence_line,
@@ -4126,6 +4122,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         let parent_map = self.parse_block_mapping(
                             node_props.take_block_mapping_anchor(mapping_line)?,
                             map,
+                            false,
                             mapping_start,
                             mapping_indent,
                             mapping_line,
@@ -4177,8 +4174,10 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                                 mapping_indent,
                                 mapping_line,
                             )?;
+                            let key_may_merge = p.scalar_may_be_merge_key;
                             p.parse_block_mapping_entries(
                                 key,
+                                key_may_merge,
                                 mapping_indent,
                                 mapping_line,
                                 flow_pair_allowed,
@@ -4220,6 +4219,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     let mapping = self.parse_block_mapping(
                         anchors.mapping_anchor,
                         first_key,
+                        false,
                         self.token.start,
                         self.token.indent,
                         colon_line,
@@ -4324,15 +4324,15 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         let implicit_key = scalar.data.to_expr(scalar_start, self.input, self.bump);
 
                         // [200] a tag on an earlier line (`foo: !custom` above
-                        // `<<: *base`) is the block mapping's, so the key
-                        // itself is untagged.
-                        if node_props
+                        // `<<: *base`) is the block mapping's, not the key's.
+                        let key_tag = if node_props
                             .tag_line()
                             .is_some_and(|line| line != scalar_line)
                         {
-                            self.scalar_may_be_merge_key =
-                                NodeTag::None.resolves_merge_key(scalar.style);
-                        }
+                            NodeTag::None
+                        } else {
+                            node_props.tag()
+                        };
 
                         let anchors = node_props.take_implicit_key_anchors(scalar_line)?;
                         if let Some(key_anchor) = anchors.key_anchor {
@@ -4342,6 +4342,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         let mapping = self.parse_block_mapping(
                             anchors.mapping_anchor,
                             implicit_key,
+                            key_tag.resolves_merge_key(scalar.style),
                             scalar_start,
                             scalar_indent,
                             scalar_line,

--- a/src/parsers/yaml.rs
+++ b/src/parsers/yaml.rs
@@ -1083,7 +1083,7 @@ impl<'i, Enc: Encoding> ScalarResolverCtx<'i, Enc> {
             NodeTag::Str => {
                 // always becomes string
             }
-            NodeTag::Verbatim(_) | NodeTag::Unknown(_) => {
+            NodeTag::Merge | NodeTag::Verbatim(_) | NodeTag::Unknown(_) => {
                 // also always becomes a string
             }
         }
@@ -1532,6 +1532,8 @@ pub enum NodeTag {
     Null,
     /// '!!str'
     Str,
+    /// '!!merge'
+    Merge,
     /// '!<...>'
     Verbatim(StringRange),
     /// '!!unknown'
@@ -1546,11 +1548,24 @@ impl NodeTag {
             | NodeTag::Int
             | NodeTag::Float
             | NodeTag::Null
+            | NodeTag::Merge
             | NodeTag::Verbatim(_)
             | NodeTag::Unknown(_) => Expr::init(E::Null {}, loc),
 
             // non-specific tags become seq, map, or str
             NodeTag::NonSpecific | NodeTag::Str => Expr::init(E::String::default(), loc),
+        }
+    }
+
+    /// Whether a `<<` scalar carrying this tag is a merge key
+    /// (yaml.org/type/merge.html). Untagged, only a plain `<<` resolves to
+    /// `!!merge`: a quoted `"<<"` (what `YAML.stringify` emits for that
+    /// property name) or a `!!str <<` is an ordinary string key.
+    pub(crate) fn resolves_merge_key(self, style: ScalarStyle) -> bool {
+        match self {
+            NodeTag::None => matches!(style, ScalarStyle::Plain { .. }),
+            NodeTag::Merge => true,
+            _ => false,
         }
     }
 }
@@ -2113,6 +2128,13 @@ pub struct Parser<'i, Enc: Encoding> {
     pub(crate) tab_after_indent: bool,
     pub(crate) line: Line,
     pub(crate) token: Token<Enc>,
+    /// `NodeTag::resolves_merge_key` for the scalar `parse_node` most
+    /// recently produced. Style and tag are gone once the scalar is an
+    /// `Expr`, so a mapping parser reads this right after it obtains a key
+    /// (parsing the value overwrites it) and hands it to `append_entry`,
+    /// which only consults it for a key whose text is `<<`. A key that is not
+    /// a scalar leaves it describing some scalar inside the key.
+    pub(crate) scalar_may_be_merge_key: bool,
 
     /// Growable buffers use the global
     /// allocator (and `Drop`); the arena is threaded for the few places that
@@ -2173,6 +2195,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                 indent: Indent::NONE,
                 line: Line::from(1),
             }),
+            scalar_may_be_merge_key: false,
             context: ContextStack::init(),
             block_indents: IndentStack::init(),
             explicit_document_start_line: None,
@@ -2545,6 +2568,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     // [150] ns-flow-pair ::= '?' s-separate ns-flow-map-explicit-entry
                     let pair_start = self.token.start;
                     let key = self.parse_flow_explicit_key()?;
+                    let key_may_merge = self.scalar_may_be_merge_key;
                     let value = if matches!(self.token.data, TokenData::MappingValue) {
                         self.scan(ScanOptions::default())?;
                         if matches!(
@@ -2567,7 +2591,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         Expr::init(E::Null {}, self.token.start.loc())
                     };
                     let mut props = MappingProps::init();
-                    self.append_entry(&mut props, key, value)?;
+                    self.append_entry(&mut props, key, key_may_merge, value)?;
                     Expr::init(
                         E::Object {
                             properties: props.move_list(),
@@ -2649,6 +2673,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     self.context.unset(Context::FlowKey);
                     k?
                 };
+                let key_may_merge = self.scalar_may_be_merge_key;
 
                 match self.token.data {
                     TokenData::CollectEntry => {
@@ -2702,7 +2727,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         current_mapping_indent: Some(self.token.indent),
                         ..Default::default()
                     })?;
-                    self.append_entry(&mut props, key, value)?;
+                    self.append_entry(&mut props, key, key_may_merge, value)?;
                 }
 
                 // [140] ns-s-flow-map-entries: after an entry, only `,` or `}`.
@@ -2853,7 +2878,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         })
     }
 
-    /// The current token is the one after `first_key`.
+    /// The current token is the one after `first_key`, which is the node
+    /// parsed most recently, so `scalar_may_be_merge_key` still describes it.
     fn parse_block_mapping_entries(
         &mut self,
         first_key: Expr,
@@ -2861,6 +2887,8 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         mapping_line: Line,
         flow_pair_allowed: bool,
     ) -> Result<E::Object, ParseError> {
+        let first_key_may_merge = self.scalar_may_be_merge_key;
+
         if let Some(explicit_document_start_line) = self.explicit_document_start_line {
             if mapping_line == explicit_document_start_line {
                 // TODO: more specific error
@@ -2942,7 +2970,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                     _ => Expr::init(E::Null {}, mapping_value_start.loc()),
                 };
 
-                self.append_entry(&mut props, first_key, value)?;
+                self.append_entry(&mut props, first_key, first_key_may_merge, value)?;
             }
 
             if self.context.get() == Context::FlowIn {
@@ -2976,6 +3004,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         current_mapping_indent: Some(mapping_indent),
                         ..Default::default()
                     })?;
+                    let key_may_merge = self.scalar_may_be_merge_key;
 
                     match self.token.data {
                         TokenData::Eof => {
@@ -3071,7 +3100,7 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
                     };
 
-                    self.append_entry(&mut props, key, value)?;
+                    self.append_entry(&mut props, key, key_may_merge, value)?;
                 }
 
                 Ok(())
@@ -3178,19 +3207,22 @@ impl MappingProps {
 }
 
 impl<'i, Enc: Encoding> Parser<'i, Enc> {
-    /// Appends `key: value` to `props`, expanding a `<<` merge key. A merge
-    /// cannot pull in a collection that is still being parsed (its properties
-    /// are not there yet).
+    /// Appends `key: value` to `props`, expanding a `<<` merge key;
+    /// `key_may_merge` is `scalar_may_be_merge_key` as read right after `key`
+    /// was parsed. A merge cannot pull in a collection that is still being
+    /// parsed (its properties are not there yet).
     fn append_entry(
         &mut self,
         props: &mut MappingProps,
         key: Expr,
+        key_may_merge: bool,
         value: Expr,
     ) -> Result<(), ParseError> {
-        let is_merge_key = match &key.data {
-            ast::ExprData::EString(key_str) => key_str.eql_comptime(b"<<"),
-            _ => false,
-        };
+        let is_merge_key = key_may_merge
+            && match &key.data {
+                ast::ExprData::EString(key_str) => key_str.eql_comptime(b"<<"),
+                _ => false,
+            };
 
         if is_merge_key {
             self.reject_open_merge_source(&value)?;
@@ -3848,6 +3880,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
             return Err(ParseError::StackOverflow);
         }
 
+        // Set by the Scalar arm; an alias to a `<<` scalar is not a merge key.
+        self.scalar_may_be_merge_key = false;
+
         // c-ns-properties
         let mut node_props: NodeProperties<Enc> = NodeProperties::default();
 
@@ -4211,6 +4246,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         _ => unreachable!("token.data was Scalar at match guard"),
                     };
 
+                    self.scalar_may_be_merge_key =
+                        node_props.tag().resolves_merge_key(scalar.style);
+
                     let json_key = if scalar.style == ScalarStyle::Quoted {
                         self.maybe_set_json_key(opts.flow_pair_allowed)?
                     } else {
@@ -4284,6 +4322,17 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
                         }
 
                         let implicit_key = scalar.data.to_expr(scalar_start, self.input, self.bump);
+
+                        // [200] a tag on an earlier line (`foo: !custom` above
+                        // `<<: *base`) is the block mapping's, so the key
+                        // itself is untagged.
+                        if node_props
+                            .tag_line()
+                            .is_some_and(|line| line != scalar_line)
+                        {
+                            self.scalar_may_be_merge_key =
+                                NodeTag::None.resolves_merge_key(scalar.style);
+                        }
 
                         let anchors = node_props.take_implicit_key_anchors(scalar_line)?;
                         if let Some(key_anchor) = anchors.key_anchor {
@@ -5674,6 +5723,9 @@ impl<'i, Enc: Encoding> Parser<'i, Enc> {
         }
         if eq_ascii::<Enc>(s, b"str") {
             return NodeTag::Str;
+        }
+        if eq_ascii::<Enc>(s, b"merge") {
+            return NodeTag::Merge;
         }
         NodeTag::Unknown(shorthand)
     }

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2787,6 +2787,21 @@ config:
       test("an explicit !!merge tag merges regardless of style", () => {
         expect(YAML.parse("base: &b {a: 1}\n!!merge <<: *b\nc: 3")).toEqual({ base: { a: 1 }, a: 1, c: 3 });
         expect(YAML.parse('base: &b {a: 1}\n!!merge "<<": *b\nc: 3')).toEqual({ base: { a: 1 }, a: 1, c: 3 });
+        // flow mapping
+        expect(YAML.parse('base: &b {a: 1}\nd: {!!merge "<<": *b, c: 3}')).toEqual({
+          base: { a: 1 },
+          d: { a: 1, c: 3 },
+        });
+        // block explicit key
+        expect(YAML.parse('base: &b {a: 1}\nd:\n  ? !!merge "<<"\n  : *b\n  c: 3')).toEqual({
+          base: { a: 1 },
+          d: { a: 1, c: 3 },
+        });
+        // flow sequence pairs
+        expect(YAML.parse('base: &b {a: 1}\nd: [!!merge "<<": *b, ? !!merge "<<" : *b]')).toEqual({
+          base: { a: 1 },
+          d: [{ a: 1 }, { a: 1 }],
+        });
       });
 
       test('a "<<" property round-trips through stringify', () => {

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2789,7 +2789,7 @@ config:
         expect(YAML.parse('base: &b {a: 1}\n!!merge "<<": *b\nc: 3')).toEqual({ base: { a: 1 }, a: 1, c: 3 });
       });
 
-      test("a \"<<\" property round-trips through stringify", () => {
+      test('a "<<" property round-trips through stringify', () => {
         for (const value of [
           { "<<": { admin: true }, user: "x" },
           { "<<": [1, 2] },
@@ -2800,7 +2800,7 @@ config:
         }
       });
 
-      test("the .yaml loader keeps a quoted \"<<\" key too", async () => {
+      test('the .yaml loader keeps a quoted "<<" key too', async () => {
         using dir = tempDir("yaml-quoted-merge-key", {
           "config.yaml": 'base: &base {a: 1}\nquoted:\n  "<<": *base\n  b: 2\nmerged:\n  <<: *base\n  b: 2\n',
           "index.ts": `

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2804,6 +2804,11 @@ config:
         });
       });
 
+      test("a tag on its own line in a flow sequence pair stays on the key", () => {
+        expect(YAML.parse("[!!str\n<<: {a: 1}]")).toEqual([{ "<<": { a: 1 } }]);
+        expect(YAML.parse('base: &b {a: 1}\nd: [!!merge\n  "<<": *b]')).toEqual({ base: { a: 1 }, d: [{ a: 1 }] });
+      });
+
       test('a "<<" property round-trips through stringify', () => {
         for (const value of [
           { "<<": { admin: true }, user: "x" },

--- a/test/js/bun/yaml/yaml.test.ts
+++ b/test/js/bun/yaml/yaml.test.ts
@@ -2704,6 +2704,126 @@ config:
           },
         });
       });
+
+      // yaml.org/type/merge.html: only a plain `<<` resolves to !!merge. Once
+      // quoted or tagged it is the two-character string key that
+      // YAML.stringify emits for a "<<" property.
+      describe.each(['"<<"', "'<<'", "!!str <<", "! <<"])("%s is an ordinary string key", key => {
+        test("as the first key of a block mapping", () => {
+          expect(YAML.parse(`${key}: {a: 1}\nb: 2`)).toEqual({ "<<": { a: 1 }, b: 2 });
+        });
+
+        test("as a later key of a block mapping", () => {
+          expect(YAML.parse(`b: 2\n${key}: {a: 1}`)).toEqual({ b: 2, "<<": { a: 1 } });
+        });
+
+        test("in a flow mapping", () => {
+          expect(YAML.parse(`{${key}: {a: 1}, b: 2}`)).toEqual({ "<<": { a: 1 }, b: 2 });
+        });
+
+        test("as an explicit key", () => {
+          expect(YAML.parse(`? ${key}\n: {a: 1}\nb: 2`)).toEqual({ "<<": { a: 1 }, b: 2 });
+        });
+
+        test("as a flow sequence pair", () => {
+          expect(YAML.parse(`[${key}: {a: 1}]`)).toEqual([{ "<<": { a: 1 } }]);
+          expect(YAML.parse(`[? ${key} : {a: 1}]`)).toEqual([{ "<<": { a: 1 } }]);
+        });
+
+        test("with a sequence value", () => {
+          expect(YAML.parse(`${key}: [{a: 1}, {c: 3}]\nb: 2`)).toEqual({ "<<": [{ a: 1 }, { c: 3 }], b: 2 });
+          expect(YAML.parse(`${key}: [1, 2]`)).toEqual({ "<<": [1, 2] });
+        });
+      });
+
+      test("a quoted key is not affected by merge keys inside its value, and vice versa", () => {
+        expect(YAML.parse('x:\n  "<<":\n    <<: {a: 1}\n    b: 2\n  c: 3')).toEqual({
+          x: { "<<": { a: 1, b: 2 }, c: 3 },
+        });
+        expect(YAML.parse('x:\n  <<:\n    "<<": {a: 1}\n    b: 2\n  c: 3')).toEqual({
+          x: { "<<": { a: 1 }, b: 2, c: 3 },
+        });
+        expect(YAML.parse('<<: {a: 1}\n"<<": {b: 2}')).toEqual({ a: 1, "<<": { b: 2 } });
+      });
+
+      test("a quoted key may hold an alias to the mapping being defined", () => {
+        const doc = YAML.parse('&a\nx: 1\n"<<": *a');
+        expect(doc["<<"]).toBe(doc);
+        expect(() => YAML.parse("&a\nx: 1\n<<: *a")).toThrow("Merge key cannot reference an enclosing node");
+      });
+
+      test("an alias to a `<<` scalar is an ordinary key", () => {
+        expect(YAML.parse("- &m <<\n- *m : {a: 1}")).toEqual(["<<", { "<<": { a: 1 } }]);
+      });
+
+      test("a plain `<<` merges in every key position", () => {
+        const merged = { base: { a: 1 }, d: { a: 1, c: 3 } };
+        expect(YAML.parse("base: &b {a: 1}\nd:\n  <<: *b\n  c: 3")).toEqual(merged);
+        expect(YAML.parse("base: &b {a: 1}\nd:\n  c: 3\n  <<: *b")).toEqual(merged);
+        expect(YAML.parse("base: &b {a: 1}\nd: {<<: *b, c: 3}")).toEqual(merged);
+        expect(YAML.parse("base: &b {a: 1}\nd:\n  ? <<\n  : *b\n  c: 3")).toEqual(merged);
+        expect(YAML.parse("base: &b {a: 1}\nd:\n  &k <<: *b\n  c: 3")).toEqual(merged);
+        expect(YAML.parse("base: &b {a: 1}\nd: [<<: *b, ? << : *b]")).toEqual({
+          base: { a: 1 },
+          d: [{ a: 1 }, { a: 1 }],
+        });
+        // A tag on the value's own line belongs to the mapping, not to its
+        // first key.
+        expect(YAML.parse("base: &b {a: 1}\nd: !custom\n  <<: *b\n  c: 3")).toEqual(merged);
+        expect(YAML.parse("base: &b {a: 1}\nd: !!map\n  <<: *b\n  c: 3")).toEqual(merged);
+        expect(YAML.parse("base: &b {a: 1}\nd:\n  - !custom\n    <<: *b\n    c: 3")).toEqual({
+          base: { a: 1 },
+          d: [{ a: 1, c: 3 }],
+        });
+        expect(YAML.parse("!!map\n<<: {a: 1}\nb: 2")).toEqual({ a: 1, b: 2 });
+        expect(YAML.parse("--- !custom\n<<: {a: 1}\nb: 2")).toEqual({ a: 1, b: 2 });
+        // A tag on the previous entry's value does not reach the next key.
+        expect(YAML.parse("base: &b {a: 1}\nd:\n  c: !!str 3\n  <<: *b")).toEqual({
+          base: { a: 1 },
+          d: { a: 1, c: "3" },
+        });
+      });
+
+      test("an explicit !!merge tag merges regardless of style", () => {
+        expect(YAML.parse("base: &b {a: 1}\n!!merge <<: *b\nc: 3")).toEqual({ base: { a: 1 }, a: 1, c: 3 });
+        expect(YAML.parse('base: &b {a: 1}\n!!merge "<<": *b\nc: 3')).toEqual({ base: { a: 1 }, a: 1, c: 3 });
+      });
+
+      test("a \"<<\" property round-trips through stringify", () => {
+        for (const value of [
+          { "<<": { admin: true }, user: "x" },
+          { "<<": [1, 2] },
+          { "<<": [{ a: 1 }] },
+          { nested: { "<<": { a: 1 } }, "<<": "s" },
+        ]) {
+          expect(YAML.parse(YAML.stringify(value))).toEqual(value);
+        }
+      });
+
+      test("the .yaml loader keeps a quoted \"<<\" key too", async () => {
+        using dir = tempDir("yaml-quoted-merge-key", {
+          "config.yaml": 'base: &base {a: 1}\nquoted:\n  "<<": *base\n  b: 2\nmerged:\n  <<: *base\n  b: 2\n',
+          "index.ts": `
+            import config from "./config.yaml";
+            console.log(JSON.stringify(config));
+          `,
+        });
+        await using proc = Bun.spawn({
+          cmd: [bunExe(), "index.ts"],
+          env: bunEnv,
+          cwd: String(dir),
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+        expect(stderr).toBe("");
+        expect(JSON.parse(stdout)).toEqual({
+          base: { a: 1 },
+          quoted: { "<<": { a: 1 }, b: 2 },
+          merged: { a: 1, b: 2 },
+        });
+        expect(exitCode).toBe(0);
+      });
     });
   });
 


### PR DESCRIPTION
### Problem
- `Bun.YAML.parse('"<<": {a: 1}\nb: 2')` returns `{ a: 1, b: 2 }`; the `"<<"` property is merged away. Same for `'<<'` and `!!str <<`, in block, flow and explicit (`?`) key positions, and through the `.yaml` import loader.
- When the value is a sequence of non-mappings the key disappears entirely: `YAML.parse('"<<": [1, 2]')` returns `{}`.
- `YAML.stringify` already quotes a `"<<"` property name so that it is not a merge key, so `YAML.parse(YAML.stringify(x))` does not round-trip any object with that property (found by a property test in the thread that reported this).
- Cause: `append_entry` (src/parsers/yaml.rs:3190 on main) decides `is_merge_key` by comparing the key's text to `<<`. By then the key is an `Expr`, and whether the scalar was plain, quoted or tagged is gone.
- The merge type (yaml.org/type/merge.html) is the plain scalar `<<` resolving to `!!merge`; a quoted or `!!str` scalar is an ordinary string key. js-yaml, the `yaml` package, PyYAML and go-yaml all behave this way.

### Fix
- `parse_node`'s scalar arm records, in `Parser::scalar_may_be_merge_key`, whether the scalar it just produced resolves to the merge type: untagged and plain, or explicitly tagged `!!merge` (new `NodeTag::Merge`, which otherwise behaves exactly like an unknown tag). The field is cleared on entry to `parse_node`, so a key produced any other way (an alias to a `<<` scalar, a collection) is not a merge key.
- The mapping parsers (block mapping, flow mapping, flow sequence pair) read the field right after they obtain a key and pass it to `append_entry`, which now requires it in addition to the `<<` text. For the first key of a block mapping the bit is computed where that key is parsed and threaded through as a `parse_block_mapping` parameter.
- When a scalar turns out to be the implicit first key of a block mapping and the tag it saw is on an earlier line, that tag belongs to the mapping ([200]), so the key counts as untagged. This keeps `foo: !custom` followed by an indented `<<: *base`, `- !custom` over a merged mapping, and `!!map` / `--- !custom` above a root-level `<<:` merging as before. This only applies in block context: a flow pair ([150]) takes no properties of its own, so in `[!!merge\n"<<": *b]` the tag stays on the key.
- Behaviour changes beyond quoted and tagged keys: an alias to a `<<` scalar (`*m : {...}`) is now an ordinary key (js-yaml and go-yaml agree; PyYAML merges), and a quoted `"<<"` whose value aliases the mapping being defined is now a plain self-reference instead of the "Merge key cannot reference an enclosing node" error, which still fires for a real merge key.
- Verified with test/js/bun/yaml/yaml.test.ts (`merge keys` block): 29 new tests fail on the released 1.4.0 and pass with this change; two positive tests pin that plain `<<` and `!!merge <<` still merge in every key position, including under tagged mappings.
- `bun bd test test/js/bun/yaml/` (3 files, 2159 tests) passes, as do test/js/bun/resolve/yaml and the bundler loader tests.

### Background
- Merge key: the YAML 1.1 convention where a `<<: *base` entry (or `<<: [*a, *b]`) copies the keys of the referenced mapping(s) into the current one, with the current mapping's own keys winning. Bun expands it at parse time in `append_entry` / `MappingProps::merge`, so a merge key never appears in the output object.
- Tag resolution: every YAML scalar gets a tag. An explicit one is written in the source (`!!str`, `!!merge`, `!custom`); otherwise the schema picks one from the text, but only for plain (unquoted) scalars. Quoted scalars are always strings, which is why `"<<"` is a string key and why `YAML.stringify` quotes it.
- In this parser the style (`ScalarStyle::Plain` / `Quoted` / `Block`) lives on the scalar token and the tag in `NodeProperties`, both local to `parse_node`; the mapping parsers only see the resulting `Expr`. `scalar_may_be_merge_key` carries that one bit across the same way `tab_after_indent` already carries a fact about the token just scanned.
- Tag attribution ([200] in the spec): properties written on the line before a block mapping (`foo: !custom` then the indented entries) annotate the mapping, while properties on the same line as an implicit key annotate the key. The scalar arm handles both because it is the place that turns a scalar into the first key of a new block mapping.

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 30 failed, 18 skipped
bun test v1.4.0-canary.1 (da3851e57)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [0.19ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [0.08ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [0.08ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [0.08ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [0.08ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [0.11ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [0.07ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [0.07ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [0.06ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [0.07ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [0.05ms]
(pass) Bun.YAML > parse > input types > parses from DataView [0.10ms]
(pass) Bun.YAML > parse > input types > parses from Blob [0.41ms]
(pass) Bun.YAML > parse > i
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: 18 skipped
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/bun/yaml/yaml.test.ts
bun test v1.4.0 (bf901fa4f)

test/js/bun/yaml/yaml.test.ts:
(pass) Bun.YAML > parse > input types > parses from Buffer [4.87ms]
(pass) Bun.YAML > parse > input types > parses from Buffer with UTF-8 [4.42ms]
(pass) Bun.YAML > parse > input types > parses from ArrayBuffer [6.09ms]
(pass) Bun.YAML > parse > input types > parses from Uint8Array [3.89ms]
(pass) Bun.YAML > parse > input types > parses from Uint16Array [6.00ms]
(pass) Bun.YAML > parse > input types > parses from Int8Array [4.23ms]
(pass) Bun.YAML > parse > input types > parses from Int16Array [5.86ms]
(pass) Bun.YAML > parse > input types > parses from Int32Array [5.69ms]
(pass) Bun.YAML > parse > input types > parses from Uint32Array [5.42ms]
(pass) Bun.YAML > parse > input types > parses from Float32Array [5.69ms]
(pass) Bun.YAML > parse > input types > parses from Float64Array [7.14ms]
(pass) Bun.YAML > parse > input types > parses from BigInt64Array [4.89ms]
(pass) Bun.YAML > parse > input types > parses from BigUint64Array [5.73ms]
(pass) Bu
... (truncated)

release with fix: 18 skipped
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     bf901fa4fe
  features     baseline

22 deps, 107 codegen, 1176 objects in 2266ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] gen bindgenv2
[3/1238] fetch tinycc
[tinycc] up to date
[4/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[5/1237] gen NodeModuleModule.lut.h
Generating /workspace/bun/build/release/codegen/NodeModuleModule.lut.h from /workspace/bun/src/jsc/modules/NodeModuleModule.cpp
[6/1237] fetch zlib
[zlib] up to date
[7/1237] gen .bind.ts → GeneratedBindings.cpp
[8/1237] gen ProcessBindingHTTPParser.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingHTTPParser.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingHTTPParser.cpp
[9/1237] fetch picohttpparser
[picohttpparser] up to date
[10/1237] fetch nodejs (prebuilt)
[nodejs] up to date
[11/1237] subst deps/zlib/zlib.h

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/parsers/yaml.rs           |  75 +++++++++++++++++++---
 test/js/bun/yaml/yaml.test.ts | 140 ++++++++++++++++++++++++++++++++++++++++++
 2 files changed, 206 insertions(+), 9 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                           reads  edits  tests
src/parsers/yaml.rs                8      6      0
test/js/bun/yaml/yaml.test.ts      1      2      0
```

</details>

**root cause** · written by the author bot

The bug was that the YAML parser treated any `<<` key as a merge key, so quoted keys like `"<<"` or keys explicitly tagged as strings (`!!str <<`) incorrectly triggered merge semantics instead of being kept as literal keys. The fix adds a `NodeTag::Merge` variant mapped from `!!merge` and restricts merge expansion to `<<` keys that are either plain scalars or explicitly merge-tagged, threading that eligibility through block and flow mapping contexts. A follow-up refinement gates the earlier-line tag reset to block context only, so a tag on a preceding line in a flow sequence pair correctly …

<!-- robobun:evidence:end -->