### PR TITLE
node:tls: destroy the wrapped net.Socket when a TLS wrap is destroyed

### DIFF
--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -142,7 +142,6 @@ const kSyncWriteFd = Symbol("kSyncWriteFd");
 const kSetKeepAliveInitialDelay = Symbol("kSetKeepAliveInitialDelay");
 const kConnectOptions = Symbol("connect-options");
 const kAttach = Symbol("kAttach");
-const kCloseRawConnection = Symbol("kCloseRawConnection");
 const kupgraded = Symbol("kupgraded");
 const kAdoptedTLSRaw = Symbol("kAdoptedTLSRaw");
 const ksocket = Symbol("ksocket");
@@ -248,6 +247,24 @@ function closeAdoptedTLSRawNT(handle, self, isException) {
 function closeAdoptedTLSRawNowNT(handle, self, isException) {
   handle.close(onSocketHandleClosed);
   setImmediate(emitCloseNT, self, isException);
+}
+// The transport a TLS socket was layered over (tls.connect({ socket }),
+// new TLSSocket(socket)) goes down with it, like the parent wrap of node's
+// TLSWrap: it emits 'close' and, if it was accepted, leaves its server's
+// connection count. Keyed on destroy rather than 'end' because a handshake
+// failure destroys the TLS socket without ever emitting 'end'. A net.Socket
+// holding the raw twin of this socket's TLS handle shares the fd that this
+// socket's own handle close tears down, so it is only detached; anything else
+// (a generic duplex, or a socket still driving its own fd under the
+// stream-level TLS engine) owns its transport and closes it itself, so a late
+// RST on it can't surface as an error after this socket is gone.
+function destroyUpgradedTransport(self) {
+  const upgraded = self[kupgraded];
+  if (!upgraded || upgraded.destroyed) return;
+  if (upgraded._handle?.[kAdoptedTLSRaw]) {
+    upgraded._handle = null;
+  }
+  upgraded.destroy();
 }
 function detachSocket(self) {
   if (!self) self = this;
@@ -1863,14 +1880,6 @@ Socket.prototype[kAttach] = function (port, socket) {
   SocketHandlers.drain(socket);
 };
 
-Socket.prototype[kCloseRawConnection] = function () {
-  const connection = this[kupgraded];
-  connection.connecting = false;
-  connection._handle = null;
-  connection.unref();
-  connection.destroy();
-};
-
 Socket.prototype.connect = function connect(...args) {
   $debug("Socket.prototype.connect");
   {
@@ -2018,7 +2027,6 @@ Socket.prototype.connect = function connect(...args) {
               // replace socket
               connection._handle = raw;
               raw[kAdoptedTLSRaw] = true;
-              this.once("end", this[kCloseRawConnection]);
               raw.connecting = false;
               this._handle = tls;
             } else {
@@ -2065,7 +2073,6 @@ Socket.prototype.connect = function connect(...args) {
                   // replace socket
                   connection._handle = raw;
                   raw[kAdoptedTLSRaw] = true;
-                  this.once("end", this[kCloseRawConnection]);
                   raw.connecting = false;
                   this._handle = tls;
                 } else {
@@ -2141,14 +2148,7 @@ Socket.prototype._destroy = function _destroy(err, callback) {
   $debug("Socket.prototype._destroy");
 
   this.connecting = false;
-  // Tear down a wrapped generic duplex with this socket: the native handle's
-  // close only flushes close_notify and lets the wrapper drain; without an
-  // explicit destroy here a late RST on the underlying transport can surface
-  // as an unhandled error after this socket is gone.
-  const upgraded = this[kupgraded];
-  if (upgraded && !(upgraded instanceof Socket) && !upgraded.destroyed) {
-    upgraded.destroy?.();
-  }
+  destroyUpgradedTransport(this);
 
   // Close an fd adopted for synchronous writes (node closes the wrapping
   // libuv handle here). Leave stdio fds 0-2 open: process.stdout/stderr and
@@ -2418,7 +2418,6 @@ Socket.prototype[Symbol.for("::bunUpgradeServerTLS::")] = function (connection, 
     const [raw, tlsHandle] = result;
     connection._handle = raw;
     raw[kAdoptedTLSRaw] = true;
-    this.once("end", this[kCloseRawConnection]);
     raw.connecting = false;
     this._handle = tlsHandle;
     this.emit(kUpgradeAttached);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -248,19 +248,11 @@ function closeAdoptedTLSRawNowNT(handle, self, isException) {
   handle.close(onSocketHandleClosed);
   setImmediate(emitCloseNT, self, isException);
 }
-// The transport a TLS socket was layered over (tls.connect({ socket }),
-// new TLSSocket(socket)) goes down with it, like the parent wrap of node's
-// TLSWrap: it emits 'close' and, if it was accepted, leaves its server's
-// connection count. Keyed on _destroy rather than on 'end' because a handshake
-// failure destroys the TLS socket without ever emitting 'end', and run a tick
-// after _destroy's callback so that, as in node, the TLS socket's 'error' (and
-// a tls.Server's 'tlsClientError') still see the transport intact and its
-// 'close' lands between the TLS socket's 'error' and 'close'. A net.Socket
-// holding the raw twin of the TLS handle shares the fd that the TLS handle's
-// own close tears down, so it is only detached; anything else (a generic
-// duplex, or a socket still driving its own fd under the stream-level TLS
-// engine) owns its transport and closes it itself, so a late RST on it can't
-// surface as an error after the TLS socket is gone.
+// A TLS socket takes the transport it was layered over down with it, like
+// node's TLSWrap does its parent wrap: on the tick after _destroy, so the TLS
+// socket's 'error' still sees the transport intact and the transport's 'close'
+// precedes the TLS socket's. The raw twin of an adopted fd is closed by the
+// TLS handle, so it is detached rather than closed a second time.
 function destroyUpgradedTransportNT(upgraded) {
   if (upgraded.destroyed) return;
   if (upgraded._handle?.[kAdoptedTLSRaw]) {
@@ -268,9 +260,7 @@ function destroyUpgradedTransportNT(upgraded) {
   }
   upgraded.destroy();
 }
-// For a socket whose handle is already gone: a detached transport queues its
-// 'close' inside destroy(), so queuing this socket's 'close' afterwards keeps
-// node's order (transport first).
+// Handle-less TLS socket: its 'close' is queued behind the transport's.
 function destroyUpgradedTransportAndCloseNT(upgraded, self, hasError) {
   destroyUpgradedTransportNT(upgraded);
   process.nextTick(emitCloseNT, self, hasError);
@@ -2007,9 +1997,8 @@ Socket.prototype.connect = function connect(...args) {
           // if is named pipe socket we can upgrade it using the same wrapper than we use for duplex
           upgradeDuplex = isNamedPipeSocket(socket) || hasUnflushedWrites(connection);
         }
-        // Recorded before the upgrade runs (which may wait for 'connect' below)
-        // so that destroying this socket at any point from here on takes the
-        // connection down with it; see destroyUpgradedTransportNT.
+        // Before the upgrade, which may wait for 'connect': from here on
+        // destroying this socket destroys the connection too.
         this[kupgraded] = connection;
         if (upgradeDuplex) {
           const [result, events] = upgradeDuplexToTLS(connection, {
@@ -2047,10 +2036,7 @@ Socket.prototype.connect = function connect(...args) {
           } else {
             // wait to be connected
             connection.once("connect", () => {
-              // The TLS socket may have been destroyed before the underlying
-              // socket connected (e.g. tls.connect({ socket }).destroy()); its
-              // teardown is already destroying the connection, don't start a
-              // handshake on it.
+              // Destroyed while connecting: _destroy is taking the connection down.
               if (this.destroyed) return;
               const socket = connection._handle;
               if (!upgradeDuplex && socket) {
@@ -2221,8 +2207,7 @@ Socket.prototype._destroy = function _destroy(err, callback) {
       this._sockname = null;
     }
     callback(err);
-    // After callback(err), which queues this socket's 'error'; 'close' comes
-    // from the handle close above (setImmediate), after the transport's.
+    // Queued after the 'error' that callback(err) queues.
     if (upgraded) process.nextTick(destroyUpgradedTransportNT, upgraded);
   } else {
     callback(err);

--- a/src/js/node/net.ts
+++ b/src/js/node/net.ts
@@ -251,20 +251,29 @@ function closeAdoptedTLSRawNowNT(handle, self, isException) {
 // The transport a TLS socket was layered over (tls.connect({ socket }),
 // new TLSSocket(socket)) goes down with it, like the parent wrap of node's
 // TLSWrap: it emits 'close' and, if it was accepted, leaves its server's
-// connection count. Keyed on destroy rather than 'end' because a handshake
-// failure destroys the TLS socket without ever emitting 'end'. A net.Socket
-// holding the raw twin of this socket's TLS handle shares the fd that this
-// socket's own handle close tears down, so it is only detached; anything else
-// (a generic duplex, or a socket still driving its own fd under the
-// stream-level TLS engine) owns its transport and closes it itself, so a late
-// RST on it can't surface as an error after this socket is gone.
-function destroyUpgradedTransport(self) {
-  const upgraded = self[kupgraded];
-  if (!upgraded || upgraded.destroyed) return;
+// connection count. Keyed on _destroy rather than on 'end' because a handshake
+// failure destroys the TLS socket without ever emitting 'end', and run a tick
+// after _destroy's callback so that, as in node, the TLS socket's 'error' (and
+// a tls.Server's 'tlsClientError') still see the transport intact and its
+// 'close' lands between the TLS socket's 'error' and 'close'. A net.Socket
+// holding the raw twin of the TLS handle shares the fd that the TLS handle's
+// own close tears down, so it is only detached; anything else (a generic
+// duplex, or a socket still driving its own fd under the stream-level TLS
+// engine) owns its transport and closes it itself, so a late RST on it can't
+// surface as an error after the TLS socket is gone.
+function destroyUpgradedTransportNT(upgraded) {
+  if (upgraded.destroyed) return;
   if (upgraded._handle?.[kAdoptedTLSRaw]) {
     upgraded._handle = null;
   }
   upgraded.destroy();
+}
+// For a socket whose handle is already gone: a detached transport queues its
+// 'close' inside destroy(), so queuing this socket's 'close' afterwards keeps
+// node's order (transport first).
+function destroyUpgradedTransportAndCloseNT(upgraded, self, hasError) {
+  destroyUpgradedTransportNT(upgraded);
+  process.nextTick(emitCloseNT, self, hasError);
 }
 function detachSocket(self) {
   if (!self) self = this;
@@ -1998,8 +2007,11 @@ Socket.prototype.connect = function connect(...args) {
           // if is named pipe socket we can upgrade it using the same wrapper than we use for duplex
           upgradeDuplex = isNamedPipeSocket(socket) || hasUnflushedWrites(connection);
         }
+        // Recorded before the upgrade runs (which may wait for 'connect' below)
+        // so that destroying this socket at any point from here on takes the
+        // connection down with it; see destroyUpgradedTransportNT.
+        this[kupgraded] = connection;
         if (upgradeDuplex) {
-          this[kupgraded] = connection;
           const [result, events] = upgradeDuplexToTLS(connection, {
             data: { self: this, req: { oncomplete: afterConnect } },
             tls,
@@ -2015,7 +2027,6 @@ Socket.prototype.connect = function connect(...args) {
           // connecting (e.g. tls.connect({ socket: net.connect(port) })) must be
           // upgraded once it emits 'connect'.
           if (socket && !connection.connecting) {
-            this[kupgraded] = connection;
             const result = upgradeTLSDeferred(socket, {
               data: { self: this, req: { oncomplete: afterConnect } },
               tls,
@@ -2037,19 +2048,16 @@ Socket.prototype.connect = function connect(...args) {
             // wait to be connected
             connection.once("connect", () => {
               // The TLS socket may have been destroyed before the underlying
-              // socket connected (e.g. tls.connect({ socket }).destroy()); don't
-              // start a handshake on a dead socket.
-              if (this.destroyed) {
-                connection.destroy();
-                return;
-              }
+              // socket connected (e.g. tls.connect({ socket }).destroy()); its
+              // teardown is already destroying the connection, don't start a
+              // handshake on it.
+              if (this.destroyed) return;
               const socket = connection._handle;
               if (!upgradeDuplex && socket) {
                 // if is named pipe socket we can upgrade it using the same wrapper than we use for duplex
                 upgradeDuplex = isNamedPipeSocket(socket) || hasUnflushedWrites(connection);
               }
               if (upgradeDuplex) {
-                this[kupgraded] = connection;
                 const [result, events] = upgradeDuplexToTLS(connection, {
                   data: { self: this, req: { oncomplete: afterConnect } },
                   tls,
@@ -2061,7 +2069,6 @@ Socket.prototype.connect = function connect(...args) {
                 connection.on("close", events[3]);
                 this._handle = result;
               } else {
-                this[kupgraded] = connection;
                 const result = upgradeTLSDeferred(socket, {
                   data: { self: this, req: { oncomplete: afterConnect } },
                   tls,
@@ -2148,7 +2155,7 @@ Socket.prototype._destroy = function _destroy(err, callback) {
   $debug("Socket.prototype._destroy");
 
   this.connecting = false;
-  destroyUpgradedTransport(this);
+  const upgraded = this[kupgraded];
 
   // Close an fd adopted for synchronous writes (node closes the wrapping
   // libuv handle here). Leave stdio fds 0-2 open: process.stdout/stderr and
@@ -2214,9 +2221,16 @@ Socket.prototype._destroy = function _destroy(err, callback) {
       this._sockname = null;
     }
     callback(err);
+    // After callback(err), which queues this socket's 'error'; 'close' comes
+    // from the handle close above (setImmediate), after the transport's.
+    if (upgraded) process.nextTick(destroyUpgradedTransportNT, upgraded);
   } else {
     callback(err);
-    process.nextTick(emitCloseNT, this, err ? true : false);
+    if (upgraded) {
+      process.nextTick(destroyUpgradedTransportAndCloseNT, upgraded, this, err ? true : false);
+    } else {
+      process.nextTick(emitCloseNT, this, err ? true : false);
+    }
   }
 
   const server = this._server;

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -1308,9 +1308,11 @@ it("SNICallback runs even when the requested servername matches the bind hostnam
   });
   server.listen(0, "localhost");
   await once(server, "listening");
-  const port = (server.address() as AddressInfo).port;
-  // host: "localhost" defaults servername to "localhost" - the bind hostname.
-  const client = connect({ port, host: "localhost", rejectUnauthorized: false });
+  const { port, address } = server.address() as AddressInfo;
+  // Connect to the literal bound address ("localhost" may resolve to a
+  // different family than the one the server picked) and request the bind
+  // hostname via SNI.
+  const client = connect({ port, host: address, servername: "localhost", rejectUnauthorized: false });
   await once(client, "secureConnect");
   expect(sniCalls).toBe(1);
   // The peer certificate must be the SNICallback's RSA cert, not COMMON_CERT.

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2019,6 +2019,130 @@ it("destroys a server wrap whose socket was destroyed before the deferred upgrad
   }
 });
 
+// The converse of the test above: destroying the wrap has to take the wrapped
+// net.Socket down with it (node's TLSWrap close() destroys its parent wrap).
+// Otherwise the accepted socket never emits 'close', stays in the net.Server's
+// connection count and server.close(cb) never calls back. Releasing it from the
+// wrap's 'end' only covered a graceful shutdown: a handshake failure destroys
+// the wrap without ever emitting 'end'.
+describe("destroying a server-side TLSSocket wrap destroys the wrapped net.Socket", () => {
+  // events.once() rejects on 'error', which several of these sockets emit
+  // before 'close'; resolves with the 'close' event's hadError argument.
+  const closed = (emitter: net.Socket | TLSSocket) => new Promise<boolean>(resolve => emitter.once("close", resolve));
+
+  type Accepted = { raw: net.Socket; rawClosed: Promise<boolean>; wrapClosed: Promise<unknown> };
+
+  async function listenRaw(onConnection: (raw: net.Socket) => Accepted) {
+    const accepted = Promise.withResolvers<Accepted>();
+    const rawServer = net.createServer(raw => accepted.resolve(onConnection(raw)));
+    rawServer.on("error", accepted.reject);
+    rawServer.listen(0, "127.0.0.1");
+    await once(rawServer, "listening");
+    return { rawServer, port: (rawServer.address() as AddressInfo).port, accepted: accepted.promise };
+  }
+
+  async function expectReleased(rawServer: net.Server, { raw, rawClosed, wrapClosed }: Accepted) {
+    await wrapClosed;
+    // The wrap's _destroy destroys the wrapped socket synchronously, so it is
+    // already destroyed once the wrap has closed, and it emits 'close' itself.
+    expect(raw.destroyed).toBe(true);
+    expect(await rawClosed).toBe(false);
+    const connections = Promise.withResolvers<number>();
+    rawServer.getConnections((err, count) => (err ? connections.reject(err) : connections.resolve(count)));
+    expect(await connections.promise).toBe(0);
+    // With the connection released, close() completes.
+    const serverClosed = once(rawServer, "close");
+    rawServer.close();
+    await serverClosed;
+  }
+
+  it("when the handshake fails", async () => {
+    const failure = Promise.withResolvers<{ code: string | undefined; hadError: boolean }>();
+    const { rawServer, port, accepted } = await listenRaw(raw => {
+      const wrap = new TLSSocket(raw, { isServer: true, ...COMMON_CERT });
+      let code: string | undefined;
+      wrap.on("error", (err: Error & { code?: string }) => (code = err.code));
+      const wrapClosed = closed(wrap).then(hadError => failure.resolve({ code, hadError }));
+      return { raw, rawClosed: closed(raw), wrapClosed };
+    });
+    // A plain TCP peer whose first bytes are not a ClientHello.
+    const client = net.connect(port, "127.0.0.1");
+    client.on("error", () => {});
+    try {
+      const conn = await accepted;
+      client.write("this is not a TLS ClientHello\r\n");
+      expect(await failure.promise).toEqual({ code: "ERR_SSL_WRONG_VERSION_NUMBER", hadError: true });
+      await expectReleased(rawServer, conn);
+    } finally {
+      client.destroy();
+      rawServer.close();
+    }
+  });
+
+  it("when the wrap is destroyed in the tick it was created, before the socket was adopted", async () => {
+    const { rawServer, port, accepted } = await listenRaw(raw => {
+      const wrap = new TLSSocket(raw, { isServer: true, ...COMMON_CERT });
+      const wrapClosed = closed(wrap);
+      wrap.destroy();
+      return { raw, rawClosed: closed(raw), wrapClosed };
+    });
+    const client = net.connect(port, "127.0.0.1");
+    client.on("error", () => {});
+    const clientClosed = closed(client);
+    try {
+      await expectReleased(rawServer, await accepted);
+      // The raw socket still owned the fd, so destroying it is what closes the
+      // connection the peer is holding.
+      await clientClosed;
+    } finally {
+      client.destroy();
+      rawServer.close();
+    }
+  });
+
+  it("when the wrap runs the TLS engine over a socket that has no handle", async () => {
+    const raw = new net.Socket();
+    const rawClosed = closed(raw);
+    const wrap = new TLSSocket(raw, { isServer: true, ...COMMON_CERT });
+    const wrapClosed = closed(wrap);
+    wrap.destroy();
+    await wrapClosed;
+    expect(raw.destroyed).toBe(true);
+    expect(await rawClosed).toBe(false);
+  });
+
+  it("when a tls.Server rejects the client certificate of a connection handed to it via emit('connection')", async () => {
+    // STARTTLS-style: a plain net.Server accepts the connection and hands it to
+    // a tls.Server, which wraps it. The rejected handshake has to release the
+    // connection from the net.Server that accepted it.
+    const tlsServer = createServer({ ...COMMON_CERT, requestCert: true, rejectUnauthorized: true });
+    tlsServer.on("secureConnection", s => s.destroy(new Error("unexpected secureConnection")));
+    const rejected = Promise.withResolvers<{ code: unknown; wrapClosed: Promise<boolean> }>();
+    // Emitted before the wrap is destroyed, so this is where its 'close' can be
+    // awaited from.
+    tlsServer.on("tlsClientError", (err: Error & { code?: string }, wrap) =>
+      rejected.resolve({ code: err.code, wrapClosed: closed(wrap) }),
+    );
+    const { rawServer, port, accepted } = await listenRaw(raw => {
+      const rawClosed = closed(raw);
+      tlsServer.emit("connection", raw);
+      return { raw, rawClosed, wrapClosed: rejected.promise.then(r => r.wrapClosed) };
+    });
+    // The client presents a self-signed certificate the server has no CA for.
+    const client = connect({ port, host: "127.0.0.1", ...COMMON_CERT, rejectUnauthorized: false });
+    client.on("error", () => {});
+    try {
+      const conn = await accepted;
+      expect((await rejected.promise).code).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+      await expectReleased(rawServer, conn);
+    } finally {
+      client.destroy();
+      rawServer.close();
+      tlsServer.close();
+    }
+  });
+});
+
 it("exposes the server-side peer verification result via socket.ssl.verifyError()", async () => {
   // Node's server path consults the same TLSWrap.verifyError() that clients
   // use, so the shim must be populated for server sockets too:

--- a/test/js/node/tls/node-tls-server.test.ts
+++ b/test/js/node/tls/node-tls-server.test.ts
@@ -2024,15 +2024,32 @@ it("destroys a server wrap whose socket was destroyed before the deferred upgrad
 // Otherwise the accepted socket never emits 'close', stays in the net.Server's
 // connection count and server.close(cb) never calls back. Releasing it from the
 // wrap's 'end' only covered a graceful shutdown: a handshake failure destroys
-// the wrap without ever emitting 'end'.
+// the wrap without ever emitting 'end'. Node's order of events, asserted below:
+// the wrap's 'error' / the server's 'tlsClientError' first, with the wrapped
+// socket still intact, then the wrapped socket's 'close', then the wrap's.
 describe("destroying a server-side TLSSocket wrap destroys the wrapped net.Socket", () => {
-  // events.once() rejects on 'error', which several of these sockets emit
-  // before 'close'; resolves with the 'close' event's hadError argument.
-  const closed = (emitter: net.Socket | TLSSocket) => new Promise<boolean>(resolve => emitter.once("close", resolve));
+  type Accepted = { raw: net.Socket; events: string[]; settled: Promise<void> };
 
-  type Accepted = { raw: net.Socket; rawClosed: Promise<boolean>; wrapClosed: Promise<unknown> };
+  // Logs both sockets' lifecycle events in order. `settled` resolves once the
+  // wrap's 'close' has been logged, plus the raw socket's if one is still due
+  // (a raw socket that was never destroyed, the bug, would never emit it, so
+  // that case settles immediately and fails on the log). Plain listeners rather
+  // than events.once(): the wrap emits 'error' before 'close' here.
+  function observe(raw: net.Socket, wrap: TLSSocket, events: string[] = []): Accepted {
+    const settled = Promise.withResolvers<void>();
+    raw.on("close", hadError => events.push(`raw close hadError=${hadError}`));
+    wrap.on("error", (err: Error & { code?: string }) =>
+      events.push(`wrap error ${err.code} raw.destroyed=${raw.destroyed}`),
+    );
+    wrap.on("close", hadError => {
+      events.push(`wrap close hadError=${hadError} raw.destroyed=${raw.destroyed}`);
+      if (raw.destroyed && !events.some(event => event.startsWith("raw close"))) raw.once("close", settled.resolve);
+      else settled.resolve();
+    });
+    return { raw, events, settled: settled.promise };
+  }
 
-  async function listenRaw(onConnection: (raw: net.Socket) => Accepted) {
+  async function listenRaw(onConnection: (raw: net.Socket) => Accepted | Promise<Accepted>) {
     const accepted = Promise.withResolvers<Accepted>();
     const rawServer = net.createServer(raw => accepted.resolve(onConnection(raw)));
     rawServer.on("error", accepted.reject);
@@ -2041,12 +2058,10 @@ describe("destroying a server-side TLSSocket wrap destroys the wrapped net.Socke
     return { rawServer, port: (rawServer.address() as AddressInfo).port, accepted: accepted.promise };
   }
 
-  async function expectReleased(rawServer: net.Server, { raw, rawClosed, wrapClosed }: Accepted) {
-    await wrapClosed;
-    // The wrap's _destroy destroys the wrapped socket synchronously, so it is
-    // already destroyed once the wrap has closed, and it emits 'close' itself.
+  async function expectReleased(rawServer: net.Server, { raw, events, settled }: Accepted, expected: string[]) {
+    await settled;
+    expect(events).toEqual(expected);
     expect(raw.destroyed).toBe(true);
-    expect(await rawClosed).toBe(false);
     const connections = Promise.withResolvers<number>();
     rawServer.getConnections((err, count) => (err ? connections.reject(err) : connections.resolve(count)));
     expect(await connections.promise).toBe(0);
@@ -2057,42 +2072,82 @@ describe("destroying a server-side TLSSocket wrap destroys the wrapped net.Socke
   }
 
   it("when the handshake fails", async () => {
-    const failure = Promise.withResolvers<{ code: string | undefined; hadError: boolean }>();
-    const { rawServer, port, accepted } = await listenRaw(raw => {
-      const wrap = new TLSSocket(raw, { isServer: true, ...COMMON_CERT });
-      let code: string | undefined;
-      wrap.on("error", (err: Error & { code?: string }) => (code = err.code));
-      const wrapClosed = closed(wrap).then(hadError => failure.resolve({ code, hadError }));
-      return { raw, rawClosed: closed(raw), wrapClosed };
-    });
+    const { rawServer, port, accepted } = await listenRaw(raw =>
+      observe(raw, new TLSSocket(raw, { isServer: true, ...COMMON_CERT })),
+    );
     // A plain TCP peer whose first bytes are not a ClientHello.
     const client = net.connect(port, "127.0.0.1");
     client.on("error", () => {});
     try {
       const conn = await accepted;
       client.write("this is not a TLS ClientHello\r\n");
-      expect(await failure.promise).toEqual({ code: "ERR_SSL_WRONG_VERSION_NUMBER", hadError: true });
-      await expectReleased(rawServer, conn);
+      await expectReleased(rawServer, conn, [
+        "wrap error ERR_SSL_WRONG_VERSION_NUMBER raw.destroyed=false",
+        "raw close hadError=false",
+        "wrap close hadError=true raw.destroyed=true",
+      ]);
     } finally {
       client.destroy();
       rawServer.close();
     }
   });
 
+  it("when a tls.Server rejects the client certificate of a connection handed to it via emit('connection')", async () => {
+    // STARTTLS-style: a plain net.Server accepts the connection and hands it to
+    // a tls.Server, which wraps it. The rejected handshake has to release the
+    // connection from the net.Server that accepted it.
+    const tlsServer = createServer({ ...COMMON_CERT, requestCert: true, rejectUnauthorized: true });
+    tlsServer.on("secureConnection", s => s.destroy(new Error("unexpected secureConnection")));
+    const { rawServer, port, accepted } = await listenRaw(raw => {
+      const observed = Promise.withResolvers<Accepted>();
+      // The wrap is only reachable through 'tlsClientError', which is emitted
+      // right before it is destroyed: observe it from inside the listener.
+      tlsServer.once("tlsClientError", (err: Error & { code?: string }, wrap) => {
+        observed.resolve(observe(raw, wrap, [`tlsClientError ${err.code} raw.destroyed=${raw.destroyed}`]));
+      });
+      tlsServer.emit("connection", raw);
+      return observed.promise;
+    });
+    // The client presents a self-signed certificate the server has no CA for.
+    const client = connect({ port, host: "127.0.0.1", ...COMMON_CERT, rejectUnauthorized: false });
+    client.on("error", () => {});
+    try {
+      await expectReleased(rawServer, await accepted, [
+        "tlsClientError DEPTH_ZERO_SELF_SIGNED_CERT raw.destroyed=false",
+        "wrap error DEPTH_ZERO_SELF_SIGNED_CERT raw.destroyed=false",
+        "raw close hadError=false",
+        "wrap close hadError=true raw.destroyed=true",
+      ]);
+    } finally {
+      client.destroy();
+      rawServer.close();
+      tlsServer.close();
+    }
+  });
+
   it("when the wrap is destroyed in the tick it was created, before the socket was adopted", async () => {
     const { rawServer, port, accepted } = await listenRaw(raw => {
       const wrap = new TLSSocket(raw, { isServer: true, ...COMMON_CERT });
-      const wrapClosed = closed(wrap);
+      const conn = observe(raw, wrap);
       wrap.destroy();
-      return { raw, rawClosed: closed(raw), wrapClosed };
+      return conn;
     });
     const client = net.connect(port, "127.0.0.1");
     client.on("error", () => {});
-    const clientClosed = closed(client);
+    const clientClosed = new Promise<void>(resolve => client.once("close", () => resolve()));
     try {
-      await expectReleased(rawServer, await accepted);
-      // The raw socket still owned the fd, so destroying it is what closes the
-      // connection the peer is holding.
+      const conn = await accepted;
+      await conn.settled;
+      // The raw socket still owned the fd, so its 'close' follows its handle
+      // close, a later phase than the handle-less wrap's 'close': the order of
+      // the two is not part of the contract here, the set of events is.
+      conn.events.sort();
+      await expectReleased(rawServer, conn, [
+        "raw close hadError=false",
+        "wrap close hadError=false raw.destroyed=true",
+      ]);
+      // Destroying the raw socket is also what closes the connection the peer
+      // is holding.
       await clientClosed;
     } finally {
       client.destroy();
@@ -2102,44 +2157,11 @@ describe("destroying a server-side TLSSocket wrap destroys the wrapped net.Socke
 
   it("when the wrap runs the TLS engine over a socket that has no handle", async () => {
     const raw = new net.Socket();
-    const rawClosed = closed(raw);
     const wrap = new TLSSocket(raw, { isServer: true, ...COMMON_CERT });
-    const wrapClosed = closed(wrap);
+    const { events, settled } = observe(raw, wrap);
     wrap.destroy();
-    await wrapClosed;
-    expect(raw.destroyed).toBe(true);
-    expect(await rawClosed).toBe(false);
-  });
-
-  it("when a tls.Server rejects the client certificate of a connection handed to it via emit('connection')", async () => {
-    // STARTTLS-style: a plain net.Server accepts the connection and hands it to
-    // a tls.Server, which wraps it. The rejected handshake has to release the
-    // connection from the net.Server that accepted it.
-    const tlsServer = createServer({ ...COMMON_CERT, requestCert: true, rejectUnauthorized: true });
-    tlsServer.on("secureConnection", s => s.destroy(new Error("unexpected secureConnection")));
-    const rejected = Promise.withResolvers<{ code: unknown; wrapClosed: Promise<boolean> }>();
-    // Emitted before the wrap is destroyed, so this is where its 'close' can be
-    // awaited from.
-    tlsServer.on("tlsClientError", (err: Error & { code?: string }, wrap) =>
-      rejected.resolve({ code: err.code, wrapClosed: closed(wrap) }),
-    );
-    const { rawServer, port, accepted } = await listenRaw(raw => {
-      const rawClosed = closed(raw);
-      tlsServer.emit("connection", raw);
-      return { raw, rawClosed, wrapClosed: rejected.promise.then(r => r.wrapClosed) };
-    });
-    // The client presents a self-signed certificate the server has no CA for.
-    const client = connect({ port, host: "127.0.0.1", ...COMMON_CERT, rejectUnauthorized: false });
-    client.on("error", () => {});
-    try {
-      const conn = await accepted;
-      expect((await rejected.promise).code).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
-      await expectReleased(rawServer, conn);
-    } finally {
-      client.destroy();
-      rawServer.close();
-      tlsServer.close();
-    }
+    await settled;
+    expect(events).toEqual(["raw close hadError=false", "wrap close hadError=false raw.destroyed=true"]);
   });
 });
 

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -9,49 +9,89 @@ import tls from "tls";
 // caller keyed on the plain socket's 'close' sees it even when the upgrade
 // fails. Releasing it from the TLS socket's 'end' only covered a graceful
 // shutdown: a failed handshake destroys the TLS socket without emitting 'end'.
+// Node's order of events, asserted below: the TLS socket's 'error' first, with
+// the plain socket still intact (a caller can still read its remoteAddress
+// there), then the plain socket's 'close', then the TLS socket's 'close'.
 describe("destroying tls.connect({ socket }) destroys the wrapped net.Socket", () => {
-  // events.once() rejects when 'error' is emitted first, which is the point of
-  // these cases; resolves with the 'close' event's hadError argument.
-  const closed = (socket: net.Socket) => new Promise<boolean>(resolve => socket.once("close", resolve));
+  // Logs both sockets' lifecycle events in order. Resolves once the TLS socket
+  // has closed, plus the plain socket's 'close' if one is still due (a plain
+  // socket that was never destroyed, the bug, would never emit it, so that case
+  // resolves right away and fails on the log). Plain listeners rather than
+  // events.once(): the TLS socket emits 'error' before 'close' here.
+  function observe(plain: net.Socket, secure: tls.TLSSocket) {
+    const events: string[] = [];
+    const { promise, resolve } = Promise.withResolvers<string[]>();
+    plain.on("error", (err: Error & { code?: string }) => events.push(`plain error ${err.code}`));
+    plain.on("close", hadError => events.push(`plain close hadError=${hadError}`));
+    secure.on("error", (err: Error & { code?: string }) =>
+      events.push(`secure error ${err.code} plain.destroyed=${plain.destroyed}`),
+    );
+    secure.on("close", hadError => {
+      events.push(`secure close hadError=${hadError} plain.destroyed=${plain.destroyed}`);
+      if (plain.destroyed && !events.some(event => event.startsWith("plain close"))) {
+        plain.once("close", () => resolve(events));
+      } else {
+        resolve(events);
+      }
+    });
+    return promise;
+  }
 
-  async function upgradeAndFail(server: net.Server, waitForConnect: boolean, options: tls.ConnectionOptions) {
+  async function failedUpgrade(server: net.Server, waitForConnect: boolean, options: tls.ConnectionOptions) {
     const plain = net.connect({ host: "127.0.0.1", port: (server.address() as net.AddressInfo).port });
-    plain.on("error", () => {});
     if (waitForConnect) await once(plain, "connect");
-    const plainClosed = closed(plain);
-
-    const secure = tls.connect({ socket: plain, servername: "localhost", ...options });
-    const secureClosed = closed(secure);
-    const [err] = (await once(secure, "error")) as [Error & { code?: string }];
-    expect(await secureClosed).toBe(true);
-    // The TLS socket's _destroy destroys the wrapped socket synchronously, so it
-    // is already destroyed once the TLS socket has closed, and it emits 'close'
-    // itself, without an error of its own.
-    expect(plain.destroyed).toBe(true);
-    expect(await plainClosed).toBe(false);
-    return err.code;
+    return observe(plain, tls.connect({ socket: plain, servername: "localhost", ...options }));
   }
 
   describe.each([
     ["an already connected socket", true],
     ["a socket that is still connecting", false],
   ])("handshake against a non-TLS peer over %s", (_, waitForConnect) => {
-    test.concurrent("destroys the wrapped socket", async () => {
+    test.concurrent("destroys the wrapped socket after the error", async () => {
       await using server = net.createServer(peer => {
         peer.on("error", () => {});
         peer.on("data", () => peer.write("this is not a TLS ServerHello\r\n"));
       });
       await once(server.listen(0, "127.0.0.1"), "listening");
-      expect(await upgradeAndFail(server, waitForConnect, {})).toBe("ERR_SSL_WRONG_VERSION_NUMBER");
+      expect(await failedUpgrade(server, waitForConnect, {})).toEqual([
+        "secure error ERR_SSL_WRONG_VERSION_NUMBER plain.destroyed=false",
+        "plain close hadError=false",
+        "secure close hadError=true plain.destroyed=true",
+      ]);
     });
   });
 
-  test.concurrent("certificate verification failure destroys the wrapped socket", async () => {
+  test.concurrent("certificate verification failure destroys the wrapped socket after the error", async () => {
     // The server's certificate is self-signed and the client is given no `ca`.
     await using server = tls.createServer(certs, socket => socket.on("error", () => {}));
     server.on("tlsClientError", () => {});
     await once(server.listen(0, "127.0.0.1"), "listening");
-    expect(await upgradeAndFail(server, true, { rejectUnauthorized: true })).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+    expect(await failedUpgrade(server, true, { rejectUnauthorized: true })).toEqual([
+      "secure error DEPTH_ZERO_SELF_SIGNED_CERT plain.destroyed=false",
+      "plain close hadError=false",
+      "secure close hadError=true plain.destroyed=true",
+    ]);
+  });
+
+  test.concurrent("destroy() while the wrapped socket is still connecting destroys it too", async () => {
+    // Nothing is listening on the port any more, so the connect would fail:
+    // a wrapped socket left behind would surface that as an error of its own.
+    const server = net.createServer();
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    const { port } = server.address() as net.AddressInfo;
+    await new Promise<void>(resolve => server.close(() => resolve()));
+
+    const plain = net.connect({ host: "127.0.0.1", port });
+    const secure = tls.connect({ socket: plain, servername: "localhost" });
+    const events = observe(plain, secure);
+    secure.destroy();
+    // The plain socket still owns its (connecting) handle, so its 'close'
+    // follows the handle close, a later phase than the handle-less TLS
+    // socket's 'close': the set of events is the contract here, not the order.
+    expect((await events).sort()).toEqual([
+      "plain close hadError=false",
+      "secure close hadError=false plain.destroyed=true",
+    ]);
   });
 });
 

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -1,8 +1,59 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { once } from "events";
 import { tls as certs } from "harness";
 import net from "net";
 import tls from "tls";
+
+// The net.Socket handed to tls.connect({ socket }) goes down with the TLS
+// socket (node's TLSWrap close() destroys its parent wrap), so a STARTTLS
+// caller keyed on the plain socket's 'close' sees it even when the upgrade
+// fails. Releasing it from the TLS socket's 'end' only covered a graceful
+// shutdown: a failed handshake destroys the TLS socket without emitting 'end'.
+describe("destroying tls.connect({ socket }) destroys the wrapped net.Socket", () => {
+  // events.once() rejects when 'error' is emitted first, which is the point of
+  // these cases; resolves with the 'close' event's hadError argument.
+  const closed = (socket: net.Socket) => new Promise<boolean>(resolve => socket.once("close", resolve));
+
+  async function upgradeAndFail(server: net.Server, waitForConnect: boolean, options: tls.ConnectionOptions) {
+    const plain = net.connect({ host: "127.0.0.1", port: (server.address() as net.AddressInfo).port });
+    plain.on("error", () => {});
+    if (waitForConnect) await once(plain, "connect");
+    const plainClosed = closed(plain);
+
+    const secure = tls.connect({ socket: plain, servername: "localhost", ...options });
+    const secureClosed = closed(secure);
+    const [err] = (await once(secure, "error")) as [Error & { code?: string }];
+    expect(await secureClosed).toBe(true);
+    // The TLS socket's _destroy destroys the wrapped socket synchronously, so it
+    // is already destroyed once the TLS socket has closed, and it emits 'close'
+    // itself, without an error of its own.
+    expect(plain.destroyed).toBe(true);
+    expect(await plainClosed).toBe(false);
+    return err.code;
+  }
+
+  describe.each([
+    ["an already connected socket", true],
+    ["a socket that is still connecting", false],
+  ])("handshake against a non-TLS peer over %s", (_, waitForConnect) => {
+    test.concurrent("destroys the wrapped socket", async () => {
+      await using server = net.createServer(peer => {
+        peer.on("error", () => {});
+        peer.on("data", () => peer.write("this is not a TLS ServerHello\r\n"));
+      });
+      await once(server.listen(0, "127.0.0.1"), "listening");
+      expect(await upgradeAndFail(server, waitForConnect, {})).toBe("ERR_SSL_WRONG_VERSION_NUMBER");
+    });
+  });
+
+  test.concurrent("certificate verification failure destroys the wrapped socket", async () => {
+    // The server's certificate is self-signed and the client is given no `ca`.
+    await using server = tls.createServer(certs, socket => socket.on("error", () => {}));
+    server.on("tlsClientError", () => {});
+    await once(server.listen(0, "127.0.0.1"), "listening");
+    expect(await upgradeAndFail(server, true, { rejectUnauthorized: true })).toBe("DEPTH_ZERO_SELF_SIGNED_CERT");
+  });
+});
 
 test("should be able to upgrade a paused socket and also have backpressure on it #15438", async () => {
   // enought to trigger backpressure

--- a/test/js/node/tls/node-tls-upgrade.test.ts
+++ b/test/js/node/tls/node-tls-upgrade.test.ts
@@ -93,6 +93,42 @@ describe("destroying tls.connect({ socket }) destroys the wrapped net.Socket", (
       "secure close hadError=false plain.destroyed=true",
     ]);
   });
+
+  test.concurrent("destroy() right after wrapping a connected socket destroys it and the connection", async () => {
+    // The socket was adopted synchronously, so the TLS socket owns the fd by
+    // now: destroying it has to release the plain socket and close the
+    // connection the peer is holding.
+    const peerClosed = Promise.withResolvers<void>();
+    await using server = net.createServer(peer => {
+      peer.on("error", () => {});
+      peer.on("close", () => peerClosed.resolve());
+      peer.resume();
+    });
+    await once(server.listen(0, "127.0.0.1"), "listening");
+
+    const plain = net.connect({ host: "127.0.0.1", port: (server.address() as net.AddressInfo).port });
+    await once(plain, "connect");
+    const secure = tls.connect({ socket: plain, servername: "localhost" });
+    const events = observe(plain, secure);
+    secure.destroy();
+    expect(await events).toEqual(["plain close hadError=false", "secure close hadError=false plain.destroyed=true"]);
+    await peerClosed.promise;
+  });
+
+  test.concurrent("a graceful shutdown after the handshake destroys the wrapped socket", async () => {
+    // No error involved: the TLS socket ends, the peer ends back and the TLS
+    // socket's own destroy takes the plain socket down.
+    await using server = tls.createServer(certs, socket => socket.on("error", () => {}));
+    await once(server.listen(0, "127.0.0.1"), "listening");
+
+    const plain = net.connect({ host: "127.0.0.1", port: (server.address() as net.AddressInfo).port });
+    await once(plain, "connect");
+    const secure = tls.connect({ socket: plain, servername: "localhost", ca: certs.cert });
+    const events = observe(plain, secure);
+    await once(secure, "secureConnect");
+    secure.end();
+    expect(await events).toEqual(["plain close hadError=false", "secure close hadError=false plain.destroyed=true"]);
+  });
 });
 
 test("should be able to upgrade a paused socket and also have backpressure on it #15438", async () => {


### PR DESCRIPTION
### Problem
- A TLS socket layered over an existing `net.Socket` (`new tls.TLSSocket(raw, { isServer: true })`, `tls.connect({ socket })`, or `tlsServer.emit("connection", raw)`) that is destroyed by a handshake failure leaves the wrapped `net.Socket` alive: it never emits `'close'`, `raw.destroyed` stays `false`, the accepting `net.Server` keeps it in its connection count (`getConnections()` reports 1) and `server.close(cb)` never calls back. Node destroys the wrapped socket in every case (probe output below).
- The wrapped socket was only released from the TLS socket's `'end'` event (`src/js/node/net.ts`, the `kCloseRawConnection` listener installed at the three adoption sites), and `Socket.prototype._destroy` tore down the wrapped transport only when it was not a `net.Socket` (`!(upgraded instanceof Socket)`). A handshake failure destroys the TLS socket with an error and never emits `'end'`, so neither path ran.
- Same gap for a wrap destroyed before its socket was adopted (server side: the accepted fd stayed open with nothing owning it; client side: `tls.connect({ socket })` on a still-connecting socket only recorded the socket once it had connected, so destroying the TLS socket left the connect running and a failed connect surfaced as an unhandled error), and for a wrap running on the stream-level TLS engine.

### Fix
- `Socket.prototype._destroy` destroys the transport recorded in `kupgraded` for every wrap (`destroyUpgradedTransportNT`), and the `'end'` listeners are removed: a clean shutdown still ends in `destroy()`, so one path covers both the graceful and the error teardown.
- The teardown runs on a `nextTick` queued after `_destroy`'s callback, i.e. after the TLS socket's `'error'` has been queued. This keeps node's observable order: the TLS socket's `'error'` (and a `tls.Server`'s `'tlsClientError'`) fire while the wrapped socket is still intact (its `remoteAddress` is still readable, a listener that detaches handlers on the wrapped socket's `'close'` does not lose the error), then the wrapped socket's `'close'`, then the TLS socket's `'close'` (which comes from its own handle close, a `setImmediate`). A TLS socket that no longer has a handle queues its own `'close'` behind the transport's teardown for the same reason (`destroyUpgradedTransportAndCloseNT`).
- When the wrapped socket's handle is the raw twin of the TLS handle (`kAdoptedTLSRaw`), it is detached before `destroy()`: the twin shares the fd that the TLS socket's own handle close tears down, so the wrapped socket only runs its `_destroy` bookkeeping (`'close'` on the next tick, `server._connections--`). Without the detach its `_destroy` would take the shared-fd arm and emit `'close'` two check phases later, after the TLS socket's. Any other transport (a generic duplex, a socket whose adoption has not run yet, a socket driving its own fd under the stream-level engine) still owns its fd and is destroyed outright, as the generic-duplex branch already did; for those the transport's `'close'` follows its handle close and may come after the TLS socket's (node emits it first), which the tests for these two cases deliberately do not pin.
- `tls.connect({ socket })` records `kupgraded` before branching on whether the socket is still connecting (as the server wrap already did), so destroying the TLS socket at any point destroys the socket; the `'connect'` listener's own destroy of the socket becomes a plain early return.
- The wrapped socket is destroyed without an error (`'close'` reports `hadError === false`), matching node's `_parentWrap.destroy()`.
- Supersedes #34507, which addressed the `tls.connect({ socket })` side with a `_destroy` change that predates the shared-fd twin handling and no longer applies to main. Its tests and the repro from its description pass on this branch (the wrapped socket's `'close'` fires and `destroyed` is `true`, same output as node); its caller-initiated teardown case is carried over below as the `destroy()` case. `Http2SecureServer.emit("connection", raw)` goes through its own upgrade path in `_http2_upgrade.ts`, has the same leak, and is not touched here (reported separately).
- Tests, each asserting the full ordered event log of both sockets, then `getConnections() === 0` and `server.close()` completing where a `net.Server` is involved:
  - `test/js/node/tls/node-tls-server.test.ts`, "destroying a server-side TLSSocket wrap destroys the wrapped net.Socket": handshake failure (the `_closeAfterHandlingError` path), `tls.Server` rejecting a client certificate on a connection injected via `emit('connection')` (the plain `destroy(err)` path, with `'tlsClientError'` observing the intact socket), destroy before adoption, stream-level engine over a handle-less socket.
  - `test/js/node/tls/node-tls-upgrade.test.ts`, "destroying tls.connect({ socket }) destroys the wrapped net.Socket": non-TLS peer over a connected and over a still-connecting socket, certificate verification failure, `destroy()` while the socket is still connecting (against a port nothing listens on, so a leaked socket would also raise `ECONNREFUSED`), `destroy()` right after wrapping a connected socket (the adopted fd has to be closed, so the peer's `'close'` is awaited too), and a graceful `end()` after the handshake (the path the removed `'end'` listener used to cover).
  - The 8 error-path, connecting-socket and unadopted/handle-less cases fail without the `net.ts` change (the wrapped socket's `'close'` never appears in the log). The `destroy()`-after-wrapping and graceful `end()` cases pass without it as well: they pin the two paths whose release this PR moves from the `'end'` listener and the native close into `_destroy`. The 6 error-path and connecting-socket tests also fail against the first revision of this PR, which ran the teardown synchronously at the top of `_destroy` (`raw.destroyed=true` inside the error listeners, wrapped socket's `'close'` before the TLS socket's `'error'`).
- Also run with the fix: the vendored `test-tls-*.js` (186 files) and `test-net-*.js` (139), the vendored `test-http(s)-proxy-*` / `*-proxy-*` suites (48 files, the https agent's `tls.connect({ socket })` tunnel path), `test/js/node/tls/`, `node-net.test.ts`, `node-http2-upgrade.test.mts`, `node-http-connect.test.ts`, `node-http-proxy-url.test.ts`. The only failures are ones that fail identically without this change (localhost bind/connect family mismatch, sandbox proxy env vars, debug-build timeouts).

### Background
- A wrap adopts the wrapped `net.Socket`'s fd into a TLS socket natively (`upgradeTLS`) and hands back two handles over the same fd: the TLS handle, which becomes the TLS socket's `_handle`, and a raw twin, which replaces the wrapped socket's `_handle` and is tagged `kAdoptedTLSRaw`. Closing either one closes the shared fd; closing the TLS handle also retires the twin natively, so the twin never needs a close of its own. The wrapping socket records the wrapped one in `kupgraded`.
- When the wrapped socket cannot be adopted (no handle yet, unflushed plain writes, named pipe, generic duplex), the TLS engine runs over the stream itself (`upgradeDuplexToTLS`) and the wrapped socket keeps driving its own fd.
- `_destroy` emits a socket's `'close'` in one of two ways: from its handle close (a `setImmediate`, or a microtask followed by a `setImmediate` when `_closeAfterHandlingError` keeps the handle around for the error listeners), or, for a socket without a handle, from a `nextTick`. The stream layer emits `destroy(err)`'s `'error'` from a `nextTick` queued by `_destroy`'s callback. Node's `TLSWrap.prototype.close` destroys its parent wrap when the TLSSocket's handle is closed and emits the TLSSocket's `'close'` once the parent has closed, which is where the ordering above comes from.
- `net.Server` counts an accepted socket in `_connections` and decrements it in that socket's `_destroy`; `server.close(cb)` emits `'close'` (and calls `cb`) only once the count reaches zero, which is why a wrapped socket that is never destroyed keeps `server.close(cb)` from completing.

<details>
<summary>Probe: standalone server wrap, node v26.3.0 vs bun (events after the client goes away)</summary>

```
node ok:      ["client-close","tls-end","raw-close","tls-close","connections=0","server-close-cb"]
node garbage: ["tls-error:ERR_SSL_WRONG_VERSION_NUMBER","raw-close","tls-close","client-close","connections=0","server-close-cb"]

bun main ok:      ["client-close","secure","raw-close","tls-close","connections=0","server-close-cb"]
bun main reject:  ["client-close","tls-error:UNABLE_TO_VERIFY_LEAF_SIGNATURE","tls-close","connections=1","TIMEOUT"]
bun main garbage: ["tls-error:ERR_SSL_WRONG_VERSION_NUMBER","tls-close","client-close","connections=1","TIMEOUT"]

bun fixed ok:      ["client-close","secure","tls-end","raw-close","tls-close","connections=0","server-close-cb"]
bun fixed reject:  ["tls-error:UNABLE_TO_VERIFY_LEAF_SIGNATURE","raw-close","tls-close","client-close","connections=0","server-close-cb"]
bun fixed garbage: ["tls-error:ERR_SSL_WRONG_VERSION_NUMBER","raw-close","tls-close","client-close","connections=0","server-close-cb"]
```

`ok`: TLS client connects and disconnects after the handshake. `reject`: wrap created with `requestCert` + `rejectUnauthorized` and the client presents an unverifiable certificate (bun rejects on a standalone wrap, node leaves that to the application, so there is no node line for it). `garbage`: a plain TCP client writes non-TLS bytes. `raw` is the accepted `net.Socket`, `connections` is `rawServer.getConnections()` before `rawServer.close()`.

State seen inside the error listeners, node vs the fix (identical): `tls.Server` + `emit('connection')` fed HTTP bytes, inside `'tlsClientError'`: `raw.destroyed=false raw.remoteAddress=127.0.0.1`; `tls.connect({ socket })` against a non-TLS peer, inside the TLS socket's `'error'`: `plain.destroyed=false`, followed by the plain socket's `'close'`, then the TLS socket's.

Further cases checked the same way (node's end state reached with the fix, `destroyed=false` / count stuck at 1 or, for the connecting case, an unhandled `ECONNREFUSED` without it): wrap destroyed synchronously after construction, wrap over a socket with unflushed writes (stream-level engine), `tls.Server` `emit('connection')` with a rejected client, and on the client side `tls.connect({ socket })` against a non-TLS peer, with a failing certificate verification, with `destroy()` and `resetAndDestroy()` after the handshake, with the server ending the connection, and `destroy()` while the socket is still connecting (to a listening and to a refused port).
</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-server.test.ts test/js/node/tls/node-tls-upgrade.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: all passed
bun test v1.4.0-canary.1 (c47dff85c)

test/js/node/tls/node-tls-server.test.ts:
(pass) tls.createServer listen > should throw when no port or path when using options [1.24ms]
(pass) tls.createServer listen > should listen on IPv6 by default [11.59ms]
(pass) tls.createServer listen > should listen on IPv4 [1.67ms]
(pass) tls.createServer listen > should call listening [1.40ms]
(pass) tls.createServer listen > should listen on localhost [1.92ms]
(pass) tls.createServer listen > should listen on localhost [1.42ms]
(pass) tls.createServer listen > should listen without port or host [1.38ms]
(pass) tls.createServer listen > should listen on unix domain socket [1.56ms]
(pass) tls.createServer listen > should not listen with wrong password [1.64ms]
(pass) tls.createServer listen > should reject passphrase longer than PEM_BUFSIZE without crashing [1.32ms]
(pass) tls.createServer listen > should not listen without cert [1.27ms]
(pass) tls.createServer listen > should not listen without password [1.34ms]
(pass) tls.createServer > should work with getCertificate [8.64ms]
(pass) tls.createServer events > should receive data [3.63ms]
(pass) tls.createServer events > should call 
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/js/node/tls/node-tls-server.test.ts test/js/node/tls/node-tls-upgrade.test.ts
bun test v1.4.0 (585f6840f)

test/js/node/tls/node-tls-server.test.ts:
(pass) tls.createServer listen > should throw when no port or path when using options [82.99ms]
(pass) tls.createServer listen > should listen on IPv6 by default [232.05ms]
(pass) tls.createServer listen > should listen on IPv4 [29.78ms]
(pass) tls.createServer listen > should call listening [11.76ms]
(pass) tls.createServer listen > should listen on localhost [45.51ms]
(pass) tls.createServer listen > should listen on localhost [12.58ms]
(pass) tls.createServer listen > should listen without port or host [15.06ms]
(pass) tls.createServer listen > should listen on unix domain socket [17.53ms]
(pass) tls.createServer listen > should not listen with wrong password [32.45ms]
(pass) tls.createServer listen > should reject passphrase longer than PEM_BUFSIZE without crashing [10.51ms]
(pass) tls.createServer listen > should not listen without cert [12.57ms]
(pass) tls.createServer listen > 
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 629ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/46] gen bindgenv2
[2/41] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/41] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[4/41] gen cpp.rs (cppbind)
[5/41] gen JS modules (bundle-modules)
Preprocess modules (8306ms)
Bundle modules (33ms)
Postprocesss modules (23ms)
Bundle Functions (766ms)
Generate Code (19ms)

[9.17s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[5/31] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0 (/wor
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/js/node/net.ts                        |  60 ++++++------
 test/js/node/tls/node-tls-server.test.ts  | 154 +++++++++++++++++++++++++++++-
 test/js/node/tls/node-tls-upgrade.test.ts | 129 ++++++++++++++++++++++++-
 3 files changed, 308 insertions(+), 35 deletions(-)
```

</details>

**gate history** · 1 passed · 1 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/js/node/net.ts                             1      1      0
test/js/node/tls/node-tls-server.test.ts       1      1      0
test/js/node/tls/node-tls-upgrade.test.ts      0      0      0
```

</details>

**root cause** · written by the author bot

The failing SNICallback test bound a TLS server to the hostname localhost while the client independently resolved localhost for its connection, so on hosts where /etc/hosts lists both ::1 and 127.0.0.1 the client could pick a different address family than the server bound, producing an ECONNREFUSED that had nothing to do with SNI behavior. The fix makes the test connect to the literal address reported by server.address() and passes the bind hostname through the servername option instead. This removes the dependency on the host's name resolution order while still exercising the intended case…

<!-- robobun:evidence:end -->