### PR TITLE
shell: stream the seq builtin's output in chunks instead of rendering it whole

### DIFF
--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -64,18 +64,14 @@ pub(crate) trait BuiltinState: Sized {
         Self::extract(&mut Builtin::of_mut(interp, cmd).impl_)
     }
 
-    /// The builtin's stdout and its state borrowed side by side (disjoint
-    /// fields of `Builtin`), so bytes kept on the state can be handed to
-    /// `stdout.enqueue` without copying them out first.
+    /// stdout and the state borrowed together: bytes kept on the state are enqueued uncopied.
     #[inline]
     #[track_caller]
     fn split_stdout(bltn: &mut Builtin) -> (&mut BuiltinIO, &mut Self) {
         (&mut bltn.stdout, Self::extract(&mut bltn.impl_))
     }
 
-    /// [`split_stdout`](Self::split_stdout) for a stdout that does not
-    /// `needs_io()`: the same contract as [`Builtin::write_no_io`], writing
-    /// bytes kept on the state without copying them out first.
+    /// `split_stdout` under `Builtin::write_no_io`'s contract: stdout must not `needs_io()`.
     #[track_caller]
     fn split_stdout_no_io(interp: &Interpreter, cmd: NodeId) -> (NoIoOutput<'_>, &mut Self) {
         let (shell, bltn) = Builtin::of_mut_with_shell(interp, cmd);
@@ -447,22 +443,17 @@ impl BuiltinIO {
     }
 }
 
-/// A builtin output stream written synchronously (see [`Builtin::write_no_io`])
-/// together with the shell env a captured stream appends to. Only this module
-/// constructs one, from a Cmd's own stream and env, which is what makes
-/// [`write`](Self::write) safe to call.
+/// A non-fd stream and the env of its own Cmd; built only in this module, so `write` can be safe.
 pub(crate) struct NoIoOutput<'a> {
     io: &'a mut BuiltinIO,
-    /// Env of the Cmd `io` is borrowed from. The env outlives the Cmd and the
-    /// Cmd stays borrowed through `io`, so it is live for `'a`.
     shell: *mut crate::shell::interpreter::ShellExecEnv,
 }
 
 impl NoIoOutput<'_> {
     /// Returns `Err(ENOSPC)` when an ArrayBuffer target is already full.
     pub(crate) fn write(&mut self, buf: &[u8]) -> bun_sys::Result<usize> {
-        // SAFETY: `shell` is the live env of the Cmd owning `io` (see the
-        // field doc); both were taken from the same Cmd by this module.
+        // SAFETY: `shell` is the env of the Cmd `io` is borrowed from; the env
+        // outlives the Cmd, which stays borrowed through `io`.
         unsafe { self.io.write_no_io_to(self.shell, buf) }
     }
 }
@@ -919,8 +910,7 @@ impl Builtin {
         Self::of_mut_with_shell(interp, cmd).1
     }
 
-    /// [`of_mut`](Self::of_mut) plus the owning Cmd's shell env, the pair a
-    /// [`NoIoOutput`] is made of. The env outlives the Cmd.
+    /// [`of_mut`](Self::of_mut) plus the Cmd's shell env, the pair a [`NoIoOutput`] needs.
     #[inline]
     #[track_caller]
     fn of_mut_with_shell<'a>(

--- a/src/runtime/shell/Builtin.rs
+++ b/src/runtime/shell/Builtin.rs
@@ -63,6 +63,25 @@ pub(crate) trait BuiltinState: Sized {
     fn state_mut(interp: &Interpreter, cmd: NodeId) -> &mut Self {
         Self::extract(&mut Builtin::of_mut(interp, cmd).impl_)
     }
+
+    /// The builtin's stdout and its state borrowed side by side (disjoint
+    /// fields of `Builtin`), so bytes kept on the state can be handed to
+    /// `stdout.enqueue` without copying them out first.
+    #[inline]
+    #[track_caller]
+    fn split_stdout(bltn: &mut Builtin) -> (&mut BuiltinIO, &mut Self) {
+        (&mut bltn.stdout, Self::extract(&mut bltn.impl_))
+    }
+
+    /// [`split_stdout`](Self::split_stdout) for a stdout that does not
+    /// `needs_io()`: the same contract as [`Builtin::write_no_io`], writing
+    /// bytes kept on the state without copying them out first.
+    #[track_caller]
+    fn split_stdout_no_io(interp: &Interpreter, cmd: NodeId) -> (NoIoOutput<'_>, &mut Self) {
+        let (shell, bltn) = Builtin::of_mut_with_shell(interp, cmd);
+        let (io, state) = Self::split_stdout(bltn);
+        (NoIoOutput { io, shell }, state)
+    }
 }
 
 macro_rules! shell_builtins {
@@ -338,16 +357,13 @@ impl BuiltinIO {
         }
     }
 
-    /// Body of [`Builtin::write_no_io`] with the Cmd split-borrow already
-    /// performed by the caller. Exists so builtins whose payload lives in
-    /// `Builtin.impl_` (disjoint from `stdout`/`stderr`) can write a borrowed
-    /// slice without an intermediate heap clone.
+    /// Body of [`NoIoOutput::write`], which pairs the stream with its `shell`.
     ///
     /// # Safety
     /// `shell` must point to the live `ShellExecEnv` owning this builtin
     /// (i.e. `cmd.base.shell`); only dereferenced for the [`BuiltinIO::Buf`]
     /// arm.
-    pub(crate) unsafe fn write_no_io_to(
+    unsafe fn write_no_io_to(
         &mut self,
         shell: *mut crate::shell::interpreter::ShellExecEnv,
         buf: &[u8],
@@ -428,6 +444,26 @@ impl BuiltinIO {
             BuiltinIO::Fd(fd) => fd.writer.enqueue_fmt_bltn(child, fd.captured, kind, args),
             _ => unreachable!("enqueue_fmt() on non-fd output; caller must check needs_io()"),
         }
+    }
+}
+
+/// A builtin output stream written synchronously (see [`Builtin::write_no_io`])
+/// together with the shell env a captured stream appends to. Only this module
+/// constructs one, from a Cmd's own stream and env, which is what makes
+/// [`write`](Self::write) safe to call.
+pub(crate) struct NoIoOutput<'a> {
+    io: &'a mut BuiltinIO,
+    /// Env of the Cmd `io` is borrowed from. The env outlives the Cmd and the
+    /// Cmd stays borrowed through `io`, so it is live for `'a`.
+    shell: *mut crate::shell::interpreter::ShellExecEnv,
+}
+
+impl NoIoOutput<'_> {
+    /// Returns `Err(ENOSPC)` when an ArrayBuffer target is already full.
+    pub(crate) fn write(&mut self, buf: &[u8]) -> bun_sys::Result<usize> {
+        // SAFETY: `shell` is the live env of the Cmd owning `io` (see the
+        // field doc); both were taken from the same Cmd by this module.
+        unsafe { self.io.write_no_io_to(self.shell, buf) }
     }
 }
 
@@ -880,8 +916,23 @@ impl Builtin {
     #[inline]
     #[track_caller]
     pub(crate) fn of_mut<'a>(interp: &'a Interpreter, cmd: NodeId) -> &'a mut Builtin {
-        match &mut interp.as_cmd_mut(cmd).exec {
-            crate::shell::states::cmd::Exec::Builtin(b) => b,
+        Self::of_mut_with_shell(interp, cmd).1
+    }
+
+    /// [`of_mut`](Self::of_mut) plus the owning Cmd's shell env, the pair a
+    /// [`NoIoOutput`] is made of. The env outlives the Cmd.
+    #[inline]
+    #[track_caller]
+    fn of_mut_with_shell<'a>(
+        interp: &'a Interpreter,
+        cmd: NodeId,
+    ) -> (
+        *mut crate::shell::interpreter::ShellExecEnv,
+        &'a mut Builtin,
+    ) {
+        let cmd_node = interp.as_cmd_mut(cmd);
+        match &mut cmd_node.exec {
+            crate::shell::states::cmd::Exec::Builtin(b) => (cmd_node.base.shell, &mut **b),
             _ => panic!("Cmd {} is not running a builtin", cmd),
         }
     }
@@ -915,20 +966,13 @@ impl Builtin {
         if buf.is_empty() {
             return Ok(0);
         }
-        // Split-borrow the Cmd so `shell`
-        // and the builtin's stdout/stderr are accessible simultaneously.
-        let cmd_node = interp.as_cmd_mut(cmd);
-        let shell = cmd_node.base.shell;
-        let crate::shell::states::cmd::Exec::Builtin(me) = &mut cmd_node.exec else {
-            panic!("Cmd {} is not running a builtin", cmd);
-        };
-        let out: &mut BuiltinIO = match io_kind {
+        let (shell, me) = Self::of_mut_with_shell(interp, cmd);
+        let io = match io_kind {
             IoKind::Stdout => &mut me.stdout,
             IoKind::Stderr => &mut me.stderr,
             IoKind::Stdin => return Ok(0),
         };
-        // SAFETY: `shell` is `cmd_node.base.shell`, live for the Cmd's lifetime.
-        unsafe { out.write_no_io_to(shell, buf) }
+        NoIoOutput { io, shell }.write(buf)
     }
 
     /// Shell exec env of the owning Cmd.

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -1,15 +1,24 @@
 use std::io::Write as _;
 
-use crate::shell::builtin::{Builtin, BuiltinState, IoKind, Kind};
-use crate::shell::interpreter::{Interpreter, NodeId};
+use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinState, Impl, Kind};
+use crate::shell::interpreter::{Interpreter, NodeId, OutputNeedsIOSafeGuard};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
+use crate::shell::states::cmd::Exec;
 use crate::shell::yield_::Yield;
+
+/// The sequence is rendered and written one chunk at a time, cut at the first
+/// value boundary at or past this size, so a long sequence streams to its
+/// consumer and the builtin never holds more than about one chunk of it.
+const CHUNK_SIZE: usize = 64 * 1024;
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
 enum State {
     #[default]
     Idle,
+    /// A chunk is being written to stdout and more values follow it.
+    Writing,
     Err,
+    /// The chunk being written (if any) is the last one.
     Done,
 }
 
@@ -18,6 +27,10 @@ pub struct Seq {
     start: f32,
     end: f32,
     increment: f32,
+    /// Next value to render.
+    current: f32,
+    /// The chunk currently being written; reused for every chunk.
+    buf: Vec<u8>,
     /// Borrowed from argv (NUL-terminated arena strings) or `'static` literals;
     /// argv outlives the builtin — `RawSlice` invariant.
     separator: bun_ptr::RawSlice<u8>,
@@ -31,6 +44,8 @@ impl Default for Seq {
             start: 1.0,
             end: 1.0,
             increment: 1.0,
+            current: 1.0,
+            buf: Vec::new(),
             separator: bun_ptr::RawSlice::new(b"\n"),
             terminator: bun_ptr::RawSlice::EMPTY,
         }
@@ -156,46 +171,83 @@ impl Seq {
     }
 
     fn do_(interp: &Interpreter, cmd: NodeId) -> Yield {
-        let needs_io = Builtin::of(interp, cmd).stdout.needs_io().is_some();
-        // Render entirely into a local Vec, then either enqueue it or
-        // write_no_io it; we buffer once for simplicity.
-        let (start, end, incr, sep, term) = {
+        {
             let me = Self::state_mut(interp, cmd);
-            (me.start, me.end, me.increment, me.separator, me.terminator)
-        };
-        let mut out = Vec::new();
-        let mut current = start;
-        while if incr > 0.0 {
-            current <= end
+            me.current = me.start;
+        }
+        if let Some(safeguard) = Builtin::of(interp, cmd).stdout.needs_io() {
+            return Self::enqueue_chunk(interp, cmd, safeguard);
+        }
+        loop {
+            let cmd_node = interp.as_cmd_mut(cmd);
+            let shell = cmd_node.base.shell;
+            let Exec::Builtin(bltn) = &mut cmd_node.exec else {
+                unreachable!()
+            };
+            let (stdout, me) = Self::split_stdout_state(bltn);
+            let last = me.render_chunk();
+            // SAFETY: `shell` is `cmd_node.base.shell`, live for the Cmd.
+            let written = unsafe { stdout.write_no_io_to(shell, &me.buf) };
+            // The only error here is a full `> ${buffer}` target, which the
+            // remaining chunks would not fit into either.
+            if last || written.is_err() {
+                break;
+            }
+        }
+        Self::state_mut(interp, cmd).state = State::Done;
+        Builtin::done(interp, cmd, 0)
+    }
+
+    /// Renders the next chunk and queues it on stdout; `on_io_writer_chunk`
+    /// continues with the following one once it has been written.
+    fn enqueue_chunk(
+        interp: &Interpreter,
+        cmd: NodeId,
+        safeguard: OutputNeedsIOSafeGuard,
+    ) -> Yield {
+        let child = ChildPtr::new(cmd, WriterTag::Builtin);
+        let (stdout, me) = Self::split_stdout_state(Builtin::of_mut(interp, cmd));
+        me.state = if me.render_chunk() {
+            State::Done
         } else {
-            current >= end
-        } {
+            State::Writing
+        };
+        stdout.enqueue(child, &me.buf, safeguard)
+    }
+
+    fn has_next(&self) -> bool {
+        if self.increment > 0.0 {
+            self.current <= self.end
+        } else {
+            self.current >= self.end
+        }
+    }
+
+    /// Replaces `buf` with the next run of values, stopping once it holds
+    /// `CHUNK_SIZE` bytes. Returns true when the sequence ended inside this
+    /// chunk, in which case the terminator has been appended too.
+    fn render_chunk(&mut self) -> bool {
+        self.buf.clear();
+        while self.has_next() {
+            if self.buf.len() >= CHUNK_SIZE {
+                return false;
+            }
             // Rust `{}` for f32 prints the shortest decimal that round-trips
             // (no exponent, no trailing ".0").
-            let _ = write!(&mut out, "{}", current);
-            out.extend_from_slice(sep.slice());
-            let next = current + incr;
-            if next == current {
+            let _ = write!(&mut self.buf, "{}", self.current);
+            self.buf.extend_from_slice(self.separator.slice());
+            let next = self.current + self.increment;
+            if next == self.current {
                 // f32 rounding can make `current + incr` equal `current`
                 // (e.g. `seq 1 99999999` saturates at 2^24, or a tiny
                 // increment relative to `current`). Without this check the
-                // loop never terminates and `out` grows without bound.
+                // sequence would never end.
                 break;
             }
-            current = next;
+            self.current = next;
         }
-        out.extend_from_slice(term.slice());
-
-        Self::state_mut(interp, cmd).state = State::Done;
-        if needs_io {
-            let safeguard = Builtin::of(interp, cmd).stdout.needs_io().unwrap();
-            let child = ChildPtr::new(cmd, WriterTag::Builtin);
-            return Builtin::of_mut(interp, cmd)
-                .stdout
-                .enqueue(child, &out, safeguard);
-        }
-        let _ = Builtin::write_no_io(interp, cmd, IoKind::Stdout, &out);
-        Builtin::done(interp, cmd, 0)
+        self.buf.extend_from_slice(self.terminator.slice());
+        true
     }
 
     pub(crate) fn on_io_writer_chunk(
@@ -209,12 +261,28 @@ impl Seq {
             return Builtin::done(interp, cmd, 1);
         }
         match Self::state_mut(interp, cmd).state {
+            State::Writing => {
+                // Chunks are only ever queued on an fd stdout, so the callback
+                // implies `needs_io()`.
+                debug_assert!(Builtin::of(interp, cmd).stdout.needs_io().is_some());
+                Self::enqueue_chunk(interp, cmd, OutputNeedsIOSafeGuard::OutputNeedsIo)
+            }
             State::Done => Builtin::done(interp, cmd, 0),
             State::Err => Builtin::done(interp, cmd, 1),
             State::Idle => {
                 crate::shell::interpreter::unreachable_state("Seq.onIOWriterChunk", "idle")
             }
         }
+    }
+
+    /// Split-borrow `&mut Builtin` into `(&mut stdout, &mut Seq)`; the fields
+    /// are disjoint so this is a sound reborrow without `unsafe`.
+    #[inline]
+    fn split_stdout_state(bltn: &mut Builtin) -> (&mut BuiltinIO, &mut Seq) {
+        let Impl::Seq(me) = &mut bltn.impl_ else {
+            unreachable!()
+        };
+        (&mut bltn.stdout, &mut **me)
     }
 }
 

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -1,9 +1,8 @@
 use std::io::Write as _;
 
-use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinState, Impl, Kind};
+use crate::shell::builtin::{Builtin, BuiltinState, Kind};
 use crate::shell::interpreter::{Interpreter, NodeId, OutputNeedsIOSafeGuard};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
-use crate::shell::states::cmd::Exec;
 use crate::shell::yield_::Yield;
 
 /// The sequence is rendered and written one chunk at a time, cut at the first
@@ -179,17 +178,11 @@ impl Seq {
             return Self::enqueue_chunk(interp, cmd, safeguard);
         }
         loop {
-            let cmd_node = interp.as_cmd_mut(cmd);
-            let shell = cmd_node.base.shell;
-            let Exec::Builtin(bltn) = &mut cmd_node.exec else {
-                unreachable!()
-            };
-            let (stdout, me) = Self::split_stdout_state(bltn);
+            let (mut stdout, me) = Self::split_stdout_no_io(interp, cmd);
             let last = me.render_chunk();
-            // SAFETY: `shell` is `cmd_node.base.shell`, live for the Cmd.
-            let written = unsafe { stdout.write_no_io_to(shell, &me.buf) };
-            // The only error here is a full `> ${buffer}` target, which the
-            // remaining chunks would not fit into either.
+            let written = stdout.write(&me.buf);
+            // A chunk that did not fit (a full `> ${buffer}`) means the rest
+            // of the sequence will not fit either.
             if last || written.is_err() {
                 break;
             }
@@ -206,7 +199,7 @@ impl Seq {
         safeguard: OutputNeedsIOSafeGuard,
     ) -> Yield {
         let child = ChildPtr::new(cmd, WriterTag::Builtin);
-        let (stdout, me) = Self::split_stdout_state(Builtin::of_mut(interp, cmd));
+        let (stdout, me) = Self::split_stdout(Builtin::of_mut(interp, cmd));
         me.state = if me.render_chunk() {
             State::Done
         } else {
@@ -273,16 +266,6 @@ impl Seq {
                 crate::shell::interpreter::unreachable_state("Seq.onIOWriterChunk", "idle")
             }
         }
-    }
-
-    /// Split-borrow `&mut Builtin` into `(&mut stdout, &mut Seq)`; the fields
-    /// are disjoint so this is a sound reborrow without `unsafe`.
-    #[inline]
-    fn split_stdout_state(bltn: &mut Builtin) -> (&mut BuiltinIO, &mut Seq) {
-        let Impl::Seq(me) = &mut bltn.impl_ else {
-            unreachable!()
-        };
-        (&mut bltn.stdout, &mut **me)
     }
 }
 

--- a/src/runtime/shell/builtin/seq.rs
+++ b/src/runtime/shell/builtin/seq.rs
@@ -5,9 +5,7 @@ use crate::shell::interpreter::{Interpreter, NodeId, OutputNeedsIOSafeGuard};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
 use crate::shell::yield_::Yield;
 
-/// The sequence is rendered and written one chunk at a time, cut at the first
-/// value boundary at or past this size, so a long sequence streams to its
-/// consumer and the builtin never holds more than about one chunk of it.
+/// Chunks are cut at the first value boundary at or past this size; about one is held at a time.
 const CHUNK_SIZE: usize = 64 * 1024;
 
 #[derive(Clone, Copy, PartialEq, Eq, Default)]
@@ -180,9 +178,8 @@ impl Seq {
         loop {
             let (mut stdout, me) = Self::split_stdout_no_io(interp, cmd);
             let last = me.render_chunk();
+            // Err: the `> ${buffer}` is full, so no later chunk would fit either.
             let written = stdout.write(&me.buf);
-            // A chunk that did not fit (a full `> ${buffer}`) means the rest
-            // of the sequence will not fit either.
             if last || written.is_err() {
                 break;
             }
@@ -191,8 +188,7 @@ impl Seq {
         Builtin::done(interp, cmd, 0)
     }
 
-    /// Renders the next chunk and queues it on stdout; `on_io_writer_chunk`
-    /// continues with the following one once it has been written.
+    /// Queues the next chunk; `on_io_writer_chunk` queues the one after it.
     fn enqueue_chunk(
         interp: &Interpreter,
         cmd: NodeId,
@@ -216,9 +212,7 @@ impl Seq {
         }
     }
 
-    /// Replaces `buf` with the next run of values, stopping once it holds
-    /// `CHUNK_SIZE` bytes. Returns true when the sequence ended inside this
-    /// chunk, in which case the terminator has been appended too.
+    /// Refills `buf`; true once the sequence (and terminator) has been rendered into it.
     fn render_chunk(&mut self) -> bool {
         self.buf.clear();
         while self.has_next() {
@@ -255,8 +249,6 @@ impl Seq {
         }
         match Self::state_mut(interp, cmd).state {
             State::Writing => {
-                // Chunks are only ever queued on an fd stdout, so the callback
-                // implies `needs_io()`.
                 debug_assert!(Builtin::of(interp, cmd).stdout.needs_io().is_some());
                 Self::enqueue_chunk(interp, cmd, OutputNeedsIOSafeGuard::OutputNeedsIo)
             }

--- a/src/runtime/shell/builtin/yes.rs
+++ b/src/runtime/shell/builtin/yes.rs
@@ -1,8 +1,7 @@
 use crate::shell::ExitCode;
-use crate::shell::builtin::{Builtin, BuiltinIO, BuiltinState, Impl, Kind};
+use crate::shell::builtin::{Builtin, BuiltinState, Kind};
 use crate::shell::interpreter::{EventLoopHandle, Interpreter, NodeId, OutputNeedsIOSafeGuard};
 use crate::shell::io_writer::{ChildPtr, WriterTag};
-use crate::shell::states::cmd::Exec;
 use crate::shell::yield_::Yield;
 
 use bun_event_loop::ConcurrentTask::AutoDeinit;
@@ -89,21 +88,12 @@ impl Yes {
     /// Write 4 chunks then bounce to the event loop so we don't hog the main
     /// thread.
     fn write_no_io_loop(interp: &Interpreter, cmd: NodeId) -> Yield {
-        // Split-borrow the Cmd so the tiled buffer (in `impl_`) and `stdout`
-        // are accessible simultaneously — the buffer is written zero-copy,
-        // which matters for `yes` throughput.
         let err = {
-            let cmd_node = interp.as_cmd_mut(cmd);
-            let shell = cmd_node.base.shell;
-            let Exec::Builtin(me) = &mut cmd_node.exec else {
-                unreachable!()
-            };
-            let (stdout, yes) = Self::split_stdout_state(me);
+            let (mut stdout, yes) = Self::split_stdout_no_io(interp, cmd);
             let chunk = &yes.buffer[..yes.buffer_used];
             let mut err = None;
             for _ in 0..4 {
-                // SAFETY: `shell` is `cmd_node.base.shell`, live for the Cmd.
-                if let Err(e) = unsafe { stdout.write_no_io_to(shell, chunk) } {
+                if let Err(e) = stdout.write(chunk) {
                     err = Some(e);
                     break;
                 }
@@ -140,9 +130,7 @@ impl Yes {
         safeguard: OutputNeedsIOSafeGuard,
     ) -> Yield {
         let child = ChildPtr::new(cmd, WriterTag::Builtin);
-        // `stdout` and `impl_` are disjoint fields of `Builtin` — split-borrow
-        // so the tiled buffer is enqueued zero-copy.
-        let (stdout, yes) = Self::split_stdout_state(Builtin::of_mut(interp, cmd));
+        let (stdout, yes) = Self::split_stdout(Builtin::of_mut(interp, cmd));
         stdout.enqueue(child, &yes.buffer[..yes.buffer_used], safeguard)
     }
 
@@ -171,16 +159,6 @@ impl Yes {
         }
         debug_assert!(Builtin::of(interp, cmd).stdout.needs_io().is_some());
         Self::enqueue_chunk(interp, cmd, OutputNeedsIOSafeGuard::OutputNeedsIo)
-    }
-
-    /// Split-borrow `&mut Builtin` into `(&mut stdout, &mut Yes)`; the fields
-    /// are disjoint so this is a sound reborrow without `unsafe`.
-    #[inline]
-    fn split_stdout_state(me: &mut Builtin) -> (&mut BuiltinIO, &mut Yes) {
-        let Impl::Yes(yes) = &mut me.impl_ else {
-            unreachable!()
-        };
-        (&mut me.stdout, &mut **yes)
     }
 }
 

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -1,5 +1,7 @@
+import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isASAN } from "harness";
+import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 import { createTestBuilder } from "../test_builder";
 const TestBuilder = createTestBuilder(import.meta.path);
 
@@ -137,38 +139,114 @@ describe("seq without stdout", async () => {
     .runAsTest("works basic down without stdout");
 });
 
-// Regression guard: the fd-output path used to build the full output into a
-// local Vec, store it into state, then clone the stored Vec to hand to
-// BuiltinIO::enqueue (which itself copies into IOWriter's buffer). That is a
-// full-output-sized clone on top of the copy that must exist, so peak RSS was
-// ~3x the output instead of ~2x. ASAN-gated because release mimalloc does not
-// retain freed pages the way ASAN's allocator does.
-test.skipIf(!isASAN)("seq piped to an fd does not clone its output buffer before enqueue", async () => {
-  // 100-byte separator keeps the output large (~32 MB) with only 300k
-  // iterations, so the child finishes in ~1s under ASAN.
-  await using proc = Bun.spawn({
-    cmd: [
-      bunExe(),
-      "-e",
-      `const rss = process.platform === "darwin" && typeof Bun.unsafe.memoryFootprint === "function" ? Bun.unsafe.memoryFootprint : process.memoryUsage.rss;` +
-        `const sep = Buffer.alloc(100, "x").toString();` +
-        `await Bun.$\`seq 1 10 > /dev/null\`;` +
-        `const b = rss();` +
-        `await Bun.$\`seq -s \${sep} 1 300000 > /dev/null\`;` +
-        `console.log(rss() - b);`,
-    ],
-    env: bunEnv,
-    stderr: "pipe",
+// The builtin renders and writes its output about 64 KiB at a time. These
+// sequences span several chunks, written to each kind of stdout that takes a
+// different path through the builtin: the captured buffer (written directly),
+// a file (fd written synchronously) and a pipe (fd completed from the event
+// loop).
+describe("seq long output", () => {
+  const COUNT = 40_000;
+  // BSD seq: the separator follows every value, the terminator comes last.
+  const expected = Array.from({ length: COUNT }, (_, i) => `${i + 1},`).join("") + "END";
+  const copyStdin = "await Bun.write(Bun.stdout, await Bun.stdin.bytes())";
+
+  test.concurrent("captured stdout", async () => {
+    expect(await $`seq -s , -t END 1 ${COUNT}`.text()).toBe(expected);
   });
-  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-  expect(stderr).toBe("");
-  const rawDelta = stdout.trim();
-  expect(rawDelta).toMatch(/^\d+$/);
-  const deltaBytes = Number(rawDelta);
-  // Output is 31_688_895 bytes. With the fix the child's RSS grows by
-  // ~128-134 MB (rendered Vec capacity + IOWriter's copy + ASAN shadow);
-  // without it the extra clone pushes it to ~170 MB.
-  expect(deltaBytes).toBeGreaterThan(0);
-  expect(deltaBytes).toBeLessThan(152 * 1024 * 1024);
-  expect(exitCode).toBe(0);
+
+  test.concurrent("redirected to a file", async () => {
+    using dir = tempDir("seq-long", {});
+    const out = join(String(dir), "out.txt");
+    await $`seq -s , -t END 1 ${COUNT} > ${out}`.quiet();
+    expect(await Bun.file(out).text()).toBe(expected);
+  });
+
+  test.concurrent("piped to a process", async () => {
+    const stdout = await $`seq -s , -t END 1 ${COUNT} | ${bunExe()} -e ${copyStdin}`.env(bunEnv).text();
+    expect(stdout).toBe(expected);
+  });
+
+  // 8192 four-digit values with a 4-byte separator are exactly 64 KiB. Ending
+  // at 9191 the sequence runs out just as the first chunk fills up; ending at
+  // 9192 one value and the terminator are left over for a second chunk.
+  describe.each([
+    [9191, 8192],
+    [9192, 8193],
+  ])("seq -s abcd -t END 1000 %i", (end, count) => {
+    const expected = Array.from({ length: count }, (_, i) => `${1000 + i}abcd`).join("") + "END";
+
+    test.concurrent("captured stdout", async () => {
+      expect(await $`seq -s abcd -t END 1000 ${end}`.text()).toBe(expected);
+    });
+
+    test.concurrent("redirected to a file", async () => {
+      using dir = tempDir("seq-boundary", {});
+      const out = join(String(dir), "out.txt");
+      await $`seq -s abcd -t END 1000 ${end} > ${out}`.quiet();
+      expect(await Bun.file(out).text()).toBe(expected);
+    });
+
+    test.concurrent("piped to a process", async () => {
+      const stdout = await $`seq -s abcd -t END 1000 ${end} | ${bunExe()} -e ${copyStdin}`.env(bunEnv).text();
+      expect(stdout).toBe(expected);
+    });
+  });
+
+  // Once the reader is gone the chunks still to come fail with EPIPE; seq has
+  // to give up on the sequence instead of rendering the rest or hanging. The
+  // pipeline's exit code is the reader's.
+  test.concurrent("stops when the reader exits after the first line", async () => {
+    const firstLine =
+      `const { value } = await Bun.stdin.stream().getReader().read();` +
+      `console.log(new TextDecoder().decode(value).split("\\n")[0]);` +
+      `process.exit(0);`;
+    const { stdout, stderr, exitCode } = await $`seq 1 500000 | ${bunExe()} -e ${firstLine}`
+      .env(bunEnv)
+      .nothrow()
+      .quiet();
+    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
+      stdout: "1\n",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  test.concurrent("stops when the reader never reads", async () => {
+    const { stdout, stderr, exitCode } = await $`seq 1 500000 | true`.nothrow().quiet();
+    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
+      stdout: "",
+      stderr: "",
+      exitCode: 0,
+    });
+  });
+
+  // seq used to render the whole sequence into one Vec before writing any of
+  // it, and IOWriter copies what it is handed, so writing N bytes to an fd
+  // took more than 2N bytes of memory: the child's RSS grew by about 90 MB for
+  // this ~30 MB sequence (130 MB under ASAN), and the freed buffers stay
+  // resident after the command (ASAN quarantines them, mimalloc keeps the
+  // pages). Streamed in chunks it grows by a couple of MB whatever the length.
+  // Measured in a child so nothing else in this file moves the numbers; the
+  // 100-byte separator makes the output large with few values, which keeps
+  // the child fast under ASAN.
+  test.concurrent("does not buffer the whole sequence before writing it", async () => {
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const sep = Buffer.alloc(100, "x").toString();` +
+          `await Bun.$\`seq -s \${sep} 1 2000 > /dev/null\`;` +
+          `const before = process.memoryUsage.rss();` +
+          `await Bun.$\`seq -s \${sep} 1 300000 > /dev/null\`;` +
+          `console.log(process.memoryUsage.rss() - before);`,
+      ],
+      env: bunEnv,
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(stdout).toMatch(/^-?\d+\n$/);
+    expect(Number(stdout) / 1024 / 1024).toBeLessThan(16);
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/shell/commands/seq.test.ts
+++ b/test/js/bun/shell/commands/seq.test.ts
@@ -166,6 +166,30 @@ describe("seq long output", () => {
     expect(stdout).toBe(expected);
   });
 
+  test.concurrent("redirected to a Buffer that holds the whole sequence", async () => {
+    const target = Buffer.alloc(expected.length);
+    const { stderr, exitCode } = await $`seq -s , -t END 1 ${COUNT} > ${target}`.nothrow().quiet();
+    expect({ stderr: stderr.toString(), exitCode, target: target.toString() }).toEqual({
+      stderr: "",
+      exitCode: 0,
+      target: expected,
+    });
+  });
+
+  // 100 KiB takes the first chunk whole and is filled up by part of the second;
+  // the third is refused. The Buffer must hold exactly that prefix. Like the
+  // other builtins, seq leaves reporting a too-small Buffer to the shared
+  // write_no_io layer, which today makes this a silent truncation with exit 0.
+  test.concurrent("redirected to a Buffer smaller than the sequence", async () => {
+    const target = Buffer.alloc(100 * 1024);
+    const { stderr, exitCode } = await $`seq -s , -t END 1 ${COUNT} > ${target}`.nothrow().quiet();
+    expect({ stderr: stderr.toString(), exitCode, target: target.toString() }).toEqual({
+      stderr: "",
+      exitCode: 0,
+      target: expected.slice(0, target.length),
+    });
+  });
+
   // 8192 four-digit values with a 4-byte separator are exactly 64 KiB. Ending
   // at 9191 the sequence runs out just as the first chunk fills up; ending at
   // 9192 one value and the terminator are left over for a second chunk.
@@ -192,31 +216,36 @@ describe("seq long output", () => {
     });
   });
 
-  // Once the reader is gone the chunks still to come fail with EPIPE; seq has
-  // to give up on the sequence instead of rendering the rest or hanging. The
-  // pipeline's exit code is the reader's.
-  test.concurrent("stops when the reader exits after the first line", async () => {
-    const firstLine =
-      `const { value } = await Bun.stdin.stream().getReader().read();` +
-      `console.log(new TextDecoder().decode(value).split("\\n")[0]);` +
-      `process.exit(0);`;
-    const { stdout, stderr, exitCode } = await $`seq 1 500000 | ${bunExe()} -e ${firstLine}`
-      .env(bunEnv)
-      .nothrow()
-      .quiet();
-    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
-      stdout: "1\n",
-      stderr: "",
-      exitCode: 0,
-    });
-  });
+  // Once the reader is gone the chunks still to come fail with EPIPE and seq
+  // has to fail instead of hanging. A pipeline only reports the reader's exit
+  // code, so seq's own failure is made visible by chaining an `echo` to stderr
+  // off it; the drained reader shows the marker is not printed otherwise.
+  // 200k lines (~1.3 MB) are far more than a pipe buffers.
+  describe("fails once the reader is gone", () => {
+    const LINES = 200_000;
+    const run = async (pipeline: Promise<{ stdout: Buffer; stderr: Buffer; exitCode: number }>) => {
+      const { stdout, stderr, exitCode } = await pipeline;
+      return { stdout: stdout.toString(), stderr: stderr.toString(), exitCode };
+    };
 
-  test.concurrent("stops when the reader never reads", async () => {
-    const { stdout, stderr, exitCode } = await $`seq 1 500000 | true`.nothrow().quiet();
-    expect({ stdout: stdout.toString(), stderr: stderr.toString(), exitCode }).toEqual({
-      stdout: "",
-      stderr: "",
-      exitCode: 0,
+    test.concurrent("reader exits after the first line", async () => {
+      const firstLine =
+        `const { value } = await Bun.stdin.stream().getReader().read();` +
+        `console.log(new TextDecoder().decode(value).split("\\n")[0]);` +
+        `process.exit(0);`;
+      const pipeline = $`(seq 1 ${LINES} || echo seq-failed 1>&2) | ${bunExe()} -e ${firstLine}`.env(bunEnv);
+      expect(await run(pipeline.nothrow().quiet())).toEqual({ stdout: "1\n", stderr: "seq-failed\n", exitCode: 0 });
+    });
+
+    test.concurrent("reader never reads", async () => {
+      const pipeline = $`(seq 1 ${LINES} || echo seq-failed 1>&2) | true`;
+      expect(await run(pipeline.nothrow().quiet())).toEqual({ stdout: "", stderr: "seq-failed\n", exitCode: 0 });
+    });
+
+    test.concurrent("reader drains the whole sequence", async () => {
+      const drain = "await Bun.stdin.bytes()";
+      const pipeline = $`(seq 1 ${LINES} || echo seq-failed 1>&2) | ${bunExe()} -e ${drain}`.env(bunEnv);
+      expect(await run(pipeline.nothrow().quiet())).toEqual({ stdout: "", stderr: "", exitCode: 0 });
     });
   });
 


### PR DESCRIPTION
### Problem
- The `seq` builtin in `Bun.$` rendered the whole sequence into one local `Vec` and wrote it with a single `enqueue` / `write_no_io` call (`src/runtime/shell/builtin/seq.rs`, `Seq::do_`).
- `IOWriter::enqueue` copies what it is handed, so writing an N byte sequence to an fd held more than 2N bytes: `seq -s <100 bytes> 1 300000 > /dev/null` (30 MB of output) grows the process by 60 to 87 MB on the release build and 127 MB under ASAN, linearly in the length of the sequence. `seq 1 16777216` is about 150 MB of output, and both the line count and the line length (`-s`) are chosen by the caller.
- Nothing reached the consumer until the whole sequence existed, so `seq 1 N | head -1` waited for (and paid the memory for) all N values.

### Fix
- `Seq` keeps a cursor (`current`) and one reusable chunk buffer; `render_chunk` appends values until the buffer holds 64 KiB, or the terminator once the sequence ends.
- fd stdout: `do_` queues the first chunk; `on_io_writer_chunk` renders and queues the next one after the previous one is written (state `Writing`) and finishes when the chunk that was in flight was the last one (state `Done`). A write error still ends the command with exit 1 and nothing further is rendered, so `seq ... | head` stops at the first EPIPE.
- Captured / `> ${buffer}` stdout: the chunks are written in a loop; a chunk the target refuses (a full `> ${buffer}`, the only error these targets produce) ends the loop, since the rest of the sequence would be refused as well.
- Correct because a chunk is only ever cut between values, so the chunks concatenate to exactly the bytes the old code built (separator after every value, terminator once), and the `next == current` saturation guard ends the sequence inside the chunk in which it fires, so no value is rendered twice across a boundary. One chunk is in flight at a time, so the builtin plus the `IOWriter` hold about two chunks however long the sequence is. It is the same structure the `yes` builtin already uses, with a finite sequence instead of an endless one.
- The piece `yes` and `seq` now both need, stdout and the builtin's own state borrowed together so the chunk is written straight from the state, lives on `BuiltinState` (`split_stdout` for the fd path, `split_stdout_no_io` for synchronous targets) instead of being copied into each builtin; `yes` is switched to it and its private copy deleted. `split_stdout_no_io` hands out a `NoIoOutput`, the stream paired with its shell env, so the one `unsafe` call into `write_no_io_to` stays in `Builtin.rs`, and `Builtin::write_no_io` is built on the same pieces, so every synchronous builtin write still goes through one place.
- Output and exit codes are unchanged. In particular a too-small `> ${buffer}` still truncates with exit 0: seq, like the other builtins, leaves reporting that to the shared write layer (#34698 is the open change doing so for all of them, and seq's writes still go through the layer it instruments), and the new tests pin today's behaviour so that interaction is visible. `yes`, which reports ENOSPC itself, is unchanged too.
- Verified with `test/js/bun/shell/commands/seq.test.ts`. New `seq long output` block: multi-chunk output compared byte for byte on a captured stdout, a file, a pipe and a `Buffer`; a `Buffer` smaller than the output; the two sequences ending exactly at and one value past the 64 KiB boundary on all three stdout kinds; seq's own exit status (made visible with `(seq ... || echo seq-failed 1>&2) | reader`) when the reader never reads, exits after the first line, or drains everything; and a memory test running the 30 MB sequence in a child whose RSS may grow by at most 16 MB. The memory test fails on the unfixed build (release: 61 to 87 MB over five runs, unfixed ASAN debug build: 127 MB) and passes with this change (about 2 MB under ASAN, still 0 to 3 MB at 121 MB of output); every other test passes on both builds, i.e. pins pre-existing behaviour. It replaces the ASAN-only RSS test whose 152 MB bound this change makes meaningless.
- `commands/*.test.ts` (including `yes`, which covers both `split_stdout` users on both paths), `bunshell`, `shell-seq-condexpr`, `pipeline_stack`, `exec`, `epipe`, `yield` and `file-io` pass apart from tests that fail identically with the released binary in this container (root bypassing the `ls` permission tests, a 5 s budget on the `rm` symlink race); `cargo clippy -p bun_runtime` and `cargo fmt` are clean.

### Background
- Shell builtins run inside the interpreter's trampoline: a step returns a `Yield` naming what runs next instead of calling it. A builtin that writes more than once queues one piece on the `IOWriter` and is called back through `on_io_writer_chunk` when it has been written (synchronously, as a returned `Yield`, for regular files and `/dev/null`; from the event loop for pipes and ttys). Queuing the next piece from that callback is how output is streamed; `yes` works this way.
- `IOWriter` is the shared queue in front of a file descriptor; `enqueue` appends a copy of the bytes to its own buffer and frees that buffer once every queued chunk is written. That copy is why buffering the whole output first cost twice its size.
- A builtin's stdout "needs io" when it is an fd. Otherwise (`.text()` / `.quiet()` capture, `> ${buffer}`, a Blob, or ignored) it is written synchronously: appended to the shell env's capture buffer, or copied into the JS buffer with `ENOSPC` once that is full. The capture buffer belongs to the shell env, which is why a synchronous write needs the env alongside the stream; the env outlives the command, which is what `NoIoOutput` relies on.
- `BuiltinState` is the per-builtin state downcast (`Impl::Seq(v) => v`) that every builtin module already uses through `state_mut`; the new methods are the same projection with stdout borrowed next to it.
- Bun's `seq` follows the BSD variant: the `-s` separator follows every value, including the last, and the `-t` terminator is written once after the sequence. A pipeline's exit code is its last command's, which is why the EPIPE tests chain an `echo` off seq to see seq's own status. The operands are `f32`, so the pre-existing `next == current` guard is what ends sequences whose increment no longer changes the value; #37923 moves the arithmetic to `f64` and is independent of the buffering changed here.
