### PR TITLE
node:zlib: apply params() as its flush retires instead of racing the next write

### DIFF
--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -586,9 +586,8 @@ function Zlib(opts, mode) {
 }
 $toClass(Zlib, "Zlib", ZlibBase);
 
-// Runs once the Z_SYNC_FLUSH issued by .params() has retired. Unlike node this is not the flush's write callback:
-// the writable machinery dispatches the next buffered chunk before running write callbacks, and the native params()
-// throws while a write is in flight, so processCallback() invokes it through kAfterFlush instead.
+// Invoked by processCallback() as the flush issued by .params() retires. Node runs this as the flush's write callback,
+// but write callbacks run after the next buffered chunk was handed to the handle, and native params() throws then.
 function paramsAfterFlushCallback(level, strategy, callback) {
   $assert(this._handle, "zlib binding closed");
   this._handle.params(level, strategy);

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -26,6 +26,7 @@ const owner_symbol = Symbol("owner_symbol");
 const { checkRangesOrGetDefault, validateFunction, validateFiniteNumber } = require("internal/validators");
 
 const kFlushFlag = Symbol("kFlushFlag");
+const kAfterFlush = Symbol("kAfterFlush");
 const kError = Symbol("kError");
 
 const { zlib: constants } = process.binding("constants");
@@ -254,13 +255,11 @@ function maxFlush(a, b) {
 // Set up a list of 'special' buffers that can be written using .write()
 // from the .flush() code as a way of introducing flushing operations into the
 // write sequence.
+const dummyArrayBuffer = new ArrayBuffer();
 const kFlushBuffers: (typeof Buffer)[] = [];
-{
-  const dummyArrayBuffer = new ArrayBuffer();
-  for (const flushFlag of kFlushFlagList) {
-    kFlushBuffers[flushFlag] = Buffer.from(dummyArrayBuffer);
-    kFlushBuffers[flushFlag][kFlushFlag] = flushFlag;
-  }
+for (const flushFlag of kFlushFlagList) {
+  kFlushBuffers[flushFlag] = Buffer.from(dummyArrayBuffer);
+  kFlushBuffers[flushFlag][kFlushFlag] = flushFlag;
 }
 
 ZlibBase.prototype.flush = function (kind, callback) {
@@ -511,7 +510,10 @@ function processCallback() {
   }
 
   // Finished with the chunk.
+  const afterFlush = this.buffer[kAfterFlush];
   this.buffer = null;
+  // Runs while the handle is still idle; this.cb() hands the next buffered chunk to it (see paramsAfterFlushCallback).
+  if (afterFlush !== undefined) afterFlush();
   this.cb();
 }
 
@@ -585,7 +587,10 @@ function Zlib(opts, mode) {
 $toClass(Zlib, "Zlib", ZlibBase);
 
 // This callback is used by `.params()` to wait until a full flush happened before adjusting the parameters.
-// In particular, the call to the native `params()` function should not happen while a write is currently in progress on the threadpool.
+// In particular, the call to the native `params()` function must not happen while a write is in progress on the
+// threadpool (the handle throws ERR_INVALID_STATE). Node makes the call from the flush's write callback, but the
+// writable machinery hands the next buffered chunk to the handle before it runs write callbacks, so a write() queued
+// behind the params() call would already be in flight by then; processCallback() runs this as the flush retires.
 function paramsAfterFlushCallback(level, strategy, callback) {
   $assert(this._handle, "zlib binding closed");
   this._handle.params(level, strategy);
@@ -596,12 +601,27 @@ function paramsAfterFlushCallback(level, strategy, callback) {
   }
 }
 
+// The user's callback still runs as the flush's write callback, i.e. at the same point as in node, so that a
+// write() or end() issued from it is dispatched the same way. It is skipped if applying the parameters failed.
+function paramsWriteCallback(callback) {
+  if (!this.destroyed) callback();
+}
+
 Zlib.prototype.params = function params(level, strategy, callback) {
   checkRangesOrGetDefault(level, "level", Z_MIN_LEVEL, Z_MAX_LEVEL);
   checkRangesOrGetDefault(strategy, "strategy", Z_DEFAULT_STRATEGY, Z_FIXED);
 
   if (this._level !== level || this._strategy !== strategy) {
-    this.flush(Z_SYNC_FLUSH, paramsAfterFlushCallback.bind(this, level, strategy, callback));
+    if (this.writableEnded) {
+      // Nothing can be queued behind the Z_FINISH chunk anymore, but _final() above lets 'finish' fire while that
+      // chunk may still be on the threadpool; the handle is idle again once it has produced 'end'.
+      this.once("end", paramsAfterFlushCallback.bind(this, level, strategy, callback));
+    } else {
+      const flush = Buffer.from(dummyArrayBuffer);
+      flush[kFlushFlag] = Z_SYNC_FLUSH;
+      flush[kAfterFlush] = paramsAfterFlushCallback.bind(this, level, strategy, undefined);
+      this.write(flush, "", callback && paramsWriteCallback.bind(this, callback));
+    }
   } else {
     process.nextTick(callback);
   }

--- a/src/js/node/zlib.ts
+++ b/src/js/node/zlib.ts
@@ -586,11 +586,9 @@ function Zlib(opts, mode) {
 }
 $toClass(Zlib, "Zlib", ZlibBase);
 
-// This callback is used by `.params()` to wait until a full flush happened before adjusting the parameters.
-// In particular, the call to the native `params()` function must not happen while a write is in progress on the
-// threadpool (the handle throws ERR_INVALID_STATE). Node makes the call from the flush's write callback, but the
-// writable machinery hands the next buffered chunk to the handle before it runs write callbacks, so a write() queued
-// behind the params() call would already be in flight by then; processCallback() runs this as the flush retires.
+// Runs once the Z_SYNC_FLUSH issued by .params() has retired. Unlike node this is not the flush's write callback:
+// the writable machinery dispatches the next buffered chunk before running write callbacks, and the native params()
+// throws while a write is in flight, so processCallback() invokes it through kAfterFlush instead.
 function paramsAfterFlushCallback(level, strategy, callback) {
   $assert(this._handle, "zlib binding closed");
   this._handle.params(level, strategy);
@@ -601,8 +599,7 @@ function paramsAfterFlushCallback(level, strategy, callback) {
   }
 }
 
-// The user's callback still runs as the flush's write callback, i.e. at the same point as in node, so that a
-// write() or end() issued from it is dispatched the same way. It is skipped if applying the parameters failed.
+// The user's callback keeps node's timing: it is the flush's write callback (test-zlib-params.js depends on this).
 function paramsWriteCallback(callback) {
   if (!this.destroyed) callback();
 }
@@ -613,8 +610,7 @@ Zlib.prototype.params = function params(level, strategy, callback) {
 
   if (this._level !== level || this._strategy !== strategy) {
     if (this.writableEnded) {
-      // Nothing can be queued behind the Z_FINISH chunk anymore, but _final() above lets 'finish' fire while that
-      // chunk may still be on the threadpool; the handle is idle again once it has produced 'end'.
+      // 'finish' fires while the Z_FINISH chunk may still be in flight (see _final); the handle is idle again at 'end'.
       this.once("end", paramsAfterFlushCallback.bind(this, level, strategy, callback));
     } else {
       const flush = Buffer.from(dummyArrayBuffer);

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -243,9 +243,13 @@ mod _impl {
             // in-flight async write's `deflate()` is using.
             CompressionStream::<Self>::throw_unless_idle(self, global)?;
 
-            let level = validators::validate_int32(global, arguments.ptr[0], "level", None, None)?;
-            let strategy =
-                validators::validate_int32(global, arguments.ptr[1], "strategy", None, None)?;
+            // ToInt32 like node's `Int32Value()`: `Zlib.prototype.params` only
+            // range-checks, so a fractional level such as 1.5 (or NaN/undefined,
+            // which its check lets through as well) has to truncate rather than
+            // throw from the deferred flush callback.
+            // https://github.com/nodejs/node/blob/v24.0.0/src/node_zlib.cc#L763-L766
+            let level = arguments.ptr[0].coerce_to_i32(global)?;
+            let strategy = arguments.ptr[1].coerce_to_i32(global)?;
 
             let err = self.stream.with_mut(|s| s.set_params(level, strategy));
             if err.is_error() {

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -239,14 +239,12 @@ mod _impl {
                     )
                     .throw());
             }
-            // ToInt32 like node's `Int32Value()`; zlib.ts only range-checks, so
-            // 1.5 / NaN / undefined reach here.
+            // ToInt32 (zlib.ts only range-checks, so 1.5 / NaN reach here), like node's `Int32Value()`:
             // https://github.com/nodejs/node/blob/v24.0.0/src/node_zlib.cc#L763-L766
             let level = arguments.ptr[0].coerce_to_i32(global)?;
             let strategy = arguments.ptr[1].coerce_to_i32(global)?;
 
-            // After the coercions: a `valueOf()` in there can start a write, whose
-            // `deflate()` would race `set_params`' `deflateParams` on the `z_stream`.
+            // After the coercions: a `valueOf()` in there can start a write that `set_params` would race.
             CompressionStream::<Self>::throw_unless_idle(self, global)?;
 
             let err = self.stream.with_mut(|s| s.set_params(level, strategy));

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -239,17 +239,14 @@ mod _impl {
                     )
                     .throw());
             }
-            // ToInt32 like node's `Int32Value()`: `Zlib.prototype.params` only
-            // range-checks, so a fractional level such as 1.5 (or NaN/undefined,
-            // which its check lets through as well) has to truncate rather than
-            // throw from the deferred flush callback.
+            // ToInt32 like node's `Int32Value()`; zlib.ts only range-checks, so
+            // 1.5 / NaN / undefined reach here.
             // https://github.com/nodejs/node/blob/v24.0.0/src/node_zlib.cc#L763-L766
             let level = arguments.ptr[0].coerce_to_i32(global)?;
             let strategy = arguments.ptr[1].coerce_to_i32(global)?;
 
-            // `set_params` calls `deflateParams` on the same `z_stream` an
-            // in-flight async write's `deflate()` is using. Checked after the
-            // coercions: a `valueOf()` running inside them can start a write.
+            // After the coercions: a `valueOf()` in there can start a write, whose
+            // `deflate()` would race `set_params`' `deflateParams` on the `z_stream`.
             CompressionStream::<Self>::throw_unless_idle(self, global)?;
 
             let err = self.stream.with_mut(|s| s.set_params(level, strategy));

--- a/src/runtime/node/zlib/NativeZlib.rs
+++ b/src/runtime/node/zlib/NativeZlib.rs
@@ -239,10 +239,6 @@ mod _impl {
                     )
                     .throw());
             }
-            // `set_params` calls `deflateParams` on the same `z_stream` an
-            // in-flight async write's `deflate()` is using.
-            CompressionStream::<Self>::throw_unless_idle(self, global)?;
-
             // ToInt32 like node's `Int32Value()`: `Zlib.prototype.params` only
             // range-checks, so a fractional level such as 1.5 (or NaN/undefined,
             // which its check lets through as well) has to truncate rather than
@@ -250,6 +246,11 @@ mod _impl {
             // https://github.com/nodejs/node/blob/v24.0.0/src/node_zlib.cc#L763-L766
             let level = arguments.ptr[0].coerce_to_i32(global)?;
             let strategy = arguments.ptr[1].coerce_to_i32(global)?;
+
+            // `set_params` calls `deflateParams` on the same `z_stream` an
+            // in-flight async write's `deflate()` is using. Checked after the
+            // coercions: a `valueOf()` running inside them can start a write.
+            CompressionStream::<Self>::throw_unless_idle(self, global)?;
 
             let err = self.stream.with_mut(|s| s.set_params(level, strategy));
             if err.is_error() {

--- a/test/js/node/zlib/zlib-handle-bounds-check.test.ts
+++ b/test/js/node/zlib/zlib-handle-bounds-check.test.ts
@@ -301,6 +301,18 @@ describe.concurrent("zlib native handle driven outside the zlib.ts lifecycle", (
        catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
       "threw ERR_INVALID_STATE: Write already in progress",
     ],
+    // params() converts its arguments with ToInt32, which runs user code; a
+    // write started from there has to be caught by the same guard.
+    [
+      "zlib: params() whose argument coercion starts an async write throws",
+      `const C = zlib.createDeflate()._handle.constructor;
+       const h = new C(1);
+       h.init(15, 6, 8, 0, new Uint32Array(2), () => {}, undefined);
+       const level = { valueOf() { h.write(0, null, 0, 0, new Uint8Array(64), 0, 64); return 1; } };
+       try { h.params(level, 0); console.log("handled"); }
+       catch (e) { console.log("threw " + e.code + ": " + e.message); }`,
+      "threw ERR_INVALID_STATE: Write already in progress",
+    ],
     [
       "brotli: init() while an async write is in flight throws",
       `const C = zlib.createBrotliCompress()._handle.constructor;

--- a/test/js/node/zlib/zlib.test.js
+++ b/test/js/node/zlib/zlib.test.js
@@ -1,6 +1,6 @@
 import { deflateSync, gunzipSync, gzipSync, inflateSync } from "bun";
 import { describe, expect, it } from "bun:test";
-import { tmpdirSync } from "harness";
+import { bunEnv, bunExe, tmpdirSync } from "harness";
 import * as buffer from "node:buffer";
 import { randomFillSync } from "node:crypto";
 import * as fs from "node:fs";
@@ -769,6 +769,147 @@ describe("dictionary buffer lifetime", () => {
     await promise;
 
     expect(Buffer.concat(chunks).toString()).toBe(input.toString());
+  });
+});
+
+// Each scenario runs in a child process: the bug is an exception thrown out of
+// a native write callback, which surfaces as an uncaught exception that kills
+// the process (non-zero exit, nothing printed) rather than as a failed
+// assertion. The fixtures print their observations as JSON on 'close'.
+describe("Zlib.prototype.params", () => {
+  async function run(fixture) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `const zlib = require("node:zlib");\n${fixture}`],
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    return JSON.parse(stdout);
+  }
+
+  it.concurrent("a params() call pipelined between two write() calls applies to the second write", async () => {
+    expect(
+      await run(/* js */ `
+        const a = Buffer.alloc(32 * 1024, "a");
+        const b = Buffer.alloc(32 * 1024, "b");
+        const d = zlib.createDeflate({ level: 9 });
+        const out = [], order = [], errors = [];
+        d.on("data", c => out.push(c));
+        d.on("error", e => errors.push(e.code));
+        d.on("close", () => {
+          const compressed = Buffer.concat(out);
+          console.log(JSON.stringify({
+            errors,
+            order,
+            level: d._level,
+            strategy: d._strategy,
+            roundTrip: zlib.inflateSync(compressed).equals(Buffer.concat([a, b])),
+            // "a" was deflated at level 9; "b" went out as stored blocks at level 0.
+            bStored: compressed.length > b.length && compressed.length < a.length + b.length,
+          }));
+        });
+        // "a" is on the threadpool when params() is called, so its flush and "b" both queue up behind it.
+        d.write(a, () => order.push("a"));
+        d.params(0, zlib.constants.Z_FILTERED, () => order.push("params"));
+        d.write(b, () => order.push("b"));
+        d.end();
+      `),
+    ).toEqual({
+      errors: [],
+      order: ["a", "params", "b"],
+      level: 0,
+      strategy: zlib.constants.Z_FILTERED,
+      roundTrip: true,
+      bStored: true,
+    });
+  });
+
+  it.concurrent("pipelined params() calls apply in order and each one runs its callback", async () => {
+    const rounds = 20;
+    expect(
+      await run(/* js */ `
+        const d = zlib.createDeflateRaw({ level: 1 });
+        const input = [], out = [], applied = [], errors = [];
+        d.on("data", c => out.push(c));
+        d.on("error", e => errors.push(e.code));
+        d.on("close", () => console.log(JSON.stringify({
+          errors,
+          applied,
+          level: d._level,
+          strategy: d._strategy,
+          roundTrip: zlib.inflateRawSync(Buffer.concat(out)).equals(Buffer.concat(input)),
+        })));
+        for (let i = 0; i < ${rounds}; i++) {
+          const chunk = Buffer.alloc(64, i);
+          input.push(chunk);
+          d.write(chunk);
+          d.params(i % 10, i % 5, () => applied.push(i));
+        }
+        // Some data has to follow the last params() call: a params() flush that ends up being the final chunk
+        // is finished instead of flushed, and deflateParams() on a finished stream fails (in node as well).
+        const last = Buffer.alloc(64, ${rounds});
+        input.push(last);
+        d.end(last);
+      `),
+    ).toEqual({
+      errors: [],
+      applied: Array.from({ length: rounds }, (_, i) => i),
+      level: (rounds - 1) % 10,
+      strategy: (rounds - 1) % 5,
+      roundTrip: true,
+    });
+  });
+
+  // Zlib.prototype.params only range-checks its arguments, and node's binding
+  // truncates them with Int32Value(), so these all reach deflateParams() as an
+  // integer instead of failing once the flush has gone through.
+  it.concurrent.each([1.5, NaN, undefined])("params(%p) is truncated to an integer like node", async level => {
+    expect(
+      await run(/* js */ `
+        const input = Buffer.alloc(1024, "x");
+        const d = zlib.createDeflate({ level: 9 });
+        const out = [], errors = [];
+        let callbacks = 0;
+        d.on("data", c => out.push(c));
+        d.on("error", e => errors.push(e.code));
+        d.on("close", () => console.log(JSON.stringify({
+          errors,
+          callbacks,
+          roundTrip: zlib.inflateSync(Buffer.concat(out)).equals(input),
+        })));
+        d.params(${level}, zlib.constants.Z_DEFAULT_STRATEGY, () => {
+          callbacks++;
+          d.end(input);
+        });
+      `),
+    ).toEqual({ errors: [], callbacks: 1, roundTrip: true });
+  });
+
+  // zlib streams emit 'finish' while the Z_FINISH chunk is still on the
+  // threadpool. params() then has to wait for it to retire; deflateParams() on
+  // the finished stream is reported through 'error', as node does for a
+  // params() call made after end().
+  it.concurrent("params() from a 'finish' handler waits for the final chunk and reports through 'error'", async () => {
+    expect(
+      await run(/* js */ `
+        const input = Buffer.alloc(1024, "x");
+        const d = zlib.createDeflate({ level: 9 });
+        const out = [], errors = [];
+        let callbacks = 0;
+        d.on("data", c => out.push(c));
+        d.on("error", e => errors.push(e.code));
+        d.on("close", () => console.log(JSON.stringify({
+          errors,
+          callbacks,
+          roundTrip: zlib.inflateSync(Buffer.concat(out)).equals(input),
+        })));
+        d.on("finish", () => d.params(0, zlib.constants.Z_DEFAULT_STRATEGY, () => callbacks++));
+        d.end(input);
+      `),
+    ).toEqual({ errors: ["Z_STREAM_ERROR"], callbacks: 0, roundTrip: true });
   });
 });
 


### PR DESCRIPTION
### Problem
- `Deflate/DeflateRaw/Gzip#params(level, strategy, cb)` called while an earlier `write()` is still being compressed (the ordinary `write(a); params(); write(b)` pipeline) throws an uncaught `ERR_INVALID_STATE: Write already in progress`, the level/strategy change is dropped and `cb` never runs. Nothing is catchable at the call site and no `'error'` event is emitted. 200 interleaved `write(); params()` pairs produce 200 uncaught exceptions on one stream.
- Cause: `Zlib.prototype.params` (`src/js/node/zlib.ts`) does `flush(Z_SYNC_FLUSH, paramsAfterFlushCallback)`, i.e. it calls the native `_handle.params()` from the flush chunk's write callback. The writable machinery runs `clearBuffer()` (which hands the next buffered chunk to the handle) before `afterWrite()` (which runs write callbacks), so by the time `paramsAfterFlushCallback` runs, `b` is already on the threadpool and the handle's `throw_unless_idle` guard (`src/runtime/node/node_zlib_binding.rs`) throws from inside a callback invoked by native code.
- Same shape after `end()`: zlib streams emit `'finish'` while the `Z_FINISH` chunk is still on the threadpool (`_final` is overridden to call back immediately), so `params()` from a `'finish'` handler hits the `writableFinished` branch of `flush()`, runs on `nextTick` and throws the same uncaught error.
- Sibling: `params(1.5 | NaN | undefined, ...)` passes the JS range check (same as in Node), then the native `params()` rejected the value with `validate_int32` from the same deferred callback, so it also surfaced as an uncaught `ERR_OUT_OF_RANGE` with `cb` never called. Node truncates these with `Int32Value()` and calls `cb`.
- Node's JS layer has the identical ordering; it only looks fine there because Node has no in-progress guard and calls `deflateParams()` concurrently with the threadpool's `deflate()`. The gzip variant works in Node because its `SetParams` is a no-op for gzip mode; the same script with `createDeflate` segfaults node v26.3.0 (5/5 runs here), and `write(a); params(); end(b)` produced corrupt output in Node in one of the runs below. So the behavior to match is the intended one (flush, then change parameters, then continue), not the race.

### Fix
- `src/js/node/zlib.ts`: `params()` now writes its own zero-length `Z_SYNC_FLUSH` chunk carrying the bound `paramsAfterFlushCallback` under a `kAfterFlush` symbol. `processCallback()` invokes it right when that flush retires, before `this.cb()` returns control to the writable machinery, so the handle is idle and the parameter change lands exactly between the data written before `params()` and the data written after it. This is also the only point where `deflateParams()` is guaranteed to find no pending input (the reason for the flush in the first place).
- The user callback is still passed as the flush's write callback (`paramsWriteCallback`), so it fires at the same point as in Node; `test-zlib-params.js` depends on that (an `end(chunk)` issued from the callback must be dispatched the same way as in Node to produce identical bytes). It is skipped when applying the parameters destroyed the stream, as in Node.
- After `end()` the change is applied from `once('end')` instead of `flush()`'s `nextTick` shortcut: the `Z_FINISH` chunk has retired by then and the handle is still open. Outcome is the same as Node gives for `end(); params()` today (`deflateParams` on a finished stream is reported through `'error'`, code `Z_STREAM_ERROR`).
- `src/runtime/node/zlib/NativeZlib.rs`: `params()` converts its arguments with ToInt32 (`coerce_to_i32`) like Node's `Int32Value()` instead of `validate_int32`. `throw_unless_idle` stays: it is the memory-safety guard for direct `_handle.params()` misuse (`zlib-handle-bounds-check.test.ts` asserts it); the JS layer just never trips it anymore. Since ToInt32 can run a `valueOf()`, and that can start a write, the guard now runs after the coercions (new case in `zlib-handle-bounds-check.test.ts`).
- Pipelined calls apply in order, each with its own callback, since each one is its own queued chunk. No native state or new fields needed.
- Verified: `test/js/node/zlib/zlib.test.js` (`Zlib.prototype.params` block, 6 cases: pipelined between writes with the change provably applied to the second write, 20 interleaved calls in order, `1.5`/`NaN`/`undefined`, `params()` from `'finish'`), all 6 fail on the unfixed build (uncaught `ERR_INVALID_STATE` / `ERR_OUT_OF_RANGE` in the child) and pass with the fix.
- Also run with the fix: the rest of `test/js/node/zlib/` (446 pass), and every `test/js/node/test/parallel/test-zlib-*.js` (`test-zlib-params.js`, `test-zlib-reset-before-write.js`, `test-zlib-deflate-constructors.js`, `test-zlib-write-after-flush.js`, flush/drain tests) still passes, so the existing `params()` byte output is unchanged.
- Supersedes #31336, which deferred the call natively and applied it at the start of whatever write came next (one chunk late, last-wins across pipelined calls, result discarded); it also conflicts with main since the `throw_unless_idle` guard landed.

### Background
- A `node:zlib` stream is a `Transform`. Each chunk goes to `processChunk()`, which calls the native handle's `write()`; the compression runs on the threadpool and, on completion, native code calls `processCallback()` on the JS thread, which pushes output and finally calls the chunk's transform callback (`this.cb()`). Only one native write can be in flight per handle; `write_in_progress` is cleared right before `processCallback()` is invoked.
- `flush()` works by writing a zero-length chunk tagged with a flush flag (`kFlushFlag`); `_transform()` reads the tag and passes it as the zlib flush mode. `params()` reuses this to get a `Z_SYNC_FLUSH` in front of the parameter change, because `deflateParams()` only takes effect when no input is pending.
- Writable's `onwrite()` (the transform callback) first dispatches the next buffered chunk (`clearBuffer`) and only then runs the finished chunk's write callback (`afterWrite`); Node v24 `lib/internal/streams/writable.js` L651 vs L664-L686. That ordering is why "run it from the write callback" is one chunk too late.
- The native `params()` guard (`throw_unless_idle`) exists because `deflateParams()` mutates the same `z_stream` the threadpool's `deflate()` is reading; calling it concurrently is what crashes Node.

<details>
<summary>Repro and runs</summary>

Ledger repro with `createDeflate` (gzip variant identical except that Node does not crash on it):

```js
import zlib from "node:zlib";
process.on("uncaughtException", e => console.log("UNCAUGHT", e.code, e.message));
const P = Buffer.alloc(90000); for (let i = 0; i < P.length; i++) P[i] = ((i * 2654435761) >>> 27) | 96;
const gz = zlib.createDeflate({ level: 1 }); let cb = 0; const out = [];
gz.on("data", d => out.push(d)); gz.on("error", e => console.log("error event", e.code));
gz.write(P.subarray(0, 30000));
gz.params(9, zlib.constants.Z_DEFAULT_STRATEGY, () => cb++);
gz.write(P.subarray(30000, 60000));
gz.end(P.subarray(60000));
gz.on("end", () => setTimeout(() => console.log({ paramsCb: cb, roundTrip: zlib.inflateSync(Buffer.concat(out)).equals(P) }), 50));
```

- bun 1.4.0: `UNCAUGHT ERR_INVALID_STATE Write already in progress` then `{ paramsCb: 0, roundTrip: true }`
- node v26.3.0: segmentation fault, 5/5 runs (gzip variant: `{ paramsCb: 1, roundTrip: true }`)
- this branch: `{ paramsCb: 1, roundTrip: true }` (both variants)

200x `write(45 B); params(i % 10, i % 5)` on one deflate stream, then `end(data)`:

- bun 1.4.0: `uncaught: 200, cbs: 0, level: 1, strategy: 0`
- this branch: `uncaught: 0, errors: 0, cbs: 200, level: 9, strategy: 4, roundTrip: true`

`d.write("hello")` on a level 9 deflate stream followed by three ways of ending it (events emitted, then `_level`, then the inflated output):

- `d.params(0, 0, cb); d.end()`
  - node v26.3.0: `error:Z_STREAM_ERROR`, 9, `"hello"`
  - bun 1.4.0: same
  - this branch: same. The params flush is the last chunk, so `_transform` finishes instead of flushing and `deflateParams()` on the finished stream fails; this is Node's behavior and is unchanged.
- `d.params(0, 0, () => d.end())` (the documented usage, also what `test-zlib-params.js` does)
  - node, bun 1.4.0, this branch: `paramsCb,end`, 0, `"hello"`
- `d.params(0, 0, cb); d.end(" world")`
  - node v26.3.0: `error:Z_STREAM_ERROR`, 9, inflate fails with `Z_BUF_ERROR` (the race corrupted the output in this run)
  - bun 1.4.0: `UNCAUGHT ERR_INVALID_STATE`, then `end`, 9, `"hello world"`
  - this branch: `paramsCb,end`, 0, `"hello world"`

Behavior change outside the bug: `params()` on a stream that has already emitted `'end'` used to crash on the closed handle (Node asserts there as well); with the `once('end')` routing it is now a silent no-op.

</details>
