### PR TITLE
bun:ffi: make cc() symbols' .ptr the address of the compiled C function

### DIFF
--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -77,9 +77,7 @@ extern "C" JSC::EncodedJSValue Bun__CreateFFIFunctionValue(Zig::GlobalObject* gl
         auto& vm = JSC::getVM(globalObject);
         auto scope = DECLARE_THROW_SCOPE(vm);
         auto* function = Zig::JSFFIFunction::createForFFI(vm, globalObject, argCount, symbolName != nullptr ? Zig::toStringCopy(*symbolName) : String(), reinterpret_cast<Bun::CFFIFunction>(functionPointer));
-        // `functionPointer` is the TinyCC-compiled JSC-ABI wrapper; `.ptr` has to be the native
-        // function it calls, encoded like the engine-native dlopen() symbols and JSCallback encode theirs,
-        // so that CFunction / linkSymbols / pointer arguments accept it.
+        // `functionPointer` is the TinyCC-compiled JSC-ABI wrapper, so `.ptr` must be the native function it calls.
         JSC::JSValue ptr = JSC::FFI::pointerToJSValue(globalObject, reinterpret_cast<uint64_t>(symbolFromDynamicLibrary));
         RETURN_IF_EXCEPTION(scope, {});
         function->putDirect(vm, JSC::Identifier::fromString(vm, "ptr"_s), ptr, JSC::PropertyAttribute::ReadOnly | 0);

--- a/src/jsc/bindings/JSFFIFunction.cpp
+++ b/src/jsc/bindings/JSFFIFunction.cpp
@@ -26,6 +26,7 @@
 #include "root.h"
 #include "JSFFIFunction.h"
 
+#include <JavaScriptCore/FFIConversions.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
 #include <JavaScriptCore/VM.h>
 #include "ZigGlobalObject.h"
@@ -73,14 +74,17 @@ extern "C" void Bun__FFIFunction_setDataPtr(JSC::EncodedJSValue jsValue, void* p
 extern "C" JSC::EncodedJSValue Bun__CreateFFIFunctionValue(Zig::GlobalObject* globalObject, const ZigString* symbolName, unsigned argCount, Zig::FFIFunction functionPointer, bool addPtrField, void* symbolFromDynamicLibrary)
 {
     if (addPtrField) {
-        auto* function = Zig::JSFFIFunction::createForFFI(globalObject->vm(), globalObject, argCount, symbolName != nullptr ? Zig::toStringCopy(*symbolName) : String(), reinterpret_cast<Bun::CFFIFunction>(functionPointer));
         auto& vm = JSC::getVM(globalObject);
-        // We should only expose the "ptr" field when it's a JSCallback for bun:ffi.
-        // Not for internal usages of this function type.
-        // We should also consider a separate JSFunction type for our usage to not have this branch in the first place...
-        function->putDirect(vm, JSC::Identifier::fromString(vm, String("ptr"_s)), JSC::jsNumber(std::bit_cast<double>(functionPointer)), JSC::PropertyAttribute::ReadOnly | 0);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        auto* function = Zig::JSFFIFunction::createForFFI(vm, globalObject, argCount, symbolName != nullptr ? Zig::toStringCopy(*symbolName) : String(), reinterpret_cast<Bun::CFFIFunction>(functionPointer));
+        // `functionPointer` is the TinyCC-compiled JSC-ABI wrapper; `.ptr` has to be the native
+        // function it calls, encoded like the engine-native dlopen() symbols and JSCallback encode theirs,
+        // so that CFunction / linkSymbols / pointer arguments accept it.
+        JSC::JSValue ptr = JSC::FFI::pointerToJSValue(globalObject, reinterpret_cast<uint64_t>(symbolFromDynamicLibrary));
+        RETURN_IF_EXCEPTION(scope, {});
+        function->putDirect(vm, JSC::Identifier::fromString(vm, "ptr"_s), ptr, JSC::PropertyAttribute::ReadOnly | 0);
         function->symbolFromDynamicLibrary = symbolFromDynamicLibrary;
-        return JSC::JSValue::encode(function);
+        RELEASE_AND_RETURN(scope, JSC::JSValue::encode(function));
     }
 
     return Bun__CreateFFIFunctionWithDataValue(globalObject, symbolName, argCount, functionPointer, nullptr);

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -165,6 +165,11 @@ mod exposed_to_ffi {
 }
 
 /// `host_fn::NewRuntimeFunction` thin wrapper. See host_fn.rs:310.
+///
+/// `input_function_ptr` is the native function `function_pointer` wraps; with
+/// `add_ptr_property` it becomes the symbol's `.ptr`. Encoding it can throw
+/// (addresses above 2^53 allocate a BigInt), in which case C++ returns zero.
+#[track_caller]
 #[inline]
 fn new_runtime_function(
     global: &JSGlobalObject,
@@ -173,19 +178,21 @@ fn new_runtime_function(
     function_pointer: *const c_void,
     add_ptr_property: bool,
     input_function_ptr: Option<*mut c_void>,
-) -> JSValue {
-    // SAFETY: thin FFI wrapper; `global` is a live opaque JSC handle,
-    // `function_pointer` is a JIT'd entry point owned by the caller.
-    unsafe {
-        Bun__CreateFFIFunctionValue(
-            global,
-            symbol_name,
-            arg_count,
-            function_pointer,
-            add_ptr_property,
-            input_function_ptr.unwrap_or(core::ptr::null_mut()),
-        )
-    }
+) -> JsResult<JSValue> {
+    jsc::call_zero_is_throw(global, || {
+        // SAFETY: thin FFI wrapper; `global` is a live opaque JSC handle,
+        // `function_pointer` is a JIT'd entry point owned by the caller.
+        unsafe {
+            Bun__CreateFFIFunctionValue(
+                global,
+                symbol_name,
+                arg_count,
+                function_pointer,
+                add_ptr_property,
+                input_function_ptr.unwrap_or(core::ptr::null_mut()),
+            )
+        }
+    })
 }
 
 /// `jsc::codegen::JSFFI::symbols_value_set_cached` thin wrapper.
@@ -1249,7 +1256,7 @@ impl FFI {
                         compiled.ptr.cast_const(),
                         true,
                         function.symbol_from_dynamic_library,
-                    );
+                    )?;
                     // `cb` is rooted by the `symbolsValue` cached own-property set below.
                     obj.put(global_this, str.slice(), cb);
                 }

--- a/src/runtime/ffi/ffi_body.rs
+++ b/src/runtime/ffi/ffi_body.rs
@@ -100,7 +100,7 @@ unsafe extern "C" {
         arg_count: u32,
         function_pointer: *const c_void,
         add_ptr_property: bool,
-        input_function_ptr: *mut c_void,
+        symbol_from_dynamic_library: *mut c_void,
     ) -> JSValue;
 
     fn Bun__CreateJSCFFIFunction(
@@ -164,11 +164,9 @@ mod exposed_to_ffi {
     }
 }
 
-/// `host_fn::NewRuntimeFunction` thin wrapper. See host_fn.rs:310.
-///
-/// `input_function_ptr` is the native function `function_pointer` wraps; with
-/// `add_ptr_property` it becomes the symbol's `.ptr`. Encoding it can throw
-/// (addresses above 2^53 allocate a BigInt), in which case C++ returns zero.
+/// `cc()`'s variant of `host_fn::new_runtime_function`: with `add_ptr_property`
+/// the C++ side encodes `symbol_from_dynamic_library` as the symbol's `.ptr`,
+/// which allocates (and can throw) for addresses above 2^53.
 #[track_caller]
 #[inline]
 fn new_runtime_function(
@@ -177,7 +175,7 @@ fn new_runtime_function(
     arg_count: u32,
     function_pointer: *const c_void,
     add_ptr_property: bool,
-    input_function_ptr: Option<*mut c_void>,
+    symbol_from_dynamic_library: Option<*mut c_void>,
 ) -> JsResult<JSValue> {
     jsc::call_zero_is_throw(global, || {
         // SAFETY: thin FFI wrapper; `global` is a live opaque JSC handle,
@@ -189,7 +187,7 @@ fn new_runtime_function(
                 arg_count,
                 function_pointer,
                 add_ptr_property,
-                input_function_ptr.unwrap_or(core::ptr::null_mut()),
+                symbol_from_dynamic_library.unwrap_or(core::ptr::null_mut()),
             )
         }
     })

--- a/test/js/bun/ffi/cc.test.ts
+++ b/test/js/bun/ffi/cc.test.ts
@@ -1189,3 +1189,73 @@ describe.skipIf(isASAN)("compiler runtime header directory under BUN_TMPDIR", ()
     expect(exitCode).toBe(0);
   });
 });
+
+describe("symbols[name].ptr", () => {
+  // `.ptr` used to be the bits of the TinyCC wrapper's address reinterpreted as
+  // a double (a denormal like 6e-310), so CFunction/linkSymbols rejected it and
+  // a C function receiving it as a function pointer called NULL. The fixture
+  // runs in a child process because that NULL call takes the process down.
+  it("is the address of the compiled C function and is accepted wherever bun:ffi takes a pointer", async () => {
+    using dir = tempDir("bun-ffi-cc-symbol-ptr", {
+      "symbols.c": /* c */ `
+        int forty_two(void) { return 42; }
+        int add(int a, int b) { return a + b; }
+        const char* greeting(void) { return "hi"; }
+        typedef int (*binop)(int, int);
+        int apply(binop f, int a, int b) { return f(a, b); }
+      `,
+      "fixture.js": /* js */ `
+        import { cc, CFunction, linkSymbols } from "bun:ffi";
+        import path from "path";
+
+        const { symbols } = cc({
+          source: path.join(import.meta.dir, "symbols.c"),
+          symbols: {
+            forty_two: { args: [], returns: "i32" },
+            add: { args: ["i32", "i32"], returns: "i32" },
+            // returns: "cstring" symbols are wrapped in JS; the wrapper copies .ptr
+            greeting: { args: [], returns: "cstring" },
+            apply: { args: ["function", "i32", "i32"], returns: "i32" },
+          },
+        });
+
+        const shape = value => [typeof value, Number.isInteger(value) && value > 0];
+        const results = {
+          forty_two_ptr: shape(symbols.forty_two.ptr),
+          add_ptr: shape(symbols.add.ptr),
+          greeting_ptr: shape(symbols.greeting.ptr),
+          distinct_addresses: new Set([symbols.forty_two.ptr, symbols.add.ptr, symbols.greeting.ptr]).size,
+          cfunction: new CFunction({ ptr: symbols.forty_two.ptr, args: [], returns: "i32" })(),
+          cfunction_cstring: new CFunction({ ptr: symbols.greeting.ptr, args: [], returns: "cstring" })(),
+          link_symbols: linkSymbols({ add: { ptr: symbols.add.ptr, args: ["i32", "i32"], returns: "i32" } }).symbols.add(40, 2),
+          function_argument: symbols.apply(symbols.add.ptr, 20, 22),
+        };
+        console.log(JSON.stringify(results));
+      `,
+    });
+
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.js"],
+      env: bunEnv,
+      cwd: String(dir),
+      stderr: "pipe",
+    });
+
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    const results = stdout.startsWith("{") ? JSON.parse(stdout) : stdout;
+    expect({ results, stderr, exitCode }).toMatchObject({
+      results: {
+        forty_two_ptr: ["number", true],
+        add_ptr: ["number", true],
+        greeting_ptr: ["number", true],
+        distinct_addresses: 3,
+        cfunction: 42,
+        cfunction_cstring: "hi",
+        link_symbols: 42,
+        function_argument: 42,
+      },
+      exitCode: 0,
+    });
+  });
+});


### PR DESCRIPTION
### Problem

- The `ptr` property on functions returned by `cc()` is a denormal double such as `2.5541185406113e-311` instead of an address.
- Feeding it back into bun:ffi fails: `new CFunction({ ptr: symbols.f.ptr, ... })` and `linkSymbols()` throw `TypeError: Symbol "CFunction" is missing a "ptr" field` (the denormal truncates to 0), and passing it to a C function as a `"function"` / `"ptr"` argument calls NULL (`Segmentation fault at address 0x0`).
- Cause: `Bun__CreateFFIFunctionValue` (src/jsc/bindings/JSFFIFunction.cpp:81) stored `jsNumber(std::bit_cast<double>(functionPointer))`: the pointer's bits reinterpreted as a double, left over from an encoding bun:ffi stopped using. It was also the wrong pointer: `functionPointer` is the TinyCC-compiled wrapper with the JSC host-function ABI, not the user's C function.
- `cc()` is the only remaining caller that asks for the `ptr` property (src/runtime/ffi/ffi_body.rs, `new_runtime_function(..., true, ...)`). `dlopen()` and `linkSymbols()` moved to the engine-native `JSC::JSFFIFunction` in #35246 and have a correct `.ptr`; #34008 fixed this same line before #35246 and was closed as covered by it, which left `cc()` out.

### Fix

- `Bun__CreateFFIFunctionValue` now sets `ptr` to `symbolFromDynamicLibrary`, the address of the user's C function that `cc()` already passes in, encoded with `JSC::FFI::pointerToJSValue`.
- Correct because `pointerToJSValue` is the encoding every other bun:ffi pointer producer uses (`dlopen()` / `linkSymbols()` symbols, `JSCallback.ptr`) and every consumer decodes (`CFunction`, `linkSymbols`, pointer-typed arguments): a number below 2^53, an exact BigInt above it. The address exposed is the one with the declared C signature, which is the only one a consumer can call.
- `pointerToJSValue` can throw when it has to allocate a BigInt, so the C++ side gets a throw scope and returns the empty value in that case; the Rust wrapper in ffi_body.rs goes through `call_zero_is_throw` and `cc()` propagates the exception. This is the same contract the `dlopen()` path has with `Bun__CreateJSCFFIFunction`. Verified with `BUN_JSC_validateExceptionChecks=1`.
- Nothing else changes: the other callers of `Bun__CreateFFIFunctionValue` pass `addPtrField = false` and take the untouched branch.
- Test: `test/js/bun/ffi/cc.test.ts`, "symbols[name].ptr". It compiles four symbols and checks that `.ptr` is a positive integer for a plain symbol and for a `returns: "cstring"` symbol (those are wrapped in JS and the wrapper copies `.ptr`), that the addresses differ, and that `.ptr` works through `CFunction`, `linkSymbols`, and as a `"function"` argument to another `cc()` symbol. It runs in a child process because on the old code the last of those calls NULL. Fails on the current release (`missing a "ptr" field`), passes with this change.
- `bun bd test test/js/bun/ffi/` passes (debug + ASAN).

### Background

- `cc()` compiles the user's C source with TinyCC, then for each requested symbol compiles a second small C function, `JSFunctionCall(globalObject, callFrame)`, that unpacks the JS arguments and calls the user's symbol. The JS function object is created around that wrapper; the user's symbol address is looked up separately (`tcc_get_symbol`) and passed along as `symbolFromDynamicLibrary`.
- bun:ffi represents pointers as JS numbers holding the address as a value (`ptr()`, `read.ptr()`, `JSCallback.ptr`, `FFIType.ptr` returns). An earlier encoding reinterpreted the pointer bits as the double's bits; `FFI.h` (`JSVALUE_TO_PTR` / `PTR_TO_JSVALUE`) documents that change, and this property was the last producer still using the old form.
- `JSC::FFI::pointerToJSValue` (JavaScriptCore `FFIConversions.h`) is the engine's encoder: `null` for 0, a number when the address fits in 53 bits, otherwise a BigInt (which is why it can throw: BigInts are heap allocated).
- `call_zero_is_throw` is the bun_jsc helper for calling a C++ function whose contract is "returns the empty JSValue if and only if it threw": it opens the exception-validation scope JSC's `validateExceptionChecks` mode expects at a Rust/C++ boundary and converts the result to `JsResult`.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/ffi/cc.test.ts

<!-- robobun:evidence:end -->