### PR TITLE
Bun.openInEditor: run vim, nvim and emacs directly on Linux and Windows

### DIFF
--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -13,10 +13,6 @@ use crate::api::bun::process::sync;
 
 #[cfg(target_os = "macos")]
 const OPENER: &[u8] = b"/usr/bin/open";
-#[cfg(windows)]
-const OPENER: &[u8] = b"start";
-#[cfg(not(any(target_os = "macos", windows)))]
-const OPENER: &[u8] = b"xdg-open";
 
 // ──────────────────────────────────────────────────────────────────────────
 
@@ -177,14 +173,14 @@ impl Editor {
             }};
         }
 
+        // `open <editor> --args ...` gives a terminal editor its own Terminal.app
+        // window. `xdg-open` and `start` accept a single file, so elsewhere
+        // terminal editors are run directly, like every other editor.
+        #[cfg(target_os = "macos")]
         if matches!(self, Editor::Vim | Editor::Emacs | Editor::Neovim) {
             push_arg!(OPENER);
             push_arg!(binary);
-
-            #[cfg(target_os = "macos")]
-            {
-                push_arg!(b"--args");
-            }
+            push_arg!(b"--args");
         }
 
         push_arg!(binary);

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -173,8 +173,7 @@ impl Editor {
             }};
         }
 
-        // Opens the editor in a new Terminal.app window; xdg-open and start have
-        // no equivalent, so elsewhere terminal editors are run directly.
+        // Runs the editor in a new Terminal.app window.
         #[cfg(target_os = "macos")]
         if matches!(self, Editor::Vim | Editor::Emacs | Editor::Neovim) {
             push_arg!(OPENER);

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -173,9 +173,8 @@ impl Editor {
             }};
         }
 
-        // `open <editor> --args ...` gives a terminal editor its own Terminal.app
-        // window. `xdg-open` and `start` accept a single file, so elsewhere
-        // terminal editors are run directly, like every other editor.
+        // Opens the editor in a new Terminal.app window; xdg-open and start have
+        // no equivalent, so elsewhere terminal editors are run directly.
         #[cfg(target_os = "macos")]
         if matches!(self, Editor::Vim | Editor::Emacs | Editor::Neovim) {
             push_arg!(OPENER);

--- a/src/runtime/cli/open.rs
+++ b/src/runtime/cli/open.rs
@@ -11,11 +11,6 @@ use crate::api::bun::process::sync;
 
 // ──────────────────────────────────────────────────────────────────────────
 
-#[cfg(target_os = "macos")]
-const OPENER: &[u8] = b"/usr/bin/open";
-
-// ──────────────────────────────────────────────────────────────────────────
-
 #[repr(u8)]
 #[derive(Copy, Clone, PartialEq, Eq, Hash, strum::IntoStaticStr, enum_map::Enum)]
 #[strum(serialize_all = "snake_case")] // Vscode → "vscode"
@@ -173,10 +168,9 @@ impl Editor {
             }};
         }
 
-        // Runs the editor in a new Terminal.app window.
         #[cfg(target_os = "macos")]
         if matches!(self, Editor::Vim | Editor::Emacs | Editor::Neovim) {
-            push_arg!(OPENER);
+            push_arg!(super::open::OPENER);
             push_arg!(binary);
             push_arg!(b"--args");
         }

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -200,7 +200,11 @@ printf '%s\\n' "\${0##*/}" "$@" > "$file.tmp" && mv "$file.tmp" "$file"
         const [file, editor] = process.argv.slice(2);
         if (editor) Bun.openInEditor(file, { editor });
         else Bun.openInEditor(file);
-        while (!(await Bun.file(file).exists())) await Bun.sleep(5);
+        const deadline = Date.now() + 3000;
+        while (!(await Bun.file(file).exists())) {
+          if (Date.now() > deadline) throw new Error("nothing was spawned: " + file + " was never written");
+          await Bun.sleep(5);
+        }
         await Bun.write(Bun.stdout, await Bun.file(file).text());
       `,
     });

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -190,6 +190,8 @@ printf '%s\\n' "\${0##*/}" "$@" > "$file.tmp" && mv "$file.tmp" "$file"
   // .cmd stub does not have, so this form only reaches these editors on Linux.
   if (!isWindows) cases.push(["nvim", "absolute path"]);
 
+  // Not concurrent: five debug builds starting at once on a loaded machine ran
+  // past the default per-test timeout; one at a time each row takes ~0.5s.
   test.each(cases)("%s given as %s", async (editor, how) => {
     const stub = isWindows ? `${editor}.cmd` : editor;
     using dir = tempDir("open-in-editor-terminal", {

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isLinux, tempDir } from "harness";
+import { bunEnv, bunExe, isLinux, isMacOS, isWindows, mergeWindowEnvs, tempDir } from "harness";
 import { chmodSync, existsSync, symlinkSync } from "node:fs";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 
 // Both ways of naming an editor (EDITOR in the environment, the `editor`
 // option) end in a PATH lookup of the editor's binary name. The fake editors
@@ -153,30 +153,49 @@ test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", asyn
   await Promise.all(runs);
 });
 
-// vim, nvim and emacs used to be launched as `xdg-open <editor> <editor> <file>`,
-// the shape of macOS's `open <editor> --args ...`. xdg-open takes one argument
-// and exits 1 on that, so these editors never opened. They are now run directly,
-// like every other editor on Linux.
-describe.skipIf(!isLinux)("Bun.openInEditor runs terminal editors directly", () => {
-  // Stands in for both the editor and xdg-open: writes its own name and its
-  // arguments into its last argument, which is the file being opened in either
-  // argv shape. The fake xdg-open is in cwd as well as on PATH so it is found
-  // however argv[0] gets resolved.
-  const recordArgv = `#!/bin/sh
+// vim, nvim and emacs used to be launched through the platform opener, in the
+// shape of macOS's `open <editor> --args ...`: `xdg-open <editor> <editor> <file>`
+// on Linux, which xdg-open rejects, and `start ...` on Windows, which is a cmd.exe
+// builtin that cannot be spawned. Either way the editor never opened. They are
+// now run directly, like every other editor. macOS keeps the opener (it would
+// open Terminal.app here), so it is skipped.
+describe.skipIf(isMacOS)("Bun.openInEditor runs terminal editors directly", () => {
+  // Stands in for the editor, and on Linux also for xdg-open: writes its own
+  // name followed by its arguments into its last argument, which is the file
+  // being opened in both argv shapes (so on Linux the old shape shows up in the
+  // diff; on Windows the old shape spawned nothing at all).
+  const recordArgv = isWindows
+    ? [
+        "@echo off",
+        "setlocal enabledelayedexpansion",
+        'set "last="',
+        'for %%a in (%*) do set "last=%%~a"',
+        "(echo %~n0",
+        'for %%a in (%*) do echo %%~a) > "!last!.tmp"',
+        'move /y "!last!.tmp" "!last!" >nul',
+        "",
+      ].join("\r\n")
+    : `#!/bin/sh
 for file; do :; done
 printf '%s\\n' "\${0##*/}" "$@" > "$file.tmp" && mv "$file.tmp" "$file"
 `;
 
-  test.concurrent.each([
-    ["vim", "absolute path"],
-    ["nvim", "absolute path"],
-    ["emacs", "absolute path"],
-    ["vim", "name"],
+  const cases: [editor: string, how: "$EDITOR" | "name" | "absolute path"][] = [
+    ["vim", "$EDITOR"],
     ["nvim", "$EDITOR"],
-  ])("%s given as %s", async (name, how) => {
+    ["emacs", "$EDITOR"],
+    ["vim", "name"],
+  ];
+  // An absolute editor path is classified by its exact basename, which the
+  // .cmd stub does not have, so this form only reaches these editors on Linux.
+  if (!isWindows) cases.push(["nvim", "absolute path"]);
+
+  test.each(cases)("%s given as %s", async (editor, how) => {
+    const stub = isWindows ? `${editor}.cmd` : editor;
     using dir = tempDir("open-in-editor-terminal", {
-      [name]: recordArgv,
-      "xdg-open": recordArgv,
+      [stub]: recordArgv,
+      // In cwd as well as on PATH so it is found however argv[0] gets resolved.
+      ...(isWindows ? {} : { "xdg-open": recordArgv }),
       "run.js": `
         const [file, editor] = process.argv.slice(2);
         if (editor) Bun.openInEditor(file, { editor });
@@ -185,21 +204,25 @@ printf '%s\\n' "\${0##*/}" "$@" > "$file.tmp" && mv "$file.tmp" "$file"
         await Bun.write(Bun.stdout, await Bun.file(file).text());
       `,
     });
-    chmodSync(join(String(dir), name), 0o755);
-    chmodSync(join(String(dir), "xdg-open"), 0o755);
+    if (!isWindows) {
+      chmodSync(join(String(dir), stub), 0o755);
+      chmodSync(join(String(dir), "xdg-open"), 0o755);
+    }
     const file = join(String(dir), "opened.txt");
 
-    const env = { ...bunEnv, PATH: `${String(dir)}:${bunEnv.PATH}` };
+    const overrides: Record<string, string> = { PATH: `${String(dir)}${delimiter}${process.env.PATH}` };
     const cmd = [bunExe(), "run.js", file];
-    if (how === "absolute path") cmd.push(join(String(dir), name));
-    else if (how === "name") cmd.push(name);
-    else env.EDITOR = name;
+    if (how === "$EDITOR") overrides.EDITOR = editor;
+    else cmd.push(how === "name" ? editor : join(String(dir), stub));
+    // bunEnv spells the variable "Path" on Windows; a second, differently
+    // cased PATH key would leave it up to the spawn which one the child sees.
+    const env = mergeWindowEnvs([bunEnv, overrides]);
 
     await using proc = Bun.spawn({ cmd, env, cwd: String(dir), stdout: "pipe", stderr: "pipe" });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
 
     expect(stderr).toBe("");
-    expect(stdout.split("\n")).toEqual([name, file, ""]);
+    expect(stdout.split(/\r?\n/)).toEqual([editor, file, ""]);
     expect(exitCode).toBe(0);
   });
 });

--- a/test/js/bun/util/open-in-editor-gc.test.ts
+++ b/test/js/bun/util/open-in-editor-gc.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, isLinux, tempDir } from "harness";
 import { chmodSync, existsSync, symlinkSync } from "node:fs";
 import { join } from "node:path";
@@ -151,4 +151,55 @@ test.skipIf(!isLinux)("Bun.openInEditor does not break GC signal handling", asyn
   });
 
   await Promise.all(runs);
+});
+
+// vim, nvim and emacs used to be launched as `xdg-open <editor> <editor> <file>`,
+// the shape of macOS's `open <editor> --args ...`. xdg-open takes one argument
+// and exits 1 on that, so these editors never opened. They are now run directly,
+// like every other editor on Linux.
+describe.skipIf(!isLinux)("Bun.openInEditor runs terminal editors directly", () => {
+  // Stands in for both the editor and xdg-open: writes its own name and its
+  // arguments into its last argument, which is the file being opened in either
+  // argv shape. The fake xdg-open is in cwd as well as on PATH so it is found
+  // however argv[0] gets resolved.
+  const recordArgv = `#!/bin/sh
+for file; do :; done
+printf '%s\\n' "\${0##*/}" "$@" > "$file.tmp" && mv "$file.tmp" "$file"
+`;
+
+  test.concurrent.each([
+    ["vim", "absolute path"],
+    ["nvim", "absolute path"],
+    ["emacs", "absolute path"],
+    ["vim", "name"],
+    ["nvim", "$EDITOR"],
+  ])("%s given as %s", async (name, how) => {
+    using dir = tempDir("open-in-editor-terminal", {
+      [name]: recordArgv,
+      "xdg-open": recordArgv,
+      "run.js": `
+        const [file, editor] = process.argv.slice(2);
+        if (editor) Bun.openInEditor(file, { editor });
+        else Bun.openInEditor(file);
+        while (!(await Bun.file(file).exists())) await Bun.sleep(5);
+        await Bun.write(Bun.stdout, await Bun.file(file).text());
+      `,
+    });
+    chmodSync(join(String(dir), name), 0o755);
+    chmodSync(join(String(dir), "xdg-open"), 0o755);
+    const file = join(String(dir), "opened.txt");
+
+    const env = { ...bunEnv, PATH: `${String(dir)}:${bunEnv.PATH}` };
+    const cmd = [bunExe(), "run.js", file];
+    if (how === "absolute path") cmd.push(join(String(dir), name));
+    else if (how === "name") cmd.push(name);
+    else env.EDITOR = name;
+
+    await using proc = Bun.spawn({ cmd, env, cwd: String(dir), stdout: "pipe", stderr: "pipe" });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+
+    expect(stderr).toBe("");
+    expect(stdout.split("\n")).toEqual([name, file, ""]);
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
### Problem
- `Bun.openInEditor(file)` never opens anything on Linux or Windows when the editor resolves to vim, nvim or emacs (`$EDITOR`/`$VISUAL`, `{ editor: "vim" }`, `{ editor: "/usr/bin/vim" }`).
- `Editor::open` (`src/runtime/cli/open.rs:180` on main) builds the argv for those three variants as `<opener> <editor> <editor> <file>` on every platform. That is the macOS form, `/usr/bin/open <editor> --args ...`, and it has been built this way for every platform since the editor support was first written (the Zig `open.zig` had the same layout), so this is not a port regression.
- On Linux the opener is `xdg-open`, which takes one argument: when it runs, it prints `xdg-open: unexpected argument '/usr/bin/vim'` and exits 1. On main it does not even run, because `auto_close` execs the bare name without a PATH search (the spawn layer #31297 fixes), so the spawn fails with ENOENT, or runs whatever `xdg-open` is in cwd. Whichever layer fails first, the editor never starts, and fixing the spawn alone only gets as far as the xdg-open error.
- On Windows the opener is `start`, a cmd.exe builtin rather than an executable, so the spawn fails and nothing opens (the same root cause as #32514, which changed the URL opener and left this call site for a follow-up).

### Fix
- The opener block is `#[cfg(target_os = "macos")]` and uses the existing `cli::open::OPENER` (`/usr/bin/open`) that the URL opener already uses; the per-platform copy in `open.rs` is gone. On Linux and Windows vim, nvim and emacs are spawned as `<editor> <file>`.
- That argv is the one `Editor::open` already produces for every editor outside this special case, including terminal editors it has no name for (`{ editor: "/usr/bin/nano" }`), and on Windows it is already what `{ editor: "C:\\...\\vim.exe" }` got, because an absolute path is classified by its exact basename and `vim.exe` falls into `Other`. It also runs the editor the user configured; `xdg-open <file>` would not (it picks the desktop's handler for the file type).
- Opening a separate window is deliberately not attempted. Linux has no standard way to start a terminal emulator (`$TERMINAL`, `x-terminal-emulator`, per-emulator `-e` conventions). Windows does have one (`cmd.exe /c start "" <editor> <file>`), but it would send the user-supplied editor and file paths through cmd.exe's re-tokenizer and need the escaping or rejection logic that made #32514 leave this site out; a direct spawn needs none of that. This settles the call site #32514 deferred.
- macOS is unchanged: the argv it builds is byte for byte what main builds. I have no macOS machine, so its behaviour is not verified here and the test skips there. It is likely wrong in its own way: `open` hands a Unix executable to Terminal.app, and `--args` goes to the launched application, not to the editor, which matches the note in `src/runtime/bake/DevServer.rs:1826` ("opens apple terminal + vim"). If someone with a Mac confirms the file does not open, the follow-up is to delete the block on macOS as well and let this test run there; I did not want to change macOS behaviour blind in this PR.
- Line and column are still not passed to these editors, as before.
- Test: `test/js/bun/util/open-in-editor-gc.test.ts`, "runs terminal editors directly". Each row installs a stub editor (shell script, or `.cmd` on Windows) that records its own name and arguments into the file it is asked to open, and asserts the record is exactly `<editor>`, `<file>`. Rows: vim, nvim and emacs via `$EDITOR`, vim via `{ editor: "vim" }`, and on Linux nvim via an absolute path (a `.cmd` stub's basename cannot select these editors). On Linux the stub is also installed as `xdg-open`, in cwd and on PATH so it is hit however argv[0] is resolved, so without the fix the rows fail showing `xdg-open <editor> <editor> <file>` being spawned. On Windows nothing is spawned without the fix, so `run.js` gives up after 3s with a "nothing was spawned" error that fails the stderr assertion.
- Runs: `bun bd test test/js/bun/util/open-in-editor-gc.test.ts` passes on Linux (7) and on Windows x64 (4; the two Linux-only tests skip). Without the src change the 5 Linux rows fail (`USE_SYSTEM_BUN=1` gives the same), and on Windows the 4 rows fail against the release build with the "nothing was spawned" message.
- #31297 changes how this argv is spawned and is independent of this change, but once every argv[0] built here outside macOS is an absolute editor path, its "finds the xdg-open opener on PATH" test has nothing left to observe and will need to go on whichever side lands second.

### Background
- `Bun.openInEditor` first resolves an editor to an enum variant plus an absolute binary path (`EditorContext::detect_editor`: explicit absolute path, known name looked up on PATH, `$EDITOR`/`$VISUAL`, then a built-in preference list). `Editor::open` then builds the argv and hands it to a detached thread that spawns it with inherited stdio and waits for it to exit.
- `/usr/bin/open` (macOS) opens a file or application; for a Unix executable the handler is Terminal.app. `xdg-open` (freedesktop) opens one file or URL with its default handler and has no way to pass arguments to a program. `start` is a cmd.exe builtin of the form `start ["title"] program [args]`; it can open a console program in a new window, but only when invoked through `cmd.exe /c`.
- The test builds the child env with `mergeWindowEnvs` because `bunEnv` spells the variable `Path` on Windows, and which of two differently cased PATH keys a child sees is currently not deterministic (#37382). The rows are not concurrent because five debug builds starting at once ran past the default per-test timeout on a loaded machine; sequentially each row takes about half a second.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/util/open-in-editor-gc.test.ts

<!-- robobun:evidence:end -->