### PR TITLE
mock.module: resolve the specifier when tail-called from a runner-invoked callback

### DIFF
--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -504,12 +504,12 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
     return object;
 }
 
-extern "C" JSC::EncodedJSValue Bun__Jest__onStackCallback();
+extern "C" JSC::EncodedJSValue Bun__Jest__onStackCallback(JSC::JSGlobalObject*);
 
 // `beforeAll(() => mock.module(...))` is a tail call, so callerSourceOrigin() finds no frame; the arrow itself still knows its file.
-static JSC::SourceOrigin onStackTestCallbackSourceOrigin()
+static JSC::SourceOrigin onStackTestCallbackSourceOrigin(JSC::JSGlobalObject* globalObject)
 {
-    JSC::JSValue callback = JSC::JSValue::decode(Bun__Jest__onStackCallback());
+    JSC::JSValue callback = JSC::JSValue::decode(Bun__Jest__onStackCallback(globalObject));
     if (!callback)
         return {};
 
@@ -564,7 +564,7 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
     auto resolveSpecifier = [&]() -> void {
         JSC::SourceOrigin sourceOrigin = callframe->callerSourceOrigin(vm);
         if (sourceOrigin.isNull())
-            sourceOrigin = onStackTestCallbackSourceOrigin();
+            sourceOrigin = onStackTestCallbackSourceOrigin(globalObject);
         if (sourceOrigin.isNull())
             return;
         const URL& url = sourceOrigin.url();

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -513,9 +513,15 @@ static JSC::SourceOrigin onStackTestCallbackSourceOrigin(JSC::JSGlobalObject* gl
     if (!callback)
         return {};
 
-    // test.each() registers the user's function bound to the row's arguments.
-    while (auto* bound = dynamicDowncast<JSC::JSBoundFunction>(callback))
-        callback = bound->targetFunction();
+    // The runner stores the user's function inside an AsyncContextFrame when it was registered under AsyncLocalStorage, and bound to the row's arguments by test.each().
+    for (;;) {
+        if (auto* frame = dynamicDowncast<AsyncContextFrame>(callback))
+            callback = frame->callback.get();
+        else if (auto* bound = dynamicDowncast<JSC::JSBoundFunction>(callback))
+            callback = bound->targetFunction();
+        else
+            break;
+    }
 
     auto* function = dynamicDowncast<JSC::JSFunction>(callback);
     if (!function || function->isHostFunction())

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -506,11 +506,8 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
 
 extern "C" JSC::EncodedJSValue Bun__Jest__onStackCallback();
 
-// `beforeAll(() => mock.module("./dep", factory))` calls mock.module in tail position, so by the
-// time we run the arrow's frame has been replaced by ours and the test runner's native code is
-// all that is left below us: callerSourceOrigin() is null. The runner publishes the callback it
-// is invoking; the file that callback was defined in is the file a non-tail call would have
-// resolved against.
+// `beforeAll(() => mock.module("./dep", f))` is a tail call: the arrow's frame is gone and only the
+// runner's native code is below us, so callerSourceOrigin() is null. The arrow itself still knows its file.
 static JSC::SourceOrigin onStackTestCallbackSourceOrigin()
 {
     JSC::JSValue callback = JSC::JSValue::decode(Bun__Jest__onStackCallback());

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -506,8 +506,7 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
 
 extern "C" JSC::EncodedJSValue Bun__Jest__onStackCallback();
 
-// `beforeAll(() => mock.module("./dep", f))` is a tail call: the arrow's frame is gone and only the
-// runner's native code is below us, so callerSourceOrigin() is null. The arrow itself still knows its file.
+// `beforeAll(() => mock.module(...))` is a tail call, so callerSourceOrigin() finds no frame; the arrow itself still knows its file.
 static JSC::SourceOrigin onStackTestCallbackSourceOrigin()
 {
     JSC::JSValue callback = JSC::JSValue::decode(Bun__Jest__onStackCallback());

--- a/src/jsc/bindings/BunPlugin.cpp
+++ b/src/jsc/bindings/BunPlugin.cpp
@@ -8,6 +8,7 @@
 #include "ZigGlobalObject.h"
 
 #include <JavaScriptCore/TopExceptionScope.h>
+#include <JavaScriptCore/JSBoundFunction.h>
 #include <JavaScriptCore/JSCInlines.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSMap.h>
@@ -503,6 +504,30 @@ JSObject* JSModuleMock::executeOnce(JSC::JSGlobalObject* lexicalGlobalObject)
     return object;
 }
 
+extern "C" JSC::EncodedJSValue Bun__Jest__onStackCallback();
+
+// `beforeAll(() => mock.module("./dep", factory))` calls mock.module in tail position, so by the
+// time we run the arrow's frame has been replaced by ours and the test runner's native code is
+// all that is left below us: callerSourceOrigin() is null. The runner publishes the callback it
+// is invoking; the file that callback was defined in is the file a non-tail call would have
+// resolved against.
+static JSC::SourceOrigin onStackTestCallbackSourceOrigin()
+{
+    JSC::JSValue callback = JSC::JSValue::decode(Bun__Jest__onStackCallback());
+    if (!callback)
+        return {};
+
+    // test.each() registers the user's function bound to the row's arguments.
+    while (auto* bound = dynamicDowncast<JSC::JSBoundFunction>(callback))
+        callback = bound->targetFunction();
+
+    auto* function = dynamicDowncast<JSC::JSFunction>(callback);
+    if (!function || function->isHostFunction())
+        return {};
+
+    return function->jsExecutable()->sourceOrigin();
+}
+
 BUN_DECLARE_HOST_FUNCTION(JSMock__jsModuleMock);
 extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject * lexicalGlobalObject, JSC::CallFrame* callframe))
 {
@@ -542,6 +567,8 @@ extern "C" JSC_DEFINE_HOST_FUNCTION(JSMock__jsModuleMock, (JSC::JSGlobalObject *
 
     auto resolveSpecifier = [&]() -> void {
         JSC::SourceOrigin sourceOrigin = callframe->callerSourceOrigin(vm);
+        if (sourceOrigin.isNull())
+            sourceOrigin = onStackTestCallbackSourceOrigin();
         if (sourceOrigin.isNull())
             return;
         const URL& url = sourceOrigin.url();

--- a/src/jsc/event_loop.rs
+++ b/src/jsc/event_loop.rs
@@ -1092,25 +1092,6 @@ impl EventLoop {
         }
     }
 
-    /// Prefer `runCallbackWithResult` unless you really need to make sure that microtasks are drained.
-    pub fn run_callback_with_result_and_forcefully_drain_microtasks(
-        &mut self,
-        callback: JSValue,
-        global_object: &JSGlobalObject,
-        this_value: JSValue,
-        arguments: &[JSValue],
-    ) -> JsResult<JSValue> {
-        // Same gate as `run_callback`.
-        if global_object.has_exception() {
-            return Ok(JSValue::UNDEFINED);
-        }
-        let result = callback.call(global_object, this_value, arguments)?;
-        result.ensure_still_alive();
-        let jsc_vm = global_object.bun_vm().jsc_vm();
-        self.drain_microtasks_with_global(global_object, jsc_vm)?;
-        Ok(result)
-    }
-
     /// Keep one poll registered with the loop so `us_loop_run_bun_tick` parks
     /// instead of returning immediately on `num_polls == 0`.
     #[cfg(not(windows))]

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -57,6 +57,19 @@ pub(crate) fn clone_active_strong() -> Option<BunTestPtr> {
     runner.bun_test_root.clone_active_file()
 }
 
+/// See [`BunTestRoot::on_stack_callback`]. Called by `mock.module()` (BunPlugin.cpp);
+/// `ZERO` outside `bun test` or outside a callback invocation.
+// HOST_EXPORT(Bun__Jest__onStackCallback, c)
+pub fn on_stack_callback() -> JSValue {
+    // `runner_ptr()` rather than `runner()`, as in `js_file_generation`: this runs
+    // while `run_test_callback` and `test_command.rs` are live further up the stack
+    // with their own borrows of the root, so only the `Cell` itself is touched.
+    // SAFETY: RUNNER is only read on the JS thread.
+    Jest::runner_ptr().map_or(JSValue::ZERO, |runner| unsafe {
+        (*runner.as_ptr()).bun_test_root.on_stack_callback.get()
+    })
+}
+
 pub use super::done_callback::DoneCallback;
 
 pub mod js_fns {
@@ -431,6 +444,15 @@ pub struct BunTestRoot {
     /// state (node:test root) resets on `--rerun-each` where `Bun.main` is
     /// unchanged across iterations.
     pub(crate) file_generation: u32,
+    /// The describe/hook/test callback `run_test_callback` is synchronously
+    /// invoking; `ZERO` outside of one. `mock.module()` resolves relative
+    /// specifiers against the file of the nearest JS frame, and
+    /// `beforeAll(() => mock.module("./x", f))` is a proper tail call: the
+    /// callback's frame is already gone and only the runner's native code is
+    /// below `mock.module`, so it reads the callback from here instead
+    /// (`Bun__Jest__onStackCallback`). Not a GC root: the entry that owns the
+    /// callback holds a `Strong` for the whole invocation.
+    pub(crate) on_stack_callback: std::cell::Cell<JSValue>,
 }
 
 impl BunTestRoot {
@@ -450,6 +472,7 @@ impl BunTestRoot {
             hook_scope,
             pending_then_refs: std::cell::RefCell::new(Vec::new()),
             file_generation: 0,
+            on_stack_callback: std::cell::Cell::new(JSValue::ZERO),
         }
     }
 
@@ -1155,12 +1178,20 @@ impl BunTest {
         // SAFETY: `UnsafeCell`-derived; sole `&mut` at this point (before JS re-entry).
         unsafe { (*this).update_min_timeout(global_this, timeout) };
         let args_slice: &[JSValue] = if !done_arg.is_empty() { core::slice::from_ref(&done_arg) } else { &[] };
-        let result: JSValue = match vm.event_loop_mut().run_callback_with_result_and_forcefully_drain_microtasks(
+        // Hold the `BackRef`, not a `&BunTestRoot`, across the call: the callback can
+        // re-enter the runner, which takes `&mut` borrows of the root. Save/restore
+        // rather than set/clear because the microtask drain inside the call can
+        // finish this entry and run the next one before returning here.
+        let bun_test_root = this_strong.bun_test_root;
+        let previous_on_stack_callback = bun_test_root.on_stack_callback.replace(cfg_callback);
+        let call_result = vm.event_loop_mut().run_callback_with_result_and_forcefully_drain_microtasks(
             cfg_callback,
             global_this,
             JSValue::UNDEFINED,
             args_slice,
-        ) {
+        );
+        bun_test_root.on_stack_callback.set(previous_on_stack_callback);
+        let result: JSValue = match call_result {
             Ok(v) => v,
             Err(_) => {
                 global_this.clear_termination_exception();

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -57,7 +57,6 @@ pub(crate) fn clone_active_strong() -> Option<BunTestPtr> {
     runner.bun_test_root.clone_active_file()
 }
 
-/// [`BunTestRoot::on_stack_callback`] for `mock.module()` (BunPlugin.cpp); `ZERO` outside `bun test`.
 // HOST_EXPORT(Bun__Jest__onStackCallback, c)
 pub fn on_stack_callback() -> JSValue {
     // `runner_ptr()` rather than `runner()` for the same reason as `js_file_generation`.
@@ -441,9 +440,7 @@ pub struct BunTestRoot {
     /// state (node:test root) resets on `--rerun-each` where `Bun.main` is
     /// unchanged across iterations.
     pub(crate) file_generation: u32,
-    /// The describe/hook/test callback `run_test_callback` is synchronously invoking
-    /// (`ZERO` outside of one), for a `mock.module()` tail call whose own frame is gone.
-    /// Rooted by the entry that owns the callback, not by this cell.
+    /// Callback `run_test_callback` is invoking (else `ZERO`), read by `mock.module()` tail-called from it; rooted by its entry.
     pub(crate) on_stack_callback: std::cell::Cell<JSValue>,
 }
 
@@ -1170,9 +1167,9 @@ impl BunTest {
         // SAFETY: `UnsafeCell`-derived; sole `&mut` at this point (before JS re-entry).
         unsafe { (*this).update_min_timeout(global_this, timeout) };
         let args_slice: &[JSValue] = if !done_arg.is_empty() { core::slice::from_ref(&done_arg) } else { &[] };
-        // `BackRef` copy, not `&BunTestRoot`: the callback re-enters the runner. Restored rather
-        // than cleared: the microtask drain inside the call can run the next entry.
+        // `BackRef` copy, not `&BunTestRoot`: the callback re-enters the runner.
         let bun_test_root = this_strong.bun_test_root;
+        // Restored below rather than cleared: the microtask drain inside the call can run the next entry.
         let previous_on_stack_callback = bun_test_root.on_stack_callback.replace(cfg_callback);
         let call_result = vm.event_loop_mut().run_callback_with_result_and_forcefully_drain_microtasks(
             cfg_callback,

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -57,13 +57,10 @@ pub(crate) fn clone_active_strong() -> Option<BunTestPtr> {
     runner.bun_test_root.clone_active_file()
 }
 
-/// See [`BunTestRoot::on_stack_callback`]. Called by `mock.module()` (BunPlugin.cpp);
-/// `ZERO` outside `bun test` or outside a callback invocation.
+/// [`BunTestRoot::on_stack_callback`] for `mock.module()` (BunPlugin.cpp); `ZERO` outside `bun test`.
 // HOST_EXPORT(Bun__Jest__onStackCallback, c)
 pub fn on_stack_callback() -> JSValue {
-    // `runner_ptr()` rather than `runner()`, as in `js_file_generation`: this runs
-    // while `run_test_callback` and `test_command.rs` are live further up the stack
-    // with their own borrows of the root, so only the `Cell` itself is touched.
+    // `runner_ptr()` rather than `runner()` for the same reason as `js_file_generation`.
     // SAFETY: RUNNER is only read on the JS thread.
     Jest::runner_ptr().map_or(JSValue::ZERO, |runner| unsafe {
         (*runner.as_ptr()).bun_test_root.on_stack_callback.get()
@@ -444,14 +441,9 @@ pub struct BunTestRoot {
     /// state (node:test root) resets on `--rerun-each` where `Bun.main` is
     /// unchanged across iterations.
     pub(crate) file_generation: u32,
-    /// The describe/hook/test callback `run_test_callback` is synchronously
-    /// invoking; `ZERO` outside of one. `mock.module()` resolves relative
-    /// specifiers against the file of the nearest JS frame, and
-    /// `beforeAll(() => mock.module("./x", f))` is a proper tail call: the
-    /// callback's frame is already gone and only the runner's native code is
-    /// below `mock.module`, so it reads the callback from here instead
-    /// (`Bun__Jest__onStackCallback`). Not a GC root: the entry that owns the
-    /// callback holds a `Strong` for the whole invocation.
+    /// The describe/hook/test callback `run_test_callback` is synchronously invoking
+    /// (`ZERO` outside of one), for a `mock.module()` tail call whose own frame is gone.
+    /// Rooted by the entry that owns the callback, not by this cell.
     pub(crate) on_stack_callback: std::cell::Cell<JSValue>,
 }
 
@@ -1178,10 +1170,8 @@ impl BunTest {
         // SAFETY: `UnsafeCell`-derived; sole `&mut` at this point (before JS re-entry).
         unsafe { (*this).update_min_timeout(global_this, timeout) };
         let args_slice: &[JSValue] = if !done_arg.is_empty() { core::slice::from_ref(&done_arg) } else { &[] };
-        // Hold the `BackRef`, not a `&BunTestRoot`, across the call: the callback can
-        // re-enter the runner, which takes `&mut` borrows of the root. Save/restore
-        // rather than set/clear because the microtask drain inside the call can
-        // finish this entry and run the next one before returning here.
+        // `BackRef` copy, not `&BunTestRoot`: the callback re-enters the runner. Restored rather
+        // than cleared: the microtask drain inside the call can run the next entry.
         let bun_test_root = this_strong.bun_test_root;
         let previous_on_stack_callback = bun_test_root.on_stack_callback.replace(cfg_callback);
         let call_result = vm.event_loop_mut().run_callback_with_result_and_forcefully_drain_microtasks(

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -58,9 +58,13 @@ pub(crate) fn clone_active_strong() -> Option<BunTestPtr> {
 }
 
 // HOST_EXPORT(Bun__Jest__onStackCallback, c)
-pub fn on_stack_callback() -> JSValue {
+pub fn on_stack_callback(global: &JSGlobalObject) -> JSValue {
+    // The runner, its slot and the callback in it all belong to the main thread; a Worker gets nothing.
+    if !global.bun_vm().is_main_thread {
+        return JSValue::ZERO;
+    }
     // `runner_ptr()` rather than `runner()` for the same reason as `js_file_generation`.
-    // SAFETY: RUNNER is only read on the JS thread.
+    // SAFETY: RUNNER and the slot are only written on the main thread, which the check above keeps us on.
     Jest::runner_ptr().map_or(JSValue::ZERO, |runner| unsafe {
         (*runner.as_ptr()).bun_test_root.on_stack_callback.get()
     })

--- a/src/runtime/test_runner/bun_test.rs
+++ b/src/runtime/test_runner/bun_test.rs
@@ -1167,17 +1167,23 @@ impl BunTest {
         // SAFETY: `UnsafeCell`-derived; sole `&mut` at this point (before JS re-entry).
         unsafe { (*this).update_min_timeout(global_this, timeout) };
         let args_slice: &[JSValue] = if !done_arg.is_empty() { core::slice::from_ref(&done_arg) } else { &[] };
-        // `BackRef` copy, not `&BunTestRoot`: the callback re-enters the runner.
-        let bun_test_root = this_strong.bun_test_root;
-        // Restored below rather than cleared: the microtask drain inside the call can run the next entry.
-        let previous_on_stack_callback = bun_test_root.on_stack_callback.replace(cfg_callback);
-        let call_result = vm.event_loop_mut().run_callback_with_result_and_forcefully_drain_microtasks(
-            cfg_callback,
-            global_this,
-            JSValue::UNDEFINED,
-            args_slice,
-        );
-        bun_test_root.on_stack_callback.set(previous_on_stack_callback);
+        // Same gate as `EventLoop::run_callback`: never enter JS with an exception pending.
+        let call_result: JsResult<JSValue> = if global_this.has_exception() {
+            Ok(JSValue::UNDEFINED)
+        } else {
+            // `BackRef` copy, not `&BunTestRoot`: the callback re-enters the runner.
+            let bun_test_root = this_strong.bun_test_root;
+            // Saved/restored like `Execution::on_stack_entry`: a timeout firing inside the callback can start the next entry.
+            let previous_on_stack_callback = bun_test_root.on_stack_callback.replace(cfg_callback);
+            let called = cfg_callback.call(global_this, JSValue::UNDEFINED, args_slice);
+            // Restored before the microtask drain: a continuation that runs there was not called by the runner.
+            bun_test_root.on_stack_callback.set(previous_on_stack_callback);
+            called.and_then(|result| {
+                result.ensure_still_alive();
+                vm.event_loop_mut().drain_microtasks_with_global(global_this, vm.jsc_vm())?;
+                Ok(result)
+            })
+        };
         let result: JSValue = match call_result {
             Ok(v) => v,
             Err(_) => {

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -200,6 +200,14 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
     ["test body", `test("registers", () => mock.module("./dep", ${mocked}));`, 2],
     ["test.each body", `test.each(["./dep"])("registers %s", specifier => mock.module(specifier, ${mocked}));`, 2],
     ["beforeAll with a relative file: URL", `beforeAll(() => mock.module("file:./dep.ts", ${mocked}));`, 1],
+    // Registering inside an AsyncLocalStorage context makes the runner store the callback wrapped in an
+    // AsyncContextFrame. (Hooks and tests registered that way currently wait for a done callback that was
+    // never declared, so describe is the shape that exercises the wrapper.)
+    [
+      "describe body registered under AsyncLocalStorage",
+      `new AsyncLocalStorage().run(1, () => describe("registers", () => mock.module("./dep", ${mocked})));`,
+      1,
+    ],
   ];
 
   test.concurrent.each(shapes)("%s", async (_shape, register, passing) => {
@@ -207,6 +215,7 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
       "dep.ts": dep,
       "tail.test.ts": `
         import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+        import { AsyncLocalStorage } from "node:async_hooks";
         import { value } from "./dep";
         ${register}
         test("mock applied to the already-imported module", () => expect(value).toBe("mocked"));
@@ -320,7 +329,9 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
         let worker: Worker;
         beforeAll(async () => {
           worker = new Worker(new URL("./worker.ts", import.meta.url).href);
-          const ready = new Promise(resolve => (worker.onmessage = resolve));
+          const { promise: ready, resolve, reject } = Promise.withResolvers();
+          worker.onmessage = resolve;
+          worker.onerror = reject;
           worker.postMessage(flags);
           await ready;
         });
@@ -328,9 +339,11 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
         test("the worker still sees the real module", () => {
           Atomics.store(flags, 0, 1);
           Atomics.notify(flags, 0);
-          // Block here so this callback is the one the runner has on the stack while the worker runs.
-          Atomics.wait(flags, 1, 0);
-          // 1: "./dep" stayed unresolved in the worker, as before; 2: it was resolved against this file.
+          // Block here so this callback is the one the runner has on the stack while the worker runs. The bound
+          // only turns a worker that never reports into a failure (below) instead of a process that never exits.
+          Atomics.wait(flags, 1, 0, 5000);
+          // 0: the worker never reported; 1: "./dep" stayed unresolved in the worker, as before; 2: it was
+          // resolved against this file.
           expect(Atomics.load(flags, 1)).toBe(1);
         });
       `,

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -174,7 +174,8 @@ test("mocking a builtin", async () => {
 // has to be resolved against the file the callback was defined in. Each scenario imports the module
 // first: the mock only takes effect if the specifier resolves to the path that is already loaded.
 describe("mock.module() tail-called from a callback the runner invokes", () => {
-  async function runBunTest(dir: string, ...args: string[]) {
+  // bun test reports to stderr; the inner test's failure output ends up in the assertion message.
+  async function expectBunTestToPass(dir: string, passing: number, ...args: string[]) {
     await using proc = Bun.spawn({
       cmd: [bunExe(), "test", ...args],
       cwd: dir,
@@ -182,8 +183,11 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
-    return { stderr, exitCode };
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toMatchObject({
+      stderr: expect.stringContaining(` ${passing} pass\n`),
+      exitCode: 0,
+    });
   }
 
   const dep = `export const value = "real";\n`;
@@ -209,9 +213,7 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
       `,
     });
 
-    const { stderr, exitCode } = await runBunTest(String(dir), "tail.test.ts");
-    expect(stderr).toContain(` ${passing} pass`);
-    expect(exitCode).toBe(0);
+    await expectBunTestToPass(String(dir), passing, "tail.test.ts");
   });
 
   test.concurrent("a package specifier is resolved to the loaded package", async () => {
@@ -226,9 +228,7 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
       `,
     });
 
-    const { stderr, exitCode } = await runBunTest(String(dir), "tail.test.ts");
-    expect(stderr).toContain(" 1 pass");
-    expect(exitCode).toBe(0);
+    await expectBunTestToPass(String(dir), 1, "tail.test.ts");
   });
 
   test.concurrent("a hook from --preload resolves against the preload file, not the test file", async () => {
@@ -249,8 +249,6 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
       `,
     });
 
-    const { stderr, exitCode } = await runBunTest(String(dir), "--preload", "./setup/preload.ts", "app.test.ts");
-    expect(stderr).toContain(" 1 pass");
-    expect(exitCode).toBe(0);
+    await expectBunTestToPass(String(dir), 1, "--preload", "./setup/preload.ts", "app.test.ts");
   });
 });

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -7,7 +7,8 @@
 // - Write test for export {foo} from "./foo"
 // - Write test for import {foo} from "./foo"; export {foo}
 
-import { expect, mock, spyOn, test } from "bun:test";
+import { describe, expect, mock, spyOn, test } from "bun:test";
+import { bunEnv, bunExe, tempDir } from "harness";
 import { default as defaultValue, fn, iCallFn, rexported, rexportedAs, variable } from "./mock-module-fixture";
 import * as spyFixture from "./spymodule-fixture";
 
@@ -165,4 +166,91 @@ test("mocking a builtin", async () => {
 
   const { readFile } = await import("node:fs/promises");
   expect(await readFile("hello.txt", "utf8")).toBe("hello world");
+});
+
+// `() => mock.module(...)` is a proper tail call (test files are modules, so strict mode), which
+// replaces the callback's frame with mock.module's own. When the test runner is what invoked the
+// callback, nothing below mock.module on the stack says which file made the call, so the specifier
+// has to be resolved against the file the callback was defined in. Each scenario imports the module
+// first: the mock only takes effect if the specifier resolves to the path that is already loaded.
+describe("mock.module() tail-called from a callback the runner invokes", () => {
+  async function runBunTest(dir: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "test", ...args],
+      cwd: dir,
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stderr, exitCode] = await Promise.all([proc.stderr.text(), proc.exited]);
+    return { stderr, exitCode };
+  }
+
+  const dep = `export const value = "real";\n`;
+  const mocked = `() => ({ value: "mocked" })`;
+
+  const shapes: [shape: string, register: string, passing: number][] = [
+    ["beforeAll", `beforeAll(() => mock.module("./dep", ${mocked}));`, 1],
+    ["beforeEach", `beforeEach(() => mock.module("./dep", ${mocked}));`, 1],
+    ["describe body", `describe("registers", () => mock.module("./dep", ${mocked}));`, 1],
+    ["test body", `test("registers", () => mock.module("./dep", ${mocked}));`, 2],
+    ["test.each body", `test.each(["./dep"])("registers %s", specifier => mock.module(specifier, ${mocked}));`, 2],
+    ["beforeAll with a relative file: URL", `beforeAll(() => mock.module("file:./dep.ts", ${mocked}));`, 1],
+  ];
+
+  test.concurrent.each(shapes)("%s", async (_shape, register, passing) => {
+    using dir = tempDir("mock-module-tail-call", {
+      "dep.ts": dep,
+      "tail.test.ts": `
+        import { beforeAll, beforeEach, describe, expect, mock, test } from "bun:test";
+        import { value } from "./dep";
+        ${register}
+        test("mock applied to the already-imported module", () => expect(value).toBe("mocked"));
+      `,
+    });
+
+    const { stderr, exitCode } = await runBunTest(String(dir), "tail.test.ts");
+    expect(stderr).toContain(` ${passing} pass`);
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a package specifier is resolved to the loaded package", async () => {
+    using dir = tempDir("mock-module-tail-call-pkg", {
+      "node_modules/some-pkg/package.json": `{ "name": "some-pkg", "main": "index.js" }`,
+      "node_modules/some-pkg/index.js": dep,
+      "tail.test.ts": `
+        import { beforeAll, expect, mock, test } from "bun:test";
+        import { value } from "some-pkg";
+        beforeAll(() => mock.module("some-pkg", ${mocked}));
+        test("mock applied to the already-imported package", () => expect(value).toBe("mocked"));
+      `,
+    });
+
+    const { stderr, exitCode } = await runBunTest(String(dir), "tail.test.ts");
+    expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
+
+  test.concurrent("a hook from --preload resolves against the preload file, not the test file", async () => {
+    using dir = tempDir("mock-module-tail-call-preload", {
+      "setup/preload.ts": `
+        import { beforeAll, mock } from "bun:test";
+        beforeAll(() => mock.module("./dep", ${mocked}));
+      `,
+      "setup/dep.ts": dep,
+      "dep.ts": `export const value = "sibling of the test file";\n`,
+      "app.test.ts": `
+        import { expect, test } from "bun:test";
+        import { value } from "./setup/dep";
+        import { value as sibling } from "./dep";
+        test("./dep meant the preload's neighbor", () => {
+          expect({ value, sibling }).toEqual({ value: "mocked", sibling: "sibling of the test file" });
+        });
+      `,
+    });
+
+    const { stderr, exitCode } = await runBunTest(String(dir), "--preload", "./setup/preload.ts", "app.test.ts");
+    expect(stderr).toContain(" 1 pass");
+    expect(exitCode).toBe(0);
+  });
 });

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -296,4 +296,46 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
 
     await expectBunTestToPass(String(dir), 2, "app.test.ts");
   });
+
+  test.concurrent("a Worker's mock.module() does not pick up the callback running on the main thread", async () => {
+    using dir = tempDir("mock-module-tail-call-worker", {
+      "dep.ts": dep,
+      "worker.ts": `
+        import { mock } from "bun:test";
+        import { value } from "./dep";
+        self.onmessage = ({ data: flags }) => {
+          Atomics.wait(flags, 0, 0); // until the main thread is blocked inside its test body
+          // A tail call from a native-invoked callback: no JS frame is left below mock.module.
+          queueMicrotask(() => mock.module("./dep", ${mocked}));
+          queueMicrotask(() => {
+            Atomics.store(flags, 1, value === "mocked" ? 2 : 1);
+            Atomics.notify(flags, 1);
+          });
+        };
+        self.postMessage("ready");
+      `,
+      "app.test.ts": `
+        import { afterAll, beforeAll, expect, test } from "bun:test";
+        const flags = new Int32Array(new SharedArrayBuffer(8));
+        let worker: Worker;
+        beforeAll(async () => {
+          worker = new Worker(new URL("./worker.ts", import.meta.url).href);
+          const ready = new Promise(resolve => (worker.onmessage = resolve));
+          worker.postMessage(flags);
+          await ready;
+        });
+        afterAll(() => worker.terminate());
+        test("the worker still sees the real module", () => {
+          Atomics.store(flags, 0, 1);
+          Atomics.notify(flags, 0);
+          // Block here so this callback is the one the runner has on the stack while the worker runs.
+          Atomics.wait(flags, 1, 0);
+          // 1: "./dep" stayed unresolved in the worker, as before; 2: it was resolved against this file.
+          expect(Atomics.load(flags, 1)).toBe(1);
+        });
+      `,
+    });
+
+    await expectBunTestToPass(String(dir), 1, "app.test.ts");
+  });
 });

--- a/test/js/bun/test/mock/mock-module.test.ts
+++ b/test/js/bun/test/mock/mock-module.test.ts
@@ -231,24 +231,69 @@ describe("mock.module() tail-called from a callback the runner invokes", () => {
     await expectBunTestToPass(String(dir), 1, "tail.test.ts");
   });
 
+  // Cross-file layout: the code that calls mock.module("./dep") lives in setup/, next to setup/dep.ts.
+  // The dep.ts next to the test file is a decoy: it changes in the assertion if "./dep" gets resolved
+  // against the test file instead of against the file that made the call.
+  const setupFiles = {
+    "setup/dep.ts": dep,
+    "dep.ts": `export const value = "decoy";\n`,
+    "setup/helpers.ts": `
+      import { mock } from "bun:test";
+      export function mockDep() {
+        mock.module("./dep", ${mocked});
+      }
+      export const mockDepLater = () => Promise.resolve().then(() => mock.module("./dep", ${mocked}));
+    `,
+  };
+  const assertWhichDepGotMocked = (setupDep: string) => `
+    import { expect, test } from "bun:test";
+    import { value as setupDep } from "./setup/dep";
+    import { value as decoy } from "./dep";
+    test("which dep got mocked", () => {
+      expect({ setupDep, decoy }).toEqual({ setupDep: ${JSON.stringify(setupDep)}, decoy: "decoy" });
+    });
+  `;
+
   test.concurrent("a hook from --preload resolves against the preload file, not the test file", async () => {
     using dir = tempDir("mock-module-tail-call-preload", {
+      ...setupFiles,
       "setup/preload.ts": `
         import { beforeAll, mock } from "bun:test";
         beforeAll(() => mock.module("./dep", ${mocked}));
       `,
-      "setup/dep.ts": dep,
-      "dep.ts": `export const value = "sibling of the test file";\n`,
-      "app.test.ts": `
-        import { expect, test } from "bun:test";
-        import { value } from "./setup/dep";
-        import { value as sibling } from "./dep";
-        test("./dep meant the preload's neighbor", () => {
-          expect({ value, sibling }).toEqual({ value: "mocked", sibling: "sibling of the test file" });
-        });
-      `,
+      "app.test.ts": assertWhichDepGotMocked("mocked"),
     });
 
     await expectBunTestToPass(String(dir), 1, "--preload", "./setup/preload.ts", "app.test.ts");
+  });
+
+  test.concurrent("a caller that still has a frame wins over the callback the runner invoked", async () => {
+    using dir = tempDir("mock-module-tail-call-frame-wins", {
+      ...setupFiles,
+      "app.test.ts": `
+        import { beforeAll } from "bun:test";
+        import { mockDep } from "./setup/helpers";
+        beforeAll(() => {
+          mockDep();
+        });
+        ${assertWhichDepGotMocked("mocked")}
+      `,
+    });
+
+    await expectBunTestToPass(String(dir), 1, "app.test.ts");
+  });
+
+  test.concurrent("a continuation queued by the callback is not resolved against the callback's file", async () => {
+    using dir = tempDir("mock-module-tail-call-continuation", {
+      ...setupFiles,
+      "app.test.ts": `
+        import { test } from "bun:test";
+        import { mockDepLater } from "./setup/helpers";
+        test("registers from a .then() that runs in the microtask drain after the test body", () => mockDepLater());
+        ${assertWhichDepGotMocked("real")}
+      `,
+    });
+
+    await expectBunTestToPass(String(dir), 2, "app.test.ts");
   });
 });


### PR DESCRIPTION
### Problem

- `beforeAll(() => mock.module("./dep", () => ({ ... })))` does not patch an already-imported `./dep`; the block-bodied `beforeAll(() => { mock.module(...); })` does. Same for `beforeEach`/`afterEach`, `describe` and `test` bodies, `test.each`, hooks registered from `--preload`, and with bare package names or `file:` URLs instead of `./dep`.
- `JSMock__jsModuleMock` (`src/jsc/bindings/BunPlugin.cpp`, `resolveSpecifier`) resolves the specifier against `callframe->callerSourceOrigin(vm)`, the origin of the nearest JS frame on the stack.
- An expression-bodied arrow makes that `mock.module` call a proper tail call (test files are modules, so strict mode), which replaces the arrow's frame with `mock.module`'s own. The runner invoked the arrow from native code, so there is no JS frame left below it: `callerSourceOrigin()` is null, `resolveSpecifier` returns early, and `"./dep"` is registered verbatim. The loaded module is keyed by its absolute path, so nothing is patched.
- The same shape in a callback called from user code (a helper called from a test body, `describe()` at module scope) works by accident: the frame below belongs to the caller, which is usually the same file.

### Fix

- `run_test_callback` (`src/runtime/test_runner/bun_test.rs`), the one place the runner invokes describe bodies, hooks and tests, stores the callback in a new `BunTestRoot.on_stack_callback` slot for the duration of the synchronous call and restores the previous value before draining microtasks. `Bun__Jest__onStackCallback` exposes it. The runner's only use of `EventLoop::run_callback_with_result_and_forcefully_drain_microtasks` is inlined so the restore can sit between the call and the drain; that helper had no other callers and is removed.
- When `callerSourceOrigin()` is null, `mock.module` resolves against the `SourceOrigin` of that callback's executable, first peeling the wrappers the runner itself stores the user's function in: the `JSBoundFunction` from `test.each` and the `AsyncContextFrame` used when the registration happened inside an `AsyncLocalStorage` context. Everything after that point (resolver call, `file:` handling, registry patching) is unchanged, and a caller that still has a frame is unaffected because the frame is consulted first.
- Why this is the right base: the frame the tail call removed belonged to the function the runner called, and that function's executable carries the file it was defined in, so the direct shape (`() => mock.module(...)`) now resolves exactly as the block-bodied one does. Hooks defined in a `--preload` file in another directory resolve against the preload file, not the test file or cwd.
- Where the fallback stops, both pinned by tests: a caller whose frame survived wins over the slot, and a continuation that runs in the microtask drain after the callback returned is not resolved against the callback's file (it has no frame and was not called by the runner, so it stays unresolved, as today). Known limitation: if the callback tail-calls a helper in another file that itself tail-calls `mock.module`, both frames are gone and the specifier resolves against the callback's file rather than the helper's; nothing on the stack distinguishes that from the direct shape.
- Outside `bun test`, or when the callback is not a JS function (for example a `mock()` wrapper), the slot is empty or has no executable and behavior is unchanged. `Bun__Jest__onStackCallback` also returns nothing unless the calling global's VM is the main thread's: `bun:test` is importable from a Worker and `Jest::RUNNER` is process-global, so without that check a Worker tail-calling `mock.module` would read the main thread's slot and touch a function from the main VM (pinned by a test that does exactly that).
- The slot is not a GC root: the queued describe item holds the callback as a `DeprecatedStrong` (`Collection.rs:33`) and execution entries as `Option<Strong>` (`bun_test.rs`, `ExecutionEntry.callback`) for the whole invocation, and the slot is restored before the call returns.
- Alternative considered and not taken here: setting `JSC::Options::useTailCalls() = false` for `bun test` (next to the existing `--isolate` option tweak in `JSCInitialize`). It would fix every shape of this bug, and also the related loss of failure locations for `test("x", () => expect(a).toBe(b))`, but it changes the engine's semantics under the test runner and would turn in-process tail-call regression tests such as `test/js/node/vm/happy-dom-vm-16277.test.ts` into tests of ordinary calls, so it is a policy decision for maintainers rather than part of this fix. If it is wanted, it supersedes this change.
- Verified with `test/js/bun/test/mock/mock-module.test.ts`: 9 scenarios (`beforeAll`, `beforeEach`, `describe` body, `test` body, `test.each`, relative `file:` URL, `describe` registered under `AsyncLocalStorage`, bare package name, `--preload` hook in another directory) each spawn `bun test` on a file that imports the module first and then registers the mock in tail position; all 9 fail on the released binary (`Expected: "mocked", Received: "real"`) and pass with this change. Three more pin the boundaries above: the "frame wins" one passes before and after by design; the continuation one and the Worker one each fail against the earlier revision of this branch that lacked the corresponding restriction and pass now. The existing tests in the file still pass.
- Also ran against the debug build: `test/js/bun/test/mock/`, `bun_test`, `jest-hooks`, `jest-each`, `describe`, `test-test`, `preload-test`, `test-on-test-finished`, `test-retry-repeats-basic`, `nested-describes`: green. `concurrent*.test.ts` hit their 5s budget in this debug/ASAN container, but their fixtures, run directly, produce exactly the snapshotted output.

### Background

- **Proper tail calls**: in strict-mode code, JavaScriptCore implements the ES2015 requirement that a call in tail position (`() => f()`, `return f()`) reuses the caller's stack frame. The callee therefore cannot see who called it; this applies to host (native) callees too.
- **`callerSourceOrigin()`**: walks the JS stack from a host function's frame and returns the `SourceOrigin` (for Bun user files, a `file:` URL of the source path) of the first frame that is not native or a JSC builtin. It returns a null origin when it runs out of frames.
- **How `mock.module` applies a mock**: the resolved specifier is used both to look up and patch modules already present in the ESM registry / `require` cache and as the key for future loads, so an unresolved relative specifier only affects future imports of that exact string.
- **`run_test_callback`**: the runner collects describe bodies, hooks and tests into entries and later invokes each one's callback from native code through this function, then drains the microtask queue. During the call itself the callback's frame is the bottom-most JS frame on the stack; microtasks drained afterwards run with no JS frames below them at all.
