### PR TITLE
build: declare the bindgen and bindgenv2 headers as outputs of their codegen edges

### DIFF
--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -16,21 +16,19 @@
  *
  * ## Undeclared outputs
  *
- * Several scripts emit MORE files than they report:
- *   - bindgen.ts emits Generated<Name>.h per namespace (only .cpp declared)
- *   - bindgenv2 emits Generated<Type>.h per type (list-outputs skips .h)
- *   - generate-node-errors.ts emits ErrorCode.d.ts (not declared)
- *   - bundle-modules.ts emits eval/ subdir, BunBuiltinNames+extras.h, etc.
+ * Every generated file that is compiled or #included must be a declared
+ * output of its step. Compiles only order-depend on codegen (bun.ts); the
+ * depfile is what rebuilds them when a generated header changes, and a
+ * depfile entry does that within the same run only if it names a declared
+ * output, which ninja re-stats after the step ran. A file no edge declares
+ * is stat'd once at startup, so a compile that includes it picks up a rerun
+ * of the step one build late. That is why emitBindgen/emitBindgenV2 declare
+ * the per-file Generated*.h headers and not just the .cpp that gets compiled.
  *
- * It WORKS because:
- *   1. The declared .cpp outputs guarantee the step runs before compile
- *   2. Compilation emits .d depfiles that track the .h files for NEXT build
- *   3. PCH order-depends on ALL codegen outputs; every cxx() waits on PCH
- *      → all codegen completes before any compile, undeclared .h exist
- *
- * Fixing properly (declaring all outputs) would require patching the
- * src/codegen/ scripts to report everything — changing contract with
- * existing tooling.
+ * Files nothing compiles may stay undeclared (.d.ts twins, bundle-modules'
+ * eval/ dir, JSSink.lut.txt consumed within its own step). The remaining
+ * #included exception is BunBuiltinNames+extras.h from bundle-functions.ts,
+ * reached through the PCH.
  */
 
 import { spawnSync } from "node:child_process";
@@ -795,7 +793,8 @@ function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   }
 }
 
-function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
+/** Exported (with emitBindgen) for test/internal/build-codegen-declared-outputs.test.ts. */
+export function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bindgenv2", "script.ts");
 
   // The script's output set depends on which NamedTypes the .bindv2.ts files
@@ -827,7 +826,8 @@ function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
   assert(allOutputs.length > 0, "bindgenv2 list-outputs returned no files");
 
   const cppOutputs = allOutputs.filter(p => p.endsWith(".cpp"));
-  const other = allOutputs.filter(p => !p.endsWith(".cpp"));
+  const headerOutputs = allOutputs.filter(p => p.endsWith(".h"));
+  const other = allOutputs.filter(p => !p.endsWith(".cpp") && !p.endsWith(".h"));
   assert(other.length === 0, `bindgenv2 emitted unexpected output type: ${other.join(", ")}`);
 
   n.build({
@@ -850,18 +850,24 @@ function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
 
   o.all.push(...allOutputs);
   o.bindgenV2Cpp.push(...cppOutputs);
+  o.cppHeaders.push(...headerOutputs);
 }
 
-function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
+export function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bindgen.ts");
 
   const cppOut = resolve(cfg.codegenDir, "GeneratedBindings.cpp");
+  // Plus one header per .bind.ts (node_os.bind.ts → GeneratedNodeOs.h), which
+  // hand-written .cpp files include; see "Undeclared outputs" above.
+  const headers = sources.bindgen.map(src =>
+    resolve(cfg.codegenDir, `Generated${pascalCase(basename(src, ".bind.ts"))}.h`),
+  );
 
-  // bindgen.ts scans src/ for .bind.ts files itself — this list is only for
-  // ninja dependency tracking. New .bind.ts files need a reconfigure to be
-  // picked up (next glob gets them).
+  // bindgen.ts scans src/ for .bind.ts files itself; this list only tells
+  // ninja the inputs and which headers come out. New .bind.ts files need a
+  // reconfigure to be picked up (next glob gets them).
   n.build({
-    outputs: [cppOut],
+    outputs: [cppOut, ...headers],
     rule: "codegen",
     inputs: [script, ...sources.bindgen],
     orderOnlyInputs: [dirStamp],
@@ -872,8 +878,14 @@ function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
     },
   });
 
-  o.all.push(cppOut);
+  o.all.push(cppOut, ...headers);
   o.cppSources.push(cppOut);
+  o.cppHeaders.push(...headers);
+}
+
+/** Same transform as `pascal()` in src/codegen/bindgen-lib-internal.ts: `node_os` → `NodeOs`. */
+function pascalCase(s: string): string {
+  return s[0]!.toUpperCase() + s.slice(1).replace(/[_-](\w)?/g, (_, c?: string) => c?.toUpperCase() ?? "");
 }
 
 function emitJsSink({ n, cfg, o, dirStamp }: Ctx): void {

--- a/src/codegen/bindgenv2/script.ts
+++ b/src/codegen/bindgenv2/script.ts
@@ -53,9 +53,11 @@ function toZigNamespace(name: string): string {
   return result;
 }
 
+/** Must name every file generate() writes: the build declares these as the outputs of the generate step. */
 function listOutputs(): void {
   const outputs: string[] = [];
   for (const type of getNamedExports()) {
+    if (type.hasCppHeader) outputs.push(cppHeaderPath(type));
     if (type.hasCppSource) outputs.push(cppSourcePath(type));
   }
   process.stdout.write(outputs.join(";"));

--- a/test/internal/build-codegen-declared-outputs.test.ts
+++ b/test/internal/build-codegen-declared-outputs.test.ts
@@ -1,0 +1,259 @@
+/**
+ * The two bindgen steps in scripts/build/codegen.ts have to declare every file
+ * their script writes, the Generated*.h headers included, not only the .cpp
+ * that gets compiled.
+ *
+ * Compiles only order-depend on codegen; the compiler's depfile is what rebuilds
+ * a TU when a generated header changes, and within one build ninja re-checks a
+ * depfile entry after the step that writes it only if the entry is a declared
+ * output of that step. A header no edge declares is stat'd once at startup, so
+ * a TU including one (BunObject.cpp includes GeneratedBunObject.h; the generated
+ * GeneratedSSLConfig.cpp includes the header-only union types next to it) was
+ * recompiled by the build AFTER the one that regenerated the header, and the
+ * first build linked the stale object against the fresh generated code.
+ *
+ * Each step is checked twice: what its emitter declares, and what its script
+ * writes when run for real into a scratch dir. The bindgenv2 cases use a probe
+ * .bindv2.ts with one header-only type (a union) and one type with a header and
+ * a .cpp (an enumeration); bindgen.ts finds the repo's .bind.ts files on its own,
+ * so its step is checked against those.
+ */
+import { describe, expect, test } from "bun:test";
+import { bunExe, bunRun, tempDir } from "harness";
+import { readdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { emitBindgen, emitBindgenV2, registerCodegenRules, type CodegenOutputs } from "../../scripts/build/codegen.ts";
+import { registerDirStamps } from "../../scripts/build/compile.ts";
+import { resolveConfig, type Config, type Toolchain } from "../../scripts/build/config.ts";
+import { Ninja } from "../../scripts/build/ninja.ts";
+import type { Sources } from "../../scripts/glob-sources.ts";
+
+/** A fully-populated fake toolchain; `bun` is the one entry that gets spawned (bindgenv2 list-outputs). */
+function mockToolchain(): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: "/fake/llvm/bin/ld64.lld",
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: "/fake/llvm/bin/dsymutil",
+    bun: bunExe(),
+    jsRuntime: bunExe(),
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+  };
+}
+
+interface Configured {
+  cfg: Config;
+  n: Ninja;
+  o: CodegenOutputs;
+  dirStamp: string;
+}
+
+/**
+ * A linux-x64 debug target in `buildDir` (resolves on every host once told where
+ * its sysroot is; the path is only recorded), with the rules the codegen
+ * emitters reference registered and the empty output groups emitCodegen hands
+ * them. Nothing is written to `buildDir`.
+ */
+function configure(buildDir: string): Configured {
+  const cfg = resolveConfig(
+    { os: "linux", arch: "x64", abi: "gnu", buildType: "Debug", buildDir, linuxSysroot: buildDir },
+    mockToolchain(),
+  );
+  const n = new Ninja({ buildDir });
+  registerDirStamps(n, cfg);
+  registerCodegenRules(n, cfg);
+  const o: CodegenOutputs = {
+    all: [],
+    rustInputs: [],
+    rustOrderOnly: [],
+    cppSources: [],
+    cppHeaders: [],
+    cppAll: [],
+    bindgenV2Cpp: [],
+    internalModulesAsm: resolve(cfg.codegenDir, "InternalModuleRegistryConstants.S"),
+    internalModulesBin: resolve(cfg.codegenDir, "InternalModuleRegistryConstants.bin"),
+    rootInstall: resolve(buildDir, "stamps", "install.stamp"),
+  };
+  return { cfg, n, o, dirStamp: resolve(cfg.codegenDir, ".dir") };
+}
+
+/** Just the lists the emitter under test reads; it never looks at the rest of `Sources`. */
+function sourceLists(lists: Partial<Sources>): Sources {
+  return lists as Sources;
+}
+
+/** The outputs of the `build` line in `n` that produces `output`, spelled as in build.ninja, sorted. */
+function edgeOutputs(n: Ninja, output: string): string[] {
+  const lines = n
+    .toString()
+    .replace(/ \$\n +/g, " ")
+    .split("\n");
+  for (const line of lines) {
+    if (!line.startsWith("build ")) continue;
+    const outputs = line
+      .slice("build ".length, line.search(/(?<!\$): /))
+      .split(/(?<!\$) /)
+      .filter(token => token !== "|");
+    if (outputs.includes(n.rel(output))) return outputs.sort();
+  }
+  throw new Error(`no build edge produces ${output}`);
+}
+
+/** `names` in the codegen dir, spelled as in build.ninja, sorted. */
+function inCodegenDir({ cfg, n }: Configured, names: string[]): string[] {
+  return names.map(name => n.rel(resolve(cfg.codegenDir, name))).sort();
+}
+
+/** `paths` normalized (bindgenv2 reports its outputs as `<codegen dir>/<name>`), sorted. */
+function normalized(paths: string[]): string[] {
+  return paths.map(p => resolve(p)).sort();
+}
+
+/**
+ * Every .bind.ts under src/: the pattern glob-sources.ts expands for
+ * emitBindgen (through node:fs globSync, which is too slow under a debug
+ * build to run its whole pattern set here).
+ */
+function repoBindFiles(cfg: Config): string[] {
+  return Array.from(new Bun.Glob("src/**/*.bind.ts").scanSync({ cwd: cfg.cwd }), p => resolve(cfg.cwd, p)).sort();
+}
+
+/** Writes the probe .bindv2.ts into `dir` and returns its path. */
+function writeProbe(dir: string, cfg: Config): string {
+  // The "bindgenv2" specifier the real files import is a path mapping in
+  // src/tsconfig.json, which a file outside src/ does not get.
+  const lib = resolve(cfg.cwd, "src", "codegen", "bindgenv2", "lib.ts");
+  const probe = resolve(dir, "probe.bindv2.ts");
+  writeFileSync(
+    probe,
+    `import * as b from ${JSON.stringify(lib)};\n` +
+      `export const ProbeUnion = b.union("ProbeUnion", { string: b.String, buffer: b.ArrayBuffer });\n` +
+      `export const ProbeEnum = b.enumeration("ProbeEnum", ["one", "two"]);\n`,
+  );
+  return probe;
+}
+
+const probeFiles = ["GeneratedProbeEnum.cpp", "GeneratedProbeEnum.h", "GeneratedProbeUnion.h"];
+
+// The tests below that run a generator script run it under the build being
+// tested; a debug build takes a few seconds to load one, more than the 5s
+// default allows for.
+const generatorTimeout = 60_000;
+
+describe("emitBindgenV2", () => {
+  test(
+    "declares the header of every type and the .cpp of the types that have one, on one edge",
+    () => {
+      using dir = tempDir("build-codegen-bindgenv2", {});
+      const c = configure(String(dir));
+      const { cfg, n, o, dirStamp } = c;
+      const probe = writeProbe(String(dir), cfg);
+
+      emitBindgenV2({ n, cfg, sources: sourceLists({ bindgenV2: [probe], bindgenV2Internal: [] }), o, dirStamp });
+
+      const cpp = resolve(cfg.codegenDir, "GeneratedProbeEnum.cpp");
+      const headers = [
+        resolve(cfg.codegenDir, "GeneratedProbeEnum.h"),
+        resolve(cfg.codegenDir, "GeneratedProbeUnion.h"),
+      ];
+      expect(edgeOutputs(n, cpp)).toEqual(inCodegenDir(c, probeFiles));
+      // Headers go in the group the PCH and every cxx edge order-depend on; the
+      // .cpp is compiled like the other bindgenv2 sources.
+      expect(normalized(o.cppHeaders)).toEqual(headers);
+      expect(normalized(o.bindgenV2Cpp)).toEqual([cpp]);
+      expect(normalized(o.all)).toEqual([cpp, ...headers]);
+    },
+    generatorTimeout,
+  );
+
+  test.concurrent(
+    "list-outputs names exactly the files generate writes",
+    async () => {
+      using dir = tempDir("build-codegen-bindgenv2-generate", {});
+      const { cfg } = configure(String(dir));
+      const probe = writeProbe(String(dir), cfg);
+      const script = resolve(cfg.cwd, "src", "codegen", "bindgenv2", "script.ts");
+      const args = [`--sources=${probe}`, `--codegen-path=${cfg.codegenDir}`];
+
+      const [listed, generated] = await Promise.all([
+        bunRun(["run", script, "--command=list-outputs", ...args]),
+        bunRun(["run", script, "--command=generate", ...args]),
+      ]);
+      expect(listed).toSpawn();
+      expect(generated).toSpawn("");
+
+      const expected = probeFiles.map(name => resolve(cfg.codegenDir, name));
+      expect(normalized(listed.stdout.split(";"))).toEqual(expected);
+      expect(readdirSync(cfg.codegenDir).sort()).toEqual(probeFiles);
+    },
+    generatorTimeout,
+  );
+});
+
+describe("emitBindgen", () => {
+  test("declares Generated<Stem>.h for every .bind.ts on the GeneratedBindings.cpp edge", () => {
+    using dir = tempDir("build-codegen-bindgen", {});
+    const c = configure(String(dir));
+    const { cfg, n, o, dirStamp } = c;
+    const bindgen = [
+      resolve(cfg.cwd, "src", "runtime", "node", "node_os.bind.ts"),
+      resolve(cfg.cwd, "src", "runtime", "api", "BunObject.bind.ts"),
+    ];
+
+    emitBindgen({ n, cfg, sources: sourceLists({ bindgen }), o, dirStamp });
+
+    const cpp = resolve(cfg.codegenDir, "GeneratedBindings.cpp");
+    const headers = [resolve(cfg.codegenDir, "GeneratedBunObject.h"), resolve(cfg.codegenDir, "GeneratedNodeOs.h")];
+    expect(edgeOutputs(n, cpp)).toEqual(
+      inCodegenDir(c, ["GeneratedBindings.cpp", "GeneratedBunObject.h", "GeneratedNodeOs.h"]),
+    );
+    expect(normalized(o.cppHeaders)).toEqual(headers);
+    expect(o.cppSources).toEqual([cpp]);
+    expect(normalized(o.all)).toEqual([cpp, ...headers]);
+  });
+
+  test.concurrent(
+    "declares exactly the files bindgen.ts writes for the repo's .bind.ts files",
+    async () => {
+      using dir = tempDir("build-codegen-bindgen-generate", {});
+      const c = configure(String(dir));
+      const { cfg, n, o, dirStamp } = c;
+      const bindgen = repoBindFiles(cfg);
+      expect(bindgen).not.toBeEmpty();
+
+      emitBindgen({ n, cfg, sources: sourceLists({ bindgen }), o, dirStamp });
+
+      const script = resolve(cfg.cwd, "src", "codegen", "bindgen.ts");
+      expect(await bunRun(["run", script, "--debug=ON", `--codegen-root=${cfg.codegenDir}`])).toSpawn("");
+
+      // GeneratedBindings.cpp plus one header per .bind.ts, and nothing else.
+      const written = readdirSync(cfg.codegenDir).sort();
+      expect(written).toHaveLength(bindgen.length + 1);
+      expect(edgeOutputs(n, resolve(cfg.codegenDir, "GeneratedBindings.cpp"))).toEqual(inCodegenDir(c, written));
+    },
+    generatorTimeout,
+  );
+});


### PR DESCRIPTION
### Problem
- On a warm tree, editing a `.bind.ts` or `.bindv2.ts` file so that its generated header changes leaves every hand-written TU that includes the header unbuilt for one `bun bd`; the second `bun bd` compiles it. Probe on `build/debug` (full transcript below): append a `fn` to `src/runtime/api/BunObject.bind.ts`, build `obj/src/jsc/bindings/BunObject.cpp.o`, and the run is `[1/1] gen .bind.ts -> GeneratedBindings.cpp` while `ninja -n` afterwards still lists `cxx obj/src/jsc/bindings/BunObject.cpp.o`. The first build therefore links a `BunObject.cpp.o` compiled against the old `GeneratedBunObject.h` (old struct layouts, old function set) with a fresh `GeneratedBindings.cpp.o`.
- Cause: none of the `Generated*.h` files is a declared output of any ninja edge. `emitBindgen` (`scripts/build/codegen.ts`) declares only `GeneratedBindings.cpp`, while `bindgen.ts` also writes one `Generated<Name>.h` per `.bind.ts` (`src/codegen/bindgen.ts:1665`); bindgenv2's `list-outputs` (`src/codegen/bindgenv2/script.ts:56`) reports only `cppSourcePath`, while `generate()` also writes `cppHeaderPath` for every type, and `emitBindgenV2` asserted that nothing but `.cpp` comes back. On a warm `build/debug`, `ninja -t query codegen/<name>` shows no producing edge for all 7 bindgen headers and all 9 bindgenv2 headers, and `ninja -t deps obj/src/jsc/bindings/BunObject.cpp.o` lists `codegen/GeneratedBunObject.h`.
- Why that makes the TU lag: compiles are order-only on codegen and rely on the depfile to be re-dirtied. Ninja re-checks a depfile entry after the edge that produces it ran only when the entry names a declared output; an entry no edge declares is a source file to ninja, stat'd once at startup, so the header rewritten later in the same run is only seen by the next run (the invariant `bun.ts` states for `cppAll`, "those headers ARE declared ninja outputs with restat, so depfile tracking is exact", did not hold for these).
- Affected includers: `BunObject.cpp` and `ZigGlobalObject.cpp` (`GeneratedBunObject.h`), `NodeModuleModule.cpp` (`GeneratedNodeModuleModule.h`), `GeneratedBindings.cpp` (`GeneratedBunObject.h`, `GeneratedNodeOs.h`, `GeneratedFmtJsc.h`), and each generated bindgenv2 `.cpp`, which includes its own header and, through it, the header-only union types (`GeneratedSSLConfig.cpp` -> `GeneratedSSLConfigFile.h`, `GeneratedALPNProtocols.h`); a union has no `.cpp`, so until now it had no declared output at all.

### Fix
- `src/codegen/bindgenv2/script.ts`: `list-outputs` reports `cppHeaderPath` for every type with a header, mirroring what `generate()` writes (`hasCppHeader` is the cheap twin of `cppHeader` that `base.ts` defines for this purpose).
- `scripts/build/codegen.ts`, `emitBindgenV2`: accepts `.h` entries from `list-outputs` (still rejecting anything else), declares them on the edge with the `.cpp` files, and pushes them into `cppHeaders`, so they reach `cppAll` like the other generated headers.
- `scripts/build/codegen.ts`, `emitBindgen`: declares `Generated<Stem>.h` for every file in `sources.bindgen` next to `GeneratedBindings.cpp` and pushes them into `cppHeaders`. The stem transform is the one `bindgen.ts` uses (`pascal()` in `bindgen-lib-internal.ts`, `node_os` -> `NodeOs`), derived at configure time like the node-fallbacks and string-map outputs are; the header set is a function of the file list the build already globs, so a configure-time spawn is not needed (bindgenv2 needs one because its set depends on what the files export). The test below pins the two sides to each other against the real `bindgen.ts`.
- The file's "Undeclared outputs" comment now states the rule (a file that gets compiled or included has to be declared) and what is still legitimately undeclared. `emitBindgen`/`emitBindgenV2` are exported for the test.
- Why this is the right fix: the build's documented design for generated headers is declared output + `restat` + order-only + depfile; these headers were the ones outside it, and declaring them makes them follow that design. Both scripts write with `writeIfNotChanged`, so `restat` still prunes: a rerun that leaves the headers unchanged recompiles nothing (checked below). No compile command changes, so existing trees do not recompile anything; each of the two gen steps runs once more (their new outputs have no build-log entry yet) and is pruned from there. If a future `.bind.ts` were named so that its header collided with another step's output, configure would now fail with ninja.ts's duplicate-output error instead of two steps silently writing the same file.
- Verified:
  - `test/internal/build-codegen-declared-outputs.test.ts`: `emitBindgenV2` run on a probe `.bindv2.ts` (one union, one enumeration) declares exactly `{GeneratedProbeEnum.cpp, GeneratedProbeEnum.h, GeneratedProbeUnion.h}` on one edge with the headers in `cppHeaders`; `list-outputs` on the probe names exactly what `generate` writes; `emitBindgen` declares `GeneratedNodeOs.h`/`GeneratedBunObject.h` next to `GeneratedBindings.cpp`; and for the repo's real `.bind.ts` files its declared set equals exactly the files `bindgen.ts` writes into a scratch dir. With `src/` stashed the two bindgenv2 tests fail (2 headers missing); with `scripts/` stashed configure fails on the old `.cpp`-only assertion; removing either `cppHeaders.push` fails the corresponding emission test.
  - Probe above on the unfixed tree: gen only, cxx deferred to the next run. Fixed tree: same edit runs gen + cxx in one invocation, `ninja -n` is then empty, reverting the edit does the same, and a `touch` of the `.bind.ts` runs gen alone (restat prunes the cxx). Transcript below.
  - After the change `ninja -t query` shows a producing edge for every `codegen/Generated*.h`; what remains undeclared in `build/debug/codegen` is `.d.ts` files, `JSSink.lut.txt`, `bake_empty_file`, the `eval/` dir, the configure-time writes, and `BunBuiltinNames+extras.h` (the PCH case #37992 handles; the two changes are independent).
  - `build.ninja` before/after differs only in the two gen edges, the `codegen` phony and the order-only lists that carry `cppAll`; `test/internal/build-post-link-ordering.test.ts` and `build-debug-info-flags.test.ts` still pass; `tsc -p scripts/build` reports the same pre-existing diagnostics as main.

### Background
- **Order-only input** (`||` in ninja): has to exist before the edge runs, but its mtime never dirties the edge. The build uses it for the codegen headers so that a compile is only rebuilt for the headers it really includes.
- **Depfile** (`deps = gcc`): the list of files clang read while compiling a TU; ninja stores it and treats each entry as an implicit input of that compile on later runs. Whether an entry can re-dirty the compile within the run that rewrites it depends on whether some edge declares the entry as an output: declared outputs are re-checked after their edge runs, anything else is stat'd once at startup.
- **restat**: after an edge runs, ninja re-stats its outputs and drops downstream work for outputs whose mtime did not move; `writeIfNotChanged` in the codegen scripts is what keeps the mtimes still. This is why declaring more outputs does not cause extra recompiles.
- **bindgen** (`src/codegen/bindgen.ts`, `*.bind.ts`): generates the C++ side of native functions; one `GeneratedBindings.cpp` plus a `Generated<Name>.h` per file holding the function pointers and struct definitions the hand-written C++ uses. **bindgenv2** (`src/codegen/bindgenv2/`, `*.bindv2.ts`): generates a conversion header per named type, plus a `.cpp` for dictionaries and enumerations; unions are header-only. Its output set depends on what the files export, so configure asks the script with `--command=list-outputs`.

<details>
<summary>Probe transcript (linux-x64, warm build/debug; the edit appends an exported <code>fn</code> to BunObject.bind.ts, which adds a declaration to GeneratedBunObject.h)</summary>

Unfixed:

```
$ bun scripts/build.ts --profile=debug --target=obj/src/jsc/bindings/BunObject.cpp.o   # baseline
ninja: no work to do.
$ printf '\nexport const undeclaredHeaderProbe = fn({ args: {}, ret: t.u64 });\n' >> src/runtime/api/BunObject.bind.ts
$ bun scripts/build.ts --profile=debug --target=obj/src/jsc/bindings/BunObject.cpp.o
[1/1] gen .bind.ts -> GeneratedBindings.cpp
$ grep -c jsUndeclaredHeaderProbe build/debug/codegen/GeneratedBunObject.h
2                                                   <- header rewritten...
$ ninja -C build/debug -n obj/src/jsc/bindings/BunObject.cpp.o
[1/1] cxx obj/src/jsc/bindings/BunObject.cpp.o      <- ...but its includer only recompiles next time
$ ninja -C build/debug -t query codegen/GeneratedBunObject.h
codegen/GeneratedBunObject.h:
  outputs:                                          <- no "input:" edge produces it
```

Fixed (tree converged first, `ninja: no work to do`):

```
$ printf '...' >> src/runtime/api/BunObject.bind.ts                                     # same edit
$ bun scripts/build.ts --profile=debug --target=obj/src/jsc/bindings/BunObject.cpp.o
[1/2] gen .bind.ts -> GeneratedBindings.cpp
[2/2] cxx obj/src/jsc/bindings/BunObject.cpp.o
$ ninja -C build/debug -n obj/src/jsc/bindings/BunObject.cpp.o
ninja: no work to do.
$ git checkout src/runtime/api/BunObject.bind.ts
$ bun scripts/build.ts --profile=debug --target=obj/src/jsc/bindings/BunObject.cpp.o
[1/2] gen .bind.ts -> GeneratedBindings.cpp
[2/2] cxx obj/src/jsc/bindings/BunObject.cpp.o
$ touch src/runtime/api/BunObject.bind.ts
$ bun scripts/build.ts --profile=debug --target=obj/src/jsc/bindings/BunObject.cpp.o
[1/2] gen .bind.ts -> GeneratedBindings.cpp         <- headers unchanged, cxx pruned by restat
```

The two edges as now written to build.ninja:

```
build codegen/GeneratedBindings.cpp codegen/GeneratedBindgenTest.h codegen/GeneratedFmtJsc.h
    codegen/GeneratedNodeModuleModule.h codegen/GeneratedBunObject.h codegen/GeneratedBake.h
    codegen/GeneratedDevServer.h codegen/GeneratedNodeOs.h: codegen ../../src/codegen/bindgen.ts ...

build codegen/GeneratedSocketConfigBinaryType.h codegen/GeneratedSocketConfigBinaryType.cpp
    codegen/GeneratedSocketConfigHandlers.h codegen/GeneratedSocketConfigHandlers.cpp codegen/GeneratedSocketConfig.h
    codegen/GeneratedSocketConfig.cpp codegen/GeneratedSocketConfigTLS.h codegen/GeneratedALPNProtocols.h
    codegen/GeneratedSSLConfig.h codegen/GeneratedSSLConfig.cpp codegen/GeneratedSSLConfigFile.h
    codegen/GeneratedSSLConfigSingleFile.h codegen/GeneratedFakeTimersConfig.h codegen/GeneratedFakeTimersConfig.cpp: codegen ...
```

</details>
