### PR TITLE
node:http: apply joinDuplicateHeaders on HTTP/1 fallback connections

### DIFF
--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -291,6 +291,11 @@ function connectionListenerHTTP1(server, socket, options) {
     req.url = url;
     req.method = typeof methodNum === "number" ? allMethods[methodNum] : methodNum;
     req.upgrade = upgrade;
+    // Like Node's parserOnHeadersComplete (and the native dispatcher): _addHeaderLine reads this
+    // off the request when it combines duplicates of a header that is not list-valued.
+    if (server.joinDuplicateHeaders) {
+      req.joinDuplicateHeaders = true;
+    }
     req._addHeaderLines(rawHeaders, rawHeaders.length);
 
     // Node's parserOnIncoming: upgrade only sticks for CONNECT or when an 'upgrade' listener

--- a/src/js/internal/http1_server_fallback.ts
+++ b/src/js/internal/http1_server_fallback.ts
@@ -291,8 +291,7 @@ function connectionListenerHTTP1(server, socket, options) {
     req.url = url;
     req.method = typeof methodNum === "number" ? allMethods[methodNum] : methodNum;
     req.upgrade = upgrade;
-    // Like Node's parserOnHeadersComplete (and the native dispatcher): _addHeaderLine reads this
-    // off the request when it combines duplicates of a header that is not list-valued.
+    // _addHeaderLine reads this off the request (Node's parserOnHeadersComplete copies it the same way).
     if (server.joinDuplicateHeaders) {
       req.joinDuplicateHeaders = true;
     }

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6804,14 +6804,14 @@ class Http2SecureServer extends tls.Server {
       this.requestTimeout = http1Options.requestTimeout ?? 300000;
       this.maxHeadersCount = http1Options.maxHeadersCount ?? null;
       this.maxRequestsPerSocket = http1Options.maxRequestsPerSocket ?? 0;
-      // connectionListenerHTTP1 reads these off the server when initializing
-      // the per-connection parser, matching Node's storeHTTP1Options.
-      this.maxHeaderSize = http1Options.maxHeaderSize;
-      this.insecureHTTPParser = http1Options.insecureHTTPParser;
-      this.httpValidation = http1Options.httpValidation;
       const joinDuplicateHeaders = http1Options.joinDuplicateHeaders;
       if (joinDuplicateHeaders !== undefined) validateBoolean(joinDuplicateHeaders, "options.joinDuplicateHeaders");
       this.joinDuplicateHeaders = joinDuplicateHeaders;
+      // connectionListenerHTTP1 reads these off the server when initializing
+      // the per-connection parser, matching Node's storeHTTPOptions.
+      this.maxHeaderSize = http1Options.maxHeaderSize;
+      this.insecureHTTPParser = http1Options.insecureHTTPParser;
+      this.httpValidation = http1Options.httpValidation;
     }
     if (typeof onRequestHandler === "function") {
       this.on("request", onRequestHandler);

--- a/src/js/node/http2.ts
+++ b/src/js/node/http2.ts
@@ -6809,6 +6809,9 @@ class Http2SecureServer extends tls.Server {
       this.maxHeaderSize = http1Options.maxHeaderSize;
       this.insecureHTTPParser = http1Options.insecureHTTPParser;
       this.httpValidation = http1Options.httpValidation;
+      const joinDuplicateHeaders = http1Options.joinDuplicateHeaders;
+      if (joinDuplicateHeaders !== undefined) validateBoolean(joinDuplicateHeaders, "options.joinDuplicateHeaders");
+      this.joinDuplicateHeaders = joinDuplicateHeaders;
     }
     if (typeof onRequestHandler === "function") {
       this.on("request", onRequestHandler);

--- a/test/js/node/http/node-http-proxy.js
+++ b/test/js/node/http/node-http-proxy.js
@@ -32,12 +32,13 @@ export async function run() {
     req.pipe(proxyRequest); // Use pipe instead of manual data handling
   });
 
-  proxyServer.listen(0, "localhost", async () => {
+  // Bound and dialed by literal address: "localhost" can bind ::1 while the client dials 127.0.0.1.
+  proxyServer.listen(0, "127.0.0.1", async () => {
     const address = proxyServer.address();
 
     const options = {
       protocol: "http:",
-      hostname: "localhost",
+      hostname: address.address,
       port: address.port,
       path: "/", // Change path to /
       headers: {

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4140,11 +4140,12 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
   }
 });
 
-it("connectionListener applies the server's joinDuplicateHeaders option like Node", async () => {
+it("connectionListener applies the server's joinDuplicateHeaders option like the native path and Node", async () => {
   // Node keeps only the first value of a header it treats as single-valued (Authorization,
   // Content-Type, ...) unless the server was created with joinDuplicateHeaders; Cookie and unknown
-  // headers are joined either way. A socket fed in through server.emit("connection", ...) is served
-  // by the JS parser path, which has to read the option off the server like the native path does.
+  // headers are joined either way. The same raw request goes through server.emit("connection", ...)
+  // (the JS parser path, which has to read the option off the server itself) and through the same
+  // server options listening normally (the native path); both must produce Node's req.headers.
   const rawRequest =
     "GET / HTTP/1.1\r\nHost: example.test\r\n" +
     "Authorization: one\r\nAuthorization: two\r\n" +
@@ -4153,40 +4154,69 @@ it("connectionListener applies the server's joinDuplicateHeaders option like Nod
     "X-Custom: first\r\nX-Custom: second\r\n" +
     "Connection: close\r\n\r\n";
 
-  async function headersSeenOverEmittedConnection(options: { joinDuplicateHeaders?: boolean }) {
-    const { promise: seen, resolve, reject } = Promise.withResolvers<Record<string, string | undefined>>();
+  function serverRecordingHeaders(options: { joinDuplicateHeaders?: boolean }) {
+    const { promise: headers, resolve, reject } = Promise.withResolvers<http.IncomingHttpHeaders>();
     const server = createServer(options, (req, res) => {
-      const { authorization, "content-type": contentType, cookie, "x-custom": xCustom } = req.headers;
-      resolve({ authorization, "content-type": contentType, cookie, "x-custom": xCustom as string });
+      resolve({ ...req.headers });
       res.end();
     });
+    // A no-op once the handler has resolved, so the connection closing after the response is fine.
+    const closedEarly = () => reject(new Error("the connection closed before the request was dispatched"));
+    return { server, headers, reject, closedEarly };
+  }
+
+  async function headersSeenOverEmittedConnection(options: { joinDuplicateHeaders?: boolean }) {
+    const { server, headers, reject, closedEarly } = serverRecordingHeaders(options);
     const [clientSide, serverSide] = duplexPair();
     clientSide.on("error", reject);
     serverSide.on("error", reject);
-    serverSide.on("close", () => reject(new Error("the server closed the connection without dispatching the request")));
+    serverSide.on("close", closedEarly);
     clientSide.resume();
     server.emit("connection", serverSide);
     clientSide.write(rawRequest);
     try {
-      return await seen;
+      return await headers;
     } finally {
       clientSide.destroy();
       serverSide.destroy();
     }
   }
 
+  async function headersSeenOverListeningServer(options: { joinDuplicateHeaders?: boolean }) {
+    const { server, headers, reject, closedEarly } = serverRecordingHeaders(options);
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    const socket = connect((server.address() as AddressInfo).port, "127.0.0.1");
+    socket.on("error", reject);
+    socket.on("close", closedEarly);
+    socket.resume();
+    socket.write(rawRequest);
+    try {
+      return await headers;
+    } finally {
+      socket.destroy();
+      server.close();
+    }
+  }
+
   const joined = {
+    host: "example.test",
     authorization: "one, two",
     "content-type": "text/plain, text/html",
     cookie: "a=1; b=2",
     "x-custom": "first, second",
+    connection: "close",
   };
   const firstValueWins = { ...joined, authorization: "one", "content-type": "text/plain" };
-  expect(
-    await Promise.all([
-      headersSeenOverEmittedConnection({ joinDuplicateHeaders: true }),
-      headersSeenOverEmittedConnection({ joinDuplicateHeaders: false }),
-      headersSeenOverEmittedConnection({}),
-    ]),
-  ).toEqual([joined, firstValueWins, firstValueWins]);
+  for (const [options, expected] of [
+    [{ joinDuplicateHeaders: true }, joined],
+    [{ joinDuplicateHeaders: false }, firstValueWins],
+    [{}, firstValueWins],
+  ] as const) {
+    expect({
+      options,
+      emitted: await headersSeenOverEmittedConnection(options),
+      listening: await headersSeenOverListeningServer(options),
+    }).toEqual({ options, emitted: expected, listening: expected });
+  }
 });

--- a/test/js/node/http/node-http.test.ts
+++ b/test/js/node/http/node-http.test.ts
@@ -4139,3 +4139,54 @@ it("connectionListener hands off Upgrade and CONNECT like Node", async () => {
     expect(serverSide.destroyed).toBe(true);
   }
 });
+
+it("connectionListener applies the server's joinDuplicateHeaders option like Node", async () => {
+  // Node keeps only the first value of a header it treats as single-valued (Authorization,
+  // Content-Type, ...) unless the server was created with joinDuplicateHeaders; Cookie and unknown
+  // headers are joined either way. A socket fed in through server.emit("connection", ...) is served
+  // by the JS parser path, which has to read the option off the server like the native path does.
+  const rawRequest =
+    "GET / HTTP/1.1\r\nHost: example.test\r\n" +
+    "Authorization: one\r\nAuthorization: two\r\n" +
+    "Content-Type: text/plain\r\nContent-Type: text/html\r\n" +
+    "Cookie: a=1\r\nCookie: b=2\r\n" +
+    "X-Custom: first\r\nX-Custom: second\r\n" +
+    "Connection: close\r\n\r\n";
+
+  async function headersSeenOverEmittedConnection(options: { joinDuplicateHeaders?: boolean }) {
+    const { promise: seen, resolve, reject } = Promise.withResolvers<Record<string, string | undefined>>();
+    const server = createServer(options, (req, res) => {
+      const { authorization, "content-type": contentType, cookie, "x-custom": xCustom } = req.headers;
+      resolve({ authorization, "content-type": contentType, cookie, "x-custom": xCustom as string });
+      res.end();
+    });
+    const [clientSide, serverSide] = duplexPair();
+    clientSide.on("error", reject);
+    serverSide.on("error", reject);
+    serverSide.on("close", () => reject(new Error("the server closed the connection without dispatching the request")));
+    clientSide.resume();
+    server.emit("connection", serverSide);
+    clientSide.write(rawRequest);
+    try {
+      return await seen;
+    } finally {
+      clientSide.destroy();
+      serverSide.destroy();
+    }
+  }
+
+  const joined = {
+    authorization: "one, two",
+    "content-type": "text/plain, text/html",
+    cookie: "a=1; b=2",
+    "x-custom": "first, second",
+  };
+  const firstValueWins = { ...joined, authorization: "one", "content-type": "text/plain" };
+  expect(
+    await Promise.all([
+      headersSeenOverEmittedConnection({ joinDuplicateHeaders: true }),
+      headersSeenOverEmittedConnection({ joinDuplicateHeaders: false }),
+      headersSeenOverEmittedConnection({}),
+    ]),
+  ).toEqual([joined, firstValueWins, firstValueWins]);
+});

--- a/test/js/node/http2/node-http2.test.js
+++ b/test/js/node/http2/node-http2.test.js
@@ -4365,6 +4365,79 @@ it("http2 allowHTTP1 fallback omits the Connection header on a close-delimited r
   }
 });
 
+// Sends a request with two Authorization and two Cookie lines over a TLS connection that negotiated
+// http/1.1 (the allowHTTP1 fallback) and returns what the handler saw, plus the option as stored on
+// the server.
+async function duplicateHeadersSeenOverAllowHTTP1(options) {
+  const server = http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true, ...options }, (req, res) => {
+    res.end(JSON.stringify({ authorization: req.headers.authorization, cookie: req.headers.cookie }));
+  });
+  await new Promise(resolve => server.listen(0, resolve));
+  try {
+    const { promise, resolve, reject } = Promise.withResolvers();
+    const socket = tls.connect(
+      { host: "localhost", port: server.address().port, ca: TLS_CERT.cert, ALPNProtocols: ["http/1.1"] },
+      () =>
+        socket.write(
+          "GET / HTTP/1.1\r\nHost: localhost\r\n" +
+            "Authorization: one\r\nAuthorization: two\r\n" +
+            "Cookie: a=1\r\nCookie: b=2\r\n" +
+            "Connection: close\r\n\r\n",
+        ),
+    );
+    const chunks = [];
+    socket.on("error", reject);
+    socket.on("data", chunk => chunks.push(chunk));
+    socket.on("end", () => resolve(Buffer.concat(chunks).toString()));
+    const raw = await promise;
+    expect(raw).toStartWith("HTTP/1.1 200 OK\r\n");
+    return { server: server.joinDuplicateHeaders, ...JSON.parse(raw.slice(raw.indexOf("\r\n\r\n") + 4)) };
+  } finally {
+    server.close();
+  }
+}
+
+it("http2 allowHTTP1 fallback applies joinDuplicateHeaders from options or options.http1Options like Node", async () => {
+  // Authorization is one of the headers Node keeps only the first value of unless the option is
+  // set; Cookie is joined either way. Node reads the option through
+  // storeHTTPOptions({ ...options, ...options.http1Options }), so http1Options takes precedence.
+  const joined = { authorization: "one, two", cookie: "a=1; b=2" };
+  const firstValueWins = { authorization: "one", cookie: "a=1; b=2" };
+  expect(
+    await Promise.all([
+      duplicateHeadersSeenOverAllowHTTP1({ joinDuplicateHeaders: true }),
+      duplicateHeadersSeenOverAllowHTTP1({ http1Options: { joinDuplicateHeaders: true } }),
+      duplicateHeadersSeenOverAllowHTTP1({ joinDuplicateHeaders: true, http1Options: { joinDuplicateHeaders: false } }),
+      duplicateHeadersSeenOverAllowHTTP1({ joinDuplicateHeaders: false }),
+      duplicateHeadersSeenOverAllowHTTP1({}),
+    ]),
+  ).toEqual([
+    { server: true, ...joined },
+    { server: true, ...joined },
+    { server: false, ...firstValueWins },
+    { server: false, ...firstValueWins },
+    { server: undefined, ...firstValueWins },
+  ]);
+});
+
+it("http2 createSecureServer type-checks joinDuplicateHeaders only when allowHTTP1 is set, like Node", () => {
+  for (const [options, received] of [
+    [{ joinDuplicateHeaders: "yes" }, "type string ('yes')"],
+    [{ http1Options: { joinDuplicateHeaders: 1 } }, "type number (1)"],
+  ]) {
+    expect(() => {
+      http2.createSecureServer({ ...TLS_CERT, allowHTTP1: true, ...options });
+    }).toThrow(
+      expect.objectContaining({
+        code: "ERR_INVALID_ARG_TYPE",
+        message: `The "options.joinDuplicateHeaders" property must be of type boolean. Received ${received}`,
+      }),
+    );
+    // Without allowHTTP1 there is no HTTP/1 side to configure: Node neither validates nor stores it.
+    expect(Object.hasOwn(http2.createSecureServer({ ...TLS_CERT, ...options }), "joinDuplicateHeaders")).toBe(false);
+  }
+});
+
 // close() must not depend on the peer sending a SETTINGS ACK — Node's kMaybeDestroy
 // waits on nghttp2_session_want_write()/want_read(), which does not track outstanding
 // ACKs. A server that never ACKs a client-sent SETTINGS must not stall close().


### PR DESCRIPTION
### Problem

- A request served by the JS HTTP/1 path in `src/js/internal/http1_server_fallback.ts` ignores the server's `joinDuplicateHeaders` option: with `http.createServer({ joinDuplicateHeaders: true })` and a request carrying `Authorization: one` and `Authorization: two`, a handler reached through `server.emit("connection", socket)` sees `req.headers.authorization === "one"`. The same server's listening (native) path, and node for both paths, give `"one, two"`.
- `http2.createSecureServer({ allowHTTP1: true, joinDuplicateHeaders: true })` (or `http1Options: { joinDuplicateHeaders: true }`) has the same problem for connections that negotiated `http/1.1`, and non-boolean values are accepted where node throws `ERR_INVALID_ARG_TYPE`.
- Cause, in two parts:
  - `connectionListenerHTTP1`'s `kOnHeadersComplete` builds the `IncomingMessage` itself and never sets `req.joinDuplicateHeaders`, so `_addHeaderLine` (`src/js/node/_http_incoming.ts`) takes its drop-duplicates branch for every single-valued header. Node's `parserOnHeadersComplete` copies the flag from the server; so does bun's native dispatcher (`_http_server.ts`, `server.joinDuplicateHeaders` -> `http_req.joinDuplicateHeaders`), which is why only the fallback differs.
  - `Http2SecureServer` copies the other HTTP/1 options (`keepAliveTimeout`, `maxHeaderSize`, ...) onto itself in its `allowHTTP1` block in `src/js/node/http2.ts` but not this one, so even with the first part fixed there would be nothing for the fallback to read. `http.Server` already stores it (`storeHTTPOptions`), so the `emit("connection")` path only needs the first part.

### Fix

- `http1_server_fallback.ts`: set `req.joinDuplicateHeaders = true` when the server has the option, before `_addHeaderLines`, in the same form as the native dispatcher.
- `http2.ts`: in the `allowHTTP1` block, read `joinDuplicateHeaders` from `{ ...options, ...options.http1Options }` like the options next to it, type-check it, and store it on the server (next to `maxRequestsPerSocket`, the other option the fallback reads per request; the comment on the three parser-init options below it now names node's `storeHTTPOptions`, the function it was already describing).
- Why this is right: it matches node. Node v26.3.0 runs `storeHTTPOptions.call(this, { ...options, ...options.http1Options })` in `Http2SecureServer` when `allowHTTP1` is set (so `http1Options` wins, non-booleans throw `ERR_INVALID_ARG_TYPE`, and nothing is validated or stored without `allowHTTP1`), and its `parserOnHeadersComplete` copies `socket.server.joinDuplicateHeaders` onto every request. The header combining itself is unchanged: `_addHeaderLine` already implements the joined form for the native path, it just never saw the flag on fallback requests. Both src changes were checked against node v26.3.0 on the scripts in the details below.
- Tests:
  - `test/js/node/http/node-http.test.ts`: the same raw request (doubled `Authorization`, `Content-Type`, `Cookie` and `X-Custom`) through `server.emit("connection")` over a `duplexPair` and through a listening server built from the same options, for `joinDuplicateHeaders` true / false / unset; both paths must produce the same complete `req.headers`, which is node's (single-valued headers joined only with the option, `Cookie` / unknown headers joined regardless).
  - `test/js/node/http2/node-http2.test.js`: `allowHTTP1` over a TLS connection negotiating `http/1.1` for the option given at top level, in `http1Options`, in both (http1Options wins), false, and unset, including the value stored on the server; and the `ERR_INVALID_ARG_TYPE` for both spellings, with nothing stored or validated without `allowHTTP1`.
  - `test/js/node/http/node-http-proxy.js` (run by `node-http.test.ts`, unrelated to the fix): the proxy server now binds 127.0.0.1 and the client dials the bound address. Listening on and dialing `"localhost"` fails with `ECONNREFUSED` on hosts where the server side resolves it to `::1` and the client side to 127.0.0.1 (node does the same with that setup), which made the full file fail in such environments. Same hunk as in #37739.
  - Without the src changes, the emit test and both http2 tests fail (`"one"` where `"one, two"` is expected; no throw); with them, all three pass, as do the full `node-http.test.ts` and `node-http2.test.js` files and the upstream `test-http-request-join-authorization-headers`, `test-http-generic-streams`, `test-http2-allow-http1`, `test-http2-https-fallback*`, `test-http2-createsecureserver-options` and `test-http-server-options-*` tests.
- Related open PRs touch the same areas but not this: #37735 (header assembly and `requireHostHeader`; it adds `requireHostHeader` at the same spot in `http2.ts` in the same style) and #37739 (switches that block to `storeHTTPOptions`, which would store this option too, but nothing on the fallback side reads it). Whichever lands second has a small, mechanical conflict.
- Deliberately not included: the same function also diverges from the native path for requests with 32 or more header fields and ignores `maxHeadersCount`; both are what #37735 fixes, so the new parity test uses a small request and leaves those cases to that PR's tests.

### Background

- `joinDuplicateHeaders` (node 18.14+): a server (and client) option. `IncomingMessage.headers` is built by `_addHeaderLine`, which has fixed rules per header name: most are joined with `", "`, `Cookie` with `"; "`, `Set-Cookie` becomes an array, and a list of single-valued headers (`Authorization`, `Content-Type`, `Host`, `User-Agent`, ...) keeps the first value. The option makes that last group join with `", "` as well (RFC 9110 section 5.3); `_addHeaderLine` reads it as `this.joinDuplicateHeaders` on the request, so whoever constructs the request has to copy it from the server.
- The HTTP/1 fallback: bun's `http.Server` normally serves connections natively. Two cases are served by JS instead, driving the llhttp-based `HTTPParser` binding over a plain `Duplex`: an `http2.createSecureServer({ allowHTTP1: true })` connection whose ALPN negotiation picked `http/1.1` (or nothing), and any socket an application hands to an `http.Server` with `server.emit("connection", socket)`. That code builds its own `IncomingMessage` / `ServerResponse`, so server options only apply there if it copies them over itself.
- `http1Options`: node lets `createSecureServer` take the HTTP/1 server options either at top level or grouped under `options.http1Options`, the latter taking precedence.

<details>
<summary>Repro scripts and output (node v26.3.0 vs bun 1.4.0 vs this PR)</summary>

`server.emit("connection")`:

```js
const http = require("http");
const { duplexPair } = require("stream");
const server = http.createServer({ joinDuplicateHeaders: true }, (req, res) => {
  console.log(req.headers.authorization);
  res.end();
});
const [c, s] = duplexPair();
server.emit("connection", s);
c.resume();
c.write("GET / HTTP/1.1\r\nHost: a\r\nAuthorization: one\r\nAuthorization: two\r\nConnection: close\r\n\r\n");
```

```
node v26.3.0: one, two
bun 1.4.0:    one        (server.listen() path on the same bun: one, two)
this PR:      one, two
```

`allowHTTP1` (TLS client with `ALPNProtocols: ["http/1.1"]`, same two `Authorization` lines), per server options, `req.headers.authorization` / `server.joinDuplicateHeaders`:

| options | node v26.3.0 | bun 1.4.0 | this PR |
| --- | --- | --- | --- |
| `{ joinDuplicateHeaders: true }` | `one, two` / `true` | `one` / `undefined` | `one, two` / `true` |
| `{ http1Options: { joinDuplicateHeaders: true } }` | `one, two` / `true` | `one` / `undefined` | `one, two` / `true` |
| `{ joinDuplicateHeaders: true, http1Options: { joinDuplicateHeaders: false } }` | `one` / `false` | `one` / `undefined` | `one` / `false` |
| `{ joinDuplicateHeaders: false }` | `one` / `false` | `one` / `undefined` | `one` / `false` |
| `{}` | `one` / `undefined` | `one` / `undefined` | `one` / `undefined` |
| `{ joinDuplicateHeaders: "yes" }` | throws `ERR_INVALID_ARG_TYPE` | constructs | throws `ERR_INVALID_ARG_TYPE` |
| `{ http1Options: { joinDuplicateHeaders: 1 } }` | throws `ERR_INVALID_ARG_TYPE` | constructs | throws `ERR_INVALID_ARG_TYPE` |
| `{ joinDuplicateHeaders: "yes" }` without `allowHTTP1` | constructs, nothing stored | same | same |

The error message is node's verbatim: `The "options.joinDuplicateHeaders" property must be of type boolean. Received type string ('yes')`.

</details>

