### PR TITLE
build: re-run glob-driven codegen steps when one of their inputs is deleted

### DIFF
--- a/scripts/build/CLAUDE.md
+++ b/scripts/build/CLAUDE.md
@@ -123,7 +123,7 @@ Tables: `cpuTargetFlags` (`-march`/`-mcpu`/`-mtune` — also forwarded to local 
 
 **Bump a dependency** — edit the `commit` in `scripts/build/deps/<name>.ts`. See `deps/README.md` for adding/removing deps.
 
-**Add a codegen step** — add a function in `codegen.ts` following the shape of `emitErrorCode` (simple) or `emitCppBind` (needs file-list input). Call it from `emitCodegen()` and add outputs to the right `CodegenOutputs` group (`rustInputs` if the Rust build reads it (the `include!`d generated `.rs` files) — `cppSources` if it's a `.cpp` to compile, `cppAll` if it's a header).
+**Add a codegen step** — add a function in `codegen.ts` following the shape of `emitErrorCode` (simple) or `emitBindgen` (reads a globbed source list). Call it from `emitCodegen()` and add outputs to the right `CodegenOutputs` group (`rustInputs` if the Rust build reads it (the `include!`d generated `.rs` files) — `cppSources` if it's a `.cpp` to compile, `cppAll` if it's a header). If the step finds its input files itself (readdir/scan/bundle) rather than taking the list on its command line, give the edge a `sourceListFile()` implicit input as well: listing the files only tracks edits, and ninja does not treat a file vanishing from an edge's input list as a change, so without the manifest a deleted input never re-runs the step (`test/internal/source-lints/build-codegen-source-lists.test.ts` pins the existing ones).
 
 **Add a Config field** — add to `Config` interface and `PartialConfig` in `config.ts`, resolve in `resolveConfig()`. If it needs a CLI flag, `build.ts`'s arg parser already handles `--anyfield=value` generically.
 

--- a/scripts/build/codegen.ts
+++ b/scripts/build/codegen.ts
@@ -9,6 +9,9 @@
  * Source lists come from the patterns in glob-sources.ts, globbed once at
  * configure time via `globAllSources()`. The expanded
  * paths are baked into build.ninja; adding a file picks up on next configure.
+ * Removing one only picks up if the step's edge also tracks the SET of files
+ * (see `sourceListFile`): to ninja, an input that vanished from the list is
+ * not a change.
  *
  * bindgenv2 is special: its output set is dynamic (depends on which types
  * the .bindv2.ts files export). We invoke it with `--command=list-outputs`
@@ -46,9 +49,14 @@ import type { Ninja } from "./ninja.ts";
 import { quote, quoteArgs } from "./shell.ts";
 import { generateXmlByteClass } from "./xmlByteClass.ts";
 
-// The individual emit functions take these four params. Bundled to keep
+// The individual emit functions take these params. Bundled to keep
 // signatures short.
-interface Ctx {
+//
+// Ctx and the emitters that take a globbed source list are exported for
+// test/internal/source-lints/build-codegen-source-lists.test.ts, which emits
+// those steps on their own: emitCodegen() as a whole spawns bun (bindgenv2
+// list-outputs).
+export interface Ctx {
   n: Ninja;
   cfg: Config;
   sources: Sources;
@@ -382,11 +390,44 @@ function shJoin(cfg: Config, args: string[]): string {
   return quoteArgs(args, cfg.host.os === "windows");
 }
 
+/**
+ * Write a globbed source list to `<codegenDir>/<name>-sources.txt` and return
+ * the path, for use as an implicit input of the step that reads those files.
+ *
+ * Listing the files themselves as inputs only tracks edits to them. Ninja
+ * re-runs an edge when an input is newer than its outputs or its command line
+ * changed; a file that disappeared from the input list is neither, so after
+ * `rm src/js/internal/foo.ts` the reconfigured bundle-modules edge is up to
+ * date and the deleted module stays in the binary until some surviving input
+ * is touched. The manifest turns the set into an input: writeIfChanged moves
+ * its mtime only when the list changes, so a removal re-runs the step and an
+ * unchanged list keeps the no-op reconfigure a no-op.
+ *
+ * Needed by every step whose output depends on which files exist without the
+ * command line saying so: bundle-modules, bindgen and generate-host-exports
+ * readdir the tree themselves, cppbind reads this very file, bun-error and
+ * bake are bundles (which files exist decides how imports resolve). Steps
+ * that pass the list on their command line (generate-classes, bindgenv2,
+ * build-fallbacks) get this from ninja's command-line tracking instead.
+ *
+ * Written at CONFIGURE time, not by a ninja rule: it's a derived manifest of
+ * our glob, like build_options.rs. One repo-relative forward-slash path per
+ * line, which is also the format cppbind reads its manifest in. codegenDir
+ * may not exist yet on a first configure.
+ */
+function sourceListFile(cfg: Config, name: string, files: string[]): string {
+  mkdirSync(cfg.codegenDir, { recursive: true });
+  const file = resolve(cfg.codegenDir, `${name}-sources.txt`);
+  const lines = files.map(p => relative(cfg.cwd, p).replace(/\\/g, "/"));
+  writeIfChanged(file, lines.join("\n") + "\n");
+  return file;
+}
+
 // ───────────────────────────────────────────────────────────────────────────
 // Individual step emitters
 // ───────────────────────────────────────────────────────────────────────────
 
-function emitBunError({ n, cfg, sources, o, dirStamp }: Ctx): void {
+export function emitBunError({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const sourceDir = resolve(cfg.cwd, "packages", "bun-error");
   const installStamp = emitBunInstall(n, cfg, sourceDir);
 
@@ -399,7 +440,7 @@ function emitBunError({ n, cfg, sources, o, dirStamp }: Ctx): void {
     inputs: sources.bunError,
     // Install stamp as implicit — changing preact version re-bundles.
     // Root install as well (esbuild tool lives there).
-    implicitInputs: [installStamp, o.rootInstall],
+    implicitInputs: [sourceListFile(cfg, "bun-error", sources.bunError), installStamp, o.rootInstall],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: sourceDir,
@@ -614,7 +655,7 @@ function emitGeneratedClasses({ n, cfg, sources, o, dirStamp }: Ctx): void {
   // .lut.txt is consumed by emitObjectLuts below
 }
 
-function emitHostExports({ n, cfg, sources, o, dirStamp }: Ctx): void {
+export function emitHostExports({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "generate-host-exports.ts");
   const output = resolve(cfg.codegenDir, "generated_host_exports.rs");
 
@@ -634,7 +675,7 @@ function emitHostExports({ n, cfg, sources, o, dirStamp }: Ctx): void {
     outputs: [output],
     rule: "codegen",
     inputs: [script],
-    implicitInputs: rsInputs,
+    implicitInputs: [sourceListFile(cfg, "host-exports", rsInputs), ...rsInputs],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: cfg.cwd,
@@ -650,24 +691,15 @@ function emitHostExports({ n, cfg, sources, o, dirStamp }: Ctx): void {
   o.rustInputs.push(output);
 }
 
-function emitCppBind({ n, cfg, sources, o, dirStamp }: Ctx): void {
+export function emitCppBind({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "cppbind.ts");
 
   const outputRs = resolve(cfg.codegenDir, "cpp.rs");
 
-  // Write the .cpp file list for cppbind to scan. Build system owns the
-  // glob (glob-sources.ts); we hand the result to cppbind
-  // as an explicit input instead of it reading a magic hardcoded path.
-  // Relative paths, forward slashes — same format cppbind expects.
-  //
-  // Written at CONFIGURE time (not via a ninja rule): it's a derived
-  // manifest from our glob, and we want writeIfChanged semantics so a
-  // stable .cpp set → unchanged mtime → ninja doesn't re-run cppbind.
-  // codegenDir may not exist yet on first configure — mkdir it.
-  mkdirSync(cfg.codegenDir, { recursive: true });
-  const cxxSourcesFile = resolve(cfg.codegenDir, "cxx-sources.txt");
-  const cxxSourcesLines = sources.cxx.map(p => relative(cfg.cwd, p).replace(/\\/g, "/"));
-  writeIfChanged(cxxSourcesFile, cxxSourcesLines.join("\n") + "\n");
+  // The .cpp file list for cppbind to scan. Build system owns the glob
+  // (glob-sources.ts); we hand the result to cppbind as an argument instead
+  // of it reading a magic hardcoded path.
+  const cxxSourcesFile = sourceListFile(cfg, "cxx", sources.cxx);
 
   n.build({
     outputs: [outputRs],
@@ -702,7 +734,7 @@ function emitCppBind({ n, cfg, sources, o, dirStamp }: Ctx): void {
   o.rustInputs.push(outputRs);
 }
 
-function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
+export function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bundle-modules.ts");
 
   // InternalModuleRegistry.cpp is read by the script (for a sanity check).
@@ -738,6 +770,9 @@ function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
     outputs,
     rule: "codegen",
     inputs: [script, ...sources.js, ...sources.jsCodegen, extraInput, errorCodeInput],
+    // The script readdirs src/js itself; the source list is what re-runs it
+    // when a module is deleted (see sourceListFile).
+    implicitInputs: [sourceListFile(cfg, "js", sources.js)],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: cfg.cwd,
@@ -754,7 +789,7 @@ function emitJsModules({ n, cfg, sources, o, dirStamp }: Ctx): void {
   o.cppHeaders.push(...outputs.filter(p => p.endsWith(".h")));
 }
 
-function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
+export function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bake-codegen.ts");
 
   // InternalModuleRegistry.cpp is listed as a dep in CMake for this step too.
@@ -777,6 +812,7 @@ function emitBakeCodegen({ n, cfg, sources, o, dirStamp }: Ctx): void {
     outputs,
     rule: "codegen",
     inputs: [script, ...sources.bakeRuntime],
+    implicitInputs: [sourceListFile(cfg, "bake", sources.bakeRuntime)],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: cfg.cwd,
@@ -852,18 +888,20 @@ function emitBindgenV2({ n, cfg, sources, o, dirStamp }: Ctx): void {
   o.bindgenV2Cpp.push(...cppOutputs);
 }
 
-function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
+export function emitBindgen({ n, cfg, sources, o, dirStamp }: Ctx): void {
   const script = resolve(cfg.cwd, "src", "codegen", "bindgen.ts");
 
   const cppOut = resolve(cfg.codegenDir, "GeneratedBindings.cpp");
 
   // bindgen.ts scans src/ for .bind.ts files itself — this list is only for
-  // ninja dependency tracking. New .bind.ts files need a reconfigure to be
-  // picked up (next glob gets them).
+  // ninja dependency tracking. Added or deleted .bind.ts files need a
+  // reconfigure to be picked up (next glob gets them; the file list is what
+  // makes a deletion re-run the step).
   n.build({
     outputs: [cppOut],
     rule: "codegen",
     inputs: [script, ...sources.bindgen],
+    implicitInputs: [sourceListFile(cfg, "bindgen", sources.bindgen)],
     orderOnlyInputs: [dirStamp],
     vars: {
       cwd: cfg.cwd,

--- a/test/internal/source-lints/build-codegen-source-lists.test.ts
+++ b/test/internal/source-lints/build-codegen-source-lists.test.ts
@@ -1,0 +1,279 @@
+/**
+ * Pins that the codegen steps which discover or bundle their globbed inputs
+ * also track the SET of those inputs (`sourceListFile` in
+ * scripts/build/codegen.ts).
+ *
+ * Ninja re-runs an edge when an input is newer than its outputs or when the
+ * command line changed. Deleting a file the step had globbed is neither: the
+ * reconfigured edge merely has a shorter input list and counts as up to date.
+ * So after `rm src/js/internal/foo.ts`, bundle-modules did not re-run and the
+ * module stayed in the binary until some surviving input was edited; the same
+ * held for bindgen, generate-host-exports, bake and bun-error. Each of those
+ * edges now has an implicit input `codegen/<name>-sources.txt`, written at
+ * configure time with writeIfChanged: its mtime moves exactly when the list
+ * changes, so a deletion re-runs the step and an unchanged list stays a no-op.
+ * (cppbind has worked this way all along; it is the pattern being generalized.)
+ *
+ * Emits the six steps into a temporary build dir and reads back the ninja text
+ * and the manifests. The source lists are made up: nothing reads the files at
+ * configure time. No ninja, compiler or subprocess; runs on every host.
+ */
+import { describe, expect, test } from "bun:test";
+import { tempDir } from "harness";
+import { readFileSync, statSync } from "node:fs";
+import { relative, resolve } from "node:path";
+
+import {
+  emitBakeCodegen,
+  emitBindgen,
+  emitBunError,
+  emitCppBind,
+  emitHostExports,
+  emitJsModules,
+  registerCodegenRules,
+  type CodegenOutputs,
+  type Ctx,
+} from "../../../scripts/build/codegen.ts";
+import { registerDirStamps } from "../../../scripts/build/compile.ts";
+import { resolveConfig, type Config, type Toolchain } from "../../../scripts/build/config.ts";
+import { Ninja } from "../../../scripts/build/ninja.ts";
+import type { Sources } from "../../../scripts/glob-sources.ts";
+
+/** A fully-populated fake toolchain; configure-time emission never runs any of it. */
+function mockToolchain(): Toolchain {
+  return {
+    cc: "/fake/llvm/bin/clang",
+    cxx: "/fake/llvm/bin/clang++",
+    hostCc: undefined,
+    hostCxx: undefined,
+    clangVersion: "21.1.8",
+    clangResourceDir: "/fake/llvm/lib/clang/21",
+    ar: "/fake/llvm/bin/llvm-ar",
+    ranlib: "/fake/llvm/bin/llvm-ranlib",
+    ld: "/fake/llvm/bin/ld.lld",
+    ld64Lld: "/fake/llvm/bin/ld64.lld",
+    rustLld: undefined,
+    rustLlvmVersion: "22.1.4",
+    rustSysroot: undefined,
+    rustHostTriple: undefined,
+    strip: "/fake/bin/strip",
+    llvmStrip: "/fake/llvm/bin/llvm-strip",
+    dsymutil: "/fake/llvm/bin/dsymutil",
+    bun: "/fake/bin/bun",
+    jsRuntime: "/fake/bin/bun",
+    esbuild: "/fake/bin/esbuild",
+    ccache: undefined,
+    cmake: "/fake/bin/cmake",
+    cargo: undefined,
+    cargoHome: undefined,
+    rustupHome: undefined,
+    msvcLinker: undefined,
+    rc: undefined,
+    mt: undefined,
+    nasm: undefined,
+  };
+}
+
+/**
+ * A linux-x64 debug target resolves on every host once it is told where its
+ * sysroot is (the path is only recorded, never opened).
+ */
+function linuxDebugConfig(buildDir: string): Config {
+  return resolveConfig(
+    { os: "linux", arch: "x64", abi: "gnu", buildType: "Debug", buildDir, linuxSysroot: buildDir },
+    mockToolchain(),
+  );
+}
+
+/**
+ * Source lists shaped like globAllSources() output (absolute paths under the
+ * repo root), plus the subset of `rust` that generate-host-exports scrapes.
+ */
+function fixture(cfg: Config): { sources: Sources; hostExportsScrape: string[] } {
+  const src = (p: string) => resolve(cfg.cwd, "src", p);
+  const hostExportsScrape = [src("jsc/lib.rs"), src("runtime/api/BunObject.rs")];
+  const sources: Sources = {
+    bunError: [resolve(cfg.cwd, "packages/bun-error/bun-error.css"), resolve(cfg.cwd, "packages/bun-error/index.tsx")],
+    js: [src("js/internal/a.ts"), src("js/internal/b.ts"), src("js/node/fs.ts")],
+    jsCodegen: [src("codegen/bundle-modules.ts"), src("codegen/replacements.ts")],
+    bakeRuntime: [src("runtime/bake/dev_server/mod.rs"), src("runtime/bake/hmr-runtime-client.ts")],
+    bindgen: [src("jsc/fmt_jsc.bind.ts"), src("runtime/node/node_os.bind.ts")],
+    cxx: [src("jsc/bindings/BunObject.cpp"), src("jsc/bindings/ZigGlobalObject.cpp")],
+    // A crate outside the scrape scope and a manifest inside it are fed to
+    // the cargo step but not to generate-host-exports.
+    rust: [resolve(cfg.cwd, "Cargo.toml"), src("bundler/lib.rs"), ...hostExportsScrape, src("runtime/Cargo.toml")],
+    // Read only by steps this test doesn't emit.
+    stringMaps: [],
+    nodeFallbacks: [],
+    zigGeneratedClasses: [],
+    bindgenV2: [],
+    bindgenV2Internal: [],
+    c: [],
+  };
+  return { sources, hostExportsScrape };
+}
+
+interface Edge {
+  outputs: string[];
+  inputs: string[];
+  implicitInputs: string[];
+}
+
+/** Undo ninja.ts's build-line path escaping. */
+function unescapePath(token: string): string {
+  return token.replace(/\$([ :$])/g, "$1");
+}
+
+/**
+ * Parse every `build` line of the generated ninja text into its output and
+ * input sections (paths buildDir-relative, as ninja.ts writes them).
+ */
+function parseEdges(ninja: string): Edge[] {
+  const edges: Edge[] = [];
+  for (const line of ninja.replace(/ \$\n +/g, " ").split("\n")) {
+    if (!line.startsWith("build ")) continue;
+    const tokens = line.slice("build ".length).split(/(?<=[^$]) /);
+    // `build out | implout: rule in | implin || orderonly`: the rule name
+    // follows the first token ending in an unescaped colon.
+    const colon = tokens.findIndex(t => t.endsWith(":") && !t.endsWith("$:"));
+    if (colon === -1) throw new Error(`unparseable build line: ${line}`);
+    const outputs = [...tokens.slice(0, colon), tokens[colon]!.slice(0, -1)].filter(t => t !== "|").map(unescapePath);
+    const rest = tokens.slice(colon + 2);
+    const implicitStart = rest.indexOf("|");
+    const orderOnlyStart = rest.indexOf("||");
+    const end = orderOnlyStart === -1 ? rest.length : orderOnlyStart;
+    const inputs = rest.slice(0, implicitStart === -1 ? end : implicitStart).map(unescapePath);
+    const implicitInputs = implicitStart === -1 ? [] : rest.slice(implicitStart + 1, end).map(unescapePath);
+    edges.push({ outputs, inputs, implicitInputs });
+  }
+  return edges;
+}
+
+/** One configure's worth of the glob-driven steps, the way emitCodegen() drives them. */
+function emit(cfg: Config, sources: Sources): Edge[] {
+  const n = new Ninja({ buildDir: cfg.buildDir });
+  registerDirStamps(n, cfg);
+  registerCodegenRules(n, cfg);
+  const o: CodegenOutputs = {
+    all: [],
+    rustInputs: [],
+    rustOrderOnly: [],
+    cppSources: [],
+    cppHeaders: [],
+    cppAll: [],
+    bindgenV2Cpp: [],
+    internalModulesAsm: resolve(cfg.codegenDir, "InternalModuleRegistryConstants.S"),
+    internalModulesBin: resolve(cfg.codegenDir, "InternalModuleRegistryConstants.bin"),
+    rootInstall: resolve(cfg.buildDir, "stamps", "install_root.stamp"),
+  };
+  const ctx: Ctx = { n, cfg, sources, o, dirStamp: resolve(cfg.codegenDir, ".dir") };
+  for (const step of [emitBunError, emitHostExports, emitCppBind, emitJsModules, emitBakeCodegen, emitBindgen]) {
+    step(ctx);
+  }
+  return parseEdges(n.toString());
+}
+
+/** `path` as ninja.ts writes it into build.ninja. */
+function ninjaPath(cfg: Config, path: string): string {
+  return relative(cfg.buildDir, path);
+}
+
+/** The edge producing `<codegenDir>/<...output>`. */
+function edgeProducing(cfg: Config, edges: Edge[], ...output: string[]): Edge {
+  const rel = ninjaPath(cfg, resolve(cfg.codegenDir, ...output));
+  const edge = edges.find(e => e.outputs.includes(rel));
+  if (edge === undefined) throw new Error(`no edge produces ${rel}`);
+  return edge;
+}
+
+/** The manifest format: repo-relative, forward slashes, one file per line. */
+function manifestText(cfg: Config, files: string[]): string {
+  return files.map(f => relative(cfg.cwd, f).replaceAll("\\", "/")).join("\n") + "\n";
+}
+
+function readManifest(cfg: Config, name: string): string {
+  return readFileSync(resolve(cfg.codegenDir, name), "utf8");
+}
+
+/**
+ * Per step: the manifest its edge has to declare, an output that identifies
+ * the edge, and the files the manifest has to list.
+ */
+function steps(cfg: Config): { manifest: string; output: string[]; files: string[] }[] {
+  const { sources, hostExportsScrape } = fixture(cfg);
+  return [
+    { manifest: "js-sources.txt", output: ["InternalModuleRegistry+enum.h"], files: sources.js },
+    { manifest: "bindgen-sources.txt", output: ["GeneratedBindings.cpp"], files: sources.bindgen },
+    { manifest: "host-exports-sources.txt", output: ["generated_host_exports.rs"], files: hostExportsScrape },
+    { manifest: "bake-sources.txt", output: ["bake.client.js"], files: sources.bakeRuntime },
+    { manifest: "bun-error-sources.txt", output: ["bun-error", "index.js"], files: sources.bunError },
+    { manifest: "cxx-sources.txt", output: ["cpp.rs"], files: sources.cxx },
+  ];
+}
+
+describe("codegen steps that glob their inputs track the set of inputs", () => {
+  test("each step's edge has a manifest as an implicit input, listing the files the edge is fed", () => {
+    using dir = tempDir("build-codegen-source-lists", {});
+    const cfg = linuxDebugConfig(String(dir));
+    const edges = emit(cfg, fixture(cfg).sources);
+
+    const actual = steps(cfg).map(({ manifest, output }) => {
+      const edge = edgeProducing(cfg, edges, ...output);
+      const tracked = new Set([...edge.inputs, ...edge.implicitInputs]);
+      const content = readManifest(cfg, manifest);
+      return {
+        manifest,
+        declared: edge.implicitInputs.includes(ninjaPath(cfg, resolve(cfg.codegenDir, manifest))),
+        content,
+        // The manifest's files are the edge's own inputs, so edits to them
+        // re-run the step as before; the manifest only adds the set itself.
+        listedButUntracked: content
+          .trimEnd()
+          .split("\n")
+          .filter(line => !tracked.has(ninjaPath(cfg, resolve(cfg.cwd, line)))),
+      };
+    });
+
+    expect(actual).toEqual(
+      steps(cfg).map(({ manifest, files }) => ({
+        manifest,
+        declared: true,
+        content: manifestText(cfg, files),
+        listedButUntracked: [],
+      })),
+    );
+  });
+
+  test("a manifest is rewritten exactly when its list changes", () => {
+    using dir = tempDir("build-codegen-source-lists", {});
+    const cfg = linuxDebugConfig(String(dir));
+    const { sources } = fixture(cfg);
+    const snapshot = () =>
+      Object.fromEntries(
+        steps(cfg).map(({ manifest }) => [
+          manifest,
+          { content: readManifest(cfg, manifest), mtimeMs: statSync(resolve(cfg.codegenDir, manifest)).mtimeMs },
+        ]),
+      );
+
+    emit(cfg, sources);
+    const before = snapshot();
+
+    // Reconfigure with nothing changed: no manifest may be touched, or every
+    // `bun bd` would re-run these steps.
+    emit(cfg, sources);
+    expect(snapshot()).toEqual(before);
+
+    // Reconfigure after `rm src/js/internal/b.ts`: the glob no longer returns
+    // it. The JS manifest is rewritten (its new mtime is what makes ninja
+    // re-run bundle-modules, which drops the module); nothing else is touched.
+    const remaining = sources.js.filter(f => !f.endsWith("b.ts"));
+    expect(remaining).toHaveLength(sources.js.length - 1);
+    emit(cfg, { ...sources, js: remaining });
+    expect(snapshot()).toEqual({
+      ...before,
+      "js-sources.txt": { content: manifestText(cfg, remaining), mtimeMs: expect.any(Number) },
+    });
+    expect(before["js-sources.txt"]!.content).toBe(manifestText(cfg, sources.js));
+  });
+});


### PR DESCRIPTION
### Problem
- On a warm tree, deleting a file that a codegen step globs does not re-run that step. `rm src/js/internal/foo.ts && bun bd` leaves `InternalModuleRegistry+enum.h` (and the module's code) in the binary until some surviving input of the same step is edited. Reproduced on linux-x64 with a probe module: after removing it, `ninja -d explain codegen/InternalModuleRegistry+enum.h` reports `no work to do` and the header still contains `InternalZzProbe` (transcript below).
- Cause: the edges in `scripts/build/codegen.ts` list the globbed files as inputs and nothing carries the input set. Ninja re-runs an edge when an input is newer than its outputs or the command line changed; after a deletion, configure regenerates `build.ninja` with a shorter input list, the command is unchanged, and the outputs are newer than every remaining input, so the edge is up to date.
- The same shape is in every step that decides what to generate by looking at the tree itself or by bundling, with the list absent from its command line: `emitJsModules` (bundle-modules readdirs `src/js`), `emitBindgen` (bindgen.ts scans for `.bind.ts`), `emitHostExports` (scrapes `src/runtime` + `src/jsc` `.rs` files), `emitBakeCodegen` and `emitBunError` (bundles; which files exist decides how imports resolve). `emitCppBind` already handled it by writing `codegen/cxx-sources.txt` at configure time and listing it as an implicit input.
- Not affected: `emitGeneratedClasses`, `emitBindgenV2` and `emitNodeFallbacks` pass the file list on the command line, so a deletion changes the command and ninja re-runs them ("command line changed"); checked with a synthetic ninja file. The cargo edge is also left alone: a `.rs` deletion that matters comes with an edit to the file that declared the module, and cargo's own fingerprinting decides what recompiles.

### Fix
- `codegen.ts`: the cxx-sources.txt logic becomes `sourceListFile(cfg, name, files)`, which writes `codegen/<name>-sources.txt` with `writeIfChanged` and returns the path. `emitCppBind` uses it (same path and content as before, so existing trees do not re-run cppbind), and the five steps above list their manifest as an implicit input: `js-sources.txt`, `bindgen-sources.txt`, `host-exports-sources.txt`, `bake-sources.txt`, `bun-error-sources.txt`.
- Why this is correct: the manifest is the input set as a file, so a deletion becomes something ninja can see (a rewritten manifest, newer than the outputs), while an unchanged set leaves the mtime alone and a reconfigure stays a no-op. It is written at configure time, which is the only point where the glob is re-evaluated anyway (adding a file already needs the reconfigure that `bun bd` always does). The codegen rule has `restat = 1` and the scripts use `writeIfNotChanged`, so a set change whose output is unchanged re-runs the step and nothing downstream, as with `cxx-sources.txt` today.
- Cost: trees configured before this change re-run the five steps once when their manifests first appear, like any new input.
- Verified:
  - `test/internal/source-lints/build-codegen-source-lists.test.ts` (the source-lints dir per its README: build-script unit test, no bun binary involved): emits the six steps into a temp build dir with made-up source lists and checks that each edge has its manifest as an implicit input listing exactly the files the edge is fed (for host-exports, only the `.rs` files in the scrape scope), that an unchanged reconfigure rewrites none of them (content and mtime), and that dropping one JS module rewrites only `js-sources.txt`. Passes with `bun bd test`; fails with `scripts/` stashed, and also fails (`js-sources.txt` missing) with only the manifest wiring removed and the exports kept. To make the steps reachable without `emitCodegen()` (which spawns bun for bindgenv2's `list-outputs`, several seconds per call under a debug build), `Ctx` and the six emitters are exported.
  - Real ninja, linux-x64 debug tree: removing the probe module now re-runs bundle-modules in the same `bun bd` (`explain` names `js-sources.txt`) and the module is gone; a reconfigure with no changes is still `no work to do`; removing a `.bind.ts` dirties the bindgen edge the same way (transcripts below).
  - `bunx tsc --noEmit -p scripts/build/tsconfig.json` reports no errors in `codegen.ts`; the rest of `test/internal/source-lints/` and the existing `test/internal/build-*` tests still pass under `bun bd test`.
  - CI: every build lane (linux, musl, android, darwin, windows, freebsd) configures and builds with the new manifests, and the binary-size annotation shows every binary at +0.0 KB against the main canary, as expected for a change that only affects when codegen re-runs.
- `scripts/build/CLAUDE.md`: the "Add a codegen step" entry says when a step needs a manifest.

### Background
- **Ninja dirtiness**: before running, ninja stats every declared input of an edge and re-runs the edge if any input is newer than the oldest output, if an output is missing, or if the edge's command differs from the one recorded in `.ninja_log`. The declared inputs come from `build.ninja`, which configure regenerates from a fresh glob on every `bun bd`; a file that is no longer in the list is simply not stat'd, so its removal is invisible unless something else records that the list changed.
- **Implicit input** (`| file` on a build line): tracked for dirtiness exactly like an explicit input, but not passed to the command as `$in`. The codegen and esbuild rules do not use `$in` at all, which is why the list itself is not on the command line and why the manifest goes in this slot.
- **`writeIfChanged`** (`scripts/build/fs.ts`): configure-time write that skips the write when the content is identical, so the file's mtime only moves when the content does. **`restat = 1`** on the codegen rule: after the command runs, ninja re-stats the outputs and prunes downstream edges whose inputs did not actually change, and records the newest input mtime so an input that triggered a no-op run does not trigger it again.

Two neighbouring gaps found on the way are filed separately and not changed here: the bundle-modules edge does not list `src/jsc/modules/NativeModuleList.h` or `src/js/builtins/BunBuiltinNames.h`, which its scripts read, and the PCH picking up a regenerated header one build late is #37992.

<details>
<summary>Probe transcripts (linux-x64, build/debug, target = codegen/InternalModuleRegistry+enum.h)</summary>

Unfixed:

```
$ echo 'export default {};' > src/js/internal/zz_probe.ts
$ bun scripts/build.ts --profile=debug --configure-only && ninja -C build/debug codegen/InternalModuleRegistry+enum.h
[1/1] gen JS modules (bundle-modules)
$ grep -c ZzProbe build/debug/codegen/InternalModuleRegistry+enum.h
1
$ rm src/js/internal/zz_probe.ts
$ bun scripts/build.ts --profile=debug --configure-only && grep -c zz_probe build/debug/build.ninja
0
$ ninja -C build/debug -d explain codegen/InternalModuleRegistry+enum.h
ninja: no work to do.
$ grep -c ZzProbe build/debug/codegen/InternalModuleRegistry+enum.h
1
```

Fixed (same sequence):

```
$ rm src/js/internal/zz_probe.ts
$ bun scripts/build.ts --profile=debug --configure-only && ninja -C build/debug -d explain codegen/InternalModuleRegistry+enum.h
ninja explain: recorded mtime of codegen/WebCoreJSBuiltins.cpp older than most recent input codegen/js-sources.txt (...)
[1/1] gen JS modules (bundle-modules)
$ grep -c ZzProbe build/debug/codegen/InternalModuleRegistry+enum.h
0
$ bun scripts/build.ts --profile=debug --configure-only && ninja -C build/debug codegen/InternalModuleRegistry+enum.h
ninja: no work to do.
```

Fixed, bindgen (dry run after moving `src/jsc/bindgen_test.bind.ts` away and reconfiguring):

```
$ ninja -C build/debug -n -d explain codegen/GeneratedBindings.cpp
ninja explain: recorded mtime of codegen/GeneratedBindings.cpp older than most recent input codegen/bindgen-sources.txt (...)
[1/1] gen .bind.ts → GeneratedBindings.cpp
```

Manifests written on this tree after the change (`cxx-sources.txt` kept its old mtime, the content is unchanged):

```
bake-sources.txt          24 lines
bindgen-sources.txt        7 lines
bun-error-sources.txt     13 lines
cxx-sources.txt          596 lines
host-exports-sources.txt 533 lines
js-sources.txt           222 lines
```

Synthetic check that a list carried on the command line already re-runs (the generate-classes / bindgenv2 / build-fallbacks shape): with `command = ls $in > /dev/null && echo out > $out`, dropping an input gives `ninja explain: command line changed for out`; with the list not in the command, `no work to do`.

</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 1 · 3 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/internal/source-lints/build-codegen-source-lists.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/internal/source-lints/build-codegen-source-lists.test.ts
bun test v1.4.0 (085f257e8)

test/internal/source-lints/build-codegen-source-lists.test.ts:
(pass) codegen steps that glob their inputs track the set of inputs > each step's edge has a manifest as an implicit input, listing the files the edge is fed [907.60ms]
(pass) codegen steps that glob their inputs track the set of inputs > a manifest is rewritten exactly when its list changes [425.69ms]

 2 pass
 0 fail
 5 expect() calls
Ran 2 tests across 1 file. [7.52s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
scripts/build/CLAUDE.md                            |   2 +-
 scripts/build/codegen.ts                           |  88 +++++--
 .../build-codegen-source-lists.test.ts             | 279 +++++++++++++++++++++
 3 files changed, 343 insertions(+), 26 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                      reads  edits  tests
scripts/build/CLAUDE.md                                       2      2      0
scripts/build/codegen.ts                                      4     20      0
…nternal/source-lints/build-codegen-source-lists.test.ts      1      0      0
```

</details>

<!-- robobun:evidence:end -->