### PR TITLE
node:fs: stop fs.copyFile(src, "") from segfaulting on Windows

### DIFF
--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -550,7 +550,27 @@ pub fn CreateHardLinkW(
     rc
 }
 
-pub use bun_windows_sys::externs::CopyFileW;
+/// This module's spelling of `CopyFileW`: raw-ABI drop-in that fails an empty
+/// destination itself. KERNELBASE looks at the destination name's last unit
+/// (`dest[len - 1]`), so for `L""` it reads the unit *before* the buffer: a
+/// fault when the buffer starts a mapping (a work-pool thread's first pooled
+/// `WPathBuffer`, i.e. `fs.promises.copyFile(src, "")`), and
+/// `ERROR_PATH_NOT_FOUND` whenever the stray read happens to land on mapped
+/// memory. Report the latter without making the call.
+///
+/// # Safety
+/// `source` and `dest` must point at NUL-terminated wide strings that stay
+/// valid for the duration of the call.
+pub unsafe fn CopyFileW(source: LPCWSTR, dest: LPCWSTR, bFailIfExists: BOOL) -> BOOL {
+    // SAFETY: caller contract — `dest` is NUL-terminated, so its first unit
+    // is readable.
+    if unsafe { *dest } == 0 {
+        kernel32::SetLastError(u32::from(Win32Error::PATH_NOT_FOUND.0));
+        return FALSE;
+    }
+    // SAFETY: caller contract.
+    unsafe { externs::CopyFileW(source, dest, bFailIfExists) }
+}
 
 pub use bun_windows_sys::externs::SetFileInformationByHandle;
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -550,25 +550,30 @@ pub fn CreateHardLinkW(
     rc
 }
 
-/// This module's spelling of `CopyFileW`: raw-ABI drop-in that fails an empty
-/// destination itself. KERNELBASE looks at the destination name's last unit
-/// (`dest[len - 1]`), so for `L""` it reads the unit *before* the buffer: a
-/// fault when the buffer starts a mapping (a work-pool thread's first pooled
-/// `WPathBuffer`, i.e. `fs.promises.copyFile(src, "")`), and
-/// `ERROR_PATH_NOT_FOUND` whenever the stray read happens to land on mapped
-/// memory. Report the latter without making the call.
+/// This module's spelling of `CopyFileW`: raw-ABI drop-in that never hands
+/// kernel32 an empty destination sitting at the start of a buffer. KERNELBASE
+/// looks at the destination name's last unit (`dest[len - 1]`), so for `L""`
+/// it reads exactly one unit *before* the string; a work-pool thread's first
+/// pooled `WPathBuffer` tends to start a mapping, so that read faulted
+/// (`fs.promises.copyFile(src, "")`). An empty destination is passed as the
+/// second unit of a NUL pair instead, the layout libuv's combined path buffer
+/// gives Node, so kernel32 still reports what it would have (a source error
+/// first, otherwise `ERROR_PATH_NOT_FOUND`).
 ///
 /// # Safety
 /// `source` and `dest` must point at NUL-terminated wide strings that stay
 /// valid for the duration of the call.
 pub unsafe fn CopyFileW(source: LPCWSTR, dest: LPCWSTR, bFailIfExists: BOOL) -> BOOL {
+    static EMPTY_DEST: [u16; 2] = [0, 0];
     // SAFETY: caller contract — `dest` is NUL-terminated, so its first unit
     // is readable.
-    if unsafe { *dest } == 0 {
-        kernel32::SetLastError(u32::from(Win32Error::PATH_NOT_FOUND.0));
-        return FALSE;
-    }
-    // SAFETY: caller contract.
+    let dest = if unsafe { *dest } == 0 {
+        EMPTY_DEST[1..].as_ptr()
+    } else {
+        dest
+    };
+    // SAFETY: caller contract; the substitute is a NUL-terminated empty string
+    // with a readable unit before it.
     unsafe { externs::CopyFileW(source, dest, bFailIfExists) }
 }
 

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -550,11 +550,8 @@ pub fn CreateHardLinkW(
     rc
 }
 
-/// `CopyFileW` with an empty destination made safe: kernel32 reads the unit
-/// before an empty destination name (its "last" unit), so one is passed as the
-/// tail of a NUL pair, libuv's layout, rather than at the start of the
-/// caller's buffer, which may start a mapping. kernel32's own error reporting
-/// is unchanged.
+/// `CopyFileW`, passing an empty destination as the tail of a NUL pair:
+/// kernel32 reads the unit before an empty destination name.
 ///
 /// # Safety
 /// `source` and `dest` must point at NUL-terminated wide strings that stay

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -550,15 +550,11 @@ pub fn CreateHardLinkW(
     rc
 }
 
-/// This module's spelling of `CopyFileW`: raw-ABI drop-in that never hands
-/// kernel32 an empty destination sitting at the start of a buffer. KERNELBASE
-/// looks at the destination name's last unit (`dest[len - 1]`), so for `L""`
-/// it reads exactly one unit *before* the string; a work-pool thread's first
-/// pooled `WPathBuffer` tends to start a mapping, so that read faulted
-/// (`fs.promises.copyFile(src, "")`). An empty destination is passed as the
-/// second unit of a NUL pair instead, the layout libuv's combined path buffer
-/// gives Node, so kernel32 still reports what it would have (a source error
-/// first, otherwise `ERROR_PATH_NOT_FOUND`).
+/// `CopyFileW` with an empty destination made safe: kernel32 reads the unit
+/// before an empty destination name (its "last" unit), so one is passed as the
+/// tail of a NUL pair, libuv's layout, rather than at the start of the
+/// caller's buffer, which may start a mapping. kernel32's own error reporting
+/// is unchanged.
 ///
 /// # Safety
 /// `source` and `dest` must point at NUL-terminated wide strings that stay
@@ -572,8 +568,7 @@ pub unsafe fn CopyFileW(source: LPCWSTR, dest: LPCWSTR, bFailIfExists: BOOL) -> 
     } else {
         dest
     };
-    // SAFETY: caller contract; the substitute is a NUL-terminated empty string
-    // with a readable unit before it.
+    // SAFETY: caller contract; the substitute is NUL-terminated too.
     unsafe { externs::CopyFileW(source, dest, bFailIfExists) }
 }
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1011,13 +1011,13 @@ describe("copyFileSync", () => {
 // async forms convert the destination into a work-pool thread's freshly pooled
 // path buffer, which tends to start a mapping, so they crashed the process
 // instead of failing with ENOENT. Runs in a child (it used to segfault) and
-// queues a batch per form so several pool threads each convert into their own
-// fresh buffer.
+// queues a batch per form: the pool keeps spawning threads while work is
+// queued, and each thread converts into a fresh buffer of its own.
 it.concurrent("copyFile to an empty destination path fails with ENOENT in every form", async () => {
   using dir = tempDir("fs-copyfile-empty-dest", { "src.txt": "x" });
   const script = `
     const fs = require("fs");
-    const N = 16;
+    const N = 64;
     const shape = e => ({ code: e.code, syscall: e.syscall, path: e.path });
     const unique = list => [...new Set(list.map(r => JSON.stringify(r)))].map(s => JSON.parse(s));
     const promiseForm = Promise.all(
@@ -1063,7 +1063,7 @@ it.concurrent("copyFile to an empty destination path fails with ENOENT in every 
         promises: [enoent],
         callback: [enoent],
         sync: enoent,
-        // fs.cp reaches the same copy routine for a file source, but reports
+        // A file source makes fs.cp call CopyFileW too on Windows. It reports
         // the parent mkdir on POSIX and copyfile on Windows, so only the code
         // is pinned.
         cpSync: { code: "ENOENT" },

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1007,62 +1007,79 @@ describe("copyFileSync", () => {
   }
 });
 
-// Windows: CopyFileW reads the code unit before an empty destination string. The
-// async forms convert the destination into a work-pool thread's freshly pooled
-// path buffer, which tends to start a mapping, so they crashed the process
-// instead of failing with ENOENT. Runs in a child (it used to segfault) and
-// queues a batch per form: the pool keeps spawning threads while work is
-// queued, and each thread converts into a fresh buffer of its own.
-it.concurrent("copyFile to an empty destination path fails with ENOENT in every form", async () => {
-  using dir = tempDir("fs-copyfile-empty-dest", { "src.txt": "x" });
+// Windows: CopyFileW reads the code unit before an empty destination string.
+// The async forms convert the destination into a work-pool thread's freshly
+// pooled path buffer, which tends to start a mapping, so they crashed the
+// process instead of failing with ENOENT. Runs in a child (it used to
+// segfault). Each pool thread converts into one buffer of its own, so every
+// thread is one chance to hit the crash: the child raises the pool's thread
+// cap (it defaults to the core count, 4 on the CI shards) and follows each
+// copy with a 1 MiB read so the threads stay busy and the pool keeps spawning
+// while the batch is queued. The directory source checks that the source is
+// still inspected before the destination: its error must come out unchanged.
+it.concurrent("copyFile to an empty destination path fails with the copyfile error in every form", async () => {
+  using dir = tempDir("fs-copyfile-empty-dest", { "src.txt": "x", "srcdir/.keep": "" });
   const script = `
     const fs = require("fs");
-    const N = 64;
+    fs.writeFileSync("big.bin", Buffer.alloc(1 << 20));
     const shape = e => ({ code: e.code, syscall: e.syscall, path: e.path });
     const unique = list => [...new Set(list.map(r => JSON.stringify(r)))].map(s => JSON.parse(s));
-    const promiseForm = Promise.all(
-      Array.from({ length: N }, () => fs.promises.copyFile("src.txt", "").then(() => "resolved", shape)),
-    );
-    const callbackForm = Promise.all(
-      Array.from(
-        { length: N },
-        () => new Promise(resolve => fs.copyFile("src.txt", "", e => resolve(e ? shape(e) : "resolved"))),
-      ),
-    );
-    let sync;
-    try {
-      fs.copyFileSync("src.txt", "");
-      sync = "resolved";
-    } catch (e) {
-      sync = shape(e);
+    const busy = [];
+    function queued(copy) {
+      const result = copy();
+      busy.push(fs.promises.readFile("big.bin"));
+      return result;
     }
-    let cpSync;
-    try {
-      fs.cpSync("src.txt", "");
-      cpSync = "resolved";
-    } catch (e) {
-      cpSync = { code: e.code };
+    async function forms(source, count) {
+      const promises = Promise.all(
+        Array.from({ length: count }, () => queued(() => fs.promises.copyFile(source, "").then(() => "resolved", shape))),
+      );
+      const callback = Promise.all(
+        Array.from({ length: count }, () =>
+          queued(() => new Promise(resolve => fs.copyFile(source, "", e => resolve(e ? shape(e) : "resolved")))),
+        ),
+      );
+      let sync;
+      try {
+        fs.copyFileSync(source, "");
+        sync = "resolved";
+      } catch (e) {
+        sync = shape(e);
+      }
+      return { promises: unique(await promises), callback: unique(await callback), sync };
     }
-    const cp = fs.promises.cp("src.txt", "").then(() => "resolved", e => ({ code: e.code }));
-    Promise.all([promiseForm, callbackForm, cp]).then(([promises, callback, cp]) => {
-      console.log(JSON.stringify({ promises: unique(promises), callback: unique(callback), sync, cpSync, cp }));
-    });
+    (async () => {
+      const file = await forms("src.txt", 32);
+      const directory = await forms("srcdir", 1);
+      let cpSync;
+      try {
+        fs.cpSync("src.txt", "");
+        cpSync = "resolved";
+      } catch (e) {
+        cpSync = { code: e.code };
+      }
+      const cp = await fs.promises.cp("src.txt", "").then(() => "resolved", e => ({ code: e.code }));
+      await Promise.all(busy);
+      console.log(JSON.stringify({ file, directory, cpSync, cp }));
+    })();
   `;
   await using proc = Bun.spawn({
     cmd: [bunExe(), "-e", script],
-    env: bunEnv,
+    env: { ...bunEnv, UV_THREADPOOL_SIZE: "32" },
     cwd: String(dir),
     stdout: "pipe",
     stderr: "pipe",
   });
   const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   const enoent = { code: "ENOENT", syscall: "copyfile", path: "src.txt" };
+  // Windows reports the directory source (ERROR_ACCESS_DENIED, as node does);
+  // POSIX bun rejects a non-regular source before touching the destination.
+  const notAFile = { code: isWindows ? "EPERM" : "ENOTSUP", syscall: "copyfile", path: "srcdir" };
   expect({ stdout, stderr, exitCode }).toEqual({
     stdout:
       JSON.stringify({
-        promises: [enoent],
-        callback: [enoent],
-        sync: enoent,
+        file: { promises: [enoent], callback: [enoent], sync: enoent },
+        directory: { promises: [notAFile], callback: [notAFile], sync: notAFile },
         // A file source makes fs.cp call CopyFileW too on Windows. It reports
         // the parent mkdir on POSIX and copyfile on Windows, so only the code
         // is pinned.

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1007,6 +1007,73 @@ describe("copyFileSync", () => {
   }
 });
 
+// Windows: CopyFileW reads the code unit before an empty destination string. The
+// async forms convert the destination into a work-pool thread's freshly pooled
+// path buffer, which tends to start a mapping, so they crashed the process
+// instead of failing with ENOENT. Runs in a child (it used to segfault) and
+// queues a batch per form so several pool threads each convert into their own
+// fresh buffer.
+it.concurrent("copyFile to an empty destination path fails with ENOENT in every form", async () => {
+  using dir = tempDir("fs-copyfile-empty-dest", { "src.txt": "x" });
+  const script = `
+    const fs = require("fs");
+    const N = 16;
+    const shape = e => ({ code: e.code, syscall: e.syscall, path: e.path });
+    const unique = list => [...new Set(list.map(r => JSON.stringify(r)))].map(s => JSON.parse(s));
+    const promiseForm = Promise.all(
+      Array.from({ length: N }, () => fs.promises.copyFile("src.txt", "").then(() => "resolved", shape)),
+    );
+    const callbackForm = Promise.all(
+      Array.from(
+        { length: N },
+        () => new Promise(resolve => fs.copyFile("src.txt", "", e => resolve(e ? shape(e) : "resolved"))),
+      ),
+    );
+    let sync;
+    try {
+      fs.copyFileSync("src.txt", "");
+      sync = "resolved";
+    } catch (e) {
+      sync = shape(e);
+    }
+    let cpSync;
+    try {
+      fs.cpSync("src.txt", "");
+      cpSync = "resolved";
+    } catch (e) {
+      cpSync = { code: e.code };
+    }
+    const cp = fs.promises.cp("src.txt", "").then(() => "resolved", e => ({ code: e.code }));
+    Promise.all([promiseForm, callbackForm, cp]).then(([promises, callback, cp]) => {
+      console.log(JSON.stringify({ promises: unique(promises), callback: unique(callback), sync, cpSync, cp }));
+    });
+  `;
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "-e", script],
+    env: bunEnv,
+    cwd: String(dir),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const enoent = { code: "ENOENT", syscall: "copyfile", path: "src.txt" };
+  expect({ stdout, stderr, exitCode }).toEqual({
+    stdout:
+      JSON.stringify({
+        promises: [enoent],
+        callback: [enoent],
+        sync: enoent,
+        // fs.cp reaches the same copy routine for a file source, but reports
+        // the parent mkdir on POSIX and copyfile on Windows, so only the code
+        // is pinned.
+        cpSync: { code: "ENOENT" },
+        cp: { code: "ENOENT" },
+      }) + "\n",
+    stderr: "",
+    exitCode: 0,
+  });
+});
+
 describe("mkdirSync", () => {
   it("should create a directory", () => {
     const now = Date.now().toString();

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -1007,16 +1007,13 @@ describe("copyFileSync", () => {
   }
 });
 
-// Windows: CopyFileW reads the code unit before an empty destination string.
-// The async forms convert the destination into a work-pool thread's freshly
-// pooled path buffer, which tends to start a mapping, so they crashed the
-// process instead of failing with ENOENT. Runs in a child (it used to
-// segfault). Each pool thread converts into one buffer of its own, so every
-// thread is one chance to hit the crash: the child raises the pool's thread
-// cap (it defaults to the core count, 4 on the CI shards) and follows each
-// copy with a 1 MiB read so the threads stay busy and the pool keeps spawning
-// while the batch is queued. The directory source checks that the source is
-// still inspected before the destination: its error must come out unchanged.
+// Windows: CopyFileW reads the code unit before an empty destination, and the
+// async forms convert the destination into the work-pool thread's own freshly
+// pooled buffer, which may start a mapping; hence the child process. Each pool
+// thread is one chance to hit that, so the child raises the pool's thread cap
+// (it defaults to the core count) and follows every copy with a 1 MiB read to
+// keep the pool spawning threads while the batch is queued. The directory
+// source checks that source errors still come out ahead of the destination's.
 it.concurrent("copyFile to an empty destination path fails with the copyfile error in every form", async () => {
   using dir = tempDir("fs-copyfile-empty-dest", { "src.txt": "x", "srcdir/.keep": "" });
   const script = `


### PR DESCRIPTION
### Problem

- On Windows, `fs.copyFile(src, "", cb)` and `fs.promises.copyFile(src, "")` frequently take the process down with `panic(thread N): Segmentation fault at address 0x...FFFE` (the address is always two bytes below a mapping boundary). Node rejects with `ENOENT`. `fs.copyFileSync(src, "")` throws `ENOENT`. POSIX is unaffected.
- Cause: kernel32's `CopyFileW` looks at the last unit of the destination name, so for an empty name it reads the one `u16` before the string. Calling it through `bun:ffi` with `L""` as the first unit of a freshly committed page faults at `page - 2` every time; with a single readable unit in front of it (any value) it returns normally. `L""` as the source, or the same placement given to `MoveFileExW`, `CreateHardLinkW`, `GetFileAttributesW`, `DeleteFileW` or `CreateDirectoryW`, returns `ERROR_PATH_NOT_FOUND` (probe output below).
- `NodeFS::copy_file_inner` converts the destination into a buffer from `os_path_buffer_pool::get()` (src/runtime/node/node_fs.rs:5289-5294). The pool is thread-local and heap-allocates a zeroed 64 KB block the first time a thread uses it; on a work-pool thread that block is normally the first object of a fresh mimalloc page with nothing committed below it, so the read faults. On the JS thread the block has committed memory below it, so the read is harmless and `CopyFileW` fails with `ERROR_PATH_NOT_FOUND` (`ENOENT`), which is why only the async forms crash.
- `fs.cp(file, "")` / `fs.cpSync(file, "")` reach `CopyFileW` through `copy_single_file_sync` (node_fs.rs:9030, 9049) with the destination in a stack buffer: the same read, surviving by the same accident.

### Fix

- `bun_sys::windows::CopyFileW` (src/sys/windows/mod.rs) was a re-export of the raw extern. It is now a wrapper with the extern's signature that, when the destination is empty, passes the second unit of a static `[0u16; 2]` instead of the caller's pointer, then makes the call. All ten call sites (node:fs `copyFile` and `cp`, `bun_sys::copy_file`, `bun install`, `bun create`, `bun build --compile`) import the name from this module, so they pick it up unchanged.
- Why this is correct: kernel32 reads exactly one unit before an empty name (measured above), and the substitute has one. Everything else about the call is unchanged, so kernel32's own reporting is preserved: it validates the source first (`copyFile(directory, "")` is `ERROR_ACCESS_DENIED` -> `EPERM`, a file open without sharing is `ERROR_SHARING_VIOLATION` -> `EBUSY`) and reports `ERROR_PATH_NOT_FOUND` -> `ENOENT` for a readable source. That is also exactly what Node reports: libuv widens both paths into one buffer with the source's NUL directly in front of the destination, so Node has always made this call in this layout.
- Why not refuse the call instead: the first version of this PR returned `ERROR_PATH_NOT_FOUND` without calling kernel32. Review pointed out that this reorders the errors, turning `copyFile(directory, "")` from `EPERM` (Node, and bun's own sync form today) into `ENOENT`; the probe confirmed it, so that version was dropped (details below).
- Why only `CopyFileW` and only its destination: the source argument and the other path APIs were probed the same way and handle an empty string correctly.
- Test: test/js/node/fs/fs.test.ts, "copyFile to an empty destination path fails with the copyfile error in every form". A child runs 32 promise-form and 32 callback-form `copyFile(src, "")` calls plus the sync form and checks that every one reports `ENOENT`/`copyfile`/`path: src`; the same three forms with a directory source must report `EPERM` on Windows (`ENOTSUP` on POSIX, bun's existing behaviour there), which is what distinguishes this fix from the refused-call version; `cpSync` and `promises.cp` on a file are pinned to `ENOENT` only, since the reported syscall differs per platform. Results: against the unfixed 1.4.0 canary the test fails 20/20 runs on a 16-core box and 20/20 with the runner pinned to 4 cores; against an unfixed debug build 10/10; with the fix it passes on the Windows debug build (11/11 across the runs made, about 630 ms each) and on the Linux debug build (1.6-2.2 s, child startup under ASAN; the bug never existed on POSIX, so it cannot fail there).
- Why the child is shaped the way it is: each pool thread converts into one buffer of its own, so each thread is one chance to hit the crash, and the pool's thread cap defaults to the core count, 4 on the Windows CI shards (`.buildkite/ci.mjs`). The child is therefore spawned with `UV_THREADPOOL_SIZE=32`, and every copy is followed by a 1 MiB `readFile` so the threads stay busy and the pool keeps spawning while the batch is queued. With a plain batch the unfixed canary crashed in only 13/20 runs at a cap of 4 (20/20 at 32); with the reads it crashed in 40/40 runs in every configuration tried (caps 4 and 32, batches of 16 to 64, with and without the 4-core pin).
- Also run on the fixed Windows debug build: test/js/node/fs/cp.test.ts, cp-symlink-target.test.ts, test/js/bun/shell/commands/cp.test.ts and the `copyFile` tests in fs.test.ts (all pass). `cargo check --target x86_64-pc-windows-msvc` for `bun_sys` and `bun_standalone_graph`.
- Related: #37995 skips its Windows async `copyFile(src, "")` cells because of this crash; they can be unskipped once this lands. #37949 covers `cp(file, "")` the same way this test does.

### Background

- `CopyFileW` is the Win32 whole-file copy. It takes two NUL-terminated UTF-16 paths, returns `FALSE` on failure and leaves the reason in the thread's last-error slot, which bun_sys translates to an errno (`ERROR_PATH_NOT_FOUND` -> `ENOENT`, `ERROR_ACCESS_DENIED` -> `EPERM`). The wrapper changes none of that.
- Wide path buffers are 64 KB each on Windows, so instead of putting them on the stack bun keeps up to four per thread in a thread-local pool (src/paths/path_buffer_pool.rs) and heap-allocates on a miss. A thread's first conversion always lands in a brand-new block; where that block sits relative to committed memory decided whether a given process crashed.
- Async node:fs calls run the same `NodeFS` method as the sync form, but on a work-pool thread (`AsyncFSTask`) with that thread's buffer pool. The pool's thread cap is `bun_core::get_thread_count()` (src/threading/work_pool.rs), which honours `UV_THREADPOOL_SIZE` and otherwise uses the core count; that is the knob the test uses.

<details>
<summary>Probe output (Windows Server 2019, 16 cores, bun 1.4.0 canary)</summary>

Direct calls through `bun:ffi`. "page start" means the string is the first unit of a committed page whose lower neighbour is reserved but not committed.

```
CopyFileW(file, L"" at page start)                     panic: Segmentation fault at address <page - 2>
CopyFileW(file, L"" at page start + 1 unit)            rc=0 lastError=3   for a preceding unit of \0, \ or x
CopyFileW(directory, L"" at page start + 1 unit)       rc=0 lastError=5
CopyFileW(L"" at page start, dest)                     rc=0 lastError=3
MoveFileExW / CreateHardLinkW (either argument),
GetFileAttributesW, DeleteFileW, CreateDirectoryW      fail normally with lastError=3
```

Error precedence with the empty destination in the middle of a buffer (libuv's situation):

```
file -> ""                  lastError=3  (ERROR_PATH_NOT_FOUND)
missing -> ""               lastError=2  (ERROR_FILE_NOT_FOUND)
directory -> ""             lastError=5  (ERROR_ACCESS_DENIED)      Node: EPERM; bun sync form today: EPERM
file opened unshared -> ""  lastError=32 (ERROR_SHARING_VIOLATION)
```

node:fs single calls, six runs each: `fs.promises.copyFile(src, "")` crashed 3/6, `fs.copyFile(src, "", cb)` 1/6, `copyFileSync` 0/6, `copyFile("", dest)` 0/6. Crash addresses seen: `0x25782DFFFFE`, `0x1E702DFFFFE`, `0x2EF82DFFFFE`, `0x29482DFFFFE` (release), `0x25BACB7FFFE` (debug): each is `buffer - 2` for a buffer starting on a 512 KB boundary.

Unfixed canary, crash rate of the test's child by work-pool cap (20 or 40 runs each):

```
plain batch of 64+64 copies:   cap 2: 5/20   cap 4: 13/20   cap 32: 20/20   cap 64: 20/20
same, runner pinned to 4 cores: cap 4: 39/40  cap 32: 37/40
copies each followed by a 1 MiB read, pinned and unpinned, caps 4 and 32, batches 16/32/64: 40/40 in every case
```

Minimal repro:

```js
const fs = require("fs");
fs.writeFileSync("src.txt", "x");
fs.promises.copyFile("src.txt", "").then(
  () => console.log("no error?!"),
  e => console.log("rejected", e.code, e.syscall),
);
```

</details>

<details>
<summary>Superseded first version</summary>

The wrapper initially set `ERROR_PATH_NOT_FOUND` and returned `FALSE` for an empty destination without calling kernel32, and the test queued a plain batch with the default thread cap. Both were replaced after review: the early return changed the error for a directory or busy source (see Fix), and the plain batch gave the unfixed build a real chance of passing on the 4-core CI shards (see the rate table above).

</details>
