### PR TITLE
dev server: rebundle a changed file with the loader it was bundled with

### DIFF
--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2599,10 +2599,15 @@ pub mod bv2_impl {
             }
         }
 
+        /// `loader` is the graph's record of the loader the file was bundled
+        /// with (`None` falls back to the file extension). The caller is the
+        /// graph itself, mid-update, so it passes the record in rather than
+        /// having [`Self::entry_point_loader`] read it back out of the dev server.
         pub fn enqueue_file_from_dev_server_incremental_graph_invalidation(
             &mut self,
             path_slice: &[u8],
             target: options::Target,
+            loader: Option<Loader>,
         ) -> Result<(), Error> {
             // TODO: plugins with non-file namespaces
             // borrowck: get-then-put (instead of a single get-or-put) so the map
@@ -2624,9 +2629,10 @@ pub mod bv2_impl {
             let mut path = result.path_pair.primary;
             self.increment_scan_counter();
             let source_index = Index::source(self.graph.input_files.len() as u32);
-            let loader = path
-                .loader(&self.transpiler.options.loaders)
-                .unwrap_or(Loader::File);
+            let loader = loader.unwrap_or_else(|| {
+                path.loader(&self.transpiler.options.loaders)
+                    .unwrap_or(Loader::File)
+            });
 
             path = self.path_with_pretty_initialized(&path, target)?;
             path.assert_pretty_is_valid();
@@ -2685,6 +2691,28 @@ pub mod bv2_impl {
             Ok(())
         }
 
+        /// Loader for a file bundled from its path alone (an entry point). The
+        /// dev server rebundles a changed file this way even when an importer
+        /// chose its loader (`import x from "./x.html" with { type: "text" }`),
+        /// so a file the dev server has bundled before keeps that loader instead
+        /// of being re-typed by its extension: with the html loader, that
+        /// `.html` file would come back as a route chunk for a file that is not
+        /// a route.
+        pub(crate) fn entry_point_loader(
+            &self,
+            path: &Fs::Path,
+            target: options::Target,
+        ) -> Loader {
+            self.dev_server_handle()
+                .and_then(|dev| {
+                    dev.bundled_loader(path.key_for_incremental_graph(), target.bake_graph())
+                })
+                .unwrap_or_else(|| {
+                    path.loader(&self.transpiler.options.loaders)
+                        .unwrap_or(Loader::File)
+                })
+        }
+
         pub(crate) fn enqueue_entry_item(
             &mut self,
             resolve: &mut _resolver::Result,
@@ -2711,9 +2739,7 @@ pub mod bv2_impl {
             self.increment_scan_counter();
             let source_index = Index::source(self.graph.input_files.len() as u32);
 
-            let loader = path
-                .loader(&self.transpiler.options.loaders)
-                .unwrap_or(Loader::File);
+            let loader = self.entry_point_loader(&path, target);
 
             // SAFETY: `path_with_pretty_initialized` allocates into `self.graph.heap`, which
             // outlives the bundle pass; erase the arena lifetime back to the resolver's
@@ -4782,9 +4808,16 @@ pub mod bv2_impl {
                             unsafe { *value_ptr = source_index.get() };
                             out_source_index = Some(source_index);
                             let _ = this.graph.ast.append(JSAst::empty_in(this.graph.heap)); // OOM/capacity: fire-and-forget
-                            let loader = path
-                                .loader(&this.transpiler.options.loaders)
-                                .unwrap_or(Loader::File);
+                            let loader =
+                                if resolve.import_record.kind == ImportKind::EntryPointBuild {
+                                    this.entry_point_loader(
+                                        &path,
+                                        resolve.import_record.original_target,
+                                    )
+                                } else {
+                                    path.loader(&this.transpiler.options.loaders)
+                                        .unwrap_or(Loader::File)
+                                };
 
                             this.graph
                                 .input_files

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2599,10 +2599,8 @@ pub mod bv2_impl {
             }
         }
 
-        /// `loader` is the graph's record of the loader the file was bundled
-        /// with (`None` falls back to the file extension). The caller is the
-        /// graph itself, mid-update, so it passes the record in rather than
-        /// having [`Self::entry_point_loader`] read it back out of the dev server.
+        /// `loader` is the graph's `File::rebundle_loader()` for the file, passed in
+        /// because the caller is inside the graph (see [`Self::entry_point_loader`]).
         pub fn enqueue_file_from_dev_server_incremental_graph_invalidation(
             &mut self,
             path_slice: &[u8],
@@ -2691,13 +2689,9 @@ pub mod bv2_impl {
             Ok(())
         }
 
-        /// Loader for a file bundled from its path alone (an entry point). The
-        /// dev server rebundles a changed file this way even when an importer
-        /// chose its loader (`import x from "./x.html" with { type: "text" }`),
-        /// so a file the dev server has bundled before keeps that loader instead
-        /// of being re-typed by its extension: with the html loader, that
-        /// `.html` file would come back as a route chunk for a file that is not
-        /// a route.
+        /// Loader for a file bundled from its path alone. The dev server rebundles
+        /// changed files this way, and their loader may have come from an importer's
+        /// `with { type }` rather than the extension, so its record wins when it has one.
         pub(crate) fn entry_point_loader(
             &self,
             path: &Fs::Path,
@@ -6485,8 +6479,7 @@ pub mod bv2_impl {
 
                 if let Some(dev_server) = self.dev_server_handle() {
                     'brk: {
-                        // The loader the import will use: `with { type: "html" }` makes
-                        // it html whatever the extension is.
+                        // `with { type: "html" }` makes the import html regardless of the extension.
                         let imported_as_html = match import_record.loader {
                             Some(loader) => loader == Loader::Html,
                             None => {
@@ -7368,8 +7361,8 @@ pub mod bv2_impl {
                 parse_task::ResultValue::Err(err) => {
                     if process_log {
                         if let Some(dev_server) = this.dev_server {
-                            // Copy out the `'static` path slice and the loader so the
-                            // `input_files` borrow ends before we coerce `this` to `*mut _`.
+                            // Copy out the `'static` path slice so the `input_files`
+                            // borrow ends before we coerce `this` to `*mut _`.
                             let abs_path: &'static [u8] = this.graph.input_files.items_source()
                                 [err.source_index.get() as usize]
                                 .path

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -3203,6 +3203,7 @@ pub mod bv2_impl {
                                 bake::Graph::Server
                             },
                             abs_path,
+                            None,
                             // SAFETY: `transpiler` points at one of self's transpilers, live for `'a`.
                             unsafe { (*transpiler).log }.cast_const(),
                             std::ptr::from_mut(self),
@@ -4592,6 +4593,8 @@ pub mod bv2_impl {
                     if let Some(dev) = this.dev_server {
                         let source = &this.graph.input_files.items_source()
                             [load.source_index.get() as usize];
+                        let loader =
+                            this.graph.input_files.items_loader()[load.source_index.get() as usize];
                         // A stack-allocated Log object containing the singular message
                         let kind = msg.kind;
                         let temp_log = bun_ast::Log {
@@ -4605,6 +4608,7 @@ pub mod bv2_impl {
                             crate::Error::Plugin,
                             load.bake_graph(),
                             source.path.key_for_incremental_graph(),
+                            Some(loader),
                             &raw const temp_log,
                             this,
                         )
@@ -5378,6 +5382,7 @@ pub mod bv2_impl {
                                         crate::Error::InvalidCssImport,
                                         bake::Graph::Client,
                                         sources[index].path.text,
+                                        Some(loaders[index]),
                                         &raw const log,
                                         self,
                                     )
@@ -6480,10 +6485,15 @@ pub mod bv2_impl {
 
                 if let Some(dev_server) = self.dev_server_handle() {
                     'brk: {
-                        if path.loader(&self.transpiler.options.loaders) == Some(Loader::Html)
-                            && (import_record.loader.is_none()
-                                || import_record.loader.unwrap() == Loader::Html)
-                        {
+                        // The loader the import will use: `with { type: "html" }` makes
+                        // it html whatever the extension is.
+                        let imported_as_html = match import_record.loader {
+                            Some(loader) => loader == Loader::Html,
+                            None => {
+                                path.loader(&self.transpiler.options.loaders) == Some(Loader::Html)
+                            }
+                        };
+                        if imported_as_html {
                             // This use case is currently not supported. This error
                             // blocks an assertion failure because the DevServer
                             // reserves the HTML file's spot in IncrementalGraph for the
@@ -7358,17 +7368,20 @@ pub mod bv2_impl {
                 parse_task::ResultValue::Err(err) => {
                     if process_log {
                         if let Some(dev_server) = this.dev_server {
-                            // Copy out the `'static` path slice so the `input_files`
-                            // borrow ends before we coerce `this` to `*mut _`.
+                            // Copy out the `'static` path slice and the loader so the
+                            // `input_files` borrow ends before we coerce `this` to `*mut _`.
                             let abs_path: &'static [u8] = this.graph.input_files.items_source()
                                 [err.source_index.get() as usize]
                                 .path
                                 .text;
+                            let loader = this.graph.input_files.items_loader()
+                                [err.source_index.get() as usize];
                             dev_server
                                 .handle_parse_task_failure(
                                     err.err,
                                     err.target.bake_graph(),
                                     abs_path,
+                                    Some(loader),
                                     &raw const err.log,
                                     std::ptr::from_mut(this),
                                 )

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -2599,8 +2599,7 @@ pub mod bv2_impl {
             }
         }
 
-        /// `loader` is the graph's `File::rebundle_loader()` for the file, passed in
-        /// because the caller is inside the graph (see [`Self::entry_point_loader`]).
+        /// `loader`: the file's `File::rebundle_loader()`, passed in since the caller is inside the graph.
         pub fn enqueue_file_from_dev_server_incremental_graph_invalidation(
             &mut self,
             path_slice: &[u8],
@@ -2689,9 +2688,7 @@ pub mod bv2_impl {
             Ok(())
         }
 
-        /// Loader for a file bundled from its path alone. The dev server rebundles
-        /// changed files this way, and their loader may have come from an importer's
-        /// `with { type }` rather than the extension, so its record wins when it has one.
+        /// Dev server rebundles reuse the file's recorded loader: an importer's `with { type }` may have chosen it.
         pub(crate) fn entry_point_loader(
             &self,
             path: &Fs::Path,

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -328,6 +328,8 @@ bun_dispatch::link_interface! {
         fn put_or_overwrite_asset(path: *const (), contents: &[u8], content_hash: u64) -> Result<(), crate::Error>;
         fn track_resolution_failure(import_source: &[u8], specifier: &[u8], renderer: bake_types::Graph, loader: bun_ast::Loader) -> Result<(), crate::Error>;
         fn is_file_cached(abs_path: &[u8], side: bake_types::Graph) -> Option<bake_types::CacheEntry>;
+        // The loader `side`'s graph last bundled `abs_path` with; `None` if it never has.
+        fn bundled_loader(abs_path: &[u8], side: bake_types::Graph) -> Option<bun_ast::Loader>;
         fn asset_hash(abs_path: &[u8]) -> Option<u64>;
         fn current_bundle_start_data() -> *mut ();
         fn register_barrel_with_deferrals(path: &[u8]) -> Result<(), crate::Error>;

--- a/src/bundler/lib.rs
+++ b/src/bundler/lib.rs
@@ -324,11 +324,12 @@ bun_dispatch::link_interface! {
         fn barrel_needed_exports() -> *mut bun_collections::StringArrayHashMap<bun_collections::StringHashMap<()>>;
         fn log_for_resolution_failures(abs_path: &[u8], graph: bake_types::Graph) -> *mut bun_ast::Log;
         fn finalize_bundle(bv2: *mut bundle_v2::BundleV2<'_>, result: *mut bundle_v2::DevServerOutput<'_>) -> Result<(), crate::Error>;
-        fn handle_parse_task_failure(err: crate::Error, graph: bake_types::Graph, abs_path: &[u8], log: *const bun_ast::Log, bv2: *mut bundle_v2::BundleV2<'_>) -> Result<(), crate::Error>;
+        // `loader` is the loader of the failed attempt, `None` when the file never got one (it did not resolve).
+        fn handle_parse_task_failure(err: crate::Error, graph: bake_types::Graph, abs_path: &[u8], loader: Option<bun_ast::Loader>, log: *const bun_ast::Log, bv2: *mut bundle_v2::BundleV2<'_>) -> Result<(), crate::Error>;
         fn put_or_overwrite_asset(path: *const (), contents: &[u8], content_hash: u64) -> Result<(), crate::Error>;
         fn track_resolution_failure(import_source: &[u8], specifier: &[u8], renderer: bake_types::Graph, loader: bun_ast::Loader) -> Result<(), crate::Error>;
         fn is_file_cached(abs_path: &[u8], side: bake_types::Graph) -> Option<bake_types::CacheEntry>;
-        // The loader `side`'s graph last bundled `abs_path` with; `None` if it never has.
+        // The loader `side`'s graph wants `abs_path` rebundled with; `None` if it has no record of the file.
         fn bundled_loader(abs_path: &[u8], side: bake_types::Graph) -> Option<bun_ast::Loader>;
         fn asset_hash(abs_path: &[u8]) -> Option<u64>;
         fn current_bundle_start_data() -> *mut ();

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -3301,11 +3301,13 @@ impl DevServer {
                     match owner.side() {
                         bake::Side::Client => self.client_graph.insert_failure(
                             incremental_graph::InsertFailureKey::Index(index),
+                            None,
                             log,
                             false,
                         )?,
                         bake::Side::Server => self.server_graph.insert_failure(
                             incremental_graph::InsertFailureKey::Index(index),
+                            None,
                             log,
                             true,
                         )?,
@@ -4083,6 +4085,33 @@ pub(super) fn finalize_bundle(
             unreachable!()
         };
         let compile_result_offset = *compile_result_offset;
+        let source = &input_file_sources[index.get() as usize];
+        let key = source.path.key_for_incremental_graph();
+        let Some(route_bundle_index) = dev
+            .client_graph
+            .bundled_files
+            .get(key)
+            .and_then(|file| file.html_route_bundle_index)
+        else {
+            // The graph entry of a file bundled with the html loader is the
+            // route it belongs to, so a file that is not a route cannot be
+            // bundled that way. Imports asking for the html loader are
+            // rejected during resolution; a plugin answering `onLoad` with
+            // `loader: "html"` gets here and is reported the same way.
+            let mut log = Log::init();
+            log.add_error(
+                Some(source),
+                bun_ast::Loc::EMPTY,
+                "Only the HTML files served as routes can be bundled with the html loader in development.",
+            );
+            dev.client_graph.insert_failure(
+                incremental_graph::InsertFailureKey::AbsPath(key),
+                Some(Loader::Html),
+                &log,
+                false,
+            )?;
+            continue;
+        };
         let generated_js = dev.generate_javascript_code_for_html_file(
             index,
             import_records,
@@ -4102,7 +4131,6 @@ pub(super) fn finalize_bundle(
             .get_cached_index(bake::Side::Client, index)
             .unwrap::<{ bake::Side::Client }>()
             .expect("unresolved index");
-        let route_bundle_index = dev.client_graph.html_route_bundle_index(client_index);
         let route_bundle = dev.route_bundle_ptr(route_bundle_index);
         debug_assert!(route_bundle.data.html().bundled_file == client_index);
         // Note: split borrow — `invalidate_client_bundle` needs `&mut RouteBundle`
@@ -4165,6 +4193,14 @@ pub(super) fn finalize_bundle(
     }
     for chunk in html_chunks_mut.iter() {
         let index = bun_ast::Index::init(chunk.entry_point.source_index());
+        // Not a route; reported as a failure in Pass 1 instead of received.
+        if ctx
+            .get_cached_index(bake::Side::Client, index)
+            .unwrap::<{ bake::Side::Client }>()
+            .is_none()
+        {
+            continue;
+        }
         dev.client_graph.process_chunk_dependencies(
             &mut ctx,
             incremental_graph::ProcessMode::Normal,
@@ -4935,12 +4971,14 @@ impl DevServer {
         }
     }
 
-    /// Note: The log is not consumed here
+    /// Note: The log is not consumed here. `loader` is the loader the failed
+    /// attempt used, if the file got far enough to have one.
     pub(crate) fn handle_parse_task_failure(
         &mut self,
         err: &crate::Error,
         graph: bake::Graph,
         abs_path: &[u8],
+        loader: Option<Loader>,
         log: &Log,
         bv2: &mut BundleV2,
     ) -> Result<(), AllocError> {
@@ -4966,16 +5004,19 @@ impl DevServer {
             match graph {
                 bake::Graph::Server => self.server_graph.insert_failure(
                     incremental_graph::InsertFailureKey::AbsPath(abs_path),
+                    loader,
                     log,
                     false,
                 )?,
                 bake::Graph::Ssr => self.server_graph.insert_failure(
                     incremental_graph::InsertFailureKey::AbsPath(abs_path),
+                    loader,
                     log,
                     true,
                 )?,
                 bake::Graph::Client => self.client_graph.insert_failure(
                     incremental_graph::InsertFailureKey::AbsPath(abs_path),
+                    loader,
                     log,
                     false,
                 )?,
@@ -5053,15 +5094,14 @@ impl DevServer {
         }
     }
 
-    /// The loader `path` was last bundled with in `side`'s graph (see
-    /// `incremental_graph::File::loader`), so that the bundler rebundles it
-    /// the same way when the dev server queues it as an entry point.
+    /// The loader `side`'s graph wants `path` bundled with when the dev server
+    /// queues it as an entry point (see `incremental_graph::File::rebundle_loader`).
     pub(crate) fn bundled_loader(&self, path: &[u8], side: bake::Graph) -> Option<Loader> {
         let _g = self.graph_safety_lock.guard();
         match side {
-            bake::Graph::Client => self.client_graph.bundled_files.get(path)?.loader,
+            bake::Graph::Client => self.client_graph.bundled_files.get(path)?.rebundle_loader(),
             bake::Graph::Server | bake::Graph::Ssr => {
-                self.server_graph.bundled_files.get(path)?.loader
+                self.server_graph.bundled_files.get(path)?.rebundle_loader()
             }
         }
     }

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4093,8 +4093,7 @@ pub(super) fn finalize_bundle(
             .get(key)
             .and_then(|file| file.html_route_bundle_index)
         else {
-            // Not a route (an `onLoad` plugin returned `loader: "html"` for an import;
-            // imports that ask for html themselves are rejected while resolving).
+            // Not a route: an `onLoad` plugin returned `loader: "html"` for an import.
             let mut log = Log::init();
             log.add_error(
                 Some(source),

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -5053,6 +5053,19 @@ impl DevServer {
         }
     }
 
+    /// The loader `path` was last bundled with in `side`'s graph (see
+    /// `incremental_graph::File::loader`), so that the bundler rebundles it
+    /// the same way when the dev server queues it as an entry point.
+    pub(crate) fn bundled_loader(&self, path: &[u8], side: bake::Graph) -> Option<Loader> {
+        let _g = self.graph_safety_lock.guard();
+        match side {
+            bake::Graph::Client => self.client_graph.bundled_files.get(path)?.loader,
+            bake::Graph::Server | bake::Graph::Ssr => {
+                self.server_graph.bundled_files.get(path)?.loader
+            }
+        }
+    }
+
     fn append_opaque_entry_point<const SIDE: bake::Side>(
         &self,
         file_names: &[Box<[u8]>],

--- a/src/runtime/bake/DevServer.rs
+++ b/src/runtime/bake/DevServer.rs
@@ -4093,11 +4093,8 @@ pub(super) fn finalize_bundle(
             .get(key)
             .and_then(|file| file.html_route_bundle_index)
         else {
-            // The graph entry of a file bundled with the html loader is the
-            // route it belongs to, so a file that is not a route cannot be
-            // bundled that way. Imports asking for the html loader are
-            // rejected during resolution; a plugin answering `onLoad` with
-            // `loader: "html"` gets here and is reported the same way.
+            // Not a route (an `onLoad` plugin returned `loader: "html"` for an import;
+            // imports that ask for html themselves are rejected while resolving).
             let mut log = Log::init();
             log.add_error(
                 Some(source),
@@ -4971,8 +4968,7 @@ impl DevServer {
         }
     }
 
-    /// Note: The log is not consumed here. `loader` is the loader the failed
-    /// attempt used, if the file got far enough to have one.
+    /// Note: The log is not consumed here
     pub(crate) fn handle_parse_task_failure(
         &mut self,
         err: &crate::Error,
@@ -5094,8 +5090,7 @@ impl DevServer {
         }
     }
 
-    /// The loader `side`'s graph wants `path` bundled with when the dev server
-    /// queues it as an entry point (see `incremental_graph::File::rebundle_loader`).
+    /// `File::rebundle_loader` of `path` in `side`'s graph, for the bundler's `entry_point_loader`.
     pub(crate) fn bundled_loader(&self, path: &[u8], side: bake::Graph) -> Option<Loader> {
         let _g = self.graph_safety_lock.guard();
         match side {

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -109,8 +109,7 @@ pub struct File {
     pub(crate) kind: FileKind,
     /// If the file has an error, the failure can be looked up in `dev.bundling_failures`.
     pub(crate) failed: bool,
-    /// Loader of the last bundle attempt (`None` before the first). It may come from an
-    /// importer's `with { type }` rather than the extension, so rebundles read it back.
+    /// Loader of the last bundle attempt; rebundles reuse it since an importer's `with { type }` may have chosen it.
     pub(crate) loader: Option<Loader>,
     // ── server-side ────────────────────────────────────────────────────
     pub(crate) is_rsc: bool,
@@ -131,8 +130,7 @@ impl File {
         self.kind
     }
 
-    /// Loader to rebundle this file with. The graph has one entry per path, so a text
-    /// import of a route's HTML file may have recorded its loader first; the route wins.
+    /// A route's HTML file is always rebundled as the route, even if a text import of it recorded `loader` first.
     #[inline]
     pub(crate) fn rebundle_loader(&self) -> Option<Loader> {
         if self.html_route_bundle_index.is_some() {
@@ -1426,8 +1424,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         Ok(())
     }
 
-    /// `IncrementalGraph(side).insertFailure` (spec :1419). `loader` is the failed
-    /// attempt's loader when known; `None` keeps the file's existing record.
+    /// `IncrementalGraph(side).insertFailure` (spec :1419). `loader: None` keeps the file's existing record.
     pub(crate) fn insert_failure(
         &mut self,
         key: InsertFailureKey<'_>,

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -11,6 +11,7 @@
 use core::mem::offset_of;
 use std::io::Write as _;
 
+use bun_ast::Loader;
 use bun_collections::{ArrayHashMap, StringArrayHashMap, bit_set::DynamicBitSetUnmanaged};
 use bun_core::strings;
 
@@ -108,6 +109,11 @@ pub struct File {
     pub(crate) kind: FileKind,
     /// If the file has an error, the failure can be looked up in `dev.bundling_failures`.
     pub(crate) failed: bool,
+    /// The loader this file was last bundled with, `None` until it has been
+    /// bundled once. The loader can come from the importer's `with { type }`
+    /// attribute rather than the file extension, and a rebundle of the file
+    /// (which receives it as a bare path entry point) must use the same one.
+    pub(crate) loader: Option<Loader>,
     // ── server-side ────────────────────────────────────────────────────
     pub(crate) is_rsc: bool,
     pub(crate) is_ssr: bool,
@@ -144,6 +150,7 @@ impl Default for File {
         Self {
             kind: FileKind::Unknown,
             failed: false,
+            loader: None,
             is_rsc: false,
             is_ssr: false,
             is_client_component_boundary: false,
@@ -547,6 +554,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
 
         let path = &ctx.sources[index.get() as usize].path;
         let key = path.key_for_incremental_graph();
+        let loader = ctx.loaders[index.get() as usize];
 
         if cfg!(debug_assertions) {
             if let ReceiveChunkContent::Js { code, .. } = &content {
@@ -622,7 +630,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                     }
                     ReceiveChunkContent::Js { code, source_map } => {
                         let len = code.len();
-                        let kind = if ctx.loaders[index.get() as usize].is_javascript_like() {
+                        let kind = if loader.is_javascript_like() {
                             Content::Js(code)
                         } else {
                             Content::Asset(code)
@@ -656,6 +664,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                 self.bundled_files.values_mut()[file_index.get() as usize] = File {
                     kind: new_content.kind(),
                     failed: false,
+                    loader: Some(loader),
                     is_rsc: false,
                     is_ssr: false,
                     is_client_component_boundary: false,
@@ -682,6 +691,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                     self.bundled_files.values_mut()[file_index.get() as usize] = File {
                         kind: new_kind,
                         failed: false,
+                        loader: Some(loader),
                         is_rsc: !is_ssr_graph,
                         is_ssr: is_ssr_graph,
                         is_client_component_boundary: scb,
@@ -698,6 +708,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                     {
                         let f = &mut self.bundled_files.values_mut()[file_index.get() as usize];
                         f.kind = new_kind;
+                        f.loader = Some(loader);
                         if is_ssr_graph {
                             f.is_ssr = true;
                         } else {
@@ -1549,9 +1560,13 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             let dep = self.edges[edge_index.get() as usize];
             it = dep.next_dependency;
             debug_assert_eq!(dep.imported.get(), index.get());
-            let key = &self.bundled_files.keys()[dep.dependency.get() as usize];
+            let dependency = dep.dependency.get() as usize;
+            let key = &self.bundled_files.keys()[dependency];
+            let loader = self.bundled_files.values()[dependency].loader;
             bun_core::handle_oom(
-                bv2.enqueue_file_from_dev_server_incremental_graph_invalidation(key, target),
+                bv2.enqueue_file_from_dev_server_incremental_graph_invalidation(
+                    key, target, loader,
+                ),
             );
         }
 

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -109,11 +109,8 @@ pub struct File {
     pub(crate) kind: FileKind,
     /// If the file has an error, the failure can be looked up in `dev.bundling_failures`.
     pub(crate) failed: bool,
-    /// The loader of this file's last bundle attempt, `None` until there has
-    /// been one. The loader can come from the importer's `with { type }`
-    /// attribute rather than the file extension, and a rebundle of the file
-    /// (which receives it as a bare path entry point) must use the same one;
-    /// read it through [`File::rebundle_loader`].
+    /// Loader of the last bundle attempt (`None` before the first). It may come from an
+    /// importer's `with { type }` rather than the extension, so rebundles read it back.
     pub(crate) loader: Option<Loader>,
     // ── server-side ────────────────────────────────────────────────────
     pub(crate) is_rsc: bool,
@@ -134,10 +131,8 @@ impl File {
         self.kind
     }
 
-    /// The loader to bundle this file with when it is queued by path alone.
-    /// A route's HTML file is bundled as the route even if client code also
-    /// imported it with another loader (the graph has one entry per path, so
-    /// such an import may have recorded its own loader here first).
+    /// Loader to rebundle this file with. The graph has one entry per path, so a text
+    /// import of a route's HTML file may have recorded its loader first; the route wins.
     #[inline]
     pub(crate) fn rebundle_loader(&self) -> Option<Loader> {
         if self.html_route_bundle_index.is_some() {
@@ -1431,12 +1426,8 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         Ok(())
     }
 
-    /// `IncrementalGraph(side).insertFailure` (spec :1419).
-    ///
-    /// `loader` is the loader of the attempt that failed, when the caller
-    /// knows it (`None` keeps whatever the file has recorded), so that a file
-    /// whose very first bundle fails is still rebundled with the loader its
-    /// importer chose once it is fixed.
+    /// `IncrementalGraph(side).insertFailure` (spec :1419). `loader` is the failed
+    /// attempt's loader when known; `None` keeps the file's existing record.
     pub(crate) fn insert_failure(
         &mut self,
         key: InsertFailureKey<'_>,

--- a/src/runtime/bake/dev_server/incremental_graph.rs
+++ b/src/runtime/bake/dev_server/incremental_graph.rs
@@ -109,10 +109,11 @@ pub struct File {
     pub(crate) kind: FileKind,
     /// If the file has an error, the failure can be looked up in `dev.bundling_failures`.
     pub(crate) failed: bool,
-    /// The loader this file was last bundled with, `None` until it has been
-    /// bundled once. The loader can come from the importer's `with { type }`
+    /// The loader of this file's last bundle attempt, `None` until there has
+    /// been one. The loader can come from the importer's `with { type }`
     /// attribute rather than the file extension, and a rebundle of the file
-    /// (which receives it as a bare path entry point) must use the same one.
+    /// (which receives it as a bare path entry point) must use the same one;
+    /// read it through [`File::rebundle_loader`].
     pub(crate) loader: Option<Loader>,
     // ── server-side ────────────────────────────────────────────────────
     pub(crate) is_rsc: bool,
@@ -131,6 +132,19 @@ impl File {
     #[inline]
     pub(crate) fn file_kind(&self) -> FileKind {
         self.kind
+    }
+
+    /// The loader to bundle this file with when it is queued by path alone.
+    /// A route's HTML file is bundled as the route even if client code also
+    /// imported it with another loader (the graph has one entry per path, so
+    /// such an import may have recorded its own loader here first).
+    #[inline]
+    pub(crate) fn rebundle_loader(&self) -> Option<Loader> {
+        if self.html_route_bundle_index.is_some() {
+            Some(Loader::Html)
+        } else {
+            self.loader
+        }
     }
 
     /// `ServerFile.stopsDependencyTrace` / `ClientFile.stopsDependencyTrace`.
@@ -355,13 +369,6 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
         self.bundled_files
             .get_index(abs_path)
             .map(|i| FileIndex::init(i as u32))
-    }
-
-    /// `IncrementalGraph(.client).htmlRouteBundleIndex`.
-    pub(crate) fn html_route_bundle_index(&self, index: FileIndex<SIDE>) -> route_bundle::Index {
-        self.bundled_files.values()[index.get() as usize]
-            .html_route_bundle_index
-            .expect("html_route_bundle_index on non-HTML file")
     }
 
     // ── per-bundle scratch accessors (kept for existing call sites) ────────
@@ -1425,9 +1432,15 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
     }
 
     /// `IncrementalGraph(side).insertFailure` (spec :1419).
+    ///
+    /// `loader` is the loader of the attempt that failed, when the caller
+    /// knows it (`None` keeps whatever the file has recorded), so that a file
+    /// whose very first bundle fails is still rebundled with the loader its
+    /// importer chose once it is fixed.
     pub(crate) fn insert_failure(
         &mut self,
         key: InsertFailureKey<'_>,
+        loader: Option<Loader>,
         log: &bun_ast::Log,
         is_ssr_graph: bool,
     ) -> Result<(), bun_alloc::AllocError> {
@@ -1483,6 +1496,9 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
                     f.failed = true;
                 }
             }
+        }
+        if loader.is_some() {
+            self.bundled_files.values_mut()[idx].loader = loader;
         }
 
         // SAFETY: see `owner()`.
@@ -1562,7 +1578,7 @@ impl<const SIDE: bake::Side> IncrementalGraph<SIDE> {
             debug_assert_eq!(dep.imported.get(), index.get());
             let dependency = dep.dependency.get() as usize;
             let key = &self.bundled_files.keys()[dependency];
-            let loader = self.bundled_files.values()[dependency].loader;
+            let loader = self.bundled_files.values()[dependency].rebundle_loader();
             bun_core::handle_oom(
                 bv2.enqueue_file_from_dev_server_incremental_graph_invalidation(
                     key, target, loader,

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1198,6 +1198,7 @@ bun_bundler::link_impl_DevServerHandle! {
                 }
             })
         },
+        bundled_loader(abs_path, side) => (*this).bundled_loader(abs_path, side),
         asset_hash(abs_path) => (*this).assets.get_hash(abs_path),
         current_bundle_start_data() => {
             (*this)

--- a/src/runtime/bake/dev_server/mod.rs
+++ b/src/runtime/bake/dev_server/mod.rs
@@ -1166,9 +1166,9 @@ bun_bundler::link_impl_DevServerHandle! {
             super::dev_server_body::finalize_bundle(&mut *this, &mut *bv2.cast(), &mut *result)
                 .map_err(|e| bun_bundler::Error::from(crate::Error::from(e)))
         },
-        handle_parse_task_failure(err, graph, abs_path, log, bv2) => {
+        handle_parse_task_failure(err, graph, abs_path, loader, log, bv2) => {
             (*this)
-                .handle_parse_task_failure(&err.into(), graph, abs_path, &*log, &mut *bv2)
+                .handle_parse_task_failure(&err.into(), graph, abs_path, loader, &*log, &mut *bv2)
                 .map_err(Into::into)
         },
         put_or_overwrite_asset(path, contents, content_hash) => {

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -694,8 +694,7 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
       DEBUG.ASSERT(current);
       DEBUG.ASSERT(current.selfAccept === null);
       if (current.importers.size === 0) {
-        // A root .html module is the route's own file; the caller should have already
-        // reloaded for it. (An .html file imported as text has importers.)
+        // Only a route's own .html file is a root module, and the caller already reloads for those.
         DEBUG.ASSERT(!boundary.endsWith(".html"));
         message += `Module "${boundary}" is a root module that does not self-accept.\n`;
         continue;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -694,10 +694,8 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
       DEBUG.ASSERT(current);
       DEBUG.ASSERT(current.selfAccept === null);
       if (current.importers.size === 0) {
-        // The only root `.html` module is the route's own HTML file, and an
-        // update to it is sent as a route reload, so the caller should have
-        // already reloaded. An `.html` file imported with another loader
-        // (`with { type: "text" }`) has importers and is an ordinary module.
+        // A root .html module is the route's own file; the caller should have already
+        // reloaded for it. (An .html file imported as text has importers.)
         DEBUG.ASSERT(!boundary.endsWith(".html"));
         message += `Module "${boundary}" is a root module that does not self-accept.\n`;
         continue;

--- a/src/runtime/bake/hmr-module.ts
+++ b/src/runtime/bake/hmr-module.ts
@@ -691,10 +691,14 @@ export async function replaceModules(modules: Record<Id, UnloadedModule>, source
     for (const boundary of failures) {
       const path: Id[] = [];
       let current = registry.get(boundary)!;
-      DEBUG.ASSERT(!boundary.endsWith(".html")); // caller should have already reloaded
       DEBUG.ASSERT(current);
       DEBUG.ASSERT(current.selfAccept === null);
       if (current.importers.size === 0) {
+        // The only root `.html` module is the route's own HTML file, and an
+        // update to it is sent as a route reload, so the caller should have
+        // already reloaded. An `.html` file imported with another loader
+        // (`with { type: "text" }`) has importers and is an ordinary module.
+        DEBUG.ASSERT(!boundary.endsWith(".html"));
         message += `Module "${boundary}" is a root module that does not self-accept.\n`;
         continue;
       }

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -504,28 +504,36 @@ devTest("editing a text-imported html file that an onResolve plugin claims (#225
     await c.expectMessage("<div>second</div>");
   },
 });
-devTest("editing a file imported with a loader other than its extension's keeps that loader", {
+devTest("editing files imported with a loader other than their extension's keeps that loader (#24893)", {
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
       scripts: ["index.ts"],
     }),
     "index.ts": `
+      import template from "./template.mustache" with { type: "text" };
       import data from "./data.json" with { type: "text" };
+      console.log(template);
       console.log(typeof data + ":" + data);
     `,
+    "template.mustache": "{{first}}",
     "data.json": `{"version":1}`,
   },
   async test(dev) {
     await using c = await dev.client("/");
-    await c.expectMessage('string:{"version":1}');
+    await c.expectMessage("{{first}}", 'string:{"version":1}');
 
-    // Before the fix, the rebundle parsed data.json with the json loader, so
-    // the module's value silently changed from a string into an object.
+    // Before the fix, the rebundle used the loader of the file extension:
+    // template.mustache came back as an asset URL and data.json as an object.
+    await c.expectReload(async () => {
+      await dev.write("template.mustache", "{{second}}");
+    });
+    await c.expectMessage("{{second}}", 'string:{"version":1}');
+
     await c.expectReload(async () => {
       await dev.write("data.json", `{"version":2}`);
     });
-    await c.expectMessage('string:{"version":2}');
+    await c.expectMessage("{{second}}", 'string:{"version":2}');
   },
 });
 devTest("deleting a file imported by a module loaded through an import attribute", {

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -433,6 +433,179 @@ devTest("importing html file with text loader (#18154)", {
     await c.expectMessage("<div>hello world</div>");
   },
 });
+devTest("editing an html file imported with the text loader (#22533, #24893)", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+      body: "<p>root document</p>",
+    }),
+    "index.ts": `
+      import html from "./app.html" with { type: "text" };
+      console.log(html);
+    `,
+    "app.html": "<div>first</div>",
+  },
+  htmlFiles: ["index.html"],
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("<div>first</div>");
+
+    // Rebundling app.html used to pick the loader from its extension instead
+    // of the import attribute, so the dev server treated it as an HTML route
+    // and crashed (#22533), or served it as the root document (#24893).
+    await c.expectReload(async () => {
+      await dev.write("app.html", "<div>second</div>");
+    });
+    await c.expectMessage("<div>second</div>");
+    await dev.fetch("/").expect.toInclude("<p>root document</p>");
+
+    await c.expectReload(async () => {
+      await dev.write("app.html", "<div>third</div>");
+    });
+    await c.expectMessage("<div>third</div>");
+    await dev.fetch("/").expect.toInclude("<p>root document</p>");
+  },
+});
+devTest("editing a text-imported html file that an onResolve plugin claims (#22533)", {
+  files: {
+    "bunfig.toml": `
+      [serve.static]
+      plugins = ["./plugin.ts"]
+    `,
+    // Entry points are resolved by the plugin, so the rebundle of app.html
+    // takes the plugin resolution path instead of the plain entry point path.
+    "plugin.ts": `
+      export default {
+        name: "resolve-html-entry-points",
+        setup(build) {
+          build.onResolve({ filter: /\\.html$/ }, args => (args.importer ? undefined : { path: args.path }));
+        },
+      };
+    `,
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import html from "./app.html" with { type: "text" };
+      console.log(html);
+    `,
+    "app.html": "<div>first</div>",
+  },
+  htmlFiles: ["index.html"],
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage("<div>first</div>");
+
+    await c.expectReload(async () => {
+      await dev.write("app.html", "<div>second</div>");
+    });
+    await c.expectMessage("<div>second</div>");
+  },
+});
+devTest("editing a file imported with a loader other than its extension's keeps that loader", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import data from "./data.json" with { type: "text" };
+      console.log(typeof data + ":" + data);
+    `,
+    "data.json": `{"version":1}`,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage('string:{"version":1}');
+
+    // Before the fix, the rebundle parsed data.json with the json loader, so
+    // the module's value silently changed from a string into an object.
+    await c.expectReload(async () => {
+      await dev.write("data.json", `{"version":2}`);
+    });
+    await c.expectMessage('string:{"version":2}');
+  },
+});
+devTest("deleting a file imported by a module loaded through an import attribute", {
+  skip: [
+    "win32", // unlinkSync is having weird behavior
+  ],
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import "./app.txt" with { type: "js" };
+    `,
+    "app.txt": `
+      import { value } from "./other";
+      console.log(value);
+    `,
+    "other.ts": `
+      export const value = 123;
+    `,
+  },
+  async test(dev) {
+    await using c = await dev.client("/");
+    await c.expectMessage(123);
+
+    // Deleting other.ts rebundles its importer. app.txt has to stay a js
+    // module for the unresolved import to be reported; rebundling it with the
+    // text loader would silently turn it into a string.
+    await dev.delete("other.ts", {
+      errors: ['app.txt:1:23: error: Could not resolve: "./other"'],
+    });
+  },
+});
+devTest("editing an html file imported with the text loader on the server (#22533)", {
+  framework: minimalFramework,
+  // Keep template.html from being registered as an HTML route.
+  htmlFiles: [],
+  files: {
+    "template.html": "<p>template</p>",
+    "routes/index.ts": `
+      import template from '../template.html' with { type: 'text' };
+      export default function (req, meta) {
+        return new Response(template);
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("<p>template</p>");
+
+    // The rebundle used to crash the dev server the same way it did on the
+    // client; `dev.write` rejects when that happens. The updated text is not
+    // asserted here: propagating a hot update of a text module to its
+    // importers is a separate HMR runtime bug.
+    await dev.write("template.html", "<p>template 2</p>");
+    await dev.write("template.html", "<p>template 3</p>");
+    await dev.fetch("/").expect.toStartWith("<p>template");
+  },
+});
+devTest("editing a server file imported with a loader other than its extension's keeps that loader", {
+  framework: minimalFramework,
+  files: {
+    "message.txt": `export const message = "first";`,
+    "routes/index.ts": `
+      import { message } from '../message.txt' with { type: 'js' };
+      export default function (req, meta) {
+        return new Response(message);
+      }
+    `,
+  },
+  async test(dev) {
+    await dev.fetch("/").equals("first");
+    // Before the fix, the rebundle used the text loader, which turned
+    // message.txt into a string module without a "message" export.
+    await dev.write("message.txt", `export const message = "second";`);
+    await dev.fetch("/").equals("second");
+    await dev.write("message.txt", `export const message = "third";`);
+    await dev.fetch("/").equals("third");
+  },
+});
 devTest("importing bun on the client", {
   files: {
     "index.html": emptyHtmlFile({

--- a/test/bake/dev/bundle.test.ts
+++ b/test/bake/dev/bundle.test.ts
@@ -415,6 +415,59 @@ devTest("importing html file", {
     });
   },
 });
+devTest("importing a file with the html loader through an import attribute", {
+  files: {
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import html from "./partial.mustache" with { type: "html" };
+      console.log(html);
+    `,
+    "partial.mustache": "<div>{{hello}}</div>",
+  },
+  async test(dev) {
+    // Used to get past the check above (which only looked at the extension)
+    // and crash the dev server with an html chunk for a file that is not a route.
+    await using c = await dev.client("/", {
+      errors: ["index.ts:1:18: error: Browser builds cannot import HTML files."],
+    });
+  },
+});
+devTest("plugin loading an imported file with the html loader", {
+  files: {
+    "bunfig.toml": `
+      [serve.static]
+      plugins = ["./plugin.ts"]
+    `,
+    "plugin.ts": `
+      export default {
+        name: "tpl-as-html",
+        setup(build) {
+          build.onLoad({ filter: /\\.tpl$/ }, () => ({ contents: "<div>hello</div>", loader: "html" }));
+        },
+      };
+    `,
+    "index.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["index.ts"],
+    }),
+    "index.ts": `
+      import "./partial.tpl";
+    `,
+    "partial.tpl": "hello",
+  },
+  async test(dev) {
+    // Nothing rejects the loader before the bundle finishes, so this used to
+    // crash the dev server; it is reported against the file instead.
+    await using c = await dev.client("/", {
+      errors: [
+        "partial.tpl: error: Only the HTML files served as routes can be bundled with the html loader in development.",
+      ],
+    });
+  },
+});
 devTest("importing html file with text loader (#18154)", {
   files: {
     "index.html": emptyHtmlFile({
@@ -504,7 +557,7 @@ devTest("editing a text-imported html file that an onResolve plugin claims (#225
     await c.expectMessage("<div>second</div>");
   },
 });
-devTest("editing files imported with a loader other than their extension's keeps that loader (#24893)", {
+devTest("editing files imported with a loader other than their extension's keeps that loader (#24893, #23299)", {
   files: {
     "index.html": emptyHtmlFile({
       styles: [],
@@ -513,27 +566,36 @@ devTest("editing files imported with a loader other than their extension's keeps
     "index.ts": `
       import template from "./template.mustache" with { type: "text" };
       import data from "./data.json" with { type: "text" };
+      import snippet from "./snippet.ts" with { type: "text" };
       console.log(template);
       console.log(typeof data + ":" + data);
+      console.log(snippet);
     `,
     "template.mustache": "{{first}}",
     "data.json": `{"version":1}`,
+    "snippet.ts": `console.log("snippet ran");`,
   },
   async test(dev) {
     await using c = await dev.client("/");
-    await c.expectMessage("{{first}}", 'string:{"version":1}');
+    await c.expectMessage("{{first}}", 'string:{"version":1}', 'console.log("snippet ran");');
 
     // Before the fix, the rebundle used the loader of the file extension:
-    // template.mustache came back as an asset URL and data.json as an object.
+    // template.mustache came back as an asset URL, data.json as an object and
+    // snippet.ts as a module that runs.
     await c.expectReload(async () => {
       await dev.write("template.mustache", "{{second}}");
     });
-    await c.expectMessage("{{second}}", 'string:{"version":1}');
+    await c.expectMessage("{{second}}", 'string:{"version":1}', 'console.log("snippet ran");');
 
     await c.expectReload(async () => {
       await dev.write("data.json", `{"version":2}`);
     });
-    await c.expectMessage("{{second}}", 'string:{"version":2}');
+    await c.expectMessage("{{second}}", 'string:{"version":2}', 'console.log("snippet ran");');
+
+    await c.expectReload(async () => {
+      await dev.write("snippet.ts", `console.log("snippet ran again");`);
+    });
+    await c.expectMessage("{{second}}", 'string:{"version":2}', 'console.log("snippet ran again");');
   },
 });
 devTest("deleting a file imported by a module loaded through an import attribute", {
@@ -612,6 +674,60 @@ devTest("editing a server file imported with a loader other than its extension's
     await dev.fetch("/").equals("second");
     await dev.write("message.txt", `export const message = "third";`);
     await dev.fetch("/").equals("third");
+  },
+});
+devTest("a file whose first bundle fails is still rebundled with the loader its import chose", {
+  framework: minimalFramework,
+  files: {
+    "message.txt": `export const message = ;`,
+    "routes/index.ts": `
+      import { message } from '../message.txt' with { type: 'js' };
+      export default function (req, meta) {
+        return new Response(message);
+      }
+    `,
+  },
+  async test(dev) {
+    expect((await dev.fetch("/")).status).toBe(500);
+    // The failed attempt is the only bundle of message.txt so far; the fix
+    // has to be bundled with the js loader it asked for, not as text.
+    await dev.write("message.txt", `export const message = "first";`);
+    await dev.fetch("/").equals("first");
+    await dev.write("message.txt", `export const message = "second";`);
+    await dev.fetch("/").equals("second");
+  },
+});
+devTest("an html route that client code also imports as text is still bundled as the route", {
+  files: {
+    "main.html": emptyHtmlFile({
+      styles: [],
+      scripts: ["main.ts"],
+    }),
+    "main.ts": `
+      import about from "./about.html" with { type: "text" };
+      console.log(typeof about);
+    `,
+    "about.html": emptyHtmlFile({
+      styles: [],
+      scripts: [],
+      body: "<p>about, first</p>",
+    }),
+  },
+  async test(dev) {
+    // Bundling /main records about.html in the client graph as a text module
+    // before the route is requested; the route must not pick up that loader.
+    await dev.fetch("/main").expect.toInclude("<script");
+    await dev.fetch("/about").expect.toInclude("<p>about, first</p>");
+
+    await dev.write(
+      "about.html",
+      emptyHtmlFile({
+        styles: [],
+        scripts: [],
+        body: "<p>about, second</p>",
+      }),
+    );
+    await dev.fetch("/about").expect.toInclude("<p>about, second</p>");
   },
 });
 devTest("importing bun on the client", {


### PR DESCRIPTION
### Problem
- Editing a file that was imported with `with { type: "text" }` while the dev server (`bun ./index.html`, `Bun.serve` with `development: true`, bake) is running kills the process when the file is an `.html` file: `panic: html_route_bundle_index on non-HTML file` (`IncrementalGraph::html_route_bundle_index`, called from `finalize_bundle` in `src/runtime/bake/DevServer.rs`). Before the Rust port the same rebundle served the imported file as the page's root document instead (#24893).
- For other extensions the rebundle silently changes what the module is: #24893's `template.mustache` imported as text comes back as `/_bun/asset/<hash>.mustache`, a `data.json` imported as text comes back as an object, and #23299's `.ts` file imported as text comes back as a module and runs in the browser.
- Cause: when a file changes, the incremental graph only gives the bundler the file's path, and `BundleV2::enqueue_entry_item` (`src/bundler/bundle_v2.rs`) picks the loader from the extension. The loader the importer chose with its import attribute is lost. The `.html` file is bundled with the html loader, lands in the dev bundle's `html_files`, and `finalize_bundle` asks for the route bundle of a file that never was a route. The same happens on the two other paths that re-queue a file by path (the `on_resolve` fallback when an `onResolve` plugin claims the entry point, and `on_file_deleted` re-queuing the importers of a deleted file), and in both graphs (the server variant is a bake route importing the `.html` file as text).
- Review of the first version found two more ways to reach the same panic that this PR also closes: `import x from "./a.mustache" with { type: "html" }` (the existing "Browser builds cannot import HTML files" check only looked at the extension) and an `onLoad` plugin returning `loader: "html"` for an imported file.

### Fix
- `incremental_graph::File` gains `loader: Option<Loader>`: the loader of the file's last bundle attempt, recorded in `receive_chunk` (both graphs) and in `insert_failure` (the bundler now passes the failed attempt's loader through `handle_parse_task_failure`), so a file whose very first bundle fails is still rebundled the way its import asked for once it is fixed.
- `File::rebundle_loader` is what gets handed out: the recorded loader, except that a file with a route bundle is always `Html`. The graph has one entry per path, so an `.html` route that client code also text-imports may have `Text` recorded before the route is first requested; without this the route would be bundled as a text module and the dev server would crash on it (a regression of the first version of this PR, caught in review). Main served the route in that situation and this keeps doing so.
- New `DevServerHandle::bundled_loader(path, graph)` slot; `BundleV2::entry_point_loader` uses it for every dev server entry point (`enqueue_entry_item`, and the `EntryPointBuild` case of `on_resolve`), falling back to the extension exactly as before when the dev server has no record of the file (first bundle, non dev-server builds). `on_file_deleted` passes the record in directly because it is iterating the graph at that point.
- Why this is the right place: the dev server is the only caller that bundles a file by bare path after something other than the extension decided the file's loader, and its graph is the only thing that remembers that decision. Records are per graph, so the client and server importing the same file with different loaders stay correct, and plugins still run on the rebundle because the record only seeds the parse task's loader, as the extension did.
- The dev server's "Browser builds cannot import HTML files" check now looks at the loader the import will use (attribute, else extension), so `with { type: "html" }` on any file is rejected at the import like a plain `.html` import.
- `finalize_bundle` looks the html chunk's file up and, when it has no route bundle, records a bundling failure for the file ("Only the HTML files served as routes can be bundled with the html loader in development.") and skips it in both passes, instead of unwrapping. The only remaining way in is a plugin answering `onLoad` with `loader: "html"`, and the result is the normal error overlay. The panicking accessor is removed, so the message in the issue titles no longer exists.
- `hmr-module.ts`: the debug-only assertion "a non-accepted `.html` module should have been reloaded by the caller" assumed every `.html` module id is a route file. A text-imported `.html` file is an ordinary module with importers, so the assertion now only applies to root modules (the route's own file). Release builds drop the assertion; this only changes what debug builds and the test harness see.
- Tests (`test/bake/dev/bundle.test.ts`): the #22533 repro (two edits, and `/` still serves `index.html` for #24893); the same through an `onResolve` plugin; `.mustache`, `.json` and `.ts` text imports (#24893, #23299); a deleted file whose importer was loaded through an import attribute (`on_file_deleted`); the two server-graph variants (an `.html` text import in a bake route, a `.txt` loaded as js); a first bundle that fails and is then fixed; an html route that is also text-imported; `with { type: "html" }` on a non-html file; an `onLoad` plugin returning `html`. All of them except the route-also-text-imported one fail on `USE_SYSTEM_BUN=1` (that one passes on main and crashed on the first version of this PR); all pass with the fix. Disabling individual hunks (`on_resolve`, `on_file_deleted`, `rebundle_loader`, the `insert_failure` record) makes exactly the corresponding test fail.
- Also ran `test/bake/dev/{bundle,html,hot,plugins,incremental-graph-edge-deletion,css,esm,react-spa,ssg-pages-router}.test.ts` and `test/bake/serve-plugins-dev-server.test.ts` on the debug build: 105 pass.
- Found along the way and reported separately, not addressed here: hot updates of CommonJS-shaped modules (text/json loaders, with or without an import attribute) keep serving the old exports to their importers because `hmr-module.ts` does not reset the cached ESM view of a reloaded CJS module. The server `.html` test here therefore only asserts that the rebundle no longer crashes, and the client tests use the full reload path, which is unaffected.

### Background
- The dev server keeps an incremental graph per side (client, server): one `File` per bundled path with its last output, its import edges, and for an HTML route file the index of its `RouteBundle`. When files change, `IncrementalGraph::invalidate` marks them stale and hands the bundler a list of paths to rebundle as entry points; `insert_failure` is how a file that failed to bundle is recorded (and shown in the error overlay).
- A loader is the bundler's per-file input type (js, css, html, text, json, file, ...). It normally comes from the extension, but an import's `with { type: "..." }` attribute overrides it for that file; `Loader::Html` produces a route chunk plus the page's HTML, `Loader::Text` a module exporting a string.
- `finalize_bundle` receives a dev bundle's chunks: one JS chunk holding every module, one chunk per CSS root, and one chunk per file bundled with the html loader, which it delivers to that file's `RouteBundle`.
- `DevServerHandle` (`bun_dispatch::link_interface!` in `src/bundler/lib.rs`) is how the bundler crate calls back into the dev server, which lives in a higher crate; `is_file_cached` and `handle_parse_task_failure` are the existing slots this change extends or sits next to.
- `hmr-module.ts` is the HMR runtime shared by the browser and the server; `DEBUG.ASSERT` calls are kept in debug builds of bun (where the bake test harness turns a failed assertion into a test failure) and dropped in release builds.

<details>
<summary>First version of this PR</summary>

The first push only recorded the loader in `receive_chunk` and consulted it from the bundler. Review against that build found: an `.html` route that was text-imported before its route was requested got rebundled as text and crashed; a file whose first bundle failed had no record and fell back to the extension (the same silent mis-typing, and for `.html` the same crash); and the two first-bundle triggers (`with { type: "html" }`, `onLoad` returning `html`) still reached the unwrap. The second commit addresses all of these; see the Fix bullets.

</details>

Fixes #22533
Fixes #24893
Fixes #23299

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 7 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 9 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-Qv77kV
[0;30mdev|[0m Started development server: http://localhost:42613
[0;30mdev|[0m [32mBundled page in 4ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 2ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 2ms[0m[2m:[0m routes/index.ts
(pass)  DEV:bundle-1: import identifier doesnt get renamed [221.44ms]
[0;30mdev|[0m Started development server: http://localhos
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bake/dev/bundle.test.ts
bun test v1.4.0 (591666b1d)

test/bake/dev/bundle.test.ts:
Dev server testing directory: /tmp/bun-dev-test-em1Gqt
[0;30mdev|[0m Started development server: http://localhost:42701
[0;30mdev|[0m [32mBundled page in 208ms[0m[2m:[0m routes/index.ts [2m+ 1 more[0m
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "db.ts" is not accepted by routes/index.ts,
[0;30mdev|[0m [32mReloaded in 88ms[0m[2m:[0m db.ts
[0;30mdev|[0m [Bun] Hot update was not accepted because it or its importers do not call `import.meta.hot.accept`. To prevent full page reloads, call `import.meta.hot.accept` in one of the following files to handle the update:
[0;30mdev|[0m 
[0;30mdev|[0m Module "routes/index.ts" is a root module that does not self-accept.
[0;30mdev|[0m [36m[x2][0m [32mReloaded in 81ms[
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1459ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/49] gen bindgenv2
[2/44] gen bake.{client,server,error}.js
-> bake.client.js, bake.server.js, bake.error.js
[3/44] gen cpp.rs (cppbind)
[4/44] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[5/44] gen JS modules (bundle-modules)
Preprocess modules (14904ms)
Bundle modules (180ms)
Postprocesss modules (834ms)
Bundle Functions (1809ms)
Generate Code (38ms)

[17.79s] Bundled "src/js" for production
  2626 kb
  197 internal modules
  13 native modules
  91 internal functions across 17 files
[5/35] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_core v0.0.0 (/workspace/bun/src/bun_core)
[1m[92m   Compiling[0m bun_errno v0.0.0 (/workspace/bun/src/errno)
[1m[92m   Compiling[0m bun_ptr v0.0.0 (/workspace/bun/src/ptr)
[1m[92m   Compiling[0m bun_boringssl_sys v0.0.0
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/bundle_v2.rs                         |  62 ++++-
 src/bundler/lib.rs                               |   5 +-
 src/runtime/bake/DevServer.rs                    |  49 +++-
 src/runtime/bake/dev_server/incremental_graph.rs |  41 +++-
 src/runtime/bake/dev_server/mod.rs               |   5 +-
 src/runtime/bake/hmr-module.ts                   |   3 +-
 test/bake/dev/bundle.test.ts                     | 297 +++++++++++++++++++++++
 7 files changed, 433 insertions(+), 29 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                              reads  edits  tests
src/bundler/bundle_v2.rs                              0      1      0
src/bundler/lib.rs                                    0      0      0
src/runtime/bake/DevServer.rs                         0      0      0
src/runtime/bake/dev_server/incremental_graph.rs      0      0      0
src/runtime/bake/dev_server/mod.rs                    0      0      0
src/runtime/bake/hmr-module.ts                        0      0      0
test/bake/dev/bundle.test.ts                          0      0      0
```

</details>

**root cause** · written by the author bot

The dev server's incremental graph did not record the loader each file was originally bundled with, so when a hot update invalidated a file it was rebundled with a loader inferred from its extension, which broke files whose import loader differed from the default, such as an HTML file imported as text or files handled by plugin loaders. The fix records the loader for each graph file from both client and server bundles, passes that recorded loader through invalidation, entry-point enqueueing, and failure paths so rebundles use the correct loader, and preserves the existing loader record when…

<!-- robobun:evidence:end -->