### PR TITLE
ci: record which instance type each job actually ran on (agent tag, log header, failure annotations)

### DIFF
--- a/scripts/agent.mjs
+++ b/scripts/agent.mjs
@@ -13,6 +13,7 @@ import {
   getAwsSecret,
   getAzureSecret,
   getCloud,
+  getCloudLaunchedInstanceType,
   getCloudMetadataTag,
   getDistro,
   getDistroVersion,
@@ -383,6 +384,12 @@ async function doBuildkiteAgent(action, cliOptions = {}) {
           tags[tag] = value;
         }
       }
+      // Deliberately not `instance-type`: that key is the type the job asked
+      // for (.buildkite/ci.mjs), and under capacity pressure this machine may
+      // be a different one. The runner reads this back from
+      // BUILDKITE_AGENT_META_DATA_LAUNCHED_INSTANCE_TYPE for the job log header
+      // and failure annotations.
+      tags["launched-instance-type"] = await getCloudLaunchedInstanceType(cloud);
     }
 
     options["tags"] = Object.entries(tags)

--- a/scripts/runner.node.mjs
+++ b/scripts/runner.node.mjs
@@ -43,6 +43,7 @@ import {
   getBuildLabel,
   getBuildMetadata,
   getBuildUrl,
+  getCloudInstanceType,
   getCommit,
   getDistro,
   getDistroVersion,
@@ -1131,7 +1132,7 @@ async function runTests() {
               context: "flaky",
               label: title,
               style: "warning",
-              content: `<details><summary><a href="${getFileUrl(title)}"><code>${title}</code></a> - ${reason} <i>(in the parallel batch on ${getBuildLabel()}; passed alone)</i></summary>${detail}</details>`,
+              content: `<details><summary><a href="${getFileUrl(title)}"><code>${title}</code></a> - ${reason} <i>(in the parallel batch on ${getTestLabel()}; passed alone)</i></summary>${detail}</details>`,
             });
           }
         }
@@ -2789,10 +2790,19 @@ function addPath(...paths) {
 }
 
 /**
+ * The lane a failure is reported against, plus the machine type the job
+ * actually ran on when that is known, e.g. ":debian: 13 x64-asan (r7i.2xlarge)".
+ * The type is what tells a timeout on fallback hardware apart from one on the
+ * hardware the lane asks for, so it goes in the annotation next to the lane.
  * @returns {string | undefined}
  */
 function getTestLabel() {
-  return getBuildLabel()?.replace(" - test-bun", "");
+  const label = getBuildLabel()?.replace(" - test-bun", "");
+  if (!label) {
+    return;
+  }
+  const instanceType = getCloudInstanceType();
+  return instanceType ? `${label} (${instanceType})` : label;
 }
 
 /**

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1899,24 +1899,28 @@ let cloudInstanceType;
  * The instance type the cloud provider actually launched for this machine,
  * e.g. "r7i.2xlarge" on EC2 or "Standard_D8s_v5" on Azure. CI asks for one
  * type per lane (.buildkite/ci.mjs), but under capacity pressure the
- * machine may be a different, slower type, and nothing else in a job log
- * records which one it was. Looked up once per process.
+ * machine may be a different, slower type. scripts/agent.mjs records the
+ * launched type as the agent's `launched-instance-type` tag, which Buildkite
+ * exposes to the job as an environment variable. Looked up once per process.
  * @returns {string | undefined}
  */
 export function getCloudInstanceType() {
   if (typeof cloudInstanceType !== "string") {
-    cloudInstanceType = fetchCloudInstanceType() || "";
+    cloudInstanceType =
+      getEnv("BUILDKITE_AGENT_META_DATA_LAUNCHED_INSTANCE_TYPE", false) || fetchCloudInstanceType() || "";
   }
   return cloudInstanceType || undefined;
 }
 
 /**
+ * Images baked before agent.mjs set the tag only have the `cloud` tag, so
+ * ask the metadata service directly. Synchronous and bounded, since this
+ * runs while printing a log header.
  * @returns {string | undefined}
  */
 function fetchCloudInstanceType() {
-  // The `cloud` tag scripts/agent.mjs puts on the agents we launch ourselves.
-  // Anything without it (the darwin fleet, GitHub Actions) is not a machine
-  // whose type we chose, so there is nothing to compare against and no request.
+  // Without a `cloud` tag (the darwin fleet, GitHub Actions) this is not a
+  // machine whose type we chose, so there is nothing to compare against.
   const cloud = getEnv("BUILDKITE_AGENT_META_DATA_CLOUD", false);
   let request;
   if (cloud === "aws") {
@@ -2341,6 +2345,34 @@ export async function getCloudMetadataTag(tag, cloud) {
   };
 
   return getCloudMetadata(metadata, cloud);
+}
+
+/**
+ * The instance type this machine was launched as, e.g. "r7i.2xlarge" or
+ * "Standard_D8s_v5". agent.mjs tags the agent with it at start; jobs read it
+ * back through getCloudInstanceType().
+ * @param {Cloud} [cloud]
+ * @returns {Promise<string | undefined>}
+ */
+export async function getCloudLaunchedInstanceType(cloud) {
+  cloud ??= await getCloud();
+
+  if (cloud === "azure") {
+    const body = await getCloudMetadata("", cloud);
+    if (!body) return;
+    try {
+      return JSON.parse(body)?.compute?.vmSize || undefined;
+    } catch {}
+    return;
+  }
+
+  const metadata = {
+    "aws": "instance-type",
+    // "projects/<number>/machineTypes/<type>"
+    "google": "machine-type",
+  };
+
+  return (await getCloudMetadata(metadata, cloud))?.split("/").pop() || undefined;
 }
 
 /**

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1901,8 +1901,9 @@ export function getCpuDescription() {
  * @returns {string | undefined}
  */
 export function getCloudInstanceType() {
-  // Set by scripts/agent.mjs on the cloud agents; absent on the darwin fleet
-  // and GitHub Actions, where there is no metadata service to ask.
+  // The `cloud` tag scripts/agent.mjs puts on the agents we launch ourselves.
+  // Anything without it (the darwin fleet, GitHub Actions) is not a machine
+  // whose type we chose, so there is nothing to compare against and no request.
   const cloud = getEnv("BUILDKITE_AGENT_META_DATA_CLOUD", false);
   let request;
   if (cloud === "aws") {

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -15,7 +15,15 @@ import {
   writeFileSync,
 } from "node:fs";
 import { connect } from "node:net";
-import { hostname, homedir as nodeHomedir, tmpdir as nodeTmpdir, release, userInfo } from "node:os";
+import {
+  availableParallelism,
+  cpus,
+  hostname,
+  homedir as nodeHomedir,
+  tmpdir as nodeTmpdir,
+  release,
+  userInfo,
+} from "node:os";
 import { basename, dirname, join, relative, resolve } from "node:path";
 import { normalize as normalizeWindows } from "node:path/win32";
 
@@ -1871,6 +1879,61 @@ export function getPublicIp() {
 }
 
 /**
+ * The CPU model and the number of CPUs this process may run on, e.g.
+ * "Intel(R) Xeon(R) Platinum 8488C x8" or "Apple M2 Ultra x24".
+ * @returns {string | undefined}
+ */
+export function getCpuDescription() {
+  const [cpu] = cpus();
+  const model = cpu?.model?.replace(/\s+/g, " ").trim();
+  if (!model) {
+    return;
+  }
+  return `${model} x${availableParallelism()}`;
+}
+
+/**
+ * The instance type the cloud provider actually launched for this machine,
+ * e.g. "r7i.2xlarge" on EC2 or "Standard_D8s_v5" on Azure. CI asks for one
+ * type per lane (.buildkite/ci.mjs), but under capacity pressure the
+ * machine may be a different, slower type, and nothing else in a job log
+ * records which one it was.
+ * @returns {string | undefined}
+ */
+export function getCloudInstanceType() {
+  // Set by scripts/agent.mjs on the cloud agents; absent on the darwin fleet
+  // and GitHub Actions, where there is no metadata service to ask.
+  const cloud = getEnv("BUILDKITE_AGENT_META_DATA_CLOUD", false);
+  let request;
+  if (cloud === "aws") {
+    request = ["http://169.254.169.254/latest/meta-data/instance-type"];
+  } else if (cloud === "azure") {
+    request = [
+      "-H",
+      "Metadata: true",
+      "http://169.254.169.254/metadata/instance/compute/vmSize?api-version=2021-02-01&format=text",
+    ];
+  } else {
+    return;
+  }
+
+  const { error, stdout } = spawnSync([
+    "curl",
+    "-sf",
+    "--noproxy",
+    "*",
+    "--connect-timeout",
+    "1",
+    "--max-time",
+    "3",
+    ...request,
+  ]);
+  if (!error) {
+    return stdout.trim() || undefined;
+  }
+}
+
+/**
  * @returns {string}
  */
 export function getHostname() {
@@ -3095,8 +3158,10 @@ export function printEnvironment() {
     }
     console.log("Distro:", getDistro());
     console.log("Distro Version:", getDistroVersion());
+    console.log("CPU:", getCpuDescription());
     console.log("Hostname:", getHostname());
     if (isCI) {
+      console.log("Instance Type:", getCloudInstanceType());
       console.log("Tailscale IP:", getTailscaleIp());
       console.log("Public IP:", getPublicIp());
     }

--- a/scripts/utils.mjs
+++ b/scripts/utils.mjs
@@ -1892,15 +1892,28 @@ export function getCpuDescription() {
   return `${model} x${availableParallelism()}`;
 }
 
+/** @type {string | undefined} "" once looked up and not available */
+let cloudInstanceType;
+
 /**
  * The instance type the cloud provider actually launched for this machine,
  * e.g. "r7i.2xlarge" on EC2 or "Standard_D8s_v5" on Azure. CI asks for one
  * type per lane (.buildkite/ci.mjs), but under capacity pressure the
  * machine may be a different, slower type, and nothing else in a job log
- * records which one it was.
+ * records which one it was. Looked up once per process.
  * @returns {string | undefined}
  */
 export function getCloudInstanceType() {
+  if (typeof cloudInstanceType !== "string") {
+    cloudInstanceType = fetchCloudInstanceType() || "";
+  }
+  return cloudInstanceType || undefined;
+}
+
+/**
+ * @returns {string | undefined}
+ */
+function fetchCloudInstanceType() {
   // The `cloud` tag scripts/agent.mjs puts on the agents we launch ourselves.
   // Anything without it (the darwin fleet, GitHub Actions) is not a machine
   // whose type we chose, so there is nothing to compare against and no request.


### PR DESCRIPTION
### Problem
- `test/js/node/fs/fs.test.ts` went red on the debian 13 x64-asan lane in build 93859: `readdirSync(path, {recursive: true, withFileTypes: true} should work x 100` timed out at 11.0s / 10.98s / 11.14s / 11.05s on its four attempts (10s budget). The branch under test only touched `bun:ffi`.
- It was not the binary and not the lane: in the same build 16 of the 20 asan shards ran at normal speed, and on the shard that failed every sequential test file ran 1.4x to 1.75x slower than the same file in builds 93850 and 93854 (`fs.test.ts` as a whole: 64.7s against 39s to 42s). The agent was a slower machine than the `r7i.2xlarge` that `.buildkite/ci.mjs` asks for; under capacity pressure the launcher falls back to other types.
- The only thing in a job log that distinguished these machines was the `free -m` total in the Memory section, so finding the slow agents meant downloading and diffing the logs of every shard. The requested type is in the pipeline; the type that was actually launched was recorded nowhere.
- The test itself is fixed separately by #37828 (200 listings of `test/js/node` become 8). This PR is the missing diagnostics, so the next time a burst lands agents on fallback hardware it is readable off the first screen of the log.

### Fix
- `scripts/agent.mjs` tags each cloud agent with `launched-instance-type`, read at agent start through the existing `getCloudMetadata()` path (EC2 `instance-type`, Azure `compute.vmSize`), next to the `kernel` / `abi-version` / `cloud` tags it already sets. Buildkite then shows the launched type per job in the API and UI (`agent.meta_data`), so requested (`agent_query_rules`, from `.buildkite/ci.mjs`) against launched is one API call per build, and hands it to the job as `BUILDKITE_AGENT_META_DATA_LAUNCHED_INSTANCE_TYPE`. It is a separate key from `instance-type` on purpose: that key is what the job asks for, and this machine may not be it.
- `printEnvironment()` (the `Machine` group at the top of every build and test job log) prints `CPU: <model> x<count>` from `os.cpus()` / `os.availableParallelism()` on every platform and `Instance Type:` on cloud agents. The test runner puts the same type into the failure annotations, which is what `bun run ci:errors` and the triage tooling read: `... - code 1 on :debian: 13 x64-asan (r6i.2xlarge)`, and the parallel-batch flaky variant likewise.
- The tag only exists on images baked after this lands, so until the next image publish `getCloudInstanceType()` falls through to asking the metadata service itself: one memoized `curl -sf --noproxy '*' --connect-timeout 1 --max-time 3`, in the same shape as the `getPublicIp()` next to it, selected by the `cloud` tag. Agents without a `cloud` tag (the darwin fleet, GitHub Actions) are not machines whose type CI chose; they make no request and gain only the CPU line. The fallback can go once the images have been republished.
- Verified: build 94115 printed the header on every cloud lane and build 94502 rendered the annotations on both clouds (both quoted below); the darwin lane prints `CPU: Apple M2 Ultra (Virtual) x8` and no type; `getCloudLaunchedInstanceType()` returns `Standard_D16ds_v6` on a live Azure VM both with the cloud passed in and with it detected, and the job side prefers the tag's variable when set; `agent.mjs` still bundles with esbuild the way the image bake builds it; `prettier --check` passes. No `src/` or test changes.

<details>
<summary>Header and annotation output from builds 94115 and 94502</summary>

Build 94115 header lines: x64-asan shards `Instance Type: r7i.2xlarge` / `CPU: Intel(R) Xeon(R) Platinum 8488C x8`, Windows 2019 `Standard_D4ds_v6` / `INTEL(R) XEON(R) PLATINUM 8573C x4`, Windows 11 aarch64 `Standard_D4pds_v6` / `Cobalt 100 x4`, alpine aarch64 `m8g.xlarge` / `Neoverse-V2 x4`, the build host `r8g.4xlarge` / `Neoverse-V2 x16`, debian x64 `c7i.xlarge` on all 20 shards. 5 of that build's 20 asan shards were not on the requested type (4x `r7a.2xlarge`, 1x `r6i.2xlarge`), and its one failed shard (`setInterval.test.js` leak test, 4 of 4 attempts) was an `r7a.2xlarge`.

Build 94502, as printed by `bun run ci:errors 94502` without any change to `find-build.ts`: `bun-patch.test.ts - code 1 on :windows: 11 aarch64 (Standard_D4pds_v6) (2 retries)`, `in-process-cron.test.ts - code 1 on :ubuntu: 25.04 aarch64 (c8g.xlarge) (1 retry)`, `inspect-error-leak.test.js - ... (in the parallel batch on :debian: 13 x64-asan (r7i.2xlarge); passed alone)`. The memoized in-job lookup measured 16ms for the first call and 0.002ms for the second against a live metadata service.
</details>

### Background
- Every Linux CI job runs on a fresh EC2 instance launched for that one job; `.buildkite/ci.mjs` names one instance type per lane (`r7i.2xlarge` for the x64 asan test lane). The launcher that creates the instances, and its list of fallback types, live outside this repo.
- Agent tags are key=value facts a Buildkite agent registers about itself; jobs target agents by them, the API reports them per job, and the agent exports each one to the job as `BUILDKITE_AGENT_META_DATA_<KEY>`. `scripts/agent.mjs` is bundled into the CI machine images, so a change there reaches the fleet at the next image publish (bump of `# Version:` in `scripts/bootstrap.sh` plus a `[publish images]` run), not on merge.
- The asan lane is where a slower type shows first: its tests run 3x to 5x slower than release, so several sit within 1.5x of their timeouts on the intended hardware. Each of the tests that tripped has its own PR (#37828 `fs.test.ts`, #35750 `setInterval.test.js`, #37586 `require-cache.test.ts`, #34786 `html-rewriter-leak`, #36867 `inspect-error-leak`, #35917 `sourcetextmodule-leak`).
- Cloud instance metadata services answer HTTP on the link-local address 169.254.169.254 from inside the VM; EC2 returns the instance type as plain text at `/latest/meta-data/instance-type`, Azure returns the VM size at `/metadata/instance/compute/vmSize` when asked with a `Metadata: true` header.

<details>
<summary>Evidence from the 2026-08-13 builds</summary>

Agents grouped by the `free -m` total they report (the memory map differs per instance family), with the median slowdown of each shard's sequential test files against the same files in builds 93850, 93854, 93922 and 93934 (79 of those 80 asan agents were the 63270 class, the other a 62932, and nothing failed). The instance types in the first column are the ones build 94115's new header has confirmed so far; the other three classes will name themselves the next time a burst runs with this header.

| `free -m` total | instance type | median slowdown per shard | what failed on it |
|---|---|---|---|
| 63270 | `r7i.2xlarge` (requested; 20/20 agents in 93922, 93934, 93960, 93986) | 1.00x | nothing timing related |
| 62932 | `r7a.2xlarge` (AMD EPYC 9R14) | 0.87x to 1.01x | `timers/setInterval.test.js` leak test (6 sightings here, 8 more on the three slow classes below, none on `r7i`) |
| 63286 | `r6i.2xlarge` (Xeon 8375C) | 1.04x to 1.14x | `run/require-cache.test.ts`, `html-rewriter-leak.test.ts` |
| 62948 | not yet seen with the header | 1.08x to 1.22x | `require-cache`, `inspect-error-leak`, `setInterval` |
| 63510 | not yet seen with the header | 1.33x to 1.59x | `fs/fs.test.ts` (7 of 7 sightings on this class), `html-rewriter-leak`, `inspect-error-leak`, `sourcetextmodule-leak`, `setInterval`, `require-cache` |
| 63680 | not yet seen with the header | 1.69x to 1.89x | `inspect-error-leak`, `sourcetextmodule-leak`, `setInterval`, `require-cache`, elysia stream tests |

Build 93859's four slow shards (0, 1, 3, 15) were all 63510; shard 15 carried `fs.test.ts` (64.7s; every test file on it 1.3x to 2.1x slower, median 1.41x). In the 03:28 to 03:39 UTC burst (builds 94018 to 94063) 44 of the 46 failed asan shards were on a non-63270 class, and builds in that burst had only 2 to 4 of their 20 asan agents on 63270 (94024: 3, 94044: 4, 94059: 2). `fs.test.ts` failed the same way in 94019, 94021, 94024, 94025, 94031 and 94058, each time on a 63510 agent. With #37828 applied the file takes 20.6s on the lane (build 93509) and no test in it is near a timeout.
</details>


