### PR TITLE
Normalize http_proxy/https_proxy env values through the WHATWG parser

### DIFF
--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -337,11 +337,8 @@ impl Loader {
     /// `hostname` is the host without port (e.g., "localhost")
     /// `host` is the host with port if present (e.g., "localhost:3000")
     ///
-    /// The env value is normalized by the WHATWG parser first, exactly like
-    /// the `proxy` option of `fetch()`, so both ways of configuring a proxy
-    /// resolve to the same URL (https://github.com/oven-sh/bun/issues/16182).
-    /// A value the WHATWG parser rejects (e.g. a scheme-less `host:port`) is
-    /// kept as written and still gets the lenient `URL::parse` treatment.
+    /// The value is WHATWG-normalized like `fetch()`'s `proxy` option (#16182);
+    /// one the WHATWG parser rejects (e.g. a scheme-less `host:port`) is used as written.
     pub fn get_http_proxy(
         &self,
         is_http: bool,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -336,7 +336,6 @@ impl Loader {
     /// Get proxy URL for HTTP/HTTPS requests, respecting NO_PROXY.
     /// `hostname` is the host without port (e.g., "localhost")
     /// `host` is the host with port if present (e.g., "localhost:3000")
-    ///
     /// Normalized like `fetch()`'s `proxy` option (#16182); a value WTF::URL rejects is used as is.
     pub fn get_http_proxy(
         &self,

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -9,7 +9,7 @@ use bun_core::{self, Output};
 use bun_core::{ZStr, strings};
 use bun_paths::{self, MAX_PATH_BYTES, PathBuffer};
 use bun_sys;
-use bun_url::URL;
+use bun_url::{OwnedURL, URL};
 use bun_which::which;
 use enumset::EnumSet;
 
@@ -322,7 +322,7 @@ impl Loader {
         result
     }
 
-    pub fn get_http_proxy_for(&self, url: &URL<'_>) -> Option<URL<'_>> {
+    pub fn get_http_proxy_for(&self, url: &URL<'_>) -> Option<OwnedURL> {
         self.get_http_proxy(url.is_http(), Some(url.hostname), Some(url.host))
     }
 
@@ -336,32 +336,36 @@ impl Loader {
     /// Get proxy URL for HTTP/HTTPS requests, respecting NO_PROXY.
     /// `hostname` is the host without port (e.g., "localhost")
     /// `host` is the host with port if present (e.g., "localhost:3000")
+    ///
+    /// The env value is normalized by the WHATWG parser first, exactly like
+    /// the `proxy` option of `fetch()`, so both ways of configuring a proxy
+    /// resolve to the same URL (https://github.com/oven-sh/bun/issues/16182).
+    /// A value the WHATWG parser rejects (e.g. a scheme-less `host:port`) is
+    /// kept as written and still gets the lenient `URL::parse` treatment.
     pub fn get_http_proxy(
         &self,
         is_http: bool,
         hostname: Option<&[u8]>,
         host: Option<&[u8]>,
-    ) -> Option<URL<'_>> {
-        // TODO: When Web Worker support is added, make sure to intern these strings
-        let mut http_proxy: Option<URL<'_>> = None;
-
+    ) -> Option<OwnedURL> {
         let proxy = if is_http {
             self.get_lower_then_upper(b"http_proxy", b"HTTP_PROXY")
         } else {
             self.get_lower_then_upper(b"https_proxy", b"HTTPS_PROXY")
-        };
-        if let Some(p) = proxy {
-            if !Self::is_emptyish(p) {
-                http_proxy = Some(URL::parse(p));
-            }
+        }?;
+        if Self::is_emptyish(proxy) || self.is_no_proxy(hostname, host) {
+            return None;
         }
+        Some(
+            URL::from_string(&bun_core::String::borrow_utf8(proxy))
+                .unwrap_or_else(|_| OwnedURL::from_href(Box::from(proxy))),
+        )
+    }
 
-        if http_proxy.is_some() && hostname.is_some() {
-            if self.is_no_proxy(hostname, host) {
-                return None;
-            }
-        }
-        http_proxy
+    /// The `no_proxy` / `NO_PROXY` list, or `None` when unset or empty-ish.
+    pub fn get_no_proxy(&self) -> Option<&[u8]> {
+        self.get_lower_then_upper(b"no_proxy", b"NO_PROXY")
+            .filter(|v| !Self::is_emptyish(v))
     }
 
     /// Returns true if the given hostname/host should bypass the proxy
@@ -371,12 +375,9 @@ impl Loader {
         // See the syntax at https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/
         let Some(hn) = hostname else { return false };
 
-        let Some(no_proxy_text) = self.get_lower_then_upper(b"no_proxy", b"NO_PROXY") else {
+        let Some(no_proxy_text) = self.get_no_proxy() else {
             return false;
         };
-        if Self::is_emptyish(no_proxy_text) {
-            return false;
-        }
 
         for no_proxy_item in strings::split(no_proxy_text, b",") {
             let mut no_proxy_entry = strings::trim(no_proxy_item, &strings::WHITESPACE_CHARS);

--- a/src/dotenv/env_loader.rs
+++ b/src/dotenv/env_loader.rs
@@ -337,8 +337,7 @@ impl Loader {
     /// `hostname` is the host without port (e.g., "localhost")
     /// `host` is the host with port if present (e.g., "localhost:3000")
     ///
-    /// The value is WHATWG-normalized like `fetch()`'s `proxy` option (#16182);
-    /// one the WHATWG parser rejects (e.g. a scheme-less `host:port`) is used as written.
+    /// Normalized like `fetch()`'s `proxy` option (#16182); a value WTF::URL rejects is used as is.
     pub fn get_http_proxy(
         &self,
         is_http: bool,

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -662,54 +662,38 @@ pub struct ProxySettings {
 }
 
 impl ProxySettings {
-    /// Returns `None` when neither proxy is set: no re-evaluation is needed.
-    pub(crate) fn new(
-        http_proxy: Option<&[u8]>,
-        https_proxy: Option<&[u8]>,
-        no_proxy: Option<&[u8]>,
+    /// An empty href means "no proxy for that scheme". Returns `None` when
+    /// neither proxy is set: no re-evaluation is needed.
+    fn new(
+        http_proxy: Box<[u8]>,
+        https_proxy: Box<[u8]>,
+        env: &bun_dotenv::Loader,
     ) -> Option<Box<Self>> {
-        let http_proxy = http_proxy.unwrap_or(b"");
-        let https_proxy = https_proxy.unwrap_or(b"");
         if http_proxy.is_empty() && https_proxy.is_empty() {
             return None;
         }
         Some(Box::new(Self {
-            http_proxy: http_proxy.into(),
-            https_proxy: https_proxy.into(),
-            no_proxy: no_proxy.unwrap_or(b"").into(),
+            http_proxy,
+            https_proxy,
+            no_proxy: env.get_no_proxy().unwrap_or(b"").into(),
         }))
     }
 
     /// Capture `http_proxy` / `https_proxy` / `no_proxy` from the process env.
+    /// The env loader hands back the proxies already normalized, so every hop
+    /// parses the same href an explicit `proxy` option would have produced.
     pub fn from_env(env: &bun_dotenv::Loader) -> Option<Box<Self>> {
-        #[inline]
-        fn is_emptyish(v: &[u8]) -> bool {
-            v.is_empty() || v == b"\"\"" || v == b"''"
-        }
-        // lowercase first; an empty lowercase value falls through to uppercase.
-        let read = |lower: &[u8], upper: &[u8]| -> Option<&[u8]> {
-            let v = env
-                .get(lower)
-                .filter(|v| !v.is_empty())
-                .or_else(|| env.get(upper))?;
-            if is_emptyish(v) { None } else { Some(v) }
+        let proxy_href = |is_http: bool| -> Box<[u8]> {
+            env.get_http_proxy(is_http, None, None)
+                .map_or_else(Box::default, bun_url::OwnedURL::into_href)
         };
-        Self::new(
-            read(b"http_proxy", b"HTTP_PROXY"),
-            read(b"https_proxy", b"HTTPS_PROXY"),
-            read(b"no_proxy", b"NO_PROXY"),
-        )
+        Self::new(proxy_href(true), proxy_href(false), env)
     }
 
     /// Build from an explicit `fetch(url, { proxy })` option. The same proxy is
     /// used for both schemes; NO_PROXY is still consulted per hop.
     pub fn from_explicit(proxy_href: &[u8], env: &bun_dotenv::Loader) -> Option<Box<Self>> {
-        let no_proxy = env
-            .get(b"no_proxy")
-            .filter(|v| !v.is_empty())
-            .or_else(|| env.get(b"NO_PROXY"))
-            .filter(|v| !(v.is_empty() || *v == b"\"\"" || *v == b"''"));
-        Self::new(Some(proxy_href), Some(proxy_href), no_proxy)
+        Self::new(proxy_href.into(), proxy_href.into(), env)
     }
 
     /// Proxy href to use for `url`, or `None` for a direct connection.

--- a/src/http/lib.rs
+++ b/src/http/lib.rs
@@ -662,8 +662,7 @@ pub struct ProxySettings {
 }
 
 impl ProxySettings {
-    /// An empty href means "no proxy for that scheme". Returns `None` when
-    /// neither proxy is set: no re-evaluation is needed.
+    /// An empty href is "no proxy for that scheme"; `None` when neither is set.
     fn new(
         http_proxy: Box<[u8]>,
         https_proxy: Box<[u8]>,
@@ -680,8 +679,6 @@ impl ProxySettings {
     }
 
     /// Capture `http_proxy` / `https_proxy` / `no_proxy` from the process env.
-    /// The env loader hands back the proxies already normalized, so every hop
-    /// parses the same href an explicit `proxy` option would have produced.
     pub fn from_env(env: &bun_dotenv::Loader) -> Option<Box<Self>> {
         let proxy_href = |is_http: bool| -> Box<[u8]> {
             env.get_http_proxy(is_http, None, None)

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -60,9 +60,8 @@ pub struct NetworkTask {
     // `tarball.url` in the latter would be a self-reference
     // into `callback`; owning avoids that at the cost of one copy per tarball download.
     pub(crate) url_buf: Box<[u8]>,
-    /// Normalized href of the proxy this request goes through; empty when it
-    /// connects directly. Owned here like `url_buf`: the `AsyncHTTP` borrows it
-    /// for as long as the request (including retries) is in flight.
+    /// Proxy href the request goes through (empty: direct); borrowed by the
+    /// `AsyncHTTP` like `url_buf`.
     pub(crate) http_proxy_buf: Box<[u8]>,
     pub(crate) retried: u16,
     pub(crate) response_buffer: MutableString,
@@ -174,8 +173,7 @@ impl NetworkTask {
         unsafe { self.package_manager.assume_mut() }
     }
 
-    /// Store the proxy `url` should go through in `http_proxy_buf` and return
-    /// the view of it that the `AsyncHTTP` built by the caller keeps.
+    /// Stores the proxy for `url` in `http_proxy_buf` and returns the view the `AsyncHTTP` keeps.
     fn http_proxy_for(&mut self, pm: &PackageManager, url: &URL<'_>) -> Option<URL<'static>> {
         self.http_proxy_buf = pm
             .http_proxy(url)
@@ -183,11 +181,9 @@ impl NetworkTask {
         if self.http_proxy_buf.is_empty() {
             return None;
         }
-        // SAFETY: lifetime extension — `http_proxy_buf` is a heap allocation
-        // owned by `*self`, which outlives the HTTP request: `run_tasks` drops
-        // `unsafe_http_client` before returning the slot (and with it this
-        // buffer) to the pool. Same pattern as `url_buf` in `for_manifest` /
-        // `for_tarball`.
+        // SAFETY: lifetime extension, same as `url_buf` in `for_manifest` /
+        // `for_tarball` — `run_tasks` drops `unsafe_http_client` before the slot
+        // (and this buffer) goes back to the pool.
         Some(URL::parse(unsafe {
             bun_ptr::detach_lifetime(&self.http_proxy_buf)
         }))

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -60,8 +60,7 @@ pub struct NetworkTask {
     // `tarball.url` in the latter would be a self-reference
     // into `callback`; owning avoids that at the cost of one copy per tarball download.
     pub(crate) url_buf: Box<[u8]>,
-    /// Proxy href the request goes through (empty: direct); borrowed by the
-    /// `AsyncHTTP` like `url_buf`.
+    /// Proxy href for this request (empty: direct); owned like `url_buf`, `AsyncHTTP` borrows it.
     pub(crate) http_proxy_buf: Box<[u8]>,
     pub(crate) retried: u16,
     pub(crate) response_buffer: MutableString,

--- a/src/install/NetworkTask.rs
+++ b/src/install/NetworkTask.rs
@@ -11,7 +11,7 @@ use bun_http::{
     HeaderBuilder, async_http::Options as AsyncHTTPOptions,
 };
 use bun_threading::thread_pool::Batch;
-use bun_url::URL;
+use bun_url::{OwnedURL, URL};
 
 use crate::extract_tarball;
 use crate::npm::{self as npm, PackageManifest};
@@ -60,6 +60,10 @@ pub struct NetworkTask {
     // `tarball.url` in the latter would be a self-reference
     // into `callback`; owning avoids that at the cost of one copy per tarball download.
     pub(crate) url_buf: Box<[u8]>,
+    /// Normalized href of the proxy this request goes through; empty when it
+    /// connects directly. Owned here like `url_buf`: the `AsyncHTTP` borrows it
+    /// for as long as the request (including retries) is in flight.
+    pub(crate) http_proxy_buf: Box<[u8]>,
     pub(crate) retried: u16,
     pub(crate) response_buffer: MutableString,
     // BACKREF: PackageManager owns this task via `preallocated_network_tasks`.
@@ -168,6 +172,25 @@ impl NetworkTask {
     fn pm_mut<'a>(&self) -> &'a mut PackageManager {
         // SAFETY: see fn doc — BACKREF, write provenance, single-threaded.
         unsafe { self.package_manager.assume_mut() }
+    }
+
+    /// Store the proxy `url` should go through in `http_proxy_buf` and return
+    /// the view of it that the `AsyncHTTP` built by the caller keeps.
+    fn http_proxy_for(&mut self, pm: &PackageManager, url: &URL<'_>) -> Option<URL<'static>> {
+        self.http_proxy_buf = pm
+            .http_proxy(url)
+            .map_or_else(Box::default, OwnedURL::into_href);
+        if self.http_proxy_buf.is_empty() {
+            return None;
+        }
+        // SAFETY: lifetime extension — `http_proxy_buf` is a heap allocation
+        // owned by `*self`, which outlives the HTTP request: `run_tasks` drops
+        // `unsafe_http_client` before returning the slot (and with it this
+        // buffer) to the pool. Same pattern as `url_buf` in `for_manifest` /
+        // `for_tarball`.
+        Some(URL::parse(unsafe {
+            bun_ptr::detach_lifetime(&self.http_proxy_buf)
+        }))
     }
 
     // Signature matches `HTTPClientResultCallback::new::<NetworkTask>`'s
@@ -647,7 +670,7 @@ impl NetworkTask {
         // because the HTTP thread reads them concurrently. See the
         // identical pattern in `s3/simple_request.rs`.
         let url = URL::parse(unsafe { bun_ptr::detach_lifetime(&self.url_buf) });
-        let http_proxy = pm.http_proxy(&url);
+        let http_proxy = self.http_proxy_for(pm, &url);
         // SAFETY: `written_slice()` is the safe (ptr,len) accessor; only the
         // `'static` erasure remains unsafe — the buffer is leaked into the
         // HTTP client below (`ManuallyDrop`), so it genuinely outlives this frame.
@@ -860,7 +883,7 @@ impl NetworkTask {
         let url = URL::parse(unsafe { bun_ptr::detach_lifetime(&self.url_buf) });
 
         let mut http_options = AsyncHTTPOptions {
-            http_proxy: pm.http_proxy(&url),
+            http_proxy: self.http_proxy_for(pm, &url),
             ..Default::default()
         };
 
@@ -992,6 +1015,7 @@ impl NetworkTask {
             // Struct-default fields.
             addr_of_mut!((*slot).response).write(HTTPClientResult::default());
             addr_of_mut!((*slot).url_buf).write(Box::default());
+            addr_of_mut!((*slot).http_proxy_buf).write(Box::default());
             addr_of_mut!((*slot).retried).write(0);
             addr_of_mut!((*slot).next).write(bun_threading::Link::new());
             addr_of_mut!((*slot).tarball_stream).write(None);

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -26,7 +26,7 @@ use bun_semver as Semver;
 use bun_sys::{self, Fd};
 use bun_threading::{ThreadPool, UnboundedQueue, thread_pool};
 use bun_transpiler as transpiler;
-use bun_url::URL;
+use bun_url::{OwnedURL, URL};
 
 // `bun.spawn.process.WaiterThread` — the force-waiter-thread flag was moved
 // down into `bun_spawn::process` (MOVE_DOWN b0); install just flips it during
@@ -946,10 +946,8 @@ impl PackageManager {
         Ok(unsafe { &mut *ptr })
     }
 
-    pub fn http_proxy(&self, url: &URL<'_>) -> Option<URL<'static>> {
-        // `env_mut()` yields an unbounded `&'a Loader` (process-lifetime
-        // singleton), so the returned `URL<'_>` borrows for `'static`.
-        self.env_mut().get_http_proxy_for(url)
+    pub fn http_proxy(&self, url: &URL<'_>) -> Option<OwnedURL> {
+        self.env().get_http_proxy_for(url)
     }
 
     pub fn tls_reject_unauthorized(&self) -> bool {

--- a/src/install/PackageManager/runTasks.rs
+++ b/src/install/PackageManager/runTasks.rs
@@ -1822,7 +1822,7 @@ pub fn generate_network_task_for_tarball<'a>(
     // Full struct overwrite that resets
     // every other field (`retried`, `response`, `streaming_committed`,
     // `tarball_stream`, `streaming_extract_task`, `next`, `url_buf`,
-    // `signal_store`) to its struct default. The slot may be uninitialized
+    // `http_proxy_buf`, `signal_store`) to its struct default. The slot may be uninitialized
     // (`HiveArrayFallback::get()` heap fallback) or stale (reused hive slot).
     // SAFETY: `net_ptr` is the unique handle to a freshly-vended pool slot; no
     // other alias exists until we return it.

--- a/src/runtime/cli/audit_command.rs
+++ b/src/runtime/cli/audit_command.rs
@@ -486,7 +486,7 @@ fn send_audit_request(
         headers.entries,
         headers_buf,
         &final_compressed_body,
-        http_proxy,
+        http_proxy.as_ref().map(|proxy| proxy.url()),
         None,
         http::FetchRedirect::Follow,
     );

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -2038,8 +2038,7 @@ impl Example {
             *URL_.get() = Some(api_url.erase_lifetime());
         }
 
-        // `async_http` below is `cli_arena()`-backed (so its type parameter is
-        // `'static`); park the proxy href in the same arena.
+        // `async_http` below lives in `cli_arena()` and is `'static`, so its proxy must be too.
         fn arena_http_proxy(env_loader: &DotEnv::Loader, url: &URL<'_>) -> Option<URL<'static>> {
             let proxy = env_loader.get_http_proxy_for(url)?;
             Some(URL::parse(crate::cli::cli_dupe(proxy.href())))

--- a/src/runtime/cli/create_command.rs
+++ b/src/runtime/cli/create_command.rs
@@ -1952,7 +1952,7 @@ impl Example {
             header_entries,
             headers_buf,
             b"",
-            http_proxy,
+            http_proxy.as_ref().map(|proxy| proxy.url()),
             None,
             HTTP::FetchRedirect::Follow,
         ));
@@ -2038,13 +2038,14 @@ impl Example {
             *URL_.get() = Some(api_url.erase_lifetime());
         }
 
-        // SAFETY: `http_proxy` borrows from `env_loader`, which outlives this
-        // fn. Erased to `'static` because `async_http` is `cli_arena()`-backed
-        // (so its type parameter is `'static`), but the proxy URL is only read
-        // during the `send_sync()` calls below while `env_loader` is live.
-        let mut http_proxy: Option<URL<'static>> = env_loader
-            .get_http_proxy_for(unsafe { (*URL_.get()).as_ref().unwrap() })
-            .map(|u| unsafe { u.erase_lifetime() });
+        // `async_http` below is `cli_arena()`-backed (so its type parameter is
+        // `'static`); park the proxy href in the same arena.
+        fn arena_http_proxy(env_loader: &DotEnv::Loader, url: &URL<'_>) -> Option<URL<'static>> {
+            let proxy = env_loader.get_http_proxy_for(url)?;
+            Some(URL::parse(crate::cli::cli_dupe(proxy.href())))
+        }
+        // SAFETY: single-threaded CLI access to static URL_ (set just above)
+        let http_proxy = arena_http_proxy(env_loader, unsafe { (*URL_.get()).as_ref().unwrap() });
 
         // ensure very stable memory address
         let async_http: &mut HTTP::AsyncHTTP =
@@ -2137,10 +2138,7 @@ impl Example {
         // ensure very stable memory address
         let parsed_tarball_url = URL::parse(tarball_url);
 
-        // SAFETY: see note on `http_proxy` above.
-        http_proxy = env_loader
-            .get_http_proxy_for(&parsed_tarball_url)
-            .map(|u| unsafe { u.erase_lifetime() });
+        let http_proxy = arena_http_proxy(env_loader, &parsed_tarball_url);
 
         *async_http = HTTP::AsyncHTTP::init_sync(
             HTTP::Method::GET,
@@ -2193,7 +2191,7 @@ impl Example {
             Default::default(),
             b"",
             b"",
-            http_proxy,
+            http_proxy.as_ref().map(|proxy| proxy.url()),
             None,
             HTTP::FetchRedirect::Follow,
         ));

--- a/src/runtime/cli/pm_view_command.rs
+++ b/src/runtime/cli/pm_view_command.rs
@@ -128,7 +128,7 @@ pub(crate) fn view(
         headers.entries,
         header_buf,
         b"",
-        http_proxy,
+        http_proxy.as_ref().map(|proxy| proxy.url()),
         None,
         http::FetchRedirect::Follow,
     );

--- a/src/runtime/cli/upgrade_command.rs
+++ b/src/runtime/cli/upgrade_command.rs
@@ -265,7 +265,7 @@ impl UpgradeCommand {
             header_entries,
             headers_buf,
             b"",
-            http_proxy,
+            http_proxy.as_ref().map(|proxy| proxy.url()),
             None,
             HTTP::FetchRedirect::Follow,
         ));
@@ -657,7 +657,7 @@ impl UpgradeCommand {
                 headers::EntryList::default(),
                 b"",
                 b"",
-                http_proxy,
+                http_proxy.as_ref().map(|proxy| proxy.url()),
                 None,
                 HTTP::FetchRedirect::Follow,
             ));
@@ -687,8 +687,6 @@ impl UpgradeCommand {
                 200 => {}
                 _ => return Err(crate::Error::HTTPError),
             }
-            // Release the immutable borrow of `env_loader` (via `http_proxy`)
-            // before the map mutations below.
             drop(async_http);
 
             let bytes = zip_file_buffer.slice();

--- a/src/runtime/server/RequestContext.rs
+++ b/src/runtime/server/RequestContext.rs
@@ -2565,20 +2565,19 @@ where
                     let path = s3.path();
                     // `Transpiler::env_mut` is the safe accessor for the
                     // process-singleton dotenv loader (set during init).
-                    let proxy_url = global_this
+                    let proxy = global_this
                         .bun_vm()
                         .as_mut()
                         .transpiler
                         .env_mut()
-                        .get_http_proxy(true, None, None)
-                        .map(|proxy| proxy.href);
+                        .get_http_proxy(true, None, None);
 
                     let _ = S3::client::stat(
                         credentials,
                         path,
                         Self::on_s3_size_resolved_thunk,
                         this.as_ctx_ptr().cast::<c_void>(),
-                        proxy_url,
+                        proxy.as_ref().map(|proxy| proxy.href()),
                         s3.request_payer,
                     ); // TODO: properly propagate exception upwards
                     return;

--- a/src/runtime/webcore/Blob.rs
+++ b/src/runtime/webcore/Blob.rs
@@ -29,12 +29,9 @@ use crate::webcore::{self, Lifetime, ReadableStream, Request, Response, streams}
 
 bun_core::define_scoped_log!(debug, Blob, visible);
 
-/// `bunVM().transpiler.env.getHttpProxy(true, null, null)?.href` as an owned
-/// buffer. Owned (not borrowed) because the env loader's `URL<'_>` ties the
-/// `href` slice to a `&mut Loader` borrow that we cannot keep open across the
-/// S3 request setup.
+/// The `http_proxy` href S3 requests go through, if one is configured.
 #[inline]
-fn http_proxy_href(global: &JSGlobalObject) -> Option<Vec<u8>> {
+fn http_proxy_href(global: &JSGlobalObject) -> Option<Box<[u8]>> {
     // `Transpiler::env_mut` is the safe accessor for the process-singleton
     // dotenv loader (initialised before any JS runs).
     global
@@ -43,7 +40,7 @@ fn http_proxy_href(global: &JSGlobalObject) -> Option<Vec<u8>> {
         .transpiler
         .env_mut()
         .get_http_proxy(true, None, None)
-        .map(|p| p.href.to_vec())
+        .map(bun_url::OwnedURL::into_href)
 }
 
 #[path = "blob/Store.rs"]
@@ -1423,12 +1420,8 @@ impl BlobExt for Blob {
             };
 
             let path = s3.path();
-            // SAFETY: bun_vm() never returns null for a Bun-owned global; `env`
-            // is a live `*mut Loader` owned by the transpiler.
-            let proxy = unsafe {
-                (*global_this.bun_vm().as_mut().transpiler.env).get_http_proxy(true, None, None)
-            };
-            let proxy_url = proxy.map(|p| p.href);
+            let proxy = http_proxy_href(global_this);
+            let proxy_url = proxy.as_deref();
 
             // When no JS overrides were supplied, hand the store's *base*
             // credentials to the upload (`upload_stream` consumes an
@@ -1711,15 +1704,7 @@ impl BlobExt for Blob {
             // content-type writes below don't conflict.
             let s3 = store.data.as_s3();
             let path = s3.path();
-            // SAFETY: `bun_vm()` returns the live per-global VM; `transpiler.env`
-            // is the process-singleton dotenv loader, never null once init'd.
-            let proxy_url: Option<bun_url::URL<'_>> = unsafe {
-                (*global_this.bun_vm().as_mut().transpiler.env).get_http_proxy(true, None, None)
-            };
-            // Copy the href out of the env map before any reentrant JS (the
-            // `get_truthy`/credential getters below) can mutate `process.env`
-            // and free the backing allocation.
-            let proxy_owned: Option<Vec<u8>> = proxy_url.as_ref().map(|p| p.href.to_vec());
+            let proxy_owned = http_proxy_href(global_this);
             let proxy = proxy_owned.as_deref();
 
             if has_args && arg0.is_object() {

--- a/src/runtime/webcore/ReadableStream.rs
+++ b/src/runtime/webcore/ReadableStream.rs
@@ -550,7 +550,7 @@ impl ReadableStream {
                     .transpiler
                     .env_mut()
                     .get_http_proxy(true, None, None);
-                let proxy_url = proxy.as_ref().map(|p| p.href);
+                let proxy_url = proxy.as_ref().map(|p| p.href());
 
                 crate::webcore::s3::client::readable_stream(
                     credentials,

--- a/src/runtime/webcore/S3File.rs
+++ b/src/runtime/webcore/S3File.rs
@@ -488,7 +488,9 @@ impl S3BlobStatTask {
             path,
             S3BlobStatTask::on_s3_exists_resolved,
             this.cast::<core::ffi::c_void>(),
-            env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
+            env.get_http_proxy(true, None, None)
+                .as_ref()
+                .map(|proxy| proxy.href()),
             s3_store.request_payer,
         )?;
         Ok(promise)
@@ -515,7 +517,9 @@ impl S3BlobStatTask {
             path,
             S3BlobStatTask::on_s3_stat_resolved,
             this.cast::<core::ffi::c_void>(),
-            env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
+            env.get_http_proxy(true, None, None)
+                .as_ref()
+                .map(|proxy| proxy.href()),
             s3_store.request_payer,
         )?;
         Ok(promise)
@@ -542,7 +546,9 @@ impl S3BlobStatTask {
             path,
             S3BlobStatTask::on_s3_size_resolved,
             this.cast::<core::ffi::c_void>(),
-            env.get_http_proxy(true, None, None).map(|proxy| proxy.href),
+            env.get_http_proxy(true, None, None)
+                .as_ref()
+                .map(|proxy| proxy.href()),
             s3_store.request_payer,
         )?;
         Ok(promise)

--- a/src/runtime/webcore/blob/Store.rs
+++ b/src/runtime/webcore/blob/Store.rs
@@ -20,7 +20,7 @@ use crate::webcore::s3::client::{
 };
 use bun_core::{ZigString, strings};
 use bun_http_types::MimeType::MimeType;
-use bun_url::URL;
+use bun_url::OwnedURL;
 
 #[cfg(unix)]
 use super::SizeType;
@@ -334,13 +334,13 @@ impl S3Ext for S3 {
         let value = promise.value();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
         // dotenv loader (never null once the VM is initialised).
-        let proxy_url: Option<URL<'_>> = global_this
+        let proxy_url: Option<OwnedURL> = global_this
             .bun_vm()
             .as_mut()
             .transpiler
             .env_mut()
             .get_http_proxy(true, None, None);
-        let proxy = proxy_url.as_ref().map(|url| url.href);
+        let proxy = proxy_url.as_ref().map(OwnedURL::href);
         let aws_options = self.get_credentials_with_options(extra_options, global_this)?;
         // `defer aws_options.deinit()` → Drop handles it.
 
@@ -429,13 +429,13 @@ impl S3Ext for S3 {
         let value = promise.value();
         // `Transpiler::env_mut` is the safe accessor for the process-singleton
         // dotenv loader (never null once the VM is initialised).
-        let proxy_url: Option<URL<'_>> = global_this
+        let proxy_url: Option<OwnedURL> = global_this
             .bun_vm()
             .as_mut()
             .transpiler
             .env_mut()
             .get_http_proxy(true, None, None);
-        let proxy = proxy_url.as_ref().map(|url| url.href);
+        let proxy = proxy_url.as_ref().map(OwnedURL::href);
         let aws_options = self.get_credentials_with_options(extra_options, global_this)?;
         // `defer aws_options.deinit()` → Drop handles it.
 

--- a/src/standalone_graph/StandaloneModuleGraph.rs
+++ b/src/standalone_graph/StandaloneModuleGraph.rs
@@ -1681,10 +1681,8 @@ pub(crate) fn download_to_path(
             // `progress.end()` below is sufficient: no fallible call sits between
             // `refresher.start` and it, so every exit path (including the
             // error returns after it) ends the node exactly once.
-            // Note: reshaped for borrowck — `get_http_proxy_for` borrows
-            // `env` for the proxy URL lifetime; read the bool first.
             let reject_unauthorized = env.get_tls_reject_unauthorized();
-            let http_proxy: Option<bun_url::URL<'_>> = env.get_http_proxy_for(&url);
+            let http_proxy = env.get_http_proxy_for(&url);
             let progress = refresher.start(b"Downloading", 0);
 
             let mut async_http = Box::new(bun_http::AsyncHTTP::init_sync(
@@ -1693,7 +1691,7 @@ pub(crate) fn download_to_path(
                 Default::default(),
                 b"",
                 b"",
-                http_proxy,
+                http_proxy.as_ref().map(|proxy| proxy.url()),
                 None,
                 bun_http::FetchRedirect::Follow,
             ));

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -600,16 +600,12 @@ impl<'a> URL<'a> {
                     // if there's no protocol or @, it's ambiguous whether the colon is a port or a username.
                     if offset > 0 {
                         let rest = &base[offset as usize..];
-                        // Only an `@` inside the authority (before the path, query or
-                        // hash, see https://github.com/oven-sh/bun/issues/1390) delimits
-                        // userinfo. `user@host:port` has its first colon after the `@`,
-                        // so the colon position says nothing about whether userinfo exists.
+                        // An `@` is userinfo only inside the authority (#1390 had one in the path).
                         let authority_len =
                             strings::index_of_any(rest, b"/?#").unwrap_or(rest.len());
                         if strings::contains_char(&rest[..authority_len], b'@') {
                             offset += url.parse_username(rest).unwrap_or(0);
-                            // `parse_username` stops at either `:` or `@`; a password only
-                            // follows the former.
+                            // The username ended at `:` (password follows) or at `@` (none).
                             if base[offset as usize - 1] == b':' {
                                 offset += url.parse_password(&base[offset as usize..]).unwrap_or(0);
                             }

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -600,9 +600,11 @@ impl<'a> URL<'a> {
                     // if there's no protocol or @, it's ambiguous whether the colon is a port or a username.
                     if offset > 0 {
                         let rest = &base[offset as usize..];
-                        // Userinfo ends at the last `@` of the authority (#1390 had one in the path).
+                        // Userinfo ends at the last `@` before the path (#1390 had one in the
+                        // path). As in `parse_host`, `#` does not end the authority: raw
+                        // .npmrc / bunfig / tarball credentials may contain one unencoded.
                         let authority =
-                            &rest[..strings::index_of_any(rest, b"/?#").unwrap_or(rest.len())];
+                            &rest[..strings::index_of_any(rest, b"/?").unwrap_or(rest.len())];
                         if let Some(at) = strings::last_index_of_char(authority, b'@') {
                             let userinfo = &authority[..at];
                             match strings::index_of_char_usize(userinfo, b':') {

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -599,19 +599,20 @@ impl<'a> URL<'a> {
                 if !is_relative_path {
                     // if there's no protocol or @, it's ambiguous whether the colon is a port or a username.
                     if offset > 0 {
-                        // see https://github.com/oven-sh/bun/issues/1390
-                        let first_at =
-                            strings::index_of_char(&base[offset as usize..], b'@').unwrap_or(0);
-                        let first_colon =
-                            strings::index_of_char(&base[offset as usize..], b':').unwrap_or(0);
-
-                        if first_at > first_colon
-                            && first_at
-                                < strings::index_of_char(&base[offset as usize..], b'/')
-                                    .unwrap_or(u32::MAX)
-                        {
-                            offset += url.parse_username(&base[offset as usize..]).unwrap_or(0);
-                            offset += url.parse_password(&base[offset as usize..]).unwrap_or(0);
+                        let rest = &base[offset as usize..];
+                        // Only an `@` inside the authority (before the path, query or
+                        // hash, see https://github.com/oven-sh/bun/issues/1390) delimits
+                        // userinfo. `user@host:port` has its first colon after the `@`,
+                        // so the colon position says nothing about whether userinfo exists.
+                        let authority_len =
+                            strings::index_of_any(rest, b"/?#").unwrap_or(rest.len());
+                        if strings::contains_char(&rest[..authority_len], b'@') {
+                            offset += url.parse_username(rest).unwrap_or(0);
+                            // `parse_username` stops at either `:` or `@`; a password only
+                            // follows the former.
+                            if base[offset as usize - 1] == b':' {
+                                offset += url.parse_password(&base[offset as usize..]).unwrap_or(0);
+                            }
                         }
                     }
 

--- a/src/url/lib.rs
+++ b/src/url/lib.rs
@@ -600,15 +600,19 @@ impl<'a> URL<'a> {
                     // if there's no protocol or @, it's ambiguous whether the colon is a port or a username.
                     if offset > 0 {
                         let rest = &base[offset as usize..];
-                        // An `@` is userinfo only inside the authority (#1390 had one in the path).
-                        let authority_len =
-                            strings::index_of_any(rest, b"/?#").unwrap_or(rest.len());
-                        if strings::contains_char(&rest[..authority_len], b'@') {
-                            offset += url.parse_username(rest).unwrap_or(0);
-                            // The username ended at `:` (password follows) or at `@` (none).
-                            if base[offset as usize - 1] == b':' {
-                                offset += url.parse_password(&base[offset as usize..]).unwrap_or(0);
+                        // Userinfo ends at the last `@` of the authority (#1390 had one in the path).
+                        let authority =
+                            &rest[..strings::index_of_any(rest, b"/?#").unwrap_or(rest.len())];
+                        if let Some(at) = strings::last_index_of_char(authority, b'@') {
+                            let userinfo = &authority[..at];
+                            match strings::index_of_char_usize(userinfo, b':') {
+                                Some(colon) => {
+                                    url.username = &userinfo[..colon];
+                                    url.password = &userinfo[colon + 1..];
+                                }
+                                None => url.username = userinfo,
                             }
+                            offset += u32::try_from(at + 1).expect("int cast");
                         }
                     }
 
@@ -715,30 +719,6 @@ impl<'a> URL<'a> {
             }
         }
 
-        None
-    }
-
-    pub(crate) fn parse_username(&mut self, str: &'a [u8]) -> Option<u32> {
-        // reset it
-        self.username = b"";
-
-        if str.len() < b"@".len() {
-            return None;
-        }
-        for i in 0..str.len() {
-            match str[i] {
-                b':' | b'@' => {
-                    // we found a username, everything before this point in the slice is a username
-                    self.username = &str[0..i];
-                    return Some(u32::try_from(i + 1).expect("int cast"));
-                }
-                // if we reach a slash or "?", there's no username
-                b'?' | b'/' => {
-                    return None;
-                }
-                _ => {}
-            }
-        }
         None
     }
 

--- a/test/cli/install/bun-install-proxy.test.ts
+++ b/test/cli/install/bun-install-proxy.test.ts
@@ -1,7 +1,7 @@
-import { beforeAll, it } from "bun:test";
+import { beforeAll, expect, it } from "bun:test";
 import { exec } from "child_process";
 import { rm } from "fs/promises";
-import { bunEnv, bunExe, dockerExe, isDockerEnabled, tempDirWithFiles } from "harness";
+import { bunEnv, bunExe, dockerExe, isDockerEnabled, tempDir, tempDirWithFiles } from "harness";
 import { join } from "path";
 import { promisify } from "util";
 const execAsync = promisify(exec);
@@ -95,3 +95,65 @@ if (isDockerEnabled()) {
     await Promise.all(promises);
   }, 60_000);
 }
+
+// No squid needed: the proxy below only records what reaches it. `bun install`
+// resolves the proxy through the same env lookup as fetch(), which since
+// #16182 normalizes the value the way new URL() would, so this padded spelling
+// has to reach the proxy instead of being parsed into a bogus host.
+it("bun install routes registry requests through a non-normalized http_proxy value", async () => {
+  let directRegistryHits = 0;
+  using registry = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch() {
+      directRegistryHits++;
+      return new Response(null, { status: 500 });
+    },
+  });
+  const proxyLog: string[] = [];
+  using proxy = Bun.listen<{ head: string }>({
+    hostname: "127.0.0.1",
+    port: 0,
+    socket: {
+      open(socket) {
+        socket.data = { head: "" };
+      },
+      data(socket, chunk) {
+        const head = (socket.data.head += new TextDecoder("latin1").decode(chunk));
+        if (!head.includes("\r\n\r\n")) return;
+        proxyLog.push(head.slice(0, head.indexOf("\r\n")));
+        socket.end("HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+      },
+    },
+  });
+  using dir = tempDir("install-env-proxy", {
+    "package.json": JSON.stringify({ name: "app", dependencies: { "only-behind-the-proxy": "1.0.0" } }),
+  });
+
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "install", "--registry", `http://127.0.0.1:${registry.port}/`],
+    cwd: String(dir),
+    env: {
+      ...bunEnv,
+      BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+      NO_PROXY: undefined,
+      no_proxy: undefined,
+      HTTP_PROXY: undefined,
+      HTTPS_PROXY: undefined,
+      https_proxy: undefined,
+      http_proxy: `  http:\\\\127.0.0.1:${proxy.port}  `,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+  const manifestUrl = `http://127.0.0.1:${registry.port}/only-behind-the-proxy`;
+  expect({ proxyLog, directRegistryHits, stdout, stderr, exitCode }).toEqual({
+    proxyLog: [`GET ${manifestUrl} HTTP/1.1`],
+    directRegistryHits: 0,
+    stdout: expect.stringContaining("bun install v"),
+    // The proxy's 404 is what fails the install, not a failure to reach the proxy.
+    stderr: expect.stringContaining(`error: GET ${manifestUrl} - 404`),
+    exitCode: 1,
+  });
+});

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4533,47 +4533,51 @@ describe.concurrent("bun-install", () => {
     });
   });
 
-  // #16181 / the second repro of #7416: the URL parser took `user@127.0.0.1` for
-  // the hostname when the userinfo had no password but the URL had a port, so
-  // the download never reached the server. (Sending the credentials as Basic
-  // auth, the rest of #7416, is a separate feature.)
-  it("connects to the host of a tarball URL that has a username but no password", async () => {
-    const requests: string[] = [];
-    using server = Bun.serve({
-      hostname: "127.0.0.1",
-      port: 0,
-      fetch(req) {
-        requests.push(`${req.method} ${new URL(req.url).pathname}`);
-        return new Response(null, { status: 404 });
-      },
-    });
-    const tarballUrl = `http://user@127.0.0.1:${server.port}/pkg.tgz`;
-    using dir = tempDir("tarball-userinfo", {
-      "package.json": JSON.stringify({ name: "foo", dependencies: { pkg: tarballUrl } }),
-    });
-    await using proc = spawn({
-      cmd: [bunExe(), "install"],
-      cwd: String(dir),
-      env: {
-        ...env,
-        BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
-        http_proxy: undefined,
-        HTTP_PROXY: undefined,
-        https_proxy: undefined,
-        HTTPS_PROXY: undefined,
-      },
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ requests, stdout, stderr, exitCode }).toEqual({
-      requests: ["GET /pkg.tgz"],
-      stdout: expect.stringContaining("bun install v1."),
-      // The server's 404 is what fails the install; before, the request never left the machine.
-      stderr: expect.stringContaining(`error: GET ${tarballUrl} - 404`),
-      exitCode: 1,
-    });
-  });
+  // Tarball URLs reach the URL parser as written, without WHATWG normalization.
+  // `user@` with a port used to be read as the hostname `user@127.0.0.1`
+  // (#16181, the second repro of #7416; sending the credentials as Basic auth,
+  // the rest of #7416, is a separate feature), and userinfo is delimited by the
+  // last `@` of the authority, so an unencoded `@` inside it stays userinfo.
+  it.each(["user@", "user:pw@", "user@pass@", "user:p@ss@"])(
+    "connects to the host of http://%s127.0.0.1:<port>/pkg.tgz",
+    async userinfo => {
+      const requests: string[] = [];
+      using server = Bun.serve({
+        hostname: "127.0.0.1",
+        port: 0,
+        fetch(req) {
+          requests.push(`${req.method} ${new URL(req.url).pathname}`);
+          return new Response(null, { status: 404 });
+        },
+      });
+      const tarballUrl = `http://${userinfo}127.0.0.1:${server.port}/pkg.tgz`;
+      using dir = tempDir("tarball-userinfo", {
+        "package.json": JSON.stringify({ name: "foo", dependencies: { pkg: tarballUrl } }),
+      });
+      await using proc = spawn({
+        cmd: [bunExe(), "install"],
+        cwd: String(dir),
+        env: {
+          ...env,
+          BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+          http_proxy: undefined,
+          HTTP_PROXY: undefined,
+          https_proxy: undefined,
+          HTTPS_PROXY: undefined,
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect({ requests, stdout, stderr, exitCode }).toEqual({
+        requests: ["GET /pkg.tgz"],
+        stdout: expect.stringContaining("bun install v1."),
+        // The server's 404 is what fails the install; before, the request never left the machine.
+        stderr: expect.stringContaining(`error: GET ${tarballUrl} - 404`),
+        exitCode: 1,
+      });
+    },
+  );
 
   it("should handle GitHub URL with existing lockfile", async () => {
     await withContext(defaultOpts, async ctx => {

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4533,6 +4533,48 @@ describe.concurrent("bun-install", () => {
     });
   });
 
+  // #16181 / the second repro of #7416: the URL parser took `user@127.0.0.1` for
+  // the hostname when the userinfo had no password but the URL had a port, so
+  // the download never reached the server. (Sending the credentials as Basic
+  // auth, the rest of #7416, is a separate feature.)
+  it("connects to the host of a tarball URL that has a username but no password", async () => {
+    const requests: string[] = [];
+    using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        requests.push(`${req.method} ${new URL(req.url).pathname}`);
+        return new Response(null, { status: 404 });
+      },
+    });
+    const tarballUrl = `http://user@127.0.0.1:${server.port}/pkg.tgz`;
+    using dir = tempDir("tarball-userinfo", {
+      "package.json": JSON.stringify({ name: "foo", dependencies: { pkg: tarballUrl } }),
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: {
+        ...env,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+        http_proxy: undefined,
+        HTTP_PROXY: undefined,
+        https_proxy: undefined,
+        HTTPS_PROXY: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ requests, stdout, stderr, exitCode }).toEqual({
+      requests: ["GET /pkg.tgz"],
+      stdout: expect.stringContaining("bun install v1."),
+      // The server's 404 is what fails the install; before, the request never left the machine.
+      stderr: expect.stringContaining(`error: GET ${tarballUrl} - 404`),
+      exitCode: 1,
+    });
+  });
+
   it("should handle GitHub URL with existing lockfile", async () => {
     await withContext(defaultOpts, async ctx => {
       const urls: string[] = [];

--- a/test/cli/install/bun-install.test.ts
+++ b/test/cli/install/bun-install.test.ts
@@ -4536,9 +4536,9 @@ describe.concurrent("bun-install", () => {
   // Tarball URLs reach the URL parser as written, without WHATWG normalization.
   // `user@` with a port used to be read as the hostname `user@127.0.0.1`
   // (#16181, the second repro of #7416; sending the credentials as Basic auth,
-  // the rest of #7416, is a separate feature), and userinfo is delimited by the
-  // last `@` of the authority, so an unencoded `@` inside it stays userinfo.
-  it.each(["user@", "user:pw@", "user@pass@", "user:p@ss@"])(
+  // the rest of #7416, is a separate feature). Userinfo is delimited by the last
+  // `@` before the path, so an unencoded `@` or `#` inside it stays userinfo.
+  it.each(["user@", "user:pw@", "user@pass@", "user:p@ss@", "user:p#ss@", "us#er:pw@"])(
     "connects to the host of http://%s127.0.0.1:<port>/pkg.tgz",
     async userinfo => {
       const requests: string[] = [];
@@ -4578,6 +4578,46 @@ describe.concurrent("bun-install", () => {
       });
     },
   );
+
+  // Registry URLs from bunfig / .npmrc are parsed as written as well, and their
+  // credentials become the Authorization header; an unencoded `#` in the
+  // password has always been accepted there.
+  it("sends the credentials of a bunfig registry URL whose password contains a #", async () => {
+    const requests: string[] = [];
+    using registry = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch(req) {
+        requests.push(`${req.method} ${new URL(req.url).pathname} ${req.headers.get("authorization")}`);
+        return new Response(null, { status: 404 });
+      },
+    });
+    using dir = tempDir("registry-userinfo", {
+      "package.json": JSON.stringify({ name: "foo", dependencies: { "some-pkg": "1.0.0" } }),
+      "bunfig.toml": `[install]\nregistry = "http://user:p#ss@127.0.0.1:${registry.port}/"\n`,
+    });
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd: String(dir),
+      env: {
+        ...env,
+        BUN_INSTALL_CACHE_DIR: join(String(dir), ".bun-cache"),
+        http_proxy: undefined,
+        HTTP_PROXY: undefined,
+        https_proxy: undefined,
+        HTTPS_PROXY: undefined,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ requests, stdout, stderr, exitCode }).toEqual({
+      requests: [`GET /some-pkg Basic ${btoa("user:p#ss")}`],
+      stdout: expect.stringContaining("bun install v1."),
+      stderr: expect.stringContaining("some-pkg@1.0.0 failed to resolve"),
+      exitCode: 1,
+    });
+  });
 
   it("should handle GitHub URL with existing lockfile", async () => {
     await withContext(defaultOpts, async ctx => {

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -523,9 +523,9 @@ test("proxy with long password (> 4096 chars) works correctly after redirect", a
 // must still send the colon. bun previously dropped the colon for empty
 // password and sent no header at all for empty username.
 //
-// Exercised via http_proxy in a subprocess (rather than the `{proxy}` option)
-// so the raw env string reaches bun_url::URL::parse without WHATWG
-// normalization first dropping the `:` and tripping the userinfo heuristic.
+// The `{proxy}` option and (since #16182) the env vars both go through the
+// WHATWG parser first, which serializes `user:@host:port` as `user@host:port`;
+// bun_url::URL::parse used to read that whole thing as the hostname.
 describe.each([
   { userinfo: "squidadmin:", decoded: "squidadmin:" },
   { userinfo: ":hunter2", decoded: ":hunter2" },
@@ -537,6 +537,20 @@ describe.each([
   // collapses to "" and the proxy is bypassed.
   const noProxyEnv = { ...bunEnv };
   for (const k of PROXY_ENV_KEYS) delete noProxyEnv[k];
+
+  test.concurrent("http target (absolute-form) via the proxy option", async () => {
+    const proxy = await createAuthCapturingProxy();
+    try {
+      const response = await fetch(httpServer.url, {
+        proxy: `http://${userinfo}@127.0.0.1:${proxy.port}`,
+        keepalive: false,
+      });
+      expect(response.status).toBe(200);
+      expect(proxy.capturedAuths).toEqual([expected]);
+    } finally {
+      await proxy.close();
+    }
+  });
 
   test.concurrent("http target (absolute-form)", async () => {
     const proxy = await createAuthCapturingProxy();
@@ -2318,5 +2332,182 @@ describe("http_proxy env var scheme is case-insensitive", () => {
     expect(stderr).toBe("");
     expect(stdout.trim()).toBe("ERR UnsupportedProxyProtocol");
     expect(exitCode).toBe(0);
+  });
+});
+
+describe("http_proxy/https_proxy env values are normalized like the fetch() proxy option (#16182)", () => {
+  // fetch(url, { proxy }) runs the proxy URL through the WHATWG parser, so each
+  // spelling below is accepted there and means http://127.0.0.1:<port>/. The env
+  // vars used to be handed to the lenient internal parser as written, which sent
+  // the request to a bogus host or port instead of the proxy.
+  const unsetProxyEnv = {
+    NO_PROXY: undefined,
+    no_proxy: undefined,
+    HTTP_PROXY: undefined,
+    http_proxy: undefined,
+    HTTPS_PROXY: undefined,
+    https_proxy: undefined,
+  };
+
+  async function fetchThroughEnvProxy(envKey: string, spell: (proxyPort: number) => string, target: string) {
+    const proxy = await createProxyServer(false);
+    try {
+      const proxyPort = (proxy.server.address() as net.AddressInfo).port;
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `const r = await fetch(process.env.TARGET, { keepalive: false, tls: { rejectUnauthorized: false } }); console.log(r.status);`,
+        ],
+        env: { ...bunEnv, ...unsetProxyEnv, [envKey]: spell(proxyPort), TARGET: target },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      return { stdout: stdout.trim(), stderr, exitCode, proxyLog: [...proxy.log] };
+    } finally {
+      // Not awaited, see the redirect test near the top of the file.
+      proxy.server.close();
+    }
+  }
+
+  const spellings = [
+    ["leading whitespace", "http_proxy", (p: number) => `  http://127.0.0.1:${p}`],
+    ["trailing whitespace", "HTTP_PROXY", (p: number) => `http://127.0.0.1:${p}  `],
+    ["tab inside the authority", "http_proxy", (p: number) => `http://127.0.0.1:\t${p}`],
+    ["backslashes", "HTTP_PROXY", (p: number) => `http:\\\\127.0.0.1:${p}`],
+    ["no slashes after the scheme", "http_proxy", (p: number) => `http:127.0.0.1:${p}`],
+    ["already normalized", "HTTP_PROXY", (p: number) => `http://127.0.0.1:${p}/`],
+    // new URL() rejects this one; it must keep getting the lenient treatment it always had.
+    ["scheme-less host:port", "http_proxy", (p: number) => `127.0.0.1:${p}`],
+  ] as const;
+
+  test.concurrent.each(spellings)("http target, %s", async (_label, envKey, spell) => {
+    const target = `http://127.0.0.1:${httpServer.port}/env-proxy`;
+    const { stdout, stderr, exitCode, proxyLog } = await fetchThroughEnvProxy(envKey, spell, target);
+    expect({ stdout, stderr, exitCode, proxyLog }).toEqual({
+      stdout: "200",
+      stderr: "",
+      exitCode: 0,
+      proxyLog: [`GET 127.0.0.1:${httpServer.port}/env-proxy`],
+    });
+  });
+
+  const httpsSpellings = [
+    ["leading whitespace", "https_proxy", (p: number) => `  http://127.0.0.1:${p}`],
+    ["backslashes", "HTTPS_PROXY", (p: number) => `http:\\\\127.0.0.1:${p}`],
+    ["no slashes after the scheme", "https_proxy", (p: number) => `http:127.0.0.1:${p}`],
+  ] as const;
+
+  test.concurrent.each(httpsSpellings)("https target (CONNECT), %s", async (_label, envKey, spell) => {
+    const target = `https://127.0.0.1:${httpsServer.port}/env-proxy`;
+    const { stdout, stderr, exitCode, proxyLog } = await fetchThroughEnvProxy(envKey, spell, target);
+    expect({ stdout, stderr, exitCode, proxyLog }).toEqual({
+      stdout: "200",
+      stderr: "",
+      exitCode: 0,
+      proxyLog: [`CONNECT 127.0.0.1:${httpsServer.port}`],
+    });
+  });
+
+  test.concurrent("every redirect hop uses the normalized proxy", async () => {
+    using origin = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: req =>
+        new URL(req.url).pathname === "/first"
+          ? new Response(null, { status: 302, headers: { Location: "/second" } })
+          : new Response("done"),
+    });
+    const { stdout, stderr, exitCode, proxyLog } = await fetchThroughEnvProxy(
+      "http_proxy",
+      p => `  http:\\\\127.0.0.1:${p}  `,
+      `http://127.0.0.1:${origin.port}/first`,
+    );
+    expect({ stdout, stderr, exitCode, proxyLog }).toEqual({
+      stdout: "200",
+      stderr: "",
+      exitCode: 0,
+      proxyLog: [`GET 127.0.0.1:${origin.port}/first`, `GET 127.0.0.1:${origin.port}/second`],
+    });
+  });
+
+  /** A proxy that answers every request itself with whatever `respond` builds from the request head. */
+  async function answeringProxy(respond: (headLines: string[]) => string) {
+    const log: string[] = [];
+    const server = net.createServer(socket => {
+      socket.on("error", () => {});
+      let head = "";
+      socket.on("data", chunk => {
+        head += chunk.toString("latin1");
+        const end = head.indexOf("\r\n\r\n");
+        if (end === -1) return;
+        socket.removeAllListeners("data");
+        const lines = head.slice(0, end).split("\r\n");
+        log.push(lines[0]);
+        socket.end(respond(lines));
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    return { port: (server.address() as net.AddressInfo).port, log, [Symbol.dispose]: () => server.close() };
+  }
+
+  test.concurrent("credentials survive normalization", async () => {
+    // The WHATWG parser percent-encodes the space in the password and leaves the
+    // %40 alone; Proxy-Authorization must still carry the decoded credentials.
+    using proxy = await answeringProxy(lines => {
+      const auth = lines
+        .find(l => /^proxy-authorization:/i.test(l))
+        ?.slice("proxy-authorization:".length)
+        .trim();
+      return `HTTP/1.1 200 OK\r\nContent-Length: ${String(auth).length}\r\nConnection: close\r\n\r\n${auth}`;
+    });
+    const target = `http://127.0.0.1:${httpServer.port}/env-proxy-auth`;
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "-e", `console.log(await (await fetch(process.env.TARGET, { keepalive: false })).text());`],
+      env: {
+        ...bunEnv,
+        ...unsetProxyEnv,
+        http_proxy: `  http://us%40er:p ss@127.0.0.1:${proxy.port}  `,
+        TARGET: target,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, proxyLog: proxy.log }).toEqual({
+      stdout: `Basic ${btoa("us@er:p ss")}`,
+      stderr: "",
+      exitCode: 0,
+      proxyLog: [`GET ${target} HTTP/1.1`],
+    });
+  });
+
+  test.concurrent("S3 requests read the same normalized value", async () => {
+    // S3 reads the env var through a different code path than fetch(), so it
+    // gets its own case. The proxy answers the absolute-form HEAD itself; the
+    // endpoint (this file's plain http origin) would answer without an ETag.
+    using proxy = await answeringProxy(
+      () => `HTTP/1.1 200 OK\r\nContent-Length: 5\r\nETag: "abc"\r\nConnection: close\r\n\r\n`,
+    );
+    const endpoint = `http://127.0.0.1:${httpServer.port}`;
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const s = await Bun.S3Client.stat("key", { accessKeyId: "x", secretAccessKey: "y", bucket: "b", endpoint: process.env.ENDPOINT }); console.log(s.size);`,
+      ],
+      env: { ...bunEnv, ...unsetProxyEnv, HTTP_PROXY: `http:127.0.0.1:${proxy.port}`, ENDPOINT: endpoint },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), stderr, exitCode, proxyLog: proxy.log }).toEqual({
+      stdout: "5",
+      stderr: "",
+      exitCode: 0,
+      proxyLog: [`HEAD ${endpoint}/b/key HTTP/1.1`],
+    });
   });
 });

--- a/test/js/bun/http/proxy.test.ts
+++ b/test/js/bun/http/proxy.test.ts
@@ -2453,9 +2453,16 @@ describe("http_proxy/https_proxy env values are normalized like the fetch() prox
     return { port: (server.address() as net.AddressInfo).port, log, [Symbol.dispose]: () => server.close() };
   }
 
-  test.concurrent("credentials survive normalization", async () => {
-    // The WHATWG parser percent-encodes the space in the password and leaves the
-    // %40 alone; Proxy-Authorization must still carry the decoded credentials.
+  const credentialSpellings = [
+    // The WHATWG parser percent-encodes the space and leaves the %40 alone;
+    // Proxy-Authorization must carry the decoded credentials.
+    ["normalized by new URL()", (p: number) => `  http://us%40er:p ss@127.0.0.1:${p}  `, "us@er:p ss"],
+    // new URL() rejects this one (the # starts a fragment, leaving the port "p"),
+    // so it is used as written and has to keep working the way it always did.
+    ["rejected by new URL()", (p: number) => `http://user:p#ss@127.0.0.1:${p}`, "user:p#ss"],
+  ] as const;
+
+  test.concurrent.each(credentialSpellings)("credentials %s reach the proxy", async (_label, spell, decoded) => {
     using proxy = await answeringProxy(lines => {
       const auth = lines
         .find(l => /^proxy-authorization:/i.test(l))
@@ -2466,18 +2473,13 @@ describe("http_proxy/https_proxy env values are normalized like the fetch() prox
     const target = `http://127.0.0.1:${httpServer.port}/env-proxy-auth`;
     await using proc = Bun.spawn({
       cmd: [bunExe(), "-e", `console.log(await (await fetch(process.env.TARGET, { keepalive: false })).text());`],
-      env: {
-        ...bunEnv,
-        ...unsetProxyEnv,
-        http_proxy: `  http://us%40er:p ss@127.0.0.1:${proxy.port}  `,
-        TARGET: target,
-      },
+      env: { ...bunEnv, ...unsetProxyEnv, http_proxy: spell(proxy.port), TARGET: target },
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout: stdout.trim(), stderr, exitCode, proxyLog: proxy.log }).toEqual({
-      stdout: `Basic ${btoa("us@er:p ss")}`,
+      stdout: `Basic ${btoa(decoded)}`,
       stderr: "",
       exitCode: 0,
       proxyLog: [`GET ${target} HTTP/1.1`],

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3477,9 +3477,11 @@ describe("connects to the host of a URL whose authority contains an @", () => {
   // was present from the position of the first colon, so `user@host:port`
   // (credentials without a password, plus an explicit port) was connected to
   // as if `user@host` were the hostname. An @ outside the authority (#1390)
-  // must still not be mistaken for userinfo.
+  // must still not be mistaken for userinfo, and the Host header the server
+  // sees must be the bare host:port in every case.
   it.each([
     ["user@", "/creds"],
+    ["user@", ""],
     ["user:pw@", "/creds"],
     [":pw@", "/creds"],
     ["", "/@/path"],
@@ -3488,12 +3490,12 @@ describe("connects to the host of a URL whose authority contains an @", () => {
     using server = Bun.serve({
       hostname: "127.0.0.1",
       port: 0,
-      fetch: req => new Response(new URL(req.url).pathname),
+      fetch: req => new Response(`${req.headers.get("host")} ${new URL(req.url).pathname}`),
     });
     const res = await fetch(`http://${userinfo}127.0.0.1:${server.port}${pathAndQuery}`, { keepalive: false });
-    expect({ status: res.status, pathname: await res.text() }).toEqual({
+    expect({ status: res.status, hostAndPath: await res.text() }).toEqual({
       status: 200,
-      pathname: new URL(pathAndQuery, "http://x").pathname,
+      hostAndPath: `127.0.0.1:${server.port} ${new URL(pathAndQuery, "http://x").pathname}`,
     });
   });
 });

--- a/test/js/web/fetch/fetch.test.ts
+++ b/test/js/web/fetch/fetch.test.ts
@@ -3470,3 +3470,30 @@ it("verbose fetch logging prints [redacted] in place of Authorization credential
   expect(stderr).not.toContain("sekret-token");
   expect(exitCode).toBe(0);
 });
+
+describe("connects to the host of a URL whose authority contains an @", () => {
+  // After WHATWG normalization the request URL is re-read by bun's own URL
+  // parser to pick the host to connect to. It used to decide whether userinfo
+  // was present from the position of the first colon, so `user@host:port`
+  // (credentials without a password, plus an explicit port) was connected to
+  // as if `user@host` were the hostname. An @ outside the authority (#1390)
+  // must still not be mistaken for userinfo.
+  it.each([
+    ["user@", "/creds"],
+    ["user:pw@", "/creds"],
+    [":pw@", "/creds"],
+    ["", "/@/path"],
+    ["", "/?next=a@b"],
+  ])("http://%s127.0.0.1:<port>%s", async (userinfo, pathAndQuery) => {
+    using server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: req => new Response(new URL(req.url).pathname),
+    });
+    const res = await fetch(`http://${userinfo}127.0.0.1:${server.port}${pathAndQuery}`, { keepalive: false });
+    expect({ status: res.status, pathname: await res.text() }).toEqual({
+      status: 200,
+      pathname: new URL(pathAndQuery, "http://x").pathname,
+    });
+  });
+});


### PR DESCRIPTION
### Problem
- `http_proxy` / `HTTP_PROXY` / `https_proxy` / `HTTPS_PROXY` are handed to Bun's lenient internal URL parser exactly as written, while `fetch(url, { proxy })` runs the same value through the WHATWG parser first. Every spelling below is accepted by `new URL()` and means `http://127.0.0.1:<port>/`, but as an env var none of them reach the proxy (probe against a local proxy, released build):

  | value | result |
  | --- | --- |
  | `  http://127.0.0.1:<port>` | `getaddrinfo ENOTFOUND` |
  | `http://127.0.0.1:<port>  ` | `ConnectionRefused` (port parsed with the spaces) |
  | `http://127.0.0.1:\t<port>` | `ConnectionRefused` |
  | `http:\\127.0.0.1:<port>` | tries to resolve a host named `http` |
  | `http:127.0.0.1:<port>` | tries to resolve a host named `http` |
- Two readers share the bug: `Loader::get_http_proxy` (`src/dotenv/env_loader.rs`, used by `bun install` / `pm view` / `audit` / `upgrade` / `create` / `build --compile` / S3) and `ProxySettings::from_env` (`src/http/lib.rs`, used by `fetch()` for hop 0 and every redirect hop), which copied the raw bytes itself.
- Found while fixing it: `bun_url::URL::parse` (`src/url/lib.rs`) decides whether an authority has userinfo from the position of the first colon, so `user@host:port` (colon after the `@`) is read as a hostname (#16181). The WHATWG serializer produces exactly that shape for `user:@host:port`, which is why today `fetch("http://user@127.0.0.1:8080/")`, `fetch(url, { proxy: "http://user:@proxy:8080" })` and `bun install` of a `http://user@host:port/pkg.tgz` tarball (the second repro in #7416) all fail with `ENOTFOUND user@127.0.0.1` / `DNSResolveFailed`, and why normalizing the env value alone made the existing "keeps the colon for userinfo `squidadmin:`" tests fail.
- Fixes #16182. Fixes #16181. Fixes #33616 (a second report of the same `user@host:port` parse; its cases were folded into the fetch test).
- Not closed here: #7416 also asks for the credentials to be sent as Basic auth (a feature this PR does not add; only its connection failure goes away), and #16183 is an umbrella: its userinfo points (no password parse after `user@`, last-`@` splitting, `?` ending the search) are covered, `#` as a delimiter is deliberately not (see the `URL::parse` bullet), and its design question stays open.

### Fix
- `Loader::get_http_proxy` normalizes the value with `bun_url::URL::from_string` (the JSC-free entry to the same WTF::URL parser `fetch`'s `proxy` option uses) and returns an `OwnedURL`. When WTF::URL rejects the value (e.g. a scheme-less `host:port`, which works today) the raw bytes are kept, so everything that works today still works; the NO_PROXY check and the empty / `""` / `''` handling are unchanged.
- `ProxySettings::from_env` is built from that lookup instead of re-reading the env, so hop 0 and the redirect re-evaluation (`reevaluate_proxy_for_redirect` compares hrefs byte for byte) use the same normalized href. The duplicated `no_proxy` reads collapse into `Loader::get_no_proxy`, also used by `is_no_proxy`.
- Load-bearing hunks, for orientation: the `URL::from_string(...)` call in `get_http_proxy`, the `get_http_proxy` call in `ProxySettings::from_env`, and the `authority` / `last_index_of_char` block in `URL::parse`; everything else is plumbing for the owned return type. The `TODO` about interning the proxy strings in `get_http_proxy` is removed on purpose: nothing hands out borrows of the env map anymore, so there is nothing left to intern.
- Callers adapt to the owned return: S3 sites pass `.href()`, the synchronous CLI sites hold the `OwnedURL` for the duration of `send_sync`, `bun create` dupes it into the CLI arena it already uses (replacing two `erase_lifetime` casts), and `NetworkTask` gets an `http_proxy_buf` field next to `url_buf` (initialised in `write_init`, freed with the task) since its `AsyncHTTP` is `'static`. The `Blob.rs` sites that copied the href defensively now just call the existing helper; the hazard they copied around (the env map entry being freed by a `process.env.HTTP_PROXY =` assignment while the request is in flight) is gone for every caller because nothing borrows the map anymore.
- `URL::parse` now splits the authority (everything before the first `/` or `?`) at its last `@`, and the userinfo at its first `:`, which is the RFC 3986 / WHATWG rule for the part that matters here: an `@` in the path (#1390, the case the old heuristic was written for) or query is still not userinfo, `user@host:port` connects to `host`, and an unencoded `@` inside the credentials (`user:p@ss@host`, which WTF::URL would serialize as `p%40ss`) stays part of them instead of becoming part of the hostname. `#` intentionally does not end the authority, exactly as in `parse_host` and the old code: registry URLs from bunfig / .npmrc, tarball dependencies and the proxy values WTF::URL rejects are parsed as written, and passwords with an unencoded `#` in them have always worked there (self-review of an earlier revision of this PR caught that cutting at `#` broke them). `parse_username` has no callers left and is deleted. The one behavior that does change for such values: an env proxy value with an unencoded `#` that WTF::URL happens to accept (`http://user#1:pass@proxy/`, which it reads as host `user` plus a fragment) is now routed the way `new URL()` and curl read it, i.e. it fails to resolve `user`; `%23` works before and after.
- Why this is the right shape: the env var and the `proxy` option are two spellings of the same setting, so they should go through the same parser; after this change Bun connects to whatever host and port `new URL(process.env.HTTP_PROXY)` reports, which is also the consistency the issue asks for. Normalizing once at the lookup means every consumer (fetch, redirects, install, S3, CLI downloads) gets it, and the parser fix makes the normalized form parse the same way the raw form did.
- Verified:
  - `test/js/bun/http/proxy.test.ts`: new `#16182` group (http and https targets for each spelling, a scheme-less value staying accepted, credentials both in a value `new URL()` normalizes and in one it rejects, every redirect hop, and S3) plus a `{ proxy }` option variant of the existing userinfo-colon group. 11 of the new cases and the `squidadmin:` option case fail on the released build; the rejected-credentials case and the scheme-less case are the regression guards for the raw fallback; the whole file passes (85 tests) with this change.
  - `test/js/web/fetch/fetch.test.ts`: `user@host:port` fetch with and without a path (#16181 / #33616) plus `user:pw@`, `:pw@`, `/@/path` and `?next=a@b` guards for the parser change; every case also checks the `Host` header the server receives is the bare `host:port`. The two `user@` cases fail on the released build.
  - `test/cli/install/bun-install-proxy.test.ts`: `bun install` sends the manifest request through a padded, backslashed `http_proxy` (fails on the released build with `DNSResolveFailed`), exercising the `NetworkTask` storage.
  - `test/cli/install/bun-install.test.ts`: tarball dependencies with `user@`, `user:pw@`, `user@pass@`, `user:p@ss@`, `user:p#ss@` and `us#er:pw@` userinfo all reach the server (#16181 / #7416's second repro; the released build fails the three `@` shapes with `DNSResolveFailed`, the `#` shapes are regression guards), and a bunfig `registry = "http://user:p#ss@..."` still produces `Authorization: Basic` for `user:p#ss`. Registry and tarball URLs are the entry points where `URL::parse` gets the raw, non-normalized string.
  - `test/js/web/fetch/fetch.test.ts` as a whole has the same set of failures with and without this change in this container (tests binding `localhost` resolve it to `::1` here); nothing new.

### Background
- Bun has two URL parsers. WTF::URL (WebKit) is the WHATWG-compliant one behind `new URL()`; `bun_url::URL::parse` is a zero-copy parser that slices an already-normalized href into protocol / host / port / path views and is what the HTTP client reads its connection target from. The convention everywhere else (request URLs, redirect `Location`, the `proxy` option) is to run user input through WTF::URL first and hand the serialized href to `URL::parse`; the proxy env vars were the exception.
- `bun_url::OwnedURL` owns a normalized href buffer and re-derives the `URL<'_>` view on demand, which is what the lookup now returns; before, it returned a view borrowing the env map's own storage, which is why every call site either kept the loader borrowed or copied the bytes.
- `ProxySettings` is the per-request snapshot of `http_proxy` / `https_proxy` / `no_proxy` that `fetch()` hands to the HTTP thread so each redirect hop can re-decide whether and which proxy applies; `HTTPClient::reevaluate_proxy_for_redirect` compares the snapshot's href with the one currently in use to decide whether to rebuild the proxy state.
- `NetworkTask` is `bun install`'s pooled per-request object; its `AsyncHTTP` is lifetime-erased to `'static`, so every buffer the request reads (already `url_buf`, now the proxy href too) has to be owned by the task itself and is dropped when the pool reclaims the slot.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/bun-install.test.ts test/js/web/fetch/fetch.test.ts

<!-- robobun:evidence:end -->