### PR TITLE
node:http2: release streams whose END_STREAM was flushed from the outbound queue

### DIFF
--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1889,6 +1889,9 @@ impl Stream {
                         identifier.ensure_still_alive();
                         if self.state == StreamState::HALF_CLOSED_REMOTE {
                             self.state = StreamState::CLOSED;
+                            // Same as send_data's direct-write close. JS skips rstStream for a
+                            // natively closed stream, so nothing else releases it.
+                            self.free_resources::<false>(client);
                         } else {
                             self.state = StreamState::HALF_CLOSED_LOCAL;
                         }

--- a/src/runtime/api/bun/h2_frame_parser.rs
+++ b/src/runtime/api/bun/h2_frame_parser.rs
@@ -1889,8 +1889,6 @@ impl Stream {
                         identifier.ensure_still_alive();
                         if self.state == StreamState::HALF_CLOSED_REMOTE {
                             self.state = StreamState::CLOSED;
-                            // Same as send_data's direct-write close. JS skips rstStream for a
-                            // natively closed stream, so nothing else releases it.
                             self.free_resources::<false>(client);
                         } else {
                             self.state = StreamState::HALF_CLOSED_LOCAL;

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1727,14 +1727,17 @@ describe("stream release after a queued END_STREAM", () => {
     const client = http2.connect(await listen(server));
     try {
       const stalled = client.request({ ":path": "/stalled" });
-      stalled.on("error", () => {});
+      let stalledError: Error | null = null;
+      stalled.on("error", err => (stalledError = err));
       await once(stalled, "response");
       for (let i = 0; i < STREAMS; i++) {
         await roundTrip(client, { ":path": "/" }).closed;
       }
       expect(refs).toHaveLength(STREAMS);
       const live = await liveCount(refs);
-      // The premise: the stalled response was still queued while the other requests were answered.
+      // The premise: the stalled stream is still open (not errored or reset into releasing the
+      // queue) and its response was still queued while the other requests were answered.
+      expect(stalledError).toBeNull();
       expect(stalledFinished()).toBe(false);
       stalled.close();
       return live;

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1627,16 +1627,28 @@ describe("inbound stream lifecycle", () => {
 // A DATA frame that cannot be written right away (the peer's flow-control window is used up, the
 // socket has backpressure, or another stream on the session already has frames waiting) is put on
 // the session's outbound queue and written later, when a WINDOW_UPDATE or a writable socket drains
-// the queue. Draining the last queued frame of a stream whose peer half is already closed
-// completes the stream, and, exactly like the direct-write path, has to release it (the JS stream
-// object and the native entry) while the session lives on. Node releases these streams too; a
-// stream that is only released at session teardown is a per-request leak on a long-lived session.
+// the queue. Writing the last queued frame of a stream whose peer half is already closed completes
+// the stream, and, exactly like the direct-write path, has to release it (the JS stream object and
+// the native entry) while the session lives on. Node releases these streams too; a stream that is
+// only released at session teardown is a per-request leak on a long-lived session. END_STREAM can
+// ride on the queued frame that carries the last of the body or on an empty frame queued by itself
+// (end() without a body, or the empty frame that follows a body once no trailers are coming); the
+// queue writes the two through different branches, so both shapes are covered below.
 describe("stream release after a queued END_STREAM", () => {
   const STREAMS = 4;
   // The peer advertises a 1 KiB stream window: a 4 KiB body cannot be written in one go, so its
   // tail (the frame carrying END_STREAM) is queued and flushed as the peer's WINDOW_UPDATEs arrive.
   const WINDOW = 1024;
   const BODY = Buffer.alloc(4 * WINDOW, "x");
+  // Far more than the default window plus the receiving stream's readable buffer can hold, so a
+  // response of this size that the client never reads stays partly queued on the server for good.
+  const STALLED_BODY = Buffer.alloc(256 * 1024, "s");
+
+  async function listen(server: http2.Http2Server): Promise<string> {
+    server.listen(0);
+    await once(server, "listening");
+    return `http://127.0.0.1:${(server.address() as net.AddressInfo).port}`;
+  }
 
   async function liveCount(refs: WeakRef<object>[]): Promise<number> {
     const live = () => refs.filter(ref => ref.deref() !== undefined).length;
@@ -1649,35 +1661,49 @@ describe("stream release after a queued END_STREAM", () => {
     return live();
   }
 
-  /** Sends one request, drains its response, and resolves once the client stream has closed. */
+  /**
+   * Sends one request and resolves once the client stream has closed, reporting how many response
+   * body bytes arrived and how many frames the client session still had queued when the response
+   * headers came in.
+   */
   function roundTrip(client: http2.ClientHttp2Session, headers: http2.OutgoingHttpHeaders, body?: Buffer) {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const { promise, resolve, reject } = Promise.withResolvers<{ received: number; queuedAtResponse: number }>();
     const req = client.request(headers);
+    let received = 0;
+    let queuedAtResponse = -1;
     req.on("error", reject);
-    req.on("close", () => resolve());
-    req.resume();
+    req.on("response", () => {
+      queuedAtResponse = client.state.outboundQueueSize!;
+    });
+    req.on("data", (chunk: Buffer) => {
+      received += chunk.length;
+    });
+    req.on("close", () => resolve({ received, queuedAtResponse }));
     req.end(body);
     return { ref: new WeakRef<object>(req), closed: promise };
   }
 
   test("server streams whose response outgrew the client's window are released", async () => {
     const refs: WeakRef<object>[] = [];
+    const queuedAfterEnd: number[] = [];
     const server = http2.createServer();
     server.on("stream", stream => {
       refs.push(new WeakRef(stream));
       stream.respond({ ":status": 200 });
       stream.end(BODY);
+      queuedAfterEnd.push(stream.session!.state.outboundQueueSize!);
     });
-    server.listen(0);
-    await once(server, "listening");
-    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`, {
-      settings: { initialWindowSize: WINDOW },
-    });
+    const client = http2.connect(await listen(server), { settings: { initialWindowSize: WINDOW } });
     try {
+      const received: number[] = [];
       for (let i = 0; i < STREAMS; i++) {
-        await roundTrip(client, { ":path": "/" }).closed;
+        received.push((await roundTrip(client, { ":path": "/" }).closed).received);
       }
-      expect(refs).toHaveLength(STREAMS);
+      // The premise: each response left part of its body queued, and the queue then delivered it.
+      expect({ tailQueued: queuedAfterEnd.map(n => n > 0), received }).toEqual({
+        tailQueued: Array(STREAMS).fill(true),
+        received: Array(STREAMS).fill(BODY.length),
+      });
       expect(await liveCount(refs)).toBe(0);
     } finally {
       client.close();
@@ -1685,34 +1711,21 @@ describe("stream release after a queued END_STREAM", () => {
     }
   });
 
-  test("server streams whose response waited behind another stream's stalled response are released", async () => {
-    const refs: WeakRef<object>[] = [];
-    let stalledResponseFinished = false;
-    const server = http2.createServer();
-    server.on("stream", (stream, headers) => {
-      if (headers[":path"] === "/stalled") {
-        stream.respond({ ":status": 200 });
-        stream.end(Buffer.alloc(256 * 1024, "s"), () => {
-          stalledResponseFinished = true;
-        });
-        return;
-      }
-      refs.push(new WeakRef(stream));
-      stream.resume();
-      // Respond once the request's END_STREAM has been processed (as a handler that consumes the
-      // request body does), so the queued response is the last frame the stream is waiting on.
-      stream.on("end", () => {
-        stream.respond({ ":status": 200 });
-        stream.end("ok");
-      });
-    });
-    server.listen(0);
-    await once(server, "listening");
-    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+  /**
+   * Stalls one response on a fresh session (never read on the client: once the client's readable
+   * buffer is full it stops replenishing that stream's window, so the server keeps the rest of the
+   * response, and with it a non-empty outbound queue, until the session goes away), then runs
+   * STREAMS ordinary requests on the same session. `server` must answer "/stalled" with
+   * STALLED_BODY and report through `stalledFinished` whether that response ever finished; every
+   * other request must register its stream in `refs`. Resolves to how many of `refs` survived GC.
+   */
+  async function liveAfterRequestsBehindStalledResponse(
+    server: http2.Http2Server,
+    refs: WeakRef<object>[],
+    stalledFinished: () => boolean,
+  ): Promise<number> {
+    const client = http2.connect(await listen(server));
     try {
-      // Never read on the client: once its readable buffer is full the client stops replenishing
-      // the stream's window, so the server keeps the rest of this response (and with it the
-      // session's outbound queue) pending for the whole test; the assertion below checks that.
       const stalled = client.request({ ":path": "/stalled" });
       stalled.on("error", () => {});
       await once(stalled, "response");
@@ -1720,36 +1733,102 @@ describe("stream release after a queued END_STREAM", () => {
         await roundTrip(client, { ":path": "/" }).closed;
       }
       expect(refs).toHaveLength(STREAMS);
-      expect(await liveCount(refs)).toBe(0);
-      expect(stalledResponseFinished).toBe(false);
+      const live = await liveCount(refs);
+      // The premise: the stalled response was still queued while the other requests were answered.
+      expect(stalledFinished()).toBe(false);
       stalled.close();
+      return live;
     } finally {
       client.close();
       server.close();
     }
+  }
+
+  test.each([
+    ['end("ok")', (stream: http2.ServerHttp2Stream) => stream.end("ok")],
+    ["end() without a body", (stream: http2.ServerHttp2Stream) => stream.end()],
+  ])("server streams answered with %s behind another stream's stalled response are released", async (_, finish) => {
+    const refs: WeakRef<object>[] = [];
+    let stalledFinished = false;
+    const server = http2.createServer();
+    server.on("stream", (stream, headers) => {
+      if (headers[":path"] === "/stalled") {
+        stream.once("finish", () => {
+          stalledFinished = true;
+        });
+        stream.respond({ ":status": 200 });
+        stream.end(STALLED_BODY);
+        return;
+      }
+      refs.push(new WeakRef(stream));
+      stream.resume();
+      // Answer once the request's END_STREAM has been processed, like a handler that consumes the
+      // request body does: the queued response is then the only thing the stream still waits for.
+      stream.on("end", () => {
+        stream.respond({ ":status": 200 });
+        finish(stream);
+      });
+    });
+    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBe(0);
+  });
+
+  // The compat API's responses wait for trailers, so after the body END_STREAM always goes out on an
+  // empty DATA frame of its own.
+  test("server streams answered through the compat API behind another stream's stalled response are released", async () => {
+    const refs: WeakRef<object>[] = [];
+    let stalledFinished = false;
+    const server = http2.createServer((req, res) => {
+      if (req.url === "/stalled") {
+        res.stream.once("finish", () => {
+          stalledFinished = true;
+        });
+        res.end(STALLED_BODY);
+        return;
+      }
+      refs.push(new WeakRef(res.stream));
+      req.resume();
+      req.on("end", () => res.end("ok"));
+    });
+    expect(await liveAfterRequestsBehindStalledResponse(server, refs, () => stalledFinished)).toBe(0);
   });
 
   test("client streams whose request body outgrew the server's window are released", async () => {
     const refs: WeakRef<object>[] = [];
+    const uploaded: Promise<number>[] = [];
     const server = http2.createServer({ settings: { initialWindowSize: WINDOW } });
     server.on("stream", stream => {
-      // Respond as soon as the headers arrive: the server closes its half of the stream before the
-      // client's queued body tail (and END_STREAM) can go out.
-      stream.resume();
+      // Answer as soon as the headers arrive, so the server's END_STREAM reaches the client while
+      // the client still has the body's tail queued, and keep reading the body so that tail really
+      // is flushed from the queue (an upload nobody reads gets reset instead, and a reset releases
+      // the stream through a different path).
+      uploaded.push(
+        new Promise(resolve => {
+          let bytes = 0;
+          stream.on("data", (chunk: Buffer) => {
+            bytes += chunk.length;
+          });
+          stream.on("end", () => resolve(bytes));
+        }),
+      );
       stream.respond({ ":status": 200 });
       stream.end();
     });
-    server.listen(0);
-    await once(server, "listening");
-    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+    const client = http2.connect(await listen(server));
     try {
       // The server's window applies to requests opened after its SETTINGS frame has been received.
       await once(client, "remoteSettings");
+      const queuedAtResponse: number[] = [];
       for (let i = 0; i < STREAMS; i++) {
         const { ref, closed } = roundTrip(client, { ":method": "POST", ":path": "/" }, BODY);
         refs.push(ref);
-        await closed;
+        queuedAtResponse.push((await closed).queuedAtResponse);
       }
+      // The premise: each response arrived while the request's tail was still queued, and the queue
+      // then delivered that tail.
+      expect({ tailQueued: queuedAtResponse.map(n => n > 0), uploaded: await Promise.all(uploaded) }).toEqual({
+        tailQueued: Array(STREAMS).fill(true),
+        uploaded: Array(STREAMS).fill(BODY.length),
+      });
       expect(await liveCount(refs)).toBe(0);
     } finally {
       client.close();

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1802,12 +1802,13 @@ describe("stream release after a queued END_STREAM", () => {
       // is flushed from the queue (an upload nobody reads gets reset instead, and a reset releases
       // the stream through a different path).
       uploaded.push(
-        new Promise(resolve => {
+        new Promise((resolve, reject) => {
           let bytes = 0;
           stream.on("data", (chunk: Buffer) => {
             bytes += chunk.length;
           });
           stream.on("end", () => resolve(bytes));
+          stream.on("error", reject);
         }),
       );
       stream.respond({ ":status": 200 });

--- a/test/js/node/http2/h2-conformance.test.ts
+++ b/test/js/node/http2/h2-conformance.test.ts
@@ -1623,3 +1623,137 @@ describe("inbound stream lifecycle", () => {
     }
   });
 });
+
+// A DATA frame that cannot be written right away (the peer's flow-control window is used up, the
+// socket has backpressure, or another stream on the session already has frames waiting) is put on
+// the session's outbound queue and written later, when a WINDOW_UPDATE or a writable socket drains
+// the queue. Draining the last queued frame of a stream whose peer half is already closed
+// completes the stream, and, exactly like the direct-write path, has to release it (the JS stream
+// object and the native entry) while the session lives on. Node releases these streams too; a
+// stream that is only released at session teardown is a per-request leak on a long-lived session.
+describe("stream release after a queued END_STREAM", () => {
+  const STREAMS = 4;
+  // The peer advertises a 1 KiB stream window: a 4 KiB body cannot be written in one go, so its
+  // tail (the frame carrying END_STREAM) is queued and flushed as the peer's WINDOW_UPDATEs arrive.
+  const WINDOW = 1024;
+  const BODY = Buffer.alloc(4 * WINDOW, "x");
+
+  async function liveCount(refs: WeakRef<object>[]): Promise<number> {
+    const live = () => refs.filter(ref => ref.deref() !== undefined).length;
+    // A completed stream's JS teardown is spread over a few immediates, and a WeakRef target
+    // survives the job that dereferenced it, so every pass gets a fresh turn before collecting.
+    for (let i = 0; i < 50 && live() > 0; i++) {
+      await new Promise(resolve => setImmediate(resolve));
+      await gcTick();
+    }
+    return live();
+  }
+
+  /** Sends one request, drains its response, and resolves once the client stream has closed. */
+  function roundTrip(client: http2.ClientHttp2Session, headers: http2.OutgoingHttpHeaders, body?: Buffer) {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const req = client.request(headers);
+    req.on("error", reject);
+    req.on("close", () => resolve());
+    req.resume();
+    req.end(body);
+    return { ref: new WeakRef<object>(req), closed: promise };
+  }
+
+  test("server streams whose response outgrew the client's window are released", async () => {
+    const refs: WeakRef<object>[] = [];
+    const server = http2.createServer();
+    server.on("stream", stream => {
+      refs.push(new WeakRef(stream));
+      stream.respond({ ":status": 200 });
+      stream.end(BODY);
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`, {
+      settings: { initialWindowSize: WINDOW },
+    });
+    try {
+      for (let i = 0; i < STREAMS; i++) {
+        await roundTrip(client, { ":path": "/" }).closed;
+      }
+      expect(refs).toHaveLength(STREAMS);
+      expect(await liveCount(refs)).toBe(0);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  test("server streams whose response waited behind another stream's stalled response are released", async () => {
+    const refs: WeakRef<object>[] = [];
+    let stalledResponseFinished = false;
+    const server = http2.createServer();
+    server.on("stream", (stream, headers) => {
+      if (headers[":path"] === "/stalled") {
+        stream.respond({ ":status": 200 });
+        stream.end(Buffer.alloc(256 * 1024, "s"), () => {
+          stalledResponseFinished = true;
+        });
+        return;
+      }
+      refs.push(new WeakRef(stream));
+      stream.resume();
+      // Respond once the request's END_STREAM has been processed (as a handler that consumes the
+      // request body does), so the queued response is the last frame the stream is waiting on.
+      stream.on("end", () => {
+        stream.respond({ ":status": 200 });
+        stream.end("ok");
+      });
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+    try {
+      // Never read on the client: once its readable buffer is full the client stops replenishing
+      // the stream's window, so the server keeps the rest of this response (and with it the
+      // session's outbound queue) pending for the whole test; the assertion below checks that.
+      const stalled = client.request({ ":path": "/stalled" });
+      stalled.on("error", () => {});
+      await once(stalled, "response");
+      for (let i = 0; i < STREAMS; i++) {
+        await roundTrip(client, { ":path": "/" }).closed;
+      }
+      expect(refs).toHaveLength(STREAMS);
+      expect(await liveCount(refs)).toBe(0);
+      expect(stalledResponseFinished).toBe(false);
+      stalled.close();
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+
+  test("client streams whose request body outgrew the server's window are released", async () => {
+    const refs: WeakRef<object>[] = [];
+    const server = http2.createServer({ settings: { initialWindowSize: WINDOW } });
+    server.on("stream", stream => {
+      // Respond as soon as the headers arrive: the server closes its half of the stream before the
+      // client's queued body tail (and END_STREAM) can go out.
+      stream.resume();
+      stream.respond({ ":status": 200 });
+      stream.end();
+    });
+    server.listen(0);
+    await once(server, "listening");
+    const client = http2.connect(`http://127.0.0.1:${(server.address() as net.AddressInfo).port}`);
+    try {
+      // The server's window applies to requests opened after its SETTINGS frame has been received.
+      await once(client, "remoteSettings");
+      for (let i = 0; i < STREAMS; i++) {
+        const { ref, closed } = roundTrip(client, { ":method": "POST", ":path": "/" }, BODY);
+        refs.push(ref);
+        await closed;
+      }
+      expect(await liveCount(refs)).toBe(0);
+    } finally {
+      client.close();
+      server.close();
+    }
+  });
+});


### PR DESCRIPTION
### Problem

- On a long-lived `node:http2` session, a stream whose final `DATA(END_STREAM)` frame is written from the outbound queue is never released: its `Http2Stream` object stays reachable (a `WeakRef` to it never clears) and its native `Stream` slot and engine entry stay in the session's maps until the whole session is torn down. Node releases such streams as soon as they complete.
- A frame goes through the outbound queue whenever it cannot be written immediately: the peer's stream window is used up (any response or request body larger than the window, 64 KiB by default), the socket has backpressure, or any other stream on the session already has frames queued. In that last case even a two-byte response leaks while one slow stream is stalled, so on a busy server this is one leaked stream per request, for every request answered after the request body was consumed.
- Cause: `Stream::flush_queue` (`src/runtime/api/bun/h2_frame_parser.rs:1699`) moves the stream from `HALF_CLOSED_REMOTE` to `CLOSED` when its last queued frame has been written and dispatches `onStreamEnd`, but never calls `free_resources`. Every other place that sends the local `END_STREAM` does (`send_data`'s direct-write close at `:7676`, `send_trailers` at `:8169`, `request()` at `:9612`), and `on_stream_end` (`:6279`) covers the opposite order, where the peer's `END_STREAM` arrives last.
- Nothing else releases the stream on this path: the JS side deliberately skips the `rstStream` host call for a stream that closed natively (`src/js/node/http2.ts:2843`), and even when that call is made, `end_stream` returns early for a stream that is already `CLOSED`.

### Fix

- Call `free_resources::<false>` in the `CLOSED` arm of `flush_queue`, mirroring `send_data`'s direct-write close (same order: identifier captured, state set, resources freed, `onStreamEnd` dispatched). The arm sits in the tail shared by both of `flush_queue`'s dequeue branches, so it covers END_STREAM riding on the last body frame as well as on an empty frame queued by itself (`end()` without a body, `noTrailers`, and therefore every compat-API response, which always ends on an empty frame after the body).
- Correct because a stream in that arm is fully closed: the peer's half was already closed (`HALF_CLOSED_REMOTE`) and the frame just written carried our `END_STREAM`, which is exactly the condition under which the direct-write path frees the stream today. The result matches node, which drops a stream when both halves close regardless of how its last frame was written.
- Safe at this call site: `free_resources::<false>` only drops the stream's JS roots, drops its abort-signal listener, and pushes the id onto `pending_engine_stream_closes`; the `Stream` box and engine entry are evicted on the next inbound batch at dispatch depth 0, as for every other caller. The stream's own queue is empty at this point, so no write callbacks are dropped. `flush()` holds a keepalive across `flush_stream_queue`, and the iterator re-looks up ids on each step, the same situation `emitAbortToAllStreams` / `emitErrorToAllStreams` already free streams in. The `HALF_CLOSED_LOCAL` arm is unchanged: `on_stream_end` frees that stream when the peer's `END_STREAM` arrives, as it does for the direct-write path.
- Independent of #34675 (which merges the stream's two JS roots into one): its `flush_queue` hunk only changes how the identifier is looked up, so this arm needs the release with or without it.
- Tests: `test/js/node/http2/h2-conformance.test.ts`, `describe("stream release after a queued END_STREAM")`, five cases driven through one real client/server session with `WeakRef`s on the streams: a response larger than the client's advertised window (server stream, END_STREAM on the last body frame); responses queued behind another stream's stalled response, as `end("ok")`, as `end()` without a body and through the compat API (server streams; the last two end on an empty queued frame); and a request body larger than the server's window when the server answered before the body finished (client stream). Each case also asserts the premise it relies on (the tail was still queued when the response was written or arrived and was then delivered in full, or the stalled response was still pending at the end), so a case that stopped exercising the queue would fail rather than pass vacuously. All five report 4/4 streams still alive on the unfixed build and 0/4 with the fix.
- Intentionally out of scope: `request()`'s validation-error rejections (malformed headers, `maxSessionMemory`, `maxSendHeaderBlockLength`) also set `CLOSED` without releasing the stream. That is a pre-existing leak on a different path (the rejected request never completes an END_STREAM, it never reaches the wire) and needs its own per-site tests, so it is left for a follow-up.
- Also run on the debug build: the full `h2-conformance.test.ts`; `node-http2.test.js` (all tests pass; four subprocess-spawning cases in the "DATA payload survives its ArrayBuffer being detached" block only pass with a raised timeout here because each debug subprocess needs ~3 s to load `node:http2`, which is independent of this change); the 261 upstream `test-http2-*.js` node tests (all pass); and `fetch-http2-client.test.ts`, the grpc-js tests, and the http2 regression tests under `test/regression/issue/` (all pass).

### Background

- `node:http2` in Bun has two native layers per session: the inbound engine (`h2/connection.rs`), which parses incoming frames and keeps one entry per stream, and the older outbound encoder in `h2_frame_parser.rs`, which keeps a `Stream` per stream in `streams` and also holds the stream's JS object rooted (a `Strong` handle, so the GC cannot collect it) in `Stream.js_context` and in the session-level `sctx` map.
- The engine never sees outbound frames, so it cannot tell when the local half of a stream closes. `Stream::free_resources` is the bridge: it drops the JS roots and queues the id on `pending_engine_stream_closes`; `rewrite_read` drains that queue before the next inbound batch, removing the engine entry and freeing the `Stream` box. A completed stream that never reaches `free_resources` therefore keeps all three things alive for the life of the session.
- Outbound queue: `send_data` writes `DATA` frames straight to the socket while the peer's flow-control window allows it. Once it cannot (window exhausted, socket backpressure, or the session already has queued frames, which must keep their order), the remaining frames are queued per stream and `flush_stream_queue` writes them later, typically from the `WINDOW_UPDATE` handler or the socket's writable callback. `flush_queue` is the per-stream step of that drain, so the stream's close tail runs there instead of in `send_data` whenever the final frame was queued.
- `HALF_CLOSED_REMOTE` / `HALF_CLOSED_LOCAL` / `CLOSED` are RFC 9113 stream states: the peer has finished sending, we have finished sending, or both. A stream is complete, and can be released, once it reaches `CLOSED`.

<details>
<summary>Standalone repro (20 sequential GETs on one session, then GC)</summary>

```js
const http2 = require("node:http2");
const size = Number(process.argv[2]);
const total = 20, refs = [];
const server = http2.createServer();
server.on("stream", s => { refs.push(new WeakRef(s)); s.respond({ ":status": 200 }); s.end(size ? Buffer.alloc(size, "a") : "ok"); });
server.listen(0, async () => {
  const client = http2.connect(`http://127.0.0.1:${server.address().port}`);
  for (let i = 0; i < total; i++) await new Promise((res, rej) => { const r = client.request({ ":path": "/" }); r.on("error", rej); r.resume(); r.on("close", res); r.end(); });
  let alive = total;
  for (let i = 0; i < 50 && alive > 0; i++) { await new Promise(r => setImmediate(r)); Bun.gc(true); await new Promise(r => setTimeout(r, 10)); alive = refs.filter(w => w.deref()).length; }
  console.log(`size=${size}: alive ${alive}/${total}`);
  client.close(); server.close();
});
```

```
bun 1.4.0:            size=0: alive 0/20      size=200000: alive 20/20
this branch (debug):  size=0: alive 0/20      size=200000: alive 0/20
node v26.3.0:         size=0: alive 0/20      size=200000: alive 0/20   (--expose-gc, global.gc())
```

The client-side counterpart (server answers as soon as the headers arrive while a 200 KB request body is still queued on the client) behaves the same way: 20/20 client streams alive on 1.4.0, 0/20 with the fix, 0/20 on node.

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 0 · 2 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 5 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [13.28ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [3.40ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [2.89ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [1.60ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [1.27ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [1.16ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [1.20ms]
(pass) PING (checklist §3.7) > a PING on a non-zero stream id is a PROTOCOL_ERROR [0.96ms]
(pass) WINDOW_UPDATE (checklist §6) > a connection-level WINDOW_UPDATE with a 0 increment is a PROTOCOL_ERROR [1.06ms]
(pass) WINDOW_UPDAT
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" "test/js/node/http2/h2-conformance.test.ts"
bun test v1.4.0 (dc50011e1)

test/js/node/http2/h2-conformance.test.ts:
(pass) connection preface & SETTINGS handshake (checklist §1) > server sends a SETTINGS frame first (§1.4) [636.18ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > server ACKs the client's SETTINGS frame (§3.5) [231.83ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame with a non-zero stream id is a PROTOCOL_ERROR (§3.5) [165.69ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS frame whose length is not a multiple of 6 is a FRAME_SIZE_ERROR (§3.5) [81.97ms]
(pass) connection preface & SETTINGS handshake (checklist §1) > a SETTINGS ACK that carries a payload is a FRAME_SIZE_ERROR (§3.5) [68.90ms]
(pass) PING (checklist §3.7) > server replies to PING with a PING ACK echoing the payload [62.33ms]
(pass) PING (checklist §3.7) > a PING with length != 8 is a FRAME_SIZE_ERROR [71.90ms]
(pass) PING (checklist §3.7) > a PING on a non-zero s
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped) in 1290ms (unchanged)
ninja: Entering directory `/workspace/bun/build/release'
[1/22] gen bindgenv2
[2/17] gen cpp.rs (cppbind)
[3/17] gen generated_host_exports.rs
generated_host_exports.rs: 93 exports (host=3, lazy=10, generic=80, rust=0); 239 extern-C blocks audited
[3/17] cargo bun_bin → libbun_rust.a (--target x86_64-unknown-linux-gnu)

  nightly-2026-07-20-x86_64-unknown-linux-gnu unchanged - rustc 1.99.0-nightly (9f36de775 2026-07-19)

[1m[92m   Compiling[0m bun_sys v0.0.0 (/workspace/bun/src/sys)
[1m[92m   Compiling[0m bun_perf v0.0.0 (/workspace/bun/src/perf)
[1m[92m   Compiling[0m bun_threading v0.0.0 (/workspace/bun/src/threading)
[1m[92m   Compiling[0m bun_spawn_sys v0.0.0 (/workspace/bun/src/spawn_sys)
[1m[92m   Compiling[0m bun_which v0.0.0 (/workspace/bun/src/which)
[1m[92m   Compiling[0m bun_libarchive v0.0.0 (/workspace/bun/src/libarchive)
[1m[92m   Compiling[0m bun_boringssl v0.0.0 (/workspace/bun/src/boringssl)
[1m[92m   Compiling[0m bun_glob v0.0.0 (/workspace/bun/src/glob)
[1m[92m   Compiling[0m bun_md v0.0.0 (/workspace/bun/src/md)

... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/runtime/api/bun/h2_frame_parser.rs    |   1 +
 test/js/node/http2/h2-conformance.test.ts | 217 ++++++++++++++++++++++++++++++
 2 files changed, 218 insertions(+)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                       reads  edits  tests
src/runtime/api/bun/h2_frame_parser.rs         0      0      0
test/js/node/http2/h2-conformance.test.ts      2      2      0
```

</details>

**root cause** · written by the author bot

The bug was in the HTTP/2 frame parser's flush path: when a stream's queued DATA frames carrying END_STREAM were finally flushed, the stream was transitioned to CLOSED without releasing its native resources, so the Stream entry remained in the session's stream map and its strong reference kept the JavaScript Http2Stream rooted until session teardown, leaking one stream per completed request. The fix adds a call to free_resources in flush_queue's CLOSED transition arm, so the native slot and the JS-side strong reference are released as soon as the queued END_STREAM frames complete. Conforman…

<!-- robobun:evidence:end -->
