### PR TITLE
install: fail the isolated install when a link: dependency's target is missing

### DIFF
--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2171,10 +2171,8 @@ pub(crate) fn install_isolated_packages(
                     entry_steps[entry_id.get() as usize]
                         .store(installer::Step::Done as u32, Ordering::Relaxed);
 
-                    // The lockfile only stores the name, so the `bun link` registration may be
-                    // gone by now. Dependents symlink to it blindly, making this the only place
-                    // a missing target can fail the install (same `openat` as hoisted's
-                    // `install_from_link`).
+                    // Dependents link to it unchecked, so fail here if the `bun link`
+                    // registration is gone (same openat as hoisted's `install_from_link`).
                     let mut link_target: AbsPath = AbsPath::init_top_level_dir();
                     installer.append_store_path(&mut link_target, entry_id);
                     match sys::openat(

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2170,7 +2170,29 @@ pub(crate) fn install_isolated_packages(
                     // .monotonic is okay because the task isn't running on another thread.
                     entry_steps[entry_id.get() as usize]
                         .store(installer::Step::Done as u32, Ordering::Relaxed);
-                    installer.on_task_complete(entry_id, installer::CompleteState::Skipped);
+
+                    // The lockfile only stores the name, so the `bun link` registration may be
+                    // gone by now. Dependents symlink to it blindly, making this the only place
+                    // a missing target can fail the install (same `openat` as hoisted's
+                    // `install_from_link`).
+                    let mut link_target: AbsPath = AbsPath::init_top_level_dir();
+                    installer.append_store_path(&mut link_target, entry_id);
+                    match sys::openat(
+                        Fd::cwd(),
+                        link_target.slice_z(),
+                        sys::O::RDONLY | sys::O::DIRECTORY,
+                        0,
+                    ) {
+                        Ok(fd) => {
+                            use bun_sys::FdExt as _;
+                            fd.close();
+                            installer.on_task_complete(entry_id, installer::CompleteState::Skipped);
+                        }
+                        Err(err) => {
+                            installer
+                                .on_task_fail(entry_id, &installer::TaskError::LinkPackage(err));
+                        }
+                    }
                     continue;
                 }
                 ResolutionTag::Folder => {

--- a/src/install/isolated_install.rs
+++ b/src/install/isolated_install.rs
@@ -2171,8 +2171,7 @@ pub(crate) fn install_isolated_packages(
                     entry_steps[entry_id.get() as usize]
                         .store(installer::Step::Done as u32, Ordering::Relaxed);
 
-                    // Dependents link to it unchecked, so fail here if the `bun link`
-                    // registration is gone (same openat as hoisted's `install_from_link`).
+                    // Same target check as the hoisted linker's `install_from_link`.
                     let mut link_target: AbsPath = AbsPath::init_top_level_dir();
                     installer.append_store_path(&mut link_target, entry_id);
                     match sys::openat(

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -368,9 +368,9 @@ test("can install folder dependencies on root package", async () => {
 });
 
 describe("link: dependencies", () => {
-  async function bunInstall(cwd: string, env: NodeJS.Dict<string>) {
+  async function runBun(args: string[], cwd: string, env: NodeJS.Dict<string>) {
     await using proc = spawn({
-      cmd: [bunExe(), "install"],
+      cmd: [bunExe(), ...args],
       cwd,
       env,
       stdout: "pipe",
@@ -389,10 +389,9 @@ describe("link: dependencies", () => {
       name: "linked-pkg",
       gone: "the package was unlinked",
       async remove(pkgDir: string, env: NodeJS.Dict<string>) {
-        await using proc = spawn({ cmd: [bunExe(), "unlink"], cwd: pkgDir, env, stdout: "pipe", stderr: "pipe" });
-        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-        expect(stdout).toContain(`success: unlinked package "linked-pkg"`);
-        expect(exitCode).toBe(0);
+        const result = await runBun(["unlink"], pkgDir, env);
+        expect(result.stdout).toContain(`success: unlinked package "linked-pkg"`);
+        expect(result.exitCode).toBe(0);
       },
     },
     {
@@ -413,31 +412,28 @@ describe("link: dependencies", () => {
     // `bun link` registers into $BUN_INSTALL/install/global; keep it private to this test.
     const env = { ...bunEnv, BUN_INSTALL: join(String(dir), "bun-install") };
 
-    {
-      await using proc = spawn({ cmd: [bunExe(), "link"], cwd: pkgDir, env, stdout: "pipe", stderr: "pipe" });
-      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-      expect(stdout).toContain(`Success! Registered "${name}"`);
-      expect(exitCode).toBe(0);
-    }
+    let result = await runBun(["link"], pkgDir, env);
+    expect(result.stdout).toContain(`Success! Registered "${name}"`);
+    expect(result.exitCode).toBe(0);
 
-    let result = await bunInstall(appDir, env);
+    result = await runBun(["install"], appDir, env);
     expect(result.stderr).toContain("Saved lockfile");
     expect(result.exitCode).toBe(0);
     expect(await file(join(appDir, "node_modules", name, "package.json")).json()).toEqual({ name, version: "1.0.0" });
 
     await remove(pkgDir, env);
 
-    // Reinstalling over the existing node_modules...
-    result = await bunInstall(appDir, env);
+    // Both reinstalling over the existing node_modules and installing into a
+    // fresh one (a clone with the lockfile checked in) must report the missing
+    // package instead of leaving a dangling symlink behind.
+    result = await runBun(["install"], appDir, env);
     expect(result.stderr).toContain("ENOENT");
     expect(result.stderr).toContain(`failed to link package: ${name}@link:`);
     expect(result.stdout).toContain("Failed to install 1 package");
     expect(result.exitCode).toBe(1);
 
-    // ...and installing into a fresh one (a clone with the lockfile checked in)
-    // must both report the missing package instead of leaving a dangling symlink.
     await rm(join(appDir, "node_modules"), { recursive: true, force: true });
-    result = await bunInstall(appDir, env);
+    result = await runBun(["install"], appDir, env);
     expect(result.stderr).toContain("ENOENT");
     expect(result.stderr).toContain(`failed to link package: ${name}@link:`);
     expect(result.stdout).toContain("Failed to install 1 package");

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -425,7 +425,9 @@ describe("link: dependencies", () => {
 
     // Both reinstalling over the existing node_modules and installing into a
     // fresh one (a clone with the lockfile checked in) must report the missing
-    // package instead of leaving a dangling symlink behind.
+    // package and exit 1 instead of silently succeeding. As with every other
+    // failed entry, node_modules/<name> still points at the registration and
+    // resolves again once the package is re-linked.
     result = await runBun(["install"], appDir, env);
     expect(result.stderr).toContain("ENOENT");
     expect(result.stderr).toContain(`failed to link package: ${name}@link:`);

--- a/test/cli/install/isolated-install.test.ts
+++ b/test/cli/install/isolated-install.test.ts
@@ -367,6 +367,84 @@ test("can install folder dependencies on root package", async () => {
   ]);
 });
 
+describe("link: dependencies", () => {
+  async function bunInstall(cwd: string, env: NodeJS.Dict<string>) {
+    await using proc = spawn({
+      cmd: [bunExe(), "install"],
+      cwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  // The lockfile records a `link:` dependency by name only, so the `bun link`
+  // registration behind that name can be gone by the time the lockfile is
+  // installed: `bun unlink` removes the global link dir entry, deleting the
+  // package leaves the entry dangling.
+  test.concurrent.each([
+    {
+      name: "linked-pkg",
+      gone: "the package was unlinked",
+      async remove(pkgDir: string, env: NodeJS.Dict<string>) {
+        await using proc = spawn({ cmd: [bunExe(), "unlink"], cwd: pkgDir, env, stdout: "pipe", stderr: "pipe" });
+        const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+        expect(stdout).toContain(`success: unlinked package "linked-pkg"`);
+        expect(exitCode).toBe(0);
+      },
+    },
+    {
+      name: "@scope/linked-pkg",
+      gone: "the linked directory was deleted",
+      async remove(pkgDir: string) {
+        await rm(pkgDir, { recursive: true, force: true });
+      },
+    },
+  ])("installing from the lockfile fails when $gone", async ({ name, remove }) => {
+    using dir = tempDir("isolated-link-target", {
+      "pkg/package.json": JSON.stringify({ name, version: "1.0.0" }),
+      "app/package.json": JSON.stringify({ name: "app", dependencies: { [name]: `link:${name}` } }),
+      "app/bunfig.toml": `[install]\nlinker = "isolated"\n`,
+    });
+    const pkgDir = join(String(dir), "pkg");
+    const appDir = join(String(dir), "app");
+    // `bun link` registers into $BUN_INSTALL/install/global; keep it private to this test.
+    const env = { ...bunEnv, BUN_INSTALL: join(String(dir), "bun-install") };
+
+    {
+      await using proc = spawn({ cmd: [bunExe(), "link"], cwd: pkgDir, env, stdout: "pipe", stderr: "pipe" });
+      const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+      expect(stdout).toContain(`Success! Registered "${name}"`);
+      expect(exitCode).toBe(0);
+    }
+
+    let result = await bunInstall(appDir, env);
+    expect(result.stderr).toContain("Saved lockfile");
+    expect(result.exitCode).toBe(0);
+    expect(await file(join(appDir, "node_modules", name, "package.json")).json()).toEqual({ name, version: "1.0.0" });
+
+    await remove(pkgDir, env);
+
+    // Reinstalling over the existing node_modules...
+    result = await bunInstall(appDir, env);
+    expect(result.stderr).toContain("ENOENT");
+    expect(result.stderr).toContain(`failed to link package: ${name}@link:`);
+    expect(result.stdout).toContain("Failed to install 1 package");
+    expect(result.exitCode).toBe(1);
+
+    // ...and installing into a fresh one (a clone with the lockfile checked in)
+    // must both report the missing package instead of leaving a dangling symlink.
+    await rm(join(appDir, "node_modules"), { recursive: true, force: true });
+    result = await bunInstall(appDir, env);
+    expect(result.stderr).toContain("ENOENT");
+    expect(result.stderr).toContain(`failed to link package: ${name}@link:`);
+    expect(result.stdout).toContain("Failed to install 1 package");
+    expect(result.exitCode).toBe(1);
+  });
+});
+
 describe("isolated workspaces", () => {
   test("basic", async () => {
     const { packageJson, packageDir } = await registry.createTestDir({ bunfigOpts: { linker: "isolated" } });


### PR DESCRIPTION
### Problem
- With `linker = "isolated"`, `bun install` of a `link:<name>` dependency whose `bun link` registration no longer exists (the package was `bun unlink`ed, or its directory was deleted) creates a dangling `node_modules/<name>` symlink, prints `Done! Checked N packages (no changes)` and exits 0. The hoisted linker fails the same state with `FileNotFound: failed linking dependency/workspace to node_modules for package <name>` and exits 1.
- Only reproduces when the dependency is already in the lockfile (a fresh resolution reads the linked package.json and fails with `Package "<name>" is not linked`). That is the common case: a clone with `bun.lock` checked in installs green with a broken `node_modules`.
- Cause: `src/install/isolated_install.rs` marks `ResolutionTag::Symlink` store entries `Done` without touching the filesystem ("no installation required"). The `node_modules/<name>` link is created later by each dependent's `SymlinkDependencies` step (`isolated_install/Installer.rs`, `append_store_path`), which builds the target path and symlinks to it without checking that it exists. Nothing in the isolated path ever opens the link target, so there is nothing to fail.

### Fix
- In the `Symlink` arm of the main-thread install loop, build the entry's target path with `append_store_path` (the same path the dependents will point their symlinks at) and `openat(O_RDONLY | O_DIRECTORY)` it. On success the entry completes as before; on failure it goes through `on_task_fail(TaskError::LinkPackage(err))`, which prints the error, counts the entry in `summary.fail` (`Failed to install 1 package`, exit 1) and lets the install continue for the other entries.
- Why this is correct:
  - `openat(O_RDONLY | O_DIRECTORY)` is the exact call `PackageInstall::install_from_link` makes for the hoisted linker, so the two linkers now fail on the same set of states (missing entry, dangling symlink or junction, entry that is a file, unreadable entry) with the same errno. It follows symlinks and junctions, so a registration left dangling by deleting the package directory fails too, not just a removed one.
  - Symlink entries have no store directory and no task; this arm is the only place in the isolated install that looks at a `link:` package, so it is the only layer that can fail the install for it. Checking in each dependent's `SymlinkDependencies` step instead would attribute the error to the dependent and, for the root entry, abort linking of all its other dependencies.
  - Using `append_store_path` from `init_top_level_dir()` checks exactly the path the dependents link to rather than a second hand-built one, so it stays correct if the Symlink target computation changes (for example path-form `link:` targets in #35461).
  - Cost is one open/close per `link:` package on the main thread, which already does an `exists` probe per npm entry in the same loop.
- What changes is the report and the exit code, not the `node_modules` end state: the dependents still create (or keep) their `node_modules/<name>` symlink after the failure, which is how every failed isolated entry is handled today (the install reports the failure and exits 1, the next install retries; hoisted differs here because `install_from_link` removes the old entry first). `bun link`ing the package again makes the next install succeed without removing `node_modules`. Removing dependents' links on failure would be a change to `on_task_fail`/`SymlinkDependencies` for every failure kind, not something specific to `link:`.
- Verified with `test/cli/install/isolated-install.test.ts` (`link: dependencies`): two cases, a plain name removed with `bun unlink` and a scoped name whose directory was deleted. Each case first installs successfully, then asserts that reinstalling over the existing `node_modules` and installing into a fresh one both print `ENOENT` + `failed to link package: <name>@link:...`, `Failed to install 1 package`, and exit 1. The `bun link` registration is pointed at a per-test `BUN_INSTALL` so the tests do not touch the real global link dir.
  - Fails on the current release (`USE_SYSTEM_BUN=1`): both installs exit 0 with empty stderr.
  - Passes with `bun bd test`.

### Background
- `link:<name>` dependency: `bun link` run inside a package registers it by creating `<global dir>/node_modules/<name>` (a symlink on POSIX, a junction on Windows) pointing at the package directory. A consumer declaring `"<name>": "link:<name>"` gets a `node_modules/<name>` symlink to that registration. The lockfile stores only the name (`Resolution.symlink`), so on later installs nothing re-reads the linked package.
- Isolated linker store entries: `install_isolated_packages` creates one store entry per package in the dependency graph and, on the main thread, either starts a worker task for it (npm, git, tarball, folder: materialize into `node_modules/.bun/<store path>`) or completes it immediately. Each entry's task then runs `SymlinkDependencies`, which symlinks its dependencies' store paths into its own `node_modules`; for the root entry that is the project's `node_modules/<dep>`.
- `on_task_fail` is the shared failure path for an entry: it prints the `TaskError`, increments the install summary's `fail` counter (which drives the `Failed to install N packages` line and the exit code) and releases the entry's pending-task slot so the install loop can finish.

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/cli/install/isolated-install.test.ts

<!-- robobun:evidence:end -->