### PR TITLE
bun build --server-components: default to --target bun and reject directives without a framework

### DIFF
--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2339,6 +2339,13 @@ pub mod parse_worker {
         // disjoint `options` field — never the whole struct — so the raw `resolver`
         // pointer (which targets `(*transpiler).resolver`) remains valid.
         let topts = unsafe { &(*transpiler).options };
+        // `bun build --server-components` bundles the server graph without a
+        // framework, so this is `None` there even though `server_components` is
+        // on. Files carrying a directive are rejected below in that case: there
+        // is no runtime to register the boundary with.
+        let framework_server_components = topts
+            .framework
+            .and_then(|framework| framework.server_components.as_ref());
         let use_directive: UseDirective = if !is_empty && topts.server_components {
             UseDirective::parse(entry_contents).unwrap_or(UseDirective::None)
         } else {
@@ -2347,15 +2354,7 @@ pub mod parse_worker {
 
         if (use_directive == UseDirective::Client
         && task.known_target != options::Target::ServerComponentsSsr
-        && worker_ctx.framework.is_some()
-        && worker_ctx
-            .framework
-            .as_ref()
-            .unwrap()
-            .server_components
-            .as_ref()
-            .unwrap()
-            .separate_ssr_graph)
+        && framework_server_components.is_some_and(|sc| sc.separate_ssr_graph))
         ||
         // set the target to the client when bundling client-side files
         ((topts.server_components || topts.has_dev_server())
@@ -2407,14 +2406,7 @@ pub mod parse_worker {
         })
         .unwrap_or_else(|| {
             if task.known_target == options::Target::ServerComponentsSsr
-                && topts
-                    .framework
-                    .as_ref()
-                    .unwrap()
-                    .server_components
-                    .as_ref()
-                    .unwrap()
-                    .separate_ssr_graph
+                && framework_server_components.is_some_and(|sc| sc.separate_ssr_graph)
             {
                 options::Target::ServerComponentsSsr
             } else {
@@ -2520,15 +2512,7 @@ pub mod parse_worker {
                 _ => match use_directive {
                     UseDirective::None => SC::WrapAnonServerFunctions,
                     UseDirective::Client => {
-                        if topts
-                            .framework
-                            .as_ref()
-                            .unwrap()
-                            .server_components
-                            .as_ref()
-                            .unwrap()
-                            .separate_ssr_graph
-                        {
+                        if framework_server_components.is_some_and(|sc| sc.separate_ssr_graph) {
                             SC::ClientSide
                         } else {
                             SC::WrapExportsForClientReference
@@ -2614,27 +2598,42 @@ pub mod parse_worker {
         // `topts` (a `&BundleOptions`) is dead past this point; the callees take
         // raw `*mut Transpiler` and reborrow `(*transpiler).options` mutably.
         let _ = topts;
-        let ast_result: core::result::Result<JSAst, AnyError> =
-            if !is_empty || loader.handles_empty_file() {
-                get_ast(
-                    log,
-                    transpiler,
-                    opts,
-                    bump,
-                    resolver,
-                    source,
-                    loader,
-                    task_ctx.unique_key,
-                    &mut unique_key_for_additional_file,
-                    &task_ctx.linker.has_any_css_locals,
-                )
-            } else if loader.is_css() {
-                get_empty_css_ast(log, transpiler, opts, bump, source)
-            } else if module_type == options::ModuleType::Esm {
-                get_empty_ast::<E::Undefined>(log, transpiler, opts, bump, source)
+        let directive_without_framework =
+            use_directive != UseDirective::None && framework_server_components.is_none();
+        let ast_result: core::result::Result<JSAst, AnyError> = if directive_without_framework {
+            let directive = if use_directive == UseDirective::Client {
+                "use client"
             } else {
-                get_empty_ast::<E::Object>(log, transpiler, opts, bump, source)
+                "use server"
             };
+            log.add_error_fmt(
+                Some(source),
+                Loc::EMPTY,
+                format_args!(
+                    "\"{directive}\" requires a framework with server components configured; \"bun build --server-components\" only bundles the server graph"
+                ),
+            );
+            Err(crate::Error::ParserError)
+        } else if !is_empty || loader.handles_empty_file() {
+            get_ast(
+                log,
+                transpiler,
+                opts,
+                bump,
+                resolver,
+                source,
+                loader,
+                task_ctx.unique_key,
+                &mut unique_key_for_additional_file,
+                &task_ctx.linker.has_any_css_locals,
+            )
+        } else if loader.is_css() {
+            get_empty_css_ast(log, transpiler, opts, bump, source)
+        } else if module_type == options::ModuleType::Esm {
+            get_empty_ast::<E::Undefined>(log, transpiler, opts, bump, source)
+        } else {
+            get_empty_ast::<E::Object>(log, transpiler, opts, bump, source)
+        };
         let mut ast = match ast_result {
             Ok(a) => a,
             Err(e) => {

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2339,10 +2339,7 @@ pub mod parse_worker {
         // disjoint `options` field — never the whole struct — so the raw `resolver`
         // pointer (which targets `(*transpiler).resolver`) remains valid.
         let topts = unsafe { &(*transpiler).options };
-        // `bun build --server-components` bundles the server graph without a
-        // framework, so this is `None` there even though `server_components` is
-        // on. Files carrying a directive are rejected below in that case: there
-        // is no runtime to register the boundary with.
+        // `None` for CLI `--server-components` builds (no framework); directive files error below.
         let framework_server_components = topts
             .framework
             .and_then(|framework| framework.server_components.as_ref());

--- a/src/bundler/ParseTask.rs
+++ b/src/bundler/ParseTask.rs
@@ -2607,7 +2607,7 @@ pub mod parse_worker {
                 Some(source),
                 Loc::EMPTY,
                 format_args!(
-                    "\"{directive}\" requires a framework with server components configured; \"bun build --server-components\" only bundles the server graph"
+                    "\"{directive}\" requires a framework with server components configured; \"bun build --server-components\" does not configure one"
                 ),
             );
             Err(crate::Error::ParserError)

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -236,12 +236,14 @@ impl<'a> BundleV2<'a> {
     }
 
     pub(crate) fn transpiler_for_target(&mut self, target: options::Target) -> &mut Transpiler<'a> {
-        // SAFETY: all three pointers are live for `'a` (set in `init`); the
-        // `client_transpiler` arm is only reached when bake populated it.
-        // Outside of server-components / dev-server,
-        // the only case that doesn't return the main transpiler is a
-        // browser-target request from a server-side build, which lazily
-        // spins up a client transpiler.
+        // SAFETY: all three pointers are live for `'a` (set in `init`). The
+        // server-components / dev-server arm below expects `client_transpiler` to
+        // be populated: by bake in `init`, or by `ensure_client_transpiler` on the
+        // HTML paths, the only source of browser-target requests in a CLI
+        // `--server-components` build (its main target is always server-side).
+        // Outside of those modes, the only case that doesn't return the main
+        // transpiler is a browser-target request from a server-side build, which
+        // lazily spins up a client transpiler.
         if !self.transpiler.options.server_components && self.linker.dev_server.is_none() {
             if target == Target::Browser && self.transpiler.options.target.is_server_side() {
                 if let Some(p) = self.client_transpiler {
@@ -257,11 +259,13 @@ impl<'a> BundleV2<'a> {
             }
             return &mut *self.transpiler;
         }
-        // SAFETY: all three pointers are live for `'a` (set in `init`); the
-        // `client_transpiler` arm is only reached when bake populated it.
+        // SAFETY: see above.
         unsafe {
             match target {
-                Target::Browser => self.client_transpiler.unwrap().assume_mut(),
+                Target::Browser => self
+                    .client_transpiler
+                    .expect("browser target requested before the client transpiler was set up")
+                    .assume_mut(),
                 Target::ServerComponentsSsr => &mut *self.ssr_transpiler,
                 _ => &mut *self.transpiler,
             }
@@ -7179,6 +7183,9 @@ pub mod bv2_impl {
                     // `result.ast` is moved into `graph.ast` and `result.source` was
                     // swapped earlier, so snapshot the data the use-directive block
                     // needs *before* the move. Only paid for files that hit the SCB gate.
+                    // A directive only survives parsing when the framework configures
+                    // server components (`directive_without_framework` in ParseTask),
+                    // which the unwraps here and below rely on.
                     let named_exports_for_scb = if result.use_directive != crate::UseDirective::None
                         && {
                             let separate = this

--- a/src/bundler/bundle_v2.rs
+++ b/src/bundler/bundle_v2.rs
@@ -7183,9 +7183,7 @@ pub mod bv2_impl {
                     // `result.ast` is moved into `graph.ast` and `result.source` was
                     // swapped earlier, so snapshot the data the use-directive block
                     // needs *before* the move. Only paid for files that hit the SCB gate.
-                    // A directive only survives parsing when the framework configures
-                    // server components (`directive_without_framework` in ParseTask),
-                    // which the unwraps here and below rely on.
+                    // ParseTask rejects directives without a framework, so the unwraps hold.
                     let named_exports_for_scb = if result.use_directive != crate::UseDirective::None
                         && {
                             let separate = this

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2588,9 +2588,7 @@ fn parse_build_command_options(
                 Global::crash();
             }
         }
-        // Server-components mode serves browser-target requests from a client
-        // transpiler that, outside Bake, only HTML reached from a server-side
-        // build creates; with the browser default every entry point would need it.
+        // Needs a server-side main target: the CLI only creates a client transpiler for HTML.
         opts.target = Some(api::Target::Bun);
     }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2588,7 +2588,9 @@ fn parse_build_command_options(
                 Global::crash();
             }
         }
-        // The browser default would need a client transpiler, which only Bake provides.
+        // Server-components mode serves browser-target requests from a client
+        // transpiler that, outside Bake, only HTML reached from a server-side
+        // build creates; with the browser default every entry point would need it.
         opts.target = Some(api::Target::Bun);
     }
 

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2586,10 +2586,12 @@ fn parse_build_command_options(
                     ),
                 );
                 Global::crash();
-            } else {
-                opts.target = Some(api::Target::Bun);
             }
         }
+        // The main transpiler is the server graph. The default target (browser)
+        // would make the bundler reach for a client transpiler, which only Bake
+        // provides.
+        opts.target = Some(api::Target::Bun);
     }
 
     if args.flag(b"--react-fast-refresh") {

--- a/src/runtime/cli/Arguments.rs
+++ b/src/runtime/cli/Arguments.rs
@@ -2588,9 +2588,7 @@ fn parse_build_command_options(
                 Global::crash();
             }
         }
-        // The main transpiler is the server graph. The default target (browser)
-        // would make the bundler reach for a client transpiler, which only Bake
-        // provides.
+        // The browser default would need a client transpiler, which only Bake provides.
         opts.target = Some(api::Target::Bun);
     }
 

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -518,6 +518,74 @@ describe("CLI argument error messages", () => {
   });
 });
 
+// `--server-components` bundles only the server graph: there is no framework
+// on the CLI, so nothing can register "use client" / "use server" boundaries.
+// Every case here used to crash the bundler instead of building or reporting.
+describe.concurrent("bun build --server-components", () => {
+  async function build(dir: string, ...args: string[]) {
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "build", ...args],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    return { stdout, stderr, exitCode };
+  }
+
+  test("builds for bun when no --target is given", async () => {
+    using dir = tempDir("sc-default-target", { "server.ts": `console.log("server");` });
+    const { stdout, stderr, exitCode } = await build(dir, "--server-components", "server.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toStartWith("// @bun\n");
+    expect(stdout).toContain('console.log("server")');
+    expect(exitCode).toBe(0);
+  });
+
+  test("rejects a client-side --target", async () => {
+    using dir = tempDir("sc-browser-target", { "server.ts": `console.log("server");` });
+    const { stdout, stderr, exitCode } = await build(dir, "--server-components", "--target=browser", "server.ts");
+    expect(stderr).toContain("Cannot use client-side --target");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("importing a 'use client' file is a build error, not a crash", async () => {
+    using dir = tempDir("sc-use-client", {
+      "server.ts": `import { Button } from "./client"; console.log(Button);`,
+      "client.ts": `"use client";\nexport function Button() { return "button"; }`,
+    });
+    const { stdout, stderr, exitCode } = await build(dir, "--server-components", "--target=bun", "server.ts");
+    expect(stderr).toContain('"use client" requires a framework with server components configured');
+    expect(stderr).toContain("client.ts");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("a 'use server' entry point is a build error, not a crash", async () => {
+    using dir = tempDir("sc-use-server", {
+      "actions.ts": `"use server";\nexport async function save() { return "saved"; }`,
+    });
+    const { stdout, stderr, exitCode } = await build(dir, "--server-components", "--target=bun", "actions.ts");
+    expect(stderr).toContain('"use server" requires a framework with server components configured');
+    expect(stderr).toContain("actions.ts");
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+  });
+
+  test("directives are still plain strings without the flag", async () => {
+    using dir = tempDir("sc-flag-off", {
+      "server.ts": `import { Button } from "./client"; console.log(Button());`,
+      "client.ts": `"use client";\nexport function Button() { return "button"; }`,
+    });
+    const { stdout, stderr, exitCode } = await build(dir, "--target=bun", "server.ts");
+    expect(stderr).toBe("");
+    expect(stdout).toContain("button");
+    expect(exitCode).toBe(0);
+  });
+});
+
 describe.concurrent("modules that fail to print", () => {
   // A TOML dotted header builds an object nested arbitrarily deep without
   // recursing in the parser, so the printer's recursion guard is the first

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -538,7 +538,7 @@ describe.concurrent("bun build --server-components", () => {
     using dir = tempDir("sc-default-target", { "server.ts": `console.log("server");` });
     const { stdout, stderr, exitCode } = await build(dir, "--server-components", "server.ts");
     expect(stderr).toBe("");
-    expect(stdout).toStartWith("// @bun\n");
+    expect(stdout).toStartWith("// @bun");
     expect(stdout).toContain('console.log("server")');
     expect(exitCode).toBe(0);
   });

--- a/test/bundler/cli.test.ts
+++ b/test/bundler/cli.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { bunEnv, bunExe, isWindows, tempDir, tmpdirSync } from "harness";
+import { bunEnv, bunExe, isWindows, normalizeBunSnapshot, tempDir, tmpdirSync } from "harness";
 import fs, { mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import path, { join } from "node:path";
 
@@ -518,9 +518,11 @@ describe("CLI argument error messages", () => {
   });
 });
 
-// `--server-components` bundles only the server graph: there is no framework
-// on the CLI, so nothing can register "use client" / "use server" boundaries.
-// Every case here used to crash the bundler instead of building or reporting.
+// `--server-components` turns on the bundler's server components mode without a
+// framework, so there is nothing to register "use client" / "use server"
+// boundaries with. Building without --target and building a file that carries a
+// directive (in the server graph, or in the browser graph an HTML import creates)
+// used to crash the bundler instead of building or reporting an error.
 describe.concurrent("bun build --server-components", () => {
   async function build(dir: string, ...args: string[]) {
     await using proc = Bun.spawn({
@@ -531,22 +533,29 @@ describe.concurrent("bun build --server-components", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    return { stdout, stderr, exitCode };
+    return {
+      stdout: normalizeBunSnapshot(stdout, String(dir)),
+      stderr: normalizeBunSnapshot(stderr, String(dir)),
+      exitCode,
+    };
   }
 
   test("builds for bun when no --target is given", async () => {
     using dir = tempDir("sc-default-target", { "server.ts": `console.log("server");` });
     const { stdout, stderr, exitCode } = await build(dir, "--server-components", "server.ts");
     expect(stderr).toBe("");
-    expect(stdout).toStartWith("// @bun");
-    expect(stdout).toContain('console.log("server")');
+    expect(stdout).toMatchInlineSnapshot(`
+      "// @bun
+      // server.ts
+      console.log("server");"
+    `);
     expect(exitCode).toBe(0);
   });
 
   test("rejects a client-side --target", async () => {
     using dir = tempDir("sc-browser-target", { "server.ts": `console.log("server");` });
     const { stdout, stderr, exitCode } = await build(dir, "--server-components", "--target=browser", "server.ts");
-    expect(stderr).toContain("Cannot use client-side --target");
+    expect(stderr).toMatchInlineSnapshot(`"error: Cannot use client-side --target=Browser with --server-components"`);
     expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });
@@ -557,8 +566,10 @@ describe.concurrent("bun build --server-components", () => {
       "client.ts": `"use client";\nexport function Button() { return "button"; }`,
     });
     const { stdout, stderr, exitCode } = await build(dir, "--server-components", "--target=bun", "server.ts");
-    expect(stderr).toContain('"use client" requires a framework with server components configured');
-    expect(stderr).toContain("client.ts");
+    expect(stderr).toMatchInlineSnapshot(`
+      "error: "use client" requires a framework with server components configured; "bun build --server-components" does not configure one
+          at <dir>/client.ts"
+    `);
     expect(stdout).toBe("");
     expect(exitCode).toBe(1);
   });
@@ -568,10 +579,52 @@ describe.concurrent("bun build --server-components", () => {
       "actions.ts": `"use server";\nexport async function save() { return "saved"; }`,
     });
     const { stdout, stderr, exitCode } = await build(dir, "--server-components", "--target=bun", "actions.ts");
-    expect(stderr).toContain('"use server" requires a framework with server components configured');
-    expect(stderr).toContain("actions.ts");
+    expect(stderr).toMatchInlineSnapshot(`
+      "error: "use server" requires a framework with server components configured; "bun build --server-components" does not configure one
+          at <dir>/actions.ts"
+    `);
     expect(stdout).toBe("");
     expect(exitCode).toBe(1);
+  });
+
+  // An HTML import makes the CLI set up a client transpiler and bundle a browser
+  // graph; a directive in that graph takes a different path to the same error.
+  test("a 'use client' script reached through an HTML import is a build error, not a crash", async () => {
+    using dir = tempDir("sc-html-use-client", {
+      "server.ts": `import page from "./index.html"; console.log(page);`,
+      "index.html": `<!DOCTYPE html><html><head><script type="module" src="./client.ts"></script></head><body></body></html>`,
+      "client.ts": `"use client";\ndocument.body.textContent = "button";`,
+    });
+    const { stdout, stderr, exitCode } = await build(
+      dir,
+      "--server-components",
+      "--target=bun",
+      "--outdir=out",
+      "server.ts",
+    );
+    expect(stderr).toMatchInlineSnapshot(`
+      "error: "use client" requires a framework with server components configured; "bun build --server-components" does not configure one
+          at <dir>/client.ts"
+    `);
+    expect(stdout).toBe("");
+    expect(exitCode).toBe(1);
+    expect(fs.existsSync(join(String(dir), "out"))).toBe(false);
+  });
+
+  test("the same HTML import bundles when no script carries a directive", async () => {
+    using dir = tempDir("sc-html", {
+      "server.ts": `import page from "./index.html"; console.log(page);`,
+      "index.html": `<!DOCTYPE html><html><head><script type="module" src="./client.ts"></script></head><body></body></html>`,
+      "client.ts": `document.body.textContent = "button";`,
+    });
+    const { stderr, exitCode } = await build(dir, "--server-components", "--outdir=out", "server.ts");
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+    expect(fs.readdirSync(join(String(dir), "out")).sort()).toEqual([
+      expect.stringMatching(/^index-\w+\.js$/),
+      "index.html",
+      "server.js",
+    ]);
   });
 
   test("directives are still plain strings without the flag", async () => {
@@ -581,7 +634,17 @@ describe.concurrent("bun build --server-components", () => {
     });
     const { stdout, stderr, exitCode } = await build(dir, "--target=bun", "server.ts");
     expect(stderr).toBe("");
-    expect(stdout).toContain("button");
+    expect(stdout).toMatchInlineSnapshot(`
+      "// @bun
+      // client.ts
+      "use client";
+      function Button() {
+        return "button";
+      }
+
+      // server.ts
+      console.log(Button());"
+    `);
     expect(exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
### Problem
- `bun build --server-components <entry>` crashes before bundling anything, for any entry point: ``panic: called `Option::unwrap()` on a `None` value`` in `BundleV2::transpiler_for_target` (src/bundler/bundle_v2.rs:264) via `enqueue_entry_item`.
- Cause: the flag only sets `options.server_components` (src/runtime/cli/Arguments.rs:2575, src/runtime/cli/build_command.rs:197). In that mode the bundler serves browser-target requests from `client_transpiler`, which the CLI only creates for HTML reached from a server-side build (`ensure_client_transpiler`). With no `--target` the main target stays at the browser default, so the very first entry point asks for a client transpiler that nothing has created.
- The `--target` handling used to default to `bun` here; a de-indentation in #14900 moved the `else { target = bun }` branch under the wrong `if`, so since then it only runs when a target was passed explicitly (where it coerces server-side targets to `bun`).
- With `--target bun` (the form `test/bake/dev/response-to-bake-response.test.ts` uses) the build works until a file carries a directive. There is no framework on the CLI, and the directive handling unwraps it in three places: a `"use client"` file in the server graph panics in `ParseTask::run_with_source_code` (src/bundler/ParseTask.rs:2529, worker thread); a `"use client"` script reached through an HTML import parses fine (browser graph) and then panics at the `framework` unwrap in `on_parse_task_complete` (`named_exports_for_scb`, bundle_v2.rs:7184); a `"use server"` file reaches `panic: TODO: registerServerReference (src/js_parser/p.rs:7635)`.

### Fix
- `Arguments.rs`: `--server-components` now always selects the `bun` target. Client-side targets are still rejected with the existing error; explicit server-side targets were already coerced to `bun`, so the only behavior change is the no-`--target` case, which used to crash.
- `ParseTask.rs`: the framework's server-components config is read once (`framework_server_components`) and replaces the three unwrap chains. A file carrying `"use client"` or `"use server"` while that config is absent fails with a build error on that file instead of being parsed, whichever graph it is in:
  ```
  error: "use client" requires a framework with server components configured; "bun build --server-components" does not configure one
      at /tmp/sc/client.ts
  ```
  The error is produced as the `ast_result` of the parse, so it takes the same error path and cleanup as any other failed parse.
- Why this is the right shape: a boundary needs the framework's runtime module and register functions (see Background), and the CLI has no way to configure a framework, so a directive file cannot be bundled in this mode and saying so is the only non-crashing option that does not silently produce a wrong bundle. Everything the flag can do without a framework (the server graph with the server-side parser transforms, plus any browser graph HTML pulls in) still builds. Rejecting the file in the parse task is what makes the remaining `framework` unwraps in `on_parse_task_complete` sound: a directive can no longer come out of a parse unless a framework is configured (noted at that site). Bake always configures a framework when it turns `server_components` on (`bake/mod.rs:243`, `bake_body.rs:1194`), so the new error cannot fire there.
- `bundle_v2.rs`: `transpiler_for_target` documents the invariant the server-components arm relies on (client transpiler populated by Bake, or by `ensure_client_transpiler` on the HTML paths, which are the only browser-target source in a CLI build now that its main target is always server-side) and names it in an `expect` instead of a bare `unwrap`. No behavior change.
- Not changed: the client transpiler that `build_command.rs` builds and discards in its `server_components` block predates this and is reshaped by #32078, so it is left alone; the `--target=Browser` spelling in the existing error and `"use server"` handling under a real framework (#33589) are unrelated.
- Tests: `test/bundler/cli.test.ts`, `describe("bun build --server-components")`. On the unfixed build 5 of the 7 cases crash (no `--target`; `"use client"` imported from the server graph; `"use client"` reached through an HTML import, which dies at the `on_parse_task_complete` unwrap, a different site from the others; `"use server"` entry; HTML import without a directive and without `--target`), the two contract cases (client-side `--target` rejected, directives are plain strings without the flag) pass both ways. All 7 pass with the fix. Also run with the fix: `test/bake/dev/response-to-bake-response.test.ts` (5 pass), `test/bake/dev/production.test.ts` (9 pass with `--timeout 120000`; its builds take 6-9s on a debug build), and the `"use client"` case in `test/bake/dev/bundle.test.ts`.

### Background
- Server components mode (`options.server_components`) makes the bundler keep one module graph per target: the main transpiler owns the server graph, `client_transpiler` the browser graph, and optionally `ssr_transpiler` a separate SSR graph. `transpiler_for_target` maps a target to one of them. Bake hands all of them to `BundleV2::init`; a plain `bun build` has only the main one and creates a client transpiler on demand when a server-side build imports HTML (the HTML and its scripts are bundled for the browser). In server-components mode that arm assumes the client transpiler is already there.
- A server component boundary is a file whose first statement is `"use client"` or `"use server"`. When a parse task reports one, the bundler generates a replacement module that registers each export with the framework's runtime. The import path and function names for that come from the framework configuration (`bake_types::ServerComponents`: `server_runtime_import`, `server_register_client_reference`, ...), which only Bake sets up (`bun build --app`, `Bun.serve({ app })`).
- The server-side parser transforms tied to this mode (`ServerComponentsMode::WrapAnonServerFunctions`, e.g. rewriting `Response` to the `bun:app` import) do not need the framework, which is what makes the flag useful on its own and what the existing bake tests exercise through it.

<details>
<summary>Repro before / after</summary>

```
$ echo 'console.log(1);' > plain.ts
$ bun build --server-components ./plain.ts
panic: called `Option::unwrap()` on a `None` value
<bun_bundler::bundle_v2::BundleV2>::transpiler_for_target       src/bundler/bundle_v2.rs:264
<bun_bundler::bundle_v2::BundleV2>::enqueue_entry_item          src/bundler/bundle_v2.rs:2772
<bun_bundler::bundle_v2::BundleV2>::enqueue_entry_points_normal src/bundler/bundle_v2.rs:3098

$ printf '"use client";\nexport function Foo() { return 1; }\n' > client.ts
$ printf 'import { Foo } from "./client";\nconsole.log(Foo());\n' > server.ts
$ bun build --server-components --target bun ./server.ts
panic: called `Option::unwrap()` on a `None` value
bun_bundler::parse_task::parse_worker::run_with_source_code     src/bundler/ParseTask.rs:2529

$ printf '<script type="module" src="./client.ts"></script>' > index.html
$ printf 'import page from "./index.html";\nconsole.log(page);\n' > page.ts
$ bun build --server-components --target bun ./page.ts --outdir out
panic: called `Option::unwrap()` on a `None` value
<bun_bundler::bundle_v2::BundleV2>::on_parse_task_complete      src/bundler/bundle_v2.rs (named_exports_for_scb framework unwrap)

$ printf '"use server";\nexport async function act() {}\n' > action.ts
$ bun build --server-components --target bun ./action.ts
panic: TODO: registerServerReference (src/js_parser/p.rs:7635)
```

With the fix:

```
$ bun build --server-components ./plain.ts
// @bun
// plain.ts
console.log(1);

$ bun build --server-components ./server.ts
error: "use client" requires a framework with server components configured; "bun build --server-components" does not configure one
    at /tmp/sc/client.ts
(exit 1)

$ bun build --server-components ./page.ts --outdir out        # same error, at /tmp/sc/client.ts; with a plain client.ts this emits server.js, index.html and the browser entry

$ bun build --server-components ./action.ts
error: "use server" requires a framework with server components configured; "bun build --server-components" does not configure one
    at /tmp/sc/action.ts
(exit 1)
```
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/bundler/cli.test.ts

<!-- robobun:evidence:end -->