### PR TITLE
install: read NPM_CONFIG_USERCONFIG as the user-level .npmrc path

### DIFF
--- a/docs/pm/npmrc.mdx
+++ b/docs/pm/npmrc.mdx
@@ -12,6 +12,21 @@ Bun loads configuration options from [`.npmrc`](https://docs.npmjs.com/cli/v10/c
 
 ---
 
+## Which files are read
+
+Bun reads up to two `.npmrc` files. Options in the later file override the earlier one:
+
+1. The user-level file. This is the file `NPM_CONFIG_USERCONFIG` (npm's `userconfig` option) points at when that variable is set; otherwise `$XDG_CONFIG_HOME/.npmrc` if it exists, otherwise `$HOME/.npmrc`.
+2. The `.npmrc` next to your project's root `package.json`.
+
+<Note>
+  `actions/setup-node` with `registry-url` writes an `.npmrc` to `$RUNNER_TEMP` and exports `NPM_CONFIG_USERCONFIG`
+  pointing at it, so `bun publish` reads the token from `NODE_AUTH_TOKEN` in that workflow the same way `npm publish`
+  does.
+</Note>
+
+---
+
 ## Supported options
 
 ### Set the default registry

--- a/src/install/PackageManager.rs
+++ b/src/install/PackageManager.rs
@@ -1879,10 +1879,24 @@ pub fn init(
         let mut buf = PathBuffer::uninit();
         let parts = [b"./.npmrc" as &[u8]];
 
-        // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
-        // `$XDG_CONFIG_HOME/.npmrc` only when that file actually exists.
         let mut global_len: usize = 0;
-        if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
+        // npm's `userconfig`: when set, this file is the per-user .npmrc and
+        // neither $XDG_CONFIG_HOME/.npmrc nor ~/.npmrc is looked at.
+        // actions/setup-node writes one to $RUNNER_TEMP and exports
+        // NPM_CONFIG_USERCONFIG pointing at it.
+        if let Some(userconfig) = [b"NPM_CONFIG_USERCONFIG" as &[u8], b"npm_config_userconfig"]
+            .into_iter()
+            .find_map(|key| env.get(key).filter(|path| !path.is_empty()))
+        {
+            global_len = resolve_path::join_abs_string_buf_z::<platform::Auto>(
+                &original_cwd_clone,
+                &mut buf,
+                &[userconfig],
+            )
+            .len();
+        } else if let Some(xdg_dir) = bun_core::env_var::XDG_CONFIG_HOME.get_not_empty() {
+            // npm reads `$HOME/.npmrc` and ignores XDG_CONFIG_HOME; keep
+            // `$XDG_CONFIG_HOME/.npmrc` only when that file actually exists.
             let p =
                 resolve_path::join_abs_string_buf_z::<platform::Auto>(xdg_dir, &mut buf, &parts);
             if bun_sys::exists_z(p) {

--- a/test/cli/install/npmrc.test.ts
+++ b/test/cli/install/npmrc.test.ts
@@ -172,16 +172,17 @@ registry = http://localhost:${registry.port}/
     const npmrc = (port: number) => `registry=http://localhost:${port}/\n//localhost:${port}/:_authToken=token\n`;
     const pkg = { "pkg/package.json": JSON.stringify({ name: "npmrc-lookup", version: "0.0.1" }) };
 
-    // `publish --dry-run` never contacts the registry, but it still requires a token
-    // for it and prints which registry it picked up, so it shows which .npmrc was read.
-    // bunEnv spreads process.env and CI runners commonly export XDG_CONFIG_HOME, so it
-    // is removed here and each case passes back exactly the value it is testing.
-    async function publishDryRun(dir: string, envOverride: Record<string, string>) {
+    // bunEnv spreads process.env, and CI runners commonly export XDG_CONFIG_HOME or
+    // (via actions/setup-node) NPM_CONFIG_USERCONFIG, so both are removed here and each
+    // case passes back exactly the variables it is testing.
+    async function publish(dir: string, envOverride: Record<string, string>, ...args: string[]) {
       const spawnEnv = { ...env, HOME: join(dir, "home"), USERPROFILE: join(dir, "home") };
       delete spawnEnv.XDG_CONFIG_HOME;
+      delete spawnEnv.NPM_CONFIG_USERCONFIG;
+      delete spawnEnv.npm_config_userconfig;
 
       await using proc = Bun.spawn({
-        cmd: [bunExe(), "publish", "--dry-run"],
+        cmd: [bunExe(), "publish", ...args],
         cwd: join(dir, "pkg"),
         env: { ...spawnEnv, ...envOverride },
         stdout: "pipe",
@@ -190,6 +191,10 @@ registry = http://localhost:${registry.port}/
       const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
       return { stdout, stderr, exitCode };
     }
+
+    // `publish --dry-run` never contacts the registry, but it still requires a token
+    // for it and prints which registry it picked up, so it shows which .npmrc was read.
+    const publishDryRun = (dir: string, envOverride: Record<string, string>) => publish(dir, envOverride, "--dry-run");
 
     const usesRegistry = (port: number) => ({
       stdout: expect.stringContaining(`Registry: http://localhost:${port}/\n`),
@@ -221,6 +226,81 @@ registry = http://localhost:${registry.port}/
       using dir = tempDir("npmrc-xdg-empty", { ...pkg, "home/.npmrc": npmrc(1) });
       const result = await publishDryRun(String(dir), { XDG_CONFIG_HOME: "" });
       expect(result).toEqual(usesRegistry(1));
+    });
+
+    // npm's `userconfig` option: the path of the per-user .npmrc, settable through
+    // NPM_CONFIG_USERCONFIG like any other npm config option.
+    it.concurrent("uses $NPM_CONFIG_USERCONFIG instead of $XDG_CONFIG_HOME/.npmrc and $HOME/.npmrc", async () => {
+      using dir = tempDir("npmrc-userconfig", {
+        ...pkg,
+        "home/.npmrc": npmrc(1),
+        "xdg/.npmrc": npmrc(2),
+        "elsewhere/ci.npmrc": npmrc(3),
+      });
+      const result = await publishDryRun(String(dir), {
+        XDG_CONFIG_HOME: join(String(dir), "xdg"),
+        NPM_CONFIG_USERCONFIG: join(String(dir), "elsewhere", "ci.npmrc"),
+      });
+      expect(result).toEqual(usesRegistry(3));
+    });
+
+    it.concurrent("accepts lowercase $npm_config_userconfig", async () => {
+      using dir = tempDir("npmrc-userconfig-lowercase", {
+        ...pkg,
+        "home/.npmrc": npmrc(1),
+        "elsewhere/ci.npmrc": npmrc(2),
+      });
+      const result = await publishDryRun(String(dir), {
+        npm_config_userconfig: join(String(dir), "elsewhere", "ci.npmrc"),
+      });
+      expect(result).toEqual(usesRegistry(2));
+    });
+
+    it.concurrent("uses $HOME/.npmrc when $NPM_CONFIG_USERCONFIG is empty", async () => {
+      using dir = tempDir("npmrc-userconfig-empty", { ...pkg, "home/.npmrc": npmrc(1) });
+      const result = await publishDryRun(String(dir), { NPM_CONFIG_USERCONFIG: "" });
+      expect(result).toEqual(usesRegistry(1));
+    });
+
+    it.concurrent("the project .npmrc still overrides $NPM_CONFIG_USERCONFIG", async () => {
+      using dir = tempDir("npmrc-userconfig-project", {
+        ...pkg,
+        "elsewhere/ci.npmrc": npmrc(1),
+        "pkg/.npmrc": npmrc(2),
+      });
+      const result = await publishDryRun(String(dir), {
+        NPM_CONFIG_USERCONFIG: join(String(dir), "elsewhere", "ci.npmrc"),
+      });
+      expect(result).toEqual(usesRegistry(2));
+    });
+
+    // https://github.com/oven-sh/bun/issues/14824: actions/setup-node with `registry-url`
+    // writes $RUNNER_TEMP/.npmrc with the contents below and exports NPM_CONFIG_USERCONFIG
+    // pointing at it; the token itself is only present as $NODE_AUTH_TOKEN.
+    it.concurrent("reads the .npmrc written by actions/setup-node, expanding ${NODE_AUTH_TOKEN}", async () => {
+      const { promise: authorization, resolve } = Promise.withResolvers<string | null>();
+      using mockRegistry = Bun.serve({
+        port: 0,
+        fetch(req) {
+          resolve(req.headers.get("authorization"));
+          return new Response("{}");
+        },
+      });
+      const { port } = mockRegistry;
+      using dir = tempDir("npmrc-setup-node", {
+        ...pkg,
+        "runner-temp/.npmrc": `//localhost:${port}/:_authToken=\${NODE_AUTH_TOKEN}\nregistry=http://localhost:${port}/\nalways-auth=true\n`,
+      });
+      const result = await publish(String(dir), {
+        NPM_CONFIG_USERCONFIG: join(String(dir), "runner-temp", ".npmrc"),
+        NODE_AUTH_TOKEN: "npm_token-from-the-workflow-env",
+      });
+      expect(result).toEqual({
+        stdout: expect.stringContaining(" + npmrc-lookup@0.0.1\n"),
+        stderr: "",
+        exitCode: 0,
+      });
+      expect(await authorization).toBe("Bearer npm_token-from-the-workflow-env");
     });
   });
 


### PR DESCRIPTION
Related: #14824 (closed on the `NPM_CONFIG_TOKEN` workaround), follow-up to #36289.

### Problem
- `bun publish` in a GitHub Actions job that uses `actions/setup-node` with `registry-url` fails with `error: missing authentication (run `bunx npm login`)` even though the workflow provides `NODE_AUTH_TOKEN` (#14824).
- setup-node writes `$RUNNER_TEMP/.npmrc` containing `//<registry>/:_authToken=${NODE_AUTH_TOKEN}` and exports `NPM_CONFIG_USERCONFIG` pointing at it. npm reads that variable as its `userconfig` option; bun never read it: the `.npmrc` block in `PackageManager::init` (src/install/PackageManager.rs, right after `initialize_store()`) only ever looked at `$XDG_CONFIG_HOME/.npmrc` and `$HOME/.npmrc`.
- #36289 only changed that XDG/HOME lookup and listed this case as not covered.

### Fix
- When `NPM_CONFIG_USERCONFIG` (or `npm_config_userconfig`) is set and non-empty, that file is loaded as the user-level `.npmrc` and the XDG/HOME lookup is skipped. The project `.npmrc` still loads after it and still takes precedence. `${VAR}` expansion is done by the existing ini loader, so setup-node's `_authToken=${NODE_AUTH_TOKEN}` line works as written.
- The variable is read through the same env loader as `NPM_CONFIG_REGISTRY` / `NPM_CONFIG_TOKEN` (PackageManagerOptions.rs), so the upper/lower-case pair and `.env` files behave the same as they do for those two.
- A relative value is resolved against the directory bun was invoked from (`original_cwd_clone`), not the package root bun has already chdir'd to at this point; npm resolves `userconfig` against cwd as well. A value naming a file that does not exist means there is no user-level file (the loader skips unreadable auto-loaded files), which is also what npm does: it does not fall back to `~/.npmrc`.
- Checked against npm 11.16.0 with the same files (`npm config get registry`): relative value, missing file, empty value and the lowercase name all behave as described above.
- Tests (test/cli/install/npmrc.test.ts, `describe("user .npmrc lookup")`): four cases through the existing `publish --dry-run` helper (userconfig wins over both `$XDG_CONFIG_HOME/.npmrc` and `$HOME/.npmrc`, lowercase name, empty value ignored, project `.npmrc` still overrides it), plus one real `bun publish` against a `Bun.serve` mock registry using a file with exactly setup-node's contents, asserting the request carries `Bearer <NODE_AUTH_TOKEN value>`. Three of the five fail on main (the `Registry:` line shows the XDG/HOME file was used, or `missing authentication`); the other two pin behavior that must not change.
- `bun bd test test/cli/install/npmrc.test.ts`: 36 pass.
- docs/pm/npmrc.mdx gains a short section on which files are read.

### Background
- `.npmrc` is npm's ini-style config file (registry URL, `//host/:_authToken=` credentials, and so on). Every install-family command loads one user-level file and then the project's `./.npmrc` through `ini::load_npmrc_config`; later files override earlier ones, and a file that cannot be read is skipped silently because these are auto-loaded.
- `userconfig` is npm's name for the path of that user-level file (default `~/.npmrc`). Any npm option can be set from the environment as `NPM_CONFIG_<OPTION>` / `npm_config_<option>`; bun already honors `registry` and `token` that way, this adds `userconfig`.
