### PR TITLE
bun build: keep NODE_ENV=production when tsconfig.json does not set "jsx"

### DIFF
--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -667,7 +667,7 @@ fn jsx_pragma_from_resolver(
 }
 
 /// D042: types unified — delegate to the resolver's own
-/// `TSConfigJSON::merge_jsx` (5-field conditional copy keyed on `jsx_flags`).
+/// `TSConfigJSON::merge_jsx` (conditional copy keyed on `jsx_flags`).
 #[inline]
 fn merge_tsconfig_jsx_into(tsconfig: &TSConfigJSON, out: &mut crate::options_impl::jsx::Pragma) {
     *out = tsconfig.merge_jsx(core::mem::take(out));
@@ -702,9 +702,12 @@ impl<'a> Transpiler<'a> {
             let top_level_dir = self.fs().top_level_dir;
             if let Ok(Some(root_dir)) = self.resolver.read_dir_info(top_level_dir) {
                 if let Some(tsconfig) = root_dir.tsconfig_json() {
-                    // If we don't explicitly pass JSX, try to get it from the root tsconfig
+                    // If we don't explicitly pass JSX, try to get it from the root tsconfig.
+                    // Merge rather than replace: `options.jsx.development` may already hold
+                    // NODE_ENV (`bun build` runs `configure_defines` first), and a tsconfig
+                    // without "jsx" has no say in it.
                     if self.options.transform_options.jsx.is_none() {
-                        self.options.jsx = jsx_pragma_from_resolver(&tsconfig.jsx);
+                        merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
                     }
                     self.options.emit_decorator_metadata = tsconfig.emit_decorator_metadata;
                     self.options.experimental_decorators = tsconfig.experimental_decorators;

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -703,9 +703,7 @@ impl<'a> Transpiler<'a> {
             if let Ok(Some(root_dir)) = self.resolver.read_dir_info(top_level_dir) {
                 if let Some(tsconfig) = root_dir.tsconfig_json() {
                     // If we don't explicitly pass JSX, try to get it from the root tsconfig.
-                    // Merge rather than replace: `options.jsx.development` may already hold
-                    // NODE_ENV (`bun build` runs `configure_defines` first), and a tsconfig
-                    // without "jsx" has no say in it.
+                    // Merged, not replaced: `jsx.development` may already carry NODE_ENV.
                     if self.options.transform_options.jsx.is_none() {
                         merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
                     }

--- a/src/bundler/transpiler.rs
+++ b/src/bundler/transpiler.rs
@@ -702,8 +702,7 @@ impl<'a> Transpiler<'a> {
             let top_level_dir = self.fs().top_level_dir;
             if let Ok(Some(root_dir)) = self.resolver.read_dir_info(top_level_dir) {
                 if let Some(tsconfig) = root_dir.tsconfig_json() {
-                    // If we don't explicitly pass JSX, try to get it from the root tsconfig.
-                    // Merged, not replaced: `jsx.development` may already carry NODE_ENV.
+                    // Merge, not replace: `jsx.development` may already carry NODE_ENV.
                     if self.options.transform_options.jsx.is_none() {
                         merge_tsconfig_jsx_into(tsconfig, &mut self.options.jsx);
                     }

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -241,7 +241,7 @@ impl TSConfigJSON {
             // "jsxImportSource" sets both: the parser imports jsx/jsxDEV from `import_source`
             // and the key-after-spread `createElement` fallback from `package_name`.
             out.import_source = self.jsx.import_source.clone();
-            out.package_name = self.jsx.package_name.clone();
+            out.package_name.clone_from(&self.jsx.package_name);
         }
 
         if self.jsx_flags.contains(JsxField::Runtime) {

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -238,7 +238,10 @@ impl TSConfigJSON {
         }
 
         if self.jsx_flags.contains(JsxField::ImportSource) {
+            // "jsxImportSource" sets both: the parser imports jsx/jsxDEV from `import_source`
+            // and the key-after-spread `createElement` fallback from `package_name`.
             out.import_source = self.jsx.import_source.clone();
+            out.package_name = self.jsx.package_name.clone();
         }
 
         if self.jsx_flags.contains(JsxField::Runtime) {

--- a/src/resolver/tsconfig_json.rs
+++ b/src/resolver/tsconfig_json.rs
@@ -238,8 +238,7 @@ impl TSConfigJSON {
         }
 
         if self.jsx_flags.contains(JsxField::ImportSource) {
-            // "jsxImportSource" sets both: the parser imports jsx/jsxDEV from `import_source`
-            // and the key-after-spread `createElement` fallback from `package_name`.
+            // "jsxImportSource" sets both; `package_name` feeds the `createElement` fallback import.
             out.import_source = self.jsx.import_source.clone();
             out.package_name.clone_from(&self.jsx.package_name);
         }

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -20,6 +20,7 @@ const shimFiles = {
     export const Fragment = Symbol.for("F");
     export const jsx = () => (console.log("prod jsx"), {});
     export const jsxs = jsx;
+    export const createElement = () => (console.log("shim createElement"), {});
   `,
   "node_modules/shim/dev.js": `
     export const Fragment = Symbol.for("F");
@@ -67,5 +68,126 @@ describe("tsconfig compilerOptions.jsx", () => {
       expect(stdout).not.toContain(importSource === "shim/jsx-runtime" ? "jsx-dev-runtime" : '"shim/jsx-runtime"');
       expect(exitCode).toBe(0);
     }
+  });
+});
+
+const noNodeEnv = { ...bunEnv, NODE_ENV: undefined, BUN_ENV: undefined };
+
+// Nothing is installed in these directories: bundled mode marks every import external, so both
+// modes leave the JSX runtime imports in the output, where the test reads them back.
+const buildModes = [
+  ["bun build", ["--external", "*"]],
+  ["bun build --no-bundle", ["--no-bundle"]],
+] as const;
+
+/** Runs `bun build` and returns the module specifiers the output imports, sorted. */
+async function buildImports(
+  cwd: string,
+  args: readonly string[],
+  env: Record<string, string | undefined> = noNodeEnv,
+): Promise<{ imports: string[]; exitCode: number }> {
+  await using proc = Bun.spawn({
+    cmd: [bunExe(), "build", ...args],
+    env,
+    cwd,
+    stdout: "pipe",
+    // A key-after-spread element logs a deprecation warning here; it is not what these tests check.
+    stderr: "pipe",
+  });
+  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  return { imports: [...stdout.matchAll(/ from "([^"]+)"/g)].map(m => m[1]).sort(), exitCode };
+}
+
+// A tsconfig.json that does not choose between "react-jsx" and "react-jsxdev" must leave the
+// dev/prod choice to NODE_ENV, exactly like having no tsconfig.json (and like `bun run`, which
+// already behaved that way). `bun build` used to switch to the development runtime as soon as any
+// tsconfig.json existed.
+describe("bun build: NODE_ENV=production with a tsconfig.json that does not choose dev/prod", () => {
+  const productionEnv = { ...noNodeEnv, NODE_ENV: "production" };
+
+  const layouts = [
+    ["no tsconfig.json", {}, "react/jsx-runtime"],
+    ["empty compilerOptions", { "tsconfig.json": JSON.stringify({ compilerOptions: {} }) }, "react/jsx-runtime"],
+    [
+      '"jsx": "preserve"',
+      { "tsconfig.json": JSON.stringify({ compilerOptions: { jsx: "preserve" } }) },
+      "react/jsx-runtime",
+    ],
+    [
+      "only jsxImportSource",
+      { "tsconfig.json": JSON.stringify({ compilerOptions: { jsxImportSource: "shim" } }) },
+      "shim/jsx-runtime",
+    ],
+  ] as const;
+
+  for (const [mode, modeArgs] of buildModes) {
+    test.concurrent.each(layouts)(`${mode}, %s`, async (_, files, runtime) => {
+      using dir = tempDir("jsx-tsconfig-node-env", { "m.jsx": shimFiles["m.jsx"], ...files });
+      expect(await buildImports(String(dir), [...modeArgs, "m.jsx"], productionEnv)).toEqual({
+        imports: [runtime],
+        exitCode: 0,
+      });
+    });
+
+    test.concurrent(`${mode}, empty compilerOptions, --define process.env.NODE_ENV`, async () => {
+      using dir = tempDir("jsx-tsconfig-define", {
+        "m.jsx": shimFiles["m.jsx"],
+        "tsconfig.json": JSON.stringify({ compilerOptions: {} }),
+      });
+      const args = [...modeArgs, "--define", 'process.env.NODE_ENV="production"', "m.jsx"];
+      expect(await buildImports(String(dir), args)).toEqual({ imports: ["react/jsx-runtime"], exitCode: 0 });
+    });
+  }
+});
+
+// A key after a {...spread} makes the automatic runtime fall back to `createElement`, imported from
+// the jsxImportSource package itself rather than from its /jsx-runtime entry. Both imports have to
+// follow jsxImportSource, including when the setting arrives through a tsconfig merge: an
+// "extends" chain, or (at build time) a tsconfig.json in the entry point's own directory.
+describe("tsconfig jsxImportSource selects the createElement fallback import too", () => {
+  const files = {
+    ...shimFiles,
+    "k.jsx": `const p = {};\nglobalThis.a = <div {...p} key="k" />;\nglobalThis.b = <span />;\n`,
+  };
+  const shimImports = { imports: ["shim", "shim/jsx-dev-runtime"], exitCode: 0 };
+
+  const rootLayouts = [
+    ["tsconfig.json", { "tsconfig.json": JSON.stringify({ compilerOptions: { jsxImportSource: "shim" } }) }],
+    [
+      "tsconfig.json extending a base config",
+      {
+        "tsconfig.json": JSON.stringify({ extends: "./base.json", compilerOptions: { jsxImportSource: "shim" } }),
+        "base.json": JSON.stringify({ compilerOptions: {} }),
+      },
+    ],
+  ] as const;
+
+  for (const [mode, modeArgs] of buildModes) {
+    test.concurrent.each(rootLayouts)(`${mode}, %s`, async (_, layout) => {
+      using dir = tempDir("jsx-import-source", { ...files, ...layout });
+      expect(await buildImports(String(dir), [...modeArgs, "k.jsx"])).toEqual(shimImports);
+    });
+
+    test.concurrent(`${mode}, tsconfig.json in the entry point's directory`, async () => {
+      using dir = tempDir("jsx-import-source-nested", {
+        "sub/k.jsx": files["k.jsx"],
+        "sub/tsconfig.json": JSON.stringify({ compilerOptions: { jsxImportSource: "shim" } }),
+      });
+      expect(await buildImports(String(dir), [...modeArgs, "sub/k.jsx"])).toEqual(shimImports);
+    });
+  }
+
+  // `bun run` only applies the project root's tsconfig.json, so the nested layout is build-only.
+  test.concurrent.each(rootLayouts)("bun run, %s", async (_, layout) => {
+    using dir = tempDir("jsx-import-source-run", { ...files, ...layout });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "run", "k.jsx"],
+      env: noNodeEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "shim createElement\ndev jsxDEV", exitCode: 0 });
   });
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -96,10 +96,10 @@ async function buildImports(
     env,
     cwd,
     stdout: "pipe",
-    // A key-after-spread element logs a deprecation warning here; it is not what these tests check.
     stderr: "pipe",
   });
-  const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+  // stderr is drained but not asserted: the key-after-spread fixture logs a deprecation warning there.
+  const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
   return { imports: importsOf(stdout), exitCode };
 }
 
@@ -205,7 +205,7 @@ describe("tsconfig jsxImportSource selects the createElement fallback import too
       stdout: "pipe",
       stderr: "pipe",
     });
-    const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
+    const [stdout, , exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "shim createElement\ndev jsxDEV", exitCode: 0 });
   });
 

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -156,6 +156,9 @@ describe("tsconfig jsxImportSource selects the createElement fallback import too
   const keyAfterSpread = `const p = {};\nglobalThis.a = <div {...p} key="k" />;\nglobalThis.b = <span />;\n`;
   const tsconfig = JSON.stringify({ compilerOptions: { jsxImportSource: "shim" } });
   const shimImports = ["shim", "shim/jsx-dev-runtime"];
+  // The in-process cases below share this test process's env loader, where NODE_ENV/BUN_ENV pick
+  // the runtime entry; the load-bearing import here is the "shim" createElement fallback.
+  const shimImportsAnyEnv = ["shim", expect.stringMatching(/^shim\/jsx(-dev)?-runtime$/)];
 
   // [name, entry point, files]. `bun run` only applies the project root's tsconfig.json, so the
   // layout whose tsconfig.json lives next to the entry point is exercised by the build paths only.
@@ -193,7 +196,7 @@ describe("tsconfig jsxImportSource selects the createElement fallback import too
   test.concurrent.each(layouts)("Bun.build(), %s", async (_, entry, files) => {
     using dir = tempDir("jsx-import-source-api", files);
     const result = await Bun.build({ entrypoints: [join(String(dir), entry)], external: ["*"] });
-    expect(importsOf(await result.outputs[0].text())).toEqual(shimImports);
+    expect(importsOf(await result.outputs[0].text())).toEqual(shimImportsAnyEnv);
   });
 
   test.concurrent.each(rootLayouts)("bun run, %s", async (_, entry, files) => {
@@ -217,7 +220,7 @@ describe("tsconfig jsxImportSource selects the createElement fallback import too
       logLevel: "error",
       tsconfig: { compilerOptions: { jsxImportSource: "shim" } },
     });
-    expect(importsOf(transpiler.transformSync(keyAfterSpread))).toEqual(shimImports);
-    expect(importsOf(await transpiler.transform(keyAfterSpread))).toEqual(shimImports);
+    expect(importsOf(transpiler.transformSync(keyAfterSpread))).toEqual(shimImportsAnyEnv);
+    expect(importsOf(await transpiler.transform(keyAfterSpread))).toEqual(shimImportsAnyEnv);
   });
 });

--- a/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
+++ b/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { bunEnv, bunExe, tempDir } from "harness";
+import { join } from "node:path";
 
 // tsconfig "jsx": "react-jsx" selects the production automatic runtime (jsx/jsxs),
 // "react-jsxdev" selects the development runtime (jsxDEV), matching TypeScript/esbuild.
@@ -80,7 +81,11 @@ const buildModes = [
   ["bun build --no-bundle", ["--no-bundle"]],
 ] as const;
 
-/** Runs `bun build` and returns the module specifiers the output imports, sorted. */
+/** The module specifiers some transpiled or bundled output imports, sorted. */
+function importsOf(code: string): string[] {
+  return [...code.matchAll(/ from "([^"]+)"/g)].map(m => m[1]).sort();
+}
+
 async function buildImports(
   cwd: string,
   args: readonly string[],
@@ -95,7 +100,7 @@ async function buildImports(
     stderr: "pipe",
   });
   const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
-  return { imports: [...stdout.matchAll(/ from "([^"]+)"/g)].map(m => m[1]).sort(), exitCode };
+  return { imports: importsOf(stdout), exitCode };
 }
 
 // A tsconfig.json that does not choose between "react-jsx" and "react-jsxdev" must leave the
@@ -142,46 +147,59 @@ describe("bun build: NODE_ENV=production with a tsconfig.json that does not choo
 
 // A key after a {...spread} makes the automatic runtime fall back to `createElement`, imported from
 // the jsxImportSource package itself rather than from its /jsx-runtime entry. Both imports have to
-// follow jsxImportSource, including when the setting arrives through a tsconfig merge: an
-// "extends" chain, or (at build time) a tsconfig.json in the entry point's own directory.
+// follow jsxImportSource. Merging a tsconfig into the JSX settings used to carry only the runtime
+// import, and every entry point merges: Bun.build() and Bun.Transpiler always, the CLI as soon as a
+// bunfig.toml or --jsx-* flag is present, "extends" chains, and (at build time) a tsconfig.json in
+// the entry point's own directory. The plain CLI case only worked because the root tsconfig.json was
+// copied over the JSX settings wholesale, which is what broke NODE_ENV above; now it merges too.
 describe("tsconfig jsxImportSource selects the createElement fallback import too", () => {
-  const files = {
-    ...shimFiles,
-    "k.jsx": `const p = {};\nglobalThis.a = <div {...p} key="k" />;\nglobalThis.b = <span />;\n`,
-  };
-  const shimImports = { imports: ["shim", "shim/jsx-dev-runtime"], exitCode: 0 };
+  const keyAfterSpread = `const p = {};\nglobalThis.a = <div {...p} key="k" />;\nglobalThis.b = <span />;\n`;
+  const tsconfig = JSON.stringify({ compilerOptions: { jsxImportSource: "shim" } });
+  const shimImports = ["shim", "shim/jsx-dev-runtime"];
 
-  const rootLayouts = [
-    ["tsconfig.json", { "tsconfig.json": JSON.stringify({ compilerOptions: { jsxImportSource: "shim" } }) }],
+  // [name, entry point, files]. `bun run` only applies the project root's tsconfig.json, so the
+  // layout whose tsconfig.json lives next to the entry point is exercised by the build paths only.
+  const layouts = [
+    ["tsconfig.json", "k.jsx", { "k.jsx": keyAfterSpread, "tsconfig.json": tsconfig }],
     [
       "tsconfig.json extending a base config",
+      "k.jsx",
       {
+        "k.jsx": keyAfterSpread,
         "tsconfig.json": JSON.stringify({ extends: "./base.json", compilerOptions: { jsxImportSource: "shim" } }),
         "base.json": JSON.stringify({ compilerOptions: {} }),
       },
     ],
+    [
+      "tsconfig.json next to a bunfig.toml",
+      "k.jsx",
+      { "k.jsx": keyAfterSpread, "tsconfig.json": tsconfig, "bunfig.toml": "# any bunfig.toml, jsx keys or not\n" },
+    ],
+    [
+      "tsconfig.json in the entry point's directory",
+      "sub/k.jsx",
+      { "sub/k.jsx": keyAfterSpread, "sub/tsconfig.json": tsconfig },
+    ],
   ] as const;
+  const rootLayouts = layouts.filter(([, entry]) => entry === "k.jsx");
 
   for (const [mode, modeArgs] of buildModes) {
-    test.concurrent.each(rootLayouts)(`${mode}, %s`, async (_, layout) => {
-      using dir = tempDir("jsx-import-source", { ...files, ...layout });
-      expect(await buildImports(String(dir), [...modeArgs, "k.jsx"])).toEqual(shimImports);
-    });
-
-    test.concurrent(`${mode}, tsconfig.json in the entry point's directory`, async () => {
-      using dir = tempDir("jsx-import-source-nested", {
-        "sub/k.jsx": files["k.jsx"],
-        "sub/tsconfig.json": JSON.stringify({ compilerOptions: { jsxImportSource: "shim" } }),
-      });
-      expect(await buildImports(String(dir), [...modeArgs, "sub/k.jsx"])).toEqual(shimImports);
+    test.concurrent.each(layouts)(`${mode}, %s`, async (_, entry, files) => {
+      using dir = tempDir("jsx-import-source", files);
+      expect(await buildImports(String(dir), [...modeArgs, entry])).toEqual({ imports: shimImports, exitCode: 0 });
     });
   }
 
-  // `bun run` only applies the project root's tsconfig.json, so the nested layout is build-only.
-  test.concurrent.each(rootLayouts)("bun run, %s", async (_, layout) => {
-    using dir = tempDir("jsx-import-source-run", { ...files, ...layout });
+  test.concurrent.each(layouts)("Bun.build(), %s", async (_, entry, files) => {
+    using dir = tempDir("jsx-import-source-api", files);
+    const result = await Bun.build({ entrypoints: [join(String(dir), entry)], external: ["*"] });
+    expect(importsOf(await result.outputs[0].text())).toEqual(shimImports);
+  });
+
+  test.concurrent.each(rootLayouts)("bun run, %s", async (_, entry, files) => {
+    using dir = tempDir("jsx-import-source-run", { ...shimFiles, ...files });
     await using proc = Bun.spawn({
-      cmd: [bunExe(), "run", "k.jsx"],
+      cmd: [bunExe(), "run", entry],
       env: noNodeEnv,
       cwd: String(dir),
       stdout: "pipe",
@@ -189,5 +207,17 @@ describe("tsconfig jsxImportSource selects the createElement fallback import too
     });
     const [stdout, exitCode] = await Promise.all([proc.stdout.text(), proc.exited]);
     expect({ stdout: stdout.trim(), exitCode }).toEqual({ stdout: "shim createElement\ndev jsxDEV", exitCode: 0 });
+  });
+
+  test("Bun.Transpiler({ tsconfig })", async () => {
+    const transpiler = new Bun.Transpiler({
+      loader: "jsx",
+      autoImportJSX: true,
+      // Otherwise the key-after-spread warning is thrown.
+      logLevel: "error",
+      tsconfig: { compilerOptions: { jsxImportSource: "shim" } },
+    });
+    expect(importsOf(transpiler.transformSync(keyAfterSpread))).toEqual(shimImports);
+    expect(importsOf(await transpiler.transform(keyAfterSpread))).toEqual(shimImports);
   });
 });


### PR DESCRIPTION
### Problem

- `NODE_ENV=production bun build ./main.tsx` emits the production automatic runtime (`jsx` from `react/jsx-runtime`) when the project has no tsconfig.json, but emits the development runtime (`jsxDEV` from `react/jsx-dev-runtime`) as soon as any tsconfig.json exists, even `{"compilerOptions":{}}`, `"jsx": "preserve"`, or one that only sets `jsxImportSource`. Same with `BUN_ENV=production` and `--define process.env.NODE_ENV='"production"'`, in both bundled and `--no-bundle` mode. `bun run` of the same project picks the production runtime; `bun build --production` is unaffected. Reproduces on bun 1.4.0.
- Cause: `configure_linker_with_auto_jsx` (`src/bundler/transpiler.rs:707`) did `options.jsx = tsconfig.jsx`, replacing the whole pragma. The tsconfig's pragma starts from `Pragma::default()` (`development: true`) and only the fields the file sets are overwritten, so a tsconfig with no dev/prod opinion still carried `development: true`. `bun build` is the one entry point that runs `configure_defines()` (which applies `NODE_ENV` via `set_production`) before `configure_linker()`, so the copy threw that value away. Bundled mode then reads `options.jsx.development` for every file (`bundle_v2.rs`, the `ForceNodeEnv::Unspecified` arms) and `--no-bundle` reads it back through `resolver.opts` after `sync_resolver_opts()`.
- Second problem in the function the fix relies on: `TSConfigJSON::merge_jsx` (`src/resolver/tsconfig_json.rs`) copied `import_source` but not `package_name` for `jsxImportSource`. `package_name` is where the key-after-spread `createElement` fallback is imported from, so every path that reaches tsconfig through the merge emitted mixed output for `{"compilerOptions":{"jsxImportSource":"preact"}}`: `jsxDEV` from `preact/jsx-dev-runtime` and `createElement` from `react`. That is every path except the plain CLI: `Bun.build()` and `Bun.Transpiler({ tsconfig })` always merge, the CLI (`bun build`, `bun run`) merges as soon as a bunfig.toml or a `--jsx-*` flag is present, and `extends` chains and nested tsconfig.json files merge as well. The plain CLI case was only right because of the wholesale copy above.

### Fix

- `configure_linker_with_auto_jsx` merges the root tsconfig into `options.jsx` (`merge_tsconfig_jsx_into`, the helper `run_env_loader` already uses a few lines below) instead of replacing it. Fields the tsconfig sets (`jsx`, `jsxFactory`, `jsxFragmentFactory`, `jsxImportSource`) still win exactly as before; fields it does not set keep what the caller configured, which for `bun build` is the `NODE_ENV`-derived `development` flag.
- `merge_jsx` copies `package_name` together with `import_source`, so a merged `jsxImportSource` drives both imports. This is what keeps the plain CLI case working once it goes through the merge, and it fixes the mixed output on the paths listed above, including a plain root tsconfig.json under `Bun.build()`, `Bun.Transpiler({ tsconfig })`, or a CLI invocation with a bunfig.toml. `createElement` now comes from the `jsxImportSource` package on all of them; nothing else in the output changes.
- Why this is right: a tsconfig.json that says nothing about `jsx` has to leave dev/prod selection where it was, the same as having no tsconfig.json and the same as `bun run` already behaves. Merging is also how every other tsconfig JSX consumer works (`resolver.rs` per-file results, `run_env_loader`, the `extends` chain, `Bun.Transpiler`); this was the one site that replaced. And `jsxImportSource` is one setting that the tsconfig parser stores in two fields, so a merge that carries one of them is incomplete by construction.
- Scope: the `configure_linker_with_auto_jsx` change only affects callers that reach it with `transform_options.jsx == None`, i.e. the CLI with no bunfig.toml and no `--jsx-*` flags; `Bun.build()` always passes `jsx` and never takes that branch. Of those callers only `bun build` had modified `options.jsx` beforehand, so `bun run`, the VM, workers, bake and `bun test --changed` see the same result as before. A tsconfig that explicitly says `"react-jsxdev"` still beats `NODE_ENV=production` in `bun build`, as today; making explicit `NODE_ENV` win over an explicit tsconfig value is what #36269 (bundled) and #36469 (`bun run`) are about, and this change composes with both. #36728 makes the same `configure_linker_with_auto_jsx` change as part of a larger bunfig/`--jsx-*` precedence rework; this PR is only the two bugs above.
- Verified with `test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts`, two new blocks with 26 cases. Block 1: `NODE_ENV=production` (plus one `--define` case) x {no tsconfig, empty `compilerOptions`, `"jsx": "preserve"`, `jsxImportSource` only} x {bundled, `--no-bundle`}. Block 2: the `createElement` fallback import for {plain root tsconfig, `extends` chain, tsconfig next to a bunfig.toml, tsconfig in the entry point's directory} x {`bun build`, `bun build --no-bundle`, `Bun.build()`}, the root layouts under `bun run`, and `Bun.Transpiler({ tsconfig })`. 21 cases fail on the released binary; the other 5 are the no-tsconfig and plain-CLI controls. All pass with this change.
- Also passing locally: `bundler_jsx`, `esbuild/tsconfig`, `transpiler/jsx-production`, `transpiler/transpiler.test.js`, `transpiler/react-compiler`, `bun-build-api`, `bake/dev/react-spa`, `cli/run/tsconfig-override`, `js/bun/resolve/tsconfig-extends-leak`, and the jsx/tsconfig-named tests of `bundler_edgecase`, `bundler_minify`, `esbuild/dce`, `esbuild/default`. `cargo clippy` is clean on `bun_resolver` and `bun_bundler`.

### Background

- JSX pragma (`options_types/jsx.rs` `Pragma`): the JSX configuration a parse runs with. `development` selects `jsxDEV` from `<pkg>/jsx-dev-runtime` versus `jsx`/`jsxs` from `<pkg>/jsx-runtime`; `import_source` holds those two specifiers and `package_name` the bare package, which the parser imports `createElement` from when an element puts `key` after a `{...spread}` (the automatic runtime cannot express that, so it falls back to the classic call).
- tsconfig JSX merge: when a tsconfig.json is parsed, each `jsx*` compiler option it contains sets a bit in `jsx_flags`, and `merge_jsx(current)` copies only the flagged fields onto `current`. `jsxImportSource` fills two fields (`package_name`, and `import_source` derived from it) under one flag.
- `set_production` (`bundler/options.rs`) is how `NODE_ENV`/`BUN_ENV`/`--define` reach JSX: it sets `options.production` and `jsx.development = !production`. `bun build` calls it from `configure_defines()` before `configure_linker()`; every other entry point calls `configure_linker()` first.
- `configure_linker()` wires the bundler's linker and, with `auto_jsx`, applies the cwd's tsconfig.json to the transpiler-wide `options.jsx`. It only does so when no JSX settings were passed explicitly (`transform_options.jsx`), and a bunfig.toml or any `--jsx-*` flag counts as explicit. `sync_resolver_opts()` then projects `options` into `resolver.opts`, which is the starting point every per-file result merges its enclosing tsconfig onto.

<details>
<summary>Repro on bun 1.4.0 (before) and this branch (after)</summary>

```sh
mkdir /tmp/t && cd /tmp/t
printf 'const Box = (p: any) => null;\nexport const el = <Box width={5}>Hello</Box>;\n' > main.tsx

NODE_ENV=production bun build --no-bundle ./main.tsx | head -1
# before/after: import { jsx ... } from "react/jsx-runtime"

echo '{"compilerOptions":{}}' > tsconfig.json
NODE_ENV=production bun build --no-bundle ./main.tsx | head -1
# before: import { jsxDEV ... } from "react/jsx-dev-runtime"
# after:  import { jsx ... } from "react/jsx-runtime"
NODE_ENV=production bun build --external 'react*' ./main.tsx | grep -o 'from "react/[a-z-]*"'
# before: from "react/jsx-dev-runtime"     after: from "react/jsx-runtime"
bun build --no-bundle --define 'process.env.NODE_ENV="production"' ./main.tsx | head -1
# before: jsx-dev-runtime                  after: jsx-runtime
BUN_ENV=production bun build --no-bundle ./main.tsx | head -1
# before: jsx-dev-runtime                  after: jsx-runtime
echo '{"compilerOptions":{"jsx":"preserve"}}' > tsconfig.json
NODE_ENV=production bun build --no-bundle ./main.tsx | head -1
# before: jsx-dev-runtime                  after: jsx-runtime

# createElement fallback
printf 'const p = {};\nglobalThis.a = <div {...p} key="k" />;\nglobalThis.b = <span />;\n' > k.jsx
echo '{"compilerOptions":{"jsxImportSource":"preact"}}' > tsconfig.json
bun -e 'const r = await Bun.build({ entrypoints: ["./k.jsx"], external: ["*"] }); console.log(await r.outputs[0].text())' | grep '^import'
# before: import { jsxDEV } from "preact/jsx-dev-runtime";  import { createElement } from "react";
# after:  import { jsxDEV } from "preact/jsx-dev-runtime";  import { createElement } from "preact";
echo '{"compilerOptions":{}}' > base.json
echo '{"extends":"./base.json","compilerOptions":{"jsxImportSource":"preact"}}' > tsconfig.json
bun build --no-bundle ./k.jsx 2>/dev/null | grep '^import'
# before: ... from "preact/jsx-dev-runtime"   ... from "react"
# after:  ... from "preact/jsx-dev-runtime"   ... from "preact"
```

</details>

<!-- robobun:evidence:begin -->

---

**[review]** gate passed · iteration 1 · 3 files touched

<details><summary>fails on main (without fix)</summary>

```console
ASAN without fix: BUILD FAILED (no junit output)
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
error: bindgenv2 emitted unexpected output type: /workspace/bun/build/debug/codegen/GeneratedSocketConfigBinaryType.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigHandlers.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfig.h, /workspace/bun/build/debug/codegen/GeneratedSocketConfigTLS.h, /workspace/bun/build/debug/codegen/GeneratedALPNProtocols.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfig.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigFile.h, /workspace/bun/build/debug/codegen/GeneratedSSLConfigSingleFile.h, /workspace/bun/build/debug/codegen/GeneratedFakeTimersConfig.h
error: script "bd" exited with code 1
__F:-1:S:0

release without fix: 21 FAILED
bun test v1.4.0-canary.1 (da3851e57)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) tsconfig compilerOptions.jsx > "react-jsx" selects the matching automatic runtime [19.58ms]
(pass) tsconfig compilerOptions.jsx > "react-jsxdev" selects the matching automatic runtime [14.40ms]
126 |   ] as const;
127 | 
128 |   for (const [mode, modeArgs] of buildModes) {
129 |     test.concurrent.each(layouts)(`${mode}, %s`, async (_, files, runtime) => {
130 |       using dir = tempDir("jsx-tsconfig-node-env", { "m.jsx": shimFiles["m.jsx"], ...files });
131 |       expect(await buildImports(String(dir), [...modeArgs, "m.jsx"], productionEnv)).toEqual({
                                                                                           ^
error: expect(received).toEqual(expected)

  {
    "exitCode": 0,
    "imports": [
-     "react/jsx-runtime",
+     "react/jsx-dev-runtime",
    ],
  }

- Expected  - 1
+ Received  + 1

      at <anonymous> (/workspace/bun/test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:131:86)
126 |   ] as const;
127 | 
128 |   for (const [mode, modeArgs] of buildModes) {
129 |     test.concurrent.each(layouts)(`${mode}, %s`, async (
... (truncated)
```

</details>

<details><summary>passes on PR (with fix)</summary>

```console
ASAN with fix: all passed
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test "--reporter=junit" "--reporter-outfile=/tmp/mechgate.xml" test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts
bun test v1.4.0 (56b2f0d6f)

test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts:
(pass) tsconfig compilerOptions.jsx > "react-jsx" selects the matching automatic runtime [626.59ms]
(pass) tsconfig compilerOptions.jsx > "react-jsxdev" selects the matching automatic runtime [608.34ms]
(pass) bun build: NODE_ENV=production with a tsconfig.json that does not choose dev/prod > bun build, empty compilerOptions [288.71ms]
(pass) bun build: NODE_ENV=production with a tsconfig.json that does not choose dev/prod > bun build, "jsx": "preserve" [291.98ms]
(pass) bun build: NODE_ENV=production with a tsconfig.json that does not choose dev/prod > bun build, only jsxImportSource [294.30ms]
(pass) bun build: NODE_ENV=production with a tsconfig.json that does not choose dev/prod > bun build, empty compilerOptions, --define process.env.NODE_ENV [296.72ms]
(pass) bun build: NODE_ENV=production with a tsconfig.json that does not choose dev/prod > bun build, no tsconfig.json [353.07ms]
(pass) bun b
... (truncated)

release with fix: all passed
$ bun scripts/build.ts --profile=release
[configured] bun-profile → bun (stripped)
  target       linux-x64-gnu
  build type   Release
  build dir    ./build/release
  revision     56b2f0d6fb
  features     baseline

22 deps, 107 codegen, 1176 objects in 738ms

ninja: Entering directory `/workspace/bun/build/release'
[1/1238] gen ErrorCode+*.h
[2/1238] install /workspace/bun
bun install v1.4.0-canary.1 (da3851e57)

Checked 107 installs across 153 packages (no changes) [18.00ms]
[3/1238] gen bindgenv2
[4/1238] install /workspace/bun/packages/bun-error
bun install v1.4.0-canary.1 (da3851e57)

Checked 1 install across 2 packages (no changes) [5.00ms]
[5/1238] fetch tinycc
[tinycc] up to date
[6/1237] fetch zlib
[zlib] up to date
[7/1237] gen .bind.ts → GeneratedBindings.cpp
[8/1237] install /workspace/bun/src/node-fallbacks
bun install v1.4.0-canary.1 (da3851e57)

Checked 129 installs across 147 packages (no changes) [10.00ms]
[9/1237] gen ProcessBindingConstants.lut.h
Generating /workspace/bun/build/release/codegen/ProcessBindingConstants.lut.h from /workspace/bun/src/jsc/bindings/ProcessBindingConstants.cpp
[10/1237] fetch libjpeg-turbo
[libjpeg-turbo] up to date
... (truncated)
```

</details>

<details><summary>diff hotspot</summary>

```
src/bundler/transpiler.rs                          |   6 +-
 src/resolver/tsconfig_json.rs                      |   2 +
 .../transpiler/jsx-tsconfig-react-jsx.test.ts      | 155 +++++++++++++++++++++
 3 files changed, 160 insertions(+), 3 deletions(-)
```

</details>

**gate history** · 2 passed · 0 rejected · iteration 1

<details><summary>evidence per changed file</summary>

```
file                                                    reads  edits  tests
src/bundler/transpiler.rs                                   1      2      0
src/resolver/tsconfig_json.rs                               0      0      0
test/bundler/transpiler/jsx-tsconfig-react-jsx.test.ts      1      2      0
```

</details>

**root cause** · written by the author bot

When `bun build` applied the root tsconfig's JSX settings, it replaced the entire pragma with a default-derived value, clobbering the NODE_ENV-based development flag that had already been configured, and the merge helper also copied `import_source` without `package_name`, leaving the `createElement` fallback pointing at `react` instead of the configured `jsxImportSource`. The fix changes `configure_linker_with_auto_jsx` to merge the tsconfig's JSX fields into the existing options via `merge_jsx`, matching every other call site, so only fields the tsconfig actually sets are copied and the ca…

<!-- robobun:evidence:end -->