### PR TITLE
sys(windows): report ENOENT for an empty path instead of acting on the directory it is relative to

### DIFF
--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6676,6 +6676,31 @@ fn is_nt_object_name(p: &[u16]) -> bool {
         || bun_core::strings::has_prefix_comptime_utf16(p, b"\\Device\\")
 }
 
+/// `OBJECT_ATTRIBUTES.RootDirectory` for an NT call naming `path`: none for
+/// an absolute NT object name, otherwise `dir` (the cwd when `dir` is the
+/// "invalid_fd" sentinel).
+///
+/// An empty name is refused with ENOENT, as POSIX `*at()` calls refuse it: NT
+/// resolves it to `RootDirectory` itself, which made `readdir("")` list and
+/// `rm -r ""` empty the directory the name was relative to.
+#[cfg(windows)]
+fn nt_root_directory(
+    dir: Fd,
+    path: &[u16],
+    syscall: Tag,
+) -> Maybe<bun_windows_sys::externs::HANDLE> {
+    if path.is_empty() {
+        return Err(Error::from_code(E::ENOENT, syscall));
+    }
+    Ok(if is_nt_object_name(path) {
+        core::ptr::null_mut()
+    } else if dir.is_valid() {
+        dir.native()
+    } else {
+        Fd::cwd().native()
+    })
+}
+
 /// `openDirAtWindowsNtPath` — `NtCreateFile` with
 /// `FILE_DIRECTORY_FILE`.
 #[cfg(windows)]
@@ -6734,6 +6759,7 @@ pub(crate) fn open_dir_at_windows_nt_path(
         );
     }
 
+    let root_directory = nt_root_directory(dir_fd, p, Tag::open)?;
     let path_len_bytes = (p.len() * 2) as u16;
     let mut nt_name = w::UNICODE_STRING {
         Length: path_len_bytes,
@@ -6742,13 +6768,7 @@ pub(crate) fn open_dir_at_windows_nt_path(
     };
     let mut attr = w::OBJECT_ATTRIBUTES {
         Length: core::mem::size_of::<w::OBJECT_ATTRIBUTES>() as u32,
-        RootDirectory: if is_nt_object_name(p) {
-            core::ptr::null_mut()
-        } else if dir_fd.is_valid() {
-            dir_fd.native()
-        } else {
-            Fd::cwd().native()
-        },
+        RootDirectory: root_directory,
         Attributes: 0, // Note we do not use OBJ_CASE_INSENSITIVE here.
         ObjectName: &mut nt_name,
         SecurityDescriptor: core::ptr::null_mut(),
@@ -6796,6 +6816,7 @@ pub(crate) fn open_file_at_windows_nt_path(
 ) -> Maybe<Fd> {
     use bun_windows_sys::externs as w;
     let p = path.as_slice();
+    let root_directory = nt_root_directory(dir, p, Tag::open)?;
     let mut result: w::HANDLE = core::ptr::null_mut();
     let path_len_bytes = match u16::try_from(p.len() * 2) {
         Ok(v) => v,
@@ -6812,13 +6833,7 @@ pub(crate) fn open_file_at_windows_nt_path(
         // name of a device object (`\??\…`, `\Device\…`), unless it is the
         // name of a file relative to the directory specified by RootDirectory.
         ObjectName: &mut nt_name,
-        RootDirectory: if is_nt_object_name(p) {
-            core::ptr::null_mut()
-        } else if dir.is_valid() {
-            dir.native()
-        } else {
-            Fd::cwd().native()
-        },
+        RootDirectory: root_directory,
         Attributes: 0, // Note we do not use OBJ_CASE_INSENSITIVE here.
         SecurityDescriptor: core::ptr::null_mut(),
         SecurityQualityOfService: core::ptr::null_mut(),
@@ -7153,6 +7168,7 @@ fn exists_at_type_nt(dir: Fd, mut path: &[u16]) -> Maybe<ExistsAtType> {
     if path.len() > 2 && path[0] == b'.' as u16 && path[1] == b'\\' as u16 {
         path = &path[2..];
     }
+    let root_directory = nt_root_directory(dir, path, Tag::access)?;
     let path_len_bytes = (path.len() * 2) as u16;
     let mut nt_name = w::UNICODE_STRING {
         Length: path_len_bytes,
@@ -7161,13 +7177,7 @@ fn exists_at_type_nt(dir: Fd, mut path: &[u16]) -> Maybe<ExistsAtType> {
     };
     let attr = w::OBJECT_ATTRIBUTES {
         Length: core::mem::size_of::<w::OBJECT_ATTRIBUTES>() as u32,
-        RootDirectory: if is_nt_object_name(path) {
-            core::ptr::null_mut()
-        } else if dir.is_valid() {
-            dir.native()
-        } else {
-            Fd::cwd().native()
-        },
+        RootDirectory: root_directory,
         Attributes: 0,
         ObjectName: &mut nt_name,
         SecurityDescriptor: core::ptr::null_mut(),

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6678,11 +6678,8 @@ fn is_nt_object_name(p: &[u16]) -> bool {
 
 /// `OBJECT_ATTRIBUTES.RootDirectory` for an NT call naming `path`: none for
 /// an absolute NT object name, otherwise `dir` (the cwd when `dir` is the
-/// "invalid_fd" sentinel).
-///
-/// An empty name is refused with ENOENT, as POSIX `*at()` calls refuse it: NT
-/// resolves it to `RootDirectory` itself, which made `readdir("")` list and
-/// `rm -r ""` empty the directory the name was relative to.
+/// "invalid_fd" sentinel). An empty name fails with ENOENT as POSIX `*at()`
+/// calls do; NT would resolve it to `RootDirectory` itself.
 #[cfg(windows)]
 fn nt_root_directory(
     dir: Fd,

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6676,10 +6676,8 @@ fn is_nt_object_name(p: &[u16]) -> bool {
         || bun_core::strings::has_prefix_comptime_utf16(p, b"\\Device\\")
 }
 
-/// `OBJECT_ATTRIBUTES.RootDirectory` for an NT call naming `path`: none for
-/// an absolute NT object name, otherwise `dir` (the cwd when `dir` is the
-/// "invalid_fd" sentinel). An empty name fails with ENOENT as POSIX `*at()`
-/// calls do; NT would resolve it to `RootDirectory` itself.
+/// `OBJECT_ATTRIBUTES.RootDirectory` for an NT call naming `path`. An empty
+/// name fails with ENOENT as on POSIX; NT would resolve it to `RootDirectory` itself.
 #[cfg(windows)]
 fn nt_root_directory(
     dir: Fd,

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1832,6 +1832,12 @@ pub fn move_opened_file_at(
 
     debug_assert!(!new_file_name.contains(&(b'/' as u16))); // Call moveOpenedFileAtLoose
 
+    // POSIX renameat() refuses an empty destination name with ENOENT; NT only
+    // refuses it as an INFO_LENGTH_MISMATCH, which has no errno.
+    if new_file_name.is_empty() {
+        return bun_sys::Result::errno(E::NOENT, bun_sys::Tag::NtSetInformationFile);
+    }
+
     // The FileName tail here is UTF-16, so the correct cap is
     // `PATH_MAX_WIDE * 2` bytes — sizing against the UTF-8 worst case
     // (PATH_MAX_WIDE*3+1, ≈98 KB) would just waste ~32 KB of stack on a

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1016,6 +1016,12 @@ const FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE: ULONG = 0x00000010;
 
 // Copy-paste of the standard library function except without unreachable.
 pub fn DeleteFileBun(sub_path_w: &[u16], options: DeleteFileOptions) -> bun_sys::Result<()> {
+    // Same rule as `nt_root_directory` in lib.rs: NT would resolve an empty
+    // name to `options.dir` itself and delete that directory.
+    if sub_path_w.is_empty() {
+        return bun_sys::Result::errno(E::NOENT, bun_sys::Tag::open);
+    }
+
     let create_options_flags: ULONG = if options.remove_dir {
         FILE_DIRECTORY_FILE | FILE_OPEN_REPARSE_POINT
     } else {
@@ -1035,14 +1041,6 @@ pub fn DeleteFileBun(sub_path_w: &[u16], options: DeleteFileOptions) -> bun_sys:
         // The Windows API makes this mutable, but it will not mutate here.
         Buffer: sub_path_w.as_ptr().cast_mut().cast::<u16>(),
     };
-
-    // Guard len ≥ 2: in practice callers pass converted NT paths (always
-    // ≥ 2 elems), but make the contract explicit rather than rely on the
-    // bounds check panicking.
-    if sub_path_w.len() >= 2 && sub_path_w[0] == b'.' as u16 && sub_path_w[1] == 0 {
-        // Windows does not recognize this, but it does work with empty string.
-        nt_name.Length = 0;
-    }
 
     let mut attr = OBJECT_ATTRIBUTES {
         Length: size_of::<OBJECT_ATTRIBUTES>() as u32,

--- a/src/sys/windows/mod.rs
+++ b/src/sys/windows/mod.rs
@@ -1016,8 +1016,7 @@ const FILE_DISPOSITION_IGNORE_READONLY_ATTRIBUTE: ULONG = 0x00000010;
 
 // Copy-paste of the standard library function except without unreachable.
 pub fn DeleteFileBun(sub_path_w: &[u16], options: DeleteFileOptions) -> bun_sys::Result<()> {
-    // Same rule as `nt_root_directory` in lib.rs: NT would resolve an empty
-    // name to `options.dir` itself and delete that directory.
+    // Empty name: ENOENT, as in `nt_root_directory` (NT would delete `options.dir` itself).
     if sub_path_w.is_empty() {
         return bun_sys::Result::errno(E::NOENT, bun_sys::Tag::open);
     }
@@ -1830,8 +1829,7 @@ pub fn move_opened_file_at(
 
     debug_assert!(!new_file_name.contains(&(b'/' as u16))); // Call moveOpenedFileAtLoose
 
-    // POSIX renameat() refuses an empty destination name with ENOENT; NT only
-    // refuses it as an INFO_LENGTH_MISMATCH, which has no errno.
+    // Empty destination: ENOENT as POSIX renameat(); NT's INFO_LENGTH_MISMATCH has no errno.
     if new_file_name.is_empty() {
         return bun_sys::Result::errno(E::NOENT, bun_sys::Tag::NtSetInformationFile);
     }

--- a/test/js/bun/shell/commands/ls.test.ts
+++ b/test/js/bun/shell/commands/ls.test.ts
@@ -267,6 +267,16 @@ describe.concurrent("bunshell ls", () => {
       .exitCode(1)
       .runAsTest("ls -R lskdjflksdjf");
 
+    // An empty operand names nothing; on Windows it used to resolve to the
+    // shell's cwd and list it.
+    TestBuilder.command`ls ${""}`
+      .ensureTempDir()
+      .file("visible", "")
+      .stdout("")
+      .stderr("ls: No such file or directory\n")
+      .exitCode(1)
+      .runAsTest("empty operand");
+
     test("multiple non-existent files", async () => {
       await TestBuilder.command`ls nonexistent1 nonexistent2`
         .exitCode(1)

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -67,6 +67,26 @@ describe("mv", async () => {
     .stderr("mv: a: Not a directory\n")
     .runAsTest("move dir -> file fails");
 
+  // An empty operand names nothing. On Windows it used to resolve to the
+  // shell's cwd itself: as the source, mv tried to rename the cwd; as the
+  // destination, it moved the file "into" the cwd and reported success.
+  TestBuilder.command`mv ${""} b`
+    .ensureTempDir()
+    .file("a", "file")
+    .exitCode(2 /* ENOENT */)
+    .stderr("mv: No such file or directory\n")
+    .fileEquals("a", "file")
+    .doesNotExist("b")
+    .runAsTest("empty source fails");
+
+  TestBuilder.command`mv a ${""}`
+    .ensureTempDir()
+    .file("a", "file")
+    .exitCode(2 /* ENOENT */)
+    .stderr("mv: a: No such file or directory\n")
+    .fileEquals("a", "file")
+    .runAsTest("empty destination fails");
+
   // POSIX `mv` must fall back to copy+unlink when `rename()` returns EXDEV
   // (source and destination on different filesystems). Requires a writable
   // mount on a different device from the harness temp dir.

--- a/test/js/bun/shell/commands/mv.test.ts
+++ b/test/js/bun/shell/commands/mv.test.ts
@@ -1,6 +1,6 @@
 import { $ } from "bun";
 import { describe, expect, test } from "bun:test";
-import { isPosix } from "harness";
+import { isPosix, isWindows } from "harness";
 import {
   accessSync,
   chmodSync,
@@ -79,11 +79,13 @@ describe("mv", async () => {
     .doesNotExist("b")
     .runAsTest("empty source fails");
 
+  // The POSIX renameat() wrapper attaches the source path to its errors; the
+  // Windows one does not yet, so the message differs by platform.
   TestBuilder.command`mv a ${""}`
     .ensureTempDir()
     .file("a", "file")
     .exitCode(2 /* ENOENT */)
-    .stderr("mv: a: No such file or directory\n")
+    .stderr(isWindows ? "mv: No such file or directory\n" : "mv: a: No such file or directory\n")
     .fileEquals("a", "file")
     .runAsTest("empty destination fails");
 

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -146,28 +146,37 @@ foo/
   });
 
   // An empty operand names nothing. On Windows it used to resolve to the
-  // shell's cwd itself, and `rm -r ""` deleted the cwd's contents.
-  TestBuilder.command`rm -r ${""}`
-    .ensureTempDir()
-    .file("keep.txt", "keep")
-    .directory("sub")
-    .file("sub/inner.txt", "keep")
-    .stderr("rm: No such file or directory\n")
-    .exitCode(1)
-    .fileEquals("keep.txt", "keep")
-    .fileEquals("sub/inner.txt", "keep")
-    .runAsTest("empty operand");
+  // shell's cwd itself: `rm ""` reported "Is a directory", `rm -r ""` deleted
+  // the cwd's contents (and the cwd too, unless it was the process cwd) and
+  // `rm -d ""` deleted an empty cwd.
+  for (const [flags, stderr, exitCode] of [
+    [[], "rm: No such file or directory\n", 1],
+    [["-f"], "", 0],
+    [["-r"], "rm: No such file or directory\n", 1],
+    [["-rf"], "", 0],
+    [["-d"], "rm: No such file or directory\n", 1],
+  ] as const) {
+    TestBuilder.command`rm ${flags} ${""}`
+      .ensureTempDir()
+      .file("keep.txt", "keep")
+      .directory("sub")
+      .file("sub/inner.txt", "keep")
+      .stderr(stderr)
+      .exitCode(exitCode)
+      .fileEquals("keep.txt", "keep")
+      .fileEquals("sub/inner.txt", "keep")
+      .runAsTest(["empty operand:", "rm", ...flags, '""'].join(" "));
+  }
 
-  TestBuilder.command`rm -rf ${""}`
-    .ensureTempDir()
-    .file("keep.txt", "keep")
-    .directory("sub")
-    .file("sub/inner.txt", "keep")
-    .stderr("")
-    .exitCode(0)
-    .fileEquals("keep.txt", "keep")
-    .fileEquals("sub/inner.txt", "keep")
-    .runAsTest("empty operand with -f");
+  test('empty operand: rm -d "" in an empty cwd', async () => {
+    using cwd = tempDir("rm-d-empty-operand", {});
+    const { stderr, exitCode } = await $`rm -d ${""}`.cwd(String(cwd)).quiet();
+    expect({ stderr: stderr.toString(), exitCode, cwdExists: existsSync(String(cwd)) }).toEqual({
+      stderr: "rm: No such file or directory\n",
+      exitCode: 1,
+      cwdExists: true,
+    });
+  });
 
   // The DirTask parent/child hand-off had a lost-wakeup window between
   // `subtask_count.load() > 1` and `need_to_wait.store(true)`: the last

--- a/test/js/bun/shell/commands/rm.test.ts
+++ b/test/js/bun/shell/commands/rm.test.ts
@@ -145,6 +145,30 @@ foo/
     }
   });
 
+  // An empty operand names nothing. On Windows it used to resolve to the
+  // shell's cwd itself, and `rm -r ""` deleted the cwd's contents.
+  TestBuilder.command`rm -r ${""}`
+    .ensureTempDir()
+    .file("keep.txt", "keep")
+    .directory("sub")
+    .file("sub/inner.txt", "keep")
+    .stderr("rm: No such file or directory\n")
+    .exitCode(1)
+    .fileEquals("keep.txt", "keep")
+    .fileEquals("sub/inner.txt", "keep")
+    .runAsTest("empty operand");
+
+  TestBuilder.command`rm -rf ${""}`
+    .ensureTempDir()
+    .file("keep.txt", "keep")
+    .directory("sub")
+    .file("sub/inner.txt", "keep")
+    .stderr("")
+    .exitCode(0)
+    .fileEquals("keep.txt", "keep")
+    .fileEquals("sub/inner.txt", "keep")
+    .runAsTest("empty operand with -f");
+
   // The DirTask parent/child hand-off had a lost-wakeup window between
   // `subtask_count.load() > 1` and `need_to_wait.store(true)`: the last
   // child could decrement and read `need_to_wait == false` in between,

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3197,6 +3197,58 @@ describe("rm", () => {
   });
 });
 
+// The empty path names nothing, so node reports ENOENT for every operation on
+// it. On Windows, Bun resolves relative paths against a directory handle with
+// NtCreateFile, which resolves an empty name to that directory itself, so
+// readdir("") listed the cwd, writeFile("") opened it and recursive rm("")
+// deleted everything inside it. Each case therefore runs in a child process
+// whose cwd is a throwaway directory, and the parent checks that directory
+// afterwards.
+describe.concurrent("operations on the empty path", () => {
+  const enoent = { code: "ENOENT" };
+  const ok = { ok: true };
+  const cases: [expression: string, expected: object][] = [
+    [`fs.readdirSync("")`, enoent],
+    [`fs.readdirSync("", { withFileTypes: true })`, enoent],
+    [`fs.readdirSync("", { recursive: true })`, enoent],
+    [`promisify(fs.readdir)("")`, enoent],
+    [`fs.promises.readdir("")`, enoent],
+    [`fs.promises.readdir("", { recursive: true })`, enoent],
+    [`fs.writeFileSync("", "data")`, enoent],
+    [`promisify(fs.writeFile)("", "data")`, enoent],
+    [`fs.promises.writeFile("", "data")`, enoent],
+    [`fs.rmSync("", { recursive: true })`, enoent],
+    [`promisify(fs.rm)("", { recursive: true })`, enoent],
+    [`fs.promises.rm("", { recursive: true })`, enoent],
+    [`fs.rmSync("", { recursive: true, force: true })`, ok],
+    [`fs.promises.rm("", { recursive: true, force: true })`, ok],
+  ];
+
+  it.each(cases)("%s", async (expression, expected) => {
+    using dir = tempDir("fs-empty-path", { "keep.txt": "keep", "sub/inner.txt": "keep" });
+    await using proc = Bun.spawn({
+      cmd: [
+        bunExe(),
+        "-e",
+        `const fs = require("node:fs");
+         const { promisify } = require("node:util");
+         Promise.resolve()
+           .then(() => ${expression})
+           .then(() => ({ ok: true }), err => ({ code: err.code }))
+           .then(result => console.log(JSON.stringify(result)));`,
+      ],
+      cwd: String(dir),
+      env: bunEnv,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect({ stdout, stderr, exitCode }).toEqual({ stdout: JSON.stringify(expected) + "\n", stderr: "", exitCode: 0 });
+    expect(readdirSync(String(dir)).sort()).toEqual(["keep.txt", "sub"]);
+    expect(readdirSync(join(String(dir), "sub"))).toEqual(["inner.txt"]);
+  });
+});
+
 describe("rmdir", () => {
   it("does not remove a file", done => {
     const path = `${tmpdir()}/${Date.now()}.rm.txt`;

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3243,9 +3243,15 @@ describe.concurrent("operations on the empty path", () => {
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect({ stdout, stderr, exitCode }).toEqual({ stdout: JSON.stringify(expected) + "\n", stderr: "", exitCode: 0 });
-    expect(readdirSync(String(dir)).sort()).toEqual(["keep.txt", "sub"]);
-    expect(readdirSync(join(String(dir), "sub"))).toEqual(["inner.txt"]);
+    const left = readdirSync(String(dir), { recursive: true })
+      .map(entry => entry.replaceAll("\\", "/"))
+      .sort();
+    expect({ stdout, stderr, exitCode, left }).toEqual({
+      stdout: JSON.stringify(expected) + "\n",
+      stderr: "",
+      exitCode: 0,
+      left: ["keep.txt", "sub", "sub/inner.txt"],
+    });
   });
 });
 

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -3201,10 +3201,9 @@ describe("rm", () => {
 // it. On Windows, Bun resolves relative paths against a directory handle with
 // NtCreateFile, which resolves an empty name to that directory itself, so
 // readdir("") listed the cwd, writeFile("") opened it and recursive rm("")
-// deleted everything inside it. Each case therefore runs in a child process
-// whose cwd is a throwaway directory, and the parent checks that directory
-// afterwards.
-describe.concurrent("operations on the empty path", () => {
+// deleted everything inside it. The cases therefore run in a child process
+// that gives each one a throwaway cwd and reports what was left of it.
+describe("operations on the empty path", () => {
   const enoent = { code: "ENOENT" };
   const ok = { ok: true };
   const cases: [expression: string, expected: object][] = [
@@ -3223,34 +3222,56 @@ describe.concurrent("operations on the empty path", () => {
     [`fs.rmSync("", { recursive: true, force: true })`, ok],
     [`fs.promises.rm("", { recursive: true, force: true })`, ok],
   ];
+  const untouched = ["keep.txt", "sub", "sub/inner.txt"];
 
-  it.each(cases)("%s", async (expression, expected) => {
-    using dir = tempDir("fs-empty-path", { "keep.txt": "keep", "sub/inner.txt": "keep" });
+  const script = `
+    const fs = require("node:fs");
+    const path = require("node:path");
+    const { promisify } = require("node:util");
+    const root = process.cwd();
+    const report = {};
+    let n = 0;
+    async function run(expression, operation) {
+      const cwd = path.join(root, String(n++));
+      fs.mkdirSync(path.join(cwd, "sub"), { recursive: true });
+      fs.writeFileSync(path.join(cwd, "keep.txt"), "keep");
+      fs.writeFileSync(path.join(cwd, "sub", "inner.txt"), "keep");
+      process.chdir(cwd);
+      let result;
+      try {
+        await operation();
+        result = { ok: true };
+      } catch (err) {
+        result = { code: err.code };
+      }
+      process.chdir(root);
+      const left = fs.readdirSync(cwd, { recursive: true }).map(entry => entry.replaceAll("\\\\", "/")).sort();
+      report[expression] = { result, left };
+    }
+    ${cases.map(([expression]) => `await run(${JSON.stringify(expression)}, () => ${expression});`).join("\n")}
+    console.log(JSON.stringify(report));
+  `;
+
+  it("every operation reports ENOENT (or is ignored by force) and leaves the cwd alone", async () => {
+    using dir = tempDir("fs-empty-path", {});
     await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `const fs = require("node:fs");
-         const { promisify } = require("node:util");
-         Promise.resolve()
-           .then(() => ${expression})
-           .then(() => ({ ok: true }), err => ({ code: err.code }))
-           .then(result => console.log(JSON.stringify(result)));`,
-      ],
+      cmd: [bunExe(), "-e", script],
       cwd: String(dir),
       env: bunEnv,
       stdout: "pipe",
       stderr: "pipe",
     });
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    const left = readdirSync(String(dir), { recursive: true })
-      .map(entry => entry.replaceAll("\\", "/"))
-      .sort();
-    expect({ stdout, stderr, exitCode, left }).toEqual({
-      stdout: JSON.stringify(expected) + "\n",
+    // If the child died before printing its report, the comparison below shows
+    // whatever it did print.
+    let report: unknown = stdout;
+    try {
+      report = JSON.parse(stdout);
+    } catch {}
+    expect({ report, stderr, exitCode }).toEqual({
+      report: Object.fromEntries(cases.map(([expression, result]) => [expression, { result, left: untouched }])),
       stderr: "",
       exitCode: 0,
-      left: ["keep.txt", "sub", "sub/inner.txt"],
     });
   });
 });

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -83,16 +83,18 @@ describe.concurrent("node-module-module", () => {
     expect(exitCode).toBe(0);
   });
 
-  test("_stat reports directories, files, missing paths and the empty path", () => {
+  test("_stat reports directories, files, missing, empty and over-long paths", () => {
     using dir = tempDir("module-stat", { "file.js": "", "sub": {} });
-    // On Windows the empty path used to be probed relative to the cwd handle,
-    // which answered for the cwd itself (1).
+    // On Windows the empty path (which is also what an over-long relative path
+    // is converted to) used to be probed relative to the cwd handle, which
+    // answered for the cwd itself (1).
     expect({
       directory: Module._stat(path.join(String(dir), "sub")),
       file: Module._stat(path.join(String(dir), "file.js")),
       missing: Module._stat(path.join(String(dir), "missing")),
       empty: Module._stat(""),
-    }).toEqual({ directory: 1, file: 0, missing: -1, empty: -1 });
+      overlong: Module._stat(Buffer.alloc(40000, "a").toString()),
+    }).toEqual({ directory: 1, file: 0, missing: -1, empty: -1, overlong: -1 });
   });
 
   test("module.enableCompileCache validates its argument", () => {

--- a/test/js/node/module/node-module-module.test.js
+++ b/test/js/node/module/node-module-module.test.js
@@ -83,6 +83,18 @@ describe.concurrent("node-module-module", () => {
     expect(exitCode).toBe(0);
   });
 
+  test("_stat reports directories, files, missing paths and the empty path", () => {
+    using dir = tempDir("module-stat", { "file.js": "", "sub": {} });
+    // On Windows the empty path used to be probed relative to the cwd handle,
+    // which answered for the cwd itself (1).
+    expect({
+      directory: Module._stat(path.join(String(dir), "sub")),
+      file: Module._stat(path.join(String(dir), "file.js")),
+      missing: Module._stat(path.join(String(dir), "missing")),
+      empty: Module._stat(""),
+    }).toEqual({ directory: 1, file: 0, missing: -1, empty: -1 });
+  });
+
   test("module.enableCompileCache validates its argument", () => {
     expect(Module.enableCompileCache.length).toBe(1);
     for (const invalid of [0, null, false, 1, NaN, true, Symbol(0)]) {


### PR DESCRIPTION
### Problem

- On Windows an empty path operand acts on the current directory. `fs.readdirSync("")` lists the cwd, `fs.writeFileSync("", data)` opens it and fails with `EISDIR` (syscall `write`), and `fs.rmSync("", { recursive: true })` (also with `force`, and `fs.rm` / `fs.promises.rm`) deletes everything inside the cwd and then throws `EBUSY` (syscall `rm`) because the cwd itself cannot be removed. In the shell, `rm -r ""` / `rm -rf ""` delete the cwd's files, `rm ""` reports `EISDIR` for the cwd and `rm -d ""` removes it when empty, `ls ""` lists the cwd, `mv "" x` tries to rename the cwd (`EBUSY`) and `mv x ""` exits 0 without moving anything. Node, and Bun on POSIX, report `ENOENT` for every one of these. Reproduced with Bun 1.4.0 on Windows Server 2019; full matrix below.
- Cause: the Windows `openat` emulation hands the caller's name to `NtCreateFile` as an `ObjectName` relative to a `RootDirectory` handle (the dirfd, or the process cwd handle). NT resolves an empty relative name to the root directory itself, so `openat(cwd, "")` returns a handle to the cwd. `open_dir_at_windows_nt_path`, `open_file_at_windows_nt_path` and `exists_at_type_nt` in `src/sys/lib.rs` each built that `OBJECT_ATTRIBUTES` with its own copy of the `RootDirectory` selection and no empty-name check, and `normalize_path_windows` passes `""` through unchanged. Everything layered on them inherits the behaviour: `bun_sys::openat` / `File::openat`, `open_dir_at_windows(_a)`, `open_file_at_windows` (which also opens `renameat`'s source) and `directory_exists_at`. `PathLike::slice_z` hands `""` through as-is, which is how `readdir`, `writeFile` and the recursive `rm` walk (`zig_delete_tree`, `src/runtime/node/node_fs.rs`) get there. The node:fs functions that go through libuv (`stat`, `open`, `unlink`, `rmdir`, `appendFile`, ...) already returned `ENOENT`.
- `DeleteFileBun` (`src/sys/windows/mod.rs`, the `unlinkat` / `rmdirat` path) built the same RootDirectory-relative `OBJECT_ATTRIBUTES`, which is how the non-recursive shell `rm ""` and `rm -d ""` reached the cwd.
- `move_opened_file_at` (`src/sys/windows/mod.rs`) with an empty destination name builds a `FILE_RENAME_INFORMATION_EX` shorter than the struct. NT rejects that with `STATUS_INFO_LENGTH_MISMATCH`, which has no errno mapping, so once the target check of `mv x ""` stops resolving to the cwd the command reports `mv: unknown error` (exit 134) instead of `ENOENT`.

### Fix

- The three copies of the `RootDirectory` selection become one helper, `nt_root_directory`, which fails an empty name with `ENOENT` (tagged with the caller's syscall: `open`, or `access` for the exists probe) and otherwise behaves as before: no root for an absolute NT object name, else the dirfd, else the cwd. `DeleteFileBun` and `move_opened_file_at` fail an empty name the same way.
- Why this is right: POSIX `openat`, `fstatat`, `unlinkat` and `renameat` fail with `ENOENT` for an empty name, and Bun on POSIX passes `""` straight to the kernel, so the Windows emulation now reports what every other platform and Node report, from the one place that knows the name is being resolved against a handle. No caller relies on the old behaviour: the codebase spells "this directory itself" as `"."` (`PackageInstaller` maps an empty folder to `"."`), and every cross-platform caller already gets `ENOENT` from the POSIX arm for `""`.
- `exists_at_type_nt` is included because it carried the same copy of the selection and `directory_exists_at(dir, "")` answered `true` where POSIX answers `false`. Its callers (installer cache probes, the `EEXIST` check in recursive mkdir, cp) do not pass an empty name in normal flows.
- `DeleteFileBun` carried a `"."` to empty-name translation for deleting a directory through its own handle; it was unreachable (every caller passes a slice without the trailing NUL it tested for) and is removed.
- Tests:
  - `test/js/node/fs/fs.test.ts`, "operations on the empty path": one child process gives each of 14 `readdir` / `writeFile` / `rm` variants (sync, callback, promises; `withFileTypes`, `recursive`, `force`) its own cwd and reports the error code plus what is left of that directory.
  - `test/js/bun/shell/commands/{rm,ls,mv}.test.ts`: `rm ""` with each flag combination (bare, `-f`, `-r`, `-rf`), `rm -d ""` in an empty cwd, `ls ""`, `mv "" b`, `mv a ""`, asserting the message, exit code and that the files are still there.
  - `test/js/node/module/node-module-module.test.js`: `Module._stat` (which is `exists_at_type` on the cwd) for `""` and for an over-long relative path, which the path conversion turns into `""` as well; both returned 1 for the cwd.
- Verification:
  - Windows Server 2019 x64, Bun 1.4.0 release: all of the new tests fail (the fs report shows `ok` for the readdir variants, `EISDIR` for writeFile, and `EBUSY` with `left: []` for the rm variants). Debug build of this branch: they pass, as do the rest of `fs.test.ts` (514 pass; the one failure, `readSync works on large files`, fails identically with the release binary on this VM), `rm` / `ls` / `mv`, `fs-mkdir`, `cp`, `dir`, `promises`, `readdir-windows-ntstatus` and `rm-windows-ntstatus`.
  - Linux debug build: the new tests pass; the source change is entirely `#[cfg(windows)]`. `cargo check -p bun_sys` passes for `x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`.
- Related open PRs that fix different things: #38002 (shell `touch` / `mkdir` / `cp` join the operand onto the cwd string themselves), #38039 (`CopyFileW` with an empty destination), #37995 (`err.path` for `""`; it keeps the shell message without the operand, so the expectations here stay valid). The Windows `renameat` arm not attaching the source path to its errors, which is why the `mv a ""` message is asserted per platform, was found here and is tracked separately.

### Background

- `openat` emulation: Windows has no `openat`, so Bun emulates "open this name relative to that directory fd" with `NtCreateFile`, whose `OBJECT_ATTRIBUTES` carries a `RootDirectory` handle and an `ObjectName` resolved relative to it. `normalize_path_windows` turns absolute inputs into NT object names (`\??\C:\...`, opened with no root) and leaves plain relative names to be resolved against the handle. `Fd::cwd()` on Windows is the process cwd handle from the PEB, so a cwd-relative open is a `RootDirectory` open too.
- Empty names: NT treats an empty `ObjectName` with a `RootDirectory` as a request for the root directory itself (that is how code holding a directory handle reopens or deletes it). POSIX treats an empty pathname as nonexistent and returns `ENOENT`, which is the behaviour Node exposes.
- `exists_at_type_nt` is the `NtQueryAttributesFile` counterpart of the open helpers and backs `directory_exists_at`; it takes the same `OBJECT_ATTRIBUTES` and has the same empty-name semantics.

<details>
<summary>Before/after on Windows (each case run in a fresh directory containing canary.txt and sub/inner.txt; "remaining" is the listing afterwards)</summary>

Bun 1.4.0 release:

```
readdirSync                    {"ok":true,"value":"2 entries","remaining":["canary.txt","sub"]}
readdirSync withFileTypes      {"ok":true,"value":"2 entries","remaining":["canary.txt","sub"]}
readdirSync recursive          {"ok":true,"value":"3 entries","remaining":["canary.txt","sub"]}
readdir cb                     {"ok":true,"value":"2 entries","remaining":["canary.txt","sub"]}
promises.readdir               {"ok":true,"value":"2 entries","remaining":["canary.txt","sub"]}
promises.readdir recursive     {"ok":true,"value":"3 entries","remaining":["canary.txt","sub"]}
opendirSync                    {"code":"ENOENT","syscall":"opendir","remaining":["canary.txt","sub"]}
writeFileSync                  {"code":"EISDIR","syscall":"write","remaining":["canary.txt","sub"]}
promises.writeFile             {"code":"EISDIR","syscall":"write","remaining":["canary.txt","sub"]}
appendFileSync                 {"code":"ENOENT","syscall":"open","remaining":["canary.txt","sub"]}
rmSync recursive               {"code":"EBUSY","syscall":"rm","remaining":[]}
rmSync recursive force         {"code":"EBUSY","syscall":"rm","remaining":[]}
promises.rm recursive          {"code":"EBUSY","syscall":"rm","remaining":[]}
promises.rm recursive force    {"code":"EBUSY","syscall":"rm","remaining":[]}
rm cb recursive                {"code":"EBUSY","syscall":"rm","remaining":[]}
rmdirSync                      {"code":"ENOENT","syscall":"rmdir","remaining":["canary.txt","sub"]}
rmSync                         {"code":"ENOENT","syscall":"lstat","remaining":["canary.txt","sub"]}
cpSync from empty              {"code":"ENOENT","syscall":"lstat","remaining":["canary.txt","sub"]}
cpSync to empty                {"code":"ENOENT","syscall":"mkdir","remaining":["canary.txt","sub"]}
Bun.write string               {"code":"ENOENT","syscall":"mkdir","remaining":["canary.txt","sub"]}
Bun.write copy                 {"code":"ENOENT","syscall":"mkdir","remaining":["canary.txt","sub"]}
Bun.write from empty           {"code":"ENOENT","syscall":"copyfile","remaining":["canary.txt","sub"]}
shell rm -rf                   {"exitCode":1,"stderr":"rm: \\sub: Invalid argument","remaining":["sub"]}
shell rm -r                    {"exitCode":1,"stderr":"rm: \\sub: Invalid argument","remaining":["sub"]}
shell ls                       {"ok":true,"value":"canary.txt\nsub","remaining":["canary.txt","sub"]}
shell mv                       {"exitCode":16,"stderr":"mv: Device or resource busy","remaining":["canary.txt","sub"]}
shell mv into                  {"ok":true,"value":"exit 0","remaining":["canary.txt","sub"]}
```

Debug build of this branch (identical to the Linux output of the same script, apart from the `mv into` message noted above):

```
readdirSync                    {"code":"ENOENT","syscall":"scandir","remaining":["canary.txt","sub"]}
readdirSync withFileTypes      {"code":"ENOENT","syscall":"scandir","remaining":["canary.txt","sub"]}
readdirSync recursive          {"code":"ENOENT","syscall":"scandir","remaining":["canary.txt","sub"]}
readdir cb                     {"code":"ENOENT","syscall":"scandir","remaining":["canary.txt","sub"]}
promises.readdir               {"code":"ENOENT","syscall":"scandir","remaining":["canary.txt","sub"]}
promises.readdir recursive     {"code":"ENOENT","syscall":"open","remaining":["canary.txt","sub"]}
opendirSync                    {"code":"ENOENT","syscall":"opendir","remaining":["canary.txt","sub"]}
writeFileSync                  {"code":"ENOENT","syscall":"open","remaining":["canary.txt","sub"]}
promises.writeFile             {"code":"ENOENT","syscall":"open","remaining":["canary.txt","sub"]}
appendFileSync                 {"code":"ENOENT","syscall":"open","remaining":["canary.txt","sub"]}
rmSync recursive               {"code":"ENOENT","syscall":"lstat","remaining":["canary.txt","sub"]}
rmSync recursive force         {"ok":true,"value":"undefined","remaining":["canary.txt","sub"]}
promises.rm recursive          {"code":"ENOENT","syscall":"lstat","remaining":["canary.txt","sub"]}
promises.rm recursive force    {"ok":true,"value":"undefined","remaining":["canary.txt","sub"]}
rm cb recursive                {"code":"ENOENT","syscall":"lstat","remaining":["canary.txt","sub"]}
rmdirSync                      {"code":"ENOENT","syscall":"rmdir","remaining":["canary.txt","sub"]}
rmSync                         {"code":"ENOENT","syscall":"lstat","remaining":["canary.txt","sub"]}
cpSync from empty              {"code":"ENOENT","syscall":"lstat","remaining":["canary.txt","sub"]}
cpSync to empty                {"code":"ENOENT","syscall":"mkdir","remaining":["canary.txt","sub"]}
Bun.write string               {"code":"ENOENT","syscall":"mkdir","remaining":["canary.txt","sub"]}
Bun.write copy                 {"code":"ENOENT","syscall":"mkdir","remaining":["canary.txt","sub"]}
Bun.write from empty           {"code":"ENOENT","syscall":"copyfile","remaining":["canary.txt","sub"]}
shell rm -rf                   {"ok":true,"value":"exit 0","remaining":["canary.txt","sub"]}
shell rm -r                    {"exitCode":1,"stderr":"rm: No such file or directory","remaining":["canary.txt","sub"]}
shell ls                       {"exitCode":1,"stderr":"ls: No such file or directory","remaining":["canary.txt","sub"]}
shell mv                       {"exitCode":2,"stderr":"mv: No such file or directory","remaining":["canary.txt","sub"]}
shell mv into                  {"exitCode":2,"stderr":"mv: No such file or directory","remaining":["canary.txt","sub"]}
```

The `unlinkat` / `rmdirat` and exists paths, each `rm` run with the shell cwd set to a fresh directory (so it is not the process cwd). Bun 1.4.0 release:

```
rm ""      (dir has a file)   exit 1  "rm: Is a directory"         dir kept
rm -f ""   (dir has a file)   exit 1  "rm: Is a directory"         dir kept
rm -d ""   (dir empty)        exit 0                               dir DELETED
rm -d ""   (dir has a file)   exit 1  "rm: Directory not empty"    dir kept
rm -r ""   (dir has a file)   exit 0                               dir DELETED
rm -rf ""  (dir empty)        exit 0                               dir DELETED
Module._stat("")                            1
Module._stat("a" * 40000)                   1
```

This branch:

```
rm ""      (dir has a file)   exit 1  "rm: No such file or directory"   dir kept
rm -f ""   (dir has a file)   exit 0                                    dir kept
rm -d ""   (dir empty)        exit 1  "rm: No such file or directory"   dir kept
rm -d ""   (dir has a file)   exit 1  "rm: No such file or directory"   dir kept
rm -r ""   (dir has a file)   exit 1  "rm: No such file or directory"   dir kept
rm -rf ""  (dir empty)        exit 0                                    dir kept
Module._stat("")                            -1
Module._stat("a" * 40000)                   -1
```

The Windows test run without this change, showing both wrong results and the emptied directory in one comparison:

```
      "fs.rmSync(\"\", { recursive: true })": {
-       "left": ["keep.txt", "sub", "sub/inner.txt"],
+       "left": [],
        "result": {
-         "code": "ENOENT",
+         "code": "EBUSY",
```

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 1 · Platform-specific test(s) that do not run on this machine. Deferring to CI, which covers all platforms: test/js/bun/shell/commands/ls.test.ts test/js/bun/shell/commands/mv.test.ts test/js/bun/shell/commands/rm.test.ts test/js/node/fs/fs.test.ts test/js/node/module/node-module-module.test.js

<!-- robobun:evidence:end -->
