### PR TITLE
node:fs: strip trailing separators from Windows path arguments

### DIFF
--- a/src/paths/string_paths.rs
+++ b/src/paths/string_paths.rs
@@ -472,6 +472,36 @@ pub fn without_trailing_slash_windows_path(input: &[u8]) -> &[u8] {
     path
 }
 
+/// Strips the trailing separators of a path argument the way Node's `fs` does
+/// on Windows before every syscall (`path.toNamespacedPath()` resolves the
+/// argument, which drops them): `dir\file.txt\` names `file.txt`. Win32 and NT
+/// themselves keep a trailing separator significant, so the raw spelling only
+/// ever matches a directory. The separator completing a root (`C:\`, `\`,
+/// `\\server\share\`) stays.
+///
+/// `\\?\`, `\\.\` and `\??\` paths are returned as they are, like every other
+/// converter in this module treats them.
+///
+/// Unlike [`without_trailing_slash_windows_path`] this floors every path
+/// shape at its root, not only drive-letter paths.
+pub fn without_trailing_separators_windows_arg(path: &[u8]) -> &[u8] {
+    let is_device_path = path.len() >= 4
+        && resolve_path::is_sep_any(path[0])
+        && resolve_path::is_sep_any(path[1])
+        && (path[2] == b'?' || path[2] == b'.')
+        && resolve_path::is_sep_any(path[3]);
+    if is_device_path || path.starts_with(&windows::NT_OBJECT_PREFIX_U8) {
+        return path;
+    }
+
+    let root_len = resolve_path::windows_filesystem_root(path).len();
+    let mut end = path.len();
+    while end > root_len && resolve_path::is_sep_any(path[end - 1]) {
+        end -= 1;
+    }
+    &path[..end]
+}
+
 pub fn without_leading_slash(this: &[u8]) -> &[u8] {
     strings::trim_left(this, b"/")
 }
@@ -720,5 +750,84 @@ mod tests {
         assert!(!fits_in_wide_path_buffer(&vec![0x80u8; 98300]));
         assert!(fits_in_wide_path_buffer(&vec![0x80u8; 32758]));
         assert!(fits_in_wide_path_buffer(&vec![0x80u8; 32757]));
+    }
+
+    #[test]
+    fn without_trailing_separators_windows_arg_strips_to_the_last_component() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (b"C:\\dir\\file.txt\\", b"C:\\dir\\file.txt"),
+            (b"C:\\dir\\file.txt/", b"C:\\dir\\file.txt"),
+            (b"C:\\dir\\file.txt\\\\/", b"C:\\dir\\file.txt"),
+            (b"C:/dir/", b"C:/dir"),
+            (b"C:file.txt\\", b"C:file.txt"),
+            (b"file.txt\\", b"file.txt"),
+            (b"file.txt/", b"file.txt"),
+            (b"dir\\sub\\", b"dir\\sub"),
+            (b".\\", b"."),
+            (b"..\\", b".."),
+            (b"\\dir\\file.txt\\", b"\\dir\\file.txt"),
+            (
+                b"\\\\server\\share\\file.txt\\",
+                b"\\\\server\\share\\file.txt",
+            ),
+            (b"//server/share/dir//", b"//server/share/dir"),
+            // Already in the form the syscall needs.
+            (b"C:\\dir\\file.txt", b"C:\\dir\\file.txt"),
+            (b"file.txt", b"file.txt"),
+            (b"", b""),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                without_trailing_separators_windows_arg(input),
+                *expected,
+                "{:?}",
+                bstr::BStr::new(input)
+            );
+        }
+    }
+
+    #[test]
+    fn without_trailing_separators_windows_arg_keeps_roots() {
+        let cases: &[(&[u8], &[u8])] = &[
+            (b"C:\\", b"C:\\"),
+            (b"C:/", b"C:/"),
+            (b"C:\\\\", b"C:\\"),
+            (b"C:", b"C:"),
+            (b"\\", b"\\"),
+            (b"/", b"/"),
+            (b"\\\\", b"\\"),
+            (b"\\\\server\\share\\", b"\\\\server\\share\\"),
+            (b"\\\\server\\share\\\\", b"\\\\server\\share\\"),
+            (b"\\\\server\\share", b"\\\\server\\share"),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                without_trailing_separators_windows_arg(input),
+                *expected,
+                "{:?}",
+                bstr::BStr::new(input)
+            );
+        }
+    }
+
+    #[test]
+    fn without_trailing_separators_windows_arg_passes_device_paths_through() {
+        for path in [
+            b"\\\\?\\C:\\dir\\".as_slice(),
+            b"\\\\?\\C:\\",
+            b"\\\\?\\UNC\\server\\share\\dir\\",
+            b"\\\\.\\pipe\\name\\",
+            b"\\\\.\\C:\\",
+            b"//?/C:/dir/",
+            b"\\??\\C:\\dir\\",
+            b"\\??\\C:\\",
+        ] {
+            assert_eq!(
+                without_trailing_separators_windows_arg(path),
+                path,
+                "{:?}",
+                bstr::BStr::new(path)
+            );
+        }
     }
 }

--- a/src/paths/string_paths.rs
+++ b/src/paths/string_paths.rs
@@ -472,18 +472,12 @@ pub fn without_trailing_slash_windows_path(input: &[u8]) -> &[u8] {
     path
 }
 
-/// Strips the trailing separators of a path argument the way Node's `fs` does
-/// on Windows before every syscall (`path.toNamespacedPath()` resolves the
-/// argument, which drops them): `dir\file.txt\` names `file.txt`. Win32 and NT
-/// themselves keep a trailing separator significant, so the raw spelling only
-/// ever matches a directory. The separator completing a root (`C:\`, `\`,
-/// `\\server\share\`) stays.
-///
-/// `\\?\`, `\\.\` and `\??\` paths are returned as they are, like every other
-/// converter in this module treats them.
-///
-/// Unlike [`without_trailing_slash_windows_path`] this floors every path
-/// shape at its root, not only drive-letter paths.
+/// Strips trailing separators the way Node's `fs` does on Windows before every
+/// syscall (`path.toNamespacedPath()` resolves the argument, dropping them), so
+/// `dir\file.txt\` names `file.txt`. Roots (`C:\`, `\`, `\\server\share\`) and
+/// `\\?\` / `\\.\` / `\??\` paths are returned unchanged. Unlike
+/// [`without_trailing_slash_windows_path`], every path shape is floored at its
+/// root, not only drive-letter paths.
 pub fn without_trailing_separators_windows_arg(path: &[u8]) -> &[u8] {
     let is_device_path = path.len() >= 4
         && resolve_path::is_sep_any(path[0])

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6247,8 +6247,8 @@ impl NodeFS {
             };
 
             if T::IS_DIRENT && dirent_path.is_empty() {
-                // `parentPath` is the argument as the caller spelled it, as in
-                // node, not the form handed to the syscall.
+                // Node keeps `parentPath` as the caller spelled it, not the
+                // syscall form.
                 dirent_path = webcore::encoding::to_bun_string(
                     args.path.slice(),
                     encoding_to_node(args.encoding),

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6762,8 +6762,7 @@ impl NodeFS {
         let _close = scopeguard::guard(fd, |fd| fd.close());
 
         let mut entries: Vec<T> = Vec::new();
-        Self::readdir_with_entries::<T>(args, fd, &mut entries)
-            .map(|()| T::into_readdir(entries))
+        Self::readdir_with_entries::<T>(args, fd, &mut entries).map(|()| T::into_readdir(entries))
     }
 
     /// Caller has already checked `is_bun_standalone_file_path(path)`.

--- a/src/runtime/node/node_fs.rs
+++ b/src/runtime/node/node_fs.rs
@@ -6226,7 +6226,6 @@ impl NodeFS {
     fn readdir_with_entries<T: ReaddirEntry>(
         args: &args::Readdir,
         fd: FD,
-        basename: &ZStr,
         entries: &mut Vec<T>,
     ) -> Maybe<()> {
         // On Windows, String/Dirent results read native UTF-16 entry names via the
@@ -6234,7 +6233,7 @@ impl NodeFS {
         // use the u8 iterator.
         #[cfg(windows)]
         if T::IS_U16 {
-            return Self::readdir_with_entries_u16::<T>(args, fd, basename, entries);
+            return Self::readdir_with_entries_u16::<T>(args, fd, entries);
         }
 
         let mut dirent_path = BunString::DEAD;
@@ -6248,8 +6247,10 @@ impl NodeFS {
             };
 
             if T::IS_DIRENT && dirent_path.is_empty() {
+                // `parentPath` is the argument as the caller spelled it, as in
+                // node, not the form handed to the syscall.
                 dirent_path = webcore::encoding::to_bun_string(
-                    without_nt_prefix::<u8>(basename.as_bytes()),
+                    args.path.slice(),
                     encoding_to_node(args.encoding),
                 );
             }
@@ -6277,7 +6278,6 @@ impl NodeFS {
     fn readdir_with_entries_u16<T: ReaddirEntry>(
         args: &args::Readdir,
         fd: FD,
-        basename: &ZStr,
         entries: &mut Vec<T>,
     ) -> Maybe<()> {
         let mut dirent_path = BunString::DEAD;
@@ -6302,7 +6302,7 @@ impl NodeFS {
 
             if T::IS_DIRENT && dirent_path.is_empty() {
                 dirent_path = webcore::encoding::to_bun_string(
-                    without_nt_prefix::<u8>(basename.as_bytes()),
+                    args.path.slice(),
                     encoding_to_node(args.encoding),
                 );
             }
@@ -6762,7 +6762,7 @@ impl NodeFS {
         let _close = scopeguard::guard(fd, |fd| fd.close());
 
         let mut entries: Vec<T> = Vec::new();
-        Self::readdir_with_entries::<T>(args, fd, path, &mut entries)
+        Self::readdir_with_entries::<T>(args, fd, &mut entries)
             .map(|()| T::into_readdir(entries))
     }
 

--- a/src/runtime/node/types.rs
+++ b/src/runtime/node/types.rs
@@ -931,6 +931,8 @@ impl PathLikeExt for PathLike {
         buf: &'a mut PathBuffer,
     ) -> &'a ZStr {
         let sliced = self.slice();
+        #[cfg(windows)]
+        let sliced = strings::without_trailing_separators_windows_arg(sliced);
 
         #[cfg(windows)]
         {
@@ -1028,6 +1030,8 @@ impl PathLikeExt for PathLike {
     #[inline]
     fn slice_w<'a>(&'a self, buf: &'a mut WPathBuffer) -> Result<&'a WStr, NameTooLong> {
         let sliced = self.slice();
+        #[cfg(windows)]
+        let sliced = strings::without_trailing_separators_windows_arg(sliced);
         if !strings::fits_in_wide_path_buffer(sliced) {
             return Err(NameTooLong);
         }
@@ -1053,7 +1057,7 @@ impl PathLikeExt for PathLike {
     ) -> Result<&'a OSPathSliceZ, NameTooLong> {
         #[cfg(windows)]
         {
-            let s = self.slice();
+            let s = strings::without_trailing_separators_windows_arg(self.slice());
             let mut b = bun_paths::path_buffer_pool::get();
             // RAII guard puts back on Drop.
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6475,11 +6475,10 @@ pub fn normalize_path_windows_opts<'a>(
     let facts = bun_paths::classify_rel_t(rel, bun_paths::PathFormat::Windows);
     let saw_sep_or_dot = facts.has_sep || facts.has_dot;
 
-    // Relative path with no separators or `.` can be passed straight through
-    // to `NtCreateFile` against `RootDirectory`. Not when it carries a drive
-    // prefix: NT would read `C:name` as the stream `name` of a file `C`, so
-    // that spelling resolves against the dirfd below like `C:a.b` does.
-    // Win32 consumers resolve drive-relative names themselves.
+    // Relative, no separators or `.`: pass straight through to `NtCreateFile`
+    // against `RootDirectory`. Drive-qualified names are excluded (NT reads
+    // `C:name` as stream `name` of file `C`) unless the caller is Win32,
+    // which resolves drive-relative names itself.
     if !saw_sep_or_dot && (!drive_qualified || !opts.add_nt_prefix) {
         if path.len() >= buf.len() {
             return Err(too_long());
@@ -10038,8 +10037,7 @@ mod normalize_path_windows_tests {
             normalize(*dir, "C:foo"),
             format!("{}\\foo", normalize(*dir, "."))
         );
-        // Win32 consumers get the drive-relative spelling, which Win32
-        // resolves itself.
+        // Win32 consumers get the drive-relative spelling unchanged.
         assert_eq!(normalize_opts(*dir, "C:foo", false), "C:foo");
     }
 

--- a/src/sys/lib.rs
+++ b/src/sys/lib.rs
@@ -6464,16 +6464,11 @@ pub fn normalize_path_windows_opts<'a>(
         return Ok(unsafe { WStr::from_raw(norm.as_ptr(), len) });
     }
 
-    // Strip a leading drive letter (`C:`) on the relative part; the bypass
-    // below still copies the original `path` verbatim.
-    let rel = if path.len() >= 2
+    // Strip a leading drive letter (`C:`) on the relative part.
+    let drive_qualified = path.len() >= 2
         && bun_paths::resolve_path::is_drive_letter_t::<u16>(path[0])
-        && path[1] == b':' as u16
-    {
-        &path[2..]
-    } else {
-        path
-    };
+        && path[1] == b':' as u16;
+    let rel = if drive_qualified { &path[2..] } else { path };
 
     // Routing = any separator or `.`; clamp relevance = `..` resolving above
     // the dirfd. One pass via the shared classifier.
@@ -6481,8 +6476,11 @@ pub fn normalize_path_windows_opts<'a>(
     let saw_sep_or_dot = facts.has_sep || facts.has_dot;
 
     // Relative path with no separators or `.` can be passed straight through
-    // to `NtCreateFile` against `RootDirectory`.
-    if !saw_sep_or_dot {
+    // to `NtCreateFile` against `RootDirectory`. Not when it carries a drive
+    // prefix: NT would read `C:name` as the stream `name` of a file `C`, so
+    // that spelling resolves against the dirfd below like `C:a.b` does.
+    // Win32 consumers resolve drive-relative names themselves.
+    if !saw_sep_or_dot && (!drive_qualified || !opts.add_nt_prefix) {
         if path.len() >= buf.len() {
             return Err(too_long());
         }
@@ -10029,11 +10027,20 @@ mod normalize_path_windows_tests {
     }
 
     #[test]
-    fn drive_qualified_bare_name_passes_through() {
+    fn drive_qualified_bare_name_resolves_under_base() {
         let _g = crate::file::tests::FD_TEST_LOCK.lock();
-        // The bypass copies the ORIGINAL path (drive prefix included); only
-        // the post-strip remainder decides the routing.
-        assert_eq!(normalize(Fd::INVALID, "C:foo"), "C:foo");
+        let tree = TempTree::new("nt_norm_drive_bare");
+        let dir = scopeguard::guard(open_dir_handle(&tree.0), |fd| {
+            let _ = close(fd);
+        });
+        // Passed through, `C:foo` would name the stream `foo` of a file `C`.
+        assert_eq!(
+            normalize(*dir, "C:foo"),
+            format!("{}\\foo", normalize(*dir, "."))
+        );
+        // Win32 consumers get the drive-relative spelling, which Win32
+        // resolves itself.
+        assert_eq!(normalize_opts(*dir, "C:foo", false), "C:foo");
     }
 
     #[test]

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5481,6 +5481,257 @@ describe.if(isWindows)("windows path handling", () => {
   }
 });
 
+// Node resolves every fs path argument on Windows (path.toNamespacedPath), which
+// drops trailing separators, so "file.txt\" names file.txt there. Win32 itself
+// only accepts the trailing separator on a directory.
+describe.if(isWindows)("windows trailing separators", () => {
+  // `spell` is fixture source: it takes a name relative to the fixture's cwd and
+  // returns it with a trailing separator, in one particular path form.
+  // `absolute` is what path.isAbsolute says about that form (symlink targets are
+  // only resolved for absolute forms, in node as in bun). Bun cannot list or
+  // recursively remove drive-relative directories yet, with or without the
+  // separator, so that form only runs the file operations.
+  const forms = {
+    absolute: { spell: `n => path.join(cwd, n) + "\\\\"`, absolute: true, directories: true },
+    absoluteForwardSlash: {
+      spell: `n => path.join(cwd, n).replaceAll("\\\\", "/") + "/"`,
+      absolute: true,
+      directories: true,
+    },
+    absoluteDoubled: { spell: `n => path.join(cwd, n) + "\\\\\\\\"`, absolute: true, directories: true },
+    rooted: { spell: `n => path.join(cwd, n).slice(2) + "\\\\"`, absolute: true, directories: true },
+    relative: { spell: `n => n + "\\\\"`, absolute: false, directories: true },
+    relativeForwardSlash: { spell: `n => n + "/"`, absolute: false, directories: true },
+    driveRelative: { spell: `n => cwd.slice(0, 2) + n + "\\\\"`, absolute: false, directories: false },
+  };
+
+  const fixture = `
+    import fs from "node:fs";
+    import path from "node:path";
+
+    const cwd = process.cwd();
+    const forms = {
+      ${Object.entries(forms)
+        .map(
+          ([name, form]) =>
+            `${name}: { spell: ${form.spell}, absolute: ${form.absolute}, directories: ${form.directories} },`,
+        )
+        .join("\n      ")}
+    };
+    const code = fn => {
+      try {
+        return fn() ?? "ok";
+      } catch (e) {
+        return e.code;
+      }
+    };
+    const codeAsync = async fn => {
+      try {
+        return (await fn()) ?? "ok";
+      } catch (e) {
+        return e.code;
+      }
+    };
+
+    fs.writeFileSync("file.txt", "contents");
+    fs.mkdirSync("dir");
+    fs.writeFileSync(path.join("dir", "inner.txt"), "");
+    const realFile = fs.realpathSync.native("file.txt");
+    const absoluteFile = path.join(cwd, "file.txt");
+
+    const results = {};
+    let n = 0;
+    const unique = prefix => prefix + "-" + n++;
+    const scratchFile = prefix => {
+      const name = unique(prefix) + ".txt";
+      fs.writeFileSync(name, prefix);
+      return name;
+    };
+
+    for (const [name, { spell, absolute, directories }] of Object.entries(forms)) {
+      const file = spell("file.txt");
+      const link = unique("symlink");
+      fs.symlinkSync("file.txt", link);
+      const hardlink = unique("hardlink") + ".txt";
+      const copy = unique("copy") + ".txt";
+      const promisesCopy = unique("copy") + ".txt";
+      const renamed = scratchFile("rename");
+      const unlinked = scratchFile("unlink");
+      const removed = scratchFile("rm");
+
+      const result = (results[name] = {
+        readFileSync: code(() => fs.readFileSync(file, "utf8")),
+        openSync: code(() => fs.closeSync(fs.openSync(file, "r"))),
+        open: await codeAsync(
+          () =>
+            new Promise((resolve, reject) =>
+              fs.open(file, "r", (err, fd) => (err ? reject(err) : resolve(fs.closeSync(fd)))),
+            ),
+        ),
+        accessSync: code(() => void fs.accessSync(file)),
+        existsSync: fs.existsSync(file),
+        statSyncSize: code(() => fs.statSync(file).size),
+        lstatSyncSize: code(() => fs.lstatSync(file).size),
+        utimesSync: code(() => fs.utimesSync(file, new Date(), new Date())),
+        chmodSync: code(() => fs.chmodSync(file, 0o644)),
+        truncateSync: code(() => fs.truncateSync(file, 4)),
+        truncated: fs.readFileSync("file.txt", "utf8"),
+        appendFileSync: code(() => fs.appendFileSync(file, "ents")),
+        appended: fs.readFileSync("file.txt", "utf8"),
+        statfsSync: code(() => typeof fs.statfsSync(file).bsize),
+        realpathSyncNative: code(() => fs.realpathSync.native(file) === realFile),
+        cpSync: code(() => fs.cpSync(file, copy)),
+        cpSyncCopied: code(() => fs.readFileSync(copy, "utf8")),
+        promisesReadFile: await codeAsync(() => fs.promises.readFile(file, "utf8")),
+        promisesAccess: await codeAsync(() => fs.promises.access(file)),
+        promisesOpen: await codeAsync(() => fs.promises.open(file, "r").then(handle => handle.close())),
+        promisesCp: await codeAsync(() => fs.promises.cp(file, promisesCopy)),
+        promisesCpCopied: code(() => fs.readFileSync(promisesCopy, "utf8")),
+        bunFile: await codeAsync(() => Bun.file(file).text()),
+        linkSync: code(() => fs.linkSync(file, spell(hardlink))),
+        linked: code(() => fs.readFileSync(hardlink, "utf8")),
+        readlinkSync: code(() => fs.readlinkSync(spell(link))),
+        renameSync: code(() => fs.renameSync(spell(renamed), spell(renamed + ".moved"))),
+        renamed: [fs.existsSync(renamed), fs.existsSync(renamed + ".moved")],
+        unlinkSync: code(() => fs.unlinkSync(spell(unlinked))),
+        unlinked: fs.existsSync(unlinked),
+        rmSync: code(() => fs.rmSync(spell(removed))),
+        removed: fs.existsSync(removed),
+      });
+
+      if (absolute) {
+        const absoluteLink = unique("symlink");
+        result.symlinkSync = code(() => fs.symlinkSync(file, absoluteLink));
+        result.symlinkTarget = code(() => fs.readlinkSync(absoluteLink) === absoluteFile || fs.readlinkSync(absoluteLink));
+        result.readThroughSymlink = code(() => fs.readFileSync(absoluteLink, "utf8"));
+      }
+
+      if (directories) {
+        const dir = spell("dir");
+        const created = unique("mkdir");
+        const createdRecursively = unique("mkdir");
+        Object.assign(result, {
+          readdirSyncOnFile: code(() => fs.readdirSync(file)),
+          readdirSync: code(() => fs.readdirSync(dir)),
+          direntPathsExist: code(() =>
+            fs.readdirSync(dir, { withFileTypes: true }).map(dirent => fs.existsSync(path.join(dirent.parentPath, dirent.name))),
+          ),
+          statSyncIsDirectory: code(() => fs.statSync(dir).isDirectory()),
+          accessSyncDirectory: code(() => void fs.accessSync(dir)),
+          existsSyncDirectory: fs.existsSync(dir),
+          mkdirSync: code(() => fs.mkdirSync(spell(created))),
+          rmdirSync: code(() => fs.rmdirSync(spell(created))),
+          removedDirectory: fs.existsSync(created),
+          mkdirSyncRecursive: code(() =>
+            path.basename(fs.mkdirSync(spell(path.join(createdRecursively, "sub")), { recursive: true })),
+          ),
+          createdRecursively: fs.existsSync(path.join(createdRecursively, "sub")),
+          rmSyncRecursive: code(() => fs.rmSync(spell(createdRecursively), { recursive: true })),
+          removedRecursively: fs.existsSync(createdRecursively),
+        });
+      }
+    }
+
+    results.cwdAndRoots = {
+      existsSyncDot: [fs.existsSync("./"), fs.existsSync(".\\\\")],
+      readdirSyncDriveRoot: code(() => Array.isArray(fs.readdirSync(cwd.slice(0, 3)))),
+      existsSyncDriveRoot: fs.existsSync(cwd.slice(0, 3)),
+      statSyncRootedRoot: code(() => fs.statSync("\\\\").isDirectory()),
+    };
+
+    try {
+      fs.readFileSync("missing.txt\\\\");
+    } catch (e) {
+      results.missingFile = { code: e.code, path: e.path, syscall: e.syscall };
+    }
+
+    console.log(JSON.stringify(results));
+  `;
+
+  it("name the same file or directory as without the separator", async () => {
+    using dir = tempDir("fs-trailing-separators", { "fixture.mjs": fixture });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs"],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const expected: Record<string, unknown> = {};
+    for (const [name, { absolute, directories }] of Object.entries(forms)) {
+      expected[name] = {
+        readFileSync: "contents",
+        openSync: "ok",
+        open: "ok",
+        accessSync: "ok",
+        existsSync: true,
+        statSyncSize: 8,
+        lstatSyncSize: 8,
+        utimesSync: "ok",
+        chmodSync: "ok",
+        truncateSync: "ok",
+        truncated: "cont",
+        appendFileSync: "ok",
+        appended: "contents",
+        statfsSync: "number",
+        realpathSyncNative: true,
+        cpSync: "ok",
+        cpSyncCopied: "contents",
+        promisesReadFile: "contents",
+        promisesAccess: "ok",
+        promisesOpen: "ok",
+        promisesCp: "ok",
+        promisesCpCopied: "contents",
+        bunFile: "contents",
+        linkSync: "ok",
+        linked: "contents",
+        readlinkSync: "file.txt",
+        renameSync: "ok",
+        renamed: [false, true],
+        unlinkSync: "ok",
+        unlinked: false,
+        rmSync: "ok",
+        removed: false,
+        ...(absolute && {
+          symlinkSync: "ok",
+          // The stored target is the resolved path, without the separator.
+          symlinkTarget: true,
+          readThroughSymlink: "contents",
+        }),
+        ...(directories && {
+          readdirSyncOnFile: "ENOTDIR",
+          readdirSync: ["inner.txt"],
+          direntPathsExist: [true],
+          statSyncIsDirectory: true,
+          accessSyncDirectory: "ok",
+          existsSyncDirectory: true,
+          mkdirSync: "ok",
+          rmdirSync: "ok",
+          removedDirectory: false,
+          mkdirSyncRecursive: expect.stringMatching(/^mkdir-\d+$/),
+          createdRecursively: true,
+          rmSyncRecursive: "ok",
+          removedRecursively: false,
+        }),
+      };
+    }
+    expected.cwdAndRoots = {
+      existsSyncDot: [true, true],
+      readdirSyncDriveRoot: true,
+      existsSyncDriveRoot: true,
+      statSyncRootedRoot: true,
+    };
+    // Errors still report the path as the caller spelled it.
+    expected.missingFile = { code: "ENOENT", path: "missing.txt\\", syscall: "open" };
+
+    expect(JSON.parse(stdout)).toEqual(expected);
+  });
+});
+
 it("using writeFile on an fd does not truncate it", () => {
   const filepath = join(tmpdir(), `file-${Math.random().toString(32).slice(2)}.txt`);
   const fd = fs.openSync(filepath, "w+");

--- a/test/js/node/fs/fs.test.ts
+++ b/test/js/node/fs/fs.test.ts
@@ -5485,26 +5485,30 @@ describe.if(isWindows)("windows path handling", () => {
 // drops trailing separators, so "file.txt\" names file.txt there. Win32 itself
 // only accepts the trailing separator on a directory.
 describe.if(isWindows)("windows trailing separators", () => {
-  // `spell` is fixture source: it takes a name relative to the fixture's cwd and
-  // returns it with a trailing separator, in one particular path form.
-  // `absolute` is what path.isAbsolute says about that form (symlink targets are
-  // only resolved for absolute forms, in node as in bun). Bun cannot list or
-  // recursively remove drive-relative directories yet, with or without the
-  // separator, so that form only runs the file operations.
-  const forms = {
-    absolute: { spell: `n => path.join(cwd, n) + "\\\\"`, absolute: true, directories: true },
+  // Each form spells a name relative to the fixture's cwd with a trailing
+  // separator. Symlink targets are only resolved when the form is absolute in
+  // path.isAbsolute's sense, in node as in bun. Recursive rmSync of a
+  // drive-relative path fails with or without the separator (its unlinkat
+  // converts the name differently), so that form skips it.
+  const forms: Record<
+    string,
+    { spell: (cwd: string, name: string) => string; absolute: boolean; recursiveRm: boolean }
+  > = {
+    absolute: { spell: (cwd, name) => path.join(cwd, name) + "\\", absolute: true, recursiveRm: true },
     absoluteForwardSlash: {
-      spell: `n => path.join(cwd, n).replaceAll("\\\\", "/") + "/"`,
+      spell: (cwd, name) => path.join(cwd, name).replaceAll("\\", "/") + "/",
       absolute: true,
-      directories: true,
+      recursiveRm: true,
     },
-    absoluteDoubled: { spell: `n => path.join(cwd, n) + "\\\\\\\\"`, absolute: true, directories: true },
-    rooted: { spell: `n => path.join(cwd, n).slice(2) + "\\\\"`, absolute: true, directories: true },
-    relative: { spell: `n => n + "\\\\"`, absolute: false, directories: true },
-    relativeForwardSlash: { spell: `n => n + "/"`, absolute: false, directories: true },
-    driveRelative: { spell: `n => cwd.slice(0, 2) + n + "\\\\"`, absolute: false, directories: false },
+    absoluteDoubled: { spell: (cwd, name) => path.join(cwd, name) + "\\\\", absolute: true, recursiveRm: true },
+    rooted: { spell: (cwd, name) => path.join(cwd, name).slice(2) + "\\", absolute: true, recursiveRm: true },
+    relative: { spell: (cwd, name) => name + "\\", absolute: false, recursiveRm: true },
+    relativeForwardSlash: { spell: (cwd, name) => name + "/", absolute: false, recursiveRm: true },
+    driveRelative: { spell: (cwd, name) => cwd.slice(0, 2) + name + "\\", absolute: false, recursiveRm: false },
   };
 
+  // Runs in a directory holding file.txt ("contents") and dir/inner.txt, with
+  // the form name as its argument, and prints one result per operation.
   const fixture = `
     import fs from "node:fs";
     import path from "node:path";
@@ -5512,12 +5516,11 @@ describe.if(isWindows)("windows trailing separators", () => {
     const cwd = process.cwd();
     const forms = {
       ${Object.entries(forms)
-        .map(
-          ([name, form]) =>
-            `${name}: { spell: ${form.spell}, absolute: ${form.absolute}, directories: ${form.directories} },`,
-        )
+        .map(([name, { spell, ...flags }]) => `${name}: { spell: ${spell.toString()}, ...${JSON.stringify(flags)} },`)
         .join("\n      ")}
     };
+    const form = forms[process.argv[2]];
+    const spell = name => form.spell(cwd, name);
     const code = fn => {
       try {
         return fn() ?? "ok";
@@ -5532,124 +5535,207 @@ describe.if(isWindows)("windows trailing separators", () => {
         return e.code;
       }
     };
-
-    fs.writeFileSync("file.txt", "contents");
-    fs.mkdirSync("dir");
-    fs.writeFileSync(path.join("dir", "inner.txt"), "");
-    const realFile = fs.realpathSync.native("file.txt");
-    const absoluteFile = path.join(cwd, "file.txt");
-
-    const results = {};
-    let n = 0;
-    const unique = prefix => prefix + "-" + n++;
-    const scratchFile = prefix => {
-      const name = unique(prefix) + ".txt";
-      fs.writeFileSync(name, prefix);
+    const scratchFile = name => {
+      fs.writeFileSync(name, name);
       return name;
     };
 
-    for (const [name, { spell, absolute, directories }] of Object.entries(forms)) {
-      const file = spell("file.txt");
-      const link = unique("symlink");
-      fs.symlinkSync("file.txt", link);
-      const hardlink = unique("hardlink") + ".txt";
-      const copy = unique("copy") + ".txt";
-      const promisesCopy = unique("copy") + ".txt";
-      const renamed = scratchFile("rename");
-      const unlinked = scratchFile("unlink");
-      const removed = scratchFile("rm");
+    const realFile = fs.realpathSync.native("file.txt");
+    const file = spell("file.txt");
+    const dir = spell("dir");
+    fs.symlinkSync("file.txt", "symlink");
+    const renamed = scratchFile("renamed.txt");
+    const unlinked = scratchFile("unlinked.txt");
+    const removed = scratchFile("removed.txt");
 
-      const result = (results[name] = {
-        readFileSync: code(() => fs.readFileSync(file, "utf8")),
-        openSync: code(() => fs.closeSync(fs.openSync(file, "r"))),
-        open: await codeAsync(
-          () =>
-            new Promise((resolve, reject) =>
-              fs.open(file, "r", (err, fd) => (err ? reject(err) : resolve(fs.closeSync(fd)))),
-            ),
-        ),
-        accessSync: code(() => void fs.accessSync(file)),
-        existsSync: fs.existsSync(file),
-        statSyncSize: code(() => fs.statSync(file).size),
-        lstatSyncSize: code(() => fs.lstatSync(file).size),
-        utimesSync: code(() => fs.utimesSync(file, new Date(), new Date())),
-        chmodSync: code(() => fs.chmodSync(file, 0o644)),
-        truncateSync: code(() => fs.truncateSync(file, 4)),
-        truncated: fs.readFileSync("file.txt", "utf8"),
-        appendFileSync: code(() => fs.appendFileSync(file, "ents")),
-        appended: fs.readFileSync("file.txt", "utf8"),
-        statfsSync: code(() => typeof fs.statfsSync(file).bsize),
-        realpathSyncNative: code(() => fs.realpathSync.native(file) === realFile),
-        cpSync: code(() => fs.cpSync(file, copy)),
-        cpSyncCopied: code(() => fs.readFileSync(copy, "utf8")),
-        promisesReadFile: await codeAsync(() => fs.promises.readFile(file, "utf8")),
-        promisesAccess: await codeAsync(() => fs.promises.access(file)),
-        promisesOpen: await codeAsync(() => fs.promises.open(file, "r").then(handle => handle.close())),
-        promisesCp: await codeAsync(() => fs.promises.cp(file, promisesCopy)),
-        promisesCpCopied: code(() => fs.readFileSync(promisesCopy, "utf8")),
-        bunFile: await codeAsync(() => Bun.file(file).text()),
-        linkSync: code(() => fs.linkSync(file, spell(hardlink))),
-        linked: code(() => fs.readFileSync(hardlink, "utf8")),
-        readlinkSync: code(() => fs.readlinkSync(spell(link))),
-        renameSync: code(() => fs.renameSync(spell(renamed), spell(renamed + ".moved"))),
-        renamed: [fs.existsSync(renamed), fs.existsSync(renamed + ".moved")],
-        unlinkSync: code(() => fs.unlinkSync(spell(unlinked))),
-        unlinked: fs.existsSync(unlinked),
-        rmSync: code(() => fs.rmSync(spell(removed))),
-        removed: fs.existsSync(removed),
-      });
-
-      if (absolute) {
-        const absoluteLink = unique("symlink");
-        result.symlinkSync = code(() => fs.symlinkSync(file, absoluteLink));
-        result.symlinkTarget = code(() => fs.readlinkSync(absoluteLink) === absoluteFile || fs.readlinkSync(absoluteLink));
-        result.readThroughSymlink = code(() => fs.readFileSync(absoluteLink, "utf8"));
-      }
-
-      if (directories) {
-        const dir = spell("dir");
-        const created = unique("mkdir");
-        const createdRecursively = unique("mkdir");
-        Object.assign(result, {
-          readdirSyncOnFile: code(() => fs.readdirSync(file)),
-          readdirSync: code(() => fs.readdirSync(dir)),
-          direntPathsExist: code(() =>
-            fs.readdirSync(dir, { withFileTypes: true }).map(dirent => fs.existsSync(path.join(dirent.parentPath, dirent.name))),
+    const results = {
+      cwd,
+      readFileSync: code(() => fs.readFileSync(file, "utf8")),
+      openSync: code(() => fs.closeSync(fs.openSync(file, "r"))),
+      open: await codeAsync(
+        () =>
+          new Promise((resolve, reject) =>
+            fs.open(file, "r", (err, fd) => (err ? reject(err) : resolve(fs.closeSync(fd)))),
           ),
-          statSyncIsDirectory: code(() => fs.statSync(dir).isDirectory()),
-          accessSyncDirectory: code(() => void fs.accessSync(dir)),
-          existsSyncDirectory: fs.existsSync(dir),
-          mkdirSync: code(() => fs.mkdirSync(spell(created))),
-          rmdirSync: code(() => fs.rmdirSync(spell(created))),
-          removedDirectory: fs.existsSync(created),
-          mkdirSyncRecursive: code(() =>
-            path.basename(fs.mkdirSync(spell(path.join(createdRecursively, "sub")), { recursive: true })),
-          ),
-          createdRecursively: fs.existsSync(path.join(createdRecursively, "sub")),
-          rmSyncRecursive: code(() => fs.rmSync(spell(createdRecursively), { recursive: true })),
-          removedRecursively: fs.existsSync(createdRecursively),
-        });
-      }
-    }
+      ),
+      accessSync: code(() => void fs.accessSync(file)),
+      existsSync: fs.existsSync(file),
+      statSyncSize: code(() => fs.statSync(file).size),
+      lstatSyncSize: code(() => fs.lstatSync(file).size),
+      utimesSync: code(() => fs.utimesSync(file, new Date(), new Date())),
+      chmodSync: code(() => fs.chmodSync(file, 0o644)),
+      truncateSync: code(() => fs.truncateSync(file, 4)),
+      truncated: fs.readFileSync("file.txt", "utf8"),
+      appendFileSync: code(() => fs.appendFileSync(file, "ents")),
+      appended: fs.readFileSync("file.txt", "utf8"),
+      writeFileSync: code(() => fs.writeFileSync(spell("written.txt"), "written")),
+      written: code(() => fs.readFileSync("written.txt", "utf8")),
+      statfsSync: code(() => typeof fs.statfsSync(file).bsize),
+      realpathSyncNative: code(() => fs.realpathSync.native(file) === realFile),
+      cpSync: code(() => fs.cpSync(file, "copy.txt")),
+      copied: code(() => fs.readFileSync("copy.txt", "utf8")),
+      promisesReadFile: await codeAsync(() => fs.promises.readFile(file, "utf8")),
+      promisesAccess: await codeAsync(() => fs.promises.access(file)),
+      promisesOpen: await codeAsync(() => fs.promises.open(file, "r").then(handle => handle.close())),
+      promisesCp: await codeAsync(() => fs.promises.cp(file, "promises-copy.txt")),
+      promisesCopied: code(() => fs.readFileSync("promises-copy.txt", "utf8")),
+      bunFile: await codeAsync(() => Bun.file(file).text()),
+      linkSync: code(() => fs.linkSync(file, spell("hardlink.txt"))),
+      linked: code(() => fs.readFileSync("hardlink.txt", "utf8")),
+      readlinkSync: code(() => fs.readlinkSync(spell("symlink"))),
+      renameSync: code(() => fs.renameSync(spell(renamed), spell("moved.txt"))),
+      renamed: [fs.existsSync(renamed), fs.existsSync("moved.txt")],
+      unlinkSync: code(() => fs.unlinkSync(spell(unlinked))),
+      unlinked: fs.existsSync(unlinked),
+      rmSync: code(() => fs.rmSync(spell(removed))),
+      removed: fs.existsSync(removed),
 
-    results.cwdAndRoots = {
-      existsSyncDot: [fs.existsSync("./"), fs.existsSync(".\\\\")],
-      readdirSyncDriveRoot: code(() => Array.isArray(fs.readdirSync(cwd.slice(0, 3)))),
-      existsSyncDriveRoot: fs.existsSync(cwd.slice(0, 3)),
-      statSyncRootedRoot: code(() => fs.statSync("\\\\").isDirectory()),
+      readdirSyncOnFile: code(() => fs.readdirSync(file)),
+      readdirSync: code(() => fs.readdirSync(dir)),
+      direntParentPaths: code(() => fs.readdirSync(dir, { withFileTypes: true }).map(dirent => dirent.parentPath)),
+      statSyncIsDirectory: code(() => fs.statSync(dir).isDirectory()),
+      accessSyncDirectory: code(() => void fs.accessSync(dir)),
+      existsSyncDirectory: fs.existsSync(dir),
+      mkdirSync: code(() => fs.mkdirSync(spell("created"))),
+      rmdirSync: code(() => fs.rmdirSync(spell("created"))),
+      removedDirectory: fs.existsSync("created"),
+      mkdirSyncRecursive: code(() => path.basename(fs.mkdirSync(spell(path.join("tree", "sub")), { recursive: true }))),
+      createdRecursively: fs.existsSync(path.join("tree", "sub")),
     };
 
-    try {
-      fs.readFileSync("missing.txt\\\\");
-    } catch (e) {
-      results.missingFile = { code: e.code, path: e.path, syscall: e.syscall };
+    if (form.recursiveRm) {
+      results.rmSyncRecursive = code(() => fs.rmSync(spell("tree"), { recursive: true }));
+      results.removedRecursively = fs.existsSync("tree");
+    }
+
+    if (form.absolute) {
+      results.symlinkSync = code(() => fs.symlinkSync(file, "absolute-symlink"));
+      results.symlinkTarget = code(() => fs.readlinkSync("absolute-symlink"));
+      results.readThroughSymlink = code(() => fs.readFileSync("absolute-symlink", "utf8"));
     }
 
     console.log(JSON.stringify(results));
   `;
 
-  it("name the same file or directory as without the separator", async () => {
-    using dir = tempDir("fs-trailing-separators", { "fixture.mjs": fixture });
+  it.concurrent.each(Object.entries(forms))("%s", async (name, form) => {
+    using dir = tempDir("fs-trailing-separators", {
+      "fixture.mjs": fixture,
+      "file.txt": "contents",
+      "dir/inner.txt": "",
+    });
+    await using proc = Bun.spawn({
+      cmd: [bunExe(), "fixture.mjs", name],
+      env: bunEnv,
+      cwd: String(dir),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+    expect(stderr).toBe("");
+    expect(exitCode).toBe(0);
+
+    const results = JSON.parse(stdout);
+    const { cwd } = results;
+    expect(results).toEqual({
+      cwd,
+      readFileSync: "contents",
+      openSync: "ok",
+      open: "ok",
+      accessSync: "ok",
+      existsSync: true,
+      statSyncSize: 8,
+      lstatSyncSize: 8,
+      utimesSync: "ok",
+      chmodSync: "ok",
+      truncateSync: "ok",
+      truncated: "cont",
+      appendFileSync: "ok",
+      appended: "contents",
+      writeFileSync: "ok",
+      written: "written",
+      statfsSync: "number",
+      realpathSyncNative: true,
+      cpSync: "ok",
+      copied: "contents",
+      promisesReadFile: "contents",
+      promisesAccess: "ok",
+      promisesOpen: "ok",
+      promisesCp: "ok",
+      promisesCopied: "contents",
+      bunFile: "contents",
+      linkSync: "ok",
+      linked: "contents",
+      readlinkSync: "file.txt",
+      renameSync: "ok",
+      renamed: [false, true],
+      unlinkSync: "ok",
+      unlinked: false,
+      rmSync: "ok",
+      removed: false,
+
+      readdirSyncOnFile: "ENOTDIR",
+      readdirSync: ["inner.txt"],
+      // parentPath is the argument as given, separator included, like node.
+      direntParentPaths: [form.spell(cwd, "dir")],
+      statSyncIsDirectory: true,
+      accessSyncDirectory: "ok",
+      existsSyncDirectory: true,
+      mkdirSync: "ok",
+      rmdirSync: "ok",
+      removedDirectory: false,
+      mkdirSyncRecursive: "tree",
+      createdRecursively: true,
+      ...(form.recursiveRm && {
+        rmSyncRecursive: "ok",
+        removedRecursively: false,
+      }),
+      ...(form.absolute && {
+        symlinkSync: "ok",
+        // The stored target is the resolved path without the separator, so
+        // readlink returns the plain file, like node.
+        symlinkTarget: join(cwd, "file.txt"),
+        readThroughSymlink: "contents",
+      }),
+    });
+  });
+
+  it.concurrent("roots, the cwd and drive-relative names", async () => {
+    using dir = tempDir("fs-trailing-separators-misc", {
+      "fixture.mjs": `
+        import fs from "node:fs";
+
+        const drive = process.cwd().slice(0, 2);
+        const code = fn => {
+          try {
+            return fn() ?? "ok";
+          } catch (e) {
+            return e.code;
+          }
+        };
+        let missing;
+        try {
+          fs.readFileSync("missing.txt\\\\");
+        } catch (e) {
+          missing = { code: e.code, syscall: e.syscall, path: e.path };
+        }
+        console.log(
+          JSON.stringify({
+            existsSyncCwd: [fs.existsSync("./"), fs.existsSync(".\\\\")],
+            readdirSyncDriveRoot: code(() => Array.isArray(fs.readdirSync(drive + "\\\\"))),
+            existsSyncDriveRoot: fs.existsSync(drive + "\\\\"),
+            statSyncRootedRoot: code(() => fs.statSync("\\\\").isDirectory()),
+            missing,
+            // Without its separator, the driveRelative form above is this
+            // spelling, which readdir has to look up against the cwd as well.
+            readdirSyncDriveRelative: code(() => fs.readdirSync(drive + "dir")),
+            direntParentPathsDriveRelative: code(() =>
+              fs.readdirSync(drive + "dir", { withFileTypes: true }).map(dirent => dirent.parentPath),
+            ),
+          }),
+        );
+      `,
+      "dir/inner.txt": "",
+    });
     await using proc = Bun.spawn({
       cmd: [bunExe(), "fixture.mjs"],
       env: bunEnv,
@@ -5660,75 +5746,16 @@ describe.if(isWindows)("windows trailing separators", () => {
     const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
     expect(stderr).toBe("");
     expect(exitCode).toBe(0);
-
-    const expected: Record<string, unknown> = {};
-    for (const [name, { absolute, directories }] of Object.entries(forms)) {
-      expected[name] = {
-        readFileSync: "contents",
-        openSync: "ok",
-        open: "ok",
-        accessSync: "ok",
-        existsSync: true,
-        statSyncSize: 8,
-        lstatSyncSize: 8,
-        utimesSync: "ok",
-        chmodSync: "ok",
-        truncateSync: "ok",
-        truncated: "cont",
-        appendFileSync: "ok",
-        appended: "contents",
-        statfsSync: "number",
-        realpathSyncNative: true,
-        cpSync: "ok",
-        cpSyncCopied: "contents",
-        promisesReadFile: "contents",
-        promisesAccess: "ok",
-        promisesOpen: "ok",
-        promisesCp: "ok",
-        promisesCpCopied: "contents",
-        bunFile: "contents",
-        linkSync: "ok",
-        linked: "contents",
-        readlinkSync: "file.txt",
-        renameSync: "ok",
-        renamed: [false, true],
-        unlinkSync: "ok",
-        unlinked: false,
-        rmSync: "ok",
-        removed: false,
-        ...(absolute && {
-          symlinkSync: "ok",
-          // The stored target is the resolved path, without the separator.
-          symlinkTarget: true,
-          readThroughSymlink: "contents",
-        }),
-        ...(directories && {
-          readdirSyncOnFile: "ENOTDIR",
-          readdirSync: ["inner.txt"],
-          direntPathsExist: [true],
-          statSyncIsDirectory: true,
-          accessSyncDirectory: "ok",
-          existsSyncDirectory: true,
-          mkdirSync: "ok",
-          rmdirSync: "ok",
-          removedDirectory: false,
-          mkdirSyncRecursive: expect.stringMatching(/^mkdir-\d+$/),
-          createdRecursively: true,
-          rmSyncRecursive: "ok",
-          removedRecursively: false,
-        }),
-      };
-    }
-    expected.cwdAndRoots = {
-      existsSyncDot: [true, true],
+    expect(JSON.parse(stdout)).toEqual({
+      existsSyncCwd: [true, true],
       readdirSyncDriveRoot: true,
       existsSyncDriveRoot: true,
       statSyncRootedRoot: true,
-    };
-    // Errors still report the path as the caller spelled it.
-    expected.missingFile = { code: "ENOENT", path: "missing.txt\\", syscall: "open" };
-
-    expect(JSON.parse(stdout)).toEqual(expected);
+      // Errors still report the path as the caller spelled it.
+      missing: { code: "ENOENT", syscall: "open", path: "missing.txt\\" },
+      readdirSyncDriveRelative: ["inner.txt"],
+      direntParentPathsDriveRelative: [String(dir).slice(0, 2) + "dir"],
+    });
   });
 });
 


### PR DESCRIPTION
### Problem
- On Windows, a regular file whose path is spelled with a trailing separator is not found by most of `node:fs`: `readFileSync(file + "\\")`, `openSync`, `accessSync`, `cpSync`, `utimesSync`, `chmodSync`, `truncateSync`, `statfsSync`, `realpathSync.native`, `appendFileSync`, `renameSync`, `unlinkSync`, `rmSync`, `linkSync`, `readlinkSync` and the callback and `fs.promises` forms all throw `ENOENT: no such file or directory, open 'C:\...\file.txt\'`, and `existsSync` returns `false` for a rooted spelling (`\Users\...\file.txt\`). Node v26.3.0 succeeds in every case, for absolute, relative, rooted and drive-relative spellings (table below).
- Bun is also inconsistent with itself: `statSync` (libuv strips one separator) and `writeFileSync`, `mkdirSync`, `readdirSync` (NT paths, see Background) accept the spelling, and an absolute path ending in `/` works where one ending in `\` does not.
- Cause: the three `PathLike` slicers in `src/runtime/node/types.rs` keep the separator. `slice_z_with_force_copy` normalizes drive-letter paths with `normalize_buf`, which preserves a trailing `\`, copies relative paths through and only prepends the drive to rooted ones; `slice_w` (behind `os_path`, used by `cp`) converts the bytes as they are; `os_path_kernel32` uses `normalize_buf` for rooted paths. Win32 and NT keep a trailing separator significant, so the name only ever matches a directory.

### Fix
- Adds `bun_paths::string_paths::without_trailing_separators_windows_arg`: removes trailing `\` and `/` down to `windows_filesystem_root`, so `C:\`, `\` and `\\server\share\` are returned unchanged, and returns `\\?\`, `\\.\` and `\??\` paths verbatim, as the other converters in that module do. The three slicers apply it first, under `cfg(windows)`; POSIX is untouched.
- Matches node: its fs binding runs every path argument through `toNamespacedPath`, which drops the separators for every operation, so `file.txt\` and `file.txt` name the same file there.
- The slicers are the layer that already performs the rest of that namespacing (the `\\?\` prefix, normalization, the cwd drive for rooted paths), so one change covers every consumer (libuv, kernel32, NT) and every `PathLike` user. The NT consumers were already stripping the separator themselves, which is why directory operations (`mkdirSync("d\\")`, `readdirSync("d\\")`, `rmdirSync`, recursive `rmSync`) behave exactly as before; `readdirSync("file\\")` still throws `ENOTDIR` as `fs.test.ts` pins. Errors still report the path as the caller spelled it, since the operations attach `args.path`.
- Other observable changes, all in the direction of node: an absolute symlink target spelled with a separator is stored without it (`readlinkSync` then returns the plain path, as in node); `Dirent.parentPath` from a non-recursive `withFileTypes` readdir of `dir\` is `dir` (it was already `dir` for `dir/` and already normalized for `.`/`..` segments; #33034 separately changes it to the caller's argument); `Bun.file("...\\file.txt\\")` reads the file, consistent with `fs`.
- Not changed here: `copyFileSync` converts its arguments itself and still rejects the spelling (separate fix); `mkdirSync("./", { recursive: true })` now reaches the same path as `mkdirSync(".", { recursive: true })`, which has its own pre-existing `EEXIST` bug on Windows (separate fix); `\\?\`-prefixed input stays verbatim on purpose.
- Compatible with the open PRs in this area: #33034 joins relative paths onto the cwd in the same slicers after this strip runs, and #37952 routes `cp` through `os_path_kernel32`, which picks this up as well.
- Verified on Windows x64:
  - `test/js/node/fs/fs.test.ts`, "windows trailing separators": one fixture runs the file operations above (sync, callback, promises and `Bun.file`) for each of 7 spellings, and pins the directory operations, symlink targets, roots and the error path alongside them. On bun 1.4.0 it fails with the operations above reporting `ENOENT` (187 differing lines); it passes with this build.
  - `cargo test -p bun_paths`: unit tests for the helper (components, roots, UNC, device paths) pass on Linux.
  - The whole `fs.test.ts`: 501 pass, 1 fail, the pre-existing 5 s timeout of "readSync works on large files" in the debug build.
  - `cp`, `cp-symlink-target`, `dir`, `fs-mkdir`, `fs-path-length`, `readdir-windows-ntstatus`, `rm-windows-ntstatus`, `promises`, `glob`, `Bun.write` and the shell `cp`/`mv`/`rm` suites: 262 pass, 0 fail.
  - The 196 ported `test-fs-*` node tests covering path operations: all pass except `test-fs-mkdir-recursive-eaccess.js`, which fails identically on unmodified bun on this box (the user is an administrator).

### Background
- `toNamespacedPath`: on Windows, node's fs binding resolves every path argument (`path.win32.resolve`: absolute, normalized, trailing separators removed unless the path is a root) and prefixes it with `\\?\` before calling libuv. In bun the equivalent step is the `PathLike` slicers: `slice_z` produces the NUL-terminated UTF-8 path most operations hand to libuv or kernel32, `os_path` (`slice_w`) the UTF-16 form the native `cp` uses, and `os_path_kernel32` a normalized `\\?\` UTF-16 form for `existsSync` and recursive `mkdir`.
- Trailing separators on Windows: Win32 passes `name\` through to the kernel, and NTFS only resolves it when `name` is a directory; for a file it fails with `STATUS_OBJECT_NAME_INVALID`, which libuv reports as `ENOENT`. Bun's NT path builder (`normalize_path_windows` in `bun_sys`, used for `writeFile`, `mkdir`, `readdir`) already normalizes the separator away, and libuv's `stat` strips one, which is why those operations accepted the spelling while the libuv and kernel32 based ones did not.
- `windows_filesystem_root`: existing `bun_paths` helper returning a path's root including its separator (`C:\`, `\`, `\\server\share\`, `\\.\`); the helper uses its length as the floor it strips down to. The existing `without_trailing_slash_windows_path` only floors drive-letter paths, so it is not reused.

<details>
<summary>Before/after on Windows Server (bun 1.4.0, node v26.3.0, this branch), file spellings ending in a separator</summary>

Same result for the absolute, relative, rooted and drive-relative spellings unless noted.

```
operation                 bun 1.4.0          node 26.3.0   this branch
readFileSync              ENOENT             contents      contents
openSync / open / promises.open
                          ENOENT             fd            fd
accessSync / promises.access
                          ENOENT             ok            ok
cpSync / promises.cp      ENOENT             ok            ok
utimesSync, chmodSync, truncateSync, appendFileSync, statfsSync
                          ENOENT             ok            ok
realpathSync.native       ENOENT             path          path
renameSync, unlinkSync, rmSync, linkSync, readlinkSync
                          ENOENT             ok            ok
existsSync                true (rooted: false)  true       true
statSync / lstatSync      ok                 ok            ok
writeFileSync             ok                 ok            ok
copyFileSync              ENOENT             ok            ENOENT (separate fix)
readdirSync on the file   ENOTDIR            ENOENT        ENOTDIR (unchanged, pinned by fs.test.ts)
symlinkSync(abs + "\\") then readlinkSync
                          "...\file.txt\"    "...\file.txt"  "...\file.txt"
symlinkSync("f.txt\\") then readlinkSync
                          "f.txt\"           "f.txt\"      "f.txt\"
error path for a missing file
                          caller's spelling  resolved path caller's spelling (unchanged)
```

Directory spellings (`dir\`, relative and rooted), `mkdirSync`, `rmdirSync`, recursive `mkdirSync`/`rmSync`, `mkdtempSync(prefix + "\\")`, `readdirSync("C:\\")` and `statSync("\\")` behave the same before and after.
</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 0 · platform-specific test(s) that do not run on this machine, deferring to CI, which covers all platforms: test/js/node/fs/fs.test.ts

<!-- robobun:evidence:end -->