### PR TITLE
test(terminal): accept ConPTY's full-repaint row padding in the LF to CRLF assertion

### DIFF
--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -215,19 +215,13 @@ describe("Bun.Terminal platform behaviour", () => {
 
   test("SAME: output LF is translated to CRLF", async () => {
     // POSIX ONLCR and ConPTY both render \n as \r\n on the master/read side.
-    // POSIX and Windows 11 emit exactly "READY\r\nLINE2". Server 2019's ConPTY
-    // pads before the \r\n: a space when it paints just the dirty cells
-    // ("READY \r\n"), erase-character + cursor-forward when it repaints the
-    // whole 80-column screen ("READY\x1b[75X\x1b[75C\r\n"). conhost 17763
-    // repaints everything when the exiting child turns VT processing back off
-    // (bun restores the console mode at exit), so a child that writes and exits
-    // within one render frame yields only the second form. Every row of a full
-    // repaint ends in \r\n, so anchor on LINE2: the markers must be on
-    // consecutive rows.
+    // Server 2019's ConPTY pads the row before the \r\n with spaces or, on a
+    // full repaint, ESC[nX ESC[nC (#38054): strip the escapes and anchor on
+    // LINE2 so the \r\n has to be the row break between the two markers.
     const { output } = await runInTerminal(`process.stdout.write('READY\\nLINE2')`, {
       done: o => o.includes("LINE2"),
     });
-    expect(output).toMatch(/READY(?: |\x1b\[\d+[XC])*\r\nLINE2/);
+    expect(Bun.stripANSI(output)).toMatch(/READY *\r\nLINE2/);
     if (!isWindows) expect(output).toContain("READY\r\nLINE2");
   });
 

--- a/test/js/bun/terminal/terminal-platform-gaps.test.ts
+++ b/test/js/bun/terminal/terminal-platform-gaps.test.ts
@@ -215,11 +215,20 @@ describe("Bun.Terminal platform behaviour", () => {
 
   test("SAME: output LF is translated to CRLF", async () => {
     // POSIX ONLCR and ConPTY both render \n as \r\n on the master/read side.
-    // Older ConPTY may pad to the cell boundary with spaces before \r\n.
+    // POSIX and Windows 11 emit exactly "READY\r\nLINE2". Server 2019's ConPTY
+    // pads before the \r\n: a space when it paints just the dirty cells
+    // ("READY \r\n"), erase-character + cursor-forward when it repaints the
+    // whole 80-column screen ("READY\x1b[75X\x1b[75C\r\n"). conhost 17763
+    // repaints everything when the exiting child turns VT processing back off
+    // (bun restores the console mode at exit), so a child that writes and exits
+    // within one render frame yields only the second form. Every row of a full
+    // repaint ends in \r\n, so anchor on LINE2: the markers must be on
+    // consecutive rows.
     const { output } = await runInTerminal(`process.stdout.write('READY\\nLINE2')`, {
       done: o => o.includes("LINE2"),
     });
-    expect(output).toMatch(/READY *\r\n/);
+    expect(output).toMatch(/READY(?: |\x1b\[\d+[XC])*\r\nLINE2/);
+    if (!isWindows) expect(output).toContain("READY\r\nLINE2");
   });
 
   test("GAP: ANSI escape sequences", async () => {


### PR DESCRIPTION
### Problem
- `test/js/bun/terminal/terminal-platform-gaps.test.ts` fails on the Windows 2019 x64 lane (all four attempts in build 93815, also seen in 91206 and 84549), so it shows up as red on unrelated PRs:
  ```
  ✗ Bun.Terminal platform behaviour > SAME: output LF is translated to CRLF
  Expected substring or pattern: /READY *\r\n/
  Received: "...\^[[?25lREADY\^[[75X\^[[75C\r\nLINE2\^[[75X\^[[75C\r\n\^[[80X\^[[80C\r\n..."
  ```
- The child did write `READY\nLINE2` and ConPTY did render it as two rows joined by `\r\n`. The assertion (`terminal-platform-gaps.test.ts:222`, added in #29522) only accepts the padding ConPTY uses when it paints just the changed cells (`READY \r\n`), not the padding it uses when it repaints the whole screen (`READY` ESC[75X ESC[75C `\r\n`: erase 75 cells, cursor forward 75, for an 80-column terminal).
- conhost 17763 (Server 2019) repaints the whole screen when the child exits: bun enables VT processing on its console at startup and restores the previous mode at exit (`src/bun_core/output.rs`, `windows_stdio::restore`), and clearing `ENABLE_VIRTUAL_TERMINAL_PROCESSING` makes that conhost invalidate everything. A child that writes and exits within one render frame gets exactly one frame carrying its text, the full repaint, so the old pattern has nothing to match. On an idle Server 2019 box this is 13% to 24% of runs; every attempt in build 93815 hit it.
- Windows 11 (24H2) ConPTY and POSIX both emit exactly `READY\r\nLINE2`, which is why only the 2019 lane fails.
- #34694 fixed the other failure mode of this file on the same lane (the final frames being lost when the inline child exited). With the frames now reliably delivered, this is the failure mode that remains.

### Fix
- `expect(Bun.stripANSI(output)).toMatch(/READY *\r\nLINE2/)`: strip the escape sequences (the same normalization `test/js/node/tty.test.ts` and `test/js/bun/repl/repl.test.ts` apply to terminal output) and require `LINE2` directly after the `\r\n`. Rows of a full repaint are all joined by `\r\n`, so anchoring on `LINE2` is what proves the child's `\n` produced the row break between the two markers.
- `Bun.stripANSI` only removes ESC/C1-introduced sequences; `\r`, `\n` and spaces pass through, so the assertion still fails for what the test exists to catch: `READY\nLINE2`, `READYLINE2`, and a cursor-move instead of a CRLF all still fail (checked against the captured forms, table below).
- POSIX additionally keeps a byte-exact `toContain("READY\r\nLINE2")`, which is stricter than the old pattern there (ONLCR inserts only the CR); this matches how `GAP: ANSI escape sequences` in the same file pins exact bytes on POSIX.
- No runtime change: restoring the console mode at exit is long-standing, deliberate behaviour, and how conhost encodes a repaint is not something Bun controls or that this test is about.
- Verified:
  - Windows Server 2019 (build 17763, conhost 10.0.17763.1, same as the lane): old assertion fails 8/60 runs of the subtest; new assertion passes 150/150 runs of the subtest and 30/30 runs of the whole file.
  - Windows 11 24H2 aarch64: whole file passes 15/15.
  - Linux x64 debug build: whole file passes (19/19).

### Background
- ConPTY (`CreatePseudoConsole`) does not pass the child's bytes through. conhost renders them into a screen buffer on the child's behalf and a separate render thread periodically emits VT sequences describing whatever changed since the last frame; what Bun's `data` callback receives is that re-encoding.
- When only some cells changed, conhost paints those cells and moves to the next row with `\r\n`, which is the `READY \r\n` form. When the whole screen is invalidated it paints every row, and for the empty remainder of a row it emits ECH (`ESC[nX`, erase n cells) followed by CUF (`ESC[nC`, move right n cells) rather than n spaces.
- On POSIX the equivalent translation is the line discipline's ONLCR flag, which rewrites `\n` to `\r\n` on the way to the master side, byte for byte.

<details>
<summary>Assertion against the captured forms</summary>

| output | old | new |
| --- | --- | --- |
| POSIX `READY\r\nLINE2` | pass | pass |
| Windows 11: `...READY\r\nLINE2...` | pass | pass |
| 2019, dirty cells only: `READY \r\nLINE2 \b` | pass | pass |
| 2019, dirty cells then full repaint | pass | pass |
| 2019, full repaint only (build 93815) | fail | pass |
| 2019, full repaint then cursor fixup (build 91206) | fail | pass |
| broken: `READY\nLINE2` | fail | fail |
| broken: `READYLINE2` | fail | fail |
| broken: `READY\x1b[2;1HLINE2` | fail | fail |
| broken: `READY\rLINE2` | fail | fail |

</details>

<details>
<summary>Probes on the Server 2019 box (Bun canary 1.4.0-canary.1+9a543cc18)</summary>

Forms seen for `process.stdout.write('READY\nLINE2')` in an inline terminal, 200 runs:

- 53: dirty-cell paint only: `READY \r\nLINE2 \b`
- 117: dirty-cell paint followed by a full repaint
- 30: full repaint(s) only: `READY\x1b[75X\x1b[75C\r\nLINE2\x1b[75X\x1b[75C\r\n\x1b[80X\x1b[80C\r\n...` (the failing form)

What triggers the full repaint (child attached to a pre-created terminal so conhost stays alive, full repaints containing READY counted while the child is still running):

- child exits normally (bun): 20/20 repaint
- child killed before it restores anything: 0/20
- `cmd.exe /c echo` child exiting: 0/20
- `SetConsoleMode(stdout, mode & ~ENABLE_VIRTUAL_TERMINAL_PROCESSING)` from a live child: 10/10 repaint
- `SetConsoleMode` with the unchanged mode, `SetConsoleOutputCP(437)`, `SetConsoleCP(437)`: 0/10 each

Windows 11 24H2: 300/300 emit the bare `READY\r\nLINE2`.

The first revision of this PR listed the two paddings explicitly (`/READY(?: |\x1b\[\d+[XC])*\r\nLINE2/`, 0 failures in 1100 Server 2019 runs); self-review pointed out that stripping escapes has the same discrimination without the allowlist or the comment needed to justify it.

</details>

<!-- robobun:evidence:begin -->

---

**no test proof** · iteration 2 · Platform-specific test-only change; deferring to CI.

<!-- robobun:evidence:end -->