### PR TITLE
test: give the worker_threads tests in message-port-pipe.test.ts a debug/ASAN budget

### DIFF
--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -6,6 +6,13 @@ import { receiveMessageOnPort } from "node:worker_threads";
 // cross-thread wakeup coalescing, per-pipe isolation (no global registry),
 // and thread-safety under concurrent channel churn.
 
+// A node:worker_threads Worker boots in ~40ms on a release build but takes
+// seconds on debug/ASAN builds (node:worker_threads, node:stream and
+// node:console are compiled before its code runs), so each subprocess below
+// that spawns one has a fixed floor near the 5s default regardless of how
+// little work it does. Release builds keep the default.
+const workerTimeout = isDebug || isASAN ? 60_000 : undefined;
+
 describe("MessagePort pipe", () => {
   test("microtasks run between message events (task-source semantics)", async () => {
     const { port1, port2 } = new MessageChannel();
@@ -275,94 +282,118 @@ describe("MessagePort pipe", () => {
   //
   // Sanitizer-gated: the race being exercised is a memory-safety bug that
   // only surfaces deterministically under ASAN/UBSan.
-  test.skipIf(!isDebug && !isASAN)("concurrent MessageChannel creation across workers is race-free", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const { Worker } = require("worker_threads");
-          const workerSrc = \`
-            const { parentPort, MessageChannel } = require("worker_threads");
-            for (let i = 0; i < 2000; i++) {
+  //
+  // Booting the workers takes far longer than the churn, so every thread waits
+  // until all of them are parked on parentPort and starts on a "go" message;
+  // churning while the workers are still booting would overlap nothing.
+  test.concurrent.skipIf(!isDebug && !isASAN)(
+    "concurrent MessageChannel creation across workers is race-free",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker } = require("worker_threads");
+            const N = 1000;
+            const workerSrc = \`
+              const { parentPort, workerData: N } = require("worker_threads");
+              parentPort.once("message", () => {
+                let i = 0;
+                for (; i < N; i++) {
+                  const { port1, port2 } = new MessageChannel();
+                  port1.postMessage(i);
+                  port1.close();
+                  port2.close();
+                }
+                parentPort.postMessage(i);
+              });
+              parentPort.postMessage("ready");
+            \`;
+            const workers = Array.from({ length: 4 }, () => new Worker(workerSrc, { eval: true, workerData: N }));
+            const nextMessage = w =>
+              new Promise((resolve, reject) => {
+                w.once("message", resolve);
+                w.once("error", reject);
+              });
+            await Promise.all(workers.map(nextMessage)); // every worker is parked on parentPort
+            const counts = Promise.all(workers.map(nextMessage));
+            for (const w of workers) w.postMessage("go");
+            // Churn on the main thread at the same time.
+            for (let i = 0; i < N; i++) {
               const { port1, port2 } = new MessageChannel();
               port1.postMessage(i);
               port1.close();
               port2.close();
             }
-            parentPort.postMessage("done");
-          \`;
-          const workers = [];
-          for (let i = 0; i < 4; i++) {
-            workers.push(new Promise((resolve, reject) => {
-              const w = new Worker(workerSrc, { eval: true });
-              w.on("message", resolve);
-              w.on("error", reject);
-            }));
-          }
-          // Churn on the main thread at the same time.
-          for (let i = 0; i < 2000; i++) {
-            const { port1, port2 } = new MessageChannel();
-            port1.postMessage(i);
-            port1.close();
-            port2.close();
-          }
-          await Promise.all(workers);
-          console.log("OK");
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  });
-
-  test.skipIf(!isDebug && !isASAN)("burst of postMessage across threads delivers every message in order", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const { Worker, MessageChannel } = require("worker_threads");
-          const { port1, port2 } = new MessageChannel();
-          const w = new Worker(
-            \`
-              const { parentPort } = require("worker_threads");
-              parentPort.once("message", ({ port }) => {
-                for (let i = 0; i < 1000; i++) port.postMessage(i);
-                port.postMessage("end");
-              });
-            \`,
-            { eval: true },
-          );
-          w.postMessage({ port: port2 }, [port2]);
-          let next = 0;
-          port1.on("message", v => {
-            if (v === "end") {
-              if (next !== 1000) { console.error("got", next); process.exit(1); }
-              console.log("OK");
-              port1.close();
-              w.terminate();
-              return;
+            // Each worker reports how many channels it churned through, so a
+            // worker that skipped its loop cannot pass the test by staying quiet.
+            const churned = await counts;
+            if (!churned.every(n => n === N)) {
+              console.error("expected every worker to churn", N, "channels, got", churned);
+              process.exit(1);
             }
-            if (v !== next) { console.error("out of order", v, next); process.exit(1); }
-            next++;
-          });
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  });
+            console.log("OK");
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("OK");
+      expect(exitCode).toBe(0);
+    },
+    workerTimeout,
+  );
+
+  test.concurrent.skipIf(!isDebug && !isASAN)(
+    "burst of postMessage across threads delivers every message in order",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker, MessageChannel } = require("worker_threads");
+            const { port1, port2 } = new MessageChannel();
+            const w = new Worker(
+              \`
+                const { parentPort } = require("worker_threads");
+                parentPort.once("message", ({ port }) => {
+                  for (let i = 0; i < 1000; i++) port.postMessage(i);
+                  port.postMessage("end");
+                });
+              \`,
+              { eval: true },
+            );
+            w.postMessage({ port: port2 }, [port2]);
+            let next = 0;
+            port1.on("message", v => {
+              if (v === "end") {
+                if (next !== 1000) { console.error("got", next); process.exit(1); }
+                console.log("OK");
+                port1.close();
+                w.terminate();
+                return;
+              }
+              if (v !== next) { console.error("out of order", v, next); process.exit(1); }
+              next++;
+            });
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("OK");
+      expect(exitCode).toBe(0);
+    },
+    workerTimeout,
+  );
 });
 
 // worker.postMessage / parentPort.postMessage go through the same coalesced
@@ -370,112 +401,120 @@ describe("MessagePort pipe", () => {
 // matches Node: messages arrive in order with a microtask checkpoint between
 // each, for both directions.
 describe("Worker postMessage inbox", () => {
-  test.skipIf(!isDebug && !isASAN)("round-trip burst delivers in order with microtasks between each", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-          const { Worker, isMainThread, parentPort } = require("node:worker_threads");
-          const N = 200;
-          const order = [];
-          const w = new Worker(
-            \`
-              const { parentPort } = require("node:worker_threads");
-              const order = [];
-              let n = 0;
-              parentPort.on("message", d => {
-                order.push("m" + d);
-                queueMicrotask(() => order.push("u" + d));
-                parentPort.postMessage(d);
-                if (++n === ${"${N}"}) {
-                  queueMicrotask(() => parentPort.postMessage({ done: order }));
-                }
-              });
-            \`,
-            { eval: true },
-          );
-          let echoed = 0;
-          w.on("message", v => {
-            if (typeof v === "object" && v.done) {
-              // Worker-side ordering: m0,u0,m1,u1,...
-              for (let i = 0; i < N; i++) {
-                if (v.done[2*i] !== "m"+i || v.done[2*i+1] !== "u"+i) {
-                  console.error("worker order wrong at", i, v.done.slice(2*i, 2*i+4));
-                  process.exit(1);
-                }
-              }
-              if (echoed !== N) { console.error("echoed", echoed, "expected", N); process.exit(1); }
-              console.log("OK");
-              w.terminate();
-              return;
-            }
-            order.push("m" + v);
-            queueMicrotask(() => order.push("u" + v));
-            if (v !== echoed) { console.error("parent out of order", v, echoed); process.exit(1); }
-            echoed++;
-            if (echoed === N) {
-              queueMicrotask(() => {
+  test.concurrent.skipIf(!isDebug && !isASAN)(
+    "round-trip burst delivers in order with microtasks between each",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker, isMainThread, parentPort } = require("node:worker_threads");
+            const N = 200;
+            const order = [];
+            const w = new Worker(
+              \`
+                const { parentPort } = require("node:worker_threads");
+                const order = [];
+                let n = 0;
+                parentPort.on("message", d => {
+                  order.push("m" + d);
+                  queueMicrotask(() => order.push("u" + d));
+                  parentPort.postMessage(d);
+                  if (++n === ${"${N}"}) {
+                    queueMicrotask(() => parentPort.postMessage({ done: order }));
+                  }
+                });
+              \`,
+              { eval: true },
+            );
+            let echoed = 0;
+            w.on("message", v => {
+              if (typeof v === "object" && v.done) {
+                // Worker-side ordering: m0,u0,m1,u1,...
                 for (let i = 0; i < N; i++) {
-                  if (order[2*i] !== "m"+i || order[2*i+1] !== "u"+i) {
-                    console.error("parent order wrong at", i, order.slice(2*i, 2*i+4));
+                  if (v.done[2*i] !== "m"+i || v.done[2*i+1] !== "u"+i) {
+                    console.error("worker order wrong at", i, v.done.slice(2*i, 2*i+4));
                     process.exit(1);
                   }
                 }
-              });
-            }
-          });
-          await new Promise(r => w.once("online", r));
-          for (let i = 0; i < N; i++) w.postMessage(i);
-        `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  });
-
-  test("messages sent before worker online are delivered once it starts", async () => {
-    await using proc = Bun.spawn({
-      cmd: [
-        bunExe(),
-        "-e",
-        `
-        const { Worker } = require("node:worker_threads");
-        const w = new Worker(
-          \`
-            const { parentPort } = require("node:worker_threads");
-            const got = [];
-            parentPort.on("message", d => {
-              got.push(d);
-              if (got.length === 5) parentPort.postMessage(got);
+                if (echoed !== N) { console.error("echoed", echoed, "expected", N); process.exit(1); }
+                console.log("OK");
+                w.terminate();
+                return;
+              }
+              order.push("m" + v);
+              queueMicrotask(() => order.push("u" + v));
+              if (v !== echoed) { console.error("parent out of order", v, echoed); process.exit(1); }
+              echoed++;
+              if (echoed === N) {
+                queueMicrotask(() => {
+                  for (let i = 0; i < N; i++) {
+                    if (order[2*i] !== "m"+i || order[2*i+1] !== "u"+i) {
+                      console.error("parent order wrong at", i, order.slice(2*i, 2*i+4));
+                      process.exit(1);
+                    }
+                  }
+                });
+              }
             });
-          \`,
-          { eval: true },
-        );
-        // Post before the worker can possibly be online.
-        for (let i = 0; i < 5; i++) w.postMessage(i);
-        w.on("message", got => {
-          if (JSON.stringify(got) !== JSON.stringify([0,1,2,3,4])) {
-            console.error("wrong", got);
-            process.exit(1);
-          }
-          console.log("OK");
-          w.terminate();
-        });
-      `,
-      ],
-      env: bunEnv,
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
-    expect(stderr).toBe("");
-    expect(stdout.trim()).toBe("OK");
-    expect(exitCode).toBe(0);
-  });
+            await new Promise(r => w.once("online", r));
+            for (let i = 0; i < N; i++) w.postMessage(i);
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("OK");
+      expect(exitCode).toBe(0);
+    },
+    workerTimeout,
+  );
+
+  test.concurrent(
+    "messages sent before worker online are delivered once it starts",
+    async () => {
+      await using proc = Bun.spawn({
+        cmd: [
+          bunExe(),
+          "-e",
+          `
+            const { Worker } = require("node:worker_threads");
+            const w = new Worker(
+              \`
+                const { parentPort } = require("node:worker_threads");
+                const got = [];
+                parentPort.on("message", d => {
+                  got.push(d);
+                  if (got.length === 5) parentPort.postMessage(got);
+                });
+              \`,
+              { eval: true },
+            );
+            // Post before the worker can possibly be online.
+            for (let i = 0; i < 5; i++) w.postMessage(i);
+            w.on("message", got => {
+              if (JSON.stringify(got) !== JSON.stringify([0,1,2,3,4])) {
+                console.error("wrong", got);
+                process.exit(1);
+              }
+              console.log("OK");
+              w.terminate();
+            });
+          `,
+        ],
+        env: bunEnv,
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([proc.stdout.text(), proc.stderr.text(), proc.exited]);
+      expect(stderr).toBe("");
+      expect(stdout.trim()).toBe("OK");
+      expect(exitCode).toBe(0);
+    },
+    workerTimeout,
+  );
 });

--- a/test/js/web/workers/message-port-pipe.test.ts
+++ b/test/js/web/workers/message-port-pipe.test.ts
@@ -283,9 +283,13 @@ describe("MessagePort pipe", () => {
   // Sanitizer-gated: the race being exercised is a memory-safety bug that
   // only surfaces deterministically under ASAN/UBSan.
   //
-  // Booting the workers takes far longer than the churn, so every thread waits
-  // until all of them are parked on parentPort and starts on a "go" message;
-  // churning while the workers are still booting would overlap nothing.
+  // Booting a worker takes far longer than the churn, and once a worker's entry
+  // script returns the worker runs a full GC before it can receive a message,
+  // so starting the workers with postMessage would stagger them by more than
+  // the few milliseconds the churn takes on a release build. Instead every
+  // worker reports in and blocks in Atomics.wait() inside its entry script,
+  // and the main thread releases all of them at once right before churning
+  // itself, so all five threads create and close channels in the same window.
   test.concurrent.skipIf(!isDebug && !isASAN)(
     "concurrent MessageChannel creation across workers is race-free",
     async () => {
@@ -296,29 +300,33 @@ describe("MessagePort pipe", () => {
           `
             const { Worker } = require("worker_threads");
             const N = 1000;
+            const start = new Int32Array(new SharedArrayBuffer(4));
             const workerSrc = \`
-              const { parentPort, workerData: N } = require("worker_threads");
-              parentPort.once("message", () => {
-                let i = 0;
-                for (; i < N; i++) {
-                  const { port1, port2 } = new MessageChannel();
-                  port1.postMessage(i);
-                  port1.close();
-                  port2.close();
-                }
-                parentPort.postMessage(i);
-              });
+              const { parentPort, workerData: { N, start } } = require("worker_threads");
               parentPort.postMessage("ready");
+              Atomics.wait(start, 0, 0);
+              let i = 0;
+              for (; i < N; i++) {
+                const { port1, port2 } = new MessageChannel();
+                port1.postMessage(i);
+                port1.close();
+                port2.close();
+              }
+              parentPort.postMessage(i);
             \`;
-            const workers = Array.from({ length: 4 }, () => new Worker(workerSrc, { eval: true, workerData: N }));
+            const workers = Array.from(
+              { length: 4 },
+              () => new Worker(workerSrc, { eval: true, workerData: { N, start } }),
+            );
             const nextMessage = w =>
               new Promise((resolve, reject) => {
                 w.once("message", resolve);
                 w.once("error", reject);
               });
-            await Promise.all(workers.map(nextMessage)); // every worker is parked on parentPort
+            await Promise.all(workers.map(nextMessage)); // "ready" from every worker
             const counts = Promise.all(workers.map(nextMessage));
-            for (const w of workers) w.postMessage("go");
+            Atomics.store(start, 0, 1);
+            Atomics.notify(start, 0);
             // Churn on the main thread at the same time.
             for (let i = 0; i < N; i++) {
               const { port1, port2 } = new MessageChannel();


### PR DESCRIPTION
### Problem
- On a debug build, `bun bd test test/js/web/workers/message-port-pipe.test.ts` fails with `this test timed out after 5000ms` on three tests, all unmodified on main: "concurrent MessageChannel creation across workers is race-free", "burst of postMessage across threads delivers every message in order" and "round-trip burst delivers in order with microtasks between each". The fourth worker test, "messages sent before worker online are delivered once it starts", passes at 4.6-4.7s.
- Cause: each of those four tests spawns a subprocess that creates a `node:worker_threads` Worker, and on a debug build a worker_threads Worker takes ~2.7s from construction until its code runs (a web `Worker` takes ~0.2s). The difference is the per-worker bootstrap from #31216 (`src/js/node/worker_threads.ts`: `preload: ["node:worker_threads"]` plus `setupWorkerStdio`, which requires `node:console` and constructs a `Console`); compiling those builtins costs ~2.2s on a debug build. With ~0.4s of debug process startup and 1-2s of worker VM teardown at exit, a subprocess that spawns a single worker and does nothing else takes ~4.3s, so the 5s default leaves these tests no room for any work or any load on the machine. The tests were written in #29937 before that bootstrap existed.
- Shrinking the iteration counts does not fix it: the race test's fixture still takes ~5.0s of wall time at 250 iterations because the boot dominates.
- This only affects debug builds. On the ASAN CI lane the whole file takes under a second (`test/expected-durations.json`), and the CI runner passes `--timeout` of 90s/270s anyway; the 5s default applies to local `bun bd test` runs, which is where this was hit.
- Separately, the race test's threads barely overlapped: the main thread's 2000 iterations finished while the workers were still booting, and the workers only overlapped each other to the extent their boots happened to line up.

### Fix
- `test/js/web/workers/message-port-pipe.test.ts`: the four tests that spawn a worker_threads Worker get a 60s timeout on debug/ASAN builds (`workerTimeout`; `undefined` on release, so release keeps whatever default is in effect) and run with `test.concurrent`, since each one is an independent subprocess. 60s matches `worker-terminate-lifetime.test.ts` and `worker_heap_snapshot_gc.test.ts`, which document the same debug/ASAN worker startup cost.
- Correct because the four tests have a fixed per-process floor that no iteration count can remove; the budget has to cover the floor. Nothing under test changes: the three gated tests still run only on debug/ASAN, and their assertions are unchanged.
- The race test now uses a start barrier: each worker posts "ready" and blocks in `Atomics.wait()` on an `Int32Array` over a `SharedArrayBuffer` passed in `workerData`, still inside its entry script; once all four have reported in, the main thread does one `Atomics.store` + `Atomics.notify` and churns itself, so all five threads create and close channels in the same window. It churns 1000 channels per thread instead of 2000, which is plenty once the windows actually coincide.
- The barrier blocks inside the entry script on purpose: after a worker's entry script returns, `src/jsc/web_worker.rs` runs a full GC (`run_gc` after `workerGlobalScopeStarted`) before the first tick that can deliver a message, and on a release build that GC takes longer than the whole churn (measured 2-33ms of skew per worker against 3-6ms of churn), so releasing the workers with `postMessage` staggers them. Measured on a release build with a shared active-thread counter (not part of the test): the fixture on main never had all five threads churning at once in 40 runs; releasing via `postMessage` got there in about half the runs and in 4 of 20 some worker churned entirely alone; the `Atomics` barrier got there in 20 of 20. The test does not assert the overlap itself, since on a small CI runner the threads can legitimately be time-sliced apart.
- Each worker reports its iteration count and the fixture fails unless every worker reports the full count, so the `workerData` plumbing cannot silently turn the test into a no-op (verified by breaking it on purpose: `expected every worker to churn 1000 channels, got [ 0, 0, 0, 0 ]`, exit 1).
- Verified: `bun bd test test/js/web/workers/message-port-pipe.test.ts` on an unmodified debug build at bdb738222e: 10 pass, 3 time out. With this change: 13 pass across 13 runs; the race test takes 5-13s depending on host load, so it would still time out at the default, and the file went from ~28s to ~14-17s. `USE_SYSTEM_BUN=1 bun test` (release): 10 pass, 3 skipped, as before. The barrier fixture was also run standalone on both builds: `Atomics.wait` is allowed in a worker, and the worker's "ready" message is delivered while it is blocked.

### Background
- `isDebug` / `isASAN` (test/harness.ts) identify debug and sanitizer builds. Three of the four tests are already gated on them because the race they cover only shows up under a sanitizer; those tests never run on a release build.
- `bun test` applies a 5s timeout to any test that does not pass its own; the third argument to `test()` sets one per test, and passing `undefined` leaves the default in place. CI (`scripts/runner.node.mjs`) raises the default with `--timeout`, local runs do not.
- `test.concurrent` runs a test in parallel with the other concurrent tests of the file instead of one at a time.
- `Atomics.wait(array, index, expected)` blocks the calling thread until another thread calls `Atomics.notify` on the same element (returning immediately if the value is no longer `expected`), which makes a `SharedArrayBuffer` element a one-shot start gate: the waiting threads all wake from a single `notify`, with no event loop involved on either side.

<details>
<summary>Timings from a debug build (linux-x64, 12 CPU cgroup)</summary>

```
bun-debug -e 1                                              ~0.4s process
web Worker, file, until its code runs                        225ms
web Worker + preload node:worker_threads                     948ms
worker_threads Worker, file or eval, until its code runs     2.7-2.8s   (release: 44ms; node v26: 43ms)
4 worker_threads Workers that post one message               ~3.2s until all online, ~4.7s process wall
race fixture as on main (2000 x 5 threads)                   7.2-8.2s process wall
race fixture as on main, 250 iterations                      5.0-5.1s process wall
race fixture from this PR (1000 x 5 threads, barrier)        6.3-7.6s process wall, ~0.4-0.6s of it churn

main thread, debug:  require(node:worker_threads) 774ms, require(node:console) 669ms, new Console() 559ms, node:stream 194ms

Unmodified file on the fresh debug build:
(fail) concurrent MessageChannel creation across workers is race-free [5007ms]  timed out
(fail) burst of postMessage across threads delivers every message in order [5007ms]  timed out
(fail) round-trip burst delivers in order with microtasks between each [5008ms]  timed out
(pass) messages sent before worker online are delivered once it starts [4731ms]
```
</details>

<details>
<summary>Superseded first version</summary>

The first push released the workers with a `postMessage("go")` fan-out after collecting "ready" messages. Review pointed out that on release-class builds the post-entry GC in `web_worker.rs` staggers delivery of that message by more than the churn takes, which the active-counter measurement above confirmed (5-way overlap in 10 of 20 runs, a lone thread in 4 of 20), so it was replaced with the `Atomics` barrier. The timeout, `test.concurrent` and count-reporting parts are unchanged from that version.
</details>

<!-- robobun:evidence:begin -->

---

**[stamp-90s]** gate passed · iteration 0 · 1 files touched

<details><summary>passes on PR (with fix)</summary>

```console
Test-only change.

Debug/ASAN (expected pass):
$ bun bd test 'test/js/web/workers/message-port-pipe.test.ts'
$ BUN_DEBUG_QUIET_LOGS=1 bun scripts/build.ts --profile=debug --quiet test test/js/web/workers/message-port-pipe.test.ts
bun test v1.4.0 (c23bec6b6)

test/js/web/workers/message-port-pipe.test.ts:
(pass) MessagePort pipe > microtasks run between message events (task-source semantics) [18.06ms]
(pass) MessagePort pipe > messages buffered before start() are delivered on start() [10.77ms]
(pass) MessagePort pipe > receiveMessageOnPort pops in FIFO order [155.84ms]
(pass) MessagePort pipe > close() inside onmessage handler still delivers already-queued messages [14.52ms]
(pass) MessagePort pipe > messages queued on a port follow it across transfer [18.96ms]
(pass) MessagePort pipe > same-context re-attach inside handler: inbox follows new wrapper [14.02ms]
(pass) MessagePort pipe > chained transfer delivers through every hop [21.55ms]
(pass) MessagePort pipe > objectTypeCounts drop after close + GC; peer-open pins listening port [2246.01ms]
(pass) MessagePort pipe > port dropped in transit does not pin its peer [790.10ms]
(pass) Worker postMessage inbox > messages sent before worker online are delivered once it starts [3095.35ms]
(pass) MessagePort pipe > burst of postMessage across threads delivers every message in order [3514.66ms]
(pass) Worker postMessage inbox > round-trip burst delivers in order with microtasks between each [4108.61ms]
(pass) MessagePort pipe > concurrent MessageChannel creation across workers is race-free [4770.48ms]

 13 pass
 0 fail
 525 expect() calls
Ran 13 tests across 1 file. [12.86s]
Exit: 0
```

</details>

<details><summary>diff hotspot</summary>

```
test/js/web/workers/message-port-pipe.test.ts | 415 ++++++++++++++------------
 1 file changed, 231 insertions(+), 184 deletions(-)
```

</details>

**gate history** · 1 passed · 0 rejected · iteration 0

<details><summary>evidence per changed file</summary>

```
file                                           reads  edits  tests
test/js/web/workers/message-port-pipe.test.ts      7      6      0
```

</details>

<!-- robobun:evidence:end -->